### PR TITLE
SMS - Merge pending message deletion ability in message manager delete function.

### DIFF
--- a/apps/sms/js/pendingDBUtils.js
+++ b/apps/sms/js/pendingDBUtils.js
@@ -44,7 +44,7 @@ var PendingMsgManager = {
 
       request.onupgradeneeded = function(event) {
         var db = event.target.result;
-        var objStore = db.createObjectStore('msgs', { keyPath: 'timestamp' });
+        var objStore = db.createObjectStore('msgs', { keyPath: 'id' });
         objStore.createIndex('receiver', 'receiver');
       };
     } catch (ex) {
@@ -88,10 +88,10 @@ var PendingMsgManager = {
     }
   },
 
-  deleteFromMsgDB: function pm_deleteFromMsgDB(msg, callback) {
+  deleteFromMsgDB: function pm_deleteFromMsgDB(id, callback) {
     var transaction = this.db.transaction('msgs', 'readwrite');
     var store = transaction.objectStore('msgs');
-    var deleteRequest = store.delete(msg.timestamp);
+    var deleteRequest = store.delete(id);
     var pendingMgr = this;
     deleteRequest.onsuccess = function onsuccess() {
       if (callback) {
@@ -105,7 +105,7 @@ var PendingMsgManager = {
       }
       // Execute save operation again if failed.
       window.setTimeout(
-        pendingMgr.deleteFromMsgDB(msg, callback).bind(pendingMgr), 500);
+        pendingMgr.deleteFromMsgDB(id, callback).bind(pendingMgr), 500);
     }
   }
 };

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -175,9 +175,16 @@ var MessageManager = {
     };
 
     req.onerror = function onerror() {
-      var msg = 'Deleting in the database. Error: ' + req.errorCode;
-      console.log(msg);
-      callback(null);
+      // Check if the message is in pending DB:
+      PendingMsgManager.deleteFromMsgDB(id, function ondelete(msg) {
+        if (!msg) {
+          var msg = 'Deleting in the database. Error: ' + req.errorCode;
+          console.log(msg);
+          callback(null);
+          return;
+        }
+        callback(req.result);
+      });
     };
   },
 
@@ -828,7 +835,8 @@ var ThreadUI = {
         delivery: 'sending',
         body: text,
         read: 1,
-        timestamp: tempDate
+        timestamp: tempDate,
+        id: tempDate
       };
 
 
@@ -842,8 +850,6 @@ var ThreadUI = {
           console.log('Message app - pending message save failed!');
           PendingMsgManager.saveToMsgDB(message, this);
         } else {
-          // Clean Fields
-          ThreadUI.cleanFields();
           // Update ThreadListUI when new message in pending database.
           if (window.location.hash == '#new') {
             window.location.hash = '#num=' + num;
@@ -857,12 +863,17 @@ var ThreadUI = {
       });
 
       MessageManager.send(num, text, function onsent(msg) {
+        var msgId = message.id;
         if (!msg) {
           var resendConfirmStr = _('resendConfirmDialogMsg');
           var result = confirm(resendConfirmStr);
-          if (!result) {
+          if (result) {
             // Remove the message from pending message DB before resend.
-            PendingMsgManager.deleteFromMsgDB(message, function ondelete(msg) {
+            PendingMsgManager.deleteFromMsgDB(msgId, function ondelete(msg) {
+              if (!msg) {
+                //TODO: Handle message delete failed in pending DB.
+                return;
+              }
               var filter = MessageManager.createFilter(num);
               MessageManager.getMessages(function(messages) {
                 if (messages.length > 0) {
@@ -879,9 +890,6 @@ var ThreadUI = {
             });
             window.setTimeout(self.sendMessage.bind(self), 500);
             return;
-          } else {
-            // TODO We found that there is no resend!
-            // Steve, could you take a look?!
           }
         } else {
           var root = document.getElementById(message.timestamp.getTime());
@@ -898,12 +906,15 @@ var ThreadUI = {
 
           // Remove the message from pending message DB since it could be sent
           // successfully.
-          PendingMsgManager.deleteFromMsgDB(message, function ondelete(msg) {
+          PendingMsgManager.deleteFromMsgDB(msgId, function ondelete(msg) {
             if (!msg) {
               //TODO: Handle message delete failed in pending DB.
             }
           });
+          // TODO: We might need to update the sent message's actual timestamp.
         }
+        // Clean Fields
+        ThreadUI.cleanFields();
       });
     }
   },


### PR DESCRIPTION
- Please modify the delete function in view page first. There is no need to separate the pending message or original message, all you have to do is record deleted numbers or IDs and call message.deleteMessages.
- Add the ability for deleting messages in both DB via message management deleteMessages. I haven't test it yet, but user should only need to call deleteMessages function with id. If the function could not work correctly, please inform me.
- I made a little modification in pending DB, so please use "make reset-gaia" to remove the pending DB if you already have it.
- Move the clearField function for resend ability. If the input has been cleared before resend, the resend could not work.
