### PR TITLE
Cancel dragstart event to workaround bug 783076

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1031,6 +1031,14 @@ var WindowManager = (function() {
     }
   });
 
+  // Cancel dragstart event to workaround
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=783076
+  // which stops OOP home screen pannable with left mouse button on
+  // B2G/Desktop.
+  windows.addEventListener('dragstart', function (evt) {
+    evt.preventDefault();
+  }, true);
+
   window.addEventListener('holdhome', function(e) {
     if (!LockScreen.locked &&
         !CardsView.cardSwitcherIsShown()) {


### PR DESCRIPTION
We might want to stop the drag events altogether on Gecko side so B2G/Desktop can behave more closely to B2G phone.
