### PR TITLE
Fix bot.io by adding wget options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@
 ###############################################################################
 -include local.mk
 
-WGET_OPTS?=''
+# Headless bot does not need the full output of wget
+# and it can cause crashes in bot.io option is here so
+# -nv can be passed and turn off verbose output.
+WGET_OPTS?=
 GAIA_DOMAIN?=gaiamobile.org
 
 DEBUG?=0

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 ###############################################################################
 -include local.mk
 
+WGET_OPTS?=''
 GAIA_DOMAIN?=gaiamobile.org
 
 DEBUG?=0
@@ -112,7 +113,7 @@ DOWNLOAD_CMD = /usr/bin/curl -O
 else
 MD5SUM = md5sum -b
 SED_INPLACE_NO_SUFFIX = sed -i
-DOWNLOAD_CMD = wget
+DOWNLOAD_CMD = wget $(WGET_OPTS)
 endif
 
 # Test agent setup


### PR DESCRIPTION
bot.io's test process is crashing because of the volume of output by xulrunner install.
Add option (WGET_OPTS) to add -nv which will silence the download progress of xulrunner-sdk
