### PR TITLE
[l10n] expose Russian in the language settings

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -122,30 +122,37 @@
     <div id="languages" class="view" data-title="Languages">
       <ul>
         <li id="language-en-us">
-          <a>English (United States)</a>
+          <a dir="ltr">English (US)</a>
           <label>
             <input type="radio" name="language.current" value="en-US"/>
             <span></span>
           </label>
         </li>
         <li id="language-fr">
-          <a>Français</a>
+          <a dir="ltr">Français</a>
           <label>
             <input type="radio" name="language.current" value="fr"/>
             <span></span>
           </label>
         </li>
         <li id="language-ar">
-          <a>العربية</a>
+          <a dir="rtl">العربية</a>
           <label class="checkbox">
             <input type="radio" name="language.current" value="ar"/>
             <span class="checkbox-inner"></span>
           </label>
         </li>
         <li id="language-zh-tw">
-          <a>正體中文</a>
+          <a dir="ltr">正體中文</a>
           <label>
             <input type="radio" name="language.current" value="zh-TW"/>
+            <span></span>
+          </label>
+        </li>
+        <li id="language-ru">
+          <a dir="ltr">Русский</a>
+          <label>
+            <input type="radio" name="language.current" value="ru"/>
             <span></span>
           </label>
         </li>

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -49,3 +49,11 @@ html, body {
   left: 20px;
   right: auto;
 }
+
+*[dir=ltr] a[dir=rtl] {
+  text-align: left;
+}
+
+*[dir=rtl] a[dir=ltr] {
+  text-align: right;
+}


### PR DESCRIPTION
Add the “Russian” item in the language settings, as proposed in pull #922.

Fixes the text direction issue with the “English (US)” item in RTL mode.
