### PR TITLE
Missed call icon was not properly shown

### DIFF
--- a/apps/dialer/js/recents.js
+++ b/apps/dialer/js/recents.js
@@ -124,12 +124,12 @@ var Recents = {
 
   createRecentEntry: function re_createRecentEntry(recent) {
     var classes = 'icon ';
-    if (recent.type.indexOf('dialing') != -1) {
+    if (recent.type == 'incoming-refused') {
+      classes += 'icon-missed';
+    } else if (recent.type.indexOf('dialing') != -1) {
       classes += 'icon-outgoing';
     } else if (recent.type.indexOf('incoming') != -1) {
       classes += 'icon-incoming';
-    } else {
-      classes += 'icon-missed';
     }
 
     var entry =


### PR DESCRIPTION
The type of recent calls was not being managed correctly and as a consequence the 'missed call' icon was never shown. The missed call icon should be shown when the type of any recent call is 'incoming-refused'. The other possible types are 'incoming-connected', 'dialing-refused' and 'dialing-connected'.
