### PR TITLE
sms: Fixing delete all in thread view

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -548,13 +548,14 @@ var ConversationListView = {
 
   executeMessageDelete: function cl_executeMessageDelete() {
     var delList = this.view.querySelectorAll('input[type=checkbox][data-num]');
-    var delNumList = [];
+    var delNum = [];
     for (var elem in delList) {
       if (delList[elem].checked) {
-        delNumList.push(delList[elem].dataset.num);
+        delNum.push(delList[elem].dataset.num);
       }
     }
-    this.deleteMessages(delNumList);
+    this.deleteMessages(delNum);
+    this.delNumList = [];
   },
 
   executeAllMessagesDelete: function cl_executeAllMessagesDelete() {


### PR DESCRIPTION
Right now in the thread view the delete all button works, but stores the old conversations in an array, making new incoming messages not appear cause a ghost conversation is still in memory.
