### PR TITLE
[CONTACT] Longs Names are not properly shown OWD-6274

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -99,7 +99,7 @@ contacts.List = (function() {
     figure.appendChild(img);
     link.appendChild(figure);
     var body = document.createElement('p');
-    body.className = 'item-body';
+    body.className = 'item-body-exp';
     var name = document.createElement('strong');
     name.className = 'block-name';
     name.innerHTML = contact.givenName;

--- a/apps/communications/contacts/style/app.css
+++ b/apps/communications/contacts/style/app.css
@@ -360,15 +360,7 @@ section[role="region"] > header:first-child {
 /* ITEM: The smallest complete structure; */
 .item {
   display: block;
-}
-
-.item:before, .item:after {
-  content: "";
-  display: table;
-}
-
-.item:after {
-  clear: both;
+  overflow: hidden;
 }
 
 .item-media {

--- a/apps/communications/contacts/style/contacts.css
+++ b/apps/communications/contacts/style/contacts.css
@@ -29,7 +29,7 @@ section[role="region"] > header:first-child sup {
 }
 
 #contact-name-title {
-  max-width: 23rem;
+  max-width: 22rem;
   float: left;
 }
 


### PR DESCRIPTION
Just changing the way how we manage the very-long-one-word names.
Also I've changed the max-width for contact name in header for giving a little bit of space to the fav star
(Long name + fav star) in contact detail.

Please @arcturus @albertopq take a look!
