### PR TITLE
Generalize all settings synchronization between apps.

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -16,20 +16,32 @@ var Settings = {
     if (!settings) // e.g. when debugging on a browser...
       return;
 
-    var airplaneCheckBox =
-        document.querySelector('input[name="ril.radio.disabled"]');
-    settings.addObserver('ril.radio.disabled', function(event) {
-       if (airplaneCheckBox.checked !== event.settingValue) {
-         airplaneCheckBox.checked = event.settingValue;
-       }
-    });
-    var mobileDataCheckBox =
-        document.querySelector('input[name="ril.data.enabled"]');
-    settings.addObserver('ril.data.enabled', function(event) {
-       if (mobileDataCheckBox.checked !== event.settingValue) {
-         mobileDataCheckBox.checked = event.settingValue;
-       }
-    });
+    settings.onsettingchange = function settingChanged(event) {
+      var key = event.settingName;
+      var value = event.settingValue;
+
+      var checkbox =
+          document.querySelector('input[name="' + key + '"]');
+      if (checkbox) {
+        if (checkbox.checked == value)
+          return;
+        checkbox.checked = value;
+        return;
+      }
+
+      var progressBar =
+          document.querySelector('[data-name="' + key + '"]');
+      if (progressBar) {
+        var intValue = Math.ceil(value * 10);
+        if (progressBar.value == intValue)
+          return;
+        progressBar.value = intValue;
+        return;
+      }
+
+      // XXX: if there are more values needs to be synced.
+    };
+
     // preset all inputs that have a `name' attribute
     var transaction = settings.getLock();
 


### PR DESCRIPTION
Now there are some settings needs to be synced between System app and Settings app.
To generalize all settings instead of registering a callback function for each of them, this way will monitor all checkbox and progress bar settings from System app, and set them back to the UI of Setting app.
