### PR TITLE
Removing the attention screen redraw hack not needed anymore.

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -68,13 +68,6 @@ var AttentionScreen = {
       var frame = WindowManager.getAppFrame(displayedOrigin);
       if ('setVisible' in frame) {
         frame.setVisible(true);
-
-        // FIXME: Forcing a repaint
-        // Tracked here https://bugzilla.mozilla.org/show_bug.cgi?id=769172
-        frame.style.MozTransform = 'translateY(1px)';
-        setTimeout(function hackRepaint() {
-          frame.style.MozTransform = '';
-        });
       }
     }
 


### PR DESCRIPTION
The bug isn't reproducible any more, and removing the hack make things much smoother.
