### PR TITLE
[BB] bug 799440: avoid CSS conflicts between the different dialogs

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -382,7 +382,7 @@
     Remove Local Data
   </a>
 
-  <form role="dialog" id="remove-account-dialog">
+  <form role="dialog" data-type="confirm" id="remove-account-dialog">
     <section>
       <h1 data-l10n-id="remove-account-dialog">>Remove Account</h1>
       <p data-l10n-id="remove-account-dialog-details">

--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -574,8 +574,8 @@
               <span data-l10n-id="settings-show-images" class="list-text">
                 AlwayS ShoW ImageS</span>
               <em class="aside end">
-                <label class="switch">
-                  <input type="checkbox" checked="checked">
+                <label >
+                  <input type="checkbox" data-type="switch" checked="checked">
                   <span></span>
                 </label>
               </em>
@@ -584,8 +584,8 @@
               <span data-l10n-id="settings-download-attachments"
                 class="list-text">DownloaD AttachmentS</span>
               <em class="aside end">
-                <label class="switch">
-                  <input type="checkbox" checked="checked">
+                <label>
+                  <input type="checkbox" data-type="switch" checked="checked">
                   <span></span>
                 </label>
               </em>
@@ -594,8 +594,8 @@
               <span data-l10n-id="settings-notify-mail" class="list-text">
                 NotifY ME OF NeW MaiL</span>
               <em class="aside end">
-                <label class="switch">
-                  <input type="checkbox" checked="checked">
+                <label>
+                  <input type="checkbox" data-type="switch" checked="checked">
                   <span></span>
                 </label>
               </em>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -246,7 +246,7 @@
       </ul>
 
       <!-- action menu -->
-      <form role="dialog" hidden>
+      <form role="dialog" data-type="action" hidden>
         <menu>
           <button data-l10n-id="forgetNetwork">Forget network</button>
           <button data-l10n-id="cancel" type="reset">Cancel</button>
@@ -263,8 +263,8 @@
 
       <ul>
         <li id="wifi-enabled">
-          <label class="switch">
-            <input type="checkbox" />
+          <label>
+            <input type="checkbox" data-type="switch" />
             <span></span>
           </label>
           <a data-l10n-id="wifi">Wi-Fi</a>
@@ -328,8 +328,8 @@
 
       <ul>
         <li id="operator-autoSelect">
-          <label class="switch">
-            <input type="checkbox" />
+          <label>
+            <input type="checkbox" data-type="switch" />
             <span></span>
           </label>
           <small></small>
@@ -452,8 +452,8 @@
           <a data-l10n-id="dataNetwork">Carrier</a>
         </li>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="ril.callwaiting.enabled"/>
+          <label>
+            <input type="checkbox" data-type="switch" name="ril.callwaiting.enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="callWaiting">Call Waiting</a>
@@ -465,15 +465,15 @@
       </header>
       <ul>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="ril.data.enabled"/>
+          <label>
+            <input type="checkbox" data-type="switch" name="ril.data.enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="dataConnection">Data Connection</a>
         </li>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="ril.data.roaming_enabled"/>
+          <label>
+            <input type="checkbox" data-type="switch" name="ril.data.roaming_enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="dataRoaming">Data Roaming</a>
@@ -517,15 +517,15 @@
 
       <ul>
         <li id="bluetooth-status">
-          <label class="switch">
-            <input type="checkbox" />
+          <label>
+            <input type="checkbox" data-type="switch" />
             <span></span>
           </label>
           <a data-l10n-id="bluetooth">Bluetooth</a>
         </li>
         <li hidden id="device-visible">
-          <label class="switch">
-            <input type="checkbox" data-ignore checked />
+          <label>
+            <input type="checkbox" data-type="switch" data-ignore checked />
             <span></span>
           </label>
           <small id="bluetooth-device-name"></small>
@@ -569,7 +569,7 @@
       </ul>
 
       <!-- action menu -->
-      <form role="dialog" id="paired-device-option" hidden>
+      <form role="dialog" data-type="action" id="paired-device-option" hidden>
         <menu>
           <button data-l10n-id="device-option-connect" id="connect-option">Connect</button>
           <button data-l10n-id="device-option-disconnect" id="disconnect-option">Disconnect</button>
@@ -623,8 +623,8 @@
       </header>
       <ul>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="tethering.wifi.enabled"/>
+          <label>
+            <input type="checkbox" data-type="switch" name="tethering.wifi.enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="wifi-hotspot">Wi-Fi HotSpot</a>
@@ -662,8 +662,8 @@
       </header>
       <ul>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="tethering.usb.enabled"/>
