### PR TITLE
[homescreen] fix: dock is cut in half if incoming call received and home button pressed

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -156,9 +156,9 @@ var AttentionScreen = {
         // not turn the sreen off when the attention screen is closed.
         this._screenInitiallyDisabled = false;
 
-        this.dispatchEvent('status-active');
-
         this.mainScreen.classList.add('active-statusbar');
+
+        this.dispatchEvent('status-active');
 
         var attentionScreen = this.attentionScreen;
         attentionScreen.addEventListener('transitionend', function trWait() {


### PR DESCRIPTION
Issue: "When an incoming call is established (either with the device locked or unlocked). if user clicks on the home button the dock with the shortcuts is partially moved the visible area, when moving to the grid, the pagination is also broken.

The expected result is what happens when an ongoing call is made and user clicks on home button, the size of the elements is adjusted to show the active call indicator and the home screen."

Issue num: #4740

@etiennesegonzac r?
@arcturus r?
