### PR TITLE
Send a mozContentEvent from the system app when it's ready to receive system messages.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -780,6 +780,13 @@ var WindowManager = (function() {
     }
   });
 
+  // With all important event handlers in place, we can now notify
+  // Gecko that we're ready for certain system services to send us
+  // messages (e.g. the radio).
+  var event = document.createEvent('CustomEvent');
+  event.initCustomEvent('mozContentEvent', true, true, { type: 'system-app-ready' });
+  window.dispatchEvent(event);
+
   // Return the object that holds the public API
   return {
     launch: launch,


### PR DESCRIPTION
That will ensure that Gecko brings up certain services only after Gaia is ready to receive their messages. See also https://bugzilla.mozilla.org/show_bug.cgi?id=787172
