### PR TITLE
Entry points

### DIFF
--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -11,7 +11,7 @@ var ApplicationMock = function(app, launchPath, alternativeOrigin) {
   for (var field in app.manifest) {
     this.manifest[field] = app.manifest[field];
   }
-  
+
   var entryPoint = app.manifest.entry_points[launchPath];
   this.manifest.name = entryPoint.name;
   this.manifest.launch_path = entryPoint.path;
@@ -56,7 +56,7 @@ var Applications = (function() {
             if (!entryPoints[launchPath].hasOwnProperty('icons')) {
               continue;
             }
-            
+
             var alternativeOrigin = app.origin + '/' + launchPath;
 
             var newApp = new ApplicationMock(app,

--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -19,7 +19,7 @@ var ApplicationMock = function(app, launchPath, alternativeOrigin) {
   this.manifest.origin = alternativeOrigin;
 
   this.manifestURL = app.manifestURL;
-  this.receips = app.receips;
+  this.receipts = app.receipts;
   this.installOrigin = app.installOrigin;
   this.installTime = app.installTime;
 

--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -45,29 +45,31 @@ var Applications = (function() {
   installer.getAll().onsuccess = function onSuccess(e) {
     var apps = e.target.result;
     apps.forEach(function parseApp(app) {
-      if (app.manifest.icons) {
-        /*
-        * If the manifest contains entry points, iterate over them
-        * and add a fake app object for each one.
-        */
-        var entryPoints = app.manifest.entry_points;
-        if (entryPoints) {
-          for (var launchPath in entryPoints) {
-            if (!entryPoints[launchPath].hasOwnProperty('icons')) {
-              continue;
-            }
-
-            var alternativeOrigin = app.origin + '/' + launchPath;
-
-            var newApp = new ApplicationMock(app,
-                                  launchPath,
-                                  alternativeOrigin);
-
-            installedApps[alternativeOrigin] = newApp;
+      if (!app.manifest && !app.manifest.icons) {
+        continue;
+      }
+      /*
+      * If the manifest contains entry points, iterate over them
+      * and add a fake app object for each one.
+      */
+      var entryPoints = app.manifest.entry_points;
+      if (entryPoints) {
+        for (var launchPath in entryPoints) {
+          if (!entryPoints[launchPath].hasOwnProperty('icons')) {
+            continue;
           }
-        } else {
-          installedApps[app.origin] = app;
+
+          var alternativeOrigin = app.origin + '/' + launchPath;
+
+          var newApp = new ApplicationMock(app,
+                                launchPath,
+                                alternativeOrigin);
+
+          installedApps[alternativeOrigin] = newApp;
         }
+      } else {
+        //Normal app, no entry points
+        installedApps[app.origin] = app;
       }
     });
 

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -557,16 +557,17 @@ var WindowManager = (function() {
           setDisplayedApp(origin, null, e.detail.url);
           return;
         }
-        
+
         var app = Applications.getByOrigin(origin);
         var name = app.manifest.name;
         //Check if it's a virtual app from a entry point
-        if(app.manifest.entry_points) {
-          for(var ep in app.manifest.entry_points) {
+        var entryPoints = app.manifest.entry_points;
+        if (entryPoints) {
+          for (var ep in entryPoints) {
             var path = e.detail.url.substr(e.detail.origin.length + 1); //Remove the origin and /
-            if(path.indexOf(ep) == 0 && (ep + app.manifest.entry_points[ep].path) == path) {
+            if (path.indexOf(ep) == 0 && (ep + entryPoints[ep].path) == path) {
               origin = origin + '/' + ep;
-              name = app.manifest.entry_points[ep].name;
+              name = entryPoints[ep].name;
             }
           }
         }

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -562,15 +562,11 @@ var WindowManager = (function() {
         var name = app.manifest.name;
         //Check if it's a virtual app from a entry point
         if(app.manifest.entry_points) {
-          console.log('FJJ::: App with entry points');
           for(var ep in app.manifest.entry_points) {
-            console.log('FJJ::: Entry point ' + ep);
             var path = e.detail.url.substr(e.detail.origin.length + 1); //Remove the origin and /
-            console.log('FJJ::: Path ' + path);
             if(path.indexOf(ep) == 0 && (ep + app.manifest.entry_points[ep].path) == path) {
               origin = origin + '/' + ep;
               name = app.manifest.entry_points[ep].name;
-              console.log('------------------------> Changed origin and name');
             }
           }
         }

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -557,13 +557,26 @@ var WindowManager = (function() {
           setDisplayedApp(origin, null, e.detail.url);
           return;
         }
-
+        
         var app = Applications.getByOrigin(origin);
-        if (!app)
-          return;
+        var name = app.manifest.name;
+        //Check if it's a virtual app from a entry point
+        if(app.manifest.entry_points) {
+          console.log('FJJ::: App with entry points');
+          for(var ep in app.manifest.entry_points) {
+            console.log('FJJ::: Entry point ' + ep);
+            var path = e.detail.url.substr(e.detail.origin.length + 1); //Remove the origin and /
+            console.log('FJJ::: Path ' + path);
+            if(path.indexOf(ep) == 0 && (ep + app.manifest.entry_points[ep].path) == path) {
+              origin = origin + '/' + ep;
+              name = app.manifest.entry_points[ep].name;
+              console.log('------------------------> Changed origin and name');
+            }
+          }
+        }
 
         appendFrame(origin, e.detail.url,
-                    app.manifest.name, app.manifest, app.manifestURL, false);
+                    name, app.manifest, app.manifestURL);
         break;
 
       // System Message Handler API is asking us to open the specific URL

--- a/build/offline-cache.js
+++ b/build/offline-cache.js
@@ -223,6 +223,18 @@ appSrcDirs.forEach(function parseDirectory(directoryName) {
           let iconURL = domain + webappManifest.icons[size];
           iconsURL.push(iconURL);
         });
+      } 
+      if (webappManifest.entry_points) {
+        for(var entry_point in webappManifest.entry_points) {
+          let ep = webappManifest.entry_points[entry_point];
+          if(ep.icons) {
+            let sizes = Object.keys(ep.icons);
+            sizes.forEach(function iconIterator(size) {
+              let iconURL = domain + '/' + entry_point + ep.icons[size];
+              iconsURL.push(iconURL);
+            });
+          }
+        }
       }
     }
 

--- a/build/offline-cache.js
+++ b/build/offline-cache.js
@@ -224,9 +224,11 @@ appSrcDirs.forEach(function parseDirectory(directoryName) {
           iconsURL.push(iconURL);
         });
       } 
-      if (webappManifest.entry_points) {
-        for(var entry_point in webappManifest.entry_points) {
-          let ep = webappManifest.entry_points[entry_point];
+      
+      var entryPoints = webappManifest.entry_points;
+      if (entryPoints) {
+        for(var entry_point in entryPoints) {
+          let ep = entryPoints[entry_point];
           if(ep.icons) {
             let sizes = Object.keys(ep.icons);
             sizes.forEach(function iconIterator(size) {


### PR DESCRIPTION
# Multiple entry points PoC

This is a test for trying the support of multiple entry points.
## General Idea

In order not to modify a lot of code from the homescreen, this patch follows the idea of creating a 'virtual' application for each entry point we find in a real manifest.
## Modifications
- appmanager.js: here is were we add the 'virtual' apps.
- window_manager.js: modified to detect if a launch event is comming from an entry point
- offline_cache.js: need to modify the way we cache the icons.
## manifest.webapp

This is the manifest used, also the idea was create an app called 'comms' and inside put the current dialer and contacts app.

```
{
  "name": "Comms",
  "description": "Gaia Comms",
  "launch_path": "/",
  "developer": {
    "name": "The Gaia Team",
    "url": "https://github.com/mozilla-b2g/gaia"
  },
  "entry_points": {
    "dialer": {
      "path": "/index.html",
      "name": "Dialer",
      "icons": {
        "120": "/style/icons/Dialer.png",
        "60": "/style/icons/60/Dialer.png"
      }
    },
    "contacts": {
      "path": "/index.html",
      "name": "Contacts",
      "icons": {
        "120": "/style/icons/Contacts.png",
        "60": "/style/icons/60/Contacts.png"
      }
    }
  },
  "permissions": [
    "telephony",
    "contacts",
    "power",
    "mozApps",
    "mobileconnection",
    "background"
  ],
  "icons": {
    "120": "/style/icons/Dialer.png",
    "60": "/style/icons/60/Dialer.png"
  },
  "background_page": "/dialer/background.html",
  "attention_page": "/dialer/oncall.html",
  "orientation": "portrait-primary"
}
```

== Findings ==
- use of the name of the entry point to compound the url
- used the path within the entry point to build the final url
- right now breaking the background and attention screen :(
- multiple apps in the task launcher, as long as we are using different origins. (faking the origin as well).
- in general a bit confusing with all the path appending
