### PR TITLE
Add Settings permission to .webapp files

### DIFF
--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "mozbrowser",
-    "systemXHR"
+    "systemXHR",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/calendar/manifest.webapp
+++ b/apps/calendar/manifest.webapp
@@ -7,7 +7,8 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "systemXHR"
+    "systemXHR",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "alarm",
-    "alarms"
+    "alarms",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/contacts/manifest.webapp
+++ b/apps/contacts/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "contacts",
-    "webcontacts-manage"
+    "webcontacts-manage",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/dialer/manifest.webapp
+++ b/apps/dialer/manifest.webapp
@@ -15,7 +15,8 @@
     "mozApps",
     "webapps",
     "mobileconnection",
-    "background"
+    "background",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -7,7 +7,8 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
-    "systemXHR"
+    "systemXHR",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/fm/manifest.webapp
+++ b/apps/fm/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "mozFM",
-    "fmradio"
+    "fmradio",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "device-storage",
-    "devicestorage"
+    "devicestorage",
+    "settings"
   ],
   "activities": {
     "browse": {

--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -11,7 +11,8 @@
     "mozApps",
     "webapps",
     "device-storage",
-    "devicestorage"
+    "devicestorage",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/keyboard/manifest.webapp
+++ b/apps/keyboard/manifest.webapp
@@ -7,5 +7,6 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": [
+    "settings"
   ]
 }

--- a/apps/music/manifest.webapp
+++ b/apps/music/manifest.webapp
@@ -8,7 +8,8 @@
   },
   "permissions": [
     "device-storage",
-    "devicestorage"
+    "devicestorage",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/apps/pdfjs/manifest.webapp
+++ b/apps/pdfjs/manifest.webapp
@@ -26,6 +26,7 @@
     }
   },
   "permissions": [
-    "systemXHR"
+    "systemXHR",
+    "settings"
   ]
 }

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -10,7 +10,8 @@
     "sms",
     "contacts",
     "webcontacts-manage",
-    "background"
+    "background",
+    "settings"
   ],
   "locales": {
     "ar": {

--- a/build/permissions.js
+++ b/build/permissions.js
@@ -61,7 +61,10 @@ function getJSON(root, dir, name) {
 let permissionList = ["power", "sms", "contacts", "telephony",
                       "mozBluetooth", "mozbrowser", "mozApps",
                       "mobileconnection", "mozFM", "systemXHR",
-                      "background"];
+                      "background", "settings", "offline-app",
+                      "indexedDB-unlimited", "alarm", "camera",
+                      "fmradio", "devicestorage", "voicemail",
+                      "pin-app"];
 
 let commonPermissionList = ['offline-app', 'indexedDB-unlimited'];
 


### PR DESCRIPTION
I looked through the usage of mozSettings and added the settings permissions to the .webapp files of the corresponding apps.
