### PR TITLE
fix Home key handling while task switcher is shown. Closes #850  Closes ...

### DIFF
--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -460,13 +460,12 @@ var WindowManager = (function() {
         timer = null;
 
         // If the screen is locked, ignore the home button.
-        // Otherwise, if the task switcher is visible, then hide it.
         // Otherwise, make the homescreen visible.
+        // Also, if the task switcher is visible, then hide it.
         if (!LockScreen.locked) {
-          if (taskManager.classList.contains('active'))
+          setDisplayedApp(null);
+          if (taskSwitcherIsShown())
             hideTaskSwitcher();
-          else
-            setDisplayedApp(null);
         }
       }
 
@@ -476,10 +475,11 @@ var WindowManager = (function() {
 
     function longPressHandler() {
       // If the timer fires, then this was a long press on the home key
-      // So bring up the app switcher overlay.
+      // So bring up the app switcher overlay if we're not locked
+      // and if the task switcher is not already shown
       timer = null;
 
-      if (!LockScreen.locked)
+      if (!LockScreen.locked && !taskSwitcherIsShown())
         showTaskSwitcher();
     }
   }());


### PR DESCRIPTION
...#849

This is a simple fix to Home button event handling when the task switcher is displayed and it should fix two simple bugs.
