### PR TITLE
Some fixes to poster handling in the video app for mp4 videos

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -113,6 +113,8 @@ window.addEventListener('DOMContentLoaded', function() {
             console.error('Failed to create a poster image:', e);
           }
 
+          testplayer.src = '';
+          testplayer = null;
           addVideo(videodata);
         }
 
@@ -137,11 +139,13 @@ window.addEventListener('DOMContentLoaded', function() {
     var index = videos.length;
     videos.push(videodata);
 
-    var poster = document.createElement('img');
-    poster.src = URL.createObjectURL(videodata.poster);
-    poster.onload = function() {
-      URL.revokeObjectURL(poster.src);
-    };
+    if (videodata.poster) {
+      var poster = document.createElement('img');
+      poster.src = URL.createObjectURL(videodata.poster);
+      poster.onload = function() {
+        URL.revokeObjectURL(poster.src);
+      };
+    }
 
     var title = document.createElement('p');
     title.className = 'name';
@@ -158,7 +162,9 @@ window.addEventListener('DOMContentLoaded', function() {
     }
 
     var thumbnail = document.createElement('li');
-    thumbnail.appendChild(poster);
+    if (poster) {
+      thumbnail.appendChild(poster);
+    }
     thumbnail.appendChild(title);
     thumbnail.appendChild(duration);
     thumbnail.addEventListener('click', function(e) {


### PR DESCRIPTION
Two fixes contained here:
- Handle failure when loading posters
- Workaround to allow hardware decoding of video playback due to codec issues

On otoro devices with hardware decoding working, and similar hardware, if an mp4 video is present in the media directory the poster loading gives an error. This results in the video not appearing in the list. This patch handles the case of the poster being invalid.

The otoro driver for the h264 hardware decoder can only be instantiated once. When it is instantiated a second time it falls back to the software decoder. In the current video app the first instantiation occurs when getting the poster image. This results in actual playback of the video to always use the software decoder.

This patch clears out the testplayer's 'src' attribute so that the decoder is unloaded. This allows it to be re-instantiated when actual playback is selected so the hardware decoder can be used.
