### PR TITLE
Add a Loading... message to iframe before loading the app.

### DIFF
--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -364,6 +364,7 @@ var WindowManager = (function() {
       frame.id = 'appframe' + nextAppId++;
       frame.className = 'appWindow';
       frame.setAttribute('mozallowfullscreen', 'true');
+      frame.src = 'data:text/html,<h1 style="text-align:center; margin-top:100px;">Loading...</h1>';
 
       // Note that we don't set the frame size here.  That will happen
       // when we display the app in setDisplayedApp()

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -364,7 +364,7 @@ var WindowManager = (function() {
       frame.id = 'appframe' + nextAppId++;
       frame.className = 'appWindow';
       frame.setAttribute('mozallowfullscreen', 'true');
-      frame.src = 'data:text/html,<h1 style="text-align:center; margin-top:100px;">Loading...</h1>';
+      frame.src = 'data:text/html,<body style="background-color:black"><h3 style="font-family:OpenSans,sans-serif;color:white;text-align:center; margin-top:100px;">Loading...</h3></body>';
 
       // Note that we don't set the frame size here.  That will happen
       // when we display the app in setDisplayedApp()

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -73,6 +73,9 @@ var WindowManager = (function() {
   // The localization of the "Loading..." message that appears while
   // and app is loading
   var localizedLoading = null;
+  window.addEventListener('localized', function() {
+    localizedLoading = document.mozL10n.get('loading') || "Loading...";
+  });
 
   // Public function. Return the origin of the currently displayed app
   // or null if there is none.

--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -70,6 +70,10 @@ var WindowManager = (function() {
   // The origin of the currently displayed app, or null if there isn't one
   var displayedApp = null;
 
+  // The localization of the "Loading..." message that appears while
+  // and app is loading
+  var localizedLoading = null;
+
   // Public function. Return the origin of the currently displayed app
   // or null if there is none.
   function getDisplayedApp() {
@@ -364,7 +368,12 @@ var WindowManager = (function() {
       frame.id = 'appframe' + nextAppId++;
       frame.className = 'appWindow';
       frame.setAttribute('mozallowfullscreen', 'true');
-      frame.src = 'data:text/html,<body style="background-color:black"><h3 style="font-family:OpenSans,sans-serif;color:white;text-align:center; margin-top:100px;">Loading...</h3></body>';
+
+      // Localize the "Loading..." message if we haven't already
+      if (!localizedLoading) 
+        localizedLoading = document.mozL10n.get('loading') || "Loading...";
+
+      frame.src = 'data:text/html,<body style="background-color:black"><h3 style="font-family:OpenSans,sans-serif;color:white;text-align:center; margin-top:100px;">' + localizedLoading + '</h3></body>';
 
       // Note that we don't set the frame size here.  That will happen
       // when we display the app in setDisplayedApp()

--- a/apps/homescreen/locale/homescreen.properties
+++ b/apps/homescreen/locale/homescreen.properties
@@ -21,6 +21,7 @@ connecting=connecting…
 roaming={{operator}} (roaming)
 unreadMessages=You have {{n}} unread messages
 missedCalls=You have {{n}} missed calls
+loading=Loading...
 # sleep menu
 airplane=Airplane Mode
 silent=Silent Mode
@@ -38,6 +39,7 @@ connecting=connexion…
 roaming={{operator}} (itinérance)
 unreadMessages=Vous avez {{n}} nouveaux messages
 missedCalls=Vous avez {{n}} appels en absence
+loading=Chargement...
 # sleep menu
 airplane=Mode avion
 silent=Mode silencieux


### PR DESCRIPTION
This addresses issue #887 is a really simple way.

cjones doesn't want anything to load into the iframe before the open animation is done because it causes slowdowns, but I'd guess that this short text-only data URL would be okay.

I'm not sure that it looks good or that we really want this for all apps instead of just bookmark apps, but its here, if we want it.
