### PR TITLE
Allow shuffling of a list with only two songs

### DIFF
--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -654,7 +654,7 @@ var SubListView = {
     // shuffle the elements of array a in place
     // http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
     function shuffle(a) {
-      for (var i = a.length - 1; i >= 1; i--) {
+      for (var i = a.length - 1; i >= 0; i--) {
         var j = Math.floor(Math.random() * (i + 1));
         if (j < i) {
           var tmp = a[j];


### PR DESCRIPTION
The old shuffling loop left out the last element... as a result, a list of two songs would not shuffle.
Fixed now. 
Maybe #5473 is related...
