### PR TITLE
Calendar chunked db load

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -39,6 +39,7 @@
   <script defer src="/js/router.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/db.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/timespan.js" type="text/javascript" charset="utf-8"></script>
+  <script defer src="/js/time_observer.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/interval_tree.js" type="text/javascript" charset="utf-8"></script>
 
   <!--- templates -->

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -94,6 +94,8 @@ Calendar.App = (function(window) {
       colors.render();
 
       this.syncController.observe();
+      this.timeController.observe();
+
       this.router.start();
       document.body.classList.remove('loading');
     },

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -58,11 +58,13 @@ Calendar.App = (function(window) {
         return selector;
       }
 
+      this.syncController.observe();
+      this.timeController.observe();
+
       /* temp views */
       this.state('/day/', setPath, tempView('#day-view'));
       this.state('/week/', setPath, tempView('#week-view'));
       this.state('/add/', setPath, tempView('#add-event-view'));
-
 
       /* routes */
 
@@ -93,8 +95,6 @@ Calendar.App = (function(window) {
       var colors = this.view('CalendarColors');
       colors.render();
 
-      this.syncController.observe();
-      this.timeController.observe();
 
       this.router.start();
       document.body.classList.remove('loading');

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -49,7 +49,7 @@ Calendar.App = (function(window) {
 
       today.addEventListener('click', function() {
         self.view('Month').render();
-        self.timeController.setSelectedDay(new Date());
+        self.timeController.selectedDay = (new Date());
       });
 
 

--- a/apps/calendar/js/calc.js
+++ b/apps/calendar/js/calc.js
@@ -1,6 +1,6 @@
-(function(window) {
-  Calendar.Calc = {
+Calendar.Calc = (function() {
 
+  var Calc = {
     PAST: 'past',
 
     NEXT_MONTH: 'next-month',
@@ -23,7 +23,7 @@
      * @return {Boolean} true when today.
      */
     isToday: function(date) {
-      return this.isSameDate(date, this.today);
+      return Calc.isSameDate(date, Calc.today);
     },
 
     offsetMinutesToMs: function(offset) {
@@ -43,7 +43,7 @@
         1
       );
 
-      var startDay = this.getWeekStartDate(month);
+      var startDay = Calc.getWeekStartDate(month);
 
       var endDay = new Date(
         month.getFullYear(),
@@ -52,7 +52,7 @@
       );
 
       endDay.setMilliseconds(-1);
-      endDay = this.getWeekEndDate(endDay);
+      endDay = Calc.getWeekEndDate(endDay);
 
       return new Calendar.Timespan(
         startDay,
@@ -65,7 +65,7 @@
      * removing offset.
      */
     utcMs: function(date) {
-      var offset = this.offsetMinutesToMs(
+      var offset = Calc.offsetMinutesToMs(
         date.getTimezoneOffset()
       );
 
@@ -87,7 +87,7 @@
       } else {
         // when there is an offset it is an absolute
         // position in time.
-        ms = ms + this.offsetMinutesToMs(offset);
+        ms = ms + Calc.offsetMinutesToMs(offset);
         return new Date(ms);
       }
     },
@@ -182,13 +182,13 @@
       var currentDay = date.getDay();
       var startDay = date.getDate() - currentDay;
 
-      return this.createDay(date, startDay);
+      return Calc.createDay(date, startDay);
     },
 
     getWeekEndDate: function(date) {
       // TODO: There are localization problems
       // with this approach as we assume a 7 day week.
-      var start = this.getWeekStartDate(date);
+      var start = Calc.getWeekStartDate(date);
       start.setDate(start.getDate() + 7);
       start.setMilliseconds(-1);
 
@@ -228,7 +228,7 @@
           );
         }
 
-        if (!this.isSameDate(next, end)) {
+        if (!Calc.isSameDate(next, end)) {
           list.push(next);
           continue;
         }
@@ -253,7 +253,7 @@
      */
     getWeeksDays: function(startDate) {
       //local day position
-      var weeksDayStart = this.getWeekStartDate(startDate);
+      var weeksDayStart = Calc.getWeekStartDate(startDate);
       var result = [weeksDayStart];
 
       for (var i = 1; i < 7; i++) {
@@ -274,7 +274,7 @@
      * @return {Boolean} true when date is in the past.
      */
     isPast: function(date) {
-      return (date.valueOf() < this.today.valueOf());
+      return (date.valueOf() < Calc.today.valueOf());
     },
 
     /**
@@ -284,7 +284,7 @@
      * @return {Boolean} true when date is in the future.
      */
     isFuture: function(date) {
-      return !this.isPast(date);
+      return !Calc.isPast(date);
     },
 
     /*
@@ -301,21 +301,21 @@
       var states;
 
       // 1. the date is today (real time)
-      if (this.isToday(day)) {
-        return this.PRESENT;
+      if (Calc.isToday(day)) {
+        return Calc.PRESENT;
       }
 
       // 2. the date is in the past (real time)
-      if (this.isPast(day)) {
-        states = this.PAST;
+      if (Calc.isPast(day)) {
+        states = Calc.PAST;
       // 3. the date is in the future (real time)
       } else {
-        states = this.FUTURE;
+        states = Calc.FUTURE;
       }
 
       // 4. the date is not in the current month (relative time)
       if (day.getMonth() !== month.getMonth()) {
-        states += ' ' + this.OTHER_MONTH;
+        states += ' ' + Calc.OTHER_MONTH;
       }
 
       return states;
@@ -323,4 +323,6 @@
 
   };
 
-}(this));
+  return Calc;
+
+}());

--- a/apps/calendar/js/calc.js
+++ b/apps/calendar/js/calc.js
@@ -26,6 +26,72 @@
       return this.isSameDate(date, this.today);
     },
 
+    offsetMinutesToMs: function(offset) {
+      return offset * (60 * 1000);
+    },
+
+    /**
+     * Creates timespan for a given month.
+     * Starts at the first week that occurs
+     * in the given month. Ends at the
+     * last day, minute, second of given month.
+     */
+    spanOfMonth: function(month) {
+      month = new Date(
+        month.getFullYear(),
+        month.getMonth(),
+        1
+      );
+
+      var startDay = this.getWeekStartDate(month);
+
+      var endDay = new Date(
+        month.getFullYear(),
+        month.getMonth() + 1,
+        1
+      );
+
+      endDay.setMilliseconds(-1);
+      endDay = this.getWeekEndDate(endDay);
+
+      return new Calendar.Timespan(
+        startDay,
+        endDay
+      );
+    },
+
+    /**
+     * Take a date and convert it to UTC-0 time
+     * removing offset.
+     */
+    utcMs: function(date) {
+      var offset = this.offsetMinutesToMs(
+        date.getTimezoneOffset()
+      );
+
+      return date.valueOf() - offset;
+    },
+
+    fromUtcMs: function(ms, offset) {
+      if (typeof(offset) === 'undefined') {
+        // no offset relative position in time.
+        var utcDate = new Date(ms);
+        return new Date(
+          utcDate.getUTCFullYear(),
+          utcDate.getUTCMonth(),
+          utcDate.getUTCDate(),
+          utcDate.getUTCHours(),
+          utcDate.getUTCMinutes(),
+          utcDate.getUTCSeconds()
+        );
+      } else {
+        // when there is an offset it is an absolute
+        // position in time.
+        ms = ms + this.offsetMinutesToMs(offset);
+        return new Date(ms);
+      }
+    },
+
     /**
      * Checks if two date objects occur
      * on the same date (in the same month, year, day).

--- a/apps/calendar/js/calendar.js
+++ b/apps/calendar/js/calendar.js
@@ -29,6 +29,20 @@
     },
 
     /**
+     * Compare numeric .start properties on an object
+     */
+    compareByStart: function(a, b) {
+      return Calendar.compare(a.start, b.start);
+    },
+
+    /**
+     * Compare numeric .end properties on an object
+     */
+    compareByEnd: function(a, b) {
+      return Calendar.compare(a.end, b.end);
+    },
+
+    /**
      * Base compare function.
      */
     compare: function(a, b) {

--- a/apps/calendar/js/controllers/time.js
+++ b/apps/calendar/js/controllers/time.js
@@ -3,35 +3,190 @@ Calendar.ns('Controllers').Time = (function() {
   function Time(app) {
     this.app = app;
     Calendar.Responder.call(this);
-  }
+    Calendar.TimeObserver.call(this);
 
-  function setter(attr, value) {
-    var oldVal = this[attr];
-    this[attr] = value;
-    this.emit(attr + 'Change', value, oldVal);
+    this._timeCache = {};
+    this._timespans = [];
+    this._collection = new Calendar.IntervalTree();
+
+    var busytime = this.busytime = app.store('Busytime');
+    busytime.on('add time', this);
+    busytime.on('remove time', this);
   }
 
   Time.prototype = {
     __proto__: Calendar.Responder.prototype,
+    _position: null,
+    _timeCache: null,
+    _timespans: null,
 
-    /**
-     * Sets current month and emits currentMonthChange event.
-     *
-     * @param {Date} month month.
-     */
-    setCurrentMonth: function(value) {
-      setter.call(this, 'currentMonth', value);
+    get timespan() {
+      return this._timespan;
+    },
+
+    get selectedDay() {
+      return this._selectedDay;
+    },
+
+    set selectedDay(value) {
+      var day = this._selectedDay;
+      if (!day || !Calendar.Calc.isSameDate(day, value)) {
+        this._selectedDay = value;
+        this.emit('selectedDayChange', value, day);
+      }
+    },
+
+    direction: 'future',
+
+    observe: function() {
+      this.on(
+        'monthChange',
+        this._loadMonthSpan.bind(this)
+      );
+    },
+
+    _updateCache: function(type, value) {
+      var old = this._timeCache[type];
+
+      if (!old || !Calendar.Calc.isSameDate(value, old)) {
+        this._timeCache[type] = value;
+        this.emit(type + 'Change', value, old);
+      }
     },
 
     /**
-     * Sets current day and emits selectedDayChange event.
+     * Loads a span of a month.
+     * Each time this method is called
+     * the same timespan should be generated.
      *
-     * @param {Date} day current day.
+     * XXX: This is going to assume for now
+     * that we can't "jump" in time from one
+     * month to a totally different one many
+     * months in the past/future. So each
+     * span is expected to be sequential.
      */
-    setSelectedDay: function(value) {
-      setter.call(this, 'selectedDay', value);
+    _loadMonthSpan: function(date) {
+      var span = Calendar.Calc.spanOfMonth(date);
+
+      var i = 0;
+      var len = this._timespans.length;
+      var existing;
+
+      // 0. No spans just add it...
+      if (len === 0) {
+        // just load the span
+        this._timespans.push(span);
+        return this.busytime.loadSpan(span);
+      }
+
+      // 1. event happens before first event
+      var first = this._timespans[0];
+
+      // > rather then >= because we only
+      // wish to do this when we don't have
+      // not loaded this span previously.
+      if (span.start < first.start) {
+        this._timespans.splice(0, 0, span);
+
+        span = first.trimOverlap(span) || span;
+        return this.busytime.loadSpan(span);
+      }
+
+      var last = this._timespans[len - 1];
+
+      if (span.end > last.end) {
+        this._timespans.push(span);
+        span = last.trimOverlap(span) || span;
+        return this.busytime.loadSpan(span);
+      }
+    },
+
+    handleEvent: function(event) {
+      var busytime = event.data[0];
+      var start = busytime.startDate;
+      var end = busytime.endDate;
+      var type;
+
+      switch (event.type) {
+        case 'add time':
+          type = 'add';
+          this._collection.add(busytime);
+          break;
+        case 'remove time':
+          type = 'remove';
+          this._collection.remove(busytime);
+          break;
+      }
+
+      if (type) {
+        this.fireTimeEvent(
+          type, start, end, busytime
+        );
+      }
+    },
+
+    get month() {
+      return this._timeCache.month;
+    },
+
+    get day() {
+      return this._timeCache.day;
+    },
+
+    get year() {
+      return this._timeCache.year;
+    },
+
+    get position() {
+      return this._position;
+    },
+
+    /**
+     * Queries busytimes cache by timespan.
+     *
+     * @param {Calendar.Timespan} timespan query range.
+     * @return {Array} busytimes ordered by start date.
+     */
+    queryCache: function(timespan) {
+      return this._collection.query(timespan);
+    },
+
+    /**
+     * Sets position of controller
+     * in time.
+     *
+     * @param {Date} date position to move to.
+     */
+    move: function(date) {
+      var year = date.getFullYear();
+      var month = date.getMonth();
+      var day = date.getDate();
+
+      var yearDate = new Date(year, 0, 1);
+      var monthDate = new Date(year, month, 1);
+
+      var oldPosition = this._position;
+      this._position = date;
+
+      this._updateCache('year', yearDate);
+      this._updateCache('month', monthDate);
+      this._updateCache('day', date);
+
+      if (oldPosition) {
+        if (oldPosition < date) {
+          this.direction = 'future';
+        } else if (oldPosition > date) {
+          this.direction = 'past';
+        } else {
+          this.direction = 'future';
+        }
+      }
+
     }
+
   };
+
+  Calendar.TimeObserver.enhance(Time.prototype);
 
   return Time;
 

--- a/apps/calendar/js/controllers/time.js
+++ b/apps/calendar/js/controllers/time.js
@@ -116,67 +116,26 @@ Calendar.ns('Controllers').Time = (function() {
 
         var isFuture = (dir === 'future');
         var start = idx;
-        var end = idx;
 
         // _maxTimespans is the total number of
         // timespans we wish to keep in memory
         // when the limit is hit we want to discard
         // extra but have _maxTimespans in length
         if (isFuture) {
-          //NOTE: when moving to a future time
-          //values to the right are likely
-          //move valuable then the left.
-          //In this case we only attempt to keep
-          //one to the left and _maxTimespans to the right.
-
-          // when starts >= 0 we position
-          // the beginning of the span before
-          // the target so user can scroll back.
-          if ((start - 1) >= 0) {
-            start -= 1;
+          start = (idx - 1);
+          if ((start + max) > len) {
+            start = start - ((start + max) - len);
           }
-
-          // while there is an available
-          // span ahead (to the right) of
-          // the target increase the size
-          // of the end.
-          while (max-- && end < len) {
-            end += 1;
-          }
-
-          // If we ran out of spans to the right
-          // add the remaining slots to the left.
-          if (max) {
-            start -= max;
-          }
-
         } else {
-          // When direction is into the past (left)
-          // we attempt to keep _maxTimespans to the left
-          // and one extra to the right.
+          start = (idx - max) + 1;
+        }
 
-          // if possible keep an extra span
-          // to the right
-          if ((end + 1) < len) {
-            end += 1;
-          }
-
-          // increase the size of the slice by
-          // starting the slice earlier (to the left).
-          while (max-- && start > 0) {
-            start -= 1;
-          }
-
-          // any remaining slots will be
-          // allocated to the right side.
-          if (max) {
-            end += max;
-          }
-
+        if (start < 0) {
+          start = 0;
         }
 
         // reduce the current list to just what we need
-        this._timespans = spans.splice(start, end);
+        this._timespans = spans.splice(start, this._maxTimespans);
 
         // Once we have reduced the number of timespans
         // we also need purge unused busytimes from the cache.
@@ -199,8 +158,8 @@ Calendar.ns('Controllers').Time = (function() {
           // ranges. Other controllers could possibly
           // listen to this event and do other kinds
           // of cleanup as well.
-          this.fireTimeEvent(
-            'purge', range.start, range.end, range
+          this.emit(
+            'purge', range
           );
         }, this);
       }

--- a/apps/calendar/js/controllers/time.js
+++ b/apps/calendar/js/controllers/time.js
@@ -17,6 +17,7 @@ Calendar.ns('Controllers').Time = (function() {
   Time.prototype = {
     __proto__: Calendar.Responder.prototype,
     _position: null,
+    _lastTimespan: null,
     _timeCache: null,
     _timespans: null,
 
@@ -87,6 +88,7 @@ Calendar.ns('Controllers').Time = (function() {
       // not loaded this span previously.
       if (span.start < first.start) {
         this._timespans.splice(0, 0, span);
+        this._lastTimespan = span;
 
         span = first.trimOverlap(span) || span;
         return this.busytime.loadSpan(span);
@@ -96,6 +98,8 @@ Calendar.ns('Controllers').Time = (function() {
 
       if (span.end > last.end) {
         this._timespans.push(span);
+        this._lastTimespan = span;
+
         span = last.trimOverlap(span) || span;
         return this.busytime.loadSpan(span);
       }

--- a/apps/calendar/js/db.js
+++ b/apps/calendar/js/db.js
@@ -43,7 +43,7 @@
      * @param {Function} callback node style.
      */
     load: function(callback) {
-      var pending = 3;
+      var pending = 2;
       var self = this;
 
       function next() {
@@ -61,15 +61,6 @@
       // fatal.
       function loadRecords() {
         self.getStore('Account').load(function(err) {
-          if (err) {
-            throw err;
-          }
-          next();
-        });
-
-        ///XXX: Taking a shortcut to load
-        // all this will change to just a slice (1-3 month period soon)
-        self.getStore('Busytime').load(function(err) {
           if (err) {
             throw err;
           }

--- a/apps/calendar/js/interval_tree.js
+++ b/apps/calendar/js/interval_tree.js
@@ -44,13 +44,8 @@
  */
 Calendar.IntervalTree = (function() {
 
-  function compareObjectStart(a, b) {
-    return Calendar.compare(a.start, b.start);
-  }
-
-  function compareObjectEnd(a, b) {
-    return Calendar.compare(a.end, b.end);
-  }
+  var compareObjectStart = Calendar.compareByStart;
+  var compareObjectEnd = Calendar.compareByEnd;
 
   /**
    * Internal function to add an item

--- a/apps/calendar/js/interval_tree.js
+++ b/apps/calendar/js/interval_tree.js
@@ -308,6 +308,9 @@ Calendar.IntervalTree = (function() {
 
       var max = this.items.len - 1;
 
+      if (!this.items[idx])
+        return;
+
       // for duplicate values we need
       // to find the very last one
       // before the split point.
@@ -353,6 +356,9 @@ Calendar.IntervalTree = (function() {
       );
 
       var max = items.len - 1;
+
+      if (!items[idx])
+        return;
 
       // for duplicate values we need
       // to find the very last one

--- a/apps/calendar/js/interval_tree.js
+++ b/apps/calendar/js/interval_tree.js
@@ -212,6 +212,8 @@ Calendar.IntervalTree = (function() {
 
       this.items.splice(idx, 0, item);
       this.synced = false;
+
+      return item;
     },
 
     indexOf: function(item) {
@@ -311,10 +313,11 @@ Calendar.IntervalTree = (function() {
       if (!this.items[idx])
         return;
 
+
       // for duplicate values we need
       // to find the very last one
       // before the split point.
-      while (this.items[idx].start <= start) {
+      while (this.items[idx] && this.items[idx].start <= start) {
         idx++;
         if (idx === max) {
           break;

--- a/apps/calendar/js/store/busytime.js
+++ b/apps/calendar/js/store/busytime.js
@@ -35,7 +35,6 @@ Calendar.ns('Store').Busytime = (function() {
     _store: 'busytimes',
 
     _setupCache: function() {
-      this._cached = Object.create(null);
       this._timeObservers = [];
 
       this._byEventId = Object.create(null);
@@ -106,6 +105,14 @@ Calendar.ns('Store').Busytime = (function() {
       var b = bObj.start;
 
       return Calendar.compare(a, b);
+    },
+
+    /**
+     * Removes all busytimes that end
+     * before given time in the cache.
+     */
+    purgeOlderFromCache: function() {
+
     },
 
     /**
@@ -308,8 +315,12 @@ Calendar.ns('Store').Busytime = (function() {
       return result;
     },
 
+    /* we don't use id based caching for busytimes */
+
+    _addToCache: function() {},
+    _removeFromCache: function() {},
+
     _onLoadCache: function(object) {
-      this._addToCache(object);
       this._addTime(
         object
       );

--- a/apps/calendar/js/store/event.js
+++ b/apps/calendar/js/store/event.js
@@ -39,6 +39,56 @@
     },
 
     /**
+     * Finds associated events with a given
+     * list of records that have a eventId property.
+     * Results are returned in the same order
+     * as the given records.
+     *
+     * Results are paired [associated, event].
+     * Commonly used for busytime to event lookups...
+     *
+     * @param {Array} records array of associated records.
+     * @param {Function} callback node style.
+     */
+    findByAssociated: function(records, callback) {
+      records = (Array.isArray(records)) ? records : [records];
+
+      var results = [];
+      var idTable = Object.create(null);
+
+      records.forEach(function(item) {
+        idTable[item.eventId] = true;
+      });
+
+      // create unique list of event ids...
+      var ids = Object.keys(idTable);
+      idTable = undefined;
+
+      this.findByIds(ids, function(err, list) {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        var i = 0;
+        var len = records.length;
+        var record;
+        var event;
+
+        for (; i < len; i++) {
+          record = records[i];
+          event = list[record.eventId];
+          if (event) {
+            results.push([record, event]);
+          }
+        }
+
+        callback(null, results);
+      });
+
+    },
+
+    /**
      * Finds a list of events by id.
      *
      * @param {Array} ids list of ids.

--- a/apps/calendar/js/time_observer.js
+++ b/apps/calendar/js/time_observer.js
@@ -1,0 +1,137 @@
+Calendar.TimeObserver = (function() {
+
+  function TimeObserver() {
+    this._timeObservers = [];
+  }
+
+  TimeObserver.enhance = function(given) {
+    var key;
+    var proto = TimeObserver.prototype;
+    for (key in proto) {
+      if (proto.hasOwnProperty(key)) {
+        given[key] = proto[key];
+      }
+    }
+  }
+
+  TimeObserver.prototype = {
+   /**
+     * Adds observer for timespan.
+     *
+     * Object example:
+     *
+     *    object.handleEvent = function(e) {
+     *      // e.type
+     *      // e.data
+     *      // e.time
+     *    }
+     *
+     *    // when given an object
+     *    EventStore.observe(timespan, object)
+     *
+     *
+     * Callback example:
+     *
+     *    EventStore.observe(timespan, function(event) {
+     *      // e.type
+     *      // e.data
+     *      // e.time
+     *    });
+     *
+     * @param {Calendar.Timespan} timespan span to observe.
+     * @param {Function|Object} callback function or object follows
+     *                                   EventTarget pattern.
+     */
+    observeTime: function(timespan, callback) {
+      if (!(timespan instanceof Calendar.Timespan)) {
+        throw new Error(
+          'must pass an instance of Calendar.Timespan as first argument'
+        );
+      }
+      this._timeObservers.push([timespan, callback]);
+    },
+
+    /**
+     * Finds index of timespan/object|callback pair.
+     *
+     * Used internally and in tests has little practical use
+     * unless you have the original timespan object.
+     *
+     * @param {Calendar.Timespan} timespan original (===) timespan used.
+     * @param {Function|Object} callback original callback/object.
+     * @return {Numeric} -1 when not found otherwise index.
+     */
+    findTimeObserver: function(timespan, callback) {
+      var len = this._timeObservers.length;
+      var idx = null;
+      var field;
+      var i = 0;
+
+      for (; i < len; i++) {
+        field = this._timeObservers[i];
+
+        if (field[0] === timespan &&
+            field[1] === callback) {
+
+          return i;
+        }
+      }
+
+      return -1;
+    },
+
+    /**
+     * Removes a time observer you
+     * must pass the same instance of both
+     * the timespan and the callback/object
+     *
+     *
+     * @param {Calendar.Timespan} timespan timespan object.
+     * @param {Function|Object} callback original callback/object.
+     * @return {Boolean} true when found & removed callback.
+     */
+    removeTimeObserver: function(timespan, callback) {
+      var idx = this.findTimeObserver(timespan, callback);
+
+      if (idx !== -1) {
+        this._timeObservers.splice(idx, 1);
+        return true;
+      } else {
+        return false;
+      }
+    },
+
+    /**
+     * Fires a time based event.
+     *
+     * @param {String} type name of event.
+     * @param {Date|Numeric} start start position of time event.
+     * @param {Date|Numeric} end end position of time event.
+     * @param {Object} data data related to event.
+     */
+    fireTimeEvent: function(type, start, end, data) {
+      var i = 0;
+      var len = this._timeObservers.length;
+      var observer;
+      var event = {
+        time: true,
+        data: data,
+        type: type
+      };
+
+      for (; i < len; i++) {
+        observer = this._timeObservers[i];
+        if (observer[0].overlaps(start, end)) {
+          if (typeof(observer[1]) === 'object') {
+            observer[1].handleEvent(event);
+          } else {
+            observer[1](event);
+          }
+        }
+      }
+    }
+  };
+
+  return TimeObserver;
+
+}());

--- a/apps/calendar/js/timespan.js
+++ b/apps/calendar/js/timespan.js
@@ -8,6 +8,66 @@ Calendar.Timespan = (function() {
   Timespan.prototype = {
 
     /**
+     * Returns all dates between the start and
+     * end of the timespan. Shortcut for Calc.daysBetween
+     *
+     * @return {Array[Date]} array of dates in order.
+     */
+    daysBetween: function() {
+      var start = new Date(this.start);
+      var end = new Date(this.end);
+
+      return Calendar.Calc.daysBetween(
+        start,
+        end
+      );
+    },
+
+    isEqual: function(inputSpan) {
+      return (
+        this.start === inputSpan.start &&
+        this.end === inputSpan.end
+      );
+    },
+
+    /**
+     * If given Timespan overlaps this timespan
+     * return a new timespan with the overlapping
+     * parts removed.
+     *
+     * See tests for examples...
+     */
+    trimOverlap: function(span) {
+      if (this.contains(span) || span.contains(this)) {
+        return null;
+      }
+
+      var start = span.start;
+      var end = span.end;
+      var ourEnd = this.end;
+      var ourStart = this.start;
+
+      var overlapsBefore = start >= ourStart && start < ourEnd;
+      var overlapsAfter = ourStart >= start && ourStart < end;
+
+      var newStart = span.start;
+      var newEnd = span.end;
+
+      if (overlapsBefore) {
+        newStart = ourEnd + 1;
+      }
+
+      if (overlapsAfter) {
+        newEnd = ourStart - 1;
+      }
+
+      return new Calendar.Timespan(
+        newStart,
+        newEnd
+      );
+    },
+
+    /**
      * Checks if given time overlaps with
      * range.
      *

--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -55,6 +55,20 @@ Calendar.ns('Views').Month = (function() {
       var self = this,
           months = this.container;
 
+      this.controller.on('purge', function(span) {
+        var key;
+        var child;
+
+        for (key in self.children) {
+          var child = self.children[key];
+
+          if (child.timespan.isEqual(span)) {
+            child.destroy();
+            delete self.children[key];
+          }
+        }
+      });
+
       this.controller.on('selectedDayChange', function(newVal, oldVal) {
         var el, id;
         self._clearSelectedDay();

--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -1,4 +1,4 @@
-(function(window) {
+Calendar.ns('Views').Month = (function() {
 
   var template = Calendar.Templates.Month;
 
@@ -11,250 +11,221 @@
     this.controller = this.app.timeController;
     this.children = Object.create(null);
     this._initEvents();
-  };
-
-  var proto = Month.prototype = Object.create(
-    Calendar.View.prototype
-  );
-
-  proto.selectors = {
-    element: '#month-view'
-  };
-
-  /**
-   * Selector for element that will contain
-   * many months.
-   *
-   * @type {String}
-   */
-  proto.monthSelector = '#month-displays';
-
-  /**
-   * Selector for element that will display the current month.
-   *
-   * @type {String}
-   */
-  proto.currentMonthSelector = '#current-month-year';
-
-  /**
-   * Hack this should be localized.
-   */
-  proto.monthNames = [
-    'January',
-    'Feburary',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ];
-
-  proto.SELECTED = 'selected';
-
-  proto.busyPercision = (24 / 12);
-
-  proto._clearSelectedDay = function() {
-    var li = this.monthsDisplayElement().querySelector('li.selected');
-    if (li) {
-      li.classList.remove('selected');
-    }
-  };
-
-  proto._initEvents = function() {
-    var self = this,
-        months = this.monthsDisplayElement();
-
-    this.controller.on('selectedDayChange', function(newVal, oldVal) {
-      var el, id;
-      self._clearSelectedDay();
-
-      id = Calendar.Calc.getDayId(newVal);
-      id = self.currentChild._dayId(id);
-      el = document.getElementById(id);
-
-      if (el) {
-        el.classList.add('selected');
-      }
-    });
-
-    this.controller.on('currentMonthChange', function(value) {
-      self.updateCurrentMonth();
-      self.activateMonth(value);
-      self._clearSelectedDay();
-    });
-
-    new GestureDetector(months).startDetecting();
-
-    months.addEventListener('swipe', function(data) {
-      self._onswipe.apply(self, arguments);
-    });
-
-    months.addEventListener('tap', function(data) {
-      self._ontap.apply(self, arguments);
-    }, false);
-  };
-
-  proto._ontap = function(event) {
-    var target = event.target,
-        id,
-        date,
-        el;
-
-    if (target.tagName.toLowerCase() == 'li') {
-      el = target;
-    } else {
-      el = target.parentNode;
-    }
-
-    id = el.getAttribute('data-date');
-
-    if (id) {
-      date = Calendar.Calc.dateFromId(id);
-      this.controller.setSelectedDay(date, el);
-    }
-
-  };
-
-  proto._onswipe = function(event) {
-    var direction = event.detail.direction;
-    if (direction === 'right') {
-      this.previous();
-    } else {
-      this.next();
-    }
-  };
-
-  /**
-   * Returns month header html blob.
-   *
-   * @return {String} html blob with current month.
-   */
-  proto._renderCurrentMonth = function() {
-    var month = this.controller.currentMonth.getMonth(),
-        year = this.controller.currentMonth.getFullYear();
-    return template.currentMonth.render({
-      year: year,
-      month: this.monthNames[month]
-    });
-  };
-
-  /**
-   * Updates month header with the current month.
-   */
-  proto.updateCurrentMonth = function() {
-    var html = this._renderCurrentMonth();
-    this.currentMonthElement().innerHTML = html;
-  };
-
-  function getEl(selectorName, elName) {
-    var selector;
-    if (!this[elName]) {
-      selector = this[selectorName];
-      this[elName] = document.body.querySelector(selector);
-    }
-    return this[elName];
   }
 
-  /**
-   * Finds and returns element.
-   *
-  * @return {HTMLElement} container for month view.
-   */
-  proto.monthsDisplayElement = function() {
-    return getEl.call(this, 'monthSelector', '_monthDisplayEl');
-  };
+  Month.prototype = {
+    __proto__: Calendar.View.prototype,
 
-  /**
-   * Finds and returns element.
-   *
-  * @return {HTMLElement} container for month view.
-   */
-  proto.currentMonthElement = function() {
-    return getEl.call(this, 'currentMonthSelector', '_headerEl');
-  };
+    selectors: {
+      element: '#month-view',
+      container: '#month-displays',
+      currentMonth: '#current-month-year'
+    },
 
-  /**
-   * Moves calendar to the next month.
-   */
-  proto.next = function() {
-    var now = this.controller.currentMonth;
-    var date = new Date(
-      now.getFullYear(),
-      now.getMonth() + 1,
-      now.getDate()
-    );
+    /**
+     * Hack this should be localized.
+     */
+    monthNames: [
+      'January',
+      'Feburary',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December'
+    ],
 
-    this.controller.setCurrentMonth(date);
-  };
+    SELECTED: 'selected',
 
-  /**
-   * Moves calendar to the previous month.
-   */
-  proto.previous = function() {
-    var now = this.controller.currentMonth;
-    var date = new Date(
-      now.getFullYear(),
-      now.getMonth() - 1,
-      now.getDate()
-    );
+    busyPercision: (24 / 12),
 
-    this.controller.setCurrentMonth(date);
-  };
-
-  /**
-   * Appends given month to display area.
-   *
-   * @param {Date} date current month this should
-   *                    usually be the starting date of
-   *                    a given month.
-   */
-  proto.activateMonth = function(date) {
-    var id = Calendar.Calc.getMonthId(date),
-        el,
-        currentEl;
-
-    if (id in this.children) {
-      this.currentChild.deactivate();
-      this.currentChild = this.children[id];
-      this.currentChild.activate();
-    } else {
-      var display = this.monthsDisplayElement();
-
-      if (this.currentChild) {
-        this.currentChild.deactivate();
+    _clearSelectedDay: function() {
+      var li = this.container.querySelector('li.selected');
+      if (li) {
+        li.classList.remove('selected');
       }
+    },
 
-      this.currentChild = new Calendar.Views.MonthChild({
-        app: this.app,
-        month: date
+    _initEvents: function() {
+      var self = this,
+          months = this.container;
+
+      this.controller.on('selectedDayChange', function(newVal, oldVal) {
+        var el, id;
+        self._clearSelectedDay();
+
+        id = Calendar.Calc.getDayId(newVal);
+        id = self.currentChild._dayId(id);
+        el = document.getElementById(id);
+
+        if (el) {
+          el.classList.add('selected');
+        }
       });
 
-      this.currentChild.attach(display);
-      this.currentChild.activate();
+      this.controller.on('currentMonthChange', function(value) {
+        self.updateCurrentMonth();
+        self.activateMonth(value);
+        self._clearSelectedDay();
+      });
 
-      this.children[id] = this.currentChild;
+      new GestureDetector(months).startDetecting();
+
+      months.addEventListener('swipe', function(data) {
+        self._onswipe.apply(self, arguments);
+      });
+
+      months.addEventListener('tap', function(data) {
+        self._ontap.apply(self, arguments);
+      }, false);
+    },
+
+    get container() {
+      return this._findElement('container');
+    },
+
+    get currentMonth() {
+      return this._findElement('currentMonth');
+    },
+
+    _ontap: function(event) {
+      var target = event.target,
+          id,
+          date,
+          el;
+
+      if (target.tagName.toLowerCase() == 'li') {
+        el = target;
+      } else {
+        el = target.parentNode;
+      }
+
+      id = el.getAttribute('data-date');
+
+      if (id) {
+        date = Calendar.Calc.dateFromId(id);
+        this.controller.setSelectedDay(date, el);
+      }
+
+    },
+
+    _onswipe: function(event) {
+      var direction = event.detail.direction;
+      if (direction === 'right') {
+        this.previous();
+      } else {
+        this.next();
+      }
+    },
+
+    /**
+     * Returns month header html blob.
+     *
+     * @return {String} html blob with current month.
+     */
+    _renderCurrentMonth: function() {
+      var month = this.controller.currentMonth.getMonth(),
+          year = this.controller.currentMonth.getFullYear();
+
+      return template.currentMonth.render({
+        year: year,
+        month: this.monthNames[month]
+      });
+    },
+
+    /**
+     * Updates month header with the current month.
+     */
+    updateCurrentMonth: function() {
+      var html = this._renderCurrentMonth();
+      this.currentMonth.innerHTML = html;
+    },
+
+    /**
+     * Moves calendar to the next month.
+     */
+    next: function() {
+      var now = this.controller.currentMonth;
+      var date = new Date(
+        now.getFullYear(),
+        now.getMonth() + 1,
+        now.getDate()
+      );
+
+      this.controller.setCurrentMonth(date);
+    },
+
+    /**
+     * Moves calendar to the next month.
+     */
+    previous: function() {
+      var now = this.controller.currentMonth;
+      var date = new Date(
+        now.getFullYear(),
+        now.getMonth() - 1,
+        now.getDate()
+      );
+
+      this.controller.setCurrentMonth(date);
+    },
+
+    /**
+     * Appends given month to display area.
+     *
+     * @param {Date} date current month this should
+     *                    usually be the starting date of
+     *                    a given month.
+     */
+    activateMonth: function(date) {
+      var id = Calendar.Calc.getMonthId(date),
+          el,
+          currentEl;
+
+      if (id in this.children) {
+        this.currentChild.deactivate();
+        this.currentChild = this.children[id];
+        this.currentChild.activate();
+      } else {
+        var display = this.container;
+
+        if (this.currentChild) {
+          this.currentChild.deactivate();
+        }
+
+        this.currentChild = new Calendar.Views.MonthChild({
+          app: this.app,
+          month: date
+        });
+
+
+        this.currentChild.attach(display);
+        this.currentChild.activate();
+
+        this.children[id] = this.currentChild;
+      }
+    },
+
+    /**
+     * Render current month
+     */
+    render: function() {
+      var el = this.container,
+          now = new Date();
+
+      now.setDate(1);
+
+      this.controller.setCurrentMonth(now);
     }
+
   };
 
-  /**
-   * Render current month
-   */
-  proto.render = function() {
-    var el = this.monthsDisplayElement(),
-        now = new Date();
+  Month.prototype.onfirstseen = Month.prototype.render;
 
-    now.setDate(1);
-
-    this.controller.setCurrentMonth(now);
-  }
-
-  proto.onfirstseen = proto.render;
-
-  Calendar.ns('Views').Month = Month;
+  return Month;
 
 }(this));

--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -68,7 +68,7 @@ Calendar.ns('Views').Month = (function() {
         }
       });
 
-      this.controller.on('currentMonthChange', function(value) {
+      this.controller.on('monthChange', function(value) {
         self.updateCurrentMonth();
         self.activateMonth(value);
         self._clearSelectedDay();
@@ -109,7 +109,7 @@ Calendar.ns('Views').Month = (function() {
 
       if (id) {
         date = Calendar.Calc.dateFromId(id);
-        this.controller.setSelectedDay(date, el);
+        this.controller.selectedDay = date;
       }
 
     },
@@ -129,8 +129,8 @@ Calendar.ns('Views').Month = (function() {
      * @return {String} html blob with current month.
      */
     _renderCurrentMonth: function() {
-      var month = this.controller.currentMonth.getMonth(),
-          year = this.controller.currentMonth.getFullYear();
+      var month = this.controller.month.getMonth(),
+          year = this.controller.month.getFullYear();
 
       return template.currentMonth.render({
         year: year,
@@ -150,28 +150,28 @@ Calendar.ns('Views').Month = (function() {
      * Moves calendar to the next month.
      */
     next: function() {
-      var now = this.controller.currentMonth;
+      var now = this.controller.month;
       var date = new Date(
         now.getFullYear(),
         now.getMonth() + 1,
         now.getDate()
       );
 
-      this.controller.setCurrentMonth(date);
+      this.controller.move(date);
     },
 
     /**
      * Moves calendar to the next month.
      */
     previous: function() {
-      var now = this.controller.currentMonth;
+      var now = this.controller.month;
       var date = new Date(
         now.getFullYear(),
         now.getMonth() - 1,
         now.getDate()
       );
 
-      this.controller.setCurrentMonth(date);
+      this.controller.move(date);
     },
 
     /**
@@ -217,9 +217,13 @@ Calendar.ns('Views').Month = (function() {
       var el = this.container,
           now = new Date();
 
-      now.setDate(1);
+      now = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        1
+      );
 
-      this.controller.setCurrentMonth(now);
+      this.controller.move(now);
     }
 
   };

--- a/apps/calendar/js/views/month_child.js
+++ b/apps/calendar/js/views/month_child.js
@@ -90,13 +90,11 @@
     },
 
     _initEvents: function() {
-      var busy = this.app.store('Busytime');
-      busy.observeTime(this._timespan, this);
+      this.controller.observeTime(this._timespan, this);
     },
 
     _destroyEvents: function() {
-      var busy = this.app.store('Busytime');
-      busy.removeTimeObserver(this._timespan, this);
+      this.controller.removeTimeObserver(this._timespan, this);
     },
 
     handleEvent: function(event) {
@@ -202,7 +200,7 @@
 
       state = Calendar.Calc.relativeState(
         date,
-        this.controller.currentMonth
+        this.controller.month
       );
 
       // register instance in map
@@ -453,12 +451,13 @@
      */
     attach: function(element) {
       var html = this._renderMonth();
-      var busytimes = this.app.store('Busytime');
+      var controller = this.controller;
+
 
       element.insertAdjacentHTML('beforeend', html);
       this.element = element.children[element.children.length - 1];
 
-      busytimes.busytimesInCachedSpan(this._timespan).forEach(
+      controller.queryCache(this._timespan).forEach(
         this._renderBusytime,
         this
       );

--- a/apps/calendar/js/views/month_child.js
+++ b/apps/calendar/js/views/month_child.js
@@ -8,7 +8,7 @@
     this.controller = this.app.timeController;
 
     this._days = Object.create(null);
-    this._timespan = this._setupTimespan(this.month);
+    this.timespan = Calendar.Calc.spanOfMonth(this.month);
   }
 
   Child.prototype = {
@@ -68,33 +68,12 @@
       return 'month-view-' + this.monthId + '-' + date;
     },
 
-    /**
-     * We care about 5 weeks (35 days)
-     */
-    _setupTimespan: function(approxStart) {
-      var approxEnd = new Date(approxStart.valueOf());
-      //TODO: Localization problems assuming
-      //length of week.
-
-      var weeks = (4 * 7) + 1;
-
-      approxEnd.setDate(approxStart.getDate() * weeks);
-
-      var start = Calendar.Calc.getWeekStartDate(approxStart);
-      var end = Calendar.Calc.getWeekEndDate(approxEnd);
-
-      return new Calendar.Timespan(
-        start,
-        end
-      );
-    },
-
     _initEvents: function() {
-      this.controller.observeTime(this._timespan, this);
+      this.controller.observeTime(this.timespan, this);
     },
 
     _destroyEvents: function() {
-      this.controller.removeTimeObserver(this._timespan, this);
+      this.controller.removeTimeObserver(this.timespan, this);
     },
 
     handleEvent: function(event) {
@@ -378,7 +357,7 @@
 
     _renderBusytime: function(busytime) {
       // render out a busytime span
-      var span = this._timespan;
+      var span = this.timespan;
 
       // 1: busytime start/end occurs all on same month/day
       var start = busytime.startDate;
@@ -412,11 +391,11 @@
         day = days[i];
         dayValue = day.valueOf();
 
-        if (dayValue < this._timespan.start) {
+        if (dayValue < this.timespan.start) {
           continue;
         }
 
-        if (dayValue > this._timespan.end) {
+        if (dayValue > this.timespan.end) {
           break;
         }
 
@@ -457,7 +436,7 @@
       element.insertAdjacentHTML('beforeend', html);
       this.element = element.children[element.children.length - 1];
 
-      controller.queryCache(this._timespan).forEach(
+      controller.queryCache(this.timespan).forEach(
         this._renderBusytime,
         this
       );

--- a/apps/calendar/js/views/months_day.js
+++ b/apps/calendar/js/views/months_day.js
@@ -5,8 +5,6 @@
     Calendar.View.apply(this, arguments);
 
     this.controller = this.app.timeController;
-    this.busytime = this.app.store('Busytime');
-
     this._initEvents();
   }
 
@@ -110,12 +108,12 @@
         date.getDate() + 1
       );
 
-      var busytime = this.busytime;
+      var controller = this.controller;
 
       endDate.setMilliseconds(-1);
 
       if (this._timespan) {
-        busytime.removeTimeObserver(
+        controller.removeTimeObserver(
           this._timespan,
           this
         );
@@ -127,7 +125,7 @@
         endDate
       );
 
-      busytime.observeTime(this._timespan, this);
+      controller.observeTime(this._timespan, this);
 
       // clear out all children
       this.events.innerHTML = '';
@@ -140,8 +138,7 @@
       // find all records for range.
       // if change state is the same
       // then run _renderDay(list)
-
-      var store = this.busytime;
+      var store = this.app.store('Event');
 
       // keep local record of original
       // token if this changes we know
@@ -149,7 +146,11 @@
       var token = this._changeToken;
       var self = this;
 
-      store.eventsInCachedSpan(this._timespan, function(err, list) {
+      var cached = this.controller.queryCache(
+        this._timespan
+      );
+
+      store.findByAssociated(cached, function(err, list) {
         if (self._changeToken !== token) {
           // tokens don't match we don't
           // care about these results anymore...

--- a/apps/calendar/test/unit/calc_test.js
+++ b/apps/calendar/test/unit/calc_test.js
@@ -1,4 +1,5 @@
 requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('timespan.js');
   requireLib('calc.js');
 });
 
@@ -28,6 +29,121 @@ suite('calendar/calc', function() {
       return value;
     };
   }
+
+  function removeOffset(date) {
+    return date.valueOf() - currentOffset();
+  }
+
+  function currentOffset() {
+    var date = new Date();
+    return (date.getTimezoneOffset() * (60 * 1000));
+  }
+
+  test('#utcMs', function() {
+    var date = new Date(2012, 0, 1, 2);
+    var offset = date.getTimezoneOffset() * (60 * 1000);
+    var value = date.valueOf() - offset;
+
+    assert.equal(subject.utcMs(date), value);
+  });
+
+  suite('#spanOfMonth', function() {
+
+    function time(year, month, day, hour, min) {
+      var date = new Date(
+        year,
+        month || 0,
+        day || 1,
+        hour || 0,
+        min || 0
+      );
+      return v(date);
+    }
+
+    function v(date) {
+      return date.valueOf();
+    }
+
+    test('5 week month', function() {
+      var date = new Date(2012, 3, 1, 5, 1);
+      var range = subject.spanOfMonth(date);
+
+      assert.equal(
+        time(2012, 3, 1),
+        range.start
+      );
+
+      var end = new Date(2012, 4, 6);
+      end.setMilliseconds(-1);
+
+      assert.equal(
+        range.end,
+        v(end)
+      );
+
+    });
+
+    test('6 week month', function() {
+      var date = new Date(2012, 11, 1);
+      var range = subject.spanOfMonth(date);
+
+      assert.equal(
+        time(2012, 10, 25),
+        range.start
+      );
+
+      var end = new Date(2013, 0, 6);
+      end.setMilliseconds(-1);
+
+      assert.equal(
+        range.end,
+        v(end)
+      );
+    });
+
+    test('4 week month', function() {
+      var date = new Date(2009, 1, 1);
+      var range = subject.spanOfMonth(date);
+
+      var end = new Date(2009, 2, 1);
+      end.setMilliseconds(-1);
+
+      assert.equal(
+        range.end,
+        v(end)
+      );
+    });
+
+  });
+
+  suite('#fromUtcMs', function() {
+    var start;
+    var ms;
+
+    setup(function() {
+      start = new Date(2012, 0, 1, 2);
+      ms = subject.utcMs(start);
+    });
+
+    test('with offset', function() {
+      var offset = start.getTimezoneOffset() - (60 * 3);
+      var out = subject.fromUtcMs(
+        ms, offset
+      );
+
+      var clone = new Date(start.valueOf());
+      clone.setHours(clone.getHours() - 3);
+      assert.equal(out.valueOf(), clone.valueOf());
+    });
+
+    test('without offset', function() {
+      var out = subject.fromUtcMs(
+        ms
+      );
+      assert.equal(start.valueOf(), out.valueOf());
+    });
+
+  });
 
   suite('#getWeekStartDate', function() {
     // we are testing for first week of Aug 2012

--- a/apps/calendar/test/unit/calc_test.js
+++ b/apps/calendar/test/unit/calc_test.js
@@ -122,6 +122,7 @@ suite('calendar/calc', function() {
 
     setup(function() {
       start = new Date(2012, 0, 1, 2);
+      console.log(subject, '<--');
       ms = subject.utcMs(start);
     });
 

--- a/apps/calendar/test/unit/calc_test.js
+++ b/apps/calendar/test/unit/calc_test.js
@@ -122,7 +122,6 @@ suite('calendar/calc', function() {
 
     setup(function() {
       start = new Date(2012, 0, 1, 2);
-      console.log(subject, '<--');
       ms = subject.utcMs(start);
     });
 

--- a/apps/calendar/test/unit/controllers/time_test.js
+++ b/apps/calendar/test/unit/controllers/time_test.js
@@ -285,6 +285,11 @@ suite('controller', function() {
 
         subject.move(date);
 
+        assert.deepEqual(
+          subject._lastTimespan,
+          range
+        );
+
         assert.ok(
           hasRange(stored, range),
           'should record new range'
@@ -309,6 +314,11 @@ suite('controller', function() {
         );
 
         subject.move(date);
+
+        assert.deepEqual(
+          subject._lastTimespan,
+          range
+        );
 
         assert.ok(
           hasRange(stored, range),

--- a/apps/calendar/test/unit/controllers/time_test.js
+++ b/apps/calendar/test/unit/controllers/time_test.js
@@ -507,8 +507,6 @@ suite('controller', function() {
       isComplete = true;
     });
 
-    //XXX: There is too much coping / pasting
-    //here....
     test('go forward', function(done) {
 
       var tries = 24;
@@ -566,6 +564,35 @@ suite('controller', function() {
       }
 
       isComplete = true;
+    });
+
+    test('jump', function(done) {
+      // reset timespans
+      subject._timespans.length = 0;
+
+      function month(year, month) {
+        return spanOfMonth(new Date(year, month));
+      }
+
+      subject.on('loadingComplete', function() {
+        done(function() {
+          var expected = [
+            month(2010, 11),
+            month(2011, 0),
+            month(2011, 1),
+
+            month(2011, 11),
+            month(2012, 0),
+            month(2012, 1)
+          ];
+
+          assert.length(subject._timespans, 6);
+          assert.deepEqual(subject._timespans, expected);
+        });
+      });
+
+      subject.move(new Date(2011, 0, 1));
+      subject.move(new Date(2012, 0, 1));
     });
 
   });

--- a/apps/calendar/test/unit/controllers/time_test.js
+++ b/apps/calendar/test/unit/controllers/time_test.js
@@ -1,4 +1,6 @@
 requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('timespan.js');
+  requireLib('interval_tree.js');
 });
 
 window.page = window.page || {};
@@ -6,38 +8,337 @@ window.page = window.page || {};
 suite('controller', function() {
   var subject;
   var app;
+  var busytime;
+  var loaded;
 
   setup(function() {
+    loaded = [];
     app = testSupport.calendar.app();
     subject = new Calendar.Controllers.Time(app);
+
+    busytime = app.store('Busytime');
+    busytime.loadSpan = function(span) {
+      loaded.push(span);
+    };
   });
 
   test('initialize', function() {
     assert.equal(subject.app, app);
     assert.instanceOf(subject, Calendar.Responder);
+    assert.instanceOf(subject._collection, Calendar.IntervalTree);
+    assert.deepEqual(subject._timespans, []);
   });
 
-  suite('setters', function() {
+  test('#selectedDay', function() {
+    var calledWith;
 
-    function isSetter(fn, attr, value) {
+    subject.on('selectedDayChange', function() {
+      calledWith = arguments;
+    });
 
-      var val = value || 'val';
+    var date = new Date(2012, 1, 1);
+    subject.selectedDay = date;
 
-      test('#' + attr, function() {
-        var eventFired;
-        subject.on(attr + 'Change', function(value) {
-          eventFired = value;
-        });
+    assert.equal(calledWith[0], date);
+    assert.equal(subject.selectedDay, date);
 
-        subject[fn](val);
+    calledWith = null;
 
-        assert.equal(subject[attr], val);
-        assert.equal(eventFired, val);
+    // try and set it again with same object...
+    subject.selectedDay = new Date(2012, 1, 1);
+    assert.isNull(calledWith, 'should not fire event when day is same');
+
+    var newDate = new Date(2012, 1, 2);
+
+    subject.selectedDay = newDate;
+    assert.equal(subject.selectedDay, newDate);
+    assert.equal(calledWith[0], newDate);
+    assert.equal(calledWith[1], date);
+  });
+
+  suite('handle busytime events', function() {
+    var store;
+    var collection;
+    var span;
+    var events;
+    var inRange;
+    var outOfRange;
+
+    setup(function() {
+      collection = subject._collection;
+      events = {
+        add: [],
+        remove: []
+      };
+
+      store = app.store('Busytime');
+      span = new Calendar.Timespan(
+        new Date(2012, 1, 1),
+        new Date(2012, 1, 5)
+      );
+
+      subject.observeTime(span, function(e) {
+        events[e.type].push(e.data);
       });
+
+      inRange = Factory('busytime', {
+        startDate: new Date(2012, 1, 2),
+        endDate: new Date(2012, 1, 3)
+      });
+
+      outOfRange = Factory('busytime', {
+        startDate: new Date(2012, 1, 6),
+        endDate: new Date(2012, 1, 8)
+      });
+
+      store.emit('add time', inRange);
+      store.emit('add time', outOfRange);
+    });
+
+    test('add time', function() {
+
+      assert.isNotNull(
+        collection.indexOf(inRange),
+        'should cache in range item'
+      );
+
+      assert.isNotNull(
+        collection.indexOf(outOfRange),
+        'should cache out of range item'
+      );
+
+      assert.equal(events.add.length, 1);
+      assert.equal(
+        events.add[0],
+        inRange,
+        'should emit time event'
+      );
+    });
+
+    test('remove time', function() {
+      store.emit('remove time', inRange);
+      store.emit('remove time', outOfRange);
+
+      assert.isNull(
+        collection.indexOf(outOfRange),
+        'should remove outOfRange'
+      );
+
+      assert.isNull(
+        collection.indexOf(inRange),
+        'should remove inRange'
+      );
+
+      assert.length(events.remove, 1);
+      assert.equal(events.remove[0], inRange);
+    });
+
+    test('#queryCache', function() {
+      var span = new Calendar.Timespan(
+        new Date(2000, 1, 1),
+        new Date(2015, 1, 1)
+      );
+
+      var results = subject._collection.query(
+        span
+      );
+
+      assert.length(results, 2);
+      assert.deepEqual(
+        subject.queryCache(span),
+        results
+      );
+    });
+  });
+
+  suite('#move', function() {
+    var events;
+    var date;
+
+    function clearEvents() {
+      events = {
+        year: [],
+        month: [],
+        day: []
+      };
     }
 
-    isSetter('setCurrentMonth', 'currentMonth', new Date());
-    isSetter('setSelectedDay', 'selectedDay');
+    setup(function() {
+      clearEvents();
+      date = new Date(2012, 5, 5);
+
+      var handle = {
+        handleEvent: function(e) {
+          var name = e.type.replace('Change', '');
+          events[name].push(e.data[0]);
+        }
+      };
+
+      subject.on('yearChange', handle);
+      subject.on('monthChange', handle);
+      subject.on('dayChange', handle);
+
+      subject.move(date);
+    });
+
+    function fires(type, value) {
+      var eventValue = events[type][0];
+
+      assert.deepEqual(
+        eventValue, value, 'fires: ' + type + ' change'
+      );
+
+      assert.deepEqual(
+        subject[type],
+        value,
+        'should update .' + type
+      );
+    }
+
+    function doesNotFire(type) {
+      assert.deepEqual(
+        events[type],
+        []
+      );
+    }
+
+    test('initial move', function() {
+      fires('year', new Date(2012, 0, 1));
+      fires('month', new Date(2012, 5, 1));
+      fires('day', new Date(2012, 5, 5));
+
+      assert.equal(subject.direction, 'future');
+    });
+
+    test('move day', function() {
+      clearEvents();
+
+      subject.move(new Date(2012, 5, 6));
+
+      doesNotFire('year');
+      doesNotFire('month');
+      fires('day', new Date(2012, 5, 6));
+    });
+
+    test('move month', function() {
+      clearEvents();
+
+      subject.move(new Date(2012, 8, 6));
+
+      doesNotFire('year');
+      fires('month', new Date(2012, 8, 1));
+      fires('day', new Date(2012, 8, 6));
+
+      assert.equal(subject.direction, 'future');
+    });
+
+    test('move into the past', function() {
+      clearEvents();
+
+      subject.move(new Date(2011, 5, 4));
+
+      fires('year', new Date(2011, 0, 1));
+      fires('month', new Date(2011, 5, 1));
+      fires('day', new Date(2011, 5, 4));
+
+      assert.equal(subject.direction, 'past');
+    });
+  });
+
+  suite('#_loadMonthSpan', function() {
+
+    var stored;
+
+    function hasRange(store, range) {
+      var i = 0;
+      var len = store.length;
+      var item;
+
+      for (; i < len; i++) {
+        item = store[i];
+        if (item.isEqual(range)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    setup(function() {
+      subject.observe();
+      stored = subject._timespans;
+      subject.move(new Date(2012, 1, 5));
+    });
+
+    test('go backwards', function() {
+      var tries = 24;
+      var idx = 0;
+
+      for (; idx < tries; idx++) {
+        var month = idx - (idx * 2);
+        var date = new Date(2012, month, 6);
+
+        var range = Calendar.Calc.spanOfMonth(date);
+        var loadRange = stored[0].trimOverlap(
+          range
+        );
+
+        subject.move(date);
+
+        assert.ok(
+          hasRange(stored, range),
+          'should record new range'
+        );
+
+        assert.ok(
+          hasRange(loaded, loadRange),
+          'should request trimmed load range'
+        );
+      }
+    });
+
+    test('going forward', function() {
+      var tries = 24;
+      var idx = 0;
+
+      for (; idx < tries; idx++) {
+        var date = new Date(2012, 2 + idx, 1);
+        var range = Calendar.Calc.spanOfMonth(date);
+        var loadRange = stored[idx].trimOverlap(
+          range
+        );
+
+        subject.move(date);
+
+        assert.ok(
+          hasRange(stored, range),
+          'should record new range'
+        );
+
+        assert.ok(
+          hasRange(loaded, loadRange),
+          'should request trimmed load range'
+        );
+      }
+    });
+
+    test('initial month load', function() {
+      // load events for jan 2012
+      var range = Calendar.Calc.spanOfMonth(
+        new Date(2012, 1, 1)
+      );
+
+      assert.ok(
+        hasRange(stored, range),
+        'should record range in controller'
+      );
+
+      assert.ok(
+        hasRange(loaded, range),
+        'should request load of range'
+      );
+    });
+
   });
 
 });

--- a/apps/calendar/test/unit/db_test.js
+++ b/apps/calendar/test/unit/db_test.js
@@ -93,7 +93,6 @@ suite('db', function() {
 
     var account = subject.getStore('Account');
     var calendar = subject.getStore('Calendar');
-    var busytime = subject.getStore('Busytime');
 
     account.load = function(callback) {
       callback(null, {});
@@ -104,11 +103,6 @@ suite('db', function() {
       callback(null, {});
       loaded.calendar = true;
     }
-
-    busytime.load = function(callback) {
-      callback(null, {});
-      loaded.busytime = true;
-    };
 
     assert.ok(!subject.isOpen);
 
@@ -121,7 +115,6 @@ suite('db', function() {
       done(function() {
         assert.ok(loaded.account, 'should load account');
         assert.ok(loaded.calendar, 'should load calendar');
-        assert.ok(loaded.busytime, 'should load busytime');
       });
     });
   });

--- a/apps/calendar/test/unit/helper.js
+++ b/apps/calendar/test/unit/helper.js
@@ -188,6 +188,7 @@
   requireLib('template.js');
   requireLib('interval_tree.js');
   requireLib('responder.js');
+  requireLib('time_observer.js');
   requireLib('provider/abstract.js');
   requireLib('provider/local.js');
   requireLib('store/abstract.js');

--- a/apps/calendar/test/unit/interval_tree_test.js
+++ b/apps/calendar/test/unit/interval_tree_test.js
@@ -92,6 +92,7 @@ suite('interval_tree', function() {
     assert.deepEqual(subject.items, list);
     assert.ok(!subject.synced);
     assert.ok(!subject.rootNode);
+    assert.deepEqual(subject.byId, {});
   });
 
   test('init without list', function() {
@@ -124,12 +125,30 @@ suite('interval_tree', function() {
       subject.add(items.after);
     });
 
+    test('re-add item with same _id', function() {
+      var id = items.after._id;
+      var obj = { _id: id };
+
+      subject.add(obj);
+
+      assert.deepEqual(
+        subject.items,
+        [items.after]
+      );
+    });
+
     test('first add', function() {
       assert.deepEqual(
         subject.items,
         [items.after]
       );
+
       assert.isFalse(subject.synced);
+      assert.equal(
+        subject.byId[items.after._id],
+        items.after,
+        'should add to byId cache'
+      );
     });
 
     test('multiple adds', function() {
@@ -178,6 +197,9 @@ suite('interval_tree', function() {
         'before',
         'on'
       ];
+
+      assert.ok(!subject.byId['just after']);
+      assert.ok(!subject.byId['after']);
 
       var ids = subject.items.map(function(item) {
         return item._id;
@@ -240,7 +262,12 @@ suite('interval_tree', function() {
         'ends after'
       ];
 
+      assert.ok(!subject.byId['ends on 1']);
+      assert.ok(!subject.byId['ends on 2']);
+      assert.ok(!subject.byId['ends on 3']);
+
       var ids = subject.items.map(function(item) {
+        assert.ok(subject.byId[item._id], 'should have: ' + item._id);
         return item._id;
       });
 
@@ -274,6 +301,7 @@ suite('interval_tree', function() {
           items.after
         ]
       );
+
     });
 
     suite('items that share start time', function() {
@@ -286,8 +314,8 @@ suite('interval_tree', function() {
         subject.items = [];
         subject.synced = false;
 
-        addedBefore = factory(1, middle.start, middle.end);
-        addedAfter = factory(1, middle.start, middle.end);
+        addedBefore = factory(10, middle.start, middle.end);
+        addedAfter = factory(12, middle.start, middle.end);
 
         // its going to shuffle
         // each item is going to displace
@@ -316,6 +344,8 @@ suite('interval_tree', function() {
             addedBefore
           ]
         );
+
+        assert.ok(!subject.byId[addedAfter._id]);
       });
 
       test('remove first added item', function() {

--- a/apps/calendar/test/unit/interval_tree_test.js
+++ b/apps/calendar/test/unit/interval_tree_test.js
@@ -187,6 +187,22 @@ suite('interval_tree', function() {
       assert.isFalse(subject.synced, 'should be synced');
     });
 
+    test('when last item needs to be removed', function() {
+      subject.removeFutureIntervals(59);
+
+      var expectedIds = [
+        'before',
+        'on',
+        'just after'
+      ];
+
+     var ids = subject.items.map(function(item) {
+        return item._id;
+      });
+
+      assert.deepEqual(ids, expectedIds);
+    });
+
   });
 
 

--- a/apps/calendar/test/unit/store/busytime_test.js
+++ b/apps/calendar/test/unit/store/busytime_test.js
@@ -1,12 +1,9 @@
 requireApp('calendar/test/unit/helper.js', function() {
   requireLib('responder.js');
-
-
   requireLib('interval_tree.js');
   requireLib('timespan.js');
   requireLib('store/event.js');
   requireLib('store/busytime.js');
-
 });
 
 suite('store/busytime', function() {
@@ -401,13 +398,11 @@ suite('store/busytime', function() {
     });
 
     test('result', function(done) {
-      subject._cached = Object.create(null);
+      subject._setupCache();
 
       subject.load(function(err, results) {
         done(function() {
-          results = Object.keys(results).map(function(key) {
-            return results[key];
-          });
+          results = subject._tree.items;
           assert.deepEqual(results, expected);
         });
       });
@@ -440,17 +435,22 @@ suite('store/busytime', function() {
     });
 
     test('removal', function(done) {
+      // just load everything...
+      var span = new Calendar.Timespan(
+        new Date(2012, 1, 1),
+        new Date(2015, 1, 1)
+      );
+
       // quick sanity check to make sure
       // we removed in memory stuff
       assert.equal(subject._tree.items.length, 1);
       assert.equal(subject._tree.items[0].eventId, keepModel._id);
 
-      subject._cached = Object.create(null);
-      subject.load(function(err, results) {
+      subject._setupCache();
+      subject.loadSpan(span, function(err, results) {
         done(function() {
-          var keys = Object.keys(results);
-          assert.equal(keys.length, 1);
-          var result = results[keys[0]];
+          assert.equal(results.length, 1);
+          var result = results[0];
           assert.equal(result.eventId, keepModel._id);
         });
       });

--- a/apps/calendar/test/unit/support/factories/all.js
+++ b/apps/calendar/test/unit/support/factories/all.js
@@ -185,11 +185,18 @@
         obj.endDate = endDate;
       }
 
+      if (obj.start && !obj.startDate)
+        obj.startDate = new Date(obj.start);
+
+      if (obj.end && !obj.endDate)
+        obj.endDate = new Date(obj.end);
+
       if (!obj.start)
         obj.start = obj.startDate.valueOf();
 
       if (!obj.end)
         obj.end = obj.endDate.valueOf();
+
 
     }
   });

--- a/apps/calendar/test/unit/time_observer_test.js
+++ b/apps/calendar/test/unit/time_observer_test.js
@@ -1,0 +1,183 @@
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('timespan.js');
+  requireLib('time_observer.js');
+});
+
+suite('time_observer', function() {
+
+  var subject;
+  var SubjectClass;
+
+  suiteSetup(function() {
+    SubjectClass = function() {
+      Calendar.TimeObserver.call(this);
+    };
+
+    Calendar.TimeObserver.enhance(
+      SubjectClass.prototype
+    );
+  });
+
+  setup(function() {
+    subject = new SubjectClass();
+  });
+
+  test('#findTimeObserver', function() {
+    var cb = {};
+    var range = new Calendar.Timespan(
+      new Date(),
+      new Date()
+    );
+
+    assert.equal(
+      subject.findTimeObserver(range, cb),
+      -1
+    );
+
+    subject.observeTime(range, cb);
+
+    assert.equal(
+      subject.findTimeObserver(range, cb),
+      0
+    );
+  });
+
+  suite('#observeTime', function() {
+    test('when given non-timespan', function() {
+      assert.throws(function() {
+        subject.observeTime('foo', function() {});
+      }, /Calendar\.Timespan/);
+    });
+
+    test('success', function() {
+      var span = new Calendar.Timespan(
+        new Date(),
+        new Date()
+      );
+
+      var cb = function() {};
+
+      subject.observeTime(span, cb);
+
+      assert.equal(
+        subject._timeObservers.length, 1
+      );
+
+      var observe = subject._timeObservers[0];
+
+      assert.equal(observe[0], span);
+      assert.equal(observe[1], cb);
+
+    });
+
+  });
+
+  suite('#removeTimeObserver', function() {
+    var span, object;
+
+    setup(function() {
+      span = new Calendar.Timespan(
+        new Date(),
+        new Date()
+      );
+
+      object = {};
+      subject.observeTime(span, object);
+    });
+
+    test('found & removed', function() {
+      var result = subject.removeTimeObserver(
+        span, object
+      );
+
+      assert.isTrue(result);
+      assert.equal(subject._timeObservers.length, 0);
+    });
+
+    test('not removed', function() {
+      var result = subject.removeTimeObserver(
+        span,
+        {}
+      );
+
+      assert.isFalse(result);
+      assert.equal(subject._timeObservers.length, 1);
+    });
+  });
+
+  suite('#fireTimeEvent', function() {
+    var span;
+
+    var startDate;
+    var endDate;
+
+    var obj;
+
+    setup(function() {
+      obj = {};
+      startDate = new Date(2011, 12, 31);
+      endDate = new Date(2012, 1, 15);
+
+      span = new Calendar.Timespan(
+        new Date(2012, 1, 1),
+        new Date(2012, 12, 1)
+      );
+    });
+
+    function fireSuccess() {
+      subject.fireTimeEvent(
+        'add',
+        startDate,
+        endDate,
+        obj
+      );
+    }
+
+    test('object', function(done) {
+      this.timeout(250);
+
+      var observer = {
+        handleEvent: function(e) {
+          done(function() {
+            assert.equal(e.time, true);
+            assert.equal(e.type, 'add');
+            assert.equal(e.data, obj);
+          });
+        }
+      };
+      subject.observeTime(span, observer);
+      fireSuccess();
+    });
+
+    test('function', function(done) {
+      this.timeout(250);
+
+      subject.observeTime(span, function(e) {
+        done(function() {
+          assert.equal(e.time, true);
+          assert.equal(e.type, 'add');
+          assert.equal(e.data, obj);
+        });
+      });
+      fireSuccess();
+    });
+
+    test('outside of range', function(done) {
+      setTimeout(function() {
+        done();
+      }, 0);
+
+      subject.observeTime(span, function() {
+        done(new Error('should not fire observe'));
+      });
+
+      subject.fireTimeEvent(
+        'remove',
+        new Date(2010, 1, 1),
+        new Date(2011, 1, 1),
+        obj
+      );
+    });
+  });
+
+});

--- a/apps/calendar/test/unit/timespan_test.js
+++ b/apps/calendar/test/unit/timespan_test.js
@@ -30,7 +30,145 @@ suite('timespan', function() {
     );
   });
 
- suite('#overlaps', function() {
+  test('#isEqual', function() {
+    var span = new Calendar.Timespan(
+      new Date(2012, 1, 1),
+      new Date(2012, 1, 5)
+    );
+
+    var eqlSpan = new Calendar.Timespan(
+      new Date(2012, 1, 1),
+      new Date(2012, 1, 5)
+    );
+
+    var notEqualSpan = new Calendar.Timespan(
+      new Date(2012, 1, 1),
+      new Date(2012, 1, 6)
+    );
+
+    assert.isTrue(span.isEqual(eqlSpan));
+    assert.isFalse(span.isEqual(notEqualSpan));
+  });
+
+  test('#daysBetween', function() {
+    var range = new Calendar.Timespan(
+      new Date(2012, 1, 1),
+      new Date(2012, 1, 3)
+    );
+
+    var dates = range.daysBetween();
+    assert.deepEqual(
+      dates[0],
+      new Date(2012, 1, 1)
+    );
+
+    assert.deepEqual(
+      dates[1],
+      new Date(2012, 1, 2)
+    );
+
+    assert.deepEqual(
+      dates[2],
+      new Date(2012, 1, 3)
+    );
+  });
+
+  suite('#trimOverlap', function() {
+    var before;
+    var subject;
+    var none;
+
+    setup(function() {
+      none = new Calendar.Timespan(
+        new Date(2012, 5, 1),
+        new Date(2012, 5, 15)
+      );
+
+      before = new Calendar.Timespan(
+        // July 1
+        new Date(2012, 6, 1),
+        // Aug 4th
+        new Date(2012, 7, 4)
+      );
+
+      subject = new Calendar.Timespan(
+        // July 29th
+        new Date(2012, 6, 29),
+        // Aug 31
+        new Date(2012, 7, 31)
+      );
+    });
+
+    test('middle', function() {
+      var long = new Calendar.Timespan(
+        new Date(2012, 0, 1),
+        new Date(2012, 0, 31)
+      );
+
+      var short = new Calendar.Timespan(
+        new Date(2012, 0, 5),
+        new Date(2012, 0, 10)
+      );
+
+      assert.isNull(
+        long.trimOverlap(short),
+        'should return null subject contains given'
+      );
+
+      assert.isNull(
+        short.trimOverlap(long),
+        'should return null when given contains subject'
+      );
+    });
+
+    test('no overlap', function() {
+      var out = before.trimOverlap(none);
+      assert.deepEqual(out, none);
+    });
+
+    test('overlaps && input.end > subject.start', function() {
+      var output = subject.trimOverlap(
+        before
+      );
+
+      var start = new Date(2012, 6, 1);
+      var end = new Date(
+        2012, 6, 29
+      );
+
+      end.setMilliseconds(-1);
+
+      var expected = new Calendar.Timespan(
+        start, end
+      );
+
+      assert.deepEqual(output, expected);
+    });
+
+    test('overlaps && subject.end > input.start', function() {
+      var output = before.trimOverlap(
+        subject
+      );
+
+      var start = new Date(2012, 7, 4);
+      start.setMilliseconds(
+        start.getMilliseconds() + 1
+      );
+
+      var end = new Date(
+        2012, 7, 31
+      );
+
+      var expected = new Calendar.Timespan(
+        start, end
+      );
+
+      assert.deepEqual(output, expected);
+    });
+
+  });
+
+  suite('#overlaps', function() {
     var dates;
 
     suiteSetup(function() {

--- a/apps/calendar/test/unit/views/month_child_test.js
+++ b/apps/calendar/test/unit/views/month_child_test.js
@@ -509,11 +509,14 @@ suite('views/month_child', function() {
       testEl.innerHTML = subject._renderDay(month);
       subject.element = testEl;
 
-      var keys = Object.keys(busytimes.cached);
-
-      list = keys.map(function(key) {
-        subject._renderBusytime(busytimes.cached[key]);
-        return busytimes.cached[key];
+      //TODO: we should probably not be using
+      //a private variable from a store here...
+      //Maybe we should expose the tree directly
+      //on busytimes and make it part of the public
+      //api?
+      list = busytimes._tree.items.map(function(item) {
+        subject._renderBusytime(item);
+        return item;
       });
 
       assert.ok(testEl.querySelector('.busy-1'));

--- a/apps/calendar/test/unit/views/month_child_test.js
+++ b/apps/calendar/test/unit/views/month_child_test.js
@@ -202,7 +202,7 @@ suite('views/month_child', function() {
   test('#_initEvents', function() {
     subject._initEvents();
 
-    var observers = busytimes._timeObservers;
+    var observers = controller._timeObservers;
     var record = observers[observers.length - 1];
 
     assert.equal(record[0], subject._timespan);
@@ -211,7 +211,7 @@ suite('views/month_child', function() {
 
   test('#_destroyEvents', function() {
     subject._initEvents();
-    var observers = busytimes._timeObservers;
+    var observers = controller._timeObservers;
     var len = observers.length;
     subject._destroyEvents();
     assert.equal(observers.length, len - 1);
@@ -233,7 +233,7 @@ suite('views/month_child', function() {
         startDate: createHour(23)
       });
 
-      busytimes.fireTimeEvent(
+      controller.fireTimeEvent(
         'add',
         createHour(23).valueOf(),
         createHour(23).valueOf(),
@@ -253,7 +253,7 @@ suite('views/month_child', function() {
         startDate: createHour(23)
       });
 
-      busytimes.fireTimeEvent(
+      controller.fireTimeEvent(
         'remove',
         createHour(23).valueOf(),
         createHour(23).valueOf(),
@@ -271,7 +271,7 @@ suite('views/month_child', function() {
     setup(function() {
       calls = [];
 
-      subject.controller.currentMonth = month;
+      subject.controller.move(month);
 
       subject.attach(testEl);
       subject._addBusytime = function() {
@@ -460,7 +460,7 @@ suite('views/month_child', function() {
   });
 
   test('#_addBusytime', function() {
-    controller.currentMonth = month;
+    controller.move(month);
     subject.element = testEl;
     testEl.innerHTML = subject._renderDay(month);
 
@@ -505,7 +505,7 @@ suite('views/month_child', function() {
     });
 
     setup(function() {
-      controller.currentMonth = month;
+      controller.move(month);
       testEl.innerHTML = subject._renderDay(month);
       subject.element = testEl;
 
@@ -514,7 +514,7 @@ suite('views/month_child', function() {
       //Maybe we should expose the tree directly
       //on busytimes and make it part of the public
       //api?
-      list = busytimes._tree.items.map(function(item) {
+      list = controller._collection.items.map(function(item) {
         subject._renderBusytime(item);
         return item;
       });
@@ -555,7 +555,7 @@ suite('views/month_child', function() {
 
     suiteSetup(function() {
       id = Calendar.Calc.getDayId(day);
-      controller.currentMonth = day;
+      controller.move(day);
     });
 
     setup(function() {
@@ -584,7 +584,7 @@ suite('views/month_child', function() {
 
     test('result', function() {
       var id = Calendar.Calc.getDayId(day);
-      controller.currentMonth = day;
+      controller.move(day);
       result = subject._renderDay(day);
 
       rendersObject();
@@ -615,6 +615,7 @@ suite('views/month_child', function() {
 
     setup(function() {
       controller.currentMonth = day;
+      controller.move(day);
       result = subject._renderWeek(Calendar.Calc.getWeeksDays(day));
     });
 
@@ -649,7 +650,7 @@ suite('views/month_child', function() {
     ];
 
     test('should compose header and five weeks', function() {
-      controller.currentMonth = days[0];
+      controller.move(month);
       var result = subject._renderMonth();
 
       assert.ok(result);
@@ -663,36 +664,35 @@ suite('views/month_child', function() {
     });
 
     test('should compose header and six weeks', function() {
-    // We want to check if sixth week is rendered properly
-    // December 2012 has six weeks
-    var newMonth = new Date(2012, 11, 1);
-    var newDays = [
-      newMonth,
-      new Date(2012, 11, 8),
-      new Date(2012, 11, 15),
-      new Date(2012, 11, 22),
-      new Date(2012, 11, 29),
-      new Date(2012, 12, 6)
-    ];
+      // We want to check if sixth week is rendered properly
+      // December 2012 has six weeks
+      var newMonth = new Date(2012, 11, 1);
+      var newDays = [
+        newMonth,
+        new Date(2012, 11, 8),
+        new Date(2012, 11, 15),
+        new Date(2012, 11, 22),
+        new Date(2012, 11, 29),
+        new Date(2012, 12, 6)
+      ];
 
-    controller.currentMonth = newDays[0];
-    var result = subject._renderMonth();
+      controller.move(newDays[0]);
+      var result = subject._renderMonth();
 
-    assert.ok(result);
+      assert.ok(result);
 
-    days.forEach(function(date) {
-      assert.include(
-        result, subject._renderWeek(Calendar.Calc.getWeeksDays(date)),
-        'should include week of ' + date.getDate()
-      );
+      days.forEach(function(date) {
+        assert.include(
+          result, subject._renderWeek(Calendar.Calc.getWeeksDays(date)),
+          'should include week of ' + date.getDate()
+        );
+      });
     });
-
-   });
   });
 
   suite('#_busyElement', function() {
     setup(function() {
-      controller.currentMonth = month;
+      controller.move(month);
     });
 
     test('trying to access outside of range', function() {
@@ -722,7 +722,7 @@ suite('views/month_child', function() {
     var calledRenderWith;
 
     setup(function() {
-      controller.currentMonth = month;
+      controller.move(month);
     });
 
     setup(function() {
@@ -731,7 +731,7 @@ suite('views/month_child', function() {
         1, 2, 3
       ];
 
-      busytimes.busytimesInCachedSpan = function() {
+      controller.queryCache = function() {
         calledCachedWith = arguments;
         return slice;
       };
@@ -769,7 +769,7 @@ suite('views/month_child', function() {
     var list;
 
     setup(function() {
-      controller.currentMonth = month;
+      controller.move(month);
       subject.attach(testEl);
 
       list = subject.element.classList;
@@ -789,7 +789,7 @@ suite('views/month_child', function() {
 
   suite('#destroy', function() {
     setup(function() {
-      controller.currentMonth = month;
+      controller.move(month);
       subject._days = true;
     });
 

--- a/apps/calendar/test/unit/views/month_child_test.js
+++ b/apps/calendar/test/unit/views/month_child_test.js
@@ -76,7 +76,7 @@ suite('views/month_child', function() {
     assert.equal(subject.monthId, Calendar.Calc.getMonthId(month));
 
     assert.instanceOf(
-      subject._timespan,
+      subject.timespan,
       Calendar.Timespan,
       'should create timespan'
     );
@@ -84,28 +84,8 @@ suite('views/month_child', function() {
     assert.deepEqual(subject._days, {});
 
     assert.deepEqual(
-      subject._timespan,
-      subject._setupTimespan(subject.month)
-    );
-  });
-
-  test('#_setupTimespan', function() {
-    var month = new Date(2012, 7, 1);
-
-    var expectedStart = new Date(2012, 6, 29);
-    var expectedEnd = new Date(2012, 8, 2);
-    expectedEnd.setMilliseconds(-1);
-
-    var range = subject._setupTimespan(month);
-
-    assert.equal(
-      range.start,
-      expectedStart.valueOf()
-    );
-
-    assert.equal(
-      range.end,
-      expectedEnd.valueOf()
+      subject.timespan,
+      Calendar.Calc.spanOfMonth(subject.month)
     );
   });
 
@@ -205,7 +185,7 @@ suite('views/month_child', function() {
     var observers = controller._timeObservers;
     var record = observers[observers.length - 1];
 
-    assert.equal(record[0], subject._timespan);
+    assert.equal(record[0], subject.timespan);
     assert.equal(record[1], subject);
   });
 
@@ -297,7 +277,7 @@ suite('views/month_child', function() {
     });
 
     test('whole month', function() {
-      var span = subject._timespan;
+      var span = subject.timespan;
 
       var record = Factory('busytime', {
         startDate: new Date(span.start - 60),
@@ -326,14 +306,14 @@ suite('views/month_child', function() {
       assert.isTrue(
         Calendar.Calc.isSameDate(
           calls[0][0],
-          new Date(subject._timespan.start)
+          new Date(subject.timespan.start)
         )
       );
 
       assert.isTrue(
         Calendar.Calc.isSameDate(
           calls[34][0],
-          new Date(subject._timespan.end)
+          new Date(subject.timespan.end)
         )
       );
 
@@ -342,7 +322,7 @@ suite('views/month_child', function() {
     return;
 
     test('trailing before the timespan', function() {
-      subject._timespan = new Calendar.Timespan(
+      subject.timespan = new Calendar.Timespan(
         new Date(2012, 2, 1),
         new Date(2012, 2, 31)
       );
@@ -380,7 +360,7 @@ suite('views/month_child', function() {
       var end = new Date(2012, 2, 4);
       end.setMilliseconds(-1);
 
-      subject._timespan = new Calendar.Timespan(
+      subject.timespan = new Calendar.Timespan(
         new Date(2012, 1, 1),
         end
       );
@@ -428,7 +408,7 @@ suite('views/month_child', function() {
     });
 
     test('three days', function() {
-      subject._timespan = new Calendar.Timespan(
+      subject.timespan = new Calendar.Timespan(
         new Date(2011, 12, 1),
         new Date(2012, 4, 1)
       );
@@ -749,7 +729,7 @@ suite('views/month_child', function() {
 
       result = subject.attach(testEl);
 
-      assert.equal(calledCachedWith[0], subject._timespan);
+      assert.equal(calledCachedWith[0], subject.timespan);
       assert.deepEqual(
         calledRenderWith,
         [1, 2, 3]

--- a/apps/calendar/test/unit/views/month_test.js
+++ b/apps/calendar/test/unit/views/month_test.js
@@ -2,9 +2,10 @@ requireCommon('test/synthetic_gestures.js');
 
 requireApp('calendar/test/unit/helper.js', function() {
   require('/shared/js/gesture_detector.js');
-  requireApp('calendar/js/templates/month.js');
-  requireApp('calendar/js/views/month_child.js');
-  requireApp('calendar/js/views/month.js');
+  requireLib('timespan.js');
+  requireLib('templates/month.js');
+  requireLib('views/month_child.js');
+  requireLib('views/month.js');
 });
 
 suite('views/month', function() {
@@ -31,8 +32,11 @@ suite('views/month', function() {
     var div = document.createElement('div');
     div.id = 'test';
     div.innerHTML = [
-      '<div id="month-view"><div class="monthView"></div>',
-      '<div class="monthHeader"></div></div>'
+      '<div id="current-month-year">',
+      '</div>',
+      '<div id="month-view">',
+        '<div id="month-displays"></div>',
+      '</div>'
     ].join('');
 
     document.body.appendChild(div);
@@ -42,19 +46,23 @@ suite('views/month', function() {
     busytimes = app.store('Busytime');
 
     subject = new Calendar.Views.Month({
-      app: app,
-      monthSelector: '#test .monthView',
-      currentMonthSelector: '#test .monthHeader'
+      app: app
     });
 
   });
 
   test('initialization', function() {
-    assert.equal(subject.monthSelector, '#test .monthView');
-    assert.equal(subject.currentMonthSelector, '#test .monthHeader');
     assert.instanceOf(subject, Calendar.View);
     assert.equal(subject.controller, controller);
     assert.equal(subject.element, document.querySelector('#month-view'));
+  });
+
+  test('#container', function() {
+    assert.ok(subject.container);
+  });
+
+  test('#currentMonth', function() {
+    assert.ok(subject.currentMonth);
   });
 
   suite('events', function() {
@@ -82,24 +90,6 @@ suite('views/month', function() {
 
   test('#onfirstseen', function() {
     assert.equal(subject.onfirstseen, subject.render);
-  });
-
-  test('#monthsDisplayElement', function() {
-    var el = document.querySelector('#test .monthView');
-
-    assert.equal(
-      subject.monthsDisplayElement(),
-      el
-    );
-  });
-
-  test('#currentMonthElement', function() {
-    var el = document.querySelector('#test .monthHeader');
-
-    assert.equal(
-      subject.currentMonthElement(),
-      el
-    );
   });
 
   test('#_renderCurrentMonth', function() {
@@ -191,7 +181,7 @@ suite('views/month', function() {
     });
 
     test('should append new month into dom', function() {
-      var el = subject.monthsDisplayElement().children[0];
+      var el = subject.container.children[0];
 
       assert.ok(subject.children[id]);
 
@@ -203,7 +193,7 @@ suite('views/month', function() {
 
     test('when trying to re-render an existing calendar', function() {
       subject.activateMonth(date);
-      var els = container.querySelectorAll('.monthView > section');
+      var els = subject.container.children;
       assert.length(els, 1, 'should not re-render calendar');
     });
 
@@ -215,7 +205,7 @@ suite('views/month', function() {
       });
 
       test('hides old month and displays new one', function() {
-        var els = container.querySelectorAll('.monthView > section');
+        var els = subject.container.children;
         assert.length(els, 2);
 
         assert.ok(els[0].classList.contains('inactive'));
@@ -224,7 +214,7 @@ suite('views/month', function() {
 
       test('when going back', function() {
         subject.activateMonth(date);
-        var els = container.querySelectorAll('.monthView > section');
+        var els = subject.container.children;
         assert.length(els, 2);
 
         assert.ok(!els[0].classList.contains('inactive'));
@@ -239,7 +229,7 @@ suite('views/month', function() {
     subject.updateCurrentMonth();
 
     assert.include(
-      subject.currentMonthElement().innerHTML,
+      subject.currentMonth.innerHTML,
       subject._renderCurrentMonth()
     );
   });
@@ -252,7 +242,7 @@ suite('views/month', function() {
     });
 
     test('rendered elements', function() {
-      var container = subject.monthsDisplayElement(),
+      var container = subject.container,
           now = new Date();
 
       now.setDate(1);

--- a/apps/calendar/test/unit/views/month_test.js
+++ b/apps/calendar/test/unit/views/month_test.js
@@ -67,7 +67,7 @@ suite('views/month', function() {
 
   suite('events', function() {
 
-    test('currentMonthChange', function() {
+    test('monthChange', function() {
       var calledUpdate = null,
           calledActivateMonth = null;
 
@@ -80,10 +80,10 @@ suite('views/month', function() {
       };
 
       var date = new Date(2012, 1, 1);
-      controller.setCurrentMonth(date);
+      controller.move(date);
 
       assert.isTrue(calledUpdate);
-      assert.equal(calledActivateMonth, date);
+      assert.deepEqual(calledActivateMonth, date);
     });
 
   });
@@ -94,7 +94,7 @@ suite('views/month', function() {
 
   test('#_renderCurrentMonth', function() {
     //September 2012
-    controller.setCurrentMonth(new Date(2012, 8, 1));
+    controller.move(new Date(2012, 8, 1));
     var result = subject._renderCurrentMonth();
 
     assert.ok(result);
@@ -121,7 +121,7 @@ suite('views/month', function() {
         calledWith = mo;
       };
       subject.render();
-      now = controller.currentMonth;
+      now = controller.month;
     });
 
     test('#next', function() {
@@ -174,7 +174,7 @@ suite('views/month', function() {
         id;
 
     setup(function() {
-      controller.currentMonth = date;
+      controller.move(date);
       id = Calendar.Calc.getMonthId(date);
       subject.activateMonth(date);
       container = document.getElementById('test');
@@ -225,7 +225,7 @@ suite('views/month', function() {
   });
 
   test('#updateCurrentMonth', function() {
-    controller.setCurrentMonth(new Date(2012, 8, 1));
+    controller.move(new Date(2012, 8, 1));
     subject.updateCurrentMonth();
 
     assert.include(
@@ -245,7 +245,11 @@ suite('views/month', function() {
       var container = subject.container,
           now = new Date();
 
-      now.setDate(1);
+      now = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        1
+      );
 
       subject.render();
 
@@ -256,7 +260,7 @@ suite('views/month', function() {
         subject.currentChild.element.id
       );
 
-      assert.deepEqual(controller.currentMonth.valueOf(), now.valueOf());
+      assert.deepEqual(controller.month.valueOf(), now.valueOf());
     });
 
   });

--- a/apps/calendar/test/unit/views/month_test.js
+++ b/apps/calendar/test/unit/views/month_test.js
@@ -224,6 +224,32 @@ suite('views/month', function() {
 
   });
 
+  suite('controller: purge event', function() {
+
+    var date;
+    var childId;
+
+    setup(function() {
+      date = new Date(2012, 8, 1);
+      controller.move(date);
+      subject.activateMonth(date);
+
+      childId = Object.keys(subject.children)[0];
+    });
+
+    test('should remove after purge', function() {
+      var child = subject.children[childId];
+      assert.ok(child);
+      assert.ok(child.element);
+
+      controller.emit('purge', child.timespan);
+
+      assert.ok(!child.element);
+      assert.deepEqual(subject.children, {});
+    });
+
+  });
+
   test('#updateCurrentMonth', function() {
     controller.move(new Date(2012, 8, 1));
     subject.updateCurrentMonth();

--- a/apps/calendar/test/unit/views/months_day_test.js
+++ b/apps/calendar/test/unit/views/months_day_test.js
@@ -64,7 +64,7 @@ suite('views/months_day', function() {
         calledWith = arguments;
       }
 
-      subject.controller.setSelectedDay(date);
+      subject.controller.selectedDay = date;
       assert.equal(
         calledWith[0],
         date,
@@ -116,7 +116,7 @@ suite('views/months_day', function() {
         new Calendar.Timespan(startTime, endTime)
       );
 
-      var eventIdx = busytimes.findTimeObserver(subject._timespan, subject);
+      var eventIdx = controller.findTimeObserver(subject._timespan, subject);
 
       assert.ok(
         eventIdx !== -1,
@@ -132,7 +132,7 @@ suite('views/months_day', function() {
 
       assert.equal(subject._changeToken, 2);
 
-      var eventIdx = busytimes.findTimeObserver(
+      var eventIdx = controller.findTimeObserver(
         oldRange, subject
       );
 
@@ -261,18 +261,24 @@ suite('views/months_day', function() {
 
   suite('#_loadRecords', function() {
     var storeCalledWith;
+    var queryCalledWith;
     var renderCalledWith;
     var list = [];
 
     setup(function() {
       storeCalledWith = [];
       renderCalledWith = [];
+      queryCalledWith = [];
+
+      controller.queryCache = function() {
+        queryCalledWith.push(arguments);
+      }
 
       subject._renderList = function() {
         renderCalledWith.push(arguments);
-      },
+      }
 
-      busytimes.eventsInCachedSpan = function() {
+      events.findByAssociated = function() {
         storeCalledWith.push(arguments);
       }
     });
@@ -304,7 +310,7 @@ suite('views/months_day', function() {
       assert.ok(!renderCalledWith.length);
 
       assert.equal(
-        storeCalledWith[0][0],
+        queryCalledWith[0][0],
         subject._timespan
       );
 


### PR DESCRIPTION
Busytime store is now transparently loaded in "chunks" as the user is moves through the app.
Cleans up the public api of the time controller and simplifies busytime store & event store.

Related to: #3526

This PR also includes new Calendar.Calc.spanOfMonth
which can be used to replace all the existing logic that determines
the number of weeks. After which point it should resolve #3336.

Month views are automatically cleaned up when going beyond a specific point in time now as well.
