### PR TITLE
Deal with home screen crash and realign z-index again

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -809,6 +809,11 @@ var WindowManager = (function() {
         { name: runningApps[origin].name });
     }
 
+    if (origin == homescreen) {
+      // We need to relaunch home screen at once.
+      kill(origin, ensureHomescreen);
+      return;
+    }
     kill(origin);
   });
 

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -106,7 +106,7 @@
 
 /* Level 9 */
 #screen > [data-z-index-level="window-sprite"] {
-  z-index: 2;
+  z-index: 5;
 }
 
 #screen > [data-z-index-level="app"] {
@@ -118,18 +118,24 @@
 }
 
 /*
- * set appWindow/homescreen z-index as 2 when it is active,
- * so that it will appear above the keyboard iframe (z-index 0) to allow
- * clicking on it
+ * The below z-index numbers is used to met the following conditions:
+ * - active ones must be on top of the inactive ones
+ * - keyboard frame must be below the active ones
+ * - keyboard frame must be above the inactive ones
+ * - app frame must be on top of homescreen frame, inactive or active.
+ * - finally, everything else need to be on top of them (hence the lowest nums)
+ *
  */
-#screen > [data-z-index-level="app"] > iframe.appWindow.active,
-#screen > [data-z-index-level="app"] > iframe.appWindow.homescreen.active {
-  z-index: 2;
+#screen > [data-z-index-level="app"] > iframe.appWindow.active {
+  z-index: 4;
 }
 
-#screen > [data-z-index-level="app"].active + section.banner[data-z-index-level="system-notification-banner"],
 #screen > [data-z-index-level="app"] > iframe.appWindow {
   z-index: 1;
+}
+
+#screen > [data-z-index-level="app"] > iframe.appWindow.homescreen.active {
+  z-index: 3;
 }
 
 #screen > [data-z-index-level="app"] > iframe.appWindow.homescreen {
@@ -138,7 +144,7 @@
 
 /* When keyboard is visible, set frame under app window */
 #screen > [data-z-index-level="keyboard-frame"].visible {
-  z-index: 0;
+  z-index: 2;
 }
 
 /* Fullscreen */

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -130,21 +130,20 @@
   z-index: 4;
 }
 
-#screen > [data-z-index-level="app"] > iframe.appWindow {
-  z-index: 1;
-}
-
 #screen > [data-z-index-level="app"] > iframe.appWindow.homescreen.active {
   z-index: 3;
 }
 
-#screen > [data-z-index-level="app"] > iframe.appWindow.homescreen {
-  z-index: 0;
-}
-
-/* When keyboard is visible, set frame under app window */
 #screen > [data-z-index-level="keyboard-frame"].visible {
   z-index: 2;
+}
+
+#screen > [data-z-index-level="app"] > iframe.appWindow {
+  z-index: 1;
+}
+
+#screen > [data-z-index-level="app"] > iframe.appWindow.homescreen {
+  z-index: 0;
 }
 
 /* Fullscreen */


### PR DESCRIPTION
Follow up of #4371
- Relaunch home screen right away if it crashes and is currently the displayed app.
- correct the z-index of things since the relaunched home screen frame changed it's position in DOM

@cgjones can you review?
