### PR TITLE
prevents unwanted taps on homescreen by adding a 5px threshold to swipes

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -144,6 +144,7 @@ DefaultPhysics.prototype = {
 
     var touchState = this.touchState;
     this.moved = false;
+    this.movedThreshold = false;
     touchState.active = true;
     touchState.startX = e.pageX;
     touchState.startY = e.pageY;
@@ -155,8 +156,11 @@ DefaultPhysics.prototype = {
     if (touchState.active) {
       var dx = touchState.startX - e.pageX;
       if (dx !== 0) {
-        iconGrid.pan(-dx);
         this.moved = true;
+        this.movedThreshold = this.movedThreshold || Math.abs(dx) > 5;
+        if (this.movedThreshold) {
+          iconGrid.pan(-dx);
+        }
       }
       e.stopPropagation();
     }
@@ -177,7 +181,7 @@ DefaultPhysics.prototype = {
     var small = Math.abs(diffX) < 20;
 
     var flick = quick && !small;
-    var tap = small;
+    var tap = !this.movedThreshold;
     var drag = !quick;
 
     var iconGrid = this.iconGrid;

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -144,7 +144,6 @@ DefaultPhysics.prototype = {
 
     var touchState = this.touchState;
     this.moved = false;
-    this.movedThreshold = false;
     touchState.active = true;
     touchState.startX = e.pageX;
     touchState.startY = e.pageY;
@@ -156,9 +155,8 @@ DefaultPhysics.prototype = {
     if (touchState.active) {
       var dx = touchState.startX - e.pageX;
       if (dx !== 0) {
-        this.moved = true;
-        this.movedThreshold = this.movedThreshold || Math.abs(dx) > 5;
-        if (this.movedThreshold) {
+        this.moved = this.moved || Math.abs(dx) >= 19;
+        if (this.moved) {
           iconGrid.pan(-dx);
         }
       }
@@ -181,7 +179,7 @@ DefaultPhysics.prototype = {
     var small = Math.abs(diffX) < 20;
 
     var flick = quick && !small;
-    var tap = !this.movedThreshold;
+    var tap = !this.moved;
     var drag = !quick;
 
     var iconGrid = this.iconGrid;

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -155,7 +155,7 @@ DefaultPhysics.prototype = {
     if (touchState.active) {
       var dx = touchState.startX - e.pageX;
       if (dx !== 0) {
-        this.moved = this.moved || Math.abs(dx) >= 19;
+        this.moved = this.moved || Math.abs(dx) > 20;
         if (this.moved) {
           iconGrid.pan(-dx);
         }
@@ -176,7 +176,7 @@ DefaultPhysics.prototype = {
 
     var quick = (e.timeStamp - touchState.startTime < 200);
     var long = (e.timeStamp - touchState.startTime > 2000);
-    var small = Math.abs(diffX) < 20;
+    var small = Math.abs(diffX) <= 20;
 
     var flick = quick && !small;
     var tap = !this.moved;


### PR DESCRIPTION
This causes a small step at the beginning of the swipe (if you move very slowly). You can prevent that by commenting lines 161 and 163, but I believe the panel should stay fixed as long as the "tap phase" is still valid. Once the panel starts moving the tap event is locked
