### PR TITLE
Bug 796432 - Avoiding remove a phone when clicking RETURN key

### DIFF
--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -598,6 +598,11 @@ contacts.Form = (function() {
     delIcon.className = 'icon-delete';
     delButton.appendChild(delIcon);
     delButton.onclick = function removeElement(event) {
+      // Workaround until 809452 is fixed.
+      // What we are avoiding with this condition is removing / restoring
+      // a field when the event is simulated by a ENTER Keyboard click
+      if ((event.clientX === 0) && (event.clientY === 0))
+        return false;
       event.preventDefault();
       var elem = document.getElementById(selector);
       elem.classList.toggle(REMOVED_CLASS);


### PR DESCRIPTION
The final fix would be adding a NEXT key in the keyboard, but this patch will at least fix the weird behavior of adding/removing a phone when clicking return
