### PR TITLE
Remove the engine code, predictiveText.js from linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ lint:
 	@# cubevid
 	@# crystalskull
 	@# towerjelly
-	@gjslint --nojsdoc -r apps -e 'cubevid,crystalskull,towerjelly,email/js/ext,music/js/ext,calendar/js/ext'
+	@gjslint --nojsdoc -r apps -e 'cubevid,crystalskull,towerjelly,email/js/ext,music/js/ext,calendar/js/ext,keyboard/js/predictive_text'
 
 # Generate a text file containing the current changeset of Gaia
 # XXX I wonder if this should be a replace-in-file hack. This would let us


### PR DESCRIPTION
This may take a long time, which cause "make lint" not responding.
Note that the JS engine will be replaced by a native engine in the near future.
