### PR TITLE
fix bug 797161

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -150,6 +150,7 @@ const IMERender = (function() {
         candidatePanelToggleButtonCode(), this.ime.firstChild);
       this.ime.insertBefore(candidatePanelCode(), this.ime.firstChild);
       this.ime.insertBefore(pendingSymbolPanelCode(), this.ime.firstChild);
+      this.ime.classList.add('candidate-panel');
       showPendingSymbols('');
       showCandidates([], true);
     }
@@ -237,16 +238,6 @@ const IMERender = (function() {
 
     if (candidatePanel) {
       candidatePanel.innerHTML = '';
-
-      if (!candidates.length) {
-        ime.classList.remove('candidate-panel');
-        ime.classList.remove('full-candidate-panel');
-        return;
-      }
-
-      if (!isFullView) {
-        ime.classList.add('candidate-panel');
-      }
 
       candidatePanel.scrollTop = candidatePanel.scrollLeft = 0;
 


### PR DESCRIPTION
modify apps/keyboard/js/render.js so that if there is a suggestion engine, the keyboard suggestion area is always displayed, even when it is empty.
