### PR TITLE
Bug 804150 - [settings] lazy-load some parts of the settings app

### DIFF
--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -221,9 +221,11 @@ var ApplicationsList = {
   }
 };
 
-window.addEventListener('localized', function init(evt) {
-  window.removeEventListener('localized', init);
+window.addEventListener('hashchange', function onHashChange(evt) {
+  if (!evt.newURL.endsWith('#appPermissions'))
+    return;
 
+  window.removeEventListener('hashchange', onHashChange);
   ApplicationsList.init();
 });
 

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -22,7 +22,14 @@ var Settings = {
     // register web activity handler
     navigator.mozSetMessageHandler('activity', this.webActivityHandler);
 
-    this.loadGaiaCommit();
+    // Load the gaia commit when the corresponding pane is shown.
+    window.addEventListener('hashchange', function onHashChange(evt) {
+      if (!evt.newURL.endsWith('#more-info'))
+        return;
+
+      window.removeEventListener('hashchange', onHashChange);
+      Settings.loadGaiaCommit();
+    });
 
     var settings = this.mozSettings;
     if (!settings)


### PR DESCRIPTION
An easy way to make the settings up start faster is to reduce unnecessary IO that isn't needed on startup. Subsections can be lazy-loaded when needed. The changes are:

1) The gaia commit hash is loaded right on start and issues an XHR request that reads from disk. This information is actually hidden behind two clicks and nothing a user would probably look for. Let's lazy-load it when its section is shown.

2) The list of applications contributes quite a lot to the long startup time. We should load it first when the user actually accesses this section. So that the user doesn't get confused by the blank screen I added a progress bar like the gallery and browser have.

I did some measurements and here are the results:

before: 6527ms
with [1]: 6544ms (no real change here but it probably doesn't hurt?)
with [2]: 4216ms

That's about 2.3ms less time to startup.
