### PR TITLE
Missed calls time shown in red

### DIFF
--- a/apps/dialer/js/recents.js
+++ b/apps/dialer/js/recents.js
@@ -124,8 +124,10 @@ var Recents = {
 
   createRecentEntry: function re_createRecentEntry(recent) {
     var classes = 'icon ';
+    var fontDateClasses = '';
     if (recent.type == 'incoming-refused') {
       classes += 'icon-missed';
+      fontDateClasses = 'missed-call-font';
     } else if (recent.type.indexOf('dialing') != -1) {
       classes += 'icon-outgoing';
     } else if (recent.type.indexOf('incoming') != -1) {
@@ -145,8 +147,8 @@ var Recents = {
       '      <section class="primary-info ellipsis">' +
       recent.number +
       '      </section>' +
-      '      <section class="secondary-info ellipsis">' +
-      prettyDate(recent.date) +
+      '      <section class="' + fontDateClasses +
+      '        secondary-info ellipsis">' + prettyDate(recent.date) +
       '      </section>' +
       '    </div>' +
       '  </section>' +

--- a/apps/dialer/style/commslog.css
+++ b/apps/dialer/style/commslog.css
@@ -137,6 +137,10 @@ button::-moz-focus-inner {
   background-image: url('images/CallLog_30x30_missed.png');
 }
 
+.missed-call-font {
+  color: red !important;
+}
+
 .log-item * {
   pointer-events: none;
 }


### PR DESCRIPTION
Although the UX team are discussing the final visuals and additional changes may come, for the time being we show the time of the missed calls in red as required by the UX team.
