### PR TITLE
[WiFi] WEP key length should be 5 or 13

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -653,7 +653,8 @@ window.addEventListener('localized', function wifiSettings(evt) {
             case 'WPA-EAP':
               disabled = disabled || (identity && identity.value.length < 1);
             case 'WEP':
-              disabled = disabled || (password && password.value.length < 1);
+              disabled = disabled || (password && password.value.length != 5 &&
+                password.value.length != 13);
               break;
           }
           dialog.querySelector('button[type=submit]').disabled = disabled;


### PR DESCRIPTION
In theory, WEP key length should be 5, 13 or 16. But in practice there is not so much station that supports 16bytes WEP key.
