### PR TITLE
Bug 796544 - partial support for inputmode attribute

### DIFF
--- a/apps/keyboard/js/controller.js
+++ b/apps/keyboard/js/controller.js
@@ -44,6 +44,7 @@ const IMEController = (function() {
   var _currentKey = null;
   var _realInputType = null;
   var _currentInputType = null;
+  var _currentInputMode = null;  // value of the inputmode attribute
   var _menuLockedArea = null;
   var _lastHeight = 0;
   var _lastKeyCode = 0;
@@ -145,8 +146,17 @@ const IMEController = (function() {
     return '';
   }
 
+  var capitalizedInputModes = {
+    "": true,
+    "latin-prose": true,
+    "latin-name": true,
+    "full-latin-width": true
+  };
+
   function _requireAutoCapitalize() {
-    return (_realInputType == 'text' || _realInputType == 'textarea');
+    return (_realInputType == 'text' || _realInputType == 'textarea') &&
+      (_currentInputMode == undefined ||
+       _currentInputMode in capitalizedInputModes);
   }
 
   // Add some special keys depending on the input's type
@@ -1121,17 +1131,18 @@ const IMEController = (function() {
     uninit: _uninit,
 
     // Show IME, receives the input's type
-    showIME: function kc_showIME(type) {
+    showIME: function kc_showIME(state) {
       delete IMERender.ime.dataset.hidden;
       IMERender.ime.classList.remove('hide');
 
-      _realInputType = type;
-      _currentInputType = _mapType(type);
+      _realInputType = state.type;
+      _currentInputType = _mapType(state.type);
+      _currentInputMode = state.inputmode;
       _reset();
 
       if (_requireIME()) {
         if (_getCurrentEngine().show) {
-          _getCurrentEngine().show(type);
+          _getCurrentEngine().show(state.type);
         }
       }
 

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -15,10 +15,10 @@ if (!window.navigator.mozKeyboard) {
   var focusChangeTimeout = 0;
   var focusChangeDelay = 20;
   window.navigator.mozKeyboard.onfocuschange = function onfocuschange(evt) {
-
+    var state = evt.detail;
     var typeToSkip = ['select-one', 'select-multiple', 'date',
                       'time', 'datetime', 'datetime-local'];
-    var type = evt.detail.type;
+    var type = state.type;
     // Skip the <select> element and inputs with type of date/time,
     // handled in system app for now
     // Also workaround an issue that type might be empty
@@ -30,7 +30,7 @@ if (!window.navigator.mozKeyboard) {
       if (type === 'blur') {
         IMEController.hideIME();
       } else {
-        IMEController.showIME(type);
+        IMEController.showIME(state);
       }
     }, focusChangeDelay);
   };

--- a/test_apps/uitest/index.html
+++ b/test_apps/uitest/index.html
@@ -33,6 +33,7 @@
       <li><a href="#test=httpauthentication">HTTP Authentication</a></li>
       <li><a href="#test=pickphoto">Pick Photo</a></li>
       <li><a href="#test=pay">navigator.mozPay tests</a></li>
+      <li><a href="#test=inputmode">text inputmode tests</a></li>
     </ul>
   </div>
   <div id="test-panel" class="panel">

--- a/test_apps/uitest/tests/inputmode.html
+++ b/test_apps/uitest/tests/inputmode.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="pragma" content="no-cache">
+    <title>Inputmode tests</title>
+    <style>
+      input { width: 150px; }
+      textarea { width: 150px; height: 30px; }
+    </style>
+    <script>
+    </script>
+  </head>
+
+  <body>
+    <p>
+      When you tap in a field labelled "latin" and "verbatim" you
+      should see a keyboard in lowercase mode. When you tap in one
+      labelled "none", "latin-prose", or "latin-name" you should see a
+      keyboard in uppercase mode. Eventually there will be other
+      differences as well (in word suggestions, for example) but for
+      now, inputmode is just controlling auto capitalization
+    </p>
+
+    none: <input type="text"><br>
+    latin: <input type="text" inputmode="latin"><br>
+    verbatim: <input type="text" inputmode="verbatim"><br>
+    latin-prose: <input type="text" inputmode="latin-prose"><br>
+    latin-name: <input type="text" inputmode="latin-name"><br>
+
+    none: <textarea></textarea><br>
+    latin: <textarea inputmode="latin"></textarea><br>
+    verbatim: <textarea inputmode="verbatim"></textarea><br>
+    latin-prose: <textarea inputmode="latin-prose"></textarea><br>
+    latin-name: <textarea inputmode="latin-name"></textarea><br>
+  </body>
+</html>


### PR DESCRIPTION
This pull request implements partial support for the inputmode attribute, so that the Gaia keyboard will not auto-capitialize for "verbatim" and "latin" modes.  It doesn't affect text suggestions at all yet, but this is enough to enable a fix for https://bugzilla.mozilla.org/show_bug.cgi?id=797867

This fix requires the forms.js patch that I'm going to up up in bugzilla, but it is safe to land this before that one lands.
