### PR TITLE
Fixing the background services

### DIFF
--- a/apps/dialer/style/oncall.css
+++ b/apps/dialer/style/oncall.css
@@ -186,7 +186,6 @@ body.hidden *[data-l10n-id] {
 
 #co-advanced {
   opacity: 0.9;
-  height: 9.5;
   margin-bottom: 4.5rem;
 }
 

--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -74,11 +74,14 @@ var BackgroundServiceManager = (function bsm() {
 
   /* Check if the app has the permission to open a background page */
   var hasBackgroundPermission = function bsm_checkPermssion(app) {
-    if (!app || !app.manifest.permissions ||
-        app.manifest.permissions.indexOf('background') == -1) {
+    if (!app || !app.manifest.permissions)
       return false;
-    }
-    return true;
+
+    var permissions = Object.keys(app.manifest.permissions).map(function map_perm(key) {
+      return app.manifest.permissions[key];
+    });
+
+    return (permissions.indexOf('background') != -1)
   };
 
   /* The open function is responsible of containing the iframe */


### PR DESCRIPTION
Apparently `app.manifest.permissions` is an object, not an array

This fixes #1864
