### PR TITLE
[email] lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ lint:
 	@# cubevid
 	@# crystalskull
 	@# towerjelly
-	@gjslint --nojsdoc -r apps -e 'cubevid,crystalskull,towerjelly,email,music/js/ext,calendar/js/ext'
+	@gjslint --nojsdoc -r apps -e 'cubevid,crystalskull,towerjelly,email/js/ext,music/js/ext,calendar/js/ext'
 
 # Generate a text file containing the current changeset of Gaia
 # XXX I wonder if this should be a replace-in-file hack. This would let us

--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -77,13 +77,7 @@ ComposeCard.prototype = {
   },
 
   die: function() {
-  },
+  }
 };
-Cards.defineCard({
-  name: 'compose',
-  modes: {
-    default: {
-    },
-  },
-  constructor: ComposeCard
-});
+Cards.defineCardWithDefaultMode('compose', {}, ComposeCard);
+

--- a/apps/email/js/folder-cards.js
+++ b/apps/email/js/folder-cards.js
@@ -77,16 +77,9 @@ AccountPickerCard.prototype = {
   },
 
   die: function() {
-  },
+  }
 };
-Cards.defineCard({
-  name: 'account-picker',
-  modes: {
-    default: {
-    },
-  },
-  constructor: AccountPickerCard
-});
+Cards.defineCardWithDefaultMode('account-picker', {}, AccountPickerCard);
 
 const FOLDER_DEPTH_CLASSES = [
     'fld-folder-depth0',
@@ -252,18 +245,19 @@ FolderPickerCard.prototype = {
    * graphical glitches.
    */
   die: function() {
-  },
+  }
 };
 Cards.defineCard({
   name: 'folder-picker',
   modes: {
     // Navigation mode acts like a tray
     navigation: {
-      tray: true,
+      tray: true
     },
     movetarget: {
-      tray: false,
-    },
+      tray: false
+    }
   },
   constructor: FolderPickerCard
 });
+

--- a/apps/email/js/mail-app.js
+++ b/apps/email/js/mail-app.js
@@ -36,7 +36,8 @@ var App = {
         foldersSlice.oncomplete = function() {
           var inboxFolder = foldersSlice.getFirstFolderWithType('inbox');
           if (!inboxFolder)
-            dieOnFatalError('We have an account without an inbox!', foldersSlice.items);
+            dieOnFatalError('We have an account without an inbox!',
+                foldersSlice.items);
 
           Cards.assertNoCards();
 
@@ -45,20 +46,20 @@ var App = {
             'account-picker', 'default', 'none',
             {
               acctsSlice: acctsSlice,
-              curAccount: account,
+              curAccount: account
             });
           Cards.pushCard(
             'folder-picker', 'navigation', 'none',
             {
               curAccount: account,
               foldersSlice: foldersSlice,
-              curFolder: inboxFolder,
+              curFolder: inboxFolder
             });
           // Push the message list card
           Cards.pushCard(
             'message-list', 'default', 'immediate',
             {
-              folder: inboxFolder,
+              folder: inboxFolder
             });
         };
       }
@@ -71,7 +72,7 @@ var App = {
           {});
       }
     };
-  },
+  }
 };
 
 function hookStartup() {
@@ -101,3 +102,4 @@ function hookStartup() {
   }, false);
 }
 hookStartup();
+

