### PR TITLE
Avoid repeat for dock background on wider than 320px screen

### DIFF
--- a/apps/homescreen/style/dock.css
+++ b/apps/homescreen/style/dock.css
@@ -5,6 +5,7 @@
   bottom: 0;
   z-index: 10000;
   background-image: url('../resources/images/footer/background.png');
+  background-size: 100%;
 }
 
 #footer .dockWrapper {


### PR DESCRIPTION
On Nexus S, the dock background is not nice because it gets repeated. Fixing this.
