### PR TITLE
Issue 3302 - Fix storage to pick up proper lock/unlock events

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -486,6 +486,7 @@ var LockScreen = {
     WindowManager.setOrientationForApp(WindowManager.getDisplayedApp());
 
     if (!wasAlreadyUnlocked) {
+      // Any changes made to this, also need to be reflected in apps/system/js/storage.js
       this.dispatchEvent('unlock');
       this.writeSetting(false);
       this.hideNotification();
@@ -511,6 +512,7 @@ var LockScreen = {
     this.updateTime();
 
     if (!wasAlreadyLocked) {
+      // Any changes made to this, also need to be reflected in apps/system/js/storage.js
       this.dispatchEvent('lock');
       this.writeSetting(true);
     }

--- a/apps/system/js/storage.js
+++ b/apps/system/js/storage.js
@@ -8,8 +8,9 @@ var Storage = {
   umsMode: 'ums.mode',
 
   init: function storageInit() {
-    window.addEventListener('unlocked', this);
-    window.addEventListener('locked', this);
+    this.setMode(this.automounterDisable, 'init');
+    window.addEventListener('lock', this);
+    window.addEventListener('unlock', this);
 
     SettingsListener.observe(this.umsEnabled, false, function umsChanged(val) {
       if (LockScreen.locked) {
@@ -38,10 +39,10 @@ var Storage = {
 
   handleEvent: function storageHandleEvent(e) {
     switch (e.type) {
-      case 'locked':
+      case 'lock':
         this.setMode(this.automounterDisableWhenUnplugged, 'screen locked');
         break;
-      case 'unlocked':
+      case 'unlock':
         var settings = window.navigator.mozSettings;
         if (!settings) {
           return;

--- a/build/settings.js
+++ b/build/settings.js
@@ -74,7 +74,7 @@ var settings = [
  new Setting("tethering.wifi.connectedClients", 0),
  new Setting("tethering.usb.connectedClients", 0),
  new Setting("ums.enabled", false),
- new Setting("ums.mode", ""),
+ new Setting("ums.mode", 0),
  new Setting("wifi.enabled", true),
  new Setting("wifi.notification", false)
 ];


### PR DESCRIPTION
Fixes issue #3302 so that the AutoMounter responds properly to the phone being locked/unlocked.
