### PR TITLE
[email] initial email activity had truncated call somehow

### DIFF
--- a/apps/email/js/mail-app.js
+++ b/apps/email/js/mail-app.js
@@ -157,7 +157,7 @@ if ('mozSetMessageHandler' in window.navigator) {
 
       var folderToUse = Cards._cardStack[Cards
         ._findCard(['folder-picker', 'navigation'])].cardImpl.curFolder;
-      var composer = MailAPI.(
+      var composer = MailAPI.beginMessageComposition(
         null, folderToUse, null,
         function() {
           /* to/cc/bcc/subject/body all have default values that shouldn't be


### PR DESCRIPTION
There was a regression in the pull request that was not noticed that
somehow nuked the function name.

@mozsquib
