### PR TITLE
[contacts] fix: value selector list is empty

### DIFF
--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -357,8 +357,8 @@ var Contacts = (function() {
             // if more than one phone number
             var prompt1 = new ValueSelector(_('select_mobile'));
             var numbers = currentContact.tel;
-            for (var key in numbers) {
-              var number = numbers[key].value;
+            for (var index=0; index<numbers.length; index++) {
+              var number = numbers[index].value;
               prompt1.addToList(number + '', function() {
                   prompt1.hide();
                   ActivityHandler.postPickSuccess(number);

--- a/apps/contacts/js/contacts.js
+++ b/apps/contacts/js/contacts.js
@@ -357,7 +357,7 @@ var Contacts = (function() {
             // if more than one phone number
             var prompt1 = new ValueSelector(_('select_mobile'));
             var numbers = currentContact.tel;
-            for (var index=0; index<numbers.length; index++) {
+            for (var index = 0; index < numbers.length; index++) {
               var number = numbers[index].value;
               prompt1.addToList(number + '', function() {
                   prompt1.hide();

--- a/apps/contacts/style/value_selector.css
+++ b/apps/contacts/style/value_selector.css
@@ -137,7 +137,6 @@ section.valueselector button {
   font-weight: 600;
   height: 3.8rem;
   line-height: 3.8rem;
-  margin: 0 0 1rem;
   outline: medium none;
   overflow: hidden;
   padding: 0 1.5rem;
@@ -148,5 +147,9 @@ section.valueselector button {
   vertical-align: middle;
   white-space: nowrap;
   width: 100%;
+  margin: 0;
+}
+
+body[role="application"] menu:not([type="toolbar"]):not([data-items="1"]) button:last-child {
   margin: 0;
 }


### PR DESCRIPTION
Bug: Go to sms, tap on new sms, than tap add contacts. On contacts list, pick a contact that has more than one phone number attached and tap it. The list should show all the pone numbers and it doesnt. Also the cancel button at the bottom isnt in the center.

The bug is because of a back-end change. Variables supplied by back-end are nut enumerable any more.

@albertopq r?
