### PR TITLE
bug 801683: [settings] apply standard style to the `#appPermissionsDetails` panels

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1201,37 +1201,41 @@
           <div id="messageHeader">The PIN was incorrect.</div>
           <span id="messageBody">3 tries left.</span>
         </div>
-        <!-- sim pin input field -->
+
+        <!-- SIM PIN input field -->
         <div id="pinArea">
           <div data-l10n-id="simPin">SIM PIN</div>
           <div class="input-wrapper">
-            <input type="number" name="simpin" size="8" maxlength="8" />
-            <input type="text" name="simpinVis" size="8" maxlength="8"/>
+            <input type="number" name="simpin" />
+            <input type="text" name="simpinVis" size="8" maxlength="8" />
           </div>
         </div>
-        <!-- sim puk input field -->
+
+        <!-- SIM PUK input field -->
         <div id="pukArea">
           <div data-l10n-id="pukCode">PUK Code</div>
           <div class="input-wrapper">
-            <input type="number" name="simpuk" size="8" maxlength="8" />
-            <input type="text" name="simpukVis" size="8" maxlength="8"/>
+            <input type="number" name="simpuk" />
+            <input type="text" name="simpukVis" size="8" maxlength="8" />
           </div>
         </div>
-        <!-- new sim pin input field -->
+
+        <!-- new SIM PIN input field -->
         <div id="newPinArea">
           <div data-l10n-id="newSimPinMsg">
             Create PIN (must contain 4 to 8 digits)
           </div>
           <div class="input-wrapper">
-            <input type="number" name="newSimpin" size="8" maxlength="8" />
+            <input type="number" name="newSimpin" />
             <input type="text" name="newSimpinVis" size="8" maxlength="8" />
           </div>
         </div>
-        <!-- confirm new sim pin input field -->
+
+        <!-- confirm new SIM PIN input field -->
         <div id="confirmPinArea">
           <div>Confirm New PIN</div>
           <div class="input-wrapper">
-            <input type="number" name="confirmNewSimpin" size="8" maxlength="8" />
+            <input type="number" name="confirmNewSimpin" />
             <input type="text" name="confirmNewSimpinVis" size="8" maxlength="8" />
           </div>
         </div>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -140,14 +140,14 @@
           <input type="text" data-ignore name="ssid" />
         </li>
         <li>
-          <a data-l10n-id="security">security
+          <span data-l10n-id="security">security
             <select>
               <option data-l10n-id="securityNone">none</option>
               <option>WEP</option>
-              <option checked>WPA-PSK</option>
+              <option selected>WPA-PSK</option>
               <option>WPA-EAP</option>
             </select>
-          </a>
+          </span>
         </li>
         <li class="identity">
           <p data-l10n-id="identity">identity</p>
@@ -377,7 +377,7 @@
         <!-- APNs matching the phone's MCC/MNC are inserted here dynamically -->
         <li id="apnSettings-custom">
           <label>
-            <input type="radio" name="APN.name" value="_custom_" selected />
+            <input type="radio" name="APN.name" value="_custom_" checked />
             <span></span>
           </label>
           <a data-l10n-id="custom">(custom settings)</a>
@@ -600,13 +600,13 @@
           <input type="text" data-setting="tethering.wifi.security.password" />
         </li>
         <li>
-          <a data-l10n-id="wifi-security">Security
+          <span data-l10n-id="wifi-security">Security
             <select data-setting="tethering.wifi.security.type">
               <option>open</option>
               <option>WPA</option>
               <option selected>WPA2</option>
             </select>
-          </a>
+          </span>
         </li>
       </ul>
     </section>
@@ -673,7 +673,7 @@
     </section>
 
     <!-- Personalization :: Sound :: Sound Selection -->
-    <section role="region" id="sound-selection" date-leaf>
+    <section role="region" id="sound-selection" data-leaf>
       <header>
         <button type="reset">
           <span data-l10n-id="back" class="icon icon-back">Back</span>
@@ -725,7 +725,7 @@
       </ul>
 
       <!-- Audio Preview -->
