### PR TITLE
Add removeFocus() for value selector

### DIFF
--- a/apps/system/js/value_selector/value_selector.js
+++ b/apps/system/js/value_selector/value_selector.js
@@ -163,6 +163,7 @@ var ValueSelector = {
 
   cancel: function vs_cancel() {
     this.debug('cancel invoked');
+    window.navigator.mozKeyboard.removeFocus();
     this.hide();
   },
 
@@ -208,7 +209,8 @@ var ValueSelector = {
 
       window.navigator.mozKeyboard.setSelectedOptions(optionIndices);
     }
-
+  
+    window.navigator.mozKeyboard.removeFocus();
     this.hide();
   },
 


### PR DESCRIPTION
Bug 793108 - value selection popup will show up again while re-entering app

Add removeFocus() in ValueSelector.confirm() and ValueSelector.cancel().
I have test for the patch.
And it's work fine as Shih-Chiang Chien 's comment.

The patch is needed to merged with https://bugzilla.mozilla.org/attachment.cgi?id=670814 ,
after Jonas' confirmation.
