### PR TITLE
[Contacts] Replacing tel.number and email.address by .value

### DIFF
--- a/apps/contacts/index.html
+++ b/apps/contacts/index.html
@@ -195,7 +195,7 @@
               <dd class="setbox-body">
                 <p class="setbox-item">
                   <label class="hide" for="tel_#i#" data-l10n-id="labelPhoneNumber">Phone number:</label>
-                  <input data-cancelable placeholder="Phone" data-field="number" name="tel" class="textfield" type="tel" value="#value#" id="number_#i#">
+                  <input data-cancelable placeholder="Phone" data-field="value" name="tel" class="textfield" type="tel" value="#value#" id="number_#i#">
                 </p>
                 <p class="setbox-item">
                   <label class="hide" for="notes_#i#" data-l10n-id="labelName">Name:</label>

--- a/apps/contacts/index.html
+++ b/apps/contacts/index.html
@@ -105,12 +105,12 @@
                   <h2>#type#</h2>
                   <div class="item">
                     <div class="item-media pull-right">
-                      <button class="action" onclick="Contacts.sendSms('#number#')"><span role="button" class="icon-message">Message</span></button>
+                      <button class="action" onclick="Contacts.sendSms('#value#')"><span role="button" class="icon-message">Message</span></button>
                     </div>
                     <div class="item-body-exp">
-                      <button class="action" onclick="Contacts.callOrPick('#number#')">
+                      <button class="action" onclick="Contacts.callOrPick('#value#')">
                         <span role="button" class="icon-call" data-l10n-id="call">Call</span>
-                        <b>#number#</b>
+                        <b>#value#</b>
                         <em>#notes#</em>
                       </button>
                     </div>
@@ -127,9 +127,9 @@
                   <h2>#type#</h2>
                   <div class="item">
                     <div class="item-body-exp">
-                      <button class="action" onclick="Contacts.sendEmailOrPick('#address#'); return false">
+                      <button class="action" onclick="Contacts.sendEmailOrPick('#value#'); return false">
                         <span role="button" class="icon-email">E-mail</span>
-                        <b>#address#</b>
+                        <b>#value#</b>
                       </button>
                     </div>
                   </div>
@@ -195,7 +195,7 @@
               <dd class="setbox-body">
                 <p class="setbox-item">
                   <label class="hide" for="tel_#i#" data-l10n-id="labelPhoneNumber">Phone number:</label>
-                  <input data-cancelable placeholder="Phone" data-field="number" name="tel" class="textfield" type="tel" value="#number#" id="number_#i#">
+                  <input data-cancelable placeholder="Phone" data-field="number" name="tel" class="textfield" type="tel" value="#value#" id="number_#i#">
                 </p>
                 <p class="setbox-item">
                   <label class="hide" for="notes_#i#" data-l10n-id="labelName">Name:</label>
@@ -215,7 +215,7 @@
               <dd class="setbox-body">
                 <p class="setbox-item">
                   <label class="hide" for="email_#i#" data-l10n-id="labelEmail">e-mail:</label>
