### PR TITLE
Bug 803148 - Initial sync of email account can cause runaway memory usag...

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -17012,10 +17012,17 @@ ImapConnection.prototype._login = function(cb) {
     }
 
     if (this.capabilities.indexOf('AUTH=XOAUTH') !== -1 &&
-        'xoauth' in this._options)
-      this._send('AUTHENTICATE XOAUTH',
-                 ' ' + escape(this._options.xoauth), fnReturn);
-    else if (this.capabilities.indexOf('AUTH=PLAIN') !== -1) {
+        'xoauth' in this._options) {
+      this._send('AUTHENTICATE XOAUTH ' + escape(this._options.xoauth),
+                 fnReturn);
+    }
+    else if (this.capabilities.indexOf('AUTH=XOAUTH2') &&
+             'xoauth2' in this._options) {
+      this._send('AUTHENTICATE XOAUTH2 ' + escape(this._options.xoauth2),
+                 fnReturn);
+    }
+    else if (this._options.username !== undefined &&
+             this._options.password !== undefined) {
       this._send('LOGIN', ' "' + escape(this._options.username) + '" "'
                  + escape(this._options.password) + '"', fnReturn);
     } else {


### PR DESCRIPTION
...e (?).  Fix gmail IMAP support to make it easier to reproduce the problem. a=blocking-basecamp rs=upstream-fix-that-passes-tests

Passes gaia-email-libs-and-more tests for gmail without regressing any tests.  Smoke-tested on b2g-desktop to great success as well.  (Note: does require a manual change to the gmail.com local autoconfig database.)

I have manually inspected the diff of gaia-email-opt.js and it is correctly limited to just the login change.
