### PR TITLE
bug 796804: [settings] better transition performances

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="pragma" content="no-cache"/>
     <title>Settings</title>
 
-    <!-- Common style -->
+    <!-- Shared style -->
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/buttons.css"/>
@@ -18,6 +18,7 @@
     <!-- Specific style -->
     <link rel="stylesheet" type="text/css" href="style/lists.css"/>
     <link rel="stylesheet" type="text/css" href="style/icons.css"/>
+    <link rel="stylesheet" type="text/css" href="style/panels.css"/>
     <link rel="stylesheet" type="text/css" href="style/settings.css"/>
     <link rel="stylesheet" type="text/css" href="style/simcard.css"/>
     <link rel="stylesheet" type="text/css" href="style/phone_lock.css"/>
@@ -27,11 +28,11 @@
     <link rel="resource" type="application/l10n" href="locales/locales.ini"/>
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini"/>
     <link rel="resource" type="application/l10n" href="shared/locales/permissions.ini"/>
+
+    <!-- Shared code -->
     <script type="application/javascript" src="shared/js/l10n.js"></script>
     <script type="application/javascript" src="shared/js/l10n_date.js"></script>
-
-    <!-- Async. Storage -->
-    <script type="application/javascript" src="/shared/js/async_storage.js"></script>
+    <script type="application/javascript" src="shared/js/async_storage.js"></script>
 
     <!-- Specific code -->
     <script type="application/javascript" defer src="js/utils.js"></script>
@@ -52,8 +53,10 @@
     <script type="application/javascript" defer src="js/factory_reset.js"></script>
     <script type="application/javascript" defer src="js/icc.js"></script>
   </head>
-  <body class="hidden skin-organic">
+  <body class="hidden skin-organic transition-none fixed-headers">
 
+  <!-- Connectivity :: Wi-Fi -->
+  <section>
     <!-- Connectivity :: Wi-Fi :: Network Status -->
     <section role="region" id="wifi-status" data-leaf>
       <header>
@@ -321,7 +324,10 @@
         </li>
       </ul>
     </section>
+  </section>
 
+  <!-- Connectivity :: Cellular & Data -->
+  <section>
     <!-- Connectivity :: Cellular & Data :: Network Operator -->
     <section role="region" id="operator">
       <header>
@@ -510,9 +516,10 @@
         </li>
       </ul>
     </section>
+  </section>
 
     <!-- Connectivity :: Bluetooth -->
-    <section role="region" id="bluetooth">
+    <section role="region" id="bluetooth" data-leaf>
       <header>
         <a href="#root"><span class="icon icon-back">back</span></a>
         <h1 data-l10n-id="bluetooth"> Bluetooth </h1>
@@ -582,6 +589,8 @@
       </form>
     </section>
 
+  <!-- Connectivity :: Internet Sharing -->
+  <section>
     <!-- Connectivity :: Internet Sharing :: Portable Wi-Fi Hotspot -->
     <section role="region" id="hotspotSettings" data-leaf>
       <header>
@@ -674,13 +683,14 @@
         </li>
       </ul>
     </section>
+  </section>
 
+  <!-- Personalization :: Sound -->
+  <section>
     <!-- Personalization :: Sound :: Sound Selection -->
     <section role="region" id="sound-selection" data-leaf>
       <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
           <button data-l10n-id="done" type="submit">Done</button>
         </menu>
@@ -693,10 +703,10 @@
       <ul>
         <li>
           <label onmouseup="audioPreview(this)">
-            <input type="radio" name="tone-option" data-ignore value="classic.ogg" data-label="Classic" checked />
+            <input type="radio" name="tone-option" data-ignore value="classic.ogg" data-label="Default" checked />
             <span></span>
           </label>
-          <a data-l10n-id="classic">Classic</a>
+          <a data-l10n-id="classic">Default</a>
         </li>
         <li>
           <label onmouseup="audioPreview(this)">
@@ -720,10 +730,10 @@
       <ul>
         <li>
           <label onmouseup="audioPreview(this)">
