### PR TITLE
[bug gh-1524] week view + hour localization improvements.

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="/style/calendar.css">
   <link rel="stylesheet" type="text/css" href="/style/ui.css">
   <link rel="stylesheet" type="text/css" href="/style/day_views.css">
+  <link rel="stylesheet" type="text/css" href="/style/week_view.css">
   <link rel="stylesheet" type="text/css" href="/style/forms.css">
   <link rel="stylesheet" type="text/css" href="/style/settings.css">
   <link rel="stylesheet" type="text/css" href="/style/overlay.css">
@@ -53,6 +54,7 @@
   <!--- templates -->
   <script defer src="/js/templates/month.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/templates/day.js" type="text/javascript" charset="utf-8"></script>
+  <script defer src="/js/templates/week.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/templates/account.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/templates/calendar.js" type="text/javascript" charset="utf-8"></script>
 
@@ -86,6 +88,8 @@
   <script defer src="/js/views/day_child.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/months_day.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/day.js" type="text/javascript" charset="utf-8"></script>
+  <script defer src="/js/views/week.js" type="text/javascript" charset="utf-8"></script>
+  <script defer src="/js/views/week_child.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/settings.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/advanced_settings.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/views/create_account.js" type="text/javascript" charset="utf-8"></script>
@@ -174,7 +178,8 @@
   </section>
 
   <section id="week-view">
