### PR TITLE
Bug 798247 [Contacts] Apply building blocks [input_areas]

### DIFF
--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -430,12 +430,14 @@
         </header>
 
         <article class="view-body">
-          <div class="view-body-inner">
+          <form class="view-body-inner">
             <ul id="tags-list" class="selection-list">
             </ul>
-            <input data-cancelable class="textfield" type="text" placeholder="Custom Tag" value="" id='custom-tag' data-l10n-id="custom">
-            <button type="reset" onclick="return false;" class="hide">Clear</button>
-          </div>
+            <p>
+              <input data-cancelable class="textfield" type="text" placeholder="Custom Tag" value="" id='custom-tag' data-l10n-id="custom">
+              <button type="reset" onclick="return false;" class="hide">Clear</button>
+            </p>
+          </form>
         </article>
       </section>
 

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -267,13 +267,8 @@
         <!-- PHONE TEMPLATE -->
         <div id='add-phone-#i#' data-template class='phone-template' data-index="#i#">
           <fieldset class="fillflow-row">
-<<<<<<< HEAD
             <legend class="action">
-              <span data-taglist='phone-type' name="tel" value="#type#" id="tel_type_#i#" data-field="type">#type#</span>
-=======
-            <legend class="action" onmousedown="Contacts.goToSelectTag(event); return false;">
               <span data-taglist="phone-type" name="tel" value="#type#" id="tel_type_#i#" data-field="type">#type#</span>
->>>>>>> Added nits fixing
             </legend>
             <section>
               <p class="setbox-item">
@@ -291,13 +286,8 @@
         <!-- EMAIL TEMPLATE -->
         <div id='add-email-#i#' data-template class='email-template' data-index="#i#">
           <fieldset class="fillflow-row">
-<<<<<<< HEAD
             <legend class="action">
-              <span data-taglist='email-type' name="email" value="#type#" id="email_type_#i#" data-field="type">#type#</span>
-=======
-            <legend class="action" onmousedown="Contacts.goToSelectTag(event); return false;">
               <span data-taglist="email-type" name="email" value="#type#" id="email_type_#i#" data-field="type">#type#</span>
->>>>>>> Added nits fixing
             </legend>
             <section>
               <p class="setbox-item">

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -126,7 +126,8 @@
         <section id="search-view" class="view">
            <form id="searchview-container" class="search">
               <label for="search-contact">
-                <input data-cancelable required type="search" name="search" class="textfield" placeholder="Search" id="search-contact" data-l10n-id="search-contact" />
+                <input data-cancelable required type="search" name="search" class="textfield" onfocus='return contacts.List.enterSearchMode();' placeholder="Search" id="search-contact" onkeyup="contacts.List.search()" data-l10n-id="search-contact" />
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
                 <button id='cancel-search' data-l10n-id="cancel">Cancel</button>
               </label>
             </form>
@@ -268,9 +269,11 @@
             <section>
               <p class="setbox-item">
                 <input data-cancelable placeholder="Phone" data-field="value" data-l10n-id="tel" name="tel" class="textfield" type="tel" value="#value#" id="number_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
               <p class="setbox-item">
                 <input data-cancelable placeholder="Carrier" data-field="carrier" data-l10n-id="carrier" name="tel" class="textfield" type="text" value="#carrier#" id="carrier_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
             </section>
           </fieldset>
@@ -285,6 +288,7 @@
             <section>
               <p class="setbox-item">
                 <input data-cancelable placeholder="Email" data-l10n-id="email" name="email" class="textfield" type="email" value="#value#" id="email_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
             </section>
           </fieldset>
@@ -299,15 +303,19 @@
             <section>
               <p class="setbox-item">
                 <input data-cancelable placeholder="Street" data-field="streetAddress" data-l10n-id="streetAddress" name="address" class="textfield" type="text" value="#streetAddress#" id="streetAddress_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
               <p class="setbox-item">
                 <input data-cancelable placeholder="Zip Code" data-field="postalCode" data-l10n-id="postalCode" name="address" class="textfield" type="text" value="#postalCode#" id="postalCode_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
               <p class="setbox-item">
                 <input data-cancelable placeholder="City" data-field="locality" data-l10n-id="locality" name="address" class="textfield" type="text" value="#locality#" id="locality_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
               <p class="setbox-item">
                 <input data-cancelable placeholder="Country" data-field="countryName" data-l10n-id="countryName" name="address" class="textfield" type="text" value="#countryName#" id="countryName_#i#">
