### PR TITLE
[video] handle localized event correctly

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -638,7 +638,9 @@ window.addEventListener('localized', function showBody() {
   document.documentElement.dir = navigator.mozL10n.language.direction;
   // <body> children are hidden until the UI is translated
   document.body.classList.remove('hidden');
-  init();
+
+  // If this is the first time we've been called, initialize the database.
+  // Don't reinitialize it if the user switches languages while we're running
+  if (!videodb)
+    init();
 });
-
-


### PR DESCRIPTION
After talking with Kaze, I learned that the localized event is not only called on startup, but also any time the user switches languages.  This pull requests prevents it from creating a new MediaDB each time that happens.

@daleharvey this is for you to review and land.  Just one line plus comments.
