### PR TITLE
Use ':root:-moz-full-screen-ancestor rather than '#screen.fullscreen'

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -153,14 +153,6 @@ var ScreenManager = {
 
         break;
 
-      case 'mozfullscreenchange':
-        if (document.mozFullScreen) {
-          this.screen.classList.add('fullscreen');
-        } else {
-          this.screen.classList.remove('fullscreen');
-        }
-        break;
-
       case 'sleep':
         if (!this._screenWakeLocked)
           this.turnScreenOff(true);
@@ -185,7 +177,6 @@ var ScreenManager = {
       return false;
 
     window.removeEventListener('devicelight', this);
-    window.removeEventListener('mozfullscreenchange', this);
 
     var self = this;
     var screenBrightness = navigator.mozPower.screenBrightness;
@@ -239,7 +230,6 @@ var ScreenManager = {
       return false;
 
     window.addEventListener('devicelight', this);
-    window.addEventListener('mozfullscreenchange', this);
 
     navigator.mozPower.screenEnabled = this.screenEnabled = true;
     navigator.mozPower.screenBrightness = this._brightness;

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -1,6 +1,6 @@
 /* The status bar disregard the rem rule because we have only 16px icons for now */
 
-#screen.fullscreen:not(.locked) > #statusbar,
+:root:-moz-full-screen-ancestor > body > #screen:not(.locked) > #statusbar,
 #screen.lockscreen-camera > #statusbar {
   display: none;
 }

--- a/apps/system/style/utility_tray/utility_tray.css
+++ b/apps/system/style/utility_tray/utility_tray.css
@@ -1,4 +1,4 @@
-#screen.fullscreen:not(.locked) > #utility-tray,
+:root:-moz-full-screen-ancestor > body > #screen:not(.locked) > #utility-tray,
 #screen.lockscreen-camera > #utility-tray {
   display: none;
 }

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -110,17 +110,17 @@
 }
 
 /* Fullscreen */
-#screen.fullscreen > [data-z-index-level="system-overlay"],
-#screen.fullscreen > [data-z-index-level="lockscreen"],
-#screen.fullscreen > [data-z-index-level="lockscreen-camera"],
-#screen.fullscreen > [data-z-index-level="value-selector"],
-#screen.fullscreen > [data-z-index-level="dialog-overlay"],
-#screen.fullscreen > [data-z-index-level="keyboard-overlay"],
-#screen.fullscreen > [data-z-index-level="keyboard-frame"],
-#screen.fullscreen > [data-z-index-level="keyboard-frame"].visible,
-#screen.fullscreen > [data-z-index-level="notification-toaster"],
-#screen.fullscreen > [data-z-index-level="cardsview"],
-#screen.fullscreen > [data-z-index-level="attention-screen"],
-#screen.fullscreen > [data-z-index-level="permission-screen"] {
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="system-overlay"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="lockscreen"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="lockscreen-camera"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="value-selector"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="dialog-overlay"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="keyboard-overlay"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="keyboard-frame"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="keyboard-frame"].visible,
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="notification-toaster"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="cardsview"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="attention-screen"],
+:root:-moz-full-screen-ancestor > body > #screen > [data-z-index-level="permission-screen"] {
   z-index: 2147483647;
 }


### PR DESCRIPTION
Fixes issue #3616 and probably issue #3522 too.

Comment describing fix in (issue #3522 comment #7924486](https://github.com/mozilla-b2g/gaia/issues/3616#issuecomment-7924486).

@timdream may decide we don't need this thanks to his work in issue #3626, but regardless we should have on file the cause of this and how to fix this, just in case we need it.
