### PR TITLE
Bug 796269 - [settings] set time manually once, cannot do again

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -310,3 +310,12 @@ section#icc .hidden {
 section#icc #icc-stk-alert {
   position: fixed;
 }
+
+/******************************************************************************
+ * Date & Time
+ */
+
+#clock-date,
+#clock-time {
+  pointer-events: none;
+}


### PR DESCRIPTION
First part. The labels showing the current date and time act as event targets themselves and prevent the time/date picker from showing up.
