### PR TITLE
fix: Do not delete invalid contacts groups

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -284,7 +284,7 @@ contacts.List = (function() {
     // from the 'start' param
     var i = start || 0;
     var length = container.children.length;
-    while (length != i) {
+    while (length > i) {
       var current = container.children[i];
       container.removeChild(current);
       length = container.children.length;


### PR DESCRIPTION
Somehow a contacts database can contains data that do not please the
current code, with 'start' being 1 and length being 0. This trigger the
following error:

E/GeckoConsole( 1084): [JavaScript Error: "NS_ERROR_INVALID_POINTER:
Component returned failure code: 0x80004003 (NS_ERROR_INVALID_POINTER)
[nsIDOMHTMLOListElement.removeChild]" {file:
"app://communications.gaiamobile.org/contacts/js/contacts_list.js" line:
291}]

And it also makes the loading ovrlay never disappearing. This change
fixes the behavior.
