### PR TITLE
SettingsListener: allow mutltiple callbacks bound to the same setting

### DIFF
--- a/apps/system/js/settings_listener.js
+++ b/apps/system/js/settings_listener.js
@@ -13,7 +13,7 @@ var SettingsListener = {
 
   onchange: function sl_onchange(evt) {
     var callbacks = this._callbacks[evt.settingName];
-    if (callbacks.length) {
+    if (callbacks) {
       callbacks.forEach(function sl_each(callback) {
         callback(evt.settingValue);
       });

--- a/apps/system/js/settings_listener.js
+++ b/apps/system/js/settings_listener.js
@@ -12,9 +12,11 @@ var SettingsListener = {
   },
 
   onchange: function sl_onchange(evt) {
-    var callback = this._callbacks[evt.settingName];
-    if (callback) {
-      callback(evt.settingValue);
+    var callbacks = this._callbacks[evt.settingName];
+    if (callbacks.length) {
+      callbacks.forEach(function sl_each(callback) {
+        callback(evt.settingValue);
+      });
     }
   },
 
@@ -31,7 +33,10 @@ var SettingsListener = {
         req.result[name] : defaultValue);
     }));
 
-    this._callbacks[name] = callback;
+    if (!this._callbacks[name])
+      this._callbacks[name] = [];
+
+    this._callbacks[name].push(callback);
   }
 };
 


### PR DESCRIPTION
I don't really know which modules will listens to the same setting (I bet it would), but I would like to patch `SettingsListener` before somebody hit some bug in the System app because of it.
