### PR TITLE
Scroll bar width calculation from Javascript

### DIFF
--- a/test_apps/uitest/tests/scrollbar.html
+++ b/test_apps/uitest/tests/scrollbar.html
@@ -22,10 +22,19 @@
       background-color: #fff;
     }
     </style>
+    <script>
+    window.onload = function () {
+      var p = document.getElementById('probe');
+      document.getElementById('report').textContent =
+        'Scroll bar width calculated from Javascript: ' +
+        (p.offsetWidth - p.scrollWidth - 2) + 'px' // 2 = border width * 2
+    };
+    </script>
   </head>
   <body>
     <p>Each box is 200px width/height, small boxes are 20px.</p>
-    <div class="box">
+    <p id="report"></p>
+    <div class="box" id="probe">
       <div class="sbox"></div>
       <div class="sbox"></div>
       <div class="sbox"></div>


### PR DESCRIPTION
It will report 0px due to `margin: -8px` in chrome css \o/
