### PR TITLE
remove hackKillMe

### DIFF
--- a/apps/crystalskull/index.html
+++ b/apps/crystalskull/index.html
@@ -65,6 +65,13 @@
 		    document.onmousemove = onMouseMove;
 		
 		    draw();
+
+              // If we become hidden, then draw() stops requesting redraws.
+              // So when we become visible again, start drawing again
+              document.addEventListener('mozvisibilitychange', function vis() {
+                if (!document.mozHidden) 
+                  draw();
+              });
 	    }
 	
 	    function onMouseMove(e) {
@@ -75,7 +82,9 @@
 	    }
 	
 	    function draw() {
-		    requestAnimationFrame(draw);
+              // Keep redrawing while we're not hidden
+              if (!document.mozHidden)
+		requestAnimationFrame(draw);
 
 		    shader.chromaticDispertion = [
           properties.dispersionRed,

--- a/apps/crystalskull/manifest.webapp
+++ b/apps/crystalskull/manifest.webapp
@@ -53,7 +53,6 @@
     }
   },
   "default_locale": "en-US",
-  "hackKillMe": true,
   "icons": {
     "120": "/style/icons/Crystalskull.png",
     "60": "/style/icons/60/Crystalskull.png"

--- a/apps/cubevid/manifest.webapp
+++ b/apps/cubevid/manifest.webapp
@@ -53,7 +53,6 @@
     }
   },
   "default_locale": "en-US",
-  "hackKillMe": true,
   "icons": {
     "120": "/style/icons/Cubevid.png",
     "60": "/style/icons/60/Cubevid.png"

--- a/apps/cubevid/webgl-demo.js
+++ b/apps/cubevid/webgl-demo.js
@@ -314,6 +314,19 @@ function videoDone() {
   videoElement.play();
 }
 
+// Pause and restart when visibility changes
+document.addEventListener('mozvisibilitychange', function visibilityChange() {
+  if (document.mozHidden) {
+    videoElement.pause();
+    // drawScene will stop when we become hidden
+  }
+  else {
+    videoElement.play();
+    drawScene();
+  }
+});
+
+
 //
 // drawScene
 //
@@ -390,7 +403,8 @@ function drawScene() {
   }
   
   lastCubeUpdateTime = currentTime;
-  window.mozRequestAnimationFrame(drawScene, canvas);
+  if (!document.mozHidden) 
+    window.mozRequestAnimationFrame(drawScene, canvas);
 }
 
 //

--- a/apps/cuttherope/manifest.webapp
+++ b/apps/cuttherope/manifest.webapp
@@ -4,7 +4,6 @@
   "launch_path": "/",
   "orientation": "landscape-primary",
   "fullscreen": true,
