### PR TITLE
[Dialer][Call log] Fit contact long names to available space

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -397,8 +397,12 @@ var Recents = {
       '  </section>' +
       '  <section class="log-item-info grid">' +
       '    <div class="grid-cell grid-v-align">' +
-      '      <section class="primary-info ellipsis">' +
-               recent.number +
+      '      <section class="primary-info">' +
+      '        <span class="primary-info-main ellipsis">' +
+                 recent.number +
+      '        </span>' +
+      '        <span class="entry-count">' +
+      '        </span>' +
       '      </section>' +
       '      <section class="secondary-info ellipsis">' +
                Utils.prettyDate(recent.date) +
@@ -482,14 +486,14 @@ var Recents = {
   contactCallBack: function re_contactCallBack(logItem, contact) {
     var contactPhoto = logItem.querySelector('.call-log-contact-photo');
     if (contact != null) {
-      // Update name
-      var primaryInfo = logItem.querySelector('.primary-info'),
+      var primaryInfoMainNode = logItem.querySelector('.primary-info-main'),
         phoneNumber = logItem.dataset.num.trim(),
         count = logItem.dataset.count;
-      primaryInfo.innerHTML = ((contact.name && contact.name != '') ?
-        contact.name : _('unknown'));
-      primaryInfo.innerHTML = primaryInfo.innerHTML.trim() +
-        ((count > 1) ? '&nbsp;&nbsp;(' + count + ')' : '');
+      primaryInfoMainNode.textContent = (contact.name && contact.name != '') ?
+        contact.name : _('unknown');
+      var entryCountNode = logItem.querySelector('.entry-count');
+      entryCountNode.textContent = (count > 1) ? '(' + count + ')' : '';
+      this.fitPrimaryInfoToSpace(logItem);
       if (contact.photo && contact.photo[0]) {
         var photoURL = URL.createObjectURL(contact.photo[0]);
         contactPhoto.style.backgroundImage = 'url(' + photoURL + ')';
@@ -580,16 +584,9 @@ var Recents = {
   groupCalls: function re_groupCalls(olderCallEl, newerCallEl, count, inc) {
     olderCallEl.classList.add('hide');
     olderCallEl.classList.add('collapsed');
-    var primaryInfo = newerCallEl.querySelector('.primary-info'),
-      callDetails = primaryInfo.textContent.trim(),
-      countIndex = callDetails.indexOf('(' + count + ')');
     count += inc;
-    if (countIndex != -1) {
-      primaryInfo.innerHTML = callDetails.substr(0, countIndex).trim() +
-        '&nbsp;&nbsp;(' + count + ')';
-    } else {
-      primaryInfo.innerHTML = callDetails + '&nbsp;&nbsp;(' + count + ')';
-    }
+    var entryCountNode = newerCallEl.querySelector('.entry-count');
+    entryCountNode.textContent = '(' + count + ')';
     newerCallEl.dataset.count = count;
   },
 
@@ -603,6 +600,25 @@ var Recents = {
       itemsLength = items.length;
     for (var i = 0; i < itemsLength; i++) {
       items[i].classList.remove('highlighted');
+    }
+  },
+
+  fitPrimaryInfoToSpace: function re_fitPrimaryInfoToSpace(logItemNode) {
+    var primaryInfoNode = logItemNode.querySelector('.primary-info'),
+      primaryInfoMainNode = logItemNode.querySelector('.primary-info-main'),
+      entryCountNode = logItemNode.querySelector('.entry-count'),
+      primaryInfoNodeCS = window.getComputedStyle(primaryInfoNode),
+      primaryInfoMainNodeCS = window.getComputedStyle(primaryInfoMainNode),
+      entryCountNodeCS = window.getComputedStyle(entryCountNode),
+      primaryInfoNodeWidth = parseInt(primaryInfoNodeCS.width),
+      primaryInfoMainNodeWidth = parseInt(primaryInfoMainNodeCS.width),
+      entryCountNodeWidth = parseInt(entryCountNodeCS.width);
+    if (!isNaN(primaryInfoNodeWidth) && !isNaN(primaryInfoMainNodeWidth) &&
+      !isNaN(entryCountNodeWidth) &&
+      (primaryInfoNodeWidth < primaryInfoMainNodeWidth + entryCountNodeWidth)) {
+      var newWidth = primaryInfoNodeWidth - entryCountNodeWidth - 4;
+      primaryInfoMainNode.classList.add('ellipsed');
+      primaryInfoMainNode.style.width = newWidth + 'px';
     }
   }
 };

--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -336,6 +336,23 @@ button::-moz-focus-inner {
   color: #000000;
 }
 
+.primary-info-main {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  white-space: nowrap;
+  padding-right: 0.6rem;
+}
+
+.primary-info-main.ellipsed {
+  padding-right: 0rem;
+}
+
+.entry-count {
+  overflow: hidden;
+  display: inline-block;
+}
+
 .secondary-info {
   font-family: FontRegular;
   font-size: -moz-calc(6 * 0.226rem);


### PR DESCRIPTION
Although long contact names were properly shown in the call log including an ellipsis on the right hand side, they did not leave space for the number of entries in the call log group shown in brackets. As a consequence we got things such as:

"This is a very very long..."

instead of, for example:

"This is a very ve... (2)"

which is the implemented behavior now.
