### PR TITLE
No double backspaces

### DIFF
--- a/apps/homescreen/js/keyboard.js
+++ b/apps/homescreen/js/keyboard.js
@@ -80,7 +80,9 @@ const IMEManager = {
         break;
       case 'click':
         var keyCode = parseInt(evt.target.getAttribute('data-keycode'));
-        if (!keyCode && keyCode === KeyEvent.DOM_VK_BACK_SPACE)
+        if (!keyCode)
+          return;
+        if (keyCode === KeyEvent.DOM_VK_BACK_SPACE)
           return;
 
         switch (keyCode) {


### PR DESCRIPTION
My bad on issue #182: That `&&` should be `||`, click event should be skipped when the keyCode represents backspaces. Without this fix backspace key currently deletes two characters.

@ThinkerYzu, my apologies :(

@vingtetun, can you take the pull request?
