### PR TITLE
[dialer] Fixing call handling and hanging up

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var dtf = new navigator.mozL10n.DateTimeFormat();
-
 function HandledCall(aCall, aNode) {
   this._ticker = null;
   this.photo = null;
@@ -63,6 +61,7 @@ HandledCall.prototype.startTimer = function hc_startTimer() {
 
   this._ticker = setInterval(function hc_updateTimer(self, startTime) {
     var elapsed = new Date(Date.now() - startTime);
+    var dtf = new navigator.mozL10n.DateTimeFormat();
     self.durationNode.textContent = dtf.localeFormat(elapsed, '%M:%S');
   }, 1000, this, Date.now());
 };

--- a/apps/communications/dialer/js/utils.js
+++ b/apps/communications/dialer/js/utils.js
@@ -2,7 +2,6 @@
 
 // Based on Resig's pretty date.
 var _ = navigator.mozL10n.get;
-var dtf = new navigator.mozL10n.DateTimeFormat();
 
 var Utils = {
   prettyDate: function ut_prettyDate(time) {
@@ -27,6 +26,7 @@ var Utils = {
   },
 
   headerDate: function ut_headerDate(time) {
+    var dtf = new navigator.mozL10n.DateTimeFormat();
     var today = _('today');
     var yesterday = _('yesterday');
     var diff = (Date.now() - time) / 1000;


### PR DESCRIPTION
Some l10n changes introduced previously were not totally tested and
broke call hanging up and displaying caller's name/phone number. This
was due to JavaScript error:
E/GeckoConsole(  550): [JavaScript Error: "TypeError:
navigator.mozL10n.DateTimeFormat is not a constructor" {file:
"app://communications.gaiamobile.org/dialer/js/utils.js" line: 5}]
E/GeckoConsole(  550): [JavaScript Error: "TypeError:
navigator.mozL10n.DateTimeFormat is not a constructor" {file:
"app://communications.gaiamobile.org/dialer/js/handled_call.js" line:
3}]
