### PR TITLE
Turn the source-viewer on/off state into a tri-state, with a third "view...

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -690,6 +690,7 @@ var SourceView = {
   handleEvent: function sv_handleEvent(evt) {
     switch (evt.type) {
       case 'locked':
+        this.state = 'inactive';
         this.hide();
         break;
     }


### PR DESCRIPTION
...-manifest" state.  This allows us to view the app hash and deduce the version.  Also fixed a couple of paper cut bugs: make viewer show about:blank when it goes inactive, and show the homescreen source.  Fixes #859.
