### PR TITLE
Add meta viewport tag to browser start page

### DIFF
--- a/apps/browser/start.html
+++ b/apps/browser/start.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="pragma" content="no-cache">
+    <meta name="viewport" content="width=device-width, user-scalable=no">
     <title data-l10n-id="firefox-start">Firefox Start</title>
     <link rel="stylesheet" href="style/start.css" type="text/css">
     <!-- Localization -->


### PR DESCRIPTION
This will have no effect until the platform code supporting meta viewport is landed. Progress can be tracked here:
https://bugzilla.mozilla.org/show_bug.cgi?id=746502

With my in-progress patch on the platform side, the viewport will be set to 980 pixels wide and the page looks pretty terrible. This pull request turns off user scaling and fits the start page to the screen again.
