### PR TITLE
update system screenshot module to latest device storage api

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -45,7 +45,8 @@ no=No
 screenshotSaved=Screenshot saved
 screenshotFailed=Screenshot failed
 screenshotNoSDCard=No SD card installed
-screenshotStorageError=Device storage error: {{error}}
+screenshotSDCardInUse=SD card in use
+screenshotSDCardFull=No space left
 
 # quick settings
 quick-settings-wifi=Wifi


### PR DESCRIPTION
This pull request updates the gaia side of the system screenshots module so that it uses the latest device storage functionality.  It can now display error notifications if there is no sd card, if the sdcard is in use (usb mass storage) or if the sdcard is full.
