### PR TITLE
Makefile simplifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,21 @@ else
 	test -d xulrunner-sdk || ($(DOWNLOAD_CMD) $(XULRUNNER_SDK_DOWNLOAD) && tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2)
 endif
 
+define run-js-command
+	@echo "run-js-command $1";                                                  \
+	JS_CONSTS='                                                                 \
+	const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)$(SEP)profile"; \
+	const GAIA_SCHEME = "$(SCHEME)"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)";      \
+	const DEBUG = $(DEBUG); const LOCAL_DOMAINS = $(LOCAL_DOMAINS);             \
+	const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)";       \
+	const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)";                             \
+  const GAIA_APP_RELATIVEPATH = "$(GAIA_APP_RELATIVEPATH)"';                  \
+	$(XULRUNNERSDK) $(XPCSHELLSDK) -e "$$JS_CONSTS" "build/$(strip $1).js"
+endef
+
 settingsdb: install-xulrunner-sdk
 	@echo "B2G pre-populate settings DB."
-	$(XULRUNNERSDK) $(XPCSHELLSDK) -e 'const PROFILE_DIR = "$(CURDIR)$(SEP)profile";' build/settings.js
+	$(call run-js-command, settings)
 
 DB_TARGET_PATH = /data/local/indexedDB
 ifneq ($(SYS),Darwin)
@@ -299,7 +311,7 @@ install-settingsdb: settingsdb install-xulrunner-sdk
 preferences: install-xulrunner-sdk
 	@echo "Generating prefs.js..."
 	test -d profile || mkdir -p profile
-	$(XULRUNNERSDK) $(XPCSHELLSDK) -e 'const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)/profile"; const GAIA_SCHEME = "$(SCHEME)"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)"; const DEBUG = $(DEBUG); const LOCAL_DOMAINS = $(LOCAL_DOMAINS); const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)"; const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)"' build/preferences.js
+	$(call run-js-command, preferences)
 	if [ -f custom-prefs.js ]; \
 	  then \
 	    cat custom-prefs.js >> profile/user.js; \
@@ -311,7 +323,7 @@ preferences: install-xulrunner-sdk
 permissions: install-xulrunner-sdk
 	@echo "Generating permissions.sqlite..."
 	test -d profile || mkdir -p profile
-	$(XULRUNNERSDK) $(XPCSHELLSDK) -e 'const GAIA_DIR = "$(CURDIR)"; const PROFILE_DIR = "$(CURDIR)/profile"; const GAIA_SCHEME = "$(SCHEME)"; const GAIA_DOMAIN = "$(GAIA_DOMAIN)"; const DEBUG = $(DEBUG); const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)"; const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)"' build/permissions.js
+	$(call run-js-command, permissions)
 	@echo "Done. If this results in an error remove the xulrunner/xulrunner-sdk folder in your gaia folder."
 
 # Generate profile/extensions

--- a/Makefile
+++ b/Makefile
@@ -334,13 +334,6 @@ extensions:
 	@rm -rf $(EXT_DIR)
 ifeq ($(DEBUG),1)
 	cp -r tools/extensions $(EXT_DIR)
-	# httpd
-	@$(SED_INPLACE_NO_SUFFIX) -e 's|@GAIA_DOMAIN@|$(GAIA_DOMAIN)|g' $(EXT_DIR)/httpd/content/httpd.js
-	@$(SED_INPLACE_NO_SUFFIX) -e 's|@GAIA_APP_RELATIVEPATH@|$(GAIA_APP_RELATIVEPATH)|g' $(EXT_DIR)/httpd/content/httpd.js
-	@$(SED_INPLACE_NO_SUFFIX) -e 's|@GAIA_DIR@|$(subst \\,\\\\,$(CURDIR))|g' $(EXT_DIR)/httpd/bootstrap.js
-	@$(SED_INPLACE_NO_SUFFIX) -e 's|@GAIA_DOMAIN@|$(GAIA_DOMAIN)|g' $(EXT_DIR)/httpd/bootstrap.js
-	@$(SED_INPLACE_NO_SUFFIX) -e 's|@GAIA_PORT@|$(subst :,,$(GAIA_PORT))|g' $(EXT_DIR)/httpd/bootstrap.js
-	@$(SED_INPLACE_NO_SUFFIX) -e 's|@GAIA_APP_SRCDIRS@|$(GAIA_APP_SRCDIRS)|g' $(EXT_DIR)/httpd/bootstrap.js
 endif
 	@echo "Done"
 

