### PR TITLE
Improving keyboard

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -477,24 +477,6 @@ const IMEController = (function() {
 
     // Locked limits
     // TODO: look for [LOCKED_AREA]
-    function getWindowTop(obj) {
-      var top;
-      top = obj.offsetTop;
-      while (!!(obj = obj.offsetParent)) {
-        top += obj.offsetTop;
-      }
-      return top;
-    }
-
-    function getWindowLeft(obj) {
-      var left;
-      left = obj.offsetLeft;
-      while (!!(obj = obj.offsetParent)) {
-        left += obj.offsetLeft;
-      }
-      return left;
-    }
-
     _menuLockedArea = {
       top: top,
       bottom: bottom,

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -212,6 +212,25 @@ const IMEManager = {
   }
 };
 
+// Utility functions
+function getWindowTop(obj) {
+  var top;
+  top = obj.offsetTop;
+  while (!!(obj = obj.offsetParent)) {
+    top += obj.offsetTop;
+  }
+  return top;
+}
+
+function getWindowLeft(obj) {
+  var left;
+  left = obj.offsetLeft;
+  while (!!(obj = obj.offsetParent)) {
+    left += obj.offsetLeft;
+  }
+  return left;
+}
+
 window.addEventListener('load', function initIMEManager(evt) {
   window.removeEventListener('load', initIMEManager);
   IMEManager.init();

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -84,11 +84,11 @@ const Keyboards = {
     label: 'English',
     menuLabel: 'English',
     alt: {
-      a: 'áàâäåãāæ',// XXX: commented to avoid overflows for the demo
+      a: 'áàâäåãāæ',
       c: 'çćč',
-      e: 'éèêëēȩ€ɛ',// XXX: commented to avoid overflows for the demo
-      i: 'ïíìîīį',// XXX: commented to avoid overflows for the demo
-      o: 'öóòôōœøɵ',// XXX: commented to avoid overflows for the demo
+      e: 'éèêëēȩ€ɛ',
+      i: 'ïíìîīį',
+      o: 'öóòôōœøɵ',
       u: 'üúùûū',
       s: 'ßśš$',
       S: 'ŚŠŞ',
@@ -749,11 +749,11 @@ const Keyboards = {
     label: 'Spanish',
     menuLabel: 'Español',
     alt: {
-      a: 'áªàâä',//åãāæ', XXX: commented to avoid overflows for the demo
+      a: 'áªàâäåãāæ',
       c: 'ç',
-      e: 'é€èêë',//ēȩɛ', XXX: commented to avoid overflows for the demo
-      i: 'íïìîī',//į', XXX: commented to avoid overflows for the demo
-      o: 'óºöòô',//ōœøɵ', XXX: commented to avoid overflows for the demo
+      e: 'é€èêëēȩɛ',
+      i: 'íïìîīį',
+      o: 'óºöòôōœøɵ',
       u: 'üúùûū',
       s: '$ßš',
       l: '£',
@@ -851,10 +851,10 @@ const Keyboards = {
     label: 'Portuguese',
     menuLabel: 'Português',
     alt: {
-      a: 'áãàâä',//åæª', XXX: commented to avoid overflows for the demo
-      e: 'éêèȩė',//ēëɛ', XXX: commented to avoid overflows for the demo
-      i: 'íîìïį',//ī', XXX: commented to avoid overflows for the demo
-      o: 'óõôòö',//œøōɵ', XXX: commented to avoid overflows for the demo
+      a: 'áãàâäåæª',
+      e: 'éêèȩėēëɛ',
+      i: 'íîìïįī',
+      o: 'óõôòöœøōɵ',
       u: 'úüùûū',
       s: '$ßš',
       l: '£',

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -84,11 +84,11 @@ const Keyboards = {
     label: 'English',
     menuLabel: 'English',
     alt: {
-      a: 'áàâäå',//ãāæ', XXX: commented to avoid overflows for the demo
+      a: 'áàâäåãāæ',// XXX: commented to avoid overflows for the demo
       c: 'çćč',
-      e: 'éèêëē',//ȩ€ɛ', XXX: commented to avoid overflows for the demo
-      i: 'ïíìîī',//į', XXX: commented to avoid overflows for the demo
-      o: 'öóòôō',//œøɵ', XXX: commented to avoid overflows for the demo
+      e: 'éèêëēȩ€ɛ',// XXX: commented to avoid overflows for the demo
+      i: 'ïíìîīį',// XXX: commented to avoid overflows for the demo
+      o: 'öóòôōœøɵ',// XXX: commented to avoid overflows for the demo
       u: 'üúùûū',
       s: 'ßśš$',
       S: 'ŚŠŞ',

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -320,18 +320,25 @@ const IMERender = (function() {
     _menuKey = key;
     key.parentNode.replaceChild(_altContainer, key);
 
-    // Adjust menu style and offset
+    // Adjust menu style
     _altContainer
       .querySelectorAll('.visual-wrapper > span')[0]
       .appendChild(this.menu);
     this.menu.style.display = 'block';
 
+    // Adjust offset when alternatives menu overflows
     var alternativesLeft = getWindowLeft(this.menu);
-    var alternativesRight = alternativesLeft + this.menu.scrollWidth;
+    var alternativesRight = alternativesLeft + this.menu.offsetWidth;
+
+    // It overflows on the right
     if (left && alternativesRight > window.innerWidth) {
-      console.log('se sale por la derecha');
+      var offset = window.innerWidth - alternativesRight;
+      this.menu.style.left = offset + 'px';
+
+    // It overflows on the left
     } else if (!left && alternativesLeft < 0) {
-      console.log('se sale por la izquierda');
+      var offset = -alternativesLeft;
+      this.menu.style.right = offset + 'px';
     }
   };
 
@@ -344,6 +351,9 @@ const IMERender = (function() {
 
     if (_altContainer)
       _altContainer.parentNode.replaceChild(_menuKey, _altContainer);
+
+    this.menu.style.left = '';
+    this.menu.style.right = '';
   };
 
   // Recalculate dimensions for the current render

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -94,7 +94,7 @@ const IMERender = (function() {
           dataset.push({'key': 'compositekey', 'value': key.compositeKey});
         }
 
-        content += buildKey(keyChar, className, keyWidth, dataset);
+        content += buildKey(keyChar, className, keyWidth + 'px', dataset);
 
       }));
       content += '</div>';
@@ -251,7 +251,7 @@ const IMERender = (function() {
       ];
       content += buildKey(
         Keyboards[kbr].menuLabel,
-        className, cssWidth,
+        className, cssWidth + 'px',
         dataset
       );
 
@@ -277,7 +277,7 @@ const IMERender = (function() {
   // Show char alternatives. The first element of altChars is ALWAYS the
   // original char.
   var showAlternativesCharMenu = function(key, altChars) {
-    var content = '', cssWidth = key.scrollWidth;
+    var content = '';
 
     var original = altChars[0];
     altChars = altChars.slice(1);
@@ -303,9 +303,10 @@ const IMERender = (function() {
       var keyCode = keyChar.keyCode || keyChar.charCodeAt(0);
       var dataset = [{'key': 'keycode', 'value': keyCode}];
       var label = keyChar.label || keyChar;
+      var cssWidth = key.scrollWidth * (1 + 0.5 * (label.length - 1));
       if (label.length > 1)
         dataset.push({'key': 'compositekey', 'value': label});
-      content += buildKey(label, '', cssWidth, dataset);
+      content += buildKey(label, '', cssWidth + 'px', dataset);
     });
     this.menu.innerHTML = content;
 
@@ -411,7 +412,7 @@ const IMERender = (function() {
     dataset.forEach(function(data) {
       content += ' data-' + data.key + '="' + data.value + '" ';
     });
-    content += ' style="width:' + width + 'px"';
+    content += ' style="width: ' + width + '"';
     content += '><span class="visual-wrapper"><span>' +
                label + '</span></span></button>';
     return content;

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -303,7 +303,8 @@ const IMERender = (function() {
       var keyCode = keyChar.keyCode || keyChar.charCodeAt(0);
       var dataset = [{'key': 'keycode', 'value': keyCode}];
       var label = keyChar.label || keyChar;
-      var cssWidth = key.scrollWidth * (1 + 0.5 * (label.length - 1));
+      var cssWidth =
+        key.scrollWidth * (1 + 0.5 * (label.length - original.length));
       if (label.length > 1)
         dataset.push({'key': 'compositekey', 'value': label});
       content += buildKey(label, '', cssWidth + 'px', dataset);
@@ -332,12 +333,16 @@ const IMERender = (function() {
 
     // It overflows on the right
     if (left && alternativesRight > window.innerWidth) {
+      console.log('overflowing right');
       var offset = window.innerWidth - alternativesRight;
+      console.log(offset);
       this.menu.style.left = offset + 'px';
 
     // It overflows on the left
     } else if (!left && alternativesLeft < 0) {
-      var offset = -alternativesLeft;
+      console.log('overflowing left');
+      var offset = alternativesLeft;
+      console.log(offset);
       this.menu.style.right = offset + 'px';
     }
   };

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -304,7 +304,7 @@ const IMERender = (function() {
       var dataset = [{'key': 'keycode', 'value': keyCode}];
       var label = keyChar.label || keyChar;
       var cssWidth =
-        key.scrollWidth * (1 + 0.5 * (label.length - original.length));
+        key.offsetWidth * (0.9 + 0.5 * (label.length - original.length));
       if (label.length > 1)
         dataset.push({'key': 'compositekey', 'value': label});
       content += buildKey(label, '', cssWidth + 'px', dataset);

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -320,11 +320,19 @@ const IMERender = (function() {
     _menuKey = key;
     key.parentNode.replaceChild(_altContainer, key);
 
-    // Adjust menu style
+    // Adjust menu style and offset
     _altContainer
       .querySelectorAll('.visual-wrapper > span')[0]
       .appendChild(this.menu);
     this.menu.style.display = 'block';
+
+    var alternativesLeft = getWindowLeft(this.menu);
+    var alternativesRight = alternativesLeft + this.menu.scrollWidth;
+    if (left && alternativesRight > window.innerWidth) {
+      console.log('se sale por la derecha');
+    } else if (!left && alternativesLeft < 0) {
+      console.log('se sale por la izquierda');
+    }
   };
 
   // Hide the alternative menu


### PR DESCRIPTION
## Overview

This branch resolve a technical debt from Barcelona working week: to let up to 10 alternatives inside the screen. With a combination of new visuals and Javascript control of the overflow, now it is possible to display up to the limit imposed.
- It reduces the key width inside alternative menu in order to keep the alternatives inside the screen.
- It now controls overflow moving the alternative menu inside the screen when overflowing.
## Flaws and future work
- It is necessary to review CSS for keys in order to let the key auto adjust its size depending on the label size.
- It should be great if position and key-size could be controlled by CSS instead of Javascript
