### PR TITLE
l10n update + \u****-encoded manifests

### DIFF
--- a/apps/bbc/manifest.json
+++ b/apps/bbc/manifest.json
@@ -1,24 +1,35 @@
 {
   "name": "BBC",
-  "description": "BBC Mobile Application",
-  "launch_path": "/",
-  "developer": {
-    "name": "BBC",
-    "url": "http://www.bbc.co.uk/"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/BBC.png"
   },
+  "description": "BBC Mobile Application",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "BBC",
+      "description": "\u041c\u043e\u0431\u0438\u043b\u044c\u043d\u043e\u0435 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0435 BBC"
+    },
+    "en-US": {
+      "name": "BBC",
+      "description": "BBC Mobile Application"
+    },
     "ar": {
-      "description": "BBC تطبيقة موبيل"
+      "name": "BBC",
+      "description": "BBC \u062a\u0637\u0628\u064a\u0642\u0629 \u0645\u0648\u0628\u064a\u0644"
     },
     "fr": {
+      "name": "BBC",
       "description": "Application mobile BBC"
     },
     "zh-TW": {
-      "description": "BBC 行動應用程式"
+      "name": "BBC",
+      "description": "BBC \u884c\u52d5\u61c9\u7528\u7a0b\u5f0f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://www.bbc.co.uk/",
+    "name": "BBC"
+  }
 }

--- a/apps/browser/manifest.json
+++ b/apps/browser/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Browser",
-  "description": "Gaia Web Browser",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Browser.png"
   },
+  "description": "Gaia Web Browser",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u041d\u0430\u0432\u0438\u0433\u0430\u0442\u043e\u0440",
+      "description": "\u0412\u0435\u0431-\u043d\u0430\u0432\u0438\u0433\u0430\u0442\u043e\u0440 Gaia"
+    },
+    "en-US": {
+      "name": "Browser",
+      "description": "Gaia Web Browser"
+    },
     "ar": {
-      "name": "المتصفح",
-      "description": "Gaia متصفح الويب"
+      "name": "\u0627\u0644\u0645\u062a\u0635\u0641\u062d",
+      "description": "Gaia \u0645\u062a\u0635\u0641\u062d \u0627\u0644\u0648\u064a\u0628"
     },
     "fr": {
       "name": "Navigateur",
       "description": "Navigateur Web Gaia"
     },
     "zh-TW": {
-      "name": "網路瀏覽器",
-      "description": "Gaia 網路瀏覽器"
+      "name": "\u7db2\u8def\u700f\u89bd\u5668",
+      "description": "Gaia \u7db2\u8def\u700f\u89bd\u5668"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/calculator/manifest.json
+++ b/apps/calculator/manifest.json
@@ -1,27 +1,35 @@
 {
   "name": "Calculator",
-  "description": "Calculator",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Calculator.png"
   },
+  "description": "Calculator",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u041a\u0430\u043b\u044c\u043a\u0443\u043b\u044f\u0442\u043e\u0440",
+      "description": "\u041a\u0430\u043b\u044c\u043a\u0443\u043b\u044f\u0442\u043e\u0440"
+    },
+    "en-US": {
+      "name": "Calculator",
+      "description": "Calculator"
+    },
     "ar": {
-      "name": "الحاسبة",
-      "description": "الحاسبة"
+      "name": "\u0627\u0644\u062d\u0627\u0633\u0628\u0629",
+      "description": "\u0627\u0644\u062d\u0627\u0633\u0628\u0629"
     },
     "fr": {
       "name": "Calculatrice",
-      "description": "Calculatrice"
+      "description": "Calculatrice Gaia"
     },
     "zh-TW": {
-      "name": "計算機",
-      "description": "計算機"
+      "name": "\u8a08\u7b97\u6a5f",
+      "description": "\u8a08\u7b97\u6a5f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }

--- a/apps/calendar/manifest.json
+++ b/apps/calendar/manifest.json
@@ -1,27 +1,35 @@
 {
   "name": "Calendar",
-  "description": "Google Calendar",
-  "launch_path": "/calendar/gp",
-  "developer": {
-    "name": "Google",
-    "url": "http://google.com"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/GoogleCalendar.png"
   },
+  "description": "Google Calendar",
+  "launch_path": "/calendar/gp",
   "locales": {
+    "ru": {
+      "name": "\u041a\u0430\u043b\u0435\u043d\u0434\u0430\u0440\u044c",
+      "description": "\u041a\u0430\u043b\u0435\u043d\u0434\u0430\u0440\u044c Google"
+    },
+    "en-US": {
+      "name": "Calendar",
+      "description": "Google Calendar"
+    },
     "ar": {
-      "name": "تقويم",
-      "description": "Google تقويم"
+      "name": "\u062a\u0642\u0648\u064a\u0645",
+      "description": "Google \u062a\u0642\u0648\u064a\u0645"
     },
     "fr": {
-      "name": "Calendrier",
-      "description": "Calendrier Google"
+      "name": "Agenda",
+      "description": "Agenda Google"
     },
     "zh-TW": {
-      "name": "行事曆",
-      "description": "Google 日曆"
+      "name": "\u884c\u4e8b\u66c6",
+      "description": "Google \u65e5\u66c6"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://google.com",
+    "name": "Google"
+  }
 }

--- a/apps/camera/manifest.json
+++ b/apps/camera/manifest.json
@@ -1,29 +1,36 @@
 {
   "name": "Camera",
-  "description": "Gaia Camera",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
-  "hackKillMe": true,
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Camera.png"
   },
+  "description": "Gaia Camera",
+  "launch_path": "/",
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  },
   "locales": {
+    "ru": {
+      "name": "\u041a\u0430\u043c\u0435\u0440\u0430",
+      "description": "\u041a\u0430\u043c\u0435\u0440\u0430 Gaia"
+    },
+    "en-US": {
+      "name": "Camera",
+      "description": "Gaia Camera"
+    },
     "ar": {
-      "name": "الكاميرا",
-      "description": " Gaiaالكاميرا"
+      "name": "\u0627\u0644\u0643\u0627\u0645\u064a\u0631\u0627",
+      "description": " Gaia\u0627\u0644\u0643\u0627\u0645\u064a\u0631\u0627"
     },
     "fr": {
-      "name": "Caméra",
-      "description": "Caméra Gaia"
+      "name": "Photo",
+      "description": "Appareil photo Gaia"
     },
     "zh-TW": {
-      "name": "相機",
-      "description": "Gaia 相機"
+      "name": "\u76f8\u6a5f",
+      "description": "Gaia \u76f8\u6a5f"
     }
   },
-  "default_locale": "en"
+  "hackKillMe": true
 }
