### PR TITLE
Copy the /OfflineCache to the device when |make install-gaia|

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 GAIA_DIR?=$(CURDIR)
 B2G_HOMESCREEN=file://$(GAIA_DIR)/homescreen.html
 
-PROFILE_DIR?=$(CURDIR)
+PROFILE_DIR?=$(CURDIR)/profile
 
 MOZ_TESTS = "$(MOZ_OBJDIR)/_tests/testing/mochitest"
 INJECTED_GAIA = "$(MOZ_TESTS)/browser/gaia"
@@ -31,10 +31,11 @@ ADB?=adb
 PROFILE := $$($(ADB) shell ls -d /data/b2g/mozilla/*.default | tr -d '\r')
 PROFILE_DATA := profile
 .PHONY: install-gaia
-install-gaia: 
+install-gaia:
 	$(ADB) start-server
-	$(ADB) shell rm -r /data/local/*
-	@for i in $$(ls); do $(ADB) push $$i /data/local/$$i; done
+	$(ADB) shell rm -r /data/local/OfflineCache
+	$(ADB) shell mkdir /data/local/OfflineCache
+	$(ADB) push $(PROFILE_DIR)/OfflineCache /data/local/OfflineCache/
 	@echo 'Rebooting b2g now'
 	$(ADB) shell killall b2g
 


### PR DESCRIPTION
This pull request will change the  |make install-gaia| target of Gaia to copy the content of the profile/OfflineCache directory only to the device. This "compile" version of Gaia will then be used.

This patch should not be landed before https://bugzilla.mozilla.org/show_bug.cgi?id=736193
When this patch lands the same patch should be applied to B2G/Makefile to make sure the install-gaia target do the same thing (or call this target!)
