### PR TITLE
possible performance improvement in predictive text

### DIFF
--- a/apps/keyboard/js/predict/latin-worker.js
+++ b/apps/keyboard/js/predict/latin-worker.js
@@ -212,10 +212,7 @@ function String2Codes(codes, word) {
 
 // Convert an array of char codes back into a string.
 function Codes2String(codes) {
-  var s = '';
-  for (var n = 0; n < codes.length; ++n)
-    s += String.fromCharCode(codes[n]);
-  return s;
+  return String.fromCharCode.apply(String, codes);
 }
 
 // Map an array of codes to the base letters, eliminating any diacritics.


### PR DESCRIPTION
@andreasgal this pull request rewrites your Code2String() function to take advantage of the fact that String.fromCharCodes() accepts multiple arguments.

My microbenchmarks indicate that this new version is faster if the input array length is > 3, and speed improves with increasing array length.  I don't know whether that translates to a win in typical use, however.