--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -105,8 +105,7 @@ const UI_WIDTH = 320, UI_HEIGHT = 480;
  * implementation created jrburke.
  */
 var Cards = {
-  /**
-   * @dictof[
+  /* @dictof[
    *   @key[name String]
    *   @value[@dict[
    *     @key[name String]{
@@ -131,8 +130,7 @@ var Cards = {
    */
   _cardDefs: {},
 
-  /**
-   * @listof[@typedef[CardInstance @dict[
+  /* @listof[@typedef[CardInstance @dict[
    *   @key[domNode]{
    *   }
    *   @key[cardDef]
@@ -265,8 +263,10 @@ var Cards = {
   },
 
   _adjustCardSizes: function() {
-    var cardWidth = Math.min(UI_WIDTH, window.innerWidth), //this._containerNode.offsetWidth,
-        cardHeight = Math.min(UI_HEIGHT, window.innerHeight), //this._containerNode.offsetHeight,
+    var cardWidth = Math.min(UI_WIDTH, window.innerWidth),
+                    //this._containerNode.offsetWidth,
+        cardHeight = Math.min(UI_HEIGHT, window.innerHeight),
+                     //this._containerNode.offsetHeight,
         totalWidth = 0;
 
     for (var i = 0; i < this._cardStack.length; i++) {
@@ -300,10 +300,20 @@ var Cards = {
     }
   },
 
+  defineCardWithDefaultMode: function(name, defaultMode, constructor) {
+    var cardDef = {
+      name: name,
+      modes: {},
+      constructor: constructor
+    };
+    cardDef.modes['default'] = defaultMode;
+    defineCard(cardDef);
+  },
+
   /**
    * Push a card onto the card-stack.
-   *
-   * @args[
+   */
+  /* @args[
    *   @param[type]
    *   @param[mode String]{
    *   }
@@ -350,7 +360,7 @@ var Cards = {
       domNode: domNode,
       cardDef: cardDef,
       modeDef: modeDef,
-      cardImpl: cardImpl,
+      cardImpl: cardImpl
     };
     var cardIndex, insertBuddy;
     if (!placement) {
@@ -472,12 +482,12 @@ var Cards = {
    *
    * https://wiki.mozilla.org/Gaia/Design/Patterns#Dialogues:_Popups
    */
-  popupMenuForNode: function(menuDomTree, domNode, legalClickTargets, callback) {
+  popupMenuForNode: function(menuTree, domNode, legalClickTargets, callback) {
     var self = this,
         bounds = domNode.getBoundingClientRect();
 
     var popupInfo = this._popupActive = {
-      popupNode: menuDomTree,
+      popupNode: menuTree,
       maskNodeCleanup: this._createMaskForNode(domNode, bounds),
       close: function(result) {
         self._popupActive = false;
@@ -531,8 +541,8 @@ var Cards = {
   /**
    * Remove the card identified by its DOM node and all the cards to its right.
    * Pass null to remove all of the cards!
-   *
-   * @args[
+   */
+  /* @args[
    *   @param[cardDomNode]{
    *     The DOM node that is the first card to remove; all of the cards to its
    *     right will also be removed.  If null is passed it is understood you
@@ -709,7 +719,7 @@ var Cards = {
     if (this._cardStack.length)
       throw new Error('There are ' + this._cardStack.length + ' cards but' +
                       ' there should be ZERO');
-  },
+  }
 };
 
 /**
@@ -737,7 +747,7 @@ var Toaster = {
    * Tell toaster listeners about a mutation we just made.
    */
   logMutation: function(undoableOp) {
-  },
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -307,7 +307,7 @@ var Cards = {
       constructor: constructor
     };
     cardDef.modes['default'] = defaultMode;
-    defineCard(cardDef);
+    this.defineCard(cardDef);
   },
 
   /**

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -362,12 +362,12 @@ MessageListCard.prototype = {
     // collapsing does not make :last-child work right).
     contents.removeChild(
       contents.getElementsByClassName(
-        header.isStarred ? 'msg-edit-menu-star'
-                         : 'msg-edit-menu-unstar')[0]);
+        header.isStarred ? 'msg-edit-menu-star' :
+                           'msg-edit-menu-unstar')[0]);
     contents.removeChild(
       contents.getElementsByClassName(
-        header.isRead ? 'msg-edit-menu-mark-read'
-                      : 'msg-edit-menu-mark-unread')[0]);
+        header.isRead ? 'msg-edit-menu-mark-read' :
+                        'msg-edit-menu-mark-unread')[0]);
 
     return contents;
   },
@@ -386,17 +386,13 @@ MessageListCard.prototype = {
       this.messagesSlice.die();
       this.messagesSlice = null;
     }
-  },
+  }
 };
-Cards.defineCard({
-  name: 'message-list',
-  modes: {
-    default: {
-      tray: false,
-    },
-  },
-  constructor: MessageListCard,
-});
+Cards.defineCardWithDefaultMode(
+    'message-list',
+    { tray: false },
+    MessageListCard
+);
 
 const CONTENT_TYPES_TO_CLASS_NAMES = [
     null,
@@ -407,7 +403,7 @@ const CONTENT_TYPES_TO_CLASS_NAMES = [
     'msg-body-disclaimer',
     'msg-body-list',
     'msg-body-product',
-    'msg-body-ads',
+    'msg-body-ads'
   ];
 const CONTENT_QUOTE_CLASS_NAMES = [
     'msg-body-q1',
@@ -418,7 +414,7 @@ const CONTENT_QUOTE_CLASS_NAMES = [
     'msg-body-q6',
     'msg-body-q7',
     'msg-body-q8',
-    'msg-body-q9',
+    'msg-body-q9'
   ];
 const MAX_QUOTE_CLASS_NAME = 'msg-body-qmax';
 
@@ -529,9 +525,9 @@ MessageReaderCard.prototype = {
     for (var i = 0; i < rep.length; i += 2) {
       var node = document.createElement('div'), cname;
 
-      var etype = rep[i]&0xf, rtype = null;
+      var etype = rep[i] & 0xf, rtype = null;
       if (etype === 0x4) {
-        var qdepth = (((rep[i] >> 8)&0xff) + 1);
+        var qdepth = (((rep[i] >> 8) & 0xff) + 1);
         if (qdepth > 8)
           cname = MAX_QUOTE_CLASS_NAME;
         else
@@ -542,7 +538,7 @@ MessageReaderCard.prototype = {
       }
       if (cname)
         node.setAttribute('class', cname);
-      node.textContent = rep[i+1];
+      node.textContent = rep[i + 1];
       bodyNode.appendChild(node);
     }
 
@@ -569,15 +565,11 @@ MessageReaderCard.prototype = {
   },
 
   die: function() {
-  },
+  }
 };
-Cards.defineCard({
-  name: 'message-reader',
-  modes: {
-    default: {
-      tray: false,
-    },
-  },
-  constructor: MessageReaderCard,
-});
+Cards.defineCardWithDefaultMode(
+    'message-reader',
+    { tray: false },
+    MessageReaderCard
+);
 

--- a/apps/email/js/setup-cards.js
+++ b/apps/email/js/setup-cards.js
@@ -65,15 +65,11 @@ SetupPickServiceCard.prototype = {
   die: function() {
   }
 };
-Cards.defineCard({
-  name: 'setup-pick-service',
-  modes: {
-    efault: {
-      tray: false
-    }
-  },
-  constructor: SetupPickServiceCard
-});
+Cards.defineCardWithDefaultMode(
+    'setup-pick-service',
+     { tray: false },
+    SetupPickServiceCard
+);
 
 /**
  * Enter basic account info card (name, e-mail address, password) to try and
@@ -133,15 +129,11 @@ SetupAccountInfoCard.prototype = {
   die: function() {
   }
 };
-Cards.defineCard({
-  name: 'setup-account-info',
-  modes: {
-    efault: {
-      tray: false
-    }
-  },
-  constructor: SetupAccountInfoCard
-});
+Cards.defineCardWithDefaultMode(
+    'setup-account-info',
+    { tray: false },
+    SetupAccountInfoCard
+);
 
 /**
  * Show a spinner until success, or errors when there is failure.
@@ -203,15 +195,11 @@ SetupProgressCard.prototype = {
     this.cancelCreation();
   }
 };
-Cards.defineCard({
-  name: 'setup-progress',
-  modes: {
-    efault: {
-      tray: false
-    }
-  },
-  constructor: SetupProgressCard
-});
+Cards.defineCardWithDefaultMode(
+    'setup-progress',
+    { tray: false },
+    SetupProgressCard
+);
 
 /**
  * Setup is done; add another account?
@@ -243,15 +231,11 @@ SetupDoneCard.prototype = {
   die: function() {
   }
 };
-Cards.defineCard({
-  name: 'setup-done',
-  modes: {
-    efault: {
-      tray: false
-    }
-  },
-  constructor: SetupDoneCard
-});
+Cards.defineCardWithDefaultMode(
+    'setup-done',
+    { tray: false },
+    SetupDoneCard
+);
 
 /**
  * Asks the user to re-enter their password for the account

--- a/apps/email/js/setup-cards.js
+++ b/apps/email/js/setup-cards.js
@@ -15,12 +15,12 @@ var MAIL_SERVICES = [
   {
     name: 'OtheR EmaiL',
     l10nId: 'setup-other-email',
-    domain: '',
+    domain: ''
   },
   {
     name: 'Fake Account',
     l10nId: null,
-    domain: 'example.com',
+    domain: 'example.com'
   }
 ];
 
@@ -58,21 +58,21 @@ SetupPickServiceCard.prototype = {
     Cards.pushCard(
       'setup-account-info', 'default', 'animate',
       {
-        serviceDef: serviceDef,
+        serviceDef: serviceDef
       });
   },
 
   die: function() {
-  },
+  }
 };
 Cards.defineCard({
   name: 'setup-pick-service',
   modes: {
-    default: {
+    efault: {
       tray: false
-    },
+    }
   },
-  constructor: SetupPickServiceCard,
+  constructor: SetupPickServiceCard
 });
 
 /**
@@ -107,7 +107,7 @@ function SetupAccountInfoCard(domNode, mode, args) {
   if (args.serviceDef.domain === 'example.com') {
     this.nameNode.value = 'John Madeup';
     this.emailNode.value = 'john@example.com';
-    this.passwordNode.value= 'secret!sosecret!';
+    this.passwordNode.value = 'secret!sosecret!';
   }
 }
 SetupAccountInfoCard.prototype = {
@@ -126,21 +126,21 @@ SetupAccountInfoCard.prototype = {
       {
         name: this.nameNode.value,
         emailAddress: this.emailNode.value,
-        password: this.passwordNode.value,
+        password: this.passwordNode.value
       });
   },
 
   die: function() {
-  },
+  }
 };
 Cards.defineCard({
   name: 'setup-account-info',
   modes: {
-    default: {
+    efault: {
       tray: false
-    },
+    }
   },
-  constructor: SetupAccountInfoCard,
+  constructor: SetupAccountInfoCard
 });
 
 /**
@@ -156,7 +156,7 @@ function SetupProgressCard(domNode, mode, args) {
     {
       displayName: args.name,
       emailAddress: args.emailAddress,
-      password: args.password,
+      password: args.password
     },
     function(err) {
       self.creationInProcess = false;
@@ -201,16 +201,16 @@ SetupProgressCard.prototype = {
 
   die: function() {
     this.cancelCreation();
-  },
+  }
 };
 Cards.defineCard({
   name: 'setup-progress',
   modes: {
-    default: {
+    efault: {
       tray: false
-    },
+    }
   },
-  constructor: SetupProgressCard,
+  constructor: SetupProgressCard
 });
 
 /**
@@ -241,16 +241,16 @@ SetupDoneCard.prototype = {
   },
 
   die: function() {
-  },
+  }
 };
 Cards.defineCard({
   name: 'setup-done',
   modes: {
-    default: {
+    efault: {
       tray: false
-    },
+    }
   },
-  constructor: SetupDoneCard,
+  constructor: SetupDoneCard
 });
 
 /**
@@ -289,17 +289,13 @@ SetupFixPassword.prototype = {
 
   die: function() {
     // no special cleanup required
-  },
+  }
 };
-Cards.defineCard({
-  name: 'setup-fix-password',
-  modes: {
-    default: {
-      tray: false,
-    }
-  },
-  constructor: SetupFixPassword,
-});
+Cards.defineCardWithDefaultMode(
+    'setup-fix-password',
+    { tray: false },
+    SetupFixPassword
+);
 
 /**
  * Global settings, list of accounts.
@@ -402,15 +398,11 @@ SettingsMainCard.prototype = {
     this.acctsSlice.die();
   }
 };
-Cards.defineCard({
-  name: 'settings-main',
-  modes: {
-    default: {
-      tray: false
-    },
-  },
-  constructor: SettingsMainCard,
-});
+Cards.defineCardWithDefaultMode(
+    'settings-main',
+    { tray: false },
+    SettingsMainCard
+);
 
 /**
  * Per-account settings, maybe some metadata.
@@ -419,15 +411,11 @@ function SettingsAccountCard(domNode, mode, args) {
 }
 SettingsAccountCard.prototype = {
 };
-Cards.defineCard({
-  name: 'settings-account',
-  modes: {
-    default: {
-      tray: false
-    },
-  },
-  constructor: SettingsAccountCard,
-});
+Cards.defineCardWithDefaultMode(
+    'settings-account',
+    { tray: false },
+    SettingsAccountCard
+);
 
 /**
  * Quasi-secret card for troubleshooting/debugging support.  Not part of the
@@ -438,12 +426,9 @@ function SettingsDebugCard(domNode, mode, args) {
 }
 SettingsDebugCard.prototype = {
 };
-Cards.defineCard({
-  name: 'settings-debug',
-  modes: {
-    default: {
-      tray: false
-    }
-  },
-  constructor: SettingsDebugCard,
-});
+Cards.defineCardWithDefaultMode(
+    'settings-debug',
+    { tray: false },
+    SettingsDebugCard
+);
+


### PR DESCRIPTION
Our linter (gjslint) chokes on:
- trailing commas in JS objects;
- using `default` as key name in JS objects;
- the documentation format used in `mail-common.js`.

This might be the ugliest and most useless pull request ever… but here’s a fix.
