### PR TITLE
[F] quick setting issue

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -87,16 +87,23 @@ var UtilityTray = {
         break;
 
       case 'transitionend':
-        if (!this.shown)
-        {
+        if (!this.shown) {
           this.screen.classList.remove('utility-tray');
-          this.firstShown.style.MozTransition = '';
+
+          var overlayStyle = this.overlay;
+          var firstShownStyle = this.firstShowStyle;
+          firstShownStyle.MozTransition = '';
+
           if (this.phase2hide) {
-            this.firstShown.style.MozTransition = '-moz-transform 0.2s linear';
-            this.firstShown.style.MozTransform =
+            firstShownStyle.MozTransition = '-moz-transform 0.2s linear';
+            firstShownStyle.MozTransform =
               'translateY(' + this.firstShownPosition + 'px)';
-            this.overlay.style.MozTransition = '-moz-transform 0.2s linear';
-            this.overlay.style.MozTransform = 'translateY(0)';
+            overlayStyle.MozTransition = '-moz-transform 0.2s linear';
+            overlayStyle.MozTransform = 'translateY(0)';
+
+            // Check the transition event is triggered at firstShown.
+            // If so, turn off the flag which represent for
+            // 'The overlay has already reached the bottom of quick-setting'
             if (evt.target == this.firstShown)
               this.phase2hide = false;
           } else {
@@ -128,7 +135,7 @@ var UtilityTray = {
     if (dy > gripBarHeight) {
       var firstShownHeight = this.firstShown.getBoundingClientRect().height;
       if (!this.targetOf2PhaseHide) {
-        this.targetOf2PhaseHide = gripBarHeight + firstShownHeight;
+        this.totalShownHeight = gripBarHeight + firstShownHeight;
       }
 
       if (dy < firstShownHeight + gripBarHeight) {

--- a/apps/system/style/utility_tray/utility_tray.css
+++ b/apps/system/style/utility_tray/utility_tray.css
@@ -25,5 +25,5 @@
 }
 
 #utility-tray-first-shown {
-    z-index: 9997;
+  z-index: 9997;
 }


### PR DESCRIPTION
- Fix #2138
  - The root case is, when orientation changes, `mozTransform` of `quick-setting` is still `translateY(SCREENHEIGHT)`. Hence the screen height is shorten by the orientationchange, the position of quick-setting is incorrect. (over the margin of utility-tray)
- Modify the behavior when the utility-tray is hidden from the screen bottom.
  - @colinfrei did good job at keep `quick-setting` in consistent position when the `utility-tray` is pulled down, by using `mozTransition` on both of them. I enhance the behavior when `utility-tray` is pulled up from the bottom, by introducing 2 hide phase here.
