### PR TITLE
Switch keypad sample rate to 8000

### DIFF
--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -23,7 +23,7 @@ SettingsListener.observe('phone.ring.keypad', true, function(value) {
 });
 
 var TonePlayer = {
-  _sampleRate: 4000,
+  _sampleRate: 8000,
 
   init: function tp_init() {
     document.addEventListener('mozvisibilitychange',


### PR DESCRIPTION
4000 isn't supported in Android's OpenSL implementation, but 8000 is.
