### PR TITLE
Fix Gaia issue #2325

### DIFF
--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -7,7 +7,8 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "mobileconnection"
+    "mobileconnection",
+    "mozBluetooth"
   ],
   "locales": {
     "ar": {

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -10,7 +10,8 @@
     "mozbrowser",
     "power",
     "mozApps",
-    "mobileconnection"
+    "mobileconnection",
+    "mozBluetooth"
   ],
   "locales": {
     "ar": {

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -86,6 +86,10 @@ let permissions = {
     "urls": [],
     "pref": "dom.telephony.app.phone.url"
   },
+  "mozBluetooth": {
+    "urls": [],
+    "pref": "dom.mozBluetooth.whitelist"
+  },
   "mozbrowser": {
     "urls": [],
     "pref": "dom.mozBrowserFramesWhitelist"


### PR DESCRIPTION
NS_NewBluetoothManager in BluetoothManager.cpp used nsContentUtils::IsOnPrefWhitelist to do permission control, so we need to add Settings app to the white list of Bluetooth.
