### PR TITLE
Bug 796082 - store cached album image to metadata

### DIFF
--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -311,11 +311,11 @@ var TilesView = {
 
   setItemImage: function tv_setItemImage(item, fileinfo) {
     // Set source to image and crop it to be fitted when it's onloded
-    if (!fileinfo.metadata.picture)
+    if (!fileinfo.metadata.thumbnail)
       return;
 
     item.addEventListener('load', cropImage);
-    createAndSetCoverURL(item, fileinfo);
+    createAndSetCoverURL(item, fileinfo, true);
   },
 
   update: function tv_update(result) {
@@ -463,9 +463,9 @@ var ListView = {
 
   setItemImage: function lv_setItemImage(item, fileinfo) {
     // Set source to image and crop it to be fitted when it's onloded
-    if (fileinfo.metadata.picture) {
+    if (fileinfo.metadata.thumbnail) {
       item.addEventListener('load', cropImage);
-      createAndSetCoverURL(item, fileinfo);
+      createAndSetCoverURL(item, fileinfo, true);
     }
   },
 
@@ -558,7 +558,7 @@ var ListView = {
 
           SubListView.setAlbumDefault(index);
 
-          if (data.metadata.picture)
+          if (data.metadata.thumbnail)
             SubListView.setAlbumSrc(data);
 
           if (option === 'artist') {
@@ -676,7 +676,7 @@ var SubListView = {
 
   setAlbumSrc: function slv_setAlbumSrc(fileinfo) {
     // Set source to image and crop it to be fitted when it's onloded
-    createAndSetCoverURL(this.albumImage, fileinfo);
+    createAndSetCoverURL(this.albumImage, fileinfo, true);
     this.albumImage.classList.remove('fadeIn');
     this.albumImage.addEventListener('load', slv_showImage.bind(this));
 

--- a/apps/music/js/utils.js
+++ b/apps/music/js/utils.js
@@ -64,21 +64,30 @@ function cropImage(evt) {
   }
 }
 
-// If the metadata music file includes embedded cover art, extract it
-// from the file, create a blob: url for it, and set it on the specified
-// img element.
-function createAndSetCoverURL(img, fileinfo) {
-  if (fileinfo.metadata.picture) {
+// If the metadata music file includes embedded cover art,
+// use the thumbnail cache or extract it from the file,
+// create a blob: url for it, and set it on the specified img element.
+function createAndSetCoverURL(img, fileinfo, isCached) {
+  var url;
+
+  function setImageURL() {
+    img.addEventListener('load', function revoke() {
+      URL.revokeObjectURL(url);
+      img.removeEventListener('load', revoke);
+    });
+    img.src = url;
+  }
+
+  if (isCached) {
+    url = URL.createObjectURL(fileinfo.metadata.thumbnail);
+    setImageURL();
+  } else {
     musicdb.getFile(fileinfo.name, function(file) {
       var cover = file.slice(fileinfo.metadata.picture.start,
                              fileinfo.metadata.picture.end,
                              fileinfo.metadata.picture.type);
-      var url = URL.createObjectURL(cover);
-      img.addEventListener('load', function revoke() {
-        URL.revokeObjectURL(url);
-        img.removeEventListener('load', revoke);
-      });
-      img.src = url;
+      url = URL.createObjectURL(cover);
+      setImageURL();
     });
   }
 }

--- a/shared/js/mediadb.js
+++ b/shared/js/mediadb.js
@@ -746,7 +746,12 @@ var MediaDB = (function() {
 
         var cursor = cursorRequest.result;
         if (cursor) {
-          callback(cursor.value);
+          try {
+            callback(cursor.value);
+          }
+          catch (e) {
+            console.warn('MediaDB.enumerate(): callback threw', e);
+          }
           cursor.continue();
         }
         else {


### PR DESCRIPTION
1. Fix https://bugzilla.mozilla.org/show_bug.cgi?id=796082
2. Store cached thumbnail to metadata, and thumbnails are resized to the size of man tile (210 x 210).
3. This is how the gallery/js/MetadataParser.js handles the thumbnails for metadata, I also used the same way in music for album art parsing.
4. A patch for shared/js/mediadb.js
