### PR TITLE
[l10n] properly switch homescreen locale + expose Greek, Italian, Spanish

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -100,7 +100,7 @@ AppScreen.prototype.build = function(rebuild) {
 
     // Localize the app name
     var name = app.manifest.name;
-    var lang = navigator.language;
+    var lang = document.mozL10n.language.code;
     if (app.manifest.locales &&
         app.manifest.locales[lang] &&
         app.manifest.locales[lang].name)

--- a/apps/homescreen/js/settings.js
+++ b/apps/homescreen/js/settings.js
@@ -35,6 +35,7 @@ SettingsListener.init();
 
 /* === Language === */
 SettingsListener.observe('language.current', 'en-US', function(value) {
+  document.mozL10n.language.code = value;
   document.documentElement.lang = document.mozL10n.language.code;
   document.documentElement.dir = document.mozL10n.language.direction;
 

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -176,6 +176,13 @@
             <span></span>
           </label>
         </li>
+        <li id="language-el">
+          <a dir="ltr">Ελληνικά</a>
+          <label>
+            <input type="radio" name="language.current" value="el"/>
+            <span></span>
+          </label>
+        </li>
         <li id="language-en-us">
           <a dir="ltr">English (US)</a>
           <label>
@@ -183,10 +190,24 @@
             <span></span>
           </label>
         </li>
+        <li id="language-es">
+          <a dir="ltr">Español</a>
+          <label>
+            <input type="radio" name="language.current" value="es"/>
+            <span></span>
+          </label>
+        </li>
         <li id="language-fr">
           <a dir="ltr">Français</a>
           <label>
             <input type="radio" name="language.current" value="fr"/>
+            <span></span>
+          </label>
+        </li>
+        <li id="language-it">
+          <a dir="ltr">Italiano</a>
+          <label>
+            <input type="radio" name="language.current" value="it"/>
             <span></span>
           </label>
         </li>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -225,14 +225,6 @@
             <span></span>
           </label>
         </li>
-        <li id="language-el">
-          <a dir="ltr">Greek</a>
-          <label>
-            <input type="radio" name="language.current" value="el"/>
-            <span></span>
-          </label>
-        </li>
-
       </ul>
     </div>
 


### PR DESCRIPTION
• settings: expose the three new locales have been contributed: Greek (el), Italian (it), Spanish (es);
• homescreen: properly switch locale.
