### PR TITLE
Bug 805504 - Setting Image Uploader as certified

### DIFF
--- a/test_apps/image-uploader/manifest.webapp
+++ b/test_apps/image-uploader/manifest.webapp
@@ -1,6 +1,7 @@
 {
   "name": "Image Uploader",
   "description": "Uploading an image to some website",
+  "type": "certified",
   "developer": {
     "name": "lissyx",
     "url": "https://github.com/lissyx/gaia/tree/image-uploader"


### PR DESCRIPTION
SystemXHR permission is now limited only to certified apps. Since we
rely on xmlHttpRequest to perform upload, we have to add this in the
manifest.webapp.
