### PR TITLE
bug 799947: `/shared/style_unstable/` support

### DIFF
--- a/shared/style_unstable/README.md
+++ b/shared/style_unstable/README.md
@@ -1,0 +1,1 @@
+This `shared/style_unstable` directory holds all building blocks that aren’t ready for `shared/style` yet.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=799947

In order to ease CSS reuse, a `shared/style_unstable` directory could be created where we could land building blocks that do not meet all the requirements for `shared/style`.

Requirements for `shared/style_unstable`:
- HTML markup is valid (passes the W3C validator);
- specific class names (if any) are documented;
- reviewed by TEF + Mozilla devs.

Additional requirements for `shared/style`:
- HTML markup is canonical (= as few elements as possible);
- block is used in at least three Gaia apps;
- no arbitrary attributes / class names.
