### PR TITLE
default to 3 disabled weekday morning alarms

### DIFF
--- a/apps/clock/js/alarmsdb.js
+++ b/apps/clock/js/alarmsdb.js
@@ -44,22 +44,20 @@ var AlarmsDB = {
       if (db.objectStoreNames.contains(storeName))
         db.deleteObjectStore(storeName);
       db.createObjectStore(storeName, {keyPath: 'id', autoIncrement: true});
-      // Add default weekday alarms.
-      for (var hour = 8; hour > 5; hour--) {
-        AlarmsDB.putAlarm({
-          label: 'Alarm',
-          hour: hour,
-          minute: 0,
-          enabled: false,
-          repeat: '1111100',
-          sound: 'ALARM_progressive_dapple.mp3',
-          snooze: 5,
-          color: 'Darkorange'
-        }, function(alarm) {
-          AlarmManager.setEnabled(alarm, alarm.enabled);
-          AlarmList.refresh();
-        });
-      }
+      // Add default weekday alarm.
+      AlarmsDB.putAlarm({
+        label: 'Alarm',
+        hour: 7,
+        minute: 0,
+        enabled: false,
+        repeat: '1111100',
+        sound: 'ALARM_progressive_dapple.mp3',
+        snooze: 5,
+        color: 'Darkorange'
+      }, function(alarm) {
+        AlarmManager.setEnabled(alarm, alarm.enabled);
+        AlarmList.refresh();
+      });
       console.log('Upgrading db done');
     };
   },

--- a/apps/clock/js/alarmsdb.js
+++ b/apps/clock/js/alarmsdb.js
@@ -44,6 +44,22 @@ var AlarmsDB = {
       if (db.objectStoreNames.contains(storeName))
         db.deleteObjectStore(storeName);
       db.createObjectStore(storeName, {keyPath: 'id', autoIncrement: true});
+      // Add default weekday alarms.
+      for (var hour = 8; hour > 5; hour--) {
+        AlarmsDB.putAlarm({
+          label: 'Alarm',
+          hour: hour,
+          minute: 0,
+          enabled: false,
+          repeat: '1111100',
+          sound: 'ALARM_progressive_dapple.mp3',
+          snooze: 5,
+          color: 'Darkorange'
+        }, function(alarm) {
+          AlarmManager.setEnabled(alarm, alarm.enabled);
+          AlarmList.refresh();
+        });
+      }
       console.log('Upgrading db done');
     };
   },


### PR DESCRIPTION
This patch leaves the defaults in the edit page the same, and instead adds three disabled weekday morning (6, 7, and 8 AM) alarms to the database. I personally like this solution, but I understand it may not be everyone's cup of tea.

What I like about it is that it gives the user a nice starting point. There's a good chance that the user will need a weekday morning alarm, and also a good chance that one of these alarms will be just what they need, so they can just turn it on and be done with it. Or if they so desire they can change one or two settings on one of them to fit their taste. The point is, they don't have to go through the full alarm edit page to get what they need.
