### PR TITLE
Sms bugfixing

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -833,7 +833,14 @@ var ConversationView = {
 
         var pic = 'style/images/contact-placeholder.png';
 
-        var body = msg.body.replace(/\n/g, '<br />');
+        //Split body in different lines if the sms contains \n
+        var msgLines = msg.body.split('\n');
+        //Apply the escapeHTML body to each line
+        msgLines.forEach(function(line, index) {
+          msgLines[index] = escapeHTML(line);
+        });
+        //Join them back with <br />
+        var body = msgLines.join('<br />');
         var timestamp = msg.timestamp.getTime();
 
         fragment += '<div class="message-block" ' + 'data-num="' + dataNum +
@@ -841,7 +848,7 @@ var ConversationView = {
                     '  <input type="checkbox" class="fake-checkbox"/>' +
                     '  <span></span>' +
                     '  <div class="message-container ' + className + '>' +
-                    '    <div class="text">' + escapeHTML(body) + '</div>' +
+                    '    <div class="text">' + body + '</div>' +
                     '    <div class="time" data-time="' + timestamp + '">' +
                     prettyDate(msg.timestamp) + '</div>' +
                     '  </div>' +

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -294,6 +294,8 @@ body.msg-search-mode #msg-conversations-list {
   border-bottom: 0.1rem solid hsla(223,7%,81%,1);
   width: 100%;
   -moz-transition: padding 0.3s ease-out;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 
@@ -698,6 +700,7 @@ body.conversation-new-msg #view-num {
   text-shadow: 0 0.1rem 0 #ddd;
   line-height: 3.2rem;
   text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 #view-list > div .time {


### PR DESCRIPTION
## Small bug fixing
### 'Ellipsising' the text for long words

We were breaking the experience for long (more than the visualisation screen size) words. Now we ellipsise the content of the message if needed.
### Allowing multiple line messages

Allowing multiple line messages. Now we split the messages by lines and apply the _escapeHTML_ function to each line to be sure we don't have malicious content. 
Finally join then back with '<br />'.
