### PR TITLE
Bug 797000 - Allow to configure builds to add payment providers information for payme...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,8 +298,11 @@ preferences: install-xulrunner-sdk
 	  then \
 	    cat custom-prefs.js >> profile/user.js; \
 	  fi
+	if [ -f build/payment-prefs.js ]; \
+		then \
+			cat build/payment-prefs.js >> profile/user.js; \
+		fi
 	@echo "Done"
-
 
 # Generate profile/permissions.sqlite
 permissions: webapp-manifests install-xulrunner-sdk

--- a/build/payment-prefs.js
+++ b/build/payment-prefs.js
@@ -1,0 +1,5 @@
+pref("dom.payment.provider.0.name", "mockpayprovider");
+pref("dom.payment.provider.0.description", "Mock Payment Provider");
+pref("dom.payment.provider.0.type", "mock/payments/inapp/v1");
+pref("dom.payment.provider.0.uri", "https://mockpayprovider.phpfogapp.com/?req=");
+pref("dom.payment.provider.0.requestMethod", "GET");


### PR DESCRIPTION
...nts (mozPay)

The latest news that I got are that BlueVia is probably no longer going to be a payment provider, at least the way that mozPay defines a payment provider. In any case, this patch should fix #4323, as it provides the tool to add any payment provider information.

For now, the mock payment provider is the only configured provider.

CC @jds2501
