### PR TITLE
smooth panning in the gallery

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -905,7 +905,7 @@ function positionImage(image, fit) {
   var style = image.style;
   style.width = fit.width + 'px';
   style.height = fit.height + 'px';
-  style.transform = 'translate(' + 
+  style.transform = 'translate(' +
     fit.left + 'px,' +
     fit.top + 'px)';
 }

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -558,7 +558,7 @@ window.addEventListener('mozvisiblitychange', function() {
 function removeTransition(event) {
   event.target.style.transition = null;
 }
-photoFrames.addEventListener('transitionend', removeTransition);
+
 previousPhotoFrame.addEventListener('transitionend', removeTransition);
 currentPhotoFrame.addEventListener('transitionend', removeTransition);
 nextPhotoFrame.addEventListener('transitionend', removeTransition);
@@ -833,7 +833,9 @@ photoFrames.addEventListener('swipe', function(event) {
     // the translations we added during panning
     var time = Math.abs(pastEdge) / TRANSITION_SPEED;
 
-    photoFrames.style.transition = 'left ' + time + 'ms linear';
+    currentPhotoFrame.style.transition =
+      nextPhotoFrame.style.transition =
+      previousPhotoFrame.style.transition = 'translate ' + time + 'ms linear';
     photoState.swipe = 0;
     photoState.setFramesPosition();
 
@@ -961,10 +963,9 @@ function nextPhoto(time) {
   previousPhotoFrame.classList.add('hidden');
 
   // Set transitions for the visible photo frames and the photoFrames element
-  var transition = 'left ' + time + 'ms linear';
+  var transition = 'transform ' + time + 'ms linear';
   currentPhotoFrame.style.transition = transition;
   nextPhotoFrame.style.transition = transition;
-  photoFrames.style.transition = transition;
 
   // Remove the classes
   previousPhotoFrame.classList.remove('previousPhoto');
@@ -1001,7 +1002,7 @@ function nextPhoto(time) {
   displayImageInFrame(currentPhotoIndex + 1, nextPhotoFrame);
 
   // When the transition is done, cleanup
-  photoFrames.addEventListener('transitionend', function done(e) {
+  currentPhotoFrame.addEventListener('transitionend', function done(e) {
     this.removeEventListener('transitionend', done);
 
     // Recompute and reposition the photo that just transitioned off the screen
@@ -1026,10 +1027,9 @@ function previousPhoto(time) {
   nextPhotoFrame.classList.add('hidden');
 
   // Set transitions for the visible photo frames and the photoFrames element
-  var transition = 'left ' + time + 'ms linear';
+  var transition = 'transform ' + time + 'ms linear';
   previousPhotoFrame.style.transition = transition;
   currentPhotoFrame.style.transition = transition;
-  photoFrames.style.transition = transition;
 
   // Remove the frame classes since we're about to cycle the frames
   previousPhotoFrame.classList.remove('previousPhoto');
@@ -1065,7 +1065,7 @@ function previousPhoto(time) {
   displayImageInFrame(currentPhotoIndex - 1, previousPhotoFrame);
 
   // When the transition is done do some cleanup
-  photoFrames.addEventListener('transitionend', function done(e) {
+  currentPhotoFrame.addEventListener('transitionend', function done(e) {
     this.removeEventListener('transitionend', done);
 
     // Recompute and reposition the photo that just transitioned off the screen
@@ -1153,6 +1153,8 @@ function PhotoState(img, width, height) {
   // Do all the calculations
   this.reset();
 }
+
+PhotoState.BORDER_WIDTH = 3;  // Border between photos
 
 // An internal method called by reset(), zoom() and pan() to
 // set the size and position of the image element.
@@ -1316,9 +1318,13 @@ PhotoState.prototype.pan = function(dx, dy) {
 };
 
 PhotoState.prototype.setFramesPosition = function() {
-  photoFrames.style.left = this.swipe + 'px';
+  // XXX we ignore rtl languages for now.
+  currentPhotoFrame.style.transform = 'translateX(' + this.swipe + 'px)';
+  nextPhotoFrame.style.transform = 'translateX(' +
+    (this.viewportWidth + PhotoState.BORDER_WIDTH + this.swipe) + 'px)';
+  previousPhotoFrame.style.transform = 'translateX(' +
+    (-(this.viewportWidth + PhotoState.BORDER_WIDTH) + this.swipe) + 'px)';
 };
-
 
 var editedPhotoIndex;
 var editedPhotoURL; // The blob URL of the photo we're currently editing

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -754,11 +754,7 @@ window.addEventListener('resize', function resizeHandler(evt) {
     var imagedata = images[n];
     var fit = fitImage(imagedata.metadata.width, imagedata.metadata.height,
                        photoView.offsetWidth, photoView.offsetHeight);
-    var style = img.style;
-    style.width = fit.width + 'px';
-    style.height = fit.height + 'px';
-    style.left = fit.left + 'px';
-    style.top = fit.top + 'px';
+    positionImage(img, fit);
   }
 });
 
@@ -902,11 +898,16 @@ function displayImageInFrame(n, frame) {
   var fit = fitImage(images[n].metadata.width, images[n].metadata.height,
                      photoView.offsetWidth, photoView.offsetHeight);
 
-  var style = img.style;
+  positionImage(img, fit);
+}
+
+function positionImage(image, fit) {
+  var style = image.style;
   style.width = fit.width + 'px';
   style.height = fit.height + 'px';
-  style.left = fit.left + 'px';
-  style.top = fit.top + 'px';
+  style.transform = 'translate(' + 
+    fit.left + 'px,' +
+    fit.top + 'px)';
 }
 
 // figure out the size and position of an image based on its size
@@ -959,9 +960,6 @@ function nextPhoto(time) {
   transitioning = true;
   setTimeout(function() { transitioning = false; }, time);
 
-  // Hide the previous photo
-  previousPhotoFrame.classList.add('hidden');
-
   // Set transitions for the visible photo frames and the photoFrames element
   var transition = 'transform ' + time + 'ms linear';
   currentPhotoFrame.style.transition = transition;
@@ -1007,9 +1005,6 @@ function nextPhoto(time) {
 
     // Recompute and reposition the photo that just transitioned off the screen
     previousPhotoState.reset();
-
-    // Make the new next photo visible again
-    nextPhotoFrame.classList.remove('hidden');
   });
 }
 
@@ -1022,9 +1017,6 @@ function previousPhoto(time) {
   // Set a flag to ignore pan and zoom gestures during the transition.
   transitioning = true;
   setTimeout(function() { transitioning = false; }, time);
-
-  // Hide the next photo
-  nextPhotoFrame.classList.add('hidden');
 
   // Set transitions for the visible photo frames and the photoFrames element
   var transition = 'transform ' + time + 'ms linear';
@@ -1070,9 +1062,6 @@ function previousPhoto(time) {
 
     // Recompute and reposition the photo that just transitioned off the screen
     nextPhotoState.reset();
-
-    // Make the new previous photo visible again
-    previousPhotoFrame.classList.remove('hidden');
   });
 }
 
@@ -1161,8 +1150,9 @@ PhotoState.BORDER_WIDTH = 3;  // Border between photos
 PhotoState.prototype._reposition = function() {
   this.img.style.width = this.width + 'px';
   this.img.style.height = this.height + 'px';
-  this.img.style.top = this.top + 'px';
-  this.img.style.left = this.left + 'px';
+  this.img.style.transform = 'translate(' +
+    this.left + 'px,' +
+    this.top + 'px)';
 };
 
 // Compute the default size and position of the photo

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -222,6 +222,8 @@ body {
 }
 
 .photoFrame > img {
+  top: 0px;  /* javascript modifies this position with a transform */
+  left: 0px;
   position: relative;
   border-width: 0px;
   padding: 0px;

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -212,35 +212,13 @@ body {
 .photoFrame {
   position: absolute;
   top: 0px;
+  left: 0px;
   width: 100%;
   height: 100%;
   padding: 0px;
   margin: 0px;
   overflow: hidden;
   -moz-user-select: none;
-}
-
-div.currentPhoto {
-  left: 0px;
-}
-
-/* the next photo is waiting in the wings just off to the right */
-/* We use 102% instead of 100% to give a small black border between photos */
-div.nextPhoto {
-  left: 102%;
-}
-
-/* In RTL languages, the next photo is off to the left */
-*[dir=rtl] div.nextPhoto {
-  left: -102%;
-}
-
-div.previousPhoto {
-  left: -102%;
-}
-
-*[dir=rtl] div.previousPhoto {
-  left: 102%;
 }
 
 .photoFrame > img {

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -228,6 +228,7 @@ body {
   border-width: 0px;
   padding: 0px;
   margin: 0px;
+  transform-origin: 0px 0px;
   pointer-events: none;
   -moz-user-select: none;
 }


### PR DESCRIPTION
This pull request changes gallery to animate with transformation rather than with .left.  It makes transitions between photos and panning within a zoomed-in photo smooth.

I still want to improve zoom animations, but this is a start.

@andreasgal this is for you if you want to review and land it :-)
