### PR TITLE
Bug 802942 - Init the time picker with current time for empty input[type...

### DIFF
--- a/apps/system/js/value_selector/value_selector.js
+++ b/apps/system/js/value_selector/value_selector.js
@@ -308,14 +308,20 @@ var ValueSelector = {
       this._timePickerInitialized = true;
     }
 
-    if (!currentValue)
-      return;
+    var time;
+    if (!currentValue) {
+      var now = new Date();
+      time = {
+        hours: now.getHours(),
+        minutes: now.getMinutes()
+      };
+    } else {
+      var inputParser = ValueSelector.InputParser;
+      if (!inputParser)
+        console.error('Cannot get input parser for value selector');
 
-    var inputParser = ValueSelector.InputParser;
-    if (!inputParser)
-      console.error('Cannot get input parser for value selector');
-
-    var time = inputParser.importTime(currentValue);
+      time = inputParser.importTime(currentValue);
+    }
 
     var timePicker = TimePicker.timePicker;
     // Set the value of time picker according to the current value


### PR DESCRIPTION
...=time]

[Bug 802942](https://bugzilla.mozilla.org/show_bug.cgi?id=802942) - The empty input[type=time] would not have the time picker init with current time
