### PR TITLE
[l10n] RTL-compliant homescreen & update zh-tw l10n

### DIFF
--- a/apps/bbc/manifest.json
+++ b/apps/bbc/manifest.json
@@ -12,6 +12,9 @@
   "locales": {
     "fr": {
       "description": "Application mobile BBC"
+    },
+    "zh-TW": {
+      "description": "BBC 行動應用程式"
     }
   },
   "default_locale": "en"

--- a/apps/browser/manifest.json
+++ b/apps/browser/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Navigateur",
       "description": "Navigateur Web Gaia"
+    },
+    "zh-TW": {
+      "name": "網路瀏覽器",
+      "description": "Gaia 網路瀏覽器"
     }
   },
   "default_locale": "en"

--- a/apps/calculator/manifest.json
+++ b/apps/calculator/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Calculatrice",
       "description": "Calculatrice"
+    },
+    "zh-TW": {
+      "name": "計算機",
+      "description": "計算機"
     }
   },
   "default_locale": "en"

--- a/apps/calendar/manifest.json
+++ b/apps/calendar/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Calendrier",
       "description": "Calendrier Google"
+    },
+    "zh-TW": {
+      "name": "行事曆",
+      "description": "Google 日曆"
     }
   },
   "default_locale": "en"

--- a/apps/camera/manifest.json
+++ b/apps/camera/manifest.json
@@ -14,6 +14,10 @@
     "fr": {
       "name": "Caméra",
       "description": "Caméra Gaia"
+    },
+    "fr": {
+      "name": "相機",
+      "description": "Gaia 相機"
     }
   },
   "default_locale": "en"

--- a/apps/clock/manifest.json
+++ b/apps/clock/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Horloge",
       "description": "Horloge Gaia"
+    },
+    "zh-TW": {
+      "name": "時鐘",
+      "description": "Gaia 時鐘"
     }
   },
   "default_locale": "en"

--- a/apps/cnn/manifest.json
+++ b/apps/cnn/manifest.json
@@ -12,6 +12,9 @@
   "locales": {
     "fr": {
       "description": "Application mobile CNN"
+    },
+    "zh-TW": {
+      "description": "CNN 行動應用程式"
     }
   },
   "default_locale": "en"

--- a/apps/crystalskull/manifest.json
+++ b/apps/crystalskull/manifest.json
@@ -12,6 +12,9 @@
   "locales": {
     "fr": {
       "description": "Démo WebGL"
+    },
+    "zh-TW": {
+      "description": "WebGL 示範"
     }
   },
   "default_locale": "en"

--- a/apps/cubevid/manifest.json
+++ b/apps/cubevid/manifest.json
@@ -13,6 +13,9 @@
     "fr": {
       "name": "CubeVid",
       "description": "Démo de vidéo cube"
+    },
+    "zh-TW": {
+      "description": "Video Cube 示範"
     }
   },
   "default_locale": "en"

--- a/apps/dialer/manifest.json
+++ b/apps/dialer/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Appel",
       "description": "Appel téléphonique Gaia"
+    },
+    "zh-TW": {
+      "name": "電話",
+      "description": "Gaia 電話"
     }
   },
   "default_locale": "en"

--- a/apps/facebook/manifest.json
+++ b/apps/facebook/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Facebook",
       "description": "Application mobile Facebook"
+    },
+    "zh-TW": {
+      "name": "Facebook",
+      "description": "Facebook 行動應用程式"
     }
   },
   "default_locale": "en"

--- a/apps/gallery/manifest.json
+++ b/apps/gallery/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Galerie",
       "description": "Galerie Gaia"
+    },
+    "zh-TW": {
+      "name": "相簿",
+      "description": "Gaia 相簿"
     }
   },
   "default_locale": "en"

--- a/apps/gmail/manifest.json
+++ b/apps/gmail/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Courriel",
       "description": "GMail"
+    },
+    "zh-TW": {
+      "name": "郵件",
+      "description": "GMail"
     }
   },
   "default_locale": "en"

--- a/apps/homescreen/homescreen.html
+++ b/apps/homescreen/homescreen.html
@@ -19,7 +19,7 @@
     <script src="js/keyboard.js"></script>
     <script src="js/homescreen.js"></script>
   </head>
-  <body>
+  <body class="hidden">
     <div id="screen">
       <div id="keyboard" data-hidden="true" onmousedown="return false;"></div>
       <div id="statusbar">

--- a/apps/homescreen/js/app_manager.js
+++ b/apps/homescreen/js/app_manager.js
@@ -62,7 +62,6 @@ Gaia.AppManager = {
           var loc = manifest.locales[lang];
           for (var k in loc)
             manifest[k] = loc[k];
-          console.log(manifest);
         }
 
         var icon = manifest.icons ? app.origin + manifest.icons['120'] : '';

