### PR TITLE
Bug 797235 -  apps/settings/index.html includes icc.js twice

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -38,7 +38,6 @@
     <script type="application/javascript" defer src="js/wallpaper.js"></script>
     <script type="application/javascript" defer src="js/battery.js"></script>
     <script type="application/javascript" defer src="js/storage.js"></script>
-    <script type="application/javascript" defer src="js/icc.js"></script>
     <script type="application/javascript" defer src="js/app_storage.js"></script>
     <script type="application/javascript" defer src="js/date_time.js"></script>
     <script type="application/javascript" defer src="js/sound.js"></script>


### PR DESCRIPTION
Bug 797235 -  apps/settings/index.html includes icc.js twice
https://bugzilla.mozilla.org/show_bug.cgi?id=797235
