### PR TITLE
document.mozL10n => navigator.mozL10n

### DIFF
--- a/apps/clock/js/clock.js
+++ b/apps/clock/js/clock.js
@@ -26,8 +26,8 @@ function choiceChanged(target) {
 
 // Set the 'lang' and 'dir' attributes to <html> when the page is translated
 window.addEventListener('localized', function showBody() {
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
   // <body> children are hidden until the UI is translated
   document.body.classList.remove('hidden');
 });

--- a/apps/dialer/js/dialer.js
+++ b/apps/dialer/js/dialer.js
@@ -89,8 +89,8 @@ window.addEventListener('localized', function startup(evt) {
   KeyHandler.init();
 
   // Set the 'lang' and 'dir' attributes to <html> when the page is translated
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
 
   // <body> children are hidden until the UI is translated
   document.body.classList.remove('hidden');

--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -2,7 +2,7 @@
  * UI infrastructure code and utility code for the gaia email app.
  **/
 
-var mozL10n = document.mozL10n;
+var mozL10n = navigator.mozL10n;
 
 function dieOnFatalError(msg) {
   console.error('FATAL:', msg);

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -296,8 +296,8 @@ function addThumbnail(imagenum) {
 // Wait for the "localized" event before displaying the document content
 window.addEventListener('localized', function showBody() {
   // Set the 'lang' and 'dir' attributes to <html> when the page is translated
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
 
   // <body> children are hidden until the UI is translated
   document.body.classList.remove('hidden');

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -166,8 +166,8 @@ window.addEventListener('keyup', function goBack(event) {
 
 // set the 'lang' and 'dir' attributes to <html> when the page is translated
 window.addEventListener('localized', function showPanel() {
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
 
   // <body> children are hidden until the UI is translated
   if (document.body.classList.contains('hidden')) {

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -5,7 +5,7 @@
 
 window.addEventListener('localized', function scanWifiNetworks(evt) {
   var wifiManager = navigator.mozWifiManager;
-  var _ = document.mozL10n.get;
+  var _ = navigator.mozL10n.get;
 
   // main wifi button
   var gStatus = (function wifiStatus(checkbox, infoBlock) {

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -1085,7 +1085,7 @@ window.addEventListener('localized', function showBody() {
   ConversationListView.init();
 
   // Set the 'lang' and 'dir' attributes to <html> when the page is translated
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
 });
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -4,7 +4,7 @@
 'use strict';
 
 // Based on Resig's pretty date
-var localeStr = document.mozL10n.get;
+var localeStr = navigator.mozL10n.get;
 function prettyDate(time) {
 
   switch (time.constructor) {

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -82,7 +82,7 @@ try {
 /* === Localization === */
 /* set the 'lang' and 'dir' attributes to <html> when the page is translated */
 window.addEventListener('localized', function onlocalized() {
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
 });
 

--- a/apps/system/js/permission_manager.js
+++ b/apps/system/js/permission_manager.js
@@ -33,7 +33,7 @@
     if (locales && locales[lang] && locales[lang].name)
       name = locales[lang].name;
 
-    var str = document.mozL10n.get('install', {
+    var str = navigator.mozL10n.get('install', {
       'name': name, 'origin': app.origin
     });
     requestPermission(str, function() { sendResponse(detail.id, true); },

--- a/apps/system/js/screenshot.js
+++ b/apps/system/js/screenshot.js
@@ -74,7 +74,7 @@
     window.dispatchEvent(new CustomEvent('mozContentEvent', screenshotProps));
   }
 
-  var _ = document.mozL10n.get;
+  var _ = navigator.mozL10n.get;
 
   // Handle notifications that screenshots have been taken
   window.addEventListener('mozChromeEvent', function ss_onMozChromeEvent(e) {

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -150,7 +150,7 @@ var StatusBar = {
     if (!conn || !conn.voice)
       return;
 
-    var _ = document.mozL10n.get;
+    var _ = navigator.mozL10n.get;
     /* Information about voice connection */
     var voice = conn.voice;
     /* Information about data connection */

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -76,7 +76,7 @@ var WindowManager = (function() {
   // an app is loading
   var localizedLoading = 'Loading...';
   window.addEventListener('localized', function() {
-    localizedLoading = document.mozL10n.get('loading');
+    localizedLoading = navigator.mozL10n.get('loading');
   });
 
   // Public function. Return the origin of the currently displayed app

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -381,8 +381,8 @@ window.addEventListener('DOMContentLoaded', function() {
 
 // Set the 'lang' and 'dir' attributes to <html> when the page is translated
 window.addEventListener('localized', function showBody() {
-  document.documentElement.lang = document.mozL10n.language.code;
-  document.documentElement.dir = document.mozL10n.language.direction;
+  document.documentElement.lang = navigator.mozL10n.language.code;
+  document.documentElement.dir = navigator.mozL10n.language.direction;
   // <body> children are hidden until the UI is translated
   document.body.classList.remove('hidden');
 });

--- a/webapi.js
+++ b/webapi.js
@@ -277,7 +277,7 @@
   };
 })(this);
 
-// document.mozL10n
+// navigator.mozL10n
 (function(window) {
   // see https://github.com/fabi1cazenave/webL10n
 
@@ -1137,7 +1137,7 @@
   }
 
   // Public API
-  document.mozL10n = {
+  navigator.mozL10n = {
     // get a localized string
     get: function(key, args, fallback) {
       var data = getL10nData(key, args) || fallback;


### PR DESCRIPTION
follow-up of issue #1805.

I remember this question has been discussed on m.d.webAPI and I don’t think anybody objected about `document.mozL10n`. I would say that it looks like a property of the document itself but that’s just my 2¢.
https://groups.google.com/d/topic/mozilla.dev.webapi/Pb6w22fTcnk/discussion
