### PR TITLE
add a string for Gallery, correct a string for Camera

### DIFF
--- a/apps/camera/locales/camera.en-US.properties
+++ b/apps/camera/locales/camera.en-US.properties
@@ -1,5 +1,5 @@
 nospace-title = Not enough space on memory card
-nospace-text  = Try freeing up space by deleting old apps and media.
+nospace-text  = Try freeing up space by deleting media.
 
 error-saving-title = Picture not saved
 error-saving-text  = An error prevented Camera from saving the picture.

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -45,3 +45,5 @@ pluggedin-title = Gallery cannot be used while phone is plugged in
 pluggedin-text  = Unplug the phone to browse pictures.
 
 share-noprovider = Cannot share this image file type.
+
+memorycardfull = Cannot edit photos: memory card is full.


### PR DESCRIPTION
I've just landed a patch to fix #3517.  In the process I discovered that I need a new string for Gallery.  I think it is not too late to land this.

Also, the equivalent string in Camera was incorrect.  It suggested freeing space on the sdcard by deleting "old app". But those are never stored on the sdcard, so that wouldn't help.  I've edited the string. 
