### PR TITLE
Bug 796246: Hide passcode lock settings when lockscreen is disabled

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1111,7 +1111,7 @@
     </section>
 
     <!-- Security :: Phone Lock -->
-    <section role="region" id="phoneLock" data-enabled="false">
+    <section role="region" id="phoneLock" data-passcode-enabled="false" data-lockscreen-enabled="false">
       <header>
         <a href="#root"><span class="icon icon-back">back</span></a>
         <h1 data-l10n-id="phoneLock"> Phone Lock </h1>
@@ -1120,14 +1120,14 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" name="lockscreen.enabled" checked />
+            <input type="checkbox" data-type="switch" name="lockscreen.enabled" id="lockscreen-enable" />
             <span></span>
           </label>
           <a data-l10n-id="lockScreen">Lock Screen</a>
         </li>
-        <li>
+        <li class="lockscreen-enabled">
           <label>
-            <input type="checkbox" name="lockscreen.passcode-lock.enabled" id="passcode-enable" checked />
+            <input type="checkbox" data-type="switch" name="lockscreen.passcode-lock.enabled" id="passcode-enable" />
             <span></span>
           </label>
           <a data-l10n-id="passcode-lock">Passcode Lock</a>

--- a/apps/settings/js/phone_lock.js
+++ b/apps/settings/js/phone_lock.js
@@ -13,7 +13,7 @@ var PhoneLock = {
 
   settings: {
     passcode: '0000',
-    enable: false
+    passcodeEnable: false
   },
 
   checkingLength: {
@@ -26,6 +26,7 @@ var PhoneLock = {
   _passcodeBuffer: '',
 
   getAllElements: function pl_getAllElements() {
+    this.lockscreenEnable = document.getElementById('lockscreen-enable');
     this.passcodeInput = document.getElementById('passcode-input');
     this.passcodeDigits = document.querySelectorAll('.passcode-digit');
     this.passcodeEnable = document.getElementById('passcode-enable');
@@ -51,27 +52,43 @@ var PhoneLock = {
     var settings = navigator.mozSettings;
 
     var lock = settings.createLock();
-    var reqCode = lock.get('lockscreen.passcode-lock.code');
     var self = this;
+
+    var reqLockscreenEnable = lock.get('lockscreen.enabled');
+    reqLockscreenEnable.onsuccess = function onLockscreenEnableSuccess() {
+      var enable = reqLockscreenEnable.result['lockscreen.enabled'];
+      self.phonelockPanel.dataset.lockscreenEnabled = enable;
+      self.lockscreenEnable.checked = enable;
+    };
+
+    var reqCode = lock.get('lockscreen.passcode-lock.code');
     reqCode.onsuccess = function onPasscodeSuccess() {
       var passcode = reqCode.result['lockscreen.passcode-lock.code'];
       self.settings.passcode = passcode;
     };
-    var reqEnable = lock.get('lockscreen.passcode-lock.enabled');
-    reqEnable.onsuccess = function onPasscodeEnableSuccess() {
-      var enable = reqEnable.result['lockscreen.passcode-lock.enabled'];
-      self.settings.enable = enable;
-      self.phonelockPanel.dataset.enabled = enable;
+
+    var reqPasscodeEnable = lock.get('lockscreen.passcode-lock.enabled');
+    reqPasscodeEnable.onsuccess = function onPasscodeEnableSuccess() {
+      var enable = reqPasscodeEnable.result['lockscreen.passcode-lock.enabled'];
+      self.settings.passcodeEnable = enable;
+      self.phonelockPanel.dataset.passcodeEnabled = enable;
+      self.passcodeEnable.checked = enable;
     };
 
+    settings.addObserver('lockscreen.enabled',
+      function onLockscreenEnabledChange(event) {
+        self.phonelockPanel.dataset.lockscreenEnabled = event.settingValue;
+    });
+
     settings.addObserver('lockscreen.passcode-lock.enabled',
-      function onLockscreenEnableChange(event) {
-        self.settings.enable = event.settingValue;
-        self.phonelockPanel.dataset.enabled = event.settingValue;
+      function onPasscodeLockEnableChange(event) {
+        self.settings.passcodeEnable = event.settingValue;
+        self.phonelockPanel.dataset.passcodeEnabled = event.settingValue;
+        self.passcodeEnable.checked = event.settingValue;
     });
 
     settings.addObserver('lockscreen.passcode-lock.code',
-      function onLockscreenCodeChange(event) {
+      function onPasscodeLockCodeChange(event) {
         self.settings.passcode = event.settingValue;
     });
   },
@@ -107,7 +124,7 @@ var PhoneLock = {
     switch (evt.target) {
       case this.passcodeEnable:
         evt.preventDefault();
-        if (this.settings.enable) {
+        if (this.settings.passcodeEnable) {
           this.changeMode('confirm');
         } else {
           this.changeMode('create');

--- a/apps/settings/style/phone_lock.css
+++ b/apps/settings/style/phone_lock.css
@@ -1,8 +1,16 @@
-#phoneLock[data-enabled="false"] li.passcode-enabled {
+#phoneLock li.lockscreen-enabled {
   display: none;
 }
 
-#phoneLock[data-enabled="true"] li.passcode-enabled {
+#phoneLock[data-lockscreen-enabled="true"] li.lockscreen-enabled {
+  display: block;
+}
+
+#phoneLock li.passcode-enabled {
+  display: none;
+}
+
+#phoneLock[data-lockscreen-enabled="true"][data-passcode-enabled="true"] li.passcode-enabled {
   display: block;
 }
 


### PR DESCRIPTION
My first attempt at a Gaia PR, so let's see if I've done this right:

This includes tweaks to the lockscreen section of settings, such that the passcode settings portion is revealed and usable only when the lockscreen itself is enabled.
