### PR TITLE
Sleep menu icons

### DIFF
--- a/apps/system/js/sleep_menu.js
+++ b/apps/system/js/sleep_menu.js
@@ -46,12 +46,12 @@ var SleepMenu = {
       restart: {
         label: _('restart'),
         value: 'restart',
-        icon: '/style/sleep_menu/images/power-off.png'
+        icon: '/style/sleep_menu/images/restart.png'
       },
       power: {
         label: _('power'),
         value: 'power',
-        icon: '/style/sleep_menu/images/restart.png'
+        icon: '/style/sleep_menu/images/power-off.png'
       }
     };
 


### PR DESCRIPTION
"Restart" and "PowerOff" icons are swapped, here’s a fix.
