### PR TITLE
GAIA_APP_SRCDIRS now works with external app directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ REPORTER=Spec
 
 GAIA_APP_SRCDIRS?=apps test_apps showcase_apps
 
+ifneq ($(GAIA_OUTOFTREE_APP_SRCDIRS),)
+  $(shell mkdir -p outoftree_apps \
+    $(foreach dir,$(GAIA_OUTOFTREE_APP_SRCDIRS),\
+      $(foreach appdir,$(wildcard $(dir)/*),\
+        && ln -sf $(appdir) outoftree_apps/)))
+  GAIA_APP_SRCDIRS += outoftree_apps
+endif
+
 GAIA_ALL_APP_SRCDIRS=$(GAIA_APP_SRCDIRS)
 
 GAIA_APP_RELATIVEPATH=$(foreach dir, $(GAIA_APP_SRCDIRS), $(wildcard $(dir)/*))
@@ -154,7 +162,7 @@ ifneq ($(DEBUG),1)
 	@cp -r apps/camera apps/system/camera
 	@rm apps/system/camera/manifest.webapp
 	@mkdir -p profile/webapps
-	@for d in `find ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
+	@for d in `find -L ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
 	do \
 	  if [ -f $$d/manifest.webapp ]; \
 		then \
@@ -354,7 +362,7 @@ test-agent-config: test-agent-bootstrap-apps
 
 .PHONY: test-agent-bootstrap-apps
 test-agent-bootstrap-apps:
-	for d in `find ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
+	for d in `find -L ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
 	do \
 		  mkdir -p $$d/test/unit ; \
 		  mkdir -p $$d/test/integration ; \
@@ -445,7 +453,7 @@ forward:
 
 # update the manifest.appcache files to match what's actually there
 update-offline-manifests:
-	for d in `find ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
+	for d in `find -L ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
 	do \
 		rm -rf $$d/manifest.appcache ;\
 		if [ -f $$d/manifest.webapp ] ;\


### PR DESCRIPTION
Note that GAIA_APP_SRCDIRS is now expected to be the
absolute path to the app directories.
