### PR TITLE
[integration tests] use gaia xpcshell when none found

### DIFF
--- a/test_apps/test-agent/common/test/bin/test
+++ b/test_apps/test-agent/common/test/bin/test
@@ -1,6 +1,15 @@
 #!/bin/bash
 
 DIR=`cd $(dirname ${BASH_SOURCE[0]}); pwd;`
-XPCWINDOW=$DIR/../../../../../tools/xpcwindow/bin/xpcwindow
+GAIA_DIR=$DIR/../../../../..
+XPCWINDOW=$GAIA_DIR/tools/xpcwindow/bin/xpcwindow
+
+XPCSHELL=`which xpcshell`
+
+if [ ! -x "$XPCSHELL" ]
+then
+  PATH=$GAIA_DIR/xulrunner-sdk/bin/:$PATH;
+  echo "xpcshell is not found adding xulrunner-sdk using $GAIA_DIR/xulrunner-sdk/bin/xpcshell."
+fi
 
 $XPCWINDOW $DIR/../xpc.js $@


### PR DESCRIPTION
Tested on ubuntu && mac osx 10.7
