### PR TITLE
Controlling wifi by mozSetting and remove wifi.setEnabled()

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -95,6 +95,7 @@ var settings = [
  new Setting("ums.enabled", false),
  new Setting("ums.mode", 0),
  new Setting("wifi.enabled", true),
+ new Setting("wifi.disabled_by_wakelock", false),
  new Setting("wifi.notification", false)
 ];
 


### PR DESCRIPTION
`wifi.js` currently generates Javascript error because 

https://bugzilla.mozilla.org/show_bug.cgi?id=729877

is landed. This pull request rewrites the script so it could handle wifi and wifi wake lock correctly.
