### PR TITLE
Add a basic touch events support

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -25,6 +25,7 @@ var Apps = {
       window.addEventListener(evt, this, true);
     }).bind(this));
 
+    TouchEventHandler.start();
     TouchHandler.start();
   },
 
@@ -33,21 +34,21 @@ var Apps = {
       window.removeEventListener(evt, this, true);
     }).bind(this));
 
+    TouchEventHandler.stop();
     TouchHandler.stop();
   }
 };
 
 var TouchHandler = {
-  events: ['touchstart', 'touchmove', 'touchend',
-           'mousedown', 'mousemove', 'mouseup'],
+  events: ['touchstart', 'touchmove', 'touchend'],
   start: function th_start() {
     this.events.forEach((function(evt) {
-      window.addEventListener(evt, this, true);
+      window.addEventListener(evt, this, false);
     }).bind(this));
   },
   stop: function th_stop() {
     this.events.forEach((function(evt) {
-      window.removeEventListener(evt, this, true);
+      window.removeEventListener(evt, this, false);
     }).bind(this));
   },
   onTouchStart: function th_touchStart(evt) {
@@ -80,17 +81,15 @@ var TouchHandler = {
     switch (evt.type) {
       case 'touchstart':
         evt.preventDefault();
-      case 'mousedown':
         this.target = evt.originalTarget;
         this.onTouchStart(evt.touches ? evt.touches[0] : evt);
         break;
       case 'touchmove':
-        evt.preventDefault();
-      case 'mousemove':
         if (!this.target)
           break;
+        evt.preventDefault();
 
-        var touchEvent =evt.touches ? evt.touches[0] : evt;
+        var touchEvent = evt.touches ? evt.touches[0] : evt;
         if (!this.panning) {
           var pan = this.isPan(evt.pageX, evt.pageY, this.startX, this.startY);
           if (pan) {
@@ -103,10 +102,9 @@ var TouchHandler = {
         this.onTouchMove(touchEvent);
         break;
       case 'touchend':
-        evt.preventDefault();
-      case 'mouseup':
         if (!this.target)
           return;
+        evt.preventDefault();
 
         if (this.panning) {
           this.target.removeAttribute('panning');
@@ -116,6 +114,59 @@ var TouchHandler = {
         this.target = null;
       break;
     }
+  }
+};
+
+var TouchEventHandler = {
+  events: ['mousedown', 'mousemove', 'mouseup', 'mouseout'],
+  start: function teh_start() {
+    this.events.forEach((function(evt) {
+      window.addEventListener(evt, this, true);
+    }).bind(this));
+  },
+  stop: function teh_stop() {
+    this.events.forEach((function(evt) {
+      window.removeEventListener(evt, this, true);
+    }).bind(this));
+  },
+  handleEvent: function teh_handleEvent(evt) {
+    var type = '';
+    switch (evt.type) {
+      case 'mousedown':
+        this.target = evt.target;
+        type = 'touchstart';
+        break;
+      case 'mousemove':
+        type = 'touchmove';
+        break;
+      case 'mouseup':
+        this.target = null;
+        type = 'touchend';
+        break;
+      case 'mouseout':
+        this.target = null;
+        type = 'touchcancel';
+        break;
+    }
+
+    if (this.target)
+      this.sendTouchEvent(evt, this.target, type);
+  },
+  uuid: 0,
+  sendTouchEvent: function teh_sendTouchEvent(evt, target, name) {
+    var touchEvent = document.createEvent("touchevent");
+    var point = document.createTouch(window, target, this.uuid++,
+                                     evt.pageX, evt.pageY,
+                                     evt.screenX, evt.screenY,
+                                     evt.clientX, evt.clientY,
+                                     1, 1, 0, 0);
+    var touches = document.createTouchList(point);
+    var targetTouches = touches;
+    var changedTouches = touches;
+    touchEvent.initTouchEvent(name, true, true, window, 0,
+                              false, false, false, false,
+                              touches, targetTouches, changedTouches);
+    return target.dispatchEvent(touchEvent);
   }
 };
 

--- a/apps.js
+++ b/apps.js
@@ -94,9 +94,9 @@ var TouchHandler = {
           var pan = this.isPan(evt.pageX, evt.pageY, this.startX, this.startY);
           if (pan) {
             this.panning = true;
+            this.target.setAttribute('panning', true);
             this.startX = this.lastX = touchEvent.pageX;
             this.startY = this.lastY = touchEvent.pageY;
-            this.target.setAttribute('panning', true);
           }
         }
         this.onTouchMove(touchEvent);
@@ -144,12 +144,14 @@ var TouchEventHandler = {
         type = 'touchend';
         break;
       case 'mouseout':
-        this.target = null;
-        type = 'touchcancel';
+        if (!evt.relatedTarget) {
+          this.target = null;
+          type = 'touchcancel';
+        }
         break;
     }
 
-    if (this.target)
+    if (type && this.target)
       this.sendTouchEvent(evt, this.target, type);
   },
   uuid: 0,


### PR DESCRIPTION
This emulate Fennec's behavior.
The platform interfaces are only exposed when the preference dom.w3c_touch_events.enabled is set to true (which is already the case in app/mobile.js) 
