### PR TITLE
Disabled <a> outlines in Settings app

### DIFF
--- a/apps/settings/style/ui.css
+++ b/apps/settings/style/ui.css
@@ -11,6 +11,10 @@ h1 {
   text-shadow: 0 0.1em 0 rgba(255, 255, 255, 0.9);
 }
 
+a {
+  outline: 0;
+}
+
 /* View */
 .view {
   border: 0;


### PR DESCRIPTION
Added CSS rule to disable outlines on <a> elements in Settings app.  This is intended to solve the issue where clicking elements like 'Display', 'Keyboard', etc will cause the standard outline to show up and persist across screens, highlighting them unnecessarily.
