### PR TITLE
make Marketplace (production) a core application (#2465)

### DIFF
--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -183,8 +183,7 @@ var Applications = (function() {
     return protocol + '//' + name + '.' + domain;
   });
 
-  // XXX which marketplace app we are going to flag as a core app?
-  coreApplications.push('https://marketplace-dev.allizom.org');
+  coreApplications.push('https://marketplace.mozilla.org');
 
   /*
    *  Returns true if it's a core application


### PR DESCRIPTION
This replaces the Marketplace dev app with the production one as a core application.
