### PR TITLE
Fix the issue to make keyboard overlay functional

### DIFF
--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -94,7 +94,6 @@ body {
   overflow: auto;
   left: 0;
   top: 20px;
-  z-index: 1;
 
 /*
  * Do not specify height/width here! They should go to
@@ -117,7 +116,6 @@ body {
 
 #windows > iframe.appWindow.active {
   background-color: #fff;
-  z-index: 2;
 }
 
 #windows > iframe.appWindow:not(.active) {

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -82,15 +82,25 @@
 }
 
 #screen > [data-z-index-level="app"] {
+    /*
+     * Should not specify z-index here */
+    /* Keyboard should be kept upon #windows
+     * and beneath #windows > iframe.appWindow
+     */
+}
+
+#screen > [data-z-index-level="app"] > iframe.appWindow {
   z-index: 1;
 }
 
+#screen > [data-z-index-level="app"] > iframe.appWindow.active {
+  z-index: 2;
+}
+
 /* When keyboard is visible, set frame under app window */
-/*
 #screen > [data-z-index-level="keyboard-frame"].visible {
   z-index: 0;
 }
-*/
 
 /* Fullscreen */
 #screen.fullscreen > [data-z-index-level="system-overlay"],

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -89,12 +89,12 @@
      */
 }
 
-#screen > [data-z-index-level="app"] > iframe.appWindow {
-  z-index: 1;
-}
-
 #screen > [data-z-index-level="app"] > iframe.appWindow.active {
   z-index: 2;
+}
+
+#screen > [data-z-index-level="app"] > iframe.appWindow {
+  z-index: 1;
 }
 
 /* When keyboard is visible, set frame under app window */


### PR DESCRIPTION
Keyboard overlay is used to enable switching focus between inputs.

**Root cause**:
 The #windows div was given a z-index 1, which would cause it stay above keyboard iFrame (set as 0), so we could not click the keyboard anymore.

**Solution**:
 Remove the z-index setting so that the order would be,
1.  #windows > iframe.appWindow
2.  #keyboard-frame
3.  #windows

Here is a detailed explanation on how this works, 
https://developer.mozilla.org/en-US/docs/CSS/Understanding_z-index/Stacking_context_example_1
