### PR TITLE
Enabling scroll inside alternatives

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -512,20 +512,21 @@ const IMEController = (function() {
     if (!_isShowingAlternativesMenu)
       return;
 
-    function _actualHideAlternatives() {
+    function actualHideAlternatives() {
       IMERender.hideAlternativesCharMenu();
       _isShowingAlternativesMenu = false;
     }
 
-    if (addDelay) {
-      clearTimeout(_hideMenuTimeout);
-      _hideMenuTimeout = window.setTimeout(
-        _actualHideAlternatives,
-        _kHideAlternativesCharMenuTimeout
-      );
-    } else {
-      _actualHideAlternatives();
+    if (!addDelay) {
+      actualHideAlternatives();
+      return;
     }
+
+    clearTimeout(_hideMenuTimeout);
+    _hideMenuTimeout = window.setTimeout(
+      actualHideAlternatives,
+      _kHideAlternativesCharMenuTimeout
+    );
   }
 
   // Test if an HTML node is a normal key

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -113,8 +113,7 @@ const IMERender = (function() {
     if (layout.needsCandidatePanel) {
       this.ime.insertBefore(
         candidatePanelToggleButtonCode(), this.ime.firstChild);
-      this.ime.insertBefore(
-        candidatePanelCode(), this.ime.firstChild);
+      this.ime.insertBefore(candidatePanelCode(), this.ime.firstChild);
       this.ime.insertBefore(pendingSymbolPanelCode(), this.ime.firstChild);
       showPendingSymbols('');
       showCandidates([], true);
@@ -231,15 +230,14 @@ const IMERender = (function() {
   // Show keyboard alternatives
   var showKeyboardAlternatives = function(key, keyboards, current, switchCode) {
     var dataset, className, content = '';
-    var alreadyAdded = {};
     var menu = this.menu;
 
     var cssWidth = key.style.width;
     menu.classList.add('kbr-menu-lang');
     key.classList.add('kbr-menu-on');
 
+    var alreadyAdded = {};
     for (var i = 0, kbr; kbr = keyboards[i]; i += 1) {
-      // Ignore if already added
       if (alreadyAdded[kbr])
         continue;
 

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -44,7 +44,13 @@ button::-moz-focus-inner {
   border: 0
 }
 
-.cache { position: absolute; left: 0; bottom: 0; z-index: 5; }
+.cache {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  z-index: -1000;
+}
+
 /* Keyboard */
 #keyboard {
   position: absolute;
@@ -323,9 +329,12 @@ margin-top: 0.3rem;
   top: auto;
   margin-bottom: -2px;
   height: auto;
-  overflow: hidden;
+  max-height: 35rem;
+  overflow-x: hidden;
+  overflow-y: auto;
   white-space: normal;
   padding: 0 0.5rem;
+  padding-right: 1rem;
   background: #fff;
 }
 
@@ -335,7 +344,7 @@ margin-top: 0.3rem;
 }
 #keyboard-accent-char-menu.kbr-menu-lang > .keyboard-key > .visual-wrapper {
   -moz-box-sizing: border-box;
-  width: 10rem;
+  width: 15rem;
 }
 
 #keyboard-accent-char-menu.kbr-menu-lang > .keyboard-key > .visual-wrapper > span { 


### PR DESCRIPTION
## Overview

This introduces a delay just before hiding alternative menus that allow the user to scroll over alternatives.

This add some improvements to language switcher:
- Highlight the current language
- Avoid duplicating languages from more than one language group
## Flaws and future work

This functionality could provide support for arbitrary long sets of alternatives but CSS should be modified in order to limit the width of the alternative menu and setting overflow-x to auto.
