### PR TITLE
Start the transition after mozfullscreenchange, workaround of #3013

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -164,6 +164,7 @@ var WindowManager = (function() {
       classes.add('faded');
       setTimeout(openCallback);
     } else if (classes.contains('faded') && prop === 'opacity') {
+
       openFrame.setVisible(true);
       openFrame.focus();
 
@@ -188,7 +189,13 @@ var WindowManager = (function() {
   function openWindow(origin, callback) {
     var app = runningApps[origin];
     openFrame = app.frame;
-    openCallback = callback || function() {};
+    openCallback = function() {
+      if (app.manifest.fullscreen)
+        openFrame.mozRequestFullScreen();
+
+      if (callback)
+        callback();
+    };
 
     sprite.className = 'open';
   }
@@ -208,6 +215,10 @@ var WindowManager = (function() {
     // Take keyboard focus away from the closing window
     closeFrame.blur();
     closeFrame.setVisible(false);
+
+    // Leave full screen
+    if (document.mozFullScreen)
+      document.mozCancelFullScreen();
 
     // And begin the transition
     sprite.classList.remove('faded');
@@ -275,11 +286,7 @@ var WindowManager = (function() {
       setOrientationForApp(newApp);
     }
 
-    // Exit fullscreen mode if we're going to the homescreen
-    if (newApp === null && document.mozFullScreen) {
-      document.mozCancelFullScreen();
-    }
-
+    // Set displayedApp to the new value
     displayedApp = origin;
 
     // Update the loading icon since the displayedApp is changed
@@ -493,10 +500,6 @@ var WindowManager = (function() {
     // when that is done.
     setDisplayedApp(origin, function() {
       frame.src = url;
-
-      if (manifest.fullscreen) {
-        frame.mozRequestFullScreen();
-      }
     });
   }
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -216,13 +216,25 @@ var WindowManager = (function() {
     closeFrame.blur();
     closeFrame.setVisible(false);
 
-    // Leave full screen
-    if (document.mozFullScreen)
-      document.mozCancelFullScreen();
-
     // And begin the transition
-    sprite.classList.remove('faded');
-    sprite.classList.add('close');
+    // Wait for we leave full screen before starting the transition
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=781014
+    if (document.mozFullScreen) {
+      document.addEventListener('mozfullscreenchange',
+        function fullscreenListener(event) {
+          document.removeEventListener('mozfullscreenchange',
+                                       fullscreenListener, false);
+          setTimeout(function() {
+            sprite.classList.remove('faded');
+            sprite.classList.add('close');
+          }, 20);
+        }, false);
+
+      document.mozCancelFullScreen();
+    } else {
+      sprite.classList.remove('faded');
+      sprite.classList.add('close');
+    }
   }
 
   //last time app was launched,


### PR DESCRIPTION
After `mozfullscreenchange`, we still need that 20ms. Going to ask cpearce to take a look before merging.
