### PR TITLE
Keep the keyboard on the top of z-index hierarchy

### DIFF
--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -171,7 +171,6 @@ iframe.backgroundWindow {
 }
 
 #keyboard-frame.visible {
-  z-index: 9000;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Overview

This modifications keeps the keyboard frame on z-index 10001 (instead of 9000) and keyboard overlay on 10002.
## Flaws and future work
- It is necessary review the behaviour when fullscreen
- It should be great to count with sendToTop / sendToBottom functionalities.
