### PR TITLE
Allow the Music app to play and shuffle albums; fix #3217

### DIFF
--- a/apps/music/index.html
+++ b/apps/music/index.html
@@ -35,7 +35,7 @@
           </div>
           <div id="views-sublist-header-controls">
             <div id="views-sublist-header-name">Name</div>
-            <button id="views-sublist-controls-play" class="album-controls-button" disabled>Play All</button>
+            <button id="views-sublist-controls-play" class="album-controls-button">Play All</button>
             <button id="views-sublist-controls-shuffle" class="album-controls-button" disabled>Shuffle</button>
           </div>
         </div>

--- a/apps/music/index.html
+++ b/apps/music/index.html
@@ -36,7 +36,7 @@
           <div id="views-sublist-header-controls">
             <div id="views-sublist-header-name">Name</div>
             <button id="views-sublist-controls-play" class="album-controls-button">Play All</button>
-            <button id="views-sublist-controls-shuffle" class="album-controls-button" disabled>Shuffle</button>
+            <button id="views-sublist-controls-shuffle" class="album-controls-button">Shuffle</button>
           </div>
         </div>
         <div id="views-sublist-anchor"></div>

--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -538,7 +538,9 @@ var SubListView = {
 
     this.albumImage = document.getElementById('views-sublist-header-image');
     this.albumName = document.getElementById('views-sublist-header-name');
-    this.playAll = document.getElementById('views-sublist-controls-play');
+    this.playAllButton = document.getElementById('views-sublist-controls-play');
+    this.shuffleButton =
+      document.getElementById('views-sublist-controls-shuffle');
 
     this.view.addEventListener('click', this);
   },
@@ -549,6 +551,30 @@ var SubListView = {
     this.albumImage.src = '';
     this.anchor.innerHTML = '';
     this.view.scrollTop = 0;
+  },
+
+  shuffle: function slv_shuffle() {
+    var list = this.dataSource;
+    shuffle(list);
+    this.dataSource = [];
+    this.index = 0;
+    this.anchor.innerHTML = '';
+    for (var i = 0; i < list.length; i++)
+      this.update(list[i]);
+
+    // shuffle the elements of array a in place
+    // http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+    function shuffle(a) {
+      for (var i = a.length - 1; i >= 1; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        if (j < i) {
+          var tmp = a[j];
+          a[j] = a[i];
+          a[i] = tmp;
+        }
+      }
+    }
+
   },
 
   setAlbumSrc: function slv_setAlbumSrc(fileinfo) {
@@ -603,7 +629,12 @@ var SubListView = {
       case 'click':
         var target = evt.target;
 
-        if (target === this.playAll) {
+        if (target === this.shuffleButton) {
+          this.shuffle();
+          break;
+        }
+
+        if (target === this.playAllButton) {
           // Clicking the play all button is the same as clicking
           // on the first item in the list.
           target = this.view.querySelector('li > a[data-index="0"]');


### PR DESCRIPTION
This pull request works around https://bugzilla.mozilla.org/show_bug.cgi?id=783512 which is the bug where mp3 files don't generate an 'ended' event reliably when they're done playing.

With the workaround, the music app can automatically play the next song, so this pull request enables the 'Play All' button for albums, too.

@dominickuo will you review and land?