-            <input type="radio" name="tone-option" data-ignore value="sms.wav" data-label="Beep Beep" />
+            <input type="radio" name="tone-option" data-ignore value="sms.wav" data-label="Sound of Message" />
             <span></span>
           </label>
-          <a data-l10n-id="beep">Beep Beep</a>
+          <a data-l10n-id="lowBit">Sound of Message</a>
         </li>
       </ul>
 
@@ -768,15 +778,18 @@
           </label>
         </li>
         <li>
-          <span data-l10n-id="call">Call
+          <label>
             <button id="call-tone-selection" class="tone-select">Old School</button>
-          </span>
+            <span></span>
+          </label>
+          <a data-l10n-id="call">Call</a>
         </li>
         <li>
-          <span data-l10n-id="message">Message
-            <button id="sms-tone-selection" class="tone-select">
-              Beep Beep</button>
-          </span>
+          <label>
+            <button id="sms-tone-selection" class="tone-select">Beep Beep</button>
+            <span></span>
+          </label>
+          <a data-l10n-id="message">Message</a>
         </li>
       </ul>
 
@@ -801,6 +814,7 @@
         </li>
       </ul>
     </section>
+  </section>
 
     <!-- Personalization :: Display -->
     <section role="region" id="display" data-leaf>
@@ -864,6 +878,8 @@
       </ul>
     </section>
 
+  <!-- Personalization :: Date & Time -->
+  <section>
     <!-- Personalization :: Date & Time :: Time Zone (Continent) :: Time Zone (Zones) -->
     <section role="region" id="timezone-zones" data-leaf>
       <header>
@@ -926,6 +942,7 @@
         </li>
       </ul>
     </section>
+  </section>
 
     <!-- Personalization :: Language & Region -->
     <section role="region" id="languages" data-leaf>
@@ -1096,6 +1113,8 @@
       </ul>
     </section>
 
+  <!-- Security :: Phone Lock -->
+  <section>
     <!-- Security :: Phone Lock :: PIN Input -->
     <section role="region" id="passcode-panel" data-leaf>
       <header>
@@ -1175,13 +1194,14 @@
         </li>
       </ul>
     </section>
+  </section>
 
+  <!-- Security :: SIM Security -->
+  <section>
     <!-- Security :: SIM Security :: SIM PIN Input -->
     <section role="region" id="simpin-dialog" data-leaf>
       <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <menu type="toolbar">
         <button data-l10n-id="done" type="submit">Done</button>
         </menu>
@@ -1198,7 +1218,7 @@
         <div id="pinArea">
           <div data-l10n-id="simPin">SIM PIN</div>
           <div class="input-wrapper">
-            <input type="number" name="simpin" size="8" maxlength="8" />
+            <input type="number" name="simpin" />
             <input type="text" name="simpinVis" size="8" maxlength="8" />
           </div>
         </div>
@@ -1207,7 +1227,7 @@
         <div id="pukArea">
           <div data-l10n-id="pukCode">PUK Code</div>
           <div class="input-wrapper">
-            <input type="number" name="simpuk" size="8" maxlength="8" />
+            <input type="number" name="simpuk" />
             <input type="text" name="simpukVis" size="8" maxlength="8" />
           </div>
         </div>
@@ -1218,7 +1238,7 @@
             Create PIN (must contain 4 to 8 digits)
           </div>
           <div class="input-wrapper">
-            <input type="number" name="newSimpin" size="8" maxlength="8" />
+            <input type="number" name="newSimpin" />
             <input type="text" name="newSimpinVis" size="8" maxlength="8" />
           </div>
         </div>
@@ -1227,7 +1247,7 @@
         <div id="confirmPinArea">
           <div>Confirm New PIN</div>
           <div class="input-wrapper">
-            <input type="number" name="confirmNewSimpin" size="8" maxlength="8" />
+            <input type="number" name="confirmNewSimpin" />
             <input type="text" name="confirmNewSimpinVis" size="8" maxlength="8" />
           </div>
         </div>
@@ -1271,7 +1291,10 @@
         </li>
       </ul>
     </section>
