### PR TITLE
Don't clear networks area if scan failed

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -333,8 +333,6 @@ window.addEventListener('localized', function wifiSettings(evt) {
       };
 
       req.onerror = function onScanError(error) {
-        clear(false);
-
         // auto-rescan if requested
         if (autoscan)
           window.setTimeout(scan, scanRate);


### PR DESCRIPTION
Network scan sometimes fail when Wifi is just enabled.
For a better user experience, showing "searching" instead of a blank area, and wait for refreshing at the second scan.
