### PR TITLE
honor manifest.orientation property with screen.mozLockOrientation

### DIFF
--- a/apps/calculator/manifest.json
+++ b/apps/calculator/manifest.json
@@ -55,5 +55,6 @@
   "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Calculator.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/clock/manifest.json
+++ b/apps/clock/manifest.json
@@ -55,5 +55,6 @@
   "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Clock.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/crystalskull/manifest.json
+++ b/apps/crystalskull/manifest.json
@@ -56,5 +56,6 @@
   "hackKillMe": true,
   "icons": {
     "120": "/style/icons/CrystalSkull.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/cubevid/manifest.json
+++ b/apps/cubevid/manifest.json
@@ -56,5 +56,6 @@
   "hackKillMe": true,
   "icons": {
     "120": "/style/icons/VideoCube.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/cuttherope/manifest.json
+++ b/apps/cuttherope/manifest.json
@@ -12,5 +12,6 @@
   },
   "icons": {
     "120": "/style/icons/CutTheRope.png"
-  }
+  },
+  "orientation": "landscape"
 }

--- a/apps/dialer/manifest.json
+++ b/apps/dialer/manifest.json
@@ -62,5 +62,6 @@
   "background_page": "/background.html",
   "icons": {
     "120": "/style/icons/Phone.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/music/manifest.json
+++ b/apps/music/manifest.json
@@ -55,5 +55,6 @@
   "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Music.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/penguinpop/manifest.json
+++ b/apps/penguinpop/manifest.json
@@ -9,6 +9,7 @@
   },
   "icons": {
     "120": "/style/icons/PenguinPop.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }
 

--- a/apps/settings/manifest.json
+++ b/apps/settings/manifest.json
@@ -59,5 +59,6 @@
   "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Settings.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/sms/manifest.json
+++ b/apps/sms/manifest.json
@@ -60,5 +60,6 @@
   "background_page": "/background.html#0",
   "icons": {
     "120": "/style/icons/Messages.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/system/js/lockscreen/lockscreen.js
+++ b/apps/system/js/lockscreen/lockscreen.js
@@ -47,6 +47,8 @@ var LockScreen = {
       style.MozTransform = 'translateY(0)';
     }
 
+    screen.mozLockOrientation('portrait');
+
     var evt = document.createEvent('CustomEvent');
     evt.initCustomEvent('locked', true, true, null);
     window.dispatchEvent(evt);
@@ -71,6 +73,8 @@ var LockScreen = {
     else
       style.MozTransition = '-moz-transform ' + time + 's linear';
     style.MozTransform = 'translateY(-100%)';
+
+    WindowManager.setOrientationForApp(WindowManager.getDisplayedApp());
 
     if (!wasAlreadyUnlocked) {
       var evt = document.createEvent('CustomEvent');

--- a/apps/system/js/lockscreen/lockscreen.js
+++ b/apps/system/js/lockscreen/lockscreen.js
@@ -47,7 +47,7 @@ var LockScreen = {
       style.MozTransform = 'translateY(0)';
     }
 
-    screen.mozLockOrientation('portrait');
+    screen.mozLockOrientation('portrait-primary');
 
     var evt = document.createEvent('CustomEvent');
     evt.initCustomEvent('locked', true, true, null);

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -341,6 +341,11 @@ var WindowManager = (function() {
   }
 
   function setOrientationForApp(origin) {
+    if (origin == null) { // homescreen
+      screen.mozLockOrientation('portrait-primary');
+      return;
+    }
+
     var app = runningApps[origin];
     if (!app)
       return;
@@ -685,6 +690,7 @@ var WindowManager = (function() {
     launch: launch,
     kill: stop,
     getDisplayedApp: getDisplayedApp,
+    setOrientationForApp: setOrientationForApp,
     getAppFrame: function(origin) {
       if (isRunning(origin))
         return runningApps[origin].frame;

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -334,21 +334,27 @@ var WindowManager = (function() {
       screen.mozLockOrientation('portrait-primary');
     }
     else {
-      var manifest = runningApps[newApp].manifest;
-      if (manifest.orientation) {
-        var rv = screen.mozLockOrientation(manifest.orientation);
-        if (rv === false) {
-          console.warn('screen.mozLockOrientation() returned false for', 
-                       origin, 'orientation', manifest.orientation);
-        }
-      }
-      else {  // If no orientation was requested, then let it rotate
-        screen.mozUnlockOrientation();
-      }
+      setOrientationForApp(newApp);
     }
 
-
     displayedApp = origin;
+  }
+
+  function setOrientationForApp(origin) {
+    var app = runningApps[origin];
+    if (!app)
+      return;
+    var manifest = app.manifest;
+    if (manifest.orientation) {
+      var rv = screen.mozLockOrientation(manifest.orientation);
+      if (rv === false) {
+        console.warn('screen.mozLockOrientation() returned false for', 
+                     origin, 'orientation', manifest.orientation);
+      }
+    }
+    else {  // If no orientation was requested, then let it rotate
+      screen.mozUnlockOrientation();
+    }
   }
 
   function appendFrame(origin, url, name, manifest) {
@@ -482,6 +488,9 @@ var WindowManager = (function() {
     // Then make the taskManager overlay active
     taskManager.classList.add('active');
 
+    // Make sure we're in portrait mode
+    screen.mozLockOrientation('portrait');
+
     // If there is a displayed app, take keyboard focus away
     if (displayedApp)
       runningApps[displayedApp].frame.blur();
@@ -537,8 +546,11 @@ var WindowManager = (function() {
     taskList.textContent = '';
 
     // If there is a displayed app, give the keyboard focus back
-    if (displayedApp)
+    // And switch back to that's apps orientation
+    if (displayedApp) {
       runningApps[displayedApp].frame.focus();
+      setOrientationForApp(displayedApp);
+    }
   }
 
   function taskSwitcherIsShown() {

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -329,6 +329,25 @@ var WindowManager = (function() {
       });
     }
 
+    // Lock orientation as needed
+    if (newApp == null) {  // going to the homescreen, so force portrait
+      screen.mozLockOrientation('portrait-primary');
+    }
+    else {
+      var manifest = runningApps[newApp].manifest;
+      if (manifest.orientation) {
+        var rv = screen.mozLockOrientation(manifest.orientation);
+        if (rv === false) {
+          console.warn('screen.mozLockOrientation() returned false for', 
+                       origin, 'orientation', manifest.orientation);
+        }
+      }
+      else {  // If no orientation was requested, then let it rotate
+        screen.mozUnlockOrientation();
+      }
+    }
+
+
     displayedApp = origin;
   }
 

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -118,10 +118,26 @@ var WindowManager = (function() {
     var frame = app.frame;
     var manifest = app.manifest;
 
-    frame.style.width = window.innerWidth + 'px';
-    frame.style.height = manifest.fullscreen ?
-      window.innerHeight + 'px' :
-      (window.innerHeight - statusbar.offsetHeight) + 'px';
+/*
+ * We've got real orientation now, so doing it here just 
+ * messes up cut the rope
+
+    // FIXME: for now, we support apps (video and cut the rope) that run
+    // in landscape mode and fullscreen. Once we get real orientation
+    // support, this code will have to become more sophisticated.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=673922
+    if (manifest.fullscreen && manifest.orientation) {
+      frame.style.width = window.innerHeight + 'px';
+      frame.style.height = window.innerWidth + 'px';
+      frame.classList.add(manifest.orientation);
+    }
+    else {
+*/
+      frame.style.width = window.innerWidth + 'px';
+      frame.style.height = manifest.fullscreen ?
+        window.innerHeight + 'px' :
+        (window.innerHeight - statusbar.offsetHeight) + 'px';
+/*    }*/
   }
 
   // Perform an "open" animation for the app's iframe

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -118,6 +118,10 @@ var WindowManager = (function() {
     var frame = app.frame;
     var manifest = app.manifest;
 
+/*
+ * We've got real orientation now, so doing it here just 
+ * messes up cut the rope
+
     // FIXME: for now, we support apps (video and cut the rope) that run
     // in landscape mode and fullscreen. Once we get real orientation
     // support, this code will have to become more sophisticated.
@@ -128,11 +132,12 @@ var WindowManager = (function() {
       frame.classList.add(manifest.orientation);
     }
     else {
+*/
       frame.style.width = window.innerWidth + 'px';
       frame.style.height = manifest.fullscreen ?
         window.innerHeight + 'px' :
         (window.innerHeight - statusbar.offsetHeight) + 'px';
-    }
+/*    }*/
   }
 
   // Perform an "open" animation for the app's iframe

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -118,26 +118,10 @@ var WindowManager = (function() {
     var frame = app.frame;
     var manifest = app.manifest;
 
-/*
- * We've got real orientation now, so doing it here just 
- * messes up cut the rope
-
-    // FIXME: for now, we support apps (video and cut the rope) that run
-    // in landscape mode and fullscreen. Once we get real orientation
-    // support, this code will have to become more sophisticated.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=673922
-    if (manifest.fullscreen && manifest.orientation) {
-      frame.style.width = window.innerHeight + 'px';
-      frame.style.height = window.innerWidth + 'px';
-      frame.classList.add(manifest.orientation);
-    }
-    else {
-*/
-      frame.style.width = window.innerWidth + 'px';
-      frame.style.height = manifest.fullscreen ?
-        window.innerHeight + 'px' :
-        (window.innerHeight - statusbar.offsetHeight) + 'px';
-/*    }*/
+    frame.style.width = window.innerWidth + 'px';
+    frame.style.height = manifest.fullscreen ?
+      window.innerHeight + 'px' :
+      (window.innerHeight - statusbar.offsetHeight) + 'px';
   }
 
   // Perform an "open" animation for the app's iframe

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -48,7 +48,7 @@ var WindowManager = (function() {
   var kLongPressInterval = 1000;
 
   // Some document elements we use
-  var screen = document.getElementById('screen');
+  var screenElement = document.getElementById('screen');
   var statusbar = document.getElementById('statusbar');
   var windows = document.getElementById('windows');
   var taskManager = document.getElementById('taskManager');
@@ -137,7 +137,7 @@ var WindowManager = (function() {
 
     if (manifest.fullscreen) {
       sprite.classList.add('fullscreen');
-      screen.classList.add('fullscreen');
+      screenElement.classList.add('fullscreen');
     }
 
     // Make the sprite look like the app that it is animating for.
@@ -232,7 +232,7 @@ var WindowManager = (function() {
 
     // If this was a fullscreen app, leave full-screen mode
     if (manifest.fullscreen)
-      screen.classList.remove('fullscreen');
+      screenElement.classList.remove('fullscreen');
 
     // If we're not doing an animation, then just switch directly
     // to the closed state. Note that we don't handle the hackKillMe
@@ -331,7 +331,6 @@ var WindowManager = (function() {
 
     displayedApp = origin;
   }
-
 
   function appendFrame(origin, url, name, manifest) {
     var frame = document.createElement('iframe');

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -118,10 +118,6 @@ var WindowManager = (function() {
     var frame = app.frame;
     var manifest = app.manifest;
 
-/*
- * We've got real orientation now, so doing it here just 
- * messes up cut the rope
-
     // FIXME: for now, we support apps (video and cut the rope) that run
     // in landscape mode and fullscreen. Once we get real orientation
     // support, this code will have to become more sophisticated.
@@ -132,12 +128,11 @@ var WindowManager = (function() {
       frame.classList.add(manifest.orientation);
     }
     else {
-*/
       frame.style.width = window.innerWidth + 'px';
       frame.style.height = manifest.fullscreen ?
         window.innerHeight + 'px' :
         (window.innerHeight - statusbar.offsetHeight) + 'px';
-/*    }*/
+    }
   }
 
   // Perform an "open" animation for the app's iframe

--- a/apps/system/style/system.css
+++ b/apps/system/style/system.css
@@ -116,6 +116,23 @@ iframe.appWindow.keyboardOn {
   border-bottom-right-radius: 0;
 }
 
+iframe.portrait-primary {
+}
+
+iframe.portrait-secondary {
+  -moz-transform: rotate(180deg);
+}
+
+iframe.landscape-primary {
+  -moz-transform-origin: left top;
+  -moz-transform: rotate(90deg) translate(0px, -480px);
+}
+
+iframe.landscape-secondary {
+  -moz-transform-origin: left top;
+  -moz-transform: rotate(-90deg) translate(-800px, 0px);
+}
+
 #taskManager {
   opacity: 0;
   position: absolute;

--- a/apps/system/style/system.css
+++ b/apps/system/style/system.css
@@ -116,23 +116,6 @@ iframe.appWindow.keyboardOn {
   border-bottom-right-radius: 0;
 }
 
-iframe.portrait-primary {
-}
-
-iframe.portrait-secondary {
-  -moz-transform: rotate(180deg);
-}
-
-iframe.landscape-primary {
-  -moz-transform-origin: left top;
-  -moz-transform: rotate(90deg) translate(0px, -480px);
-}
-
-iframe.landscape-secondary {
-  -moz-transform-origin: left top;
-  -moz-transform: rotate(-90deg) translate(-800px, 0px);
-}
-
 #taskManager {
   opacity: 0;
   position: absolute;

--- a/apps/tasks/manifest.json
+++ b/apps/tasks/manifest.json
@@ -55,5 +55,6 @@
   "default_locale": "en-US",
   "icons": {
     "120": "/style/icons/Tasks.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }

--- a/apps/test-agent/manifest.json
+++ b/apps/test-agent/manifest.json
@@ -12,7 +12,8 @@
   "developer": {
     "url": "https://github.com/andreasgal/gaia",
     "name": "The Gaia Team"
-  }
+  },
+  "orientation": "portrait-primary"
 }
 
 

--- a/apps/towerjelly/manifest.json
+++ b/apps/towerjelly/manifest.json
@@ -9,6 +9,7 @@
   },
   "icons": {
     "120": "/style/icons/TowerJelly.png"
-  }
+  },
+  "orientation": "portrait-primary"
 }
 


### PR DESCRIPTION
This pull request changes many app manifests to lock them into portrait-primary orientation.
It locks cut the rope to landscape, but allows it to be primary or secondary.
It leaves browser, camera, gallery and video unlocked.

The changes are to system/js/window/window_manager.js

The first first 6 commits are three mistakes and three reverts so this isn't as big a patch as it appears.

Note that the calls to mozLockOrientation currently require a hack to dom/base/nsScreen.cpp in order to work, but Mounir is working on a more general patch.
