### PR TITLE
[email] Hookup forward button and its localizations.

### DIFF
--- a/apps/email/js/mail-app.js
+++ b/apps/email/js/mail-app.js
@@ -7,7 +7,7 @@ var MailAPI = null;
 
 var App = {
   /**
-   * Bind any global notifications.
+   * Bind any global notifications, relay localizations to the back-end.
    */
   _init: function() {
     // If our password is bad, we need to pop up a card to ask for the updated
@@ -17,6 +17,19 @@ var App = {
                      { account: account, restoreCard: Cards.activeCardIndex },
                      'right');
     };
+
+    MailAPI.useLocalizedStrings({
+      wrote: mozL10n.get('reply-quoting-wrote'),
+      originalMessage: mozL10n.get('forward-original-message'),
+      forwardHeaderLabels: {
+        subject: mozL10n.get('forward-header-subject'),
+        date: mozL10n.get('forward-header-date'),
+        from: mozL10n.get('forward-header-from'),
+        replyTo: mozL10n.get('forward-header-reply-to'),
+        to: mozL10n.get('forward-header-to'),
+        cc: mozL10n.get('forward-header-cc'),
+      }
+    });
   },
 
   /**

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -641,6 +641,8 @@ function MessageReaderCard(domNode, mode, args) {
     .addEventListener('click', this.onToggleRead.bind(this), false);
   domNode.getElementsByClassName('msg-move-btn')[0]
     .addEventListener('click', this.onMove.bind(this), false);
+  domNode.getElementsByClassName('msg-forward-btn')[0]
+    .addEventListener('click', this.onForward.bind(this), false);
 
   this.envelopeNode = domNode.getElementsByClassName('msg-envelope-bar')[0];
   this.envelopeNode
@@ -690,6 +692,7 @@ MessageReaderCard.prototype = {
   },
 
   onReply: function(event) {
+    Cards.eatEventsUntilNextCard();
     var composer = this.header.replyToMessage(null, function() {
       Cards.pushCard('compose', 'default', 'animate',
                      { composer: composer });
@@ -697,7 +700,16 @@ MessageReaderCard.prototype = {
   },
 
   onReplyAll: function(event) {
+    Cards.eatEventsUntilNextCard();
     var composer = this.header.replyToMessage('all', function() {
+      Cards.pushCard('compose', 'default', 'animate',
+                     { composer: composer });
+    });
+  },
+
+  onForward: function(event) {
+    Cards.eatEventsUntilNextCard();
+    var composer = this.header.forwardMessage('inline', function() {
       Cards.pushCard('compose', 'default', 'animate',
                      { composer: composer });
     });

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -111,3 +111,12 @@ message-contact-menu-reply = Reply
 
 folder-list-header=Folders
 
+reply-quoting-wrote={name} wrote
+forward-original-message=Original Message
+
+forward-header-subject=Subject
+forward-header-date=Date
+forward-header-from=From
+forward-header-reply-to=Reply-To
+forward-header-to=To
+forward-header-cc=CC


### PR DESCRIPTION
The back-end does the forward email generation, so it needs the
strings to be forwarded from the front-end to the back-end.  (Unless we
have the back-end provide its own string bundles.  That seems highly
undesirable.)

This will resolve https://github.com/mozilla-b2g/gaia/issues/4844 and depends on https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/43.

r? @mozsquib because this is mainly back-end stuff; the UI bit is pretty trivial.  One notable bit is that I have added the 'ignore events while this async thing is happening so if the user is faster than our async requests, we don't end up with the UI in a freaky state' call.
