### PR TITLE
Gaia apps in system for user (production) builds

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,9 +16,11 @@ include $(BUILD_PREBUILT)
 
 $(LOCAL_INSTALLED_MODULE):
 	@echo Install dir: $(TARGET_OUT_DATA)/local
-	rm -rf $(TARGET_OUT_DATA)/local/webapps
 	mkdir -p $(TARGET_OUT_DATA)/local
 	cd $(TARGET_OUT_DATA)/local && tar xfz $(abspath $<)
+	mkdir -p $(TARGET_OUT)/b2g
+	rm -rf $(TARGET_OUT)/b2g/webapps
+	mv $(TARGET_OUT_DATA)/local/webapps $(TARGET_OUT)/b2g
 
 .PHONY: $(LOCAL_PATH)/profile.tar.gz
 $(LOCAL_PATH)/profile.tar.gz:

--- a/Android.mk
+++ b/Android.mk
@@ -14,16 +14,35 @@ LOCAL_SRC_FILES := profile.tar.gz
 LOCAL_MODULE_PATH := $(TARGET_OUT_DATA)/local
 include $(BUILD_PREBUILT)
 
+GAIA_MAKE_FLAGS := -C $(GAIA_PATH)
+GAIA_PROFILE_INSTALL_PARENT := $(TARGET_OUT_DATA)/local
+GAIA_APP_INSTALL_PARENT := $(GAIA_PROFILE_INSTALL_PARENT)
+CLEAN_PROFILE := 0
+
+# In user (production) builds we put gaia apps in /system/b2g/webapps
+ifneq ($(filter user userdebug, $(TARGET_BUILD_VARIANT)),)
+GAIA_MAKE_FLAGS += PRODUCTION=1
+GAIA_APP_INSTALL_PARENT := $(TARGET_OUT)/b2g
+CLEAN_PROFILE := 1
+endif
+
+GAIA_APP_INSTALL_PATH := $(GAIA_APP_INSTALL_PARENT)/webapps
+
 $(LOCAL_INSTALLED_MODULE):
-	@echo Install dir: $(TARGET_OUT_DATA)/local
-	mkdir -p $(TARGET_OUT_DATA)/local
-	cd $(TARGET_OUT_DATA)/local && tar xfz $(abspath $<)
-	mkdir -p $(TARGET_OUT)/b2g
-	rm -rf $(TARGET_OUT)/b2g/webapps
-	mv $(TARGET_OUT_DATA)/local/webapps $(TARGET_OUT)/b2g
+	@echo Gaia install path: $(GAIA_INSTALL_PATH)
+	mkdir -p $(GAIA_PROFILE_INSTALL_PARENT) $(GAIA_APP_INSTALL_PARENT)
+	rm -rf $(GAIA_APP_INSTALL_PATH)
+	cd $(GAIA_PROFILE_INSTALL_PARENT) && tar xfz $(abspath $<)
+
+ifneq ($(GAIA_PROFILE_INSTALL_PARENT), $(GAIA_APP_INSTALL_PARENT))
+	mv $(GAIA_PROFILE_INSTALL_PARENT)/webapps $(GAIA_APP_INSTALL_PARENT)
+endif
 
 .PHONY: $(LOCAL_PATH)/profile.tar.gz
 $(LOCAL_PATH)/profile.tar.gz:
-	$(MAKE) -C $(GAIA_PATH) profile
+ifeq ($(CLEAN_PROFILE), 1)
+	rm -rf $(GAIA_PATH)/profile $(GAIA_PATH)/profile.tar.gz
+endif
+	$(MAKE) $(GAIA_MAKE_FLAGS) profile
 	cd $(GAIA_PATH)/profile && tar cfz $(abspath $@) indexedDB webapps user.js permissions.sqlite
 

--- a/Makefile
+++ b/Makefile
@@ -512,19 +512,19 @@ update-offline-manifests:
 # working on just gaia itself, and you already have B2G firmware on your
 # phone, and you have adb in your path, then you can use the install-gaia
 # target to update the gaia files and reboot b2g
