### PR TITLE
Lock screen: use setProperty() and removeProperty()

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -298,9 +298,8 @@ var LockScreen = {
     var dx = pageX - touch.initX;
 
     var handleMax = touch.maxHandleOffset;
-    this.areaHandle.style.MozTransition = 'none';
-    this.areaHandle.style.MozTransform =
-      'translateX(' + Math.max(- handleMax, Math.min(handleMax, dx)) + 'px)';
+    this.areaHandle.style.setProperty('transform',
+      'translateX(' + Math.max(- handleMax, Math.min(handleMax, dx)) + 'px)');
 
     var railMax = touch.initRailLength;
     var railLeft = railMax + dx;
@@ -345,7 +344,7 @@ var LockScreen = {
   handleGesture: function ls_handleGesture() {
     var touch = this._touch;
     var target = touch.target;
-    this.areaHandle.style.MozTransition = null;
+    this.areaHandle.style.removeProperty('transition');
 
     if (!target) {
       this.unloadPanel();


### PR DESCRIPTION
Fix #3871.

Lessen learned from bz in https://bugzilla.mozilla.org/show_bug.cgi?id=786105
- Use empty string instead of 'null' to unset a CSS property.
- Or, use `removeProperty()` which is even better.

I suspect other part of Gaia is also broken because of this Gecko behavior change. I will write an e-mail to dev-gaia for that.
