### PR TITLE
bug 797367: don't let STK-UI break Gaia in desktop Firefox

### DIFF
--- a/apps/settings/js/icc.js
+++ b/apps/settings/js/icc.js
@@ -80,7 +80,8 @@
    */
   function responseSTKCommand(response, force) {
     if (!force && (!iccLastCommand || !iccLastCommandProcessed)) {
-      return debug('sendStkResponse NO COMMAND TO RESPONSE. Ignoring');
+      debug('sendStkResponse NO COMMAND TO RESPONSE. Ignoring');
+      return;
     }
 
     debug('sendStkResponse to command: ', iccLastCommand);

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -420,6 +420,9 @@ window.addEventListener('localized', function showBody() {
   // <body> children are hidden until the UI is translated
   if (document.body.classList.contains('hidden')) {
     // first run: show main page
+    if (!document.location.hash) {
+      document.location.hash = 'root';
+    }
     document.body.classList.remove('hidden');
   } else {
     // we were in #languages and selected another locale:


### PR DESCRIPTION
this should fix the last regression brought by https://bugzilla.mozilla.org/show_bug.cgi?id=797367
