### PR TITLE
[Attention screen] Close the card view if visible before showing the incoming call screen

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -57,6 +57,11 @@ var AttentionScreen = {
     this.attentionScreen.appendChild(attentionFrame);
     this.attentionScreen.classList.add('displayed');
 
+    // Close the card view if visible.
+    if (this._cardsViewVisible = CardsView.cardSwitcherIsShown()) {
+      CardsView.hideCardSwitcher();
+    }
+
     // We want the user attention, so we need to turn the screen on
     // if it's off.
     this._screenInitiallyDisabled = !ScreenManager.screenEnabled;
@@ -95,6 +100,10 @@ var AttentionScreen = {
     if (this.attentionScreen.querySelectorAll('iframe').length == 0)
       this.attentionScreen.classList.remove('displayed');
 
+    if (this._cardsViewVisible) {
+      CardsView.showCardSwitcher();
+    }
+    
     if (this._screenInitiallyDisabled)
       ScreenManager.turnScreenOff(true);
 


### PR DESCRIPTION
The card view is closed before showing the attention screen if a new incoming call reaches de phone. Once the call is finalized, the card view is restored (if was previously shown).
