### PR TITLE
remove old manifest-based orientation code and styles

### DIFF
--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -118,6 +118,10 @@ var WindowManager = (function() {
     var frame = app.frame;
     var manifest = app.manifest;
 
+/*
+ * We've got real orientation now, so doing it here just 
+ * messes up cut the rope
+
     // FIXME: for now, we support apps (video and cut the rope) that run
     // in landscape mode and fullscreen. Once we get real orientation
     // support, this code will have to become more sophisticated.
@@ -128,11 +132,12 @@ var WindowManager = (function() {
       frame.classList.add(manifest.orientation);
     }
     else {
+*/
       frame.style.width = window.innerWidth + 'px';
       frame.style.height = manifest.fullscreen ?
         window.innerHeight + 'px' :
         (window.innerHeight - statusbar.offsetHeight) + 'px';
-    }
+/*    }*/
   }
 
   // Perform an "open" animation for the app's iframe

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -118,26 +118,10 @@ var WindowManager = (function() {
     var frame = app.frame;
     var manifest = app.manifest;
 
-/*
- * We've got real orientation now, so doing it here just 
- * messes up cut the rope
-
-    // FIXME: for now, we support apps (video and cut the rope) that run
-    // in landscape mode and fullscreen. Once we get real orientation
-    // support, this code will have to become more sophisticated.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=673922
-    if (manifest.fullscreen && manifest.orientation) {
-      frame.style.width = window.innerHeight + 'px';
-      frame.style.height = window.innerWidth + 'px';
-      frame.classList.add(manifest.orientation);
-    }
-    else {
-*/
-      frame.style.width = window.innerWidth + 'px';
-      frame.style.height = manifest.fullscreen ?
-        window.innerHeight + 'px' :
-        (window.innerHeight - statusbar.offsetHeight) + 'px';
-/*    }*/
+    frame.style.width = window.innerWidth + 'px';
+    frame.style.height = manifest.fullscreen ?
+      window.innerHeight + 'px' :
+      (window.innerHeight - statusbar.offsetHeight) + 'px';
   }
 
   // Perform an "open" animation for the app's iframe

--- a/apps/system/style/system.css
+++ b/apps/system/style/system.css
@@ -116,23 +116,6 @@ iframe.appWindow.keyboardOn {
   border-bottom-right-radius: 0;
 }
 
-iframe.portrait-primary {
-}
-
-iframe.portrait-secondary {
-  -moz-transform: rotate(180deg);
-}
-
-iframe.landscape-primary {
-  -moz-transform-origin: left top;
-  -moz-transform: rotate(90deg) translate(0px, -480px);
-}
-
-iframe.landscape-secondary {
-  -moz-transform-origin: left top;
-  -moz-transform: rotate(-90deg) translate(-800px, 0px);
-}
-
 #taskManager {
   opacity: 0;
   position: absolute;


### PR DESCRIPTION
Cut the rope is the only app that was using manifest.orientation, and it breaks with the new real orientation code. So I've removed the old code and supporting css styles.
