### PR TITLE
[Browser] Gaia side of Clear Private Data, closes #3124 once platform support lands

### DIFF
--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -188,25 +188,18 @@
       </ul>
       <h3 data-l10n-id="privacy-and-security">Privacy & Security</h3>
       <ul>
-        <li id="enable-cookies">
-          <label>
-            <input type="checkbox" name="enable-cookies" disabled="disabled" />
-            <span data-l10n-id="enable-cookies" disabled="disabled">Enable Cookies</span>
-          </label>
-        </li>
         <li>
           <button id="clear-history-button"
                   data-l10n-id="clear-history">Clear History</button>
         </li>
         <li>
-          <button id="clear-private-data-button" disabled="disabled"
+          <button id="clear-private-data-button"
                   data-l10n-id="clear-private-data">Clear Private Data</button>
         </li>
 
       </ul>
     </div>
 
-    <script src="js/GestureDetector.js"></script>
     <script src="js/places.js"></script>
     <script src="js/date_helper.js"></script>
     <script src="js/modal_dialog.js"></script>

--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -95,6 +95,8 @@ var Browser = {
       this.saveBookmark.bind(this));
     this.awesomescreenCancelButton.addEventListener('click',
      this.handleAwesomescreenCancel.bind(this));
+    this.clearPrivateDataButton.addEventListener('click',
+      this.clearPrivateData.bind(this));
 
     this.tabsSwipeMngr.browser = this;
     ['mousedown', 'pan', 'tap', 'swipe'].forEach(function(evt) {
@@ -150,7 +152,7 @@ var Browser = {
       'bookmark-entry-sheet', 'bookmark-entry-sheet-cancel',
       'bookmark-entry-sheet-done', 'bookmark-title', 'bookmark-url',
       'bookmark-previous-url', 'bookmark-menu-add-home', 'new-tab-button',
-      'awesomescreen-cancel-button'];
+      'awesomescreen-cancel-button', 'clear-private-data-button'];
 
     // Loop and add element with camel style name to Modal Dialog attribute.
     elementIDs.forEach(function createElementRef(name) {
@@ -1272,6 +1274,7 @@ var Browser = {
   showSettingsScreen: function browser_showSettingsScreen() {
     this.switchScreen(this.SETTINGS_SCREEN);
     this.clearHistoryButton.disabled = false;
+    this.clearPrivateDataButton.disabled = false;
   },
 
   showAboutPage: function browser_showAboutPage() {
@@ -1289,6 +1292,17 @@ var Browser = {
       Places.clearHistory((function() {
         this.clearHistoryButton.setAttribute('disabled', 'disabled');
       }).bind(this));
+    }
+  },
+
+  clearPrivateData: function browser_clearPrivateData() {
+    var msg = navigator.mozL10n.get('confirm-clear-private-data');
+    if (confirm(msg)) {
+      var request = navigator.mozApps.getSelf();
+      request.onsuccess = (function() {
+        request.result.clearBrowserData();
+        this.clearPrivateDataButton.setAttribute('disabled', 'disabled');
+      }).bind(this);
     }
   },
 

--- a/apps/browser/locales/browser.en-US.properties
+++ b/apps/browser/locales/browser.en-US.properties
@@ -41,10 +41,10 @@ no-top-sites=You don’t have Top Sites yet. Enter a search term or web address 
 firefox-settings=Settings
 about-firefox=About Firefox
 privacy-and-security=Privacy & Security
-enable-cookies=Enable Cookies
 clear-history=Clear History
 confirm-clear-history=Clear browsing history?
 clear-private-data=Clear Private Data
+confirm-clear-private-data=Clear private data including cookies?
 
 # About Page
 faq-about=FAQ


### PR DESCRIPTION
This is the Gaia part and can be landed without breaking anything. The API call has landed in Mozilla Central but isn't actually hooked up to anything yet so no data will actually get cleared. localStorage and cookie clearing is coming soon!

I think that's https://bugzilla.mozilla.org/show_bug.cgi?id=786301 and https://bugzilla.mozilla.org/show_bug.cgi?id=783408 respectively, but there might be other work necessary on the platform to hook it up to this API call.

There's a new string in here so landing this before string freeze would be good.

Note: The removal of the gesture detector library is intentional, this version doesn't seem to be used any more and just 404s, there's a new shared version.
