### PR TITLE
Use only domain names in network.dns.localDomains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ install-settingsdb: settingsdb install-xulrunner
 preferences: install-xulrunner
 	@echo "Generating prefs.js..."
 	@mkdir -p profile
-	$(XULRUNNER) $(XPCSHELL) -e 'const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)/profile"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)$(GAIA_PORT)"; const DEBUG = $(DEBUG); const HOMESCREEN = "$(HOMESCREEN)"; GAIA_PORT = "$(GAIA_PORT)"' build/preferences.js
+	$(XULRUNNER) $(XPCSHELL) -e 'const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)/profile"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)"; const DEBUG = $(DEBUG); const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)"' build/preferences.js
 	if [ -f custom-prefs.js ]; \
 	  then \
 	    cat custom-prefs.js >> profile/user.js; \

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -110,6 +110,8 @@ let homescreen = HOMESCREEN + (GAIA_PORT ? GAIA_PORT : '');
 content += "user_pref(\"browser.homescreenURL\",\"" + homescreen + "\");\n\n";
 
 let privileges = [];
+let domains = [];
+domains.push(GAIA_DOMAIN);
 
 let directories = getDirectories();
 directories.forEach(function readManifests(dir) {
@@ -117,24 +119,26 @@ directories.forEach(function readManifests(dir) {
   if (!manifest)
     return;
 
-  let domain = "http://" + dir + "." + GAIA_DOMAIN;
-  privileges.push(domain);
+  let rootURL = "http://" + dir + "." + GAIA_DOMAIN + (GAIA_PORT ? GAIA_PORT : '');
+  let domain = dir + "." + GAIA_DOMAIN;
+  privileges.push(rootURL);
+  domains.push(domain);
 
   let perms = manifest.permissions;
   if (perms) {
     for each(let name in perms) {
-      permissions[name].urls.push(domain);
+      permissions[name].urls.push(rootURL);
 
       // special case for the telephony API which needs full URLs
       if (name == 'telephony')
         if (manifest.background_page)
-          permissions[name].urls.push(domain + manifest.background_page);
+          permissions[name].urls.push(rootURL + manifest.background_page);
     }
   }
 });
 
 content += "user_pref(\"b2g.privileged.domains\", \"" + privileges.join(",") + "\");\n\n";
-content += "user_pref(\"network.dns.localDomains\", \"" + privileges.join(",") + "\");\n";
+content += "user_pref(\"network.dns.localDomains\", \"" + domains.join(",") + "\");\n";
 
 for (let name in permissions) {
   let perm = permissions[name];


### PR DESCRIPTION
After tested, #1391 doesn't work since network.dns.localDomains seems to support domains only (not URLs).
This fixes build/preferences.js to generate a list of domains to be filled into network.dns.localDomains.
