### PR TITLE
[Contacts] Picking the correct number when a contact has multiple numbers

### DIFF
--- a/apps/contacts/index.html
+++ b/apps/contacts/index.html
@@ -97,10 +97,10 @@
                   <h2>#type#</h2>
                   <div class="item">
                     <div class="item-media pull-right">
-                      <button class="action" onclick="Contacts.sendSms()"><span role="button" class="icon-message">Message</span></button>
+                      <button class="action" onclick="Contacts.sendSms('#number#')"><span role="button" class="icon-message">Message</span></button>
                     </div>
                     <div class="item-body-exp">
-                      <button class="action" onclick="Contacts.callOrPick()">
+                      <button class="action" onclick="Contacts.callOrPick('#number#')">
                         <span role="button" class="icon-call" data-l10n-id="call">Call</span>
                         <b>#number#</b>
                         <em>#notes#</em>

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -675,14 +675,12 @@ var Contacts = (function() {
     this.goBack();
   };
 
-  var sendSms = function sendSms() {
+  var sendSms = function sendSms(number) {
     if (!ActivityHandler.currentlyHandling)
-      SmsIntegration.sendSms(currentContact.tel[0].number);
+      SmsIntegration.sendSms(number);
   }
 
-  var callOrPick = function callOrPick() {
-    // FIXME: only handling 1 number
-    var number = currentContact.tel[0].number;
+  var callOrPick = function callOrPick(number) {
     if (ActivityHandler.currentlyHandling) {
       ActivityHandler.postPickSuccess(number);
     } else {


### PR DESCRIPTION
When selecting a phone for an activity or launching the dialer, if a contact has multiple numbers now we will send the correct number.

Fix #3045
