### PR TITLE
Showing USB Mass Storage status

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -35,6 +35,7 @@ var StatusBar = {
 
   recordingActive: false,
   recordingTimer: null,
+  umsShared: false,
 
   /* For other app to acquire */
   get height() {
@@ -123,6 +124,11 @@ var StatusBar = {
           case 'recording-status':
             this.recordingActive = evt.detail.active;
             this.update.recording.call(this);
+            break;
+
+          case 'volume-state-changed':
+            this.umsShared = evt.detail.active;
+            this.update.usb.call(this);
             break;
         }
 
@@ -407,11 +413,10 @@ var StatusBar = {
     },
 
     usb: function sb_updateUsb() {
-      // XXX no way to probe active state of USB mess storage right now
-      // https://github.com/mozilla-b2g/gaia/issues/2333
+      var icon = this.icons.usb;
+      icon.hidden = !this.umsShared;
+    },
 
-      // this.icon.usb.hidden = ?
-    }
   },
 
   updateNotification: function sb_updateNotification(count) {


### PR DESCRIPTION
Catching the event 'volume-state-changed' and notifying the user wether
USB Mass Storage is en route. Needs https://bugzilla.mozilla.org/show_bug.cgi?id=784684.
