### PR TITLE
[Homescreen] Bug fixed transitioning in edit mode worked slow

### DIFF
--- a/apps/homescreen/js/dock.js
+++ b/apps/homescreen/js/dock.js
@@ -13,7 +13,7 @@ const DockManager = (function() {
     evt.preventDefault();
     evt.stopPropagation();
     if (GridManager.pageHelper.getCurrentPageNumber() >= 1) {
-      document.body.dataset.mode = 'edit';
+      Homescreen.setMode('edit');
 
       if ('origin' in evt.target.dataset) {
         document.body.dataset.transitioning = true;

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -70,7 +70,7 @@ const GridManager = (function() {
           evt.stopPropagation();
           evt.preventDefault();
           goToPage(pages.current);
-          document.body.dataset.mode = 'edit';
+          Homescreen.setMode('edit');
           if ('origin' in evt.target.dataset) {
             DragDropManager.start(evt, startEvent);
           }
@@ -142,35 +142,35 @@ const GridManager = (function() {
   }
 
   function goToPage(index, callback) {
+
+    if (index === 0 && pages.current === 1 && Homescreen.isInEditMode()) {
+      index = 1;
+    }
+
     var previousIndex = pages.current;
     var isSamePage = pages.current === index;
     pages.current = index;
     callback = callback || function() {};
-    var panEnd = isSamePage ? function fncSamePage() {
-      callback();
-      if (!dragging) {
-        delete document.body.dataset.transitioning;
-      }
-    } : function fncNoSamePage() {
-      callback();
+
+    var currentPageContainer = pageHelper.getCurrent().container;
+
+    currentPageContainer.addEventListener('transitionend', function end(e) {
+      currentPageContainer.removeEventListener('transitionend', end);
       Search.resetIcon();
       pageHelper.getCurrent().bounce(previousIndex - index,
       function bounceEnd() {
         if (!dragging) {
           delete document.body.dataset.transitioning;
         }
+        callback();
       });
-    }
-
-    var currentPageContainer = pageHelper.getCurrent().container;
-
-    currentPageContainer.addEventListener('transitionend', function end(e) {
-      currentPageContainer.removeEventListener('transitionend', end);
-      panEnd();
     });
 
-    pan(0, .2);
-    updatePaginationBar();
+    pan(0, .3);
+
+    if(!isSamePage) {
+      updatePaginationBar();
+    }
   }
 
   function goToNextPage(callback) {

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -69,7 +69,7 @@ const GridManager = (function() {
         if (pages.current !== 0) {
           evt.stopPropagation();
           evt.preventDefault();
-
+          goToPage(pages.current);
           document.body.dataset.mode = 'edit';
           if ('origin' in evt.target.dataset) {
             DragDropManager.start(evt, startEvent);
@@ -146,27 +146,28 @@ const GridManager = (function() {
     var isSamePage = pages.current === index;
     pages.current = index;
     callback = callback || function() {};
-
-    if (isSamePage) {
+    var panEnd = isSamePage ? function fncSamePage() {
       callback();
       if (!dragging) {
         delete document.body.dataset.transitioning;
       }
-    } else {
-      var currentPageContainer = pageHelper.getCurrent().container;
-
-      currentPageContainer.addEventListener('transitionend', function end(e) {
-        currentPageContainer.removeEventListener('transitionend', end);
-        callback();
-        Search.resetIcon();
-        pageHelper.getCurrent().bounce(previousIndex - index,
-        function bounceEnd() {
-          if (!dragging) {
-            delete document.body.dataset.transitioning;
-          }
-        });
+    } : function fncNoSamePage() {
+      callback();
+      Search.resetIcon();
+      pageHelper.getCurrent().bounce(previousIndex - index,
+      function bounceEnd() {
+        if (!dragging) {
+          delete document.body.dataset.transitioning;
+        }
       });
     }
+
+    var currentPageContainer = pageHelper.getCurrent().container;
+
+    currentPageContainer.addEventListener('transitionend', function end(e) {
+      currentPageContainer.removeEventListener('transitionend', end);
+      panEnd();
+    });
 
     pan(0, .2);
     updatePaginationBar();

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -143,11 +143,11 @@ const GridManager = (function() {
 
   function goToPage(index, callback) {
 
-    if (index === 0 && pages.current === 1 && Homescreen.isInEditMode()) {
+    var previousIndex = pages.current;
+    if (index === 0 && previousIndex === 1 && Homescreen.isInEditMode()) {
       index = 1;
     }
 
-    var previousIndex = pages.current;
     var isSamePage = pages.current === index;
     pages.current = index;
     callback = callback || function() {};

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -158,12 +158,12 @@ const GridManager = (function() {
       currentPageContainer.removeEventListener('transitionend', end);
       Search.resetIcon();
       pageHelper.getCurrent().bounce(previousIndex - index,
-      function bounceEnd() {
-        if (!dragging) {
-          delete document.body.dataset.transitioning;
-        }
-        callback();
-      });
+        function bounceEnd() {
+          if (!dragging) {
+            delete document.body.dataset.transitioning;
+          }
+          callback();
+        });
     });
 
     pan(0, .3);
@@ -555,4 +555,3 @@ const GridManager = (function() {
     }
   };
 })();
-

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -119,9 +119,8 @@ const Homescreen = (function() {
       return mode === 'edit';
     },
 
-    setMode: function(pmode) {
-      mode = document.body.dataset.mode = pmode;
+    setMode: function(newMode) {
+      mode = document.body.dataset.mode = newMode;
     }
   };
 })();
-

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -7,6 +7,8 @@ const Homescreen = (function() {
   var domain = host.replace(/(^[\w\d]+\.)?([\w\d]+\.[a-z]+)/, '$2');
   Search.init(domain);
 
+  var mode = 'normal';
+
   // Initialize the pagination scroller
   PaginationBar.init('.paginationScroller');
 
@@ -34,8 +36,8 @@ const Homescreen = (function() {
   window.addEventListener('message', function onMessage(e) {
     switch (e.data) {
       case 'home':
-        if (document.body.dataset.mode === 'edit') {
-          document.body.dataset.mode = 'normal';
+        if (Homescreen.isInEditMode()) {
+          Homescreen.setMode('normal');
           GridManager.saveState();
           DockManager.saveState();
           Permissions.hide();
@@ -111,6 +113,14 @@ const Homescreen = (function() {
       Permissions.show(title, body,
                        function onAccept() { app.uninstall() },
                        function onCancel() {});
+    },
+
+    isInEditMode: function() {
+      return mode === 'edit';
+    },
+
+    setMode: function(pmode) {
+      mode = document.body.dataset.mode = pmode;
     }
   };
 })();

--- a/apps/homescreen/js/page.js
+++ b/apps/homescreen/js/page.js
@@ -327,7 +327,7 @@ Page.prototype = {
    * @param{Object} DOM element
    */
   tap: function pg_tap(elem) {
-    if (document.body.dataset.mode === 'edit') {
+    if (Homescreen.isInEditMode()) {
       if (elem.className === 'options') {
         Homescreen.showAppDialog(elem.dataset.origin);
       }

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -9,10 +9,6 @@ html, body {
   overflow: hidden;
 }
 
-body {
-  background-color: rgba(52,64,82,.3);
-}
-
 * {
   -moz-user-select:none;
 }


### PR DESCRIPTION
Hi,

   1) Transitions between pages were slow in edit mode because the pulsating effect was enabled before the transition end event

   2) If users tap&hold and move a few pixels we should keep the position of the current page -> goToPage(pages.current)

Thanks
