### PR TITLE
Fit Lock Screen passcode pad into HVGA

### DIFF
--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -278,12 +278,12 @@
   position: absolute;
   display: block;
 
-  top: 80px;
+  top: 16px;
   width: 100%;
   text-align: center;
 
   color: #ccc;
-  font-size: 100px;
+  font-size: 80px;
   font-weight: 600;
   letter-spacing: -2px;
   line-height: 1.1em;
@@ -300,8 +300,8 @@
 
 #lockscreen-passcode-code {
   position: absolute;
-  bottom: 400px;
-  height: 120px;
+  bottom: 240px;
+  height: 80px;
   width: 100%;
   background-color: rgba(255, 255, 255, 0.5);
   margin: 0;
@@ -314,7 +314,7 @@
   width: 25%;
   height: 100%;
   text-align: center;
-  border: 20px solid #919191;
+  border: 15px solid #919191;
   box-shadow: 0 0 10px #fff inset;
 
   position: relative;
@@ -356,7 +356,7 @@
   border: 1px solid #919191;
   position: absolute;
   bottom: 0;
-  height: 400px;
+  height: 240px;
   width: 100%;
 }
 
@@ -364,16 +364,16 @@
   -moz-box-sizing: border-box;
   display: block;
   float: left;
-  width: -moz-calc(33.333% - 16px);
-  height: 84px;
-  margin: 8px;
+  width: -moz-calc(33.333% - 8px);
+  height: 52px;
+  margin: 4px;
   text-align: center;
   border: 1px solid #919191;
   border-radius: 8px;
   outline: none;
 
-  font-size: 64px;
-  line-height: 84px;
+  font-size: 40px;
+  line-height: 52px;
 
   color: #919191;
   text-decoration: none;
@@ -385,7 +385,7 @@
 }
 
 #lockscreen-passcode-pad > a.lockscreen-passcode-pad-func {
-  font-size: 20px;
+  font-size: 16px;
 }
 
 #lockscreen-panel-emergency-call {

--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -341,14 +341,14 @@
   display: block;
   position: absolute;
 
-  width: 50px;
-  height: 50px;
+  width: 30px;
+  height: 30px;
   background-color: #000;
-  border-radius: 25px;
+  border-radius: 15px;
   top: 50%;
   left: 50%;
-  margin-left: -25px;
-  margin-top: -25px;
+  margin-left: -15px;
+  margin-top: -15px;
 }
 
 #lockscreen-passcode-pad {

--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -290,6 +290,13 @@
   text-shadow: 0 0 10px rgba(255, 255, 255, .4), 0 0 3px rgba(255, 255, 255, .3);
 }
 
+@media screen and (height: 800px) {
+  #lockscreen-panel-passcode::before {
+    top: 80px;
+    font-size: 100px;
+  }
+}
+
 [data-passcode-status="error"] #lockscreen-panel-passcode::before {
   content: ":'(";
 }
@@ -307,6 +314,13 @@
   margin: 0;
 }
 
+@media screen and (height: 800px) {
+  #lockscreen-passcode-code {
+    bottom: 400px;
+    height: 120px;
+  }
+}
+
 #lockscreen-passcode-code > span {
   -moz-box-sizing: border-box;
   display: block;
@@ -319,6 +333,13 @@
 
   position: relative;
 }
+
+@media screen and (height: 800px) {
+  #lockscreen-passcode-code > span {
+    border: 20px solid #919191;
+  }
+}
+
 
 [data-passcode-status="error"] #keypadscreen-code > span {
   box-shadow: 0 0 10px #f00 inset;
@@ -351,6 +372,16 @@
   margin-top: -15px;
 }
 
+@media screen and (height: 800px) {
+  #lockscreen-passcode-code > span[data-dot]::before {
+    width: 50px;
+    height: 50px;
+    border-radius: 25px;
+    margin-left: -25px;
+    margin-top: -25px;
+  }
+}
+
 #lockscreen-passcode-pad {
   -moz-box-sizing: border-box;
   border: 1px solid #919191;
@@ -359,6 +390,13 @@
   height: 240px;
   width: 100%;
 }
+
+@media screen and (height: 800px) {
+  #lockscreen-passcode-pad {
+    height: 400px;
+  }
+}
+
 
 #lockscreen-passcode-pad > a {
   -moz-box-sizing: border-box;
@@ -379,6 +417,17 @@
   text-decoration: none;
 }
 
+@media screen and (height: 800px) {
+  #lockscreen-passcode-pad > a {
+    width: -moz-calc(33.333% - 16px);
+    height: 84px;
+    margin: 8px;
+
+    font-size: 64px;
+    line-height: 84px;
+  }
+}
+
 #lockscreen-passcode-pad > a:active {
   background-color: rgb(0, 0, 0);
   color: #ccc;
@@ -386,6 +435,12 @@
 
 #lockscreen-passcode-pad > a.lockscreen-passcode-pad-func {
   font-size: 16px;
+}
+
+@media screen and (height: 800px) {
+  #lockscreen-passcode-pad > a.lockscreen-passcode-pad-func {
+    font-size: 20px;
+  }
 }
 
 #lockscreen-panel-emergency-call {


### PR DESCRIPTION
... and breaking layout on SGS2

I can use media queries to fit both of them but I am lazy and I guess the actual visual and Gaia CSS patten is coming up shortly.
