### PR TITLE
Permissions

### DIFF
--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -8,9 +8,7 @@
   },
   "permissions": [
     "mozbrowser",
-    "systemXHR",
-    "indexedDB-unlimited",
-    "offline-app"
+    "systemXHR"
   ],
   "locales": {
     "ar": {

--- a/apps/calculator/manifest.webapp
+++ b/apps/calculator/manifest.webapp
@@ -7,7 +7,6 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "offline-app"
   ],
   "locales": {
     "ar": {

--- a/apps/calendar/manifest.webapp
+++ b/apps/calendar/manifest.webapp
@@ -7,8 +7,7 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "systemXHR",
-    "offline-app"
+    "systemXHR"
   ],
   "locales": {
     "ar": {

--- a/apps/camera/manifest.webapp
+++ b/apps/camera/manifest.webapp
@@ -10,8 +10,7 @@
   },
   "permissions": [
     "content-camera",
-    "camera",
-    "offline-app"
+    "camera"
   ],
   "activities": {
     "record": {

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -8,8 +8,7 @@
   },
   "permissions": [
     "alarm",
-    "alarms",
-    "offline-app"
+    "alarms"
   ],
   "locales": {
     "ar": {

--- a/apps/contacts/manifest.webapp
+++ b/apps/contacts/manifest.webapp
@@ -8,9 +8,7 @@
   },
   "permissions": [
     "contacts",
-    "webcontacts-manage",
-    "contacts-read",
-    "contacts-write"
+    "webcontacts-manage"
   ],
   "locales": {
     "ar": {

--- a/apps/contacts/manifest.webapp
+++ b/apps/contacts/manifest.webapp
@@ -10,9 +10,7 @@
     "contacts",
     "webcontacts-manage",
     "contacts-read",
-    "contacts-write",
-    "indexedDB-unlimited",
-    "offline-app"
+    "contacts-write"
   ],
   "locales": {
     "ar": {

--- a/apps/dialer/manifest.webapp
+++ b/apps/dialer/manifest.webapp
@@ -17,8 +17,7 @@
     "mozApps",
     "webapps",
     "mobileconnection",
-    "background",
-    "offline-app"
+    "background"
   ],
   "locales": {
     "ar": {

--- a/apps/dialer/manifest.webapp
+++ b/apps/dialer/manifest.webapp
@@ -10,8 +10,6 @@
     "telephony",
     "voicemail",
     "webcontacts-manage",
-    "contacts-read",
-    "contacts-write",
     "contacts",
     "power",
     "mozApps",

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -7,9 +7,7 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "systemXHR",
-    "indexedDB-unlimited",
-    "offline-app"
+    "systemXHR"
   ],
   "locales": {
     "ar": {

--- a/apps/fm/manifest.webapp
+++ b/apps/fm/manifest.webapp
@@ -8,8 +8,7 @@
   },
   "permissions": [
     "mozFM",
-    "fmradio",
-    "offline-app"
+    "fmradio"
   ],
   "locales": {
     "ar": {

--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -8,9 +8,7 @@
   },
   "permissions": [
     "device-storage",
-    "devicestorage",
-    "indexedDB-unlimited",
-    "offline-app"
+    "devicestorage"
   ],
   "activities": {
     "browse": {

--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -11,8 +11,7 @@
     "mozApps",
     "webapps",
     "device-storage",
-    "devicestorage",
-    "offline-app"
+    "devicestorage"
   ],
   "locales": {
     "ar": {

--- a/apps/keyboard/manifest.webapp
+++ b/apps/keyboard/manifest.webapp
@@ -7,6 +7,5 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "offline-app"
   ]
 }

--- a/apps/music/manifest.webapp
+++ b/apps/music/manifest.webapp
@@ -8,9 +8,7 @@
   },
   "permissions": [
     "device-storage",
-    "devicestorage",
-    "indexedDB-unlimited",
-    "offline-app"
+    "devicestorage"
   ],
   "locales": {
     "ar": {

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -12,8 +12,7 @@
     "device-storage",
     "devicestorage",
     "websettings-readwrite",
-    "settings-read",
-    "settings-write"
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -13,8 +13,7 @@
     "devicestorage",
     "websettings-readwrite",
     "settings-read",
-    "settings-write",
-    "offline-app"
+    "settings-write"
   ],
   "locales": {
     "ar": {

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -10,10 +10,7 @@
     "sms",
     "contacts",
     "webcontacts-manage",
-    "contacts-read",
-    "contacts-write",
-    "background",
-    "indexedDB-unlimited"
+    "background"
   ],
   "locales": {
     "ar": {

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -13,8 +13,7 @@
     "contacts-read",
     "contacts-write",
     "background",
-    "indexedDB-unlimited",
-    "offline-app"
+    "indexedDB-unlimited"
   ],
   "locales": {
     "ar": {

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -17,10 +17,8 @@
     "voicemail",
     "device-storage",
     "devicestorage",
-    "indexedDB-unlimited",
     "websettings-readwrite",
-    "settings-read",
-    "settings-write",
+    "settings",
     "pin-app"
   ],
   "locales": {

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -21,8 +21,7 @@
     "websettings-readwrite",
     "settings-read",
     "settings-write",
-    "pin-app",
-    "offline-app"
+    "pin-app"
   ],
   "locales": {
     "ar": {

--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -8,9 +8,7 @@
   },
   "permissions": [
     "device-storage",
-    "devicestorage",
-    "indexedDB-unlimited",
-    "offline-app"
+    "devicestorage"
   ],
   "locales": {
     "ar": {

--- a/build/permissions.js
+++ b/build/permissions.js
@@ -63,6 +63,8 @@ let permissionList = ["power", "sms", "contacts", "telephony",
                       "mobileconnection", "mozFM", "systemXHR",
                       "background"];
 
+let commonPermissionList = ['offline-app', 'indexedDB-unlimited'];
+
 let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
 
 (function registerProfileDirectory() {
@@ -106,7 +108,8 @@ appSrcDirs.forEach(function parseDirectory(directoryName) {
 
     let rootURL = GAIA_SCHEME + dir + "." + GAIA_DOMAIN + (GAIA_PORT ? GAIA_PORT : '');
 
-    let perms = manifest.permissions;
+    let perms = commonPermissionList.concat(manifest.permissions);
+
     if (perms) {
       for each(let name in perms) {
         if (permissionList.indexOf(name) == -1) {

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -143,7 +143,7 @@ appSrcDirs.forEach(function parseDirectory(directoryName) {
     let domain = dir + "." + GAIA_DOMAIN;
     privileges.push(rootURL);
     domains.push(domain);
-    dump("name:" + dir + "\n");
+
     let perms = manifest.permissions;
     if (perms) {
       for each(let name in perms) {

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -143,7 +143,7 @@ appSrcDirs.forEach(function parseDirectory(directoryName) {
     let domain = dir + "." + GAIA_DOMAIN;
     privileges.push(rootURL);
     domains.push(domain);
-
+    dump("name:" + dir + "\n");
     let perms = manifest.permissions;
     if (perms) {
       for each(let name in perms) {

--- a/test_apps/template/manifest.webapp
+++ b/test_apps/template/manifest.webapp
@@ -7,7 +7,6 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "offline-app"
   ],
   "locales": {
     "ar": {

--- a/test_apps/test-agent/manifest.webapp
+++ b/test_apps/test-agent/manifest.webapp
@@ -4,8 +4,7 @@
   "description": "Gaia Test Agent",
   "launch_path": "/index.html",
   "permissions": [
-    "power",
-    "offline-app"
+    "power"
   ],
   "locales": {
     "en-US": {

--- a/test_apps/uitest/manifest.webapp
+++ b/test_apps/uitest/manifest.webapp
@@ -14,7 +14,6 @@
     "contacts-read",
     "contacts-write",
     "settings-read",
-    "settings-write",
-    "offline-app"
+    "settings-write"
   ]
 }

--- a/test_apps/uitest/manifest.webapp
+++ b/test_apps/uitest/manifest.webapp
@@ -11,9 +11,6 @@
   "permissions": [
     "background",
     "contacts",
-    "contacts-read",
-    "contacts-write",
-    "settings-read",
-    "settings-write"
+    "settings"
   ]
 }


### PR DESCRIPTION
I added a list of permission that we want to add to all apps. We should remove them from shell.js in hg.
We are not adding contacts-read and contacts-write and settings-read.... Instead, the new .webapp will have an additional access field.
For example
  "permissions": {
    "mozbrowser": {
      description: "...",
      access: "read"
    },
  },
