### PR TITLE
Define a public WindowManager.kill(origin) function for mdas' tests

### DIFF
--- a/apps/homescreen/js/window_manager.js
+++ b/apps/homescreen/js/window_manager.js
@@ -662,6 +662,7 @@ var WindowManager = (function() {
   // Return the object that holds the public API
   return {
     launch: launch,
+    kill: stop,
     getDisplayedApp: getDisplayedApp,
     getAppFrame: function(origin) {
       if (isRunning(origin))


### PR DESCRIPTION
This is a one-line change that exports an existing function in apps/homescreen/js/window_manager.js so that it can be used for writing tests.  We already had WindowManager.launch(origin) to start an app. Now we have WindowManager.kill(origin) to kill a running app.

mdas reports that this change works for her, so I'm just going to go ahead and land it.
