### PR TITLE
Hiding the utility tray when an activity is launched

### DIFF
--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -59,7 +59,6 @@ var QuickSettings = {
                   section: 'wifi'
                 }
               });
-              UtilityTray.hide();
             }
             break;
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -586,6 +586,7 @@ var WindowManager = (function() {
                       app.manifest.name, app.manifest, app.manifestURL, true);
         }
 
+        UtilityTray.hide();
         setDisplayedApp(origin);
         break;
     }


### PR DESCRIPTION
## Overview

Hiding utility tray when launching a web activity
## Flaws and future work

Is necessary to hide the utility tray when launching any application (not a web activity)?
