### PR TITLE
Add "idle" permissions

### DIFF
--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -23,7 +23,8 @@
     "geolocation",
     "wifi-manage",
     "wifi",
-    "desktop-notification"
+    "desktop-notification",
+    "idle"
   ],
   "locales": {
     "ar": {

--- a/build/permissions.js
+++ b/build/permissions.js
@@ -16,6 +16,7 @@ let permissionList = ["power", "sms", "contacts", "telephony",
                       "device-storage:pictures", "device-storage:music", "device-storage:videos", "device-storage:apps",
                       "alarms", "alarm", "attention",
                       "content-camera", "camera", "tcp-socket", "bluetooth", "storage", "time", "networkstats-manage",
+                      "idle",
                       // Just don't.
                       "deprecated-hwvideo"];
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=783500 implemented checking permissions for idle observers. Here is the code to ensure system app can get correct permission.
