### PR TITLE
Bug 796461 - Make sure wireless network list is always up-to-date

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -163,12 +163,32 @@ window.addEventListener('localized', function wifiSettings(evt) {
   if (!settings)
     return;
 
+  var gWifi = document.querySelector('#wifi');
   var gWifiCheckBox = document.querySelector('#wifi-enabled input');
   var gWifiInfoBlock = document.querySelector('#wifi-desc');
   var gWpsInfoBlock = document.querySelector('#wps-column small');
   var gWpsPbcLabelBlock = document.querySelector('#wps-column a');
 
   var gCurrentNetwork = gWifiManager.connection.network;
+
+  var gWifiSectionVisible = false;
+  function updateVisibilityStatus() {
+    var computedStyle = window.getComputedStyle(gWifi);
+    gWifiSectionVisible = (!document.mozHidden &&
+                           computedStyle.visibility != 'hidden');
+
+    if (gWifiSectionVisible && gScanPending) {
+      gNetworkList.scan();
+      gScanPending = false;
+    }
+  }
+
+  document.addEventListener('mozvisibilitychange', updateVisibilityStatus);
+  gWifi.addEventListener('transitionend', function (evt) {
+    if (evt.target == gWifi) {
+      updateVisibilityStatus();
+    }
+  });
 
   // toggle wifi on/off
   gWifiCheckBox.onchange = function toggleWifi() {
@@ -192,12 +212,17 @@ window.addEventListener('localized', function wifiSettings(evt) {
    *        disconnected.
    */
 
+  var gScanPending = false;
+  var gScanStates = new Set(['connected', 'connectingfailed', 'disconnected']);
   gWifiManager.onstatuschange = function(event) {
     updateNetworkState();
 
-    // refresh the network list when network is connected.
-    if (event.status === 'connected') {
-      gNetworkList.scan();
+    if (gScanStates.has(event.status)) {
+      if (gWifiSectionVisible) {
+        gNetworkList.scan();
+      } else {
+        gScanPending = true;
+      }
     }
   };
 


### PR DESCRIPTION
This patch uses 'transitionend' and 'mozvisibilitychange' to keep track of the wifi section's visibility. While the section is hidden, we'll not scan for new networks but set the pending flag. Once the section becomes visible again and a scan is pending, we kick it off.

The visibility change works for putting the settings apps in the background with the home key, closing the wifi settings and going back to the main settings screen, and locking the screen.
