### PR TITLE
[#5222] Hookup statusbar net activity icon with moznetwork* events

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -229,8 +229,7 @@
         <div id="statusbar-flight-mode" class="sb-icon sb-icon-flight-mode" hidden></div>
         <div id="statusbar-signal" class="sb-icon sb-icon-signal"
           data-level="5" hidden></div>
-        <!-- XXX: this should be real network activity instead of mozbrowserloadstart/end -->
-        <div id="statusbar-loading" class="sb-icon sb-icon-network-activity"></div>
+        <div id="statusbar-network-activity" class="sb-icon sb-icon-network-activity" hidden></div>
         <div id="statusbar-headphones" class="sb-icon sb-icon-headphones" hidden></div>
 
         <!-- Permissions -->

--- a/apps/system/js/popup_manager.js
+++ b/apps/system/js/popup_manager.js
@@ -21,8 +21,6 @@ var PopupManager = {
 
   closeButton: document.getElementById('popup-close'),
 
-  loadingIcon: document.getElementById('statusbar-loading'),
-
   init: function pm_init() {
     this.title = document.getElementById('popup-title');
     window.addEventListener('mozbrowseropenwindow', this);
@@ -34,14 +32,6 @@ var PopupManager = {
     window.addEventListener('keyboardhide', this);
     window.addEventListener('keyboardchange', this);
     this.closeButton.addEventListener('click', this);
-  },
-
-  _showWait: function pm_showWait() {
-    this.loadingIcon.classList.add('popup-loading');
-  },
-
-  _hideWait: function pm_hideWait() {
-    this.loadingIcon.classList.remove('popup-loading');
   },
 
   open: function pm_open(name, frame, origin, trusted) {
@@ -80,8 +70,6 @@ var PopupManager = {
 
     this.screen.classList.add('popup');
 
-    popup.addEventListener('mozbrowserloadend', this);
-    popup.addEventListener('mozbrowserloadstart', this);
     popup.addEventListener('mozbrowserlocationchange', this);
   },
 
@@ -116,26 +104,6 @@ var PopupManager = {
     window.focus();
   },
 
-  // Workaround for Bug: 781452
-  // - when window.open is called mozbrowserloadstart and mozbrowserloadend
-  // are fired two times
-  handleLoadStart: function pm_handleLoadStart(evt) {
-     this._startTimes++;
-     if (this._startTimes > 1) {
-      this._showWait();
-     }
-  },
-
-  // Workaround for Bug: 781452
-  // - when window.open is called mozbrowserloadstart and mozbrowserloadend
-  // are fired two times
-  handleLoadEnd: function pm_handleLoadEnd(evt) {
-      this._endTimes++;
-      if (this._endTimes > 1) {
-        this._hideWait();
-      }
-  },
-
   backHandling: function pm_backHandling() {
     if (!this._currentPopup[this._currentOrigin])
       return;
@@ -156,14 +124,6 @@ var PopupManager = {
     switch (evt.type) {
       case 'click':
         this.backHandling();
-        break;
-      case 'mozbrowserloadstart':
-        this.throbber.classList.add('loading');
-        this.handleLoadStart(evt);
-        break;
-      case 'mozbrowserloadend':
-        this.throbber.classList.remove('loading');
-        this.handleLoadEnd(evt);
         break;
 
       case 'mozbrowserlocationchange':

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -92,7 +92,7 @@ var StatusBar = {
 
     // Listen to 'bluetoothconnectionchange' from bluetooth.js
     window.addEventListener('bluetoothconnectionchange', this);
-    
+
     // Listen to 'moztimechange'
     window.addEventListener('moztimechange', this);
 
@@ -122,7 +122,7 @@ var StatusBar = {
 
       case 'bluetoothconnectionchange':
         this.update.bluetooth.call(this);
-        
+
       case 'moztimechange':
         this.update.time.call(this);
         break;
@@ -149,6 +149,13 @@ var StatusBar = {
             this.update.headphones.call(this);
             break;
         }
+
+        break;
+
+      case 'moznetworkupload':
+      case 'moznetworkdownload':
+        this.update.networkActivity.call(this);
+        break;
     }
   },
 
@@ -179,6 +186,9 @@ var StatusBar = {
           wifiManager.connectionInfoUpdate = (this.update.wifi).bind(this);
         this.update.wifi.call(this);
       }
+
+      window.addEventListener('moznetworkupload', this);
+      window.addEventListener('moznetworkdownload', this);
     } else {
       clearTimeout(this._clockTimer);
 
@@ -194,6 +204,9 @@ var StatusBar = {
         conn.removeEventListener('voicechange', this);
         conn.removeEventListener('datachange', this);
       }
+
+      window.removeEventListener('moznetworkupload', this);
+      window.removeEventListener('moznetworkdownload', this);
     }
   },
 
@@ -263,6 +276,20 @@ var StatusBar = {
       icon.hidden = false;
       icon.dataset.charging = battery.charging;
       icon.dataset.level = Math.floor(battery.level * 10) * 10;
+    },
+
+    networkActivity: function sb_updateNetworkActivity() {
+      // Each time we receive an update, make network activity indicator
+      // show up for 500ms.
+
+      var icon = this.icons.networkActivity;
+
+      clearTimeout(this._networkActivityTimer);
+      icon.hidden = false;
+
+      this._networkActivityTimer = setTimeout(function hideNetActivityIcon() {
+        icon.hidden = true;
+      }, 500);
     },
 
     signal: function sb_updateSignal() {
@@ -469,7 +496,7 @@ var StatusBar = {
   getAllElements: function sb_getAllElements() {
     // ID of elements to create references
     var elements = ['notification', 'time',
-    'battery', 'wifi', 'data', 'flight-mode', 'signal',
+    'battery', 'wifi', 'data', 'flight-mode', 'signal', 'network-activity',
     'tethering', 'alarm', 'bluetooth', 'mute', 'headphones',
     'recording', 'sms', 'geolocation', 'usb', 'label'];
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -65,7 +65,6 @@ var WindowManager = (function() {
   var inlineActivityFrame = null;
 
   // Some document elements we use
-  var loadingIcon = document.getElementById('statusbar-loading');
   var windows = document.getElementById('windows');
   var screenElement = document.getElementById('screen');
   var banner = document.getElementById('system-banner');
@@ -729,9 +728,6 @@ var WindowManager = (function() {
     // Set displayedApp to the new value
     displayedApp = newApp;
 
-    // Update the loading icon since the displayedApp is changed
-    updateLoadingIcon();
-
     // If the app has a attention screen open, displaying it
     AttentionScreen.showForOrigin(newApp);
   }
@@ -1257,59 +1253,6 @@ var WindowManager = (function() {
     var app = runningApps[origin];
     app.frame.reload(true);
   }
-
-  // Update the loading icon on the status bar
-  function updateLoadingIcon() {
-    var origin = displayedApp;
-    // If there aren't any origin, that means we are moving to
-    // the homescreen. Let's hide the icon.
-    if (!origin) {
-      loadingIcon.classList.remove('app-loading');
-      return;
-    }
-
-    // Actually update the icon.
-    // Hide it if the loading property is not true.
-    var app = runningApps[origin];
-
-    if (app.frame.dataset.loading) {
-      loadingIcon.classList.add('app-loading');
-    } else {
-      loadingIcon.classList.remove('app-loading');
-    }
-  };
-
-  // Listen for mozbrowserloadstart to update the loading status
-  // of the frames
-  window.addEventListener('mozbrowserloadstart', function(e) {
-    var dataset = e.target.dataset;
-    // Only update frames open by ourselves
-    if (!('frameType' in dataset) || dataset.frameType !== 'window')
-      return;
-
-    dataset.loading = true;
-
-    // Update the loading icon only if this is the displayed app
-    if (displayedApp == dataset.frameOrigin) {
-      updateLoadingIcon();
-    }
-  });
-
-  // Listen for mozbrowserloadend to update the loading status
-  // of the frames
-  window.addEventListener('mozbrowserloadend', function(e) {
-    var dataset = e.target.dataset;
-    // Only update frames open by ourselves
-    if (!('frameType' in dataset) || dataset.frameType !== 'window')
-      return;
-
-    delete dataset.loading;
-
-    // Update the loading icon only if this is the displayed app
-    if (displayedApp == dataset.frameOrigin) {
-      updateLoadingIcon();
-    }
-  });
 
   // When a resize event occurs, resize the running app, if there is one
   // When the status bar is active it doubles in height so we need a resize

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -24,7 +24,8 @@
     "wifi-manage",
     "wifi",
     "desktop-notification",
-    "idle"
+    "idle",
+    "network-events"
   ],
   "locales": {
     "ar": {

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -61,20 +61,6 @@
   -moz-transform: translateY(20px);
 }
 
-#statusbar-loading {
-  display: none;
-  opacity: 0;
-}
-
-#statusbar-loading.popup-loading, #statusbar-loading.app-loading {
-  display: block;
-
-  /* If mozbrowserloadstart/end happens less than 0.5s,
-  we will not show the icon at all. */
-  -moz-transition: opacity 0.1s ease 0.5s;
-  opacity: 1;
-}
-
 #statusbar-label {
   padding: 0;
   color: #999;

--- a/build/permissions.js
+++ b/build/permissions.js
@@ -16,7 +16,7 @@ let permissionList = ["power", "sms", "contacts", "telephony",
                       "device-storage:pictures", "device-storage:music", "device-storage:videos", "device-storage:apps",
                       "alarms", "alarm", "attention",
                       "content-camera", "camera", "tcp-socket", "bluetooth", "storage", "time", "networkstats-manage",
-                      "idle",
+                      "idle", "network-events",
                       // Just don't.
                       "deprecated-hwvideo"];
 


### PR DESCRIPTION
This patch will make Gaia show/hide the network activity indication according to the received `moznetworkupload` and `moznetworkdownload` events implemented here:

https://bugzilla.mozilla.org/show_bug.cgi?id=795136

**However**, I am not getting any events so far, so landing this effectively disable network indicator icon (until that is fixed).
