### PR TITLE
Fix the issue that the prompt dialog would not be resized after hiding keyboard

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -55,6 +55,10 @@ var KeyboardManager = (function() {
     keyboardOverlay.hidden = true;
 
     if (message.hidden) {
+      // To reset dialog height
+      if (TrustedDialog.isVisible() || ModalDialog.isVisible())
+        currentApp.style.height = height + 'px';
+
       keyboardFrame.classList.add('hide');
       keyboardFrame.classList.remove('visible');
       return;


### PR DESCRIPTION
The logic to modify dialog-overlay height is removed in #2951.
