### PR TITLE
[Bug 795184] Browser app needs to set "mozallowfullscreen" on browser tabs

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1101,6 +1101,7 @@ var Browser = {
     if (!iframe) {
       iframe = document.createElement('iframe');
       iframe.mozbrowser = true;
+      iframe.setAttribute('mozallowfullscreen', true);
 
       if (url) {
         iframe.setAttribute('src', url);


### PR DESCRIPTION
Gecko bug 795184, the Gaia browser app needs to set the "mozallowfullscreen" attribute on the tabs it creates, otherwise web content won't be able to enter fullscreen once the gecko part of bug 795184 lands.

Unfortunately we don't have tests for fullscreen on B2G/Gaia yet, so this doesn't have any tests. I'm going to add tests in gecko bug 775967, once I figure out how to get the tests to work and test the permission model...
