### PR TITLE
Bug 796739: [Settings] remove inline scripts

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -691,21 +691,21 @@
       </header>
       <ul>
         <li>
-          <label onmouseup="audioPreview(this)">
+          <label>
             <input type="radio" name="tone-option" data-ignore value="classic.ogg" data-label="Classic" checked />
             <span></span>
           </label>
           <a data-l10n-id="classic">Classic</a>
         </li>
         <li>
-          <label onmouseup="audioPreview(this)">
+          <label>
             <input type="radio" name="tone-option" data-ignore value="old_school.ogg" data-label="Old School" />
             <span></span>
           </label>
           <a data-l10n-id="oldSchool">Old School</a>
         </li>
         <li>
-          <label onmouseup="audioPreview(this)">
+          <label>
             <input type="radio" name="tone-option" data-ignore value="low_bit.ogg" data-label="Low Bit" />
             <span></span>
           </label>
@@ -718,7 +718,7 @@
       </header>
       <ul>
         <li>
-          <label onmouseup="audioPreview(this)">
+          <label>
             <input type="radio" name="tone-option" data-ignore value="sms.wav" data-label="Beep Beep" />
             <span></span>
           </label>

--- a/apps/settings/js/sound.js
+++ b/apps/settings/js/sound.js
@@ -36,6 +36,12 @@ var SoundSettings = {
       self.smsSettings.value = req2.result['sms.ringtone'] || 'sms.wav';
       self.updateButton(self.smsSettings);
     };
+    // Listen to touch on tones
+    var labels = this.dialog.querySelectorAll('label');
+    for (var i = 0; i < labels.length; i++) {
+      var label = labels[i];
+      label.onmouseup = audioPreview.bind(null, label);
+    }
   },
 
   showDialog: function ss_showDialog(target) {


### PR DESCRIPTION
We should avoid any inline html js, like `<node onclick="foo()" />` in order to enable all safe security checks implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=768029

https://bugzilla.mozilla.org/show_bug.cgi?id=796739
