### PR TITLE
Using the call's state change to stop vibration/ringing (#715)

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -749,21 +749,15 @@ var TelephonyListener = function() {
       ringtonePlayer.play();
     }
 
-    telephony.oncallschanged = function() {
-      try {
-        var incoming = false;
-        telephony.calls.forEach(function(call) {
-          if (call.state == 'incoming')
-            incoming = true;
-        });
-
-        if (!incoming) {
+    telephony.calls.forEach(function(call) {
+      if (call.state == 'incoming') {
+        call.onstatechange = function () {
+          call.oncallschanged = null;
           ringtonePlayer.pause();
-          telephony.oncallschanged = null;
           window.clearInterval(vibrateInterval);
-        }
-      } catch (e) {}
-    };
+        };
+      }
+    });
 
     var url = '../dialer/dialer.html';
     var launchFunction = function launchDialer() {


### PR DESCRIPTION
Apparently it works better than the global oncallschanged.

This fixes issue #715, need to investigate the oncallschanged issue separately.
