### PR TITLE
Issue 4314: ensure xulrunner sdk is installed before running webapp-zip rule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ webapp-manifests: install-xulrunner-sdk
 	@echo "Done"
 
 # Generate profile/webapps/APP/application.zip
-webapp-zip: stamp-commit-hash
+webapp-zip: stamp-commit-hash install-xulrunner-sdk
 ifneq ($(DEBUG),1)
 	@echo "Packaged webapps"
 	@rm -rf apps/system/camera


### PR DESCRIPTION
Oops, I forgot `install-xulrunner-sdk` for `wepapp-zip`.
Should solve:
https://github.com/mozilla-b2g/gaia/issues/4314
