### PR TITLE
Add a small text block to the USB Mass Storage Settings

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -25,6 +25,7 @@
     <script type="application/javascript" defer src="js/bluetooth.js"></script>
     <script type="application/javascript" defer src="js/wallpaper.js"></script>
     <script type="application/javascript" defer src="js/battery.js"></script>
+    <script type="application/javascript" defer src="js/storage.js"></script>
   </head>
   <body class="hidden skin-organic">
 
@@ -1132,6 +1133,7 @@
             <input type="checkbox" name="ums.enabled"/>
             <span></span>
           </label>
+          <small id="ums-desc" data-l10-id="umsUnplugToDisable">Unplug USB cable to disable</small>
           <a data-l10n-id="umsEnabled">USB Mass Storage Enabled</a>
         </li>
       </ul>

--- a/apps/settings/js/storage.js
+++ b/apps/settings/js/storage.js
@@ -1,0 +1,92 @@
+// The whole purpose of this code is to detect when we're in the state
+// of having the UMS Enabled checkbox unchecked, but the sdcard is still
+// being shared with the PC. In this case, the user has to unplug the
+// USB cable in order to actually turn off UMS, and we put some text
+// to that effect on the settings screen.
+
+'use strict';
+
+var StorageSettings = {
+
+  init: function storageSettingsInit() {
+    this.umsEnabledCheckBox  = document.querySelector('[name="ums.enabled"]');
+    if (!this.umsEnabledCheckBox) {
+      return;
+    }
+    this.umsEnabledInfoBlock = document.querySelector('#ums-desc');
+    if (!this.umsEnabledInfoBlock) {
+      return;
+    }
+
+    // The normal handling of the checkboxes in the settings is done through
+    // a 'change' event listener in settings.js
+    this.umsEnabledCheckBox.onchange = function umsEnabledChanged() {
+      StorageSettings.updateInfo();
+    };
+
+    this.deviceStorage = navigator.getDeviceStorage('pictures');
+    this.documentStorageListener = false;
+    this.updateListeners();
+
+    window.addEventListener('localized', this);
+
+    // Use mozvisibilitychange so that we don't get notified of device
+    // storage notifications when the settings app isn't visible.
+    document.addEventListener('mozvisibilitychange', this);
+  },
+
+  handleEvent: function storageSettingsHandleEvent(evt) {
+    switch (evt.type) {
+      case 'localized':
+        this.updateInfo();
+        break;
+      case 'change':
+        switch (evt.reason) {
+          case 'available':
+          case 'unavailable':
+          case 'shared':
+            this.updateInfo();
+            break;
+        }
+        break;
+      case 'mozvisibilitychange':
+        this.updateListeners();
+        break;
+    }
+  },
+
+  updateListeners: function storageSettingsUpdateListeners() {
+    if (document.mozHidden) {
+      // Settings is being hidden. Unregister our change listener
+      // so we won't get notifications whenever files are added in
+      // another app.
+      if (this.documentStorageListener) {
+        this.deviceStorage.removeEventListener('change', this);
+        this.documentStorageListener = false;
+      }
+    }
+    else {
+      if (!this.documentStorageListener) {
+        this.deviceStorage.addEventListener('change', this);
+        this.documentStorageListener = true;
+      }
+      this.updateInfo();
+    }
+  },
+
+  updateInfo: function storageSettingsUpdateInfo() {
+    var statreq = this.deviceStorage.stat();
+    statreq.onsuccess = function storageSettingsStatSuccess(evt) {
+      if ((evt.target.result.state === 'shared') && !StorageSettings.umsEnabledCheckBox.checked) {
+        // Show the 'Unplug USB cable to disable' message
+        StorageSettings.umsEnabledInfoBlock.style.display = 'block';
+      }
+      else {
+        // Hide the 'Unplug USB cable to disable' message
+        StorageSettings.umsEnabledInfoBlock.style.display = 'none';
+      }
+    };
+  }
+};
+
+StorageSettings.init();

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -244,6 +244,7 @@ oop-disabled=Disable Out-Of-Process
 # Device :: Device Storage
 deviceStorage=Device Storage
 umsEnabled=USB Mass Storage Enabled
+umsUnplugToDisable=Unplug USB cable to disable
 
 # Device :: Media Storage
 mediaStorage=Media Storage


### PR DESCRIPTION
This allows us to tell the user that they need to unplug
the USB cable in order to complete disabling UMS.
