### PR TITLE
Video app: Remove fullscreen in webapp manifest

### DIFF
--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -53,7 +53,6 @@
     }
   },
   "default_locale": "en-US",
-  "fullscreen": true,
   "hackKillMe": true,
   "icons": {
     "120": "/style/icons/Video.png"


### PR DESCRIPTION
... so we can make sure that `mozRequestFullScreen()` is in effect, and fix some bug triggered by it.
