### PR TITLE
Keypad typing during a call according to #4376

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -88,6 +88,7 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
   Contacts.findByNumber(number, function lookupContact(contact) {
     if (contact && contact.name) {
       node.textContent = contact.name;
+      KeypadManager.formatPhoneNumber('on-call', 'right');
       var additionalInfo = Utils.getPhoneNumberAdditionalInfo(
         number, contact);
       additionalInfoNode.textContent = additionalInfo ?

--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -7,7 +7,6 @@
 'use strict';
 
 var kFontStep = 4;
-var minFontSize = 12;
 
 // Frequencies comming from http://en.wikipedia.org/wiki/Telephone_keypad
 var gTonesFrequencies = {
@@ -157,7 +156,8 @@ var KeypadManager = {
     // to the font-size property of the body element.
     var defaultFontSize = window.getComputedStyle(document.body, null)
                                 .getPropertyValue('font-size');
-    minFontSize = parseInt(parseInt(defaultFontSize) * 10 * 0.226);
+    this.minFontSize = parseInt(parseInt(defaultFontSize) * 10 * 0.226);
+    this.maxFontSize = parseInt(parseInt(defaultFontSize) * 18 * 0.226);
 
     this.phoneNumberView.value = '';
     this._phoneNumber = '';
@@ -222,6 +222,10 @@ var KeypadManager = {
       this._onCall = true;
       var numberNode = CallScreen.activeCall.querySelector('.number');
       this._phoneNumber = numberNode.textContent;
+      var additionalContactInfoNode = CallScreen.activeCall.
+        querySelector('.additionalContactInfo');
+      this._additionalContactInfo = additionalContactInfoNode.textContent;
+      this._isKeypadClicked = false;
       this.phoneNumberViewContainer.classList.add('keypad-visible');
       if (this.callBar) {
         this.callBar.classList.add('hide');
@@ -298,7 +302,7 @@ var KeypadManager = {
     OnCallHandler.end();
   },
 
-  formatPhoneNumber: function kh_formatPhoneNumber(mode) {
+  formatPhoneNumber: function kh_formatPhoneNumber(mode, ellipsisSide) {
     switch (mode) {
       case 'dialpad':
         var fakeView = this.fakePhoneNumberView;
@@ -307,7 +311,7 @@ var KeypadManager = {
         // We consider the case where the delete button may have
         // been used to delete the whole phone number.
         if (view.value == '') {
-          view.style.fontSize = view.dataset.size;
+          view.style.fontSize = this.maxFontSize;
           return;
         }
       break;
@@ -318,59 +322,68 @@ var KeypadManager = {
       break;
     }
 
-    var computedStyle = window.getComputedStyle(view, null);
-    var currentFontSize = computedStyle.getPropertyValue('font-size');
-    if (!('size' in view.dataset)) {
-      view.dataset.size = currentFontSize;
-    }
-
-    var newFontSize = this.getNextFontSize(view, fakeView,
-                                           parseInt(view.dataset.size),
-                                           parseInt(currentFontSize));
+    var newFontSize = this.getNextFontSize(view, fakeView);
     view.style.fontSize = newFontSize + 'px';
-    this.addEllipsis(view, fakeView, newFontSize);
+    this.addEllipsis(view, fakeView, ellipsisSide);
   },
 
-  addEllipsis: function kh_addEllipsis(view, fakeView, currentFontSize) {
+  addEllipsis: function kh_addEllipsis(view, fakeView, side) {
+    var side = (side ? side : 'left');
+    var computedStyle = window.getComputedStyle(view, null);
+    var currentFontSize = parseInt(computedStyle.getPropertyValue('font-size'));
     var viewWidth = view.getBoundingClientRect().width;
     fakeView.style.fontSize = currentFontSize + 'px';
-    fakeView.innerHTML = view.value;
+    fakeView.innerHTML = (view.value ? view.value : view.innerHTML);
 
     var counter = 1;
-    var value = view.value;
+    var value = fakeView.innerHTML;
 
     var newPhoneNumber;
-    while (fakeView.getBoundingClientRect().width > viewWidth) {
-      newPhoneNumber = '\u2026' + value.substr(-value.length + counter);
-      fakeView.innerHTML = newPhoneNumber;
-      counter++;
+    if (side == 'left') {
+      while (fakeView.getBoundingClientRect().width > viewWidth) {
+        newPhoneNumber = '\u2026' + value.substr(-value.length + counter);
+        fakeView.innerHTML = newPhoneNumber;
+        counter++;
+      }
+    } else if (side == 'right') {
+      while (fakeView.getBoundingClientRect().width > viewWidth) {
+        newPhoneNumber = value.substr(0, value.length - counter) + '\u2026';
+        fakeView.innerHTML = newPhoneNumber;
+        counter++;
+      }
     }
 
     if (newPhoneNumber) {
-      view.value = newPhoneNumber;
+      if (view.value) {
+        view.value = newPhoneNumber;
+      } else {
+        view.innerHTML = newPhoneNumber;
+      }
     }
   },
 
-  getNextFontSize: function kh_getNextFontSize(view, fakeView,
-                                               fontSize, initialFontSize) {
+  getNextFontSize: function kh_getNextFontSize(view, fakeView) {
+    var computedStyle = window.getComputedStyle(view, null);
+    var fontSize = parseInt(computedStyle.getPropertyValue('font-size'));
     var viewWidth = view.getBoundingClientRect().width;
+    var viewHeight = view.getBoundingClientRect().height;
     fakeView.style.fontSize = fontSize + 'px';
-    fakeView.innerHTML = view.value;
+    fakeView.innerHTML = (view.value ? view.value : view.innerHTML);
 
     var rect = fakeView.getBoundingClientRect();
-    while ((rect.width > viewWidth) && (fontSize > minFontSize)) {
-      fontSize = Math.max(fontSize - kFontStep, minFontSize);
+
+    while ((rect.width < viewWidth) && (fontSize < this.maxFontSize)) {
+      fontSize = Math.min(fontSize + kFontStep, this.maxFontSize);
       fakeView.style.fontSize = fontSize + 'px';
       rect = fakeView.getBoundingClientRect();
     }
 
-    if ((rect.width < viewWidth) && (fontSize < initialFontSize)) {
-      fakeView.style.fontSize = (fontSize + kFontStep) + 'px';
+    while ((rect.width > viewWidth) && (fontSize > this.minFontSize)) {
+      fontSize = Math.max(fontSize - kFontStep, this.minFontSize);
+      fakeView.style.fontSize = fontSize + 'px';
       rect = fakeView.getBoundingClientRect();
-      if (rect.width <= viewWidth) {
-        fontSize += kFontStep;
-      }
     }
+
     return fontSize;
   },
 
@@ -432,6 +445,18 @@ var KeypadManager = {
       }
       if (key == 'delete') {
         this._phoneNumber = this._phoneNumber.slice(0, -1);
+      } else if (this.phoneNumberViewContainer.classList.
+          contains('keypad-visible')) {
+        if (!this._isKeypadClicked) {
+          this._isKeypadClicked = true;
+          this._originalPhoneNumber = this._phoneNumber;
+          this._originalAdditionalContactInfo = this._additionalContactInfo;
+          this._phoneNumber = key;
+          this._additionalContactInfo = '';
+          this._updateAdditionalContactInfoView();
+        } else {
+          this._phoneNumber += key;
+        }
       } else {
         this._phoneNumber += key;
       }
@@ -466,6 +491,26 @@ var KeypadManager = {
       this.moveCaretToEnd(this.phoneNumberView);
       this.formatPhoneNumber('dialpad');
     }
+  },
+
+  restorePhoneNumber: function kh_restorePhoneNumber() {
+    this.updatePhoneNumber(this._originalPhoneNumber);
+  },
+
+  updateAdditionalContactInfo:
+    function kh_updatePhoneNumber(additionalContactInfo) {
+    this._additionalContactInfo = additionalContactInfo;
+    this._updateAdditionalContactInfoView();
+  },
+
+  _updateAdditionalContactInfoView:
+    function kh__updateAdditionalContactInfoView() {
+    var view = CallScreen.activeCall.querySelector('.additionalContactInfo');
+    view.textContent = this._additionalContactInfo;
+  },
+
+  restoreAdditionalContactInfo: function kh_restoreAdditionalContactInfo() {
+    this.updateAdditionalContactInfo(this._originalAdditionalContactInfo);
   },
 
   _callVoicemail: function kh_callVoicemail() {

--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -327,13 +327,13 @@ var KeypadManager = {
     this.addEllipsis(view, fakeView, ellipsisSide);
   },
 
-  addEllipsis: function kh_addEllipsis(view, fakeView, side) {
-    var side = (side ? side : 'left');
+  addEllipsis: function kh_addEllipsis(view, fakeView, ellipsisSide) {
+    var side = ellipsisSide || 'left';
     var computedStyle = window.getComputedStyle(view, null);
     var currentFontSize = parseInt(computedStyle.getPropertyValue('font-size'));
     var viewWidth = view.getBoundingClientRect().width;
     fakeView.style.fontSize = currentFontSize + 'px';
-    fakeView.innerHTML = (view.value ? view.value : view.innerHTML);
+    fakeView.innerHTML = view.value ? view.value : view.innerHTML;
 
     var counter = 1;
     var value = fakeView.innerHTML;

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -79,15 +79,13 @@ var CallScreen = {
 
   showKeypad: function cs_showKeypad() {
     KeypadManager.render('oncall');
-
-    KeypadManager.formatPhoneNumber('on-call');
-
-    KeypadManager.phoneNumberView.value = KeypadManager._phoneNumber;
-    KeypadManager.moveCaretToEnd(KeypadManager.phoneNumberView);
     this.views.classList.add('show');
   },
 
   hideKeypad: function cs_hideKeypad() {
+    KeypadManager.restorePhoneNumber();
+    KeypadManager.restoreAdditionalContactInfo();
+    KeypadManager.formatPhoneNumber('on-call');
     this.views.classList.remove('show');
   },
 

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -326,6 +326,14 @@ button[disabled] .icon-keypad-visibility {
   color: black;
 }
 
+#calls > section .fake-number {
+  position: absolute;
+  line-height: 0rem;
+  visibility: hidden;
+  white-space: nowrap;
+}
+
+
 #calls[data-count="1"] > section .additionalContactInfo {
   height: 2rem;
   padding: 0 2rem 2rem 2rem;
@@ -356,7 +364,6 @@ button[disabled] .icon-keypad-visibility {
 
 #calls > section .number {
   font-size: 1.5em;
-  text-overflow: ellipsis;
 }
 
 #calls > section .duration {
@@ -367,12 +374,6 @@ button[disabled] .icon-keypad-visibility {
 
 #calls > section.held .duration {
   display: none;
-}
-
-#calls > section .fake-number {
-  position: absolute;
-  line-height: 0;
-  visibility: hidden;
 }
 
 #calls > section .duration > .direction {
@@ -547,8 +548,6 @@ button[disabled] .icon-keypad-visibility {
     line-height: 100%;
     color: white;
     background-color: transparent;
-    overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
   }
 

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -1,5 +1,6 @@
 requireApp('communications/dialer/js/handled_call.js');
 
+requireApp('communications/dialer/test/unit/mock_keypad.js');
 requireApp('communications/dialer/test/unit/mock_call.js');
 requireApp('communications/dialer/test/unit/mock_contacts.js');
 requireApp('communications/dialer/test/unit/mock_call_screen.js');
@@ -17,7 +18,9 @@ if (!this.RecentsDBManager) {
 if (!this.CallScreen) {
   this.CallScreen = null;
 }
-
+if (!this.KeypadManager) {
+  this.KeypadManager = null;
+}
 if (!this.Utils) {
   this.Utils = null;
 }
@@ -30,6 +33,7 @@ suite('dialer/handled_call', function() {
   var realContacts;
   var realRecents;
   var realCallScreen;
+  var realKeypadManager;
   var realL10n;
   var realUtils;
   var phoneNumber;
@@ -43,6 +47,9 @@ suite('dialer/handled_call', function() {
 
     realCallScreen = window.CallScreen;
     window.CallScreen = MockCallScreen;
+
+    realKeypadManager = window.KeypadManager;
+    window.KeypadManager = MockKeypadManager;
 
     realL10n = navigator.mozL10n;
     navigator.mozL10n = {
@@ -61,6 +68,7 @@ suite('dialer/handled_call', function() {
     window.Contacts = realContacts;
     window.RecentsDBManager = realRecents;
     window.CallScreen = realCallScreen;
+    // window.KeypadManager = realKeypadManager;
     navigator.mozL10n = realL10n;
     window.Utils = realUtils;
   });
@@ -97,6 +105,7 @@ suite('dialer/handled_call', function() {
     MockRecentsDBManager.mTearDown();
     MockContacts.mTearDown();
     MockCallScreen.mTearDown();
+    MockKeypadManager.mTearDown();
     MockUtils.mTearDown();
   });
 
@@ -119,6 +128,10 @@ suite('dialer/handled_call', function() {
 
     test('node', function() {
       assert.equal(subject.node, fakeNode);
+    });
+
+    test('format phone number', function() {
+      assert.isTrue(MockKeypadManager.mFormatPhoneNumberCalled);
     });
 
     test('duration outgoing', function() {

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -68,7 +68,7 @@ suite('dialer/handled_call', function() {
     window.Contacts = realContacts;
     window.RecentsDBManager = realRecents;
     window.CallScreen = realCallScreen;
-    // window.KeypadManager = realKeypadManager;
+    window.KeypadManager = realKeypadManager;
     navigator.mozL10n = realL10n;
     window.Utils = realUtils;
   });

--- a/apps/communications/dialer/test/unit/mock_keypad.js
+++ b/apps/communications/dialer/test/unit/mock_keypad.js
@@ -1,0 +1,9 @@
+var MockKeypadManager = {
+  formatPhoneNumber: function khm_formatPhoneNumber(mode, ellipsisSide) {
+    this.mFormatPhoneNumberCalled = true;
+  },
+  mFormatPhoneNumberCalled: false,
+  mTearDown: function khm_tearDown() {
+    this.mFormatPhoneNumberCalled = false;
+  }
+};

--- a/apps/communications/dialer/test/unit/mock_keypad.js
+++ b/apps/communications/dialer/test/unit/mock_keypad.js
@@ -1,5 +1,6 @@
 var MockKeypadManager = {
-  formatPhoneNumber: function khm_formatPhoneNumber(mode, ellipsisSide) {
+  formatPhoneNumber:
+    function khm_formatPhoneNumber(mode, ellipsisSide) {
     this.mFormatPhoneNumberCalled = true;
   },
   mFormatPhoneNumberCalled: false,


### PR DESCRIPTION
As requested by UX in #4376, if during a call the keypad is clicked, the information about the contact (or phone number), type of phone and carrier (if any) is hidden and only the keypad keys pressed are shown.

Apart from this I solve several bugs which came up through this testing such as dealing with very long contact names when making or receiving a call, dealing with a lot of keypad keys pressed during a call, etc. :-) 
