### PR TITLE
[Browser] Fix media query for when keyboard shown, closes bug 796186

### DIFF
--- a/apps/browser/style/browser.css
+++ b/apps/browser/style/browser.css
@@ -233,7 +233,6 @@ input[type="image"] {
 }
 
 #toolbar-end {
-  border-top: solid 2px #a6b3bb;
   display: none;
   position: absolute;
   bottom: 0;
@@ -705,7 +704,7 @@ li[role="listitem"] small {
 }
 
 .awesome-screen #frames {
-  height: calc(100% - 50px);
+  bottom: 0;
 }
 
 .awesome-screen #tabs-badge {
@@ -1036,9 +1035,11 @@ li[role="listitem"] small {
 @media (device-height: 480px) and (max-height: 450px),
        (device-height: 320px) and (max-height: 290px) {
   .page-screen #toolbar-end { display: none; }
+  .page-screen #frames { bottom: 0; }
 }
 /* For the Galaxy SII, 640x480 */
 @media (device-height: 480px) and (max-height: 450px),
        (device-height: 640px) and (max-height: 610px) {
   .page-screen #toolbar-end { display: none; }
+  .page-screen #frames { bottom: 0; }
 }


### PR DESCRIPTION
This used to be taken care of automatically by -moz-box-flex but that's not used any more.

Can't be 100% sure this fixes the bug completely until https://bugzilla.mozilla.org/show_bug.cgi?id=797406 is fixed too
