### PR TITLE
don't let background apps show through the corners of the homescreen

### DIFF
--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -285,6 +285,14 @@ var WindowManager = (function() {
       openWindow(url);
     }
 
+    // If there was no app before and now there is one, make
+    // the window container active and visible.  Or, if
+    // there was an app but now there is none, do the opposite.
+    if (!displayedApp && url)
+      windows.classList.add('active');
+    else if (displayedApp && !url) 
+      windows.classList.remove('active');
+
     displayedApp = url;
   }
 

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -173,11 +173,17 @@ body {
   position: absolute;
   left: 0px;
   width: 100%;
+  top: -100%;
+  height: 0;
+  max-height: 0;
+  border: 0px;
+  overflow: hidden;
+}
+
+#windows.active {
   top: 0;
   height: 100%;
   max-height: 100%;
-  border: 0px;
-  overflow: hidden;
 }
 
 iframe.appWindow {

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -182,7 +182,7 @@ body {
 
 iframe.appWindow {
   position: absolute;
-  background: url("themes/default/images/noise.png") repeat scroll 50% 50%, #373a3d;
+  background-color: #373a3d;
   -moz-transition: background-color 1s ease;
   border: 0;
   margin: 0;
@@ -219,7 +219,6 @@ div.windowSprite {
   width: 100%;
   height: -moz-calc(100% - 32px);
   z-index: 999999;
-  background: url("themes/default/images/noise.png") repeat scroll 50% 50%, #373a3d;
   -moz-transition: -moz-transform 0.5s ease, opacity 0.5s ease;
 }
 

--- a/apps/homescreen/style/themes/default/homescreen.css
+++ b/apps/homescreen/style/themes/default/homescreen.css
@@ -25,7 +25,8 @@ body {
 /* Home Screen */
 
 #home {
-  border-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
   background: url(backgrounds/default.png);
 }
 
@@ -136,7 +137,8 @@ body {
 
 div.windowSprite {
   background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
-  border-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
 }
 
 /* Task Manager */

--- a/apps/homescreen/style/themes/default/homescreen.css
+++ b/apps/homescreen/style/themes/default/homescreen.css
@@ -25,8 +25,7 @@ body {
 /* Home Screen */
 
 #home {
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
+  border-radius: 8px;
   background: url(backgrounds/default.png);
 }
 
@@ -137,8 +136,7 @@ body {
 
 div.windowSprite {
   background: url("images/noise.png") repeat scroll 50% 50%, #373a3d;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
+  border-radius: 8px;
 }
 
 /* Task Manager */


### PR DESCRIPTION
This fixes #840 but does so in a heavy-handed manner: it just gets rid of the rounded corners at the bottom of the homescreen.

There doesn't seem to be much point in rounded corners at the bottom, so this is probably okay as a temporary fix, at least.
