### PR TITLE
Bug 796334 - Gaia system app: don't short-sell the signal strength when computing bars

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -326,7 +326,7 @@ var StatusBar = {
 
       } else {
         // "Emergency Calls Only (REASON)" / "Carrier" / "Carrier (Roaming)"
-        icon.dataset.level = Math.floor(voice.relSignalStrength / 20); // 0-5
+        icon.dataset.level = Math.ceil(voice.relSignalStrength / 20); // 0-5
       }
     },
 


### PR DESCRIPTION
@timdream, can you review? Thanks!

See https://bugzilla.mozilla.org/show_bug.cgi?id=796334
