### PR TITLE
Remove appcache manifest if there's no webapp manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *~
 manifest.appcache
 apps/settings/gaia-commit.txt
-apps/test-agent/test/config.json
+test_apps/test-agent/test/config.json
 apps/*/test/unit/_sandbox.html
 apps/*/test/unit/_proxy.html
+test_apps/*/test/unit/_sandbox.html
+test_apps/*/test/unit/_proxy.html
 profile/
 xulrunner/
 xulrunner-sdk/

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ ifneq ($(DEBUG),1)
 	@rm -rf profile/OfflineCache
 	@mkdir -p profile/OfflineCache
 	@cd ..
-	$(XULRUNNER) $(XPCSHELL) -e 'const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)/profile"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)$(GAIA_PORT)"' build/offline-cache.js
+	$(XULRUNNER) $(XPCSHELL) -e 'const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)/profile"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)$(GAIA_PORT)"; const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)"' build/offline-cache.js
 	@echo "Done"
 endif
 
@@ -404,6 +404,7 @@ forward:
 update-offline-manifests:
 	for d in `find ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
 	do \
+		rm -rf $$d/manifest.appcache ;\
 		if [ -f $$d/manifest.webapp ] ;\
 		then \
 			echo \\t$$d ;  \

--- a/build/offline-cache.js
+++ b/build/offline-cache.js
@@ -191,7 +191,9 @@ let applicationCacheService = Cc["@mozilla.org/network/application-cache-service
 
 let iconsToInject = [];
 
-['apps', 'test_apps'].forEach(function parseDirectory(directoryName) {
+let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
+
+appSrcDirs.forEach(function parseDirectory(directoryName) {
   let directories = getSubDirectories(directoryName);
 
   directories.forEach(function generateAppCache(dir) {


### PR DESCRIPTION
As title.

Also add `test_apps` related path to `.gitignore`

Also fix problems coming w/ #1608, export `GAIA_APP_SRCDIRS` to `build/offline-cache.js`.