+                <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
             </section>
           </fieldset>
@@ -319,6 +327,7 @@
             <dd class="setbox-body">
               <p class="setbox-item">
                <input data-cancelable placeholder="Comment" data-l10n-id="comment" name="note" class="textfield" type="text" value="#note#" id="note_#i#">
+               <button type="reset" onclick="return false;" class="hide">Clear</button>
               </p>
             </dd>
           </dl>
@@ -340,13 +349,16 @@
                 <div class="item-body-exp">
                   <p class="fillflow-row">
                     <input data-cancelable placeholder="Name" data-l10n-id="givenName" name="givenName" class="textfield" type="text" value="#givenName#" id="givenName">
+                    <button type="reset" onclick="return false;" class="hide">Clear</button>
                   </p>
                   <p class="fillflow-row">
                     <input data-cancelable placeholder="Last name" data-l10n-id="familyName" name="familyName" class="textfield" type="text" value="#familyName#" id="familyName">
+                    <button type="reset" onclick="return false;" class="hide">Clear</button>
                   </p>
                 </div>
                 <p class="fillflow-row">
                   <input data-cancelable placeholder="Company Name" data-l10n-id="org" name="org" class="textfield" type="text" value="" id="org">
+                  <button type="reset" onclick="return false;" class="hide">Clear</button>
                 </p>
               </section>
 
@@ -418,6 +430,7 @@
             <ul id="tags-list" class="selection-list">
             </ul>
             <input data-cancelable class="textfield" type="text" placeholder="Custom Tag" value="" id='custom-tag' data-l10n-id="custom">
+            <button type="reset" onclick="return false;" class="hide">Clear</button>
           </div>
         </article>
       </section>

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -126,15 +126,15 @@
         <div id="current-jumper" class="view-jumper-current"></div>
 
         <section id="search-view" class="view">
-           <form id="searchview-container" class="search" role="search">
-              <button id='cancel-search' data-l10n-id="cancel" type="submit">Cancel</button>
-              <p>
-                <label for="search-contact">
-                  <input data-cancelable required type="search" name="search" class="textfield" onfocus='return contacts.List.enterSearchMode();' placeholder="Search" id="search-contact" onkeyup="contacts.List.search()" data-l10n-id="search-contact" />
-                  <button type="reset" onclick="return false;" class="hide">Clear</button>
-                </label>
-              </p>
-            </form>
+        <form id="searchview-container" class="search" role="search">
+          <button id='cancel-search' data-l10n-id="cancel" type="submit">Cancel</button>
+          <p>
+            <label for="search-contact">
+              <input data-cancelable required type="search" name="search" class="textfield" onfocus='return contacts.Search.enterSearchMode();' placeholder="Search" id="search-contact" onkeyup="contacts.Search.search()" data-l10n-id="search-contact" />
+              <button type="reset" onclick="return false;" class="hide">Clear</button>
+            </label>
+          </p>
+        </form>
         </section>
       </section>
 
@@ -267,8 +267,13 @@
         <!-- PHONE TEMPLATE -->
         <div id='add-phone-#i#' data-template class='phone-template' data-index="#i#">
           <fieldset class="fillflow-row">
+<<<<<<< HEAD
             <legend class="action">
               <span data-taglist='phone-type' name="tel" value="#type#" id="tel_type_#i#" data-field="type">#type#</span>
+=======
+            <legend class="action" onmousedown="Contacts.goToSelectTag(event); return false;">
+              <span data-taglist="phone-type" name="tel" value="#type#" id="tel_type_#i#" data-field="type">#type#</span>
+>>>>>>> Added nits fixing
             </legend>
             <section>
               <p class="setbox-item">
@@ -286,8 +291,13 @@
         <!-- EMAIL TEMPLATE -->
         <div id='add-email-#i#' data-template class='email-template' data-index="#i#">
           <fieldset class="fillflow-row">
+<<<<<<< HEAD
             <legend class="action">
               <span data-taglist='email-type' name="email" value="#type#" id="email_type_#i#" data-field="type">#type#</span>
