### PR TITLE
remove unused strings from l10n properties files

### DIFF
--- a/apps/music/locales/music.en-US.properties
+++ b/apps/music/locales/music.en-US.properties
@@ -1,6 +1,4 @@
 music = Music
-noSongs = No songs
-clickToStart.innerHTML = Click <br> to <br> Start!
 
 mix       = Mix
 playlists = Playlist
@@ -14,9 +12,6 @@ songAlbum  = Song album
 unknownArtist = Unknown artist
 unknownAlbum  = Unknown album
 unknownTitle  = Unknown title
-
-scanning-title = Scanning for songs…
-scanning-text  = This may take a few moments.
 
 empty-title = Add songs to get started
 empty-text = Load songs on to the memory card.

--- a/apps/video/locales/video.en-US.properties
+++ b/apps/video/locales/video.en-US.properties
@@ -1,8 +1,4 @@
 videos   = Videos
-novideos = No videos
-
-scanning-title = Scanning for videos...
-scanning-text  = This may take a few moments.
 
 empty-title = Add videos to get started
 empty-text  = Load videos on to the memory card.


### PR DESCRIPTION
The Music and Video apps changed recent so that they don't display scanning messages anymore. This pull request removes the unused localization of the scanning messages from the english properties files.
It also removes a couple of miscellanous strings that have been unused for a long time.