-      <audio style="display: none;" src="style/ringtones/classic.ogg" />
+      <audio style="display: none;" src="style/ringtones/classic.ogg"></audio>
     </section>
 
     <!-- Personalization :: Sound -->
@@ -762,7 +762,7 @@
           <label>
             <input type="range" name="audio.volume.master" min="0.1" value="0.5" max="1">
             <span class="range-icons volume"></span>
-          <label>
+          </label>
         </li>
         <li>
           <label>
@@ -812,7 +812,7 @@
       <ul>
         <li>
           <a data-l10n-id="wallpaper">Wallpaper</a>
-          <img id="wallpaper-preview"></img>
+          <img id="wallpaper-preview" alt="wallpaper preview"/>
         </li>
         <li>
           <p data-l10n-id="screen-timeout">Screen Timeout</p>
@@ -861,6 +861,7 @@
           </label>
           <a data-l10n-id="lockscreen-notifications">Show on Lock Screen</a>
         </li>
+      </ul>
     </section>
 
     <!-- Personalization :: Date & Time :: Time Zone (Continent) :: Time Zone (Zones) -->
@@ -935,7 +936,7 @@
 
       <ul>
         <li>
-          <a data-l10n-id="language">Language
+          <span data-l10n-id="language">Language
             <select name="language.current">
               <option value="ar">العربية</option>
               <option value="de">Deutsch</option>
@@ -950,10 +951,10 @@
               <option value="tr">Türkçe</option>
               <option value="zh-TW">正體中文</option>
             </select>
-          </a>
+          </span>
         </li>
         <li>
-          <a data-l10n-id="region">Region
+          <span data-l10n-id="region">Region
             <select name="region.current">
               <option value="BR">Brasil</option>
               <option value="CO">Columbia</option>
@@ -965,7 +966,7 @@
               <option value="US">United States</option>
               <option value="VZ">Venezuela</option>
             </select>
-          </a>
+          </span>
         </li>
       </ul>
 
@@ -1275,42 +1276,58 @@
       </ul>
     </section>
 
-    <!-- [TODO] Security :: SIM Card Lock -->
-    <!-- Security :: App Permissions -->
+    <!-- Security :: Application Permissions :: Details -->
     <section role="region" id="appPermissionsDetails" data-leaf>
       <header>
         <a href="#appPermissions"><span class="icon icon-back">back</span></a>
-        <h1>
-        </h1>
+        <h1> </h1>
       </header>
+
       <header>
         <h2 data-l10n-id="developer">Developer</h2>
       </header>
-      <div id="developer-infos">
-        <h3></h3>
-        <a target="_blank"></a>
-      </div>
+      <ul>
+        <!-- this will be updated dynamically by js/apps.js -->
+        <li id="developer-infos">
+          <small><a target="_blank" href="http://github.com/mozilla-b2g/gaia/">http://github.com/mozilla-b2g/gaia/</a></small>
+          <a target="_blank" href="http://github.com/mozilla-b2g/gaia/"> The Gaia Team </a>
+        </li>
+      </ul>
+
       <header id="permissionsListHeader">
         <h2 data-l10n-id="permissions">Permissions</h2>
       </header>
       <ul>
+        <!-- this will be replaced dynamically by js/apps.js -->
+        <li>
+          <span>settings
+            <select>
+              <option>ask</option>
+              <option>deny</option>
+              <option>allow</option>
+            </select>
+          </span>
+        </li>
       </ul>
+
       <header>
         <h2 data-l10n-id="uninstallApp">Uninstall App</h2>
       </header>
       <button id="uninstall-app" data-l10n-id="uninstallApp" class="danger">Uninstall App</button>
     </section>
 
+    <!-- Security :: Application Permissions -->
     <section role="region" id="appPermissions">
       <header>
         <a href="#root"><span class="icon icon-back">back</span></a>
         <h1 data-l10n-id="appPermissions">
-          App Permissions
+          Application Permissions
         </h1>
       </header>
       <ul>
       </ul>
     </section>
+
     <!-- Security :: Do Not Track -->
     <section role="region" id="doNotTrack" data-leaf>
       <header>
