### PR TITLE
Reset idle timeout on screen.timeout setting change

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -110,6 +110,7 @@ var ScreenManager = {
     SettingsListener.observe('screen.timeout', 60,
     function screenTimeoutChanged(value) {
       self._idleTimeout = value;
+      self.setIdleTimeout(self._idleTimeout)
 
       if (!self._firstOn) {
         (function handleInitlogo() {


### PR DESCRIPTION
Currently can't frob the screen.timeout from the Gaia settings UI, but if one does so via a test app or other mechanism we want the idle timeout behaviour to actually change as requested.
