### PR TITLE
[Contacts] Picking the contact when it only has 1 number

### DIFF
--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -315,6 +315,13 @@ var Contacts = (function() {
 
       var request = navigator.mozContacts.find(options);
       request.onsuccess = function findCallback() {
+        var contact = request.result[0];
+        var onlyOneTel = contact.tel && contact.tel.length == 1;
+        if (ActivityHandler.currentlyHandling && onlyOneTel) {
+          var number = contact.tel[0].number;
+          ActivityHandler.postPickSuccess(number);
+          return;
+        }
         currentContact = request.result[0];
         reloadContactDetails();
         navigation.go('view-contact-details', 'right-left');

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -315,14 +315,13 @@ var Contacts = (function() {
 
       var request = navigator.mozContacts.find(options);
       request.onsuccess = function findCallback() {
-        var contact = request.result[0];
-        var onlyOneTel = contact.tel && contact.tel.length === 1;
+        currentContact = request.result[0];
+        var onlyOneTel = currentContact.tel && currentContact.tel.length === 1;
         if (ActivityHandler.currentlyHandling && onlyOneTel) {
-          var number = contact.tel[0].number;
+          var number = currentContact.tel[0].number;
           ActivityHandler.postPickSuccess(number);
           return;
         }
-        currentContact = request.result[0];
         reloadContactDetails();
         navigation.go('view-contact-details', 'right-left');
       };

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -316,7 +316,7 @@ var Contacts = (function() {
       var request = navigator.mozContacts.find(options);
       request.onsuccess = function findCallback() {
         var contact = request.result[0];
-        var onlyOneTel = contact.tel && contact.tel.length == 1;
+        var onlyOneTel = contact.tel && contact.tel.length === 1;
         if (ActivityHandler.currentlyHandling && onlyOneTel) {
           var number = contact.tel[0].number;
           ActivityHandler.postPickSuccess(number);


### PR DESCRIPTION
Instead of showing contact details, we need to direclty pick the contact when it only has 1 number in a Pick activity.
Following last wireframes indications:

https://wiki.mozilla.org/images/8/8c/HTML5_SMS_20120810_R2S1_V7.0.pdf p11

@etiennesegonzac r?
