### PR TITLE
add preliminary start up performance tests

### DIFF
--- a/tests/perf/app_perf.py
+++ b/tests/perf/app_perf.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+from marionette_test import MarionetteTestCase
+
+class TestLaunch(MarionetteTestCase):
+    def test_launch(self):
+        self.marionette.execute_script("window.wrappedJSObject.LockScreen.unlock();")
+        apps = ['cuttherope','music','dialer','gallery','video','clock','browser','sms','camera',
+                'calculator','market','cubevid','crystalskull','towerjelly','penguinpop','settings']
+
+        #kill all apps we're testing, then launch
+        for app in apps:
+            self.marionette.execute_script("window.wrappedJSObject.WindowManager.kill('http://%s.gaiamobile.org');" % app)
+        for app in apps:
+            self.marionette.set_script_timeout(10000)
+            time = self.marionette.execute_async_script("let marionetteAppStart = Date.now();"
+                                                  + "window.addEventListener('mozChromeEvent', function(e) {"
+                                                  + "if (e.detail.type === 'webapps-launch') {"
+                                                  +  " let marionetteAppLoad = Date.now() - marionetteAppStart;"
+                                                  +  " window.removeEventListener('mozChromeEvent', arguments.callee);"
+                                                  +  " marionetteScriptFinished(marionetteAppLoad);"
+                                                  +  "}"
+                                                  +  "});"
+                                                  +  "window.wrappedJSObject.WindowManager.launch('http://%s.gaiamobile.org');" % app)
+            self.marionette.add_perf_data("startup", app, time)
+            self.marionette.execute_script("window.wrappedJSObject.WindowManager.kill('http://%s.gaiamobile.org');" % app)

--- a/tests/perf/perf.ini
+++ b/tests/perf/perf.ini
@@ -1,0 +1,11 @@
+[DEFAULT]
+perfserv = http://10.8.73.32/b2g/load_test
+platform = emulator
+build_name = b2g
+version = prerelease
+branch = master
+
+b2g = true
+skip = false
+
+[app_perf.py]


### PR DESCRIPTION
This adds a perf.ini file required by marionette test runner for submission to datazilla metrics database, and an app_perf.py performance test.

This test has a whitelist of apps whose startup times will be measured. Our CI will consume the perf.ini file and repeatedly run this test X times, and will submit the startup times to datazilla.

Right now, it's a python marionette test, but it can be changed to a JS test as soon as we have a JS marionette client working in the mocha framework.
