### PR TITLE
Fixing the `appscreen is null` issue 

### DIFF
--- a/apps/homescreen/index.html
+++ b/apps/homescreen/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta http-equiv="pragma" content="no-cache">
 
+    <!-- The helper can be removed once bug 731746 lands -->
+    <script src="js/settings.js"></script>
+
     <link rel="stylesheet" type="text/css" href="style/homescreen.css">
     <script defer src="js/homescreen.js"></script>
 
@@ -16,9 +19,6 @@
      -->
     <link rel="stylesheet" type="text/css" href="style/request.css">
     <script defer src="js/request.js"></script>
-
-    <!-- The helper can be removed once bug 731746 lands -->
-    <script defer src="js/settings.js"></script>
 
     <!-- Compatibility -->
     <script>

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -8,6 +8,22 @@
 var appscreen = null;
 navigator.mozApps.mgmt.getAll().onsuccess = function(e) {
   appscreen = new AppScreen(e.target.result);
+
+  // Appscreen ready, now settings
+  SettingsListener.observe('language.current', 'en-US', function(value) {
+    document.mozL10n.language.code = value;
+    document.documentElement.lang = document.mozL10n.language.code;
+    document.documentElement.dir = document.mozL10n.language.direction;
+
+    appscreen.build(true);
+  });
+
+  SettingsListener.observe('homescreen.wallpaper', 'default.png',
+    function(value) {
+      document.getElementById('home').style.backgroundImage =
+        'url(style/backgrounds/' + value + ')';
+    }
+  );
 };
 
 function AppScreen(apps) {

--- a/apps/homescreen/js/settings.js
+++ b/apps/homescreen/js/settings.js
@@ -1,4 +1,3 @@
-
 var SettingsListener = {
   _callbacks: {},
 
@@ -32,23 +31,3 @@ var SettingsListener = {
 };
 
 SettingsListener.init();
-
-/* === Language === */
-SettingsListener.observe('language.current', 'en-US', function(value) {
-  document.mozL10n.language.code = value;
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
-
-  setTimeout(function() {
-    appscreen.build(true);
-  });
-});
-
-/* === Wallpapers === */
-SettingsListener.observe('homescreen.wallpaper', 'default.png',
-  function(value) {
-    document.getElementById('home').style.backgroundImage =
-      'url(style/backgrounds/' + value + ')';
-  }
-);
-


### PR DESCRIPTION
And restoring the homescreen background setting too :) (was broken by this)

It makes sense to me to have the SettingsObserver defined in `settings.js` and then start using it when we have the `appscreen`.

But if it's an issue I'm open to suggestions.
