### PR TITLE
Bug 804328 - Fix setScreenBrightness() assertion failure. r=vingtetun

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -46,6 +46,7 @@ var ScreenManager = {
    * sync with setting 'screen.brightness'
   */
   _userBrightness: 1,
+  _savedBrightness: 1,
 
   /*
    * Wait for _dimNotice milliseconds during idle-screen-off


### PR DESCRIPTION
https://bugzil.la/804328
r=vingetun
approval-gaia-master=vingtetun

Fix setScreenBrightness assertion failure because ScreenManager._savedBrightness is undefined.