+  </section>
 
+  <!-- Security :: Application Permissions -->
+  <section>
     <!-- Security :: Application Permissions :: Details -->
     <section role="region" id="appPermissionsDetails" data-leaf>
       <header>
@@ -1323,6 +1346,7 @@
       <ul>
       </ul>
     </section>
+  </section>
 
     <!-- Security :: Do Not Track -->
     <section role="region" id="doNotTrack" data-leaf>
@@ -1359,6 +1383,8 @@
       </dl>
     </section>
 
+  <!-- Device :: Information -->
+  <section>
     <!-- Device :: Information :: More Information :: Developer -->
     <section role="region" id="developer" data-leaf>
       <header>
@@ -1427,9 +1453,7 @@
     <!-- Device :: Information :: More Information -->
     <section role="region" id="more-info">
       <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <h1 data-l10n-id="more-info"> More Information </h1>
       </header>
 
@@ -1482,9 +1506,7 @@
     <!-- Device :: Information :: About Your Rights -->
     <section role="region" id="about-your-rights" data-leaf>
       <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <h1 data-l10n-id="about-your-rights"> About Your Rights </h1>
       </header>
 
@@ -1519,9 +1541,7 @@
     <!-- Device :: Information :: About Your Privacy -->
     <section role="region" id="about-your-privacy" data-leaf>
       <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <h1 data-l10n-id="about-your-privacy"> About Your Privacy </h1>
       </header>
 
@@ -1538,9 +1558,7 @@
     <!-- Device :: Information :: Licensing -->
     <section role="region" id="licensing" data-leaf>
       <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
+        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
         <h1 data-l10n-id="licensing"> Licensing </h1>
       </header>
 
@@ -1662,6 +1680,7 @@
         </li>
       </ul>
     </section>
+  </section>
 
     <!-- Device :: Battery -->
     <section role="region" id="battery" data-leaf>
@@ -1839,7 +1858,7 @@
     </section>
 
     <!-- SIM Toolkit -->
-    <section role="region" id="icc">
+    <section role="region" id="icc" data-leaf>
       <header>
         <button id="icc-stk-app-back" class="hidden">
           <span data-l10n-id="back" class="icon icon-back">Back</span>
@@ -1869,7 +1888,7 @@
     </section>
 
     <!-- Main List -->
-    <section role="region" id="root">
+    <section role="region" id="root" class="active">
       <header>
         <h1 data-l10n-id="settings"> Settings </h1>
       </header>

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -352,16 +352,6 @@ window.addEventListener('load', function loadSettings(evt) {
   }
 });
 
