### PR TITLE
[Contacts] Avoiding DomNodeInserted in the input_cancel_button lib

### DIFF
--- a/apps/contacts/js/input_cancel_button.js
+++ b/apps/contacts/js/input_cancel_button.js
@@ -20,19 +20,11 @@ var InputCancelButton = (function inputCancelButton() {
 
   // Waiting for new input additions to the DOM
   var initMutationsListener = function initMutationsListener() {
-    document.addEventListener('DOMNodeInserted', function(e) {
-      var inserted = e.target;
-      if (inserted.tagName == 'INPUT') {
-        listenForCheck(inserted);
-        return;
+    document.addEventListener('animationstart', function(event) {
+      if (event.animationName == 'nodeInserted') {
+        listenForCheck(event.target);
       }
-      var childInputs = inserted.querySelectorAll(selector);
-      if (childInputs) {
-        for (var i = 0; i < childInputs.length; i++) {
-          listenForCheck(childInputs[i]);
-        }
-      }
-    }, false);
+    }, true);
   };
 
   // Listening when someone is typing

--- a/apps/contacts/js/input_cancel_button.js
+++ b/apps/contacts/js/input_cancel_button.js
@@ -24,7 +24,7 @@ var InputCancelButton = (function inputCancelButton() {
       if (event.animationName == 'nodeInserted') {
         listenForCheck(event.target);
       }
-    }, true);
+    }, false);
   };
 
   // Listening when someone is typing

--- a/apps/contacts/style/input_cancel_button.css
+++ b/apps/contacts/style/input_cancel_button.css
@@ -4,3 +4,18 @@ span[role="button"].icon-clear {
   height: 1.7rem;
   margin-left: -2.7rem;
 }
+
+/* DOMNodeInserted more efficient workaround */
+@keyframes nodeInserted {  
+  from {  
+    clip: rect(1px, auto, auto, auto);  
+  }
+  to {  
+    clip: rect(0px, auto, auto, auto);
+  }  
+}
+
+input[data-cancelable] {
+  animation-duration: 0.001s;
+  animation-name: nodeInserted;
+}


### PR DESCRIPTION
As DOMNodeInserted decreases performance, we are using the CSS animations trick to detect new inputs, in order to apply them the cancel button

@arcturus @lightsofapollo r?
