### PR TITLE
Use Array.isArray function from ES5 because it is faster and easier to read

### DIFF
--- a/apps/communications/contacts/js/value_selector.js
+++ b/apps/communications/contacts/js/value_selector.js
@@ -73,7 +73,7 @@ function ValueSelector(title, list) {
       setTitle(title);
     }
 
-    if (Object.prototype.toString.call(list) == '[object Array]') {
+    if (Array.isArray(list)) {
       data.list = list;
     }
   }

--- a/apps/homescreen/js/state.js
+++ b/apps/homescreen/js/state.js
@@ -91,7 +91,7 @@ const HomeState = (function() {
       }
 
       newTxn('readwrite', function(txn, store) {
-        if (Object.prototype.toString.call(pages) === '[object Array]') {
+        if (Array.isArray(pages)) {
           store.clear();
           var len = pages.length;
           for (var i = 0; i < len; i++) {


### PR DESCRIPTION
ECMAScript 5 provides this function, so it should be used.

https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/isArray

This is actually the same change as discussed here: https://github.com/mozilla-b2g/gaia/pull/4164

And yes, these are the only occurences of Object.prototype.toString in the gaia code base which can be replaced with Array.isArray. Other occurences are only found in external libs and https://github.com/mozilla-b2g/gaia-email-libs-and-more
