### PR TITLE
Don't attach devicelight event listener if it's not enabled

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -229,7 +229,9 @@ var ScreenManager = {
     if (this.screenEnabled)
       return false;
 
-    window.addEventListener('devicelight', this);
+    if (this._deviceLightEnabled)
+      window.addEventListener('devicelight', this);
+
     window.addEventListener('mozfullscreenchange', this);
 
     this.setScreenBrightness(this._userBrightness, instant);


### PR DESCRIPTION
Follow up of #4548
