### PR TITLE
Refine set Date and Time

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -666,22 +666,12 @@
       </header>
       <ul id="time-manual" hidden>
         <li id="setDate">
-          <small id="clock-date"></small>
-          <a data-l10n-id="dateMessage">Date</a>
+          <a data-l10n-id="dateMessage">Date<span id="clock-date"></span></a>
           <input type="date" id="date-picker"/>
         </li>
         <li id="setTime">
-          <small id="clock-display">
-            <span id="clock-time"></span>
-            <span id="clock-hour24-state"></span>
-          </small>
-          <a data-l10n-id="timeMessage">Time</a>
+          <a data-l10n-id="timeMessage">Time<span id="clock-time"></span></a>
           <input type="time" id="time-picker"/>
-        </li>
-        <li>
-          <label>
-            <button id="confirmTime-button">Confirm</button>
-          </label>
         </li>
       </ul>
     </section>

--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -198,7 +198,7 @@ ul li p + input[type=password] {
 #root li [data-l10n-id="simSecurity"]       { background-image: url(images/settings/sim_card_lock.png); }
 #root li [data-l10n-id="sound"]             { background-image: url(images/settings/sound.png); }
 #root li [data-l10n-id="storage"]           { background-image: url(images/settings/storage.png); }
-#root li [data-l10n-id="timeAndDate"]       { background-image: url(images/settings/date_time.png); }
+#root li [data-l10n-id="dateAndTime"]       { background-image: url(images/settings/date_time.png); }
 #root li [data-l10n-id="wallpaper"]         { background-image: url(images/settings/wallpaper.png); }
 #root li [data-l10n-id="wifi"]              { background-image: url(images/settings/wifi.png); }
 


### PR DESCRIPTION
1. Remove confirm button since we can receive 'input' event from pickers.
2. Fixed no icon for settings date and time.
3. Modify the date/time display to let it readable.

High light risk:
1. There are twice 'input' callbacks come from the pickers' value change.
(It will set the system time twice. And may let platform crash or system time incorrectly!!)
2. There is no 'input' callback come from the pickers' value change.
