### PR TITLE
mkdir -p screenshotdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ XULRUNNER=./xulrunner-sdk/bin/run-mozilla.sh
 XPCSHELL=./xulrunner-sdk/bin/xpcshell
 
 install-xulrunner:
-	test -d xulrunner-sdk || (wget $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2) 
+	test -d xulrunner-sdk || (wget $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
 
 else
 # Not a mac: assume linux
@@ -164,8 +164,8 @@ delete-databases:
 
 # Take a screenshot of the device and put it in screenshot.png
 screenshot:
-	mkdir screenshotdata
-	$(ADB) pull /dev/graphics/fb0 screenshotdata/fb0 
+	mkdir -p screenshotdata
+	$(ADB) pull /dev/graphics/fb0 screenshotdata/fb0
 	dd bs=1920 count=800 if=screenshotdata/fb0 of=screenshotdata/fb0b
 	ffmpeg -vframes 1 -vcodec rawvideo -f rawvideo -pix_fmt rgb32 -s 480x800 -i screenshotdata/fb0b -f image2 -vcodec png screenshot.png
 	rm -rf screenshotdata


### PR DESCRIPTION
Fix #1098 with `mkdir -p` so won't fail even if the dir is there.

`dd` or `ffmpeg` should not fail even if the files are already there so no checks for them.
