### PR TITLE
remove backquotes from comments so `make webapp-zip` works on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ ifneq ($(DEBUG),1)
 				mkdir -p profile/webapps/$$dirname; \
 				cdir=`pwd`; \
 				\
-				`# include shared JS scripts`; \
+				# include shared JS scripts \
 				for f in `grep -r shared/js $$d` ;\
 				do \
 					if [[ "$$f" == *shared/js* ]] ;\
@@ -210,7 +210,7 @@ ifneq ($(DEBUG),1)
 					fi \
 				done; \
 				\
-				`# include shared l10n resources`; \
+				# include shared l10n resources \
 				for f in `grep -r shared/locales $$d` ;\
 				do \
 					if [[ "$$f" == *shared/locales* ]] ;\
@@ -227,7 +227,7 @@ ifneq ($(DEBUG),1)
 					fi \
 				done; \
 				\
-				`# include shared building blocks`; \
+				# include shared building blocks \
 				for f in `grep -r shared/style $$d` ;\
 				do \
 					if [[ "$$f" == *shared/style* ]] ;\
@@ -245,7 +245,7 @@ ifneq ($(DEBUG),1)
 					fi \
 				done; \
 				\
-				`# zip application` \
+				# zip application \
 				cd $$d; \
 				zip -r application.zip *; \
 				cd $$cdir; \


### PR DESCRIPTION
On Windows (7; latest MozillaBuild with bash 3.1), `make webapp-zip` fails:

```
> make webapp-zip
(if [ -d ./.git ]; then \
          git log -1 --format="%H%n%at" HEAD > apps/settings/gaia-commit.txt; \
        else \
          echo 'Unknown Git commit; build date shown here.' > apps/settings/gaia-commit.txt; \
          date +%s >> apps/settings/gaia-commit.txt; \
        fi)
Packaged webapps
/bin/bash: -c: line 11: unexpected EOF while looking for matching ``'
/bin/bash: -c: line 70: syntax error: unexpected end of file
make: *** [webapp-zip] Error 2
```

This turns out to be caused by backquoted comments:

```
            `# include shared JS scripts`; \
            `# include shared l10n resources`; \
            `# include shared building blocks`; \
            `# zip application` \
```

Removing the backquotes gets things working, and the command still works on Linux (Ubuntu 12.04; bash 4.2.24).  I haven't tested Mac yet, but I expect it to behave like Linux.
