### PR TITLE
Operator variant mechanism. Set Voicemail number.

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -79,7 +79,8 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
   var voicemail = navigator.mozVoicemail;
   if (voicemail) {
     if (voicemail.number == number) {
-      node.textContent = voicemail.displayName;
+      node.textContent = voicemail.displayName ?
+        voicemail.displayName : number;
       return;
     }
   }

--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -478,7 +478,7 @@ var KeypadManager = {
      if (!settings) {
       return;
      }
-     var transaction = settings.getLock();
+     var transaction = settings.createLock();
      var request = transaction.get("ro.moz.ril.iccmbdn");
      request.onsuccess = function() {
        if (request.result["ro.moz.ril.iccmbdn"]) {

--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -472,6 +472,19 @@ var KeypadManager = {
      var voicemail = navigator.mozVoicemail;
      if (voicemail && voicemail.number) {
        CallHandler.call(voicemail.number);
+       return;
      }
+     var settings = navigator.mozSettings;
+     if (!settings) {
+      return;
+     }
+     var transaction = settings.getLock();
+     var request = transaction.get("ro.moz.ril.iccmbdn");
+     request.onsuccess = function() {
+       if (request.result["ro.moz.ril.iccmbdn"]) {
+         CallHandler.call(request.result["ro.moz.ril.iccmbdn"]);
+       }
+     };
+     request.onerror = function() {};
   }
 };

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -130,6 +130,9 @@
     <!-- Payment -->
     <script defer src="js/payment.js"></script>
 
+    <!-- Operator Variant Mechanism -->
+    <script defer src="js/operator_variant/operator_variant.js"></script>
+
     <!-- Windows -->
     <!-- Any module that wants to intercept the Home button and prevent the -->
     <!-- homescreen from being displayed must come before this script. -->

--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -1,0 +1,116 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+(function OperatorVariant() {
+  var gNetwork = null;
+  var cset = null;
+
+  // Ensure Home Network Identity data.
+  function ensureHNI() {
+    var iccInfo = mobileConnection.iccInfo;
+    if (!iccInfo) {
+      return;
+    }
+
+    if (gNetwork && gNetwork.mcc == iccInfo.mcc && gNetwork.mnc == iccInfo.mnc) {
+      return;
+    }
+
+    gNetwork = {};
+    gNetwork.mcc = iccInfo.mcc;
+    gNetwork.mnc = iccInfo.mnc;
+    applyOperatorVariantSettings();
+  };
+
+  function handleSettingsReady(key, value) {
+    cset[key] = value;
+    ensureHNI();
+    applyOperatorVariantSettings();
+  };
+
+  function applyOperatorVariantSettings() {
+    if (!cset["operatorvariant.mcc"] ||
+        !cset["operatorvariant.mnc"]) {
+      return;
+    }
+    if ((gNetwork.mcc == cset["operatorvariant.mcc"]) &&
+        (gNetwork.mnc == cset["operatorvariant.mnc"])) {
+      return;
+    }
+
+    cset["operatorvariant.mnc"] = gNetwork.mnc;
+    cset["operatorvariant.mcc"] = gNetwork.mcc;
+    retrieveOperatorVariantSettings();
+    storeSettings();
+  };
+
+  function retrieveOperatorVariantSettings() {
+    var OPERATOR_VARIANT_FILE = 'serviceproviders.xml';
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', OPERATOR_VARIANT_FILE, false);
+    xhr.send();
+
+    // Set specific operator settings. Add them here.
+
+    // At the moment we set voicemail number to be used for the dialer app 
+    // if it's not in the ICC card.
+    var voicemailResult = querySettings(xhr.responseXML,
+                                        cset["operatorvariant.mcc"],
+                                        cset["operatorvariant.mnc"],
+                                        "voicemail");
+    var voicemailNode = voicemailResult.iterateNext();
+    cset["ro.moz.ril.iccmbdn"] = voicemailNode.textContent;
+  };
+
+  function querySettings(document, mcc, mnc, setting) {
+    var query = '//gsm[network-id[@mcc=' + mcc + '][@mnc=' + mnc + ']]/' + setting;
+    var xpe = new XPathEvaluator();
+    var nsResolver = xpe.createNSResolver(document);
+    return xpe.evaluate(query, document, nsResolver, 0, null);
+  };
+
+  function storeSettings() {
+    var transaction = settings.getLock();
+    transaction.set(cset);
+  };
+
+  function onerrorRequest() {
+  };
+
+  var settings = window.navigator.mozSettings;
+  if (!settings) {
+    return;
+  }
+  var mobileConnection = window.navigator.mozMobileConnection;
+  if (!mobileConnection) {
+    return;
+  }
+
+  cset = {};
+  var transaction = settings.getLock();
+
+  var mcc_request = transaction.get("operatorvariant.mcc");
+  mcc_request.onsuccess = function() {
+    var value = -1;
+    if (mcc_request.result["operatorvariant.mcc"]) {
+      value = mcc_request.result["operatorvariant.mcc"];
+    }
+    handleSettingsReady("operatorvariant.mcc", value);
+  };
+  mcc_request.onerror = onerrorRequest;
+
+  var mnc_request = transaction.get("operatorvariant.mnc");
+  mnc_request.onsuccess = function() {
+    var value = -1;
+    if (mnc_request.result["operatorvariant.mnc"]) {
+      value = mnc_request.result["operatorvariant.mnc"];
+    }
+    handleSettingsReady("operatorvariant.mnc", value);
+  };
+  mnc_request.onerror = onerrorRequest;
+
+  mobileConnection.addEventListener('iccinfochange', ensureHNI);
+})();

--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -73,7 +73,7 @@
   };
 
   function storeSettings() {
-    var transaction = settings.getLock();
+    var transaction = settings.createLock();
     transaction.set(cset);
   };
 
@@ -90,7 +90,7 @@
   }
 
   cset = {};