+=======
+            <legend class="action" onmousedown="Contacts.goToSelectTag(event); return false;">
+              <span data-taglist="email-type" name="email" value="#type#" id="email_type_#i#" data-field="type">#type#</span>
+>>>>>>> Added nits fixing
             </legend>
             <section>
               <p class="setbox-item">

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -109,10 +109,12 @@
           </div>
 
           <div id="groups-container" class="view-body-inner">
-            <form id="search-container" class="search">
-              <label for="search-contact">
-                <input type="search" name="search" class="textfield" placeholder="Search" data-l10n-id="search-contact" />
-              </label>
+            <form id="search-container" class="search" role="search">
+              <p>
+                <label for="search-contact">
+                  <input type="search" name="search" class="textfield" placeholder="Search" data-l10n-id="search-contact" />
+                </label>
+              </p>
             </form>
             <p id="no-result" class="hide" data-l10n-id="noResults">No contacts found</p>
             <ol class="block-list" id="groups-list">
@@ -124,12 +126,14 @@
         <div id="current-jumper" class="view-jumper-current"></div>
 
         <section id="search-view" class="view">
-           <form id="searchview-container" class="search">
-              <label for="search-contact">
-                <input data-cancelable required type="search" name="search" class="textfield" onfocus='return contacts.List.enterSearchMode();' placeholder="Search" id="search-contact" onkeyup="contacts.List.search()" data-l10n-id="search-contact" />
-                <button type="reset" onclick="return false;" class="hide">Clear</button>
-                <button id='cancel-search' data-l10n-id="cancel">Cancel</button>
-              </label>
+           <form id="searchview-container" class="search" role="search">
+              <button id='cancel-search' data-l10n-id="cancel" type="submit">Cancel</button>
+              <p>
+                <label for="search-contact">
+                  <input data-cancelable required type="search" name="search" class="textfield" onfocus='return contacts.List.enterSearchMode();' placeholder="Search" id="search-contact" onkeyup="contacts.List.search()" data-l10n-id="search-contact" />
+                  <button type="reset" onclick="return false;" class="hide">Clear</button>
+                </label>
+              </p>
             </form>
         </section>
       </section>

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -6,6 +6,7 @@
 
     <!-- Buildging Blocks -->
     <link href="/shared/style/headers.css" rel="stylesheet">
+    <link href="/shared/style/input_areas.css" rel="stylesheet">
 
     <link href="/contacts/style/app.css" rel="stylesheet">
     <link href="/contacts/style/contacts.css" rel="stylesheet">
@@ -260,66 +261,56 @@
 
         <!-- PHONE TEMPLATE -->
         <div id='add-phone-#i#' data-template class='phone-template' data-index="#i#">
-          <dl class="setbox fillflow-row">
-            <dt class="setbox-title">
-              <a class='with-arrow' data-taglist='phone-type' name="tel" value="#type#" id="tel_type_#i#" data-field="type">#type#</a>
-              <span role="button" class="icon-arrow icon-arrow-bottom setbox-icon">Expand</span>
-            </dt>
-            <dd class="setbox-body">
+          <fieldset class="fillflow-row">
+            <legend class="action">
+              <span data-taglist='phone-type' name="tel" value="#type#" id="tel_type_#i#" data-field="type">#type#</span>
+            </legend>
+            <section>
               <p class="setbox-item">
-                <label class="hide" for="tel_#i#" data-l10n-id="labelPhoneNumber">Phone number:</label>
                 <input data-cancelable placeholder="Phone" data-field="value" data-l10n-id="tel" name="tel" class="textfield" type="tel" value="#value#" id="number_#i#">
               </p>
               <p class="setbox-item">
-                <label class="hide" for="carrier_#i#" data-l10n-id="labelCarrier">Carrier:</label>
                 <input data-cancelable placeholder="Carrier" data-field="carrier" data-l10n-id="carrier" name="tel" class="textfield" type="text" value="#carrier#" id="carrier_#i#">
               </p>
-            </dd>
-          </dl>
+            </section>
+          </fieldset>
         </div>
 
         <!-- EMAIL TEMPLATE -->
         <div id='add-email-#i#' data-template class='email-template' data-index="#i#">
