### PR TITLE
Feature dialer missed calls highlighting

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -400,8 +400,12 @@ var Recents = {
       '      <section class="primary-info ellipsis">' +
                recent.number +
       '      </section>' +
-      '      <section class="secondary-info ellipsis">' +
-               Utils.prettyDate(recent.date) +
+      '      <section class="secondary-info">' +
+      '        <span class="call-time">' + 
+                 Utils.prettyDate(recent.date) +
+      '        </span>' +
+      '        <span class="call-additional-info ellipsis">' +
+      '        </span>' +
       '      </section>' +
       '    </div>' +
       '  </section>' +
@@ -497,14 +501,8 @@ var Recents = {
       }
       var phoneNumberAdditionalInfo = Utils.getPhoneNumberAdditionalInfo(
         phoneNumber, contact);
-      var secondaryInfo = logItem.querySelector('.secondary-info');
-      var secondaryInfoText = secondaryInfo.innerHTML.trim();
-      var secondaryInfoIndex = secondaryInfoText.indexOf('&nbsp;&nbsp;&nbsp;');
-      if (secondaryInfoIndex > 0) {
-        secondaryInfoText = secondaryInfoText.substring(0, secondaryInfoIndex);
-      }
-      secondaryInfo.innerHTML = secondaryInfoText +
-        '&nbsp;&nbsp;&nbsp;' + phoneNumberAdditionalInfo;
+      var phoneNumberAdditionalInfoNode = logItem.querySelector('.call-additional-info');
+      phoneNumberAdditionalInfoNode.textContent = phoneNumberAdditionalInfo;
       logItem.classList.add('isContact');
       logItem.dataset['contactId'] = contact.id;
     } else {

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -401,7 +401,7 @@ var Recents = {
                recent.number +
       '      </section>' +
       '      <section class="secondary-info">' +
-      '        <span class="call-time">' + 
+      '        <span class="call-time">' +
                  Utils.prettyDate(recent.date) +
       '        </span>' +
       '        <span class="call-additional-info ellipsis">' +
@@ -501,7 +501,8 @@ var Recents = {
       }
       var phoneNumberAdditionalInfo = Utils.getPhoneNumberAdditionalInfo(
         phoneNumber, contact);
-      var phoneNumberAdditionalInfoNode = logItem.querySelector('.call-additional-info');
+      var phoneNumberAdditionalInfoNode = logItem.
+        querySelector('.call-additional-info');
       phoneNumberAdditionalInfoNode.textContent = phoneNumberAdditionalInfo;
       logItem.classList.add('isContact');
       logItem.dataset['contactId'] = contact.id;

--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -308,11 +308,11 @@ button::-moz-focus-inner {
   background-image: url('images/CallLog_30x30_missed.png');
 }
 
-.log-item.highlighted[data-type='incoming'] .secondary-info {
+.log-item.highlighted[data-type='incoming'] .call-time {
   color: red !important;
 }
 
-.log-item.highlighted[data-type='incoming-refused'] .secondary-info {
+.log-item.highlighted[data-type='incoming-refused'] .call-time {
   color: red !important;
 }
 
@@ -338,6 +338,10 @@ button::-moz-focus-inner {
   font-family: FontRegular;
   font-size: -moz-calc(6 * 0.226rem);
   color: #5b5b5b;
+}
+
+.call-additional-info {
+  padding-left: 0.7rem;
 }
 
 .call-log-contact-photo {


### PR DESCRIPTION
According to the latest input by the UX team (https://www.dropbox.com/s/ppszgh08ovxnh11/CallLog-states_vpg_0001_b.png), only the time should be highlighted in red in the case of new missed calls. Previously, the type of phone number and the carrier if any were also highlighted.
