### PR TITLE
Bug 798517 - Do not register Browser as an event listener.

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -45,7 +45,6 @@ var Browser = {
     this.getAllElements();
 
     // Add event listeners
-    window.addEventListener('keyup', this, true);
     window.addEventListener('resize', this.handleWindowResize.bind(this));
 
     this.backButton.addEventListener('click', this.goBack.bind(this));


### PR DESCRIPTION
https://bugzil.la/798517

This is a regression from commit 70eb9c3. Browser's handleEvent() was replaced by handleUrlInputKeypress(), but Browser was still being registered as a 'keyup' event listener.
