### PR TITLE
Changed all manifest.webapp to add 'index.html' to launch_path where needed

### DIFF
--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Browser",
   "description": "Gaia Web Browser",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/calculator/manifest.webapp
+++ b/apps/calculator/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Calculator",
   "description": "Calculator",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/calendar/manifest.webapp
+++ b/apps/calendar/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Calendar",
   "description": "Gaia Calendar",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/camera/manifest.webapp
+++ b/apps/camera/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Camera",
   "description": "Gaia Camera",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "orientation": "portrait-primary",
   "fullscreen": true,
   "developer": {

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Clock",
   "description": "Gaia Clock",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/dialer/manifest.webapp
+++ b/apps/dialer/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Dialer",
   "description": "Gaia Dialer",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "E-Mail",
   "description": "Gaia E-Mail",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/fm/manifest.webapp
+++ b/apps/fm/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "FM Radio",
   "description": "Gaia FM Radio",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Gallery",
   "description": "Gaia Gallery",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Homescreen",
   "description": "Gaia Homescreen",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/andreasgal/gaia"

--- a/apps/music/manifest.webapp
+++ b/apps/music/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Music",
   "description": "Gaia Music",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Settings",
   "description": "Gaia Settings",
-  "launch_path": "/#root",
+  "launch_path": "/index.html#root",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Messages",
   "description": "Gaia Messages",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "System",
   "description": "Main System",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Video",
   "description": "Gaia Video",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/showcase_apps/crystalskull/manifest.webapp
+++ b/showcase_apps/crystalskull/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "CrystalSkull",
   "description": "WebGL Demo",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The J3D Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/showcase_apps/cubevid/manifest.webapp
+++ b/showcase_apps/cubevid/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "CubeVid",
   "description": "Video Cube Demo",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Original Author",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/showcase_apps/cuttherope/manifest.webapp
+++ b/showcase_apps/cuttherope/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Cut The Rope",
   "description": "http://cuttherope.ie",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "orientation": "landscape-primary",
   "fullscreen": true,
   "hackNetworkBound": "true",

--- a/showcase_apps/penguinpop/manifest.webapp
+++ b/showcase_apps/penguinpop/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "PenguinPop",
   "description": "PenGuin Pop",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "hackNetworkBound": "true",
   "developer": {
     "name": "The Original Author",

--- a/showcase_apps/tasks/manifest.webapp
+++ b/showcase_apps/tasks/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Tasks",
   "description": "Gaia Tasks",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/showcase_apps/towerjelly/manifest.webapp
+++ b/showcase_apps/towerjelly/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "TowerJelly",
   "description": "Tower Jelly",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "hackNetworkBound": "true",
   "developer": {
     "name": "The Original Author",

--- a/test_apps/template/manifest.webapp
+++ b/test_apps/template/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Template",
   "description": "Web app template",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/test_apps/test-agent/manifest.webapp
+++ b/test_apps/test-agent/manifest.webapp
@@ -2,7 +2,7 @@
   "name": "Test Agent",
   "default_locale": "en-US",
   "description": "Gaia Test Agent",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "permissions": [
     "power"
   ],

--- a/test_apps/uitest/manifest.webapp
+++ b/test_apps/uitest/manifest.webapp
@@ -1,6 +1,6 @@
 {
   "name": "UI tests",
-  "launch_path": "/",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"


### PR DESCRIPTION
Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=773884 made changes to the way app:// protocol works. Previously it automatically added 'index.html' to paths that ended in / or /#whatever. Now it doesn't. Since the homescreen app uses launch_path on the manifest to launch apps, and all the apps had '/' as their launch path, it broke them.

This change just modifies all the manifests so they include the index.html.
