### PR TITLE
Bug 800209 - Improves sync indication logic ground work for sync

### DIFF
--- a/apps/calendar/js/controllers/sync.js
+++ b/apps/calendar/js/controllers/sync.js
@@ -22,7 +22,10 @@ Calendar.ns('Controllers').Sync = (function() {
 
       // used instead of bind for testing reasons.
       account.on('add', function(id, data) {
-        self._syncAccount(data);
+        self.emit('sync start');
+        self._syncAccount(data, function() {
+          self.emit('sync complete');
+        });
       });
     },
 

--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -107,7 +107,7 @@ body[data-path^='/settings'] #time-views {
   background-color: rgba(0, 0, 0, 0.3);
 }
 
-#settings .sync.active {
+.sync-in-progress #settings .sync {
   display: none;
 }
 

--- a/apps/calendar/test/unit/controllers/sync_test.js
+++ b/apps/calendar/test/unit/controllers/sync_test.js
@@ -50,19 +50,39 @@ suite('controllers/sync', function() {
   });
 
   test('#observe', function(done) {
-    var model;
+    var model = Factory('account');
+    var calledWith;
+    var syncStart;
+    var syncEnd;
+
+    function complete() {
+      done(function() {
+        assert.equal(calledWith[0], model);
+        assert.ok(syncStart, 'start sync');
+        assert.ok(syncEnd, 'end sync');
+      });
+    };
+
+    subject.on('sync start', function() {
+      syncStart = true;
+    });
+
+    subject.on('sync complete', function() {
+      syncEnd = true;
+    });
 
     subject.observe();
 
     subject._syncAccount = function(data) {
-      done(function() {
-        assert.equal(model, data);
-      });
+      calledWith = arguments;
+      setTimeout(complete, 0);
+      var cb = arguments[1];
+      cb();
     }
 
-    model = Factory('account');
-
-    account.persist(model);
+    account.persist(model, function() {
+      console.log(arguments[1]);
+    });
   });
 
   suite('#sync', function() {

--- a/apps/calendar/test/unit/views/settings_test.js
+++ b/apps/calendar/test/unit/views/settings_test.js
@@ -43,7 +43,8 @@ suite('views/settings', function() {
     template = Calendar.Templates.Calendar;
 
     subject = new Calendar.Views.Settings({
-      app: app
+      app: app,
+      syncProgressTarget: div
     });
   });
 
@@ -65,6 +66,10 @@ suite('views/settings', function() {
 
   test('#syncButton', function() {
     assert.ok(subject.syncButton);
+  });
+
+  test('#syncProgressTarget', function() {
+    assert.ok(subject.syncProgressTarget);
   });
 
   suite('#_initEvents', function() {
@@ -139,6 +144,34 @@ suite('views/settings', function() {
       assert.equal(children.length, 0);
     });
 
+    suite('sync (start|complete)', function() {
+      var classList;
+
+      setup(function() {
+        classList = subject.syncProgressTarget.classList;
+        console.log(classList.toString());
+        assert.ok(
+          !classList.contains(subject.syncClass),
+          'not active initially'
+        );
+
+        app.syncController.emit('sync start');
+      });
+
+      teardown(function() {
+        classList.remove(subject.syncClass);
+      });
+
+      test('start', function() {
+        assert.ok(classList.contains(subject.syncClass), 'is active');
+      });
+
+      test('complete', function() {
+        app.syncController.emit('sync complete');
+        assert.ok(!classList.contains(subject.syncClass), 'remove active');
+      });
+    });
+
   });
 
   test('sync', function() {
@@ -151,17 +184,7 @@ suite('views/settings', function() {
     }
 
     triggerEvent(subject.syncButton, 'click');
-
-    assert.isTrue(el.classList.contains(
-      subject.activeClass
-    ));
-
     assert.ok(calledWith);
-    calledWith[0]();
-
-    assert.isFalse(el.classList.contains(
-      subject.activeClass
-    ));
   });
 
   suite('#_onCalendarDisplayToggle', function() {


### PR DESCRIPTION
Small set of improvements to the sync indicator logic. This also changes how we hide/show the sync button (by applying a css class to the body instead of just the button) which should allow us to actually display the real sync indicator once we have one.

This should land first it blocks the blocker (799135).