-          <dl class="setbox fillflow-row">
-            <dt class="setbox-title">
-              <a data-taglist='email-type' name="email" value="#type#" id="email_type_#i#" data-field="type">#type#</a>
-              <span role="button" class="icon-arrow icon-arrow-bottom setbox-icon">Expand</span>
-            </dt>
-            <dd class="setbox-body">
+          <fieldset class="fillflow-row">
+            <legend class="action">
+              <span data-taglist='email-type' name="email" value="#type#" id="email_type_#i#" data-field="type">#type#</span>
+            </legend>
+            <section>
               <p class="setbox-item">
-                <label class="hide" for="email_#i#" data-l10n-id="labelEmail">e-mail:</label>
                 <input data-cancelable placeholder="Email" data-l10n-id="email" name="email" class="textfield" type="email" value="#value#" id="email_#i#">
               </p>
-            </dd>
-          </dl>
+            </section>
+          </fieldset>
         </div>
 
         <!-- ADDRESS TEMPLATE -->
         <div id='add-address-#i#' data-template class='address-template' data-index="#i#">
-          <dl class="setbox fillflow-row">
-            <dt class="setbox-title">
-              <a data-taglist="address-type" name="address" value="#type#" id="address_type_#i#" data-field="type">#type#</a>
-              <span role="button" class="icon-arrow icon-arrow-bottom setbox-icon">Expand</span>
-            </dt>
-            <dd class="setbox-body">
+          <fieldset class="fillflow-row">
+            <legend class="action">
+              <span data-taglist="address-type" name="address" value="#type#" id="address_type_#i#" data-field="type">#type#</span>
+            </legend>
+            <section>
               <p class="setbox-item">
-                <label class="hide" for="streetAddress_#i#" data-l10n-id="labelStreet">Street:</label>
                 <input data-cancelable placeholder="Street" data-field="streetAddress" data-l10n-id="streetAddress" name="address" class="textfield" type="text" value="#streetAddress#" id="streetAddress_#i#">
               </p>
               <p class="setbox-item">
-                <label class="hide" for="postalCode_#i#" data-l10n-id="labelZip">Zip Code:</label>
                 <input data-cancelable placeholder="Zip Code" data-field="postalCode" data-l10n-id="postalCode" name="address" class="textfield" type="text" value="#postalCode#" id="postalCode_#i#">
               </p>
               <p class="setbox-item">
-                <label class="hide" for="locality_#i#" data-l10n-id="labelCity">City:</label>
                 <input data-cancelable placeholder="City" data-field="locality" data-l10n-id="locality" name="address" class="textfield" type="text" value="#locality#" id="locality_#i#">
               </p>
               <p class="setbox-item">
-                <label class="hide" for="countryName_#i#" data-l10n-id="labelCountry">Country:</label>
                 <input data-cancelable placeholder="Country" data-field="countryName" data-l10n-id="countryName" name="address" class="textfield" type="text" value="#countryName#" id="countryName_#i#">
               </p>
-            </dd>
-          </dl>
+            </section>
+          </fieldset>
         </div>
 
         <!-- COMMENTS TEMPLATE -->
@@ -327,8 +318,7 @@
           <dl class="setbox fillflow-row">
             <dd class="setbox-body">
               <p class="setbox-item">
-                <label class="hide" for="note_#i#" data-l10n-id="labelComment">comment:</label>
-                <input data-cancelable placeholder="Comment" data-l10n-id="comment" name="note" class="textfield" type="text" value="#note#" id="note_#i#">
+               <input data-cancelable placeholder="Comment" data-l10n-id="comment" name="note" class="textfield" type="text" value="#note#" id="note_#i#">
               </p>
             </dd>
           </dl>
@@ -339,8 +329,7 @@
           <div class="view-body-inner">
             <form id="contact-form" action="#" class="fill-flow">
               <input name="id" id="contact-form-id" type="hidden" value="">
-              <fieldset class="item first">
-                <legend class="hide" data-l10n-id="legendTitleMain">Main information</legend>
+              <section class="item first">
                 <a id="thumbnail-action" href="#" class="item-media fillflow-media">
                   <p>
                     <span role="button" class="icon-addimage"></span>
@@ -350,61 +339,55 @@
                 </a>
                 <div class="item-body-exp">
                   <p class="fillflow-row">
-                    <label class="hide" for="givenName" data-l10n-id="labelName">Name:</label>
                     <input data-cancelable placeholder="Name" data-l10n-id="givenName" name="givenName" class="textfield" type="text" value="#givenName#" id="givenName">
                   </p>
                   <p class="fillflow-row">
