### PR TITLE
fix splash screen position and broken media queries for games

### DIFF
--- a/apps/penguinpop/style/penguinpop.css
+++ b/apps/penguinpop/style/penguinpop.css
@@ -4,8 +4,8 @@ body {
 
 #splash {
     position: fixed;
-    top: 220px;
-    left: 103px;
+    top: -moz-calc((100% - 360px)/2);
+    left: -moz-calc((100% - 273px)/2);
     -moz-transition: opacity .5s;
 }
 
@@ -20,20 +20,11 @@ body {
     -moz-transition: opacity .5s;
 }
 
-@media (min-width: 480px) and (min-height:720px) {
+@media (min-width: 480px) and (min-height: 720px) {
     #gameframe {
         /* The game was written at 320x480 */
         /* But we want to display it at 480x720 */
         -moz-transform-origin: 0px 0px;
         -moz-transform: scale(1.5);
-    }
-}
-
-@media (width 320px) and (height 480px) {
-    /* These styles are for screens where we don't scale the game */
-    /* In that case, we've got to position the splash icon differently */
-    #splash {
-        top: 60px;
-        left: 23px;
     }
 }

--- a/apps/towerjelly/style/towerjelly.css
+++ b/apps/towerjelly/style/towerjelly.css
@@ -4,8 +4,8 @@ body {
 
 #splash {
     position: fixed;
-    top: 275px;
-    left: 115px;
+    top: -moz-calc((100% - 250px)/2);
+    left: -moz-calc((100% - 250px)/2);
     -moz-transition: opacity .5s;
 }
 
@@ -20,19 +20,11 @@ body {
     -moz-transition: opacity .5s;
 }
 
-@media (min-width: 480px) and (min-height:720px) {
+@media (min-width: 480px) and (min-height: 720px) {
     #gameframe {
         /* The game was written at 320x480 */
         /* But we want to display it at 480x720 */
         -moz-transform-origin: 0px 0px;
         -moz-transform: scale(1.5);
-    }
-}
-
-@media (width 320px) and (height 480px) {
-    /* For a small screen, we want to position the splash icon differently */
-    #splash {
-        top: 115px;
-        left: 35px;
     }
 }


### PR DESCRIPTION
Fixes the splash screen position for TowerJelly and PenguinPop.

Note that these games are not working reliably for me on b2g desktop (I suspect they do user agent sniffing) but they seem to work on otoro.
