### PR TITLE
[Dialer][USSD] Properly dealing with DOMRequest.result/error when sending MMI

### DIFF
--- a/apps/communications/dialer/js/ussd.js
+++ b/apps/communications/dialer/js/ussd.js
@@ -46,11 +46,8 @@ var UssdManager = {
 
   notifySuccess: function um_notifySuccess(evt) {
     var message = {
-      type: 'success'
-      // For the time being the RIL sends an Object in the
-      // DOMRequest.result with no content so we notify no result
-      // to the UI instead of:
-      // result: evt.target.result
+      type: 'success',
+      result: evt.target.result
     };
     if (this._popup && this._popup.ready) {
       this._popup.postMessage(message, this._origin);

--- a/apps/communications/dialer/js/ussd.js
+++ b/apps/communications/dialer/js/ussd.js
@@ -85,10 +85,12 @@ var UssdManager = {
     var message;
     switch (evt.type) {
       case 'ussdreceived':
-        message = {
-          type: 'ussdreceived',
-          message: evt.message
-        };
+        // Do not notify the UI if no message to show.
+        if (evt.message)
+          message = {
+            type: 'ussdreceived',
+            message: evt.message
+          };
         break;
       case 'voicechange':
         // Even without SIM card, the mozMobileConnection.voice.network object
@@ -111,10 +113,9 @@ var UssdManager = {
             break;
         }
         return;
-        break;
     }
 
-    if (this._popup && this._popup.ready) {
+    if (message && this._popup && this._popup.ready) {
       this._popup.postMessage(message, this._origin);
     }
   }

--- a/apps/communications/dialer/js/ussd_ui.js
+++ b/apps/communications/dialer/js/ussd_ui.js
@@ -104,25 +104,10 @@ var UssdUI = {
 
     switch (evt.data.type) {
       case 'success':
-        var message = '',
-          result = evt.data.result;
-        if (typeof result === 'object') {
-          var keys = Object.keys(result),
-            keysLength = keys.length;
-          for (var i = 0; i < keysLength; i++)
-            message += keys[i] + ": " + result[keys[i]] + '\n';
-          // We have observed that in some cases we get an Object as
-          // the evt.data.result with no properties.
-          if (keysLength === 0)
-            message = this._('message-successfully-sent');
-        }
-        else
-          message = this._('message-successfully-sent');
-        this.showMessage(message);
+        this.showMessage(evt.data.result);
         break;
       case 'error':
-        this.showMessage(evt.data.error ?
-          evt.data.error : this._('ussd-server-error'));
+        this.showMessage(evt.data.error);
         break;
       case 'ussdreceived':
         this.showMessage(evt.data.message);

--- a/apps/communications/dialer/js/ussd_ui.js
+++ b/apps/communications/dialer/js/ussd_ui.js
@@ -104,8 +104,21 @@ var UssdUI = {
 
     switch (evt.data.type) {
       case 'success':
-        this.showMessage(evt.data.result ?
-          evt.data.result : this._('message-successfully-sent'));
+        var message = '',
+          result = evt.data.result;
+        if (typeof result === 'object') {
+          var keys = Object.keys(result),
+            keysLength = keys.length;
+          for (var i = 0; i < keysLength; i++)
+            message += keys[i] + ": " + result[keys[i]] + '\n';
+          // We have observed that in some cases we get an Object as
+          // the evt.data.result with no properties.
+          if (keysLength === 0)
+            message = this._('message-successfully-sent');
+        }
+        else
+          message = this._('message-successfully-sent');
+        this.showMessage(message);
         break;
       case 'error':
         this.showMessage(evt.data.error ?

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -45,4 +45,3 @@ clear-all-text=Clear all text
 
 
 
-

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -42,7 +42,7 @@ sending=Sending...
 ussd-services={{ operator }} services
 type-your-response.placeholder=Type your response...
 clear-all-text=Clear all text
-message-successfully-sent=MESSAGE SUCCESSFULLY SENT
-ussd-server-error=THERE WAS AN ERROR IN THE COMMUNICATION, PLEASE TRY IT AGAIN LATER
+
+
 
 

--- a/apps/communications/dialer/test/unit/mock_mozMobileConnection.js
+++ b/apps/communications/dialer/test/unit/mock_mozMobileConnection.js
@@ -5,7 +5,7 @@ var MockMozMobileConnection = {
   _ussd_listener_object: null,
   _ussd_message_sent: false,
   _ussd_cancelled: false,
-  sendUSSD: function mmmc_sendUSSD(message) {
+  sendMMI: function mmmc_sendMMI(message) {
     this._ussd_message_sent = true;
     var evt = {
       type: 'ussdreceived',
@@ -19,7 +19,7 @@ var MockMozMobileConnection = {
     var domRequest = {};
     return domRequest;
   },
-  cancelUSSD: function mmmc_cancelUSSD() {
+  cancelMMI: function mmmc_cancelMMI() {
     this._ussd_cancelled = true;
   },
   addEventListener: function mmmc_addEventListener(event_name, listener) {

--- a/apps/communications/dialer/ussd.html
+++ b/apps/communications/dialer/ussd.html
@@ -52,7 +52,7 @@
       </section>
       <form id="response" role="region">
         <p>
-          <input id="response-text" type="tel" data-l10n-id="type-your-response" placeholder="Type your selection..." required disabled>
+          <input id="response-text" type="text" data-l10n-id="type-your-response" placeholder="Type your selection..." required disabled>
           <button id="response-text-reset" type="reset" data-l10n-id="clear-all-text"> Clear-all-text </button>  
         </p>
       </form>


### PR DESCRIPTION
After confirming it with the backend guys, in case of success or error when sending MMI the corresponding DOMRequest.result or DOMRequest.error are properly filled. The code on the client side has been simplified accordingly.

On the other hand, in case of ussdreceived, the message is only shown if the RIL provides any information in the event.message property.
