### PR TITLE
[Dialer] Calling directly when coming from an activity

### DIFF
--- a/apps/dialer/js/dialer.js
+++ b/apps/dialer/js/dialer.js
@@ -100,6 +100,7 @@ window.navigator.mozSetMessageHandler('activity', function actHandle(activity) {
       if (window.location.hash != '#keyboard-view') {
         window.location.hash = '#keyboard-view';
       }
+      CallHandler.call(number);
     }
   }
 

--- a/apps/dialer/js/recents.js
+++ b/apps/dialer/js/recents.js
@@ -428,8 +428,7 @@ var Recents = {
       var number = target.dataset.num.trim();
       if (number) {
         this.updateLatestVisit();
-        KeypadManager.updatePhoneNumber(number);
-        window.location.hash = '#keyboard-view';
+        CallHandler.call(number);
       }
     } else {
       target.classList.toggle('selected');


### PR DESCRIPTION
The behaviour when clicking a number from the call log and when launching an activity for dialing was different (one show the Keypad with the number filled and the other one automatically call).

This pull request unifies this behaviour to always call automatically.

@arcturus r?
