### PR TITLE
Need to display the homescreen app during its first open.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1088,7 +1088,6 @@ var WindowManager = (function() {
           // the homescreen later, if necessary.
           homescreenURL = e.detail.url;
           homescreenManifestURL = manifestURL;
-          return;
         }
 
         // XXX: the correct way would be for UtilityTray to close itself


### PR DESCRIPTION
Please refer to Bug 796293. System Message mechanism would ask for opening apps twice, which is redundant. After fixing that, we also need to have some corresponding changes in the window_manager.js to let homescreen app display during its first open. I see no reason why we need to return that and rely on the second attempt to display it, which should be a potential logic error.
