### PR TITLE
Bug 799037 - basic integration tests for calendar.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,9 +340,16 @@ INJECTED_GAIA = "$(MOZ_TESTS)/browser/gaia"
 
 TEST_PATH=gaia/tests/${TEST_FILE}
 
-TESTS := $(shell find apps -name "*_test.js" -type f | grep integration)
+ifneq ($(TESTS), '')
+	ifneq ($(APP), '')
+		TESTS=$(shell find apps/$(APP)/test/integration/ -name "*_test.js" -type f )
+	else
+		TESTS=$(shell find apps -name "*_test.js" -type f | grep integration)
+	endif
+endif
 .PHONY: test-integration
 test-integration:
+	echo $(TESTS)
 	@test_apps/test-agent/common/test/bin/test $(TESTS)
 
 .PHONY: tests

--- a/apps/calendar/test/integration/app.js
+++ b/apps/calendar/test/integration/app.js
@@ -1,0 +1,329 @@
+function CalendarIntegration(device) {
+  this.device = device;
+  this.defaultCallback = device.defaultCallback;
+}
+
+CalendarIntegration.prototype = {
+  appName: 'Calendar',
+
+  origin: null,
+
+  src: null,
+
+  name: null,
+
+  frame: null,
+
+  /** selector tables */
+
+  selectors: {
+    /** views */
+    settingsView: '#settings',
+    monthView: '#month-view',
+    monthsDayView: '#months-day-view',
+    weekView: '#week-view',
+    dayView: '#day-view',
+    modifyEventView: '#modify-event-view',
+
+    /** buttons */
+    showSettingsBtn: '#time-header button.settings',
+    addEventBtn: '#time-header a[href="/add/"]',
+    eventSaveBtn: '#modify-event-view > header .save',
+
+    /** lists */
+    calendarList: '#settings .calendars',
+
+    /** forms */
+    eventForm: '#modify-event-view > form',
+    eventFormFields: '#modify-event-view form [name]',
+
+    /** generic */
+    present: '.present'
+  },
+
+  task: function(generator, callback) {
+    callback = (callback || this.defaultCallback);
+    var instance;
+
+    function next(err, value) {
+      if (err) {
+        instance.close();
+        callback(err, null);
+      } else {
+        try {
+          instance.send(value);
+        } catch (e) {
+          if (!(e instanceof StopIteration)) {
+            throw e;
+          }
+        }
+      }
+    }
+
+    // ugly but awesome hack
+    var app = Object.create(this);
+    app.defaultCallback = next;
+    app.device = Object.create(app.device);
+    app.device.defaultCallback = next;
+
+    var instance = generator(app, next, callback);
+    instance.next();
+  },
+
+  /**
+   * Deletes the calendar database and closes the app.
+   */
+  close: function(callback) {
+    var self = this;
+
+    this.task(function(app, next, done) {
+      var device = app.device;
+
+      yield device.executeScript(function() {
+        window.wrappedJSObject.Calendar.App.db.deleteDatabase(function() {
+        });
+      });
+
+      yield device.switchToFrame();
+
+      yield device.executeScript(function(app) {
+        window.wrappedJSObject.WindowManager.kill(app);
+      }, [self.origin]);
+
+      done();
+
+    }, callback);
+  },
+
+  /**
+   * Launch calendar application and focus on its frame.
+   */
+  launch: function(callback) {
+    var self = this;
+
+    this.task(function(app, next, done) {
+      var device = app.device;
+
+      yield IntegrationHelper.sendAtom(
+        device,
+        '/apps/calendar/test/integration/atoms/gaia_unlock',
+        true,
+        next
+      );
+
+      var result = yield device.executeAsyncScript(
+        'launchAppWithName("' + self.appName + '")'
+      );
+
+      yield device.switchToFrame(result.frame);
+
+      self.origin = result.origin;
+      self.src = result.src;
+      self.name = result.name;
+      self.frame = result.frame;
+
+      done(null, self);
+
+    }, callback);
+  },
+
+  /**
+   * Wait until element condition is met.
+   */
+  waitUntilElement: function(element, method, callback) {
+    this.waitFor(element[method].bind(element), 3000, callback);
+  },
+
+  /**
+   * Fired callback when condition is true or after
+   * it has timed out.
+   */
+  waitFor: function(test, timeout, callback) {
+    IntegrationHelper.waitFor(test, timeout, callback || this.defaultCallback);
+  },
+
+  /**
+   * Finds a named selector.
+   *
+   * @param {String} name aliased css selector.
+   * @return {String} css selector.
+   */
+  selector: function(name) {
+    var selector;
+    if (!(name in this.selectors)) {
+      throw new Error('unknown element "' + name + '"');
+    }
+
+    return this.selectors[name];
+  },
+
+  /**
+   * Finds a group of elements based on named selector.
+   * (see .selectors)
+   *
+   * @param {String} name selector alias.
+   * @param {Function} [callback] uses driver by default.
+   */
+  elements: function(name, callback) {
+    this.device.findElements(this.selector(name), callback);
+  },
+
+  /**
+   * Returns the current remote time in MS
+   *
+   *    var time = yield app.remoteTime();
+   *    var date = new Date(time);
+   */
+  remoteTime: function(callback) {
+    this.task(function(app, next, done) {
+      var ms = yield app.device.executeScript(function() {
+        return Date.now();
+      });
+
+      done(null, ms);
+    }, callback);
+  },
+
+  remoteDate: function(date, callback) {
+    callback = (callback || this.defaultCallback);
+
+    this.remoteDateObject(date, function(err, result) {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      callback(null, new Date(
+        result.year,
+        result.month,
+        result.date,
+        result.hours,
+        result.minutes,
+        result.seconds
+      ));
+    });
+  },
+
+  /**
+   * Given a date object returns an object with
+   * date information relative to the remote runtime.
+   *
+   *    var result = yield app.deviceDate(new Date());
+   *    // { year: .., month: ..., date: ...,
+   *    //   hours: ..., minutes: .., seconds: ... }
+   *
+   * @param {Date} date date object local to test runtime.
+   */
+  remoteDateObject: function(date, callback) {
+    if (typeof(date) === 'undefined') {
+      date = new Date();
+    }
+
+    this.task(function(app, next, done) {
+      var result = yield IntegrationHelper.sendAtom(
+        app.device,
+        '/apps/calendar/test/integration/atoms/remote_date',
+        false,
+        [date.valueOf()],
+        next
+      );
+
+      done(null, result);
+
+    }, callback);
+  },
+
+  /**
+   * Find a named selector.
+   * (see .selectors)
+   *
+   *
+   *    var dayView = yield app.element('dayView');
+   *
+   *
+   * @param {String} name selector alias.
+   * @param {Function} [callback] uses driver by default.
+   */
+  element: function(name, callback) {
+    this.device.findElement(this.selector(name), callback);
+  },
+
+  /**
+   * gets all values from the form.
+   *
+   * @param {Array|String|Marionette.Element} form named element,
+   *                                               array of elements or element.
+   */
+  formValues: function(form, callback) {
+    this.task(function(app, next, done) {
+      var elements;
+
+      if (typeof(form) === 'string') {
+        elements = yield app.elements(form);
+      } else if (form instanceof Marionette.Element) {
+        elements = yield form.findElements('[name]', next);
+      } else {
+        elements = form;
+      }
+
+      var values = {};
+      var i = 0;
+      var len = elements.length;
+
+      for (; i < len; i++) {
+        var element = elements[i];
+        var tagName = yield element.tagName(next);
+        var type = yield element.getAttribute('type', next);
+        var name = yield element.getAttribute('name', next);
+        var value = yield element.getAttribute('value', next);
+
+        values[name] = value;
+      }
+
+
+      done(null, values);
+    }, callback);
+  },
+
+  /**
+   * Updates form values.
+   * Will clear the original value then
+   * send the inputs keys for the given string.
+   *
+   *
+   *     var values = {
+   *       title': 'my title',
+   *       location: 'foobar'
+   *     };
+   *
+   *     yield app.updateForm(form, values);
+   *
+   *
+   * @param {Marionette.Element} formElement form or container for inputs.
+   * @param {Object} values object of key/value pairs
+   *                        (where key is the name attr).
+   * @param {Function} [callback] optional uses default callback of driver.
+   */
+  updateForm: function(formElement, values, callback) {
+    var self = this;
+
+    this.task(function(app, next, done) {
+      for (var field in values) {
+
+        // the use of 'next' here is required because
+        // we are using the externally found formElement.
+        var el = yield formElement.findElement(
+          '[name="' + field + '"]',
+          'css selector',
+          next
+        );
+
+        yield el.clear(next);
+        yield el.sendKeys([values[field]], next);
+      }
+
+      done();
+    }, callback);
+  }
+
+};

