### PR TITLE
[Settings] fix css problem on bluetooth and action menu

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -203,21 +203,21 @@ window.addEventListener('localized', function bluetoothSettings(evt) {
         // we only support audio-card device to connect atm
         if (device.icon === 'audio-card') {
           if (device.connected) {
-            this.connectOpt.hidden = true;
-            this.disconnectOpt.hidden = false;
+            this.connectOpt.style.visibility = 'hidden';
+            this.disconnectOpt.style.visibility = 'visible';
             this.disconnectOpt.onclick = function() {
               setDeviceDisconnect(device);
             };
           } else {
-            this.connectOpt.hidden = false;
-            this.disconnectOpt.hidden = true;
+            this.connectOpt.style.visibility = 'visible';
+            this.disconnectOpt.style.visibility = 'hidden';
             this.connectOpt.onclick = function() {
               setDeviceConnect(device);
             };
           }
         } else {
-          this.connectOpt.hidden = true;
-          this.disconnectOpt.hidden = true;
+          this.connectOpt.style.visibility = 'hidden';
+          this.disconnectOpt.style.visibility = 'hidden';
         }
         this.unpairOpt.onclick = function() {
           setDeviceUnpair(device);

--- a/shared/style/action_menu.css
+++ b/shared/style/action_menu.css
@@ -8,7 +8,7 @@ form[role="dialog"] {
     url(action_menu/images/ui/pattern.png) repeat left top,
     url(action_menu/images/ui/gradient.png) no-repeat left top / 100% 100%;
   overflow: hidden;
-  position: absolute;
+  position: fixed;
   z-index: 100;
   top: 0;
   left: 0;


### PR DESCRIPTION
1. Hide some options of a paired device that we don't allow the user to operate.
2. fix action menu position. it should align at the bottom of screen.
