### PR TITLE
[WiFi] Identity is only required by WPA-EAP

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -212,6 +212,12 @@ label[for="show-pwd"] {
 
 /* hide identifier field on non-EAP networks */
 
+section li.identity,
+section.WEP li.identity,
+section.WPA-PSK li.identity {
+  display: none;
+}
+
 section.WPA-EAP li.identity {
   display: block;
 }


### PR DESCRIPTION
Identity is only required by WPA-EAP. So hide it on other security method.
