### PR TITLE
[l10n] fixed a typo in the Camera manifest

### DIFF
--- a/apps/camera/manifest.json
+++ b/apps/camera/manifest.json
@@ -15,7 +15,7 @@
       "name": "Caméra",
       "description": "Caméra Gaia"
     },
-    "fr": {
+    "zh-TW": {
       "name": "相機",
       "description": "Gaia 相機"
     }


### PR DESCRIPTION
In the last zh-TW update, a typo in the Camera manifest caused the Camera app to be shown in Chinese on the homescreen for the French local. Here’s the fix.
