### PR TITLE
latin keyboard predictions don't need to be so big

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -1243,6 +1243,11 @@ const IMEController = (function() {
       if (this.suggestionEngines[engineName])
         return;
 
+      // Tell the rendering module which suggestion engine we're using.
+      // Asian suggestion engines need more vertical space than latin ones.
+      // The renderer can use the engine name as a CSS class
+      IMERender.setSuggestionEngineName(engineName);
+
       // We might get a setLanguage call as the engine is loading. Ignore it.
       // We will set the language via init anyway.
       this.suggestionEngines[engineName] = {

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -20,6 +20,8 @@ const IMERender = (function() {
 
   var layoutWidth = 10;
 
+  var suggestionEngineName; // used as a CSS class on the candidatePanel
+
   // Initiaze the render. It needs some business logic to determine:
   //   1- The uppercase for a key object
   //   2- When a key is a special key
@@ -28,6 +30,24 @@ const IMERender = (function() {
     isSpecialKey = keyTest;
     onScroll = scrollHandler;
     this.ime = document.getElementById('keyboard');
+  }
+
+  var setSuggestionEngineName = function(name) {
+    var candidatePanel = document.getElementById('keyboard-candidate-panel');
+    if (candidatePanel) {
+      if (suggestionEngineName)
+        candidatePanel.classList.remove(suggestionEngineName);
+      candidatePanel.classList.add(name);
+    }
+    var togglebutton =
+      document.getElementById('keyboard-candidate-panel-toggle-button');
+    if (togglebutton) {
+      if (suggestionEngineName)
+        togglebutton.classList.remove(suggestionEngineName);
+      toggleButton.classList.add(name);
+    }
+
+    suggestionEngineName = name;
   }
 
   // Accepts three values: true / 'locked' / false
@@ -460,6 +480,8 @@ const IMERender = (function() {
   var candidatePanelCode = function() {
     var candidatePanel = document.createElement('div');
     candidatePanel.id = 'keyboard-candidate-panel';
+    if (suggestionEngineName)
+      candidatePanel.classList.add(suggestionEngineName);
     candidatePanel.addEventListener('scroll', onScroll);
     return candidatePanel;
   };
@@ -468,6 +490,8 @@ const IMERender = (function() {
     var toggleButton = document.createElement('span');
     toggleButton.innerHTML = '⇪';
     toggleButton.id = 'keyboard-candidate-panel-toggle-button';
+    if (suggestionEngineName)
+      toggleButton.classList.add(suggestionEngineName);
     toggleButton.dataset.keycode = -4;
     return toggleButton;
   };
@@ -530,6 +554,7 @@ const IMERender = (function() {
   // Exposing pattern
   return {
     'init': init,
+    'setSuggestionEngineName': setSuggestionEngineName,
     'draw': draw,
     'ime': ime,
     'hideIME': hideIME,

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -535,10 +535,21 @@ background-position: center 2.2rem;
   display: none;
   margin: 0 -1rem 0 -1rem;
 }
+
 #keyboard.candidate-panel #keyboard-candidate-panel {
   display: block;
   width: -moz-calc(100% - 62px + 1rem);
   overflow-y: hidden;
+}
+
+/* for latin suggestions we don't need such a tall box */
+#keyboard-candidate-panel.latin {
+  height: 30px;
+}
+
+/* and in latin we hide the toggle button, so we can be full-width */
+#keyboard.candidate-panel #keyboard-candidate-panel.latin {
+  width: 100%;
 }
 
 #keyboard.full-candidate-panel {
@@ -586,6 +597,16 @@ background-position: center 2.2rem;
   background: -moz-linear-gradient(top, rgb(191,191,183) 10%, rgb(161,158,153) 90%);
 }
 
+#keyboard-candidate-panel.latin span,
+#keyboard-candidate-panel[data-truncated].latin::after {
+  font-family: MozTT;
+  font-size: 12pt;
+  line-height: 30px;
+  height: 30px;
+  width: 33.3%;
+  padding: 0;
+}
+
 #keyboard-candidate-panel-toggle-button {
   border-left: 1px solid #e8e8ff;
   border-right: 1px solid #808098;
@@ -604,6 +625,7 @@ background-position: center 2.2rem;
   display: none;
 }
 
+
 #keyboard.full-candidate-panel #keyboard-candidate-panel-toggle-button {
   display: block;
   border-top: 1px solid #e8e8ff;
@@ -613,6 +635,14 @@ background-position: center 2.2rem;
 
 #keyboard.candidate-panel #keyboard-candidate-panel-toggle-button {
   display: block;
+}
+
+/*
+ * Don't display the toggle button for latin suggestions.
+ * For now, at least, we only ever get 3 at a time 
+ */
+#keyboard.candidate-panel #keyboard-candidate-panel-toggle-button.latin {
+  display: none
 }
 
 #keyboard-candidate-panel span[data-active],


### PR DESCRIPTION
The keyboard suggestion panel is really tall, for displaying asian language characters. But the latin prediction engine displays wide words and doesn't need to be so tall.  This pull request changes the size when the latin prediction engine is in use.

I think it should keep the size the same for asian languages, but I don't know how to test the keyboard with those languages.
