### PR TITLE
Fix dialer when opening from web activities

### DIFF
--- a/apps/dialer/js/dialer.js
+++ b/apps/dialer/js/dialer.js
@@ -97,6 +97,9 @@ window.navigator.mozSetMessageHandler('activity', function actHandle(activity) {
   var fillNumber = function actHandleDisplay() {
     if (number) {
       KeypadManager.updatePhoneNumber(number);
+      if (window.location.hash != '#keyboard-view') {
+        window.location.hash = '#keyboard-view';
+      }
     }
   }
 


### PR DESCRIPTION
If we had the dialer opened with the call log and we open contacts and try to do a call via web activities, we were bringing back to front the dialer but with the call log instead of the keypad.

Now fixed, if we are in dialer and not in the keypad view and we receive an activity to call, we change to the keypadview then.
