### PR TITLE
Email - Add folder empty string and fix label size affected by building-blocks.

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -164,6 +164,8 @@
           <button class="msg-star-btn bottom-btn"></button>
           <button class="msg-mark-read-btn bottom-btn"></button>
         </div>
+        <div class="msg-list-empty" data-l10n-id="messages-folder-empty">No messagE
+        </div>
       </div>
 
       <!-- Message search UI; variant on the message list -->
@@ -215,22 +217,22 @@
           <div class="msg-envelope-bar">
             <div class="msg-envelope-date"></div>
             <div class="msg-envelope-from-line msg-envelope-line">
-              <label class="msg-envelope-key"
-                     data-l10n-id="envelope-from">FroM</label>
+              <span class="msg-envelope-key"
+                     data-l10n-id="envelope-from">FroM</span>
             </div>
             <!-- the details starts out collapsed, but can be toggled -->
             <div class="msg-envelope-details collapsed">
               <div class="msg-envelope-to-line msg-envelope-line">
-                <label class="msg-envelope-key"
-                       data-l10n-id="envelope-to">tO</label>
+                <span class="msg-envelope-key"
+                       data-l10n-id="envelope-to">tO</span>
               </div>
               <div class="msg-envelope-cc-line msg-envelope-line">
-                <label class="msg-envelope-key"
-                       data-l10n-id="envelope-cc">cC</label>
+                <span class="msg-envelope-key"
+                       data-l10n-id="envelope-cc">cC</span>
               </div>
               <div class="msg-envelope-bcc-line msg-envelope-line">
-                <label class="msg-envelope-key"
-                       data-l10n-id="envelope-bcc">BcC</label>
+                <span class="msg-envelope-key"
+                       data-l10n-id="envelope-bcc">BcC</span>
               </div>
             </div>
             <h3 class="msg-envelope-subject"></h3>
@@ -266,8 +268,8 @@
         <div class="scrollregion-below-header">
           <div class="cmp-envelope-bar">
             <div class="cmp-envelope-line">
-              <label class="cmp-to-label cmp-addr-label"
-                     data-l10n-id="compose-to">tO:</label>
+              <span class="cmp-to-label cmp-addr-label"
+                     data-l10n-id="compose-to">tO:</span>
               <div class="cmp-to-container cmp-addr-container">
                 <input class="cmp-to-text cmp-addr-text" type="text" />
                 <div class="cmp-to-add cmp-contact-add"></div>
@@ -277,24 +279,24 @@
                  but there is also the case where replying itself might need
                  to expand, so we are deferring that feature -->
             <div class="cmp-envelope-line">
-              <label class="cmp-cc-label cmp-addr-label"
-                     data-l10n-id="compose-cc">cC:</label>
+              <span class="cmp-cc-label cmp-addr-label"
+                     data-l10n-id="compose-cc">cC:</span>
               <div class="cmp-cc-container cmp-addr-container">
                 <input class="cmp-cc-text cmp-addr-text" type="text" />
                 <div class="cmp-cc-add cmp-contact-add"></div>
               </div>
             </div>
             <div class="cmp-envelope-line">
-              <label class="cmp-bcc-label cmp-addr-label"
-                     data-l10n-id="compose-bcc">BcC:</label>
+              <span class="cmp-bcc-label cmp-addr-label"
+                     data-l10n-id="compose-bcc">BcC:</span>
               <div class="cmp-bcc-container cmp-addr-container">
                 <input class="cmp-bcc-text cmp-addr-text" type="text" />
                 <div class="cmp-bcc-add cmp-contact-add"></div>
               </div>
             </div>
             <div class="cmp-envelope-line">
-              <label class="cmp-subject-label"
-                     data-l10n-id="compose-subject">SubjecT:</label>
+              <span class="cmp-subject-label"
+                     data-l10n-id="compose-subject">SubjecT:</span>
               <input class="cmp-subject-text" type="text" />
             </div>
           </div>

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -46,6 +46,8 @@ function MessageListCard(domNode, mode, args) {
   this.messagesContainer =
     domNode.getElementsByClassName('msg-messages-container')[0];
 
+  this.messageEmptyTitle =
+    domNode.getElementsByClassName('msg-list-empty')[0];
   // - message actions
   bindContainerClickAndHold(
     this.messagesContainer,
@@ -360,8 +362,14 @@ MessageListCard.prototype = {
     }
 
     // - added/existing
-    if (!addedItems.length)
+    if (!addedItems.length) {
+      if (this.messagesContainer.children.length === 0) {
+        this.messageEmptyTitle.classList.add('show');
+      }
       return;
+    } else {
+      this.messageEmptyTitle.classList.remove('show');
+    }
     var insertBuddy, self = this;
     if (index >= this.messagesContainer.childElementCount)
       insertBuddy = null;

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -83,6 +83,7 @@ message-multiedit-cancel=Cancel
 
 messages-syncing=Loading messages
 messages-sync-more=Load more messages from server
+messages-folder-empty=No Mail in this Folder
 
 folder-list-header=Folders
 

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -349,3 +349,17 @@
   width: 6rem;
   background: url("images/icons/forward.png") no-repeat scroll center transparent;
 }
+
+.msg-list-empty {
+  position: absolute;
+  top: 40%;
+  width: 80%;
+  margin : 0 10%;
+  font-size: 2em;
+  font-weight: bolder;
+  text-align: center;
+  display: none;
+}
+.msg-list-empty.show {
+  display: block;
+}


### PR DESCRIPTION
- Add folder empty string and display the message while the folder in empty.
- Change label to span because switches style in building-blocks will overwrite the label's style. 
