### PR TITLE
Move settings out of process.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -670,7 +670,7 @@ var WindowManager = (function() {
 
       // /!\ Also remove it from outOfProcessBlackList of background_service.js
       // Once this app goes OOP. (can be done by reverting a commit)
-      'Messages',
+      'Messages'
       // Crashes when launched OOP (bug 775997)
     ];
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -672,9 +672,6 @@ var WindowManager = (function() {
       // Once this app goes OOP. (can be done by reverting a commit)
       'Messages',
       // Crashes when launched OOP (bug 775997)
-
-      'Settings'
-      // Bluetooth is not remoted yet (bug 755943)
     ];
 
     if (!isOutOfProcessDisabled &&


### PR DESCRIPTION
There might be a regression from this, which is https://bugzilla.mozilla.org/show_bug.cgi?id=791189 .

In exchange, we make the settings app memory reclaimable, and
- fix bluetooth device scanning
- improve scrolling fps in settings app by 6-8fps

I think we should merge.
