### PR TITLE
[Bug 796596][Dialer][Call log] Preventing swiping from provoking a click event

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -17,7 +17,8 @@ var Recents = {
 
   get recentsIconClose() {
     delete this.recentsIconClose;
-    return this.recentsIconClose = document.getElementById('recents-icon-close');
+    return this.recentsIconClose =
+      document.getElementById('recents-icon-close');
   },
 
   get recentsIconDelete() {

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -95,6 +95,10 @@ var Recents = {
         this.selectAllEntries.bind(this));
     }
     if (this.recentsContainer) {
+      this.recentsContainer.addEventListener('mousedown',
+        this.mouseDown.bind(this));
+      this.recentsContainer.addEventListener('mouseup',
+        this.mouseUp.bind(this));
       this.recentsContainer.addEventListener('click',
         this.click.bind(this));
     }
@@ -318,7 +322,24 @@ var Recents = {
     return entriesInGroup;
   },
 
+  mouseDown: function re_mouseDown(event) {
+    this._mouseDownX = event.screenX;
+    this._mouseDownY = event.screenY;
+  },
+
+  mouseUp: function re_mouseUp(event) {
+    if (Math.abs(this._mouseDownX - event.screenX) > 10 ||
+      Math.abs(this._mouseDownY - event.screenY) > 10) {
+      this._ignoreClickEvent = true;
+    } else {
+      this._ignoreClickEvent = false;
+    }
+  },
+
   click: function re_click(event) {
+    if (this._ignoreClickEvent) {
+      return;
+    }
     var target = event.target;
     if (!target) {
       return;
@@ -670,4 +691,3 @@ window.addEventListener('localized', function recentsSetup() {
     FixedHeader.init('#recents-container', '#fixed-container', headerSelector);
     Recents.init();
 });
-


### PR DESCRIPTION
We have to prevent the click event from being processed on the client side in case the user has also swiped on the call log. The underlying framework is currently notifying this click event, being under discussion if it should be notified or not. See https://bugzilla.mozilla.org/show_bug.cgi?id=796596 for furher information.
