### PR TITLE
Use curl on Mac OS X for xulrunner downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,11 @@ SYS=$(shell uname -s)
 ifeq ($(SYS),Darwin)
 MD5SUM = md5 -r
 SED_INPLACE_NO_SUFFIX = sed -i ''
+DOWNLOAD_CMD = curl -s -O
 else
 MD5SUM = md5sum -b
 SED_INPLACE_NO_SUFFIX = sed -i
+DOWNLOAD_CMD = wget
 endif
 
 #Marionette testing variables
@@ -124,7 +126,7 @@ XULRUNNER=./xulrunner-sdk/bin/run-mozilla.sh
 XPCSHELL=./xulrunner-sdk/bin/xpcshell
 
 install-xulrunner:
-	test -d xulrunner-sdk || (wget $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
+	test -d xulrunner-sdk || ($(DOWNLOAD_CMD) $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
 
 else
 # Not a mac: assume linux
@@ -136,7 +138,7 @@ XULRUNNER=./xulrunner/run-mozilla.sh
 XPCSHELL=./xulrunner/xpcshell
 
 install-xulrunner:
-	test -d xulrunner || (wget $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
+	test -d xulrunner || ($(DOWNLOAD_CMD) $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
 endif
 
 # Generate profile/prefs.js


### PR DESCRIPTION
wget is not installed by default on Mac OS X. This patch uses curl
instead, which is available.

See also: #967 #974
