### PR TITLE
Support shared/locales in httpd.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ manifest.appcache
 /local.mk
 
 /tools/xpcwindow/vendor/
+
+locales/*

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ manifest.appcache
 
 /tools/xpcwindow/vendor/
 
-locales/*
+/locales/*

--- a/tools/extensions/httpd/content/httpd.js
+++ b/tools/extensions/httpd/content/httpd.js
@@ -1436,14 +1436,14 @@ RequestReader.prototype =
             // building packages apps, there is no provision for DEBUG=1 in
             // the build system, so we must map things here.
             var filePath = this._findRealPath(applicationName);
-            if (oldPath.indexOf('/shared/') === 0) {
-              filePath += '/../..';
+            if (oldPath.indexOf("/shared/") === 0) {
+              filePath += "/../..";
             }
             request._path = filePath + oldPath;
 
             // Handle localization files
-            if (oldPath.indexOf('.properties') !== -1 && 
-                oldPath.indexOf('en-US.properties') === -1) {
+            if (oldPath.indexOf(".properties") !== -1 && 
+                oldPath.indexOf("en-US.properties") === -1) {
               request._path = this._findPropertiesPath(request._path);
             }
           }
@@ -1475,7 +1475,7 @@ RequestReader.prototype =
 
     var appPathList = GAIA_APP_RELATIVEPATH.trim().split(" ");
     for (var i = 0; i < appPathList.length; i++) {
-      var currentAppName = appPathList[i].split('/')[1];
+      var currentAppName = appPathList[i].split("/")[1];
 
       if (!currentAppName) {
         continue;
@@ -1483,7 +1483,7 @@ RequestReader.prototype =
 
       this._realPath[currentAppName] = appPathList[i];
     }
-    return '/' + this._realPath[appName];
+    return "/" + this._realPath[appName];
   },
 
   /**
@@ -1492,29 +1492,29 @@ RequestReader.prototype =
   _findPropertiesPath: function(path) {
     // /apps/browser/locales/browser.fr.properties
     // /apps/calendar/../../shared/locales/date/date.fr.properties
-    var parts = path.split('/');
+    var parts = path.split("/");
     var appDir = parts[1]; // apps, apps
     var appName = parts[2]; // browser, calendar
     var component = parts[3]; // locales, ..
 
     // browser.fr.properties, date/date.fr.properties
-    var resource = path.split('/locales/')[1];
+    var resource = path.split("/locales/")[1];
     var resourceParts = resource.split(".");
     var resourceName = resourceParts[0]; // browser
     var localeCode = resourceParts[1]; // date/date
 
     var debugPath;
-    if (component === 'locales') {
+    if (component === "locales") {
       // /locales/fr/apps/browser/browser.properties
-      debugPath = ('/' + GAIA_LOCALES_PATH + '/' + localeCode + '/' + appDir + 
-                   '/' + appName + '/' + resourceName + '.properties');
+      debugPath = ("/" + GAIA_LOCALES_PATH + "/" + localeCode + "/" + appDir + 
+                   "/" + appName + "/" + resourceName + ".properties");
     } else {
       // /locales/fr/shared/date/date.properties
-      debugPath = ('/' + GAIA_LOCALES_PATH + '/' + localeCode + '/shared' + 
-                   '/' + resourceName + '.properties');
+      debugPath = ("/" + GAIA_LOCALES_PATH + "/" + localeCode + "/shared" + 
+                   "/" + resourceName + ".properties");
     }
 
-    dumpn('l10n: try loading ' + debugPath + ' instead of ' + path);
+    dumpn("l10n: try loading " + debugPath + " instead of " + path);
 
     // check if the file at the new path exists
     var file = this._connection.server._handler._getFileForPath(debugPath);


### PR DESCRIPTION
This pull request adds support for .properties files in shared/locales.  It also changes the path in which httpd.js looks for .properties files in order to conform to the directory structure of gaia-l10n repos (see https://hg.mozilla.org/gaia-l10n/en-US/ for an example).

Lastly, I'm adding everything in /locales/ to .gitignore so that the localizers can freely hg-clone the gaia-l10n repos.

@fabi1cazenave: r?
