### PR TITLE
metadata parsing improvements

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -183,7 +183,7 @@ window.addEventListener('localized', function showBody() {
 
 function init() {
   photodb = new MediaDB('pictures', metadataParser, {
-    indexes: ['metadata.date'],
+    indexes: ['date'],
     mimeTypes: ['image/jpeg', 'image/png']
   });
 
@@ -464,7 +464,7 @@ function createThumbnailList() {
 
   // Enumerate existing image entries in the database and add thumbnails
   // List them all, and sort them in descending order by date.
-  photodb.enumerate('metadata.date', null, 'prev', function(imagedata) {
+  photodb.enumerate('date', null, 'prev', function(imagedata) {
     if (imagedata === null) // No more images
       return;
 


### PR DESCRIPTION
This pull request improves metadata parsing for the gallery app, with the particular goal of reducing memory usage to avoid OOM crashes.  It changes parsing in these ways:

1) When looking for the image size and thumbnail in the jpeg file itself, it reads the file one JPEG segment at a time, rather than reading the entire file into memory at once.

2) It doesn't bother parsing and storing the EXIF data that the app doesn't use

3) The backup parser for images without an embedded thumbnail is now more careful to avoid gecko image-related memory leaks. It uses only a single offscreen image, and sets the src property to null when done, with the hope that this will cause gecko to release the image memory more quickly

4) calls to the metadataParser() function are now serialized so that there can never be more than one running at a time.