-

--- a/apps/clock/locale/clock.properties
+++ b/apps/clock/locale/clock.properties
@@ -16,6 +16,12 @@ start=Démarrer
 stop=Stop
 cancel=Annuler
 
+[ru]
+reset=Сбросить
+start=Старт
+stop=Стоп
+cancel=Отменить
+
 [zh-TW]
 reset=歸零
 start=開始

--- a/apps/clock/manifest.json
+++ b/apps/clock/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Clock",
-  "description": "Gaia Clock",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Clock.png"
   },
+  "description": "Gaia Clock",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u0427\u0430\u0441\u044b",
+      "description": "\u0427\u0430\u0441\u044b Gaia"
+    },
+    "en-US": {
+      "name": "Clock",
+      "description": "Gaia Clock"
+    },
     "ar": {
-      "name": "الساعة",
-      "description": "Gaia الساعة"
+      "name": "\u0627\u0644\u0633\u0627\u0639\u0629",
+      "description": "Gaia \u0627\u0644\u0633\u0627\u0639\u0629"
     },
     "fr": {
       "name": "Horloge",
       "description": "Horloge Gaia"
     },
     "zh-TW": {
-      "name": "時鐘",
-      "description": "Gaia 時鐘"
+      "name": "\u6642\u9418",
+      "description": "Gaia \u6642\u9418"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/cnn/manifest.json
+++ b/apps/cnn/manifest.json
@@ -1,24 +1,35 @@
 {
   "name": "CNN",
-  "description": "CNN Mobile Application",
-  "launch_path": "/",
-  "developer": {
-    "name": "CNN",
-    "url": "http://www.cnn.com/"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/CNN.png"
   },
+  "description": "CNN Mobile Application",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "CNN",
+      "description": "\u041c\u043e\u0431\u0438\u043b\u044c\u043d\u043e\u0435 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0435 CNN"
+    },
+    "en-US": {
+      "name": "CNN",
+      "description": "CNN Mobile Application"
+    },
     "ar": {
-      "description": "CNN تطبيقة موبيل"
+      "name": "CNN",
+      "description": "CNN \u062a\u0637\u0628\u064a\u0642\u0629 \u0645\u0648\u0628\u064a\u0644"
     },
     "fr": {
+      "name": "CNN",
       "description": "Application mobile CNN"
     },
     "zh-TW": {
-      "description": "CNN 行動應用程式"
+      "name": "CNN",
+      "description": "CNN \u884c\u52d5\u61c9\u7528\u7a0b\u5f0f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://www.cnn.com/",
+    "name": "CNN"
+  }
 }

