### PR TITLE
[Contacts] Disabling Done button after removing fields

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -988,6 +988,7 @@ var Contacts = (function() {
       event.preventDefault();
       var elem = document.getElementById(selector);
       elem.parentNode.removeChild(elem);
+      checkDisableButton();
       return false;
     };
     return delButton;


### PR DESCRIPTION
We were checking if the Done button should be disabled when removing the content of the inputs, but not when removing the whole field. This PR fixes that
