### PR TITLE
Feature open settings from external app

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -117,11 +117,9 @@ var Settings = {
             }
 
             // Go to that section
-            setTimeout(
-              function settings_goToSection() {
-                document.location.hash = section;
-              }, 0
-            );
+            setTimeout(function settings_goToSection() {
+              document.location.hash = section;
+            });
             break;
         }
       }

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -1,4 +1,4 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 'use strict';
@@ -98,6 +98,40 @@ var Settings = {
         };
       })(progresses[i]);
     }
+
+    // handle web activity
+    navigator.mozSetMessageHandler('activity',
+      function settings_handleActivity(activityRequest) {
+        var name = activityRequest.source.name;
+        switch (name) {
+          case 'configure':
+            var section = activityRequest.source.data.section || 'root';
+
+            // Validate if the section exists
+            var actualSection = 
+              document.querySelector('section[id="' + section + '"]');
+            if (!actualSection) {
+              var msg = 'Trying to open an unexistent section: ' + section;
+              console.warn(msg);
+              activityRequest.postError(msg);
+              return;
+            }
+
+            // Emulate a click over a link to the specified section
+            var linkToSection = document.createElement('a');
+            linkToSection.href = '#' + section;
+            linkToSection.style.display = 'none';
+            document.body.appendChild(linkToSection);
+            var event = document.createEvent('MouseEvents');
+            event.initMouseEvent('click', true, true, window,
+                                 0, 0, 0, 0, 0,
+                                 false, false, false, false, 0, null);
+            linkToSection.dispatchEvent(event);
+            document.body.removeChild(linkToSection);
+            break;
+        }
+      }
+    );
   },
 
   handleEvent: function settings_handleEvent(evt) {

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -108,26 +108,20 @@ var Settings = {
             var section = activityRequest.source.data.section || 'root';
 
             // Validate if the section exists
-            var actualSection = 
-              document.querySelector('section[id="' + section + '"]');
-            if (!actualSection) {
+            var actualSection = document.getElementById(section);
+            if (!actualSection || actualSection.tagName !== 'SECTION') {
               var msg = 'Trying to open an unexistent section: ' + section;
               console.warn(msg);
               activityRequest.postError(msg);
               return;
             }
 
-            // Emulate a click over a link to the specified section
-            var linkToSection = document.createElement('a');
-            linkToSection.href = '#' + section;
-            linkToSection.style.display = 'none';
-            document.body.appendChild(linkToSection);
-            var event = document.createEvent('MouseEvents');
-            event.initMouseEvent('click', true, true, window,
-                                 0, 0, 0, 0, 0,
-                                 false, false, false, false, 0, null);
-            linkToSection.dispatchEvent(event);
-            document.body.removeChild(linkToSection);
+            // Go to that section
+            setTimeout(
+              function settings_goToSection() {
+                document.location.hash = section;
+              }, 0
+            );
             break;
         }
       }

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -16,6 +16,13 @@
     "settings-write",
     "offline-app"
   ],
+  "activities": {
+    "configure": {
+      "filters": {
+       },
+      "disposition": "window"
+    }
+  },
   "locales": {
     "ar": {
       "name": "\u0627\u0644\u0636\u0628\u0637",

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -17,6 +17,7 @@
   "activities": {
     "configure": {
       "filters": {
+        "target": "device"
        },
       "disposition": "window"
     }

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -44,6 +44,7 @@ var QuickSettings = {
               var activity = new MozActivity({
                 name: 'configure',
                 data: {
+                  target: 'device',
                   section: 'wifi'
                 }
               });

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -40,6 +40,15 @@ var QuickSettings = {
             navigator.mozSettings.getLock().set({
               'wifi.enabled': !enabled
             });
+            if (!enabled) {
+              var activity = new MozActivity({
+                name: 'configure',
+                data: {
+                  section: 'wifi'
+                }
+              });
+              UtilityTray.hide();
+            }
             break;
 
           case this.data:


### PR DESCRIPTION
# Overview

This pull request adds the feature to request the settings to be opened by another application displaying a specified section via web activities.

The web activity is named "configure" and it accepts a data entry called "section" in order to indicate the section which setting will be open at. Furthermore, you must pass a **"target"** entry (now, settings application only accepts <tt>"device"</tt> value) in order to specify what to configure.
# Flaws and future work
- Other parameter could be accepted such as the key you want to modify, subsections...
