### PR TITLE
Settings: backout pull #854

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -97,6 +97,8 @@ window.addEventListener('load', function loadSettings(evt) {
 });
 
 window.addEventListener('DOMContentLoaded', function showRoot() {
+  document.location.hash = '#root';
+
   // update UI when the language setting is changed
   // XXX there's no way currently to fire a callback when a pref is changed
   //     so we're using an ugly onclick + timeout :-/
@@ -111,24 +113,9 @@ window.addEventListener('DOMContentLoaded', function showRoot() {
   });
 });
 
-// When the user clicks on a link to display a new panel then change
-// to the CSS :target pseudo-element will trigger a transition that makes
-// that panel slide in.  We also have to hide the root panel, and there
-// seems to be a gecko bug that prevents that from happening with the same
-// :target pseudo-element trick.  So as a workaround we listen for hashchange
-// events here to be notified when document.location.hash changes and we
-// explicitly remove the 'active' class of the root panel to hide it.
-// The back button event listener below adds the 'active' class back in.
-window.addEventListener('hashchange', function hashChange(evt) {
-  // If the hash has changed to be non-empty, then a settings panel
-  // is being displayed and we need to hide the root panel
-  if (document.location.hash)
-    document.getElementById('root').classList.remove('active');
-});
-
 // back button = close dialog || back to the root page
 window.addEventListener('keyup', function goBack(event) {
-  if (document.location.hash != '' &&
+  if (document.location.hash != '#root' &&
       event.keyCode === event.DOM_VK_ESCAPE) {
     event.preventDefault();
     event.stopPropagation();
@@ -139,8 +126,7 @@ window.addEventListener('keyup', function goBack(event) {
       document.body.classList.remove('dialog');
     }
     else {
-      document.location.hash = '';
-      document.getElementById('root').classList.add('active');
+      document.location.hash = '#root';
     }
   }
 });

--- a/apps/settings/settings.html
+++ b/apps/settings/settings.html
@@ -17,7 +17,7 @@
       <h1 data-l10n-id="settings">Settings</h1>
     </header>
 
-    <div id="root" class="active view" data-title="Settings">
+    <div id="root" class="view" data-title="Settings">
       <ul>
         <li>
           <a href="#wifi">

--- a/apps/settings/style/ui.css
+++ b/apps/settings/style/ui.css
@@ -70,11 +70,12 @@ header h1 {
   -moz-transform: translateX(-100%);
 }
 
+#root:target,
 .view:target {
   -moz-transform: none;
 }
 
-#root.active {
+body.hidden #root {
   -moz-transform: none;
   -moz-transition: none;
 }


### PR DESCRIPTION
The pull request #854 was landed to fix bug #852. However, it created two new bugs:
1. the resulting animation wasn’t kept: the root panel didn’t move along with the 2nd-level panel any more
2. various bugs in RTL mode (e.g. Arabic locale)

This is mostly a backout of this pull request: as the `launch_path` in the manifest now includes the `#root` target, bug #852 is gone anyway. The #root panel doesn’t need any `.active` class any more.
