### PR TITLE
add 'make marionette' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,18 @@ MD5SUM = md5sum -b
 SED_INPLACE_NO_SUFFIX = sed -i
 endif
 
+#Marionette testing variables
+#make sure we're python 2.7.x
+ifeq ($(strip $(PYTHON_27)),)
+PYTHON_27 := `which python`
+endif
+PYTHON_FULL := $(wordlist 2,4,$(subst ., ,$(shell $(PYTHON_27) --version 2>&1)))
+PYTHON_MAJOR := $(word 1,$(PYTHON_FULL))
+PYTHON_MINOR := $(word 2,$(PYTHON_FULL))
+MARIONETTE_HOST ?= localhost
+MARIONETTE_PORT ?= 2828
+TEST_DIRS ?= $(CURDIR)/tests
+
 # Generate profile/
 profile: stamp-commit-hash update-offline-manifests preferences manifests offline extensions
 	@echo "\nProfile Ready: please run [b2g|firefox] -profile $(CURDIR)/profile"
@@ -171,6 +183,27 @@ tests: manifests offline
 	test -L $(INJECTED_GAIA) || ln -s $(CURDIR) $(INJECTED_GAIA)
 	TEST_PATH=$(TEST_PATH) make -C $(MOZ_OBJDIR) mochitest-browser-chrome EXTRA_TEST_ARGS="--browser-arg=\"\" --extra-profile-file=$(CURDIR)/profile/webapps --extra-profile-file=$(CURDIR)/profile/OfflineCache --extra-profile-file=$(CURDIR)/profile/user.js"
 
+.PHONY: marionette
+marionette:
+#need the profile
+	test -d $(GAIA)/profile || $(MAKE) profile
+ifneq ($(PYTHON_MAJOR), 2)
+	@echo "Python 2.7.x is needed for the marionette client. You can set the PYTHON_27 variable to your python2.7 path." && exit 1
+endif
+ifneq ($(PYTHON_MINOR), 7)
+	@echo "Python 2.7.x is needed for the marionette client. You can set the PYTHON_27 variable to your python2.7 path." && exit 1
+endif
+ifeq ($(strip $(MC_DIR)),)
+	@echo "Please have the MC_DIR environment variable point to the top of your mozilla-central tree." && exit 1
+endif
+#if B2G_BIN is defined, we will run the b2g binary, otherwise, we assume an instance is running
+ifneq ($(strip $(B2G_BIN)),)
+	cd $(MC_DIR)/testing/marionette/client/marionette && \
+	sh venv_test.sh $(PYTHON_27) --address=$(MARIONETTE_HOST):$(MARIONETTE_PORT) --b2gbin=$(B2G_BIN) $(TEST_DIRS)
+else
+	cd $(MC_DIR)/testing/marionette/client/marionette && \
+	sh venv_test.sh $(PYTHON_27) --address=$(MARIONETTE_HOST):$(MARIONETTE_PORT) $(TEST_DIRS)
+endif
 
 ###############################################################################
 # Utils                                                                       #


### PR DESCRIPTION
This command is similar to the 'make test' command in b2g.

By default, it will assume you are already running a b2g instance with marionette. It will check if you have python 2.7, create a virtualenv with all the right packages, and run all the tests in gaia's tests/ directory. You will need to set the MC_DIR environment variable to point to your mozilla-central directory. This is so the make command can find the marionette client package, which is now in m-c.

If python 2.7 is not the default python on your system, you can set the PYTHON_27 variable to point to some python2.7 bin on your system, and we'll take care of the rest.

If you want to run tests other than those in gaia/tests, you can set TEST_DIRS to be any test ini, file or directory, and those will be run instead. 

If you'd like the command to launch an instance of b2g on your behalf, you can set the path to the b2g executable in the B2G_BIN variable. We will then launch that executable before running the tests, and terminate it when we finish.

You can also change the host and port with MARIONETTE_HOST and MARIONETTE_PORT variables.

As soon as https://bugzilla.mozilla.org/show_bug.cgi?id=742513 lands in m-c, you can start to use this command.
