### PR TITLE
Split the file path and use file name only as title for metadata

### DIFF
--- a/apps/music/js/MetadataParser.js
+++ b/apps/music/js/MetadataParser.js
@@ -25,7 +25,7 @@ var metadataParser = (function() {
 
         metadata.album = tags.album;
         metadata.artist = tags.artist;
-        metadata.title = tags.title || file.name;
+        metadata.title = tags.title || splitFileName(file.name);
         metadata.picture = tags.picture;
 
         callback(metadata);

--- a/apps/music/js/utils.js
+++ b/apps/music/js/utils.js
@@ -64,3 +64,8 @@ function cropImage(evt) {
 function createBase64URL(image) {
   return 'data:' + image.format + ';base64,' + Base64.encodeBytes(image.data);
 }
+
+function splitFileName(path) {
+  var stringArray = path.split('/');
+  return stringArray[stringArray.length - 1];
+}


### PR DESCRIPTION
This is a refinement of #2860.
see first point of https://github.com/mozilla-b2g/gaia/pull/2860#issuecomment-7298380
Also it will fix #2944
