### PR TITLE
Phone hangs when dialing

### DIFF
--- a/apps/dialer/js/keypad.js
+++ b/apps/dialer/js/keypad.js
@@ -311,10 +311,13 @@ var KeypadManager = {
           // Sending the DTMF tone
           var telephony = navigator.mozTelephony;
           if (telephony) {
-            telephony.startTone(key);
-            window.setTimeout(function ch_stopTone() {
-              telephony.stopTone();
-            }, 100);
+            if ((telephony.active != null) 
+                 && (telephony.active.state == 'connected')) {
+              telephony.startTone(key);
+              window.setTimeout(function ch_stopTone() {
+                telephony.stopTone();
+              }, 100);
+            }
           }
         }
 


### PR DESCRIPTION
If dialer state is not connected, DTMF can make dialer hang.
