### PR TITLE
Bug 761482: update Gaia status bar to use the new OperatorInfo API

### DIFF
--- a/apps/system/js/statusbar/statusbar.js
+++ b/apps/system/js/statusbar/statusbar.js
@@ -137,10 +137,15 @@ function updateConnection(event) {
       title = _('searching');
     }
   } else {
+    var operatorName = '';
+    if (voice.operator) {
+      operatorName = voice.operator.shortName || '';
+    }
+
     if (voice.roaming) {
-      title = _('roaming', { operator: (voice.operator || '') });
+      title = _('roaming', { operator: operatorName });
     } else {
-      title = voice.operator || '';
+      title = operatorName;
     }
   }
   document.getElementById('titlebar').textContent = title;


### PR DESCRIPTION
Note: Wait for https://bugzilla.mozilla.org/show_bug.cgi?id=761482 to land before merging this pull request
