### PR TITLE
Recover more gracefully after a failed scan

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -463,10 +463,8 @@ window.addEventListener('localized', function wifiSettings(evt) {
       };
 
       req.onerror = function onScanError(error) {
-        // auto-rescan if requested
-        if (autoscan)
-          window.setTimeout(scan, scanRate);
-        scanning = false;
+        // always try again.
+        window.setTimeout(scan, scanRate);
       };
 
     }


### PR DESCRIPTION
If our scan command fails, we'll wait potentially forever at the scanning screen. This pull request makes us recover more gracefully by continually trying again until the command succeeds. I don't know if it's worth it to have a "stop" button in cases where wpa_supplican gets really out of whack, though.
