### PR TITLE
Bug 798227 - "All Day Event" checkbox. Small create event improvements.

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -22,6 +22,7 @@
   <!--- shared styles -->
   <link rel="stylesheet" type="text/css" href="/shared/style/buttons.css" />
   <link rel="stylesheet" type="text/css" href="/shared/style/confirm.css" />
+  <link rel="stylesheet" type="text/css" href="/shared/style/switches.css" />
 
   <!--- shared scripts -->
   <script src="/shared/js/l10n.js" type="text/javascript" charset="utf-8"></script>
@@ -293,6 +294,14 @@
 
       <li class="location">
         <input name="location" data-l10n-id="event-location" placeholder="Where?" />
+      </li>
+
+      <li class="allday">
+        <label>
+          <input name="allday" type="checkbox" />
+          <span></span>
+        </label>
+        <a data-l10n-id="event-is-allday">All Day Event?</a>
       </li>
 
       <li class="start-date">

--- a/apps/calendar/js/controllers/time.js
+++ b/apps/calendar/js/controllers/time.js
@@ -93,6 +93,14 @@ Calendar.ns('Controllers').Time = (function() {
       return this._mostRecentDayType;
     },
 
+    get mostRecentDay() {
+      if (this.mostRecentDayType === 'selectedDay') {
+        return this.selectedDay;
+      } else {
+        return this.position;
+      }
+    },
+
     get timespan() {
       return this._timespan;
     },

--- a/apps/calendar/js/input_parser.js
+++ b/apps/calendar/js/input_parser.js
@@ -22,6 +22,10 @@ Calendar.InputParser = (function() {
         seconds: 0
       };
 
+      if (typeof(value) !== 'string') {
+        return result;
+      }
+
       var parts = value.split(':');
       var part;
       var partName;

--- a/apps/calendar/js/models/event.js
+++ b/apps/calendar/js/models/event.js
@@ -61,6 +61,25 @@ Calendar.ns('Models').Event = (function() {
       this.remote.startDate = value;
     },
 
+    /**
+     * Checks if date object only contains date information (not time).
+     *
+     * Exampe:
+     *
+     *    var time = new Date(2012, 0, 1, 1);
+     *    this._isOnlyDate(time); // false
+     *
+     *    var time = new Date(2012, 0, 1);
+     *    this._isOnlyDate(time); // true
+     *
+     * @return {Boolean} see above.
+     */
+    _isOnlyDate: function(date) {
+      return (!date.getHours() &&
+              !date.getMinutes() &&
+              !date.getSeconds());
+    },
+
     /* end date */
 
     get endDate() {
@@ -76,6 +95,14 @@ Calendar.ns('Models').Event = (function() {
 
       this.remote.end = time;
       this.remote.endDate = value;
+    },
+
+    get isAllDay() {
+      var start = this.remote.startDate;
+      var end = this.remote.endDate;
+
+      return (this._isOnlyDate(start) &&
+              this._isOnlyDate(end));
     },
 
     /* associated records */

--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -54,6 +54,7 @@ event-title.placeholder=Title
 event-location.placeholder=Where?
 event-description.placeholder=Notes
 
+event-is-allday=All Day Event?
 event-start-date.placeholder=Start Date
 event-end-date.placeholder=End Date
 event-start-time.placeholder=Start Time

--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -119,6 +119,13 @@ body[data-path^='/settings'] #time-views {
   display: block;
 }
 
+
+#settings .calendars > li label {
+  text-transform: none;
+  font: inherit;
+  text-transform: none;
+}
+
 #settings .calendars input[type="checkbox"] {
  display: none;
 }
@@ -134,4 +141,9 @@ body[data-path^='/settings'] #time-views {
   width: 14px;
   height: 14px;
   float: right;
+  position: static;
+  background: transparent;
+  left: inherit;
+  top: inherit;
+  margin: 0;
 }

--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -130,6 +130,7 @@ ol.link-list a {
 
 #advanced-settings-view .settings-list label,
 #advanced-settings-view .account-list a {
+  text-transform: none;
   padding-right: 4rem;
   overflow: hidden;
   white-space: nowrap;
@@ -179,6 +180,29 @@ ol.link-list a {
 
 #modify-event-view form ol li {
   margin: 0rem;
+}
+
+#modify-event-view li.allday {
+  padding: 1rem;
+  position: relative;
+}
+
+#modify-event-view li.allday > label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+#modify-event-view li.allday > label > span {
+  left: auto;
+  right: 1rem;
+}
+
+#modify-event-view.allday .start-time,
+#modify-event-view.allday .end-time {
+  visibility: hidden;
 }
 
 #modify-event-view.update .calendar-id {

--- a/apps/calendar/test/unit/controllers/time_test.js
+++ b/apps/calendar/test/unit/controllers/time_test.js
@@ -73,6 +73,12 @@ suite('controller', function() {
 
       subject.selectedDay = new Date(2012, 1, 5);
 
+      assert.deepEqual(
+        subject.mostRecentDay,
+        subject.selectedDay,
+        'mostRecentDay - selected day'
+      );
+
       assert.equal(
         type(),
         'selectedDay',
@@ -84,6 +90,12 @@ suite('controller', function() {
       assert.equal(
         type(), 'day',
         'move - sets most recent type'
+      );
+
+      assert.deepEqual(
+        subject.mostRecentDay,
+        subject.position,
+        'mostRecentDay - day'
       );
 
       // back & forth

--- a/apps/calendar/test/unit/models/event_test.js
+++ b/apps/calendar/test/unit/models/event_test.js
@@ -113,7 +113,41 @@ suite('models/event', function() {
         '.start'
       );
     });
+  });
 
+  suite('#isAllDay', function() {
+    setup(function() {
+      subject.startDate = new Date(
+        2012, 0, 1, 1, 1
+      );
+
+      subject.endDate = new Date(
+        2012, 0, 1, 2, 2
+      );
+    });
+
+    test('start 00:00:00', function() {
+      subject.startDate.setMinutes(0);
+      subject.startDate.setHours(0);
+      assert.isFalse(subject.isAllDay);
+    });
+
+    test('end 00:00:00', function() {
+      subject.endDate.setMinutes(0);
+      subject.endDate.setHours(0);
+      assert.isFalse(subject.isAllDay);
+    });
+
+    test('both at 00:00:00', function() {
+      // reset end
+      subject.endDate.setHours(0);
+      subject.endDate.setMinutes(0);
+      // reset start
+      subject.startDate.setHours(0);
+      subject.startDate.setMinutes(0);
+
+      assert.isTrue(subject.isAllDay);
+    });
   });
 
   test('#calendarId', function() {


### PR DESCRIPTION
In addition to the spec'ed behavior of all day event checkbox, the currently selected time in the calendar is used for the initial start/end date when creating a new event if it occurs in the future.

The changes needed for the above also closely relate to the groundwork for "tap to create an event at this time"
