### PR TITLE
force text/plain MIME type for *.properties files

### DIFF
--- a/webapi.js
+++ b/webapi.js
@@ -1330,6 +1330,7 @@
   function loadResource(href, lang, onSuccess, onFailure) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', href, true);
+    xhr.overrideMimeType('text/plain; charset=utf-8');
     xhr.onreadystatechange = function() {
       if (xhr.readyState == 4) {
         if (xhr.status == 200 || xhr.status == 0) {


### PR DESCRIPTION
This prevents an irritating (though harmless) JS error report that comes up with every page.
