### PR TITLE
updated otoro-install to be sticky instead of going away after device reboot

### DIFF
--- a/build/otoro-install-busybox.sh
+++ b/build/otoro-install-busybox.sh
@@ -5,11 +5,12 @@
 
 # Remount file system with read/write permissions
 adb shell "mount -o rw,remount -t rootfs /"
-adb push busybox-armv6l /sbin/busybox
-adb shell "chmod 555 /sbin/busybox"
+adb shell "mkdir -p /system/vendor/bin"
+adb push busybox-armv6l /vendor/bin/busybox
+adb shell "chmod 555 /vendor/bin/busybox"
 
 # Perform the symbolic links
-adb shell "for x in \`busybox --list\`; do ln -s /sbin/busybox sbin/\$x; done"
+adb shell "for x in \`busybox --list\`; do ln -s /vendor/bin/busybox /vendor/bin/\$x; done"
 
 # Remount file system with read-only permissions
 adb shell "mount -o ro,remount -t rootfs /"


### PR DESCRIPTION
busybox install gets removed after every reboot which is a bit tedious. 
