### PR TITLE
[SMS] Visual fixes

### DIFF
--- a/apps/sms/style/common.css
+++ b/apps/sms/style/common.css
@@ -34,7 +34,7 @@
   text-align: left;
   padding-left: 3rem;
   text-overflow: ellipsis;
-  overflow: hidden; 
+  overflow: hidden;
   height: 2rem;
   box-sizing: border-box;
   box-shadow: inset 0 0.1rem 0.1rem #666666;
@@ -90,6 +90,7 @@
   overflow: hidden;
   -moz-box-sizing: border-box;
   width: -moz-calc(100% - 8rem);
+  padding-right: 4rem;
   margin: 1rem 3rem;
   position: relative;
   height: -moz-calc(100% - 2rem);

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -309,6 +309,7 @@ a.unread .unread-mark .icon-unread-mark {
   font-size: -moz-calc(8 * 0.226rem);
   color: #000000;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   width: -moz-calc(100% - 7rem);
   position: relative;


### PR DESCRIPTION
- Text overlapping the 'clear input' button
- Too long name overlapping sms content
