### PR TITLE
Get tests working with Marionette

### DIFF
--- a/tests/browser_clock_stopwatch.js
+++ b/tests/browser_clock_stopwatch.js
@@ -40,7 +40,7 @@ function test() {
         finish();
       }, function() {
         let clockWindow = clockFrame.contentWindow;
-        return 'StopWatch' in clockWindow;
+        return 'StopWatch' in clockWindow && clockWindow.document.getElementById('stopwatch-action-button') != null;
       });
     }, 300);
   }

--- a/tests/browser_clock_timer.js
+++ b/tests/browser_clock_timer.js
@@ -57,7 +57,7 @@ function test() {
         finish();
       }, function() {
         let clockWindow = clockFrame.contentWindow;
-        return 'Timer' in clockWindow;
+        return 'Timer' in clockWindow && clockWindow.document.getElementById('timer-action-button') != null;
       });
     }, 300);
   }

--- a/tests/browser_dialer_contact_intent.js
+++ b/tests/browser_dialer_contact_intent.js
@@ -19,7 +19,7 @@ function test() {
         finish();
       }, function() {
         let dialerWindow = dialerFrame.contentWindow;
-        return 'KeyHandler' in dialerWindow;
+        return 'KeyHandler' in dialerWindow && dialerWindow.document.getElementById('contacts-view') != null;
       });
     }, 300);
   }

--- a/tests/browser_dialer_keypad.js
+++ b/tests/browser_dialer_keypad.js
@@ -24,7 +24,7 @@ function test() {
         finish();
       }, function() {
         let dialerWindow = dialerFrame.contentWindow;
-        return 'KeyHandler' in dialerWindow;
+        return 'KeyHandler' in dialerWindow && dialerWindow.document.querySelector(".keyboard-key[data-value='3']") != null;
       });
     }, 300);
   }


### PR DESCRIPTION
Most of these Gaia tests have been failing under Marionette due to timing issues.  The apps on an emulator on our slow test slave are very slow, and code like this:

```
  waitFor(function() {
    // something...
  }, function() {
    let dialerWindow = dialerFrame.contentWindow;
    return 'KeyHandler' in dialerWindow;
  });
```

would sometimes allow the test to progress before the DOM was fully generated.  I've added some checks to make sure that expected DOM elements are present before continuing, and this change allows all Gaia tests to pass under the Marionette continuous-integration system we've setup at http://brasstacks.mozilla.com/autolog/?tree=b2g&source=autolog.  This should allow new breakages to be easily seen.
