### PR TITLE
Sexy transition on app launch

### DIFF
--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -84,7 +84,7 @@ Window.prototype = {
       if (callback)
         callback();
     };
-    sprite.element.addEventListener('animationiteration', focus.bind(this));
+    sprite.element.addEventListener('transitionend', focus.bind(this));
 
     if (this.application.fullscreen) {
       document.getElementById('screen').classList.add('fullscreen');

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -24,7 +24,16 @@ WindowSprite.prototype = {
   },
 
   remove: function ws_remove() {
-    document.body.removeChild(this.element);
+    if (this.element)
+      document.body.removeChild(this.element);
+  },
+
+  crossFade: function ws_crossFade() {
+    var afterCrossFade = (this.remove).bind(this);
+    setTimeout((function () {
+      this.element.addEventListener('transitionend', afterCrossFade);
+      this.element.classList.add('crossFade');
+    }).bind(this), 0);
   }
 };
 
@@ -66,8 +75,10 @@ Window.prototype = {
     sprite.add();
     this.setActive(true);
 
-    var focus = function(evt) {
-      sprite.remove();
+    var focus = (function(evt) {
+      sprite.element.removeEventListener('transitionend', focus);
+
+      sprite.crossFade();
 
       var element = this.element;
       if (!this._loaded) {
@@ -83,8 +94,8 @@ Window.prototype = {
 
       if (callback)
         callback();
-    };
-    sprite.element.addEventListener('transitionend', focus.bind(this));
+    }).bind(this);
+    sprite.element.addEventListener('transitionend', focus);
 
     if (this.application.fullscreen) {
       document.getElementById('screen').classList.add('fullscreen');

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -8,7 +8,6 @@ function WindowSprite(win) {
   element.className = 'windowSprite';
   element.style.width = win.element.style.width;
   element.style.height = win.element.style.height;
-  element.style.background = '-moz-element(#window_' + win.id + ') no-repeat';
 }
 
 WindowSprite.prototype = {
@@ -85,7 +84,7 @@ Window.prototype = {
       if (callback)
         callback();
     };
-    sprite.element.addEventListener('transitionend', focus.bind(this));
+    sprite.element.addEventListener('animationiteration', focus.bind(this));
 
     if (this.application.fullscreen) {
       document.getElementById('screen').classList.add('fullscreen');

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -249,12 +249,29 @@ div.windowSprite {
   top: 32px;
   left: 0;
   z-index: 999999;
-  -moz-transform-origin: center bottom;
-  -moz-transform: scale(0);
+  -moz-transform: scale(0.5);
   -moz-transition: all 0.5s ease;
+  opacity: 0;
+  background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
+  color: #fff;
+  font-size: 100px;
+  text-align: center;
+  text-shadow: 2px 2px 0 #ccc;
+  vertical-align: middle;
+}
+
+div.windowSprite > span {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 150px;
+  line-height: 150px;
+  margin-top: -75px;
 }
 
 div.windowSprite.active {
+  opacity: 1;
   -moz-transform: scale(1);
 }
 

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -216,7 +216,7 @@ body {
 
 iframe.appWindow {
   position: absolute;
-  background-color: #000;
+  background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
   border: 0;
   margin: 0;
   padding: 0;
@@ -250,14 +250,19 @@ div.windowSprite {
   left: 0;
   z-index: 999999;
   -moz-transform: scale(0.5);
-  -moz-transition: all 0.5s ease;
+  -moz-transition: -moz-transform 0.5s ease, opacity 0.5s ease;
   opacity: 0;
   background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
+  border-radius: 8px;
 }
 
 div.windowSprite.active {
   opacity: 1;
   -moz-transform: scale(1);
+}
+
+div.windowSprite.crossFade {
+  opacity: 0;
 }
 
 iframe.portrait-primary {

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -253,21 +253,6 @@ div.windowSprite {
   -moz-transition: all 0.5s ease;
   opacity: 0;
   background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
-  color: #fff;
-  font-size: 100px;
-  text-align: center;
-  text-shadow: 2px 2px 0 #ccc;
-  vertical-align: middle;
-}
-
-div.windowSprite > span {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 150px;
-  line-height: 150px;
-  margin-top: -75px;
 }
 
 div.windowSprite.active {


### PR DESCRIPTION
Sexy transition on app launch. New design from Josh.

Iframe still loads after the transition ends, coz for an app that request keyboard onload, loading it before transition would break the app and keyboard.

need detail fix in keyboard.js before removing the `this._loaded` check in `focus()` and load the app as soon as transition starts.
