### PR TITLE
Entry points

### DIFF
--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -13,7 +13,7 @@ var ApplicationMock = function(app, launchPath, alternativeOrigin) {
 
   var entryPoint = app.manifest.entry_points[launchPath];
   this.manifest.name = entryPoint.name;
-  this.manifest.launch_path = entryPoint.path;
+  this.manifest.launch_path = entryPoint.launch_path;
   this.manifest.icons = entryPoint.icons;
   this.manifest.origin = alternativeOrigin;
 

--- a/apps/system/js/windows/window_manager.js
+++ b/apps/system/js/windows/window_manager.js
@@ -496,7 +496,8 @@ var WindowManager = (function() {
       for (var ep in entryPoints) {
         //Remove the origin and / to find if if the url is the entry point
         var path = e.detail.url.substr(e.detail.origin.length + 1);
-        if (path.indexOf(ep) == 0 && (ep + entryPoints[ep].path) == path) {
+        if (path.indexOf(ep) == 0 &&
+            (ep + entryPoints[ep].launch_path) == path) {
           origin = origin + '/' + ep;
           name = entryPoints[ep].name;
         }


### PR DESCRIPTION
Following the same syntax that normal apps, the field 'path' in a
entry point should be 'launch_path'.
