### PR TITLE
Improvement keyboard fallback detection

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -48,11 +48,14 @@ const IMEManager = {
   // keyboard setting groups selected by the user from settings
   settingGroups: [],
 
-  // Default layout group
+  // Default layout group.
+  // XXX: This should be in settings, see:
+  // https://github.com/mozilla-b2g/gaia/issues/2346
   defaultGroup: 'english',
 
   // layouts to turn on correspond to keyboard.layouts.* setting
   // TODO: gaia issue 347, better setting UI and setting data store
+  // XXX: See https://github.com/mozilla-b2g/gaia/issues/2346 for more info
   keyboardSettingGroups: {
     'english': ['en'],
     'dvorak': ['en-Dvorak'],
@@ -70,6 +73,9 @@ const IMEManager = {
 
   enableSetting: function km_enableSetting(theKey) {
     // Remove the fallback
+    // XXX: This is here to workaround the lack of defined behaviour related
+    // with fallback options for the keyboard layout.
+    // https://github.com/mozilla-b2g/gaia/issues/2346
     if (this.fallback) {
       this.settingGroups.splice(
         this.settingGroups.indexOf(this.defaultGroup),

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -48,6 +48,9 @@ const IMEManager = {
   // keyboard setting groups selected by the user from settings
   settingGroups: [],
 
+  // Default layout group
+  defaultGroup: 'english',
+
   // layouts to turn on correspond to keyboard.layouts.* setting
   // TODO: gaia issue 347, better setting UI and setting data store
   keyboardSettingGroups: {
@@ -66,6 +69,15 @@ const IMEManager = {
   },
 
   enableSetting: function km_enableSetting(theKey) {
+    // Remove the fallback
+    if (this.fallback) {
+      this.settingGroups.splice(
+        this.settingGroups.indexOf(this.defaultGroup),
+        1
+      )
+      delete this.fallback;
+    }
+
     if (this.settingGroups.indexOf(theKey) === -1)
       this.settingGroups.push(theKey);
 
@@ -86,9 +98,11 @@ const IMEManager = {
   updateSettings: function km_updateSettings() {
     this.keyboards = [];
 
-    // Default to english
-    if (!this.settingGroups.length)
-      this.settingGroups.push('english');
+    // Default
+    if (!this.settingGroups.length) {
+      this.settingGroups.push(this.defaultGroup);
+      this.fallback = true;
+    }
 
     for (var key in this.keyboardSettingGroups) {
       if (this.settingGroups.indexOf(key) === -1)

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -74,7 +74,7 @@ const IMEManager = {
       this.settingGroups.splice(
         this.settingGroups.indexOf(this.defaultGroup),
         1
-      )
+      );
       delete this.fallback;
     }
 

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -78,9 +78,7 @@ const IMEManager = {
     // https://github.com/mozilla-b2g/gaia/issues/2346
     if (this.fallback) {
       this.settingGroups.splice(
-        this.settingGroups.indexOf(this.defaultGroup),
-        1
-      );
+        this.settingGroups.indexOf(this.defaultGroup), 1);
       delete this.fallback;
     }
 

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -313,8 +313,7 @@
         </h1>
       </header>
 
-    <!-- Phone -->
-    <div id="phone" class="view" data-title="Phone">
+      <!-- Phone -->
       <ul>
         <li>
           <label>


### PR DESCRIPTION
## Overview

Storing when keyboard is automatically falling back to a default layout group (due to no actual layouts are selected in the settings) let us to keep consistently the behaviour when actually selecting **only one language** by removing the fallback.
