### PR TITLE
remove broken filmstrip from single-photo display mode

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -52,11 +52,8 @@
       </div>
 
       <div id="photos-overlay">
-        <div id="photos-overlay-top">
-          <div id="photos-filmstrip"><!-- thumbnails here --></div>
-          <a id="photos-back-button" class="button"></a>
-        </div>
         <div id="photos-overlay-bottom">
+          <a id="photos-back-button" class="button"></a>
           <a id="photos-camera-button" class="button"></a>
           <a id="photos-edit-button" class="button"></a>
           <a id="photos-share-button" class="button"></a>

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -422,27 +422,17 @@ function setView(view) {
   switch (view) {
   case thumbnailListView:
     thumbnailListView.appendChild(thumbnails);
-    thumbnails.style.width = '';
     break;
   case thumbnailSelectView:
     thumbnailSelectView.appendChild(thumbnails);
-    thumbnails.style.width = '';
     // Set the view header to a localized string
     updateSelectionState();
     break;
-  case photoView:
-    // photoView is a special case because we need to insert
-    // the thumbnails into the filmstrip container and set its width
-    $('photos-filmstrip').appendChild(thumbnails);
-    // In order to get a working scrollbar, we apparently have to specify
-    // an explict width for list of thumbnails.
-    // XXX: we need to update this when images are added or deleted.
-    // XXX: avoid using hardcoded 50px per image?
-    thumbnails.style.width = (images.length * 50) + 'px';
-    break;
   case pickView:
     pickView.appendChild(thumbnails);
-    thumbnails.style.width = '';
+    break;
+  case photoView:
+    // No thumbnails in photoView
     break;
   case editView:
     // We don't display the thumbnails in edit view.

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -84,12 +84,8 @@ body {
  * Thumbnails are implemented as <li> elements in a <ul> with background-image
  * set to display the image. We use background-size: cover to automatically
  * resize the image as needed.
- * 
  * The thumbnail list appears in regular browsing mode, in selection mode, 
- * and also in "filmstrip" form in single-photo mode. So the thumbnail list
- * and the individual thumbnails are styled differently depending on 
- * what element they are contained within, and also depending on the phone
- * resolution and orientation (and also language direction).
+ * and in pick mode.
  */
 
 #thumbnails {
@@ -174,29 +170,6 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-}
-
-/*
- * In photo view mode, the thumbnail list becomes a "filmstrip"
- * and the thumbnail images become much smaller.
- * JavaScript will set the width of the thumbnails container so that 
- * we get working scrollbars
- */
-#photos-filmstrip #thumbnails {
-  left:0;
-  top:0;
-  height:50px;
-  overflow-y: hidden;
-  overflow-x: scroll;
-}
-
-#photos-filmstrip li.thumbnail {
-    border-left: solid black 2px;
-    border-right: none;
-    border-top: solid black 2px;
-    border-bottom: solid black 2px;
-    width: 50px;
-    height: 50px;
 }
 
 #photo-frames {
@@ -346,17 +319,6 @@ a.button.disabled {
   background-image: url('images/share.png');
 }
 
-#photos-overlay-top {
-  position: absolute;
-  height: 50px;
-  top: 0;
-  left: 0;
-  right: 0;
-  background: rgba(0, 0, 0, 0.4);
-  /* the filmstrip is taller than 50px so we can hide its scrollbar */
-  overflow: hidden; 
-}
-
 #photos-filmstrip {
   position: absolute;
   height: 100%;
@@ -365,19 +327,6 @@ a.button.disabled {
   overflow-x: scroll;
   overflow-y: hidden;
 }
-
-#photos-back-button {
-  position: absolute;
-  width: 50px;
-  height: 100%;
-  right: 0;
-  /*
-   * XXX
-   * The dialpad icon looks kind of like a  grid of thumbnail images
-   */
-  background-image: url('images/actionicon_dialpad.png');
-}
-
 
 #photos-overlay-bottom {
   background: rgba(0, 0, 0, 0.4);
@@ -388,35 +337,47 @@ a.button.disabled {
   right: 0;
 }
 
-#photos-camera-button {
+#photos-back-button {
   position: absolute;
-  width: 25%;
+  width: 20%;
   height: 100%;
   left: 0;
+  /*
+   * XXX
+   * The dialpad icon looks kind of like a  grid of thumbnail images
+   */
+  background-image: url('images/actionicon_dialpad.png');
+}
+
+#photos-camera-button {
+  position: absolute;
+  width: 20%;
+  height: 100%;
+  left: 20%;
   background-image: url('images/camera.png');
 }
 
 #photos-edit-button {
   position: absolute;
-  width: 25%;
+  width: 20%;
   height: 100%;
-  left: 25%;
+  left: 40%;
   background-image: url('images/edit.png');
 }
 
 #photos-share-button {
   position: absolute;
-  width: 25%;
+  width: 20%;
   height: 100%;
-  left: 50%;
+  left: 60%;
   background-image: url('images/share.png');
 }
 
 #photos-delete-button {
   position: absolute;
-  width: 25%;
+  width: 20%;
   height: 100%;
-  left: 75%;
+  left: 80%;
   background-image: url('images/delete.png');
 }
 


### PR DESCRIPTION
This pull request removes the 'filmstrip' view from the single photo view mode of the gallery app.
See the discussion in #4161.

@daleharvey @autonome: do either of you have a moment to review and land this?
