### PR TITLE
add pull-prefs and push-prefs targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ pull-prefs:
 	sleep 1
 	$(ADB) pull $(PROFILE)/prefs.js
 	$(ADB) shell mv /system/b2g/b2g.hidden /system/b2g/b2g
+	sleep 1
 	$(ADB) reboot
 
 push-prefs:
@@ -78,4 +79,5 @@ push-prefs:
 	sleep 1
 	$(ADB) push prefs.js $(PROFILE)/prefs.js
 	$(ADB) shell mv /system/b2g/b2g.hidden /system/b2g/b2g
+	sleep 1
 	$(ADB) reboot

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,18 @@ forward:
 offline:
 	$(MOZ_OBJDIR)/dist/bin/run-mozilla.sh $(MOZ_OBJDIR)/dist/bin/xpcshell -e 'const GAIA_DIR = "$(GAIA_DIR)"; const PROFILE_DIR = "$(PROFILE_DIR)"' offline-cache.js
 
+pull-prefs:
+	$(ADB) shell mv /system/b2g/b2g /system/b2g/b2g.hidden
+	$(ADB) shell killall b2g
+	sleep 1
+	$(ADB) pull $(PROFILE)/prefs.js
+	$(ADB) shell mv /system/b2g/b2g.hidden /system/b2g/b2g
+	$(ADB) reboot
+
+push-prefs:
+	$(ADB) shell mv /system/b2g/b2g /system/b2g/b2g.hidden
+	$(ADB) shell killall b2g
+	sleep 1
+	$(ADB) push prefs.js $(PROFILE)/prefs.js
+	$(ADB) shell mv /system/b2g/b2g.hidden /system/b2g/b2g
+	$(ADB) reboot


### PR DESCRIPTION
This adds two targets to the makefile to grab prefs.js off the phone and to push an edited prefs.js back onto the phone.  Thanks to @cjones for telling me how to get the files on and off.

I created these when I thought there was a pref I could set to get orientation working.  Apparently there isn't but I'd guess that eventually we'll have preferences we want to be able to tweak, so these targets might end up being useful.
