### PR TITLE
Screen brightness changes due to device light sensor should be graceful

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -319,13 +319,8 @@ var ScreenManager = {
     }
 
     this.idleObserver.time = time;
-    // XXX: wrap addIdleObserver in try catch to workaround
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=781076
-    try {
-      navigator.addIdleObserver(this.idleObserver);
-    } catch (e) {
-      console.log(e);
-    }
+    navigator.addIdleObserver(this.idleObserver);
+    this.isIdleObserverInitialized = true;
   },
 
   fireScreenChangeEvent: function scm_fireScreenChangeEvent() {

--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -45,7 +45,7 @@ var ScreenManager = {
    * Preferred brightness without considering device light nor dimming
    * sync with setting 'screen.brightness'
   */
-  _brightness: 1,
+  _userBrightness: 1,
 
   /*
    * Wait for _dimNotice milliseconds during idle-screen-off
@@ -102,7 +102,7 @@ var ScreenManager = {
       self._idled = false;
       if (self._inTransition) {
         self._inTransition = false;
-        navigator.mozPower.screenBrightness = self._brightness;
+        self.setScreenBrightness(self._userBrightness, true);
       }
     };
 
@@ -122,24 +122,26 @@ var ScreenManager = {
         })();
 
         self._firstOn = true;
-        self.turnScreenOn();
+
+        // During boot up, the brightness was set by bootloader as 0.5,
+        // Let's set the API value to that so setScreenBrightness() can
+        // dim nicely to value set by user.
+        power.screenBrightness = 0.5;
+
+        // Turn screen on with dim.
+        self.turnScreenOn(false);
       }
     });
 
     SettingsListener.observe('screen.automatic-brightness', true,
     function deviceLightSettingChanged(value) {
-      if (typeof value === 'string')
-        value = (value == 'true');
-
       self.setDeviceLightEnabled(value);
     });
 
     SettingsListener.observe('screen.brightness', 1,
     function brightnessSettingChanged(value) {
-      if (typeof value === 'string')
-        value = parseFloat(value);
-
-      self.setBrightness(value);
+      self._userBrightness = value;
+      self.setScreenBrightness(value, false);
     });
   },
 
@@ -152,8 +154,8 @@ var ScreenManager = {
 
         // This is a rather naive but pretty effective heuristic
         var brightness =
-          Math.max(Math.min((evt.value / 1100), this._brightness), 0.2);
-        navigator.mozPower.screenBrightness = brightness;
+          Math.max(Math.min((evt.value / 1100), this._userBrightness), 0.1);
+        this.setScreenBrightness(brightness, false);
 
         break;
 
@@ -210,7 +212,7 @@ var ScreenManager = {
         return;
       }
 
-      navigator.mozPower.screenBrightness = screenBrightness;
+      self.setScreenBrightness(screenBrightness, true);
       setTimeout(dim, 10);
     };
 
@@ -221,7 +223,7 @@ var ScreenManager = {
       self._inTransition = false;
       self.screen.classList.add('screenoff');
       setTimeout(function realScreenOff() {
-        navigator.mozPower.screenBrightness = 0;
+        self.setScreenBrightness(0, true);
         navigator.mozPower.screenEnabled = false;
       }, 20);
 
@@ -238,18 +240,20 @@ var ScreenManager = {
     return true;
   },
 
-  turnScreenOn: function scm_turnScreenOn() {
+  turnScreenOn: function scm_turnScreenOn(instant) {
     if (this.screenEnabled)
       return false;
 
     window.addEventListener('devicelight', this);
     window.addEventListener('mozfullscreenchange', this);
 
+    this.setScreenBrightness(this._userBrightness, instant);
+
     var power = navigator.mozPower;
-    if (power) {
-      navigator.mozPower.screenEnabled = this.screenEnabled = true;
-      navigator.mozPower.screenBrightness = this._brightness;
-    }
+    if (power)
+      power.screenEnabled = true;
+
+    this.screenEnabled = true;
     this.screen.classList.remove('screenoff');
 
     // The screen should be turn off with shorter timeout if
@@ -269,23 +273,47 @@ var ScreenManager = {
     return true;
   },
 
-  setBrightness: function scm_setBrightness(brightness) {
-    this._brightness = brightness;
+  setScreenBrightness: function scm_setScreenBrightness(brightness, instant) {
+    this._targetBrightness = brightness;
     var power = navigator.mozPower;
     if (!power)
       return;
 
-    /* Disregard devicelight value here and be responsive to setting changes.
-    * Actual screen brightness will be updated shortly
-    * with next devicelight event.
-    */
-    navigator.mozPower.screenBrightness = this._brightness;
+    if (typeof instant !== 'boolean')
+      instant = true;
+
+    if (instant) {
+      power.screenBrightness = brightness;
+      return;
+    }
+
+    this.dim();
+  },
+
+  dim: function scm_dim() {
+    var self = this;
+    var screenBrightness = navigator.mozPower.screenBrightness;
+
+    if (Math.abs(this._targetBrightness - screenBrightness) < 0.05)
+      return;
+
+    var dalta = 0.02;
+    if (screenBrightness > this._targetBrightness)
+      dalta *= -1;
+
+    screenBrightness += dalta;
+    navigator.mozPower.screenBrightness = screenBrightness;
+
+    clearTimeout(this._dimTimer);
+    this._dimTimer = setTimeout(function() {
+      self.dim();
+    }, 10);
   },
 
   setDeviceLightEnabled: function scm_setDeviceLightEnabled(enabled) {
-    if (!enabled && this._deviceLightEnabled && navigator.mozPower) {
+    if (!enabled && this._deviceLightEnabled) {
       // Disabled -- set the brightness back to preferred brightness
-      navigator.mozPower.screenBrightness = this._brightness;
+      this.setScreenBrightness(this._userBrightness, false);
     }
     this._deviceLightEnabled = enabled;
   },

--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -190,34 +190,12 @@ var ScreenManager = {
     if (!this.screenEnabled)
       return false;
 
-    window.removeEventListener('devicelight', this);
-    window.removeEventListener('mozfullscreenchange', this);
-
     var self = this;
-    var screenBrightness = navigator.mozPower.screenBrightness;
-
-    var dim = function scm_dim() {
-      if (!self._inTransition)
-        return;
-
-      screenBrightness -= 0.02;
-
-      if (screenBrightness < 0.1) {
-        setTimeout(function noticeTimeout() {
-          if (!self._inTransition)
-            return;
-
-          finish();
-        }, self._dimNotice);
-        return;
-      }
-
-      self.setScreenBrightness(screenBrightness, true);
-      setTimeout(dim, 10);
-    };
-
-    var finish = function scm_finish() {
+    var screenOff = function scm_screenOff() {
       self.setIdleTimeout(0);
+
+      window.removeEventListener('devicelight', this);
+      window.removeEventListener('mozfullscreenchange', this);
 
       self.screenEnabled = false;
       self._inTransition = false;
@@ -231,11 +209,18 @@ var ScreenManager = {
     };
 
     if (instant) {
-      finish();
-    } else {
-      this._inTransition = true;
-      dim();
+      screenOff();
+      return true;
     }
+
+    this.setScreenBrightness(0.1, false);
+    this._inTransition = true;
+    setTimeout(function noticeTimeout() {
+      if (!self._inTransition)
+        return;
+
+      screenOff();
+    }, self._dimNotice);
 
     return true;
   },

--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -244,7 +244,7 @@ var ScreenManager = {
     // The screen should be turn off with shorter timeout if
     // it was never unlocked
     if (LockScreen.locked) {
-      this.setIdleTimeout(10 * 1000);
+      this.setIdleTimeout(10);
       var self = this;
       window.addEventListener('unlock', function scm_unlocked() {
         window.removeEventListener('unlock', scm_unlocked);


### PR DESCRIPTION
and,
- Real fix of #2166: Shorter screen off time if lock screen is never unlocked (correction error made in #3858)
- Revert workaround for #3268 since https://bugzilla.mozilla.org/show_bug.cgi?id=781076 is fixed
