### PR TITLE
Attampt to fix #371

### DIFF
--- a/apps/homescreen/MozSettings.js
+++ b/apps/homescreen/MozSettings.js
@@ -123,12 +123,12 @@
           for (var setting in settings) {
             var request = objectStore.put(settings[setting]);
 
-            request.onsuccess = function onsuccess(e) {
-              console.log('Success to add a setting to: ' + store);
+            request.onsuccess = function onsuccess(ev) {
+              console.log('Success to add setting ' + ev.target.result + ' to: ' + store);
             }
 
-            request.onerror = function onerror(e) {
-              console.log('Failed to add a setting to: ' + store);
+            request.onerror = function onerror(ev) {
+              console.log('Failed to add setting  ' + ev.target.result + ' to: ' + store);
             }
           }
         });

--- a/apps/homescreen/js/keyboard.js
+++ b/apps/homescreen/js/keyboard.js
@@ -65,8 +65,21 @@ const IMEManager = {
           );
         }
 
-        i++;
-        if (i === keyboardSettingGroupKeys.length) {
+        if (++i === keyboardSettingGroupKeys.length) {
+          completeSettingRequests();
+        } else {
+          keyboardSettingRequest.call(this, keyboardSettingGroupKeys[i]);
+        }
+      }).bind(this);
+
+      request.onerror = (function onerror(evt) {
+        // XXX: workaround with gaia issue 342
+        if (keyboardSettingGroupKeys.indexOf(key) !== i)
+          return;
+
+        dump('Having trouble getting setting for keyboard setting group: ' + key);
+
+        if (++i === keyboardSettingGroupKeys.length) {
           completeSettingRequests();
         } else {
           keyboardSettingRequest.call(this, keyboardSettingGroupKeys[i]);

--- a/apps/homescreen/js/keyboard.js
+++ b/apps/homescreen/js/keyboard.js
@@ -447,15 +447,21 @@ const IMEManager = {
           }).bind(this)
         );
 
-        var request = navigator.mozSettings.get('keyboard.vibration');
-        request.addEventListener('success', (function onsuccess(evt) {
-          this.vibrate = (request.result.value === 'true');
-        }).bind(this));
+        // TODO: workaround gaia issue 374
+        setTimeout((function keyboardVibrateSettingRequest() {
+          var request = navigator.mozSettings.get('keyboard.vibration');
+          request.addEventListener('success', (function onsuccess(evt) {
+            this.vibrate = (request.result.value === 'true');
+          }).bind(this));
 
-        var request = navigator.mozSettings.get('keyboard.clicksound');
-        request.addEventListener('success', (function onsuccess(evt) {
-          this.clicksound = (request.result.value === 'true');
-        }).bind(this));
+          setTimeout((function keyboardClickSoundSettingRequest() {
+            var request = navigator.mozSettings.get('keyboard.clicksound');
+            request.addEventListener('success', (function onsuccess(evt) {
+              this.clicksound = (request.result.value === 'true');
+            }).bind(this));
+          }).bind(this), 0);
+
+        }).bind(this), 0);
 
         break;
 


### PR DESCRIPTION
Add some checks and event handlers to MozSettings requests, and workarounds.

Should leave #371 open till no one can report it is unreproducible anymore.

If problem still present, I can add another more aggressive workaround that use `setTimeout` to continue show keyboard it the setting request timeouts.
