### PR TITLE
Fixing orientation changes on Nexus S

### DIFF
--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -37,6 +37,7 @@ function startup() {
   // It appears to workaround the Nexus S bug where we're not
   // getting orientation data.  See:
   // https://bugzilla.mozilla.org/show_bug.cgi?id=753245
+  // It seems it needs to be in both window_manager.js and bootstrap.js.
   function dumbListener2(event) {}
   window.addEventListener('devicemotion', dumbListener2);
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1229,6 +1229,19 @@ var WindowManager = (function() {
     window.dispatchEvent(evt);
   });
 
+  // This is code copied from
+  // http://dl.dropbox.com/u/8727858/physical-events/index.html
+  // It appears to workaround the Nexus S bug where we're not
+  // getting orientation data.  See:
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=753245
+  // It seems it needs to be in both window_manager.js and bootstrap.js.
+  function dumbListener2(event) {}
+  window.addEventListener('devicemotion', dumbListener2);
+
+  window.setTimeout(function() {
+    window.removeEventListener('devicemotion', dumbListener2);
+  }, 2000);
+
   // Return the object that holds the public API
   return {
     launch: launch,


### PR DESCRIPTION
Re-using an old hack, it seems that the hack needs to be in both file in
order to have an effect now. No idea why. Tried only in bootstrap.js, or
only in window_manager.js, no success. Device orientation handling only
got working back once the hack was in both.
