### PR TITLE
Share xpcshell code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,8 +265,9 @@ define run-js-command
 	const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)";       \
 	const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)";                             \
 	const GAIA_APP_RELATIVEPATH = "$(GAIA_APP_RELATIVEPATH)";                   \
-	const BUILD_APP_NAME = "$(BUILD_APP_NAME)";';                               \
-	$(XULRUNNERSDK) $(XPCSHELLSDK) -e "$$JS_CONSTS" "build/$(strip $1).js"
+	const BUILD_APP_NAME = "$(BUILD_APP_NAME)";                                 \
+	';                                                                          \
+	$(XULRUNNERSDK) $(XPCSHELLSDK) -e "$$JS_CONSTS" -f build/utils.js "build/$(strip $1).js"
 endef
 
 settingsdb: install-xulrunner-sdk

--- a/build/permissions.js
+++ b/build/permissions.js
@@ -1,61 +1,7 @@
-const { 'classes': Cc, 'interfaces': Ci, 'results': Cr, } = Components;
 
 function debug(msg) {
   if (DEBUG)
     dump("-*- " + msg + "\n");
-}
-
-function getSubDirectories(directory) {
-  let appsDir = Cc["@mozilla.org/file/local;1"]
-               .createInstance(Ci.nsILocalFile);
-  appsDir.initWithPath(GAIA_DIR);
-  appsDir.append(directory);
-
-  let dirs = [];
-  let files = appsDir.directoryEntries;
-  while (files.hasMoreElements()) {
-    let file = files.getNext().QueryInterface(Ci.nsILocalFile);
-    if (file.isDirectory()) {
-      dirs.push(file.leafName);
-    }
-  }
-  return dirs;
-}
-
-function getFileContent(file) {
-  let fileStream = Cc['@mozilla.org/network/file-input-stream;1']
-                   .createInstance(Ci.nsIFileInputStream);
-  fileStream.init(file, 1, 0, false);
-
-  let converterStream = Cc["@mozilla.org/intl/converter-input-stream;1"]
-                          .createInstance(Ci.nsIConverterInputStream);
-  converterStream.init(fileStream, "utf-8", fileStream.available(),
-                       Ci.nsIConverterInputStream.DEFAULT_REPLACEMENT_CHARACTER);
-
-  let out = {};
-  let count = fileStream.available();
-  converterStream.readString(count, out);
-
-  let content = out.value;
-  converterStream.close();
-  fileStream.close();
-
-  return [content, count];
-}
-
-function getJSON(root, dir, name) {
-  let file = Cc["@mozilla.org/file/local;1"]
-               .createInstance(Ci.nsILocalFile);
-  file.initWithPath(GAIA_DIR);
-  file.append(root);
-  file.append(dir);
-  file.append(name);
-
-  if (!file.exists())
-    return null;
-
-  let [content, length] = getFileContent(file);
-  return JSON.parse(content);
 }
 
 let permissionList = ["power", "sms", "contacts", "telephony",
@@ -102,9 +48,10 @@ let ioservice = Components.classes["@mozilla.org/network/io-service;1"].getServi
 appSrcDirs.forEach(function parseDirectory(directoryName) {
   let directories = getSubDirectories(directoryName);
   directories.forEach(function readManifests(dir) {
-    let manifest = getJSON(directoryName, dir, "manifest.webapp");
-    if (!manifest)
+    let manifestFile = getFile(GAIA_DIR, directoryName, dir, "manifest.webapp");
+    if (!manifestFile.exists())
       return;
+    let manifest = getJSON(manifestFile);
 
     let rootURL = GAIA_SCHEME + dir + "." + GAIA_DOMAIN + (GAIA_PORT ? GAIA_PORT : '');
 

--- a/build/settings.js
+++ b/build/settings.js
@@ -108,8 +108,6 @@ function Setting(aName, aValue) {
   Setting.counter++;
 }
 
-const { 'classes': Cc, 'interfaces': Ci, 'results': Cr, 'utils' : Cu } = Components;
-
 (function registerProfileDirectory() {
 
   let directoryProvider = {

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,0 +1,65 @@
+const { 'classes': Cc, 'interfaces': Ci, 'results': Cr, } = Components;
+
+function getSubDirectories(directory) {
+  let appsDir = Cc['@mozilla.org/file/local;1']
+               .createInstance(Ci.nsILocalFile);
+  appsDir.initWithPath(GAIA_DIR);
+  appsDir.append(directory);
+
+  let dirs = [];
+  let files = appsDir.directoryEntries;
+  while (files.hasMoreElements()) {
+    let file = files.getNext().QueryInterface(Ci.nsILocalFile);
+    if (file.isDirectory()) {
+      dirs.push(file.leafName);
+    }
+  }
+  return dirs;
+}
+
+function getFileContent(file) {
+  let fileStream = Cc['@mozilla.org/network/file-input-stream;1']
+                   .createInstance(Ci.nsIFileInputStream);
+  fileStream.init(file, 1, 0, false);
+
+  let converterStream = Cc['@mozilla.org/intl/converter-input-stream;1']
+                          .createInstance(Ci.nsIConverterInputStream);
+  converterStream.init(fileStream, 'utf-8', fileStream.available(),
+                       Ci.nsIConverterInputStream.DEFAULT_REPLACEMENT_CHARACTER);
+
+  let out = {};
+  let count = fileStream.available();
+  converterStream.readString(count, out);
+
+  let content = out.value;
+  converterStream.close();
+  fileStream.close();
+
+  return content;
+}
+
+function writeContent(file, content) {
+  let stream = Cc['@mozilla.org/network/file-output-stream;1']
+                   .createInstance(Ci.nsIFileOutputStream);
+  stream.init(file, 0x02 | 0x08 | 0x20, 0666, 0);
+  stream.write(content, content.length);
+  stream.close();
+}
+
+// Return an nsIFile by joining paths given as arguments
+// First path has to be an absolute one
+function getFile() {
+  let file = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsILocalFile);
+  file.initWithPath(arguments[0]);
+  if (arguments.length > 1) {
+    for (let i = 1; i < arguments.length; i++) {
+      file.append(arguments[i]);
+    }
+  }
+  return file;
+}
+
+function getJSON(file) {
+  let content = getFileContent(file);
+  return JSON.parse(content);
+}

--- a/build/utils.js
+++ b/build/utils.js
@@ -63,3 +63,30 @@ function getJSON(file) {
   let content = getFileContent(file);
   return JSON.parse(content);
 }
+
+const Gaia = {
+  webapps: {
+    forEach: function (fun) {
+      let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
+      appSrcDirs.forEach(function parseDirectory(directoryName) {
+        let directories = getSubDirectories(directoryName);
+        directories.forEach(function readManifests(dir) {
+          let manifestFile = getFile(GAIA_DIR, directoryName, dir, "manifest.webapp");
+          // Ignore directories without manifest
+          if (!manifestFile.exists())
+            return;
+          let domain = dir + "." + GAIA_DOMAIN;
+
+          let webapp = {
+            manifest: getJSON(manifestFile),
+            manifestFile: manifestFile,
+            url: GAIA_SCHEME + domain + (GAIA_PORT ? GAIA_PORT : ''),
+            domain: domain,
+            sourceDirectoryName: dir
+          };
+          fun(webapp);
+        });
+      });
+    }
+  }
+};

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -1,67 +1,7 @@
-const { 'classes': Cc, 'interfaces': Ci, 'results': Cr, } = Components;
 
 function debug(msg) {
   if (DEBUG)
     dump('-*- ' + msg + '\n');
-}
-
-function getSubDirectories(directory) {
-  let appsDir = Cc['@mozilla.org/file/local;1']
-               .createInstance(Ci.nsILocalFile);
-  appsDir.initWithPath(GAIA_DIR);
-  appsDir.append(directory);
-
-  let dirs = [];
-  let files = appsDir.directoryEntries;
-  while (files.hasMoreElements()) {
-    let file = files.getNext().QueryInterface(Ci.nsILocalFile);
-    if (file.isDirectory()) {
-      dirs.push(file.leafName);
-    }
-  }
-  return dirs;
-}
-
-function getFileContent(file) {
-  let fileStream = Cc['@mozilla.org/network/file-input-stream;1']
-                   .createInstance(Ci.nsIFileInputStream);
-  fileStream.init(file, 1, 0, false);
-
-  let converterStream = Cc['@mozilla.org/intl/converter-input-stream;1']
-                          .createInstance(Ci.nsIConverterInputStream);
-  converterStream.init(fileStream, 'utf-8', fileStream.available(),
-                       Ci.nsIConverterInputStream.DEFAULT_REPLACEMENT_CHARACTER);
-
-  let out = {};
-  let count = fileStream.available();
-  converterStream.readString(count, out);
-
-  let content = out.value;
-  converterStream.close();
-  fileStream.close();
-
-  return content;
-}
-
-function writeContent(file, content) {
-  let stream = Cc['@mozilla.org/network/file-output-stream;1']
-                   .createInstance(Ci.nsIFileOutputStream);
-  stream.init(file, 0x02 | 0x08 | 0x20, 0666, 0);
-  stream.write(content, content.length);
-  stream.close();
-}
-
-// Return an nsIFile by joining paths given as arguments
-// First path has to be an absolute one
-function getFile() {
-  let file = Cc['@mozilla.org/file/local;1'].createInstance(Ci.nsILocalFile);
-  file.initWithPath(arguments[0]);
-  if (arguments.length > 1) {
-    for (let i = 1; i < arguments.length; i++) {
-      file.append(arguments[i]);
-    }
-  }
-  return file;
 }
 
 let webappsTargetDir = Cc['@mozilla.org/file/local;1']

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -18,44 +18,30 @@ if (!webappsTargetDir.exists())
 let manifests = {};
 let id = 1;
 
-// Process webapps from GAIA_APP_SRCDIRS folders
-let appSrcDirs = GAIA_APP_SRCDIRS.split(' ');
-appSrcDirs.forEach(function parseDirectory(srcDir) {
-  getSubDirectories(srcDir).forEach(function readManifests(webappSrcDirName) {
-    let webappSrcDir = getFile(GAIA_DIR, srcDir, webappSrcDirName);
-    let manifest = webappSrcDir.clone();
-    manifest.append('manifest.webapp');
+Gaia.webapps.forEach(function (webapp) {
+  // If BUILD_APP_NAME isn't `*`, we only accept one webapp
+  if (BUILD_APP_NAME != '*' && webapp.sourceDirectoryName != BUILD_APP_NAME)
+    return;
 
-    // Ignore directories without manifest
-    if (!manifest.exists())
-      return;
+  // Compute webapp folder name in profile
+  let webappTargetDirName = webapp.domain;
 
-    // If BUILD_APP_NAME isn't `*`, we only accept one webapp
-    if (BUILD_APP_NAME != '*' && webappSrcDirName != BUILD_APP_NAME)
-      return;
+  // Copy webapp's manifest to the profile
+  let webappTargetDir = webappsTargetDir.clone();
+  webappTargetDir.append(webappTargetDirName);
+  webapp.manifestFile.copyTo(webappTargetDir, 'manifest.webapp');
 
-    // Compute webapp folder name in profile
-    let webappTargetDirName = webappSrcDirName + '.' + GAIA_DOMAIN;
+  // Add webapp's entry to the webapps global manifest
+  let url = webapp.url;
+  manifests[webappTargetDirName] = {
+    origin:        url,
+    installOrigin: url,
+    receipt:       null,
+    installTime:   132333986000,
+    manifestURL:   url + '/manifest.webapp',
+    localId:       id++
+  };
 
-    // Copy webapp's manifest to the profile
-    let webappTargetDir = webappsTargetDir.clone();
-    webappTargetDir.append(webappTargetDirName);
-    manifest.copyTo(webappTargetDir, 'manifest.webapp');
-
-    // Compute its URL
-    let url = GAIA_SCHEME + webappTargetDirName + GAIA_PORT;
-
-    // Add webapp's entry to the webapps global manifest
-    manifests[webappTargetDirName] = {
-      origin:        url,
-      installOrigin: url,
-      receipt:       null,
-      installTime:   132333986000,
-      manifestURL:   url + '/manifest.webapp',
-      localId:       id++
-    };
-
-  });
 });
 
 // Process external webapps from /gaia/external-app/ folder


### PR DESCRIPTION
A bunch of code was duplicated between each xpcshell build scripts.
Here is a patch to factorise this code.
I'm wondering if we should include:

```
  // If BUILD_APP_NAME isn't `*`, we only accept one webapp
  if (BUILD_APP_NAME != '*' && webappSrcDirName != BUILD_APP_NAME)
    return;
```

In utils.js: Gaia.webapps.forEach?
Same question for external-apps folder?

In its current state BUILD_APP_NAME env variable and external-apps are only used in webapp manifest code, but not preferences nor permission code.
If you think it would be helpfull, I'd prefer doing this in a followup patch!
