### PR TITLE
Typo on workaround for installing handlers

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -1186,7 +1186,7 @@ function AppScreen() {
 
   // Installing these handlers on desktop causes JS execution to stop silently,
   // so work around that for now here.
-  if (navigator.userAgent.indexOf('Mobile') != -1) {
+  if (navigator.userAgent.indexOf('Mobile') == -1) {
     // Listen for app installations and rebuild the appscreen when we get one
     navigator.mozApps.mgmt.oninstall = function(event) {
       var newapp = event.application;

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -1184,23 +1184,19 @@ function AppScreen() {
     appscreen.grid.update();
   });
 
-  // Installing these handlers on desktop causes JS execution to stop silently,
-  // so work around that for now here.
-  if (navigator.userAgent.indexOf('Mobile') == -1) {
-    // Listen for app installations and rebuild the appscreen when we get one
-    navigator.mozApps.mgmt.oninstall = function(event) {
-      var newapp = event.application;
-      appscreen.installedApps[newapp.origin] = newapp;
-      appscreen.build(true);
-    };
+  // Listen for app installations and rebuild the appscreen when we get one
+  navigator.mozApps.mgmt.oninstall = function(event) {
+    var newapp = event.application;
+    appscreen.installedApps[newapp.origin] = newapp;
+    appscreen.build(true);
+  };
 
-    // Do the same for uninstalls
-    navigator.mozApps.mgmt.onuninstall = function(event) {
-      var newapp = event.application;
-      delete appscreen.installedApps[newapp.origin];
-      appscreen.build(true);
-    };
-  }
+  // Do the same for uninstalls
+  navigator.mozApps.mgmt.onuninstall = function(event) {
+    var newapp = event.application;
+    delete appscreen.installedApps[newapp.origin];
+    appscreen.build(true);
+  };
 }
 
 // Look up the app object for a specified app origin


### PR DESCRIPTION
I think there was a typo when trying to workaround this. It ends up on not being able to install apps from the market on b2g desktop nor the homescreen refreshing after an app install.

Besides the comparison doesn't make much sense if the comments are taken into account.
