### PR TITLE
[3G] display a clickable list of compatible <apn>'s

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -254,6 +254,12 @@
         <input type="button" id="autoAPN"
           data-l10n-id="autoConfigure" value="Auto-Configure" />
       </p>
+      <p id="autoAPN-list">
+        <!-- list of compatible <apn> elements
+          <input type="button" value="Orange" />
+          <input type="button" value="Telefonica" />
+        -->
+      </p>
     </form>
 
     <!-- Connectivity :: 3G/data :: MMS Settings Dialog -->

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -1,5 +1,5 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
- /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 'use strict';
 

--- a/apps/settings/style/dialogs.css
+++ b/apps/settings/style/dialogs.css
@@ -172,3 +172,18 @@ form[role=dialog] label input {
   border: none;
 }
 
+#autoAPN-list input[type=button] {
+  display: block;
+  height: 1.4em;
+  margin: 5px;
+  border: none;
+  font-size: 1em;
+  text-decoration: underline;
+  color: navy;
+  background-color: transparent;
+}
+
+#autoAPN-list input[type=button]:active {
+  color: brown;
+}
+

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -57,3 +57,4 @@ html, body {
 *[dir=rtl] a[dir=ltr] {
   text-align: right;
 }
+


### PR DESCRIPTION
For quite a few cases, the same combination of MCC/MNC values returns several `<apn>` elements, each APN element being a different set of data settings.

This patch still auto-selects the first APN set that matches the data carrier’s MCC/MNC settings but displays a clickable list of all compatible APN’s.
