### PR TITLE
Fixed HTML syntax error in settings app

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -43,7 +43,7 @@
     <!-- Connectivity :: Wi-Fi :: Network Status Dialog -->
     <section role="region" id="wifi-status" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button></button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="forget">Forget</span></button>
         </menu>
@@ -78,7 +78,7 @@
     <!-- Connectivity :: Wi-Fi :: Network Authentication Dialog -->
     <section role="region" id="wifi-auth" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button></button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="ok">OK</span></button>
         </menu>
@@ -115,7 +115,7 @@
     <!-- Connectivity :: Wi-Fi :: WPS Dialog -->
     <section role="region" id="wifi-wps" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button></button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="ok">OK</span></button>
         </menu>
@@ -248,7 +248,7 @@
     <!-- Connectivity :: 3G/data :: APN Settings Dialog -->
     <section role="region" id="apnSettings" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button></button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="ok">OK</span></button>
         </menu>
@@ -298,7 +298,7 @@
     <!-- Connectivity :: 3G/data :: MMS Settings Dialog -->
     <section role="region" id="mmsSettings" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button></button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="ok">OK</span></button>
         </menu>
@@ -467,7 +467,7 @@
     <!-- Connectivity :: Internet Sharing :: Portable Wi-Fi Hotspot -->
     <section role="region" id="hotspotSettings" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button></button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="ok">OK</span></button>
         </menu>


### PR DESCRIPTION
In several places in settings app the span is closed as button ... this PR fix this.
