### PR TITLE
Fix Profile Push / Fix Emulator CI Scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,13 +427,12 @@ update-offline-manifests:
 # working on just gaia itself, and you already have B2G firmware on your
 # phone, and you have adb in your path, then you can use the install-gaia
 # target to update the gaia files and reboot b2g
-PROFILE_PATH = /data/b2g/mozilla/`$(ADB) shell ls -1 /data/b2g/mozilla/ | grep default | tr -d [:cntrl:]`
+PROFILE_PATH = /data/local/
 install-gaia: profile
 	$(ADB) start-server
 	$(ADB) shell rm -r /cache/*
 	python build/install-gaia.py "$(ADB)"
 
-	# Until bug 746121 lands, push user.js in the profile
 	$(ADB) push profile/user.js ${PROFILE_PATH}/user.js
 
 	@echo "Installed gaia into profile/."

--- a/tools/ci/unit/emulator.sh
+++ b/tools/ci/unit/emulator.sh
@@ -58,7 +58,6 @@ then
   echo $?;
 fi
 
-
 $B2G_SCRIPTS cmd goUrl $DOMAIN;
 
 echo "Running tests";

--- a/tools/ci/unit/pr.sh
+++ b/tools/ci/unit/pr.sh
@@ -16,7 +16,7 @@ else
 fi
 
 $DIR/../../test-agent/node_modules/b2g-scripts/bin/b2g-scripts server \
-  --port $GAIA_PORT --gaia $DIR/../../../ &
+  --port $GAIA_PORT --gaia $DIR/../../../ --dir apps --dir test_apps  &
 
 SERVER_PID=`jobs -p | tail -n 1`;
 echo $SERVER_PID > $PID_FILE;

--- a/tools/ci/unit/test.sh
+++ b/tools/ci/unit/test.sh
@@ -22,8 +22,6 @@ then
   $AGENT test --reporter $REPORTER --server $TEST_AGENT_SERVER --wait-for-event="test data" --event-timeout="30000"
 else
   rm -f $TEST_OUTPUT;
-  echo $TEST_AGENT_SERVER
-  echo $REPORTER
   $AGENT test --reporter $REPORTER --server $TEST_AGENT_SERVER --wait-for-event="test data" --event-timeout="30000" > $TEST_OUTPUT
 fi
 

--- a/tools/ci/unit/test.sh
+++ b/tools/ci/unit/test.sh
@@ -22,6 +22,8 @@ then
   $AGENT test --reporter $REPORTER --server $TEST_AGENT_SERVER --wait-for-event="test data" --event-timeout="30000"
 else
   rm -f $TEST_OUTPUT;
+  echo $TEST_AGENT_SERVER
+  echo $REPORTER
   $AGENT test --reporter $REPORTER --server $TEST_AGENT_SERVER --wait-for-event="test data" --event-timeout="30000" > $TEST_OUTPUT
 fi
 

--- a/tools/test-agent/package.json
+++ b/tools/test-agent/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "test-agent": "0.6.3",
     "marionette-client": "0.3.0",
-    "b2g-scripts": "0.2.1",
+    "b2g-scripts": "0.3.0",
     "chai": "0.5.3",
     "mocha": "~1.0"
   }


### PR DESCRIPTION
This changes the profile push step in make install-gaia to push the profile to /data/local/user.js.
The original step will not work in otoro or the emulators (really only sgs2).

Also makes changes to the ci scripts to correctly load apps for multiple directories.
