### PR TITLE
smooth zooming in gallery app

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -742,6 +742,7 @@ $('edit-cancel-button').onclick = function() {
 window.addEventListener('resize', function resizeHandler(evt) {
   // Abandon any current pan or zoom and reset the current photo view
   photoState.reset();
+  photoState.setFramesPosition();
 
   // Also reset the size and position of the previous and next photos
   resetPhoto(currentPhotoIndex - 1, previousPhotoFrame.firstElementChild);
@@ -831,7 +832,7 @@ photoFrames.addEventListener('swipe', function(event) {
 
     currentPhotoFrame.style.transition =
       nextPhotoFrame.style.transition =
-      previousPhotoFrame.style.transition = 'translate ' + time + 'ms linear';
+      previousPhotoFrame.style.transition = 'translate ' + time + 'ms ease';
     photoState.swipe = 0;
     photoState.setFramesPosition();
 
@@ -844,12 +845,12 @@ photoFrames.addEventListener('swipe', function(event) {
 // Quick zoom in and out with dbltap events
 photoFrames.addEventListener('dbltap', function(e) {
   var scale;
-  if (photoState.scale > 1)      // If already zoomed in,
-    scale = 1 / photoState.scale;  // zoom out to starting scale
-  else                           // Otherwise
-    scale = 2;                   // Zoom in by a factor of 2
+  if (photoState.fit.scale > photoState.fit.baseScale)   // If already zoomed in
+    scale = photoState.fit.baseScale / photoState.scale; // zoom back out
+  else                                                   // Otherwise
+    scale = 2;                                           // zoom in
 
-  photoState.zoom(scale, e.detail.clientX, e.detail.clientY, true, 200);
+  photoState.zoom(scale, e.detail.clientX, e.detail.clientY, 200);
 });
 
 // We also support pinch-to-zoom
@@ -857,20 +858,9 @@ photoFrames.addEventListener('transform', function(e) {
   if (transitioning)
     return;
 
-  // Transform events scale the photo with a CSS transform rather
-  // than actually resizing it.  We defer the resize until transformend
   photoState.zoom(e.detail.relative.scale,
                   e.detail.midpoint.clientX,
-                  e.detail.midpoint.clientY,
-                  false);
-});
-
-photoFrames.addEventListener('transformend', function(e) {
-  if (transitioning)
-    return;
-
-  // Now that the series of transforms is done, we actually resize the image
-  photoState.zoom(1, 0, 0, true);
+                  e.detail.midpoint.clientY);
 });
 
 // A utility function to set the src attribute of the <img> element inside
@@ -888,7 +878,6 @@ function displayImageInFrame(n, frame) {
   // Make sure n is in range
   if (n < 0 || n >= images.length) {
     img.src = null;
-    img.style.width = img.style.height = 0;
     return;
   }
 
@@ -907,13 +896,10 @@ function displayImageInFrame(n, frame) {
   positionImage(img, fit);
 }
 
-function positionImage(image, fit) {
-  var style = image.style;
-  style.width = fit.width + 'px';
-  style.height = fit.height + 'px';
-  style.transform = 'translate(' +
-    fit.left + 'px,' +
-    fit.top + 'px)';
+function positionImage(img, fit) {
+  img.style.transform =
+    'translate(' + fit.left + 'px,' + fit.top + 'px) ' +
+    'scale(' + fit.scale + ')';
 }
 
 // figure out the size and position of an image based on its size
@@ -932,7 +918,8 @@ function fitImage(photoWidth, photoHeight, viewportWidth, viewportHeight) {
     height: height,
     left: Math.floor((viewportWidth - width) / 2),
     top: Math.floor((viewportHeight - height) / 2),
-    scale: scale
+    scale: scale,
+    baseScale: scale
   };
 }
 
@@ -967,7 +954,7 @@ function nextPhoto(time) {
   setTimeout(function() { transitioning = false; }, time);
 
   // Set transitions for the visible photo frames and the photoFrames element
-  var transition = 'transform ' + time + 'ms linear';
+  var transition = 'transform ' + time + 'ms ease';
   currentPhotoFrame.style.transition = transition;
   nextPhotoFrame.style.transition = transition;
 
@@ -1025,7 +1012,7 @@ function previousPhoto(time) {
   setTimeout(function() { transitioning = false; }, time);
 
   // Set transitions for the visible photo frames and the photoFrames element
-  var transition = 'transform ' + time + 'ms linear';
+  var transition = 'transform ' + time + 'ms ease';
   previousPhotoFrame.style.transition = transition;
   currentPhotoFrame.style.transition = transition;
 
@@ -1154,12 +1141,7 @@ PhotoState.BORDER_WIDTH = 3;  // Border between photos
 // An internal method called by reset(), zoom() and pan() to
 // set the size and position of the image element.
 PhotoState.prototype._reposition = function() {
-  this.img.style.width = this.width + 'px';
-  this.img.style.height = this.height + 'px';
-  this.img.style.transform = 'translate(' +
-    this.left + 'px,' +
-    this.top + 'px)';
-  this.currentImageWidth = this.width; // used by zoom() animations
+  positionImage(this.img, this.fit);
 };
 
 // Compute the default size and position of the photo
@@ -1170,13 +1152,8 @@ PhotoState.prototype.reset = function() {
   this.viewportHeight = photoFrames.offsetHeight;
 
   // Compute the default size and position of the image
-  var fit = fitImage(this.photoWidth, this.photoHeight,
-                     this.viewportWidth, this.viewportHeight);
-  this.baseScale = fit.scale;
-  this.width = fit.width;
-  this.height = fit.height;
-  this.top = fit.top;
-  this.left = fit.left;
+  this.fit = fitImage(this.photoWidth, this.photoHeight,
+                      this.viewportWidth, this.viewportHeight);
 
   // Start off with no zoom
   this.scale = 1;
@@ -1191,145 +1168,135 @@ PhotoState.prototype.reset = function() {
 // the image pixels at (centerX, centerY) remain at that position.
 // Assume that zoom gestures can't be done in the middle of swipes, so
 // if we're calling zoom, then the swipe property will be 0.
-// If resize is true, then this method actually changes the width and
-// height of the image. Otherwise, it uses a CSS transform instead for
-// smoother animations.  If time is specified and non-zero, then it uses
-// a CSS transition to animate the CSS transform, and then resizes the image.
-PhotoState.prototype.zoom = function(scale, centerX, centerY, resize, time) {
+// If time is specified and non-zero, then we set a CSS transition
+// to animate the zoom.
+PhotoState.prototype.zoom = function(scale, centerX, centerY, time) {
   // Never zoom in farther than the native resolution of the image
-  if (this.baseScale * this.scale * scale > 1) {
-    scale = 1 / (this.baseScale * this.scale);
+  if (this.fit.scale * scale > 1) {
+    scale = 1 / (this.fit.scale);
   }
   // And never zoom out to make the image smaller than it would normally be
-  else if (this.scale * scale < 1) {
-    scale = 1 / this.scale;
+  else if (this.fit.scale * scale < this.fit.baseScale) {
+    scale = this.fit.baseScale / this.fit.scale;
   }
 
-  this.scale = this.scale * scale;
+  this.fit.scale = this.fit.scale * scale;
 
   // Change the size of the photo
-  this.width = Math.floor(this.photoWidth * this.baseScale * this.scale);
-  this.height = Math.floor(this.photoHeight * this.baseScale * this.scale);
+  this.fit.width = Math.floor(this.photoWidth * this.fit.scale);
+  this.fit.height = Math.floor(this.photoHeight * this.fit.scale);
 
   // centerX and centerY are in viewport coordinates.
   // These are the photo coordinates displayed at that point in the viewport
-  var photoX = centerX - this.left;
-  var photoY = centerY - this.top;
+  var photoX = centerX - this.fit.left;
+  var photoY = centerY - this.fit.top;
 
   // After zooming, these are the new photo coordinates.
-  // Note we just use the relative scale amount here, not this.scale
+  // Note we just use the relative scale amount here, not this.fit.scale
   var photoX = Math.floor(photoX * scale);
   var photoY = Math.floor(photoY * scale);
 
   // To keep that point still, here are the new left and top values we need
-  this.left = centerX - photoX;
-  this.top = centerY - photoY;
+  this.fit.left = centerX - photoX;
+  this.fit.top = centerY - photoY;
 
   // Now make sure we didn't pan too much: If the image fits on the
   // screen, center it. If the image is bigger than the screen, then
   // make sure we haven't gone past any edges
-  if (this.width <= this.viewportWidth) {
-    this.left = (this.viewportWidth - this.width) / 2;
+  if (this.fit.width <= this.viewportWidth) {
+    this.fit.left = (this.viewportWidth - this.fit.width) / 2;
   }
   else {
     // Don't let the left of the photo be past the left edge of the screen
-    if (this.left > 0)
-      this.left = 0;
+    if (this.fit.left > 0)
+      this.fit.left = 0;
 
     // Right of photo shouldn't be to the left of the right edge
-    if (this.left + this.width < this.viewportWidth) {
-      this.left = this.viewportWidth - this.width;
+    if (this.fit.left + this.fit.width < this.viewportWidth) {
+      this.fit.left = this.viewportWidth - this.fit.width;
     }
   }
 
-  if (this.height <= this.viewportHeight) {
-    this.top = (this.viewportHeight - this.height) / 2;
+  if (this.fit.height <= this.viewportHeight) {
+    this.fit.top = (this.viewportHeight - this.fit.height) / 2;
   }
   else {
     // Don't let the top of the photo be below the top of the screen
-    if (this.top > 0)
-      this.top = 0;
+    if (this.fit.top > 0)
+      this.fit.top = 0;
 
     // bottom of photo shouldn't be above the bottom of screen
-    if (this.top + this.height < this.viewportHeight) {
-      this.top = this.viewportHeight - this.height;
+    if (this.fit.top + this.fit.height < this.viewportHeight) {
+      this.fit.top = this.viewportHeight - this.fit.height;
     }
   }
 
-  if (resize && !time) {
-    // If time was 0 or undefined, just resposition the image now
-    this._reposition();
+  // If a time was specified, set up a transition so that the
+  // call to reposition below is animated
+  if (time) {
+    // If a time was specfied, animate the transformation
+    this.img.style.transition = 'transform ' + time + 'ms ease';
+    var self = this;
+    this.img.addEventListener('transitionend', function done(e) {
+      self.img.removeEventListener('transitionend', done);
+      self.img.style.transition = null;
+    });
   }
-  else {
-    if (time) {
-      // If a time was specfied, animate the transformation
-      this.img.style.transition = 'transform ' + time + 'ms ease';
-      var self = this;
-      this.img.addEventListener('transitionend', function done(e) {
-        self.img.removeEventListener('transitionend', done);
-        self.img.style.transition = null;
-        if (resize) // Actually resize after the transition
-          self._reposition();
-      });
-    }
 
-    this.img.style.transform =
-      'translate(' + this.left + 'px,' + this.top + 'px) ' +
-      'scale(' + (this.width / this.currentImageWidth) + ')';
-  }
+  this._reposition();
 };
 
 PhotoState.prototype.pan = function(dx, dy) {
   // Handle panning in the y direction first, since it is easier.
   // Don't pan in the y direction if we already fit on the screen
-  if (this.height > this.viewportHeight) {
-    this.top += dy;
+  if (this.fit.height > this.viewportHeight) {
+    this.fit.top += dy;
 
     // Don't let the top of the photo be below the top of the screen
-    if (this.top > 0)
-      this.top = 0;
+    if (this.fit.top > 0)
+      this.fit.top = 0;
 
     // bottom of photo shouldn't be above the bottom of screen
-    if (this.top + this.height < this.viewportHeight)
-      this.top = this.viewportHeight - this.height;
+    if (this.fit.top + this.fit.height < this.viewportHeight)
+      this.fit.top = this.viewportHeight - this.fit.height;
   }
 
   // Now handle the X dimension. In this case, we have to handle panning within
   // a zoomed image, and swiping to transition from one photo to the next
   // or previous.
-  if (this.width <= this.viewportWidth) {
+  if (this.fit.width <= this.viewportWidth) {
     // In this case, the photo isn't zoomed in, so we're just doing swiping
     this.swipe += dx;
   }
   else {
     if (this.swipe === 0) {
-      this.left += dx;
+      this.fit.left += dx;
 
       // If this would take the left edge of the photo past the
       // left edge of the screen, then we've got to do a swipe
-      if (this.left > 0) {
-        this.swipe += this.left;
-        this.left = 0;
+      if (this.fit.left > 0) {
+        this.swipe += this.fit.left;
+        this.fit.left = 0;
       }
 
       // Or, if this would take the right edge of the photo past the
       // right edge of the screen, then we've got to swipe the other way
-      if (this.left + this.width < this.viewportWidth) {
-        this.swipe += this.left + this.width - this.viewportWidth;
-        this.left = this.viewportWidth - this.width;
+      if (this.fit.left + this.fit.width < this.viewportWidth) {
+        this.swipe += this.fit.left + this.fit.width - this.viewportWidth;
+        this.fit.left = this.viewportWidth - this.fit.width;
       }
     }
     else if (this.swipe > 0) {
       this.swipe += dx;
       if (this.swipe < 0) {
-        this.left += this.swipe;
+        this.fit.left += this.swipe;
         this.swipe = 0;
       }
     }
     else if (this.swipe < 0) {
       this.swipe += dx;
       if (this.swipe > 0) {
-        this.left += this.swipe;
+        this.fit.left += this.swipe;
         this.swipe = 0;
       }
     }

--- a/apps/gallery/test/unit/GestureDetector_test.js
+++ b/apps/gallery/test/unit/GestureDetector_test.js
@@ -39,7 +39,7 @@ suite('GestureDetector', function() {
         'tap', 'dbltap',
         'pan', 'swipe',
         'holdstart', 'holdmove', 'holdend',
-        'transform'
+        'transform', 'transformend'
       ].forEach(function(type) {
         element.addEventListener(type, function(e) { events.push(e); });
       });
@@ -223,7 +223,7 @@ suite('GestureDetector', function() {
                                   p.scale, p.duration, checkpinch);
           function checkpinch() {
             done(function() {
-              assert.match(eventseq(), /(transform )*transform/);
+              assert.match(eventseq(), /(transform )+transformend/);
               var e = events[events.length - 1];
               var d = e.detail;
               between(d.absolute.scale, 0.95 * p.scale, 1.05 * p.scale);

--- a/shared/js/gesture_detector.js
+++ b/shared/js/gesture_detector.js
@@ -279,6 +279,7 @@ var GestureDetector = (function() {
       d.vx = d.vy = null;
       d.startDistance = d.lastDistance = null;
       d.startDirection = d.lastDirection = null;
+      d.lastMidpoint = null;
       d.scaled = d.rotated = null;
     },
 
@@ -579,6 +580,7 @@ var GestureDetector = (function() {
 
         d.lastDistance = distance;
         d.lastDirection = direction;
+        d.lastMidpoint = midpoint;
       }
     },
 
@@ -599,6 +601,25 @@ var GestureDetector = (function() {
       }
       else
         return; // It was a touch we weren't tracking
+
+      // If we emitted any transform events, now we need to emit
+      // a transformend event to end the series.  The details of this
+      // event use the values from the last touchmove, and the
+      // relative amounts will 1 and 0, but they are included for
+      // completeness even though they are not useful.
+      if (d.scaled || d.rotated) {
+        d.emitEvent('transformend', {
+          absolute: { // transform details since gesture start
+            scale: d.lastDistance / d.startDistance,
+            rotate: touchRotation(d.startDirection, d.lastDirection)
+          },
+          relative: { // nothing has changed relative to the last touchmove
+            scale: 1,
+            rotate: 0
+          },
+          midpoint: d.lastMidpoint
+        });
+      }
 
       d.switchTo(afterTransformState);
     }


### PR DESCRIPTION
This pull request makes pinch-to-zoom gestures smooth in the gallery app.

The first two commits convert the app to do smooth animations and then resize the zoomed image.

The third commit refactors things so that the image never needs to be resized: we just use the image at full size and CSS transform it as needed everywhere.  This third commit means that the gesture detector changes in the first commit are no longer needed.  They seem generally useful, however, so I'm going to leave them in.

All the gallery animations should be nice and fast now.

@andreasgal: since you reviewed the last one, do you have time for this one, too?
