### PR TITLE
Use 'bluetooth.enabled' in mozSettings to represent bluetooth status.

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -10,14 +10,24 @@ window.addEventListener('DOMContentLoaded', function bluetoothSettings(evt) {
   var settings = window.navigator.mozSettings;
   if (settings) {
     settings.addObserver('bluetooth.enabled', function(event) {
-      gBluetoothPowerStatus.textContent = (event.settingValue)? 'Enabled':'Disabled';
+      if (event.settingValue) {
+        gBluetoothPowerStatus.textContent = 'Enabled';
+      }
+      else {
+        gBluetoothPowerStatus.textContent = 'Disabled';
+      }
       gBluetoothCheckBox.checked = event.settingValue;
     });
 
     var req = settings.getLock().get('bluetooth.enabled');
     req.onsuccess = function bt_EnabledSuccess() {
       var enabled = req.result['bluetooth.enabled'];
-      gBluetoothPowerStatus.textContent = (enabled)? 'Enabled':'Disabled';
+      if (enabled) {
+        gBluetoothPowerStatus.textContent = 'Enabled';
+      }
+      else {
+        gBluetoothPowerStatus.textContent = 'Disabled';
+      }
       gBluetoothCheckBox.checked = enabled;
     };
 

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -4,49 +4,35 @@
 'use strict';
 
 window.addEventListener('DOMContentLoaded', function bluetoothSettings(evt) {
-  var gBluetoothManager = navigator.mozBluetooth;
-
   var gBluetoothPowerStatus = document.querySelector('#bluetooth-status small');
+  var gBluetoothCheckBox = document.querySelector('#bluetooth-status input');
 
   var settings = window.navigator.mozSettings;
   if (settings) {
+    settings.addObserver('bluetooth.enabled', function(event) {
+      gBluetoothPowerStatus.textContent = (event.settingValue)? 'Enabled':'Disabled';
+      gBluetoothCheckBox.checked = event.settingValue;
+    });
+
     var req = settings.getLock().get('bluetooth.enabled');
     req.onsuccess = function bt_EnabledSuccess() {
-      var bluetooth = window.navigator.mozBluetooth;
-      if (!bluetooth)
-        return;
-
       var enabled = req.result['bluetooth.enabled'];
-      bluetooth.setEnabled(enabled);
-      document.querySelector('#bluetooth-status input').checked = enabled;
+      gBluetoothPowerStatus.textContent = (enabled)? 'Enabled':'Disabled';
+      gBluetoothCheckBox.checked = enabled;
     };
 
     req.onerror = function bt_EnabledError() {
       console.log('Settings error when reading bluetooth setting!');
     };
+
   }
 
   function changeBT() {
-    var req = gBluetoothManager.setEnabled(this.checked);
-
-    req.onsuccess = function bt_enabledSuccess() {
-      if (gBluetoothManager.enabled) {
-        gBluetoothPowerStatus.textContent = 'Enabled';
-      } else {
-        gBluetoothPowerStatus.textContent = 'Disabled';
-      }
-
-      var settings = window.navigator.mozSettings;
-      if (settings) {
-        settings.getLock().set({
-          'bluetooth.enabled': gBluetoothManager.enabled
-        });
-      }
-    };
-
-    req.onerror = function bt_enabledError() {
-      gBluetoothPowerStatus.textContent = 'Error';
-    };
+    if (settings) {
+      settings.getLock().set({
+        'bluetooth.enabled': this.checked
+      });
+    }
   };
 
   document.querySelector('#bluetooth-status input').onchange = changeBT;

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -12,8 +12,7 @@ window.addEventListener('DOMContentLoaded', function bluetoothSettings(evt) {
     settings.addObserver('bluetooth.enabled', function(event) {
       if (event.settingValue) {
         gBluetoothPowerStatus.textContent = 'Enabled';
-      }
-      else {
+      } else {
         gBluetoothPowerStatus.textContent = 'Disabled';
       }
       gBluetoothCheckBox.checked = event.settingValue;
@@ -24,8 +23,7 @@ window.addEventListener('DOMContentLoaded', function bluetoothSettings(evt) {
       var enabled = req.result['bluetooth.enabled'];
       if (enabled) {
         gBluetoothPowerStatus.textContent = 'Enabled';
-      }
-      else {
+      } else {
         gBluetoothPowerStatus.textContent = 'Disabled';
       }
       gBluetoothCheckBox.checked = enabled;

--- a/apps/system/js/bluetooth.js
+++ b/apps/system/js/bluetooth.js
@@ -5,23 +5,25 @@
 
 var Bluetooth = {
   init: function bt_init() {
-    var settings = window.navigator.mozSettings;
-    if (!settings) {
-      return;
-    }
 
-    var req = settings.getLock().get('bluetooth.enabled');
-    req.onsuccess = function bt_EnabledSuccess() {
+    SettingsListener.observe('bluetooth.enabled', true, function(value) {
       var bluetooth = window.navigator.mozBluetooth;
-      if (!bluetooth)
+      if (!bluetooth) {
         return;
-
-      var enabled = req.result['bluetooth.enabled'];
-      bluetooth.setEnabled(enabled);
-    };
-
-    req.onerror = function bt_EnabledError() {
-      console.log('Settings error when reading bluetooth setting!');
-    };
+      }
+      if (bluetooth.enabled == value) {
+        return;
+      }
+      var req = bluetooth.setEnabled(value);
+      req.onerror = function bt_EnabledError(){
+        // rollback
+        var settings = window.navigator.mozSettings;
+        if (settings) {
+          settings.getLock().set({
+            'bluetooth.enabled': !value
+          });
+        }
+      }
+    });
   }
 };

--- a/apps/system/js/bluetooth.js
+++ b/apps/system/js/bluetooth.js
@@ -15,8 +15,9 @@ var Bluetooth = {
         return;
       }
       var req = bluetooth.setEnabled(value);
-      req.onerror = function bt_EnabledError(){
-        // rollback
+      req.onerror = function bt_EnabledError() {
+        // roll back the setting value to notify the UIs
+        // that bluetooth has failed to enable.
         var settings = window.navigator.mozSettings;
         if (settings) {
           settings.getLock().set({

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -12,8 +12,14 @@ var QuickSettings = {
 
     var self = this;
 
+    // monitor data status
     SettingsListener.observe('ril.data.enabled', true, function(value) {
       self.data.dataset.enabled = value;
+    });
+
+    // monitor bluetooth status
+    SettingsListener.observe('bluetooth.enabled', true, function(value) {
+      self.bluetooth.dataset.enabled = value;
     });
 
   },
@@ -24,6 +30,7 @@ var QuickSettings = {
       case 'click':
         switch (evt.target) {
           case this.wifi:
+            // XXX: should use mozSettings instead
             var wifiManager = navigator.mozWifiManager;
             if (!wifiManager)
               return;
@@ -47,13 +54,11 @@ var QuickSettings = {
             break;
 
           case this.bluetooth:
-            var bluetooth = navigator.mozBluetooth;
-            if (!bluetooth)
-              return;
-
             var enabled = (this.bluetooth.dataset.enabled == 'true');
-            bluetooth.setEnabled(!enabled);
             this.bluetooth.dataset.enabled = !enabled;
+            navigator.mozSettings.getLock().set({
+              'bluetooth.enabled': !enabled
+            });
             break;
 
           case this.powerSave:
@@ -68,6 +73,7 @@ var QuickSettings = {
               };
 
               // Turn off Wifi
+              // XXX: should use mozSetting instead
               var wifiManager = navigator.mozWifiManager;
               if (wifiManager) {
                 wifiManager.setEnabled(false);
@@ -76,23 +82,22 @@ var QuickSettings = {
 
               // Turn off Data
               this.data.dataset.enabled = false;
-
               navigator.mozSettings.getLock().set({
                 'ril.data.enabled': false
               });
 
               // Turn off Bluetooth
-              var bluetooth = navigator.mozBluetooth;
-              if (bluetooth) {
-                bluetooth.setEnabled(false);
-                this.bluetooth.dataset.enabled = false;
-              }
+              this.bluetooth.dataset.enabled = false;
+              navigator.mozSettings.getLock().set({
+                'bluetooth.enabled': false
+              });
 
               // XXX: How do I turn off GPS?
 
             } else if (this._powerSaveResume) {
               if (this._powerSaveResume.wifi) {
                 // Turn on Wifi
+                // XXX: use mozSetting instead
                 var wifiManager = navigator.mozWifiManager;
                 if (wifiManager) {
                   wifiManager.setEnabled(true);
@@ -110,11 +115,10 @@ var QuickSettings = {
 
               if (this._powerSaveResume.bluetooth) {
                 // Turn on Bluetooth
-                var wifiManager = navigator.mozBluetooth;
-                if (bluetooth) {
-                  bluetooth.setEnabled(true);
-                  this.bluetooth.dataset.enabled = true;
-                }
+                this.bluetooth.dataset.enabled = true;
+                navigator.mozSettings.getLock().set({
+                  'bluetooth.enabled': true
+                });
               }
 
               delete this._powerSaveResume;
@@ -145,11 +149,9 @@ var QuickSettings = {
   },
 
   updateStatus: function qs_updateStatus() {
+    //XXX: if use mozSetting instead, remove here and add a observe at init()
     var wifiManager = navigator.mozWifiManager;
     this.wifi.dataset.enabled = !!(wifiManager && wifiManager.enabled);
-
-    var bluetooth = navigator.mozBluetooth;
-    this.bluetooth.dataset.enabled = !!(bluetooth && bluetooth.enabled);
   },
 
   getAllElements: function qs_getAllElements() {

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -81,13 +81,11 @@ var QuickSettings = {
               }
 
               // Turn off Data
-              this.data.dataset.enabled = false;
               navigator.mozSettings.getLock().set({
                 'ril.data.enabled': false
               });
 
               // Turn off Bluetooth
-              this.bluetooth.dataset.enabled = false;
               navigator.mozSettings.getLock().set({
                 'bluetooth.enabled': false
               });
@@ -107,7 +105,6 @@ var QuickSettings = {
 
               if (this._powerSaveResume.data) {
                 // Turn on Data
-                this.data.dataset.enabled = true;
                 navigator.mozSettings.getLock().set({
                   'ril.data.enabled': true
                 });
@@ -115,7 +112,6 @@ var QuickSettings = {
 
               if (this._powerSaveResume.bluetooth) {
                 // Turn on Bluetooth
-                this.bluetooth.dataset.enabled = true;
                 navigator.mozSettings.getLock().set({
                   'bluetooth.enabled': true
                 });

--- a/apps/system/js/sleep_menu.js
+++ b/apps/system/js/sleep_menu.js
@@ -24,18 +24,16 @@ var SleepMenu = {
   // https://bugzilla.mozilla.org/show_bug.cgi?id=766895
   turnOffFlightMode: function sm_turnOffFlightMode() {
     var settings = navigator.mozSettings;
-    if (settings && this.reservedSettings.data) {
-      settings.getLock().set({'ril.data.disabled': this.reservedSettings.data});
+    if (settings) {
+      settings.getLock().set({'ril.data.enabled': this.reservedSettings.data});
+      settings.getLock().set({'bluetooth.enabled': this.reservedSettings.bluetooth});
     }
 
+    // Set wifi as previous
+    // XXX: should set mozSettings instead
     var wifiManager = navigator.mozWifiManager;
     if (wifiManager && this.reservedSettings.wifi && !wifiManager.enabled) {
       wifiManager.setEnabled(true);
-    }
-
-    var bluetooth = navigator.mozBluetooth;
-    if (bluetooth && this.reservedSettings.bluetooth && !bluetooth.enabled) {
-      bluetooth.setEnabled(true);
     }
   },
 
@@ -43,24 +41,28 @@ var SleepMenu = {
     var settings = navigator.mozSettings;
     var self = this;
     if (settings) {
-      var req = settings.getLock().get('ril.data.disabled');
+      // Turn off data
+      var req = settings.getLock().get('ril.data.enabled');
       req.onsuccess = function sm_EnabledFetched() {
-        self.reservedSettings.data = req.result['ril.data.disabled'];
-        settings.getLock().set({'ril.data.disabled': true});
+        self.reservedSettings.data = req.result['ril.data.enabled'];
+        settings.getLock().set({'ril.data.enabled': false});
+      };
+      // Turn off blueTooth
+      var req = settings.getLock().get('bluetooth.enabled');
+      req.onsuccess = function bt_EnabledSuccess() {
+        self.reservedSettings.bluetooth = req.result['bluetooth.enabled'];
+        settings.getLock().set({'bluetooth.enabled': false});
       };
     }
 
+    // Turn off wifi
+    // XXX: should set mozSettings instead
     var wifiManager = navigator.mozWifiManager;
     if (wifiManager) {
       this.reservedSettings.wifi = wifiManager.enabled;
       wifiManager.setEnabled(false);
     }
 
-    var bluetooth = navigator.mozBluetooth;
-    if (bluetooth) {
-      this.reservedSettings.bluetooth = bluetooth.enabled;
-      bluetooth.setEnabled(false);
-    }
   },
 
   init: function sm_init() {
@@ -173,7 +175,7 @@ var SleepMenu = {
         // Airplane mode should turn off
         //
         // Radio ('ril.radio.disabled'`)
-        // Data ('ril.data.disabled'`)
+        // Data ('ril.data.enabled'`)
         // Wifi
         // Bluetooth
         // Geolocation

--- a/apps/system/js/sleep_menu.js
+++ b/apps/system/js/sleep_menu.js
@@ -25,8 +25,12 @@ var SleepMenu = {
   turnOffFlightMode: function sm_turnOffFlightMode() {
     var settings = navigator.mozSettings;
     if (settings) {
-      settings.getLock().set({'ril.data.enabled': this.reservedSettings.data});
-      settings.getLock().set({'bluetooth.enabled': this.reservedSettings.bluetooth});
+      if (this.reservedSettings.data) {
+        settings.getLock().set({'ril.data.enabled': true});
+      }
+      if (this.reservedSettings.bluetooth) {
+        settings.getLock().set({'bluetooth.enabled': true});
+      }
     }
 
     // Set wifi as previous


### PR DESCRIPTION
#2402: [System][Settings] Reorganize bluetooth module

use 'bluetooth.enabled' in mozSettings to represent bluetooth status.
all user setting inputs is going to change this value, instead of enable/disable bluetooth.
system/js/bluetooth.js implements desired state.
