### PR TITLE
workaround for bug 765267

### DIFF
--- a/tests/perf/app_perf.py
+++ b/tests/perf/app_perf.py
@@ -3,11 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import time
 from marionette_test import MarionetteTestCase
 
 class TestLaunch(MarionetteTestCase):
     def test_launch(self):
-        self.marionette.execute_script("window.wrappedJSObject.LockScreen.unlock();")
         apps = ['cuttherope','music','dialer','gallery','video','clock','browser','sms','camera',
                 'calculator','market','cubevid','crystalskull','towerjelly','penguinpop','settings']
 
@@ -16,7 +16,7 @@ class TestLaunch(MarionetteTestCase):
             self.marionette.execute_script("window.wrappedJSObject.WindowManager.kill('http://%s.gaiamobile.org');" % app)
         for app in apps:
             self.marionette.set_script_timeout(10000)
-            time = self.marionette.execute_async_script("let marionetteAppStart = Date.now();"
+            t = self.marionette.execute_async_script("let marionetteAppStart = Date.now();"
                                                   + "window.addEventListener('mozChromeEvent', function(e) {"
                                                   + "if (e.detail.type === 'webapps-launch') {"
                                                   +  " let marionetteAppLoad = Date.now() - marionetteAppStart;"
@@ -25,5 +25,6 @@ class TestLaunch(MarionetteTestCase):
                                                   +  "}"
                                                   +  "});"
                                                   +  "window.wrappedJSObject.WindowManager.launch('http://%s.gaiamobile.org');" % app)
-            self.marionette.add_perf_data("startup", app, time)
+            self.marionette.add_perf_data("startup", app, t)
+            time.sleep(1)
             self.marionette.execute_script("window.wrappedJSObject.WindowManager.kill('http://%s.gaiamobile.org');" % app)


### PR DESCRIPTION
The perf tests weren't running well in the CI due to this timing bug: https://bugzilla.mozilla.org/show_bug.cgi?id=765267. This is a workaround that will let us run the tests for now until it gets solved.
