### PR TITLE
Use URL hash to move panels in SMS

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -1038,7 +1038,7 @@ var MessagesListener = function() {
     // a particular sender, but don't have a good way to do it.
     // This should be replaced with a web intent or similar.
     WindowManager.launch('http://sms.' + domain
-                         /* +'?sender=' + sender*/);
+                         /* +'#num=' + sender*/);
   });
 
   var hasMessages = document.getElementById('state-messages');
@@ -1128,7 +1128,7 @@ function AppScreen() {
 
   navigator.mozApps.mgmt.getAll().onsuccess = function(e) {
     var apps = e.target.result;
-    
+
     var lastSlash = new RegExp(/\/$/);
     var currentHost = document.location.toString().replace(lastSlash, '');
     apps.forEach(function(app) {

--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -20,7 +20,7 @@
   <body class="hidden">
     <div id="view" class="panel">
       <div id="view-toolbar" class="toolbar toolbar-top">
-        <div id="view-back" data-l10n-id="messages">Messages</div>
+        <a href="#" id="view-back" data-l10n-id="messages">Messages</a>
         <h2 id="view-name">
 
         </h2>
@@ -49,8 +49,7 @@
       </div>
       <div id="msg-bottom-toolbar" class="toolbar toolbar-bottom">
         <div id="msg-new-message-container">
-          <button id="msg-new-message" class="button"
-            onclick="ConversationView.showConversation();" data-l10n-id="newMessage">New Message</button>
+          <a href="#num=*" id="msg-new-message" class="button" data-l10n-id="newMessage">New Message</a>
         </div>
       </div>
     </div>

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -422,8 +422,10 @@ var ConversationView = {
 
       case 'hashchange':
         var num = this.getNumFromHash();
-        if (!num)
+        if (!num) {
+          this.filter = null;
           return;
+        }
 
         this.showConversation(num);
         break;
@@ -440,7 +442,7 @@ var ConversationView = {
   close: function cv_close() {
     if (!document.body.classList.contains('conversation'))
       return false;
-    this.filter = null;
+
     window.location.hash = '';
     return true;
   },
@@ -456,8 +458,12 @@ var ConversationView = {
         ConversationView.input.value = text;
         ConversationView.updateInputHeight();
 
-        if (ConversationView.filter)
-          ConversationView.showConversation(ConversationView.filter);
+        if (ConversationView.filter) {
+          if (window.location.hash !== '#num=' + ConversationView.filter)
+            window.location.hash = '#num=' + ConversationView.filter;
+          else
+            ConversationView.showConversation(ConversationView.filter);
+        }
         ConversationListView.updateConversationList();
         return;
       }
@@ -466,8 +472,12 @@ var ConversationView = {
       // message in the background. Ideally we'd just be updating the UI
       // from "sending..." to "sent" at this point...
       window.setTimeout(function() {
-        if (ConversationView.filter)
-          ConversationView.showConversation(ConversationView.filter);
+        if (ConversationView.filter) {
+          if (window.location.hash !== '#num=' + ConversationView.filter)
+            window.location.hash = '#num=' + ConversationView.filter;
+          else
+            ConversationView.showConversation(ConversationView.filter);
+        }
         ConversationListView.updateConversationList();
       }, 100);
     });

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -60,10 +60,10 @@ var ConversationListView = {
 
     window.addEventListener('hashchange', this);
 
-    this.updateConversationList(null);
+    this.updateConversationList();
   },
 
-  updateConversationList: function cl_updateCL(pendingMsg, callback) {
+  updateConversationList: function cl_updateCL(pendingMsg) {
     var self = this;
     /*
       TODO: Conversation list is always order by contact family names
@@ -132,9 +132,6 @@ var ConversationListView = {
           fragment += msg;
         }
         self.view.innerHTML = fragment;
-
-        if (callback)
-          callback();
       };
     }, null);
   },

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -57,12 +57,10 @@ var ConversationListView = {
       navigator.mozSms.addEventListener('received', this);
 
     this.searchInput.addEventListener('keyup', this);
-    this.view.addEventListener('click', this);
 
-    this.updateConversationList(null, function fireAppReady() {
-      var url = document.location.toString();
-      visibilityChanged(url);
-    });
+    window.addEventListener('hashchange', this);
+
+    this.updateConversationList(null);
   },
 
   updateConversationList: function cl_updateCL(pendingMsg, callback) {
@@ -142,7 +140,7 @@ var ConversationListView = {
   },
 
   createNewConversation: function cl_createNewConversation(conversation) {
-    return '<div data-num="' + conversation.num + '"' +
+    return '<a href="#num=' + conversation.num + '"' +
            ' data-name="' + (conversation.name || conversation.num) + '"' +
            ' data-notempty="' + (conversation.timestamp ? 'true' : '') + '"' +
            ' class="' + (conversation.hidden ? 'hide' : '') + '">' +
@@ -154,7 +152,7 @@ var ConversationListView = {
            (conversation.timestamp ?
              '  <div class="time" data-time="' + conversation.timestamp + '">' +
                  prettyDate(conversation.timestamp) + '</div>' : '') +
-           '</div>';
+           '</a>';
   },
 
   searchConversations: function cl_searchConversations() {
@@ -195,7 +193,7 @@ var ConversationListView = {
     if (!num)
       return;
 
-    ConversationView.showConversation(num == '*' ? '' : num);
+    window.location.hash = '#num=' + num;
   },
 
   handleEvent: function cl_handleEvent(evt) {
@@ -204,13 +202,14 @@ var ConversationListView = {
         ConversationListView.updateConversationList(evt.message);
         break;
 
-      case 'click':
-        this.openConversationView(evt.target.dataset.num);
-        break;
-
       case 'keyup':
         this.searchConversations();
         break;
+
+      case 'hashchange':
+        if (window.location.hash)
+          return;
+        document.body.classList.remove('conversation');
     }
   }
 };
@@ -240,19 +239,25 @@ var ConversationView = {
     if (navigator.mozSms)
       navigator.mozSms.addEventListener('received', this);
 
-    document.getElementById('view-back').addEventListener(
-      'click', this.close.bind(this));
-
     // click event does not trigger when keyboard is hiding
     document.getElementById('view-msg-send').addEventListener(
       'mousedown', this.sendMessage.bind(this));
 
     this.input.addEventListener('input', this.updateInputHeight.bind(this));
 
-    var windowEvents = ['resize', 'keyup', 'transitionend'];
+    var windowEvents = ['resize', 'keyup', 'transitionend', 'hashchange'];
     windowEvents.forEach((function(eventName) {
       window.addEventListener(eventName, this);
     }).bind(this));
+
+
+    var num = this.getNumFromHash();
+    if (num)
+      this.showConversation(num);
+  },
+
+  getNumFromHash: function cv_getNumFromHash() {
+    return (/\bnum=(.+)(&|$)/.exec(window.location.hash) || [])[1];
   },
 
   scrollViewToBottom: function cv_scrollViewToBottom(animateFromPos) {
@@ -297,7 +302,7 @@ var ConversationView = {
     var bodyclassList = document.body.classList;
     var currentScrollTop;
 
-    if (num) {
+    if (num !== '*') {
       var filter = new MozSmsFilter();
       filter.numbers = [num || ''];
 
@@ -415,6 +420,14 @@ var ConversationView = {
         this.view.innerHTML = '';
         break;
 
+      case 'hashchange':
+        var num = this.getNumFromHash();
+        if (!num)
+          return;
+
+        this.showConversation(num);
+        break;
+
       case 'resize':
         if (!document.body.classList.contains('conversation'))
           return;
@@ -427,8 +440,8 @@ var ConversationView = {
   close: function cv_close() {
     if (!document.body.classList.contains('conversation'))
       return false;
-    document.body.classList.remove('conversation');
     this.filter = null;
+    window.location.hash = '';
     return true;
   },
   sendMessage: function cv_sendMessage() {

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -102,12 +102,14 @@ if (!navigator.mozSms) {
         receiver: '1-977-743-6797',
         body: 'Nothing :)',
         delivery: 'sent',
+        id: 41,
         timestamp: new Date(Date.now() - 44000000)
       },
       {
         sender: '1-977-743-6797',
         body: 'Hey! What\s up?',
         delivery: 'received',
+        id: 40,
         timestamp: new Date(Date.now() - 50000000)
       }
     ];
@@ -117,6 +119,7 @@ if (!navigator.mozSms) {
         sender: '1-488-678-3487',
         body: 'Hello world!',
         delivery: 'received',
+        id: 39 - i,
         timestamp: new Date(Date.now() - 60000000)
       });
     }
@@ -157,6 +160,7 @@ if (!navigator.mozSms) {
       receiver: number,
       delivery: 'sent',
       body: text,
+      id: messagesHack.length,
       timestamp: new Date()
     };
 
@@ -187,6 +191,7 @@ if (!navigator.mozSms) {
         receiver: null,
         delivery: 'received',
         body: 'Hi back! ' + text,
+        id: messagesHack.length,
         timestamp: new Date()
       };
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -59,33 +59,6 @@ function prettyDate(time) {
   });
 })();
 
-window.addEventListener('message', function visibleApp(evt) {
-  var data = evt.data;
-  if (data.message == 'visibilitychange' && !data.hidden) {
-    visibilityChanged(data.url);
-  }
-});
-
-function visibilityChanged(url) {
-  var params = (function makeURL() {
-    var a = document.createElement('a');
-    a.href = url;
-
-    var rv = {};
-    var params = a.search.substring(1, a.search.length).split('&');
-    for (var i = 0; i < params.length; i++) {
-      var data = params[i].split('=');
-      rv[data[0]] = data[1];
-    }
-    return rv;
-  })();
-
-  var sender = params['sender'];
-  if (sender) {
-    ConversationListView.openConversationView(sender);
-  }
-}
-
 /* ***********************************************************
 
   Code below are for desktop testing!

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -195,8 +195,11 @@ input, textarea {
   background: url("images/app-texture.png") repeat scroll 50% 50%, rgb(243, 243, 243);
 }
 
-#msg-conversations-list > div {
+#msg-conversations-list > a {
   -moz-box-sizing: border-box;
+  display: block;
+  text-decoration: none;
+  outline: none;
   height: 96px;
   position: relative;
   padding: 13px 16px 0 112px;
@@ -204,19 +207,19 @@ input, textarea {
   border-bottom: 1px solid hsla(223,7%,81%,1);
 }
 
-#msg-conversations-list > div:active {
+#msg-conversations-list > a:active {
   background: hsla(35,100%,50%,.2);
 }
 
-#msg-conversations-list > div.hide {
+#msg-conversations-list > a.hide {
   display: none;
 }
 
-#msg-conversations-list > div > * {
+#msg-conversations-list > a > * {
   pointer-events: none;
 }
 
-#msg-conversations-list > div:first-child {
+#msg-conversations-list > a:first-child {
   border-top-color: transparent;
 }
 
@@ -267,6 +270,7 @@ input, textarea {
 }
 
 #msg-new-message {
+  display: block;
   margin-top: 14px;
   margin-left: 32px;
   height: 48px;
@@ -274,6 +278,8 @@ input, textarea {
   font-size: 24px;
   font-weight: bold;
   width: -moz-calc(100% - 32px - 32px);
+  text-decoration: none;
+  outline: none;
 }
 
 #view-back {
@@ -283,6 +289,8 @@ input, textarea {
   font-size: 18px;
   font-weight: 600;
   color: #828282;
+  text-decoration: none;
+  outline: none;
 
   position: absolute;
   top: 3px; left: 0;


### PR DESCRIPTION
Use URL hash to move between panels will help if we have decided to use url to specify which thread we want to read (from the notification, for example)

Alternatively the hash url can be saved by window manager during reboot (or kill & reopen), to save the "state" of app. Much like "When Firefox exits [show my windows and tabs from the last time]".

The code where a new message of a new thread is strange cause we want to update the view with pending message; the url hash only gets updated when the message is actually sent and in the db.
