### PR TITLE
Fix the misspelled data-l10n-id attributes

### DIFF
--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -60,15 +60,15 @@
                   <div class="modal-dialog-message-container">
                     <span id="modal-dialog-alert-message"></span>
                   </div>
-                  <button id="modal-dialog-alert-ok" data-i10n-id="ok">OK</button>
+                  <button id="modal-dialog-alert-ok" data-l10n-id="ok">OK</button>
                 </div>
 
                 <div id="modal-dialog-confirm">
                   <div class="modal-dialog-message-container">
                     <span id="modal-dialog-confirm-message"></span>
                   </div>
-                  <button id="modal-dialog-confirm-ok" data-i10n-id="ok">OK</button>
-                  <button id="modal-dialog-confirm-cancel" data-i10n-id="cancel">
+                  <button id="modal-dialog-confirm-ok" data-l10n-id="ok">OK</button>
+                  <button id="modal-dialog-confirm-cancel" data-l10n-id="cancel">
                     Cancel
                   </button>
                 </div>
@@ -78,8 +78,8 @@
                     <span id="modal-dialog-prompt-message"></span>
                     <input id="modal-dialog-prompt-input" />
                   </div>
-                  <button id="modal-dialog-prompt-ok" data-i10n-id="ok">OK</button>
-                  <button id="modal-dialog-prompt-cancel" data-i10n-id="cancel">
+                  <button id="modal-dialog-prompt-ok" data-l10n-id="ok">OK</button>
+                  <button id="modal-dialog-prompt-cancel" data-l10n-id="cancel">
                     Cancel
                   </button>
                 </div>
@@ -115,29 +115,29 @@
         <menu type="toolbar">
           <button id="settings-done-button"></button>
         </menu>
-        <h1 data-i10n-id="firefox-settings">Firefox Settings</h1>
+        <h1 data-l10n-id="firefox-settings">Firefox Settings</h1>
       </header>
       <ul>
         <li>
           <button id="about-firefox-button"
-                  data-i10n-id="about-firefox">About Firefox</button>
+                  data-l10n-id="about-firefox">About Firefox</button>
         </li>
       </ul>
-      <h3 data-i10n-id="privacy-and-security">Privacy & Security</h3>
+      <h3 data-l10n-id="privacy-and-security">Privacy & Security</h3>
       <ul>
         <li id="enable-cookies">
           <label>
             <input type="checkbox" name="enable-cookies" disabled="disabled" />
-            <span data-i10n-id="enable-cookies" disabled="disabled">Enable Cookies</span>
+            <span data-l10n-id="enable-cookies" disabled="disabled">Enable Cookies</span>
           </label>
         </li>
         <li>
           <button id="clear-history-button"
-                  data-i10n-id="clear-history">Clear History</button>
+                  data-l10n-id="clear-history">Clear History</button>
         </li>
         <li>
           <button id="clear-private-data-button" disabled="disabled"
-                  data-i10n-id="clear-private-data">Clear Private Data</button>
+                  data-l10n-id="clear-private-data">Clear Private Data</button>
         </li>
 
       </ul>

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -164,11 +164,11 @@
             </div>
           </div>
           <div id="modal-dialog-buttons">
-            <button id="modal-dialog-alert-ok" data-i10n-id="ok">OK</button>
-            <button id="modal-dialog-confirm-ok" data-i10n-id="ok">OK</button>
-            <button id="modal-dialog-confirm-cancel" data-i10n-id="cancel">Cancel</button>
-            <button id="modal-dialog-prompt-ok" data-i10n-id="ok">OK</button>
-            <button id="modal-dialog-prompt-cancel" data-i10n-id="cancel">Cancel</button>
+            <button id="modal-dialog-alert-ok" data-l10n-id="ok">OK</button>
+            <button id="modal-dialog-confirm-ok" data-l10n-id="ok">OK</button>
+            <button id="modal-dialog-confirm-cancel" data-l10n-id="cancel">Cancel</button>
+            <button id="modal-dialog-prompt-ok" data-l10n-id="ok">OK</button>
+            <button id="modal-dialog-prompt-cancel" data-l10n-id="cancel">Cancel</button>
           </div>
         </div>
 
@@ -317,8 +317,8 @@
       <div id="value-selector" hidden>
          <div id="value-selector-container" onmousedown="return false;"> </div>
          <div id="value-selector-buttons">
-           <button id="value-selector-cancel" data-i10n-id="cancel">Cancel</button>
-           <button id="value-selector-confirm" data-i10n-id="ok" onmousedown="return false;">Ok</button>
+           <button id="value-selector-cancel" data-l10n-id="cancel">Cancel</button>
+           <button id="value-selector-confirm" data-l10n-id="ok" onmousedown="return false;">Ok</button>
          </div>
       </div>
 


### PR DESCRIPTION
I found a few cases where the `data-l10n-id` is misspelled as `data-i10n-id`. 
