### PR TITLE
fix first day of the week

### DIFF
--- a/apps/browser/js/date_helper.js
+++ b/apps/browser/js/date_helper.js
@@ -29,8 +29,16 @@ DateHelper = {
   thisWeekStarted: function dh_thisWeekStarted() {
     var now = new Date();
     var dayOfTheWeek = now.getDay();
-    var offset = 1 - dayOfTheWeek;
-    var firstDay = now.valueOf() + offset * 86400000;
+    var firstDay = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      //getDay is zero based so if today
+      //is the start of the week it will not
+      //change the date. Also if we get
+      //into negative days the date object
+      //handles that too...
+      now.getDate() - dayOfTheWeek
+    );
     return this.getMidnight(firstDay);
   },
 

--- a/apps/browser/test/unit/date_helper_test.js
+++ b/apps/browser/test/unit/date_helper_test.js
@@ -34,8 +34,9 @@ suite('Date Helper', function() {
       var now = new Date();
       var weekStartedTimestamp = DateHelper.thisWeekStarted();
       var weekStarted = new Date(weekStartedTimestamp);
+      console.log(now, weekStarted);
       assert.equal(true, weekStartedTimestamp <= now.valueOf());
-      assert.equal(weekStarted.getDay(), 1);
+      assert.equal(weekStarted.getDay(), 0);
       assertMidnight(weekStarted);
     });
 


### PR DESCRIPTION
This fixes a test failure I found while testing out a calendar feature... (by running all the tests)

I think whats going on here ( I have not slept much or maybe I am misunderstanding the intent of this function ) but it seems like there is an assumption that Date#getDay starts at 1 instead of zero so its failing because its Sunday. Ben take a look and let me know what you think.

Also- I should have mentioned this before but date takes negative numbers so it may feel cleaner to use them for your calculations if that makes sense to you. I found it was easier then going from Date -> Numeric -> Date.
