### PR TITLE
[contacts] fix: carrier null displayed

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -253,7 +253,7 @@ var Contacts = (function() {
         var prompt1 = new ValueSelector(selectDataStr);
         for (var i = 0; i < dataSet.length; i++) {
           var data = dataSet[i].value,
-              carrier = dataSet[i].carrier;
+              carrier = dataSet[i].carrier || '';
           prompt1.addToList(data + ' ' + carrier, function(itemData) {
             return function() {
               prompt1.hide();


### PR DESCRIPTION
If user opens up Contacts App through an activity, like picking contact for SMS App. If user taps on a contact that has more then one phone number, a popup shows up (value selector) that list the phone numbers registered with the chosen contact. If there is no carrier registered with any of the phone numbers, on that list next to the phone number, it says "null", where the carrier supposed to be.
This PR fixes that null issue, shows an empty string instead of null.

@albertopq r?
