### PR TITLE
bug 800919: [WiFi] use oninput instead of onchange for PIN input event

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -294,7 +294,7 @@ window.addEventListener('localized', function wifiSettings(evt) {
       var pinItem = document.getElementById('wifi-wps-pin-area');
       var pinDesc = pinItem.querySelector('p');
       var pinInput = pinItem.querySelector('input');
-      pinInput.onchange = function() {
+      pinInput.oninput = function() {
         submitWpsButton.disabled = !isValidWpsPin(pinInput.value);
       }
 


### PR DESCRIPTION
When using oninput, we can see OK button enabled/disabled result after screen keyboard disappeared. When using onchange, we can see it just after key input.