-PROFILE_PATH = /data/local/
 TARGET_FOLDER = webapps/$(BUILD_APP_NAME).$(GAIA_DOMAIN)
 install-gaia: profile
 	$(ADB) start-server
 	@echo 'Stoping b2g'
 	$(ADB) shell stop b2g
 	$(ADB) shell rm -r /cache/*
+	$(ADB) remount
 
 ifeq ($(BUILD_APP_NAME),*)
 	python build/install-gaia.py "$(ADB)"
 else
-	$(ADB) push profile/$(TARGET_FOLDER)/manifest.webapp /data/local/$(TARGET_FOLDER)/manifest.webapp
-	$(ADB) push profile/$(TARGET_FOLDER)/application.zip /data/local/$(TARGET_FOLDER)/application.zip
+	$(ADB) push profile/$(TARGET_FOLDER)/manifest.webapp /system/b2g/$(TARGET_FOLDER)/manifest.webapp
+	$(ADB) push profile/$(TARGET_FOLDER)/application.zip /system/b2g/$(TARGET_FOLDER)/application.zip
 endif
 	@echo "Installed gaia into profile/."
 	@echo 'Starting b2g'
@@ -567,8 +567,8 @@ purge:
 	$(ADB) shell mkdir -p /data/local/tmp
 	$(ADB) shell rm -r /cache/*
 	$(ADB) shell rm -r /data/b2g/*
+	$(ADB) shell rm -r /system/b2g/webapps
 
 # clean out build products
 clean:
 	rm -rf profile xulrunner-sdk .xulrunner-url
-

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ WGET_OPTS?=
 GAIA_DOMAIN?=gaiamobile.org
 
 DEBUG?=0
+PRODUCTION?=0
 
 LOCAL_DOMAINS?=1
 
@@ -45,14 +46,8 @@ BUILD_APP_NAME?=*
 REPORTER?=Spec
 
 GAIA_APP_SRCDIRS?=apps test_apps showcase_apps
-
-ifneq ($(GAIA_OUTOFTREE_APP_SRCDIRS),)
-  $(shell mkdir -p outoftree_apps \
-    $(foreach dir,$(GAIA_OUTOFTREE_APP_SRCDIRS),\
-      $(foreach appdir,$(wildcard $(dir)/*),\
-        && ln -sf $(appdir) outoftree_apps/)))
-  GAIA_APP_SRCDIRS += outoftree_apps
-endif
+GAIA_INSTALL_PARENT?=/data/local
+ADB_REMOUNT?=0
 
 GAIA_ALL_APP_SRCDIRS=$(GAIA_APP_SRCDIRS)
 
@@ -62,9 +57,23 @@ ifeq ($(MAKECMDGOALS), demo)
 GAIA_DOMAIN=thisdomaindoesnotexist.org
 GAIA_APP_SRCDIRS=apps showcase_apps
 else ifeq ($(MAKECMDGOALS), production)
-GAIA_APP_SRCDIRS=apps
+PRODUCTION=1
 endif
 
+# PRODUCTION is also set for user and userdebug B2G builds
+ifeq ($(PRODUCTION), 1)
+GAIA_APP_SRCDIRS=apps
+GAIA_INSTALL_PARENT=/system/b2g
+ADB_REMOUNT=1
+endif
+
+ifneq ($(GAIA_OUTOFTREE_APP_SRCDIRS),)
+  $(shell mkdir -p outoftree_apps \
+    $(foreach dir,$(GAIA_OUTOFTREE_APP_SRCDIRS),\
+      $(foreach appdir,$(wildcard $(dir)/*),\
+        && ln -sf $(appdir) outoftree_apps/)))
+  GAIA_APP_SRCDIRS += outoftree_apps
+endif
 
 ###############################################################################
 # The above rules generate the profile/ folder and all its content.           #
@@ -518,13 +527,16 @@ install-gaia: profile
 	@echo 'Stoping b2g'
 	$(ADB) shell stop b2g
 	$(ADB) shell rm -r /cache/*
+
+ifeq ($(ADB_REMOUNT),1)
 	$(ADB) remount
+endif
 
 ifeq ($(BUILD_APP_NAME),*)
-	python build/install-gaia.py "$(ADB)"
+	python build/install-gaia.py "$(ADB)" "$(GAIA_INSTALL_PARENT)"
 else
-	$(ADB) push profile/$(TARGET_FOLDER)/manifest.webapp /system/b2g/$(TARGET_FOLDER)/manifest.webapp
-	$(ADB) push profile/$(TARGET_FOLDER)/application.zip /system/b2g/$(TARGET_FOLDER)/application.zip
+	$(ADB) push profile/$(TARGET_FOLDER)/manifest.webapp $(GAIA_INSTALL_PARENT)/$(TARGET_FOLDER)/manifest.webapp
+	$(ADB) push profile/$(TARGET_FOLDER)/application.zip $(GAIA_INSTALL_PARENT)/$(TARGET_FOLDER)/application.zip
 endif
 	@echo "Installed gaia into profile/."
 	@echo 'Starting b2g'
@@ -567,7 +579,7 @@ purge:
 	$(ADB) shell mkdir -p /data/local/tmp
 	$(ADB) shell rm -r /cache/*
 	$(ADB) shell rm -r /data/b2g/*
-	$(ADB) shell rm -r /system/b2g/webapps
+	$(ADB) shell rm -r $(GAIA_INSTALL_PARENT)/webapps
 
 # clean out build products
 clean:

--- a/apps/homescreen/js/appmanager.js
+++ b/apps/homescreen/js/appmanager.js
@@ -46,7 +46,7 @@ var Applications = (function() {
     apps.forEach(function parseApp(app) {
       var manifest = app.manifest;
       if (!manifest ||
-          (isCore(app.origin) && manifest.launch_path === undefined)) {
+          (isCore(app) && manifest.launch_path === undefined)) {
         return;
       }
 
@@ -171,38 +171,14 @@ var Applications = (function() {
     return app ? app.manifest : null;
   };
 
-  // Core applications should be flagged at some point. Not sure how?
-  var protocol = window.location.protocol;
-  var host = window.location.host;
-  var domain = host.replace(/(^[\w\d]+\.)?([\w\d]+\.[a-z]+)/, '$2');
-
-  var coreApplications = [
-    'sms', 'settings', 'camera', 'gallery', 'browser',
-    'music', 'clock', 'email', 'fm', 'calculator',
-    'calendar', 'video', 'fm', 'pdfjs', 'keyboard', 'system',
-    'homescreen', 'costcontrol'
-  ];
-
-  coreApplications = coreApplications.map(function mapCoreApp(name) {
-    return protocol + '//' + name + '.' + domain;
-  });
-
-  coreApplications.push('https://marketplace.mozilla.org/telefonica/');
-
-  var communicationsApplications = ['dialer', 'contacts'];
-  communicationsApplications.forEach(function mapCommunicationsApp(name) {
-    coreApplications.push(protocol + '//communications.' + domain + '/' +
-                          name);
-  });
-
   /*
    *  Returns true if it's a core application
    *
-   *  {String} App origin
+   *  {Object} Moz application
    *
    */
