### PR TITLE
fix window resizing

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -1135,7 +1135,7 @@ IconGrid.prototype = {
     }
 
     // issue #723 - The calculation of the width/height of the icons
-    // should be dynamic and ot harcoded like that. The reason why it
+    // should be dynamic and not harcoded like that. The reason why it
     // it is done like that at this point is because there is no icon
     // when the application starts and so there is nothing to calculate
     // against.
@@ -1144,8 +1144,8 @@ IconGrid.prototype = {
     var iconWidth = 132;
 
     var rect = container.getBoundingClientRect();
-    var rows = Math.floor(rect.height / iconHeight);
-    var columns = Math.floor(rect.width / iconWidth);
+    var rows = Math.max(1, Math.floor(rect.height / iconHeight));
+    var columns = Math.max(1, Math.floor(rect.width / iconWidth));
 
     var targetHeight = iconHeight * rows + 'px';
     container.style.minHeight = container.style.maxHeight = targetHeight;

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -363,8 +363,8 @@ var WindowManager = (function() {
 
   // When a resize event occurs, resize the running app, if there is one
   window.addEventListener('resize', function() {
-    if (runningApp)
-      setAppSize(runningApp);
+    if (displayedApp)
+      setAppSize(displayedApp);
   });
 
   // Listen for the Back button.  We need both a capturing listener


### PR DESCRIPTION
Steps to reproduce:
1. open Gaia in Firefox
2. open Firebug in this window (e.g. Firebug > Firebug UI location > right)
3. move the splitter until Gaia is hidden

Expected result: nothing happens
Actual result: browser is frozen

This page should fix that by ensuring there’s at least one icon per page, as suggested by @andreasgal in this pull request: https://github.com/andreasgal/gaia/pull/829
