### PR TITLE
Bug 805532 - [gallery] share activity does not expose the filename of the shared file

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -883,17 +883,21 @@ $('thumbnails-share-button').onclick = function() {
  * Image data is passed as data: URLs because we can't pass blobs
  */
 function shareFiles(filenames) {
-  var urls = [];
+  var urls = [], justnames = [];
   getDataURLForNextFile();
 
   function getDataURLForNextFile() {
     if (urls.length === filenames.length) {
-      shareURLs(urls);
+      shareURLs(urls, justnames);
     }
     else {
       var i = urls.length;
       var filename = filenames[i];
       photodb.getFile(filename, function(file) {
+        // filename is identical to file.name, both of which may contain path
+        // information.  We want to let the recipient know the name of the
+        // file, but not the path components.
+        justnames.push(filename.substring(filename.lastIndexOf('/') + 1));
         var reader = new FileReader();
         reader.readAsBinaryString(file);
         reader.onload = function() {
@@ -907,13 +911,14 @@ function shareFiles(filenames) {
 
 // This is called by shareFile once the filenames have
 // been converted to data URLs
-function shareURLs(urls) {
+function shareURLs(urls, filenames) {
   var a = new MozActivity({
     name: 'share',
     data: {
       type: 'image/*',
       number: urls.length,
-      urls: urls
+      urls: urls,
+      filenames: filenames
     }
   });
 

--- a/test_apps/share-receiver/js/share-receiver.js
+++ b/test_apps/share-receiver/js/share-receiver.js
@@ -2,7 +2,7 @@ window.onload = function() {
   navigator.mozSetMessageHandler('activity', function(activityRequest) {
     activity = activityRequest;
     if (activityRequest.source.name === 'share') {
-      addImages(activityRequest.source.data.urls);
+      addImages(activityRequest.source.data);
     }
   });
 
@@ -15,12 +15,16 @@ function done() {
   activity.postResult('shared');
 }
 
-function addImages(urls) {
+function addImages(data) {
+  var urls = data.urls, filenames = data.filenames;
   console.log('share receiver: got', urls.length, 'images');
-  urls.forEach(function(url) {
+  urls.forEach(function(url, iUrl) {
     var img = document.createElement('img');
     img.style.width = '100px';
     img.src = url;
     document.body.appendChild(img);
+    var label = document.createElement('span');
+    label.textContent = filenames[iUrl];
+    document.body.appendChild(label);
   });
 }


### PR DESCRIPTION
r? @davidflanagan for a fix to https://bugzilla.mozilla.org/show_bug.cgi?id=805532

Expose the filenames (sans path components) of shared images.  This includes a change to the share-receiver to show the filenames.

For posterity: This patch is being made for the blocking-basecamp e-mail bug https://bugzilla.mozilla.org/show_bug.cgi?id=799827 about e-mail sharing images.