-    [Week] Coming soon...
+    <ol class="sidebar"></ol>
+    <section class="children"></section>
   </section>
 
   <menu id="view-selector">

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -50,10 +50,8 @@ Calendar.App = (function(window) {
         next();
       }
 
-      /* temp views */
-      this.state('/week/', setPath, tempView('#week-view'));
-
       /* routes */
+      this.state('/week/', setPath, 'Week');
       this.state('/day/', setPath, 'Day');
       this.state('/month/', setPath, 'Month', 'MonthsDay');
       this.modifier('/settings/', setPath, 'Settings', { clear: false });

--- a/apps/calendar/js/calc.js
+++ b/apps/calendar/js/calc.js
@@ -6,6 +6,8 @@ Calendar.Calc = (function() {
 
   var Calc = {
 
+    _hourDate: new Date(),
+
     FLOATING: 'floating',
 
     ALLDAY: 'allday',
@@ -37,6 +39,37 @@ Calendar.Calc = (function() {
     get today() {
       //TODO: implement cache
       return new Date();
+    },
+
+    /**
+     * Formats a numeric value for an hour.
+     * Useful to convert absolute hour into
+     * a display hour localizes for am/pm
+     */
+    formatHour: function(hour) {
+      if (hour === Calc.ALLDAY) {
+        return Calc.ALLDAY;
+      }
+
+      var format = navigator.mozL10n.get('hour-format');
+
+      format = format || '%I %p';
+
+      Calc._hourDate.setHours(hour);
+
+      var result = Calendar.App.dateFormat.localeFormat(
+        Calc._hourDate,
+        format
+      );
+
+
+      // remove leading zero
+      // XXX: rethink this?
+      if (result[0] == '0') {
+        result = result.slice(1);
+      }
+
+      return result;
     },
 
     daysInWeek: function() {

--- a/apps/calendar/js/templates/week.js
+++ b/apps/calendar/js/templates/week.js
@@ -1,0 +1,23 @@
+(function(window) {
+  var Week = Calendar.Template.create({
+    header: '<h1 class="date">{value}</h1>',
+
+    sidebarHour: '<li class="hour-{hour}">{displayHour}</li>',
+
+    hour: [
+      '<ol class="hour-{hour} events">',
+        '{items|s}',
+      '</ol>'
+    ].join(''),
+
+    event: [
+      '<li class="event calendar-id-{calendarId}' +
+           'calendar-display calendar-color" data-id="{eventId}">',
+        '{title}',
+      '</li>'
+    ].join('')
+  });
+
+  Calendar.ns('Templates').Week = Week;
+}(this));
+

--- a/apps/calendar/js/views/day.js
+++ b/apps/calendar/js/views/day.js
@@ -20,7 +20,7 @@ Calendar.ns('Views').Day = (function() {
     _initEvents: function() {
       Parent.prototype._initEvents.call(this);
 
-      this.delegate(this.element, 'click', '[data-id]', function(e, target) {
+      this.delegate(this.childContainer, 'click', '[data-id]', function(e, target) {
         Calendar.App.router.show('/event/' + target.dataset.id + '/');
       });
     },

--- a/apps/calendar/js/views/day_child.js
+++ b/apps/calendar/js/views/day_child.js
@@ -7,6 +7,7 @@ Calendar.ns('Views').DayChild = (function() {
     Calendar.Views.DayBased.apply(this, arguments);
 
     this.controller = this.app.timeController;
+    this.hourEventsSelector = template.hourEventsSelector;
   }
 
   Day.prototype = {
@@ -14,6 +15,10 @@ Calendar.ns('Views').DayChild = (function() {
     __proto__: Calendar.Views.DayBased.prototype,
 
     renderAllHours: true,
+
+    hourEventsSelector: null,
+
+    classType: 'day-events',
 
     get element() {
       return this._element;
@@ -154,9 +159,12 @@ Calendar.ns('Views').DayChild = (function() {
       var idx = records.insertIndexOf(busytime._id);
 
       var html = this._renderEvent(event);
-      var eventArea = hour.element.querySelector(
-        template.hourEventsSelector
-      );
+
+      var eventArea = hour.element;
+
+      if (this.hourEventsSelector) {
+        eventArea = eventArea.querySelector(template.hourEventsSelector);
+      }
 
       var el = this._insertElement(
         html, eventArea, records.items, idx
@@ -219,7 +227,7 @@ Calendar.ns('Views').DayChild = (function() {
       var idx = this.hours.insertIndexOf(hour);
 
       var html = template.hour.render({
-        displayHour: this._formatHour(hour),
+        displayHour: Calendar.Calc.formatHour(hour),
         hour: String(hour)
       });
 
@@ -235,24 +243,6 @@ Calendar.ns('Views').DayChild = (function() {
         records: new OrderedMap(),
         flags: []
       };
-    },
-
-    _formatHour: function(hour) {
-      if (hour === Calendar.Calc.ALLDAY) {
-        //XXX: Localize
-        return Calendar.Calc.ALLDAY;
-      }
-
-      newHour = hour;
-      if (hour > 12) {
-        var newHour = (hour - 12) || 12;
-        return String(newHour) + ' pm';
-      } else {
-        if (hour == 0) {
-          hour = 12;
-        }
-        return String(hour) + 'am';
-      }
     },
 
     _renderEvent: function(object) {
@@ -290,7 +280,7 @@ Calendar.ns('Views').DayChild = (function() {
 
       this._eventsElement = el;
       this._element = el;
-      this._eventsElement.classList.add('day-events');
+      this._eventsElement.classList.add(this.classType);
 
       return el;
     },

--- a/apps/calendar/js/views/week.js
+++ b/apps/calendar/js/views/week.js
@@ -1,0 +1,114 @@
+Calendar.ns('Views').Week = (function() {
+
+  var Parent = Calendar.Views.Day;
+  var template = Calendar.Templates.Week;
+
+  function Week() {
+    Parent.apply(this, arguments);
+  }
+
+  Week.prototype = {
+    __proto__: Parent.prototype,
+
+    panThreshold: 50,
+    childThreshold: 3,
+
+    visibleChildren: 5,
+    paddingAfter: 4,
+    paddingBefore: 1,
+    maxChildren: 7,
+
+    scale: 'day',
+
+    selectors: {
+      element: '#week-view',
+      sidebar: '#week-view > .sidebar',
+      container: '#week-view > .children'
+    },
+
+    get sidebar() {
+      return this._findElement('sidebar');
+    },
+
+    get childContainer() {
+      return this._findElement('container');
+    },
+
+    handleEvent: function(e) {
+      Parent.prototype.handleEvent.apply(
+        this, arguments
+      );
+
+      switch (e.type) {
+        case 'selectedDayChange':
+        case 'dayChange':
+          this._activateTime(e.data[0]);
+          this._moveFrames(0);
+          break;
+      }
+    },
+
+    /**
+     * Creates child week view.
+     *
+     * @param {Date} time date.
+     */
+    _createChild: function(time) {
+      return new Calendar.Views.WeekChild({
+        date: time,
+        app: this.app
+      });
+    },
+
+    _appendSidebarHours: function() {
+      var element = this.sidebar;
+      var allday = template.sidebarHour.render({
+        hour: Calendar.Calc.ALLDAY,
+        displayHour: Calendar.Calc.ALLDAY
+      });
+
+      element.insertAdjacentHTML(
+        'beforeend',
+        allday
+      );
+
+      var i = 0;
+      var hour;
+      var displayHour;
+
+      for (; i < 24; i++) {
+        hour = String(i);
+        displayHour = Calendar.Calc.formatHour(i);
+
+        element.insertAdjacentHTML(
+          'beforeend',
+          template.sidebarHour.render({
+            hour: hour,
+            displayHour: displayHour
+          })
+        );
+      }
+    },
+
+    render: function() {
+      this._appendSidebarHours();
+      this._activateTime(
+        this.app.timeController.day
+      );
+    },
+
+    onactive: function() {
+      Parent.prototype.onactive.apply(this, arguments);
+      var width = this.childContainer.offsetWidth;
+      this.viewportSize = width;
+      this.recalculateWidth();
+
+      this._moveFrames(0);
+    }
+  };
+
+  Week.prototype.onfirstseen = Week.prototype.render;
+
+  return Week;
+
+}());

--- a/apps/calendar/js/views/week_child.js
+++ b/apps/calendar/js/views/week_child.js
@@ -1,0 +1,73 @@
+Calendar.ns('Views').WeekChild = (function() {
+
+  var template = Calendar.Templates.Week;
+  var OrderedMap = Calendar.OrderedMap;
+  var _super = Calendar.Views.DayChild.prototype;
+
+  function Week(options) {
+    Calendar.Views.DayChild.apply(this, arguments);
+    this.hourEventsSelector = null;
+  }
+
+  Week.prototype = {
+    __proto__: Calendar.Views.DayChild.prototype,
+
+
+    classType: 'week-events',
+
+    _renderHeader: function() {
+      var format = this.app.dateFormat.localeFormat(
+        this.date,
+        '%a %e'
+      );
+      return template.header.render(format);
+    },
+
+    _renderEvent: function(event) {
+      return template.event.render({
+        calendarId: event.calendarId,
+        eventId: event._id,
+        title: event.remote.title
+      });
+    },
+
+    _insertHour: function(hour) {
+      this.hours.indexOf(hour);
+
+      var len = this.hours.items.length;
+      var idx = this.hours.insertIndexOf(hour);
+
+      var html = template.hour.render({
+        hour: String(hour)
+      });
+
+      var el = this._insertElement(
+        html,
+        this.events,
+        this.hours.items,
+        idx
+      );
+
+      return {
+        element: el,
+        records: new OrderedMap(),
+        flags: []
+      };
+    },
+
+    create: function() {
+      var el = _super.create.apply(this, arguments);
+
+      el.insertAdjacentHTML(
+        'afterbegin',
+        this._renderHeader()
+      );
+
+      return el;
+    }
+
+  };
+
+  return Week;
+
+}(this));

--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -51,3 +51,6 @@ sync-frequency-hourly.textContent=Each hour
 
 alarm-starting={{title}} started {{distance}}
 alarm-started={{title}} starting in {{distance}}
+
+# 24 vs 12 see http://www.cplusplus.com/reference/clibrary/ctime/strftime/
+hour-format=%I %p

--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -91,8 +91,8 @@ ol.link-list a {
 /* temp views */
 
 #week-view {
-  text-align: center;
-  padding-top: 5rem;
+  height: calc(35% - 3.33rem);
+  overflow: hidden;
 }
 
 /* advanced settings */
@@ -221,7 +221,7 @@ body[role="application"] section[role="region"] > header h1 {
 /* sub common: day headers, day boxes */
 
 #month-days {
-  overflow: hidden;
+  overflow: scroll;
 }
 
 #month-view .month li,
@@ -247,6 +247,7 @@ body[role="application"] section[role="region"] > header h1 {
   overflow: hidden;
 }
 
+#week-view .day-header,
 #month-days li {
   height: 2rem;
   color: white;

--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -1,0 +1,111 @@
+#week-view {
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+#week-view h1 {
+  color: white;
+  background-color: #2A2A2A;
+  text-transform: uppercase;
+  font-size: 1.3rem;
+  height: 2rem;
+  padding: 0.5rem 0.5rem;
+  border-right: 1px solid #131314;
+  border-left: 1px solid #515051;
+  font-weight: normal;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+#week-view {
+  counter-reset: week-children;
+  position: relative;
+}
+
+#week-view .sidebar {
+   min-height: 6rem;
+   width: 2rem;
+   color: black;
+   text-align: center;
+   text-transform: uppercase;
+   font-size: 1.3rem;
+   padding: 0.185rem 0;
+   border: 1px solid #131314;
+   border-left: none;
+   border-top: none;
+   float: left;
+   position: relative;
+   top: 1.8rem;
+}
+
+#week-view .sidebar:first-child {
+  border-top: 1px solid #131314;
+}
+
+
+#week-view .sidebar li:last-child {
+  border-bottom: none;
+}
+
+#week-view .sidebar > li {
+  transform: rotate(-90deg);
+  line-height: 120%;
+  width: 6rem;
+  float: left;
+  height: 6.1rem;
+  text-align: right;
+  border-left: 1px solid #CCC;
+  padding: 0.2rem
+  overflow: hidden;
+}
+
+
+#week-view .children {
+  position: relative;
+  height: 100%;
+  float: left;
+  width: calc(100% - 2rem);
+}
+
+#week-view .week-events {
+  display: none;
+  position: absolute;
+  height: 100%;
+  width: 20%;
+  top: 0px;
+}
+
+#week-view .week-events.active {
+  display: block;
+}
+
+#week-view .week-events > ol {
+  border-bottom: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  text-align: center;
+  color: white;
+  font-size: 120%;
+  margin: 1px;
+  height: 6rem;
+  width: 6rem;
+}
+
+#week-view .week-events li {
+  height: 6rem;
+  width: 6rem;
+  height: 100%;
+  margin: 1px;
+  line-height: 120%;
+  font-size: 120%;
+  padding: 0.2rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  position: relative;
+
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255,255,255,0.5) 0%,
+    rgba(255,255,255,0) 60%,
+    rgba(0, 0, 0, 0.2) 100%
+  )
+}

--- a/apps/calendar/test/unit/calc_test.js
+++ b/apps/calendar/test/unit/calc_test.js
@@ -39,6 +39,32 @@ suite('calendar/calc', function() {
     return (date.getTimezoneOffset() * (60 * 1000));
   }
 
+  suite('#formatHour', function() {
+    var realDateFormat;
+    var fmt;
+
+    suiteSetup(function() {
+      realDateFormat = Calendar.App.dateFormat;
+      fmt = navigator.mozL10n.DateTimeFormat();
+      Calendar.App.dateFormat = fmt;
+    });
+
+    suiteTeardown(function() {
+      Calendar.App.dateFormat = realDateFormat;
+    });
+
+    test('7 hours', function() {
+      var result = subject.formatHour(7);
+      assert.equal(result, '7 AM');
+    });
+
+    test('23 hours', function() {
+      var result = subject.formatHour(23);
+      assert.equal(result, '11 PM');
+    });
+
+  });
+
   suite('#spanOfMonth', function() {
 
     function time(year, month, day, hour, min) {

--- a/apps/calendar/test/unit/controllers/alarm_test.js
+++ b/apps/calendar/test/unit/controllers/alarm_test.js
@@ -39,6 +39,10 @@ suite('controllers/alarm', function() {
     );
   });
 
+  teardown(function() {
+    db.close();
+  });
+
 
   suite('#observe', function() {
     var worksQueue;

--- a/apps/calendar/test/unit/templates/week_test.js
+++ b/apps/calendar/test/unit/templates/week_test.js
@@ -1,0 +1,66 @@
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('template.js');
+  requireLib('templates/week.js');
+});
+
+suite('templates/week', function() {
+  var subject;
+
+  suiteSetup(function() {
+    subject = Calendar.Templates.Week;
+  });
+
+  function a() {
+    return '<a></a>';
+  }
+
+  test('#sidebarHour', function() {
+    var result = subject.sidebarHour.render({
+      hour: '5',
+      displayHour: 'foo'
+    });
+
+    assert.ok(result);
+    assert.include(result, 'hour-5');
+    assert.include(result, 'foo');
+  });
+
+  test('#hour', function() {
+    var hour = 'my-hour-5';
+    var result = subject.hour.render({
+      items: a(),
+      hour: hour
+    });
+
+    assert.ok(hour, 'renders');
+    assert.include(result, hour, 'has hour');
+    assert.include(result, a(), 'has link');
+  });
+
+  test('#event', function() {
+    var calId = 'calid';
+    var eventId = 'eventId';
+    var title = 'foo';
+
+    var result = subject.event.render({
+      calendarId: calId,
+      eventId: eventId,
+      title: title
+    });
+
+    assert.ok(result, 'has html');
+
+    assert.include(result, calId, 'has calendarId');
+    assert.include(result, eventId, 'has eventId');
+    assert.include(result, title, 'has title');
+  });
+
+  test('#header', function() {
+    var result = subject.header.render('foo');
+    assert.ok(result);
+    assert.include(result, 'foo');
+  });
+
+});
+
+

--- a/apps/calendar/test/unit/views/day_child_test.js
+++ b/apps/calendar/test/unit/views/day_child_test.js
@@ -354,7 +354,7 @@ suite('views/day_child', function() {
 
     function hourHTML(hour) {
       return template.hour.render({
-        displayHour: subject._formatHour(hour),
+        displayHour: Calendar.Calc.formatHour(hour),
         hour: hour
       });
     }
@@ -458,14 +458,14 @@ suite('views/day_child', function() {
 
     assert.include(
       html,
-      subject._formatHour('allday'),
+      Calendar.Calc.formatHour('allday'),
       'should have all day'
     );
 
     for (; hour < 24; hour++) {
       assert.include(
         html,
-        subject._formatHour(hour),
+        Calendar.Calc.formatHour(hour),
         'should have rendered:' + hour
       );
     }

--- a/apps/calendar/test/unit/views/time_parent_test.js
+++ b/apps/calendar/test/unit/views/time_parent_test.js
@@ -294,6 +294,20 @@ suite('views/time_parent', function() {
     });
   });
 
+  test('#recalculateWidth', function() {
+    subject.viewportSize = 200;
+    subject.visibleChildren = 2;
+    subject.recalculateWidth();
+
+    assert.equal(subject._childWidth, 100, 'width');
+
+    assert.equal(
+      subject._childThreshold,
+      subject._childWidth / subject.childThreshold,
+      'threshold'
+    );
+  });
+
   suite('#purgeChildren', function() {
     var purgeSpan;
     var items;
@@ -562,23 +576,47 @@ suite('views/time_parent', function() {
       assert.length(subject.children, 9);
     });
 
+    suite('#_moveFrames', function() {
+
+      test('while panning', function() {
+        // going into the future...
+        subject._childWidth = 200;
+        subject._moveFrames(-15);
+
+
+        // four frames.
+        // each frame is 200px wide
+        var expected = [
+          -215,
+          -15,
+          185,
+          385
+        ];
+
+        assert.length(subject._activeChildren, 4);
+        expectFrameOffset(expected);
+      });
+
+      test('while not panning', function() {
+        // remove extra padding
+        subject._activeChildren.items.shift();
+        subject._activeChildren.items.pop();
+
+        subject._childWidth = 200;
+        subject._moveFrames(0);
+
+        var expected = [
+          0,
+          200
+        ];
+
+        expectFrameOffset(expected);
+      });
+
+    });
+
     test('#_moveFrames', function() {
-      // going into the future...
-      subject._childWidth = 200;
-      subject._moveFrames(-15);
 
-
-      // four frames.
-      // each frame is 200px wide
-      var expected = [
-        -215,
-        -15,
-        185,
-        385
-      ];
-
-      assert.length(subject._activeChildren, 4);
-      expectFrameOffset(expected);
     });
 
     test('#_unshiftFrame', function() {
@@ -948,5 +986,18 @@ suite('views/time_parent', function() {
 
   });
 
+  suite('multiple children', function() {
+    var start = new Date(2012, 0, 1);
+
+    setup(function() {
+      subject.paddingBefore = 1;
+      subject.visibleChildren = 4;
+      subject.paddingAfter = 5;
+    });
+
+    test('initial render', function() {
+      subject._activateTime(start);
+    });
+  });
 
 });

--- a/apps/calendar/test/unit/views/week_child_test.js
+++ b/apps/calendar/test/unit/views/week_child_test.js
@@ -1,0 +1,69 @@
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('timespan.js');
+  requireLib('ordered_map.js');
+  requireLib('templates/day.js');
+  requireLib('templates/week.js');
+  requireLib('views/day_based.js');
+  requireLib('views/day_child.js');
+  requireLib('views/week_child.js');
+});
+
+suite('views/day_child', function() {
+  var subject;
+  var app;
+  var controller;
+  var events;
+  var template;
+  var viewDate = new Date(2012, 1, 15);
+
+  setup(function() {
+    app = testSupport.calendar.app();
+    controller = app.timeController;
+    events = app.store('Event');
+
+    subject = new Calendar.Views.WeekChild({
+      app: app,
+      date: viewDate
+    });
+
+    template = Calendar.Templates.Day;
+  });
+
+  test('initialization', function() {
+    assert.equal(subject.controller, controller);
+    assert.instanceOf(subject, Calendar.Views.DayChild);
+  });
+
+  test('#_renderEvent', function() {
+    var data = Factory('event', {
+      remote: {
+        title: 'UX'
+      }
+    });
+
+    var result = subject._renderEvent(data);
+    assert.ok(result);
+
+    assert.include(result, 'UX');
+  });
+
+  test('#_renderHeader', function() {
+    var format = app.dateFormat.localeFormat(
+      subject.date,
+      '%a %e'
+    );
+
+    var out = subject._renderHeader();
+    assert.ok(out, 'html');
+    assert.include(out, format, 'has format');
+  });
+
+  test('#create', function() {
+    var element = subject.create();
+    var html = element.innerHTML;
+    assert.ok(html);
+    assert.include(html, subject._renderHeader());
+  });
+
+});
+

--- a/apps/calendar/test/unit/views/week_test.js
+++ b/apps/calendar/test/unit/views/week_test.js
@@ -1,0 +1,133 @@
+requireCommon('test/synthetic_gestures.js');
+
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('ordered_map.js');
+  requireLib('timespan.js');
+  requireLib('templates/day.js');
+  requireLib('templates/week.js');
+  requireLib('views/time_parent.js');
+  requireLib('views/day_based.js');
+  requireLib('views/day_child.js');
+  requireLib('views/week_child.js');
+  requireLib('views/day.js');
+  requireLib('views/week.js');
+});
+
+suite('views/day', function() {
+  var subject,
+      app,
+      controller,
+      busytimes,
+      triggerEvent;
+
+
+  suiteSetup(function() {
+    triggerEvent = testSupport.calendar.triggerEvent;
+  });
+
+  teardown(function() {
+    var el = document.getElementById('test');
+    el.parentNode.removeChild(el);
+  });
+
+  setup(function() {
+    var div = document.createElement('div');
+    div.id = 'test';
+    div.innerHTML = [
+      '<div id="week-view">',
+        '<section class="sidebar">a</section>',
+        '<section class="children">a</section>',
+      '</div>'
+    ].join('');
+
+    document.body.appendChild(div);
+
+    app = testSupport.calendar.app();
+    controller = app.timeController;
+    controller.move(new Date());
+
+    subject = new Calendar.Views.Week({
+      app: app
+    });
+
+  });
+
+  test('#initialize', function() {
+    assert.instanceOf(subject, Calendar.Views.Day);
+  });
+
+  test('#element', function() {
+    assert.equal(
+      subject.element.id,
+      'week-view'
+    );
+  });
+
+  test('#childContainer', function() {
+    assert.ok(subject.childContainer);
+  });
+
+  test('#sidebar', function() {
+    assert.ok(subject.sidebar);
+  });
+
+  test('#_createChild', function() {
+    var time = new Date();
+    var child = subject._createChild(time);
+
+    assert.equal(child.date, time);
+    assert.equal(child.app, app);
+    assert.instanceOf(
+      child, Calendar.Views.WeekChild
+    );
+  });
+
+  test('#onfirstseen', function() {
+    assert.equal(subject.onfirstseen, subject.render);
+  });
+
+  test('#onactive', function() {
+    subject.onactive();
+
+    var frames = [];
+    var container = subject.childContainer.children;
+    var i = 0;
+    var len = container.length;
+    var key;
+
+    for (; i < len; i++) {
+      // gather all active children
+      if (container[i].classList.contains('active')) {
+        frames.push(container[i].style.transform);
+      }
+    }
+
+    // verify that we have positioned them.
+    assert.length(
+      frames, subject.visibleChildren
+    );
+  });
+
+  suite('#render', function() {
+    setup(function() {
+      subject.render();
+    });
+
+    test('#_appendSidebarHours', function() {
+      var html = subject.sidebar.outerHTML;
+      assert.ok(html, 'has contents');
+
+      assert.include(html, Calendar.Calc.ALLDAY);
+
+      var i = 0;
+      for (; i < 24; i++) {
+        assert.include(html, i, 'has hour #' + i);
+        assert.include(
+          html, Calendar.Calc.formatHour(i),
+          'has display hour #' + i
+        );
+      }
+    });
+  });
+
+});


### PR DESCRIPTION
Update week view PR
## includes

localized 24 hour (everywhere not just week view)
5 day week pages by day
event hookup to week view.
closely (but not completely) conforms to visuals.
unit tests
## missing

Grouping "all day" events at top always.
Start week view at current hour.?
## Bugs

The vertical scrolling issues are present here too.
