### PR TITLE
A fix for |make purge| or |make reset-gaia| for indexedDB initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,5 +524,6 @@ reset-gaia: purge install-settingsdb install-gaia
 purge:
 	$(ADB) shell stop b2g
 	$(ADB) shell rm -r /data/local/*
+	$(ADB) shell mkdir -p /data/local/tmp
 	$(ADB) shell rm -r /cache/*
 	$(ADB) shell rm -r /data/b2g/*


### PR DESCRIPTION
I made a fix for |make purge| or |make reset-gaia|. It seems that data/local/tmp/ cannot be removed, which is needed for the initialization processes of indexedDB databases; otherwise, it would destroy all the app functions involved with indexedDB.
