### PR TITLE
Feature replacements by input type

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -315,7 +315,11 @@ const IMEController = (function() {
     IMERender.draw(
       _currentLayout,
       _onScroll,
-      {uppercase: uppercase} // 3- Setup rendering flags
+      // 3- Setup rendering flags
+      {
+        uppercase: uppercase,
+        inputType: _currentInputType
+      }
     );
 
     // 5- If needed, empty the candidate panel

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -116,7 +116,10 @@ const Keyboards = {
         { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
         { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
       ]
-    ]
+    ],
+    urlOverrides: {
+      "'": ':'
+    }
   },
   fr: {
     type: 'keyboard',
@@ -778,6 +781,9 @@ const Keyboards = {
         { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
       ]
     ],
+    urlOverrides: {
+      'ñ': ':'
+    },
     alternateLayout: {
       alt: {
         '€': '$ £ ¥ R$',
@@ -869,6 +875,9 @@ const Keyboards = {
         { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
       ]
     ],
+    urlOverrides: {
+      'ç': ':'
+    },
     alternateLayout: {
       alt: {
         'R$': '€$£¥',

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -64,28 +64,20 @@ const IMERender = (function() {
       content += '<div class="keyboard-row">';
       row.forEach((function buildKeyboardColumns(key, ncolumn) {
 
-        // Get key value
-        var debug;
-        var keyChar = debug = key.value;
+        var keyChar = key.value;
+        var overrides = layout[flags.inputType+'Overrides'];
 
-        // Depending on input type, consider alternatives for that key
-        var overrides = layout[inputType + 'Overrides'];
-        if (overrides && overrides[keyChar]) {
-          keyChar = overrides[keyChar];
-          var virtualKey = {};
-          for (var property in key) {
-            virtualKey[property] = key[property];
-          }
-          virtualKey.value = keyChar;
-          virtualKey.keyCode = keyChar.charCodeAt(0);
-          key = virtualKey;
-        }
-
-        // Take in count uppercase
-        var code;
+        // Handle uppercase
         if (flags.uppercase) {
           keyChar = getUpperCaseValue(key);
+        }
+
+        // Handle override
+        var code;
+        if (overrides && overrides[keyChar]) {
+          keyChar = overrides[keyChar];
           code = keyChar.charCodeAt(0);
+
         } else {
           code = key.keyCode || keyChar.charCodeAt(0);
         }

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -65,7 +65,7 @@ const IMERender = (function() {
       row.forEach((function buildKeyboardColumns(key, ncolumn) {
 
         var keyChar = key.value;
-        var overrides = layout[flags.inputType+'Overrides'];
+        var overrides = layout[flags.inputType + 'Overrides'];
 
         // Handle uppercase
         if (flags.uppercase) {

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -57,17 +57,39 @@ const IMERender = (function() {
     var layoutWidth = layout.width || 10;
     var totalWidth = document.getElementById('keyboard').clientWidth;
     var placeHolderWidth = totalWidth / layoutWidth;
+    var inputType = flags.inputType || 'text';
 
     layout.upperCase = layout.upperCase || {};
     layout.keys.forEach((function buildKeyboardRow(row, nrow) {
       content += '<div class="keyboard-row">';
       row.forEach((function buildKeyboardColumns(key, ncolumn) {
 
-        var keyChar = key.value;
-        if (flags.uppercase)
-          keyChar = getUpperCaseValue(key);
+        // Get key value
+        var debug;
+        var keyChar = debug = key.value;
 
-        var code = key.keyCode || keyChar.charCodeAt(0);
+        // Depending on input type, consider alternatives for that key
+        var overrides = layout[inputType + 'Overrides'];
+        if (overrides && overrides[keyChar]) {
+          keyChar = overrides[keyChar];
+          var virtualKey = {};
+          for (var property in key) {
+            virtualKey[property] = key[property];
+          }
+          virtualKey.value = keyChar;
+          virtualKey.keyCode = keyChar.charCodeAt(0);
+          key = virtualKey;
+        }
+
+        // Take in count uppercase
+        var code;
+        if (flags.uppercase) {
+          keyChar = getUpperCaseValue(key);
+          code = keyChar.charCodeAt(0);
+        } else {
+          code = key.keyCode || keyChar.charCodeAt(0);
+        }
+
         var className = isSpecialKey(key) ? 'special-key' : '';
         var ratio = key.ratio || 1;
 


### PR DESCRIPTION
## Overview

Supose you need to type an URL, some characters of the basic layout (text) should be not valid for URL so we should be able to replace these useless characters by more useful characters like : @ ~ ...
## Layout specification

Inside the layout specification you can add a field named <tt>&lt;inputType&gt;Overrides</tt> with an object with pairs <tt>'&lt;originalCharacter&gt;': '&lt;replacement&gt;'</tt>. I.e, for URL (extracted from **en** layout):

``` javascript
urlOverrides: {
  "'": ':'
}
```
## Flaws and future work
- Should be specified if we can handle compositeKey, uppercase and alternatives for the replacements.
