### PR TITLE
Hack to get orientation working on Nexus S

### DIFF
--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -20,6 +20,18 @@ function startup() {
 
     ScreenManager.turnScreenOn();
   });
+
+  // This is code copied from
+  // http://dl.dropbox.com/u/8727858/physical-events/index.html
+  // It appears to workaround the Nexus S bug where we're not
+  // getting orientation data.  See:
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=753245
+  function dumbListener2(event) {}
+  window.addEventListener("devicemotion", dumbListener2, false);
+  
+  window.setTimeout(function() {
+      window.removeEventListener("devicemotion", dumbListener2, false);
+    }, 2000);
 }
 
 var SoundManager = {


### PR DESCRIPTION
This is a bizarre hack, but it works for me.

See https://bugzilla.mozilla.org/show_bug.cgi?id=753245

If we're going to demo the camera on the nexus s, we need orientation working on that phone, so we need to land this.
