### PR TITLE
Set up dom.mozApps.whitelist so homescreen works in Firefox desktop nightly

### DIFF
--- a/apps/dialer/manifest.json
+++ b/apps/dialer/manifest.json
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "telephony",
-    "contacts"
+    "contacts",
+    "mozApps"
   ],
   "locales": {
     "ar": {

--- a/apps/homescreen/manifest.json
+++ b/apps/homescreen/manifest.json
@@ -10,7 +10,8 @@
     "telephony",
     "mozbrowser",
     "sms",
-    "power"
+    "power",
+    "mozApps"
   ],
   "locales": {
     "ar": {

--- a/preferences.js
+++ b/preferences.js
@@ -93,6 +93,10 @@ let permissions = {
   "mozbrowser": {
     "urls": [],
     "pref": "dom.mozBrowserFramesWhitelist"
+  },
+  "mozApps": {
+    "urls": [],
+    "pref": "dom.mozApps.whitelist"
   }
 };
 


### PR DESCRIPTION
In Firefox Nightly, navigator.mozApps.mgmt now seems to use the `dom.mozApps.whitelist` to know what apps can access/set properties like `oninstall` and `getAll`:

http://mxr.mozilla.org/mozilla-central/source/dom/base/Webapps.jsm#54

This patch sets up the apps that use mgmt to be in the dom.mozApps.whitelist. Tested with Firefox Nightly 14.0a1 (2012-04-10)
