### PR TITLE
Revert the change to keyboard iFrame z-index when it is active,

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -86,9 +86,11 @@
 }
 
 /* When keyboard is visible, set frame under app window */
+/*
 #screen > [data-z-index-level="keyboard-frame"].visible {
   z-index: 0;
 }
+*/
 
 /* Fullscreen */
 #screen.fullscreen > [data-z-index-level="system-overlay"],


### PR DESCRIPTION
which cause keyboard not clickable