--- a/Makefile
+++ b/Makefile
@@ -142,55 +142,7 @@ LANG=POSIX # Avoiding sort order differences between OSes
 webapp-manifests:
 	@echo "Generated webapps"
 	@mkdir -p profile/webapps
-	@echo { > profile/webapps/webapps.json
-	id=1; \
-	for d in `find ${GAIA_APP_SRCDIRS} -mindepth 1 -maxdepth 1 -type d` ;\
-	do \
-	  if [ -f $$d/manifest.webapp ]; \
-		then \
-			n=$$(basename $$d); \
-			if [ "$(BUILD_APP_NAME)" = "$$n" -o "$(BUILD_APP_NAME)" = "*" ]; \
-			then \
-				dirname=$$n.$(GAIA_DOMAIN); \
-				mkdir -p profile/webapps/$$dirname; \
-				cp $$d/manifest.webapp profile/webapps/$$dirname/manifest.webapp  ;\
-				(\
-				echo \"$$dirname\": { ;\
-				echo \"origin\": \"$(SCHEME)$$n.$(GAIA_DOMAIN)$(GAIA_PORT)\", ;\
-				echo \"installOrigin\": \"$(SCHEME)$$n.$(GAIA_DOMAIN)$(GAIA_PORT)\", ;\
-				echo \"receipt\": null, ;\
-				echo \"installTime\": 132333986000, ;\
-				echo \"manifestURL\": \"$(SCHEME)$$n.$(GAIA_DOMAIN)$(GAIA_PORT)/manifest.webapp\", ;\
-				echo \"localId\": $$id ;\
-				echo },) >> profile/webapps/webapps.json;\
-				: $$((id++)); \
-			fi \
-		fi \
-	done; \
-	cd external-apps; \
-	for d in `find * -maxdepth 0 -type d` ;\
-	do \
-	  if [ -f $$d/manifest.webapp ]; \
-		then \
-			if [ "$(BUILD_APP_NAME)" = "$$d" -o "$(BUILD_APP_NAME)" = "*" ]; \
-			then \
-		  	mkdir -p ../profile/webapps/$$d; \
-		  	cp $$d/manifest.webapp ../profile/webapps/$$d/manifest.webapp  ;\
-                  (\
-				echo \"$$d\": { ;\
-				echo \"origin\": \"`cat $$d/origin`\", ;\
-				echo \"installOrigin\": \"`cat $$d/origin`\", ;\
-				echo \"receipt\": null, ;\
-				echo \"installTime\": 132333986000, ;\
-				echo \"manifestURL\": \"`cat $$d/origin`/manifest.webapp\", ;\
-				echo \"localId\": $$id ;\
-				echo },) >> ../profile/webapps/webapps.json;\
-				: $$((id++)); \
-			fi \
-		fi \
-	done
-	@$(SED_INPLACE_NO_SUFFIX) -e '$$s|,||' profile/webapps/webapps.json
-	@echo } >> profile/webapps/webapps.json
+	$(call run-js-command, webapp-manifests)
 	@cat profile/webapps/webapps.json
 	@echo "Done"
 
@@ -285,7 +237,8 @@ define run-js-command
 	const DEBUG = $(DEBUG); const LOCAL_DOMAINS = $(LOCAL_DOMAINS);             \
 	const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)";       \
 	const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)";                             \