--- a/apps/calendar/test/integration/atoms/gaia_unlock.js
+++ b/apps/calendar/test/integration/atoms/gaia_unlock.js
@@ -1,0 +1,20 @@
+let setlock = window.wrappedJSObject.SettingsListener.getSettingsLock();
+let obj = {'screen.timeout': 0};
+setlock.set(obj);
+
+waitFor(
+    function() {
+        window.wrappedJSObject.LockScreen.unlock();
+        waitFor(
+            function() {
+                finish(window.wrappedJSObject.LockScreen.locked);
+            },
+            function() {
+                return !window.wrappedJSObject.LockScreen.locked;
+            }
+        );
+    },
+    function() {
+        return !!window.wrappedJSObject.LockScreen;
+    }
+);

--- a/apps/calendar/test/integration/atoms/remote_date.js
+++ b/apps/calendar/test/integration/atoms/remote_date.js
@@ -1,0 +1,14 @@
+return (function(ms) {
+
+  var date = new Date(ms);
+
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth(),
+    date: date.getDate(),
+    hours: date.getHours(),
+    minutes: date.getMinutes(),
+    seconds: date.getSeconds()
+  };
+
+}.apply(this, arguments));

--- a/apps/calendar/test/integration/integration_helper.js
+++ b/apps/calendar/test/integration/integration_helper.js
@@ -1,0 +1,108 @@
+var IntegrationHelper = {
+
+  /** static cache of js blobs */
+  _fileCache: {},
+
+  cacheFile: function(file, callback) {
+    if ((file in IntegrationHelper._fileCache)) {
+      callback(null, IntegrationHelper._fileCache[file]);
+      return;
+    }
+
+    var xhr = new XMLHttpRequest();
+    var path = 'file://' + testSupport.appPath(file);
+    xhr.open('GET', path, true);
+
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState === 4) {
+        if (xhr.status !== 0 && xhr.status !== 200) {
+          callback(new Error(
+            'cannot load file "' + path + '" status: "' + xhr.status + '"'
+          ));
+          return;
+        }
+
+        IntegrationHelper._fileCache[file] = xhr.responseText;
+        callback(null, xhr.responseText);
+      }
+    }
+
+    xhr.send(null);
+  },
+
+  importScript: function(driver, file, callback) {
+    IntegrationHelper.cacheFile(file, function(err, content) {
+      driver.importScript(content, callback);
+    });
+  },
+
+  waitFor: function(test, timeout, callback, _start) {
+    if (typeof(timeout) === 'function') {
+      callback = timeout;
+      timeout = null;
+    }
+
+    if (!timeout)
+      timeout = 3000;
+
+    test(function(err, result) {
+      _start = _start || Date.now();
+
+      if (Date.now() - _start > timeout) {
+        callback(new Error('Timeout'));
+        return;
+      }
+
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      if (result) {
+        callback(null, result);
+      } else {
+        setTimeout(function() {
+          IntegrationHelper.waitFor(test, callback, timeout, _start);
+        }, 100);
+      }
+    });
+  },
+
+  /**
+   * send a js blob to marionette.
+   *
+   * @param {Marionette.Client} driver marionette driver.
+   * @param {String} name filename of atom (minus the js).
+   * @param {Boolean} async  true for async.
+   * @param {Array} [arguments] optional arguments.
+   * @param {Function} callback node style callback.
+   */
+  sendAtom: function(driver, name, async, args, callback) {
+    if (typeof(args) === 'function') {
+      callback = args;
+      args = null;
+    }
+
+    var method;
+
+    if (async) {
+      method = 'executeAsyncScript';
+    } else {
+      method = 'executeScript';
+    }
+
+    if (name.lastIndexOf('.js', name.length - 1) === -1) {
+      name += '.js';
+    }
+
+    IntegrationHelper.cacheFile(name, function(err, data) {
+      if (err) {
+        callback(err);
+        return;
+      }
+      driver[method](data, (args || []), callback);
+    });
+  }
+
+};
+

