### PR TITLE
Bug 796543 - only autocapitialize the first letter in empty textarea elements

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -43,6 +43,7 @@ const IMEController = (function() {
   var _currentLayoutMode = LAYOUT_MODE_DEFAULT;
   var _currentKey = null;
   var _realInputType = null;
+  var _elementIsEmpty = false;
   var _currentInputType = null;
   var _menuLockedArea = null;
   var _lastHeight = 0;
@@ -1032,7 +1033,7 @@ const IMEController = (function() {
   // Turn to default values
   function _reset() {
     _currentLayoutMode = LAYOUT_MODE_DEFAULT;
-    _isUpperCase = _requireAutoCapitalize();
+    _isUpperCase = _elementIsEmpty && _realInputType === 'textarea';
     _isUpperCaseLocked = false;
     _lastKeyCode = 0;
 
@@ -1121,11 +1122,12 @@ const IMEController = (function() {
     uninit: _uninit,
 
     // Show IME, receives the input's type
-    showIME: function kc_showIME(type) {
+    showIME: function kc_showIME(type, isEmpty) {
       delete IMERender.ime.dataset.hidden;
       IMERender.ime.classList.remove('hide');
 
       _realInputType = type;
+      _elementIsEmpty = isEmpty || false;
       _currentInputType = _mapType(type);
       _reset();
 

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -19,6 +19,8 @@ if (!window.navigator.mozKeyboard) {
     var typeToSkip = ['select-one', 'select-multiple', 'date',
                       'time', 'datetime', 'datetime-local'];
     var type = evt.detail.type;
+    var value = evt.detail.value;
+
     // Skip the <select> element and inputs with type of date/time,
     // handled in system app for now
     // Also workaround an issue that type might be empty
@@ -30,7 +32,8 @@ if (!window.navigator.mozKeyboard) {
       if (type === 'blur') {
         IMEController.hideIME();
       } else {
-        IMEController.showIME(type);
+        var isEmpty = !value || value.length === 0;
+        IMEController.showIME(type, isEmpty);
       }
     }, focusChangeDelay);
   };


### PR DESCRIPTION
This pull request is a proposed fix for https://bugzilla.mozilla.org/show_bug.cgi?id=796543
