### PR TITLE
Allow absolute http:// and https:// URIs for icons

### DIFF
--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -235,7 +235,9 @@ var Applications = (function() {
     // have those). Otherwise return the url directly as it could be
     // a data: url.
     var icon = icons[getIconSize(sizes)];
-    if (icon.indexOf('data:') !== 0) {
+    if ((icon.indexOf('data:') !== 0) &&
+        (icon.indexOf('http://') !== 0)  &&
+        (icon.indexOf('https://') !== 0)) {
       icon = origin + icon;
     }
 


### PR DESCRIPTION
This is a fix for issue #2837
