### PR TITLE
Fix: app iframe height

### DIFF
--- a/apps/dialer/style/dialer.css
+++ b/apps/dialer/style/dialer.css
@@ -46,7 +46,7 @@ html * {
 #tabs-container {
   position: absolute;
   width: 100%;
-  bottom: 10px;
+  bottom: 0;
   padding: 20px 0px 15px 0px;
 
   -moz-transition: bottom 0.3s ease;
@@ -745,7 +745,7 @@ html * {
   top: 0;
   left: 0;
   width: 100%;
-  height: 98%;
+  height: 100%;
   border: 0;
 
   opacity: 0;

--- a/apps/homescreen/js/app_manager.js
+++ b/apps/homescreen/js/app_manager.js
@@ -83,7 +83,7 @@ if (!window['Gaia'])
         iframe.src = url;
         iframe.id = 'app_' + id;
         iframe.style.width = documentElement.clientWidth + 'px';
-        iframe.style.height = documentElement.clientHeight - 24 + 'px';
+        iframe.style.height = documentElement.clientHeight - 37 + 'px';
         iframe.taskElement = Gaia.TaskManager.add(app, id);
         element.appendChild(iframe);
         return iframe;


### PR DESCRIPTION
Accounting for the new height of the status bar when creating the app iframe.

(the iframe is styled inline and the change of height was only made in the CSS file when the new status bar was introduced)

Also backing out the css changes on the dialer since they aren't needed with the good iframe size.
