### PR TITLE
bug 802361 - stop deleting xulrunner in clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -585,5 +585,9 @@ purge:
 	$(ADB) shell rm -r $(GAIA_INSTALL_PARENT)/webapps
 
 # clean out build products
-clean:
-	rm -rf profile xulrunner-sdk .xulrunner-url
+clean: 
+	rm -rf profile
+
+# clean out build products
+really-clean: clean
+	rm -rf xulrunner-sdk .xulrunner-url


### PR DESCRIPTION
This change stops deleting the xulrunner sdk in the clean target but adds another target to replicate the old functionality of the clean target (really-clean)
