### PR TITLE
Czech qwerty keyboard layout added

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -57,7 +57,7 @@ const IMEManager = {
     'dvorak': ['en-Dvorak'],
     'spanish' : ['es'],
     'portuguese' : ['pt_BR'],
-    'otherlatins': ['fr', 'de', 'nb', 'sk', 'tr', 'es', 'pt_BR'],
+    'otherlatins': ['cz', 'fr', 'de', 'nb', 'sk', 'tr', 'es', 'pt_BR'],
     'cyrillic': ['ru', 'sr-Cyrl'],
     'hebrew': ['he'],
     'zhuyin': ['zh-Hant-Zhuyin'],

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -125,6 +125,45 @@ const Keyboards = {
       "'": '_'
     }
   },
+  cz: {
+    type: 'keyboard',
+    label: 'Czech',
+    menuLabel: 'Česká',
+    alt: {
+      a: 'á',
+      c: 'č',
+      d: 'ď',
+      e: 'éě',
+      i: 'í',
+      n: 'ň',
+      o: 'ó',
+      r: 'ř',
+      s: 'š',
+      t: 'ť',
+      u: 'úů',
+      y: 'ý',
+      z: 'ž'
+    },
+    keys: [
+      [
+        { value: 'q' }, { value: 'w' }, { value: 'e' }, { value: 'r' },
+        { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
+        { value: 'o' }, { value: 'p' }
+      ], [
+        { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
+        { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
+        { value: 'l' }, { value: "'", keyCode: 39 }
+      ], [
+        { value: '&#8682;', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+        { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
+        { value: 'b' }, { value: 'n' }, { value: 'm' },
+        { value: '&#9003;', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '&#8629;', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  },
   fr: {
     type: 'keyboard',
     label: 'French',


### PR DESCRIPTION
Basic qwerty keyboard layout added, the qwertz one will follow (there are two Czech keyboard layouts - qwerty and qwertz).