+          <label>
+            <input type="checkbox" data-type="switch" name="tethering.usb.enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="usb-tethering">USB Tethering</a>
@@ -742,15 +742,15 @@
       <!-- Ring and Vibrate -->
       <ul>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="ring.enabled" checked />
+          <label>
+            <input type="checkbox" data-type="switch" name="ring.enabled" checked />
             <span></span>
           </label>
           <a data-l10n-id="ring">Ring</a>
         </li>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="vibration.enabled" checked />
+          <label>
+            <input type="checkbox" data-type="switch" name="vibration.enabled" checked />
             <span></span>
           </label>
           <a data-l10n-id="vibrate">Vibrate</a>
@@ -900,8 +900,8 @@
 
       <ul>
         <li id="time-nitz-automatic-update">
-          <label class="switch">
-            <input type="checkbox" name="time.nitz.automatic-update.enabled"/>
+          <label>
+            <input type="checkbox" data-type="switch" name="time.nitz.automatic-update.enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="setTimeAutomatically">Set Automatically</a>
@@ -1250,8 +1250,8 @@
 
       <ul>
         <li id="simpin-enabled">
-          <label class="switch">
-            <input type="checkbox"/>
+          <label>
+            <input type="checkbox"/> data-type="switch"
             <span></span>
           </label>
           <a data-l10n-id="simPin">SIM PIN</a>
@@ -1648,8 +1648,8 @@
       </header>
       <ul>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="powersave.enabled" />
+          <label>
+            <input type="checkbox" data-type="switch" name="powersave.enabled" />
             <span></span>
           </label>
           <a data-l10n-id="powerSaveMode">Power Save Mode</a>
@@ -1850,15 +1850,15 @@
       </header>
       <ul>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="ril.radio.disabled" />
+          <label>
+            <input type="checkbox" data-type="switch" name="ril.radio.disabled" />
             <span></span>
           </label>
           <a data-l10n-id="airplaneMode">Airplane Mode</a>
         </li>
         <li>
-          <label class="switch">
-            <input type="checkbox" name="geolocation.enabled" />
+          <label>
+            <input type="checkbox" data-type="switch" name="geolocation.enabled" />
             <span></span>
           </label>
           <a data-l10n-id="gps">GPS</a>

--- a/apps/settings/onpair.html
+++ b/apps/settings/onpair.html
@@ -21,7 +21,7 @@
     <script type="application/javascript" defer src="js/onpair.js"></script>
   </head>
   <body role="application">
-    <form role="dialog" id="pair-view">
+    <form role="dialog" data-type="confirm" id="pair-view">
       <section>
         <h1 id="pair-title"></h1>
         <p id="device-info" class="deviceInfo">
@@ -45,7 +45,7 @@
       </menu>
     </form>
 
-    <form role="dialog" id="alert-view" hidden>
+    <form role="dialog" data-type="confirm" id="alert-view" hidden>
       <section>
         <h1 data-l10n-id="error-pair-title">Unable to Pair Devices</h1>
         <p data-l10n-id="error-pair-pincode">

--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -104,7 +104,7 @@ ul li > label:not([for]) {
 }
 
 ul li > label:not([for]) > span,
