### PR TITLE
Bug 803178: [Calendar] Remove inline scripts

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -111,7 +111,7 @@
   <script defer src="/js/app.js" type="text/javascript" charset="utf-8"></script>
 </head>
 
-<body role="application" class="loading" onload="Calendar.App.init();">
+<body role="application" class="loading">
 
 <nav class="skin-organic" id="settings" role="region">
 
@@ -216,9 +216,9 @@
 
 <section class="fullscreen-view skin-organic" id="create-account-view" role="region">
   <header>
-    <a data-l10n-id="cancel" href="javascript: window.history.go(-1);">
-      <span class="icon icon-back">Cancel</span>
-    </a>
+    <button class="cancel">
+      <span data-l10n-id="cancel" class="icon icon-back">Cancel</span>
+    </button>
 
     <h1 data-l10n-id="add-account">
       Add an account
@@ -277,16 +277,14 @@
 
 <section class="fullscreen-view" id="modify-event-view" role="region">
   <header>
-    <a href="javascript: window.history.go(-1);">
-       <span data-l10n-id="cancel" class="icon icon-back">
-         Cancel
-       </span
-    </a>
+    <button class="cancel">
+      <span data-l10n-id="cancel" class="icon icon-back">Cancel</span>
+    </button>
 
     <menu type="toolbar">
-      <a class="save" href="#">
+      <button class="save">
         <span data-l10n-id="save">Save</span>
-      </a>
+      </button>
     </menu>
 
     <h1 data-l10n-id="add-event-header">
@@ -357,9 +355,9 @@
 
 <section class="fullscreen-view skin-organic" id="modify-account-view" role="region">
   <header>
-    <a href="javascript: window.history.go(-1);">
-      <span data-l10n-id="back" class="icon icon-back">Back</span>
-    </a>
+    <button class="cancel">
+      <span data-l10n-id="back" class="cancel icon icon-back">Back</span>
+    </button>
 
     <menu type="toolbar">
       <button class="save">
@@ -404,7 +402,7 @@
       </p>
     </section>
     <menu>
-      <button type="reset" onclick="window.back()" data-l10n-id="cancel">Cancel</button>
+      <button type="reset" class="delete-cancel" data-l10n-id="cancel">Cancel</button>
       <button type="submit" class="delete-confirm" data-l10n-id="confirm">Confirm</button>
     </menu>
   </form>

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -293,3 +293,9 @@ Calendar.App = (function(window) {
 
 }(this));
 
+window.addEventListener('load', function onLoad() {
+  window.removeEventListener('load', onLoad);
+
+  Calendar.App.init();
+});
+

--- a/apps/calendar/js/views/create_account.js
+++ b/apps/calendar/js/views/create_account.js
@@ -4,6 +4,7 @@
 
   function CreateAccount(options) {
     Calendar.View.apply(this, arguments);
+    this.cancel = this.cancel.bind(this);
     this._initEvents();
   }
 
@@ -14,11 +15,16 @@
 
     selectors: {
       element: '#create-account-view',
-      accounts: '#create-account-presets'
+      accounts: '#create-account-presets',
+      cancelButton: '#create-account-view .cancel'
     },
 
     get accounts() {
       return this._findElement('accounts');
+    },
+
+    get cancelButton() {
+      return this._findElement('cancelButton');
     },
 
     _initEvents: function() {
@@ -33,6 +39,8 @@
 
       store.on('remove', render);
       store.on('add', render);
+
+      this.cancelButton.addEventListener('click', this.cancel);
     },
 
     render: function() {
@@ -54,6 +62,10 @@
         output = template.provider.render({ name: preset });
         this.accounts.insertAdjacentHTML('beforeend', output);
       }, this);
+    },
+
+    cancel: function() {
+      window.back();
     }
   };
 

--- a/apps/calendar/js/views/modify_account.js
+++ b/apps/calendar/js/views/modify_account.js
@@ -5,6 +5,7 @@
 
     this.save = this.save.bind(this);
     this.deleteRecord = this.deleteRecord.bind(this);
