### PR TITLE
fix: Handling <select> for settings

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -216,6 +216,7 @@ var Settings = {
       case 'range':
         value = parseFloat(input.value).toFixed(1); // float
         break;
+      case 'select-one':
       case 'radio':
       case 'text':
       case 'password':


### PR DESCRIPTION
Some settings are handled in a <select> but the settings setting call
does not pull the value in this case. This commit fixes the issue by
adding a case 'select-one'.
