### PR TITLE
[contcats] Fixing infinite spinner for first launch

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -153,7 +153,7 @@ var Contacts = (function() {
     };
   };
 
-  window.addEventListener('localized', function initContacts(evt) {
+  var onLocalized = function onLocalized() {
     initLanguages();
     initContainers();
     initContactsList();
@@ -162,7 +162,7 @@ var Contacts = (function() {
     checkUrl();
     window.addEventListener('hashchange', checkUrl);
     document.body.classList.remove('hide');
-  });
+  };
 
   var initContactsList = function initContactsList() {
     var list = document.getElementById('groups-list');
@@ -549,23 +549,29 @@ var Contacts = (function() {
     'handleVisibilityChange': handleVisibilityChange,
     'showForm': showForm,
     'setCurrent': setCurrent,
-    'getTags': TAG_OPTIONS
+    'getTags': TAG_OPTIONS,
+    'onLocalized': onLocalized
   };
 })();
 
-fb.init(function contacts_init() {
-  if (window.navigator.mozSetMessageHandler && window.self == window.top) {
-    var actHandler = ActivityHandler.handle.bind(ActivityHandler);
-    window.navigator.mozSetMessageHandler('activity', actHandler);
-  }
-  document.addEventListener('mozvisibilitychange', function visibility(e) {
-    if (ActivityHandler.currentlyHandling && document.mozHidden) {
-      ActivityHandler.postCancel();
-      return;
+window.addEventListener('localized', function initContacts(evt) {
+  fb.init(function contacts_init() {
+    Contacts.onLocalized();
+
+    if (window.navigator.mozSetMessageHandler && window.self == window.top) {
+      var actHandler = ActivityHandler.handle.bind(ActivityHandler);
+      window.navigator.mozSetMessageHandler('activity', actHandler);
     }
-    if (!ActivityHandler.currentlyHandling && !document.mozHidden) {
-      Contacts.handleVisibilityChange();
-    }
-    Contacts.checkCancelableActivity();
+    document.addEventListener('mozvisibilitychange', function visibility(e) {
+      if (ActivityHandler.currentlyHandling && document.mozHidden) {
+        ActivityHandler.postCancel();
+        return;
+      }
+      if (!ActivityHandler.currentlyHandling && !document.mozHidden) {
+        Contacts.handleVisibilityChange();
+      }
+      Contacts.checkCancelableActivity();
+    });
   });
+
 });


### PR DESCRIPTION
Sometimes we have a race condition between the localized event (when we start loading the screens) and the fb.contact.init that creates the fb database if needed.

@albertopq @jmcanterafonseca @etiennesegonzac can you take a look?

Fixes #5101
