### PR TITLE
change the way offline cache updates are handled

### DIFF
--- a/webapi.js
+++ b/webapi.js
@@ -895,18 +895,35 @@
 // Register a handler to automatically update apps when the app cache
 // changes.
 (function(window) {
-  var cache = window.applicationCache;
-  if (!cache)
+  if (!window.applicationCache)
     return;
 
-  // We can force an update every time by uncommenting the next line:
-  // cache.update();
+  window.applicationCache.addEventListener('updateready', function(evt) {
+      if (!navigator.mozNotification)
+        return;
 
-  cache.addEventListener('updateready', function updateReady(evt) {
-    // XXX Add a nice UI when an update is ready asking if the user
-    // want to reload the application now.
-    cache.swapCache();
-    window.document.location.reload();
+      // Figure out what our name is and where we come from
+      navigator.mozApps.getSelf().onsuccess = function(e) {
+        var app = e.target.result;
+        var name = app.manifest.name;
+        var origin = app.origin;
+
+        // FIXME Localize this message:
+        var notification = navigator.mozNotification.createNotification(
+                   'Update Available',
+                   'A new version of ' + name + ' is available');
+
+        notification.onclick = function(event) {
+
+          // If we're still running when the user taps on the notification
+          // then ask if they want to reload now
+          // FIXME: uncomment and localize when confirm() dialogs work
+          /* if (confirm('Update ' + name + ' from ' + origin + ' now?')) */
+          window.location.reload();
+        };
+
+        notification.show();
+      }
   });
 })(this);
 


### PR DESCRIPTION
we used to force an application reload when an updateready event was received.

This pull request displays a notification, and then does the reload when and if the user clicks on the notification.  Ideally, once we have confirm() dialogs, I'd have the notification trigger a confirm() before reloading.

I've tested this on the Galaxy S2.  It works if the app being updated is the current app.  If there is some other app "on top", then the notification click never gets delivered....  I haven't looked into why that is.

But for now, even partially working, this is better than the old behavior.

This addresses issue #1204

@cgjones @vingtetun what do you think?