-  const GAIA_APP_RELATIVEPATH = "$(GAIA_APP_RELATIVEPATH)"';                  \
+	const GAIA_APP_RELATIVEPATH = "$(GAIA_APP_RELATIVEPATH)";                   \
+	const BUILD_APP_NAME = "$(BUILD_APP_NAME)";';                               \
 	$(XULRUNNERSDK) $(XPCSHELLSDK) -e "$$JS_CONSTS" "build/$(strip $1).js"
 endef
 

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -207,11 +207,11 @@ if (DEBUG) {
 
   // Preferences for httpd
   // (Use JSON.stringify in order to avoid taking care of `\` escaping)
-  content += "user_pref(\"gaia.dir\", " + JSON.stringify(GAIA_DIR) + ");\n";
-  content += "user_pref(\"gaia.domain\", " + JSON.stringify(GAIA_DOMAIN) + ");\n";
-  content += "user_pref(\"gaia.port\", "+ GAIA_PORT.replace(/:/g, "") + ");\n";
-  content += "user_pref(\"gaia.app_src_dirs\", " + JSON.stringify(GAIA_APP_SRCDIRS) + ");\n";
-  content += "user_pref(\"gaia.app_relative_path\", " + JSON.stringify(GAIA_APP_RELATIVEPATH) + ");\n";
+  content += "user_pref(\"extensions.gaia.dir\", " + JSON.stringify(GAIA_DIR) + ");\n";
+  content += "user_pref(\"extensions.gaia.domain\", " + JSON.stringify(GAIA_DOMAIN) + ");\n";
+  content += "user_pref(\"extensions.gaia.port\", "+ GAIA_PORT.replace(/:/g, "") + ");\n";
+  content += "user_pref(\"extensions.gaia.app_src_dirs\", " + JSON.stringify(GAIA_APP_SRCDIRS) + ");\n";
+  content += "user_pref(\"extensions.gaia.app_relative_path\", " + JSON.stringify(GAIA_APP_RELATIVEPATH) + ");\n";
 
   content += "\n";
 }

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -204,6 +204,15 @@ if (DEBUG) {
   content += "user_pref(\"dom.mozContacts.enabled\", true);\n";
   content += "user_pref(\"dom.mozSettings.enabled\", true);\n";
   content += "user_pref(\"device.storage.enabled\", true);\n";
+
+  // Preferences for httpd
+  // (Use JSON.stringify in order to avoid taking care of `\` escaping)
+  content += "user_pref(\"gaia.dir\", " + JSON.stringify(GAIA_DIR) + ");\n";
+  content += "user_pref(\"gaia.domain\", " + JSON.stringify(GAIA_DOMAIN) + ");\n";
+  content += "user_pref(\"gaia.port\", "+ GAIA_PORT.replace(/:/g, "") + ");\n";
+  content += "user_pref(\"gaia.app_src_dirs\", " + JSON.stringify(GAIA_APP_SRCDIRS) + ");\n";
+  content += "user_pref(\"gaia.app_relative_path\", " + JSON.stringify(GAIA_APP_RELATIVEPATH) + ");\n";
+
   content += "\n";
 }
 

