### PR TITLE
Operator Variant: Don't store operator settings if mcc and mnc are equal...

### DIFF
--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -37,6 +37,9 @@
         !cset['operatorvariant.mnc']) {
       return;
     }
+    if (gNetwork.mcc == 0 && gNetwork.mnc == 0) {
+      return;
+    }
     if ((gNetwork.mcc == cset['operatorvariant.mcc']) &&
         (gNetwork.mnc == cset['operatorvariant.mnc'])) {
       return;
@@ -64,6 +67,9 @@
                                         cset['operatorvariant.mnc'],
                                         'voicemail');
     var voicemailNode = voicemailResult.iterateNext();
+    if (!voicemailNode) {
+      return;
+    }
     cset['ro.moz.ril.iccmbdn'] = voicemailNode.textContent;
   };
 


### PR DESCRIPTION
... 0. This was causing the following error "TypeError: voicemailNode is null" {file: "app://system.gaiamobile.org/js/operator_variant/operator_variant.js" line: 67}.
