### PR TITLE
Fix: to remove the weired 1px gap upon the keyboard

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -70,7 +70,7 @@ button::-moz-focus-inner {
 .keyboard-key {
   -moz-box-sizing: border-box;
   box-sizing: boder-box;
-  padding: 0.25rem 0.2rem 0.15rem;
+  padding: 0.2rem 0.2rem;
   border: none;
   background: none;
   min-width: 2.6rem;


### PR DESCRIPTION
Should be able to fix #1957
- Modify the key up/bottom padding
