### PR TITLE
Bug 803490 - System Message API: System App fails to receive system messages (follow-up).

### DIFF
--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -2,6 +2,7 @@
   "name": "System",
   "type": "certified",
   "description": "Main System",
+  "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"


### PR DESCRIPTION
This issue is very tricky. When starting up, the app will register all the messages based on the launch_path. When registering handlers, the app will register them based on the current page URI. Therefore, it'd be better to add the correct launch_path for System App as well so that the app won't reject to handle the coming messages.
