### PR TITLE
add .xulrunner-url to clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,5 +561,5 @@ purge:
 
 # clean out build products
 clean:
-	rm -rf profile xulrunner-sdk
+	rm -rf profile xulrunner-sdk .xulrunner-url
 


### PR DESCRIPTION
I just realized that we should also clean out the xulrunner sdk download file in the clean target
