### PR TITLE
Make permission manager UI appear over fullscreen content

### DIFF
--- a/apps/system/js/permission_manager.js
+++ b/apps/system/js/permission_manager.js
@@ -194,7 +194,11 @@ var PermissionManager = (function() {
       no.id = 'permission-no';
       dialog.appendChild(no);
 
-      document.body.appendChild(overlay);
+      // Note that 'overlay' needs to be the last child in 'screen' otherwise
+      // its zIndex value won't override the zIndex value of the element
+      // before it in the DOM, i.e. the permission prompt won't appear over
+      // top of the fullscreen window!
+      document.getElementById('screen').appendChild(overlay);
     }
 
     // Put the message in the dialog.

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -119,6 +119,7 @@
 #screen.fullscreen > [data-z-index-level="keyboard-frame"],
 #screen.fullscreen > [data-z-index-level="keyboard-frame"].visible,
 #screen.fullscreen > [data-z-index-level="notification-toaster"],
-#screen.fullscreen > [data-z-index-level="cardsview"] {
+#screen.fullscreen > [data-z-index-level="cardsview"],
+#screen.fullscreen > [data-z-index-level="permission-screen"] {
   z-index: 2147483647;
 }


### PR DESCRIPTION
The permission manager prompt does not appear over top of fullscreen content. This means that fullscreen pages can't be approved for fullscreen, and no other permissions can be granted either while an app is fullscreen.

I think this was broken by the zindex changes that merged afterwards. :(

This PR fixes issue #3489.
