### PR TITLE
[Calendar] avoid the blank screen at startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,12 @@ ifneq ($(DEBUG),1)
 				do \
 					if [[ "$$f" == *shared/js* ]] ;\
 					then \
-						file_to_copy=`echo "$$f" | cut -d'/' -f 3 | cut -d'"' -f1;`; \
+						if [[ "$$f" == */shared/js* ]] ;\
+						then \
+							file_to_copy=`echo "$$f" | cut -d'/' -f 4 | cut -d'"' -f1 | cut -d"'" -f1;`; \
+						else \
+							file_to_copy=`echo "$$f" | cut -d'/' -f 3 | cut -d'"' -f1 | cut -d"'" -f1;`; \
+						fi; \
 						mkdir -p $$d/shared/js ;\
 						cp shared/js/$$file_to_copy $$d/shared/js/ ;\
 					fi \

--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -17,15 +17,15 @@
   <link rel="resource" type="application/l10n" href="/locales/locales.ini">
 
   <!--- shared -->
+  <script src="/shared/js/l10n.js" type="text/javascript" charset="utf-8"></script>
   <script src="/shared/js/desktop.js" type="text/javascript" charset="utf-8"></script>
   <script src="/shared/js/gesture_detector.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/shared/js/l10n.js" type="text/javascript" charset="utf-8"></script>
 
   <!--- vendor -->
   <script defer src="/js/ext/page.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/ext/caldav.js" type="text/javascript" charset="utf-8"></script>
 
-  <!--lib root must load before anything else -->
+  <!-- lib root must load before anything else -->
   <script defer src="/js/calendar.js" type="text/javascript" charset="utf-8"></script>
 
   <!--- utils -->
@@ -77,8 +77,6 @@
   <script defer src="/js/controllers/time.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/controllers/sync.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/app.js" type="text/javascript" charset="utf-8"></script>
-
-  <title>Gaia Calendar</title>
 </head>
 
 <body role="app" class="loading" onload="Calendar.App.init();">

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -118,9 +118,13 @@ Calendar.App = (function(window) {
         );
       }
 
-      window.addEventListener('localized', function() {
+      if (navigator.mozL10n && navigator.mozL10n.readyState == 'complete') {
         next();
-      });
+      } else {
+        window.addEventListener('localized', function() {
+          next();
+        });
+      }
 
       this.db.load(function() {
         next();
@@ -252,3 +256,12 @@ Calendar.App = (function(window) {
   return App;
 
 }(this));
+
+/*
+window.addEventListener('localized', function() {
+  console.log('(l10n) localized');
+  Calendar.App.init();
+});
+console.log('(l10n) loaded');
+*/
+

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -119,8 +119,10 @@ Calendar.App = (function(window) {
       }
 
       if (navigator.mozL10n && navigator.mozL10n.readyState == 'complete') {
+        // document is already localized
         next();
       } else {
+        // waiting for the document to be localized (= standard case)
         window.addEventListener('localized', function() {
           next();
         });
@@ -256,12 +258,4 @@ Calendar.App = (function(window) {
   return App;
 
 }(this));
-
-/*
-window.addEventListener('localized', function() {
-  console.log('(l10n) localized');
-  Calendar.App.init();
-});
-console.log('(l10n) loaded');
-*/
 

--- a/apps/calendar/js/calendar.js
+++ b/apps/calendar/js/calendar.js
@@ -29,4 +29,12 @@
 
   };
 
+  /*
+  window.addEventListener('localized', Calendar.App.init);
+  window.addEventListener('localized', function() {
+    Calendar.App.init();
+  });
+  */
+
 }(this));
+

--- a/apps/calendar/js/calendar.js
+++ b/apps/calendar/js/calendar.js
@@ -29,12 +29,5 @@
 
   };
 
-  /*
-  window.addEventListener('localized', Calendar.App.init);
-  window.addEventListener('localized', function() {
-    Calendar.App.init();
-  });
-  */
-
 }(this));
 

--- a/apps/calendar/test.js
+++ b/apps/calendar/test.js
@@ -1,0 +1,2 @@
+document.write('document loaded.<br>');
+

--- a/apps/calendar/test.js
+++ b/apps/calendar/test.js
@@ -1,2 +1,0 @@
-document.write('document loaded.<br>');
-

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -61,7 +61,6 @@
   }
 
   function fireL10nReadyEvent(lang) {
-    gReadyState = 'complete';
     var evtObject = document.createEvent('Event');
     evtObject.initEvent('localized', false, false);
     evtObject.language = lang;
@@ -235,6 +234,7 @@
     if (langCount == 0) {
       consoleLog('no resource to load, early way out');
       fireL10nReadyEvent(lang);
+      gReadyState = 'complete';
       return;
     }
 
@@ -247,6 +247,7 @@
         if (callback) // execute the [optional] callback
           callback();
         fireL10nReadyEvent(lang);
+        gReadyState = 'complete';
       }
     };
 

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -18,7 +18,7 @@
   var gAsyncResourceLoading = true;
 
   // debug helpers
-  var gDEBUG = true;
+  var gDEBUG = false;
   function consoleLog(message) {
     if (gDEBUG)
       console.log('[l10n] ' + message);

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -120,7 +120,7 @@
       var reComment = /^\s*#|^\s*$/;
       var reSection = /^\s*\[(.*)\]\s*$/;
       var reImport = /^\s*@import\s+url\((.*)\)\s*$/i;
-      var reSplit = /\s*=\s*/; // TODO: support backslashes to escape EOLs
+      var reSplit = /^([^=\s]*)\s*=\s*(.+)$/; // TODO: escape EOLs with '\'
 
       // parse the *.properties file into an associative array
       function parseRawLines(rawText, extendedSyntax) {
@@ -142,8 +142,8 @@
             if (reSection.test(line)) { // section start?
               match = reSection.exec(line);
               currentLang = match[1];
-              skipLang = (currentLang != '*') &&
-                  (currentLang != lang) && (currentLang != genericLang);
+              skipLang = (currentLang !== '*') &&
+                  (currentLang !== lang) && (currentLang !== genericLang);
               continue;
             } else if (skipLang) {
               continue;
@@ -155,9 +155,9 @@
           }
 
           // key-value pair
-          var tmp = line.split(reSplit);
-          if (tmp.length > 1)
-            dictionary[tmp[0]] = evalString(tmp[1]);
+          var tmp = line.match(reSplit);
+          if (tmp && tmp.length == 3)
+            dictionary[tmp[1]] = evalString(tmp[2]);
         }
       }
 


### PR DESCRIPTION
See issue #2729 — we had two problems there:
- sometimes, the `l10n.js` library fired the `localized` event _before_ the main calendar JS files started;
- the `Makefile` could not copy shared files (including `l10n.js) because their URLs were starting with a slash.

The `l10n.js` library now exposes a `readyState` property that can be checked to prevent race conditions.
