### PR TITLE
Email - Fix contact email launcher bug.

### DIFF
--- a/apps/email/js/mail-app.js
+++ b/apps/email/js/mail-app.js
@@ -56,6 +56,10 @@ var App = {
             {
               folder: inboxFolder
             });
+          if (activityCallback) {
+            activityCallback();
+            activityCallback = null;
+          }
         };
       }
       // - no accounts, show the setup page!
@@ -142,6 +146,7 @@ var queryURI = function _queryURI(uri) {
 
 };
 
+var activityCallback = null;
 if ('mozSetMessageHandler' in window.navigator) {
   window.navigator.mozSetMessageHandler('activity',
                                         function actHandle(activity) {
@@ -176,10 +181,7 @@ if ('mozSetMessageHandler' in window.navigator) {
     if (document.readyState == 'complete') {
       sendMail();
     } else {
-      window.addEventListener('localized', function loadWait() {
-        window.removeEventListener('localized', loadWait);
-        sendMail();
-      });
+      activityCallback = sendMail;
     }
 
     activity.postResult({ status: 'accepted' });


### PR DESCRIPTION
- Email launcher in contact could not work while the email app hasn't started before. The root cause it we need to wait the email api to get the email account data before entering the compose view. Here we put the activity callback after the account and pages ready.
