### PR TITLE
[F] #3026

### DIFF
--- a/apps/system/js/cards_view/cards_view.js
+++ b/apps/system/js/cards_view/cards_view.js
@@ -198,6 +198,10 @@ var CardsView = (function() {
 
   function runApp() {
     hideCardSwitcher();
+
+    // Close utility tray if it is opened.
+    UtilityTray.hide(true);
+
     WindowManager.launch(this.dataset['origin']);
   }
 


### PR DESCRIPTION
Fix #3026 in this way:
1. When the utility tray is pulled down, if the user invokes the card view, do nothing.
2. When the user clicks one app after 1. happens, close the utility tray instantly. (android does so).

c.c. @jcarpenter, @timdream, @michalbe
