### PR TITLE
Bug 796778 - [Browser] Page titles on start page not same width as thumbnails

### DIFF
--- a/apps/browser/style/browser.css
+++ b/apps/browser/style/browser.css
@@ -483,7 +483,8 @@ input::-moz-focus-inner {
 #top-site-thumbnails li span {
   font-size: 12px;
   display: block;
-  width: 140px;
+  width: 134px;
+  height: 15px;
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -492,6 +493,7 @@ input::-moz-focus-inner {
   position: absolute;
   bottom: 0px;
   padding: 3px;
+  pointer-events: none;
 }
 
 #awesomescreen {


### PR DESCRIPTION
This pull request fixes three issues:

1) The labels for top site thumbnails are now as wide as the thumbnails.
2) Labels for top site thumbnails aren't contained in the anchor element and thus will intercept clicks. Not anymore since they're now ignore any pointer-events.
3) If a top site doesn't have a title the label will just collapse to its padding height. We can fix this by explicitly inserting a white space.
