### PR TITLE
Add ril.callwaiting.enabled to settings DB

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -72,6 +72,7 @@ var settings = [
  new Setting("ril.data.roaming_enabled", false),
  new Setting("ril.data.user", ""),
  new Setting("ril.radio.disabled", false),
+ new Setting("ril.callwaiting.enabled", true),
  new Setting("screen.automatic-brightness", true),
  new Setting("screen.brightness", 1),
  new Setting("sms.ring.received", true),


### PR DESCRIPTION
For issue #3227,  the platform implementation is going to land.
We need this setting for settings app.
