### PR TITLE
fix https://github.com/andreasgal/gaia/issues/560

### DIFF
--- a/apps/homescreen/js/task_manager.js
+++ b/apps/homescreen/js/task_manager.js
@@ -119,6 +119,9 @@ if (!window['Gaia'])
       var item = document.getElementById('task_' + id);
       this.items.removeChild(item);
       WindowManager.kill(app.url);
+
+      if (this.items.children.length === 0) 
+        this.setActive(false);
     },
 
     sendToFront: function(id) {


### PR DESCRIPTION
A simple patch that closes #560 : when you kill the only remaining task in the task switcher, the task switcher itself should close.

There is still a remaining UX question: if there are no tasks running, what should happen if you press and hold the home button?  Currently it enters the task switcher and shows you that there are no tasks, which is probably the right thing to do there.
