### PR TITLE
Fill in missing navigator.mozTelephony stub properties. Fixes #726

### DIFF
--- a/webapi.js
+++ b/webapi.js
@@ -1415,18 +1415,33 @@
   if ('mozTelephony' in navigator)
     return;
 
+  var TelephonyCalls = [];
+
   navigator.mozTelephony = {
     dial: function(number) {
-      return {
+      var TelephonyCall = {
         number: number,
         state: 'dialing',
         addEventListener: function() {},
         hangUp: function() {},
-        removeEventListener: function(){}
+        removeEventListener: function() {}
       };
+
+      TelephonyCalls.push(TelephonyCall);
+
+      return TelephonyCall;
     },
     addEventListener: function(name, handler) {
-    }
+    },
+    get calls() {
+      return TelephonyCalls;
+    },
+    muted: false,
+    speakerEnabled: false,
+
+    // Stubs
+    onincoming: null,
+    oncallschanged: null
   };
 })(this);
 


### PR DESCRIPTION
This prevents errors when running Gaia anywhere that `navigator.mozTelephony` is stubbed 

Signed-off-by: Rick Waldron waldron.rick@gmail.com waldron.rick@gmail.com
