### PR TITLE
Remove the link closing tag

### DIFF
--- a/homescreen.html
+++ b/homescreen.html
@@ -1,7 +1,7 @@
 <html>
   <head>
-    <link href='system.css' rel='stylesheet' type='text/css'></link>
-    <link href='homescreen.css' rel='stylesheet' type='text/css'></link>
+    <link href='system.css' rel='stylesheet' type='text/css'>
+    <link href='homescreen.css' rel='stylesheet' type='text/css'>
 	  <script type="text/javascript" src="appManager.js"></script>
     <script type="text/javascript" src="scenegraph.js"></script>
     <script type="text/javascript" src="homescreen.js"></script> 

--- a/sms/sms.html
+++ b/sms/sms.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="sms.css"></link>
+    <link rel="stylesheet" type="text/css" href="sms.css">
     <script type="text/javascript" src="sms.js"></script>
     <script type="text/javascript" src="../apps.js"></script>
   </head>


### PR DESCRIPTION
The HTML5 link element does not need a close tag, let's clean it up!
