### PR TITLE
[Dialer][Attention screen] Card view (task switcher) is close if incoming call

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -94,8 +94,10 @@ var AttentionScreen = {
     this.dispatchEvent('status-inactive');
     this.attentionScreen.removeChild(evt.target);
 
-    if (this.attentionScreen.querySelectorAll('iframe').length == 0)
+    if (this.attentionScreen.querySelectorAll('iframe').length == 0) {
       this.attentionScreen.classList.remove('displayed');
+      this.dispatchEvent('attentionscreenhide');
+    }
 
     if (this._screenInitiallyDisabled)
       ScreenManager.turnScreenOff(true);
@@ -104,7 +106,6 @@ var AttentionScreen = {
     // without any focused window, let's fix this.
     window.focus();
 
-    this.dispatchEvent('attentionscreenhide');
   },
 
   show: function as_show() {

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -71,6 +71,8 @@ var AttentionScreen = {
         frame.setVisible(false);
       }
     }
+
+    this.dispatchEvent('attentionscreenshow');
   },
 
   close: function as_close(evt) {
@@ -101,6 +103,8 @@ var AttentionScreen = {
     // We just removed the focused window leaving the system
     // without any focused window, let's fix this.
     window.focus();
+
+    this.dispatchEvent('attentionscreenhide');
   },
 
   show: function as_show() {
@@ -116,6 +120,8 @@ var AttentionScreen = {
         self.dispatchEvent('status-inactive');
       });
     });
+
+    this.dispatchEvent('attentionscreenshow');
   },
 
   // Invoked when we get a "home" event
@@ -135,6 +141,8 @@ var AttentionScreen = {
             attentionScreen.removeEventListener('transitionend', trWait);
             attentionScreen.classList.add('status-mode');
         });
+
+        this.dispatchEvent('attentionscreenhide');
       }
     }
   },

--- a/apps/system/js/cards_view/cards_view.js
+++ b/apps/system/js/cards_view/cards_view.js
@@ -457,6 +457,15 @@ var CardsView = (function() {
     hideCardSwitcher();
   });
 
+  window.addEventListener('attentionscreenshow',
+    function cv_attentionScreenShowEvent(evt) {
+    if (!cardSwitcherIsShown()) {
+      return;
+    }
+
+    hideCardSwitcher();
+  });
+
   function cv_handleEvent(evt) {
     switch (evt.type) {
       case 'mousedown':


### PR DESCRIPTION
If the card view is shown, it is close if an incoming call reaches the phone. In case that after attending the call, the user opens any other app, then after hanging the call that will be the app shown. Please see #4378 ;-)
