### PR TITLE
Bug 796488 - [Contacts] The selection list won't show up after press Add Picture field in the first time

### DIFF
--- a/apps/system/js/list_menu.js
+++ b/apps/system/js/list_menu.js
@@ -116,11 +116,17 @@ var ListMenu = {
   },
 
   show: function lm_show() {
+    if (this.visible)
+      return;
+
     this.container.classList.remove('slidedown');
     this.element.classList.add('visible');
   },
 
   hide: function lm_hide() {
+    if (!this.visible)
+      return;
+
     var self = this;
     this.container.addEventListener('transitionend',
       function onTransitionEnd() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=796488#c9

"Locking the screen causes a LM.hide() call which registers a "transitionend" listener. There is no transition so the handler stays registered until LM.show() is called. A transition occurs and the class 'visible' is removed."
