### PR TITLE
long press on home button always brings up task switcher

### DIFF
--- a/apps/homescreen/js/task_manager.js
+++ b/apps/homescreen/js/task_manager.js
@@ -28,7 +28,7 @@ var TaskManager = {
 
   enabled: true,
   init: function tm_init() {
-    ['keydown', 'keyup', 'locked', 'unlocked'].forEach((function attachKey(type) {
+    ['locked', 'unlocked'].forEach((function attachKey(type) {
       window.addEventListener(type, this);
     }).bind(this));
   },
@@ -36,29 +36,6 @@ var TaskManager = {
   _timeout: 0,
   handleEvent: function tm_handleEvent(evt) {
     switch (evt.type) {
-      case 'keydown':
-        if (!this.enabled || evt.keyCode !== evt.DOM_VK_HOME || this._timeout)
-          return;
-
-        if (this.isActive()) {
-          this.hide();
-          return;
-        }
-
-        this._timeout = window.setTimeout(function checkKeyPress(self) {
-          self.show();
-        }, 1000, this);
-        break;
-
-      case 'keyup':
-        if (evt.keyCode !== evt.DOM_VK_HOME)
-          return;
-
-        window.clearTimeout(this._timeout);
-        this._timeout = 0;
-        break;
-
-
       case 'locked':
         this.enabled = false;
         break;


### PR DESCRIPTION
This pull request, along with the gecko patch https://bugzilla.mozilla.org/show_bug.cgi?id=730434 addresses https://github.com/andreasgal/gaia/issues/642

The gecko patch in bugzilla edits b2g/chrome/content/shell.js so that it sends a 'home' event on a short press and release of the home button, but sends a new 'switcher' event on a long (1 second) press and hold of the home button.

This pull request edits apps/homescreen/js/window_mananger.js to respond to that new 'switcher' event.  It also removes some event handling code in task_manager.js that is no longer necessary with this new scheme.

What this means is that you can now bring up the task switcher even when an app is displayed. You don't have to go to the homescreen first.

Note, however, that this was much tricker to do than I thought. There were a few places in window_mananger.js which implicitly assumed that if tasks were being switched there was no current window and we were at the homescreen.

The event handling logic of the homescreen is really complicated because there are so many moving part. Post demo it needs a re-write, or at least some good documentation, because it is hard to figure out...

So this pull request needs a careful review and careful testing if it is going to be pulled before the demo
