### PR TITLE
Set title for mp3 files which have no title in the metadata.

### DIFF
--- a/apps/music/js/MetadataParser.js
+++ b/apps/music/js/MetadataParser.js
@@ -25,7 +25,7 @@ var metadataParser = (function() {
 
         metadata.album = tags.album;
         metadata.artist = tags.artist;
-        metadata.title = tags.title;
+        metadata.title = tags.title || file.name;
         metadata.picture = tags.picture;
 
         callback(metadata);


### PR DESCRIPTION
This helps fix the cases where mp3 files with no metadata don't
show up in the music app.
