### PR TITLE
Remove extra sorting in SMS conversation view.

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -286,12 +286,6 @@ var ConversationListView = {
       It should be timestamp in normal view, and order by name while searching
     */
     MessageManager.getMessages(function getMessagesCallback(messages) {
-      /** Once https://bugzilla.mozilla.org/show_bug.cgi?id=769347
-      lands, this fix should be removed.*/
-      messages.sort(function(a, b) {
-        return b.timestamp - a.timestamp;
-      });
-
       var conversations = {};
       for (var i = 0; i < messages.length; i++) {
         var message = messages[i];


### PR DESCRIPTION
Gecko [bug 769347](https://bugzilla.mozilla.org/show_bug.cgi?id=769347) had been landed. We can now remove additional sorting in Gaia.
