### PR TITLE
Still requesting a lock on the screen during a call

### DIFF
--- a/apps/dialer/js/dialer.js
+++ b/apps/dialer/js/dialer.js
@@ -481,8 +481,11 @@ var CallHandler = {
     // Assume we always either onCall or not, and always onCall before
     // not onCall.
     if (this._onCall) {
+      this._screenLock = navigator.requestWakeLock('screen');
       ProximityHandler.enable();
     } else {
+      this._screenLock.unlock();
+      this._screenLock = null;
       ProximityHandler.disable();
     }
   },

--- a/apps/dialer/style/dialer.css
+++ b/apps/dialer/style/dialer.css
@@ -987,7 +987,7 @@ html * {
   background: url(images/call-screen-bg.png) center top no-repeat #575B66;
 
   color: white;
-  z-index: 200;
+  z-index: 500;
 }
 
 #mainKeyset.overlay .keyboard-row .keyboard-key {
@@ -1011,7 +1011,7 @@ html * {
   height: 100%;
 
   background: black;
-  z-index: 100;
+  z-index: 1000;
 
   display: none;
 }


### PR DESCRIPTION
With the current implementation of the proximity sensor we could get in a tricky scenario where the screen would still be tuned off (after a delay) when removing the phone from the face and not turned on again.
