### PR TITLE
Bug 802448 - ignore profile.tar.gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ manifest.appcache
 /showcase_apps/*/test/unit/_proxy.html
 
 /profile/
+/profile.tar.gz
 /.xulrunner-url
 /xulrunner/
 /xulrunner-sdk/


### PR DESCRIPTION
The build succeeded, but the build created a gaia/profile.tar.gz file that wasn't ignored by the gaia repo. I think profile.tar.gz should be in .gitignore

https://bugzilla.mozilla.org/show_bug.cgi?id=802448
