### PR TITLE
Bug 796739: [Clock] remove inline scripts

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -90,13 +90,13 @@
           </div>
         </div>
 
-        <div id="reset-button" class="button-container" data-action="reset" onclick="StopWatch.execute(this.dataset.action)">
+        <div id="reset-button" class="button-container">
           <div>
             <span data-l10n-id="reset">Reset</span>
           </div>
         </div>
 
-        <div id="stopwatch-action-button" class="button-container" data-action="start" onclick="StopWatch.execute(this.dataset.action)">
+        <div id="stopwatch-action-button" class="button-container">
           <div>
             <span data-l10n-id="start">Start</span>
             <span data-l10n-id="stop">Stop</span>
@@ -119,7 +119,7 @@
           </div>
         </div>
 
-        <div id="timer-action-button" class="button-container" data-action="start" onclick="Timer.execute(this.dataset.action)">
+        <div id="timer-action-button" class="button-container">
           <div>
             <span data-l10n-id="start">Start</span>
             <span data-l10n-id="cancel">Cancel</span>
@@ -128,7 +128,7 @@
       </div>
     </div>
     <div id="tabs-container">
-      <div id="tabs" onclick="choiceChanged(event.target)">
+      <div id="tabs">
         <fieldset>
           <label id="alarm-label" for="alarm-choice" data-choice="alarm" data-active="true"><input id="alarm-choice" type="radio" name="tabs" checked="true" /></label>
           <label id="stopwatch-label" for="stopwatch-choice" data-choice="stopwatch"><input id="stopwatch-choice" type="radio" name="tabs" checked="" /></label>

--- a/apps/clock/js/clock.js
+++ b/apps/clock/js/clock.js
@@ -1,6 +1,7 @@
 'use strict';
 
-function choiceChanged(target) {
+function onTabClick(event) {
+  var target = event.target;
   var choice = target.dataset.choice;
   if (!choice)
     return;
@@ -30,5 +31,11 @@ window.addEventListener('localized', function showBody() {
   document.documentElement.dir = navigator.mozL10n.language.direction;
   // <body> children are hidden until the UI is translated
   document.body.classList.remove('hidden');
+});
+
+window.addEventListener('load', function onLoad() {
+  window.removeEventListener('load', onLoad);
+
+  document.getElementById('tabs').onclick = onTabClick;
 });
 

--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -9,6 +9,11 @@ var StopWatch = {
     return this.actionButton = document.getElementById(id);
   },
 
+  get resetButton() {
+    delete this.resetButton;
+    return this.actionButton = document.getElementById('reset-button');
+  },
+
   get tickerView() {
     delete this.tickerView;
     return this.tickerView = document.getElementById('stopwatch-ticker-view');
@@ -64,3 +69,11 @@ var StopWatch = {
       this.chronoView.innerHTML = newValue;
   }
 };
+
+window.addEventListener('load', function onLoad() {
+  window.removeEventListener('load', onLoad);
+
+  StopWatch.actionButton.onclick = StopWatch.start.bind(StopWatch);
+  StopWatch.resetButton.onclick = StopWatch.reset.bind(StopWatch);
+});
+

--- a/apps/clock/js/timer.js
+++ b/apps/clock/js/timer.js
@@ -96,3 +96,9 @@ var Timer = {
   }
 };
 
+window.addEventListener('load', function onLoad() {
+  window.removeEventListener('load', onLoad);
+
+  Timer.actionButton.onclick = Timer.start.bind(Timer);
+});
+


### PR DESCRIPTION
We should avoid any inline html js, like `<node onclick="foo()" />` in order to enable all safe security checks implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=768029

https://bugzilla.mozilla.org/show_bug.cgi?id=796739