-                    <label class="hide" for="user_lastname" data-l10n-id="labelLastName">Last name:</label>
                     <input data-cancelable placeholder="Last name" data-l10n-id="familyName" name="familyName" class="textfield" type="text" value="#familyName#" id="familyName">
                   </p>
                 </div>
                 <p class="fillflow-row">
                   <input data-cancelable placeholder="Company Name" data-l10n-id="org" name="org" class="textfield" type="text" value="" id="org">
                 </p>
-              </fieldset>
+              </section>
 
-              <fieldset>
-                <legend data-l10n-id="legendPhones">Phone numbers</legend>
+              <section>
                 <div id="contacts-form-phones">
                   <!-- Iterating over phone template here -->
                 </div>
-              </fieldset>
+              </section>
 
               <button data-field-type="tel" id='add-new-phone' class="fillflow-row action action-add">
                 <span role="button" class="icon-add"></span>
                 <b data-l10n-id="addPhone">Add phone number</b>
               </button>
 
-              <fieldset>
-                <legend data-l10n-id="legendEmail">E-mail address</legend>
+              <section>
                 <div id="contacts-form-emails">
                   <!-- Iterating over email template here -->
                 </div>
-              </fieldset>
+              </section>
 
               <button data-field-type="email" id='add-new-email' class="fillflow-row action action-add">
                 <span role="button" class="icon-add"></span>
                 <b data-l10n-id="addEmail">Add email address</b>
               </button>
 
-              <fieldset>
-                <legend data-l10n-id="legendAddress">Address</legend>
+              <section>
                 <div id="contacts-form-addresses">
                   <!-- Iterating over address template here -->
                 </div>
-              </fieldset>
+              </section>
 
               <button data-field-type="adr" id='add-new-address' class="fillflow-row action action-add">
                 <span role="button" class="icon-add"></span>
                 <b data-l10n-id="addAddress">Add new address</b>
               </button>
 
-              <fieldset>
-                <legend data-l10n-id="comments">Comments</legend>
+              <section>
                 <div id="contacts-form-notes">
                   <!-- Iterating over comment template here -->
                 </div>
-              </fieldset>
+              </section>
 
               <button data-field-type="note" id='add-new-note' class="fillflow-row action action-add">
                 <span role="button" class="icon-add"></span>