--- a/apps/calendar/test/integration/launch_test.js
+++ b/apps/calendar/test/integration/launch_test.js
@@ -1,0 +1,75 @@
+requireCommon('/test/marionette.js');
+require('apps/calendar/test/integration/integration_helper.js');
+require('apps/calendar/test/integration/app.js');
+
+require('apps/calendar/js/calendar.js');
+require('apps/calendar/js/calc.js');
+
+suite('calendar - launch', function() {
+
+  var device;
+  var helper = IntegrationHelper;
+  var app;
+
+  suiteTeardown(function() {
+    yield app.close();
+  });
+
+  testSupport.startMarionette(function(driver) {
+    device = driver;
+    app = new CalendarIntegration(device);
+  });
+
+  suiteSetup(function() {
+    this.timeout(15000);
+    yield device.setScriptTimeout(15000);
+    yield helper.importScript(
+      device,
+      '/tests/marionette/gaiatest/gaia_apps.js',
+      MochaTask.nodeNext
+    );
+
+    yield app.launch();
+  });
+
+  test('starting display', function() {
+    var remoteDate = yield app.remoteDate();
+    var month = yield app.element('monthView');
+
+    // should start at month view
+    yield app.waitUntilElement(month, 'displayed');
+
+    var today = yield month.findElement(app.selector('present'));
+    var id = yield today.getAttribute('data-date');
+    var date = Calendar.Calc.dateFromId(id);
+
+    // should highlight current date at the 'present'
+    assert.deepEqual(
+      Calendar.Calc.createDay(remoteDate),
+      Calendar.Calc.createDay(date),
+      'should display present day'
+    );
+  });
+
+  test('initial calendars', function() {
+    var toggle = yield app.element('showSettingsBtn');
+
+    yield helper.waitFor(
+      toggle.displayed.bind(toggle),
+      MochaTask.nextNodeStyle
+    );
+
+    yield toggle.click();
+
+    var calendars = yield app.element('calendarList');
+    var text = yield calendars.text();
+
+    assert.ok(text, 'has calendars');
+
+    assert.match(
+      text, /offline/i,
+      'starts with offline calendar'
+    );
+  });
+
+});

--- a/apps/calendar/test/integration/modify_events_test.js
+++ b/apps/calendar/test/integration/modify_events_test.js
@@ -1,0 +1,166 @@
+requireCommon('/test/marionette.js');
+require('apps/calendar/test/integration/integration_helper.js');
+require('apps/calendar/test/integration/app.js');
+
+/** require calc stuff to make things easier */
+require('apps/calendar/js/calendar.js');
+require('apps/calendar/js/calc.js');
+require('apps/calendar/js/input_parser.js');
+
+suite('calendar - modify events', function() {
+
+  var InputParser = Calendar.InputParser;
+  var device;
+  var helper = IntegrationHelper;
+  var app;
+
+  /**
+   * Converts a js date object into a HTML input[type="time"] format.
+   * By default it will omit minutes and seconds
+   *
+   * @param {Date} date js date.
+   * @return {String} hh:mm::ss (02:23:59).
+   */
+  function htmlTime(date, minutes=false, seconds=false) {
+    // clone so we don't modify the original
+    date = new Date(date.valueOf());
+
+    if (!minutes)
+      date.setMinutes(0);
+
+    if (!seconds)
+      date.setSeconds(0);
+
+    // convert to string
+    return InputParser.exportTime(date);
+  }
+
+  function parseDate(object) {
+    if (typeof(object) === 'string') {
+      object = InputParser.importDate(object);
+    }
+
+    return new Date(
+      object.year,
+      object.month,
+      object.date
+    );
+  }
+
+  function assertFormDate(values, start, end) {
+    assert.deepEqual(
+      Calendar.Calc.createDay(start),
+      parseDate(values.startDate),
+      'start date'
+    );
+
+    assert.deepEqual(
+      Calendar.Calc.createDay(end),
+      parseDate(values.endDate),
+      'end date'
+    );
+
+    assert.deepEqual(
+      htmlTime(start),
+      values.startTime,
+      'start time'
+    );
+
+    assert.deepEqual(
+      htmlTime(end),
+      values.endTime,
+      'end time'
+    );
+  }
+
+  suiteTeardown(function() {
+    yield app.close();
+  });
+
+  testSupport.startMarionette(function(driver) {
+    device = driver;
+    app = new CalendarIntegration(device);
+  });
+
+  suiteSetup(function() {
+    yield device.setScriptTimeout(5000);
+    yield helper.importScript(
+      device,
+      '/tests/marionette/gaiatest/gaia_apps.js',
+      MochaTask.nodeNext
+    );
+
+    yield app.launch();
+  });
+
+  teardown(function() {
+    // doing something somewhat sneaky here
+    // we use calendar js methods to force display
+    // of month view. This may be a bad idea later...
+    yield device.executeScript(function() {
+      window.wrappedJSObject.Calendar.App.go('/month/');
+    });
+
+    // don't continue until we know month is displayed...
+    var month = yield app.element('monthView');
+    yield app.waitUntilElement(month, 'displayed');
+  });
+
+  function showView(app, next, callback) {
+    var add = yield app.element('addEventBtn');
+
+    yield helper.waitFor(add.displayed.bind(add), next);
+
+    yield add.click(next);
+    // show view
+    var view = yield app.element('modifyEventView');
+    var viewVisible = yield view.displayed();
+
+    // verify visible
+    assert.isTrue(viewVisible, 'shows modify event');
+
+    callback(null, view);
+  };
+
+  test('add event - without pre-selected date', function() {
+    var now = yield app.remoteDate();
+
+    var view = yield app.task(showView);
+    var values = yield app.formValues('eventFormFields');
+
+    var start = new Date(now.valueOf());
+    start.setHours(start.getHours() + 1);
+
+    var end = new Date(now.valueOf());
+    end.setHours(end.getHours() + 2);
+
+    assertFormDate(values, start, end);
+  });
+
+  test('add event - different day selected', function() {
+    var now = yield app.remoteDate();
+
+    // remove the time information
+    now = Calendar.Calc.createDay(now);
+
+    // increment to tomorrow
+    now.setDate(now.getDate() + 1);
+
+    // tap the next day in the month view
+    var id = Calendar.Calc.getDayId(now);
+    var month = yield app.element('monthView');
+    var dayEl = yield month.findElement('[data-date="' + id + '"]');
+    yield dayEl.click();
+
+    // click create event
+    yield app.task(showView);
+
+    var values = yield app.formValues('eventFormFields');
+    var end = new Date(now.valueOf());
+    end.setHours(end.getHours() + 1);
+
+    // should start the times at the selected date
+    assertFormDate(values, now, end);
+  });
+
+});

