### PR TITLE
Bug 796189 - [Homescreen] Can't edit the text fields on the Add to Home ...

### DIFF
--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -36,7 +36,11 @@ html, body {
 }
 
 * {
-  -moz-user-select:none;
+  -moz-user-select: -moz-none;
+}
+
+input {
+  -moz-user-select: text;
 }
 
 section,footer,nav,a,img {


### PR DESCRIPTION
...Screen UI

https://bugzilla.mozilla.org/show_bug.cgi?id=796189
This issue that we could not change the value of an input field is because the input field was set as unselectable by `-moz-user-select: none;`.
