### PR TITLE
don't clear the plural macro

### DIFF
--- a/webapi.js
+++ b/webapi.js
@@ -605,7 +605,8 @@
     gL10nData = {};
     gTextData = '';
     gLanguage = '';
-    gMacros = {};
+    // TODO: clear all non predefined macros.
+    // There's no such macro /yet/ but we're planning to have some...
   }
 
   // rules for plural forms (shared with JetPack)


### PR DESCRIPTION
Fixes a last-minute silly addition to the l10n library, see last comments in issue #1511.