--- a/apps/calendar/test/integration/support/app.js
+++ b/apps/calendar/test/integration/support/app.js
@@ -1,0 +1,5 @@
+IntegrationHelper.App = function(options) {
+  for (var key in options) {
+    this[key] = options[key];
+  }
+};

--- a/test_apps/test-agent/common/test/marionette.js
+++ b/test_apps/test-agent/common/test/marionette.js
@@ -6,6 +6,16 @@
 
   support = window.testSupport;
 
+  /**
+   * Returns a filesystem apps relative to the root of gaia.
+   *
+   * @param {String} path relative path.
+   * @return {String} absolute path output.
+   */
+  support.appPath = function(path) {
+    return _IMPORT_ROOT + '/../../../../' + path;
+  };
+
   support.startMarionette = function(cb) {
     var device;
 

--- a/test_apps/test-agent/common/test/mocha_task.js
+++ b/test_apps/test-agent/common/test/mocha_task.js
@@ -89,7 +89,8 @@ var MochaTask = (function() {
           handler = errorHandler;
 
       if (error) {
-        throw error;
+        handler(error);
+        return;
       }
 
       try {

--- a/test_apps/test-agent/common/test/xpc.js
+++ b/test_apps/test-agent/common/test/xpc.js
@@ -105,10 +105,12 @@ if (!(reporter in mocha.reporters)) {
 } else {
   mocha.setup({
     ui: 'tdd',
-    reporter: mocha.reporters[reporter]
+    reporter: mocha.reporters[reporter],
+    // change the default timeout to all tests to 6 seconds
+    timeout: 6000
   });
 
-  require('integration_helper.js')
+  require('integration_helper.js');
 
   window.xpcArgv.slice(2).forEach(function(test) {
     require(test);

--- a/test_apps/test-agent/common/vendor/marionette-client/marionette.js
+++ b/test_apps/test-agent/common/vendor/marionette-client/marionette.js
@@ -738,7 +738,7 @@
    * Command stream accepts a socket or any event
    * emitter that will emit data events
    *
-   * @class
+   * @class Marionette.CommandStream
    * @param {EventEmitter} socket socket instance.
    * @constructor
    */
@@ -751,7 +751,7 @@
     Responder.apply(this);
 
     socket.on('data', this.add.bind(this));
-    socket.on('error', function(){
+    socket.on('error', function() {
       console.log(arguments);
     });
   }
@@ -763,6 +763,7 @@
   /**
    * Length prefix
    *
+   * @property prefix
    * @type String
    */
   proto.prefix = ':';
@@ -772,6 +773,7 @@
    * will emit when a response to a
    * command is received.
    *
+   * @property commandEvent
    * @type String
    */
   proto.commandEvent = 'command';
@@ -781,7 +783,7 @@
    * be sent over a tcp socket to marionette.
    *
    *
-   * @this
+   * @method stringify
    * @param {Object} command marionette command.
    * @return {String} command as a string.
    */
@@ -800,7 +802,8 @@
    * Accepts raw string command parses it and
    * emits a commandEvent.
    *
-   * @this
+   * @private
+   * @method _handleCommand
    * @param {String} string raw response from marionette.
    */
   proto._handleCommand = function _handleCommand(string) {
@@ -813,7 +816,9 @@
 
   /**
    * Checks if current buffer is ready to read.
-   * @this
+   *
+   * @private
+   * @method _checkBuffer
    * @return {Boolean} true when in a command and buffer \
    *                   is ready to begin reading.
    */
@@ -835,7 +840,8 @@
    * Read current buffer.
    * Drain and emit all comands from the buffer.
    *
-   * @this
+   * @method _readBuffer
+   * @private
    * @return {Object} self.
    */
   proto._readBuffer = function _readBuffer() {
@@ -858,12 +864,12 @@
    * Writes a command to the socket.
    * Handles conversion and formatting of object.
    *
-   * @this
+   * @method send
    * @param {Object} data marionette command.
    */
   proto.send = function send(data) {
     debug('writing ', data, 'to socket');
-    if(this.socket.write) {
+    if (this.socket.write) {
       //nodejs socket
       this.socket.write(this.stringify(data), 'utf8');
     } else {
@@ -905,12 +911,11 @@
    * You should never need to manually create
    * an instance of element.
    *
-   * Use {@link Marionette.Client#findElement} or
-   * {@link Marionette.Client#findElements} to create
+   * Use {{#crossLink "Marionette.Client/findElement"}}{{/crossLink}} or
+   * {{#crossLink "Marionette.Client/findElements"}}{{/crossLink}} to create
    * instance(s) of this class.
    *
-   * @class
-   * @name Marionette.Element
+   * @class Marionette.Element
    * @param {String} id id of element.
    * @param {Marionette.Client} client client instance.
    */
@@ -920,12 +925,13 @@
   }
 
   Element.prototype = {
-    /** @scope Marionette.Element.prototype */
-
     /**
      * Sends remote command processes the result.
      * Appends element id to each command.
      *
+     * @method _sendCommand
+     * @chainable
+     * @private
      * @param {Object} command marionette request.
      * @param {String} responseKey key in the response to pass to callback.
      * @param {Function} callback callback function receives the result of
@@ -945,6 +951,7 @@
     /**
      * Finds a single child of this element.
      *
+     * @method findElement
      * @param {String} query search string.
      * @param {String} method search method.
      * @param {Function} callback element callback.
@@ -958,6 +965,7 @@
     /**
      * Finds a all children of this element that match a pattern.
      *
+     * @method findElements
      * @param {String} query search string.
      * @param {String} method search method.
      * @param {Function} callback element callback.
@@ -973,6 +981,7 @@
      * a function with this element as first argument.
      *
      *
+     * @method scriptWith
      * @param {Function|String} script remote script.
      * @param {Function} callback callback when script completes.
      */
@@ -983,6 +992,7 @@
     /**
      * Checks to see if two elements are equal
      *
+     * @method equals
      * @param {String|Marionette.Element} element element to test.
      * @param {Function} callback called with boolean.
      * @return {Object} self.
@@ -1004,6 +1014,7 @@
     /**
      * Gets attribute value for element.
      *
+     * @method getAttribute
      * @param {String} attr attribtue name.
      * @param {Function} callback gets called with attribute's value.
      * @return {Object} self.
@@ -1021,6 +1032,7 @@
      * Sends typing event keys to element.
      *
      *
+     * @method sendKeys
      * @param {String} string message to type.
      * @param {Function} callback boolean success.
      * @return {Object} self.
@@ -1036,6 +1048,7 @@
     /**
      * Clicks element.
      *
+     * @method click
      * @param {Function} callback boolean result.
      * @return {Object} self.
      */
@@ -1049,7 +1062,7 @@
     /**
      * Gets text of element
      *
-     *
+     * @method text
      * @param {Function} callback text of element.
      * @return {Object} self.
      */
@@ -1061,15 +1074,13 @@
     },
 
     /**
-     * Gets value of element
+     * Returns tag name of element.
      *
-     *
-     * @param {Function} callback value of element.
-     * @return {Object} self.
+     * @param {Function} callback node style [err, tagName].
      */
-    value: function value(callback) {
+    tagName: function tagName(callback) {
       var cmd = {
-        type: 'getElementValue'
+        type: 'getElementTagName',
       };
       return this._sendCommand(cmd, 'value', callback);
     },
@@ -1077,7 +1088,7 @@
     /**
      * Clears element.
      *
-     *
+     * @method clear
      * @param {Function} callback value of element.
      * @return {Object} self.
      */
@@ -1092,6 +1103,7 @@
      * Checks if element is selected.
      *
      *
+     * @method selected
      * @param {Function} callback boolean argument.
      * @return {Object} self.
      */
@@ -1105,7 +1117,7 @@
     /**
      * Checks if element is enabled.
      *
-     *
+     * @method enabled
      * @param {Function} callback boolean argument.
      * @return {Object} self.
      */
@@ -1120,6 +1132,7 @@
      * Checks if element is displayed.
      *
      *
+     * @method displayed
      * @param {Function} callback boolean argument.
      * @return {Object} self.
      */
@@ -1140,9 +1153,6 @@
     [Marionette('element'), Marionette] :
     [module, require('../../lib/marionette/marionette')]
 ));
-/**
-@namespace
-*/
 (function(module, ns) {
 
   var Element = ns.require('element'),
@@ -1165,16 +1175,43 @@
   }
 
   /**
-   * @name Marionette.Client
-   * @class
-   * @constructs
-   * @exports Client as Marionette.Client
-   *
    * Initializes client.
    * You must create and initialize
    * a driver and pass it into the client before
    * using the client itself.
    *
+   *     // all drivers conform to this api
+   *
+   *     var driver = new Marionette.Dirver.MozTcp({});
+   *     var client;
+   *
+   *     driver.connect(function(err) {
+   *       if (err) {
+   *         // handle error case...
+   *       }
+   *
+   *       client = new Marionette.Client(driver, {
+   *           // optional default callback can be used to implement
+   *           // a generator interface or other non-callback based api.
+   *          defaultCallback: function(err, result) {
+   *            console.log('CALLBACK GOT:', err, result);
+   *          }
+   *       });
+   *
+   *       // by default commands run in a queue.
+   *       // assuming there is not a fatal error each command
+   *       // will execute sequentially.
+   *       client.startSession().
+   *              goUrl('http://google.com').
+   *              executeScript(function() {
+   *                alert(document.title);
+   *              });
+   *       }
+   *     });
+   *
+   *
+   * @class Marionette.Client
+   * @constructor
    * @param {Marionette.Drivers.Abstract} driver fully initialized client.
    * @param {Object} options options for driver.
    */
@@ -1188,13 +1225,26 @@
 
   Client.prototype = {
 
+    /**
+     * Constant for chrome context.
+     *
+     * @type {String}
+     * @property CHROME
+     */
     CHROME: 'chrome',
+
+    /**
+     * Constant for content context.
+     *
+     * @type {String}
+     * @property CONTENT
+     */
     CONTENT: 'content',
 
     /**
      * Actor id for instance
-      *
      *
+     * @property actor
      * @type String
      */
     actor: null,
@@ -1202,6 +1252,7 @@
     /**
      * Session id for instance.
      *
+     * @property session
      * @type String
      */
     session: null,
@@ -1212,6 +1263,8 @@
      * to command if not present.
      *
      *
+     * @method send
+     * @chainable
      * @param {Function} cb executed when response is sent.
      */
     send: function send(cmd, cb) {
@@ -1252,6 +1305,9 @@
      * Sends request and formats response.
      *
      *
+     * @private
+     * @method _sendCommand
+     * @chainable
      * @param {Object} command marionette command.
      * @param {String} responseKey the part of the response to pass \
      *                             unto the callback.
@@ -1271,6 +1327,7 @@
      * Finds the actor for this instance.
      *
      * @private
+     * @method _getActorId
      * @param {Function} callback executed when response is sent.
      */
     _getActorId: function _getActorId(callback) {
@@ -1290,6 +1347,7 @@
      * Starts a remote session.
      *
      * @private
+     * @method _newSession
      * @param {Function} callback optional.
      */
     _newSession: function _newSession(callback) {
@@ -1307,6 +1365,7 @@
      * Finds actor and creates connection to marionette.
      * This is a combination of calling getMarionetteId and then newSession.
      *
+     * @method startSession
      * @param {Function} callback executed when session is started.
      */
     startSession: function startSession(callback) {
@@ -1321,6 +1380,8 @@
      * Destroys current session.
      *
      *
+     * @chainable
+     * @method deleteSession
      * @param {Function} callback executed when session is destroyed.
      */
     deleteSession: function destroySession(callback) {
@@ -1338,6 +1399,8 @@
     /**
      * Callback will receive the id of the current window.
      *
+     * @chainable
+     * @method getWindow
      * @param {Function} callback executed with id of current window.
      * @return {Object} self.
      */
@@ -1349,7 +1412,8 @@
     /**
      * Callback will receive an array of window ids.
      *
-     *
+     * @method getWindow
+     * @chainable
      * @param {Function} callback executes with an array of ids.
      */
     getWindows: function getWindows(callback) {
@@ -1361,6 +1425,8 @@
      * Switches context of marionette to specific window.
      *
      *
+     * @method switchToWindow
+     * @chainable
      * @param {String} id window id you can find these with getWindow(s).
      * @param {Function} callback called with boolean.
      */
@@ -1375,6 +1441,8 @@
      *
      * Good for prototyping new marionette commands.
      *
+     * @method importScript
+     * @chainable
      * @param {String} script javascript string blob.
      * @param {Function} callback called with boolean.
      */
@@ -1387,15 +1455,22 @@
      * Switches context of marionette to specific iframe.
      *
      *
+     * @method switchToFrame
+     * @chainable
      * @param {String|Marionette.Element} id iframe id or element.
      * @param {Function} callback called with boolean.
      */
     switchToFrame: function switchToFrame(id, callback) {
+      if (typeof(id) === 'function') {
+        callback = id;
+        id = null;
+      }
+
       var cmd = { type: 'switchToFrame' };
 
       if (id instanceof Element) {
         cmd.element = id.id;
-      } else {
+      } else if (id) {
         cmd.value = id;
       }
 
@@ -1405,6 +1480,8 @@
     /**
      * Switches context of window.
      *
+     * @method setContext
+     * @chainable
      * @param {String} context either: 'chome' or 'content'.
      * @param {Function} callback receives boolean.
      */
@@ -1420,8 +1497,8 @@
     /**
      * Sets the script timeout
      *
-     *
-     *
+     * @method setScriptTimeout
+     * @chainable
      * @param {Numeric} timeout max time in ms.
      * @param {Function} callback executed with boolean status.
      * @return {Object} self.
@@ -1434,6 +1511,8 @@
     /**
      * setSearchTimeout
      *
+     * @method setSearchTimeout
+     * @chainable
      * @param {Numeric} timeout max time in ms.
      * @param {Function} callback executed with boolean status.
      * @return {Object} self.
@@ -1446,6 +1525,8 @@
     /**
      * Gets url location for device.
      *
+     * @method getUrl
+     * @chainable
      * @param {Function} callback receives url.
      */
     getUrl: function getUrl(callback) {
@@ -1456,6 +1537,7 @@
     /**
      * Refreshes current window on device.
      *
+     * @method refresh
      * @param {Function} callback boolean success.
      * @return {Object} self.
      */
@@ -1467,6 +1549,8 @@
     /**
      * Drives browser to a url.
      *
+     * @method goUrl
+     * @chainable
      * @param {String} url location.
      * @param {Function} callback executes when finished driving browser to url.
      */
@@ -1479,6 +1563,8 @@
      * Drives window forward.
      *
      *
+     * @method goForward
+     * @chainable
      * @param {Function} callback receives boolean.
      */
     goForward: function goForward(callback) {
@@ -1489,7 +1575,8 @@
     /**
      * Drives window back.
      *
-     *
+     * @method goBack
+     * @chainable
      * @param {Function} callback receives boolean.
      */
     goBack: function goBack(callback) {
@@ -1501,6 +1588,8 @@
      * Logs a message on marionette server.
      *
      *
+     * @method log
+     * @chainable
      * @param {String} message log message.
      * @param {String} level arbitrary log level.
      * @param {Function} callback receives boolean.
@@ -1515,17 +1604,19 @@
      * Retrieves all logs on the marionette server.
      * The response from marionette is an array of arrays.
      *
-     *    device.getLogs(function(logs){
-     *      //logs => [
-     *        [
-     *          'msg',
-     *          'level',
-     *          'Fri Apr 27 2012 11:00:32 GMT-0700 (PDT)'
-     *        ]
-     *      ]
-     *    });
+     *     device.getLogs(function(err, logs){
+     *       //logs => [
+     *         [
+     *           'msg',
+     *           'level',
+     *           'Fri Apr 27 2012 11:00:32 GMT-0700 (PDT)'
+     *         ]
+     *       ]
+     *     });
      *
      *
+     * @method getLogs
+     * @chainable
      * @param {Function} callback receive an array of logs.
      */
     getLogs: function getLogs(callback) {
@@ -1537,6 +1628,8 @@
      * Executes a remote script will block.
      * Script is *not* wrapped in a function.
      *
+     * @method executeJsScript
+     * @chainable
      * @param {String} script script to run.
      * @param {Array} [args] optional args for script.
      * @param {Array} [timeout] optional args for timeout.
@@ -1565,9 +1658,40 @@
     },
 
     /**
-     * Executes a remote script will block.
-     * Script is wrapped in a function.
+     * Executes a remote script will block. Script is wrapped in a function.
      *
+     *     // its is very important to remember that the contents of this
+     *     // method are "stringified" (Function#toString) and sent over the
+     *     // wire to execute on the device. So things like scope will not be
+     *     // the same. If you need to pass other information in arguments
+     *     // option should be used.
+     *
+     *     // assume that this element is the result of findElement
+     *     var element;
+     *     var config = {
+     *        event: 'magicCustomEvent',
+     *        detail: { foo: true  }
+     *     };
+     *
+     *     var remoteArgs = [element, details];
+     *
+     *     // unlike other callbacks this one will execute _on device_
+     *     function remoteFn(element, details) {
+     *        // element in this context is a real dom element now.
+     *        var event = document.createEvent('CustomEvent');
+     *        event.initCustomEvent(config.event, true, true, event.detail);
+     *        element.dispatchEvent(event);
+     *
+     *        return { success: true };
+     *     }
+     *
+     *     client.executeJsScript(remoteFn, remoteArgs, function(err, value) {
+     *       // value => { success: true }
+     *     });
+     *
+     *
+     * @method executeScript
+     * @chainable
      * @param {String} script script to run.
      * @param {Array} [args] optional args for script.
      * @param {Function} callback will receive result of the return \
@@ -1587,9 +1711,26 @@
     },
 
     /**
-     * Executes a remote script will block.
      * Script is wrapped in a function and will be executed asynchronously.
      *
+     * NOTE: that setScriptTimeout _must_ be set prior to using this method
+     *       as the timeout defaults to zero.
+     *
+     *
+     *    function remote () {
+     *      window.addEventListener('someevent', function() {
+     *        // special method to notify that async script is complete.
+     *        marionetteScriptFinished({ fromRemote: true })
+     *      });
+     *    }
+     *
+     *    client.executeAsyncScript(remote, function(err, value) {
+     *      // value === { fromRemote: true }
+     *    });
+     *
+     *
+     * @method executeAsyncScript
+     * @chainable
      * @param {String} script script to run.
      * @param {Array} [args] optional args for script.
      * @param {Function} callback will receive result of the return \
@@ -1611,6 +1752,8 @@
     /**
      * Finds element.
      *
+     * @method _findElement
+     * @private
      * @param {String} type type of command to send like 'findElement'.
      * @param {String} query search query.
      * @param {String} method search method.
@@ -1647,7 +1790,8 @@
       }
 
       //proably should extract this function into a private
-      return this._sendCommand(cmd, 'value', function processElements(err, result) {
+      return this._sendCommand(cmd, 'value',
+                               function processElements(err, result) {
         var element;
 
         if (result instanceof Array) {
@@ -1663,8 +1807,27 @@
     },
 
     /**
-     * Finds element.
+     * Attempts to find a dom element (via css selector, xpath, etc...)
+     * "elements" returned are instances of
+     * {{#crossLink "Marionette.Element"}}{{/crossLink}}
      *
+     *
+     *     // with default options
+     *     client.findElement('#css-selector', function(err, element) {
+     *        if (err) {
+     *          // handle case where element was not found
+     *        }
+     *
+     *        // see element interface for all methods, etc..
+     *        element.click(function() {
+     *
+     *        });
+     *     });
+     *
+     *
+     *
+     * @method findElement
+     * @chainable
      * @param {String} query search query.
      * @param {String} method search method.
      * @param {String} elementId id of element to search within.
@@ -1677,8 +1840,19 @@
     },
 
     /**
-     * Finds elements.
+     * Finds multiple elements in the dom. This method has the same
+     * api signature as {{#crossLink "findElement"}}{{/crossLink}} the
+     * only difference is where findElement returns a single element
+     * this method will return an array of elements in the callback.
      *
+     *
+     *     // find all links in the document
+     *     client.findElements('a[href]', function(err, element) {
+     *     });
+     *
+     *
+     * @method findElements
+     * @chainable
      * @param {String} query search query.
      * @param {String} method search method.
      * @param {String} elementId id of element to search within.
@@ -1695,6 +1869,8 @@
      * Converts an function into a string
      * that can be sent to marionette.
      *
+     * @private
+     * @method _convertFunction
      * @param {Function|String} fn function to call on the server.
      * @return {String} function string.
      */
@@ -1713,6 +1889,8 @@
      * instance will be created and returned.
      *
      *
+     * @private
+     * @method _transformResultValue
      * @param {Object} value original result from server.
      * @return {Object|Marionette.Element} processed result.
      */
@@ -1729,6 +1907,8 @@
      * marionette can use them in script commands.
      *
      *
+     * @private
+     * @method _prepareArguments
      * @param {Array} arguments list of args for wrapped function.
      * @return {Array} processed arguments.
      */
@@ -1751,6 +1931,8 @@
      * by marionette.
      *
      *
+     * @method _executeScript
+     * @private
      * @param {Object} options objects of execute script.
      * @param {String} options.type command type like 'executeScript'.
      * @param {String} options.value javascript string.
@@ -1797,20 +1979,17 @@
     [Marionette('client'), Marionette] :
     [module, require('./marionette')]
 ));
-/**
- * @namespace
- */
 (function(module, ns) {
 
   /**
-   * @class
    *
    * Abstract driver that will handle
    * all common tasks between implementations.
    * Such as error handling, request/response queuing
    * and timeouts.
    *
-   * @name Marionette.Drivers.Abstract
+   * @constructor
+   * @class Marionette.Drivers.Abstract
    * @param {Object} options set options on prototype.
    */
   function Abstract(options) {
@@ -1819,11 +1998,11 @@
   }
 
   Abstract.prototype = {
-    /** @scope Marionette.Drivers.Abstract.prototype */
 
     /**
      * Timeout for commands
      *
+     * @property timeout
      * @type Numeric
      */
     timeout: 10000,
@@ -1831,6 +2010,8 @@
     /**
      * Waiting for a command to finish?
      *
+     * @private
+     * @property _waiting
      * @type Boolean
      */
     _waiting: true,
@@ -1838,6 +2019,7 @@
     /**
      * Is system ready for commands?
      *
+     * @property ready
      * @type Boolean
      */
     ready: false,
@@ -1845,6 +2027,7 @@
     /**
      * Connection id for the server.
      *
+     * @property connectionId
      * @type Numeric
      */
     connectionId: null,
@@ -1856,6 +2039,7 @@
      * response is correct.
      *
      *
+     * @method send
      * @param {Object} command remote command to send to marionette.
      * @param {Function} callback executed when response comes back.
      */
@@ -1879,18 +2063,18 @@
     /**
      * Connects to a remote server.
      * Requires a _connect function to be defined.
-     * @example
      *
-     *  MyClass.prototype._connect = function _connect(){
-     *    //open a socket to marrionete accept response
-     *    //you *must* call _onDeviceResponse with the first
-     *    //response from marionette it looks like this:
-     *    //{ from: 'root', applicationType: 'gecko', traits: [] }
-     *    this.connectionId = result.id;
-     *  }
+     *     MyClass.prototype._connect = function _connect(){
+     *       //open a socket to marrionete accept response
+     *       //you *must* call _onDeviceResponse with the first
+     *       //response from marionette it looks like this:
+     *       //{ from: 'root', applicationType: 'gecko', traits: [] }
+     *       this.connectionId = result.id;
+     *     }
      *
-     * @param {Function} callback
-     *  executes after successfully connecting to the server.
+     * @method connect
+     * @param {Function} callback executes
+     *   after successfully connecting to the server.
      */
     connect: function connect(callback) {
       this.ready = true;
@@ -1907,6 +2091,8 @@
      *
      * Will immediately close connection to server
      * closing any pending responses.
+     *
+     * @method close
      */
     close: function() {
       this.ready = false;
@@ -1921,6 +2107,7 @@
      * Sends command to websocket server
      *
      * @private
+     * @method _nextCommand
      */
     _nextCommand: function _nextCommand() {
       var nextCmd;
@@ -1938,6 +2125,7 @@
      *
      * @param {Object} data response from server.
      * @private
+     * @method _onDeviceResponse
      */
     _onDeviceResponse: function _onDeviceResponse(data) {
       var cb;
@@ -1964,12 +2152,23 @@
   var WebsocketClient,
       Abstract = ns.require('drivers/abstract');
 
-  if(!this.TestAgent) {
+  if (!this.TestAgent) {
     WebsocketClient = require('test-agent/lib/test-agent/websocket-client');
   } else {
     WebsocketClient = TestAgent.WebsocketClient;
   }
 
+  /**
+   * WebSocket interface for marionette.
+   * Generally {{#crossLink "Marionette.Drivers.Tcp"}}{{/crossLink}}
+   * will be faster and more reliable but WebSocket can expose devices
+   * over http instead of a pure socket.
+   *
+   *
+   * @extend Marionette.Drivers.Abstract
+   * @class Marionette.Drivers.Websocket
+   * @param {Object} options options for abstract/prototype.
+   */
   function Websocket(options) {
     Abstract.call(this, options);
 
@@ -2099,6 +2298,26 @@
   /** TCP **/
   Tcp.Socket = SocketWrapper;
 
+  /**
+   * Connects to gecko marionette server using mozTCP api.
+   *
+   *
+   *     // default options are fine for b2g-desktop
+   *     // or a device device /w port forwarding.
+   *     var tcp = new Marionette.Drivers.MozTcp();
+   *
+   *     tcp.connect(function() {
+   *       // ready to use with client
+   *     });
+   *
+   *
+   * @class Marionette.Drivers.MozTcp
+   * @extends Marionette.Drivers.Abstract
+   * @constructor
+   * @param {Object} options connection options.
+   *   @param {String} [options.host="127.0.0.1"] ip/host.
+   *   @param {Numeric} [options.port="2828"] marionette server port.
+   */
   function Tcp(options) {
     if (typeof(options)) {
       options = {};
@@ -2174,9 +2393,9 @@
   /**
    * Creates instance of http proxy backend.
    *
-   * @class
+   * @deprecated
+   * @class Marionette.Drivers.Httpd
    * @extends Marionette.Drivers.Abstract
-   * @name Marionette.Drivers.Httpd
    * @param {Object} options key/value pairs to add to prototype.
    */
   function Httpd(options) {


### PR DESCRIPTION
# General
- Updates MarionetteJS client to latest version
- Adds make test-integration APP=foo
# Calendar
- Launch test to verify today's date is selected & offline calendar was created.
- Tests initial values in creating events.
- Selecting day in month view.
# Runtimes
- b2g-desktop
- otoro

---

This serves as a good example of the current capabilities of marionette & the js client.
It is fairly easy to write tests to now that we have a really easy way to launch apps.

I am not 100% happy with these interfaces quite yet but it is my intent that all the generic reusable bits can go into a common folder.

Semi-related note there is a new doc site for the JS driver here:

Site: http://lightsofapollo.github.com/marionette_js_client/
API Docs: http://lightsofapollo.github.com/marionette_js_client/api-docs/classes/Marionette.Client.html

The docs are not specific to gaia so they don't cover any of the generator bits.
