### PR TITLE
Use curl instead of wget on OSX given that it’s not usually available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ XULRUNNER=./xulrunner-sdk/bin/run-mozilla.sh
 XPCSHELL=./xulrunner-sdk/bin/xpcshell
 
 install-xulrunner:
-	test -d xulrunner-sdk || (wget $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
+	test -d xulrunner-sdk || (curl -O $(XULRUNNER_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
 
 else
 # Not a mac: assume linux


### PR DESCRIPTION
(I’m on OSX.)

While following https://wiki.mozilla.org/B2G/DeveloperPhone my `make install-gaia` build failed because `wget` was not available – it’s sadly not something installed by default.

This patch updates the makefile to use `curl` instead, which is always going to be available.
