### PR TITLE
window.open progress bar issues fixed

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -115,7 +115,7 @@
     <!-- Any module that wants to intercept the Home button and prevent the -->
     <!-- homescreen from being displayed must come before this script. -->
     <script defer src="js/window_manager.js"></script>
-    
+
     <!-- Module Hierarchy collection -->
     <link rel="stylesheet" type="text/css" href="style/zindex.css">
 
@@ -136,10 +136,10 @@
       <div id="windows" data-type="APP">
         <!-- application windows are added here -->
       </div>
-      
+
       <div id="dialog-overlay" data-type="DIALOG_OVERLAY">
         <div id="trustedDialog">
-        </div> 
+        </div>
         <div id="popup-container">
         </div>
         <div id="modal-dialog">
@@ -183,8 +183,8 @@
             <button id="modal-dialog-prompt-cancel" data-l10n-id="cancel">Cancel</button>
           </div>
         </div>
-      </div> 
-      
+      </div>
+
       <!-- value selector -->
       <div id="value-selector" hidden data-type="VALUE_SELECTOR">
          <div id="value-selector-container" onmousedown="return false;"> </div>
@@ -263,9 +263,9 @@
           <div id="lockscreen-emergency-pad">TBD</div>
         </div>
       </div>
-      
+
       <div id="lockscreen-camera" hidden data-type="LOCKSCREEN_CAMERA"></div>
-      
+
       <div id="pinkeypadscreen" data-type="PINKEYPADSCREEN">
         <div id="pinkeypadscreen-container">
           <p id="pinkeypadscreen-desc"><span>Enter PIN</span></p>
@@ -289,10 +289,10 @@
           </div>
         </div>
       </div>
-      
+
       <div id="statusbar" data-type="STATUSBAR">
         <!-- Loading -->
-        <div id="statusbar-loading" hidden></div>
+        <div id="statusbar-loading"></div>
         <!-- Carrier & date label -->
         <div id="statusbar-label" class="sb-start-upper"></div>
         <!-- Notification -->
@@ -323,13 +323,13 @@
         <div id="statusbar-geolocation" class="sb-icon sb-icon-geolocation" hidden></div>
         <div id="statusbar-usb" class="sb-icon sb-icon-usb" hidden></div>
       </div>
-      
+
       <div id="notification-toaster" class="notification" data-type="NOTIFICATION_TOASTER">
         <img id="toaster-icon" />
         <div id="toaster-title"></div>
         <div id="toaster-detail"></div>
       </div>
-      
+
       <div id="attention-screen" data-type="ATTENTION_SCREEN">
         <div id="attention-bar"></div>
       </div>
@@ -338,7 +338,7 @@
         <div class="list-menu" id="listmenu-container">
         </div>
       </div>
-      
+
       <div id="keyboard-overlay" data-type="KEYBOARD_OVERLAY"></div>
 
       <!-- keyboard -->
@@ -348,7 +348,7 @@
         <ul>
         </ul>
       </div>
-      
+
       <div id="sleep-menu" data-type="SLEEP_MENU">
         <div class="sleepmenu" id="sleepmenu-container">
         </div>

--- a/apps/system/js/popup_manager.js
+++ b/apps/system/js/popup_manager.js
@@ -4,11 +4,8 @@
 
 var PopupManager = {
   _currentPopup: null,
-  _wait: null,
   _endTimes: 0,
   _startTimes: 0,
-  _loadingIconEle: null,
-
 
   overlay: document.getElementById('dialog-overlay'),
 
@@ -16,13 +13,7 @@ var PopupManager = {
 
   screen: document.getElementById('screen'),
 
-  _loadingIcon: function() {
-    if (!this._loadingIconEle) {
-      this._loadingIconEle = document.getElementById('statusbar-loading');
-    }
-
-    return this._loadingIconEle;
-  },
+  loadingIcon: document.getElementById('statusbar-loading'),
 
   init: function pm_init() {
     window.addEventListener('mozbrowseropenwindow', this);
@@ -32,11 +23,11 @@ var PopupManager = {
   },
 
   _showWait: function pm_showWait() {
-    this._loadingIcon().hidden = false;
+    this.loadingIcon.classList.add('popup-loading');
   },
 
   _hideWait: function pm_hideWait() {
-    this._loadingIcon().hidden = true;
+    this.loadingIcon.classList.remove('popup-loading');
   },
 
   open: function pm_open(evt) {

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -629,14 +629,20 @@ var WindowManager = (function() {
     // If there aren't any origin, that means we are moving to
     // the homescreen. Let's hide the icon.
     if (!origin) {
-      loadingIcon.hidden = true;
+      loadingIcon.classList.remove('app-loading');
       return;
     }
 
     // Actually update the icon.
     // Hide it if the loading property is not true.
     var app = runningApps[origin];
-    loadingIcon.hidden = !app.frame.dataset.loading;
+
+    if(app.frame.dataset.loading) {
+       loadingIcon.classList.add('app-loading');
+    }
+    else {
+      loadingIcon.classList.remove('app-loading');
+    }
   };
 
   // Listen for mozbrowserloadstart to update the loading status
@@ -717,4 +723,3 @@ var WindowManager = (function() {
     setDisplayedApp: setDisplayedApp
   };
 }());
-

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -57,7 +57,7 @@
   -moz-transform: translateY(20px);
 }
 
-#statusbar-loading {
+#statusbar-loading.popup-loading, #statusbar-loading.app-loading {
   position: absolute;
   top: 0;
   left: 0;
@@ -66,9 +66,10 @@
   background: url('images/loading.gif') center center repeat-x;
 
   -moz-transition: opacity 0.1s ease 0.2s;
+  visibility: visible;
 }
 
-#statusbar-loading[hidden] {
+#statusbar-loading {
   display: block;
   visibility: hidden;
 


### PR DESCRIPTION
Now when an app is loading and a window.open is in progress they do not conflict. CSS-based implementation as suggested by @timdream. 