--- a/apps/crystalskull/manifest.json
+++ b/apps/crystalskull/manifest.json
@@ -1,26 +1,36 @@
 {
   "name": "CrystalSkull",
-  "description": "WebGL Demo",
-  "launch_path": "/",
-  "hackKillMe": true,
-  "developer": {
-    "name": "The J3D Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/CrystalSkull.png"
   },
+  "description": "WebGL Demo",
+  "launch_path": "/",
+  "hackKillMe": true,
   "locales": {
+    "ru": {
+      "name": "CrystalSkull",
+      "description": "\u0414\u0435\u043c\u043e\u043d\u0441\u0442\u0440\u0430\u0446\u0438\u044f WebGL"
+    },
+    "en-US": {
+      "name": "CrystalSkull",
+      "description": "WebGL Demo"
+    },
     "ar": {
-      "description": " WebGL عرض"
+      "name": "CrystalSkull",
+      "description": " WebGL \u0639\u0631\u0636"
     },
     "fr": {
-      "description": "Démo WebGL"
+      "name": "CrystalSkull",
+      "description": "D\u00e9mo WebGL"
     },
     "zh-TW": {
-      "description": "WebGL 示範"
+      "name": "CrystalSkull",
+      "description": "WebGL \u793a\u7bc4"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The J3D Team"
+  }
 }
-

--- a/apps/cubevid/manifest.json
+++ b/apps/cubevid/manifest.json
@@ -1,28 +1,36 @@
 {
   "name": "CubeVid",
-  "description": "Video Cube Demo",
-  "launch_path": "/",
-  "hackKillMe": true,
-  "developer": {
-    "name": "The Original Author",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/VideoCube.png"
   },
+  "description": "Video Cube Demo",
+  "launch_path": "/",
+  "hackKillMe": true,
   "locales": {
+    "ru": {
+      "name": "CubeVid",
+      "description": "\u0414\u0435\u043c\u043e\u043d\u0441\u0442\u0440\u0430\u0446\u0438\u044f Video Cube"
+    },
+    "en-US": {
+      "name": "CubeVid",
+      "description": "Video Cube Demo"
+    },
     "ar": {
       "name": "CubeVid",
-      "description": " cube عرض لشريط"
+      "description": " cube \u0639\u0631\u0636 \u0644\u0634\u0631\u064a\u0637"
     },
     "fr": {
       "name": "CubeVid",
-      "description": "Démo de vidéo cube"
+      "description": "D\u00e9mo de vid\u00e9o cube"
     },
     "zh-TW": {
-      "description": "Video Cube 示範"
+      "name": "CubeVid",
+      "description": "Video Cube \u793a\u7bc4"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Original Author"
+  }
 }
-

--- a/apps/dialer/locale/dialer.properties
+++ b/apps/dialer/locale/dialer.properties
@@ -43,6 +43,21 @@ hold=En attente
 answer=Répondre
 end=Terminer
 
+[ru]
+call=Звонить
+email=e-mail
+phone=Телефон
+firstName=Имя
+lastName=Фамилия
+edit=Изменить
+delete=Удалить
+mute=Молчание
+keypad=Клавиатура
+speaker=Громкоговоритель
+hold=Держать
+answer=Ответить
+end=Закончить
+
 [zh-TW]
 call=撥號
 email=E-mail

--- a/apps/dialer/manifest.json
+++ b/apps/dialer/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Dialer",
-  "description": "Gaia Dialer",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Phone.png"
   },
+  "description": "Gaia Dialer",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u0422\u0435\u043b\u0435\u0444\u043e\u043d",
+      "description": "\u0422\u0435\u043b\u0435\u0444\u043e\u043d Gaia"
+    },
+    "en-US": {
+      "name": "Dialer",
+      "description": "Gaia Dialer"
+    },
     "ar": {
-      "name": "مكالمة",
-      "description": "Gaia مكالمة هاتفية"
+      "name": "\u0645\u0643\u0627\u0644\u0645\u0629",
+      "description": "Gaia \u0645\u0643\u0627\u0644\u0645\u0629 \u0647\u0627\u062a\u0641\u064a\u0629"
     },
     "fr": {
       "name": "Appel",
-      "description": "Appel téléphonique Gaia"
+      "description": "Appel t\u00e9l\u00e9phonique Gaia"
     },
     "zh-TW": {
-      "name": "電話",
-      "description": "Gaia 電話"
+      "name": "\u96fb\u8a71",
+      "description": "Gaia \u96fb\u8a71"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/facebook/manifest.json
+++ b/apps/facebook/manifest.json
@@ -1,18 +1,23 @@
 {
   "name": "Facebook",
-  "description": "Facebook Mobile Application",
-  "launch_path": "/",
-  "developer": {
-    "name": "Facebook",
-    "url": "http://www.facebook.com/"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Facebook.png"
   },
+  "description": "Facebook Mobile Application",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "Facebook",
+      "description": "\u041c\u043e\u0431\u0438\u043b\u044c\u043d\u043e\u0435 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0435 Facebook"
+    },
+    "en-US": {
+      "name": "Facebook",
+      "description": "Facebook Mobile Application"
+    },
     "ar": {
       "name": "Facebook",
-      "description": "Facebook تطبيقة موبيل"
+      "description": "Facebook \u062a\u0637\u0628\u064a\u0642\u0629 \u0645\u0648\u0628\u064a\u0644"
     },
     "fr": {
       "name": "Facebook",
@@ -20,8 +25,11 @@
     },
     "zh-TW": {
       "name": "Facebook",
-      "description": "Facebook 行動應用程式"
+      "description": "Facebook \u884c\u52d5\u61c9\u7528\u7a0b\u5f0f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://www.facebook.com/",
+    "name": "Facebook"
+  }
 }

