### PR TITLE
Disable hardware keys to task manager and window manager when the lockscreen is locked

### DIFF
--- a/apps/homescreen/js/task_manager.js
+++ b/apps/homescreen/js/task_manager.js
@@ -39,15 +39,19 @@ if (!window['Gaia'])
       return this.items = this.container.getElementsByTagName('ul')[0];
     },
 
+    enabled: true,
+
     init: function() {
       window.addEventListener('keydown', this);
       window.addEventListener('keyup', this);
+      window.addEventListener('locked', this);
+      window.addEventListener('unlocked', this);
     },
 
     handleEvent: function(evt) {
       switch (evt.type) {
         case 'keydown':
-          if (evt.keyCode !== evt.DOM_VK_HOME || timeout)
+          if (!this.enabled || evt.keyCode !== evt.DOM_VK_HOME || timeout)
             return;
 
           if (this.isActive) {
@@ -66,6 +70,13 @@ if (!window['Gaia'])
 
           window.clearTimeout(timeout);
           timeout = 0;
+          break;
+
+        case 'locked':
+          this.enabled = false;
+          break;
+        case 'unlocked':
+          this.enabled = true;
           break;
       }
     },

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -174,24 +174,32 @@ var WindowManager = {
     window.addEventListener('resize', this);
   },
 
+  enabled: true,
+
   handleEvent: function wm_handleEvent(evt) {
     switch (evt.type) {
       case 'message':
+        if (!this.enabled)
+          return;
         if (evt.data == 'appclose')
           this.closeForegroundWindow();
         break;
       case 'home':
+        if (!this.enabled)
+          return;
         this.closeForegroundWindow();
         break;
       case 'locked':
         if (this._foregroundWindow.application.fullscreen) {
           document.getElementById('screen').classList.remove('fullscreen');
         }
+        this.enabled = false;
         break;
       case 'unlocked':
         if (this._foregroundWindow.application.fullscreen) {
           document.getElementById('screen').classList.add('fullscreen');
         }
+        this.enabled = true;
         break;
       case 'resize':
         this._foregroundWindow.resize();


### PR DESCRIPTION
... but not apps nor keyboards (`hideime` fires on chrome script when press the back button).
