### PR TITLE
[calendar] implement calendar colors & display toggle

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <meta http-equiv="pragma" content="no-cache">
   <title>Calendar</title>
-
   <link rel="stylesheet" type="text/css" href="/style/calendar.css">
   <link rel="stylesheet" type="text/css" href="/style/ui.css">
   <link rel="stylesheet" type="text/css" href="/style/events.css">
@@ -64,6 +63,7 @@
   <script defer src="/js/models/calendar.js" type="text/javascript" charset="utf-8"></script>
 
   <!--- views -->
+  <script defer src="/js/views/calendar_colors.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/month.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/month_child.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/months_day.js" type="text/javascript" charset="utf-8"></script>

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -90,6 +90,9 @@ Calendar.App = (function(window) {
         this.go('/month/');
       }
 
+      var colors = this.view('CalendarColors');
+      colors.render();
+
       this.syncController.observe();
       this.router.start();
       document.body.classList.remove('loading');

--- a/apps/calendar/js/models/calendar.js
+++ b/apps/calendar/js/models/calendar.js
@@ -93,6 +93,12 @@
     },
 
     get color() {
+      var color = this.remote.color;
+      if (color) {
+        if (color.substr(0, 1) === '#') {
+          return color.substr(0, 7);
+        }
+      }
       return this.remote.color;
     },
 

