### PR TITLE
bugfix for selecting word suggestions

### DIFF
--- a/apps/keyboard/js/predict/latin-worker.js
+++ b/apps/keyboard/js/predict/latin-worker.js
@@ -551,16 +551,19 @@ function Predict(word) {
 
 var PredictiveText = {
   key: function PTW_key(keyCode, keyX, keyY) {
+    if (keyCode == 32) {
+      self.postMessage({ cmd: 'sendCandidates', args: [[]] });
+      _currentWord = '';
+      return;
+    }
     if (keyCode == 8) {
       _currentWord = _currentWord.substr(0, _currentWord.length - 1);
     } else {
       _currentWord += String.fromCharCode(keyCode);
     }
     var wordList = [];
-    var spaceIndex = _currentWord.lastIndexOf(' ');
-    spaceIndex = spaceIndex > 0 ? (spaceIndex + 1) : 0;
-    if (_currentWord.substring(spaceIndex).length > 0) {
-      var candidates = Predict(_currentWord.substring(spaceIndex));
+    if (_currentWord.length > 0) {
+      var candidates = Predict(_currentWord);
       for (var n = 0, len = candidates.length; n < len; ++n) {
         var word = candidates[n].word;
         wordList.push([word, word]);


### PR DESCRIPTION
_currentWord should only store the current word, and not a whole sentence. This doesn't allow the engine to pick up earlier typed words, but allows for correct selection of words without bringing the sentence out of order.
