### PR TITLE
fix an endless loop by limiting pageCount to 32

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -1170,6 +1170,12 @@ IconGrid.prototype = {
     // adjust existing pages and create new ones as needed
     var itemsPerPage = rows * columns;
     var pageCount = Math.ceil(icons.length / itemsPerPage);
+
+    // prevent an endless loop when shrinking the window to zero
+    // (this might happen when debugging with Firebug)
+    var maxPageCount = 32;
+    pageCount = Math.min(pageCount, maxPageCount);
+
     for (var n = 0; n < pageCount; n++) {
       var page = pages[n];
       if (page)
@@ -1191,9 +1197,8 @@ IconGrid.prototype = {
       }
     }
 
-
     // adjust existing icons and create new ones as needed
-    var iconsCount = icons.length;
+    var iconsCount = Math.min(icons.length, itemsPerPage * maxPageCount);
     for (var n = 0; n < iconsCount; ++n) {
       var icon = icons[n];
 


### PR DESCRIPTION
Steps to reproduce:
1. open Gaia in Firefox
2. open Firebug in this window (e.g. Firebug > Firebug UI location > right)
3. move the splitter until Gaia is hidden

Expected result: nothing happens
Actual result: browser is frozen

This page should fix that by limiting the number of pages to 32 (= purely arbitrary limit).
