### PR TITLE
Fix wrong placement of header's close button in wallpaper app

### DIFF
--- a/apps/wallpaper/style/wallpaper.css
+++ b/apps/wallpaper/style/wallpaper.css
@@ -34,13 +34,6 @@ html, body {
   height: 50px;
 }
 
-#cancel {
-  position: absolute;
-  left: 0;
-  width: 50%;
-  height: 100%;
-}
-
 #set-wallpaper {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
Fixes this:

![badheader](http://i.imgur.com/t4Rl3.png)
