### PR TITLE
Do not wipe the indexeddb databases on each `make install-gaia`

### DIFF
--- a/build/install-gaia.py
+++ b/build/install-gaia.py
@@ -128,7 +128,9 @@ def install_gaia_fast():
 
 def install_gaia_slow():
     global adb_cmd
-    adb_shell("rm -r /data/local/*")
+    adb_shell("rm -r /data/local/OfflineCache")
+    adb_shell("rm -r /data/local/webapps")
+    adb_shell("rm /data/local/user.js")
     adb_push('profile/OfflineCache', '/data/local/OfflineCache')
     adb_push('profile/webapps', '/data/local/webapps')
     adb_push('profile/user.js', '/data/local')


### PR DESCRIPTION
Concerning only "slow" devices.
