### PR TITLE
Bug 796771 Making the font-size not being overwriten on the call status bar

### DIFF
--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -541,15 +541,22 @@ button[disabled] .icon-keypad-visibility {
 
   #calls > section .number,
   #calls[data-count="1"] > section .number {
-    width: -moz-calc(100% - 10rem);
+    width: -moz-calc(100% - 12rem);
     height: -moz-calc(100% - 2rem);
     padding: 1rem;
     margin-left: 3rem;
-    font-size: 1.1em;
     line-height: 100%;
     color: white;
     background-color: transparent;
     white-space: nowrap;
+    text-overflow: ellipsis;
+
+    /* font-size is overwriten via JS and we need
+    to be sure it doesn't happen when the call is
+    in the status bar. Workarounds would imply
+    listening resize event and JS changes, so we
+    need to add !important here */
+    font-size: 1.1em !important;
   }
 
   #calls > section .duration,


### PR DESCRIPTION
Tricky bug here, as the font-size is calculated manually in [1]. As we have a media query for the status bar, I just set the !important attribute to don't be overwritten. I also tested it in the device with long names and it wasn't displayed correctly, so I added a new width an elliipsis.

r? @gtorodelvalle @etiennesegonzac 

[1] https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/dialer/js/keypad.js#L359