-                  <input data-cancelable placeholder="Email" name="email" class="textfield" type="email" value="#address#" id="email_#i#">
+                  <input data-cancelable placeholder="Email" name="email" class="textfield" type="email" value="#value#" id="email_#i#">
                 </p>
               </dd>
             </dl>

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -411,7 +411,7 @@ var Contacts = (function() {
     for (var tel in contact.tel) {
       var currentTel = contact.tel[tel];
       var telField = {
-        number: currentTel.value || '',
+        value: currentTel.value || '',
         type: currentTel.type || TAG_OPTIONS['phone-type'][0].value,
         notes: '',
         i: tel
@@ -519,7 +519,7 @@ var Contacts = (function() {
     for (var tel in currentContact.tel) {
       var currentTel = currentContact.tel[tel];
       var telField = {
-        number: currentTel.value,
+        value: currentTel.value,
         type: currentTel.type || default_type,
         notes: '',
         i: tel
@@ -932,7 +932,7 @@ var Contacts = (function() {
       contact['tel'] = contact['tel'] || [];
       // TODO: Save notes
       contact['tel'][i] = {
-        number: numberValue,
+        value: numberValue,
         type: typeField
       };
     }
@@ -1013,7 +1013,7 @@ var Contacts = (function() {
 
   var insertPhone = function insertPhone(phone) {
     var telField = {
-      number: phone || '',
+      value: phone || '',
       type: TAG_OPTIONS['phone-type'][0].value,
       notes: '',
       i: numberPhones || 0

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -331,7 +331,7 @@ var Contacts = (function() {
         currentContact = request.result[0];
         var onlyOneTel = currentContact.tel && currentContact.tel.length === 1;
         if (ActivityHandler.currentlyHandling && onlyOneTel) {
-          var number = currentContact.tel[0].number;
+          var number = currentContact.tel[0].value;
           ActivityHandler.postPickSuccess(number);
           return;
         }
@@ -411,7 +411,7 @@ var Contacts = (function() {
     for (var tel in contact.tel) {
       var currentTel = contact.tel[tel];
       var telField = {
-        number: currentTel.number || '',
+        number: currentTel.value || '',
         type: currentTel.type || TAG_OPTIONS['phone-type'][0].value,
         notes: '',
         i: tel
@@ -424,7 +424,7 @@ var Contacts = (function() {
     for (var email in contact.email) {
       var currentEmail = contact.email[email];
       var emailField = {
-        address: currentEmail['address'] || '',
+        value: currentEmail['value'] || '',
         type: currentEmail['type'] || TAG_OPTIONS['email-type'][0].value,
         i: email
       };
@@ -519,7 +519,7 @@ var Contacts = (function() {
     for (var tel in currentContact.tel) {
       var currentTel = currentContact.tel[tel];
       var telField = {
-        number: currentTel.number,
+        number: currentTel.value,
         type: currentTel.type || default_type,
         notes: '',
         i: tel
@@ -535,7 +535,7 @@ var Contacts = (function() {
       var currentEmail = currentContact.email[email];
       var default_type = TAG_OPTIONS['email-type'][0].value;
       var emailField = {
-        address: currentEmail['address'] || '',
+        value: currentEmail['value'] || '',
         type: currentEmail['type'] || default_type,
         i: email
       };
@@ -953,7 +953,7 @@ var Contacts = (function() {
 
       contact['email'] = contact['email'] || [];
       contact['email'][i] = {
-        address: emailValue,
+        value: emailValue,
         type: typeField
       };
     }
@@ -1026,7 +1026,7 @@ var Contacts = (function() {
 
   var insertEmail = function insertEmail(email) {
     var emailField = {
-      address: email || '',
+      value: email || '',
       type: TAG_OPTIONS['email-type'][0].value,
       i: numberEmails || 0
     };

--- a/apps/contacts/js/contacts_list.js
+++ b/apps/contacts/js/contacts_list.js
@@ -296,9 +296,9 @@ contacts.List = (function() {
   var refillContactData = function refillContactData(contact) {
     if (!contact.givenName && !contact.familyName) {
       if (contact.tel && contact.tel.length > 0) {
-        contact.givenName = contact.tel[0].number;
+        contact.givenName = contact.tel[0].value;
       } else if (contact.email && contact.email.length > 0) {
-        contact.givenName = contact.email[0].address;
+        contact.givenName = contact.email[0].value;
       } else {
         contact.givenName = _('noName');
       }
@@ -369,9 +369,9 @@ contacts.List = (function() {
     ret.push(contact.givenName && contact.givenName.length > 0 ?
       contact.givenName[0] : '');
     ret.push(contact.tel && contact.tel.length > 0 ?
-      contact.tel[0].number : '');
+      contact.tel[0].value : '');
     ret.push(contact.email && contact.email.length > 0 ?
-      contact.email[0].address : '');
+      contact.email[0].value : '');
     ret.push('#');
 
     return ret.join('');

--- a/apps/dialer/js/recents.js
+++ b/apps/dialer/js/recents.js
@@ -590,7 +590,7 @@ var Recents = {
         length = contact.tel.length;
       for (var i = 0; i < length; i++) {
         phoneEntry = contact.tel[i];
-        contactPhoneNumber = phoneEntry.number.replace(' ', '', 'g');
+        contactPhoneNumber = phoneEntry.value.replace(' ', '', 'g');
         if ((phoneNumber == contactPhoneNumber) && (phoneEntry.type)) {
           secondaryInfo.textContent = secondaryInfo.textContent.trim() +
             '   ' + phoneEntry.type;

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -1050,7 +1050,7 @@ var ThreadUI = {
     var tels = contact.tel;
     for (var i = 0; i < tels.length; i++) {
       var input = this.contactInput.value;
-      var number = tels[i].number.toString();
+      var number = tels[i].value.toString();
       var reg = new RegExp(input, 'ig');
       if (!(name.match(reg) || (number.match(reg)))) {
         continue;


### PR DESCRIPTION
After https://bugzilla.mozilla.org/show_bug.cgi?id=782136 landed, tel and address are ContactFields, so we need to replace number and address by value.

This PR do it in contacts, sms, and dialer app.

sms and dialer devs, please, take a look if I forgot any case.

@etiennesegonzac, @borjasalguero , @fcampo r?
