### PR TITLE
SIM Toolkit - "no available apps" message

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1739,28 +1739,29 @@
       </ul>
     </section>
 
-    <!-- Device :: SIM Toolkit -->
-    <section role="region" id="icc" data-leaf>
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 id="icc-stk-operator-header">SIM Toolkit</h1>
-      </header>
-
-      <ul id="icc-stk-apps">
-      </ul>
-    </section>
-
-    <!-- Device :: SIM Toolkit -->
+    <!-- SIM Toolkit :: Application -->
     <section role="region" id="icc-stk-app" data-leaf>
       <header>
         <button id="icc-stk-app-back"><span data-l10n-id="back" class="icon icon-back">Back</button>
         <menu type="toolbar">
           <button type="submit"><span data-l10n-id="done">Done</span></button>
         </menu>
+        <!-- the title content is filled by icc.js -->
         <h1 id="icc-stk-selection-header">STK Application Name</h1>
       </header>
-
       <ul id="icc-stk-selection">
+        <!-- filled by icc.js -->
+      </ul>
+    </section>
+
+    <!-- SIM Toolkit -->
+    <section role="region" id="icc">
+      <header>
+        <a href="#root"><span class="icon icon-back">back</span></a>
+        <h1 id="icc-stk-operator-header">SIM Toolkit</h1>
+      </header>
+      <ul id="icc-stk-apps">
+        <!-- filled by icc.js -->
       </ul>
     </section>
 
@@ -1898,7 +1899,7 @@
         </li>
       </ul>
 
-      <!-- Main :: STK -->
+      <!-- Main :: SIM Toolkit -->
       <header>
         <h2 data-l10n-id="simToolkit">SIM Toolkit</h2>
       </header>

--- a/apps/settings/js/icc.js
+++ b/apps/settings/js/icc.js
@@ -108,11 +108,13 @@
       }
 
       if (!menu) {
+        var _ = window.navigator.mozL10n.get;
         debug('STK Main App Menu not available.');
         var li = document.createElement('li');
-        var a = document.createElement('a');
-        a.textContent = _('stkAppsNotAvailable');
-        li.appendChild(a);
+        var p = document.createElement('p');
+        p.textContent = _('stkAppsNotAvailable');
+        p.className = 'description';
+        li.appendChild(p);
         iccStkAppsList.appendChild(li);
         return;
       }


### PR DESCRIPTION
see #5139 and #4339

This ensures the SIM Toolkit panel isn’t empty when no STK apps are available on the phone.
