### PR TITLE
[calendar] use the en-US locale by default

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html class="ltr">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta charset="utf-8">
+  <meta http-equiv="pragma" content="no-cache">
+  <title>Calendar</title>
+
   <link rel="stylesheet" type="text/css" href="/style/calendar.css">
   <link rel="stylesheet" type="text/css" href="/style/ui.css">
   <link rel="stylesheet" type="text/css" href="/style/events.css">

--- a/apps/calendar/locales/locales.ini
+++ b/apps/calendar/locales/locales.ini
@@ -1,3 +1,5 @@
+@import url(calendar.en-US.properties)
+
 [ar]
 @import url(calendar.ar.properties)
 
@@ -10,8 +12,8 @@
 [el]
 @import url(calendar.el.properties)
 
-[en-US]
-@import url(calendar.en-US.properties)
+#[en-US]
+#@import url(calendar.en-US.properties)
 
 [es]
 @import url(calendar.es.properties)

--- a/apps/calendar/style/events.css
+++ b/apps/calendar/style/events.css
@@ -1,9 +1,9 @@
-.day-events h4, 
+.day-events h4,
 .day-events h5 {
   font-weight: normal;
   /*overflow: hidden;
     word-wrap: break-word;
-    text-overflow: '...';  
+    text-overflow: '...';
     white-space: nowrap;
     max-width: -moz-calc(50% - 10rem);*/
 
@@ -32,7 +32,7 @@
 
 .rtl .day-events section > h4 {
   -moz-box-ordinal-group: 2;
-  text-aligh: left;
+  text-align: left;
   padding-left: 0.52rem;
 }
 


### PR DESCRIPTION
Some strings have been added to the `en-US` locale but not to other locales, which can lead to blank UI widgets. If we suppose that an untranslated string is better than no string at all, there here are two ways to handle this situation:
- copy all untranslated English strings into other l10n resource files;
- always preload the `en-US` l10n resource before the l10n resource that matches the current locale.

Here we’re choosing the second method. This adds a disk I/O for non-English locales but it’s simpler to handle. If our l10n driver can provide tools to apply the first method automatically (hi Staś!), that’d be great. 
