### PR TITLE
Wait for MozAfterPaint before dim the screen, prevent lock-screen jank

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -176,7 +176,7 @@ var LockScreen = {
         window.clearTimeout(this._timeout);
 
         if (screen.mozEnabled) {
-          this.update(ScreenManager.turnScreenOff);
+          this.update(ScreenManager.turnScreenOff.bind(this));
         } else {
           ScreenManager.turnScreenOn();
         }

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -49,8 +49,6 @@ var LockScreen = {
     var settings = window.navigator.mozSettings;
     if (!settings) {
       this.lock(true, callback);
-      if (callback)
-        setTimeout(callback, 0, true);
       return;
     }
 


### PR DESCRIPTION
Fixes issue #330.

It is currently no way to be notified when the screen is turned off by power manager, evidently by the fact that lock screen is not present when the screen is turned back on. Need to add the same `MozAfterPaint` code for that if the event is available.
