### PR TITLE
Disable the startup timer by default.

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -21,7 +21,7 @@ var settings = [
  new Setting("debug.grid.enabled", false),
  new Setting("debug.oop.disabled", false),
  new Setting("debug.fps.enabled", false),
- new Setting("debug.ttl.enabled", true),
+ new Setting("debug.ttl.enabled", false),
  new Setting("debug.log-animations.enabled", false),
  new Setting("debug.paint-flashing.enabled", false),
  new Setting("debug.peformancedata.shared", false),


### PR DESCRIPTION
This is a really cool feature, but non-developers don't care about it.  (The first time I saw it I was quite confused.)
