### PR TITLE
Ensure this._closingWindow will be cleaned up when the window is closed

### DIFF
--- a/apps/homescreen/js/keyboard.js
+++ b/apps/homescreen/js/keyboard.js
@@ -450,7 +450,8 @@ const IMEManager = {
 
   handleEvent: function km_handleEvent(evt) {
     var activeWindow = Gaia.AppManager.foregroundWindow;
-    if (!activeWindow || activeWindow == this._closingWindow)
+    if (!activeWindow ||
+        (activeWindow == this._closingWindow && evt.type != 'appclose'))
       return;
 
     var target = evt.target;


### PR DESCRIPTION
There is a few times where the keyboard does not want to show up on the device.
For example it happens if you go to the sms app, click on the text field, then click on the home button while the keyoard is visible. If you go back to the sms app the keyboard won't show up. You will have to kill the application.

The bug just fix that by letting the appclose reach the cleaning spot.
