### PR TITLE
[Keyboard] Changed the font weight from "faux" bold to Medium

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -105,7 +105,7 @@ button::-moz-focus-inner {
   left: -1px;
   right: -1px;
   font: 2.4rem/3.5rem MozTT, Sans-serif;
-  font-weight: 600;
+  font-weight: 500;
   text-align: center;
   color: #fff;
 }
@@ -148,7 +148,7 @@ button::-moz-focus-inner {
 
 .keyboard-key:not(.special-key).highlighted > .visual-wrapper > span {
   font: 3.8rem/4.5rem MozTT, Sans-serif;
-  font-weight: bold;
+  font-weight: 500;
   background: #6ec5d5;
   color: #1a3f46;
   border: solid 1px #8BD1DD;
@@ -386,7 +386,7 @@ background-position: center 2.2rem;
 #keyboard-accent-char-menu .keyboard-key > .visual-wrapper > span {
   border: none;
   font: 3rem/5rem MozTT, Sans-serif;
-  font-weight: bold;
+  font-weight: 500;
   color: #333;
 }
 
@@ -484,7 +484,7 @@ background-position: center 2.2rem;
 
 #keyboard-accent-char-menu.kbr-menu-lang > .keyboard-key > .visual-wrapper > span { 
   font-family: 'MozTT', Sans-serif;  
-  font-weight: 600;
+  font-weight: 500;
   font-size: 1.8rem;
   line-height: 4rem;
 }


### PR DESCRIPTION
Bold doesn't exist, so the system applies an ugly stroke. 
So I changed Bold / 600 to Medium / 500.
