### PR TITLE
[Dialer] Switching to Keypad instead calling directly

### DIFF
--- a/apps/dialer/js/recents.js
+++ b/apps/dialer/js/recents.js
@@ -428,7 +428,8 @@ var Recents = {
       var number = target.dataset.num.trim();
       if (number) {
         this.updateLatestVisit();
-        CallHandler.call(number);
+        KeypadManager.updatePhoneNumber(number);
+        window.location.hash = '#keyboard-view';
       }
     } else {
       target.classList.toggle('selected');


### PR DESCRIPTION
In order to be more consistent, when clicking in a recent call, we are going to open the keypad with the number preloaded instead call directly.

This pull request implement that change.

@arcturus r?
