### PR TITLE
fix uninstall bug

### DIFF
--- a/apps/homescreen/js/request.js
+++ b/apps/homescreen/js/request.js
@@ -43,7 +43,7 @@ var requestPermission = (function() {
     // If there is already a pending permission request, queue this one
     if (screen.classList.contains('visible')) {
       pending.push({
-        message: message,
+        message: msg,
         yescallback: yescallback,
         nocallback: nocallback
       });


### PR DESCRIPTION
This fixes a recent regression in the app uninstall process.  Addresses #1293.  #1325 is related but is not fixed by this patch.

The change to request.js is a simple fix to the bug that was causing [object HTMLDivElement] to appear.

The change to homescreen.js fixes the more basic problem of the dialog being displayed twice.  The fix here is less clear. This is a temporary patch pending an overhaul of the homescreen event handling code.
