### PR TITLE
[Facebook & Popup manager] Facebook contacts import or link are stuck

### DIFF
--- a/apps/communications/contacts/fb_import.html
+++ b/apps/communications/contacts/fb_import.html
@@ -102,6 +102,9 @@
 
     <section id="curtain" role="region">
       <header>
+        <a href="#" onclick="window.close();">
+          <span class="icon icon-close">close</span>
+        </a>
         <h1>Facebook</h1>
       </header>
       <p class="message">Hold on. We are connecting to obtain your friend list</p>

--- a/apps/communications/contacts/fb_link.html
+++ b/apps/communications/contacts/fb_link.html
@@ -74,6 +74,9 @@
 
      <section id="curtain" role="region">
         <header>
+          <a href="#" onclick="fb.link.ui.end(event)">
+            <span class="icon icon-close">close</span>
+          </a>
           <h1>Facebook</h1>
         </header>
         <p class="message">Hold on. We are connecting to obtain your friend list</p>

--- a/apps/system/js/popup_manager.js
+++ b/apps/system/js/popup_manager.js
@@ -118,6 +118,7 @@ var PopupManager = {
     if (!this._currentPopup)
       return;
 
+    evt.stopImmediatePropagation();
     this.close();
   },
 


### PR DESCRIPTION
Hi all,

 This pull request tries to solve this issue #4387. 

 Basically I have a doubt, I resolved the problem providing with a new mechanism to exit from popup windows clicking on home button. I don't know if it breaks any philosophy although it makes sense for me.  This phone has only one button, so it's not weird that the home button should kill the popup. But it's only my opinion.

 Please anyone close the pr if you decide that it is a crazy idea :)

 Any comments @vingtetun, @mounirlamouri, @jcarpenter, @dcoloma,...

Thanks a lot!!!
