### PR TITLE
It is possible that getScreenshot().onsuccess fires after 500 ms, fix #4444

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -340,12 +340,17 @@ var WindowManager = (function() {
     var req = app.frame.getScreenshot();
 
     // Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=787519
+    var isTimeout = false;
     var timer = setTimeout(function getScreenshotTimeout() {
       console.warn('Window Manager: getScreenshot timeout.');
+      isTimeout = true;
       callback();
     }, 500);
 
     req.onsuccess = function(evt) {
+      if (isTimeout)
+        return;
+
       clearTimeout(timer);
       var result = evt.target.result;
       callback(result, false);
@@ -354,7 +359,11 @@ var WindowManager = (function() {
     };
 
     req.onerror = function(evt) {
+      if (isTimeout)
+        return;
+
       clearTimeout(timer);
+
       console.warn('Window Manager: getScreenshot failed.');
       callback();
     };


### PR DESCRIPTION
#4444 is a smoke test item so this need to be landed in time.

Sorry about overlooking this urgent item for two workdays + a weekend.
