### PR TITLE
Only listen to idle state changes when the screen is on to avoid the tim...

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -5,52 +5,57 @@
 
 var ScreenManager = {
   /*
-  * return the current screen status
-  * Must not mutate directly - use toggleScreen/turnScreenOff/turnScreenOn.
-  * Listen to 'screenchange' event to properly handle status changes
-  * This value can be "out of sync" with real mozPower value,
-  * we do this to give screen some time to flash before actual turn off.
-  */
+   * return the current screen status
+   * Must not mutate directly - use toggleScreen/turnScreenOff/turnScreenOn.
+   * Listen to 'screenchange' event to properly handle status changes
+   * This value can be "out of sync" with real mozPower value,
+   * we do this to give screen some time to flash before actual turn off.
+   */
   screenEnabled: false,
 
   /*
-  * before idle-screen-off, invoke a nice dimming to the brightness
-  * to notify the user that the screen is about to be turn off.
-  * The user can cancel the idle-screen-off by touching the screen
-  * and by pressing a button (trigger onactive callback on Idle API)
-  *
-  */
+   * before idle-screen-off, invoke a nice dimming to the brightness
+   * to notify the user that the screen is about to be turn off.
+   * The user can cancel the idle-screen-off by touching the screen
+   * and by pressing a button (trigger onactive callback on Idle API)
+   *
+   */
   _inTransition: false,
 
   /*
-  * Idle API controls the value of this Boolean.
-  * Together with wake lock, this would decide whether to turn off
-  * the screen when wake lock is released
-  *
-  */
+   * Idle API controls the value of this Boolean.
+   * Together with wake lock, this would decide whether to turn off
+   * the screen when wake lock is released
+   *
+   */
   _idled: false,
 
   /*
-  * Whether the wake lock is enabled or not
-  */
+   * Whether the wake lock is enabled or not
+   */
   _screenWakeLocked: false,
 
   /*
-  * Whether the device light is enabled or not
-  * sync with setting 'screen.automatic-brightness'
-  */
+   * Whether the device light is enabled or not
+   * sync with setting 'screen.automatic-brightness'
+   */
   _deviceLightEnabled: true,
 
   /*
-  * Preferred brightness without considering device light nor dimming
-  * sync with setting 'screen.brightness'
+   * Preferred brightness without considering device light nor dimming
+   * sync with setting 'screen.brightness'
   */
   _brightness: 1,
 
   /*
-  * Wait for _dimNotice milliseconds during idle-screen-off
-  */
+   * Wait for _dimNotice milliseconds during idle-screen-off
+   */
   _dimNotice: 10 * 1000,
+
+  /*
+   * We track the value of the idle timeout pref in this variable.
+   */
+  _idleTimeout: 0,
 
   init: function scm_init() {
     /* Allow others to cancel the keyup event but not the keydown event */
@@ -107,7 +112,7 @@ var ScreenManager = {
 
     SettingsListener.observe('screen.timeout', 60,
     function screenTimeoutChanged(value) {
-      self.setIdleTimeout(value);
+      self._idleTimeout = value;
     });
 
     SettingsListener.observe('screen.automatic-brightness', true,
@@ -193,6 +198,8 @@ var ScreenManager = {
     window.removeEventListener('devicelight', this);
     window.removeEventListener('mozfullscreenchange', this);
 
+    this.setIdleTimeout(0);
+
     var self = this;
     var screenBrightness = navigator.mozPower.screenBrightness;
 
@@ -248,6 +255,8 @@ var ScreenManager = {
     navigator.mozPower.screenEnabled = this.screenEnabled = true;
     navigator.mozPower.screenBrightness = this._brightness;
     this.screen.classList.remove('screenoff');
+
+    this.setIdleTimeout(this._idleTimeout);
 
     this.fireScreenChangeEvent();
     return true;


### PR DESCRIPTION
...er but also to avoid a race condition where the idle state switches the screen of immediately after we try to switch it on.