-  "hackKillMe": true,
   "hackNetworkBound": "true",
   "developer": {
     "name": "CutTheRope",

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -224,11 +224,7 @@ var WindowManager = (function() {
     }
 
     // If we're not doing an animation, then just switch directly
-    // to the closed state. Note that we don't handle the hackKillMe
-    // flag here. If we bring up the task switcher and switch to another
-    // app then the video or camera or whatever should keep running
-    // in the background. Its only animated transitions to the homescreen
-    // that should kill those resource-intensive apps.
+    // to the closed state. 
     if (instant) {
       frame.classList.remove('active');
       if (callback)
@@ -254,14 +250,6 @@ var WindowManager = (function() {
     frame.classList.remove('active');
     windows.classList.remove('active');
 
-    // If this is an hackKillMe app, set the apps iframe's src attribute
-    // to an empty file to get rid of whatever resource-intensive
-    // app it is currently running. For some reason actually removing
-    // the iframe from the document here does not work, so we remove it
-    // after the transition below.
-    if (manifest.hackKillMe)
-      frame.src = 'blank.html';
-
     // Query css to flush this change
     var width = document.documentElement.clientWidth;
 
@@ -270,12 +258,9 @@ var WindowManager = (function() {
     sprite.classList.add('closed');
 
     // When the transition ends, discard the sprite.
-    // For hackKillMe apps, stop running the app, too
     sprite.addEventListener('transitionend', function transitionListener() {
       sprite.removeEventListener('transitionend', transitionListener);
       document.body.removeChild(sprite);
-      if (manifest.hackKillMe)
-        kill(origin);
       if (callback)
         callback();
     });

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -5,6 +5,7 @@ window.addEventListener('DOMContentLoaded', function() {
     return document.getElementById(id);
   }
   var player = $('player');
+  var playing = false;
 
   // if this is true then the video tag is showing
   // if false, then the gallery is showing
@@ -168,12 +169,47 @@ window.addEventListener('DOMContentLoaded', function() {
   }
 
   // When we exit fullscreen mode, stop playing the video.
-  // This happens automatically when the user uses the back button.
+  // This happens automatically when the user uses the back button (because
+  // back is Escape, which is also the "leave fullscreen mode" command).
+  // It also happens when the user uses the Home button to go to the
+  // homescreen or another app.
+  //
+  // XXX:
+  // If the user switches to the homescreen, we want to pause the video,
+  // of course, but we'd like to come right back to it and be able to resume
+  // in place. That's a little tricky because we get the mozvisiblitychange
+  // event after we get the mozfullscreenchange event. So for now, we just
+  // go back to the thumbnail view and loose the user's place when the user
+  // presses the Home button.
   document.addEventListener('mozfullscreenchange', function() {
-    if (document.mozFullScreenElement === null) {
+    if (document.mozFullScreenElement === null)
       hidePlayer();
+  });
+
+/*
+ * XXX
+ * This code is commented out because the mozvisibilitychange event is
+ * delivered after the mozfullscreenchange event, so by the time we get
+ * it the video is already paused. We either need to get gecko to deliver
+ * the events in the other order, or do something clever with timers, or
+ * just add code to retain the user's current playback position for resuming
+ * videos from the thumbnail screen
+ *
+  // Pause on visibility change
+  document.addEventListener('mozvisibilitychange', function visibilityChange() {
+    if (document.mozHidden && playing) {
+      // If we've been hidden, stop playing the video
+      pause();
+    }
+    else {
+      // If we've just become visible again, go back into fullscreen mode
+      // if we are supposed to be in fullscreen
+      if (playerShowing && !document.mozFullScreenElement) {
+        $('videoFrame').mozRequestFullScreen();
+      }
     }
   });
+*/
 
   // show|hide controls over the player
   $('videoControls').addEventListener('click', function(event) {
@@ -220,16 +256,13 @@ window.addEventListener('DOMContentLoaded', function() {
     // Go into full screen mode
     $('videoFrame').mozRequestFullScreen();
 
-    // Don't blank the screen while the video is playing
-    screenLock = navigator.requestWakeLock('screen');
-
     // Get the video file and start the player
     storage.get(data.name).onsuccess = function(event) {
       var file = event.target.result;
       var url = URL.createObjectURL(file);
       player.src = url;
-      player.play();
       setPlayerSize();
+      play();
     }
   }
 
@@ -266,32 +299,40 @@ window.addEventListener('DOMContentLoaded', function() {
       hidePlayer();
   });
 
+  function play() {
+    // Switch the button icon
+    $('play').classList.remove('paused');
+
+    // Start playing
+    player.play();
+    playing = true;
+
+    // Don't let the screen go to sleep
+    if (!screenLock)
+      screenLock = navigator.requestWakeLock('screen');
+  }
+
+  function pause() {
+    // Switch the button icon
+    $('play').classList.add('paused');
+
+    // Stop playing the video
+    player.pause();
+    playing = false;
+
+    // Let the screen go to sleep
+    if (screenLock) {
+      screenLock.unlock();
+      screenLock = null;
+    }
+  }
+
   // Handle clicks on the play/pause button
   $('play').addEventListener('click', function() {
-    if (player.paused) {
-      // Switch the button icon
-      this.classList.remove('paused');
-
-      // Start playing
-      player.play();
-
-      // Don't let the screen go to sleep
-      if (!screenLock)
-        screenLock = navigator.requestWakeLock('screen');
-    }
-    else {
-      // Switch the button icon
-      this.classList.add('paused');
-
-      // Stop playing the video
-      player.pause();
-
-      // Let the screen go to sleep
-      if (screenLock) {
-        screenLock.unlock();
-        screenLock = null;
-      }
-    }
+    if (player.paused)
+      play();
+    else
+      pause();
   });
 
   // XXX: the back and forward buttons aren't working for my webm videos

--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -53,7 +53,6 @@
     }
   },
   "default_locale": "en-US",
-  "hackKillMe": true,
   "icons": {
     "120": "/style/icons/Video.png",
     "60": "/style/icons/60/Video.png"


### PR DESCRIPTION
This pull request removes hackKillMe support from apps/system/js/windows/window_manager.js
It removes the hackKillMe flag from the manifests of the four apps that used it, and gives those apps mozvisibilitychange handlers that pause the app when it is hidden.
