### PR TITLE
make app switcher close buttons bigger

### DIFF
--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -453,9 +453,9 @@ iframe.landscape-secondary {
   width: 32px;
   height: 32px;
   position: absolute;
-  top: -16px;
-  right: -16px;
-  -moz-transform: scale(2.5);
+  top: 10px;
+  right: 10px;
+  -moz-transform: scale(5);
 }
 
 #taskManager li > h1 {


### PR DESCRIPTION
This fixes https://github.com/andreasgal/gaia/issues/561

It doubles the size of the close button and pulls it down and to the left so it doesn't stick out too far at that new larger size.