--- a/apps/gallery/locale/gallery.properties
+++ b/apps/gallery/locale/gallery.properties
@@ -5,7 +5,10 @@ pictures=صور
 pictures=Pictures
 
 [fr]
-pictures=Photos
+pictures=Galerie
+
+[ru]
+pictures=Фотографии
 
 [zh-TW]
 pictures=照片

--- a/apps/gallery/manifest.json
+++ b/apps/gallery/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Gallery",
-  "description": "Gaia Gallery",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Gallery.png"
   },
+  "description": "Gaia Gallery",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u0413\u0430\u043b\u0435\u0440\u0435\u044f",
+      "description": "\u0413\u0430\u043b\u0435\u0440\u0435\u044f Gaia"
+    },
+    "en-US": {
+      "name": "Gallery",
+      "description": "Gaia Gallery"
+    },
     "ar": {
-      "name": "إستديو",
-      "description": "Gaia إستديو"
+      "name": "\u0625\u0633\u062a\u062f\u064a\u0648",
+      "description": "Gaia \u0625\u0633\u062a\u062f\u064a\u0648"
     },
     "fr": {
       "name": "Galerie",
       "description": "Galerie Gaia"
     },
     "zh-TW": {
-      "name": "相簿",
-      "description": "Gaia 相簿"
+      "name": "\u76f8\u7c3f",
+      "description": "Gaia \u76f8\u7c3f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/gmail/manifest.json
+++ b/apps/gmail/manifest.json
@@ -1,17 +1,22 @@
 {
   "name": "Mail",
-  "description": "GMail",
-  "launch_path": "/mail/mu",
-  "developer": {
-    "name": "GMail",
-    "url": "http://google.com/"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/GMail.png"
   },
+  "description": "GMail",
+  "launch_path": "/mail/mu",
   "locales": {
+    "ru": {
+      "name": "\u041f\u043e\u0447\u0442\u0430",
+      "description": "GMail"
+    },
+    "en-US": {
+      "name": "Mail",
+      "description": "GMail"
+    },
     "ar": {
-      "name": "البريد",
+      "name": "\u0627\u0644\u0628\u0631\u064a\u062f",
       "description": "GMail"
     },
     "fr": {
@@ -19,9 +24,12 @@
       "description": "GMail"
     },
     "zh-TW": {
-      "name": "郵件",
+      "name": "\u90f5\u4ef6",
       "description": "GMail"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://google.com/",
+    "name": "GMail"
+  }
 }

--- a/apps/homescreen/locale/homescreen.properties
+++ b/apps/homescreen/locale/homescreen.properties
@@ -37,6 +37,19 @@ normal=Mode normal
 restart=Redémarrer
 power=Éteindre
 
+[ru]
+noSimCard=Нет SIM-карты
+connecting=соединяется…
+roaming={{operator}} (роуминг)
+unreadMessages={{n}} непрочитанных сообщений
+missedCalls={{n}} пропущенных звонков
+# sleep menu
+airplane=Режим "самолёт"
+silent=Режим "молчание"
+normal=Режим "нормальный"
+restart=Перезагрузка
+power=Выключить
+
 [zh-TW]
 noSimCard=無 SIM 卡
 connecting=連線中…

--- a/apps/homescreen/manifest.json
+++ b/apps/homescreen/manifest.json
@@ -1,25 +1,32 @@
 {
   "name": "Homescreen",
+  "default_locale": "en-US",
   "description": "Gaia Homescreen",
   "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
   "locales": {
+    "ru": {
+      "name": "\u0413\u043b\u0430\u0432\u043d\u044b\u0439 \u044d\u043a\u0440\u0430\u043d",
+      "description": "\u0413\u043b\u0430\u0432\u043d\u044b\u0439 \u044d\u043a\u0440\u0430\u043d Gaia"
+    },
+    "en-US": {
+      "name": "Homescreen",
+      "description": "Gaia Homescreen"
+    },
     "ar": {
-      "name": "الشاشة الرئيسية",
-      "description": "Gaia الشاشة الرئيسية "
+      "name": "\u0627\u0644\u0634\u0627\u0634\u0629 \u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629",
+      "description": "Gaia \u0627\u0644\u0634\u0627\u0634\u0629 \u0627\u0644\u0631\u0626\u064a\u0633\u064a\u0629 "
     },
     "fr": {
-      "name": "Écran d’accueil",
-      "description": "Écran d’accueil Gaia"
+      "name": "\u00c9cran d\u2019accueil",
+      "description": "\u00c9cran d\u2019accueil Gaia"
     },
     "zh-TW": {
-      "name": "主畫面",
-      "description": "Gaia 主畫面"
+      "name": "\u4e3b\u756b\u9762",
+      "description": "Gaia \u4e3b\u756b\u9762"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/maps/manifest.json
+++ b/apps/maps/manifest.json
@@ -1,17 +1,22 @@
 {
   "name": "Maps",
-  "description": "Google Maps",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Maps.png"
   },
+  "description": "Google Maps",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u041a\u0430\u0440\u0442\u044b",
+      "description": "Google Maps"
+    },
+    "en-US": {
+      "name": "Maps",
+      "description": "Google Maps"
+    },
     "ar": {
-      "name": "خرائط",
+      "name": "\u062e\u0631\u0627\u0626\u0637",
       "description": "Google Maps"
     },
     "fr": {
@@ -19,10 +24,12 @@
       "description": "Google Maps"
     },
     "zh-TW": {
-      "name": "地圖",
-      "description": "Google 地圖"
+      "name": "\u5730\u5716",
+      "description": "Google \u5730\u5716"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/market/manifest.json
+++ b/apps/market/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Market",
-  "description": "Market for downloading and installing apps",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Market.png"
   },
+  "description": "Market for downloading and installing apps",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u041c\u0430\u0440\u043a\u0435\u0442",
+      "description": "\u041a\u0430\u0442\u0430\u043b\u043e\u0433 \u0434\u043b\u044f \u0437\u0430\u0433\u0440\u0443\u0437\u043a\u0438 \u0438 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0439"
+    },
+    "en-US": {
+      "name": "Market",
+      "description": "Market for downloading and installing apps"
+    },
     "ar": {
-      "name": "مكتبة البرامج",
-      "description": "مكتبة برامج اونلاين"
+      "name": "\u0645\u0643\u062a\u0628\u0629 \u0627\u0644\u0628\u0631\u0627\u0645\u062c",
+      "description": "\u0645\u0643\u062a\u0628\u0629 \u0628\u0631\u0627\u0645\u062c \u0627\u0648\u0646\u0644\u0627\u064a\u0646"
     },
     "fr": {
-      "name": "Logithèque",
-      "description": "Catalogue en ligne d’applications"
+      "name": "Logith\u00e8que",
+      "description": "Catalogue en ligne d\u2019applications"
     },
     "zh-TW": {
-      "name": "市集",
-      "description": "下載與安裝應用程式"
+      "name": "\u5e02\u96c6",
+      "description": "\u4e0b\u8f09\u8207\u5b89\u88dd\u61c9\u7528\u7a0b\u5f0f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/music/manifest.json
+++ b/apps/music/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Music",
-  "description": "Gaia Music",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Music.png"
   },
+  "description": "Gaia Music",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u041c\u0443\u0437\u044b\u043a\u0430",
+      "description": "\u041c\u0443\u0437\u044b\u043a\u0430 Gaia"
+    },
+    "en-US": {
+      "name": "Music",
+      "description": "Gaia Music"
+    },
     "ar": {
-      "name": "موسيقى",
-      "description": "Gaia موسيقى"
+      "name": "\u0645\u0648\u0633\u064a\u0642\u0649",
+      "description": "Gaia \u0645\u0648\u0633\u064a\u0642\u0649"
     },
     "fr": {
       "name": "Musique",
-      "description": "Musique Gaia"
+      "description": "Lecteur audio Gaia"
     },
     "zh-TW": {
-      "name": "音樂",
-      "description": "Gaia 音樂"
+      "name": "\u97f3\u6a02",
+      "description": "Gaia \u97f3\u6a02"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/nytimes/manifest.json
+++ b/apps/nytimes/manifest.json
@@ -1,18 +1,23 @@
 {
   "name": "NY Times",
-  "description": "NY Times Mobile Application",
-  "launch_path": "/",
-  "developer": {
-    "name": "NY Times",
-    "url": "http://www.nytimes.com/"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/NYT.png"
   },
+  "description": "NY Times Mobile Application",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "NY Times",
+      "description": "\u041c\u043e\u0431\u0438\u043b\u044c\u043d\u043e\u0435 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0435 NY Times"
+    },
+    "en-US": {
+      "name": "NY Times",
+      "description": "NY Times Mobile Application"
+    },
     "ar": {
       "name": "NY Times",
-      "description": "NY Times تطبيقة موبيل"
+      "description": "NY Times \u062a\u0637\u0628\u064a\u0642\u0629 \u0645\u0648\u0628\u064a\u0644"
     },
     "fr": {
       "name": "NY Times",
@@ -20,8 +25,11 @@
     },
     "zh-TW": {
       "name": "NY Times",
-      "description": "NY Times 行動應用程式"
+      "description": "NY Times \u884c\u52d5\u61c9\u7528\u7a0b\u5f0f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://www.nytimes.com/",
+    "name": "NY Times"
+  }
 }

--- a/apps/settings/locale/settings.properties
+++ b/apps/settings/locale/settings.properties
@@ -144,7 +144,6 @@ ring=Ring
 debug=Debug
 grid=Grid
 
-
 [fr]
 settings=Paramètres
 doNotTrack=Ne pas me pister
@@ -218,6 +217,78 @@ ring=Sonnerie
 debug=Débogage
 grid=Grille
 
+[ru]
+settings=Установки
+doNotTrack=Do Not Track (не следить)
+languages=Языки
+default=По имолчанию
+ok=OK
+cancel=Отменить
+
+# wifi
+wifi=Wi-Fi
+wifiNetworks=Wi-Fi сети
+disabled=запрещено
+offline=не подключено
+scanning=Сканирование…
+connecting=соединяется с {{ssid}}…
+connected=соединено с {{ssid}}.
+associating=получает IP-адрес…
+securedBy=защищено {{capabilities}}
+security=защита
+securityNone=нет
+securityOpen=open
+signalStrength=сила сигнала
+signalLevel0=плохой
+signalLevel1=слабый
+signalLevel2=средний
+signalLevel3=хороший
+signalLevel4=отличный
+password=пароль
+showPassword=показать пароль
+networkNotification=Извещения сети
+networkNotification-expl=Известить меня когда сеть доступна
+
+# wallpapers
+wallpapers=Обои
+water=Вода
+leaves=Листья
+
+# display
+display=Экран
+brightness=Яркость
+lockScreen=Заблокировать экран
+
+# keyboard
+keyboard=Клавиатура
+vibration=Вибрация
+clickSound=Щелчок
+english=Английский
+dvorak=Английский (Дворжак)
+latin=Другие латинские шрифты
+latin-desc=Францизкий, немецкий, норвежский, словацкий, турецкий
+cyrillic=Кириллические шрифты
+cyrillic-desc=Русский, сербский (кириллица)
+arabic=Арабский
+hebrew=Иврит
+traditionalChines=Традиционый китайский
+traditionalChines-desc=ZhuYing
+simplifiedChinese=Упрощённый китайский
+simplifiedChinese-desc=Pinyin
+
+# sounds
+sounds=Звуки
+bosscaling=Bosscaling
+goodmight=GoodMight
+
+# phone
+phone=Телефон
+vibrate=Вибрация
+ring=Звонок
+
+# debug
+debug=Отладка
+grid=Сетка
 
 [zh-TW]
 settings=偏好設定

--- a/apps/settings/manifest.json
+++ b/apps/settings/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Settings",
-  "description": "Gaia Settings",
-  "launch_path": "/#root",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Settings.png"
   },
+  "description": "Gaia Settings",
+  "launch_path": "/#root",
   "locales": {
+    "ru": {
+      "name": "\u0423\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438",
+      "description": "\u0423\u0441\u0442\u0430\u043d\u043e\u0432\u043a\u0438 Gaia"
+    },
+    "en-US": {
+      "name": "Settings",
+      "description": "Gaia Settings"
+    },
     "ar": {
-      "name": "الضبط",
-      "description": "Gaia الضبط"
+      "name": "\u0627\u0644\u0636\u0628\u0637",
+      "description": "Gaia \u0627\u0644\u0636\u0628\u0637"
     },
     "fr": {
-      "name": "Paramètres",
-      "description": "Paramètres Gaia"
+      "name": "Param\u00e8tres",
+      "description": "Param\u00e8tres Gaia"
     },
     "zh-TW": {
-      "name": "設定",
-      "description": "Gaia 設定"
+      "name": "\u8a2d\u5b9a",
+      "description": "Gaia \u8a2d\u5b9a"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/sms/locale/sms.properties
+++ b/apps/sms/locale/sms.properties
@@ -1,9 +1,13 @@
-# TODO: include localized phone number formatting?
+[ar]
+messages=رسائل
+edit=تعديل
+send=إرسال
+newMessage=رسائل جديدة
 
 [en-US]
 messages=Messages
 edit=Edit
-send=send
+send=Send
 newMessage=New Message
 
 [fr]
@@ -11,6 +15,12 @@ messages=Messages
 edit=Modifier
 send=Envoyer
 newMessage=Nouveau message
+
+[ru]
+messages=Сообщения
+edit=Изменить
+send=послать
+newMessage=Новое сообщение
 
 [zh-TW]
 messages=訊息

--- a/apps/sms/manifest.json
+++ b/apps/sms/manifest.json
@@ -1,28 +1,35 @@
 {
   "name": "Messages",
-  "description": "Gaia Messages",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Messages.png"
   },
+  "description": "Gaia Messages",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u0421\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u044f",
+      "description": "\u0421\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u044f Gaia"
+    },
+    "en-US": {
+      "name": "Messages",
+      "description": "Gaia Messages"
+    },
     "ar": {
-      "name": "رسائل",
-      "description": "Gaia رسائل"
+      "name": "\u0631\u0633\u0627\u0626\u0644",
+      "description": "Gaia \u0631\u0633\u0627\u0626\u0644"
     },
     "fr": {
       "name": "Messages",
       "description": "Messages Gaia"
     },
     "zh-TW": {
-      "name": "訊息",
-      "description": "Gaia 訊息"
+      "name": "\u8a0a\u606f",
+      "description": "Gaia \u8a0a\u606f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  }
 }
-

--- a/apps/video/locale/video.properties
+++ b/apps/video/locale/video.properties
@@ -1,8 +1,14 @@
+[ar]
+videos=فيديو
+
 [en-US]
 videos=Videos
 
 [fr]
 videos=Vidéos
+
+[ru]
+videos=Видео
 
 [zh-TW]
 videos=影片

--- a/apps/video/manifest.json
+++ b/apps/video/manifest.json
@@ -1,30 +1,37 @@
 {
+  "fullscreen": true,
   "name": "Video",
-  "description": "Gaia Video",
-  "launch_path": "/",
-  "developer": {
-    "name": "The Gaia Team",
-    "url": "https://github.com/andreasgal/gaia"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Video.png"
   },
-  "hackKillMe": true,
-  "fullscreen": true,
+  "description": "Gaia Video",
+  "launch_path": "/",
+  "developer": {
+    "url": "https://github.com/andreasgal/gaia",
+    "name": "The Gaia Team"
+  },
   "locales": {
+    "ru": {
+      "name": "\u0412\u0438\u0434\u0435\u043e",
+      "description": "\u0412\u0438\u0434\u0435\u043e Gaia"
+    },
+    "en-US": {
+      "name": "Video",
+      "description": "Gaia Video"
+    },
     "ar": {
-      "name": "فيديو",
-      "description": "Gaia فيديو"
+      "name": "\u0641\u064a\u062f\u064a\u0648",
+      "description": "Gaia \u0641\u064a\u062f\u064a\u0648"
     },
     "fr": {
-      "name": "Vidéo",
-      "description": "Vidéo Gaia"
+      "name": "Vid\u00e9o",
+      "description": "Lecteur vid\u00e9o Gaia"
     },
     "zh-TW": {
-      "name": "影片",
-      "description": "Gaia 影片"
+      "name": "\u5f71\u7247",
+      "description": "Gaia \u5f71\u7247"
     }
   },
-  "default_locale": "en"
+  "hackKillMe": true
 }
-

--- a/apps/wikipedia/manifest.json
+++ b/apps/wikipedia/manifest.json
@@ -1,27 +1,35 @@
 {
   "name": "Wikipedia",
-  "description": "Wikipedia Mobile Application",
-  "launch_path": "/",
-  "developer": {
-    "name": "Wikipedia",
-    "url": "http://www.wikipedia.org/"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Wikipedia.png"
   },
+  "description": "Wikipedia Mobile Application",
+  "launch_path": "/",
   "locales": {
+    "ru": {
+      "name": "\u0412\u0438\u043a\u0438\u043f\u0435\u0434\u0438\u044f",
+      "description": "\u041c\u043e\u0431\u0438\u043b\u044c\u043d\u043e\u0435 \u043f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u044f \u0412\u0438\u043a\u0438\u043f\u0435\u0434\u0438\u044f"
+    },
+    "en-US": {
+      "name": "Wikipedia",
+      "description": "Wikipedia Mobile Application"
+    },
     "ar": {
-      "name": "ويكيبيديا",
-      "description": "تطبيقة موبيل ويكيبيديا"
+      "name": "\u0648\u064a\u0643\u064a\u0628\u064a\u062f\u064a\u0627",
+      "description": "\u062a\u0637\u0628\u064a\u0642\u0629 \u0645\u0648\u0628\u064a\u0644 \u0648\u064a\u0643\u064a\u0628\u064a\u062f\u064a\u0627"
     },
     "fr": {
       "name": "Wikipedia",
       "description": "Application mobile Wikipedia"
     },
     "zh-TW": {
-      "name": "維基百科",
-      "description": "維基百科行動應用程式"
+      "name": "\u7dad\u57fa\u767e\u79d1",
+      "description": "\u7dad\u57fa\u767e\u79d1\u884c\u52d5\u61c9\u7528\u7a0b\u5f0f"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://www.wikipedia.org/",
+    "name": "Wikipedia"
+  }
 }

--- a/apps/zimbra/manifest.json
+++ b/apps/zimbra/manifest.json
@@ -1,18 +1,23 @@
 {
   "name": "Zimbra",
-  "description": "Mozilla Zimbra Mail",
-  "launch_path": "/zimbra/m",
-  "developer": {
-    "name": "Zimbra",
-    "url": "http://zimbra.com"
-  },
+  "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Zimbra.png"
   },
+  "description": "Mozilla Zimbra Mail",
+  "launch_path": "/zimbra/m",
   "locales": {
+    "ru": {
+      "name": "Zimbra",
+      "description": "\u041f\u043e\u0447\u0442\u0430 Mozilla Zimbra"
+    },
+    "en-US": {
+      "name": "Zimbra",
+      "description": "Mozilla Zimbra Mail"
+    },
     "ar": {
       "name": "Zimbra",
-      "description": "Mozilla Zimbra البريد"
+      "description": "Mozilla Zimbra \u0627\u0644\u0628\u0631\u064a\u062f"
     },
     "fr": {
       "name": "Zimbra",
@@ -20,8 +25,11 @@
     },
     "zh-TW": {
       "name": "Zimbra",
-      "description": "Mozilla Zimbra 郵件"
+      "description": "Mozilla Zimbra \u90f5\u4ef6"
     }
   },
-  "default_locale": "en"
+  "developer": {
+    "url": "http://zimbra.com",
+    "name": "Zimbra"
+  }
 }


### PR DESCRIPTION
No code involved, only JSON/properties files.

This adds the Russian locale and encodes non-ascii characters as \u***\* in JSON manifests, as a workaround to the recent regression that breaked non-ascii characters in the homescreen.

These JSON/properties files have been generated from [this l10n repository](https://github.com/fabi1cazenave/gaia-l10n): Mozilla l10n localizers (and localization tools…) expect such a file structure, with one directory per locale. This will make it easier for us to delegate the l10n part to the appropriate teams.
