### PR TITLE
gallery app: fix https://github.com/andreasgal/gaia/issues/532

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -238,7 +238,7 @@ var Gallery = {
     this.header.classList.add('hidden');
     this.photos.classList.remove('hidden');
     this.playerControls.classList.remove('hidden');
-
+    this.focusedPhoto = true;
     this.currentPage = parseInt(focusedPhoto.index);
 
     this.pan(0);

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -277,8 +277,7 @@ var Gallery = {
   },
 
   tap: function() {
-    // This is part of the Physics client interface, but isn't used
-    // for the Gallery.  We use a click listener instead.
+    this.toggleControls();
   },
 
   handleEvent: function(e) {


### PR DESCRIPTION
This pull request includes 3 commits:

1) The big one takes all the indexed db stuff out of the app and changes it so that thumbnail and photos are just read directly from the internal webserver.  This fixes https://github.com/andreasgal/gaia/issues/532 and is something that @andreasgal wants us to do eventually anyway.  This mostly deletes code, and what's left is a lot simpler 

2) The second commit fixes a bug (I think it was a bug) that was preventing the back soft key (the VK_ESCAPE one) from going from a photo back to the thumbnails

3) The third commit restores the feature where tapping on a photo toggles the visibilty of the controls.  

@benfrancis I hope these changes are okay!
