### PR TITLE
[Dialer] * and # not responding properly on clicking

### DIFF
--- a/apps/dialer/style/keypad.css
+++ b/apps/dialer/style/keypad.css
@@ -122,6 +122,7 @@
   background-size: 3rem 3rem;
   background-position: center;
   margin: auto;
+  pointer-events: none;
 }
 
 .sharp {
@@ -132,6 +133,7 @@
   background-size: 3rem 3rem;
   background-position: center;
   margin: auto;
+  pointer-events: none;
 }
 
 #keypad-callbar {


### PR DESCRIPTION
As a consequence of including these keys as icons, we had to include "pointer-events: none" in their styles for a proper processing of the key clicking events.