-  var transaction = settings.getLock();
+  var transaction = settings.createLock();
 
   var mcc_request = transaction.get("operatorvariant.mcc");
   mcc_request.onsuccess = function() {

--- a/apps/system/serviceproviders.xml
+++ b/apps/system/serviceproviders.xml
@@ -1,0 +1,11021 @@
+<?xml version="1.0"?>
+<!-- -*- Mode: XML; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4 -*- -->
+<!DOCTYPE serviceproviders SYSTEM "serviceproviders.2.dtd">
+
+<!-- Authors:
+     2008 Antti Kaijanmäki <antti@kaijanmaki.net>
+     2009 Dan Williams <dcbw@redhat.com>
+     2011 Antti Kaijanmäki <antti@canonical.com>
+-->
+
+<!-- THIS WORK IS IN PUBLIC DOMAIN:
+The person or persons who have associated work with this document
+(the "Dedicator" or "Certifier") hereby either (a) certifies that, to the best
+of his knowledge, the work of authorship identified is in the public domain of
+the country from which the work is published, or (b) hereby dedicates whatever
+copyright the dedicators holds in the work of authorship identified below
+(the "Work") to the public domain. A certifier, moreover, dedicates any
+copyright interest he may have in the associated work, and for these purposes,
+is described as a "dedicator" below.
+
+A certifier has taken reasonable steps to verify the copyright status of this
+work. Certifier recognizes that his good faith efforts may not shield him from
+liability if in fact the work certified is not in the public domain.
+
+Dedicator makes this dedication for the benefit of the public at large and to
+the detriment of the Dedicator's heirs and successors. Dedicator intends this
+dedication to be an overt act of relinquishment in perpetuity of all present
+and future rights under copyright law, whether vested or contingent, in the
+Work. Dedicator understands that such relinquishment of all rights includes the
+relinquishment of all rights to enforce (by lawsuit or otherwise) those
+copyrights in the Work.
+
+Dedicator recognizes that, once placed in the public domain, the Work may be
+freely reproduced, distributed, transmitted, used, modified, built upon, or
+otherwise exploited by anyone for any purpose, commercial or non-commercial,
+and in any way, including by methods that have not yet been invented or
+conceived.
+-->
+
+<serviceproviders format="2.0">
+
+<!-- United Arab Emirates -->
+<country code="ae">
+	<provider>
+		<name>Etisalat</name>
+		<gsm>
+			<network-id mcc="424" mnc="02"/>
+			<apn value="mnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Etisalat</name>
+				<username>mnet</username>
+				<password>mnet</password>
+				<dns>194.170.1.6</dns>
+				<dns>194.170.1.7</dns>
+			</apn>
+			<apn value="etisalat.ae">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Etisalat 3G</name>
+				<username>etisalat.ae</username>
+				<password>etisalat.ae</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>du</name>
+		<gsm>
+			<network-id mcc="424" mnc="03"/>
+			<msisdn-query>
+				<ussd>*#100#</ussd>
+			</msisdn-query>
+			<apn value="du">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Afghanistan -->
+<country code="af">
+	<provider>
+		<name>AWCC</name>
+		<gsm>
+			<network-id mcc="412" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>awcc</username>
+				<password>1111</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Albania -->
+<country code="al">
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="276" mnc="02"/>
+			<apn value="Twa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>TWA</name>
+			</apn>
+			<apn value="vodafoneweb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vodafone Web</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Armenia -->
+<country code="am">
+	<provider>
+		<name>Beeline</name>
+		<gsm>
+			<network-id mcc="283" mnc="01"/>
+			<apn value="internet.beeline.am">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="283" mnc="10"/>
+			<apn value="internet.orange">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Hima (USB)</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>VivaCell/MTS</name>
+		<gsm>
+			<network-id mcc="283" mnc="05"/>
+			<apn value="connect.vivacell.am">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>MTS connect</name>
+			</apn>
+			<apn value="inet.vivacell.am">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+
+<!-- Angola -->
+<country code="ao">
+	<provider>
+		<name>Movinet</name>
+		<cdma>
+			<username>uname</username>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Unitel</name>
+		<gsm>
+			<network-id mcc="631" mnc="02"/>
+			<apn value="internet.unitel.co.ao" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Argentina -->
+<country code="ar">
+	<provider>
+		<name>Personal</name>
+		<gsm>
+			<network-id mcc="722" mnc="341"/>
+			<apn value="gprs.personal.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>gprs</username>
+				<password>adgj</password>
+				<dns>172.25.7.6</dns>
+				<dns>172.25.7.7</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Arnet</name>
+		<gsm>
+			<network-id mcc="722" mnc="340"/>
+			<apn value="arnet.personal.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>172.25.7.6</dns>
+				<dns>172.25.7.7</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="722" mnc="310"/>
+			<network-id mcc="722" mnc="320"/>
+			<network-id mcc="722" mnc="330"/>
+			<apn value="gprs.claro.com.ar">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G Internet</name>
+				<username>clarogprs</username>
+				<password>clarogprs999</password>
+				<dns>170.51.255.100</dns>
+				<dns>170.51.242.18</dns>
+			</apn>
+			<apn value="internet.ctimovil.com.ar">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<username>clarogprs</username>
+				<password>clarogprs999</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="722" mnc="010"/>
+			<network-id mcc="722" mnc="070"/>
+			<apn value="internet.gprs.unifon.com.ar">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Austria -->
+<country code="at">
+	<provider>
+		<name>A1/Telekom Austria</name>
+		<gsm>
+			<!-- Vodafone Broadband Connect version 10.1.0.23908 2010-06-07T17:47:01 -->
+			<network-id mcc="232" mnc="01"/>
+			<apn value="a1.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>A1 Breitband</name>
+				<username>ppp@a1plus.at</username>
+				<password>ppp</password>
+				<dns>194.48.124.202</dns>
+				<dns>194.48.124.200</dns>
+			</apn>
+			<!-- https://www.aon.at/export/sites/default/residential/pdf/produktfolder/aonFlex_Mobiltelefon.pdf-->
+			<apn value="aon.data">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>aon (Flex, Breitband-Duo, BusinessFlex)</name>
+				<username>mobile@aon.at</username>
+				<password>ppp</password>
+			</apn>
+			<!-- http://konfigurator.aon.at/otauseraon/templates/user/aon/manuals/AON_Installation.pdf -->
+			<apn value="aon.at">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>aonMobile</name>
+				<username>mobile@aon.at</username>
+				<password>ppp</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>ABroadband</name>
+		<gsm>
+			<network-id mcc="232" mnc="01"/>
+			<apn value="mdata.com">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>International Roaming</name>
+				<username>mdata@mdata.com</username>
+				<password>ppp</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Bob</name>
+		<gsm>
+			<network-id mcc="232" mnc="11"/>
+			<apn value="bob.at">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>data@bob.at</username>
+				<password>ppp</password>
+			</apn>
+			<apn value="bob.at">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>ppp@bob.at</username>
+				<password>ppp</password>
+				<dns>194.48.139.254</dns>
+				<dns>194.48.124.200</dns>
+			</apn>
+			<apn value="mms.bob.at">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>data@bob.at</username>
+				<password>ppp</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="232" mnc="03"/>
+			<apn value="gprswap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>t-mobile</username>
+				<password>tm</password>
+			</apn>
+			<apn value="gprsinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<username>t-mobile</username>
+				<password>tm</password>
+				<dns>213.162.69.169</dns>
+				<dns>213.162.65.1</dns>
+			</apn>
+			<apn value="business.gprsinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Business Internet</name>
+				<username>t-mobile</username>
+				<password>tm</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>tele.ring</name>
+		<gsm>
+			<network-id mcc="232" mnc="07"/>
+			<apn value="web">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Ge org:)</name>
+				<username>web@telering.at</username>
+				<password>web</password>
+				<dns>213.162.69.170</dns>
+				<dns>213.162.65.2</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="232" mnc="05"/>
+			<apn value="web.one.at">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>OneNet Web</name>
+				<username>web</username>
+				<password>web</password>
+				<dns>194.24.128.100</dns>
+				<dns>194.24.128.102</dns>
+			</apn>
+			<apn value="wap.one.at">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>Orange WAP</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+			<apn value="mms.one.at">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Orange MMS</name>
+				<username>mms</username>
+				<password>mms</password>
+			</apn>
+			<apn value="fullspeed">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web (no filtering)</name>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+			<apn value="orange.web">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Orange Web</name>
+				<username>Orange</username>
+				<password>Orange</password>
+				<dns>81.3.216.100</dns>
+				<dns>194.24.128.100</dns>
+			</apn>
+			<apn value="orange.mms">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Orange Web</name>
+				<username>mms</username>
+				<password>mms</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Drei (3)</name>
+		<name xml:lang="de">Drei</name>
+		<gsm>
+			<network-id mcc="232" mnc="10"/>
+			<apn value="drei.at">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.94.78.17</dns>
+				<dns>213.94.78.16</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Yesss</name>
+		<gsm>
+			<network-id mcc="232" mnc="12"/>
+			<apn value="web.yesss.at">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Australia -->
+<!-- http://whirlpool.net.au/wiki/mobiles_apn
+     http://ausdroid.net/apns/ -->
+<country code="au">
+	<provider>
+		<name>Amaysim</name>
+		<!-- http://www.amaysim.com.au/help-support/amaysim-mobile-broadband.html/ -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="internet"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Apex Telecom</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="splns357"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Beagle</name>
+		<!-- http://www.beagle.com.au/support/faq/wireless.html -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="splns357"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>BLiNK</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="splns888a1">
+				<name>BLiNK (services after 04/08/09)</name>
+			</apn>
+			<apn value="connect">
+				<name>BLiNK (services prior to 04/08/09)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Crazy John's</name>
+		<gsm>
+			<network-id mcc="505" mnc="03"/>
+			<network-id mcc="505" mnc="38"/>
+			<apn value="purtona.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Crazy NET</name>
+				<dns>203.21.112.40</dns>
+				<dns>203.21.113.40</dns>
+			</apn>
+			<apn value="purtona.wap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>Crazy WAP/MMS</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Dodo</name>
+		<!-- http://www.dodo.com/top-right-navigation/support/technical-support/wireless-broadband/wireless-broadband-settings/ -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="WirelessBroadband">
+				<name>Postpaid</name>
+			</apn>
+			<apn value="DODOLNS1">
+				<name>Prepaid</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Escape Net</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="splns357"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Exetel</name>
+		<!-- http://www.exetel.com.au/mobile_faq.php -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="exetel1">
+				<name>Exetel (Optus Based HSPA plans)</name>
+			</apn>
+			<apn value="INTERNET">
+				<name>Exetel (Optus Based CAP Plans) not iPhone</name>
+			</apn>
+			<apn value="OPTUSWAP">
+				<name>Exetel (Optus Based CAP Plans) not iPhone</name>
+			</apn>
+			<apn value="YesINTERNET">
+				<name>Exetel (Optus Based CAP Plans) iPhone</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Exetel (Vodafone based)</name>
+		<gsm>
+			<network-id mcc="505" mnc="03"/>
+			<apn value="vfinternet.au">
+				<name>Exetel (Vodafone Based)</name>
+			</apn>
+		</gsm>
+	</provider>
+<!-- Not validated yet
+	<provider>
+		<name>GRL / Red Bull Mobile</name>
+		<gsm>
+			<network-id mcc="505" mnc="03"/>
+			<apn value="purtona.net"/>
+		</gsm>
+	</provider>
+-->
+	<provider>
+		<name>Highway1</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="splns357"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>iiNet</name>
+		<!-- https://iihelp.iinet.net.au/BoB_MBB -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="iinet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Internode</name>
+		<gsm>
+			<!-- http://www.internode.on.net/residential/broadband/3g_wireless/nodemobile_data/faq/#What_is_the_APN -->
+			<network-id mcc="505" mnc="02"/>
+			<apn value="internode">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>NodeMobile Data</name>
+			</apn>
+			<apn value="splns333a1">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old NodeMobile Data (before 2009-08-26)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>iPrimus</name>
+		<!-- http://support.iprimus.com.au/index.php?option=com_content&task=view&id=559&Itemid=203 -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="primuslns1"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Optus</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet (handsets)</name>
+				<dns>211.29.132.12</dns>
+				<dns>198.142.0.51</dns>
+			</apn>
+			<apn value="yesinternet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Optus Yes Internet</name>
+				<dns>211.29.132.12</dns>
+				<dns>198.142.0.51</dns>
+			</apn>
+			<apn value="connect">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Wireless Broadband</name>
+				<dns>211.29.132.12</dns>
+				<dns>198.142.0.51</dns>
+			</apn>
+			<apn value="connectcap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Post-Paid Mobile Broadband</name>
+				<dns>211.29.132.12</dns>
+				<dns>198.142.0.51</dns>
+			</apn>
+			<apn value="preconnect">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Pre-Paid Mobile Broadband</name>
+				<dns>211.29.132.12</dns>
+				<dns>198.142.0.51</dns>
+			</apn>
+			<apn value="mms">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Optus MMS</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TPG Mobile</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="yesinternet">
+				<name>TPG (iPhone)</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>TPG (all except iPhone)</name>
+			</apn>
+			<apn value="mms">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>MMS</name>
+			</apn>
+		</gsm>
+	</provider>
+<!-- not yet validated
+	<provider>
+		<name>Pacnet – Optus</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="pacnet"/>
+			<apn value="internet"/>
+		</gsm>
+	</provider>
+-->
+	<provider>
+		<name>Pennytel</name>
+		<!-- https://www.pennytel.com.au/faqs?f-answer-search=apn&x=0&y=0 -->
+		<gsm>
+			<network-id mcc="505" mnc="03"/>
+			<apn value="live.vodafone.com">
+				<name>Pennytel (Vodafone) live.vodafone.com</name>
+			</apn>
+			<apn value="vfinternet.au">
+				<name>Pennytel (Vodafone) vfinternet.au</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Smelly Black Dog</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="splns357"/>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telstra</name>
+		<gsm>
+			<network-id mcc="505" mnc="01"/>
+			<balance-check>
+				<dtmf>125111</dtmf>
+				<dtmf>1258888</dtmf>
+				<ussd-response>*100#</ussd-response>
+			</balance-check>
+			<apn value="telstra.wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>139.130.4.4</dns>
+				<dns>203.50.2.71</dns>
+			</apn>
+			<apn value="telstra.datapack">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Telstra (3G data pack)</name>
+				<password>Telstra</password>
+				<dns>139.130.4.4</dns>
+				<dns>203.50.2.71</dns>
+			</apn>
+			<apn value="telstra.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Telstra (Next G)</name>
+				<dns>10.4.85.138</dns>
+				<dns>10.4.176.234</dns>
+			</apn>
+			<apn value="telstra.pcpack">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Telstra (3G PC pack - pay by time)</name>
+				<password>Telstra</password>
+				<dns>139.130.4.4</dns>
+				<dns>203.50.2.71</dns>
+			</apn>
+			<apn value="telstra.iph">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>Telstra Internet/Wap</name>
+			</apn>
+			<apn value="telstra.mms">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Telstra MMS</name>
+			</apn>
+			<apn value="telstra.bigpond">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Telstra BigPond</name>
+				<!-- username/password per-user -->
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Three</name>
+		<gsm>
+			<network-id mcc="505" mnc="06"/>
+			<apn value="3netaccess">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>a</username>
+				<password>a</password>
+				<dns>202.124.68.130</dns>
+				<dns>202.124.76.66</dns>
+			</apn>
+			<apn value="3services">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Three Prepaid</name>
+				<username>a</username>
+				<password>a</password>
+				<dns>202.124.68.130</dns>
+				<dns>202.124.76.66</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Virgin Mobile</name>
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="VirginInternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+				<username>guest</username>
+				<password>guest</password>
+				<dns>61.88.88.88</dns>
+			</apn>
+			<apn value="VirginBroadband">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<!-- http://www.vodafone.com.au/personal/mobile-broadband/modem-setup/index.htm -->
+			<network-id mcc="505" mnc="03"/>
+			<apn value="vfinternet.au">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid and some prepaid phone plans</name>
+			</apn>
+			<!-- username/password included in Vodafone Broadband Connect version 10.1.0.23908 2010-06-07T17:47:01 -->
+			<!-- username/password not on site http://www.vodafone.com.au/personal/mobile-broadband/modem-setup/index.htm -->
+			<apn value="vfprepaymbb">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+				<!-- username>web</username -->
+				<!-- password>web</password -->
+				<dns>203.21.112.40</dns>
+				<dns>203.21.113.40</dns>
+			</apn>
+			<apn value="live.vodafone.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vodafone Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Westnet</name>
+		<!-- http://myhelp.westnet.com.au/pages/releaseview.action;jsessionid=2C8E8DAB3826667BAA24105E467B31DF?pageId=17073209#FAQs-WestnetMobilePhone-link31 -->
+		<gsm>
+			<network-id mcc="505" mnc="02"/>
+			<apn value="yesinternet">
+				<name>Westnet (iPhone)</name>
+			</apn>
+			<apn value="internet">
+				<name>Westnet (all except iPhone)</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Azerbaijan -->
+<country code="az">
+	<provider>
+		<name>Azercell</name>
+		<gsm>
+			<network-id mcc="400" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Bakcell</name>
+		<gsm>
+			<network-id mcc="400" mnc="02"/>
+			<apn value="mms">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Azerfon</name>
+		<gsm>
+			<network-id mcc="400" mnc="04"/>
+			<msisdn-query>
+				<ussd>*100#3#</ussd>
+			</msisdn-query>
+			<apn value="azerfon">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Bosnia & Herzegovina -->
+<country code="ba">
+	<provider>
+		<name>BH GSM</name>
+		<gsm>
+			<network-id mcc="218" mnc="90"/>
+			<apn value="mms.bhmobile.ba">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>m:tel</name>
+		<gsm>
+			<network-id mcc="218" mnc="05"/>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<apn value="mtelgprs1">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Package 1</name>
+				<dns>81.93.67.2</dns>
+				<dns>81.93.67.3</dns>
+			</apn>
+			<apn value="mtelgprs2">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Package 2</name>
+				<dns>81.93.67.2</dns>
+				<dns>81.93.67.3</dns>
+			</apn>
+			<apn value="mtelgprs3">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Package 3</name>
+				<dns>81.93.67.2</dns>
+				<dns>81.93.67.3</dns>
+			</apn>
+			<apn value="mtelgprs4">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Package 4</name>
+				<dns>81.93.67.2</dns>
+				<dns>81.93.67.3</dns>
+			</apn>
+			<apn value="mtelfun">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+				<dns>81.93.67.2</dns>
+				<dns>81.93.67.3</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>HT-ERONET</name>
+		<gsm>
+			<network-id mcc="218" mnc="03"/>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<apn value="gprs.eronet.ba">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Barbados -->
+<country code="bb">
+	<provider>
+		<name>Digicel</name>
+		<gsm>
+			<network-id mcc="342" mnc="750"/>
+			<apn value="isp.digicelbarbados.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Bangladesh -->
+<country code="bd">
+	<provider>
+		<name>Robi (AKTel)</name>
+		<gsm>
+			<network-id mcc="470" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<dns>192.168.23.7</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Banglalink</name>
+		<gsm>
+			<network-id mcc="470" mnc="03"/>
+			<apn value="blweb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web</name>
+				<dns>10.10.55.34</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>GrameenPhone</name>
+		<gsm>
+			<network-id mcc="470" mnc="01"/>
+			<apn value="gpinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>202.56.4.120</dns>
+				<dns>202.56.4.121</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Warid</name>
+		<gsm>
+			<network-id mcc="470" mnc="07"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<dns>10.6.0.2</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Citycell</name>
+		<cdma>
+			<username>waps</username>
+			<password>waps</password>
+			<dns>117.18.224.146</dns>
+			<dns>117.18.224.147</dns>
+			<sid value="13480"/>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Belgium -->
+<country code="be">
+	<provider>
+		<name>Mobistar</name>
+		<gsm>
+			<network-id mcc="206" mnc="10"/>
+			<voicemail>5555</voicemail>
+			<balance-check>
+				<ussd>#123#</ussd>
+			</balance-check>
+			<apn value="web.pro.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Business</name>
+				<username>mobistar</username>
+				<password>mobistar</password>
+				<dns>212.65.63.10</dns>
+				<dns>212.65.63.145</dns>
+			</apn>
+			<apn value="internet.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Personal</name>
+				<username>mobistar</username>
+				<password>mobistar</password>
+				<dns>212.65.63.10</dns>
+				<dns>212.65.63.145</dns>
+			</apn>
+			<apn value="iew.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere</name>
+				<username>mobistar</username>
+				<password>mobistar</password>
+				<dns>212.224.255.252</dns>
+				<dns>212.65.63.217</dns>
+			</apn>
+			<apn value="mworld.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mobistar</username>
+				<password>mobistar</password>
+				<dns>212.65.63.10</dns>
+				<dns>212.65.63.145</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telenet Mobile</name>
+		<gsm>
+			<network-id mcc="206" mnc="10"/>
+			<apn value="mobile.internet.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old Walk &amp; Surf</name>
+			</apn>
+			<apn value="telenetwap.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Walk &amp; Talk</name>
+			</apn>
+			<apn value="telenetwap.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Walk &amp; Surf</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="206" mnc="10"/>
+			<apn value="orangeinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Proximus</name>
+		<gsm>
+			<network-id mcc="206" mnc="01"/>
+			<voicemail>1230</voicemail>
+			<!-- no balancecheck method ('auto-recharge') -->
+			<apn value="internet.proximus.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Inter</name>
+				<dns>195.238.2.21</dns>
+				<dns>81.169.60.107</dns>
+			</apn>
+			<apn value="intraprox.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Intra</name>
+				<dns>195.238.2.21</dns>
+				<dns>195.238.2.22</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Base</name>
+		<gsm>
+			<network-id mcc="206" mnc="20"/>
+			<voicemail>1933</voicemail>
+			<!-- no balancecheck method ('auto-recharge') -->
+			<apn value="gprs.base.be">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>base</username>
+				<password>base</password>
+				<dns>195.130.131.139</dns>
+				<dns>212.53.4.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Bulgaria -->
+<country code="bg">
+	<provider>
+		<name>GloBul</name>
+		<gsm>
+			<network-id mcc="284" mnc="05"/>
+			<voicemail>120</voicemail>
+			<balance-check>
+				<ussd>*125#</ussd>
+			</balance-check>
+			<apn value="internet.globul.bg">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>globul</username>
+				<dns>192.168.88.11</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>M-Tel</name>
+		<gsm>
+			<network-id mcc="284" mnc="01"/>
+			<voicemail>131</voicemail>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<!-- username/password not included in Vodafone Broadband Connect version 10.1.0.23908 2010-06-07T17:47:01 -->
+			<apn value="inet-gprs.mtel.bg">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.226.7.34</dns>
+				<dns>213.226.7.35</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vivacom</name>
+		<gsm>
+			<network-id mcc="284" mnc="03"/>
+			<voicemail>110</voicemail>
+			<balance-check>
+				<ussd>*102#</ussd>
+			</balance-check>
+			<apn value="internet.vivacom.bg">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<!-- http://www.vivacom.bg/en/residential/help_and_advice/common_questions/mobile_postpaid/8/ -->
+				<name>Vivacom Internet (Postpaid)</name>
+				<username>vivacom</username>
+				<password>vivacom</password>
+			</apn>
+			<apn value="internet.vivatel.bg">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vivatel (old)</name>
+				<username>vivatel</username>
+				<password>vivatel</password>
+				<dns>192.168.123.123</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Bahrain -->
+<country code="bh">
+	<provider>
+		<name>Batelco</name>
+		<gsm>
+			<network-id mcc="426" mnc="01"/>
+			<apn value="internet.batelco.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>oNet</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Zain BH</name>
+		<gsm>
+			<network-id mcc="426" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+			<apn value="hsdpa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>eGO</name>
+				<username>hsdpa</username>
+				<password>hsdpa</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>STC</name>
+		<gsm>
+			<network-id mcc="426" mnc="04"/>
+			<apn value="viva.bh">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Viva</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Brazil -->
+<country code="br">
+	<provider>
+		<!-- Brasil Telecom was bought by Oi on 2009-01-09 and will be phased
+		     out and transitioned to Oi.
+		  -->
+		<name>Brasil Telecom</name>
+		<gsm>
+			<network-id mcc="724" mnc="16"/>
+			<apn value="brt.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>BrT</username>
+				<password>BrT</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="724" mnc="05"/>
+			<voicemail>*100</voicemail>
+			<balance-check>
+				<ussd>*544#</ussd>
+				<ussd>*545#</ussd>
+				<ussd>*546#</ussd>
+			</balance-check>
+			<apn value="claro.com.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>claro</username>
+				<password>claro</password>
+			</apn>
+			<apn value="bandalarga.claro.com.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G</name>
+				<username>claro</username>
+				<password>claro</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>CTBC</name>
+		<gsm>
+			<network-id mcc="724" mnc="07"/>
+			<network-id mcc="724" mnc="32"/>
+			<network-id mcc="724" mnc="33"/>
+			<network-id mcc="724" mnc="34"/>
+			<balance-check>
+				<dtmf>*22</dtmf>
+			</balance-check>
+			<apn value="ctbc.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>ctbc</username>
+				<password>1212</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Oi</name>
+		<gsm>
+			<network-id mcc="724" mnc="16"/>
+			<network-id mcc="724" mnc="31"/>
+			<network-id mcc="724" mnc="24"/>
+			<voicemail>*100</voicemail>
+			<balance-check>
+				<dtmf>*804</dtmf>
+				<dtmf>*805</dtmf>
+			</balance-check>
+			<apn value="gprs.oi.com.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<password>oioioi</password>
+			</apn>
+			<apn value="wapgprs.oi.com.br">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>oiwap</username>
+				<password>oioioi</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TIM</name>
+		<gsm>
+			<network-id mcc="724" mnc="02"/>
+			<network-id mcc="724" mnc="03"/>
+			<network-id mcc="724" mnc="04"/>
+			<network-id mcc="724" mnc="08"/>
+			<voicemail>*100</voicemail>
+			<balance-check>
+				<ussd>*222#</ussd>
+				<dtmf>*222</dtmf>
+			</balance-check>
+			<apn value="tim.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>tim</username>
+				<password>tim</password>
+				<dns>10.223.246.102</dns>
+				<dns>10.223.246.103</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Velox</name>
+		<gsm>
+			<apn value="wap.telcel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>iesgprs</username>
+				<password>iesgprs2002</password>
+				<dns>66.36.250.14</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vivo</name>
+		<gsm>
+			<network-id mcc="724" mnc="06"/>
+			<network-id mcc="724" mnc="10"/>
+			<network-id mcc="724" mnc="11"/>
+			<network-id mcc="724" mnc="23"/>
+			<voicemail>*555</voicemail>
+			<balance-check>
+				<dtmf>*8000</dtmf>
+				<dtmf>*5005</dtmf>
+			</balance-check>
+			<apn value="zap.vivo.com.br">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>vivo</username>
+				<password>vivo</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Bahamas -->
+<country code="bs">
+	<provider>
+		<name>Batelco</name>
+		<gsm>
+			<network-id mcc="364" mnc="390"/>
+			<apn value="internet.btcbahamas.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Brunei -->
+<country code="bn">
+	<provider>
+		<name>B-Mobile</name>
+		<gsm>
+			<network-id mcc="528" mnc="02"/>
+			<apn value="bmobilewap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>DSTCOM</name>
+		<gsm>
+			<network-id mcc="528" mnc="11"/>
+			<apn value="dst.wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Belarus -->
+<country code="by">
+	<provider>
+		<!-- http://www.velcom.by/ru/services/gprs/settings/ -->
+		<name>velcom</name>
+		<gsm>
+			<network-id mcc="257" mnc="01"/>
+			<apn value="wap.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>GPRS WAP</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+			<apn value="web.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS WEB</name>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+			<apn value="plus.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS WEB PLUS</name>
+				<username>plus</username>
+				<password>plus</password>
+			</apn>
+			<apn value="privet.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS PRIVET</name>
+				<username>privet</username>
+				<password>privet</password>
+			</apn>
+			<apn value="web1.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WEB BASIC</name>
+				<username>web1</username>
+				<password>web1</password>
+			</apn>
+			<apn value="web2.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WEB 25</name>
+				<username>web2</username>
+				<password>web2</password>
+			</apn>
+			<apn value="web3.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WEB 150</name>
+				<username>web3</username>
+				<password>web3</password>
+			</apn>
+			<apn value="vmi.velcom.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WEB 500</name>
+				<username>vmi</username>
+				<password>vmi</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTS</name>
+		<gsm>
+			<network-id mcc="257" mnc="02"/>
+			<apn value="internet.mts.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mts</username>
+				<password>mts</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<!-- http://life.com.by/en/services/internet-105.html -->
+		<name>life:)</name>
+		<gsm>
+			<network-id mcc="257" mnc="03"/>
+			<apn value="internet.life.com.by">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Botswana -->
+<country code="bw">
+	<provider>
+		<name>Mascom Wireless</name>
+		<gsm>
+			<network-id mcc="652" mnc="01"/>
+			<apn value="internet.mascom">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Burundi -->
+<country code="bi">
+	<provider>
+		<name>Leo/UCom</name>
+		<gsm>
+			<network-id mcc="642" mnc="03"/>
+			<apn value="ucnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tempo/Africell</name>
+		<gsm>
+			<network-id mcc="642" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Canada -->
+<country code="ca">
+	<provider>
+		<name>Fido</name>
+		<gsm>
+			<network-id mcc="302" mnc="370"/>
+			<apn value="internet.fido.ca">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>fido</username>
+				<password>fido</password>
+				<dns>204.92.15.211</dns>
+				<dns>207.181.101.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Rogers</name>
+		<gsm>
+			<network-id mcc="302" mnc="720"/>
+			<apn value="internet.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wapuser1</username>
+				<password>wap</password>
+				<dns>207.181.101.4</dns>
+				<dns>207.181.101.5</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Bell Mobility</name>
+		<gsm>
+			<network-id mcc="302" mnc="610"/>
+			<network-id mcc="302" mnc="640"/>
+			<network-id mcc="302" mnc="651"/>
+			<network-id mcc="302" mnc="880"/>
+			<apn value="inet.bell.ca">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="pda.bell.ca">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Web</name>
+			</apn>
+			<apn value="pda2.bell.ca">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Fast Web</name>
+			</apn>
+		</gsm>
+		<cdma>
+			<sid value="16420"/>
+			<sid value="16440"/>
+			<sid value="16456"/>
+			<sid value="16410"/>
+			<sid value="16444"/>
+			<sid value="16390"/>
+			<sid value="16394"/>
+			<sid value="16402"/>
+			<sid value="16414"/>
+			<sid value="16416"/>
+			<sid value="16418"/>
+			<sid value="16462"/>
+			<sid value="16472"/>
+			<sid value="16408"/>
+			<sid value="16404"/>
+			<sid value="16430"/>
+			<sid value="16396"/>
+			<sid value="16426"/>
+			<sid value="16388"/>
+			<sid value="16390"/>
+			<sid value="16408"/>
+			<sid value="16414"/>
+			<sid value="16430"/>
+			<sid value="16460"/>
+			<sid value="16468"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Telus Mobility</name>
+		<gsm>
+			<network-id mcc="302" mnc="220"/>
+			<network-id mcc="302" mnc="860"/>
+			<network-id mcc="302" mnc="880"/>
+			<apn value="isp.telus.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="vpn.telus.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet (with VPN)</name>
+			</apn>
+			<apn value="bb.telus.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Blackberry</name>
+			</apn>
+			<apn value="sp.telus.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Web/Smartphone</name>
+			</apn>
+		</gsm>
+		<cdma>
+			<sid value="16422"/>
+			<sid value="17500"/>
+			<sid value="16438"/>
+			<sid value="16458"/>
+			<sid value="16436"/>
+			<sid value="16434"/>
+			<sid value="16384"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Virgin Mobile</name>
+		<cdma/>
+	</provider>
+	<provider>
+		<name>SaskTel</name>
+		<cdma>
+			<sid value="16410"/>
+			<sid value="16412"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Vidéotron</name>
+		<gsm>
+			<network-id mcc="302" mnc="500"/>
+			<network-id mcc="302" mnc="510"/>
+			<apn value="ihvm.videotron">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>IHVM</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>WIND Mobile</name>
+		<gsm>
+			<network-id mcc="302" mnc="490"/>
+			<apn value="broadband.windmobile.ca">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Laptop (data stick)</name>
+			</apn>
+			<apn value="internet.windmobile.ca">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile (add-on for phone)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Mobilicity</name>
+		<gsm>
+			<network-id mcc="302" mnc="320"/>
+			<apn value="wap.davewireless.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Web</name>
+			</apn>
+			<apn value="internet.davewireless.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Congo (Dem. Rep.) -->
+<country code="cd">
+	<provider>
+		<name>Vodacom</name>
+		<gsm>
+			<network-id mcc="630" mnc="01"/>
+			<apn value="vodanet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>vodalive</username>
+				<dns>172.24.97.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Congo (Rep.) -->
+<country code="cg">
+</country>
+
+<!-- Switzerland -->
+<country code="ch">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="228" mnc="03"/>
+			<apn value="mobileoffice3g">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere - Standard</name>
+				<dns>213.55.128.1</dns>
+				<dns>213.55.128.2</dns>
+			</apn>
+			<apn value="click">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere - Prepaid</name>
+				<dns>213.55.128.1</dns>
+				<dns>213.55.128.2</dns>
+			</apn>
+			<apn value="intranetaccess">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere - Intranet Access</name>
+			</apn>
+			<apn value="internet">
+				<name>Internet Everywhere - Postpaid</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sunrise</name>
+		<gsm>
+			<network-id mcc="228" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+				<dns>194.230.1.103</dns>
+				<dns>194.230.1.71</dns>
+			</apn>
+			<apn value="wap.sunrise.ch">
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+			<apn value="mms.sunrise.ch">
+				<username>mms</username>
+				<password>mms</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Swisscom</name>
+		<gsm>
+			<!-- username/password not included in Vodafone Broadband Connect version 10.1.0.23908 2010-06-07T17:47:01 -->
+			<!-- http://www.swisscom.ch/res/hilfe/mobile/einstellungen/index.htm -->
+			<network-id mcc="228" mnc="01"/>
+			<balance-check>
+				<ussd>*130#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*123*CODE#</ussd>
+			</balance-top-up>
+			<apn value="gprs.swisscom.ch">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Swisscom GPRS</name>
+				<dns>138.188.101.189</dns>
+				<dns>138.188.101.186</dns>
+			</apn>
+			<apn value="corporate.swisscom.ch">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Swisscom CAA</name>
+				<username>testprofil</username>
+				<password>temporary</password>
+			</apn>
+			<apn value="event.swisscom.ch">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Swisscom MMS</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>M-Budget</name>
+		<gsm>
+			<network-id mcc="228" mnc="01"/>
+			<msisdn-query>
+				<ussd>*#100#</ussd>
+			</msisdn-query>
+			<apn value="gprs.swisscom.ch">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Migros Data</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Cote d'Ivoire -->
+<country code="ci">
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="612" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>172.16.100.5</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Chile -->
+<country code="cl">
+	<provider>
+		<name>Claro Chile</name>
+		<gsm>
+			<network-id mcc="730" mnc="03"/>
+			<apn value="bam.clarochile.cl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>clarochile</username>
+				<password>clarochile</password>
+			</apn>
+			<apn value="bap.clarochile.cl">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepago</name>
+				<username>clarochile</username>
+				<password>clarochile</password>
+			</apn>
+			<apn value="wap.clarochile.cl">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>clarochile</username>
+				<password>clarochile</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Entel PCS</name>
+		<gsm>
+			<network-id mcc="730" mnc="01"/>
+			<apn value="imovil.entelpcs.cl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract / Prepaid / WebSession</name>
+				<username>entelpcs</username>
+				<password>entelpcs</password>
+			</apn>
+			<apn value="bam.entelpcs.cl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WAP</name>
+				<username>entelpcs</username>
+				<password>entelpcs</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="730" mnc="10"/>
+			<apn value="web.tmovil.cl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web</name>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+			<apn value="wap.tmovil.cl">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Cameroon -->
+<country code="cm">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="624" mnc="02"/>
+			<apn value="orangecmgprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>orange</username>
+				<password>orange</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="624" mnc="01"/>
+			<apn value="INTERNET">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>guest</username>
+				<password>guest</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- China -->
+<country code="cn">
+	<provider>
+		<name>China Mobile</name>
+		<gsm>
+			<network-id mcc="460" mnc="00"/>
+			<network-id mcc="460" mnc="02"/>
+			<apn value="cmwap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>guest</username>
+				<password>guest</password>
+			</apn>
+			<apn value="cmnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<username>guest</username>
+				<password>guest</password>
+				<dns>211.136.20.203</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>China Unicom</name>
+		<gsm>
+			<network-id mcc="460" mnc="01"/>
+			<apn value="3gnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>uninet</username>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>China Telecom</name>
+		<cdma>
+			<username>ctnet@mycdma.cn</username>
+			<password>vnet.mobi</password>
+			<sid value="11296"/>
+			<sid value="11298"/>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Costa Rica -->
+<country code="cr">
+	<provider>
+		<name>IceCelular</name>
+		<gsm>
+			<network-id mcc="712" mnc="01"/>
+			<network-id mcc="712" mnc="02"/>
+			<apn value="icecelular">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>guest</username>
+				<password>guest</password>
+				<dns>208.133.206.44</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Kolbi</name>
+		<gsm>
+			<network-id mcc="712" mnc="03"/>
+			<voicemail>190</voicemail>
+			<balance-check>
+				<sms text="">1150</sms>
+			</balance-check>
+			<apn value="kolbi3g">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Kolbi 3g</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Colombia -->
+<country code="co">
+	<provider>
+		<name>Comcel</name>
+		<gsm>
+			<network-id mcc="732" mnc="101"/>
+			<apn value="internet.comcel.com.co">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>COMCELWEB</username>
+				<password>COMCELWEB</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>eTb</name>
+		<gsm>
+			<apn value="moviletb.net.co">
+			     <plan type="postpaid"/>
+			     <usage type="internet"/>
+			     <username>etb</username>
+			     <password>etb</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="732" mnc="102"/>
+			<network-id mcc="732" mnc="123"/>
+			<apn value="internet.movistar.com.co">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistar</username>
+				<password>movistar</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="732" mnc="103"/>
+			<network-id mcc="732" mnc="111"/>
+			<apn value="web.colombiamovil.com.co">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Uff</name>
+		<gsm>
+			<apn value="web.uffmovil.com.co">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>UNE</name>
+		<gsm>
+			<apn value="www.une.net.co">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>une</username>
+				<password>une</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Cyprus -->
+<country code="cy">
+	<provider>
+		<name>Cytamobile-Vodafone</name>
+		<gsm>
+			<network-id mcc="280" mnc="01"/>
+			<msisdn-query>
+				<ussd>*#109#</ussd>
+			</msisdn-query>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+			</apn>
+			<apn value="pp.internet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="280" mnc="10"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Czech Republic -->
+<country code="cz">
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="230" mnc="03"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>217.77.161.130</dns>
+				<dns>217.77.161.131</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>O2</name>
+		<gsm>
+			<network-id mcc="230" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>160.218.10.200</dns>
+				<dns>160.218.43.200</dns>
+			</apn>
+			<apn value="internet.open">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>160.218.10.200</dns>
+				<dns>160.218.43.200</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="230" mnc="01"/>
+			<apn value="internet.t-mobile.cz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>62.141.0.1</dns>
+				<dns>213.162.65.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Germany -->
+<country code="de">
+	<provider>
+		<name>AldiTalk/MedionMobile</name>
+		<gsm>
+			<network-id mcc="262" mnc="03"/>
+			<network-id mcc="262" mnc="05"/>
+			<network-id mcc="262" mnc="77"/>
+			<voicemail>9911</voicemail>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*104*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet.eplus.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Volume rate/30 Day Flatrate</name>
+				<username>eplus</username>
+				<password>gprs</password>
+				<dns>212.23.97.2</dns>
+				<dns>212.23.97.3</dns>
+			</apn>
+			<apn value="tagesflat.eplus.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>24 Hour Flatrate</name>
+				<name xml:lang="de">Tages-Flatrate</name>
+				<username>eplus</username>
+				<password>gprs</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>blau.de</name>
+		<gsm>
+			<network-id mcc="262" mnc="03"/>
+			<network-id mcc="262" mnc="05"/>
+			<network-id mcc="262" mnc="77"/>
+
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*104*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet.eplus.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>blau</username>
+				<password>blau</password>
+			</apn>
+			<apn value="tagesflat.eplus.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>24 Hour Flatrate</name>
+				<name xml:lang="de">Tages-Flatrate</name>
+				<username>blau</username>
+				<password>blau</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Bild Mobil</name>
+		<gsm>
+			<!-- http://www.bildmobil.de/info_handyeinstellungen.html -->
+			<network-id mcc="262" mnc="02"/>
+			<apn value="access.vodafone.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>BILD Mobilportal</name>
+			</apn>
+			<apn value="web.vodafone.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+				<dns>139.7.30.125</dns>
+				<dns>139.7.30.126</dns>
+			</apn>
+			<!-- http://www.prepaid-wiki.de/index.php5/BILDmobil_Daten-SIM -->
+			<apn value="event.vodafone.de">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>BILDmobil Speedstick (Surfpakete)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>E-Plus</name>
+		<gsm>
+			<network-id mcc="262" mnc="03"/>
+			<network-id mcc="262" mnc="05"/>
+			<network-id mcc="262" mnc="77"/>
+
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*104*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet.eplus.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>eplus</username>
+				<password>gprs</password>
+				<dns>212.23.97.2</dns>
+				<dns>212.23.97.3</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>O2</name>
+		<gsm>
+			<network-id mcc="262" mnc="07"/>
+			<network-id mcc="262" mnc="08"/>
+			<network-id mcc="262" mnc="11"/>
+
+			<voicemail>333</voicemail>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*103*CODE#</ussd>
+			</balance-top-up>
+
+			<apn value="pinternet.interkom.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>LOOP</name>
+				<dns>193.189.244.225</dns>
+				<dns>193.189.244.206</dns>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Pay-by-MB</name>
+				<dns>195.182.110.132</dns>
+				<dns>62.134.11.4</dns>
+			</apn>
+			<apn value="surfo2">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Pay-by-time</name>
+				<dns>195.182.110.132</dns>
+				<dns>62.134.11.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tchibo-Mobil</name>
+		<gsm>
+			<network-id mcc="262" mnc="07"/>
+			<network-id mcc="262" mnc="08"/>
+			<network-id mcc="262" mnc="11"/>
+
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*103*CODE#</ussd>
+			</balance-top-up>
+			<apn value="webmobil1">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Tagesflat / Monats-Flatrate L / Monats-Flatrate XL</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile(Telekom)</name>
+		<gsm>
+			<network-id mcc="262" mnc="01"/>
+			<network-id mcc="262" mnc="06"/>
+
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*101*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet.t-d1.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<password>t-d1</password>
+				<dns>193.254.160.1</dns>
+				<dns>193.254.160.130</dns>
+			</apn>
+			<apn value="internet.t-mobile">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>t-mobile</username>
+				<password>tm</password>
+				<dns>10.74.83.22</dns>
+				<dns>193.254.160.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Congstar</name>
+		<gsm>
+			<network-id mcc="262" mnc="01"/>
+
+			<apn value="internet.t-mobile">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid Contracts</name>
+				<username>t-mobile</username>
+				<password>tm</password>
+				<dns>193.254.160.1</dns>
+				<dns>10.74.83.22</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="262" mnc="02"/>
+			<network-id mcc="262" mnc="04"/>
+			<network-id mcc="262" mnc="09"/>
+
+			<voicemail>5500</voicemail>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*100*CODE#</ussd>
+			</balance-top-up>
+
+			<apn value="web.vodafone.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>139.7.30.125</dns>
+				<dns>139.7.30.126</dns>
+			</apn>
+			<apn value="event.vodafone.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WebSessions</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>139.7.30.125</dns>
+				<dns>139.7.30.126</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>FONIC</name>
+		<gsm>
+			<network-id mcc="262" mnc="07"/>
+			<network-id mcc="262" mnc="08"/>
+			<network-id mcc="262" mnc="11"/>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*103*CODE#</ussd>
+			</balance-top-up>
+			<apn value="pinternet.interkom.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>fonic</username>
+				<password>fonic</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>simyo Internet</name>
+		<gsm>
+			<network-id mcc="262" mnc="03"/>
+			<network-id mcc="262" mnc="05"/>
+			<network-id mcc="262" mnc="77"/>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*104*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet.eplus.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>simyo</username>
+				<password>simyo</password>
+				<dns>212.23.97.2</dns>
+				<dns>212.23.97.3</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<!-- This configuration is valid for all vistream retailers like
+		     solomo, igge & ko, sdt.net, Südkurier-Tel etc.-->
+		<name>vistream</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>solomo</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Materna BR</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>sdt.net</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>igge &amp; ko</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>PTT mobile</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TouristMobile</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SunSIM</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SüdkurierTel</name>
+		<gsm>
+			<network-id mcc="262" mnc="16"/>
+			<apn value="internet.vistream.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>vistream</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>NetCologne</name>
+		<gsm>
+			<network-id mcc="262" mnc="03"/>
+			<apn value="internet.netcologne.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>password</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Alice</name>
+		<gsm>
+			<network-id mcc="262" mnc="07"/>
+			<apn value="internet.partner1">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Option Mobile</name>
+				<dns>193.189.244.225</dns>
+				<dns>193.189.244.206</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>1&amp;1</name>
+		<gsm>
+			<!-- Vodafone (D2) network -->
+			<network-id mcc="262" mnc="02"/>
+			<network-id mcc="262" mnc="04"/>
+			<network-id mcc="262" mnc="09"/>
+
+			<voicemail>5500</voicemail>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+
+			<apn value="web.vodafone.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+			</apn>
+			<apn value="mail.partner.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Web</name>
+				<username>D2</username>
+				<password>Web</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Netzclub</name>
+		<gsm>
+			<!-- O2 network -->
+			<network-id mcc="262" mnc="07"/>
+			<network-id mcc="262" mnc="08"/>
+			<network-id mcc="262" mnc="11"/>
+			<apn value="pinternet.interkom.de">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<!-- Information taken from https://www.netzclub.net/downloads/default/Manuelle_Handyeinstellungen.pdf -->
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Denmark -->
+<country code="dk">
+	<provider primary="true">
+		<name>3</name>
+		<gsm>
+			<network-id mcc="238" mnc="06"/>
+			<apn value="bredband.tre.dk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Bredbånd (standard)</name>
+ 			</apn>
+			<apn value="net.tre.dk">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Bredbånd Premium Kontant</name>
+			</apn>
+			<apn value="data.tre.dk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3 (standard for mobilkunder; spærret for indgående trafik)</name>
+			</apn>
+			<apn value="static.tre.dk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3 (statisk IP)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<!-- http://oister.dk - Same network as 3.dk -->
+	<provider>
+		<name>OiSTER</name>
+		<gsm>
+			<network-id mcc="238" mnc="06"/>
+			<apn value="bredband.oister.dk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+
+	<!-- http://www.ice-net.dk/mobiltbredbaand.php -->
+	<provider>
+		<name>ice.net (Nordisk Mobiltelefon)</name>
+		<cdma>
+			<username>cdma</username>
+			<password>cdma</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Telenor</name>
+		<gsm>
+			<network-id mcc="238" mnc="02"/>
+			<network-id mcc="238" mnc="77"/>
+
+			<voicemail>20171717</voicemail>
+			<balance-check>
+				<ussd>*101#</ussd>
+				<dtmf>40454545</dtmf>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.88.64.199</dns>
+				<dns>212.88.64.14</dns>
+			</apn>
+		</gsm>
+	</provider>
+
+	<!-- http://www.cbb.dk/mobil/hjaelp/manuel-opsaetning-af-mms-og-gprs/ -->
+	<provider>
+		<name>CBB Mobil</name>
+		<gsm>
+			<network-id mcc="238" mnc="02"/>
+			<network-id mcc="238" mnc="77"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TDC</name>
+		<gsm>
+			<network-id mcc="238" mnc="01"/>
+
+			<voicemail>20171717</voicemail>
+			<balance-check>
+				<ussd>*101#</ussd>
+				<dtmf>40454545</dtmf>
+			</balance-check>
+
+			<!-- http://kundeservice.tdc.dk/privat/faq.php?id=20063 -->
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>194.239.134.83</dns>
+				<dns>193.162.153.164</dns>
+			</apn>
+			<!-- mnc="0171" in Vodafone XML -->
+			<apn value="internet.no">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+			<!-- mnc="0172" in Vodafone XML -->
+			<apn value="internet.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Fullrate</name>
+		<gsm>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>Fullrate</username>
+				<password>Fullrate</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telia</name>
+		<gsm>
+			<network-id mcc="238" mnc="30"/>
+
+			<voicemail>28184000</voicemail>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+
+			<apn value="www.internet.mtelia.dk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>BiBoB</name>
+		<gsm>
+			<network-id mcc="238" mnc="02"/>
+			<apn value="internet.bibob.dk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<!-- Telmore - Same network as TDC -->
+	<provider>
+		<name>Telmore</name>
+		<gsm>
+			<network-id mcc="238" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>194.239.134.83</dns>
+				<dns>193.162.153.164</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Unotel</name>
+		<gsm>
+			<network-id mcc="238" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>happiimobil</name>
+		<gsm>
+			<network-id mcc="238" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<!-- Onfone: https://www.onfone.dk/Kundeservice/mobil/saet_din_mobil_op/internet-gprs-3g/ --> 
+	<provider>
+		<name>Onfone Internet DK</name>
+		<gsm>
+			<network-id mcc="238" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Dominican Republic -->
+<country code="do">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="370" mnc="01"/>
+			<voicemail>*777</voicemail>
+			<balance-check>
+				<ussd>#131#</ussd>
+			</balance-check>
+			<apn value="orangenet.com.do">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="370" mnc="02"/>
+			<voicemail>*99</voicemail>
+			<balance-check>
+				<ussd>*122#</ussd>
+				<dtmf>*22</dtmf>
+			</balance-check>
+			<apn value="internet.ideasclaro.com.do">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>196.3.81.5</dns>
+				<dns>196.3.81.132</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Viva</name>
+		<gsm>
+			<network-id mcc="370" mnc="04"/>
+			<balance-check>
+				<ussd>#111#</ussd>
+				<dtmf>*74</dtmf>
+			</balance-check>
+			<apn value="edge.viva.net.do">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>viva</username>
+				<password>viva</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Algeria -->
+<country code="dz">
+	<provider>
+		<name>Djezzy</name>
+		<gsm>
+			<network-id mcc="603" mnc="02"/>
+			<apn value="djezzy.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Mobilis</name>
+		<gsm>
+			<network-id mcc="603" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Nedjma</name>
+		<gsm>
+			<network-id mcc="603" mnc="03"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WEB</name>
+				<username>nedjma</username>
+				<password>nedjma</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Ecuador -->
+<country code="ec">
+	<provider>
+		<name>Movistar UMTS</name>
+		<gsm>
+			<network-id mcc="740" mnc="00"/>
+			<apn value="navega.movistar.ec">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistar</username>
+				<password>movistar</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Porta 3G</name>
+		<gsm>
+			<network-id mcc="740" mnc="01"/>
+			<apn value="internet.porta.com.ec">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Estonia -->
+<country code="ee">
+	<provider>
+		<name>EMT</name>
+		<gsm>
+			<network-id mcc="248" mnc="01"/>
+			<apn value="internet.emt.ee">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>217.71.32.116</dns>
+				<dns>217.71.32.115</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Nordea</name>
+		<gsm>
+			<network-id mcc="248" mnc="01"/>
+			<apn value="internet.emt.ee">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Elisa</name>
+		<gsm>
+			<network-id mcc="248" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>194.204.0.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="248" mnc="03"/>
+			<apn value="internet.tele2.ee">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Egypt -->
+<country code="eg">
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="602" mnc="02"/>
+			<msisdn-query>
+				<ussd>*878#</ussd>
+			</msisdn-query>
+			<apn value="internet.vodafone.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+				<dns>163.121.128.134</dns>
+				<dns>212.103.160.18</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Etisalat</name>
+		<gsm>
+			<network-id mcc="602" mnc="03"/>
+			<apn value="etisalat">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MobiNil</name>
+		<gsm>
+			<network-id mcc="602" mnc="01"/>
+			<apn value="mobinilweb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>80.75.166.250</dns>
+				<dns>163.121.163.201</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Spain -->
+<country code="es">
+	<provider>
+		<name>Euskaltel</name>
+		<gsm>
+			<network-id mcc="214" mnc="08"/>
+			<apn value="internet.euskaltel.mobi">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>CLIENTE</username>
+				<password>EUSKALTEL</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Másmovil</name>
+		<gsm>
+			<network-id mcc="214" mnc="03"/>
+			<apn value="internetmas" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>móbil R (Mundo-R)</name>
+		<gsm>
+			<network-id mcc="214" mnc="17"/>
+			<apn value="internet.mundo-r.com" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>moviData</name>
+		<gsm>
+			<network-id mcc="214" mnc="03"/>
+			<apn value="INTERNETTPH">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.143.33.8</dns>
+				<dns>62.36.225.150</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>ONO</name>
+		<gsm>
+			<network-id mcc="214" mnc="18"/>
+			<apn value="internet.ono.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>62.42.230.24</dns>
+				<dns>62.42.63.52</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Pepephone</name>
+		<gsm>
+			<network-id mcc="214" mnc="06"/>
+			<apn value="gprs.pepephone.com" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="214" mnc="03"/>
+			<network-id mcc="214" mnc="09"/>
+
+			<voicemail>242</voicemail>
+			<balance-check>
+				<ussd>*111#</ussd>
+				<ussd>*113#</ussd>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Orange</name>
+				<username>ORANGE</username>
+				<password>ORANGE</password>
+				<dns>85.62.229.133</dns>
+				<dns>85.62.229.134</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Simyo/Blau</name>
+		<gsm>
+			<network-id mcc="214" mnc="19"/>
+			<apn value="gprs-service.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>195.230.105.134</dns>
+				<dns>195.230.105.135</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telecable</name>
+		<gsm>
+			<network-id mcc="214" mnc="16"/>
+			<apn value="internet.telecable.es">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>telecable</username>
+				<password>telecable</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar (Telefónica)</name>
+		<gsm>
+			<network-id mcc="214" mnc="05"/>
+			<network-id mcc="214" mnc="07"/>
+
+			<voicemail>123</voicemail>
+			<balance-check>
+				<dtmf>2266</dtmf>
+			</balance-check>
+                        <ecclist>112,911</ecclist>
+                        <smscb>whatever</smscb>
+			<apn value="movistar.es">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistar</username>
+				<password>movistar</password>
+				<dns>194.179.1.100</dns>
+				<dns>194.179.1.101</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone (Airtel)</name>
+		<gsm>
+			<network-id mcc="214" mnc="01"/>
+			<network-id mcc="214" mnc="06"/>
+			<msisdn-query>
+				<ussd>*138#</ussd>
+			</msisdn-query>
+			<apn value="ac.vodafone.es">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vodafone</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>212.73.32.96</dns>
+				<dns>212.73.32.67</dns>
+			</apn>
+			<apn value="airtelnet.es">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Airtel (old)</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>212.73.32.3</dns>
+				<dns>212.73.32.67</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Yoigo</name>
+		<gsm>
+			<network-id mcc="214" mnc="04"/>
+
+			<voicemail>633</voicemail>
+			<balance-check>
+				<ussd>*111#</ussd>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.248.76.210</dns>
+				<dns>213.248.100.54</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Jazztel</name>
+		<gsm>
+			<network-id mcc="214" mnc="21"/>
+			<apn value="jazzinternet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<dns>87.216.1.65</dns>
+				<dns>87.216.1.66</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Carrefour Móvil</name>
+		<gsm>
+			<apn value="CARREFOURINTERNET">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<!-- from http://www.eroskimovil.es/geomv/c/pub/en/servicios/datos -->
+		<name>Eroski Móvil</name>
+		<gsm>
+			<network-id mcc="214" mnc="24"/>
+			<apn value="gprs.eroskimovil.es">
+				<name>Eroski Móvil GPRS</name>
+				<username>wap@wap</username>
+				<password>wap125</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Ethiopia -->
+<country code="et">
+	<provider>
+		<name>Ethio Telecom</name>
+		<gsm>
+			<network-id mcc="636" mnc="01"/>
+			<balance-check>
+				<ussd>*804#</ussd>
+			</balance-check>
+
+			<apn value="etc.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.55.96.148</dns>
+				<dns>213.55.96.166</dns>
+			</apn>
+		</gsm>
+		<cdma>
+			<username>etc</username>
+			<password>etc</password>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Faroe Islands -->
+<country code="fo">
+	<provider>
+		<name>Vodafone FO</name>
+		<gsm>
+			<network-id mcc="288" mnc="02"/>
+			<msisdn-query>
+				<ussd>*#100#</ussd>
+			</msisdn-query>
+			<apn value="vmc.vodafone.fo">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Finland -->
+<country code="fi">
+	<provider>
+		<name>Dna</name>
+		<gsm>
+			<network-id mcc="244" mnc="03"/>
+			<!-- Phone number dependent:
+			 - Numbers beginning with 044 XXXXXXX turn in to 044 6 XXXXXXX
+			 - Numbers beginning with 041 XXXXXXX turn in to 041 6 XXXXXXX
+			 - Others case by case
+			 http://www.dna.fi/Yrityksille/Matkaviestinpalvelut/LiittymienLisapalvelut/dnafaksivastaaja/Documents/dna_vastaaja_kayttohje_120310.pdf
+			<voicemail/> -->
+			<balance-check>
+				<ussd>*100#</ussd>
+				<dtmf>0800412582</dtmf>
+				<sms text="SALDO">14000</sms>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>dna internet</name>
+				<dns>217.78.192.22</dns>
+				<dns>217.78.192.78</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Elisa</name>
+		<gsm>
+			<network-id mcc="244" mnc="05"/>
+			<voicemail>777</voicemail>
+			<balance-check>
+				<dtmf>080090598</dtmf>
+				<sms text="SALDO">18258</sms>
+				<sms text="PAKETTI">18258</sms>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Saunalahti</name>
+		<gsm>
+			<network-id mcc="244" mnc="21"/>
+
+			<!-- Phone number dependent:
+				 - Numbers beginning with 045 67 XXXXX turn in to 045 66 XXXXX
+				 - Numbers beginning with 045 63 XXXXX turn in to 045 62 XXXXX
+				 - Others case by case
+				 http://saunalahti.fi/tuki/gsm/vo/ohjevastaaja.php
+			<voicemail/> -->
+			<balance-check>
+					<sms text="SALDO">16304</sms>
+					<sms text="SALDO">15045</sms>
+					<sms text="KOKOSALDO">16304</sms>
+					<sms text="GSALDO">16304</sms>
+					<sms text="PAKETTI">16304</sms>
+			</balance-check>
+
+			<apn value="internet.saunalahti">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid (contract) NAT (available for all subscribers)</name>
+				<dns>195.74.0.47</dns>
+				<dns>195.197.54.100</dns>
+			</apn>
+			<apn value="internet4">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid (contract) public IP address (needs to be ordered)</name>
+				<dns>195.74.0.47</dns>
+				<dns>195.197.54.100</dns>
+			</apn>
+			<apn value="internet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid (no contract)</name>
+				<dns>195.74.0.47</dns>
+				<dns>195.197.54.100</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sonera</name>
+		<gsm>
+			<network-id mcc="244" mnc="91"/>
+
+			<!-- Phone number dependent:
+				 - Numbers beginning with 040 XXXXXXX turns in to 042 XXXXXXX
+				 - Others case by case
+			<voicemail/> -->
+			<balance-check>
+					<sms text="EASY SALDO">15400</sms>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>192.89.123.230</dns>
+				<dns>192.89.123.231</dns>
+			</apn>
+			<apn value="prointernet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Prointernet (public IP)</name>
+				<dns>192.89.123.230</dns>
+				<dns>192.89.123.231</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Welho</name>
+		<gsm>
+			<apn value="internet.welho.fi">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Wekkula</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Fiji -->
+<country code="fj">
+	<provider>
+		<name>Vodafone / Kidanet</name>
+		<gsm>
+			<network-id mcc="542" mnc="01"/>
+			<msisdn-query>
+				<ussd>*999#</ussd>
+			</msisdn-query>
+			<apn value="vfinternet.fj">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+			<apn value="kidanet.fj">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+			<!-- http://www.vodafone.com.fj/pages.cfm/personal/services/prepay-flashnet/installation-guide.html -->
+			<apn value="prepay.vfinternet.fj">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- France -->
+<country code="fr">
+	<provider>
+		<name>A Mobile (Auchan Telecom)</name>
+		<gsm>
+			<apn value="wap65">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Bouygues Telecom</name>
+		<gsm>
+			<network-id mcc="208" mnc="20"/>
+			<network-id mcc="208" mnc="21"/>
+
+			<voicemail>660</voicemail>
+			<balance-check>
+				<dtmf>630</dtmf>
+			</balance-check>
+
+			<apn value="a2bouygtel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contrat Pro Data Illimité</name>
+				<dns>62.201.129.99</dns>
+			</apn>
+			<apn value="b2bouygtel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>B2Bouygtel</name>
+				<dns>62.201.129.99</dns>
+			</apn>
+			<apn value="ebouygtel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Forfait Data</name>
+				<dns>62.201.129.99</dns>
+			</apn>
+			<apn value="mmsbouygtel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Forfait Data</name>
+				<dns>62.201.129.99</dns>
+			</apn>
+			<apn value="pcebouygtel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contrat Pro Data</name>
+				<dns>62.201.129.99</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Free Mobile</name>
+		<gsm>
+			<!-- http://mobile.free.fr/faq-config-apn-autres.html -->
+			<network-id mcc="208" mnc="15"/>
+			<apn value="free">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Free-Mobile</name>
+				<username>free</username>
+				<password>free</password>
+			</apn>
+			<apn value="mmsfree">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Free-Mobile</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="208" mnc="01"/>
+			<network-id mcc="208" mnc="00"/>
+
+			<voicemail>888</voicemail>
+			<balance-check>
+				<ussd>#123#</ussd>
+			</balance-check>
+
+			<apn value="orange.fr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Orange Internet</name>
+				<dns>194.51.3.56</dns>
+				<dns>194.51.3.76</dns>
+			</apn>
+			<apn value="internet-entreprise">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Business Contract</name>
+				<dns>194.51.3.56</dns>
+				<dns>194.51.3.76</dns>
+			</apn>
+			<apn value="orange">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>No Contract / Mobicarte</name>
+				<username>orange</username>
+				<password>orange</password>
+				<dns>194.51.3.56</dns>
+				<dns>194.51.3.76</dns>
+			</apn>
+			<apn value="orange-mib">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Orange Entreprises</name>
+				<username>mportail</username>
+				<password>mib</password>
+				<dns>172.17.0.2</dns>
+				<dns>172.17.0.4</dns>
+			</apn>
+			<apn value="orange-acte">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Orange MMS</name>
+				<username>orange</username>
+				<password>orange</password>
+			</apn>
+			<apn value="orange.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SFR</name>
+		<gsm>
+			<!-- http://assistance.sfr.fr/internet-partout/Mobile/difference-wap-web/fc-2302-62196 -->
+			<network-id mcc="208" mnc="10"/>
+			<network-id mcc="208" mnc="11"/>
+			<msisdn-query>
+				<sms text="ABCd84367">9445</sms>
+			</msisdn-query>
+			<voicemail>123</voicemail>
+			<balance-check>
+				<dtmf>950</dtmf>
+			</balance-check>
+
+			<apn value="websfr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web / Prepaid</name>
+				<dns>172.20.2.10</dns>
+				<dns>172.20.2.39</dns>
+			</apn>
+			<apn value="wapsfr">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+			</apn>
+			<apn value="internetpro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>SFR internetpro</name>
+			</apn>
+			<apn value="ipnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>SFR ipnet</name>
+			</apn>
+			<apn value="slsfr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<dns>172.20.2.10</dns>
+				<dns>172.20.2.39</dns>
+			</apn>
+			<apn value="sl2sfr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Full Internet (Webphone)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Transatel Telecom</name>
+		<gsm>
+			<network-id mcc="208" mnc="22"/>
+			<apn value="netgprs.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TEN</name>
+		<gsm>
+			<network-id mcc="208" mnc="01"/>
+			<apn value="ao.fr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>orange</username>
+				<password>orange</password>
+			</apn>
+			<apn value="ofnew.fr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Pay-by-MB</name>
+				<username>orange</username>
+				<password>orange</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Britain -->
+<country code="gb">
+	<provider>
+		<name>Asda Mobile</name>
+		<gsm>
+			<network-id mcc="234" mnc="15"/>
+			<apn value="asdamobiles.co.uk">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>BT Mobile</name>
+		<gsm>
+			<network-id mcc="234" mnc="00"/>
+			<apn value="btmobile.bt.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>bt</username>
+				<password>bt</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>GiffGaff</name>
+		<gsm>
+			<network-id mcc="234" mnc="02"/>
+			<network-id mcc="234" mnc="10"/>
+			<network-id mcc="234" mnc="11"/>
+			<apn value="giffgaff.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>giffgaff</username>
+				<password>password</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>O2</name>
+		<gsm>
+			<network-id mcc="234" mnc="02"/>
+			<network-id mcc="234" mnc="10"/>
+			<network-id mcc="234" mnc="11"/>
+			<voicemail>901</voicemail>
+			<balance-check>
+				<ussd>*#10#</ussd>
+				<dtmf>4444</dtmf>
+			</balance-check>
+			<apn value="mobile.o2.co.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+				<username>o2web</username>
+				<password>password</password>
+				<dns>193.113.200.200</dns>
+				<dns>193.113.200.201</dns>
+			</apn>
+			<apn value="mobile.o2.co.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract (faster)</name>
+				<username>faster</username>
+				<password>password</password>
+				<dns>193.113.200.200</dns>
+				<dns>193.113.200.201</dns>
+			</apn>
+			<apn value="payandgo.o2.co.uk">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Pay and Go (Prepaid)</name>
+				<username>payandgo</username>
+				<password>payandgo</password>
+			</apn>
+			<apn value="idata.o2.co.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>iPhone (Contract)</name>
+				<username>vertigo</username>
+				<password>password</password>
+			</apn>
+			<apn value="m-bb.o2.co.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<username>o2bb</username>
+				<password>password</password>
+				<dns>82.132.254.2</dns>
+				<dns>82.132.254.3</dns>
+			</apn>
+			<apn value="wap.o2.co.uk">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>o2wap</username>
+				<password>password</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="234" mnc="30"/>
+			<voicemail>222</voicemail>
+			<balance-check>
+				<dtmf>150</dtmf>
+				<sms text="BA">150</sms>
+				<sms text="AL">150</sms>
+			</balance-check>
+			<apn value="general.t-mobile.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>User</username>
+				<password>mms</password>
+				<dns>149.254.201.126</dns>
+				<dns>149.254.192.126</dns>
+			</apn>
+			<apn value="general.t-mobile.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>149.254.230.7</dns>
+				<dns>149.254.199.126</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tesco Mobile</name>
+		<gsm>
+			<network-id mcc="234" mnc="02"/>
+			<network-id mcc="234" mnc="10"/>
+			<network-id mcc="234" mnc="11"/>
+			<apn value="prepay.tesco-mobile.com">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>tescowap</username>
+				<password>password</password>
+				<dns>193.113.200.195</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Virgin Mobile</name>
+		<gsm>
+			<network-id mcc="234" mnc="31"/>
+			<network-id mcc="234" mnc="32"/>
+			<apn value="vdata">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>196.7.0.138</dns>
+				<dns>196.7.142.132</dns>
+			</apn>
+			<apn value="goto.virginmobile.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>user</username>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="234" mnc="15"/>
+			<msisdn-query>
+				<ussd>*#100#</ussd>
+			</msisdn-query>
+			<voicemail>121</voicemail>
+			<balance-check>
+				<ussd>*#1345#</ussd>
+				<dtmf>2345</dtmf>
+			</balance-check>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+				<username>web</username>
+				<password>web</password>
+				<dns>10.206.65.68</dns>
+				<dns>10.203.65.68</dns>
+			</apn>
+			<apn value="pp.vodafone.co.uk">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+				<username>web</username>
+				<password>web</password>
+				<dns>172.29.1.11</dns>
+				<dns>172.29.1.11</dns>
+			</apn>
+			<apn value="ppbundle.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>TopUp and Go</name>
+				<username>web</username>
+				<password>web</password>
+				<dns>10.203.129.68</dns>
+				<dns>10.203.129.68</dns>
+			</apn>
+			<apn value="pp.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>TopUp and Go (older 1GB SIMs)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>3</name>
+		<gsm>
+			<network-id mcc="234" mnc="20"/>
+			<apn value="3internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="three.co.uk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Handsets</name>
+				<dns>172.30.139.17</dns>
+				<dns>172.30.140.69</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="234" mnc="33"/>
+			<network-id mcc="234" mnc="34"/>
+			<voicemail>123</voicemail>
+			<balance-check>
+				<dtmf>453</dtmf>
+			</balance-check>
+			<apn value="orangeinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+				<username>orange</username>
+				<password>orange</password>
+				<dns>193.35.133.10</dns>
+				<dns>193.35.134.10</dns>
+			</apn>
+			<apn value="internetvpn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract (with VPN)</name>
+				<username>orange</username>
+				<password>orange</password>
+				<dns>193.35.133.10</dns>
+				<dns>193.35.134.10</dns>
+			</apn>
+			<apn value="orangewap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>Orange WAP</name>
+				<username>orange</username>
+				<password>multimedia</password>
+				<dns>158.43.192.1</dns>
+				<dns>158.43.128.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Georgia -->
+<country code="ge">
+	<provider>
+		<name>Geocell</name>
+		<gsm>
+			<network-id mcc="282" mnc="01"/>
+			<apn value="Internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.72.130.20</dns>
+				<dns>212.72.152.001</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Guernsey -->
+<country code="gg">
+	<provider>
+		<name>Airtel-Vodaphone</name>
+		<gsm>
+			<network-id mcc="234" mnc="03"/>
+			<apn value="airtel-ci-gprs.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sure (Cable &amp; Wireless)</name>
+		<gsm>
+			<network-id mcc="234" mnc="55"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Wave Telecom</name>
+		<gsm>
+			<network-id mcc="234" mnc="50"/>
+			<apn value="pepper">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.9.0.135</dns>
+				<dns>212.9.0.136</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Ghana -->
+<country code="gh">
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="620" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone (ONEtouch)</name>
+		<gsm>
+			<network-id mcc="620" mnc="02"/>
+			<msisdn-query>
+				<ussd>*127#</ussd>
+			</msisdn-query>
+			<apn value="browse">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="620" mnc="03"/>
+			<apn value="web.tigo.com.gh">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="620" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Kasapa</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Greece -->
+<country code="gr">
+	<provider>
+		<name>Cosmote</name>
+		<gsm>
+			<network-id mcc="202" mnc="01"/>
+
+			<voicemail>123</voicemail>
+			<balance-check>
+				<dtmf>1314</dtmf>
+				<sms text="YP">1314</sms>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="202" mnc="05"/>
+			<voicemail>121</voicemail>
+			<balance-check>
+				<dtmf>1252</dtmf>
+				<sms text="Y">1252</sms>
+			</balance-check>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+			</apn>
+			<apn value="web.session">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband On Demand</name>
+				<dns>213.249.17.10</dns>
+				<dns>213.249.17.11</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Wind</name>
+		<gsm>
+			<network-id mcc="202" mnc="09"/>
+			<network-id mcc="202" mnc="10"/>
+
+			<voicemail>122</voicemail>
+			<voicemail>1333</voicemail>
+			<balance-check>
+				<dtmf>1269</dtmf>
+				<dtmf>1225</dtmf>
+				<sms text="">1269</sms>
+				<sms text="">1225</sms>
+			</balance-check>
+
+			<apn value="gint.b-online.gr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Guatemala -->
+<country code="gt">
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="704" mnc="01"/>
+			<apn value="internet.ideasclaro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Comcel / Tigo</name>
+		<gsm>
+			<network-id mcc="704" mnc="02"/>
+			<apn value="Wap.tigo.gt">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>Wap</username>
+				<password>Wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Guyana -->
+<country code="gy">
+	<provider>
+		<name>GT&amp;T Cellink Plus</name>
+		<gsm>
+			<network-id mcc="738" mnc="02"/>
+			<apn value="wap.cellinkgy.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>test</username>
+				<password>test</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>DigiCel</name>
+		<gsm>
+			<network-id mcc="738" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Hong Kong -->
+<country code="hk">
+	<provider>
+		<name>CSL</name>
+		<gsm>
+			<network-id mcc="454" mnc="00"/>
+			<network-id mcc="454" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>202.84.255.1</dns>
+				<dns>203.116.254.150</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>New World</name>
+		<gsm>
+			<network-id mcc="454" mnc="10"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>China Mobile</name>
+		<gsm>
+			<network-id mcc="454" mnc="12"/>
+			<apn value="peoples.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SmarTone</name>
+		<gsm>
+			<network-id mcc="454" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>PCCW (Sunday)</name>
+		<gsm>
+			<network-id mcc="454" mnc="16"/>
+			<network-id mcc="454" mnc="19"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Sunday (Old)</name>
+			</apn>
+			<apn value="pccwdata">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>PCCW 2G/GPRS</name>
+			</apn>
+			<apn value="pccw">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>PCCW 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sunday</name>
+		<gsm>
+			<network-id mcc="454" mnc="16"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="454" mnc="04"/>
+			<apn value="web.orangehk.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Three</name>
+		<gsm>
+			<network-id mcc="454" mnc="03"/>
+			<network-id mcc="454" mnc="04"/>
+			<apn value="mobile.three.com.hk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Honduras -->
+<country code="hn">
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="708" mnc="02"/>
+			<apn value="internet.tigo.hn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Croatia -->
+<country code="hr">
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="219" mnc="01"/>
+			<apn value="web.htgprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>10.12.0.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>VIPNET</name>
+		<gsm>
+			<network-id mcc="219" mnc="10"/>
+			<apn value="data.vip.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract and Prepaid</name>
+			</apn>
+			<apn value="gprs5.vipnet.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS 5</name>
+				<username>38591</username>
+				<password>38591</password>
+				<dns>195.29.159.15</dns>
+			</apn>
+			<apn value="gprs0.vipnet.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS 0</name>
+				<username>38591</username>
+				<password>38591</password>
+				<dns>195.29.159.15</dns>
+			</apn>
+			<apn value="3g.vip.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G</name>
+				<username>38591</username>
+				<password>38591</password>
+				<dns>212.91.97.3</dns>
+				<dns>212.91.97.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>CARNet VIPNET</name>
+		<gsm>
+			<network-id mcc="219" mnc="10"/>
+			<apn value="carnet.vip.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>AAIEDU</username>
+				<password></password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>CARNet Tele2</name>
+		<gsm>
+			<network-id mcc="219" mnc="02"/>
+			<apn value="carnet.tele2.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>AAIEDU</username>
+				<password></password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="219" mnc="02"/>
+			<apn value="mobileinternet.tele2.hr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.247.156.66</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Hungary -->
+<country code="hu">
+	<provider>
+		<name>Telenor</name>
+		<gsm>
+			<network-id mcc="216" mnc="01"/>
+			<apn value="net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>mobilinternet</name>
+				<dns>217.79.128.40</dns>
+				<dns>217.79.128.45</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>DIGI</name>
+		<gsm>
+			<!-- Using Telenor's network -->
+			<network-id mcc="216" mnc="01"/>
+			<apn value="digi">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>DIGI Move</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="216" mnc="30"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.51.115.1</dns>
+				<dns>194.176.224.6</dns>
+			</apn>
+			<apn value="mms-westel">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>MMS</name>
+				<username>mms</username>
+				<dns>212.51.115.1</dns>
+				<dns>194.176.224.3</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="216" mnc="70"/>
+			<apn value="standardnet.vodafone.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Előf. Normál</name>
+				<username>vodawap</username>
+				<password>vodawap</password>
+				<dns>80.244.97.30</dns>
+				<dns>80.244.96.1</dns>
+			</apn>
+			<!-- http://www.vodafone.hu/en/support/questions-answers/pay-monthly/internet -->
+			<apn value="internet.vodafone.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Előf. töm.</name>
+				<dns>80.244.97.30</dns>
+				<dns>80.244.96.1</dns>
+			</apn>
+			<apn value="vitamax.snet.vodafone.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Felt. norm.</name>
+				<dns>80.244.97.30</dns>
+				<dns>80.244.96.1</dns>
+			</apn>
+			<apn value="vitamax.internet.vodafone.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vodafone (felt. töm.)</name>
+				<dns>80.244.97.30</dns>
+				<dns>80.244.96.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Invitel</name>
+                <!-- MVNO operating on Telenor's network -->
+		<gsm>
+			<apn value="invitel.mobilnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>net.and.go</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Indonesia -->
+<country code="id">
+	<provider>
+		<name>3</name>
+		<gsm>
+			<network-id mcc="510" mnc="89"/>
+			<apn value="3gprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<username>3gprs</username>
+				<password>3gprs</password>
+			</apn>
+			<apn value="3data">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Monthly Internet Service</name>
+				<name xml:lang="id">Layanan Internet Bulanan</name>
+				<username>3data</username>
+				<password>3data</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>AXIS</name>
+		<gsm>
+			<network-id mcc="510" mnc="08"/>
+			<apn value="AXIS">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>axis</username>
+				<password>123456</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Indosat</name>
+		<gsm>
+			<network-id mcc="510" mnc="21"/>
+			<network-id mcc="510" mnc="01"/>
+
+			<!-- http://www.indosat.com/Customer_Support/Customer_Support/Setting_GPRS_MMS_WAP_dan_BroadBand -->
+			<!-- http://3g.indosat.com/about/FAQ.php -->
+			<!-- http://www.indosat.com/Mentari/Mentari_Update/Voucher_Internet_Indosat -->
+			<!-- It seems that the APN is pretty much the same for plans -->
+
+			<apn value="indosatgprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>IM3/Mentari Time-based</name>
+				<username>indosat@durasi</username>
+				<password>indosat@durasi</password>
+			</apn>
+			<apn value="indosatgprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>IM3/Mentari Volume-based</name>
+				<username>indosat</username>
+				<password>indosat</password>
+			</apn>
+			<apn value="indosatgprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Matrix 3G/3.5G</name>
+				<username>indosat</username>
+				<password>indosat</password>
+			</apn>
+		</gsm>
+		<cdma>
+			<name>StarOne</name>
+			<username>starone</username>
+			<password>indosat</password>
+			<sid value="10817"/>
+			<sid value="10819"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Telkomsel</name>
+		<gsm>
+			<network-id mcc="510" mnc="10"/>
+			<network-id mcc="510" mnc="20"/>
+
+			<!-- http://www.telkomsel.com/customer-service/manual-setting/ -->
+			<apn value="telkomsel">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap123</password>
+				<dns>202.152.0.2</dns>
+				<dns>202.155.14.251</dns>
+			</apn>
+
+			<!-- http://www.telkomsel.com/telkomselflash/telkomsel-flash -->
+			<apn value="flash">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Flash Time-based</name>
+				<username>foo</username>
+				<password>bar</password>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Flash Volume-based</name>
+				<username>foo</username>
+				<password>bar</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Excelcomindo (XL)</name>
+		<gsm>
+			<network-id mcc="510" mnc="11"/>
+			<apn value="www.xlgprs.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>xlgprs</username>
+				<password>proxl</password>
+				<dns>202.152.254.245</dns>
+				<dns>202.152.254.246</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SMART</name>
+		<cdma>
+			<username>smart</username>
+			<password>smart</password>
+			<sid value="10608"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Ceria</name>
+		<cdma>
+			<username>internet</username>
+			<password>ceria</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Fren</name>
+		<cdma>
+			<username>m8</username>
+			<password>m8</password>
+			<sid value="10530"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Telkom Flexy</name>
+		<cdma>
+			<username>telkomnet@flexi</username>
+			<password>telkom</password>
+			<sid value="10496"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Esia</name>
+		<cdma>
+			<sid value="10623"/>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Ireland -->
+<country code="ie">
+	<provider>
+		<name>O2</name>
+		<gsm>
+			<network-id mcc="272" mnc="02"/>
+			<balance-check>
+				<ussd>*#100#</ussd>
+			</balance-check>
+			<apn value="open.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+				<username>gprs</username>
+				<password>gprs</password>
+				<dns>62.40.32.33</dns>
+				<dns>62.40.32.34</dns>
+			</apn>
+			<apn value="pp.internet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+				<username>faster</username>
+				<password>web</password>
+				<dns>62.40.32.33</dns>
+				<dns>62.40.32.34</dns>
+			</apn>
+			<apn value="internet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Old Config Internet and MMS</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="272" mnc="01"/>
+			<msisdn-query>
+				<sms text="MYMSISDN:">50189</sms>
+			</msisdn-query>
+			<apn value="hs.vodafone.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>89.19.64.36</dns>
+				<dns>89.19.64.164</dns>
+			</apn>
+			<apn value="isp.vodafone.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+			</apn>
+			<apn value="live.vodafone.com">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>10.24.59.100</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>E-Mobile</name>
+		<gsm>
+			<network-id mcc="272" mnc="03"/>
+			<!-- Information not found on the web but with the Windows connection software -->
+			<apn value="broadband.eircommbb.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Broadband To Go</name>
+				<dns>212.129.64.220</dns>
+				<dns>212.129.64.221</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Meteor</name>
+		<gsm>
+			<network-id mcc="272" mnc="03"/>
+			<apn value="data.mymeteor.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Meteor Data</name>
+				<username>my</username>
+				<password>meteor</password>
+			</apn>
+			<apn value="broadband.mymeteor.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Broadband To Go</name>
+				<dns>212.129.64.220</dns>
+				<dns>212.129.64.221</dns>
+			</apn>
+			<apn value="isp.mymeteor.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<username>my</username>
+				<password>isp</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Three Ireland</name>
+		<gsm>
+			<network-id mcc="272" mnc="05"/>
+			<apn value="3ireland.ie">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>172.31.140.69</dns>
+				<dns>172.30.140.69</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Israel -->
+<country code="il">
+	<provider>
+		<name>CellCom</name>
+		<gsm>
+			<network-id mcc="425" mnc="02"/>
+			<apn value="internetg">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="425" mnc="01"/>
+			<apn value="uinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G Internet</name>
+				<dns>158.43.192.1</dns>
+				<dns>158.43.128.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Pelephone</name>
+		<gsm>
+			<network-id mcc="425" mnc="03"/>
+			<apn value="internet.pelephone.net.il">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G</name>
+				<username>pcl@3g</username>
+				<password>pcl</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Isle of Man -->
+<country code="im">
+	<provider>
+		<name>Manx Telecom</name>
+		<gsm>
+			<network-id mcc="234" mnc="58"/>
+			<apn value="3gpronto">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sure (Cable &amp; Wireless)</name>
+		<gsm>
+			<network-id mcc="234" mnc="36"/>
+			<network-id mcc="234" mnc="55"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- India -->
+<country code="in">
+	<provider>
+		<name>AIRCEL</name>
+		<gsm>
+			<network-id mcc="404" mnc="17"/>
+			<network-id mcc="404" mnc="28"/>
+			<network-id mcc="404" mnc="29"/>
+			<network-id mcc="404" mnc="37"/>
+			<network-id mcc="404" mnc="41"/>
+			<network-id mcc="404" mnc="42"/>
+			<network-id mcc="404" mnc="91"/>
+			<network-id mcc="405" mnc="800"/>
+			<network-id mcc="405" mnc="801"/>
+			<network-id mcc="405" mnc="802"/>
+			<network-id mcc="405" mnc="803"/>
+			<network-id mcc="405" mnc="804"/>
+			<network-id mcc="405" mnc="805"/>
+			<network-id mcc="405" mnc="806"/>
+			<network-id mcc="405" mnc="807"/>
+			<network-id mcc="405" mnc="808"/>
+			<network-id mcc="405" mnc="809"/>
+			<network-id mcc="405" mnc="810"/>
+			<network-id mcc="405" mnc="811"/>
+			<network-id mcc="405" mnc="812"/>
+
+			<apn value="aircelweb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web</name>
+			</apn>
+			<apn value="aircelgprs">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+			</apn>
+			<apn value="aircelgprs.po">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS (Postpaid)</name>
+			</apn>
+			<apn value="aircelgprs.pr">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>GPRS (Prepaid)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Airtel</name>
+		<gsm>
+			<network-id mcc="404" mnc="02"/>
+			<network-id mcc="404" mnc="03"/>
+			<network-id mcc="404" mnc="06"/>
+			<network-id mcc="404" mnc="10"/>
+			<network-id mcc="404" mnc="28"/>
+			<network-id mcc="404" mnc="31"/>
+			<network-id mcc="404" mnc="37"/>
+			<network-id mcc="404" mnc="40"/>
+			<network-id mcc="404" mnc="41"/>
+			<network-id mcc="404" mnc="42"/>
+			<network-id mcc="404" mnc="45"/>
+			<network-id mcc="404" mnc="49"/>
+			<network-id mcc="404" mnc="70"/>
+			<network-id mcc="404" mnc="90"/>
+			<network-id mcc="404" mnc="92"/>
+			<network-id mcc="404" mnc="93"/>
+			<network-id mcc="404" mnc="96"/>
+			<network-id mcc="404" mnc="97"/>
+			<network-id mcc="404" mnc="98"/>
+			<network-id mcc="405" mnc="51"/>
+			<network-id mcc="405" mnc="52"/>
+			<network-id mcc="405" mnc="54"/>
+			<network-id mcc="405" mnc="56"/>
+
+			<apn value="airtelgprs.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>202.56.230.5</dns>
+				<dns>202.56.240.5</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="404" mnc="01"/>
+			<network-id mcc="404" mnc="05"/>
+			<network-id mcc="404" mnc="11"/>
+			<network-id mcc="404" mnc="13"/>
+			<network-id mcc="404" mnc="15"/>
+			<network-id mcc="404" mnc="20"/>
+			<network-id mcc="404" mnc="27"/>
+			<network-id mcc="404" mnc="30"/>
+			<network-id mcc="404" mnc="43"/>
+			<network-id mcc="404" mnc="46"/>
+			<network-id mcc="404" mnc="60"/>
+			<network-id mcc="404" mnc="84"/>
+			<network-id mcc="404" mnc="86"/>
+			<network-id mcc="404" mnc="88"/>
+			<network-id mcc="405" mnc="66"/>
+			<network-id mcc="405" mnc="750"/>
+			<network-id mcc="405" mnc="751"/>
+			<network-id mcc="405" mnc="752"/>
+			<network-id mcc="405" mnc="753"/>
+			<network-id mcc="405" mnc="754"/>
+			<network-id mcc="405" mnc="755"/>
+			<network-id mcc="405" mnc="756"/>
+			<apn value="www">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vodafone Connect</name>
+			</apn>
+			<apn value="portalnmms">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Vodafone Live</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>BSNL/CellOne</name>
+		<gsm>
+			<network-id mcc="404" mnc="34"/>
+			<network-id mcc="404" mnc="38"/>
+			<network-id mcc="404" mnc="51"/>
+			<network-id mcc="404" mnc="53"/>
+			<network-id mcc="404" mnc="54"/>
+			<network-id mcc="404" mnc="55"/>
+			<network-id mcc="404" mnc="57"/>
+			<network-id mcc="404" mnc="58"/>
+			<network-id mcc="404" mnc="59"/>
+			<network-id mcc="404" mnc="62"/>
+			<network-id mcc="404" mnc="64"/>
+			<network-id mcc="404" mnc="66"/>
+			<network-id mcc="404" mnc="71"/>
+			<network-id mcc="404" mnc="72"/>
+			<network-id mcc="404" mnc="73"/>
+			<network-id mcc="404" mnc="74"/>
+			<network-id mcc="404" mnc="75"/>
+			<network-id mcc="404" mnc="76"/>
+			<network-id mcc="404" mnc="77"/>
+			<network-id mcc="404" mnc="80"/>
+			<network-id mcc="404" mnc="81"/>
+
+			<!-- http://cellone.in/cellone_msp.htm -->
+			<apn value="bsnlnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>New GPRS/3G</name>
+			</apn>
+
+			<apn value="bsnlwap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>New WAP</name>
+			</apn>
+
+			<apn value="bsnlsouth">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old South Zone A (Karnatka, Andhra Pradesh, Chennai, Tamil Nadu, Kerala)</name>
+			</apn>
+			<apn value="gprssouth.cellone.in">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old South Zone B (Karnatka, Andhra Pradesh, Chennai, Tamil Nadu, Kerala)</name>
+			</apn>
+			<apn value="gprsnorth.cellone.in">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old North Zone (Haryana, Punjab, UP(East), UP(West), Himachal Pradesh, Rajasthan, Jammu &amp; Kashmir)</name>
+			</apn>
+			<apn value="gprswest.cellone.in">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old West Zone (Maharashtra, Gujrat, Madhya Pradesh, Chattishgarh)</name>
+			</apn>
+			<apn value="www.e.pr">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Old East Zone Prepaid (Jharkhand, Bihar, Kolkata, West Bengal, Orissa, Assam, North East, Adman Nicobar)</name>
+				<dns>218.248.240.208</dns>
+				<dns>218.248.240.135</dns>
+			</apn>
+			<apn value="www.e.po">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Old East Zone Postpaid (Jharkhand, Bihar, Kolkata, West Bengal, Orissa, Assam, North East, Adman Nicobar)</name>
+				<dns>218.248.240.208</dns>
+				<dns>218.248.240.135</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Idea Cellular</name>
+		<gsm>
+			<network-id mcc="404" mnc="04"/>
+			<network-id mcc="404" mnc="07"/>
+			<network-id mcc="404" mnc="12"/>
+			<network-id mcc="404" mnc="14"/>
+			<network-id mcc="404" mnc="19"/>
+			<network-id mcc="404" mnc="22"/>
+			<network-id mcc="404" mnc="24"/>
+			<network-id mcc="404" mnc="44"/>
+			<network-id mcc="404" mnc="56"/>
+			<network-id mcc="404" mnc="82"/>
+			<network-id mcc="405" mnc="70"/>
+			<network-id mcc="405" mnc="799"/>
+			<network-id mcc="405" mnc="845"/>
+			<network-id mcc="405" mnc="848"/>
+			<network-id mcc="405" mnc="850"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTNL</name>
+		<gsm>
+			<network-id mcc="404" mnc="68"/>
+			<network-id mcc="404" mnc="69"/>
+			<apn value="gprsmtnldel">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Delhi</name>
+				<username>mtnl</username>
+				<password>mtnl123</password>
+			</apn>
+			<apn value="gprsppsmum">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Mumbai (Prepaid)</name>
+				<username>mtnl</username>
+				<password>mtnl123</password>
+			</apn>
+			<apn value="gprsmtnlmum">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mumbai (Postpaid / Plan 2)</name>
+				<username>mtnl</username>
+				<password>mtnl123</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Reliance</name>
+		<gsm>
+			<network-id mcc="404" mnc="09"/>
+			<network-id mcc="404" mnc="36"/>
+			<network-id mcc="404" mnc="52"/>
+			<network-id mcc="404" mnc="83"/>
+			<network-id mcc="404" mnc="85"/>
+			<network-id mcc="405" mnc="05"/>
+			<network-id mcc="405" mnc="10"/>
+			<network-id mcc="405" mnc="13"/>
+			<apn value="smartnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Smart Net</name>
+			</apn>
+			<apn value="smartwap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>Smart WAP</name>
+			</apn>
+			<apn value="rcomnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Netconnect (RCOMNET)</name>
+			</apn>
+		</gsm>
+		<cdma>
+			<name>Reliance Netconnect</name>
+			<sid value="14655"/>
+			<sid value="14656"/>
+			<sid value="14657"/>
+			<sid value="14658"/>
+			<sid value="14659"/>
+			<sid value="14660"/>
+			<sid value="14661"/>
+			<sid value="14662"/>
+			<sid value="14663"/>
+			<sid value="14664"/>
+			<sid value="14665"/>
+			<sid value="14666"/>
+			<sid value="14667"/>
+			<sid value="14668"/>
+			<sid value="14669"/>
+			<sid value="14670"/>
+			<sid value="14671"/>
+			<sid value="14672"/>
+			<sid value="14673"/>
+			<sid value="14674"/>
+			<sid value="14675"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Spice telecom</name>
+		<gsm>
+			<network-id mcc="404" mnc="14"/>
+			<network-id mcc="404" mnc="44"/>
+
+			<apn value="Simplyenjoy">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>spice</username>
+				<password>spice</password>
+			</apn>
+			<apn value="simplydownload">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>kar</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tata Docomo</name>
+		<gsm>
+			<network-id mcc="405" mnc="025"/>
+			<network-id mcc="405" mnc="026"/>
+			<network-id mcc="405" mnc="027"/>
+			<network-id mcc="405" mnc="029"/>
+			<network-id mcc="405" mnc="030"/>
+			<network-id mcc="405" mnc="031"/>
+			<network-id mcc="405" mnc="032"/>
+			<network-id mcc="405" mnc="034"/>
+			<network-id mcc="405" mnc="035"/>
+			<network-id mcc="405" mnc="036"/>
+			<network-id mcc="405" mnc="037"/>
+			<network-id mcc="405" mnc="038"/>
+			<network-id mcc="405" mnc="039"/>
+			<network-id mcc="405" mnc="041"/>
+			<network-id mcc="405" mnc="042"/>
+			<network-id mcc="405" mnc="043"/>
+			<network-id mcc="405" mnc="044"/>
+			<network-id mcc="405" mnc="045"/>
+			<network-id mcc="405" mnc="046"/>
+			<network-id mcc="405" mnc="047"/>
+
+			<apn value="TATA.DOCOMO.INTERNET">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="TATADOCOMO3G">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tata Indicom (Plug2Surf)</name>
+		<cdma>
+			<username>internet</username>
+			<password>internet</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Tata Indicom (Photon+)</name>
+		<cdma>
+			<username>internet</username>
+			<password>internet</password>
+			<sid value="14836"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>MTS MBlaze</name>
+		<cdma>
+			<username>internet@internet.mtsindia.in</username>
+			<password>mts</password>
+			<sid value="14554"/>
+			<sid value="14555"/>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Iraq -->
+<country code="iq">
+	<provider>
+		<name>Itisaluna</name>
+		<cdma>
+			<username>itisaluna</username>
+			<password>itisaluna</password>
+			<sid value="15456"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Omnea Telecom</name>
+		<cdma>
+			<username>omnea</username>
+			<password>omnea</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Kalimat Telecom</name>
+		<cdma>
+			<sid value="15470"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Korek</name>
+		<gsm>
+			<network-id mcc="418" mnc="40"/>
+			<apn value="net.korek.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>korek</username>
+				<password>korek</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Asia Cell</name>
+		<gsm>
+			<network-id mcc="418" mnc="50"/>
+			<apn value="net.asiacell.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Iran -->
+<country code="ir">
+	<provider>
+		<name>همراه اول</name>
+		<gsm>
+			<network-id mcc="432" mnc="11"/>
+			<apn value="mcinet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>ایرانسل</name>
+		<gsm>
+			<network-id mcc="432" mnc="35"/>
+			<apn value="mtnirancell">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Iceland -->
+<country code="is">
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="274" mnc="02"/>
+			<network-id mcc="274" mnc="03"/>
+			<apn value="vmc.gprs.is">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.176.128.51</dns>
+				<dns>213.176.128.50</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Nova</name>
+		<gsm>
+			<network-id mcc="274" mnc="11"/>
+			<apn value="internet.nova.is">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>192.168.190.54</dns>
+				<dns>192.168.190.55</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Síminn</name>
+		<gsm>
+			<network-id mcc="274" mnc="01"/>
+			<apn value="wap.simi.is">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>194.105.224.1</dns>
+				<dns>212.30.200.200</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Italy -->
+<country code="it">
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="222" mnc="10"/>
+			<apn value="mobile.vodafone.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+			</apn>
+			<apn value="web.omnitel.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Facile (old)</name>
+				<dns>83.224.70.62</dns>
+				<dns>83.224.70.78</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TIM</name>
+		<gsm>
+			<network-id mcc="222" mnc="01"/>
+			<apn value="ibox.tim.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Maxxi Alice/Internet</name>
+				<dns>217.200.200.42</dns>
+				<dns>213.230.129.10</dns>
+			</apn>
+			<apn value="wap.tim.it">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>WAPTIM</username>
+				<dns>213.230.155.94</dns>
+				<dns>213.230.130.222</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Wind</name>
+		<gsm>
+			<network-id mcc="222" mnc="88"/>
+			<apn value="internet.wind">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Non-business</name>
+				<username>Wind</username>
+				<password>Wind</password>
+				<dns>193.70.152.25</dns>
+				<dns>193.70.192.25</dns>
+			</apn>
+			<apn value="internet.wind.biz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Business</name>
+				<username>Wind</username>
+				<password>Wind</password>
+				<dns>193.70.152.25</dns>
+				<dns>193.70.192.25</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>3</name>
+		<gsm>
+			<network-id mcc="222" mnc="99"/>
+			<apn value="tre.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Ricaricabile</name>
+				<dns>62.13.169.92</dns>
+				<dns>62.13.169.93</dns>
+			</apn>
+			<apn value="datacard.tre.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Abbonamento</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Fastweb</name>
+		<gsm>
+			<network-id mcc="222" mnc="99"/>
+			<apn value="apn.fastweb.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Voce/dati</name>
+			</apn>
+			<apn value="datacard.fastweb.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Solo dati</name>
+				<dns>213.140.2.43</dns>
+				<dns>213.140.2.49</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>PosteMobile</name>
+		<gsm>
+			<network-id mcc="222" mnc="10"/>
+			<apn value="internet.postemobile.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>CoopVoce</name>
+		<gsm>
+			<network-id mcc="222" mnc="01"/>
+			<apn value="web.coopvoce.it">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Mobile</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Jersey -->
+<country code="je">
+	<provider>
+		<name>Airtel-Vodaphone</name>
+		<gsm>
+			<network-id mcc="234" mnc="03"/>
+			<apn value="airtel-ci-gprs.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sure (Cable &amp; Wireless)</name>
+		<gsm>
+			<network-id mcc="234" mnc="55"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Jersey Telecom</name>
+		<gsm>
+			<network-id mcc="234" mnc="50"/>
+			<apn value="pepper">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>abc</username>
+				<password>abc</password>
+				<dns>212.9.0.135</dns>
+				<dns>212.9.0.136</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Jamaica -->
+<country code="jm">
+	<provider>
+		<name>Cable &amp; Wireless</name>
+		<gsm>
+			<network-id mcc="338" mnc="020"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Digicel</name>
+		<gsm>
+			<network-id mcc="338" mnc="050"/>
+			<apn value="web.digiceljamaica.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wapuser</username>
+				<password>wap03jam</password>
+				<dns>208.131.176.126</dns>
+				<dns>200.10.152.232</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Hashemite Kingdom of Jordan -->
+<country code="jo">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="416" mnc="77"/>
+			<apn value="net.orange.jo">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<username>net</username>
+				<password>net</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="416" mnc="01"/>
+			<apn value="zain">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<username>Zain</username>
+				<password>Zain</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Japan -->
+<country code="jp">
+	<provider>
+		<name>Softbank Mobile</name>
+		<gsm>
+			<network-id mcc="440" mnc="04"/>
+			<network-id mcc="440" mnc="06"/>
+			<network-id mcc="440" mnc="20"/>
+			<network-id mcc="440" mnc="40"/>
+			<network-id mcc="440" mnc="41"/>
+			<network-id mcc="440" mnc="42"/>
+			<network-id mcc="440" mnc="43"/>
+			<network-id mcc="440" mnc="44"/>
+			<network-id mcc="440" mnc="45"/>
+			<network-id mcc="440" mnc="46"/>
+			<network-id mcc="440" mnc="47"/>
+			<network-id mcc="440" mnc="48"/>
+			<network-id mcc="440" mnc="90"/>
+			<network-id mcc="440" mnc="92"/>
+			<network-id mcc="440" mnc="93"/>
+			<network-id mcc="440" mnc="94"/>
+			<network-id mcc="440" mnc="95"/>
+			<network-id mcc="440" mnc="96"/>
+			<network-id mcc="440" mnc="97"/>
+			<network-id mcc="440" mnc="98"/>
+			<apn value="softbank">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>ai@softbank</username>
+				<password>softbank</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>b-mobile</name>
+		<gsm>
+			<network-id mcc="440" mnc="10"/>
+			<apn value="dm.jplat.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>u300</name>
+				<username>bmobile@u300</username>
+				<password>bmobile</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>e-mobile</name>
+		<gsm>
+			<network-id mcc="440" mnc="00"/>
+			<apn value="emb.ne.jp">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>em</username>
+				<password>em</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>NTTdocomo</name>
+		<gsm>
+			<network-id mcc="440" mnc="01"/>
+			<network-id mcc="440" mnc="02"/>
+			<network-id mcc="440" mnc="03"/>
+			<network-id mcc="440" mnc="09"/>
+			<network-id mcc="440" mnc="10"/>
+			<network-id mcc="440" mnc="11"/>
+			<network-id mcc="440" mnc="12"/>
+			<network-id mcc="440" mnc="13"/>
+			<network-id mcc="440" mnc="14"/>
+			<network-id mcc="440" mnc="15"/>
+			<network-id mcc="440" mnc="16"/>
+			<network-id mcc="440" mnc="17"/>
+			<network-id mcc="440" mnc="18"/>
+			<network-id mcc="440" mnc="19"/>
+			<network-id mcc="440" mnc="21"/>
+			<network-id mcc="440" mnc="22"/>
+			<network-id mcc="440" mnc="23"/>
+			<network-id mcc="440" mnc="24"/>
+			<network-id mcc="440" mnc="25"/>
+			<network-id mcc="440" mnc="26"/>
+			<network-id mcc="440" mnc="27"/>
+			<network-id mcc="440" mnc="28"/>
+			<network-id mcc="440" mnc="29"/>
+			<network-id mcc="440" mnc="30"/>
+			<network-id mcc="440" mnc="31"/>
+			<network-id mcc="440" mnc="32"/>
+			<network-id mcc="440" mnc="33"/>
+			<network-id mcc="440" mnc="34"/>
+			<network-id mcc="440" mnc="35"/>
+			<network-id mcc="440" mnc="36"/>
+			<network-id mcc="440" mnc="37"/>
+			<network-id mcc="440" mnc="38"/>
+			<network-id mcc="440" mnc="39"/>
+			<network-id mcc="440" mnc="49"/>
+			<network-id mcc="440" mnc="58"/>
+			<network-id mcc="440" mnc="60"/>
+			<network-id mcc="440" mnc="61"/>
+			<network-id mcc="440" mnc="62"/>
+			<network-id mcc="440" mnc="63"/>
+			<network-id mcc="440" mnc="64"/>
+			<network-id mcc="440" mnc="65"/>
+			<network-id mcc="440" mnc="66"/>
+			<network-id mcc="440" mnc="67"/>
+			<network-id mcc="440" mnc="68"/>
+			<network-id mcc="440" mnc="69"/>
+			<network-id mcc="440" mnc="87"/>
+			<network-id mcc="440" mnc="99"/>
+
+			<apn value="mopera.ne.jp">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>mopera</name>
+			</apn>
+			<apn value="mopera.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>mopera U</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>au(KDDI)</name>
+		<cdma>
+			<username>au@au-win.ne.jp</username>
+			<password>au</password>
+			<dns>210.196.3.183</dns>
+			<dns>210.141.112.163</dns>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Kenya -->
+<country code="ke">
+	<provider>
+		<name>Airtel</name>
+		<gsm>
+			<network-id mcc="639" mnc="03"/>
+			<apn value="ke.celtel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Safaricom</name>
+		<gsm>
+			<network-id mcc="639" mnc="02"/>
+			<apn value="safaricom">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>yu (Econet)</name>
+		<gsm>
+			<network-id mcc="639" mnc="05"/>
+			<apn value="internet.econet.co.ke">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="639" mnc="07"/>
+			<apn value="bew.orange.co.ke">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+		<cdma>
+			<name>Orange Fixed Plus</name>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Kyrgyzstan -->
+<country code="kg">
+	<provider>
+		<name>Beeline</name>
+		<gsm>
+			<network-id mcc="437" mnc="01"/>
+			<apn value="internet.beeline.kg">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MegaCom</name>
+		<gsm>
+			<network-id mcc="437" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>O!</name>
+		<gsm>
+			<network-id mcc="437" mnc="09"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>FONEX</name>
+		<cdma>
+			<username>cdma</username>
+			<password>cdma</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>nexi (mir+kg)</name>
+		<name xml:lang="ru">Зона Мир+КГ</name>
+		<cdma>
+			<username>555@mir</username>
+			<password>555</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>nexi (kg)</name>
+		<name xml:lang="ru">Зона КГ</name>
+		<cdma>
+			<username>999@kg</username>
+			<password>999</password>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Cambodia -->
+<country code="kh">
+	<provider>
+		<name>Cellcard</name>
+		<gsm>
+			<network-id mcc="456" mnc="01"/>
+
+			<balance-check>
+				<ussd>#124#</ussd>
+			</balance-check>
+
+			<!-- http://www.cellcard.com.kh/en/service/data_3.5G_internet.php -->
+			<apn value="cellcard">
+				<usage type="internet"/>
+				<username>mobitel</username>
+				<password>mobitel</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Hello</name>
+		<gsm>
+			<network-id mcc="456" mnc="02"/>
+
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+
+			<!-- http://www.tmic.com.kh/public/mobile_broadband/mobile_broadband.aspx?page=broadband_faq -->
+			<!-- in reality any APN value works -->
+			<apn value="hellowww">
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>qb</name>
+		<gsm>
+			<network-id mcc="456" mnc="04"/>
+
+			<balance-check>
+				<ussd>#132#</ussd>
+			</balance-check>
+
+			<!-- http://www.qbmore.com/download/handsetconfiguration.html -->
+			<apn value="WAP">
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Smart Mobile</name>
+		<gsm>
+			<network-id mcc="456" mnc="06"/>
+
+			<balance-check>
+				<ussd>*888#</ussd>
+			</balance-check>
+
+			<!-- http://www.smart.com.kh/en/services/internet -->
+			<apn value="smart">
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Metfone</name>
+		<gsm>
+			<network-id mcc="456" mnc="08"/>
+
+			<balance-check>
+				<ussd>*097#</ussd>
+			</balance-check>
+
+			<!-- http://metfone.com.kh/home/metfone.mf?id=20&task=detailpac -->
+			<apn value="metfone">
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Beeline</name>
+		<gsm>
+			<network-id mcc="456" mnc="09"/>
+
+			<balance-check>
+				<ussd>*102#</ussd>
+			</balance-check>
+
+			<!-- in reality any APN value works -->
+			<apn value="gprs.beeline.com.kh">
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Excell</name>
+			<!-- mcc="456" mnc="11" -->
+		<cdma/>
+	</provider>
+	<provider>
+		<name>Mfone</name>
+		<gsm>
+			<network-id mcc="456" mnc="18"/>
+
+			<balance-check>
+				<ussd>*222#</ussd>
+			</balance-check>
+
+			<!-- http://www.mfone.com.kh/images/3g/mfone_3g.pdf -->
+			<apn value="Mfone">
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Korea, Republic of -->
+<country code="kr">
+	<provider>
+		<name>KTF</name>
+		<gsm>
+			<network-id mcc="450" mnc="08"/>
+			<apn value="hsdpa-internet.ktfwing.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+		<cdma>
+			<!-- cid: "016" -->
+			<username>ktf</username>
+			<password>ktf</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>LGTelecom</name>
+		<cdma>
+			<!-- cid: "109" -->
+			<!--
+			username must be xxxx(yournumber)@lgt.co.kr and
+			password must be your last 4 number
+			<username>number@lgt.co.kr</username>
+			<password></password>
+			-->
+		</cdma>
+	</provider>
+	<provider>
+		<name>SKTelecom</name>
+		<gsm>
+			<network-id mcc="450" mnc="05"/>
+			<apn value="nate.sktelecom.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+		<cdma>
+			<!-- cid: 1501 -->
+			<username>sktelecom</username>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Kuwait -->
+<country code="kw">
+	<provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="419" mnc="02"/>
+			<apn value="pps">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Personal</name>
+				<username>pps</username>
+				<password>pps</password>
+			</apn>
+			<apn value="apn01">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Corporate</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Wataniya</name>
+		<gsm>
+			<network-id mcc="419" mnc="03"/>
+			<apn value="action.wataniya.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Viva</name>
+		<gsm>
+			<network-id mcc="419" mnc="04"/>
+			<apn value="viva">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Kazakhstan -->
+<country code="kz">
+	<provider>
+		<name>Beeline</name>
+		<gsm>
+			<network-id mcc="401" mnc="01"/>
+			<apn value="internet.beeline.kz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>@internet.beeline</username>
+				<dns>212.19.149.53</dns>
+				<dns>194.226.128.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>K'CELL</name>
+		<gsm>
+			<network-id mcc="401" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<!-- Owned by K'CELL -->
+		<name>Activ</name>
+		<gsm>
+			<network-id mcc="401" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="401" mnc="77"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Pathword</name>
+		<cdma>
+			<username>Pathword</username>
+			<password>Pathword</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Dalacom</name>
+		<cdma>
+			<username>Dalacom</username>
+			<password>Dalacom</password>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Laos -->
+<country code="la">
+	<provider>
+		<name>ETL</name>
+		<gsm>
+			<network-id mcc="457" mnc="02"/>
+			<apn value="etlnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>192.168.4.130</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Lao Telecom</name>
+		<gsm>
+			<network-id mcc="457" mnc="01"/>
+			<balance-check>
+				<ussd>*122#</ussd>
+			</balance-check>			
+			<apn value="ltcnet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Unitel</name>
+		<gsm>
+			<network-id mcc="457" mnc="03"/>
+			<apn value="startelecom">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Unitel (2G)</name>
+			</apn>
+			<apn value="unitel3g">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Unitel (3G)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Beeline (Tigo)</name>
+		<gsm>
+			<network-id mcc="457" mnc="08"/>
+			<apn value="beelinenet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Lebanon -->
+<country code="lb">
+	<provider>
+		<name>MTC Touch</name>
+		<gsm>
+			<network-id mcc="415" mnc="03"/>
+			<apn value="gprs.mtctouch.com.lb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- St Lucia -->
+<country code="lc">
+	<provider>
+		<name>Cable &amp; Wireless</name>
+		<gsm>
+			<network-id mcc="358" mnc="110"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Sri Lanka -->
+<country code="lk">
+	<provider>
+		<name>Airtel</name>
+		<gsm>
+			<network-id mcc="413" mnc="05"/>
+			<apn value="www.wap.airtel.lk">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Dialog GSM</name>
+		<gsm>
+			<network-id mcc="413" mnc="02"/>
+			<apn value="www.dialogsl.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid</name>
+			</apn>
+			<apn value="ppinternet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+			</apn>
+			<apn value="dialogbb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Unlimited Broadband</name>
+			</apn>
+			<apn value="kitbb.com">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid (Kitbb)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Hutch</name>
+		<gsm>
+			<network-id mcc="413" mnc="08"/>
+			<apn value="htwap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Mobitel</name>
+		<gsm>
+			<network-id mcc="413" mnc="01"/>
+			<apn value="isp">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="413" mnc="03"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Lesotho -->
+<country code="ls">
+	<provider>
+		<name>Vodacom Lesotho</name>
+		<gsm>
+			<network-id mcc="651" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Lithuania -->
+<country code="lt">
+	<provider>
+		<name>Bite</name>
+		<gsm>
+			<network-id mcc="246" mnc="02"/>
+			<apn value="banga">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.226.131.131</dns>
+				<dns>193.219.88.36</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TELE2 GPRS</name>
+		<gsm>
+			<network-id mcc="246" mnc="03"/>
+			<apn value="internet.tele2.lt">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Omnitel (contract)</name>
+		<gsm>
+			<network-id mcc="246" mnc="01"/>
+			<apn value="gprs.omnitel.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+				<dns>194.176.32.129</dns>
+				<dns>195.22.175.1</dns>
+			</apn>
+			<apn value="gprs.startas.lt">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>No contract</name>
+				<username>omni</username>
+				<password>omni</password>
+				<dns>194.176.32.129</dns>
+				<dns>195.22.175.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Luxembourg -->
+<country code="lu">
+	<provider>
+		<name>LUXGSM</name>
+		<gsm>
+			<network-id mcc="270" mnc="01"/>
+			<apn value="web.pt.lu">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>194.154.192.101</dns>
+				<dns>194.154.192.102</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tango</name>
+		<gsm>
+			<network-id mcc="270" mnc="77"/>
+			<apn value="hspa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>hspa</name>
+				<username>tango</username>
+				<password>tango</password>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>internet</name>
+				<username>tango</username>
+				<password>tango</password>
+				<dns>212.66.70.3</dns>
+				<dns>212.66.75.7</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="270" mnc="99"/>
+			<apn value="orange.lu">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>85.94.224.1</dns>
+				<dns>85.94.224.2</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>VOXmobile</name>
+		<gsm>
+			<network-id mcc="270" mnc="99"/>
+			<apn value="vox.lu">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Latvia -->
+<country code="lv">
+	<provider>
+		<name>LMT</name>
+		<gsm>
+			<network-id mcc="247" mnc="01"/>
+			<apn value="internet.lmt.lv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.93.96.2</dns>
+				<dns>212.93.96.4</dns>
+			</apn>
+			<apn value="open.lmt.lv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>O!Karte internet</name>
+			</apn>
+			<apn value="okarte.lmt.lv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>O!Karte</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="247" mnc="02"/>
+			<apn value="internet.tele2.lv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Regular</name>
+				<username>gprs</username>
+				<password>internet</password>
+			</apn>
+			<apn value="mobileinternet.tele2.lv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+			<apn value="data.tele2.lv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Zelta Zivtina</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Bite</name>
+		<gsm>
+			<network-id mcc="247" mnc="05"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Bite plus</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Prepaid/Contract</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Morocco -->
+<country code="ma">
+	<provider>
+		<name>Ittissalat Al Maghrib (IAM)</name>
+		<gsm>
+			<network-id mcc="604" mnc="01"/>
+			<apn value="www.iamgprs1.ma">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Abonnement</name>
+			</apn>
+			<apn value="www.iamgprs2.ma">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Pre-payé</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Medi Telecom</name>
+		<gsm>
+			<network-id mcc="604" mnc="00"/>
+			<apn value="internet1.meditel.ma">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Abonnement</name>
+				<username>MEDINET</username>
+				<password>MEDINET</password>
+			</apn>
+			<apn value="internet2.meditel.ma">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Pre-payé</name>
+				<username>MEDINET</username>
+				<password>MEDINET</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>WANA</name>
+		<gsm>
+			<network-id mcc="604" mnc="02"/>
+			<apn value="www.wana.ma">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>INWI</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Moldova -->
+<country code="md">
+	<provider>
+		<name>Moldcell</name>
+		<gsm>
+			<network-id mcc="259" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<username>gprs</username>
+				<password>gprs</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Eventis</name>
+		<gsm>
+			<network-id mcc="259" mnc="04"/>
+			<apn value="internet.md">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="259" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Montenegro -->
+<country code="me">
+	<provider>
+		<name>ProMonte GSM</name>
+		<gsm>
+			<network-id mcc="297" mnc="01"/>
+			<apn value="gprs.promonte.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="297" mnc="02"/>
+			<apn value="tmcg-data">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<username>38267</username>
+				<password>38267</password>
+			</apn>
+			<apn value="tmcg-nw">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<username>38267</username>
+				<password>38267</password>
+			</apn>
+			<apn value="internet-postpaid">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid (old)</name>
+			</apn>
+			<apn value="internet-prepaid">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid (old)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>m:tel</name>
+		<gsm>
+			<network-id mcc="297" mnc="03"/>
+			<apn value="gprsinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Mali -->
+<country code="ml">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="610" mnc="02"/>
+			<apn value="iew">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>iew</username>
+				<password>iew</password>
+			</apn>
+			<apn value="internet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Malitel</name>
+		<cdma>
+			<username>card</username>
+			<password>card</password>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Mongolia -->
+<country code="mn">
+	<provider>
+		<name>MobiCom</name>
+		<gsm>
+			<network-id mcc="428" mnc="99"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Macau -->
+<country code="mo">
+	<provider>
+		<name>3 / Hutchison</name>
+		<gsm>
+			<network-id mcc="455" mnc="03"/>
+			<network-id mcc="455" mnc="05"/>
+			<apn value="web.hutchisonmacau.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>hutchison</username>
+				<password>1234</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>CTM</name>
+		<gsm>
+			<network-id mcc="455" mnc="01"/>
+			<network-id mcc="455" mnc="04"/>
+			<apn value="ctm-mobile">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>China Telecom</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Macedonia -->
+<country code="mk">
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="294" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>One</name>
+		<gsm>
+			<network-id mcc="294" mnc="02"/>
+			<apn value="datacard">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="294" mnc="03"/>
+			<apn value="vipoperator">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>vipoperator</username>
+				<password>vipoperator</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Malta -->
+<country code="mt">
+	<provider>
+		<name>GO Mobile</name>
+		<gsm>
+			<network-id mcc="278" mnc="21"/>
+			<apn value="gosurfing">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid</name>
+			</apn>
+			<apn value="rtgsurfing">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="278" mnc="01"/>
+			<apn value="Internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+				<dns>80.85.96.131</dns>
+				<dns>80.85.97.70</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Mauritius -->
+<country code="mu">
+	<provider>
+		<name>Emtel</name>
+		<gsm>
+			<network-id mcc="617" mnc="10"/>
+			<apn value="WEB">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Maldives -->
+<country code="mv">
+	<provider>
+		<name>Dhiraagu</name>
+		<gsm>
+			<network-id mcc="472" mnc="01"/>
+			<apn value="internet.dhimobile">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Wataniya</name>
+		<gsm>
+			<network-id mcc="472" mnc="02"/>
+			<apn value="WataniyaNet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Malawi -->
+<country code="mw">
+	<provider>
+		<name>TNM</name>
+		<gsm>
+			<network-id mcc="650" mnc="01"/>
+			<apn value="Internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Mexico -->
+<country code="mx">
+	<provider>
+		<name>Telcel</name>
+		<gsm>
+			<network-id mcc="334" mnc="02"/>
+
+			<voicemail>*86</voicemail>
+			<balance-check>
+				<dtmf>*333</dtmf>
+			</balance-check>
+
+			<apn value="internet.itelcel.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>webgprs</username>
+				<password>webgprs2002</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="334" mnc="03"/>
+
+			<voicemail>*86</voicemail>
+			<balance-check>
+				<dtmf>*133#</dtmf>
+			</balance-check>
+
+			<apn value="internet.movistar.mx">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistar</username>
+				<password>movistar</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Iusacell</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Malaysia -->
+<country code="my">
+	<provider>
+		<name>DiGi</name>
+		<gsm>
+			<network-id mcc="502" mnc="16"/>
+			<apn value="diginet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+				<dns>203.92.128.131</dns>
+				<dns>203.92.128.132</dns>
+			</apn>
+			<apn value="3gdgnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Maxis</name>
+		<gsm>
+			<network-id mcc="502" mnc="12"/>
+			<network-id mcc="502" mnc="17"/>
+			<apn value="maxisbb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Broadband</name>
+				<username>maxis</username>
+				<password>wap</password>
+			</apn>
+			<apn value="net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<username>maxis</username>
+				<password>net</password>
+			</apn>
+			<apn value="unet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G (handsets)</name>
+				<username>maxis</username>
+				<password>wap</password>
+				<dns>10.213.17.1</dns>
+				<dns>10.213.17.2</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Celcom</name>
+		<gsm>
+			<network-id mcc="502" mnc="13"/>
+			<network-id mcc="502" mnc="19"/>
+			<!-- http://www.channelx.com.my/mdp/gprs/internet_config.jsp?model_name=motorola_e398 -->
+			<apn value="celcom.net.my">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+			</apn>
+			<!-- http://www.channelx.com.my/mdp/3g/wap_config_3g.jsp?model_name=huwei_u600_3g -->
+			<apn value="celcom3g">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Celcom 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Mozambique -->
+<country code="mz">
+	<provider>
+		<name>MCel</name>
+		<gsm>
+			<network-id mcc="643" mnc="01"/>
+			<apn value="isp.mcel.mz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>guest</username>
+				<password>guest</password>
+				<dns>212.96.24.2</dns>
+				<dns>212.96.24.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodacom</name>
+		<gsm>
+			<network-id mcc="643" mnc="04"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract / Prepaid</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Namibia -->
+<country code="na">
+	<provider>
+		<name>MTC</name>
+		<gsm>
+			<network-id mcc="649" mnc="01"/>
+			<apn value="ppsinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Tango</name>
+				<username>ppsuser</username>
+				<password>ppsuser</password>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telecom</name>
+		<cdma>
+			<name>switch</name>
+			<password>telecom</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Leo</name>
+		<gsm>
+			<network-id mcc="649" mnc="03"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Leo</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Nigeria -->
+<country code="ng">
+	<provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="621" mnc="20"/>
+			<network-id mcc="621" mnc="80"/>
+			<apn value="wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="621" mnc="30"/>
+			<network-id mcc="621" mnc="60"/>
+			<apn value="web.gprs.mtnnigeria.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Glo Mobile</name>
+		<gsm>
+			<network-id mcc="621" mnc="50"/>
+			<network-id mcc="621" mnc="70"/>
+			<apn value="glosecure">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Pay as You Go</name>
+				<username>gprs</username>
+				<password>gprs</password>
+			</apn>
+			<apn value="gloflat">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Glo 3G Packs</name>
+				<username>flat</username>
+				<password>flat</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Etisalat</name>
+		<gsm>
+			<network-id mcc="621" mnc="90"/>
+			<apn value="etisalat">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Etisalat Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Starcomms</name>
+		<cdma>
+			<username>your_phone_number@starcomms.com</username>
+			<password>your_phone_number</password>
+			<sid value="2"/>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Nicaragua -->
+<country code="ni">
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="710" mnc="21"/>
+			<network-id mcc="710" mnc="73"/>
+			<apn value="wap.emovil">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>wapemovil</username>
+				<password>wapemovil</password>
+			</apn>
+			<apn value="web.emovil">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web</name>
+				<username>webemovil</username>
+				<password>webemovil</password>
+			</apn>
+			<apn value="internet.ideasalo.ni">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web (Alo pcs)</name>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+			<apn value="wap.ideasalo.ni">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP (Alo pcs)</name>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="710" mnc="30"/>
+			<apn value="internet.movistar.ni">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Netherlands -->
+<country code="nl">
+	<provider>
+		<name>Hi</name>
+		<gsm>
+			<network-id mcc="204" mnc="08"/>
+			<apn value="portalmmm.nl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>KPN NL</name>
+		<gsm>
+			<network-id mcc="204" mnc="08"/>
+			<apn value="prepaidinternet" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+			<apn value="fastinternet" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>KPN</username>
+				<password>gprs</password>
+				<dns>62.133.126.28</dns>
+				<dns>62.133.126.29</dns>
+			</apn>
+			<apn value="noapn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>62.133.126.28</dns>
+				<dns>62.133.126.29</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MEDIONmobile</name>
+		<gsm>
+			<network-id mcc="204" mnc="08"/>
+			<network-id mcc="204" mnc="10"/>
+			<apn value="portalmmm.nl">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Aldi Talk Mobiel Prepaid Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telfort</name>
+		<gsm>
+			<network-id mcc="204" mnc="12"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>telfortnl</username>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="204" mnc="16"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>193.78.240.12</dns>
+				<dns>193.79.242.39</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Ben</name>
+		<gsm>
+			<network-id mcc="204" mnc="16"/>
+			<apn value="internet.ben">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>193.78.240.12</dns>
+				<dns>193.79.242.39</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="204" mnc="20"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>orange</username>
+				<password>orange</password>
+			</apn>
+		</gsm>
+	</provider>
+		<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="204" mnc="02"/>
+			<apn value="data.tele2.nl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>XS4ALL Mobiel Internet</name>
+		<gsm>
+			<apn value="umts.xs4all.nl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>xs4all</username>
+				<password>xs4all</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="204" mnc="04"/>
+			<msisdn-query>
+				<ussd>*#100#</ussd>
+			</msisdn-query>
+			<apn value="live.vodafone.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Non-business</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>62.140.138.237</dns>
+				<dns>62.140.140.250</dns>
+			</apn>
+			<apn value="office.vodafone.nl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Business</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Norway -->
+<country code="no">
+	<provider>
+		<name>Netcom</name>
+		<gsm>
+			<network-id mcc="242" mnc="02"/>
+
+			<balance-check>
+				<ussd>*150#</ussd>
+			</balance-check>
+
+			<apn value="internet.netcom.no">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>netcom</username>
+				<password>netcom</password>
+				<dns>212.169.123.67</dns>
+				<dns>212.45.188.254</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<!-- http://www.ice.no/Mobilt-bredb%C3%A5nd-1046.aspx -->
+	<provider>
+		<name>ice.net (Nordisk Mobiltelefon)</name>
+		<cdma>
+			<username>cdma</username>
+			<password>cdma</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Telenor</name>
+		<gsm>
+			<network-id mcc="242" mnc="01"/>
+
+			<voicemail>91500002</voicemail>
+			<balance-check>
+				<sms text="saldo">2525</sms>
+			</balance-check>
+
+			<apn value="telenor">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.17.131.3</dns>
+				<dns>148.122.161.2</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TDC</name>
+		<gsm>
+			<network-id mcc="242" mnc="08"/>
+			<apn value="internet.no">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>80.232.41.10</dns>
+				<dns>80.232.41.20</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>NetworkNorway</name>
+		<gsm>
+			<network-id mcc="242" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>OneCall</name>
+		<gsm>
+			<network-id mcc="242" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Lebara</name>
+		<gsm>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Altibox</name>
+		<gsm>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SheTalks</name>
+		<gsm>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telipol</name>
+		<gsm>
+			<network-id mcc="242" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Ventelo</name>
+		<gsm>
+			<network-id mcc="242" mnc="07"/>
+			<apn value="internet.ventelo.no">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Ludo Mobil</name>
+		<gsm>
+			<network-id mcc="242" mnc="07"/>
+			<apn value="internet.ventelo.no">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="242" mnc="02"/>
+			<network-id mcc="242" mnc="04"/>
+
+			<voicemail>47230000</voicemail>
+			<balance-check>
+				<ussd>*111#</ussd>
+				<dtmf>47300000</dtmf>
+			</balance-check>
+
+			<apn value="internet.tele2.no">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>Mobilt internet</name>
+			</apn>
+			<!-- http://www.tele2.no/mobilt-bredbaand.html -->
+			<apn value="mobileinternet.tele2.no">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt bredbånd</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Nepal -->
+<country code="np">
+	<provider>
+		<name>Nepal Telecom</name>
+		<gsm>
+			<network-id mcc="429" mnc="01"/>
+			<apn value="ntnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Mero Mobile</name>
+		<gsm>
+			<network-id mcc="429" mnc="02"/>
+			<apn value="mero">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- New Zealand -->
+<country code="nz">
+	<provider>
+		<name>Telecom New Zealand</name>
+		<gsm>
+			<network-id mcc="530" mnc="00"/>
+			<network-id mcc="530" mnc="05"/>
+			<apn value="wap.telecom.co.nz">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>XT mobile (WAP)</name>
+			</apn>
+			<apn value="internet.telecom.co.nz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>XT mobile (Internet with Firewall)</name>
+				<dns>202.27.156.72</dns>
+				<dns>202.27.158.40</dns>
+			</apn>
+			<apn value="direct.telecom.co.nz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>XT mobile (Direct Internet)</name>
+				<dns>202.27.156.72</dns>
+				<dns>202.27.158.40</dns>
+			</apn>
+			<apn value="oa.telecom.co.nz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>XT mobile (One Office/Remote Office)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="530" mnc="01"/>
+			<apn value="live.vodafone.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WAP</name>
+				<dns>202.73.206.16</dns>
+				<dns>202.73.198.16</dns>
+			</apn>
+			<apn value="www.vodafone.net.nz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract / Prepaid (Restricted)</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Unrestricted (public)</name>
+				<dns>202.73.206.16</dns>
+				<dns>202.73.198.16</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>2-Degrees</name>
+		<gsm>
+			<network-id mcc="530" mnc="24"/>
+			<apn value="mms">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>MMS</name>
+			</apn>
+			<apn value="internet">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Broadband</name>
+				<dns>118.148.1.10</dns>
+				<dns>118.148.1.20</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TelstraClear</name>
+		<gsm>
+			<apn value="www.telstraclear.net.nz">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orcon</name>
+		<gsm>
+			<apn value="www.orcon.net.nz">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Broadband</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Oman -->
+<country code="om">
+	<provider>
+		<name>Oman Mobile</name>
+		<gsm>
+			<network-id mcc="422" mnc="02"/>
+			<apn value="taif">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<username>taif</username>
+				<password>taif</password>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet (old)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Nawras</name>
+		<gsm>
+			<network-id mcc="422" mnc="03"/>
+			<apn value="isp.nawras.com.om">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Panama -->
+<country code="pa">
+	<provider>
+		<name>Cable and Wireless</name>
+		<gsm>
+			<network-id mcc="714" mnc="01"/>
+			<apn value="apn01.cwpanama.com.pa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="714" mnc="02"/>
+			<apn value="internet.movistar.pa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistarpa</username>
+				<password>movistarpa</password>
+				<dns>200.39.10.1</dns>
+				<dns>200.36.160.237</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Peru -->
+<country code="pe">
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="716" mnc="10"/>
+			<apn value="tim.pe">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>tim</username>
+				<password>tulibertad</password>
+			</apn>
+			<apn value="ba.amx">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Internet Móvil Prepago</name>
+				<username>amx</username>
+				<password>amx</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="716" mnc="06"/>
+			<apn value="movistar.pe">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistar@datos</username>
+				<password>movistar</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Nextel</name>
+		<gsm>
+			<network-id mcc="716" mnc="07"/>
+			<apn value="datacard.nextel.com.pe">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- French Polynesia -->
+<country code="pf">
+	<provider>
+		<name>Vini</name>
+		<gsm>
+			<network-id mcc="547" mnc="20"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Philippines -->
+<country code="ph">
+	<provider>
+		<name>Globe Telecom</name>
+		<gsm>
+			<network-id mcc="515" mnc="02"/>
+			<apn value="internet.globe.com.ph">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid</name>
+				<username>globe</username>
+				<password>globe</password>
+				<dns>203.127.225.10</dns>
+				<dns>203.127.225.11</dns>
+			</apn>
+			<apn value="http.globe.com.ph">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+				<username>globe</username>
+				<password>globe</password>
+				<dns>203.127.225.10</dns>
+				<dns>203.127.225.11</dns>
+			</apn>
+			<apn value="www.globe.com.ph">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WAP</name>
+				<username>globe</username>
+				<password>globe</password>
+				<dns>203.127.225.10</dns>
+				<dns>203.127.225.11</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Smart</name>
+		<gsm>
+			<network-id mcc="515" mnc="03"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>witsductoor</username>
+				<password>banonoy</password>
+				<dns>202.57.96.3</dns>
+				<dns>202.57.96.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Digitel (Sun Cellular)</name>
+		<gsm>
+			<network-id mcc="515" mnc="05"/>
+			<apn value="minternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Pakistan -->
+<country code="pk">
+	<provider>
+		<name>Djuice</name>
+		<gsm>
+			<network-id mcc="515" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>telenor</username>
+				<password>telenor</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Mobilink</name>
+		<gsm>
+			<network-id mcc="515" mnc="01"/>
+			<apn value="connect.mobilinkworld.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="jazzconnect.mobilinkworld.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Jazz</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telenor</name>
+		<gsm>
+			<network-id mcc="515" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>telenor</username>
+				<password>telenor</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Ufone</name>
+		<gsm>
+			<network-id mcc="410" mnc="03"/>
+			<apn value="ufone.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>ufone</username>
+				<password>ufone</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Warid</name>
+		<gsm>
+			<network-id mcc="515" mnc="07"/>
+			<apn value="warid">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>ZONG</name>
+		<gsm>
+			<network-id mcc="515" mnc="04"/>
+			<apn value="zonginternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Ptcl EVO</name>
+		<cdma>
+			<username>vwireless@ptcl.com</username>
+			<password>ptcl</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>WorldCall Wireless</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Poland -->
+<country code="pl">
+	<!-- Polish physical operators -->
+	<provider primary="true">
+		<name>T-mobile</name><!-- rebranded from Era in 2011 -->
+		<gsm>
+			<network-id mcc="260" mnc="02"/>
+			<voicemail>602950</voicemail>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*111*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<dns>213.158.194.1</dns>
+				<dns>213.158.193.38</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>Play Online</name>
+		<gsm>
+			<network-id mcc="260" mnc="06"/>
+			<balance-check>
+				<ussd>*101#</ussd>
+				<ussd>*155#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*100*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="260" mnc="03"/>
+			<voicemail>*501</voicemail>
+			<balance-check>
+				<ussd>*124*#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*125*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Standard access - with image compression</name>
+				<name xml:lang="pl">Dostęp standardowy - z kompresją grafiki</name>
+				<username>internet</username>
+				<password>internet</password>
+				<dns>194.9.223.79</dns>
+				<dns>194.204.159.1</dns>
+			</apn>
+			<apn value="vpn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>VPN mode access without compression (requires activation)</name>
+				<name xml:lang="pl">Dostęp VPN bez kompresji (wymaga aktywacji)</name>
+				<username>internet</username>
+				<password>internet</password>
+				<dns>194.9.223.79</dns>
+				<dns>194.204.159.1</dns>
+			</apn>
+		</gsm>
+		<cdma>
+			<username>cdma@orange</username>
+			<password>orange</password>
+		</cdma>
+	</provider>
+	<provider primary="true">
+		<name>Plus</name>
+		<gsm>
+			<network-id mcc="260" mnc="01"/>
+			<voicemail>2222</voicemail>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*123*CODE#</ussd>
+			</balance-top-up>
+			<apn value="www.plusgsm.pl">
+				<plan type="postpaid"/>
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Standard access</name>
+				<name xml:lang="pl">Dostęp standardowy</name>
+				<username>plusgsm</username>
+				<password>plusgsm</password>
+				<dns>212.2.96.51</dns>
+				<dns>212.2.96.52</dns>
+			</apn>
+			<apn value="pro.plusgsm.pl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>External dynamic IP address (requires activation)</name>
+				<name xml:lang="pl">Zewnętrzny dynamiczny adres IP (wymaga aktywacji)</name>
+				<username>plusgsm</username>
+				<password>plusgsm</password>
+				<dns>212.2.96.51</dns>
+				<dns>212.2.96.52</dns>
+			</apn>
+			<apn value="m2m.plusgsm.pl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>External static IP address (requires activation)</name>
+				<name xml:lang="pl">Zewnętrzny statyczny adres IP (wymaga aktywacji)</name>
+				<username>plusgsm</username>
+				<password>plusgsm</password>
+				<dns>212.2.96.51</dns>
+				<dns>212.2.96.52</dns>
+			</apn>
+			<apn value="optimizer">
+				<plan type="postpaid"/>
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>iPlus optimizer with data compression</name>
+				<name xml:lang="pl">iPlus optimizer z kompresją danych</name>
+				<dns>212.2.96.51</dns>
+				<dns>212.2.96.52</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>Cyfrowy Polsat</name>
+		<gsm>
+			<network-id mcc="260" mnc="12"/>
+			<apn value="multi.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="true">
+		<name>aero2</name>
+		<gsm>
+			<network-id mcc="260" mnc="17"/>
+			<apn value="darmowy">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<!-- Polish MVNO operators -->
+	<provider primary="false">
+		<name>Multimo</name>
+		<gsm>
+			<network-id mcc="260" mnc="03"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Default APN</name>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+			<apn value="mni.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>APN: mni.internet</name>
+				<username>mni.internet</username>
+			</apn>
+			<apn value="telogic.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>APN: telogic.internet</name>
+				<username>telogic.internet</username>
+			</apn>
+		</gsm>
+		<cdma>
+			<username>cdma@orange</username>
+			<password>orange</password>
+		</cdma>
+	</provider>
+	<provider primary="false">
+		<name>FreeM</name>
+		<gsm>
+			<network-id mcc="260" mnc="01"/>
+			<apn value="freedata.pl">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+ 		</gsm>
+ 	</provider>
+ 	<provider primary="false">
+ 		<name>Heyah</name>
+ 		<gsm>
+ 			<network-id mcc="260" mnc="02"/>
+			<balance-check>
+				<ussd>*108#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*109*CODE#</ussd>
+			</balance-top-up>
+ 			<apn value="heyah.pl">
+ 				<plan type="prepaid"/>
+				<usage type="internet"/>
+ 				<username>heyah</username>
+ 				<password>heyah</password>
+				<dns>213.158.194.1</dns>
+				<dns>213.158.193.38</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="false">
+		<name>GaduAIR</name>
+		<gsm>
+			<network-id mcc="260" mnc="01"/>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<apn value="internet.gadu-gadu.pl">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="false">
+		<name>Aster</name>
+ 		<gsm>
+ 			<network-id mcc="260" mnc="03"/>
+			<apn value="aster.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+ 				<username>internet</username>
+ 				<password>internet</password>
+ 			</apn>
+ 		</gsm>
+ 	</provider>
+ 	<provider primary="false">
+		<name>Netia</name>
+		<gsm>
+			<network-id mcc="260" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="false">
+		<name>Vectra</name>
+		<gsm>
+			<network-id mcc="260" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="false">
+		<name>mBank mobile</name>
+ 		<gsm>
+ 			<network-id mcc="260" mnc="01"/>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<apn value="www.mobile.pl">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="false">
+		<name>INEA</name>
+		<gsm>
+			<network-id mcc="260" mnc="03"/>
+			<apn value="telogic.internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+ 			</apn>
+ 		</gsm>
+ 	</provider>
+ 	<provider primary="false">
+		<name>Mobilking</name>
+		<gsm>
+			<network-id mcc="260" mnc="02"/>
+			<apn value="wapMOBILKING">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>mobilking</username>
+				<password>mobilking</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider primary="false">
+		<name>SamiSwoi</name>
+ 		<gsm>
+ 			<network-id mcc="260" mnc="01"/>
+			<apn value="www.plusgsm.pl">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+ 		</gsm>
+ 	</provider>
+	<provider primary="false">
+		<name>Sferia</name>
+		<cdma>
+			<username>sferia</username>
+			<password>sferia</password>
+		</cdma>
+	</provider>
+	<provider primary="false">
+		<name>Nordisk Polska</name>
+		<cdma>
+			<username>CDMA</username>
+			<password>CDMA</password>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Portugal -->
+<country code="pt">
+	<provider>
+		<name>Kanguru</name>
+		<gsm>
+			<network-id mcc="268" mnc="03"/>
+			<apn value="kanguru-portatil">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Portable</name>
+				<name xml:lang="pt">Portátil</name>
+				<dns>62.169.67.172</dns>
+				<dns>62.169.67.171</dns>
+			</apn>
+			<apn value="kanguru-tempo">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Tempo (Prepaid)</name>
+				<dns>62.169.67.172</dns>
+				<dns>62.169.67.171</dns>
+			</apn>
+			<apn value="kangurufixo">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Fixo</name>
+				<dns>62.169.67.172</dns>
+				<dns>62.169.67.171</dns>
+			</apn>
+			<apn value="noapn">
+				<name>Apn dinâmico (no apn)</name>
+				<dns>62.169.67.172</dns>
+				<dns>62.169.67.171</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<!-- Merged with Optimus in 2010 -->
+		<name>Clix</name>
+		<gsm>
+			<network-id mcc="268" mnc="03"/>
+			<apn value="clixinternetmovel">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Optimus</name>
+		<gsm>
+			<network-id mcc="268" mnc="03"/>
+			<apn value="umts">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G</name>
+			</apn>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<dns>194.79.69.129</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TMN</name>
+		<gsm>
+			<network-id mcc="268" mnc="06"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Tmn Internet</name>
+				<username>tmn</username>
+				<password>tmn</password>
+				<dns>88.214.178.1</dns>
+				<dns>88.214.182.2</dns>
+			</apn>
+			<apn value="mmsc.tmn.pt">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Tmn Mms</name>
+				<username>tmn</username>
+				<password>tmnnet</password>
+				<dns>194.65.3.20</dns>
+				<dns>194.65.3.21</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="268" mnc="01"/>
+			<apn value="internet.vodafone.pt">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>vodafone</username>
+				<password>vodafone</password>
+				<dns>212.18.160.133</dns>
+				<dns>212.18.160.134</dns>
+			</apn>
+			<apn value="net2.vodafone.pt">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Vodafone Internet</name>
+			</apn>
+			<apn value="vas.vodafone.pt">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Vodafone MMS</name>
+				<username>vas</username>
+				<password>vas</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>ZON</name>
+		<gsm>
+			<network-id mcc="268" mnc="01"/>
+			<apn value="internet.zon.pt">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Dados Móveis</name>
+			</apn>
+			<apn value="vas.zon.pt">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>MMS</name>
+				<username>vas</username>
+				<password>vas</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Paraguay -->
+<country code="py">
+	<provider>
+		<name>VOX</name>
+		<gsm>
+			<network-id mcc="744" mnc="01"/>
+			<apn value="vox.wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/></apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Personal</name>
+		<gsm>
+			<network-id mcc="744" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/></apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="744" mnc="04"/>
+			<apn value="internet.tigo.py">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="broadband.tigo.py">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Broadband</name>
+				<name xml:lang="es">Banda Ancha Móvil</name>
+				<username>tigo</username>
+				<password>tigo</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="744" mnc="02"/>
+			<apn value="gprs.claro.com.py">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Qatar -->
+<country code="qa">
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="427" mnc="02"/>
+			<msisdn-query>
+				<ussd>*#100#</ussd>
+			</msisdn-query>
+			<apn value="web.vodafone.com.qa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web</name>
+			</apn>
+			<apn value="vodafone.com.qa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web (old)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Q-Tel</name>
+		<gsm>
+			<network-id mcc="427" mnc="01"/>
+			<apn value="gprs.qtel">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Qatarnet</name>
+				<username>gprs</username>
+				<password>gprs</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Réunion (France) -->
+<country code="re">
+	<provider>
+		<name>SFR Réunion</name>
+		<gsm>
+			<network-id mcc="647" mnc="10"/>
+			<msisdn-query>
+				<sms text="ABCd84367">+33621012555</sms>
+			</msisdn-query>
+			<apn value="websfr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract / Prepaid</name>
+			</apn>
+			<apn value="slsfr">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>SFR slsfr</name>
+			</apn>
+			<apn value="internetpro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>SFR internetpro</name>
+			</apn>
+			<apn value="ipnet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>SFR ipnet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Romania -->
+<country code="ro">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="226" mnc="10"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>172.22.7.21</dns>
+				<dns>172.22.7.20</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="226" mnc="01"/>
+			<apn value="tobe.vodafone.ro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet (Prepaid)</name>
+				<username>tobe.vodafone.ro</username>
+				<password>vodafone</password>
+			</apn>
+			<apn value="internet.vodafone.ro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet (Postpaid)</name>
+				<username>internet.vodafone.ro</username>
+				<password>vodafone</password>
+			</apn>
+			<apn value="internet.pre.vodafone.ro">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet (Prepaid)</name>
+				<username>internet.pre.vodafone.ro</username>
+				<password>vodafone</password>
+			</apn>
+			<apn value="live.vodafone.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Live! (Postpaid)</name>
+				<username>live</username>
+				<password>vodafone</password>
+			</apn>
+			<apn value="live.pre.vodafone.ro">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Live! (Prepaid)</name>
+				<username>live.pre.vodafone.com</username>
+				<password>vodafone</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Zapp</name>
+		<cdma>
+			<username>zapp</username>
+			<password>zapp</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Digi.Net Mobil</name>
+		<gsm>
+			<network-id mcc="226" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Home</name>
+			</apn>
+			<apn value="static">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Business (static)</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Serbia -->
+<country code="rs">
+	<provider>
+		<name>Telenor</name>
+		<gsm>
+			<network-id mcc="220" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>telenor</username>
+				<password>gprs</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telekom Srbija</name>
+		<gsm>
+			<network-id mcc="220" mnc="03"/>
+			<apn value="gprsinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mts</username>
+				<password>064</password>
+				<dns>195.178.38.3</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>VIP Mobile</name>
+		<gsm>
+			<network-id mcc="220" mnc="05"/>
+			<apn value="vipmobile">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>vipmobile</username>
+				<password>vipmobile</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Rwanda -->
+<country code="rw">
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="635" mnc="10"/>
+			<apn value="internet.mtn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="635" mnc="13"/>
+			<apn value="web.tigo.rw">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Russia -->
+<country code="ru">
+	<provider>
+		<name>BaikalWestCom</name>
+		<name xml:lang="ru">БайкалВестКом</name>
+		<gsm>
+			<network-id mcc="250" mnc="12"/>
+			<apn value="inet.bwc.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>bwc</username>
+				<password>bwc</password>
+				<dns>81.18.113.2</dns>
+				<dns>81.18.112.50</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Beeline</name>
+		<name xml:lang="ru">Билайн</name>
+		<gsm>
+			<network-id mcc="250" mnc="28"/>
+			<network-id mcc="250" mnc="99"/>
+			<apn value="home.beeline.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G modem</name>
+				<name xml:lang="ru">USB-модем</name>
+				<username>beeline</username>
+				<password>beeline</password>
+				<dns>212.44.130.6</dns>
+				<dns>217.118.83.6</dns>
+			</apn>
+			<apn value="internet.beeline.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile phone</name>
+				<name xml:lang="ru">Мобильный телефон</name>
+				<username>beeline</username>
+				<password>beeline</password>
+				<dns>217.118.66.243</dns>
+				<dns>217.118.66.244</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>ETK</name>
+		<gsm>
+			<network-id mcc="250" mnc="05"/>
+			<apn value="wap.etk.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTS</name>
+		<gsm>
+			<network-id mcc="250" mnc="01"/>
+			<apn value="internet.mts.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mts</username>
+				<password>mts</password>
+				<dns>213.87.0.1</dns>
+				<dns>213.87.1.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Megafon</name>
+		<name xml:lang="ru">Мегафон</name>
+
+		<gsm>
+			<network-id mcc="250" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>RUS</name>
+				<name xml:lang="ru">Россия</name>
+				<username>gdata</username>
+				<password>gdata</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>NCC</name>
+		<gsm>
+			<network-id mcc="250" mnc="03"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>ncc</username>
+				<dns>10.0.3.5</dns>
+				<dns>10.0.3.2</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>NTC</name>
+		<gsm>
+			<network-id mcc="250" mnc="16"/>
+			<apn value="internet.ntc">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>80.243.64.67</dns>
+				<dns>80.243.68.34</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Enisey TeleCom</name>
+		<name xml:lang="ru">Енисей Телеком</name>
+		<gsm>
+			<network-id mcc="250" mnc="05"/>
+			<apn value="internet.etk.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>etk</username>
+				<dns>10.10.30.3</dns>
+				<dns>10.10.30.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Motiv</name>
+		<name xml:lang="ru">Мотив</name>
+		<gsm>
+			<network-id mcc="250" mnc="35"/>
+			<apn value="inet.ycc.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>motiv</username>
+				<dns>217.148.52.34</dns>
+				<dns>217.148.52.3</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tatincom</name>
+		<name xml:lang="ru">Татинком</name>
+		<gsm>
+			<apn value="internet.tatincom.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>tatincom</username>
+				<password>tatincom</password>
+				<dns>89.207.96.2</dns>
+				<dns>89.207.97.18</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<name xml:lang="ru">Теле2</name>
+		<gsm>
+			<network-id mcc="250" mnc="20"/>
+			<apn value="internet.tele2.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>130.244.127.161</dns>
+				<dns>130.244.127.169</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Skylink</name>
+		<name xml:lang="ru">Скайлинк</name>
+		<cdma>
+			<username>mobile</username>
+			<password>internet</password>
+
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="11396"/>  <!-- Khabarovsk area -->
+			<sid value="11398"/>  <!-- Adygeya -->
+			<sid value="11400"/>  <!-- Altay republic -->
+			<sid value="11418"/>  <!-- Bashkostostan -->
+			<sid value="11424"/>  <!-- Buryatiya -->
+			<sid value="11432"/>  <!-- Dagestan -->
+			<sid value="11434"/>  <!-- Ingushetia -->
+			<sid value="11438"/>  <!-- Kabardino-Balkariya -->
+			<sid value="11440"/>  <!-- Kalmykia -->
+			<sid value="11442"/>  <!-- Karachayevo-Cherkessiya -->
+			<sid value="11446"/>  <!-- Karelia -->
+			<sid value="11452"/>  <!-- Komi -->
+			<sid value="11456"/>  <!-- Mordovia -->
+			<sid value="11462"/>  <!-- Yakutiya -->
+			<sid value="11465"/>  <!-- North Osetia -->
+			<sid value="11482"/>  <!-- Tatarstan -->
+			<sid value="11484"/>  <!-- Tuva -->
+			<sid value="11492"/>  <!-- Udmurtiya -->
+			<sid value="11494"/>  <!-- Khakasia -->
+			<sid value="11498"/>  <!-- Chechnya -->
+			<sid value="11510"/>  <!-- Altay area -->
+			<sid value="11532"/>  <!-- Krasnodar -->
+			<sid value="11546"/>  <!-- Krasnoyarsk -->
+			<sid value="11556"/>  <!-- Primorsky area -->
+			<sid value="11568"/>  <!-- Stavropol -->
+			<sid value="11572"/>  <!-- Amur area -->
+			<sid value="11578"/>  <!-- Arkhangelsk -->
+			<sid value="11582"/>  <!-- Astrakhan -->
+			<sid value="11590"/>  <!-- Belgorod -->
+			<sid value="11596"/>  <!-- Bryansk -->
+			<sid value="11604"/>  <!-- Vladimir -->
+			<sid value="11616"/>  <!-- Volgograd -->
+			<sid value="11622"/>  <!-- Vologda -->
+			<sid value="11630"/>  <!-- Ivanovo -->
+			<sid value="11642"/>  <!-- Irkutsk -->
+			<sid value="11646"/>  <!-- Kaliningrad -->
+			<sid value="11650"/>  <!-- Kaluga -->
+			<sid value="11668"/>  <!-- Kemerovo -->
+			<sid value="11672"/>  <!-- Kostroma -->
+			<sid value="11676"/>  <!-- Kurgan -->
+			<sid value="11684"/>  <!-- Kursk -->
+			<sid value="11692"/>  <!-- Leningrad area -->
+			<sid value="11698"/>  <!-- Lipetsk -->
+			<sid value="11700"/>  <!-- Magadan -->
+			<sid value="11732"/>  <!-- Moscow area -->
+			<sid value="11736"/>  <!-- Murmansk -->
+			<sid value="11754"/>  <!-- Nizhniy Novgorod -->
+			<sid value="11758"/>  <!-- V. Novgorog -->
+			<sid value="11772"/>  <!-- Novosibirsk -->
+			<sid value="11780"/>  <!-- Kirov -->
+			<sid value="11784"/>  <!-- Chuvashia -->
+			<sid value="11788"/>  <!-- Evreysky district -->
+			<sid value="11790"/>  <!-- Aginsky-Buryatsky district -->
+			<sid value="11794"/>  <!-- Penza -->
+			<sid value="11802"/>  <!-- Mariy El -->
+			<sid value="11806"/>  <!-- Koryak district -->
+			<sid value="11816"/>  <!-- Omsk -->
+			<sid value="11826"/>  <!-- Orenburg -->
+			<sid value="11830"/>  <!-- Orel -->
+			<sid value="11844"/>  <!-- Perm -->
+			<sid value="11848"/>  <!-- Pskov -->
+			<sid value="11868"/>  <!-- Rostov -->
+			<sid value="11874"/>  <!-- Tomsk -->
+			<sid value="11884"/>  <!-- Voronezh -->
+			<sid value="11892"/>  <!-- Ryazan -->
+			<sid value="11908"/>  <!-- Samara -->
+			<sid value="11922"/>  <!-- Saratov -->
+			<sid value="11924"/>  <!-- Sakhalin -->
+			<sid value="11948"/>  <!-- Sverdlovsk -->
+			<sid value="11960"/>  <!-- Tambov -->
+			<sid value="11964"/>  <!-- Smolensk -->
+			<sid value="11968"/>  <!-- Tver -->
+			<sid value="11978"/>  <!-- Tula -->
+			<sid value="11984"/>  <!-- Tyumen -->
+			<sid value="11990"/>  <!-- Ul yanovsk -->
+			<sid value="12006"/>  <!-- Chelyabinsk -->
+			<sid value="12012"/>  <!-- Chita -->
+			<sid value="12020"/>  <!-- Yaroslavl -->
+			<sid value="12060"/>  <!-- Moscow -->
+			<sid value="12061"/>  <!-- Moscow -->
+			<sid value="12063"/>  <!-- St. Petersburg -->
+			<sid value="12064"/>  <!-- St. Petersburg -->
+			<sid value="12065"/>  <!-- Kemerovo -->
+			<sid value="12066"/>  <!-- Kemerovo -->
+			<sid value="12067"/>  <!-- Sverdlovsk -->
+			<sid value="12085"/>  <!-- Nenetskiy district -->
+			<sid value="12087"/>  <!-- Ust-Ordynsky district -->
+			<sid value="12090"/>  <!-- Khanty-Mansi district -->
+			<sid value="12092"/>  <!-- Chukotsky district -->
+			<sid value="12094"/>  <!-- Yamal-Nenets district -->
+			<sid value="12095"/>  <!-- Kamchatka -->
+		</cdma>
+	</provider>
+	<provider>
+		<name>U-tel</name>
+		<gsm>
+			<network-id mcc="250" mnc="39"/>
+			<apn value="internet.usi.ru">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Saudi Arabia -->
+<country code="sa">
+	<provider>
+		<name>Mobily</name>
+		<gsm>
+			<network-id mcc="420" mnc="03"/>
+			<apn value="web1">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid</name>
+			</apn>
+			<apn value="web2">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Prepaid</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>STC</name>
+		<gsm>
+			<network-id mcc="420" mnc="01"/>
+			<apn value="jawalnet.com.sa">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.118.133.101</dns>
+				<dns>212.118.133.102</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="420" mnc="04"/>
+			<apn value="zain">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+
+<!-- Sweden -->
+<country code="se">
+	<provider primary="true">
+		<name>3</name>
+		<gsm>
+			<network-id mcc="240" mnc="02"/>
+			<network-id mcc="240" mnc="04"/>
+			<!-- http://www.tre.se/templates/Sporg3_02.aspx?id=4231 -->
+			<apn value="data.tre.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobiltelefon</name>
+			</apn>
+			<!-- http://www.tre.se/templates/Sporg3_02.aspx?id=4231 -->
+			<apn value="bredband.tre.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Bredband</name>
+			</apn>
+			<apn value="net.tre.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Bredband Kontantkort</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Glocalnet</name>
+		<gsm>
+			<network-id mcc="240" mnc="08"/>
+			<!-- http://glocalnet.se/mobiltbredband -->
+			<apn value="bredband.glocalnet.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Bredband</name>
+			</apn>
+			<!-- http://kundservice.glocalnet.se/Kundservice/Mobiltelefoni/Installningar/ -->
+			<apn value="internet.glocalnet.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Glocalnet Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Halebop</name>
+		<gsm>
+			<network-id mcc="240" mnc="01"/>
+
+			<!-- http://www.halebop.se/halebop_kundtjanst/vanliga_fragor_kontantkort/ -->
+			<apn value="halebop.telia.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<!-- http://www.ice.net/Mobilt-bredband-1373.aspx -->
+		<name>ice.net (Nordisk Mobiltelefon)</name>
+		<cdma>
+			<username>cdma</username>
+			<password>cdma</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Tele2</name>
+		<gsm>
+			<network-id mcc="240" mnc="07"/>
+			<network-id mcc="240" mnc="05"/>
+
+			<voicemail>222</voicemail>
+			<balance-check>
+				<ussd>*111#</ussd>
+				<dtmf>211</dtmf>
+			</balance-check>
+
+			<!-- http://www.tele2.se/internet-via-gprs.html -->
+			<apn value="internet.tele2.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Internet</name>
+			</apn>
+			<!-- http://www.tele2.se/alien-modem.html -->
+			<apn value="mobileinternet.tele2.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Bredband</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Comviq</name>
+		<gsm>
+			<network-id mcc="240" mnc="07"/>
+			<network-id mcc="240" mnc="05"/>
+
+			<voicemail>222</voicemail>
+			<balance-check>
+				<ussd>*111#</ussd>
+				<dtmf>211</dtmf>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*110*CODE#</ussd>
+			</balance-top-up>
+
+			<apn value="data.comviq.se">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Surf</name>
+			</apn>
+
+			<apn value="internet.tele2.se">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Tele2 Comviq 3G</name>
+			</apn>
+			<apn value="mobileinternet.tele2.se">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Tele2 Comviq 3G (7,2 Mbit/s)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Multicom Security</name>
+		<gsm>
+			<network-id mcc="240" mnc="01"/>
+			<network-id mcc="240" mnc="05"/>
+			
+			<!-- http://multicomsecurity.se/produkter-tjanster/mobil-datakommunikation/mobiflex/ -->
+			<apn value="mobiflex.telia.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobiflex</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telenor</name>
+		<gsm>
+			<network-id mcc="240" mnc="04"/>
+			<network-id mcc="240" mnc="06"/>
+			<network-id mcc="240" mnc="08"/>
+
+			<voicemail>888</voicemail>
+			<balance-check>
+				<ussd>*222#</ussd>
+			</balance-check>
+
+			<!-- http://www.telenor.se/privat/mobiltelefoni/alla-mobiltjanster/alla-mobiltjanster.html#C45-2100 -->
+			<apn value="internet.telenor.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Internet</name>
+			</apn>
+			<apn value="services.telenor.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilsurf med maxtaxa</name>
+			</apn>
+			<apn value="bredband.telenor.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Bredband</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Telia</name>
+		<gsm>
+			<network-id mcc="240" mnc="01"/>
+			<network-id mcc="240" mnc="05"/>
+
+			<voicemail>*133#</voicemail>
+			<balance-check>
+				<ussd>*120#</ussd>
+				<ussd>*121#</ussd>
+			</balance-check>
+
+			<!-- http://www3.telia.se/foretag/mobilguiden/ -->
+			<apn value="online.telia.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Telia 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TDC</name>
+		<gsm>
+			<network-id mcc="240" mnc="14"/>
+			<apn value="internet.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>djuice</name>
+		<gsm>
+			<network-id mcc="240" mnc="09"/>
+			<apn value="internet.djuice.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Com Hem</name>
+		<gsm>
+			<network-id mcc="240" mnc="02"/>
+			<network-id mcc="240" mnc="04"/>
+			<!-- MVNO operating on 3's network -->
+			<apn value="bredband.comhem.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Parlino</name>
+		<gsm>
+			<network-id mcc="240" mnc="07"/>
+			<apn value="internet.parlino.se">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Universal Telecom</name>
+		<gsm>
+			<!-- http://www.uvtc.com/SWEDEN/internet/mobiltbredband/Default.aspx -->
+			<apn value="sp-internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Bredband</name>
+			</apn>
+			<!-- http://www.uvtc.com/sweden/Mobil/Faq/default.aspx -->
+			<apn value="internet.uvtc.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobilt Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Singapore -->
+<country code="sg">
+	<provider>
+		<name>M1</name>
+		<gsm>
+			<network-id mcc="525" mnc="03"/>
+			<!-- http://m1.com.sg/filedownloads/popup/Miworld/popup_se2.5.html mid page -->
+			<apn value="sunsurf">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>SunSurf/Mobile Broadband (postpaid)</name>
+				<username>65</username>
+				<dns>202.79.64.21</dns>
+				<dns>202.79.64.26</dns>
+			</apn>
+			<!-- http://m1.com.sg/filedownloads/popup/Miworld/popup_se2.5.html top page-->
+			<apn value="miworld">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>MiWorld Mobile (postpaid)</name>
+				<username>65(mobilenumber)</username>
+				<password>user123</password>
+			</apn>
+			<!-- http://m1.com.sg/filedownloads/popup/Miworld/popup_se2.5.html lower page -->
+			<apn value="miworldcard">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>MiWorld Mobile (prepaid)</name>
+				<username>65(mobilenumber)</username>
+				<password>user123</password>
+			</apn>
+			<apn value="prepaidbb">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband (prepaid)</name>
+			</apn>
+			<apn value="sunsurfmcard">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>M Card (prepaid)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>SingTel</name>
+		<gsm>
+			<network-id mcc="525" mnc="01"/>
+			<network-id mcc="525" mnc="02"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>165.21.100.88</dns>
+				<dns>165.21.83.88</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Starhub</name>
+		<gsm>
+			<network-id mcc="525" mnc="05"/>
+			<apn value="shwap">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>WAP</name>
+				<username>star</username>
+				<password>hub</password>
+				<dns>203.116.1.78</dns>
+			</apn>
+			<apn value="shppd">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>MaxMobile Broadband (prepaid)</name>
+			</apn>
+			<apn value="shinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>MaxMobile Broadband (postpaid)</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Slovenia -->
+<country code="si">
+	<provider>
+		<name>Mobitel</name>
+		<gsm>
+			<network-id mcc="293" mnc="41"/>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Postpaid</name>
+				<username>mobitel</username>
+				<password>internet</password>
+				<dns>213.229.248.161</dns>
+				<dns>193.189.160.11</dns>
+			</apn>
+			<apn value="internetpro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mobitel</username>
+				<password>internet</password>
+				<dns>213.229.248.161</dns>
+				<dns>193.189.160.11</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone / Simobil</name>
+		<gsm>
+			<network-id mcc="293" mnc="40"/>
+			<msisdn-query>
+				<ussd>*100#</ussd>
+			</msisdn-query>
+			<apn value="internet.simobil.si">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>simobil</username>
+				<password>internet</password>
+				<dns>121.30.86.130</dns>
+				<dns>193.189.160.11</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-2</name>
+		<gsm>
+			<network-id mcc="293" mnc="64"/>
+			<apn value="internet.t-2.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Slovakia -->
+<country code="sk">
+	<provider>
+		<name>Slovak Telekom</name>
+		<gsm>
+			<network-id mcc="231" mnc="02"/>
+			<network-id mcc="231" mnc="04"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>195.91.0.17</dns>
+				<dns>194.154.227.17</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="231" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>213.151.200.31</dns>
+				<dns>213.151.208.162</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>O2</name>
+		<gsm>
+			<network-id mcc="231" mnc="06"/>
+			<apn value="o2internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+				<dns>160.218.161.60</dns>
+				<dns>194.228.211.33</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Senegal -->
+<country code="sn">
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="608" mnc="02"/>
+			<apn value="wap.sentelgsm.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>200.85.0.104</dns>
+				<dns>200.85.0.107</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- El Salvador -->
+<country code="sv">
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="706" mnc="04"/>
+			<apn value="internet.movistar.sv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>movistarsv</username>
+				<password>movistarsv</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>digicel</name>
+		<gsm>
+			<network-id mcc="706" mnc="02"/>
+			<apn value="wap.digicelsv.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tigo</name>
+		<gsm>
+			<network-id mcc="706" mnc="03"/>
+			<apn value="internet.tigo.sv">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="706" mnc="10"/>
+			<apn value="internet.ideasclaro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Sudan -->
+<country code="sd">
+	<provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="634" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Thailand -->
+<country code="th">
+	<provider>
+		<name>AIS</name>
+		<gsm>
+			<network-id mcc="520" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>202.183.255.20</dns>
+				<dns>202.183.255.21</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>DTAC</name>
+		<gsm>
+			<network-id mcc="520" mnc="18"/>
+			<apn value="www.dtac.co.th">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>202.44.202.2</dns>
+				<dns>203.44.144.33</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>True Move</name>
+		<gsm>
+			<network-id mcc="520" mnc="99"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>true</username>
+				<password>true</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TOT 3G</name>
+		<gsm>
+			<network-id mcc="520" mnc="15"/>
+			<apn value="internet" >
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Tunisia -->
+<country code="tn">
+	<provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="605" mnc="01"/>
+			<apn value="weborange">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet</name>
+			</apn>
+			<apn value="mms.otun">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>Internet + MMS</name>
+			</apn>
+			<apn value="keygp">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere Prepaid</name>
+			</apn>
+			<apn value="keypro">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet Everywhere Professional</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tunisie Télécom / TUNTEL</name>
+		<gsm>
+			<network-id mcc="605" mnc="02"/>
+			<apn value="mms.tn">
+				<plan type="postpaid"/>
+				<usage type="mms"/>
+				<name>MMS</name>
+				<username>mms@tt1</username>
+				<password>mms</password>
+			</apn>
+			<apn value="gprs.tn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS DATA</name>
+				<username>gprs</username>
+				<password>gprs</password>
+			</apn>
+			<apn value="internet.tn">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>WEB DATA</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Tunisiana</name>
+		<gsm>
+			<network-id mcc="605" mnc="03"/>
+			<apn value="internet.tunisiana.com">
+				<name>Internet</name>
+				<username>internet</username>
+				<password>internet</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Turkey -->
+<country code="tr">
+	<provider>
+		<name>Avea</name>
+		<gsm>
+			<network-id mcc="286" mnc="03"/>
+			<network-id mcc="286" mnc="04"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>212.156.4.4</dns>
+				<dns>212.156.4.20</dns>
+			</apn>
+
+			<apn value="aycell">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>(former Aycell)</name>
+				<dns>212.156.4.1</dns>
+				<dns>212.156.4.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Turkcell</name>
+		<gsm>
+			<network-id mcc="286" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>gprs</username>
+				<password>gprs</password>
+				<dns>86.108.136.27</dns>
+				<dns>86.108.136.26</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodafone</name>
+		<gsm>
+			<network-id mcc="286" mnc="02"/><!-- mnc="0251" in Vodofone XML -->
+			<msisdn-query>
+				<ussd>*101#</ussd>
+			</msisdn-query>
+			<apn value="internet">
+				<usage type="internet"/>
+				<name>Vodafone Internet</name>
+				<username>vodafone</username>
+				<password>vodafone</password>
+			</apn>
+			<!--
+				KKTC Telsim was a subsidiary of Telsim Group in Turkey which was taken
+				over by the Vodafone Group 2006 and rebranded as Vodafone in 2007.
+				Due to the political situation in Northern Cyprus the company shares the
+				Vodafone Turkey MCC and MNC codes although it is logically a separate
+				operator. The brand KKTC Telsim is still used in Northern Cyprus due to
+				Vodafone Group agreements with Cytamobile-Vodafone in Southern Cyprus.
+			-->
+			<apn value="edge.kktctelsim.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>KKTC Telsim</name>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Trinidad & Tobago -->
+<country code="tt">
+	<provider>
+		<name>Digicel</name>
+		<gsm>
+			<network-id mcc="374" mnc="13"/>
+			<apn value="wap.digiceltt.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>bmobile / TSTT</name>
+		<gsm>
+			<network-id mcc="374" mnc="12"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wap</username>
+				<password>wap</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Taiwan -->
+<country code="tw">
+	<provider>
+		<name>Chunghwa Telecom (emome)</name>
+		<name xml:lang="zh">中華電信 (emome)</name>
+		<gsm>
+			<network-id mcc="466" mnc="92"/>
+			<!-- http://www.nav4all.com/site2/www.nav4all.com/enguk/gprs_settings_taiwan_chunghwatelekom_nav4all.php?m=F3 -->
+			<apn value="emome">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>web</username>
+				<password>web</password>
+			</apn>
+			<!-- Vodafone Broadband Connect version 10.1.0.23908 2010-06-07T17:47:01 lists username/pass = web. Others list empty -->
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Far EasTone / KGT</name>
+		<name xml:lang="zh">遠傳電信 / 和信電訊</name>
+		<gsm>
+			<network-id mcc="466" mnc="01"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TW Mobile</name>
+		<name xml:lang="zh">台湾大哥大</name>
+		<gsm>
+			<network-id mcc="466" mnc="99"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>TransAsia</name>
+		<name xml:lang="zh">泛亞電信</name>
+		<gsm>
+			<network-id mcc="466" mnc="97"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vibo Telecom / Aurora</name>
+		<name xml:lang="zh">威寶電信 (Vibo) / 震旦電信 (Aurora)</name>
+		<gsm>
+			<network-id mcc="466" mnc="89"/>
+			<apn value="vibo">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Asia Pacific Telecom (APBW)</name>
+		<name xml:lang="zh">亞太電信 (亞太行動寬頻電信)</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Tanzania, United Republic of -->
+<country code="tz">
+	<provider>
+		<name>Airtel Tanzania</name>
+		<gsm>
+			<network-id mcc="640" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodacom</name>
+		<gsm>
+			<network-id mcc="640" mnc="04"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Zantel</name>
+		<gsm>
+			<network-id mcc="640" mnc="03"/>
+			<apn value="znet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+		<cdma>
+			<username>@zantel.com</username>
+			<password> </password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Sasatel</name>
+		<cdma>
+			<username>sasatel</username>
+			<password>sasatel</password>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="9891"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>TTCL</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Ukraine -->
+<country code="ua">
+	<provider>
+		<name>kyivstar</name>
+		<gsm>
+			<network-id mcc="255" mnc="03"/>
+
+			<apn value="www.ab.kyivstar.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Ace&amp;Base</name>
+				<username>igprs</username>
+				<password>internet</password>
+			</apn>
+			<apn value="www.kyivstar.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Contract GPRS</name>
+			</apn>
+			<apn value="3g.kyivstar.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Djuice</name>
+		<gsm>
+			<network-id mcc="255" mnc="03"/>
+
+			<apn value="www.djuice.com.ua">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet GPRS</name>
+			</apn>
+			<apn value="xl.kyivstar.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet XL</name>
+			</apn>
+			<apn value="3g.kyivstar.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Life</name>
+		<gsm>
+			<network-id mcc="255" mnc="06"/>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Standard</name>
+				<dns>212.58.160.33</dns>
+				<dns>212.58.160.34</dns>
+			</apn>
+			<apn value="speed">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Faster</name>
+				<dns>212.58.160.33</dns>
+				<dns>212.58.160.34</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Beeline</name>
+		<gsm>
+			<network-id mcc="255" mnc="02"/>
+			<apn value="internet.beeline.ua">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Jeans</name>
+		<gsm>
+			<network-id mcc="255" mnc="01"/>
+			<apn value="www.jeans.ua">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>80.255.64.23</dns>
+				<dns>80.255.64.24</dns>
+			</apn>
+			<apn value="hyper.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Hyper.NET</name>
+				<dns>212.58.160.33</dns>
+				<dns>212.58.160.34</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTS</name>
+		<gsm>
+			<network-id mcc="255" mnc="01"/>
+
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS Internet</name>
+				<username>internet</username>
+				<dns>212.58.160.33</dns>
+				<dns>212.58.160.34</dns>
+			</apn>
+			<apn value="hyper.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Hyper.NET</name>
+			</apn>
+			<apn value="active">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>HyperActive</name>
+			</apn>
+			<apn value="www.umc.ua">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>umc.ua</name>
+				<dns>80.255.64.23</dns>
+				<dns>80.255.64.24</dns>
+			</apn>
+		</gsm>
+		<cdma>
+			<name>MTS Connect 3G</name>
+			<username>mobile</username>
+			<password>internet</password>
+			<sid value="15907"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Utel</name>
+		<gsm>
+			<network-id mcc="255" mnc="07"/>
+			<apn value="3g.utel.ua">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>CDMA Ukraine</name>
+		<cdma>
+			<username>cdma</username>
+			<password>cdma</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>InterTelecom</name>
+		<cdma>
+			<username>IT@IT</username>
+			<password>IT</password>
+			<sid value="15906"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>PEOPLEnet</name>
+		<cdma/>
+	</provider>
+</country>
+
+<!-- Uganda -->
+<country code="ug">
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="641" mnc="10"/>
+			<apn value="yellopix.mtn.co.ug">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>193.108.252.50</dns>
+				<dns>193.108.252.51</dns>
+			</apn>
+		</gsm>
+	</provider>
+    <provider>
+		<name>Orange</name>
+		<gsm>
+			<network-id mcc="641" mnc="14"/>
+			<apn value="orange.ug">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+    <provider>
+		<name>UTL</name>
+		<gsm>
+			<network-id mcc="641" mnc="11"/>
+			<apn value="utbroadband">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+			</apn>
+			<apn value="utweb">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+			</apn>
+		</gsm>
+	</provider>
+    <provider>
+		<name>Warid</name>
+		<gsm>
+			<network-id mcc="641" mnc="22"/>
+			<!-- http://www.waridtel.co.ug/gprs.php -->
+			<apn value="web.waridtel.co.ug">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+    <provider>
+		<name>Zain</name>
+		<gsm>
+			<network-id mcc="641" mnc="01"/>
+			<apn value="web.ug.zain.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- United States -->
+<country code="us">
+	<provider>
+		<name>AT&amp;T</name>
+		<gsm>
+			<network-id mcc="310" mnc="038"/>
+			<network-id mcc="310" mnc="090"/>
+			<network-id mcc="310" mnc="150"/>
+			<network-id mcc="310" mnc="410"/>
+			<network-id mcc="310" mnc="560"/>
+			<network-id mcc="310" mnc="680"/>
+			<!-- http://www.wireless.att.com/answer-center/main.jsp?solutionId=35078&t=solutionTab -->
+			<apn value="wap.cingular">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>MEdia Net (phones)</name>
+			</apn>
+			<apn value="Broadband">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>LaptopConnect (data cards)</name>
+			</apn>
+			<apn value="isp.cingular">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Data Connect (old)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>T-Mobile</name>
+		<gsm>
+			<network-id mcc="310" mnc="160"/>
+			<network-id mcc="310" mnc="200"/>
+			<network-id mcc="310" mnc="210"/>
+			<network-id mcc="310" mnc="220"/>
+			<network-id mcc="310" mnc="230"/>
+			<network-id mcc="310" mnc="240"/>
+			<network-id mcc="310" mnc="250"/>
+			<network-id mcc="310" mnc="260"/>
+			<network-id mcc="310" mnc="270"/>
+			<network-id mcc="310" mnc="310"/>
+			<network-id mcc="310" mnc="490"/>
+			<network-id mcc="310" mnc="580"/>
+			<network-id mcc="310" mnc="660"/>
+			<network-id mcc="310" mnc="800"/>
+
+			<voicemail>123</voicemail>
+			<apn value="epc.tmobile.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet/WebConnect</name>
+				<dns>10.177.0.34</dns>
+				<dns>10.164.103.44</dns>
+			</apn>
+			<apn value="wap.voicestream.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Web2Go/t-zones</name>
+			</apn>
+			<apn value="internet2.voicestream.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet (old)</name>
+			</apn>
+			<apn value="internet3.voicestream.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Internet with VPN (old)</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Cincinnati Bell Wireless</name>
+		<gsm>
+			<network-id mcc="310" mnc="420"/>
+			<apn value="wap.gocbw.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>cbw</username>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Sprint</name>
+		<cdma>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="4103"/>
+			<sid value="4106"/>
+			<sid value="4107"/>
+			<sid value="4120"/>
+			<sid value="4121"/>
+			<sid value="4124"/>
+			<sid value="4126"/>
+			<sid value="4132"/>
+			<sid value="4135"/>
+			<sid value="4139"/>
+			<sid value="4144"/>
+			<sid value="4145"/>
+			<sid value="4148"/>
+			<sid value="4151"/>
+			<sid value="4153"/>
+			<sid value="4155"/>
+			<sid value="4157"/>
+			<sid value="4159"/>
+			<sid value="4162"/>
+			<sid value="4164"/>
+			<sid value="4166"/>
+			<sid value="4168"/>
+			<sid value="4170"/>
+			<sid value="4171"/>
+			<sid value="4174"/>
+			<sid value="4180"/>
+			<sid value="4181"/>
+			<sid value="4183"/>
+			<sid value="4184"/>
+			<sid value="4186"/>
+			<sid value="4188"/>
+			<sid value="4190"/>
+			<sid value="4194"/>
+			<sid value="4195"/>
+			<sid value="4198"/>
+			<sid value="4274"/>
+			<sid value="4376"/>
+			<sid value="4379"/>
+			<sid value="4384"/>
+			<sid value="4390"/>
+			<sid value="4396"/>
+			<sid value="4418"/>
+			<sid value="4622"/>
+			<sid value="4654"/>
+			<sid value="4694"/>
+			<sid value="4812"/>
+			<sid value="4982"/>
+			<sid value="5116"/>
+			<sid value="5142"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Boost Mobile (Prepaid)</name>
+		<cdma />
+	</provider>
+	<provider>
+		<name>Verizon</name>
+		<gsm>
+			<network-id mcc="310" mnc="995"/>
+			<network-id mcc="311" mnc="480"/>
+			<apn value="vzwims">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>4G LTE Contract</name>
+			</apn>
+			<apn value="vzwinternet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>4G LTE Contract</name>
+				<dns>66.174.92.14</dns>
+				<dns>69.78.96.14</dns>
+			</apn>
+			<apn value="vzwapp">
+				<plan type="postpaid"/>
+				<usage type="wap"/>
+				<name>4G LTE Contract</name>
+			</apn>
+		</gsm>
+		<cdma>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="2"/>
+			<sid value="4"/>
+			<sid value="5"/>
+			<sid value="6"/>
+			<sid value="8"/>
+			<sid value="12"/>
+			<sid value="15"/>
+			<sid value="17"/>
+			<sid value="18"/>
+			<sid value="20"/>
+			<sid value="21"/>
+			<sid value="22"/>
+			<sid value="26"/>
+			<sid value="28"/>
+			<sid value="30"/>
+			<sid value="32"/>
+			<sid value="33"/>
+			<sid value="37"/>
+			<sid value="40"/>
+			<sid value="41"/>
+			<sid value="48"/>
+			<sid value="51"/>
+			<sid value="54"/>
+			<sid value="56"/>
+			<sid value="58"/>
+			<sid value="59"/>
+			<sid value="60"/>
+			<sid value="64"/>
+			<sid value="65"/>
+			<sid value="69"/>
+			<sid value="73"/>
+			<sid value="75"/>
+			<sid value="78"/>
+			<sid value="80"/>
+			<sid value="86"/>
+			<sid value="92"/>
+			<sid value="93"/>
+			<sid value="94"/>
+			<sid value="95"/>
+			<sid value="96"/>
+			<sid value="104"/>
+			<sid value="107"/>
+			<sid value="110"/>
+			<sid value="112"/>
+			<sid value="113"/>
+			<sid value="119"/>
+			<sid value="126"/>
+			<sid value="127"/>
+			<sid value="133"/>
+			<sid value="137"/>
+			<sid value="139"/>
+			<sid value="143"/>
+			<sid value="150"/>
+			<sid value="154"/>
+			<sid value="162"/>
+			<sid value="163"/>
+			<sid value="165"/>
+			<sid value="170"/>
+			<sid value="172"/>
+			<sid value="179"/>
+			<sid value="180"/>
+			<sid value="181"/>
+			<sid value="186"/>
+			<sid value="189"/>
+			<sid value="190"/>
+			<sid value="203"/>
+			<sid value="213"/>
+			<sid value="214"/>
+			<sid value="222"/>
+			<sid value="224"/>
+			<sid value="226"/>
+			<sid value="228"/>
+			<sid value="241"/>
+			<sid value="250"/>
+			<sid value="258"/>
+			<sid value="262"/>
+			<sid value="263"/>
+			<sid value="266"/>
+			<sid value="272"/>
+			<sid value="276"/>
+			<sid value="284"/>
+			<sid value="286"/>
+			<sid value="294"/>
+			<sid value="298"/>
+			<sid value="299"/>
+			<sid value="300"/>
+			<sid value="314"/>
+			<sid value="316"/>
+			<sid value="319"/>
+			<sid value="323"/>
+			<sid value="328"/>
+			<sid value="329"/>
+			<sid value="330"/>
+			<sid value="349"/>
+			<sid value="356"/>
+			<sid value="377"/>
+			<sid value="385"/>
+			<sid value="404"/>
+			<sid value="428"/>
+			<sid value="443"/>
+			<sid value="456"/>
+			<sid value="465"/>
+			<sid value="482"/>
+			<sid value="483"/>
+			<sid value="486"/>
+			<sid value="490"/>
+			<sid value="498"/>
+			<sid value="502"/>
+			<sid value="506"/>
+			<sid value="528"/>
+			<sid value="530"/>
+			<sid value="532"/>
+			<sid value="539"/>
+			<sid value="1015"/>
+			<sid value="1026"/>
+			<sid value="1032"/>
+			<sid value="1034"/>
+			<sid value="1062"/>
+			<sid value="1072"/>
+			<sid value="1074"/>
+			<sid value="1076"/>
+			<sid value="1083"/>
+			<sid value="1086"/>
+			<sid value="1088"/>
+			<sid value="1094"/>
+			<sid value="1103"/>
+			<sid value="1129"/>
+			<sid value="1131"/>
+			<sid value="1137"/>
+			<sid value="1139"/>
+			<sid value="1145"/>
+			<sid value="1151"/>
+			<sid value="1153"/>
+			<sid value="1164"/>
+			<sid value="1166"/>
+			<sid value="1174"/>
+			<sid value="1180"/>
+			<sid value="1189"/>
+			<sid value="1193"/>
+			<sid value="1196"/>
+			<sid value="1220"/>
+			<sid value="1224"/>
+			<sid value="1227"/>
+			<sid value="1230"/>
+			<sid value="1267"/>
+			<sid value="1285"/>
+			<sid value="1330"/>
+			<sid value="1358"/>
+			<sid value="1417"/>
+			<sid value="1429"/>
+			<sid value="1476"/>
+			<sid value="1488"/>
+			<sid value="1492"/>
+			<sid value="1494"/>
+			<sid value="1506"/>
+			<sid value="1510"/>
+			<sid value="1514"/>
+			<sid value="1516"/>
+			<sid value="1517"/>
+			<sid value="1519"/>
+			<sid value="1523"/>
+			<sid value="1548"/>
+			<sid value="1552"/>
+			<sid value="1563"/>
+			<sid value="1567"/>
+			<sid value="1614"/>
+			<sid value="1626"/>
+			<sid value="1630"/>
+			<sid value="1632"/>
+			<sid value="1637"/>
+			<sid value="1639"/>
+			<sid value="1641"/>
+			<sid value="1653"/>
+			<sid value="1679"/>
+			<sid value="1736"/>
+			<sid value="1740"/>
+			<sid value="1749"/>
+			<sid value="1760"/>
+			<sid value="1776"/>
+			<sid value="1780"/>
+			<sid value="1790"/>
+			<sid value="1792"/>
+			<sid value="1824"/>
+			<sid value="1826"/>
+			<sid value="1827"/>
+			<sid value="1830"/>
+			<sid value="1832"/>
+			<sid value="1857"/>
+			<sid value="1910"/>
+			<sid value="1912"/>
+			<sid value="1940"/>
+			<sid value="1969"/>
+			<sid value="2004"/>
+			<sid value="2054"/>
+			<sid value="2058"/>
+			<sid value="2060"/>
+			<sid value="2076"/>
+			<sid value="2115"/>
+			<sid value="2119"/>
+			<sid value="2125"/>
+			<sid value="2127"/>
+			<sid value="2149"/>
+			<sid value="3004"/>
+			<sid value="3008"/>
+			<sid value="3046"/>
+			<sid value="3066"/>
+			<sid value="3216"/>
+			<sid value="3218"/>
+			<sid value="3228"/>
+			<sid value="6709"/>
+			<sid value="6711"/>
+			<sid value="7532"/>
+			<sid value="7536"/>
+			<sid value="9640"/>
+			<sid value="9642"/>
+			<sid value="9644"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>US Cellular</name>
+		<cdma>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm
+			     NOTE: SIDs listed as "HOLLAND & KNIGHT LLP" are counted for US Cellular
+			           because HOLLAND & KNIGHT LLP/Peter M. Connolly appears to be the
+			           license administrator for US Cellular in those license areas listed
+			           in the IFAST SID database as assigned to HOLLAND & KNIGHT LLP.
+			           When a search of the FCC's ULS for the CMA noted for a SID by
+			           IFAST does not return an active license held by
+			           US Cellular/HOLLAND & KNIGHT LLP, that SID is not counted
+			           for US Cellular (ex SID 1925, 1935, 5289, 5291, 5293, etc).
+			-->
+			<sid value="5"/>
+			<sid value="104"/>
+			<sid value="166"/>
+			<sid value="191"/>
+			<sid value="193"/>
+			<sid value="195"/>
+			<sid value="217"/>
+			<sid value="221"/>
+			<sid value="246"/>
+			<sid value="298"/>
+			<sid value="303"/>
+			<sid value="309"/>
+			<sid value="331"/>
+			<sid value="333"/>
+			<sid value="340"/>
+			<sid value="364"/>
+			<sid value="384"/>
+			<sid value="389"/>
+			<sid value="393"/>
+			<sid value="413"/>
+			<sid value="445"/>
+			<sid value="580"/>
+			<sid value="599"/>
+			<sid value="1059"/>
+			<sid value="1061"/>
+			<sid value="1075"/>
+			<sid value="1173"/>
+			<sid value="1175"/>
+			<sid value="1200"/>
+			<sid value="1211"/>
+			<sid value="1213"/>
+			<sid value="1219"/>
+			<sid value="1223"/>
+			<sid value="1228"/>
+			<sid value="1229"/>
+			<sid value="1237"/>
+			<sid value="1272"/>
+			<sid value="1317"/>
+			<sid value="1320"/>
+			<sid value="1399"/>
+			<sid value="1403"/>
+			<sid value="1406"/>
+			<sid value="1419"/>
+			<sid value="1425"/>
+			<sid value="1427"/>
+			<sid value="1484"/>
+			<sid value="1521"/>
+			<sid value="1541"/>
+			<sid value="1543"/>
+			<sid value="1574"/>
+			<sid value="1595"/>
+			<sid value="1607"/>
+			<sid value="1610"/>
+			<sid value="1643"/>
+			<sid value="1753"/>
+			<sid value="1779"/>
+			<sid value="1783"/>
+			<sid value="1794"/>
+			<sid value="1802"/>
+			<sid value="1819"/>
+			<sid value="1821"/>
+			<sid value="1881"/>
+			<sid value="1914"/>
+			<sid value="1983"/>
+			<sid value="2066"/>
+			<sid value="2141"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Alltel</name>
+		<gsm>
+			<!-- Former Western Wireless (roaming only) -->
+			<network-id mcc="310" mnc="590"/>
+		</gsm>
+		<cdma>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="32"/>
+			<sid value="42"/>
+			<sid value="52"/>
+			<sid value="53"/>
+			<sid value="54"/>
+			<sid value="57"/>
+			<sid value="71"/>
+			<sid value="74"/>
+			<sid value="79"/>
+			<sid value="83"/>
+			<sid value="84"/>
+			<sid value="85"/>
+			<sid value="97"/>
+			<sid value="100"/>
+			<sid value="114"/>
+			<sid value="116"/>
+			<sid value="120"/>
+			<sid value="126"/>
+			<sid value="130"/>
+			<sid value="142"/>
+			<sid value="144"/>
+			<sid value="152"/>
+			<sid value="156"/>
+			<sid value="182"/>
+			<sid value="186"/>
+			<sid value="188"/>
+			<sid value="202"/>
+			<sid value="204"/>
+			<sid value="205"/>
+			<sid value="208"/>
+			<sid value="212"/>
+			<sid value="216"/>
+			<sid value="220"/>
+			<sid value="240"/>
+			<sid value="244"/>
+			<sid value="256"/>
+			<sid value="260"/>
+			<sid value="272"/>
+			<sid value="281"/>
+			<sid value="282"/>
+			<sid value="292"/>
+			<sid value="304"/>
+			<sid value="306"/>
+			<sid value="312"/>
+			<sid value="318"/>
+			<sid value="338"/>
+			<sid value="342"/>
+			<sid value="344"/>
+			<sid value="348"/>
+			<sid value="350"/>
+			<sid value="368"/>
+			<sid value="374"/>
+			<sid value="376"/>
+			<sid value="386"/>
+			<sid value="387"/>
+			<sid value="392"/>
+			<sid value="396"/>
+			<sid value="416"/>
+			<sid value="418"/>
+			<sid value="424"/>
+			<sid value="430"/>
+			<sid value="440"/>
+			<sid value="444"/>
+			<sid value="448"/>
+			<sid value="462"/>
+			<sid value="478"/>
+			<sid value="487"/>
+			<sid value="491"/>
+			<sid value="504"/>
+			<sid value="518"/>
+			<sid value="520"/>
+			<sid value="544"/>
+			<sid value="546"/>
+			<sid value="547"/>
+			<sid value="550"/>
+			<sid value="558"/>
+			<sid value="570"/>
+			<sid value="578"/>
+			<sid value="1008"/>
+			<sid value="1012"/>
+			<sid value="1014"/>
+			<sid value="1016"/>
+			<sid value="1025"/>
+			<sid value="1031"/>
+			<sid value="1033"/>
+			<sid value="1038"/>
+			<sid value="1040"/>
+			<sid value="1042"/>
+			<sid value="1044"/>
+			<sid value="1046"/>
+			<sid value="1048"/>
+			<sid value="1052"/>
+			<sid value="1054"/>
+			<sid value="1056"/>
+			<sid value="1058"/>
+			<sid value="1093"/>
+			<sid value="1118"/>
+			<sid value="1120"/>
+			<sid value="1124"/>
+			<sid value="1126"/>
+			<sid value="1148"/>
+			<sid value="1154"/>
+			<sid value="1156"/>
+			<sid value="1236"/>
+			<sid value="1244"/>
+			<sid value="1246"/>
+			<sid value="1248"/>
+			<sid value="1250"/>
+			<sid value="1252"/>
+			<sid value="1254"/>
+			<sid value="1256"/>
+			<sid value="1258"/>
+			<sid value="1260"/>
+			<sid value="1262"/>
+			<sid value="1264"/>
+			<sid value="1266"/>
+			<sid value="1268"/>
+			<sid value="1270"/>
+			<sid value="1271"/>
+			<sid value="1296"/>
+			<sid value="1298"/>
+			<sid value="1302"/>
+			<sid value="1311"/>
+			<sid value="1332"/>
+			<sid value="1334"/>
+			<sid value="1336"/>
+			<sid value="1338"/>
+			<sid value="1340"/>
+			<sid value="1342"/>
+			<sid value="1344"/>
+			<sid value="1346"/>
+			<sid value="1348"/>
+			<sid value="1370"/>
+			<sid value="1372"/>
+			<sid value="1375"/>
+			<sid value="1383"/>
+			<sid value="1385"/>
+			<sid value="1393"/>
+			<sid value="1400"/>
+			<sid value="1414"/>
+			<sid value="1422"/>
+			<sid value="1424"/>
+			<sid value="1426"/>
+			<sid value="1466"/>
+			<sid value="1493"/>
+			<sid value="1495"/>
+			<sid value="1499"/>
+			<sid value="1501"/>
+			<sid value="1526"/>
+			<sid value="1528"/>
+			<sid value="1530"/>
+			<sid value="1532"/>
+			<sid value="1534"/>
+			<sid value="1536"/>
+			<sid value="1538"/>
+			<sid value="1540"/>
+			<sid value="1542"/>
+			<sid value="1544"/>
+			<sid value="1546"/>
+			<sid value="1558"/>
+			<sid value="1560"/>
+			<sid value="1566"/>
+			<sid value="1568"/>
+			<sid value="1638"/>
+			<sid value="1640"/>
+			<sid value="1642"/>
+			<sid value="1650"/>
+			<sid value="1652"/>
+			<sid value="1654"/>
+			<sid value="1688"/>
+			<sid value="1712"/>
+			<sid value="1720"/>
+			<sid value="1763"/>
+			<sid value="1765"/>
+			<sid value="1800"/>
+			<sid value="1816"/>
+			<sid value="1818"/>
+			<sid value="1866"/>
+			<sid value="1874"/>
+			<sid value="1900"/>
+			<sid value="1913"/>
+			<sid value="1916"/>
+			<sid value="1928"/>
+			<sid value="1930"/>
+			<sid value="1934"/>
+			<sid value="1938"/>
+			<sid value="1972"/>
+			<sid value="1982"/>
+			<sid value="1984"/>
+			<sid value="1986"/>
+			<sid value="1989"/>
+			<sid value="1992"/>
+			<sid value="2010"/>
+			<sid value="2012"/>
+			<sid value="2014"/>
+			<sid value="2018"/>
+			<sid value="2022"/>
+			<sid value="2026"/>
+			<sid value="2040"/>
+			<sid value="2044"/>
+			<sid value="2046"/>
+			<sid value="2064"/>
+			<sid value="2133"/>
+			<sid value="3020"/>
+			<sid value="3226"/>
+			<sid value="3244"/>
+			<sid value="3292"/>
+			<sid value="30524"/>
+			<sid value="30635"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Leap Wireless</name>
+		<cdma />
+	</provider>
+	<provider>
+		<name>Cricket Communications</name>
+		<gsm>
+			<network-id mcc="310" mnc="000"/>
+		</gsm>
+		<cdma />
+	</provider>
+	<provider>
+		<name>Jump Mobile (Prepaid)</name>
+		<cdma />
+	</provider>
+	<provider>
+		<name>MetroPCS</name>
+		<cdma>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="4269"/>
+			<sid value="4273"/>
+			<sid value="4387"/>
+			<sid value="4531"/>
+			<sid value="4533"/>
+			<sid value="4547"/>
+			<sid value="4815"/>
+			<sid value="4855"/>
+			<sid value="5007"/>
+			<sid value="5023"/>
+			<sid value="5037"/>
+			<sid value="5097"/>
+			<sid value="5167"/>
+			<sid value="5199"/>
+			<sid value="21580"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Virgin Mobile / Helio</name>
+		<cdma>
+			<sid value="4183"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Cellular South</name>
+		<cdma>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm
+			     NOTE: Cellular South appears to use "Lukas, Nace, Gutierrez & Sachs, Chartered"
+			     as their license administrator, but that firm also administers Rural Cellular
+			     Corporation (recently bought by Verizon) as well, so SIDs counted for
+			     Cellular South were found by searching the FCC database for "Cellular South",
+			     looking up the returned Cellular Market Areas in the IFAST database, and from
+			     the IFAST database results using SIDs attributed to "Lukas, Nace, ..."
+			-->
+			<sid value="160"/>
+			<sid value="264"/>
+			<sid value="1382"/>
+			<sid value="1394"/>
+			<sid value="1996"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>BendBroadband</name>
+		<gsm>
+			<network-id mcc="311" mnc="570"/>
+			<apn value="ISP">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTPCS (Cellular One)</name>
+		<gsm>
+			<network-id mcc="310" mnc="570"/>
+			<apn value="wapgw.chinookwireless.net">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Mid-Rivers Cellular</name>
+		<cdma>
+			<sid value="3102"/>
+		</cdma>
+	</provider>
+</country>
+
+<!-- Uruguay -->
+<country code="uy">
+	<provider>
+		<name>Ancel</name>
+		<gsm>
+			<network-id mcc="748" mnc="00"/>
+			<network-id mcc="748" mnc="01"/>
+			<apn value="adslmovil">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>ADSL Móvil</name>
+				<dns>200.40.30.245</dns>
+				<dns>200.40.220.245</dns>
+			</apn>
+			<apn value="prepago.ancel">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>ADSL Móvil Prepago</name>
+				<username>BAM</username>
+				<password>BAM</password>
+			</apn>
+			<apn value="gprs.ancel">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>GPRS</name>
+				<dns>200.40.30.245</dns>
+				<dns>200.40.220.245</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Claro</name>
+		<gsm>
+			<network-id mcc="748" mnc="10"/>
+			<apn value="gprs.claro.com.uy">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G Internet</name>
+				<username>ctigprs</username>
+				<password>ctigprs999</password>
+			</apn>
+			<apn value="internet.ctimovil.com.uy">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>2G Internet</name>
+				<username>ctiweb</username>
+				<password>ctiweb999</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="748" mnc="07"/>
+			<apn value="apnumt.movistar.com.uy">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>3G Internet</name>
+				<username>movistar</username>
+				<password>movistar</password>
+			</apn>
+			<apn value="webapn.movistar.com.uy">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>2G Internet</name>
+				<username>movistar</username>
+				<password>movistar</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Uzbekistan -->
+<country code="uz">
+	<provider>
+		<name>Beeline</name>
+		<gsm>
+			<network-id mcc="434" mnc="04"/>
+			<apn value="internet.beeline.uz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>beeline</username>
+				<password>beeline</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTS (Uzdunrobita)</name>
+		<gsm>
+			<network-id mcc="434" mnc="07"/>
+			<apn value="net.mts.uz">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mts</username>
+				<password>mts</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Ucell</name>
+		<gsm>
+			<network-id mcc="434" mnc="05"/>
+			<apn value="internet">
+				<username></username>
+				<password></password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- St Vincent -->
+<country code="vc">
+	<provider>
+		<name>Digicel</name>
+		<gsm>
+			<network-id mcc="360" mnc="070"/>
+			<apn value="wap.digiceloecs.com">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>wapoecs</username>
+				<password>wap03oecs</password>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Venezuela -->
+<country code="ve">
+	<provider>
+		<name>Digitel TIM</name>
+		<gsm>
+			<network-id mcc="734" mnc="01"/>
+			<network-id mcc="734" mnc="02"/>
+			<network-id mcc="734" mnc="03"/>
+			<apn value="gprsweb.digitel.ve">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>57.67.127.195</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movilnet</name>
+		<gsm>
+			<network-id mcc="734" mnc="06"/>
+			<apn value="int.movilnet.com.ve">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>200.44.32.12</dns>
+				<dns>200.11.248.12</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Movistar</name>
+		<gsm>
+			<network-id mcc="734" mnc="04"/>
+			<apn value="internet.movistar.ve">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>200.35.65.3</dns>
+				<dns>200.35.65.4</dns>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- Viet Nam -->
+<country code="vn">
+	<provider>
+		<name>MobiFone</name>
+		<gsm>
+			<network-id mcc="452" mnc="01"/>
+			<apn value="m-wap">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<username>mms</username>
+				<password>mms</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vinaphone</name>
+		<gsm>
+			<network-id mcc="452" mnc="02"/>
+			<apn value="m3-world">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+				<username>mms</username>
+				<password>mms</password>
+			</apn>
+			<apn value="m3-card">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Broadband</name>
+				<username>mms</username>
+				<password>mms</password>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>S-Fone</name>
+		<cdma>
+			<!-- phone number dialed appears to be 1501 not 777 (???
+			     http://www.sfone.com.vn/webportal/guideMobile02_vi.html?pageNum=3&subNum=9&idxNum=091
+			  -->
+			<username>S-Fone</username>
+			<!-- Assignments taken from IFAST: http://www.ifast.org/files/NationalSID.htm -->
+			<sid value="13331"/>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Viettel Mobile</name>
+		<gsm>
+			<network-id mcc="452" mnc="04"/>
+			<apn value="v-internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Mobile Internet</name>
+			</apn>
+			<apn value="e-connect">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>D-com 3G</name>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vietnamobile</name>
+		<gsm>
+			<network-id mcc="452" mnc="05"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>EVNTelecom/E-Mobile</name>
+		<gsm>
+			<network-id mcc="452" mnc="08"/>
+			<apn value="e-internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>EVNTelecomNet</name>
+			</apn>
+		</gsm>
+		<cdma>
+			<username>evntelecom</username>
+			<password>evntelecom</password>
+		</cdma>
+	</provider>
+	<provider>
+		<name>Beeline VN</name>
+		<gsm>
+			<network-id mcc="452" mnc="07"/>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+<!-- South Africa -->
+<country code="za">
+	<provider>
+		<name>Cell-c</name>
+		<gsm>
+			<network-id mcc="655" mnc="07"/>
+			<msisdn-query>
+				<ussd>*147*100#</ussd>
+			</msisdn-query>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*102*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>196.7.0.138</dns>
+				<dns>196.7.142.132</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>MTN</name>
+		<gsm>
+			<network-id mcc="655" mnc="10"/>
+			<msisdn-query>
+				<ussd>*123*888#</ussd>
+			</msisdn-query>
+			<balance-check>
+				<ussd>*141#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*141*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>196.11.240.241</dns>
+				<dns>209.212.97.1</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Vodacom</name>
+		<gsm>
+			<network-id mcc="655" mnc="01"/>
+			<msisdn-query>
+				<ussd>*111*501#</ussd>
+			</msisdn-query>
+			<balance-check>
+				<ussd>*100#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*100*01*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>196.207.40.165</dns>
+				<dns>196.43.46.190</dns>
+			</apn>
+			<apn value="unrestricted">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<name>Unrestricted</name>
+				<dns>196.207.32.69</dns>
+				<dns>196.43.45.190</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Virgin Mobile</name>
+		<gsm>
+			<network-id mcc="655" mnc="07"/>
+			<balance-check>
+				<ussd>*101#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*102*CODE#</ussd>
+			</balance-top-up>
+			<apn value="vdata">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+				<dns>196.7.0.138</dns>
+				<dns>196.7.142.132</dns>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>8.ta</name>
+		<gsm>
+			<network-id mcc="655" mnc="02"/>
+			<msisdn-query>
+				<ussd>*1#</ussd>
+			</msisdn-query>
+			<balance-check>
+				<ussd>*188#</ussd>
+			</balance-check>
+			<balance-top-up>
+				<ussd replacement="CODE">*188*CODE#</ussd>
+			</balance-top-up>
+			<apn value="internet">
+				<plan type="postpaid"/>
+				<usage type="internet"/>
+			</apn>
+		</gsm>
+	</provider>
+</country>
+
+</serviceproviders>
+


### PR DESCRIPTION
Here is the code that is part of the operator variant feature I've talked about in the past (mostly in dev-b2g mailing list). Basically it's in charge of setting all the carrier settings related to the subscriber's home network. Some examples are the voicemail number if it's not in the ICC card, the APN setting for data calls (this will be done in setting app not here), the list of valid emergency calls if needed, the SMS cell broadcast service settings and any other settings.