@@ -1412,7 +1429,9 @@
     <!-- Device :: Information :: More Information -->
     <section role="region" id="more-info">
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button>
+        <button type="reset">
+          <span data-l10n-id="back" class="icon icon-back">Back</span>
+        </button>
         <h1 data-l10n-id="more-info"> More Information </h1>
       </header>
 
@@ -1465,7 +1484,9 @@
     <!-- Device :: Information :: About Your Rights -->
     <section role="region" id="about-your-rights" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button>
+        <button type="reset">
+          <span data-l10n-id="back" class="icon icon-back">Back</span>
+        </button>
         <h1 data-l10n-id="about-your-rights"> About Your Rights </h1>
       </header>
 
@@ -1500,7 +1521,9 @@
     <!-- Device :: Information :: About Your Privacy -->
     <section role="region" id="about-your-privacy" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button>
+        <button type="reset">
+          <span data-l10n-id="back" class="icon icon-back">Back</span>
+        </button>
         <h1 data-l10n-id="about-your-privacy"> About Your Privacy </h1>
       </header>
 
@@ -1517,7 +1540,9 @@
     <!-- Device :: Information :: Licensing -->
     <section role="region" id="licensing" data-leaf>
       <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</button>
+        <button type="reset">
+          <span data-l10n-id="back" class="icon icon-back">Back</span>
+        </button>
         <h1 data-l10n-id="licensing"> Licensing </h1>
       </header>
 
@@ -1626,14 +1651,14 @@
         </li>
         <li>
           <label for="share-performance-data" class="description">
-            <div>
+            <span>
               <input type="checkbox" id="share-performance-data" name="debug.peformancedata.shared" />
               <span data-l10n-id="share-performance-data">
                 I want to help make Firefox OS faster and easier to use by
                 sharing information about my phone’s performance.
               </span>
               <a href="https://www.mozilla.org/" data-l10n-id="learn-more"> Learn More </a>
-            </div>
+            </span>
           </label>
         </li>
       </ul>
@@ -1694,7 +1719,7 @@
       </header>
       <ul>
         <li>
-          <meter id="apps-space-bar" min="0" max="100"></meter>
+          <meter id="apps-space-bar" min="0" value="0" max="100"></meter>
         </li>
 
         <li>
@@ -1725,7 +1750,6 @@
         <a href="#root"><span class="icon icon-back">back</span></a>
         <h1 data-l10n-id="mediaStorage"> Media Storage </h1>
       </header>
-
       <ul>
         <li>
           <a id="music-space" data-l10n-id="music-space"> Music
@@ -1752,7 +1776,6 @@
       <header>
         <h2 data-l10n-id="advanced">Advanced</h2>
       </header>
-
       <ul>
         <li>
           <label>
@@ -1763,7 +1786,6 @@
           <a data-l10n-id="umsEnabled">USB Mass Storage Enabled</a>
         </li>
       </ul>
-
     </section>
 
     <!-- Device :: Accessibility -->
@@ -1820,7 +1842,9 @@
     <!-- SIM Toolkit -->
     <section role="region" id="icc">
       <header>
-        <button id="icc-stk-app-back" class="hidden"><span data-l10n-id="back" class="icon icon-back">Back</button>
+        <button id="icc-stk-app-back" class="hidden">
+          <span data-l10n-id="back" class="icon icon-back">Back</span>
+        </button>
         <a href="#root" id="icc-stk-exit"><span data-l10n-id="back" class="icon icon-back">Back</span></a>
         <h1 id="icc-stk-header"> SIM Toolkit </h1>
       </header>

