### PR TITLE
Ask user to unlock the SIM when leaving airplane mode

### DIFF
--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -10,9 +10,19 @@ var SimLock = {
 
     // Listen to appopen event
     window.addEventListener('appopen', this);
+
+    var conn = window.navigator.mozMobileConnection;
+    if (!conn)
+      return;
+    conn.addEventListener('cardstatechange', this);
   },
   handleEvent: function sl_handleEvent(evt) {
     switch (evt.type) {
+      case 'cardstatechange':
+        this.showIfLocked();
+
+        break;
+
       case 'appwillopen':
         window.removeEventListener('appwillopen', this);
         this.showIfLocked();


### PR DESCRIPTION
If the SIM unlock panel doesn't show again, the phone will remain in "Emergency calls only (SIM PIN Required)" state.
