### PR TITLE
[bugfix] SMS: checkbox selected when choosing single message in edit mode

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -955,7 +955,7 @@ var ConversationView = {
       break;
 
       case 'click':
-        var targetIsMessage = evt.target.classList.contains('message');
+        var targetIsMessage = ~evt.target.className.indexOf('message');
         if (evt.currentTarget == this.view && targetIsMessage) {
           this.onListItemClicked(evt);
         }


### PR DESCRIPTION
Previous change from ~evt.target.className.indexOf('message') to evt.target.classList.contains('message') didn't work. 

This is just a dirty fix, will modify the message structure in future iterations.
