### PR TITLE
[SMS] Fix call to contact activity

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -600,10 +600,6 @@ var ThreadUI = {
     return this.doneButton = document.getElementById('messages-delete-button');
   },
 
-  get headerTitle() {
-    delete this.headerTitle;
-    return this.headerTitle = document.getElementById('header-text');
-  },
 
   get editHeader() {
       delete this.editHeader;
@@ -629,7 +625,7 @@ var ThreadUI = {
     this.contactInput.addEventListener('input', this.searchContact.bind(this));
     this.deleteButton.addEventListener('click',
                                        this.executeDeletion.bind(this));
-    this.headerTitle.addEventListener('click', this.activateContact.bind(this));
+    this.title.addEventListener('click', this.activateContact.bind(this));
     this.clearButton.addEventListener('click', this.clearContact.bind(this));
     this.view.addEventListener('click', this);
   },

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -79,6 +79,8 @@ var MessageManager = {
             } else {
               MessageManager.slide();
             }
+            // Update the data for next time we enter a thread
+            ThreadUI.title.removeAttribute('is-contact');
             break;
           case '#edit':
             ThreadListUI.cleanForm();
@@ -691,6 +693,9 @@ var ThreadUI = {
   updateHeaderData: function thui_updateHeaderData(number) {
     var self = this;
     self.title.innerHTML = number;
+    // Add data to contact activity interaction
+    self.title.setAttribute('phone-number', number);
+
     ContactDataManager.getContactData(number, function gotContact(contact) {
       //TODO what if return multiple contacts?
       var carrierTag = document.getElementById('contact-carrier');
@@ -703,6 +708,9 @@ var ThreadUI = {
             phone = contact[0].tel[i];
           }
         }
+        // Add data values for contact activity interaction
+        self.title.setAttribute('is-contact', true);
+
         if (name && name != '') { // contact with name
           self.title.innerHTML = name;
           carrierTag.innerHTML =
@@ -1221,14 +1229,30 @@ var ThreadUI = {
   },
 
   activateContact: function thui_activateContact() {
-    try {
-      //TODO: We should provide correct params for contact activiy handler.
-      var activity = new MozActivity({
+    var options = {};
+    // Call to 'new' or 'view' depending on existence of contact
+    if (this.title.getAttribute('is-contact') == 'true') {
+      //TODO modify this when 'view' activity is available on contacts
+      // options = {
+      //   name: 'view',
+      //   data: {
+      //     type: 'webcontacts/contact'
+      //   }
+      // };
+    } else {
+      options = {
         name: 'new',
         data: {
-          type: 'webcontacts/contact'
+          type: 'webcontacts/contact',
+          params: {
+            'tel': this.title.getAttribute('phone-number')
+          }
         }
-      });
+      };
+    }
+
+    try {
+      var activity = new MozActivity(options);
     } catch (e) {
       console.log('WebActivities unavailable? : ' + e);
     }

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -80,7 +80,7 @@ var MessageManager = {
               MessageManager.slide();
             }
             // Update the data for next time we enter a thread
-            ThreadUI.title.removeAttribute('data-is-contact');
+            delete ThreadUI.title.dataset.isContact;
             break;
           case '#edit':
             ThreadListUI.cleanForm();
@@ -540,8 +540,8 @@ var ThreadListUI = {
     // Create DOM Element
     var headerHTML = document.createElement('h2');
     // Append 'time-update' state
-    headerHTML.setAttribute('data-time-update', true);
-    headerHTML.setAttribute('data-time', timestamp);
+    headerHTML.dataset.timeUpdate = true;
+    headerHTML.dataset.time = timestamp;
     // Add text
     headerHTML.innerHTML = Utils.getHeaderDate(timestamp);
     //Add to DOM
@@ -683,8 +683,8 @@ var ThreadUI = {
     // Create DOM Element
     var headerHTML = document.createElement('h2');
     // Append 'time-update' state
-    headerHTML.setAttribute('data-time-update', true);
-    headerHTML.setAttribute('data-time', timestamp);
+    headerHTML.dataset.timeUpdate = true;
+    headerHTML.dataset.time = timestamp;
     // Add text
     headerHTML.innerHTML = Utils.getHeaderDate(timestamp);
     // Append to DOM
@@ -694,7 +694,7 @@ var ThreadUI = {
     var self = this;
     self.title.innerHTML = number;
     // Add data to contact activity interaction
-    self.title.setAttribute('data-phone-number', number);
+    self.title.dataset.phoneNumber = number;
 
     ContactDataManager.getContactData(number, function gotContact(contact) {
       //TODO what if return multiple contacts?
@@ -709,7 +709,7 @@ var ThreadUI = {
           }
         }
         // Add data values for contact activity interaction
-        self.title.setAttribute('data-is-contact', true);
+        self.title.dataset.isContact = true;
 
         if (name && name != '') { // contact with name
           self.title.innerHTML = name;

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -80,7 +80,7 @@ var MessageManager = {
               MessageManager.slide();
             }
             // Update the data for next time we enter a thread
-            ThreadUI.title.removeAttribute('is-contact');
+            ThreadUI.title.removeAttribute('data-is-contact');
             break;
           case '#edit':
             ThreadListUI.cleanForm();
@@ -694,7 +694,7 @@ var ThreadUI = {
     var self = this;
     self.title.innerHTML = number;
     // Add data to contact activity interaction
-    self.title.setAttribute('phone-number', number);
+    self.title.setAttribute('data-phone-number', number);
 
     ContactDataManager.getContactData(number, function gotContact(contact) {
       //TODO what if return multiple contacts?
@@ -709,7 +709,7 @@ var ThreadUI = {
           }
         }
         // Add data values for contact activity interaction
-        self.title.setAttribute('is-contact', true);
+        self.title.setAttribute('data-is-contact', true);
 
         if (name && name != '') { // contact with name
           self.title.innerHTML = name;
@@ -1231,7 +1231,7 @@ var ThreadUI = {
   activateContact: function thui_activateContact() {
     var options = {};
     // Call to 'new' or 'view' depending on existence of contact
-    if (this.title.getAttribute('is-contact') == 'true') {
+    if (this.title.getAttribute('data-is-contact') == 'true') {
       //TODO modify this when 'view' activity is available on contacts
       // options = {
       //   name: 'view',
@@ -1245,7 +1245,7 @@ var ThreadUI = {
         data: {
           type: 'webcontacts/contact',
           params: {
-            'tel': this.title.getAttribute('phone-number')
+            'tel': this.title.getAttribute('data-phone-number')
           }
         }
       };

--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -1231,7 +1231,7 @@ var ThreadUI = {
   activateContact: function thui_activateContact() {
     var options = {};
     // Call to 'new' or 'view' depending on existence of contact
-    if (this.title.getAttribute('data-is-contact') == 'true') {
+    if (this.title.dataset.isContact == 'true') {
       //TODO modify this when 'view' activity is available on contacts
       // options = {
       //   name: 'view',
@@ -1245,7 +1245,7 @@ var ThreadUI = {
         data: {
           type: 'webcontacts/contact',
           params: {
-            'tel': this.title.getAttribute('data-phone-number')
+            'tel': this.title.dataset.phoneNumber
           }
         }
       };


### PR DESCRIPTION
Now, when the number belongs to a contact, we don't make the call to the activity contacts, due to the lack of a 'view' option

When the contact doesn't exist, we call 'new' with phone number as parameter to populate the field on opening
