### PR TITLE
Status bar loading icon CSS clean up, restore 0.2s workaround

### DIFF
--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -62,23 +62,25 @@
   -moz-transform: translateY(20px);
 }
 
-#statusbar-loading.popup-loading, #statusbar-loading.app-loading {
+#statusbar-loading {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 1px;
   background: url('images/loading.gif') center center repeat-x;
-
-  -moz-transition: opacity 0.1s ease 0.2s;
-  visibility: visible;
-}
-
-#statusbar-loading {
   display: block;
   visibility: hidden;
 
   -moz-transition: none;
+  opacity: 0;
+}
+
+#statusbar-loading.popup-loading, #statusbar-loading.app-loading {
+  visibility: visible;
+
+  -moz-transition: opacity 0.1s ease 0.2s;
+  opacity: 1;
 }
 
 #statusbar-label {


### PR DESCRIPTION
See #2565, broken since #3060.
