### PR TITLE
[email] Ensure that the sender and date take up one line

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -452,9 +452,10 @@
     <div id="templ-msg">
       <a class="msg-header-item"><div class="msg-header-unread-section">
         </div><div class="msg-header-details-section">
-          <span class="msg-header-author"></span>
-          <span class="msg-header-date"></span>
-          <span class="msg-header-subject"></span>
+          <span class="msg-header-author-and-date">
+            <span class="msg-header-author"></span>
+            <span class="msg-header-date"></span>
+          </span><span class="msg-header-subject"></span>
           <span class="msg-header-snippet"></span>
         </div><div class="msg-header-icons-section">
           <span class="msg-header-star"></span>

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -101,12 +101,25 @@
   height: 100%;
 }
 
+.msg-header-author-and-date {
+  display: -moz-box;
+  -moz-box-align: baseline;
+}
 .msg-header-author {
   font-size: 110%;
   color: black;
+  display: -moz-box;
+  -moz-box-flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .msg-header-date {
   color: gray;
+  display: -moz-box;
+  /* Override the line-height in .msg-header-details-section so that aligning
+     to the baseline of the text works. */
+  line-height: normal;
+  margin-left: 1ch;
 }
 .msg-header-date-unread {
   color: #1D8399;

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -79,7 +79,8 @@
   position: absolute;
   top: 0px;
   left: 1.2rem;
-  width: -moz-calc(100% - 5.6rem);
+  /* 100% - (unread-section) - (icons-section) - (avatar-section) */
+  width: -moz-calc(100% - 1.2rem - 2rem - 2.8rem);
   height: 100%;
   font-size: 1.6rem;
   line-height: 2.5rem;
@@ -88,9 +89,10 @@
   display: block;
   position: absolute;
   top: 0px;
-  left: 26rem;
-  width: 3.2rem;
+  right: 2.8rem; /* The width of the avatar-section. */
+  width: 2rem;
   height: 100%;
+  padding-top: 2.5rem;
 }
 .msg-header-avatar-section {
   display: block;
@@ -102,23 +104,24 @@
 }
 
 .msg-header-author-and-date {
-  display: -moz-box;
-  -moz-box-align: baseline;
+  display: table;
+  table-layout: fixed;
+  width: -moz-available;
 }
 .msg-header-author {
   font-size: 110%;
   color: black;
-  display: -moz-box;
-  -moz-box-flex: 1;
+  display: table-cell;
+  width: -moz-available;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .msg-header-date {
   color: gray;
-  display: -moz-box;
-  /* Override the line-height in .msg-header-details-section so that aligning
-     to the baseline of the text works. */
-  line-height: normal;
+  display: table-cell;
+  width: -moz-min-content;
+  white-space: nowrap;
   margin-left: 1ch;
 }
 .msg-header-date-unread {


### PR DESCRIPTION
@asutherland: This PR makes sure that long sender names don't screw up the UI in the message list. I see this all the time in Hotmail, since one of the welcome emails has a long display name for the sender.
