### PR TITLE
[Contacts] Avoiding 'undefined' letter on the fast scroll

### DIFF
--- a/apps/contacts/js/contacts_shortcuts.js
+++ b/apps/contacts/js/contacts_shortcuts.js
@@ -52,7 +52,7 @@
     }
 
     var current = evt.target.dataset.letter;
-    overlayContent.textContent = current;
+    overlayContent.textContent = current || null;
 
     if (previous === current) {
       return;


### PR DESCRIPTION
If yo scroll to the top right now, it shows an ugly 'undefined' instead of any letter. This pull request fixes it.
