### PR TITLE
[settings] handle the "empty shortName" case + desktop debug

### DIFF
--- a/apps/settings/js/data.js
+++ b/apps/settings/js/data.js
@@ -13,7 +13,8 @@ var gMobileConnection = (function(window) {
   }
 
   var initialized = false;
-  var fakeNetwork = { shortName: 'Fake Orange', mcc: 208, mnc: 1 };
+  var fakeICCInfo = { shortName: 'Fake Free-Mobile', mcc: 208, mnc: 15 };
+  var fakeNetwork = { shortName: 'Fake Orange F', mcc: 208, mnc: 1 };
 
   function fakeEventListener(type, callback, bubble) {
     if (initialized)
@@ -28,6 +29,7 @@ var gMobileConnection = (function(window) {
 
   return {
     addEventListener: fakeEventListener,
+    iccInfo: fakeICCInfo,
     get data() {
       return initialized ? { network: fakeNetwork } : null;
     }
@@ -129,7 +131,7 @@ window.addEventListener('load', function getCarrierSettings() {
     }
 
     // find the current APN
-    var settings = window.navigator.mozSettings;
+    var settings = Settings.mozSettings;
     if (settings && !gUserChosenAPN) {
       var radios = apnList.querySelectorAll('input[type="radio"]');
       var key = 'APN.name';
@@ -164,7 +166,7 @@ window.addEventListener('load', function getCarrierSettings() {
 
   // restart data connection by toggling it off and on again
   function restartDataConnection() {
-    var settings = window.navigator.mozSettings;
+    var settings = Settings.mozSettings;
     if (!settings)
       return;
 
@@ -204,9 +206,9 @@ window.addEventListener('load', function getCarrierSettings() {
     }
 
     // display data carrier name
-    var shortName = data ? data.shortName : '';
-    document.getElementById('data-desc').textContent = shortName;
-    document.getElementById('dataNetwork-desc').textContent = shortName;
+    var name = data ? (data.shortName || data.longName) : '';
+    document.getElementById('data-desc').textContent = name;
+    document.getElementById('dataNetwork-desc').textContent = name;
 
     // toggle advanced settings when required
     var advSettings = document.getElementById('apnSettings-advanced');

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -9,11 +9,19 @@
  */
 
 var Settings = {
+  get mozSettings() {
+    // return navigator.mozSettings when properly supported, null otherwise
+    // (e.g. when debugging on a browser...)
+    var settings = window.navigator.mozSettings;
+    return (settings && typeof(settings.createLock) == 'function') ?
+        settings : null;
+  },
+
   init: function settings_init() {
     this.loadGaiaCommit();
 
-    var settings = window.navigator.mozSettings;
-    if (!settings) // e.g. when debugging on a browser...
+    var settings = this.mozSettings;
+    if (!settings)
       return;
 
     settings.onsettingchange = function settingChanged(event) {
@@ -142,7 +150,7 @@ var Settings = {
   handleEvent: function settings_handleEvent(evt) {
     var input = evt.target;
     var key = input.name || input.dataset.name;
-    var settings = window.navigator.mozSettings;
+    var settings = this.mozSettings;
     if (!key || !settings || input.dataset.ignore)
       return;
 
@@ -215,7 +223,7 @@ var Settings = {
   },
 
   openDialog: function settings_openDialog(dialogID) {
-    var settings = window.navigator.mozSettings;
+    var settings = this.mozSettings;
     var dialog = document.getElementById(dialogID);
     var fields =
         dialog.querySelectorAll('input[data-setting]:not([data-ignore])');


### PR DESCRIPTION
See issue #4599, sometimes the carrier `shortName` property is empty, we have to use the `longName` instead.

This PR also fixes a couple bugs that made it difficult to debug in a desktop browser.
