### PR TITLE
Background service: Add name attribute to iframes

### DIFF
--- a/apps/system/js/background_service.js
+++ b/apps/system/js/background_service.js
@@ -92,8 +92,9 @@ var BackgroundServiceManager = (function bsm() {
       return false;
 
     if (frames[origin] && frames[origin][name]) {
-      // XXX: the window with the same name is opened but we cannot
-      // return the window reference back to mozbrowseropenwindow request
+      console.error('Window with the same name is there but Gecko ' +
+        ' failed to use it. See bug 766873. origin: "' + origin +
+        '", name: "' + name + '".');
       return false;
     }
 
@@ -104,6 +105,7 @@ var BackgroundServiceManager = (function bsm() {
       // it has the mozbrowser, mozapp, and src attributes set already.
       frame.setAttribute('mozbrowser', 'mozbrowser');
       frame.setAttribute('mozapp', app.manifestURL);
+      frame.setAttribute('name', name);
       frame.src = url;
     }
     frame.className = 'backgroundWindow';


### PR DESCRIPTION
Feature introduced in Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=781320

Pass the name so we can match the background_page feature from Google Chrome. See https://bugzilla.mozilla.org/show_bug.cgi?id=766873#c8
