### PR TITLE
[Ev.me] Fixed helper horizontal scrolling

### DIFF
--- a/apps/homescreen/everything.me/js/external/iscroll.js
+++ b/apps/homescreen/everything.me/js/external/iscroll.js
@@ -183,6 +183,10 @@ iScroll.prototype = {
         if (that.options.onBeforeScrollStart) that.options.onBeforeScrollStart.call(that, e);
         
         if (that.options.useTransition) that._transitionTime(0);
+
+        if (that.hScroll) {
+            e.preventDefault();
+        }
         
         that.moved = false;
         that.animating = false;


### PR DESCRIPTION
The fix is to prevent page move while scrolling the helper horizontally.
(the helper is the suggestion list under the searchbar)

Only Evme files are affected.
