### PR TITLE
[l10n] send a warning when a string is not internationalized

### DIFF
--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -763,7 +763,9 @@
   function getL10nData(key, args) {
     var data = gL10nData[key];
     if (!data) {
-      consoleWarn('#' + key + ' missing for [' + gLanguage + ']');
+      //consoleWarn('#' + key + ' missing for [' + gLanguage + ']');
+      // XXX temporary log, to be removed after the string freeze
+      console.warn('[l10n] #' + key + ' is undefined.');
     }
 
     /** This is where l10n expressions should be processed.
@@ -842,7 +844,9 @@
     // get the related l10n object
     var data = getL10nData(l10n.id, l10n.args);
     if (!data) {
-      consoleWarn('#' + l10n.id + ' missing for [' + gLanguage + ']');
+      //consoleWarn('#' + l10n.id + ' missing for [' + gLanguage + ']');
+      // XXX temporary log, to be removed after the string freeze
+      console.warn('[l10n] #' + key + ' is undefined.');
       return;
     }
 

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -846,7 +846,7 @@
     if (!data) {
       //consoleWarn('#' + l10n.id + ' missing for [' + gLanguage + ']');
       // XXX temporary log, to be removed after the string freeze
-      console.warn('[l10n] #' + key + ' is undefined.');
+      console.warn('[l10n] #' + l10n.id + ' is undefined.');
       return;
     }
 


### PR DESCRIPTION
As the string freeze is approaching, this is proposed as a temporary procedure to log all string references that aren’t properly internationalized. This can be backed out after the string freeze.

Note: we could have just set DEBUG to `true` in l10n.js, but this small patch will leave less messages in `adb logcat`.
