### PR TITLE
[demo hack] Send a sms from the contacts app

### DIFF
--- a/apps/contacts/index.html
+++ b/apps/contacts/index.html
@@ -22,6 +22,7 @@
     <script defer type="text/javascript" src="js/contacts_list.js"></script>
     <script defer type="text/javascript" src="js/contacts_shortcuts.js"></script>
     <script defer type="text/javascript" src="js/contacts.js"></script>
+    <script defer type="text/javascript" src="js/sms_integration.js"></script>
   </head>
 
   <body class="app-contacts">
@@ -115,7 +116,7 @@
                 <h2>#type#</h2>
                 <div class="item">
                   <div class="item-media pull-right">
-                    <button class="action"><span role="button" class="icon-message">Message</span></button>
+                    <button class="action" onClick="Contacts.sendSms()"><span role="button" class="icon-message">Message</span></button>
                   </div>
                   <div class="item-body-exp">
                     <button class="action">

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -246,6 +246,10 @@ var Contacts = (function() {
     link.appendChild(icon);
     selectedTag = link;
   };
+  
+  var sendSms = function sendSms() {
+    SmsIntegration.sendSms(currentContact.tel[0].number)
+  }
 
 
   var showAdd = function showAdd() {
@@ -406,6 +410,7 @@ var Contacts = (function() {
     'addNewPhone' : insertEmptyPhone,
     'addNewEmail' : insertEmptyEmail,
     'goBack' : navigation.back,
-    'goToSelectTag': goToSelectTag
+    'goToSelectTag': goToSelectTag,
+    'sendSms': sendSms
   };
 })();

--- a/apps/contacts/js/sms_integration.js
+++ b/apps/contacts/js/sms_integration.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var SmsIntegration = (function() {
+  
+  var smsApp;
+  
+  //Walk the apps and look for the sms one
+  navigator.mozApps.mgmt.getAll().onsuccess = function onSuccess(e) {
+    var apps = e.target.result;
+    apps.forEach(function parseApp(app) {
+      if(app.manifest.permissions) {
+        
+        var keys = Object.keys(app.manifest.permissions);
+        var permissions = keys.map(function map_perm(key) {
+          return app.manifest.permissions[key];
+        });
+        
+        if(permissions.indexOf('sms') != -1) {
+          smsApp = app;
+          return;
+        }
+      }
+    });
+  };
+  
+  return {
+    sendSms: function(phoneNumber) {
+      smsApp.launch('#' + phoneNumber);
+    }
+  };
+  
+})();

--- a/apps/contacts/js/sms_integration.js
+++ b/apps/contacts/js/sms_integration.js
@@ -25,7 +25,7 @@ var SmsIntegration = (function() {
   
   return {
     sendSms: function(phoneNumber) {
-      smsApp.launch('#' + phoneNumber);
+      smsApp.launch('#num=' + phoneNumber);
     }
   };
   

--- a/apps/contacts/manifest.webapp
+++ b/apps/contacts/manifest.webapp
@@ -6,7 +6,8 @@
     "url": "http://openwebdevice.com"
   },
   "permissions": [
-    "contacts"
+    "contacts",
+    "mozApps"
   ],
   "locales": {
     "en-US": {

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -286,7 +286,7 @@ var WindowManager = (function() {
   }
 
   // Switch to a different app
-  function setDisplayedApp(origin, callback) {
+  function setDisplayedApp(origin, callback, url) {
     var currentApp = displayedApp, newApp = origin;
 
     // There are four cases that we handle in different ways:
@@ -314,6 +314,12 @@ var WindowManager = (function() {
     }
     // Case 4: app-to-app transition
     else {
+      // XXX Note: Hack for demo when current app want to set specific hash
+      //           url in newApp(e.g. contact trigger SMS message list page).
+      var frame= runningApps[newApp].frame;
+      if (url && frame.src != url) {
+        frame.src = url;
+      }      
       setAppSize(newApp);
       updateLaunchTime(newApp);
       openWindow(newApp, function() {
@@ -542,7 +548,7 @@ var WindowManager = (function() {
       // We will launch it in foreground
       case 'webapps-launch':
         if (isRunning(origin)) {
-          setDisplayedApp(origin);
+          setDisplayedApp(origin, null, e.detail.url);
           return;
         }
 


### PR DESCRIPTION
We did a hack to launch the sms app from the contacts app and the correct number to send a sms (actually show the conversation thread).

This requires mozApps permissions to launch the sms apps (<--- hack).
Also, the modification in the system is for updating the location of an application (frame) that is already open. This is a bit hacky as well but could be useful.