--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -254,7 +254,7 @@ contacts.Form = (function() {
     }
 
     // Add event listeners
-    var boxTitle = rendered.querySelector('.setbox-title');
+    var boxTitle = rendered.querySelector('legend.action');
     if (boxTitle) {
       boxTitle.addEventListener('mousedown', onGoToSelectTag);
     }

--- a/apps/communications/contacts/js/input_cancel_button.js
+++ b/apps/communications/contacts/js/input_cancel_button.js
@@ -56,12 +56,10 @@ var InputCancelButton = (function inputCancelButton() {
 
     var parentElement = input.parentNode;
     input.classList.add('cancel-button');
-    var cancelButton = document.createElement('button');
-    cancelButton.setAttribute('type', 'reset');
-    var afterInput = input.nextSibling;
-    var newElement = parentElement.insertBefore(cancelButton, afterInput);
+    var clearButton = parentElement.querySelector('[type=reset]');
+    clearButton.classList.remove("hide");
 
-    newElement.addEventListener('mousedown', function removeText() {
+    clearButton.addEventListener('mousedown', function removeText() {
       input.value = '';
       var event = new CustomEvent('cancelInput');
       document.dispatchEvent(event);
@@ -83,7 +81,7 @@ var InputCancelButton = (function inputCancelButton() {
 
     var parentElement = input.parentNode;
     input.classList.remove('cancel-button');
-    parentElement.removeChild(input.nextSibling);
+    parentElement.querySelector('[type=reset]').classList.add("hide");
   };
 
 }());

--- a/apps/communications/contacts/js/input_cancel_button.js
+++ b/apps/communications/contacts/js/input_cancel_button.js
@@ -56,9 +56,8 @@ var InputCancelButton = (function inputCancelButton() {
 
     var parentElement = input.parentNode;
     input.classList.add('cancel-button');
-    var cancelButton = document.createElement('span');
-    cancelButton.className = 'icon-clear';
-    cancelButton.setAttribute('role', 'button');
+    var cancelButton = document.createElement('button');
+    cancelButton.setAttribute('type', 'reset');
     var afterInput = input.nextSibling;
     var newElement = parentElement.insertBefore(cancelButton, afterInput);
 

--- a/apps/communications/contacts/style/app.css
+++ b/apps/communications/contacts/style/app.css
@@ -138,25 +138,6 @@ form {
   margin: 0;
 }
 
-fieldset {
-  margin: 2rem 0 0 0;
-  padding: 0;
-  border: none;
-}
-fieldset.first {
-  margin: 0;
-}
-
-legend {
-  padding: 0;
-  display: block;
-  width: 0;
-  height: 0;
-  overflow: hidden;
-  font: 0/0 a;
-}
-
-
 button {
   height: auto;
   width: auto;
@@ -557,7 +538,7 @@ span[role="button"].icon-arrow.icon-arrow-right {
 
 /* BUTTONS */
 
-.action {
+button.action {
   position: relative;
   display: block;
   width: 100%;
@@ -574,30 +555,30 @@ span[role="button"].icon-arrow.icon-arrow-right {
   background-color: #fff;
 }
 
-.action:hover {
+button.action:hover {
   text-decoration: none;
 }
 
-.action:active {
+button.action:active {
   border-color: #7a7a7a;
 }
 
-.action span[role="button"] {
+button.action span[role="button"] {
   margin-right: 0.5rem;
   margin-left: 0.5rem;
 }
 
-.action b, .action em {
+button.action b, button.action em {
   vertical-align: middle;
   margin: 0 0.5rem;
 }
 
-.action em {
+button.action em {
   color: #727272;
   font-style: normal;
 }
 
-.action b + em, .action span[role="button"] + b {
+button.action b + em, button.action span[role="button"] + b {
   margin-left: 0;
 }
 
@@ -645,121 +626,6 @@ span[role="button"].icon-arrow.icon-arrow-right {
   background: -moz-linear-gradient(bottom, #900010, #c90010);
   border: none;
   padding-left: 0.8rem;
-}
-
-/* FORMS */
-
-/* TEXTFIELD: we use a classname to avoid redefine with type=mail, type=number, type=text, etc...; */
-.textfield {
-  font: 1.3rem/4rem Open Sans, Sans-serif;
-  font-weight: 600;
-  border-radius: 0.3rem;
-  border: solid 1px #c8c8c8;
-  width: 100%;
-  height: 4rem;
-  padding: 0 1rem;
-  -moz-box-sizing: border-box;
-  text-overflow: ellipsis;
-}
-
-input:-moz-placeholder {
-  color: #5b5b5b;
-}
-
-.textfield:focus {
-  border-color: #7a7a7a;
-}
-
-textarea.textfield {
-  line-height: 1.3em;
-  padding-top: 0.8rem;
-  height: 12rem;
-  overflow: auto;
-}
-
-/* SETBOX: used for grouping inputs with data asociations; */
-.setbox {
-  background: #fff; border: solid 1px #c8c8c8; border-radius: 0.3rem; overflow: hidden;
-}
-
-.setbox-title {
-  float: left;
-  display: inline;
-  width: 9.3rem;
-  height: 100%;
-  min-height: 4rem;
-  padding: 0 0.5rem 0 1.4rem;
-  position: relative;
-  -moz-box-sizing: border-box;
-  font-size: 1.2rem;
-  line-height: 1.6rem;
-  text-transform: uppercase;
-}
-
-.setbox-title label {
-  position: relative;
-  display: block;
-}
-
-.setbox-title input {
-  border: none;
-  background: none;
-  display: block;
-  width: 100%;
-  font-size: 1.2rem;
-  line-height: 1.6rem;
-  text-transform: uppercase;
-}
-
-.setbox-title a {
-  color: #333;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  width: 6.8rem;
-}
-
-.setbox-title a, .setbox-title:before, .setbox-title label {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.setbox-title:before {
-  content: "";
-  width: 1px;
-  height: 100%;
-  min-height: 4rem;
-  margin-left: -0.44rem;
-}
-
-.setbox-icon {
-  position: absolute;
-  right: 0.5rem;
-  top: 50%;
-}
-
-.setbox .setbox-icon.icon-arrow[role="button"] {
-  margin-top: -0.2rem;
-}
-
-.setbox-body {
-  display: block;
-  overflow: hidden;
-  border-left: solid 1px #ddd;
-  border-radius: 0 0.3rem 0.3rem 0;
-}
-
-.setbox-item {
-  border-bottom: solid 1px #ddd;
-}
-
-.setbox-item:last-child {
-  border-bottom: none;
-}
-
-.setbox-body .textfield {
-  border: none;
-  border-radius: 0;
-  margin-bottom: 0;
 }
 
 /* FILL FLOW: general components for helping in defining basic flows in forms; */

--- a/apps/communications/contacts/style/contacts.css
+++ b/apps/communications/contacts/style/contacts.css
@@ -122,13 +122,24 @@ section[role="region"] > header:first-child sup {
 }
 
 /* Edit contact section */
-.view-edit-contact fieldset:not(.first) {
+.view-edit-contact form  > section {
+  margin: 2rem 0 0 0;
+  padding: 0;
+  border: none;
+}
+.view-edit-contact form  > section.first {
+  margin: 0;
+}
+
+.view-edit-contact form  > section:not(.first) {
   position: relative;
   margin-right: 3rem;
 }
-.view-edit-contact fieldset div {
+
+.view-edit-contact form  > section div {
   position: relative;
 }
+
 .view-edit-contact .fillflow-row-action {
   width: 5rem;
   height: 5rem;
@@ -139,6 +150,21 @@ hr {
   background-color: #BCBCBC;
   border: 0;
   height: 1px;
+}
+
+/* Overriding Input areas BB */
+form p input + button[type="reset"],
+form p textarea + button[type="reset"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+fieldset legend.action {
+  padding-right: 1rem;
+}
+
+fieldset legend.action:after {
+  right: 1rem;
 }
 
 /* Favorites handling */
@@ -246,10 +272,14 @@ hr {
   opacity: 0.85;
 }
 
-.removed dl, .removed a, .removed input {
+.removed fieldset, .removed legend, .removed input {
   background-color: transparent;
-  color: #cccccc;
+  color: #ccc
   pointer-events: none;
+}
+
+.removed legend.action:after {
+  border-top-color: #666;
 }
 
 .removed button span.icon-delete {

--- a/apps/communications/contacts/style/contacts.css
+++ b/apps/communications/contacts/style/contacts.css
@@ -153,10 +153,11 @@ hr {
 }
 
 /* Overriding Input areas BB */
-form p input + button[type="reset"],
-form p textarea + button[type="reset"] {
-  opacity: 1;
-  pointer-events: auto;
+form p input + button[type="reset"].hide,
+form p textarea + button[type="reset"].hide {
+  display: block!important;
+  opacity: 0;
+  pointer-events: none;
 }
 
 fieldset legend.action {

--- a/apps/communications/contacts/style/input_cancel_button.css
+++ b/apps/communications/contacts/style/input_cancel_button.css
@@ -1,22 +1,11 @@
-span[role="button"].icon-clear {
-  background-image: url(gphx/bitmap/default/vw-header/icons/clear.png);
-  width: 1.7rem;
-  height: 1.7rem;
-  margin-left: -2.7rem;
-}
-
 /* DOMNodeInserted more efficient workaround */
 @keyframes nodeInserted {
   from {
-    clip: rect(1px, auto, auto, auto);
+    /*clip: rect(1px, auto, auto, auto);*/
   }
   to {
-    clip: rect(0px, auto, auto, auto);
+    /*clip: rect(0px, auto, auto, auto);*/
   }
-}
-
-input.cancel-button {
-  padding-right: 3rem;
 }
 
 input[data-cancelable] {

--- a/apps/communications/contacts/style/search.css
+++ b/apps/communications/contacts/style/search.css
@@ -1,31 +1,36 @@
 /* Search */
+.facebook form.search {
+  position: relative;
+  height: 3.5rem;
+}
+
+.facebook form.search input {
+  height: 2.5rem;
+  pointer-events: none;
+  width: 100%
+}
 
 #groups-list {
   padding-top: 2.5rem;
 }
 
-.facebook #groups-list {
-  padding-top: 0;
+.search-hide {
+  display: none;
 }
 
 /* Common search styles */
 form.search {
-  background: url(gphx/bitmap/default/search/searchbar_1x35.png) repeat-x scroll left bottom transparent;
   position: absolute;
   width: 100%;
   -moz-box-sizing: border-box;
   top: 0;
   left: 0;
-  color: #000;
-  font-family: 'Open Sans', Sans-serif;
-  font-size: 1.2rem;
   text-align: left;
   pointer-events: auto;
 }
 
-.facebook form.search {
-  position: relative;
-  height: 3.5rem;
+form.search p {
+  padding: 0;
 }
 
 form.search label {
@@ -36,32 +41,10 @@ form.search label {
 form.search input {
   height: 2.5rem;
   pointer-events: none;
-  width: 100%;
 }
 
-.facebook form.search input {
-  height: 2.5rem;
-  pointer-events: none;
-  width: 100%
-}
-
-form.search button {
-  line-height: 2.5rem;
-  padding: 0 .5rem 0 0;
-  margin-top: -0.5rem;
-  width: 7rem;
-  height: 3.5rem;
-  font-family: 'Open Sans', Sans-serif;
-  font-weight: 600;
-  font-size: 1.2rem;
-  color: #707070;
-  float: right;
-  vertical-align: middle;
-  background: none;
-  border: none;
-  outline: none;
-  white-space: nowrap;
-  cursor: pointer;
+form.search button[type="submit"] {
+  height: 3.3rem;
 }
 
 /* Search view */
@@ -71,40 +54,35 @@ form.search button {
   z-index: 10;
 }
 
-#view-contacts-list.searching #search-view,
-#content.searching #search-view {
+#view-contacts-list.searching #search-view {
   transform: translateX(0);
 }
 
 #search-view form.search label {
-  padding: 0.5rem 0 0.5rem 2.5rem;
+  padding: 0.5rem 1rem 0.5rem 2.5rem;
 }
 
 #search-view form.search input {
   pointer-events: auto;
-  width: 21.5rem;
+  width: 100%;
   box-shadow: none;
 }
 
 /* Searching state */
-#view-contacts-list.searching > header,
-#content.searching > header {
+#view-contacts-list.searching > header {
   transform: scale(0);
   pointer-events: none;
 }
 
-#view-contacts-list.searching .fixed-title,
-#content.searching .fixed-title {
+#view-contacts-list.searching .fixed-title {
   transform: scale(0) !important;
 }
 
-#view-contacts-list.searching .view-jumper,
-#content.searching #shortcuts {
+#view-contacts-list.searching .view-jumper {
   transform: scale(0);
 }
 
-#view-contacts-list.searching #groups-list h2,
-#content.searching #groups-list h2 {
+#view-contacts-list.searching #groups-list h2 {
   display: none;
 }
 
@@ -113,23 +91,8 @@ form.search button {
   margin-top: -5rem;
 }
 
-#content.searching #main {
-  height: 100%;
-  margin-top: -5rem;
-}
-
-#content.searching #mainContent {
-  height: 100%;
-}
-
-#content.searching #select-all-wrapper, #content.searching .friends-msg,
-#content.searching .fixed-title-fb {
-  display: none;
-}
-
 #no-result {
   margin-top: -moz-calc((100% - 0.5rem) / 2);
   text-align: center;
   margin-left: -0.8rem;
-  font-size: 1.4rem;
 }

--- a/apps/communications/contacts/style/search.css
+++ b/apps/communications/contacts/style/search.css
@@ -91,6 +91,20 @@ form.search button[type="submit"] {
   margin-top: -5rem;
 }
 
+#content.searching #main {
+  height: 100%;
+  margin-top: -5rem;
+}
+
+#content.searching #mainContent {
+  height: 100%;
+}
+
+#content.searching #select-all-wrapper, #content.searching .friends-msg,
+#content.searching .fixed-title-fb {
+  display: none;
+}
+
 #no-result {
   margin-top: -moz-calc((100% - 0.5rem) / 2);
   text-align: center;


### PR DESCRIPTION
Applied latest stable Building Block: input_areas in to contact creation/contact edition and search bar.
I've removed the hack for avoiding repaints when showing the clear button, we do not generate ever on the fly the clear buttons, only toggling show/hide.

Maybe we should remove the mousedown event listener when hiding the clear, but that is on your side :D, I've just made the basic implementation.

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=798247

Please @arcturus @albertopq take a look!
