### PR TITLE
[settings] disable the "Invert Colors" setting

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1115,7 +1115,7 @@
       </header>
 
       <ul>
-        <li>
+        <li hidden>
           <label>
             <input type="checkbox" name="accessibility.invert"/>
             <span></span>


### PR DESCRIPTION
This feature won’t ever work well on an Otoro. We probably should think of high-contrast color themes instead… until then, let’s disable it — see issue #3128.