-window.addEventListener('hashchange', function handleHashChange(event) {
-  // most browsers now scroll content into view taking CSS transforms
-  // into account.  That's not what we want when moving between
-  // <section>s, because the being-moved-to section is offscreen when
-  // we navigate to its #hash.  The transitions assume the viewport is
-  // always at document 0,0.  So add a hack here to make that
-  // assumption true again.
-  window.scrollTo(0, 0);
-});
-
 // back button = close dialog || back to the root page
 // + prevent the [Return] key to validate forms
 window.addEventListener('keydown', function handleSpecialKeys(event) {
@@ -396,6 +386,7 @@ window.addEventListener('localized', function showBody() {
       document.location.hash = 'root';
     }
     document.body.classList.remove('hidden');
+    document.getElementById('root').className = 'current';
   } else {
     // we were in #languages and selected another locale:
     // reset the hash to prevent weird focus bugs when switching LTR/RTL
@@ -418,5 +409,25 @@ window.addEventListener('localized', function showBody() {
       navigator.mozL10n.language.code + '"]';
   document.getElementById('language-desc').textContent =
       document.querySelector(selector).textContent;
+});
+
+// panel navigation
+var gOldHash = '#root';
+window.addEventListener('hashchange', function showPanel() {
+  var hash = document.location.hash;
+  var oldPanel = document.querySelector(gOldHash);
+  var newPanel = document.querySelector(hash);
+  oldPanel.className = newPanel.className ? '' : 'active';
+  newPanel.className = 'active';
+  gOldHash = hash;
+
+  /**
+   * Most browsers now scroll content into view taking CSS transforms into
+   * account.  That's not what we want when moving between <section>s, because
+   * the being-moved-to section is offscreen when we navigate to its #hash.
+   * The transitions assume the viewport is always at document 0,0.  So add a
+   * hack here to make that assumption true again.
+   */
+  window.scrollTo(0, 0);
 });
 

--- a/apps/settings/style/panels.css
+++ b/apps/settings/style/panels.css
@@ -1,0 +1,178 @@
+/**
+ * Setting panels: full-size blocks, identified by a 'region' role
+ */
+
+[role="region"] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow-y: scroll;
+  background: url(images/document_bg.png);
+}
+
+/**
+ * Headers don't scroll with the rest of the page, except for #root
+ * -- this is only enabled when <body> has the '.fixed-headers' class.
+ */
+
+.fixed-headers [role="region"]:not(#root) > header:first-child {
+  position: fixed;
+  width: 100%;
+}
+
+.fixed-headers [role="region"]:not(#root) > header:first-child + * {
+  margin-top: 5rem;
+}
+
+/******************************************************************************
+ * Panel transitions :: 'target'
+ *
+ * This relise purely on the `:target' pseudo-selector;
+ * it looks super nice on a desktop but sketchy on an Otoro :-(
+ *
+ * The main trick is that <section role="dialog"> elements must be
+ * reverse-ordered in the HTML document (see ~ selector): the main panel comes
+ * last, and 'child' panels (menu-wise) shoudl be inserted before their parents.
+ */
+
+.transition-target [role="region"] {
+  visibility: hidden;
+  transform: translateX(100%);
+  transition: visibility 0s ease 0.3s, transform 0.3s ease;
+}
+
+.transition-target [role="region"]:target,
+.transition-target #root:target {
+  visibility: visible;
+  transform: none;
+  transition: visibility 0s ease, transform 0.3s ease;
+}
+
+.transition-target [role="region"]:target ~ [role="region"],
+.transition-target #root {
+  transform: translateX(-100%);
+}
+
+/* Right-to-Left layout */
+
+[dir="rtl"] .transition-target [role="region"] {
+  transform: translateX(-100%);
+}
+
+[dir="rtl"] .transition-target #root {
+  transform: translateX(+100%);
+}
+
+[dir="rtl"] .transition-target #root:target,
+[dir="rtl"] .transition-target [role="region"]:target {
+  transform: none;
+}
+
+
+/******************************************************************************
+ * Panel transitions :: 'leaf'
+ *
+ * Slight improvement on 'target': rely on `data-leaf' attributes to identify
+ * tree leaves, in order not to move them when it's not necessary.
+ * TODO: Right-to-Left layout.
+ */
+
+.transition-leaf [role="region"] {
+  visibility: hidden;
+  transform: translateX(100%);
+  transition: visibility 0s ease 0.3s, transform 0.3s ease;
+}
+
+.transition-leaf [role="region"]:target {
+  visibility: visible;
+  transform: translateX(0);
+  transition: visibility 0s ease, transform .5s ease;
+}
+
+.transition-leaf [role="region"]:target ~ [role="region"]:not([data-leaf]) {
+  transform: translateX(-100%);
+}
+
+.transition-leaf.hidden #root {
+  transform: none;
+  transition: none;
+}
+
+
+/******************************************************************************
+ * Panel transitions :: 'nested'
+ *
+ * Slight improvement on 'leaf', requires sections to be nested
+ * -- e.g. all 'wifi-*' panels must be in a common <section> element.
+ * TODO: Right-to-Left layout.
+ */
+
+.transition-nested [role="region"] {
+  transition: transform 0.3s ease;
+  transform: translateX(100%);
+}
+
+.transition-nested [role="region"]:target {
+  transform: translateX(0);
+}
+
+.transition-nested [role="region"]:target ~ [role="region"]:not([data-leaf]),
+.transition-nested #root:not(:target) {
+  transform: translateX(-100%);
+}
+
+
+/******************************************************************************
+ * Panel transitions :: 'js-active'
+ *
+ * This relies on JS (onhashchange) to assign an `.active' class to the current
+ * panel and its "parents" (menu-wise, not DOM-wise).
+ *
+ * This doesn't require any specific HTML structure nor `data-leaf' attributes.
+ */
+
+.transition-js-active [role="region"] {
+  transition: transform 0.3s ease;
+  transform: translateX(100%);
+}
+
+.transition-js-active [role="region"].active {
+  transform: translateX(-100%);
+}
+
+.transition-js-active [role="region"]:target {
+  transform: none;
+}
+
+/* Right-To-Left layout */
+
+[dir="rtl"] .transition-target [role="region"] {
+  transform: translateX(-100%);
+}
+
+[dir="rtl"] .transition-js-active [role="region"].active {
+  transform: translateX(100%);
+}
+
+[dir="rtl"] .transition-js-active [role="region"]:target {
+  transform: none;
+}
+
+
+/******************************************************************************
+ * Panel transitions :: 'none'
+ *
+ * Fast is nice. RTL-ready.
+ */
+
+.transition-none [role="region"] {
+  display: none;
+}
+
+.transition-none [role="region"]:target {
+  display: block;
+}
+

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -1,6 +1,6 @@
 /**
  * Settings style & layout
- * note: `lists.css' must be loaded before this stylesheet
+ * note: `lists.css' and `panels.css' must be loaded before this stylesheet
  */
 
 html, body {
@@ -15,98 +15,10 @@ body.hidden * {
   display: none;
 }
 
-/* Setting panels: full-size blocks, identified by a 'region' role */
-[role=region] {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  overflow-y: scroll;
-  background: url(images/document_bg.png);
-}
-
-
-/******************************************************************************
- * Panel targets -- transitions
- *
- * this looks super nice on a desktop but not on an Otoro :-(
- *
- *  [role="region"] {
- *    visibility: hidden;
- *    transform: translateX(100%);
- *    transition: visibility 0s ease 0.3s, transform 0.3s ease;
- *  }
- *
- *  [role="region"]:target, #root:target {
- *    visibility: visible;
- *    transform: none;
- *    transition: visibility 0s ease, transform 0.3s ease;
- *  }
- *
- *  [role="region"]:target ~ [role="region"], #root {
- *    transform: translateX(-100%);
- *  }
- *
- * So we rely on `data-leaf' attributes to identify tree leafs,
- * in order not to move them when it's not necessary.
- */
-
-[role="region"] {
-  visibility: hidden;
-  transform: translateX(100%);
-  transition: visibility 0s ease .5s, transform .5s ease;
-}
-
-[role="region"]:target {
-  visibility: visible;
-  transform: translateX(0);
-  transition: visibility 0s ease, transform .5s ease;
-}
-
-[role="region"]:target ~ [role="region"]:not([data-leaf]) {
-  transform: translateX(-100%);
-}
-
-body.hidden #root {
-  transform: none;
-  transition: none;
-}
-
-
-/******************************************************************************
- * Headers don't scroll with the rest of the page, except for #root
- */
-
-[role="region"]:not(#root) > header:first-child {
-  position: fixed;
-  width: 100%;
-}
-
-[role="region"]:not(#root) > header:first-child + * {
-  margin-top: 5rem;
-}
-
 
 /******************************************************************************
  * Right-to-Left layout
  */
-
-/* transitions */
-
-[dir=rtl] [role="region"] {
-  transform: translateX(-100%);
-}
-
-[dir=rtl] #root {
-  transform: translateX(+100%);
-}
-
-[dir=rtl] #root:target,
-[dir=rtl] [role=region]:target {
-  transform: none;
-}
 
 /* setting lists */
 


### PR DESCRIPTION
/!\ WIP /!\

this is an attempt to get smoother panel transitions in the Settings app. The `transition-js-active` transition moves only **one** panel but as you can see on the device, it’s still very slow.
