### PR TITLE
Preventing the lockscreen from eating the volume keydown events

### DIFF
--- a/apps/system/js/lockscreen/lockscreen.js
+++ b/apps/system/js/lockscreen/lockscreen.js
@@ -262,15 +262,18 @@ var LockScreen = {
         break;
 
       case 'keydown':
+        if (e.keyCode !== e.DOM_VK_SLEEP && e.keyCode !== e.DOM_VK_HOME)
+          return;
+
         if (navigator.mozPower.screenEnabled) {
           if (e.keyCode == e.DOM_VK_SLEEP && !SleepMenu.visible) {
             this._timeout = window.setTimeout(function() {
               SleepMenu.show();
             }, 1500);
           }
-        } else if (e.keyCode == e.DOM_VK_SLEEP || e.keyCode == e.DOM_VK_HOME) {
-            this.update();
-            ScreenManager.turnScreenOn();
+        } else {
+          this.update();
+          ScreenManager.turnScreenOn();
         }
 
         e.preventDefault();


### PR DESCRIPTION
It only appeared in some cases.
But this was causing the chrome volume and the gaia volume reference to get out of sync.

This is why this pull request also fixes #1499.
