### PR TITLE
[email] Add support for a per-account synchronization range for messages, fixes #4094

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -535,6 +535,30 @@
             </em>
           </li>
           <li>
+            <span data-l10n-id="settings-account-synchronize" class="list-text">
+              SynchronizE</span>
+            <em class="aside end">
+              <select class="mail-select tng-account-synchronize">
+                <option value="1d" data-l10n-id="settings-synchronize-one-day">
+                  1 DaY</option>
+                <option value="3d" data-l10n-id="settings-synchronize-three-days">
+                  3 DayS</option>
+                <option value="1w" data-l10n-id="settings-synchronize-one-week">
+                  1 WeeK</option>
+                <option value="2w" data-l10n-id="settings-synchronize-two-weeks">
+                  2 WeekS</option>
+                <option value="1m" data-l10n-id="settings-synchronize-one-month">
+                  1 MontH</option>
+                <option value="3m" data-l10n-id="settings-synchronize-three-months">
+                  3 MonthS</option>
+                <option value="6m" data-l10n-id="settings-synchronize-six-months">
+                  6 MonthS</option>
+                <option value="all" data-l10n-id="settings-synchronize-all">
+                  AlL MessageS</option>
+              </select>
+            </em>
+          </li>
+          <li>
             <a href="#" data-l10n-id="settings-account-credentials"
               class="tng-account-credentials list-text">CredentialS</a>
             <em class="aside end"></em>

--- a/apps/email/js/setup-cards.js
+++ b/apps/email/js/setup-cards.js
@@ -493,6 +493,12 @@ function SettingsAccountCard(domNode, mode, args) {
   domNode.getElementsByClassName('tng-account-type')[0].textContent =
     (this.account.type === 'activesync') ? 'ActiveSync' : 'IMAP+SMTP';
 
+  var synchronizeNode = domNode.getElementsByClassName(
+    'tng-account-synchronize')[0];
+  synchronizeNode.value = this.account.syncRange;
+  synchronizeNode.addEventListener(
+    'change', this.onChangeSynchronize.bind(this), false);
+
   this.account.servers.forEach(function(server, index) {
     var serverNode = tngNodes['account-settings-server'].cloneNode(true);
     var serverLabel =
@@ -531,6 +537,18 @@ SettingsAccountCard.prototype = {
         index: index
       },
       'right');
+  },
+
+  onChangeSynchronize: function(event) {
+    this.account.modifyAccount({syncRange: event.target.value});
+
+    // If we just changed the currently-selected account, refresh the
+    // currently-open folder to propagate the syncRange change.
+    var curAccount = Cards.findCardObject(['folder-picker', 'navigation'])
+                          .cardImpl.curAccount;
+    if (curAccount.id === this.account.id) {
+      Cards.findCardObject(['message-list', 'default']).cardImpl.onRefresh();
+    }
   },
 
   die: function() {

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -48,6 +48,7 @@ settings-check-manually=Manually
 settings-default-account=Default account
 settings-account-type=Account type
 settings-account-credentials=Credentials
+settings-account-synchronize=Synchronize
 settings-activesync-label=ActiveSync settings
 settings-imap-label=IMAP settings
 settings-smtp-label=SMTP settings
@@ -57,6 +58,15 @@ settings-username=Username
 settings-password=Password
 settings-save=Save
 settings-password-empty=Password should not be empty!
+
+settings-synchronize-one-day=1 day
+settings-synchronize-three-days=3 days
+settings-synchronize-one-week=1 week
+settings-synchronize-two-weeks=2 weeks
+settings-synchronize-one-month=1 month
+settings-synchronize-three-months=3 months
+settings-synchronize-six-months=6 months
+settings-synchronize-all=All messages
 
 accounts-header=Accounts
 accounts-button=Accounts


### PR DESCRIPTION
@asutherland, This PR, which requires mozilla-b2g/gaia-email-libs-and-more#52 to do anything useful, lets us change the synchronization range for all folders for a given account. This is mostly useful for ActiveSync.

One limitation is that we don't immediately refresh the current folder when changing the sync range; we probably should, assuming it's a folder in the account we just changed.
