### PR TITLE
[contacts] fix: ellipsis missing on address

### DIFF
--- a/apps/communications/contacts/style/app.css
+++ b/apps/communications/contacts/style/app.css
@@ -619,6 +619,9 @@ span[role="button"].icon-arrow.icon-arrow-right {
 }
 .action-block span {
   display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
 }
 
 /* Add style */

--- a/apps/communications/contacts/style/app.css
+++ b/apps/communications/contacts/style/app.css
@@ -621,7 +621,6 @@ span[role="button"].icon-arrow.icon-arrow-right {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: block;
 }
 
 /* Add style */


### PR DESCRIPTION
Issue: In Contacts app, a long Street address don't show the ellipsis in contact detail.

@albertopq r? @arcturus r?
