### PR TITLE
Dont load background_service iframes until system page is loaded

### DIFF
--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -16,13 +16,15 @@ var BackgroundServiceManager = (function bsm() {
   var frames = {};
 
   /* Init */
-  var apps = navigator.mozApps;
-  apps.mgmt.getAll().onsuccess = function settings_getAll(evt) {
-    evt.target.result.forEach(function app_forEach(app) {
-      installedApps[app.origin] = app;
-      open(app.origin);
-    });
-  };
+  window.addEventListener('load', function() {
+    var apps = navigator.mozApps;
+    apps.mgmt.getAll().onsuccess = function settings_getAll(evt) {
+      evt.target.result.forEach(function app_forEach(app) {
+        installedApps[app.origin] = app;
+        open(app.origin);
+      });
+    };
+  });
 
   /* XXX: https://bugzilla.mozilla.org/show_bug.cgi?id=731746
   addEventListener does't work for now (workaround follows) */

--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -15,10 +15,11 @@ var BackgroundServiceManager = (function bsm() {
     The iframes will be append to body */
   var frames = {};
 
+  var apps = navigator.mozApps;
+
   /* Init */
-  window.addEventListener('load', function() {
-    var apps = navigator.mozApps;
-    apps.mgmt.getAll().onsuccess = function settings_getAll(evt) {
+  window.addEventListener('load', function bsm_init() {
+    apps.mgmt.getAll().onsuccess = function mgmt_getAll(evt) {
       evt.target.result.forEach(function app_forEach(app) {
         installedApps[app.origin] = app;
         open(app.origin);


### PR DESCRIPTION
Opening iframes blocks the page load event, due to a related
bug this could block the homepage being loaded for ~30 seconds