+    this.cancel = this.cancel.bind(this);
   }
 
   ModifyAccount.prototype = {
@@ -16,6 +17,8 @@
       fields: '*[name]',
       saveButton: '#modify-account-view .save',
       deleteButton: '#modify-account-view .delete-confirm',
+      cancelDeleteButton: '#modify-account-view .delete-cancel',
+      backButton: '#modify-account-view .cancel',
       errors: '#modify-account-view .errors'
     },
 
@@ -23,6 +26,14 @@
 
     get deleteButton() {
       return this._findElement('deleteButton');
+    },
+
+    get cancelDeleteButton() {
+      return this._findElement('cancelDeleteButton');
+    },
+
+    get backButton() {
+      return this._findElement('backButton');
     },
 
     get saveButton() {
@@ -100,6 +111,10 @@
       });
     },
 
+    cancel: function() {
+      window.back();
+    },
+
     save: function() {
       var list = this.element.classList;
       var self = this;
@@ -167,10 +182,13 @@
       var list = this.element.classList;
 
       this.saveButton.addEventListener('click', this.save);
+      this.backButton.addEventListener('click', this.cancel);
 
       if (this.model._id) {
         this.type = 'update';
         this.deleteButton.addEventListener('click', this.deleteRecord);
+        this.cancelDeleteButton.addEventListener('click',
+                                                 this.cancel);
       } else {
         this.type = 'create';
       }
@@ -196,6 +214,10 @@
 
       this.saveButton.removeEventListener('click', this.save);
       this.deleteButton.removeEventListener('click', this.deleteRecord);
+      this.cancelDeleteButton.removeEventListener('click',
+                                                  this.cancel);
+      this.backButton.removeEventListener('click',
+                                                this.cancel);
     },
 
     dispatch: function(data) {

--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -11,6 +11,7 @@ Calendar.ns('Views').ModifyEvent = (function() {
 
     this.save = this.save.bind(this);
     this.deleteRecord = this.deleteRecord.bind(this);
+    this.cancel = this.cancel.bind(this);
     this._toggleAllDay = this._toggleAllDay.bind(this);
 
     this._initEvents();
@@ -35,7 +36,8 @@ Calendar.ns('Views').ModifyEvent = (function() {
       status: '#modify-event-view section[role="status"]',
       errors: '#modify-event-view .errors',
       saveButton: '#modify-event-view .save',
-      deleteButton: '#modify-event-view .delete-record'
+      deleteButton: '#modify-event-view .delete-record',
+      cancelButton: '#modify-event-view .cancel'
     },
 
     _initEvents: function() {
@@ -47,6 +49,7 @@ Calendar.ns('Views').ModifyEvent = (function() {
 
       this.saveButton.addEventListener('click', this.save);
       this.deleteButton.addEventListener('click', this.deleteRecord);
+      this.cancelButton.addEventListener('click', this.cancel);
       this.form.addEventListener('submit', this.save);
 
       var allday = this.getField('allday');
@@ -185,12 +188,16 @@ Calendar.ns('Views').ModifyEvent = (function() {
       return this._findElement('form');
     },
 
+    get saveButton() {
+      return this._findElement('saveButton');
+    },
+
     get deleteButton() {
       return this._findElement('deleteButton');
     },
 
-    get saveButton() {
-      return this._findElement('saveButton');
+    get cancelButton() {
+      return this._findElement('cancelButton');
     },
 
     get status() {
@@ -355,6 +362,13 @@ Calendar.ns('Views').ModifyEvent = (function() {
       } else {
         this._persistEvent('createEvent', 'canCreate');
       }
+    },
+
+    /**
+     * Dismiss modification and go back to previous screen.
+     */
+    cancel: function() {
+      window.back();
     },
 
     /**


### PR DESCRIPTION
We should avoid any inline html js, like <node onclick="foo()" /> in order to enable all safe security checks implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=768029

https://bugzilla.mozilla.org/show_bug.cgi?id=803178
