### PR TITLE
Fix for the first run of the install-gaia script

### DIFF
--- a/build/install-gaia.py
+++ b/build/install-gaia.py
@@ -65,7 +65,7 @@ def adb_shell(cmd):
 
 def compute_remote_hashes():
     hashes = {}
-    adb_out = adb_shell('cd /data/local && find . -type f | xargs sha1sum')
+    adb_out = adb_shell('cd /data/local && find . -type f | xargs -r sha1sum')
     for (hash, filename) in [line.split() for line in adb_out]:
         # Strip off './' from the filename.
         if filename.startswith('./'):


### PR DESCRIPTION
on an empty `/data/local`
Just adding a `--no-run-if-empty` to `xargs` in order to avoid returning
a fake file named `-` to the script.
