### PR TITLE
Fixed a typo in the comment for EventEmitter.prototype.listeners

### DIFF
--- a/common/vendor/mocha/mocha.js
+++ b/common/vendor/mocha/mocha.js
@@ -188,7 +188,7 @@ EventEmitter.prototype.removeAllListeners = function (name) {
 /**
  * Gets all listeners for a certain event.
  *
- * @api publci
+ * @api public
  */
 
 EventEmitter.prototype.listeners = function (name) {


### PR DESCRIPTION
Just a simple typo fix.
