### PR TITLE
Fix #585 (Cut the rope sizing) and change the background color of iframe

### DIFF
--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -153,16 +153,16 @@ Window.prototype = {
 
   resize: function window_resize() {
     var element = this.element;
+    var documentElement = document.documentElement;
     // NOTE: for the moment, orientation only works when fullscreen because of a
     // too dirty hack...
     if (this.application.fullscreen && this.application.orientation) {
       var width = this.element.style.width;
-      element.style.width = this.element.style.height;
-      element.style.height = width;
+      element.style.width = documentElement.clientHeight + 'px';
+      element.style.height = documentElement.clientWidth + 'px';
 
       element.classList.add(this.application.orientation);
     } else {
-      var documentElement = document.documentElement;
       element.style.width = documentElement.clientWidth + 'px';
 
       var height = documentElement.clientHeight;

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -233,9 +233,14 @@ iframe.appWindow {
   padding: 0;
   overflow: auto;
   left: 0;
-  width: 100%;
   top: 32px;
   z-index: 1;
+/*
+ * Do not specify height/width here! They should go to
+ * Window.prototype.resize() in window_manager.js
+ *
+ */
+
 /*
  * Disable this for now because it forces an expensive fallback path in
  * Gecko.  The performance issue should be fixed by
@@ -251,6 +256,11 @@ iframe.appWindow.active {
 
 #screen.fullscreen iframe.appWindow {
   top: 0;
+/*
+ * Do not specify height/width here! They should go to
+ * Window.prototype.resize() in window_manager.js
+ *
+ */
 }
 
 #screen.fullscreen iframe.appWindow.active {

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -227,7 +227,8 @@ body {
 
 iframe.appWindow {
   position: absolute;
-  background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
+  background-color: #373a3d;
+  -moz-transition: background-color 1s ease;
   border: 0;
   margin: 0;
   padding: 0;
@@ -252,6 +253,7 @@ iframe.appWindow {
 
 iframe.appWindow.active {
   z-index: 9995;
+  background-color: #000;
 }
 
 #screen.fullscreen iframe.appWindow {


### PR DESCRIPTION
iframe color has been changed to #000 instead of the color of mask so that there will still be a little transition as the web page loads
