### PR TITLE
Notify when an update is downloaded, add support for update-prompt-apply

### DIFF
--- a/apps/system/js/system_updater.js
+++ b/apps/system/js/system_updater.js
@@ -58,8 +58,6 @@ var SystemUpdater = {
   },
 
   hideStatus: function su_hideStatus() {
-    var _ = navigator.mozL10n.get;
-
     this.updateStatus.classList.remove('displayed');
     this.updateStatus.classList.remove('applying');
 
@@ -67,14 +65,32 @@ var SystemUpdater = {
     progressEl.value = 0;
   },
 
+  showApplyPrompt: function su_showApplyPrompt() {
+    var _ = navigator.mozL10n.get;
+
+    var cancel = {
+      title: _('later'),
+      callback: this.declineInstall.bind(this)
+    };
+
+    var confirm = {
+      title: _('installNow'),
+      callback: this.acceptInstall.bind(this)
+    };
+
+    UtilityTray.hide();
+    CustomDialog.show(_('updateReady'), _('wantToInstall'),
+                      cancel, confirm);
+  },
+
   declineInstall: function su_declineInstall() {
     CustomDialog.hide();
-    this._dispatchEvent('update-downloaded-result', 'wait');
+    this._dispatchEvent('update-prompt-apply-result', 'wait');
   },
 
   acceptInstall: function su_acceptInstall() {
     CustomDialog.hide();
-    this._dispatchEvent('update-downloaded-result', 'restart');
+    this._dispatchEvent('update-prompt-apply-result', 'restart');
   },
 
   handleEvent: function su_handleEvent(evt) {
@@ -95,20 +111,13 @@ var SystemUpdater = {
                                 this.declineDownload.bind(this));
         break;
       case 'update-downloaded':
-        var cancel = {
-          title: _('later'),
-          callback: this.declineInstall.bind(this)
-        };
-
-        var confirm = {
-          title: _('restart'),
-          callback: this.acceptInstall.bind(this)
-        };
-
-        UtilityTray.hide();
         this.hideStatus();
-        CustomDialog.show(_('updateReady'), _('wantToInstall'),
-                          cancel, confirm);
+        NotificationHelper.send(_('updateApplyTitle'), _('updateApplyBody'),
+                                'style/system_updater/images/download.png',
+                                this.showApplyPrompt.bind(this));
+        break;
+      case 'update-prompt-apply':
+        this.showApplyPrompt();
         break;
       case 'update-progress':
         var progress = detail.progress / detail.total;

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -48,16 +48,19 @@ no=Cancel
 
 # system update
 applying=Applying update…
+later=Later
 download=Download
 # Note: don’t do a too litteral translation here ;-)
 getIt=This is where the magic happens…
-later=Later
-restart=Restart
 updateAvailable=System update available
 updateProgress=Downloading system update…
 updateReady=System update ready
 wantToDownload=Download update now?
 wantToInstall=Install update now?
+installNow=Install Now
+
+updateApplyTitle=System update ready to install
+updateApplyBody=Download complete
 
 # screenshots
 screenshotSaved       = Screenshot saved to Gallery

--- a/shared/js/notification_helper.js
+++ b/shared/js/notification_helper.js
@@ -55,7 +55,7 @@ var NotificationHelper = {
     this._referencesArray.push(notification);
   },
   _forget: function nc_forget(notification) {
-    this._referencesArray.splice(referencesArray.indexOf(notification), 1);
+    this._referencesArray.splice(this._referencesArray.indexOf(notification), 1);
   }
 };
 


### PR DESCRIPTION
The "apply" action can now be short-circuited by clicking on the new notification. This improves usability in Gaia when the new idle timeout is added to the updater.

This PR depends on this platform patch landing:
https://bugzilla.mozilla.org/show_bug.cgi?id=740722
