### PR TITLE
"Disabling" the screen using the proximity sensor during a call.

### DIFF
--- a/apps/dialer/index.html
+++ b/apps/dialer/index.html
@@ -17,6 +17,7 @@
     <script type="application/javascript" src="js/contacts.js"></script>
     <script type="application/javascript" src="js/dialer.js"></script>
     <script type="application/javascript" src="js/recents.js"></script>
+    <script type="application/javascript" src="js/proximity.js"></script>
   </head>
 
   <body class="hidden">
@@ -234,5 +235,6 @@
         </div>
       </div>
     </div>
+    <div id="screen-off"></div>
   </body>
 </html>

--- a/apps/dialer/js/dialer.js
+++ b/apps/dialer/js/dialer.js
@@ -481,10 +481,9 @@ var CallHandler = {
     // Assume we always either onCall or not, and always onCall before
     // not onCall.
     if (this._onCall) {
-      this._screenLock = navigator.requestWakeLock('screen');
+      ProximityHandler.enable();
     } else {
-      this._screenLock.unlock();
-      this._screenLock = null;
+      ProximityHandler.disable();
     }
   },
 

--- a/apps/dialer/js/proximity.js
+++ b/apps/dialer/js/proximity.js
@@ -1,0 +1,29 @@
+var ProximityHandler = {
+  // XXX: due to some issue with event dispatch when the screen
+  // is disabled, we just put a black div on screen for now.
+
+  get screenOff() {
+    delete this.screenOff;
+    return this.screenOff = document.getElementById('screen-off');
+  },
+
+  enable: function ph_enable() {
+    window.addEventListener('deviceproximity', this);
+  },
+
+  disable: function ph_disable() {
+    window.removeEventListener('deviceproximity', this);
+    this.screenOff.classList.remove('displayed');
+  },
+
+  handleEvent: function ph_handleEvent(evt) {
+    if (evt.type != 'deviceproximity')
+      return;
+
+    if (evt.value == evt.min) {
+      this.screenOff.classList.add('displayed');
+    } else {
+      this.screenOff.classList.remove('displayed');
+    }
+  }
+};

--- a/apps/dialer/js/proximity.js
+++ b/apps/dialer/js/proximity.js
@@ -1,6 +1,7 @@
 var ProximityHandler = {
   // XXX: due to some issue with event dispatch when the screen
   // is disabled, we just put a black div on screen for now.
+  // See: https://bugzilla.mozilla.org/show_bug.cgi?id=753842
 
   get screenOff() {
     delete this.screenOff;

--- a/apps/dialer/style/dialer.css
+++ b/apps/dialer/style/dialer.css
@@ -1013,10 +1013,10 @@ html * {
   background: black;
   z-index: 100;
 
-  -moz-transform: translateY(-100%);
+  display: none;
 }
 #screen-off.displayed {
-  -moz-transform: translateY(0);
+  display: block;
 }
 
 /* === Recents === */

--- a/apps/dialer/style/dialer.css
+++ b/apps/dialer/style/dialer.css
@@ -1002,6 +1002,23 @@ html * {
   background: rgba(255, 255, 255, .3);
 }
 
+/* == Screen turn off hack == */
+#screen-off {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  background: black;
+  z-index: 100;
+
+  -moz-transform: translateY(-100%);
+}
+#screen-off.displayed {
+  -moz-transform: translateY(0);
+}
+
 /* === Recents === */
 #recents-view {
   overflow-y: scroll;


### PR DESCRIPTION
**/!\ Waiting on https://bugzilla.mozilla.org/show_bug.cgi?id=752683 before merging.**

Disabling in quotes because right now there are some issues with event dispatch when we disable the screen (with mozPower).
-> so just putting a black div on top of the screen to "disable" it for now.

It's not pretty but it works very well.
