### PR TITLE
[contacts] feature: carrier next to phone number if multiple phone numbers

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -357,8 +357,9 @@ var Contacts = (function() {
         // if more than one required type of data
         var prompt1 = new ValueSelector(selectDataStr);
         for (var i = 0; i < dataSet.length; i++) {
-          var data = dataSet[i].value;
-          prompt1.addToList(data + '', function(itemData) {
+          var data = dataSet[i].value,
+              carrier = dataSet[i].carrier;
+          prompt1.addToList(data + ' ' + carrier, function(itemData) {
             return function() {
               prompt1.hide();
               result[type] = itemData;


### PR DESCRIPTION
If user comes form another app to pick a contact (to send sms for example) on the contact list, the user taps on a contact with multiple phone numbers, on the popup, next to the phone number there is not carrier. This PR adds that feature.

*Procedure
1- Open sms app
2- Press new sms button
3- Press search contcar button
4- Select a contact with 2 phone numbers

*Expected Result
User access to selection of contact phone number and the phone carriers are shows

*Acutal Result
The carrier does not appear in the window to select the phone number

@albertopq r? @arcturus r?
