### PR TITLE
Remove CSS rounded icons

### DIFF
--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -59,7 +59,6 @@
 .apps ol > li > div > img {
   width: 6rem;
   height: 6rem;
-  border-radius: 50%; /* rounded icons */
 }
 
 /* label wrapper */
@@ -99,7 +98,6 @@
   margin-bottom: .5rem;
   box-shadow: 0 0 5px 5px #666;
   -moz-transform: scale(1.1);
-  border-radius: 50%; /* rounded icons */
   width: 6rem;
   height: 6rem;
 }
@@ -162,8 +160,3 @@
   opacity: 0;
 }
 
-@media screen and (min-device-width: 480px) {
-  .apps ol > li > div > img, .apps .draggable > img {
-    border-radius: .5rem; /* squared icons */
-  }
-}


### PR DESCRIPTION
@crdlc Sorry I have missed that in my review but per spec icons should not be forced to be rounded.
