### PR TITLE
Fixing permission handling during build process.

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -134,7 +134,7 @@ domains.push(GAIA_DOMAIN);
     if (perms) {
       for each(let name in perms) {
         if (!permissions[name])
-          return;
+          continue;
 
         permissions[name].urls.push(rootURL);
 


### PR DESCRIPTION
After the 'background' permission any other permission was ignored.