--- a/apps/calendar/js/templates/calendar.js
+++ b/apps/calendar/js/templates/calendar.js
@@ -2,13 +2,12 @@
 
   var Cal = Calendar.Template.create({
     item: [
-      '<li id="calendar-{_id}" data-id="{_id}">',
+      '<li id="calendar-{_id}">',
         '<label>',
           '<span class="name">{name}</span>',
           '<input ',
+            'value="{_id}" ',
             'type="checkbox" ',
-            // this is temp until toggle actually works
-            'disabled="disabled" ',
             '{localDisplayed|bool=checked} />',
           '<span></span>',
         '</label>',

--- a/apps/calendar/js/templates/day.js
+++ b/apps/calendar/js/templates/day.js
@@ -1,8 +1,11 @@
 (function(window) {
   var Day = Calendar.Template.create({
     hour: [
-      '<section class="hour-{hour}">',
-        '<h4>{displayHour}</h4>',
+      '<section class="hour-{hour} {classes} calendar-display">',
+        '<h4>',
+          '<span class="calendar-color"></span>',
+          '{displayHour}',
+        '</h4>',
         '<ol class="events">',
           '{items|s}',
         '</ol>',
@@ -12,7 +15,7 @@
     attendee: '<span class="attendee">{value}</span>',
 
     event: [
-      '<li class="event">',
+      '<li class="event calendar-id-{calendarId} calendar-display">',
         '<h5>{title}</h5>',
         '<span class="details">',
           '<span class="location">',

--- a/apps/calendar/js/templates/month.js
+++ b/apps/calendar/js/templates/month.js
@@ -5,7 +5,7 @@
               'busytime-{_id} ' +
               'busy-length-{length} ' +
               'busy-{start} ' +
-              'calendar-id-{calendarId}' +
+              'calendar-id-{calendarId} calendar-color calendar-display' +
             '">' +
             '&nbsp;' +
           '</span>',

--- a/apps/calendar/js/views/calendar_colors.js
+++ b/apps/calendar/js/views/calendar_colors.js
@@ -1,0 +1,143 @@
+Calendar.ns('Views').CalendarColors = (function() {
+
+  function Colors() {
+    this.colorMap = Object.create(null);
+    this._ruleMap = Object.create(null);
+
+    // create style sheet for us to play with
+    var sheet = document.createElement('style');
+    sheet.type = 'text/css';
+    sheet.id = '_dynamic-calendar-styles';
+
+    document.head.appendChild(sheet);
+
+    this._styles = document.styleSheets[document.styleSheets.length - 1];
+
+    this._initEvents();
+  }
+
+  Colors.prototype = {
+
+    prefix: 'calendar-id-',
+
+    _initEvents: function() {
+      // handle changes in calendar
+      var store = Calendar.App.store('Calendar');
+      store.on('persist', this);
+      store.on('remove', this);
+    },
+
+    handleEvent: function(e) {
+      switch (e.type) {
+        case 'persist':
+          // 1 is the model
+          this.updateRule(e.data[1]);
+          break;
+        case 'remove':
+          // 0 is an id of a model
+          this.removeRule(e.data[0]);
+          break;
+      }
+    },
+
+    render: function() {
+      var store = Calendar.App.store('Calendar');
+      var key;
+
+      for (key in store.cached) {
+        this.updateRule(store.cached[key]);
+      }
+    },
+
+    /**
+     * Returns prefixed calendar id used
+     * in css classes, etc...
+     *
+     * Uses _id field when given a model
+     *
+     * @param {Calendar.Models.Calendar|String} item model or string.
+     */
+    getId: function(item) {
+      if (item instanceof Calendar.Models.Calendar) {
+        return this.prefix + item._id;
+      } else {
+        return this.prefix + item;
+      }
+    },
+
+    /**
+     * associates a color with a
+     * calendar/calendar id with a color.
+     *
+     * @param {Calendar.Model.Calendar} calendar model.
+     */
+    updateRule: function(calendar) {
+      var id = this.getId(calendar);
+      var styles = this.colorMap[id];
+      var color = calendar.color;
+      var rules = this._styles.cssRules;
+      var map;
+
+      if (id in this.colorMap) {
+        map = this._ruleMap[id];
+        var bgStyle = map.bg.style;
+        var displayStyle = map.display.style;
+
+        bgStyle.backgroundColor = color;
+
+        if (!calendar.localDisplayed) {
+          displayStyle.setProperty('display', 'none');
+        } else {
+          displayStyle.setProperty('display', 'inherit', 'important');
+        }
+
+      } else {
+        var idx = this._styles.cssRules.length;
+        this.colorMap[id] = color;
+        map = this._ruleMap[id] = {};
+
+        var bgBlock = '.' + id + '.calendar-color, ';
+        bgBlock += '.' + id + ' .calendar-color ';
+        bgBlock += '{ background-color: ' + color + '; }';
+
+        this._styles.insertRule(bgBlock, idx);
+
+        map.bg = rules[idx++];
+
+        var displayBlock = '.' + id + '.calendar-display';
+
+        if (!calendar.localDisplayed) {
+          displayBlock += '{ display: none; }';
+        } else {
+          displayBlock += '{ display: inherit; }';
+        }
+
+        this._styles.insertRule(
+          displayBlock,
+          idx
+        );
+
+        map.display = rules[idx];
+      }
+    },
+
+    /**
+     * Removes color rule associated
+     * with given id.
+     */
+    removeRule: function(id) {
+      id = this.getId(id);
+      if (id in this.colorMap) {
+        delete this.colorMap[id];
+
+        var idx = this._ruleMap[id];
+        delete this._ruleMap[id];
+        this._styles.deleteRule(idx);
+      }
+    }
+
+  };
+
+  return Colors;
+
+}());

--- a/apps/calendar/js/views/months_day.js
+++ b/apps/calendar/js/views/months_day.js
@@ -179,6 +179,7 @@
 
       var hour = 0;
       var hours = 23;
+      var calendarIds = [];
       var group;
 
       // find matching items in the day
@@ -190,6 +191,7 @@
         var end = item[0].endDate;
 
         if (hourSpan.overlaps(start, end)) {
+          calendarIds.push(item[0].calendarId);
           group.push(item);
         } else if (end < hourStart) {
           records.splice(idx, 1);
@@ -199,6 +201,7 @@
       // iterate through all hours
       for (; hour <= hours; hour++) {
         group = [];
+        calendarIds = [];
         hourStart.setHours(hour);
         hourEnd.setHours(hour + 1);
 
@@ -217,7 +220,7 @@
         // even if there are no events on a given
         // hour.
         if (group.length) {
-          this._renderHour(hour, group);
+          this._renderHour(hour, group, calendarIds);
         }
       }
     },
@@ -226,15 +229,28 @@
      * Renders an hour. Note it is assumed
      * that this function is called in the correct
      * order and does not attempt to order content.
+     *
+     * @param {String} hour display hour.
+     * @param {Array} group list of events.
+     * @param {Array} ids calendar ids associated with this hour.
+     *                    duplicates allowed.
      */
-    _renderHour: function(hour, group) {
+    _renderHour: function(hour, group, ids) {
       var eventHtml = [];
+      var classFlags = '';
+
+      if (ids) {
+        ids.forEach(function(id) {
+          classFlags += ' calendar-id-' + id;
+        });
+      }
 
       group.forEach(function(item) {
         eventHtml.push(this._renderEvent(item[1]));
       }, this);
 
       var html = template.hour.render({
+        classes: classFlags,
         displayHour: this._formatHour(hour),
         hour: String(hour),
         items: eventHtml.join('')
@@ -271,6 +287,7 @@
       }
 
       return template.event.render({
+        calendarId: object.calendarId,
         title: remote.title,
         location: remote.location,
         attendees: attendees

--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -318,7 +318,6 @@ section.month li .busy-indicator:before {
 
 section.month li .busy-indicator > span {
   top: 0px;
-  background-color: #FCA900;
   position: absolute;
   text-indent: -1000em;
 }
@@ -377,6 +376,8 @@ Indicators are in units of 12
 
 #months-day-view .day-events {
   height: -moz-calc(100% - 7.7rem);
+  display: -moz-box;
+  -moz-box-orient: vertical;
   overflow-y: auto;
 }
 

--- a/apps/calendar/test/unit/models/calendar_test.js
+++ b/apps/calendar/test/unit/models/calendar_test.js
@@ -94,9 +94,18 @@ suite('models/calendar', function() {
     assert.equal(subject.name, 'foo');
   });
 
-  test('#color', function() {
-    subject.remote.color = '#ccc';
-    assert.equal(subject.color, '#ccc');
+  suite('#color', function() {
+
+    test('basic getter', function() {
+      subject.remote.color = '#ccc';
+      assert.equal(subject.color, '#ccc');
+    });
+
+    test('filter hex value', function() {
+      subject.remote.color = '#7BD148FF';
+      assert.equal(subject.color, '#7BD148');
+    });
+
   });
 
   test('#description', function() {

--- a/apps/calendar/test/unit/views/calendar_colors_test.js
+++ b/apps/calendar/test/unit/views/calendar_colors_test.js
@@ -1,0 +1,189 @@
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('models/calendar.js');
+  requireLib('views/calendar_colors.js');
+});
+
+suite('views/calendar_colors', function() {
+
+  var subject;
+  var model;
+  var app;
+  var store;
+
+  setup(function() {
+    this.timeout(5000);
+
+    app = testSupport.calendar.app();
+    store = app.store('Calendar');
+    subject = new Calendar.Views.CalendarColors();
+
+    model = Factory.create('calendar', {
+      _id: '1xx',
+      localDisplayed: true
+    });
+  });
+
+  test('initialization', function() {
+    assert.deepEqual(subject.colorMap, {});
+    assert.deepEqual(subject._ruleMap, {});
+    assert.instanceOf(subject._styles, CSSStyleSheet);
+  });
+
+  test('#getId', function() {
+    var expected = 'calendar-id-1xx';
+    assert.equal(subject.getId(model), expected);
+    assert.equal(subject.getId('1xx'), expected);
+  });
+
+  suite('#render', function() {
+    var calledWith;
+    var first = {};
+    var second = {};
+
+    setup(function() {
+      calledWith = [];
+      subject.updateRule = function(item) {
+        calledWith.push(item);
+      }
+
+      store.cached[0] = first;
+      store.cached[1] = second;
+
+      subject.render();
+    });
+
+    test('calls update', function() {
+      assert.deepEqual(calledWith, [first, second]);
+    });
+
+  });
+
+  suite('#handleEvent', function() {
+    var calls;
+
+    setup(function() {
+      calls = {
+        add: [],
+        remove: []
+      };
+
+      subject.updateRule = function(item) {
+        calls.add.push(item);
+      }
+
+      subject.removeRule = function(item) {
+        calls.remove.push(item);
+      }
+    });
+
+    test('type: persist', function() {
+      store.emit('persist', model._id, model);
+
+      assert.deepEqual(calls.add, [model]);
+    });
+
+    test('type: remove', function() {
+      store.emit('remove', model._id);
+      assert.deepEqual(calls.remove, [model._id]);
+    });
+  });
+
+  suite('#removeRule', function() {
+    return;
+
+    test('when it does not exist', function() {
+      subject.removeRule(model);
+    });
+
+    test('when it exists', function() {
+      var id = subject.getId(model);
+
+      subject.updateRule(model);
+      subject.removeRule(model._id);
+
+      assert.ok(!subject.colorMap[id], 'removed color map');
+      assert.ok(!subject._ruleMap[id], 'removed rule map');
+
+      var rules = subject._styles.cssRules;
+
+      assert.equal(rules.length, 0, 'should remove css rules');
+    });
+
+  });
+
+  suite('#updateRule', function() {
+
+    test('first time', function() {
+      var id = subject.getId(model);
+      assert.ok(!subject.colorMap[id]);
+      subject.updateRule(model);
+
+      assert.equal(subject.colorMap[id], model.color);
+
+      // check that the actual style is flushed to the dom...
+      assert.equal(subject._styles.cssRules.length, 2);
+      var bgRule = subject._styles.cssRules[0];
+      var displayRule = subject._styles.cssRules[1];
+
+      assert.include(bgRule.selectorText, subject.getId(model._id));
+      assert.include(bgRule.selectorText, 'calendar-color');
+
+      assert.include(displayRule.selectorText, subject.getId(model._id));
+      assert.include(displayRule.selectorText, 'calendar-display');
+
+      // it may do the RGB conversion so its not strictly equal...
+      assert.ok(
+        bgRule.style.backgroundColor,
+        'should have set background color'
+      );
+    });
+
+    test('first time hidden', function() {
+      model.localDisplayed = false;
+      subject.updateRule(model);
+
+      // check that the actual style is flushed to the dom...
+      var bgRule = subject._styles.cssRules[0];
+
+      // it may do the RGB conversion so its not strictly equal...
+      assert.ok(
+        bgRule.style.backgroundColor,
+        'should have set background color'
+      );
+
+      var displayRule = subject._styles.cssRules[1];
+      assert.equal(
+        displayRule.style.display, 'none',
+        'should set display to none'
+      );
+    });
+
+    test('second time', function() {
+      subject.updateRule(model);
+
+      var bgStyle = subject._styles.cssRules[0].style;
+      var displayStyle = subject._styles.cssRules[1].style;
+
+      var oldColor = bgStyle.backgroundColor;
+
+      model.remote.color = '#FAFAFA';
+
+      subject.updateRule(model);
+
+      assert.notEqual(bgStyle.backgroundColor, oldColor, 'should change color');
+
+
+      model.localDisplayed = false;
+      subject.updateRule(model);
+
+      assert.equal(displayStyle.display, 'none');
+
+      model.localDisplayed = true;
+      subject.updateRule(model);
+      assert.equal(displayStyle.display, 'inherit');
+    });
+
+
+  });
+
+});

--- a/apps/calendar/test/unit/views/months_day_test.js
+++ b/apps/calendar/test/unit/views/months_day_test.js
@@ -152,16 +152,22 @@ suite('views/months_day', function() {
       return new Date(2012, 1, 2, hours, min);
     }
 
+    function groupAdd(group, idx) {
+      var item = list[idx];
+      groups[group][0].push(item);
+      groups[group][1].push(item[0].calendarId);
+    }
+
     setup(function() {
       list = [];
       groups = {
-        0: [],
-        5: [],
-        6: [],
-        7: [],
-        21: [],
-        22: [],
-        23: []
+        0: [[], []],
+        5: [[], []],
+        6: [[], []],
+        7: [[], []],
+        21: [[], []],
+        22: [[], []],
+        23: [[], []]
       };
 
       // starts on a different day
@@ -173,7 +179,7 @@ suite('views/months_day', function() {
         })
       ]);
 
-      groups[0].push(list[0]);
+      groupAdd(0, 0);
 
       // same day skip some hours
       // this should not render into
@@ -185,7 +191,7 @@ suite('views/months_day', function() {
         })
       ]);
 
-      groups[5].push(list[1]);
+      groupAdd(5, 1);
 
 
       // Also on fifth hour
@@ -198,7 +204,7 @@ suite('views/months_day', function() {
         })
       ]);
 
-      groups[5].push(list[2]);
+      groupAdd(5, 2);
 
 
       // multi hour
@@ -210,10 +216,9 @@ suite('views/months_day', function() {
         })
       ]);
 
-      groups[5].push(list[3]);
-      groups[6].push(list[3]);
-      groups[7].push(list[3]);
-
+      groupAdd(5, 3);
+      groupAdd(6, 3);
+      groupAdd(7, 3);
 
       // ends on a different day
       // but not an all day event.
@@ -226,17 +231,17 @@ suite('views/months_day', function() {
         })
       ]);
 
-      groups[21].push(list[4]);
-      groups[22].push(list[4]);
-      groups[23].push(list[4]);
+      groupAdd(21, 4);
+      groupAdd(22, 4);
+      groupAdd(23, 4);
     });
 
     var calledHours;
 
     setup(function() {
       calledHours = {};
-      subject._renderHour = function(hour, group) {
-        calledHours[hour] = group;
+      subject._renderHour = function(hour, group, ids) {
+        calledHours[hour] = [group, ids];
       };
     });
 
@@ -332,13 +337,16 @@ suite('views/months_day', function() {
     });
 
     test('output', function() {
-      subject._renderHour(5, group);
+      subject._renderHour(5, group, ['1', '2']);
       var children = subject.events.children;
       assert.equal(children.length, 1);
 
       var el = children[0];
       assert.ok(el.outerHTML);
       var html = el.outerHTML;
+
+      assert.include(html, 'calendar-id-1');
+      assert.include(html, 'calendar-id-2');
 
       assert.include(
         html,


### PR DESCRIPTION
Hooks up calendar toggle & color.
- Implements toggling local display of calendar (& persistence of that state).
- Implements real calendar coloring based on the value sent from the server.

Tested with colors sent from Google & Zimbra.
