### PR TITLE
Generic caller contact image and deletion of no longer needed buttons

### DIFF
--- a/apps/dialer/js/oncall.js
+++ b/apps/dialer/js/oncall.js
@@ -28,6 +28,12 @@ var CallScreen = {
     return this.keypadButton = document.getElementById('keypad-visibility');
   },
 
+  get callContainer() {
+    delete this.contactContainer;
+    return this.contactContainer =
+      document.getElementById('call-container');
+  },
+
   get contactPrimaryInfo() {
     delete this.contactPrimaryInfo;
     return this.contactPrimaryInfo =
@@ -74,6 +80,14 @@ var CallScreen = {
       KeypadManager._phoneNumber;
     KeypadManager.moveCaretToEnd(
       KeypadManager.phoneNumberView);
+  },
+
+  /*
+   * Sets the caller contact image in the background container.
+   * @param {String} image_url The URL of the image.
+   */
+  setCallerContactImage: function cm_setCallerContactImage(image_url) {
+    this.callContainer.style.backgroundImage = "url(" + image_url + ")";
   },
 
   toggleMute: function cm_toggleMute() {

--- a/apps/dialer/js/oncall.js
+++ b/apps/dialer/js/oncall.js
@@ -82,12 +82,8 @@ var CallScreen = {
       KeypadManager.phoneNumberView);
   },
 
-  /*
-   * Sets the caller contact image in the background container.
-   * @param {String} image_url The URL of the image.
-   */
   setCallerContactImage: function cm_setCallerContactImage(image_url) {
-    this.callContainer.style.backgroundImage = "url(" + image_url + ")";
+    this.callContainer.style.backgroundImage = 'url(' + image_url + ')';
   },
 
   toggleMute: function cm_toggleMute() {

--- a/apps/dialer/oncall.html
+++ b/apps/dialer/oncall.html
@@ -51,28 +51,16 @@
                       <span class="icon-mute">
                       </span>
                     </button>
-                    <button class="co-advanced-option grid-wraper grid center" disabled="disabled">
-                      <span class="icon-contacts">
-                      </span>
-                    </button>
                   </span>
                   <span class="grid-cell options-column">
                     <button id="keypad-visibility" class="co-advanced-option grid-wraper grid center">
                       <span class="icon-keypad">
                       </span>
                     </button>
-                    <button class="co-advanced-option grid-wraper grid" disabled="disabled">
-                      <span class="icon-timeline">
-                      </span>
-                    </button>
                   </span>
                   <span class="grid-cell options-column">
                     <button id="speaker" class="co-advanced-option grid-wraper grid">
                       <span>
-                      </span>
-                    </button>
-                    <button class="co-advanced-option grid-wraper grid" disabled="disabled">
-                      <span class="icon-message">
                       </span>
                     </button>
                   </span>

--- a/apps/dialer/style/oncall.css
+++ b/apps/dialer/style/oncall.css
@@ -173,29 +173,39 @@ body.hidden *[data-l10n-id] {
   padding:0 3rem;
 }
 
+#call-container {
+  background-image: url("images/Generic_image.png");
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
+}
+
 #call-options{
-  height:28.5rem;
+  height:20.5rem;
 }
 
-.options-column{
-  border-right:1px solid #3A3A3A;
+#co-advanced {
+  opacity: 0.9;
+  height: 9.5;
+  margin-bottom: 4.5rem;
 }
 
-.options-column:last-child{
-  border-right:0;
+#co-basic {
+  opacity: 1.0;
 }
 
 .co-advanced-option{
-  background:rgba(0,0,0,.8);
-  height:11rem;
-  width:100%;
-  border:0;
-  border-top:1px solid #3A3A3A;
-  border-bottom:1px solid #3A3A3A;
+  background: rgba(0,0,0,.8);
+  height: 9.5rem;
+  width: 100%;
+  border: 0;
+  border-top: 1px solid #3A3A3A;
+  border-bottom: 1px solid #3A3A3A;
+  border-right: 1px solid #3A3A3A;
 }
 
-.co-advanced-option:last-child{
-  border-top:0;
+#co-advanced span.grid-cell:last-child .co-advanced-option {
+  border-right: 0px;
 }
 
 #mute > span {
@@ -209,16 +219,6 @@ body.hidden *[data-l10n-id] {
 
 #mute.mute {
   background-color: #bcbcbc;
-}
-
-.icon-contacts {
-  display: inline-block;
-  background-color: #DDD;
-  background: url('images/dialer_icon_contact.png');
-  background-size: 2.2rem 2.4rem;
-  width: 2.2rem;
-  height: 2.4rem;
-  opacity: 0.3;
 }
 
 button[disabled] .icon-keypad {
@@ -245,26 +245,6 @@ button[disabled] .icon-keypad {
 
 #speaker.speak {
   background-color: #bcbcbc;
-}
-
-.icon-timeline{
-  display:inline-block;
-  background-color: #DDD;
-  background:url('images/dialer_icon_history.png');
-  background-size: 2.5rem 2.4rem;
-  width:2.5rem;
-  height:2.4rem;
-  opacity:0.3;
-}
-
-.icon-message{
-  display:inline-block;
-  background-color: #DDD;
-  background:url('images/dialer_icon_message.png');
-  background-size: 2.5rem 2.4rem;
-  width:2.5rem;
-  height:2.4rem;
-  opacity:0.3;
 }
 
 #co-basic{


### PR DESCRIPTION
Hi guys,

Just some minor changes according to the latest version of the UX layouts and visuals designed by the Telefónica UX team:
- Inclusion of the caller contact image as the caller screen background image (for the time being and until the communication with the Contacts app is available, we have included a generic image).
- Deletion of no longer needed buttons from the on call screen (timeline, message and contacts).

Enjoy! ;-)
