### PR TITLE
make install-gaia requires real reboot or indexedDB is broken on otoro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ install-gaia: profile
 	$(ADB) push profile/user.js ${PROFILE_PATH}/user.js
 
 	@echo "Installed gaia into profile/."
-	$(ADB) shell kill $(shell $(ADB) shell toolbox ps | grep "b2g" | awk '{ print $$2; }')
+	$(ADB) reboot
 	@echo 'Rebooting b2g now'
 
 # Copy demo media to the sdcard.


### PR DESCRIPTION
On my otoro device, doing make install-gaia breaks the gallery app with IndexedDB errors in the console. Rebooting the device makes the problem go away.  With adb logcat I can also observe IndexedDB errors occurring in the homescreen app and the browser app.

The install-gaia target does not reboot the device; instead it just kills the b2g process, which is automatically restarted by the system.  This has always seemed to work. I hypothesize that there is now some other process involved in managing the databases, and that process would need to be killed and restarted too.

Its easier, though to just reboot. So this pull request alters the Makefile to do an ordinary adb reboot as part of the make install-gaia process.
