### PR TITLE
Add WPS AP selection

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -306,6 +306,12 @@
             <input type="text" />
           </label>
         </li>
+        <li>
+          <label id="wifi-wps-pin-aps">
+            <span data-l10n-id="wpsPinAps">Select an opposite device</span>
+            <select></select>
+          </label>
+        </li>
       </ul>
 
       <!-- start WPS -->

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -28,28 +28,28 @@ var gWifiManager = (function(window) {
     'Mozilla-G': {
       ssid: 'Mozilla-G',
       bssid: 'xx:xx:xx:xx:xx:xx',
-      capabilities: ['WPA-EAP'],
+      capabilities: '[WPA-EAP]',
       relSignalStrength: 67,
       connected: false
     },
     'Livebox 6752': {
       ssid: 'Livebox 6752',
       bssid: 'xx:xx:xx:xx:xx:xx',
-      capabilities: ['WEP'],
+      capabilities: '[WEP]',
       relSignalStrength: 32,
       connected: false
     },
     'Mozilla Guest': {
       ssid: 'Mozilla Guest',
       bssid: 'xx:xx:xx:xx:xx:xx',
-      capabilities: [],
+      capabilities: '',
       relSignalStrength: 98,
       connected: false
     },
     'Freebox 8953': {
       ssid: 'Freebox 8953',
       bssid: 'xx:xx:xx:xx:xx:xx',
-      capabilities: ['WPA2-PSK'],
+      capabilities: '[WPA2-PSK]',
       relSignalStrength: 89,
       connected: false
     }
@@ -369,7 +369,7 @@ window.addEventListener('localized', function wifiSettings(evt) {
 
       // supported authentication methods
       var small = document.createElement('small');
-      var keys = network.capabilities;
+      var keys = getKeyManagement(network.capabilities);
       if (keys && keys.length) {
         small.textContent = _('securedBy', { capabilities: keys.join(', ') });
         var secure = document.createElement('span');
@@ -500,6 +500,20 @@ window.addEventListener('localized', function wifiSettings(evt) {
     return currentNetwork && (currentNetwork.ssid == network.ssid);
   }
 
+  function getKeyManagement(flags) {
+    var types = [];
+    if (!flags)
+      return types;
+
+    if (/\[WPA2?-PSK/.test(flags))
+      types.push('WPA-PSK');
+    if (/\[WPA2?-EAP/.test(flags))
+      types.push('WPA-EAP');
+    if (/\[WEP/.test(flags))
+      types.push('WEP');
+    return types;
+  }
+
   // UI to connect/disconnect
   function toggleNetwork(network) {
     if (isConnected(network)) {
@@ -512,7 +526,7 @@ window.addEventListener('localized', function wifiSettings(evt) {
       wifiConnect();
     } else {
       // offline, unknonw network: offer to connect
-      var key = getKeyManagement();
+      var key = getFirstKeyManagement(network.capabilities);
       switch (key) {
         case 'WEP':
         case 'WPA-PSK':
@@ -536,19 +550,13 @@ window.addEventListener('localized', function wifiSettings(evt) {
       gNetworkList.scan();
     }
 
-    function getKeyManagement() {
-      var key = network.capabilities[0];
-      if (/WEP$/.test(key))
-        return 'WEP';
-      if (/PSK$/.test(key))
-        return 'WPA-PSK';
-      if (/EAP$/.test(key))
-        return 'WPA-EAP';
-      return '';
+    function getFirstKeyManagement(flags) {
+      var types = getKeyManagement(flags);
+      return types.length < 1 ? '' : types[0];
     }
 
     function setPassword(password, identity) {
-      var key = getKeyManagement();
+      var key = getFirstKeyManagement(network.capabilities);
       if (key == 'WEP') {
         network.wep = password;
       } else if (key == 'WPA-PSK') {
@@ -571,7 +579,7 @@ window.addEventListener('localized', function wifiSettings(evt) {
         return null;
 
       // network info
-      var keys = network.capabilities;
+      var keys = getKeyManagement(network.capabilities);
       var sl = Math.min(Math.floor(network.relSignalStrength / 20), 4);
       dialog.querySelector('[data-ssid]').textContent = network.ssid;
       dialog.querySelector('[data-signal]').textContent = _('signalLevel' + sl);

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -223,7 +223,7 @@ window.addEventListener('localized', function wifiSettings(evt) {
       wpsDialog('#wifi-wps', wpsCallback);
     }
 
-    function wpsCallback(method, pin) {
+    function wpsCallback(bssid, method, pin) {
       var req;
       if (method === 'pbc') {
         req = gWifiManager.wps({
@@ -231,11 +231,13 @@ window.addEventListener('localized', function wifiSettings(evt) {
         });
       } else if (method === 'myPin') {
         req = gWifiManager.wps({
-          method: 'pin'
+          method: 'pin',
+          bssid: bssid
         });
       } else {
         req = gWifiManager.wps({
           method: 'pin',
+          bssid: bssid,
           pin: pin
         });
       }
@@ -317,7 +319,8 @@ window.addEventListener('localized', function wifiSettings(evt) {
       // OK|Cancel buttons
       dialog.onreset = close;
       dialog.onsubmit = function() {
-        callback(dialog.querySelector("input[type='radio']:checked").value,
+        callback('any',
+          dialog.querySelector("input[type='radio']:checked").value,
           pinInput.value);
         return close();
       };

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -65,7 +65,8 @@ wpsPbcLabel=Button connection
 wpsMyPinLabel=My PIN connection
 wpsApPinLabel=AP PIN connection
 wpsPinDescription=PIN is 4 or 8 digits
-wpsPinInput=Input {{pin}} to opposite device
+wpsPinInput=Input {{pin}} to an opposite device
+wpsPinAps=Select an opposite device
 wpsCancelMessage=Cancel WPS
 wpsCancelFailedMessage=Failed to cancel WPS
 


### PR DESCRIPTION
If there are some WPS APs, the WPS PIN connection procedure could take some times.
Because wpa_supplicant tries to connect to all WPS APs until correct AP found.

This patch adds WPS PIN AP selection to fix the issue.
