### PR TITLE
Don't set .src on iframes created by window.open. (#2249)

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -42,10 +42,6 @@ var AttentionScreen = {
     this.attentionScreen.appendChild(attentionFrame);
     this.attentionScreen.classList.add('displayed');
 
-    // XXX: before probing ScreenManager.screenEnabled,
-    // sync it's value with mozPower
-    ScreenManager._syncScreenEnabledValue();
-
     // We want the user attention, so we need to turn the screen on
     // if it's off.
     this._screenInitiallyDisabled = !ScreenManager.screenEnabled;

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -35,17 +35,16 @@ var AttentionScreen = {
     evt.stopPropagation();
 
     var attentionFrame = evt.detail.frameElement;
-    attentionFrame.setAttribute('mozapp', evt.target.getAttribute('mozapp'));
     attentionFrame.dataset.frameType = 'attention';
     attentionFrame.dataset.frameName = evt.detail.name;
     attentionFrame.dataset.frameOrigin = evt.target.dataset.frameOrigin;
 
-    // FIXME: won't be needed once
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=769182 is fixed
-    attentionFrame.src = evt.detail.url;
-
     this.attentionScreen.appendChild(attentionFrame);
     this.attentionScreen.classList.add('displayed');
+
+    // XXX: before probing ScreenManager.screenEnabled,
+    // sync it's value with mozPower
+    ScreenManager._syncScreenEnabledValue();
 
     // We want the user attention, so we need to turn the screen on
     // if it's off.

--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -99,11 +99,14 @@ var BackgroundServiceManager = (function bsm() {
 
     if (!frame) {
       frame = document.createElement('iframe');
+
+      // If we have a frame element, it's provided by mozbrowseropenwindow, and
+      // it has the mozbrowser, mozapp, and src attributes set already.
+      frame.setAttribute('mozbrowser', 'true');
+      frame.setAttribute('mozapp', app.manifestURL);
+      frame.src = url;
     }
     frame.className = 'backgroundWindow';
-    frame.setAttribute('mozbrowser', 'true');
-    frame.setAttribute('mozapp', app.manifestURL);
-    frame.src = url;
     frame.dataset.frameType = 'background';
     frame.dataset.frameName = name;
     frame.dataset.frameOrigin = origin;

--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -102,7 +102,7 @@ var BackgroundServiceManager = (function bsm() {
 
       // If we have a frame element, it's provided by mozbrowseropenwindow, and
       // it has the mozbrowser, mozapp, and src attributes set already.
-      frame.setAttribute('mozbrowser', 'true');
+      frame.setAttribute('mozbrowser', 'mozbrowser');
       frame.setAttribute('mozapp', app.manifestURL);
       frame.src = url;
     }

--- a/apps/system/js/popup_manager.js
+++ b/apps/system/js/popup_manager.js
@@ -27,10 +27,6 @@ var PopupManager = {
     popup.dataset.frameName = evt.detail.name;
     popup.dataset.frameOrigin = evt.target.dataset.frameOrigin;
 
-    // FIXME: won't be needed once
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=769182 is fixed
-    popup.src = evt.detail.url;
-
     this.container.appendChild(popup);
     this.screen.classList.add('popup');
   },


### PR DESCRIPTION
This needs https://bugzilla.mozilla.org/show_bug.cgi?id=769182 to land first.

I tested this by going through the Gaia window.open tests.
