### PR TITLE
Bug 799132 - [DIALER] more contacts with same number

### DIFF
--- a/apps/communications/dialer/js/contacts.js
+++ b/apps/communications/dialer/js/contacts.js
@@ -52,6 +52,13 @@ var Contacts = {
       var matchResult = SimplePhoneMatcher.bestMatch(variants, matches);
 
       var contact = request.result[matchResult.bestMatchIndex];
+
+      if (request.result.length > 1) {
+        var name = contact.name[0].substring(0, 8),
+            numOfothers = request.result.length - 1;
+        contact.name[0] = _('lineContactName', {name: name, n: numOfothers});
+      }
+
       var matchingTel = contact.tel[matchResult.localIndex];
       callback(contact, matchingTel);
     };

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -22,7 +22,7 @@ function HandledCall(aCall, aNode) {
   this.node = aNode;
   this.durationNode = aNode.querySelector('.duration span');
   this.directionNode = aNode.querySelector('.duration .direction');
-  this.numberNode = aNode.querySelector('.number');
+  this.numberNode = aNode.querySelector('.numberWrapper .number');
   this.additionalInfoNode = aNode.querySelector('.additionalContactInfo');
 
 
@@ -99,7 +99,6 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
   Contacts.findByNumber(number, function lookupContact(contact, matchingTel) {
     if (contact && contact.name) {
       node.textContent = contact.name;
-      KeypadManager.formatPhoneNumber('right');
       var additionalInfo = Utils.getPhoneNumberAdditionalInfo(matchingTel,
                                                               contact);
       additionalInfoNode.textContent = additionalInfo ?

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -42,6 +42,6 @@ sending=Sending...
 ussd-services={{ operator }} services
 type-your-response.placeholder=Type your response...
 clear-all-text=Clear all text
-
-
-
+message-successfully-sent=MESSAGE SUCCESSFULLY SENT
+ussd-server-error=THERE WAS AN ERROR IN THE COMMUNICATION, PLEASE TRY IT AGAIN LATER
+lineContactName={{ name }}... or {{ n }} other

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -30,7 +30,8 @@
     <article id="call-screen" class="grid">
       <article id="calls" data-count="0">
         <section>
-          <div class="number">
+          <div class="numberWrapper">
+            <div class="number"></div>
           </div>
           <div class="fake-number">
           </div>

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -317,13 +317,20 @@ button[disabled] .icon-keypad-visibility {
   background-color: transparent;
 }
 
-#calls[data-count="1"] > section .number {
-  height: 4rem;
-  padding: 2rem 2rem 0 2rem;
+#calls[data-count="1"] > section .numberWrapper {
   background: #01c5ed;
-  font-size: 1.6em;
+  overflow: auto;
+}
+
+#calls[data-count="1"] > section .numberWrapper .number{
+  height: 4rem;
+  padding: 2rem 2rem 0 0;
+  font-size: 2.4rem;
   line-height: 4rem;
   color: black;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #calls > section .fake-number {
@@ -362,7 +369,7 @@ button[disabled] .icon-keypad-visibility {
   opacity: 0.7;
 }
 
-#calls > section .number {
+#calls > section .numberWrapper {
   font-size: 1.5em;
   white-space: nowrap;
 }
@@ -539,24 +546,22 @@ button[disabled] .icon-keypad-visibility {
     font-size: 1.8em;
   }
 
-  #calls > section .number,
-  #calls[data-count="1"] > section .number {
-    width: -moz-calc(100% - 12rem);
+  #calls > section .numberWrapper,
+  #calls[data-count="1"] > section .numberWrapper {
+    width: -moz-calc(100% - 10rem);
     height: -moz-calc(100% - 2rem);
-    padding: 1rem;
-    margin-left: 3rem;
+    background-color: transparent;
+  }
+
+  #calls > section .numberWrapper .number,
+  #calls[data-count="1"] > section .numberWrapper .number{
+    width: 100%;
+    padding: 1rem 1rem 1rem 1.5rem;
+    font-size: 2rem;
     line-height: 100%;
     color: white;
-    background-color: transparent;
     white-space: nowrap;
-    text-overflow: ellipsis;
-
-    /* font-size is overwriten via JS and we need
-    to be sure it doesn't happen when the call is
-    in the status bar. Workarounds would imply
-    listening resize event and JS changes, so we
-    need to add !important here */
-    font-size: 1.1em !important;
+    overflow: hidden;
   }
 
   #calls > section .duration,


### PR DESCRIPTION
Issue: it is not managed if there are more than one contact with the same phone number. Only the last contacts name is showed on the call screens and call log.

This pull request extends the contacts.name property if there are more contacts with same phone number.

Further issues:
1) Not so sure how to handle localasation. I can replace "or" and "other" with localised versions but is that good enouhg from grammer point of view for other languages than english.
2) During the call user presses home button, a green rectangle contains the name of the contact at the top of the screen. We could change the CSS to make the refactored name fit in that area (CSS seems to be broken anyway), or change the original method to take one more attribute as a limit for trucation(ellipsis), but Im not sure if that would make any sense.

Im happy to take suggestions into account reagarding the matters metioned above.

Related: 
1) #4617
2) https://bugzilla.mozilla.org/show_bug.cgi?id=796630

@arcturus r?
