### PR TITLE
Fix syntax error in manifest.appcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ appcache-manifests:
 		then \
 			echo \\t$$d ;\
 			cd $$d ;\
-			cat `find * -type f | sort` | $(MD5SUM) | cut -f 1 -d ' ' | sed s/^/\#\ Version\ / > manifest.appcache ;\
-			echo "CACHE MANIFEST" >> manifest.appcache ;\
+			echo "CACHE MANIFEST" > manifest.appcache ;\
+			cat `find * -type f | sort` | $(MD5SUM) | cut -f 1 -d ' ' | sed s/^/\#\ Version\ / >> manifest.appcache ;\
 			find * -type f | grep -v tools | sort >> manifest.appcache ;\
 			sed -i$(SED_IN_PLACE_NO_SUFFIX) -e 's|manifest.appcache||g' manifest.appcache ;\
 			echo "http://$(GAIA_DOMAIN)/webapi.js" >> manifest.appcache ;\

--- a/apps/bbc/manifest.appcache
+++ b/apps/bbc/manifest.appcache
@@ -1,5 +1,5 @@
-# Version eb6ed6b574997515b48e4450bd89cffd
 CACHE MANIFEST
+# Version 405fe6606b5520cc3ba9307f7d3c9cd0
 
 manifest.json
 style/icons/BBC.png

--- a/apps/browser/manifest.appcache
+++ b/apps/browser/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 9005c783124769a6c5068b492cfe723f
 CACHE MANIFEST
+# Version 1b87f1b172e1a248317f1597a4f3fce7
 index.html
 js/browser.js
 

--- a/apps/calculator/manifest.appcache
+++ b/apps/calculator/manifest.appcache
@@ -1,5 +1,5 @@
-# Version db3313efa37fef166847bd099623fdd6
 CACHE MANIFEST
+# Version c5211103feb507bc1c6d4cf71acb7c2d
 index.html
 js/calculator.js
 

--- a/apps/calendar/manifest.appcache
+++ b/apps/calendar/manifest.appcache
@@ -1,5 +1,5 @@
-# Version d984523827a7f4e256fd97edbc0c7c44
 CACHE MANIFEST
+# Version e976d26470f8c79931445a44f349b6cc
 
 manifest.json
 style/icons/GoogleCalendar.png

--- a/apps/camera/manifest.appcache
+++ b/apps/camera/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 1da1425e2d21eb5bdee928d557184e17
 CACHE MANIFEST
+# Version e57573db457148f036eafe9fc7ac79f5
 index.html
 js/camera.js
 

--- a/apps/clock/manifest.appcache
+++ b/apps/clock/manifest.appcache
@@ -1,5 +1,5 @@
-# Version a6c5c6e106015194221303f757137641
 CACHE MANIFEST
+# Version 1120269ed3f79baeec3bd39e009d73df
 index.html
 js/clock.js
 js/stopwatch.js

--- a/apps/cnn/manifest.appcache
+++ b/apps/cnn/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 403351157ff733fd44f2b35892345fc1
 CACHE MANIFEST
+# Version fa639893cad4f9c11dcfd1d2566559cd
 
 manifest.json
 style/icons/CNN.png

--- a/apps/crystalskull/manifest.appcache
+++ b/apps/crystalskull/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 0d95d0671dce90264493d405e2012b26
 CACHE MANIFEST
+# Version 55b1ed779ceb63a3f07c0985f283c906
 index.html
 j3d.js
 

--- a/apps/cubevid/manifest.appcache
+++ b/apps/cubevid/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 44bc955e2224225d3ee68889400beced
 CACHE MANIFEST
+# Version c923f737b1d35a8448870d26e34157eb
 glUtils.js
 icon.png
 index.html

--- a/apps/cuttherope/manifest.appcache
+++ b/apps/cuttherope/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 4e9c1c96c4363dc92b9950dba7e7c19d
 CACHE MANIFEST
+# Version 55b31110e493e85ad7cb90e548c7fd93
 
 manifest.json
 style/icons/CutTheRope.png

--- a/apps/dialer/manifest.appcache
+++ b/apps/dialer/manifest.appcache
@@ -1,5 +1,5 @@
-# Version c8772b756ed2f4e74ffc83b7c3f0450e
 CACHE MANIFEST
+# Version 789446cdd8e860c7f3e197816bc59e36
 index.html
 js/contacts.js
 js/dialer.js

--- a/apps/facebook/manifest.appcache
+++ b/apps/facebook/manifest.appcache
@@ -1,5 +1,5 @@
-# Version fb81bcaf351bb2fa7dbddb65e67ffc90
 CACHE MANIFEST
+# Version 0dd52c19c12705453004deb83e935592
 
 manifest.json
 style/icons/Facebook.png

--- a/apps/gallery/manifest.appcache
+++ b/apps/gallery/manifest.appcache
@@ -1,5 +1,5 @@
-# Version e7e47496ca1469ebf15a18a722fd77d1
 CACHE MANIFEST
+# Version 7f43b57f7de4f5f35abab76c10628d15
 index.html
 js/gallery.js
 locale/gallery.properties

