### PR TITLE
SMS contact bug fixing.

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -277,7 +277,7 @@ var ThreadListUI = {
   updateMsgWithContact: function thlui_updateMsgWithContact(number, contact) {
     var element =
             this.view.querySelector('a[data-num="' + number + '"] div.name');
-    if (element && contact[0].name && contact[0].name != '') {
+    if (element && contact[0].name) {
       element.innerHTML = contact[0].name;
     }
   },
@@ -667,7 +667,7 @@ var ThreadUI = {
   updateHeaderData: function thui_updateHeaderData(number) {
     ThreadUI.title.innerHTML = number;
     ContactDataManager.getContactData(number, function gotContact(contact) {
-      if (contact && contact[0].name && contact[0].name != '') {
+      if (contact && contact.length > 0 && contact[0].name) {
         ThreadUI.title.innerHTML = contact[0].name;
       }
     });


### PR DESCRIPTION
- We need to check the returning contact length because it might be an empty array.
- There is no need to check contact name is am empty string or not(it is already false state if empty string).
