### PR TITLE
oops. insert new photos by date, not by name

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -186,7 +186,6 @@ window.addEventListener('localized', function showBody() {
 
 function init() {
   photodb = new MediaDB('pictures', metadataParser, {
-    indexes: ['date'],
     mimeTypes: ['image/jpeg', 'image/png']
   });
 
@@ -314,9 +313,9 @@ function imageCreated(fileinfo) {
   else {
     // Otherwise we have to search for the right insertion spot
     insertPosition = binarysearch(images, fileinfo, function(a, b) {
-      if (a.name < b.name)
+      if (a.date < b.date)
         return -1;
-      else if (a.name > b.name)
+      else if (a.date > b.date)
         return 1;
       return 0;
     });

--- a/shared/js/mediadb.js
+++ b/shared/js/mediadb.js
@@ -1162,20 +1162,23 @@ var MediaDB = (function() {
     }
 
     function parseMetadata(file, filename) {
+      if (!file.lastModifiedDate) {
+        console.warn('MediaDB: parseMetadata: no lastModifiedDate for',
+                     filename,
+                     'using Date.now() until #793955 is fixed');
+      }
+
       // Basic information about the file
       var fileinfo = {
         name: filename, // we can't trust file.name
         type: file.type,
         size: file.size,
-        date: file.lastModifiedDate ? file.lastModifiedDate.getTime() : null
+        date: file.lastModifiedDate ?
+          file.lastModifiedDate.getTime() :
+          Date.now()
       };
 
-      if (fileinfo.date === null) {
-        console.warn('MediaDB: parseMetadata: no lastModifiedDate for',
-                     filename);
-      }
-
-      if (fileinfo.date && fileinfo.date > details.newestFileModTime)
+      if (fileinfo.date > details.newestFileModTime)
         details.newestFileModTime = fileinfo.date;
 
       // Get metadata about the file


### PR DESCRIPTION
This fixes two bugs that were causing Gallery to display new photos and newly edited files in the wrong spot in the thumbnail list.
