### PR TITLE
workaround bug #785554

### DIFF
--- a/shared/js/gesture_detector.js
+++ b/shared/js/gesture_detector.js
@@ -85,8 +85,19 @@ var GestureDetector = (function() {
 
     // If this is a touch event handle each changed touch separately
     if (e.changedTouches) {
+      // XXX https://bugzilla.mozilla.org/show_bug.cgi?id=785554
+      // causes touchend events to list all touches as changed, so
+      // warn if we see that bug
+      if (e.type === 'touchend' && e.changedTouches.length > 1) {
+        console.warn('gesture_detector.js: spurious extra changed touch on touchend. See https://bugzilla.mozilla.org/show_bug.cgi?id=785554');
+      }
+
       for (var i = 0; i < e.changedTouches.length; i++) {
         handler(this, e, e.changedTouches[i]);
+        // The first changed touch might have changed the state of the
+        // FSM. We need this line to workaround the bug 785554, but it is
+        // probably the right thing to have here, even once that bug is fixed.
+        handler = this.state[e.type];
       }
     }
     else {    // Otherwise, just dispatch the event to the handler

--- a/shared/js/gesture_detector.js
+++ b/shared/js/gesture_detector.js
@@ -89,7 +89,9 @@ var GestureDetector = (function() {
       // causes touchend events to list all touches as changed, so
       // warn if we see that bug
       if (e.type === 'touchend' && e.changedTouches.length > 1) {
-        console.warn('gesture_detector.js: spurious extra changed touch on touchend. See https://bugzilla.mozilla.org/show_bug.cgi?id=785554');
+        console.warn('gesture_detector.js: spurious extra changed touch on ' +
+                     'touchend. See ' +
+                     'https://bugzilla.mozilla.org/show_bug.cgi?id=785554');
       }
 
       for (var i = 0; i < e.changedTouches.length; i++) {


### PR DESCRIPTION
A small patch to shared/js/gesture_detector.js to workaround a platform bug for OOP apps.  This only affects two-finger gestures, so is probably limited to the gallery app.
