### PR TITLE
Fix calculator evaluation

### DIFF
--- a/apps/calculator/js/calculator.js
+++ b/apps/calculator/js/calculator.js
@@ -24,7 +24,7 @@ var Calculator = {
   },
 
   isOperator: function calculator_isOperator(val) {
-    return this.operators.indexOf(val) !== -1;
+    return Calculator.operators.indexOf(val) !== -1;
   },
 
   appendValue: function calculator_appendValue(value) {


### PR DESCRIPTION
A minor change to the calculator pull request changed
the execution context of a call and broke all calculations,
Change just ensures isOperator will work regardless of
the context it is called in.
