### PR TITLE
[SMS] Add carrier info on sms details

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -97,7 +97,7 @@
               <h1 id="messages-edit-title" data-l10n-id="editMode">Edit mode</h1>
             </header>
           </div>
-          <div class="carrier-wrapper">
+          <div id="contact-carrier" data-l10n-id="carrier-unknown" class="carrier-wrapper">
             Carrier unknown
           </div>
         </div>

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -501,8 +501,9 @@ var ThreadListUI = {
 
     // Get the contact data for the number
     ContactDataManager.getContactData(thread.num, function gotContact(contact) {
-      if (contact && contact.length > 0)
+      if (contact && contact.length > 0) {
         ThreadListUI.updateMsgWithContact(thread.num, contact);
+      }
     });
   },
 
@@ -665,10 +666,23 @@ var ThreadUI = {
     ThreadUI.view.appendChild(headerHTML);
   },
   updateHeaderData: function thui_updateHeaderData(number) {
-    ThreadUI.title.innerHTML = number;
+    var self = this;
+    self.title.innerHTML = number;
     ContactDataManager.getContactData(number, function gotContact(contact) {
-      if (contact && contact[0].name && contact[0].name != '') {
-        ThreadUI.title.innerHTML = contact[0].name;
+      var carrier = document.getElementById('contact-carrier');
+      if (contact.length > 0) { // we have a contact
+        if (contact[0].name && contact[0].name != '') { // contact with name
+          self.title.innerHTML = contact[0].name;
+          carrier.innerHTML =
+                  contact[0].tel[0].type + ' | ' +
+                  (contact[0].tel[0].carrier || _('carrier-unknown'));
+    // TODO check if contact has different numbers with same type and carrier
+        } else { // no name of contact
+          carrier.innerHTML =
+                  contact[0].tel[0].type;
+        }
+      } else { // we don't have a contact
+        carrier.style.display = 'none';
       }
     });
   },

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -33,6 +33,7 @@ newMessage=New Message
 /* Search functionality */
 search=Search
 unknown-contact=Unknown
+carrier-unknown=Carrier unknown
 
 /* Date and time */
 justNow=just now


### PR DESCRIPTION
The info shown is based on this criteria:
- When there's a matching contact for the number:
  - If contact have a name --> Name is main header, type and carrier as secondary (carrier unknown if no carrier field).
  - If contact doesn't have a name --> Number is shown as a main header, type and number as secondary
- When there's no matching contact for the number -> secondary header is hidden