-  function isCore(origin) {
-    return coreApplications.indexOf(origin) !== -1;
+  function isCore(app) {
+    return !app.removable;
   };
 
   var deviceWidth = document.documentElement.clientWidth;

--- a/apps/homescreen/js/page.js
+++ b/apps/homescreen/js/page.js
@@ -12,7 +12,8 @@ var Icon = function Icon(app) {
     origin: origin,
     name: Applications.getName(origin),
     icon: Applications.getIcon(origin),
-    isHidden: Applications.getManifest(origin).hidden
+    isHidden: Applications.getManifest(origin).hidden,
+    isCore: Applications.isCore(app)
   };
 
   this.type = 'ApplicationIcon';
@@ -73,7 +74,7 @@ Icon.prototype = {
 
     container.appendChild(icon);
 
-    if (!Applications.isCore(this.descriptor.origin)) {
+    if (!this.descriptor.isCore) {
       // Menu button to delete the app
       var options = document.createElement('span');
       options.className = 'options';

--- a/build/install-gaia.py
+++ b/build/install-gaia.py
@@ -139,15 +139,18 @@ def install_gaia_fast():
 
 def install_gaia_slow():
     global adb_cmd
-    adb_shell("rm -r /data/local/webapps", ignore_error=True)
+    adb_shell("rm -r /system/b2g/webapps", ignore_error=True)
     adb_shell("rm /data/local/user.js", ignore_error=True)
-    adb_push('profile/webapps', '/data/local/webapps')
+    adb_push('profile/webapps', '/system/b2g/webapps')
     adb_push('profile/user.js', '/data/local')
     adb_push('profile/permissions.sqlite', '/data/local')
 
 def install_gaia():
     try:
-        install_gaia_fast()
+        # XXX Force slow method until we fix the fast one to support
+        # files in both /system/b2g and /data/local
+        # install_gaia_fast()
+        install_gaia_slow()
     except:
         # If anything goes wrong, fall back to the slow method.
         install_gaia_slow()

--- a/build/install-gaia.py
+++ b/build/install-gaia.py
@@ -1,6 +1,7 @@
-"""Usage: python %prog [ADB_PATH]
+"""Usage: python %prog [ADB_PATH] [REMOTE_PATH]
 
 ADB_PATH is the path to the |adb| executable we should run.
+REMOTE_PATH is the path to push the gaia webapps directory to.
 
 Used by |make install-gaia| to push files to a device.  You shouldn't run
 this file directly.
@@ -138,31 +139,40 @@ def install_gaia_fast():
         os.chdir('..')
 
 def install_gaia_slow():
-    global adb_cmd
-    adb_shell("rm -r /system/b2g/webapps", ignore_error=True)
+    global adb_cmd, remote_path
+    webapps_path = remote_path + '/webapps'
+    adb_shell("rm -r " + webapps_path, ignore_error=True)
     adb_shell("rm /data/local/user.js", ignore_error=True)
-    adb_push('profile/webapps', '/system/b2g/webapps')
+    adb_push('profile/webapps', webapps_path)
     adb_push('profile/user.js', '/data/local')
     adb_push('profile/permissions.sqlite', '/data/local')
 
 def install_gaia():
+    global remote_path
     try:
-        # XXX Force slow method until we fix the fast one to support
-        # files in both /system/b2g and /data/local
-        # install_gaia_fast()
-        install_gaia_slow()
+        if remote_path == "/system/b2g":
+            # XXX Force slow method until we fix the fast one to support
+            # files in both /system/b2g and /data/local
+            # install_gaia_fast()
+            install_gaia_slow()
+        else:
+            install_gaia_fast()
     except:
         # If anything goes wrong, fall back to the slow method.
         install_gaia_slow()
 
 if __name__ == '__main__':
-    if len(sys.argv) > 2:
-        print 'Too many arguments!  Usage: python %s [ADB_PATH]' % __FILE__
+    if len(sys.argv) > 3:
+        print >>sys.stderr, 'Too many arguments!\n'
+        print >>sys.stderr, \
+            'Usage: python %s [ADB_PATH] [REMOTE_PATH]\n' % __FILE__
         sys.exit(1)
 
-    if len(sys.argv) == 2:
+    adb_cmd = 'adb'
+    remote_path = '/data/local/webapps'
+    if len(sys.argv) >= 2:
         adb_cmd = sys.argv[1]
-    else:
-        adb_cmd = 'adb'
+    if len(sys.argv) >= 3:
+        remote_path = sys.argv[2]
 
     install_gaia()


### PR DESCRIPTION
By default, all Gaia apps will be built and packaged as usual (in /data/local/webapps).

When the "user" AOSP build variant is used from B2G, Gaia apps will be packaged into /system/b2g/webapps. This is controlled by a new make flag: PRODUCTION

We need to make sure this gets merged at the same time as these other pull requests:
https://github.com/mozilla-b2g/gonk-misc/pull/24
https://github.com/mozilla-b2g/B2G/pull/107
https://github.com/mozilla-b2g/platform_build/pull/4

(replaces pull request #4482)
