### PR TITLE
[Bug 796244] Remove lockscreen timeout after multiple failed attempts

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -65,24 +65,9 @@ var LockScreen = {
   passCodeEntered: '',
 
   /*
-  * Number of passcode tries
-  */
-  passCodeError: 0,
-
-  /*
   * Timeout after incorrect attempt
   */
   kPassCodeErrorTimeout: 500,
-
-  /*
-  * Number of attempts allowed
-  */
-  kPassCodeTries: 3,
-
-  /*
-  * Cool down period after kPassCodeTries
-  */
-  kPassCodeTriesTimeout: 5 * 60 * 1000,
 
   /*
   * Airplane mode
@@ -873,17 +858,12 @@ var LockScreen = {
       if ('vibrate' in navigator)
         navigator.vibrate([50, 50, 50]);
 
-      var timeout = this.kPassCodeErrorTimeout;
-      this.passCodeError++;
-      if (this.passCodeError >= 3)
-        timeout = this.kPassCodeTriesTimeout;
-
       var self = this;
       setTimeout(function error() {
         delete self.overlay.dataset.passcodeStatus;
         self.passCodeEntered = '';
         self.updatePassCodeUI();
-      }, timeout);
+      }, this.kPassCodeErrorTimeout);
     }
   },
 


### PR DESCRIPTION
This patch removes the frozen state you currently enter after multiple failed attempts to unlock the device. Because we don't have clear UX for this state, Josh decided that it would be best to just remove this functionality for v1. See the bug for more discussion: https://bugzilla.mozilla.org/show_bug.cgi?id=796244
