### PR TITLE
fixed various UI bugs on the Video app

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -10,7 +10,6 @@ window.addEventListener('DOMContentLoaded', function() {
       width: '640',
       height: '360',
       duration: '2:05'
-
     },
     {
       title: 'Meet The Cubs',
@@ -68,6 +67,12 @@ window.addEventListener('DOMContentLoaded', function() {
     }
   }
 
+  // show|hide controls over the player
+  $('videoControls').addEventListener('click', function(event) {
+    if (event.target == this)
+      this.classList.toggle('hidden');
+  }, false);
+
   // show|hide video player
   function showPlayer(sample) {
     // switch to the video player view
@@ -102,7 +107,7 @@ window.addEventListener('DOMContentLoaded', function() {
   $('close').addEventListener('click', hidePlayer, false);
   player.addEventListener('ended', hidePlayer, false);
   window.addEventListener('keypress', function(event) {
-    if (event.keyCode == event.DOM_VK_ESCAPE) {
+    if (playerShowing && event.keyCode == event.DOM_VK_ESCAPE) {
       hidePlayer();
       event.preventDefault();
     }
@@ -111,13 +116,9 @@ window.addEventListener('DOMContentLoaded', function() {
     }
   }, false);
 
-  // show|hide controls over the player
-  $('videoControls').addEventListener('click', function() {
-    $('videoControls').classList.toggle('hidden');
-  }, false);
-
   // media events: play|pause, rwd|fwd, timeupdate
   playHead = $('playHead');
+  elapsedTime = $('elapsedTime');
   $('play').addEventListener('click', function() {
     if (player.paused) {
       $('videoBar').classList.remove('paused');
@@ -134,7 +135,12 @@ window.addEventListener('DOMContentLoaded', function() {
     player.currentTime += 15;
   }, false);
   player.addEventListener('timeupdate', function() {
-    var pos = (player.currentTime / player.duration) * 100;
-    playHead.style.top = pos + '%';
+    var pos = (player.currentTime / player.duration) * 100 + '%';
+    playHead.style.top = pos;
+    elapsedTime.style.height = pos;
+  }, false);
+
+  // handle clicks on the time slider
+  $('timeSlider').addEventListener('click', function() {
   }, false);
 });

--- a/apps/video/style/controls.css
+++ b/apps/video/style/controls.css
@@ -3,7 +3,6 @@
  */
 #videoControls {
   position: absolute;
-  /*display: block;*/
   top: 0;
   left: 0;
   width: 100%;
@@ -18,14 +17,13 @@
   border: none;
 }
 #videoControls.hidden {
-  /*display: none;*/
   opacity: 0;
 }
 
 /* close button */
 #close {
-  top: 10px;
-  right: 10px;
+  top: 16px;
+  right: 16px;
   width: 80px;
   height: 80px;
   background-image: url("images/btn_close_off.png");
@@ -37,11 +35,12 @@
 
 /* main control bar: play|pause, timeupdate, rwd|fwd */
 #videoBar {
+  position: relative;
+  left: 16px;
   width: 112px;
   height: 800px;
   margin: 0;
   padding: 0;
-  position: relative;
   background-image: url("images/controls.png");
 }
 #videoBar button {
@@ -86,17 +85,29 @@
 /* time slider */
 #timeSlider {
   position: relative;
-  top: 135px;
-  left: 31px;
+  top: 166px;
+  left: 32px;
   width: 64px;
-  height: 375px;
+  height: 378px;
+}
+#elapsedTime {
+  position: absolute;
+  top: 0;
+  left: 30px;
+  width: 6px;
+  height: 0; /* updated by script (ontimeupdate) */
+  background-color: #fff;
+  border-radius: 6px;
 }
 button#playHead {
+  top: 0; /* updated by script (ontimeupdate) */
   left: 0;
+  margin-top: -31px;
   width: 64px;
   height: 64px;
   background-image: url("images/btn_playhead_off.png");
   background-position: center center;
+  display: none;
 }
 button#playHead:active {
   background-image: url("images/btn_playhead_press.png");

--- a/apps/video/style/video.css
+++ b/apps/video/style/video.css
@@ -66,7 +66,6 @@ ul li:first-child {
 li {
   margin: 0;
   padding: 0 20px 0 150px;
-  /*height: 72px;*/
   height: 98px;
   border-bottom: 1px solid #cbcdd1;
   border-top: 1px solid #e6ebef;

--- a/apps/video/video.html
+++ b/apps/video/video.html
@@ -34,6 +34,7 @@
           <button id="rwd"></button>
           <button id="fwd"></button>
           <div id="timeSlider">
+            <div id="elapsedTime"></div>
             <button id="playHead"></button>
           </div>
         </div>


### PR DESCRIPTION
The time slider is now filled with a white progress line, and the “playHead” button has been removed (display: none) until it’s made draggable.

The “back” button now works properly. The video control layer toggles properly again on click/tap.
