### PR TITLE
Coordinate the module ordering according to UI order(z-index)

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -28,53 +28,70 @@
     <link rel="stylesheet" type="text/css" href="style/gridview/gridview.css">
     <script defer src="js/gridview.js"></script>
 
-    <!-- Modal Dialog -->
-    <link rel="stylesheet" type="text/css" href="style/modal_dialog/prompt.css">
-    <link rel="stylesheet" type="text/css" href="style/modal_dialog/modal_dialog.css">
-    <script defer src="js/modal_dialog.js"></script>
-
     <!-- Accessibility -->
     <link rel="stylesheet" type="text/css" href="style/accessibility/accessibility.css">
     <script defer src="js/accessibility.js"></script>
-
-    <!-- List Menu -->
-    <link rel="stylesheet" type="text/css" href="style/list_menu/list_menu.css">
-    <script defer src="js/list_menu.js"></script>
-
-    <!-- Airplane Mode -->
-    <script defer src="js/airplane_mode.js"></script>
-
+    
     <!-- Sleep Menu -->
     <link rel="stylesheet" type="text/css" href="style/sleep_menu/sleep_menu.css">
     <script defer src="js/sleep_menu.js"></script>
-
-    <!-- Context Menu -->
-    <script defer src="js/context_menu.js"></script>
-
-    <!-- PIN Unlocking -->
-    <link rel="stylesheet" type="text/css" href="style/pinlock/pinlock.css">
-    <script defer src="js/pinlock/pinlock.js"></script>
-
+    
+    <!-- Cards View -->
+    <link rel="stylesheet" type="text/css" href="style/cards_view/cards_view.css">
+    <script defer src="js/cards_view/cards_view.js"></script>
+    
+    <!-- Keyboard -->
+    <script defer src="js/keyboard_manager.js"></script>
+    
+    <!-- Utility Tray -->
+    <link rel="stylesheet" type="text/css" href="style/utility_tray/utility_tray.css">
+    <script defer src="js/utility_tray.js"></script>
+    
     <!-- Attention Screen -->
     <link rel="stylesheet" type="text/css" href="style/attention_screen.css">
     <script defer src="js/attention_screen.js"></script>
 
+    <!-- List Menu -->
+    <link rel="stylesheet" type="text/css" href="style/list_menu/list_menu.css">
+    <script defer src="js/list_menu.js"></script>
+    
+    <!-- Context Menu -->
+    <script defer src="js/context_menu.js"></script>
+    
+    <!-- Statusbar -->
+    <link rel="stylesheet" type="text/css" href="style/statusbar/statusbar.css">
+    <script defer src="js/statusbar.js"></script>
+    
     <!-- LockScreen -->
     <link rel="stylesheet" type="text/css" href="style/lockscreen/lockscreen.css">
     <script defer src="js/mobile_info.js"></script>
     <script defer src="js/lockscreen.js"></script>
+    
+    <!-- PIN Unlocking -->
+    <link rel="stylesheet" type="text/css" href="style/pinlock/pinlock.css">
+    <script defer src="js/pinlock/pinlock.js"></script>
+
+    <!-- Airplane Mode -->
+    <script defer src="js/airplane_mode.js"></script>
+
+    <!-- Modal Dialog -->
+    <link rel="stylesheet" type="text/css" href="style/modal_dialog/prompt.css">
+    <link rel="stylesheet" type="text/css" href="style/modal_dialog/modal_dialog.css">
+    <script defer src="js/modal_dialog.js"></script>
+    
+    <!-- Value selector -->
+    <link rel="stylesheet" type="text/css" href="style/value_selector/value_selector.css">
+    <link rel="stylesheet" type="text/css" href="style/value_selector/time_picker.css">
+    <script defer src="js/value_selector/value_picker.js"></script>
+    <script defer src="js/value_selector/value_selector.js"></script>
 
     <!-- Popup Manager -->
     <link rel="stylesheet" type="text/css" href="style/popup_manager/popup_manager.css">
     <script defer src="js/popup_manager.js"></script>
-
-    <!-- Statusbar -->
-    <link rel="stylesheet" type="text/css" href="style/statusbar/statusbar.css">
-    <script defer src="js/statusbar.js"></script>
-
-    <!-- Utility Tray -->
-    <link rel="stylesheet" type="text/css" href="style/utility_tray/utility_tray.css">
-    <script defer src="js/utility_tray.js"></script>
+    
+    <!-- Permission Manager -->
+    <link rel="stylesheet" type="text/css" href="style/permission_manager/permission_manager.css">
+    <script defer src="js/permission_manager.js"></script>
 
     <!-- Cost Control -->
     <link rel="stylesheet" type="text/css" href="style/cost_control/cost_control.css">
@@ -87,17 +104,6 @@
     <!-- Notifications -->
     <link rel="stylesheet" type="text/css" href="style/notifications/notifications.css">
     <script defer src="js/notifications.js"></script>
-
-    <!-- Permission Manager -->
-    <link rel="stylesheet" type="text/css" href="style/permission_manager/permission_manager.css">
-    <script defer src="js/permission_manager.js"></script>
-
-    <!-- Cards View -->
-    <link rel="stylesheet" type="text/css" href="style/cards_view/cards_view.css">
-    <script defer src="js/cards_view/cards_view.js"></script>
-
-    <!-- Keyboard -->
-    <script defer src="js/keyboard_manager.js"></script>
 
     <!-- Bluetooth -->
     <script defer src="js/bluetooth.js"></script>
@@ -126,12 +132,6 @@
 
     <!-- z-indexes of all the overlays in the system -->
     <link rel="stylesheet" type="text/css" href="style/zindex.css">
-
-    <!-- Value selector -->
-    <link rel="stylesheet" type="text/css" href="style/value_selector/value_selector.css">
-    <link rel="stylesheet" type="text/css" href="style/value_selector/time_picker.css">
-    <script defer src="js/value_selector/value_picker.js"></script>
-    <script defer src="js/value_selector/value_selector.js"></script>
 
     <style>
     /* initlogo style is here to prevent flashing */

--- a/apps/system/js/cards_view/cards_view.js
+++ b/apps/system/js/cards_view/cards_view.js
@@ -450,6 +450,14 @@ var CardsView = (function() {
     },
   false);
 
+  window.addEventListener('home', function cv_homeEvent(evt) {
+    if (!cardSwitcherIsShown())
+      return;
+
+    hideCardSwitcher();
+    evt.stopImmediatePropagation();
+  });
+
   function cv_handleEvent(evt) {
     switch (evt.type) {
       case 'mousedown':

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -622,9 +622,7 @@ var WindowManager = (function() {
     // Note that for this to work, the lockscreen and other overlays must
     // be included in index.html before this one, so they can register their
     // event handlers before we do.
-    if (CardsView.cardSwitcherIsShown()) {
-      CardsView.hideCardSwitcher();
-    } else if (document.mozFullScreen) {
+    if (document.mozFullScreen) {
       document.mozCancelFullScreen();
     } else if (displayedApp !== homescreen) {
       setDisplayedApp(homescreen);


### PR DESCRIPTION
I find that many modules in system app handle and **dismiss** home event on their own.
Dismissing is according to module(js file) order in `index.html` now,
it is to say, the ordering of home event dismissing is incorrect.
It must base on zIndex -- UI ordering.

Also, the PR modify the home event handling of `CardsView` module, not living in `window manager` anymore.