--- a/apps/homescreen/locale/homescreen.properties
+++ b/apps/homescreen/locale/homescreen.properties
@@ -31,4 +31,9 @@ roaming={{operator}}（漫遊）
 unreadMessages=您有 {{n}} 個未讀訊息
 missedCalls=您有 {{n}} 通未接來電
 # sleep menu
+airplane=通訊關閉模式
+silent=靜音模式
+normal=一般模式
+restart=重新啟動
+power=關機
 

--- a/apps/homescreen/manifest.json
+++ b/apps/homescreen/manifest.json
@@ -10,6 +10,10 @@
     "fr": {
       "name": "Écran d’accueil",
       "description": "Écran d’accueil Gaia"
+    },
+    "zh-TW": {
+      "name": "主畫面",
+      "description": "Gaia 主畫面"
     }
   },
   "default_locale": "en"

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -369,3 +369,23 @@ iframe.landscape-secondary {
   width: 100%;
 }
 
+/* localization */
+body.hidden * {
+  visibility: hidden;
+}
+
+*[dir=rtl] .page {
+  left: auto;
+  right: 42px;
+}
+
+*[dir=rtl] .icon {
+  float: right;
+  margin-left: 4px;
+  margin-right: auto;
+}
+
+*[dir=rtl] .icon > .label {
+  padding-left: auto;
+  padding-right: 8px;
+}

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -369,10 +369,9 @@ iframe.landscape-secondary {
   width: 100%;
 }
 
-/* localization */
-body.hidden * {
-  visibility: hidden;
-}
+/*
+ * Localization: RTL layout
+ */
 
 *[dir=rtl] .page {
   left: auto;

--- a/apps/maps/manifest.json
+++ b/apps/maps/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Cartes",
       "description": "Google Maps"
+    },
+    "zh-TW": {
+      "name": "地圖",
+      "description": "Google 地圖"
     }
   },
   "default_locale": "en"

--- a/apps/market/manifest.json
+++ b/apps/market/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Logithèque",
       "description": "Catalogue en ligne d’applications"
+    },
+    "zh-TW": {
+      "name": "市集",
+      "description": "下載與安裝應用程式"
     }
   },
   "default_locale": "en"

--- a/apps/music/manifest.json
+++ b/apps/music/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Musique",
       "description": "Musique Gaia"
+    },
+    "zh-TW": {
+      "name": "音樂",
+      "description": "Gaia 音樂"
     }
   },
   "default_locale": "en"

--- a/apps/nytimes/manifest.json
+++ b/apps/nytimes/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "NY Times",
       "description": "Application mobile NY Times"
+    },
+    "zh-TW": {
+      "name": "NY Times",
+      "description": "NY Times 行動應用程式"
     }
   },
   "default_locale": "en"

--- a/apps/settings/manifest.json
+++ b/apps/settings/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Paramètres",
       "description": "Paramètres Gaia"
+    },
+    "zh-TW": {
+      "name": "設定",
+      "description": "Gaia 設定"
     }
   },
   "default_locale": "en"

--- a/apps/sms/manifest.json
+++ b/apps/sms/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Messages",
       "description": "Messages Gaia"
+    },
+    "zh-TW": {
+      "name": "訊息",
+      "description": "Gaia 訊息"
     }
   },
   "default_locale": "en"

--- a/apps/video/manifest.json
+++ b/apps/video/manifest.json
@@ -16,6 +16,10 @@
     "fr": {
       "name": "Vidéo",
       "description": "Vidéo Gaia"
+    },
+    "zh-TW": {
+      "name": "影片",
+      "description": "Gaia 影片"
     }
   },
   "default_locale": "en"

--- a/apps/wikipedia/manifest.json
+++ b/apps/wikipedia/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Wikipedia",
       "description": "Application mobile Wikipedia"
+    },
+    "zh-TW": {
+      "name": "維基百科",
+      "description": "維基百科行動應用程式"
     }
   },
   "default_locale": "en"

--- a/apps/zimbra/manifest.json
+++ b/apps/zimbra/manifest.json
@@ -13,6 +13,10 @@
     "fr": {
       "name": "Zimbra",
       "description": "Courriel Mozilla Zimbra"
+    },
+    "zh-TW": {
+      "name": "Zimbra",
+      "description": "Mozilla Zimbra 郵件"
     }
   },
   "default_locale": "en"


### PR DESCRIPTION
This reorders the application list in the homescreen in order to work properly with right-to-left languages such as Arabic.
