### PR TITLE
Fix Gallery crash during thumbnail generation

### DIFF
--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -130,14 +130,13 @@ var metadataParser = (function() {
 
       // Take the larger of the two scales: we crop the image to the thumbnail
       var scale = Math.max(scalex, scaley);
-
       // If the image was already thumbnail size, it is its own thumbnail
-      if (scale >= 1) {
+      /*if (scale >= 1) {
         offscreenImage.src = null;
         metadata.thumbnail = file;
         callback(metadata);
         return;
-      }
+      }*/
 
       // Calculate the region of the image that will be copied to the
       // canvas to create the thumbnail

--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -130,13 +130,18 @@ var metadataParser = (function() {
 
       // Take the larger of the two scales: we crop the image to the thumbnail
       var scale = Math.max(scalex, scaley);
-      // If the image was already thumbnail size, it is its own thumbnail
-      /*if (scale >= 1) {
+      /* If the image was already thumbnail size, it is its own thumbnail.
+         The following block is commented out as a temporary workaround, because setting
+         images smaller than the thumbnail as thumbnail crashes the gallery app, see
+         issue https://github.com/mozilla-b2g/gaia/issues/4852
+      
+      if (scale >= 1) {
         offscreenImage.src = null;
         metadata.thumbnail = file;
         callback(metadata);
         return;
-      }*/
+      }
+      */
 
       // Calculate the region of the image that will be copied to the
       // canvas to create the thumbnail


### PR DESCRIPTION
This attempts to fix the blocking issue #4852.

If you try to use an image that is smaller than the 120x120 size as the thumbnail, there's a crash. Not sure why, but this avoids the crash by not using the original image as a thumbnail - just let it upscale.
