### PR TITLE
fix build failure due to missing profile/OfflineCache

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,6 @@ include $(BUILD_PREBUILT)
 
 $(LOCAL_INSTALLED_MODULE):
 	@echo Install dir: $(TARGET_OUT_DATA)/local
-	rm -rf $(TARGET_OUT_DATA)/local/OfflineCache
 	rm -rf $(TARGET_OUT_DATA)/local/webapps
 	mkdir -p $(TARGET_OUT_DATA)/local
 	cd $(TARGET_OUT_DATA)/local && tar xfz $(abspath $<)
@@ -24,5 +23,5 @@ $(LOCAL_INSTALLED_MODULE):
 .PHONY: $(LOCAL_PATH)/profile.tar.gz
 $(LOCAL_PATH)/profile.tar.gz:
 	$(MAKE) -C $(GAIA_PATH) profile
-	cd $(GAIA_PATH)/profile && tar cfz $(abspath $@) OfflineCache webapps user.js
+	cd $(GAIA_PATH)/profile && tar cfz $(abspath $@) webapps user.js
 

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ tests: webapp-manifests offline
 	test -d $(MOZ_TESTS) || (echo "Please ensure you don't have |ac_add_options --disable-tests| in your mozconfig." && exit 1)
 	echo "Checking the injected Gaia..."
 	test -L $(INJECTED_GAIA) || ln -s $(CURDIR) $(INJECTED_GAIA)
-	TEST_PATH=$(TEST_PATH) make -C $(MOZ_OBJDIR) mochitest-browser-chrome EXTRA_TEST_ARGS="--browser-arg=\"\" --extra-profile-file=$(CURDIR)/profile/webapps --extra-profile-file=$(CURDIR)/profile/OfflineCache --extra-profile-file=$(CURDIR)/profile/user.js"
+	TEST_PATH=$(TEST_PATH) make -C $(MOZ_OBJDIR) mochitest-browser-chrome EXTRA_TEST_ARGS="--browser-arg=\"\" --extra-profile-file=$(CURDIR)/profile/webapps --extra-profile-file=$(CURDIR)/profile/user.js"
 
 .PHONY: common-install
 common-install:


### PR DESCRIPTION
profile/OfflineCache is no longer created/referenced in gaia/. Remove
all references in Android.mk & Makefile as well.
