### PR TITLE
[settings] "git commit info" and "debug" on the same "About" panel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ DEBUG?=0
 
 # In debug mode the offline cache is not used (even if it is generated) and
 # Gaia is loaded by a built-in web server via port GAIA_PORT.
-# 
+#
 # XXX For now the name of the domain should be mapped to localhost manually
-# by editing /etc/hosts on linux/mac. This steps would not be required 
+# by editing /etc/hosts on linux/mac. This steps would not be required
 # anymore once https://bugzilla.mozilla.org/show_bug.cgi?id=722197 will land.
 ifeq ($(DEBUG),1)
 GAIA_PORT=:8080
@@ -182,7 +182,7 @@ tests: manifests offline
 #     let us remove the update-offline-manifests target dependancy of the
 #     default target.
 stamp-commit-hash:
-	git rev-parse HEAD > apps/settings/gaia-commit.txt
+	git log -1 --format="%H%n%at" HEAD > apps/settings/gaia-commit.txt
 
 
 # Erase all the indexedDB databases on the phone, so apps have to rebuild them.

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -80,11 +80,6 @@
             <span data-l10n-id="about">About</span>
           </a>
         </li>
-        <li>
-          <a href="#debug">
-            <span data-l10n-id="debug">Debug</span>
-          </a>
-        </li>
       </ul>
     </div>
 
@@ -214,15 +209,14 @@
 
     <!-- About -->
     <div id="about" class="view" data-title="About">
+      <h2> Git commit info </h2>
       <ul>
         <li>
-          <a id="gaia-commit">(fetching commit rev...)</a>
+          <span id="gaia-commit-date">(fetching commit rev...)</span>
+          <small id="gaia-commit-hash"></small>
         </li>
       </ul>
-    </div>
-
-    <!-- Debug -->
-    <div id="debug" class="view" data-title="Debug">
+      <h2 data-l10n-id="debug">Debug</h2>
       <ul>
         <li>
           <a data-l10n-id="grid">Grid</a>

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -66,7 +66,8 @@ var Settings = {
         var value;
         if (input.type === 'checkbox') {
           value = input.checked;
-        } else if (input.type == 'radio') {
+        }
+        else if (input.type == 'radio') {
           value = input.value;
         }
         var cset = { }; cset[key] = value;
@@ -89,17 +90,31 @@ var Settings = {
     }
   },
   loadGaiaCommit: function() {
+    function dateToUTC(d) {
+      var arr = [];
+      [ d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
+        d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds()
+      ].forEach(function(n) {
+        arr.push((n >= 10) ? n : '0' + n);
+      });
+      return arr.splice(0, 3).join('-') + ' ' + arr.join(':');
+    }
     var req = new XMLHttpRequest();
     req.onreadystatechange = (function(e) {
       if (req.readyState === 4) {
         if (req.status === 200) {
-          var hash = req.responseText;
-          var disp = document.getElementById('gaia-commit');
+          var data = req.responseText.split('\n');
+          var dispDate = document.getElementById('gaia-commit-date');
+          var disp = document.getElementById('gaia-commit-hash');
           // XXX it would be great to pop a link to the github page
           // showing the commit but there doesn't seem to be any way
           // to tell the browser to do it.
-          disp.textContent = 'Git commit ' + hash;
-        } else {
+          //dispDate.textContent = data[1];
+          var d = new Date(parseInt(data[1] + '000', 10));
+          dispDate.textContent = dateToUTC(d);
+          disp.textContent = data[0];
+        }
+        else {
           console.error('Failed to fetch gaia commit: ', req.statusText);
         }
       }
@@ -154,7 +169,7 @@ window.addEventListener('localized', function showPanel() {
     // reset the hash to prevent weird focus bugs when switching LTR/RTL
     setTimeout(function() {
       document.location.hash = 'languages';
-    }, 0);
+    });
   }
 });
 

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -92,7 +92,8 @@ var Settings = {
   loadGaiaCommit: function() {
     function dateToUTC(d) {
       var arr = [];
-      [ d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
+      [
+        d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
         d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds()
       ].forEach(function(n) {
         arr.push((n >= 10) ? n : '0' + n);
@@ -109,7 +110,6 @@ var Settings = {
           // XXX it would be great to pop a link to the github page
           // showing the commit but there doesn't seem to be any way
           // to tell the browser to do it.
-          //dispDate.textContent = data[1];
           var d = new Date(parseInt(data[1] + '000', 10));
           dispDate.textContent = dateToUTC(d);
           disp.textContent = data[0];


### PR DESCRIPTION
This also changes the “git commit info” a bit in order to display:
- the UTC date in ISO format on the main line
- the git commit hash on the second line
