### PR TITLE
call mozHasPendingMessage *before* registering the message handler

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -416,7 +416,9 @@ function createThumbnail(imagenum) {
 //
 // Web Activities
 //
-navigator.mozSetMessageHandler('activity', function(activityRequest) {
+
+// Register this with navigator.mozSetMessageHandler
+function webActivityHandler(activityRequest) {
   if (pendingPick)
     cancelPick();
 
@@ -486,6 +488,9 @@ window.addEventListener('localized', function showBody() {
   // initial view
   if (!navigator.mozHasPendingMessage('activity'))
     setView(thumbnailListView);
+
+  // Register a handler for activities
+  navigator.mozSetMessageHandler('activity', webActivityHandler);
 });
 
 // Each of the photoFrame <div> elements may be subject to animated


### PR DESCRIPTION
This fixes a bug in the way the gallery app responds to Pick requests.
