### PR TITLE
Permission dialog - Sync the permission dialog layout to homescreen confirm dialog for demo.

### DIFF
--- a/apps/system/js/permission_manager.js
+++ b/apps/system/js/permission_manager.js
@@ -61,7 +61,7 @@
         screen.appendChild(dialog);
 
         message = document.createElement('div');
-        message.id = 'permissions-message';
+        message.id = 'permission-message';
         dialog.appendChild(message);
 
         yes = document.createElement('button');

--- a/apps/system/style/permission_manager/permission_manager.css
+++ b/apps/system/style/permission_manager/permission_manager.css
@@ -19,24 +19,40 @@
 
 #permission-dialog {
   position: absolute;
-  top: 20%;
-  left: 50%;
-  width: 320px;
-  height: 300px;
-  margin: 0 0 0 -160px;
-  color: #778;
-  background: -moz-linear-gradient(center top , rgb(244, 244, 244), rgb(234, 234, 234)) repeat scroll 0% 0% white;
-  border-radius: 8px;
-  border: 1px solid hsla(0,0%,0%,0);
-  font-size: 20px;
+  top: 35%; /* 10% is the dock */
+  width: 100%;
+  background-color: rgba(0,0,0,0.9);
+  border-top: 1px solid rgba(256,256,256,0.9);
+  -moz-box-sizing: border-box;
+  padding: 6px 9px;
+  box-shadow:0 6px 12px #000;
 }
 
 #permission-message {
-  margin: 20px;
+  font-size: 20px;
+  color: #fff;
+  margin: 0 0 9px 0;
+  padding: 0;
 }
 
 #permission-dialog button {
-  margin: 30px;
-  padding: 20px;
+  font-size: 20px;
+  font-weight: bold;
+  width: -moz-calc(50% - 4px);
+  height: 40px;
+  border-radius: 4px;
+  color: #000;
+  border: 0;
+  text-align: left;
+  margin: 0;
+  padding: 0 0 0 8px;
 }
 
+#permission-yes {
+  background-color: #51b2c7;
+  float: right;
+}
+
+#permission-no {
+  background-color: #fff;
+}


### PR DESCRIPTION
Temp version for demo and 2 known issue:
1. The style is for otoro(HVGA) only and it could not suit the other resolution like homescreen confirm dialog. It could not apply rem for size since the (system) body font-size wont adjust depends on resolution.
2. It should dismiss the dialog instead of back to homescreen when click the back key.
