### PR TITLE
Bug 801045 - [Workaround] Do updateSettings() to init layout info before

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -122,7 +122,15 @@ const IMEManager = {
 
   init: function km_init() {
     IMEController.init();
-    IMEFeedback.init();
+
+    // Bug 801045 - Can't enter numbers
+    // IMEFeedback.init() would check settings DB, which may cause uncaught
+    // exception and the following code would not be executed
+    try {
+      IMEFeedback.init();
+    } catch (e) {
+      console.error('Exception occurred: ' + e);
+    }
 
     this.updateSettings();
     this._events.forEach((function attachEvents(type) {


### PR DESCRIPTION
trying to get settings for IMEFeedback
# Note

This is just a workaround for [Bug 801045](https://bugzilla.mozilla.org/show_bug.cgi?id=801045) -- Can't enter numbers.

The root cause of this issue is Keyboard app. could not get layout settings due to permission issue.
We are still investigating permission issue and this workaround would make us be able to input numbers  to address #5800.
