### PR TITLE
[Homescreen] Fixing bounce effect at the end of page translations

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -63,11 +63,6 @@ const GridManager = (function() {
         onTouchEnd(evt.clientX - startEvent.clientX, evt.target);
         break;
 
-      case 'resize':
-        limits.left = container.offsetWidth * 0.05;
-        limits.right = container.offsetWidth * 0.95;
-        break;
-
       case 'contextmenu':
         if (pages.current !== 0) {
           evt.stopPropagation();

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -72,7 +72,6 @@ const GridManager = (function() {
         if (pages.current !== 0) {
           evt.stopPropagation();
           evt.preventDefault();
-          goToPage(pages.current, {noBounce: true});
           Homescreen.setMode('edit');
           if ('origin' in evt.target.dataset) {
             DragDropManager.start(evt, startEvent);
@@ -529,11 +528,10 @@ const GridManager = (function() {
       }
 
       if (animation) {
-        goToPage(index,{callback: function() {
-                    setTimeout(function() {
-                      pageHelper.getCurrent().
-                        applyInstallingEffect(Applications.getOrigin(app));
-                    }, 200);
+        goToPage(index,{callback: function ins_goToPage() {
+          pageHelper.getCurrent().
+                    applyInstallingEffect(Applications.getOrigin(app));
+
         }});
       }
 

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -72,7 +72,7 @@ const GridManager = (function() {
         if (pages.current !== 0) {
           evt.stopPropagation();
           evt.preventDefault();
-          goToPage({index: pages.current, noBounce: true});
+          goToPage(pages.current, {noBounce: true});
           Homescreen.setMode('edit');
           if ('origin' in evt.target.dataset) {
             DragDropManager.start(evt, startEvent);
@@ -129,16 +129,16 @@ const GridManager = (function() {
       } else if (!forward && currentPage > 0) {
         goToPreviousPage();
       } else {
-        goToPage({index: currentPage});
+        goToPage(currentPage);
       }
     } else if (Math.abs(deltaX) < thresholdForTapping) {
       pageHelper.getCurrent().tap(target);
 
       // Sometime poor devices fire touchmove events when users are only
       // tapping
-      goToPage({index: currentPage, noBounce: true});
+      goToPage(currentPage, {noBounce: true});
     } else {
-      goToPage({index: currentPage});
+      goToPage(currentPage);
     }
   }
 
@@ -171,8 +171,8 @@ const GridManager = (function() {
     });
   }
 
-  function goToPage(props) {
-    var index = props.index;
+  function goToPage(index, props) {
+    props = props || {};
     var callback = props.callback || function() {};
 
     if (index === 0 && pages.current === 1 && Homescreen.isInEditMode()) {
@@ -203,11 +203,11 @@ const GridManager = (function() {
   }
 
   function goToNextPage(callback) {
-    goToPage({index: pages.current + 1, callback: callback});
+    goToPage(pages.current + 1, {callback: callback});
   }
 
   function goToPreviousPage(callback) {
-    goToPage({index: pages.current - 1, callback: callback});
+    goToPage(pages.current - 1, {callback: callback});
   }
 
   function updatePaginationBar() {
@@ -407,7 +407,7 @@ const GridManager = (function() {
      * @param {int} index of the page
      */
     remove: function gm_remove(index) {
-      goToPage({index: index - 1});
+      goToPage(index - 1);
 
       pages[index].destroy(); // Destroy page
       pages.splice(index, 1); // Removes page from the list
@@ -529,13 +529,12 @@ const GridManager = (function() {
       }
 
       if (animation) {
-        goToPage({index: index,
-                  callback: function() {
+        goToPage(index,{callback: function() {
                     setTimeout(function() {
                       pageHelper.getCurrent().
                         applyInstallingEffect(Applications.getOrigin(app));
                     }, 200);
-                  }});
+        }});
       }
 
       pageHelper.saveAll();

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -18,7 +18,7 @@ const Homescreen = (function() {
 
     setLocale();
     GridManager.init('.apps', function gm_init() {
-      GridManager.goToPage({index: 1});
+      GridManager.goToPage(1);
       PaginationBar.show();
       DragDropManager.init();
 
@@ -45,10 +45,10 @@ const Homescreen = (function() {
           var num = GridManager.pageHelper.getCurrentPageNumber();
           switch (num) {
             case 1:
-              GridManager.goToPage({index: 0});
+              GridManager.goToPage(0);
               break;
             default:
-              GridManager.goToPage({index: 1});
+              GridManager.goToPage(1);
               break;
           }
         }

--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -18,7 +18,7 @@ const Homescreen = (function() {
 
     setLocale();
     GridManager.init('.apps', function gm_init() {
-      GridManager.goToPage(1);
+      GridManager.goToPage({index: 1});
       PaginationBar.show();
       DragDropManager.init();
 
@@ -45,10 +45,10 @@ const Homescreen = (function() {
           var num = GridManager.pageHelper.getCurrentPageNumber();
           switch (num) {
             case 1:
-              GridManager.goToPage(0);
+              GridManager.goToPage({index: 0});
               break;
             default:
-              GridManager.goToPage(1);
+              GridManager.goToPage({index: 1});
               break;
           }
         }

--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -4,35 +4,6 @@
 	z-index: 1;
 }
 
-/* Page have movement feedback */
-@-moz-keyframes bounceRight {
-  0% { -moz-transform: translateX(0px); }
-	50% { -moz-transform: translateX(10px); }
-	100% { -moz-transform: translateX(0px); }
-}
-
-@-moz-keyframes bounceLeft {
-  0% { -moz-transform: translateX(0px); }
-  50% { -moz-transform: translateX(-10px); }
-  100% { -moz-transform: translateX(0px); }
-}
-
-.apps > div[data-bouncing = 'right'] {
-  -moz-animation-name: bounceRight;
-  -moz-animation-duration: .2s;
-  -moz-animation-iteration-count: 1;
-  -moz-animation-timing-function: ease-out;
-  -moz-transform-origin:50% 50%;
-}
-
-.apps > div[data-bouncing = 'left'] {
-  -moz-animation-name: bounceLeft;
-  -moz-animation-duration: .2s;
-  -moz-animation-iteration-count: 1;
-  -moz-animation-timing-function: ease-out;
-  -moz-transform-origin:50% 50%;
-}
-
 /* pages */
 .apps > div {
   position: absolute;

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -43,7 +43,7 @@ section,footer,nav,a,img {
   width: 100%;
   height: 100%;
   background-color: #ff7f02;
-  -moz-transition: -moz-transform .5s ease;
+  -moz-transition: -moz-transform .35s ease;
   visibility: hidden;
 }
 


### PR DESCRIPTION
Hi,

   I've implemented the bounce effect in the same transform that implements the movement of the pagination instead of an animation because we had a lot of problems paginating fast. Currently this wrong behaviour can be tested paginating fast. Merging this pull request our problems will be fixed and end-users can paginate as fast as they want

Thanks 
