### PR TITLE
Use visibility:hidden to prevent the loading-status gif from invalidatin...

### DIFF
--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -49,7 +49,7 @@
 
 #statusbar-loading[hidden] {
   display: block;
-  opacity: 0;
+  visibility: hidden;
 
   -moz-transition: none;
 }


### PR DESCRIPTION
...g and triggering repaints when it's supposed to be hidden.

Patch from Matt Woodrow.  This fixes a bug in which we were invalidating and repainting the homescreen too much because of the loading-image gif.
