### PR TITLE
Force x86_64 for OSX/i386

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ SHELL := /bin/bash
 # what OS are we on?
 SYS=$(shell uname -s)
 ARCH?=$(shell uname -m)
+ifeq (${SYS}/${ARCH},Darwin/i386)
+ARCH=x86_64
+endif
 SEP=/
 ifneq (,$(findstring MINGW32_,$(SYS)))
 CURDIR:=$(shell pwd -W | sed -e 's|/|\\\\|g')


### PR DESCRIPTION
Maybe this patch is not necessary because it can be overriden by specifying ARCH=x86_64 when running 'make'. But as long as there's no b2g nightly build and newer OSX releases are x86_64 only this fix can make the live a lot easier to new users because b2g fails to run because it's trying to load 32bit libraries from a 64bit runtime.

On OSX 10.6 uname -s returns "i386", but the kernel can run 32 and 64bit binaries.

It's true that old intel hardware on OSX does not gets updates because it's 32bit only, but if anyone still uses this hw/OS can override that option when running make.
