### PR TITLE
[Facebook] Hotfix JSONP no longer used for FB API. Now using system XHR

### DIFF
--- a/apps/communications/contacts/js/fb/fb_import.js
+++ b/apps/communications/contacts/js/fb/fb_import.js
@@ -219,7 +219,7 @@ if (typeof fb.importer === 'undefined') {
 
         fb.utils.runQuery(oneFriendQuery, {
                             success: fb.importer.importDataReady,
-                            error:   fb.importer.errorHandler,
+                            error: fb.importer.errorHandler,
                             timeout: fb.importer.timeoutHandler
         }, access_token);
       },0);

--- a/apps/communications/contacts/js/fb/fb_import.js
+++ b/apps/communications/contacts/js/fb/fb_import.js
@@ -188,7 +188,11 @@ if (typeof fb.importer === 'undefined') {
     Importer.getFriends = function(access_token) {
       document.body.dataset.state = 'waiting';
 
-      fb.utils.runQuery(multiQStr, 'fb.importer.friendsReady', access_token);
+      fb.utils.runQuery(multiQStr, {
+          success: fb.importer.friendsReady,
+          error: fb.importer.errorHandler,
+          timeout: fb.importer.timeoutHandler
+      },access_token);
 
       // In the meantime we obtain the FB friends already on the Address Book
       if (!navigator.mozContacts) {
@@ -213,8 +217,11 @@ if (typeof fb.importer === 'undefined') {
       window.setTimeout(function do_importFriend() {
         var oneFriendQuery = buildFriendQuery(uid);
 
-        fb.utils.runQuery(oneFriendQuery,
-                                'fb.importer.importDataReady', access_token);
+        fb.utils.runQuery(oneFriendQuery, {
+                            success: fb.importer.importDataReady,
+                            error:   fb.importer.errorHandler,
+                            timeout: fb.importer.timeoutHandler
+        }, access_token);
       },0);
 
       return currentRequest;
@@ -305,6 +312,17 @@ if (typeof fb.importer === 'undefined') {
       }
     }
 
+    Importer.timeoutHandler = function() {
+      // TODO: figure out with UX what to do in that case
+      window.alert('Timeout!!');
+      document.body.dataset.state = '';
+    }
+
+    Importer.errorHandler = function() {
+      // TODO: figure out with UX what to do in that case
+      window.alert('Error!');
+      document.body.dataset.state = '';
+    }
 
     function fillData(f) {
       // givenName is put as name but it should be f.first_name

--- a/apps/communications/contacts/js/fb/fb_link.js
+++ b/apps/communications/contacts/js/fb/fb_link.js
@@ -167,15 +167,22 @@ if (!fb.link) {
 
       */
 
-      fb.utils.runQuery(query, 'fb.link.proposalReady', access_token);
+      fb.utils.runQuery(query, {
+        success: fb.link.proposalReady,
+        error: fb.link.errorHandler,
+        timeout: fb.link.TimeoutHandler
+      }, access_token);
     }
 
 
     function getRemoteAll() {
       document.body.dataset.state = 'waiting';
 
-      fb.utils.runQuery(ALL_QUERY.join(''), 'fb.link.friendsReady',
-                                                            access_token);
+      fb.utils.runQuery(ALL_QUERY.join(''), {
+        success: fb.link.friendsReady,
+        error: fb.link.errorHandler,
+        timeout: fb.link.TimeoutHandler
+      }, access_token);
     }
 
     // When the access_token is available it is executed
@@ -191,7 +198,7 @@ if (!fb.link) {
       fb.oauth.getAccessToken(tokenReady, 'proposal');
     }
 
-    // Executed when the jsonp response is available
+    // Executed when the server response is available
     link.proposalReady = function(response) {
       var inError = false;
 
@@ -223,6 +230,18 @@ if (!fb.link) {
       if (numQueries > 1) {
         document.body.dataset.state = 'selection';
       }
+    }
+
+    link.timeoutHandler = function() {
+       // TODO: figure out with UX what to do in that case
+      window.alert('Timeout!!');
+      document.body.dataset.state = 'selection';
+    }
+
+    link.errorHandler = function() {
+       // TODO: figure out with UX what to do in that case
+      window.alert('Error!!');
+      document.body.dataset.state = 'selection';
     }
 
     /**

--- a/apps/communications/contacts/js/fb/fb_link.js
+++ b/apps/communications/contacts/js/fb/fb_link.js
@@ -170,7 +170,7 @@ if (!fb.link) {
       fb.utils.runQuery(query, {
         success: fb.link.proposalReady,
         error: fb.link.errorHandler,
-        timeout: fb.link.TimeoutHandler
+        timeout: fb.link.timeoutHandler
       }, access_token);
     }
 
@@ -181,7 +181,7 @@ if (!fb.link) {
       fb.utils.runQuery(ALL_QUERY.join(''), {
         success: fb.link.friendsReady,
         error: fb.link.errorHandler,
-        timeout: fb.link.TimeoutHandler
+        timeout: fb.link.timeoutHandler
       }, access_token);
     }
 

--- a/apps/communications/contacts/js/fb/fb_utils.js
+++ b/apps/communications/contacts/js/fb/fb_utils.js
@@ -5,6 +5,8 @@ var fb = window.fb || {};
 if (!fb.utils) {
   fb.utils = {};
 
+  var TIMEOUT_QUERY = 15000;
+
   fb.utils.getContactData = function(cid) {
     var outReq = new fb.utils.Request();
 
@@ -65,14 +67,44 @@ if (!fb.utils) {
     queryService += encodeURIComponent(query);
 
     var params = [fb.ACC_T + '=' + access_token,
-                    'format=json', 'callback' + '=' + callback];
+                    'format=json'];
 
     var queryParams = params.join('&');
 
-    var jsonp = document.createElement('script');
-    jsonp.src = queryService + '&' + queryParams;
+    var remote = queryService + '&' + queryParams;
 
-    document.body.appendChild(jsonp);
+    var xhr = new XMLHttpRequest({mozSystem: true});
+
+    xhr.open('GET', remote, true);
+    xhr.responseType = 'json';
+
+    xhr.timeout = TIMEOUT_QUERY;
+
+    xhr.onload = function(e) {
+      if (xhr.status === 200 || xhr.status === 0) {
+        if(callback && typeof callback.success === 'function')
+          callback.success(xhr.response);
+      }
+      else {
+        window.console.error('FB: Error executing query. Status: ', xhr.status);
+        if(callback && typeof callback.error === 'function')
+          callback.error();
+      }
+    }
+
+    xhr.ontimeout = function(e) {
+      window.console.error('FB: Timeout!!! while executing query', query);
+      if(callback && typeof callback.timeout === 'function')
+        callback.timeout();
+    }
+
+    xhr.onerror = function(e) {
+      window.console.error('FB: Error while executing query', e);
+      if(callback && typeof callback.error === 'function')
+        callback.error();
+    }
+
+    xhr.send();
   };
 
 

--- a/apps/communications/contacts/js/fb/fb_utils.js
+++ b/apps/communications/contacts/js/fb/fb_utils.js
@@ -82,25 +82,25 @@ if (!fb.utils) {
 
     xhr.onload = function(e) {
       if (xhr.status === 200 || xhr.status === 0) {
-        if(callback && typeof callback.success === 'function')
+        if (callback && typeof callback.success === 'function')
           callback.success(xhr.response);
       }
       else {
         window.console.error('FB: Error executing query. Status: ', xhr.status);
-        if(callback && typeof callback.error === 'function')
+        if (callback && typeof callback.error === 'function')
           callback.error();
       }
     }
 
     xhr.ontimeout = function(e) {
       window.console.error('FB: Timeout!!! while executing query', query);
-      if(callback && typeof callback.timeout === 'function')
+      if (callback && typeof callback.timeout === 'function')
         callback.timeout();
     }
 
     xhr.onerror = function(e) {
       window.console.error('FB: Error while executing query', e);
-      if(callback && typeof callback.error === 'function')
+      if (callback && typeof callback.error === 'function')
         callback.error();
     }
 


### PR DESCRIPTION
CSP landing in today's build had broken the FB Integration as JSONP was being used. This hotfix fixes the issue by means of using XHR. In addition the app is more robust as errors and timeouts are captured properly. 

A chat with UX is pending to decide what to do in error / timeout situations. But we need to land this ASAP in order not to block QA. 

@crdlc R?
