### PR TITLE
Bug 798953 move out cardstatechange event listener, so the dialog won't sense 'absent' card status.

### DIFF
--- a/apps/settings/js/simcard_lock.js
+++ b/apps/settings/js/simcard_lock.js
@@ -38,21 +38,44 @@ var SimPinLock = {
     if (!this.mobileConnection)
       return;
 
+    this.mobileConnection.addEventListener('cardstatechange',
+      this.updateSimCardStatus.bind(this));
+
     var self = this;
     this.simPinCheckBox.onchange = function spl_toggleSimPin() {
-      var enabled = this.checked;
-      SimPinDialog.show('enable',
-        function() {
-          self.updateSimCardStatus();
-        },
-        function() {
-          self.simPinCheckBox.checked = !enabled;
-          self.updateSimCardStatus();
-        }
-      );
+      switch (self.mobileConnection.cardState) {
+        case 'pukRequired':
+          var enabled = this.checked;
+          SimPinDialog.show('unlock',
+            function() {
+              // successful unlock puk will be in simcard lock enabled state
+              self.simPinCheckBox.checked = true;
+              self.updateSimCardStatus();
+            },
+            function() {
+              self.simPinCheckBox.checked = !enabled;
+              self.updateSimCardStatus();
+            },
+            document.location.hash
+          );
+          break;
+        default:
+          var enabled = this.checked;
+          SimPinDialog.show('enable',
+            function() {
+              self.updateSimCardStatus();
+            },
+            function() {
+              self.simPinCheckBox.checked = !enabled;
+              self.updateSimCardStatus();
+            },
+            document.location.hash
+          );
+          break;
+      }
     };
     this.changeSimPinButton.onclick = function spl_changePin() {
-      SimPinDialog.show('changePin', null, null);
+      SimPinDialog.show('changePin', null, null, document.location.hash);
     };
 
     this.updateSimCardStatus();

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -30,9 +30,9 @@
        },
       "disposition": "window"
     },
-    "configure": {
+    "unlock": {
       "filters": {
-        "target": "simpin-unlock"
+        "target": "sim"
        },
       "disposition": "inline",
       "href": "unlock_simpin.html",

--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -56,9 +56,9 @@ var SimLock = {
       case 'pukRequired':
       case 'pinRequired':
         var activity = new MozActivity({
-          name: 'configure',
+          name: 'unlock',
           data: {
-            target: 'simpin-unlock'
+            target: 'sim'
           }
         });
         activity.onsuccess = function sl_unlockSuccess() {


### PR DESCRIPTION
1. move cardstatechange event listener to SIM Security menu
2. add 'origin' parameter to distinguish simcard dialog caller, so we can
   relocate back to the caller's div when the dialog is closed.
3. use wildcard as query key for getting all initial settings values in
   mozSettings
