### PR TITLE
set currentOrigin to the origin of the popup, so that close works

### DIFF
--- a/apps/system/js/popup_manager.js
+++ b/apps/system/js/popup_manager.js
@@ -52,6 +52,9 @@ var PopupManager = {
     dataset.frameName = name;
     dataset.frameOrigin = origin;
 
+    // this seems needed, or an override to origin in close()
+    this._currentOrigin = origin;
+
     this.container.appendChild(popup);
 
     this.screen.classList.add('popup');


### PR DESCRIPTION
this fix is needed to make popups work as expected for the identity implementation (pull request coming for that piece afterwards).
