### PR TITLE
Pause the camera when the app is minimized

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -77,7 +77,7 @@ window.addEventListener('DOMContentLoaded', function CameraInit() {
 window.addEventListener('message', function CameraPause(evt) {
   if (evt.data.hidden) {
     Camera.pause();
-  } else {
+  } else if (evt.data.hidden === false) {
     Camera.init();
   }
 });

--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -37,13 +37,17 @@ var Camera = {
 
     video.src = navigator.mozCamera.getCameraURI(config);
   },
-  
+
+  pause: function pause() {
+    this.video.pause();
+  },
+
   toggleCamera: function toggleCamera() {
     this._camera = 1 - this._camera;
     this.video.src = '';
     this.init();
   },
-  
+
   toggleFilter: function toggleFilter(target) {
     var filter = '';
 
@@ -67,3 +71,13 @@ window.addEventListener('DOMContentLoaded', function CameraInit() {
   Camera.init();
 });
 
+// Bug 690056 implement a visibility API, and it's likely that
+// we want this event to be fire when an app come back to life
+// or is minimized (it does not now).
+window.addEventListener('message', function CameraPause(evt) {
+  if (evt.data.hidden) {
+    Camera.pause();
+  } else {
+    Camera.init();
+  }
+});

--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -75,9 +75,12 @@ window.addEventListener('DOMContentLoaded', function CameraInit() {
 // we want this event to be fire when an app come back to life
 // or is minimized (it does not now).
 window.addEventListener('message', function CameraPause(evt) {
+  if (evt.data.message !== 'visibilitychange')
+    return;
+
   if (evt.data.hidden) {
     Camera.pause();
-  } else if (evt.data.hidden === false) {
+  } else {
     Camera.init();
   }
 });


### PR DESCRIPTION
Running camera in the background will slow down the phone, and provide funny effect on task manager.
