### PR TITLE
Adapting the contact primary info font-size to the available space

### DIFF
--- a/apps/dialer/index.html
+++ b/apps/dialer/index.html
@@ -158,7 +158,7 @@
             <span role="button" id="keypad-callbar-add-contact" data-type="action" data-value="add-contact" >
               <div class="icon-add-contact"></div>
             </span>
-            <span role="button" id="keypad-callbar-call-action" Fdata-type="action" data-value="make-call">
+            <span role="button" id="keypad-callbar-call-action" data-type="action" data-value="make-call">
               <div>
               </div>
             </span>

--- a/apps/dialer/index.html
+++ b/apps/dialer/index.html
@@ -158,7 +158,7 @@
             <span role="button" id="keypad-callbar-add-contact" data-type="action" data-value="add-contact" >
               <div class="icon-add-contact"></div>
             </span>
-            <span role="button" id="keypad-callbar-call-action" data-type="action" data-value="make-call">
+            <span role="button" id="keypad-callbar-call-action" Fdata-type="action" data-value="make-call">
               <div>
               </div>
             </span>

--- a/apps/dialer/js/keypad.js
+++ b/apps/dialer/js/keypad.js
@@ -268,9 +268,9 @@ var KeypadManager = {
           if (!ocMaxNumberOfDigits) {
             ocMaxNumberOfDigits = view.value.length;
           }
-          if (phoneNumber.length >= ocMaxNumberOfDigits) {
+          if (phoneNumber.length >= (ocMaxNumberOfDigits + 3)) {
             phoneNumber = '...' + phoneNumber
-              .substr(-(ocMaxNumberOfDigits - 2));
+              .substr(-(ocMaxNumberOfDigits + 3 - 2));
           }
         break;
       }

--- a/apps/dialer/js/keypad.js
+++ b/apps/dialer/js/keypad.js
@@ -219,7 +219,7 @@ var KeypadManager = {
       // If there are no digits in the phone number, hide the delete
       // button.
       if ((this._phoneNumber.length == 0) &&
-          (typeof CallScreen == 'undefined')) {
+        (typeof CallScreen == 'undefined')) {
         this.deleteButton.classList.remove('show');
       }
       this.phoneNumberView.value = this._phoneNumber;
@@ -366,7 +366,7 @@ var KeypadManager = {
 
         // If there are digits in the phone number, show the delete button.
         if ((this._phoneNumber.length > 0) &&
-            (typeof CallScreen == 'undefined')) {
+          (typeof CallScreen == 'undefined')) {
           this.deleteButton.classList.add('show');
         }
 

--- a/apps/dialer/js/oncall.js
+++ b/apps/dialer/js/oncall.js
@@ -88,7 +88,8 @@ var CallScreen = {
   },
 
   update: function cm_update(phone_number) {
-    this.contactPrimaryInfo.value = phone_number;
+    this.contactPrimaryInfo.value = KeypadManager.formatPhoneNumber(
+      'on-call', this.contactPrimaryInfo, phone_number);
     KeypadManager._phoneNumber = phone_number;
     KeypadManager.phoneNumberView.value =
       KeypadManager._phoneNumber;

--- a/apps/dialer/oncall.html
+++ b/apps/dialer/oncall.html
@@ -26,8 +26,8 @@
       <header id="cs-header" class="grid-row">
         <div class="grid-wrapper grid">
           <article id="contact-info" class="grid-cell grid-v-align">
-            <section>
-              <input id="contact-primary-info" type="text" readonly="readonly" class="contact-primary-info font-light contact-info">
+            <section class="contact-info-wrapper">
+              <input id="contact-primary-info" type="text" readonly="readonly" class="contact-primary-info font-light">
               <div id="fake-contact-primary-info"></div>
             </section>
             <section id="contact-secondary-info" class="contact-secondary-info font-light contact-info">

--- a/apps/dialer/style/oncall.css
+++ b/apps/dialer/style/oncall.css
@@ -35,6 +35,10 @@ html * {
   -moz-user-select: none;
 }
 
+.contact-info-wrapper {
+  padding: 0rem 2rem 0rem 2rem;
+}
+
 .contact-primary-info {
   font-size:-moz-calc(15*0.226rem);
   color:black;
@@ -171,7 +175,7 @@ body.hidden *[data-l10n-id] {
   overflow: hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
-  padding: 0 0 0 2rem;
+  padding: 0 2rem 0 2rem;
 }
 
 #call-duration {


### PR DESCRIPTION
This pull request includes minor changes concerning to the adaptation of the contact primary information (this is, the phone number or contact name which is shown on a blue background during a call) to the space available in case the user uses the on call keypad to send additional tones.
