### PR TITLE
Fix the issue that the keyboard mode may be wrongly kept as "symbol"

### DIFF
--- a/apps/system/js/keyboard/keyboard.js
+++ b/apps/system/js/keyboard/keyboard.js
@@ -1159,6 +1159,9 @@ const IMEManager = {
     targetWindow.style.height = targetWindow.dataset.cssHeight;
     targetWindow.classList.remove('keyboardOn');
 
+    // Reset the keyboard mode
+    this.currentKeyboardMode = '';
+
     if (imminent) {
       var ime = this.ime;
       ime.classList.add('imminent');


### PR DESCRIPTION
Fix the issue that the keyboard mode is wrong when we switched to symbol layout and then dismiss the keyboard
