### PR TITLE
Bug 798265 798263 798256 798266 [Email] Message list layout polish.

### DIFF
--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -61,11 +61,11 @@
   vertical-align: 0%;
 }
 .msg-header-item:active {
-  background-color: #ffc48c;
+  background-color: #b1f1ff;
 }
 .msg-header-unread-section {
   position: absolute;
-  left: .5rem;
+  left: 1.5rem;
   top: 50%;
   display: inline-block;
   height: .9rem;
@@ -80,12 +80,13 @@
   display: block;
   position: absolute;
   top: 0px;
-  left: 1.9rem;
+  left: 3.8rem;
   /* 100% - (unread-section) - (icons-section) - (avatar-section) */
   width: -moz-calc(100% - 1.9rem - 2rem - 2.8rem);
   height: 100%;
   font-size: 1.6rem;
-  line-height: 2.5rem;
+  line-height: 2.0rem;
+  padding: 1rem 0;
 }
 .msg-header-icons-section {
   display: block;
@@ -132,7 +133,7 @@
 .msg-header-subject {
   display: block;
   color: black;
-  font-weight: bold;
+  font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -367,7 +368,7 @@
 }
 
 .msg-messages-container.show-edit .msg-header-unread-section {
-  left: 4.5rem;
+  left: 3.9rem;
 }
 .msg-messages-container.show-edit .msg-header-details-section {
   left: 5.9rem;


### PR DESCRIPTION
- Polish [Bug 798256](https://bugzilla.mozilla.org/show_bug.cgi?id=798256) - [Email] Inbox. Text baseline not correct
- Polish [Bug 798263](https://bugzilla.mozilla.org/show_bug.cgi?id=798263) -  [Email] [VD implementation] Inbox. Subject text should be semibold not bold
- Polish [Bug 798265](https://bugzilla.mozilla.org/show_bug.cgi?id=798265) -  [Email] [VD implementation] Inbox. Wrong highlight color for rows
- Polish [Bug 798266](https://bugzilla.mozilla.org/show_bug.cgi?id=798266) -  [Email] [VD implementation] Inbox. Left aligning wrong
