### PR TITLE
Quick settings nits, l10n fix, and cleanup

### DIFF
--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -54,11 +54,8 @@ var Shortcuts = {
   }
 };
 
-window.addEventListener('mozfullscreenchange', function onfullscreen(e) {
-  var classes = document.getElementById('screen').classList;
-  document.mozFullScreen ?
-    classes.add('fullscreen') : classes.remove('fullscreen');
-});
+/* === focuschange === */
+/* XXX: should go to keyboard_manager.js */
 
 try {
   window.navigator.mozKeyboard.onfocuschange = function onfocuschange(evt) {

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -74,3 +74,36 @@ try {
     }
   };
 } catch (e) {}
+
+/* === Localization ===
+*  This thing here will push setting change into mozL10n for it to
+*  load the new locale.
+*  Each time mozL10n loads the new locale (including first load),
+*  it will dispatch a 'localized' event.
+*
+*  XXX: mozL10n should handle setting change by itself if possible.
+*
+*/
+
+(function l10n() {
+  var called = false;
+  SettingsListener.observe('language.current', 'en-US',
+    (function localeChanged(lang) {
+      // Skip the first callback firing
+      if (!called) {
+        called = true;
+        return;
+      }
+
+      // Update <html> lang attribute
+      document.documentElement.lang = lang;
+      // Setting the code properties here will make mozL10n translate
+      // HTML again
+      document.mozL10n.language.code = lang;
+
+      // Update <html> dir attribute
+      document.documentElement.dir =
+        document.mozL10n.language.direction;
+    }).bind(this)
+  );
+})();

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -41,7 +41,8 @@ var QuickSettings = {
             this.data.dataset.enabled = !enabled;
 
             navigator.mozSettings.getLock().set({
-              'ril.data.enabled': !enabled });
+              'ril.data.enabled': !enabled
+            });
 
             break;
 
@@ -77,7 +78,8 @@ var QuickSettings = {
               this.data.dataset.enabled = false;
 
               navigator.mozSettings.getLock().set({
-                'ril.data.enabled': false });
+                'ril.data.enabled': false
+              });
 
               // Turn off Bluetooth
               var bluetooth = navigator.mozBluetooth;
@@ -102,7 +104,8 @@ var QuickSettings = {
                 // Turn on Data
                 this.data.dataset.enabled = true;
                 navigator.mozSettings.getLock().set({
-                  'ril.data.enabled': true });
+                  'ril.data.enabled': true
+                });
               }
 
               if (this._powerSaveResume.bluetooth) {

--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -25,6 +25,9 @@ var ScreenManager = {
     /* Respect the information from DeviceLight sensor */
     window.addEventListener('devicelight', this);
 
+    /* fullscreenchange event */
+    window.addEventListener('mozfullscreenchange', this);
+
     this.screen = document.getElementById('screen');
     this.screen.classList.remove('screenoff');
 
@@ -61,8 +64,16 @@ var ScreenManager = {
 
         break;
 
-        // The screenshot module also listens for the SLEEP key and
-        // may call preventDefault() on the keyup and keydown events.
+      case 'mozfullscreenchange':
+        if (document.mozFullScreen) {
+          this.screen.classList.add('fullscreen');
+        } else {
+          this.screen.classList.remove('fullscreen');
+        }
+        break;
+
+      // The screenshot module also listens for the SLEEP key and
+      // may call preventDefault() on the keyup and keydown events.
       case 'keydown':
         if (evt.keyCode !== evt.DOM_VK_SLEEP && evt.keyCode !== evt.DOM_VK_HOME)
           return;

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -7,13 +7,6 @@ var StatusBar = {
   radioDisabled: false,
 
   init: function sb_init() {
-    // XXX: is this the correct way to probe language changes?
-    SettingsListener.observe('language.current', 'en-US',
-      (function localeChanged(value) {
-        this.updateConnection();
-      }).bind(this)
-    );
-
     SettingsListener.observe('ril.radio.disabled', false,
       (function rilDisable(value) {
         this.radioDisabled = value;
@@ -165,6 +158,7 @@ var StatusBar = {
 
     if (this.radioDisabled) {
       this.conn.textContent = _('airplane');
+      this.comm.dataset.l10nId = 'airplane';
       this.signal.hidden = true;
       this.data.textContent = '';
       return;
@@ -172,28 +166,29 @@ var StatusBar = {
     this.signal.hidden = false;
 
     // Update the operator name / SIM status.
+    var titleL10nId = '';
     var title = '';
     switch (conn.cardState) {
       case 'absent':
-        title = _('noSimCard');
+        titleL10nId = 'noSimCard';
         break;
       case 'pin_required':
-        title = _('pinCodeRequired');
+        titleL10nId = 'pinCodeRequired';
         break;
       case 'puk_required':
-        title = _('pukCodeRequired');
+        titleL10nId = 'pukCodeRequired';
         break;
       case 'network_locked':
-        title = _('networkLocked');
+        titleL10nId = 'networkLocked';
         break;
     }
 
-    if (!title) {
+    if (!titleL10nId) {
       if (!voice.connected) {
         if (voice.emergencyCallsOnly) {
-          title = _('emergencyCallsOnly');
+          titleL10nId = 'emergencyCallsOnly';
         } else {
-          title = _('searching');
+          titleL10nId = 'searching';
         }
       } else {
         // voice.network will be introduced by bug 761482
@@ -209,7 +204,16 @@ var StatusBar = {
       }
     }
 
-    this.conn.textContent = title;
+    if (title) {
+      this.conn.textContent = title;
+      delete this.conn.dataset.l10nId;
+    } else if (titleL10nId) {
+      this.conn.textContent = _(titleL10nId) || '';
+      this.conn.dataset.l10nId = titleL10nId;
+    } else {
+      this.conn.textContent = '';
+      delete this.conn.dataset.l10nId;
+    }
 
     // Update the 3G/data status.
     // XXX: need icon for 3G/EDGE/etc instead of expose the type text


### PR DESCRIPTION
Some nits from yesterday's push of quick settings.

Move locale change to bootstrap.js (!) and properly assign l10n id to status on status bar.

Move `mozfullscreenchange` out of bootstrap.js
