### PR TITLE
[F] #4430 -- Keyboard overlay under lockscreen

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -87,6 +87,11 @@
   z-index: 2046;
 }
 
+/* Keep keyboard overlay under lockscreen when locked */
+#screen.locked > [data-z-index-level="keyboard-overlay"] {
+  z-index: 2045;
+}
+
 /* Level 7: Debug grid */
 #screen > [data-z-index-level="debug-grid"] {
   z-index: 1024;


### PR DESCRIPTION
Fix #4430,
it's a workaround.

I try by blur the main screen but nothing happens.
If we are going to show keyboard when locking, need to consider what to do again.
But it's not required now.

ping @RudyLu, @timdream
