### PR TITLE
[#5061] Allow SIM PIN Lock loads after homesceeen loads, and,

### DIFF
--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -91,8 +91,10 @@ var SimPinDialog = {
         break;
       case 'pukRequired':
         this.lockType = 'puk';
-        this.errorMsgHeader.textContent = _('simCardLockedMsg');
-        this.errorMsgBody.textContent = _('enterPukMsg');
+        this.errorMsgHeader.textContent = _('simCardLockedMsg') || '';
+        this.errorMsgHeader.dataset.l10nId = 'simCardLockedMsg';
+        this.errorMsgBody.textContent = _('enterPukMsg') || '';
+        this.errorMsgBody.dataset.l10nId = 'enterPukMsg';
         this.errorMsg.hidden = false;
         this.inputFieldControl(false, true, true);
         this.pukInput.focus();
@@ -101,15 +103,25 @@ var SimPinDialog = {
         this.skip();
         break;
     }
-    this.dialogTitle.textContent = _(this.lockType + 'Title');
+    this.dialogTitle.textContent = _(this.lockType + 'Title') || '';
+    this.dialogTitle.dataset.l10nId = this.lockType + 'Title';
   },
 
   showErrorMsg: function spl_showErrorMsg(retry, type) {
     var _ = navigator.mozL10n.get;
 
     this.errorMsgHeader.textContent = _(type + 'ErrorMsg');
-    this.errorMsgBody.textContent = (retry === 1) ?
-      _(type + 'LastChanceMsg') : _(type + 'AttemptMsg', {n: retry});
+    this.errorMsgHeader.dataset.l10nId = type + 'ErrorMsg';
+
+    if (retry !== 1) {
+      var l10nArgs = { n: retry };
+      this.errorMsgBody.dataset.l10nId = type + 'AttemptMsg';
+      this.errorMsgBody.dataset.l10nArgs = JSON.stringify(l10nArgs);
+      this.errorMsgBody.textContent = _(type + 'AttemptMsg', l10nArgs);
+    } else {
+      this.errorMsgBody.dataset.l10nId = type + 'LastChanceMsg';
+      this.errorMsgBody.textContent = _(type + 'LastChanceMsg');
+    }
 
     this.errorMsg.hidden = false;
   },
@@ -135,6 +147,7 @@ var SimPinDialog = {
 
     if (newPin !== confirmPin) {
       this.errorMsgHeader.textContent = _('newPinErrorMsg');
+      this.errorMsgHeader.dataset.l10nId = 'newPinErrorMsg';
       this.errorMsgBody.textContent = '';
       this.errorMsg.hidden = false;
       return false;
@@ -185,6 +198,7 @@ var SimPinDialog = {
 
     if (newPin !== confirmPin) {
       this.errorMsgHeader.textContent = _('newPinErrorMsg');
+      this.errorMsgHeader.dataset.l10nId = 'newPinErrorMsg';
       this.errorMsgBody.textContent = '';
       this.errorMsg.hidden = false;
       return false;
@@ -257,11 +271,13 @@ var SimPinDialog = {
         break;
       case 'enable':
         this.inputFieldControl(true, false, false);
-        this.dialogTitle.textContent = _('pinTitle');
+        this.dialogTitle.textContent = _('pinTitle') || '';
+        this.dialogTitle.dataset.l10nId = 'pinTitle';
         break;
       case 'changePin':
         this.inputFieldControl(true, false, true);
-        this.dialogTitle.textContent = _('newpinTitle');
+        this.dialogTitle.textContent = _('newpinTitle') || '';
+        this.dialogTitle.dataset.l10nId = 'newpinTitle';
         break;
     }
 

--- a/apps/settings/js/unlock.js
+++ b/apps/settings/js/unlock.js
@@ -24,6 +24,4 @@ var SimPinUnLock = {
 
 };
 
-window.addEventListener('localized', function spl_ready() {
-  SimPinUnLock.init();
-});
+SimPinUnLock.init();

--- a/apps/settings/unlock-simpin.html
+++ b/apps/settings/unlock-simpin.html
@@ -48,23 +48,23 @@
         </div>
 
         <!-- sim pin input field -->
-        <div id="pinArea">
+        <div id="pinArea" hidden>
           <div data-l10n-id="simPin">SIM PIN</div>
           <div class="input-wrapper">
             <input name="simpin" type="number" size="8" maxlength="8" />
-            <input name="simpinVis" type="text" size="8" maxlength="8"/>
+            <input name="simpinVis" type="text" size="8" maxlength="8" />
           </div>
         </div>
         <!-- sim puk input field -->
-        <div id="pukArea">
+        <div id="pukArea" hidden>
           <div data-l10n-id="pukCode">PUK Code</div>
           <div class="input-wrapper">
             <input name="simpuk" type="number" size="8" maxlength="8" />
-            <input name="simpukVis" type="text" size="8" maxlength="8"/>
+            <input name="simpukVis" type="text" size="8" maxlength="8" />
           </div>
         </div>
         <!-- new sim pin input field -->
-        <div id="newPinArea">
+        <div id="newPinArea" hidden>
           <div data-l10n-id="newSimPinMsg">
             Create PIN (must contain 4 to 8 digits)
           </div>
@@ -74,7 +74,7 @@
           </div>
         </div>
         <!-- confirm new sim pin input field -->
-        <div id="confirmPinArea">
+        <div id="confirmPinArea" hidden>
           <div>Confirm New PIN</div>
           <div class="input-wrapper">
             <input name="confirmNewSimpin" type="number" size="8" maxlength="8" />

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -23,10 +23,6 @@ function startup() {
     });
   }
 
-  window.addEventListener('unlock', function() {
-    SimLock.init();
-  });
-
   SourceView.init();
   Shortcuts.init();
 

--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -5,7 +5,49 @@
 
 var SimLock = {
   init: function sl_init() {
-    switch (window.navigator.mozMobileConnection.cardState) {
+    // Listen to the first appwillopen event, where homescreen launches
+    window.addEventListener('appwillopen', this);
+
+    // Listen to appopen event
+    window.addEventListener('appopen', this);
+  },
+  handleEvent: function sl_handleEvent(evt) {
+    switch (evt.type) {
+      case 'appwillopen':
+        window.removeEventListener('appwillopen', this);
+        this.showIfLocked();
+
+        break;
+
+      case 'appopen':
+        // if an app needs telephony or sms permission,
+        // we will launch the unlock screen if needed.
+
+        var app = Applications.getByManifestURL(
+          evt.target.getAttribute('mozapp'));
+
+        if (!app || !app.manifest.permissions)
+          return;
+
+        var keys = Object.keys(app.manifest.permissions);
+        var permissions = keys.map(function map_perm(key) {
+          return app.manifest.permissions[key];
+        });
+
+        if (permissions.indexOf('telephony') === -1 &&
+          permissions.indexOf('sms') === -1)
+          return;
+
+        this.showIfLocked();
+        break;
+    }
+  },
+  showIfLocked: function sl_showIfLocked() {
+    var conn = window.navigator.mozMobileConnection;
+    if (!conn)
+      return;
+
+    switch (conn.cardState) {
       case 'pukRequired':
       case 'pinRequired':
         var activity = new MozActivity({
@@ -15,10 +57,8 @@ var SimLock = {
           }
         });
         activity.onsuccess = function sl_unlockSuccess() {
-          if (!this.result.unlock) {
-            ModalDialog.alert('SIM Locked');
-          }
-          WindowManager.setDisplayedApp(null);
+          // Go back to the current displayed app
+          WindowManager.setDisplayedApp(WindowManager.getDisplayedApp());
         };
         break;
       case 'ready':
@@ -27,3 +67,5 @@ var SimLock = {
     }
   }
 };
+
+SimLock.init();

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -522,6 +522,11 @@ var WindowManager = (function() {
         });
       });
     }
+
+    // Dispatch a appwillopen event
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent('appwillopen', true, false, { origin: displayedApp });
+    openFrame.dispatchEvent(evt);
   }
 
   // Perform a "close" animation for the app's iframe


### PR DESCRIPTION
- dispatch appwillopen event in WindowManager,
- properly localized SIM PIN Lock panel, allow faster load,
- trigger SIM PIN lock if user access telephony/sms app while SIM is locked

Fixes #5061
