### PR TITLE
Feature dialer speaker bug 4382

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -148,5 +148,7 @@ HandledCall.prototype.disconnected = function hc_disconnected() {
       });
     });
   }
+  CallScreen.unmute();
+  CallScreen.setSpeakerOff();
   this.remove();
 };

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -149,6 +149,6 @@ HandledCall.prototype.disconnected = function hc_disconnected() {
     });
   }
   CallScreen.unmute();
-  CallScreen.setSpeakerOff();
+  CallScreen.turnSpeakerOff();
   this.remove();
 };

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -62,9 +62,19 @@ var CallScreen = {
     OnCallHandler.toggleMute();
   },
 
+  unmute: function cs_unmute() {
+    this.muteButton.classList.remove('mute');
+    OnCallHandler.unmute();
+  },
+
   toggleSpeaker: function cs_toggleSpeaker() {
     this.speakerButton.classList.toggle('speak');
     OnCallHandler.toggleSpeaker();
+  },
+
+  setSpeakerOff: function cs_setSpeakerOff() {
+    this.speakerButton.classList.remove('speak');
+    OnCallHandler.setSpeakerOff();
   },
 
   showKeypad: function cs_showKeypad() {
@@ -263,8 +273,16 @@ var OnCallHandler = {
     this.handledCalls[lastCallIndex].call.hangUp();
   },
 
+  unmute: function ch_unmute() {
+    this._telephony.muted = false;
+  },
+
   toggleMute: function ch_toggleMute() {
     this._telephony.muted = !this._telephony.muted;
+  },
+
+  setSpeakerOff: function ch_setSpeakeroff() {
+    this._telephony.speakerEnabled = false;
   },
 
   toggleSpeaker: function ch_toggleSpeaker() {

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -388,5 +388,6 @@ window.addEventListener('localized', function callSetup(evt) {
 
   KeypadManager.init();
   CallScreen.init();
+  CallScreen.syncSpeakerEnabled();
   OnCallHandler.setup();
 });

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -72,9 +72,9 @@ var CallScreen = {
     OnCallHandler.toggleSpeaker();
   },
 
-  setSpeakerOff: function cs_setSpeakerOff() {
+  turnSpeakerOff: function cs_turnSpeakerOff() {
     this.speakerButton.classList.remove('speak');
-    OnCallHandler.setSpeakerOff();
+    OnCallHandler.turnSpeakerOff();
   },
 
   showKeypad: function cs_showKeypad() {
@@ -281,7 +281,7 @@ var OnCallHandler = {
     this._telephony.muted = !this._telephony.muted;
   },
 
-  setSpeakerOff: function ch_setSpeakeroff() {
+  turnSpeakerOff: function ch_turnSpeakeroff() {
     this._telephony.speakerEnabled = false;
   },
 


### PR DESCRIPTION
There was some desynchronization regarding the speaker button between calls. Now they are synchronized, this means that the speaker status is kept between calls (if you make a call and set the speaker on, it will be on on the next call). This is the current behavior. I am going to check with UX that this is the desired one ;-) or maybe the speaker status should be set to off on every new call ;-)