--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -1,4 +1,4 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 'use strict';
@@ -26,9 +26,9 @@ var ApplicationsList = {
 
   container: document.querySelector('#appPermissions > ul'),
   detailTitle: document.querySelector('#appPermissionsDetails > header > h1'),
-  developerName: document.querySelector('#developer-infos > h3'),
-  developerLink: document.querySelector('#developer-infos > a'),
-  detailPermissionsList: document.querySelector('#appPermissionsDetails > ul'),
+  developerName: document.querySelector('#developer-infos > a'),
+  developerLink: document.querySelector('#developer-infos > small > a'),
+  detailPermissionsList: document.querySelector('#permissionsListHeader + ul'),
   detailPermissionsHeader: document.getElementById('permissionsListHeader'),
   uninstallButton: document.getElementById('uninstall-app'),
 
@@ -143,7 +143,8 @@ var ApplicationsList = {
       if ((manifest.permissions && perm in manifest.permissions)
           || value === 'allow') {
         var item = document.createElement('li');
-        item.textContent = _(perm);
+        var content = document.createElement('p');
+        content.textContent = _(perm);
 
         var select = document.createElement('select');
         select.dataset.perm = perm;
@@ -171,7 +172,8 @@ var ApplicationsList = {
           select.focus();
         };
 
-        item.appendChild(select);
+        content.appendChild(select);
+        item.appendChild(content);
         this.detailPermissionsList.appendChild(item);
       }
     }, this);
@@ -227,3 +229,4 @@ window.addEventListener('localized', function init(evt) {
 
   ApplicationsList.init();
 });
+

--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -143,7 +143,7 @@ var ApplicationsList = {
       if ((manifest.permissions && perm in manifest.permissions)
           || value === 'allow') {
         var item = document.createElement('li');
-        var content = document.createElement('p');
+        var content = document.createElement('span');
         content.textContent = _(perm);
 
         var select = document.createElement('select');

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -263,13 +263,12 @@ mail=Mail
 
 securityAndPrivacy=Security & Privacy
 passcode-lock=Passcode Lock
-appPermissions=App Permissions
 passcode-lock-desc=Passcode: {{code}}
 phoneLock=Phone Lock
 simSecurity=SIM Security
 
-# Security :: Apps Permissions
-appPermissions=Applications Permissions
+# Security :: Application Permissions
+appPermissions=Application Permissions
 permissions=Permissions
 revoke=Revoke
 ask=Ask

--- a/apps/settings/style/apps.css
+++ b/apps/settings/style/apps.css
@@ -2,14 +2,6 @@
  * Applications Permissions
  */
 
-#appPermissions ul li > a {
-  padding: 0 calc(4.1rem - 30px);
-  height: 6rem;
-  line-height: 6rem;
-  font-size: 1.8rem;
-  color: #000;
-}
-
 #appPermissions ul li img {
   float: left;
   margin-top: calc(3rem - 15px);
@@ -18,17 +10,8 @@
   height: 30px;
 }
 
-#appPermissionsDetails ul li {
-  padding: 0 0 0 10px;
-  font-size: 1.6rem;
-  line-height: 60px;
-}
-
-#appPermissionsDetails ul li select {
-  float: right;
-  display: block;
+#permissionsListHeader + ul li select {
   width: 25%;
-  margin: 15px 10px 0 0;
   padding: 5px;
   border: 0;
   background: #367fa2;
@@ -37,17 +20,12 @@
   font-size: 1.3rem;
 }
 
-#appPermissionsDetails ul li select[value='allow'] {
+#permissionsListHeader + ul li select[value='allow'] {
   background: #22aa22;
 }
 
-#appPermissionsDetails ul li select[value='deny'] {
+#permissionsListHeader + ul li select[value='deny'] {
   background: #da4e49;
-}
-
-#developer-infos {
-  font-size: 1.2em;
-  padding: 0 10px 10px 10px;
 }
 
 #uninstall-app {

--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -24,7 +24,8 @@ ul li:active {
   color: #222;
 }
 
-ul li > a {
+ul li > a,
+ul li > span {
   display: block;
   text-decoration: none;
   outline: 0;
@@ -262,7 +263,7 @@ ul li select {
 }
 
 /* half-width select boxes */
-ul li a select {
+ul li span select {
   display: inline-block;
   position: absolute;
   top: 1.5rem;


### PR DESCRIPTION
follow-up for https://bugzilla.mozilla.org/show_bug.cgi?id=801683

The `#appPermissionsDetails` panels do not use the same HTML structure as the other Settings panel, hence the different look’n’feel. Here’s a proposed fix.
