### PR TITLE
Allow apps to get the window object reference of their background service

### DIFF
--- a/apps/dialer/js/background.js
+++ b/apps/dialer/js/background.js
@@ -1,5 +1,7 @@
 'use strict';
 
+dump('==== hi!');
+
 (function() {
   var telephony = navigator.mozTelephony;
   if (!telephony) {

--- a/apps/dialer/js/background.js
+++ b/apps/dialer/js/background.js
@@ -1,7 +1,5 @@
 'use strict';
 
-dump('==== hi!');
-
 (function() {
   var telephony = navigator.mozTelephony;
   if (!telephony) {

--- a/apps/dialer/manifest.webapp
+++ b/apps/dialer/manifest.webapp
@@ -11,7 +11,8 @@
     "contacts",
     "power",
     "mozApps",
-    "mobileconnection"
+    "mobileconnection",
+    "background"
   ],
   "locales": {
     "ar": {

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "sms",
-    "contacts"
+    "contacts",
+    "background"
   ],
   "locales": {
     "ar": {

--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -30,9 +30,21 @@ var BackgroundServiceManager = (function bsm() {
     close(origin);
   });
 
+  /* Check if the app has the permission to open a background page */
+  var hasBackgroundPermission = function bsm_checkPermssion(app) {
+    if (!app || !app.manifest.permissions ||
+        app.manifest.permissions.indexOf('background') == -1) {
+      return false;
+    }
+    return true;
+  };
+
   /* The open function is responsible of containing the iframe */
   var open = function bsm_open(origin) {
     var app = Applications.getByOrigin(origin);
+    if (!hasBackgroundPermission(app))
+      return false;
+
     if (!app || !app.manifest.background_page)
       return false;
 

--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -140,20 +140,10 @@ var BackgroundServiceManager = (function bsm() {
     return true;
   };
 
-  // Getting the window object reference of the background page. Unused.
-  // We have no way to give the object reference to the the app iframe for now
-  var getWindow = function bsm_getWindow(origin) {
-    var frame = frames[origin];
-    if (frame)
-      return frame.contentWindow || null;
-    return null;
-  };
-
   /* Return the public APIs */
   return {
     'open': open,
-    'close': close,
-    'getWindow': getWindow
+    'close': close
   };
 }());
 

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -129,6 +129,9 @@ domains.push(GAIA_DOMAIN);
     let perms = manifest.permissions;
     if (perms) {
       for each(let name in perms) {
+        if (!permissions[name])
+          return;
+
         permissions[name].urls.push(rootURL);
 
         // special case for the telephony API which needs full URLs


### PR DESCRIPTION
also allowing them to open up multiple background window, and proper permission check.

Fixes #1664
