### PR TITLE
[SMS] Fix message word break issue.

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -38,7 +38,7 @@ var Utils = {
     var stringHTML = str;
     stringHTML = stringHTML.replace(/\</g, '&#60;');
     stringHTML = stringHTML.replace(/(\r\n|\n|\r)/gm, '<br/>');
-    stringHTML = stringHTML.replace(/\s/g, '&nbsp;');
+    stringHTML = stringHTML.replace(/\s\s/g, ' &nbsp;');
 
     if (escapeQuotes)
       return stringHTML.replace(/"/g, '&quot;').replace(/'/g, '&#x27;');


### PR DESCRIPTION
If we escape the space with &nbsp, the string could not be broke properly. So we fix the multi-space issue by replacing every 2 spaces with 1 space + &nbsp to make the word break could work correctly.
