### PR TITLE
Fixed text-align style after last gaia commit

### DIFF
--- a/apps/homescreen/everything.me/css/common.css
+++ b/apps/homescreen/everything.me/css/common.css
@@ -1,10 +1,4 @@
 #evmeContainer {
-    font: normal 12px 'Open Sans', Sans-Serif;
-}
-#evmeContainer fieldset {
-    border-width: 0;
-}
-#evmeContainer {
     position: fixed;
     overflow: hidden;
     margin: 0;
@@ -15,10 +9,15 @@
     height: 100%;
     background: transparent;
     background-size: 100% 100%;
+    font: normal 12px 'Open Sans', Sans-Serif;
+    text-align: left;
 }
 #evmeContainer * {
     margin: 0;
     padding: 0;
+}
+#evmeContainer fieldset {
+    border-width: 0;
 }
 #evmeContainer a {
     text-decoration: none;


### PR DESCRIPTION
After the last grid.css text-align styling change https://github.com/ranbena/gaia/blob/embedded3/apps/homescreen/style/grid.css#L12
Had to change value back to "left"  in Evme style.

Affects Evme only.
