### PR TITLE
[Contacts] Using new or old DeviceStorage API

### DIFF
--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -1108,7 +1108,7 @@ var Contacts = (function() {
       return;
     }
     var storageAreas = navigator.getDeviceStorage('pictures');
-    var storage = storageAreas[0];
+    var storage = storageAreas[0] || storageAreas;
     var request = storage.get(image);
     request.onsuccess = function() {
       var img = document.createElement('img');


### PR DESCRIPTION
Changes on the DeviceStorage API were preventing picking an image from contacts

@arcturus r?