-ul li > label:not([for]).switch > span {
+ul li > label:not([for]) > input[data-type="switch"] + span {
   left: auto;
   right: 2rem;
 }
@@ -112,11 +112,6 @@ ul li > label:not([for]).switch > span {
 ul li > label:not([for]) + a,
 ul li > label:not([for]) + small + a {
   padding-right: 6rem;
-}
-
-ul li > label.switch + a,
-ul li > label.switch + small + a {
-  padding-right: 8.4rem;
 }
 
 

--- a/shared/style/README.md
+++ b/shared/style/README.md
@@ -1,8 +1,37 @@
-Class Name Usage
-================
+Building Blocks
+===============
 
-Common Class Names
-------------------
+Taxonomy
+--------
+
+* `action_menu.css`: context menus
+* `buttons.css`: common buttons
+* `confirm.css`: dialog boxes with message + accept/dismiss buttons
+* `edit_mode.css`: edition panels with a dialog-like button toolbar
+* `headers.css`: common header bars (title + navigation buttons)
+* `input_areas.css`: common input areas (e.g. search bars)
+* `status.css`: notification toasters
+* `switches.css`: checkboxes, radio buttons, ON/OFF switches
+
+
+Specific Attributes
+-------------------
+
+A `data-type` attribute is used when the `type` and `role` attributes are not specific enough. Here’s the list of its possible values.
+
+* `action`: used in `action_menu.css`, title + action selection + accept/dismiss buttons
+* `confirm`: used in `confirm.css`, message + accept/dismiss buttons
+* `edit`: used in `edit_mode.css`, edition panel with dialog-like button toolbar
+* `object`: used in `action_menu.css`, action selection + accept/dismiss buttons
+* `switch`: used in `switches.css`, turns a checkbox into an ON/OFF switch
+
+
+Class Name Usage
+----------------
+
+We try to avoid arbitrary class names as much as possible, but sometimes we have to use some — here’s the list.
+
+### Common Class Names
 
 **Icons**
 
@@ -26,21 +55,14 @@ Common Class Names
 * `.danger`: dangerous choice, e.g. delete something
 * `.recommend`: default/recommended choice, should be safe
 
-**Dialogs**
-
-* `.edit`: accept/dismiss panel with dialog-like button toolbar
-* TODO: `.action` and `.object` could be added as well (w/ prefix)
-
 **Other**
 
-* `.action`: ??? applies to fieldset elements
+* `.action`: applies to fieldset elements (explanation needed)
 * `.bottom`: bottom-positioned element, applies to search forms
 * `.compact`: compact list, applies to button lists
 * `.full`: full-width element, applies to buttons or search forms
-* `.switch`: ON/OFF switch, applies to checkboxes
 
-Usage by Block
---------------
+### Usage by Block
 
 **action_menu.css**
 
@@ -61,7 +83,6 @@ None
 **edit_mode.css**
 
 * `.danger`
-* `.edit`
 * `.full`
 * `.icon`
 * `.recommend`
@@ -80,9 +101,9 @@ None
 
 **input_areas.css**
 
-* `.action`
+* `.action` (explanation needed)
 * `.bottom`
-* `.full` (should be dropped!)
+* `.full`
 
 **status.css**
 
@@ -91,5 +112,4 @@ None
 **switches.css**
 
 * `.danger`
-* `.switch`
 

--- a/shared/style/action_menu.css
+++ b/shared/style/action_menu.css
@@ -3,7 +3,8 @@
  * ---------------------------------- */
 
 /* Main dialog setup */
-form[role="dialog"] {
+form[role="dialog"][data-type="action"],
+form[role="dialog"][data-type="object"] {
   background:
     url(action_menu/images/ui/pattern.png) repeat left top,
     url(action_menu/images/ui/gradient.png) no-repeat left top / 100% 100%;
@@ -24,7 +25,8 @@ form[role="dialog"] {
   color: #fff;
 }
 
-form[role="dialog"]:before {
+form[role="dialog"][data-type="action"]:before,
+form[role="dialog"][data-type="object"]:before {
   content: '';
   display: inline-block;
   vertical-align: top;
@@ -33,7 +35,8 @@ form[role="dialog"]:before {
   margin-left: -1px;
 }
 
-form[role="dialog"] > header:first-child {
+form[role="dialog"][data-type="action"] > header:first-child,
+form[role="dialog"][data-type="object"] > header:first-child {
   -moz-box-sizing: padding-box;
   width: 100%;
   display: inline-block;
@@ -48,7 +51,8 @@ form[role="dialog"] > header:first-child {
   -moz-box-sizing: border-box;
 }
 
-form[role="dialog"] > header:after {
+form[role="dialog"][data-type="action"] > header:after,
+form[role="dialog"][data-type="object"] > header:after {
   content: '';
   position: absolute;
   width: 100%;
@@ -59,7 +63,8 @@ form[role="dialog"] > header:after {
 }
 
 /* Specific component code */
-form[role="dialog"] > menu {
+form[role="dialog"][data-type="action"] > menu,
+form[role="dialog"][data-type="object"] > menu {
   margin: 0;
   padding: 0;
   width: auto;
@@ -71,7 +76,8 @@ form[role="dialog"] > menu {
   bottom: 0;
 }
 
-form[role="dialog"] > menu > button {
+form[role="dialog"][data-type="action"] > menu > button,
+form[role="dialog"][data-type="object"] > menu > button {
   width: calc(100% - 5rem);
   height: 4rem;
   -moz-box-sizing: border-box;
@@ -94,7 +100,8 @@ form[role="dialog"] > menu > button {
   border: solid 1px rgba(0, 0, 0, 0.25);
 }
 
-form[role="dialog"] > menu > button:last-child {
+form[role="dialog"][data-type="action"] > menu > button:last-child,
+form[role="dialog"][data-type="object"] > menu > button:last-child {
   text-shadow: 1px 1px 0 rgba(255,255,255,0.3);
   color: #333;
   background-image: url(action_menu/images/ui/default.png);
@@ -106,7 +113,8 @@ form[role="dialog"] > menu > button:last-child {
   font-size: 1.6rem;
 }
 
-form[role="dialog"] > menu > button:last-child:before {
+form[role="dialog"][data-type="action"] > menu > button:last-child:before,
+form[role="dialog"][data-type="object"] > menu > button:last-child:before {
   content: '';
   position: absolute;
   width: 100%;
@@ -119,13 +127,15 @@ form[role="dialog"] > menu > button:last-child:before {
 }
 
 /* Press state */
-form[role="dialog"] > menu > button:active {
+form[role="dialog"][data-type="action"] > menu > button:active,
+form[role="dialog"][data-type="object"] > menu > button:active {
   background-color: #006f86;
   color: #333;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
-form[role="dialog"] > menu > button:last-child:active {
+form[role="dialog"][data-type="action"] > menu > button:last-child:active,
+form[role="dialog"][data-type="object"] > menu > button:last-child:active {
   border: solid 1px #008aaa;
   background: #008aaa;
   color: #333;

--- a/shared/style/action_menu/index.html
+++ b/shared/style/action_menu/index.html
@@ -7,8 +7,8 @@
 
   <link rel="stylesheet" href="../action_menu.css">
   <!--
-    - This stylesheet is only used by the example code,
-    - it is not required for the real case use.
+    - This <style> element is only used for the example code;
+    - it is not required for the real use case.
     -->
   <style type="text/css">
     html, body {
@@ -24,7 +24,7 @@
 </head>
 <body role="application">
 
-  <form role="dialog" onsubmit="return false;">
+  <form role="dialog" data-type="action" onsubmit="return false;">
     <header> Title </header> <!-- this header is optional -->
     <menu>
       <button> Action 1 </button>

--- a/shared/style/confirm.css
+++ b/shared/style/confirm.css
@@ -3,8 +3,10 @@
  * ---------------------------------- */
 
 /* Main dialog setup */
-form[role="dialog"] {
-  background: url(confirm/images/ui/pattern.png) repeat left top, url(confirm/images/ui/gradient.png) no-repeat left top;
+form[role="dialog"][data-type="confirm"] {
+  background:
+    url(confirm/images/ui/pattern.png) repeat left top,
+    url(confirm/images/ui/gradient.png) no-repeat left top;
   background-size: auto auto, 100% 100%;
   /* We can't use shortand with background size because is not implemented yet:
   https://bugzilla.mozilla.org/show_bug.cgi?id=570326; */
@@ -23,7 +25,7 @@ form[role="dialog"] {
   color: #fff;
 }
 
-form[role="dialog"]:before {
+form[role="dialog"][data-type="confirm"]:before {
   content: "";
   display: inline-block;
   vertical-align: middle;
@@ -32,7 +34,7 @@ form[role="dialog"]:before {
   margin-left: -1px;
 }
 
-form[role="dialog"] > section {
+form[role="dialog"][data-type="confirm"] > section {
   font-weight: lighter;
   font-size: 2.2rem;
   color: #FAFAFA;
@@ -44,7 +46,7 @@ form[role="dialog"] > section {
   white-space: normal;
 }
 
-form[role="dialog"] h1 {
+form[role="dialog"][data-type="confirm"] h1 {
   font-weight: normal;
   font-size: 1.6rem;
   line-height: 1em;
@@ -54,7 +56,7 @@ form[role="dialog"] h1 {
 }
 
 /* Menu & buttons setup */
-form[role="dialog"] menu {
+form[role="dialog"][data-type="confirm"] menu {
   white-space: nowrap;
   margin: 0;
   padding: 1.5rem;
@@ -68,7 +70,7 @@ form[role="dialog"] menu {
   bottom: 0;
 }
 
-form[role="dialog"] menu button {
+form[role="dialog"][data-type="confirm"] menu button {
   width: 100%;
   height: 3.8rem;
   margin: 0 0 1rem;
@@ -94,49 +96,49 @@ form[role="dialog"] menu button {
 }
 
 /* Press */
-form[role="dialog"] menu button:active {
+form[role="dialog"][data-type="confirm"] menu button:active {
   background-image: url(confirm/images/ui/button_press.png);
   background-color: #890707;
 }
 
 /* Disabled */
-form[role="dialog"] menu button[disabled] {
+form[role="dialog"][data-type="confirm"] menu button[disabled] {
   background-image: url(confirm/images/ui/button_disabled.png);
   text-shadow: none;
 }
 
 /* Reset & submit defaults */
-form[role="dialog"] menu button[type="reset"],
-form[role="dialog"] menu button[type="submit"] {
+form[role="dialog"][data-type="confirm"] menu button[type="reset"],
+form[role="dialog"][data-type="confirm"] menu button[type="submit"] {
   text-shadow: 1px 1px 0 rgba(255,255,255,0.3);
   color: #333;
 }
 
 /* Reset */
-form[role="dialog"] menu button[type="reset"] {
+form[role="dialog"][data-type="confirm"] menu button[type="reset"] {
   background-image: url(confirm/images/ui/button_reset.png);
   background-color: #fafafa;
   border: solid 1px #9f9f9f;
 }
 
 /* Submit */
-form[role="dialog"] menu button[type="submit"] {
+form[role="dialog"][data-type="confirm"] menu button[type="submit"] {
   background-image: url(confirm/images/ui/button_submit.png) ;
   background-color: #00caf2;
   border: 1px solid #00acce;
 }
 
 /* Pressed state, reset & submit */
-form[role="dialog"] menu button[type="reset"]:active,
-form[role="dialog"] menu button[type="submit"]:active {
+form[role="dialog"][data-type="confirm"] menu button[type="reset"]:active,
+form[role="dialog"][data-type="confirm"] menu button[type="submit"]:active {
   border: solid 1px #008aaa;
   background: #008aaa;
   color: #333;
 }
 
 /* Disabled, reset & submit) */
-form[role="dialog"] menu button[type="reset"][disabled],
-form[role="dialog"] menu button[type="submit"][disabled] {
+form[role="dialog"][data-type="confirm"] menu button[type="reset"][disabled],
+form[role="dialog"][data-type="confirm"] menu button[type="submit"][disabled] {
   background-image: url(confirm/images/ui/button_special_disabled.png);
   background-color: transparent;
   border: none;
@@ -144,43 +146,44 @@ form[role="dialog"] menu button[type="submit"][disabled] {
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
-form[role="dialog"] menu button:last-child {
+form[role="dialog"][data-type="confirm"] menu button:last-child {
   margin-left: 1rem;
 }
 
-form[role="dialog"] menu button,
-form[role="dialog"] menu button:first-child {
+form[role="dialog"][data-type="confirm"] menu button,
+form[role="dialog"][data-type="confirm"] menu button:first-child {
   margin: 0;
 }
 
-form[role="dialog"] menu button {
+form[role="dialog"][data-type="confirm"] menu button {
   width: calc((100% - 1rem) / 2);
 }
 
-form[role="dialog"] menu button.full {
+form[role="dialog"][data-type="confirm"] menu button.full {
   width: 100%;
 }
 
 /* Specific component code */
-form[role="dialog"] p {
+form[role="dialog"][data-type="confirm"] p {
   overflow: hidden;
   margin: 1rem 0 0;
   padding-top: 1rem;
   border-top: 0.1rem solid #686868;
 }
 
-form[role="dialog"] p img {
+form[role="dialog"][data-type="confirm"] p img {
   float: left;
   margin-right: 2rem;
 }
 
-form[role="dialog"] p strong {
+form[role="dialog"][data-type="confirm"] p strong {
   font-weight: lighter;
 }
 
-form[role="dialog"] p small {
+form[role="dialog"][data-type="confirm"] p small {
   font-size: 1.4rem;
   font-weight: normal;
   color: #cbcbcb;
   display: block;
 }
+

--- a/shared/style/confirm/content.html
+++ b/shared/style/confirm/content.html
@@ -9,16 +9,16 @@
   <link rel="stylesheet" href="../confirm.css">
 
   <!--
-  This <style> and <link> is only used for the example code, is no needed for the real case use
-  -->
-  <style>
+    - This <style> element is only used for the example code;
+    - it is not required for the real use case.
+    -->
+  <style type="text/css">
     html, body {
       margin: 0;
       padding: 0;
       font-size: 10px;
       background-color: #fff;
     }
-
     body {
       background: none;
     }
@@ -27,7 +27,7 @@
 
 <body role="application">
 
-  <form role="dialog">
+  <form role="dialog" data-type="confirm">
     <section>
       <h1>Confirmation</h1>
       <p>
@@ -45,3 +45,4 @@
 
 </body>
 </html>
+

--- a/shared/style/confirm/index.html
+++ b/shared/style/confirm/index.html
@@ -9,16 +9,16 @@
   <link rel="stylesheet" href="../confirm.css">
 
   <!--
-  This <style> and <link> is only used for the example code, is no needed for the real case use
-  -->
-  <style>
+    - This <style> element is only used for the example code;
+    - it is not required for the real use case.
+    -->
+  <style type="text/css">
     html, body {
       margin: 0;
       padding: 0;
       font-size: 10px;
       background-color: #fff;
     }
-
     body {
       background: none;
     }
@@ -27,7 +27,7 @@
 
 <body role="application">
 
-  <form role="dialog">
+  <form role="dialog" data-type="confirm">
     <section>
       <h1>Confirmation</h1>
       <p>Are you sure you want to delete this contact?</p>
@@ -40,3 +40,4 @@
 
 </body>
 </html>
+

--- a/shared/style/confirm/no_title.html
+++ b/shared/style/confirm/no_title.html
@@ -9,16 +9,16 @@
   <link rel="stylesheet" href="../confirm.css">
 
   <!--
-  This <style> and <link> is only used for the example code, is no needed for the real case use
-  -->
-  <style>
+    - This <style> element is only used for the example code;
+    - it is not required for the real use case.
+    -->
+  <style type="text/css">
     html, body {
       margin: 0;
       padding: 0;
       font-size: 10px;
       background-color: #fff;
     }
-
     body {
       background: none;
     }
@@ -27,7 +27,7 @@
 
 <body role="application">
 
-  <form role="dialog">
+  <form role="dialog" data-type="confirm">
     <section>
       <p>Are you sure you want to delete this contact?</p>
     </section>
@@ -39,3 +39,4 @@
 
 </body>
 </html>
+

--- a/shared/style/edit_mode.css
+++ b/shared/style/edit_mode.css
@@ -2,7 +2,7 @@
  * Edit mode
  * ---------------------------------- */
 
-form[role="dialog"].edit {
+form[role="dialog"][data-type="edit"] {
   overflow: hidden;
   position: absolute;
   z-index: 100;
@@ -17,7 +17,7 @@ form[role="dialog"].edit {
 }
 
 /* Header */
-form[role="dialog"].edit header {
+form[role="dialog"][data-type="edit"] header {
   pointer-events: auto;
   position: relative;
   z-index: 10;
@@ -28,7 +28,7 @@ form[role="dialog"].edit header {
   border: none;
 }
 
-form[role="dialog"].edit header:after {
+form[role="dialog"][data-type="edit"] header:after {
   content: "";
   display: block;
   height: 0.3rem;
@@ -40,7 +40,7 @@ form[role="dialog"].edit header:after {
   background-size: auto 100%;
 }
 
-form[role="dialog"].edit header h1 {
+form[role="dialog"][data-type="edit"] header h1 {
   font: 2.2rem/4.8rem "Open Sans", Sans-serif;
   text-align: left;
   color: #fff;
@@ -52,7 +52,7 @@ form[role="dialog"].edit header h1 {
   height: 100%
 }
 
-form[role="dialog"].edit header button {
+form[role="dialog"][data-type="edit"] header button {
   border: none;
   background: none;
   padding: 0;
@@ -62,14 +62,14 @@ form[role="dialog"].edit header button {
   border-radius: 0;
 }
 
-form[role="dialog"].edit header menu[type="toolbar"] {
+form[role="dialog"][data-type="edit"] header menu[type="toolbar"] {
   height: 100%;
   float: right;
   margin: 0;
   padding: 0;
 }
 
-form[role="dialog"].edit header menu[type="toolbar"] button {
+form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
   height: 5rem;
   min-width: 5rem;
   width: auto;
@@ -86,26 +86,26 @@ form[role="dialog"].edit header menu[type="toolbar"] button {
   z-index: 5;
 }
 
-form[role="dialog"].edit header menu[type="toolbar"] button:last-child {
+form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button:last-child {
   background: url(edit_mode/images/ui/separator.png) no-repeat left center;
   margin-left: -2px;
   z-index: 1;
 }
 
 /* Press state */
-form[role="dialog"].edit header button:active .icon:after,
-form[role="dialog"].edit header menu[type="toolbar"] button:active  {
+form[role="dialog"][data-type="edit"] header button:active .icon:after,
+form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button:active  {
   background: #008aaa !important;
   transition: background 0.2s ease;
   border-bottom: solid 1px rgba(0, 0, 0, 0.2) !important;
   color: #fff;
 }
 
-form[role="dialog"].edit header button:first-letter {
+form[role="dialog"][data-type="edit"] header button:first-letter {
   text-transform: uppercase;
 }
 
-form[role="dialog"].edit header > button {
+form[role="dialog"][data-type="edit"] header > button {
   position: absolute;
   left: 0;
   width: 4rem;
@@ -115,7 +115,7 @@ form[role="dialog"].edit header > button {
   text-align: center;
 }
 
-form[role="dialog"].edit header > button span {
+form[role="dialog"][data-type="edit"] header > button span {
   background: url(edit_mode/images/icons/close.png) no-repeat center center;
   overflow: visible;
   font: 0/0 a;
@@ -125,7 +125,7 @@ form[role="dialog"].edit header > button span {
   display: block;
 }
 
-form[role="dialog"].edit header > button span:after {
+form[role="dialog"][data-type="edit"] header > button span:after {
   content: "";
   position: absolute;
   left: 0;
@@ -136,7 +136,7 @@ form[role="dialog"].edit header > button span:after {
 }
 
 /* Menu */
-form[role="dialog"].edit > menu {
+form[role="dialog"][data-type="edit"] > menu {
   pointer-events: auto;
   white-space: nowrap;
   margin: 0;
@@ -151,7 +151,7 @@ form[role="dialog"].edit > menu {
   bottom: 0;
 }
 
-form[role="dialog"] menu button {
+form[role="dialog"][data-type="edit"] menu button {
   width: 100%;
   height: 3.8rem;
   margin: 0 0 1rem;
@@ -177,22 +177,22 @@ form[role="dialog"] menu button {
 }
 
 /* Press (default & recommend) */
-form[role="dialog"] menu button:active,
-form[role="dialog"] menu button.recommend:active {
+form[role="dialog"][data-type="edit"] menu button:active,
+form[role="dialog"][data-type="edit"] menu button.recommend:active {
   border-color: #008aaa;
   background: #008aaa;
   color: #333;
 }
 
 /* Recommend */
-form[role="dialog"] menu button.recommend{
+form[role="dialog"][data-type="edit"] menu button.recommend{
   background-image: url(edit_mode/images/ui/recommend.png);
   background-color: #00caf2;
   border-color: #00acce;
 }
 
 /* Danger */
-form[role="dialog"] menu button.danger{
+form[role="dialog"][data-type="edit"] menu button.danger{
   background-image: url(edit_mode/images/ui/danger.png);
   background-color: #b70404;
   color: #fff;
@@ -201,14 +201,14 @@ form[role="dialog"] menu button.danger{
 }
 
 /* Danger Press */
-form[role="dialog"] menu button.danger:active{
+form[role="dialog"][data-type="edit"] menu button.danger:active{
   background-image: url(edit_mode/images/ui/danger-press.png);
   background-color: #890707;
 }
 
 /* Disabled (default & recommend) */
-form[role="dialog"] menu button[disabled],
-form[role="dialog"] menu button[disabled].recommend {
+form[role="dialog"][data-type="edit"] menu button[disabled],
+form[role="dialog"][data-type="edit"] menu button[disabled].recommend {
   background-image: url(edit_mode/images/ui/disabled.png);
   background-color: transparent;
   border: none;
@@ -218,26 +218,27 @@ form[role="dialog"] menu button[disabled].recommend {
 }
 
 /* Danger disabled */
-form[role="dialog"] menu button[disabled].danger {
+form[role="dialog"][data-type="edit"] menu button[disabled].danger {
   background-image: url(edit_mode/images/ui/danger-disabled.png);
   color: #fff;
   text-shadow: none;
   pointer-events: none;
 }
 
-form[role="dialog"] menu button:last-child {
+form[role="dialog"][data-type="edit"] menu button:last-child {
   margin-left: 1rem;
 }
 
-form[role="dialog"] menu button,
-form[role="dialog"] menu button:first-child {
+form[role="dialog"][data-type="edit"] menu button,
+form[role="dialog"][data-type="edit"] menu button:first-child {
   margin: 0;
 }
 
-form[role="dialog"] menu button {
+form[role="dialog"][data-type="edit"] menu button {
   width: calc((100% - 1rem) / 2);
 }
 
-form[role="dialog"] menu button.full {
+form[role="dialog"][data-type="edit"] menu button.full {
   width: 100%;
 }
+

--- a/shared/style/edit_mode/index.html
+++ b/shared/style/edit_mode/index.html
@@ -9,16 +9,16 @@
   <link rel="stylesheet" href="../edit_mode.css">
 
   <!--
-  This <style> and <link> is only used for the example code, is no needed for the real case use
-  -->
-  <style>
+    - This <style> element is only used for the example code;
+    - it is not required for the real use case.
+    -->
+  <style type="text/css">
     html, body {
       margin: 0;
       padding: 0;
       font-size: 10px;
       background-color: #fff;
     }
-
     body {
       background: none;
     }
@@ -26,7 +26,8 @@
 </head>
 
 <body role="application">
-  <form role="dialog" class="edit" onsubmit="return false;">
+
+  <form role="dialog" data-type="edit" onsubmit="return false;">
     <section>
       <header>
         <button><span class="icon icon-close">close</span></button>
@@ -44,3 +45,4 @@
 
 </body>
 </html>
+

--- a/shared/style/switches.css
+++ b/shared/style/switches.css
@@ -1,6 +1,7 @@
 /* ----------------------------------
  * CHECKBOXES / RADIOS
  * ---------------------------------- */
+
 label:not([for])  {
   display: inline-block;
   vertical-align: middle;
@@ -9,10 +10,10 @@ label:not([for])  {
   position: relative;
 }
 
-label:not([for]) > input {
+label:not([for]) input {
   margin: 0;
   opacity: 0;
-  position:absolute;
+  position: absolute;
   top: 0;
   left: 0;
 }
@@ -35,7 +36,7 @@ label:not([for]) input[type="radio"] + span {
   background: url(switches/images/radio/default.png) no-repeat center top;
 }
 
-label:not([for]) > input:checked + span {
+label:not([for]) input:checked + span {
   background-position: center bottom;
 }
 
@@ -49,23 +50,12 @@ label:not([for]).danger input[type="radio"] + span {
   background-image: url(switches/images/radio/danger.png);
 }
 
+
 /* ----------------------------------
  * ON/OFF SWITCHES
  * ---------------------------------- */
-label.switch {
-  display: inline-block;
-  vertical-align: middle;
-  position: relative;
-  z-index: 1;
-  width: 6rem;
-  height: 4rem;
-}
 
-label.switch input {
-  opacity: 0;
-}
-
-label.switch input[type="checkbox"] + span {
+label input[type="checkbox"][data-type="switch"] + span {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -81,8 +71,8 @@ label.switch input[type="checkbox"] + span {
   transition: background 0.18s ease;
 }
 
-label.switch span:after,
-label.switch span:before {
+label input[data-type="switch"] + span:after,
+label input[data-type="switch"] + span:before {
   content: "";
   position: absolute;
   top: 0;
@@ -92,28 +82,30 @@ label.switch span:before {
   transition: transform 0.2s ease;
 }
 
-label.switch span:before {
+label input[data-type="switch"] + span:before {
   right: 100%;
   background: #00c3ea url(switches/images/switch/icon.png) no-repeat 0.5rem center;
   background-size: auto calc(100% - 2px);
 }
 
-label.switch span:after {
+label input[data-type="switch"] + span:after {
   left: 100%;
   background: #e6e6e6;
   transform: translateX(-5.4rem);
 }
 
-/* state ON */
-label.switch input:checked + span {
+/* 'ON' state */
+
+label input[data-type="switch"]:checked + span {
   border-color: #00acce;
   background-position: 3.2rem center;
 }
 
-label.switch input:checked + span:before {
+label input[data-type="switch"]:checked + span:before {
   transform: translateX(5.4rem);
 }
 
-label.switch input:checked + span:after {
+label input[data-type="switch"]:checked + span:after {
   transform: translateX(0);
 }
+

--- a/shared/style/switches/index.html
+++ b/shared/style/switches/index.html
@@ -6,9 +6,10 @@
   <meta name="description" content="Activates/Deactivates a given item. It's also used to select an element within a list">
   <link rel="stylesheet" href="../switches.css">
   <!--
-    This <style> and <link> is only used for the example code, is no needed for the real case use
-  -->
-  <style>
+    - This <style> element is only used for the example code;
+    - it is not required for the real use case.
+    -->
+  <style type="text/css">
     html, body {
       margin: 0;
       padding: 0;
@@ -31,6 +32,7 @@
   </style>
 </head>
 <body role="application">
+
   <h2 class="bb-docs">Checkbox, commonly used in edit mode</h2>
   <label>
     <input type="checkbox" checked>
@@ -42,12 +44,12 @@
     <span></span>
   </label>
 
-  <label class="negative">
+  <label class="danger">
     <input type="checkbox" checked>
     <span></span>
   </label>
 
-  <label class="negative">
+  <label class="danger">
     <input type="checkbox">
     <span></span>
   </label>
@@ -63,25 +65,26 @@
     <span></span>
   </label>
 
-  <label class="negative">
+  <label class="danger">
     <input type="radio" name="example2" checked>
     <span></span>
   </label>
 
-  <label class="negative">
+  <label class="danger">
     <input type="radio" name="example2">
     <span></span>
   </label>
 
   <h2 class="bb-docs">Switch, commonly used in settings</h2>
   <label class="switch">
-    <input type="checkbox" checked>
+    <input type="checkbox" data-type="switch" checked>
     <span></span>
   </label>
 
   <label class="switch">
-    <input type="checkbox">
+    <input type="checkbox" data-type="switch">
     <span></span>
   </label>
 </body>
 </html>
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=799440

I suggest using `dialog-*` class names to avoid these conflicts:
- `.dialog-action`: title + action selection + accept/dismiss buttons
- `.dialog-confirm`: message + accept/dismiss buttons
- `.dialog-edit`: edition panel with dialog-like button toolbar
- `.dialog-object`: action selection + accept/dismiss buttons
