### PR TITLE
modify apps to use new or old DeviceStorage API

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -270,8 +270,8 @@ var Camera = {
     this.hideFocusRing();
     this.restartPreview();
 
-    var storageAreas = navigator.getDeviceStorage('pictures');
-    var storage = storageAreas[0];
+    var storage = navigator.getDeviceStorage('pictures');
+    storage = storage[0] || storage; // Avoid API version skew
     var rightnow = new Date();
     var filename = 'img_' + rightnow.toLocaleFormat('%Y%m%d-%H%M%S') + '.jpg';
 

--- a/apps/gallery/js/MediaDB.js
+++ b/apps/gallery/js/MediaDB.js
@@ -191,7 +191,8 @@ function MediaDB(mediaType, metadataParser, options) {
 
   // Set up DeviceStorage
   try {
-    this.storage = navigator.getDeviceStorage(mediaType)[0];
+    this.storage = navigator.getDeviceStorage(mediaType);
+    this.storage = this.storage[0] || this.storage; // avoid API version skew
   }
   catch (e) {
     console.error("MediaDB(): can't get DeviceStorage object", e);

--- a/apps/music/js/MediaDB.js
+++ b/apps/music/js/MediaDB.js
@@ -191,7 +191,8 @@ function MediaDB(mediaType, metadataParser, options) {
 
   // Set up DeviceStorage
   try {
-    this.storage = navigator.getDeviceStorage(mediaType)[0];
+    this.storage = navigator.getDeviceStorage(mediaType);
+    this.storage = this.storage[0] || this.storage; // avoid API version skew
   }
   catch (e) {
     console.error("MediaDB(): can't get DeviceStorage object", e);

--- a/apps/system/js/screenshot.js
+++ b/apps/system/js/screenshot.js
@@ -33,7 +33,8 @@
   window.addEventListener('mozChromeEvent', function ss_onMozChromeEvent(e) {
     try {
       if (e.detail.type === 'take-screenshot-success') {
-        var storage = navigator.getDeviceStorage('pictures')[0];
+        var storage = navigator.getDeviceStorage('pictures');
+        storage = storage[0] || storage;  // avoid API version skew 
         if (!storage) { // If we don't have an SD card to save to, send an error
           navigator.mozNotification
             .createNotification(_('screenshotFailed'), _('screenshotNoSDCard'))

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -27,15 +27,8 @@ window.addEventListener('DOMContentLoaded', function() {
   var THUMBNAIL_WIDTH = 160;  // Just a guess at a size for now
   var THUMBNAIL_HEIGHT = 160;
 
-  //
-  // XXX
-  // We want /sdcard storage. Right now, that will be the last
-  // element in the array returned by getDeviceStorage().  But that is
-  // fragile and may change, so this code needs to evolve with the
-  // device storage API
-  //
-  var storages = navigator.getDeviceStorage('videos');
-  var storage = storages[storages.length - 1];
+  var storage = navigator.getDeviceStorage('videos');
+  storage = storage[0] || storage; // Avoid API version skew
 
   try {
     var cursor = storage.enumerate();


### PR DESCRIPTION
navigator.getDeviceStorage() used to return an array of objects, and now it returns a single object.

This pull request modifies Gallery, Music, Video, Camera, and the system screenshot module so that they can use either the new or old DeviceStorage API.

Once everyone is on the new API we may want to modify the apps again to abandon the old.

@daleharvey review?
