### PR TITLE
switch language dynamically in the Settings app

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -134,7 +134,7 @@ window.addEventListener('keyup', function goBack(event) {
 });
 
 // Set the 'lang' and 'dir' attributes to <html> when the page is translated
-window.addEventListener('l10nLocaleLoaded', function showBody() {
+window.addEventListener('localized', function showBody() {
   var html = document.querySelector('html');
   html.setAttribute('lang', document.mozL10n.language);
   html.setAttribute('dir', document.mozL10n.direction);

--- a/webapi.js
+++ b/webapi.js
@@ -1840,7 +1840,7 @@
         // execute the [optional] callback
         if (callback)
           callback();
-        // fire an 'localized' DOM event
+        // fire a 'localized' DOM event
         var evtObject = document.createEvent('Event');
         evtObject.initEvent('localized', false, false);
         evtObject.language = lang;


### PR DESCRIPTION
When I renamed the 'l10nLocaleLoaded' event to 'localized', I forgot to apply the changes in settings.js. Here’s a fix.