--- a/build/settings.js
+++ b/build/settings.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-const DEBUG = false;
+const SETTINGS_DEBUG = false;
 function debug(msg) {
-  if (DEBUG)
+  if (SETTINGS_DEBUG)
     dump("-*- Populate SettingsDB: " + msg + "\n");
 }
 

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -2,11 +2,11 @@ const { 'classes': Cc, 'interfaces': Ci, 'results': Cr, } = Components;
 
 function debug(msg) {
   if (DEBUG)
-    dump("-*- " + msg + "\n");
+    dump('-*- ' + msg + '\n');
 }
 
 function getSubDirectories(directory) {
-  let appsDir = Cc["@mozilla.org/file/local;1"]
+  let appsDir = Cc['@mozilla.org/file/local;1']
                .createInstance(Ci.nsILocalFile);
   appsDir.initWithPath(GAIA_DIR);
   appsDir.append(directory);
@@ -27,9 +27,9 @@ function getFileContent(file) {
                    .createInstance(Ci.nsIFileInputStream);
   fileStream.init(file, 1, 0, false);
 
-  let converterStream = Cc["@mozilla.org/intl/converter-input-stream;1"]
+  let converterStream = Cc['@mozilla.org/intl/converter-input-stream;1']
                           .createInstance(Ci.nsIConverterInputStream);
-  converterStream.init(fileStream, "utf-8", fileStream.available(),
+  converterStream.init(fileStream, 'utf-8', fileStream.available(),
                        Ci.nsIConverterInputStream.DEFAULT_REPLACEMENT_CHARACTER);
 
   let out = {};
@@ -44,7 +44,7 @@ function getFileContent(file) {
 }
 
 function writeContent(file, content) {
-  let stream = Cc["@mozilla.org/network/file-output-stream;1"]
+  let stream = Cc['@mozilla.org/network/file-output-stream;1']
                    .createInstance(Ci.nsIFileOutputStream);
   stream.init(file, 0x02 | 0x08 | 0x20, 0666, 0);
   stream.write(content, content.length);
@@ -54,7 +54,7 @@ function writeContent(file, content) {
 // Return an nsIFile by joining paths given as arguments
 // First path has to be an absolute one
 function getFile() {
-  let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsILocalFile);
+  let file = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsILocalFile);
   file.initWithPath(arguments[0]);
   if (arguments.length > 1) {
     for (let i = 1; i < arguments.length; i++) {
@@ -64,16 +64,16 @@ function getFile() {
   return file;
 }
 
-let webappsTargetDir = Cc["@mozilla.org/file/local;1"]
+let webappsTargetDir = Cc['@mozilla.org/file/local;1']
                .createInstance(Ci.nsILocalFile);
 webappsTargetDir.initWithPath(PROFILE_DIR);
 // Create profile folder if doesn't exists
 if (!webappsTargetDir.exists())
-  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt("0755", 8));
+  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt('0755', 8));
 // Create webapps folder if doesn't exists
-webappsTargetDir.append("webapps");
+webappsTargetDir.append('webapps');
 if (!webappsTargetDir.exists())
-  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt("0755", 8));
+  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt('0755', 8));
 
 let manifests = {};
 let id = 1;
@@ -83,19 +83,19 @@ let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
 appSrcDirs.forEach(function parseDirectory(srcDir) {
   getSubDirectories(srcDir).forEach(function readManifests(webappSrcDirName) {
     // If BUILD_APP_NAME isn't `*`, we only accept one webapp
-    if (BUILD_APP_NAME != "*" && webappSrcDirName != BUILD_APP_NAME)
+    if (BUILD_APP_NAME != '*' && webappSrcDirName != BUILD_APP_NAME)
       return;
     let webappSrcDir = getFile(GAIA_DIR, srcDir, webappSrcDirName);
 
     // Compute webapp folder name in profile
-    let webappTargetDirName = webappSrcDirName + "." + GAIA_DOMAIN;
+    let webappTargetDirName = webappSrcDirName + '.' + GAIA_DOMAIN;
 
     // Copy webapp's manifest to the profile
     let manifest = webappSrcDir.clone();
-    manifest.append("manifest.webapp");
+    manifest.append('manifest.webapp');
     let webappTargetDir = webappsTargetDir.clone();
     webappTargetDir.append(webappTargetDirName);
-    manifest.copyTo(webappTargetDir, "manifest.webapp");
+    manifest.copyTo(webappTargetDir, 'manifest.webapp');
 
     // Compute its URL
     let url = GAIA_SCHEME + webappTargetDirName + GAIA_PORT;
@@ -106,7 +106,7 @@ appSrcDirs.forEach(function parseDirectory(srcDir) {
       installOrigin: url,
       receipt:       null,
       installTime:   132333986000,
-      manifestURL:   url + "/manifest.webapp",
+      manifestURL:   url + '/manifest.webapp',
       localId:       id++
     };
 
@@ -114,10 +114,10 @@ appSrcDirs.forEach(function parseDirectory(srcDir) {
 });
 
 // Process external webapps from /gaia/external-app/ folder
-const EXTERNAL_APPS_DIR = "external-apps";
+const EXTERNAL_APPS_DIR = 'external-apps';
 getSubDirectories(EXTERNAL_APPS_DIR).forEach(function readManifests(webappSrcDirName) {
   // If BUILD_APP_NAME isn't `*`, we only accept one webapp
-  if (BUILD_APP_NAME != "*" && webappSrcDirName != BUILD_APP_NAME)
+  if (BUILD_APP_NAME != '*' && webappSrcDirName != BUILD_APP_NAME)
     return;
   let webappSrcDir = getFile(GAIA_DIR, EXTERNAL_APPS_DIR, webappSrcDirName);
 
@@ -126,17 +126,17 @@ getSubDirectories(EXTERNAL_APPS_DIR).forEach(function readManifests(webappSrcDir
 
   // Copy webapp's manifest to the profile
   let manifest = webappSrcDir.clone();
-  manifest.append("manifest.webapp");
+  manifest.append('manifest.webapp');
   let webappTargetDir = webappsTargetDir.clone();
   webappTargetDir.append(webappTargetDirName);
-  manifest.copyTo(webappTargetDir, "manifest.webapp");
+  manifest.copyTo(webappTargetDir, 'manifest.webapp');
 
   let origin = webappSrcDir.clone();
-  origin.append("origin");
+  origin.append('origin');
 
   let url = getFileContent(origin);
   // Strip any leading/ending spaces
-  url = url.replace(/^\s+|\s+$/, "");
+  url = url.replace(/^\s+|\s+$/, '');
 
   // Add webapp's entry to the webapps global manifest
   manifests[webappTargetDirName] = {
@@ -144,13 +144,13 @@ getSubDirectories(EXTERNAL_APPS_DIR).forEach(function readManifests(webappSrcDir
     installOrigin: url,
     receipt:       null,
     installTime:   132333986000,
-    manifestURL:   url + "/manifest.webapp",
+    manifestURL:   url + '/manifest.webapp',
     localId:       id++
   };
 });
 
 // Write webapps global manifest
 let manifestFile = webappsTargetDir.clone();
-manifestFile.append("webapps.json");
+manifestFile.append('webapps.json');
 // stringify json with 2 spaces indentation
-writeContent(manifestFile, JSON.stringify(manifests, null, 2) + "\n");
+writeContent(manifestFile, JSON.stringify(manifests, null, 2) + '\n');

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -1,0 +1,156 @@
+const { 'classes': Cc, 'interfaces': Ci, 'results': Cr, } = Components;
+
+function debug(msg) {
+  if (DEBUG)
+    dump("-*- " + msg + "\n");
+}
+
+function getSubDirectories(directory) {
+  let appsDir = Cc["@mozilla.org/file/local;1"]
+               .createInstance(Ci.nsILocalFile);
+  appsDir.initWithPath(GAIA_DIR);
+  appsDir.append(directory);
+
+  let dirs = [];
+  let files = appsDir.directoryEntries;
+  while (files.hasMoreElements()) {
+    let file = files.getNext().QueryInterface(Ci.nsILocalFile);
+    if (file.isDirectory()) {
+      dirs.push(file.leafName);
+    }
+  }
+  return dirs;
+}
+
+function getFileContent(file) {
+  let fileStream = Cc['@mozilla.org/network/file-input-stream;1']
+                   .createInstance(Ci.nsIFileInputStream);
+  fileStream.init(file, 1, 0, false);
+
+  let converterStream = Cc["@mozilla.org/intl/converter-input-stream;1"]
+                          .createInstance(Ci.nsIConverterInputStream);
+  converterStream.init(fileStream, "utf-8", fileStream.available(),
+                       Ci.nsIConverterInputStream.DEFAULT_REPLACEMENT_CHARACTER);
+
+  let out = {};
+  let count = fileStream.available();
+  converterStream.readString(count, out);
+
+  let content = out.value;
+  converterStream.close();
+  fileStream.close();
+
+  return content;
+}
+
+function writeContent(file, content) {
+  let stream = Cc["@mozilla.org/network/file-output-stream;1"]
+                   .createInstance(Ci.nsIFileOutputStream);
+  stream.init(file, 0x02 | 0x08 | 0x20, 0666, 0);
+  stream.write(content, content.length);
+  stream.close();
+}
+
+// Return an nsIFile by joining paths given as arguments
+// First path has to be an absolute one
+function getFile() {
+  let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsILocalFile);
+  file.initWithPath(arguments[0]);
+  if (arguments.length > 1) {
+    for (let i = 1; i < arguments.length; i++) {
+      file.append(arguments[i]);
+    }
+  }
+  return file;
+}
+
+let webappsTargetDir = Cc["@mozilla.org/file/local;1"]
+               .createInstance(Ci.nsILocalFile);
+webappsTargetDir.initWithPath(PROFILE_DIR);
+// Create profile folder if doesn't exists
+if (!webappsTargetDir.exists())
+  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt("0755", 8));
+// Create webapps folder if doesn't exists
+webappsTargetDir.append("webapps");
+if (!webappsTargetDir.exists())
+  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt("0755", 8));
+
+let manifests = {};
+let id = 1;
+
+// Process webapps from GAIA_APP_SRCDIRS folders
+let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
+appSrcDirs.forEach(function parseDirectory(srcDir) {
+  getSubDirectories(srcDir).forEach(function readManifests(webappSrcDirName) {
+    // If BUILD_APP_NAME isn't `*`, we only accept one webapp
+    if (BUILD_APP_NAME != "*" && webappSrcDirName != BUILD_APP_NAME)
+      return;
+    let webappSrcDir = getFile(GAIA_DIR, srcDir, webappSrcDirName);
+
+    // Compute webapp folder name in profile
+    let webappTargetDirName = webappSrcDirName + "." + GAIA_DOMAIN;
+
+    // Copy webapp's manifest to the profile
+    let manifest = webappSrcDir.clone();
+    manifest.append("manifest.webapp");
+    let webappTargetDir = webappsTargetDir.clone();
+    webappTargetDir.append(webappTargetDirName);
+    manifest.copyTo(webappTargetDir, "manifest.webapp");
+
+    // Compute its URL
+    let url = GAIA_SCHEME + webappTargetDirName + GAIA_PORT;
+
+    // Add webapp's entry to the webapps global manifest
+    manifests[webappTargetDirName] = {
+      origin:        url,
+      installOrigin: url,
+      receipt:       null,
+      installTime:   132333986000,
+      manifestURL:   url + "/manifest.webapp",
+      localId:       id++
+    };
+
+  });
+});
+
+// Process external webapps from /gaia/external-app/ folder
+const EXTERNAL_APPS_DIR = "external-apps";
+getSubDirectories(EXTERNAL_APPS_DIR).forEach(function readManifests(webappSrcDirName) {
+  // If BUILD_APP_NAME isn't `*`, we only accept one webapp
+  if (BUILD_APP_NAME != "*" && webappSrcDirName != BUILD_APP_NAME)
+    return;
+  let webappSrcDir = getFile(GAIA_DIR, EXTERNAL_APPS_DIR, webappSrcDirName);
+
+  // Compute webapp folder name in profile
+  let webappTargetDirName = webappSrcDirName;
+
+  // Copy webapp's manifest to the profile
+  let manifest = webappSrcDir.clone();
+  manifest.append("manifest.webapp");
+  let webappTargetDir = webappsTargetDir.clone();
+  webappTargetDir.append(webappTargetDirName);
+  manifest.copyTo(webappTargetDir, "manifest.webapp");
+
+  let origin = webappSrcDir.clone();
+  origin.append("origin");
+
+  let url = getFileContent(origin);
+  // Strip any leading/ending spaces
+  url = url.replace(/^\s+|\s+$/, "");
+
+  // Add webapp's entry to the webapps global manifest
+  manifests[webappTargetDirName] = {
+    origin:        url,
+    installOrigin: url,
+    receipt:       null,
+    installTime:   132333986000,
+    manifestURL:   url + "/manifest.webapp",
+    localId:       id++
+  };
+});
+
+// Write webapps global manifest
+let manifestFile = webappsTargetDir.clone();
+manifestFile.append("webapps.json");
+// stringify json with 2 spaces indentation
+writeContent(manifestFile, JSON.stringify(manifests, null, 2) + "\n");

--- a/tools/extensions/httpd/bootstrap.js
+++ b/tools/extensions/httpd/bootstrap.js
@@ -12,10 +12,10 @@ function startup(data, reason) {
   Cu.import('resource://gre/modules/Services.jsm');
   Cu.import('resource:///modules/devtools/dbg-client.jsm');
   
-  const GAIA_DOMAIN = Services.prefs.getCharPref("gaia.domain");
-  const GAIA_APP_SRCDIRS = Services.prefs.getCharPref("gaia.app_src_dirs");
-  const GAIA_DIR = Services.prefs.getCharPref("gaia.dir");
-  const GAIA_PORT = Services.prefs.getIntPref("gaia.port");
+  const GAIA_DOMAIN = Services.prefs.getCharPref("extensions.gaia.domain");
+  const GAIA_APP_SRCDIRS = Services.prefs.getCharPref("extensions.gaia.app_src_dirs");
+  const GAIA_DIR = Services.prefs.getCharPref("extensions.gaia.dir");
+  const GAIA_PORT = Services.prefs.getIntPref("extensions.gaia.port");
 
   const LocalFile = CC('@mozilla.org/file/local;1',
                        'nsILocalFile',

--- a/tools/extensions/httpd/bootstrap.js
+++ b/tools/extensions/httpd/bootstrap.js
@@ -12,6 +12,11 @@ function startup(data, reason) {
   Cu.import('resource://gre/modules/Services.jsm');
   Cu.import('resource:///modules/devtools/dbg-client.jsm');
   
+  const GAIA_DOMAIN = Services.prefs.getCharPref("gaia.domain");
+  const GAIA_APP_SRCDIRS = Services.prefs.getCharPref("gaia.app_src_dirs");
+  const GAIA_DIR = Services.prefs.getCharPref("gaia.dir");
+  const GAIA_PORT = Services.prefs.getIntPref("gaia.port");
+
   const LocalFile = CC('@mozilla.org/file/local;1',
                        'nsILocalFile',
                        'initWithPath');
@@ -40,7 +45,7 @@ function startup(data, reason) {
     let identity = server.identity;
     let scheme = 'http';
   
-    let host = '@GAIA_DOMAIN@';
+    let host = GAIA_DOMAIN;
     identity.add(scheme, host, port);
   
     let directories = getDirectories(baseDir);
@@ -53,7 +58,7 @@ function startup(data, reason) {
   
   function getDirectories(dir) {
     let dirs = [];
-    let appSrcDirs = '@GAIA_APP_SRCDIRS@'.split(' ');
+    let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
 
     appSrcDirs.forEach(function addDirectory(name) {
       let appsDir = Cc['@mozilla.org/file/local;1']
@@ -333,7 +338,7 @@ function startup(data, reason) {
     }
   };
   
-  startupHttpd('@GAIA_DIR@', @GAIA_PORT@);
+  startupHttpd(GAIA_DIR, GAIA_PORT);
 }
   
 function shutdown(data, reason) {

--- a/tools/extensions/httpd/content/httpd.js
+++ b/tools/extensions/httpd/content/httpd.js
@@ -42,8 +42,8 @@
 
 // GAIA-
 Components.utils.import('resource://gre/modules/Services.jsm');
-const GAIA_DOMAIN = Services.prefs.getCharPref("gaia.domain");
-const GAIA_APP_RELATIVEPATH = Services.prefs.getCharPref("gaia.app_relative_path");
+const GAIA_DOMAIN = Services.prefs.getCharPref("extensions.gaia.domain");
+const GAIA_APP_RELATIVEPATH = Services.prefs.getCharPref("extensions.gaia.app_relative_path");
 // -GAIA
 
 /*

--- a/tools/extensions/httpd/content/httpd.js
+++ b/tools/extensions/httpd/content/httpd.js
@@ -40,6 +40,12 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
+// GAIA-
+Components.utils.import('resource://gre/modules/Services.jsm');
+const GAIA_DOMAIN = Services.prefs.getCharPref("gaia.domain");
+const GAIA_APP_RELATIVEPATH = Services.prefs.getCharPref("gaia.app_relative_path");
+// -GAIA
+
 /*
  * An implementation of an HTTP server both as a loadable script and as an XPCOM
  * component.  See the accompanying README file for user documentation on
@@ -1420,7 +1426,7 @@ RequestReader.prototype =
           var hostPort = request._headers.getHeader("Host");
           var colon = hostPort.indexOf(":");
           var host = (colon < 0) ? hostPort : hostPort.substring(0, colon);
-          if (host != "@GAIA_DOMAIN@" && host.indexOf(".") != -1) {
+          if (host != GAIA_DOMAIN && host.indexOf(".") != -1) {
             var oldPath = request._path;
             var applicationName = host.split(".")[0];
 
@@ -1458,7 +1464,7 @@ RequestReader.prototype =
 
     this._realPath = {};
 
-    var appPathList = "@GAIA_APP_RELATIVEPATH@".trim().split(" ");
+    var appPathList = GAIA_APP_RELATIVEPATH.trim().split(" ");
     for (var i = 0; i < appPathList.length; i++) {
       var currentAppName = appPathList[i].split('/')[1];
 


### PR DESCRIPTION
Some Makefile "simplications" in order to ease building an addon allowing to play with b2g desktop without make or any other dependency than b2g and an addon.
Ideally all rules necessary to make gaia working on desktop should be implemented in an xpcshell script.
One of this pull request commit ease the use and call of such xpcshell script.
And two other commits are converting Makefile code into xpcshell one.