--- a/apps/gmail/manifest.appcache
+++ b/apps/gmail/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 5caef1d19f702fb7e039a8528db2476d
 CACHE MANIFEST
+# Version 97f7efa2481ec14446b1b28d9012e1ad
 
 manifest.json
 style/icons/GMail.png

--- a/apps/homescreen/manifest.appcache
+++ b/apps/homescreen/manifest.appcache
@@ -1,5 +1,5 @@
-# Version fd166c4a3f97a23b6f4d9a7c87934c3c
 CACHE MANIFEST
+# Version 530d3632ca84f1c19d5bcd849a1fc80c
 blank.html
 imes/jspinyin/COPYING
 imes/jspinyin/db.json

--- a/apps/maps/manifest.appcache
+++ b/apps/maps/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 3674f1c92cec0c76bbc9fb24b22508b0
 CACHE MANIFEST
+# Version 6778e82075616acf1deceb760f051f96
 
 manifest.json
 style/icons/Maps.png

--- a/apps/market/manifest.appcache
+++ b/apps/market/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 8c0333a6fa554be605c131b5b488214a
 CACHE MANIFEST
+# Version 15c2268756d50bcef26f601664fbad9d
 index.html
 
 manifest.json

--- a/apps/music/manifest.appcache
+++ b/apps/music/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 4bf2bb98501a490d5182105cdd35ed27
 CACHE MANIFEST
+# Version f4a5384d3cdf7be27cc1facb4bc52559
 audio/b2g.ogg
 audio/jonobacon-freesoftwaresong2.ogg
 audio/Salt_Creek.ogg

--- a/apps/nytimes/manifest.appcache
+++ b/apps/nytimes/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 0d982e0b33190b19946ecd0465878043
 CACHE MANIFEST
+# Version be9b1d02647a3c3c479faea87df75f5e
 
 manifest.json
 style/icons/NYT.png

--- a/apps/penguinpop/manifest.appcache
+++ b/apps/penguinpop/manifest.appcache
@@ -1,5 +1,5 @@
-# Version f03bb093f44584d5b3a906bcc42f0b2b
 CACHE MANIFEST
+# Version 46694da86a91a068b82af465f7e9a69f
 index.html
 js/penguinpop.js
 

--- a/apps/settings/manifest.appcache
+++ b/apps/settings/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 528f1da756bbda2d705603afa8263e5f
 CACHE MANIFEST
+# Version 79bdac2d220b1bf3b1b6b9b5bdae57b6
 gaia-commit.txt
 index.html
 js/settings.js

--- a/apps/sms/manifest.appcache
+++ b/apps/sms/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 8fb481ef0ae3387ee9f6ef04c7b380b6
 CACHE MANIFEST
+# Version ac110139edbcd9aac7071eb6cfb75ff7
 index.html
 js/sms.js
 js/utils.js

--- a/apps/towerjelly/manifest.appcache
+++ b/apps/towerjelly/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 6cf606818b7c7e6622caf60ca19527ca
 CACHE MANIFEST
+# Version c9350a45bd7fd870a15df45498cbd951
 index.html
 js/towerjelly.js
 

--- a/apps/video/manifest.appcache
+++ b/apps/video/manifest.appcache
@@ -1,5 +1,5 @@
-# Version ae9b778fb3a4881e7dd29c5032efaa12
 CACHE MANIFEST
+# Version 11ee577090155a23ecc2f5a1265b4814
 index.html
 js/domutils.js
 js/video.js

--- a/apps/wikipedia/manifest.appcache
+++ b/apps/wikipedia/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 5f09da8fb0e11a7aa539eab2c47b6797
 CACHE MANIFEST
+# Version d2f24d1f812b7cf5795b7be3dcc342fe
 
 manifest.json
 style/icons/Wikipedia.png

--- a/apps/zimbra/manifest.appcache
+++ b/apps/zimbra/manifest.appcache
@@ -1,5 +1,5 @@
-# Version 10bd1575482a6fecaa8d425aea530635
 CACHE MANIFEST
+# Version 8c45981efdb8ae23445aa2fa93c6150f
 
 manifest.json
 style/icons/Zimbra.png

--- a/offline-cache.js
+++ b/offline-cache.js
@@ -48,6 +48,7 @@ function storeCache(id, url, content, count) {
   let cacheEntry = session.openCacheEntry(url, nsICache.ACCESS_WRITE, false);
   cacheEntry.setMetaDataElement("request-method", "GET");
   cacheEntry.setMetaDataElement("response-head", "GET / HTTP/1.1\r\n");
+  cacheEntry.setExpirationTime(0); // will force an update. the default expiration time is way too far in the future.
 
   let outputStream = cacheEntry.openOutputStream(0);
   
@@ -186,7 +187,7 @@ directories.forEach(function generateAppCache(dir) {
                  .createInstance(Ci.nsILocalFile);
     file.initWithPath(root);
 
-    if (name == ("http://gaiamobile.org/webapi.js")) {
+    if (name == ("http://" + GAIA_DOMAIN + "/webapi.js")) {
       hasWebapi = true;
       return;
     }


### PR DESCRIPTION
That allows us to actually update apps, except the homescreen for a yet unknown reason.
