### PR TITLE
Permit to override ARCH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ SHELL := /bin/bash
 
 # what OS are we on?
 SYS=$(shell uname -s)
-ARCH=$(shell uname -m)
+ARCH?=$(shell uname -m)
 
 ifeq ($(SYS),Darwin)
 MD5SUM = md5 -r


### PR DESCRIPTION
This lets building on mixed environments when kernel is 64bit and
userspace is 32bit.

Signed-off-by: Riccardo Magliocchetti riccardo.magliocchetti@gmail.com
