### PR TITLE
Bug 805735 - check CapsLock Key element is available in setUpperCaseLock...

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -59,6 +59,9 @@ const IMERender = (function() {
       'button[data-keycode="' + KeyboardEvent.DOM_VK_CAPS_LOCK + '"]'
     );
 
+    if (!capsLockKey)
+      return;
+
     if (state === 'locked') {
       capsLockKey.classList.remove('kbr-key-active');
       capsLockKey.classList.add('kbr-key-hold');


### PR DESCRIPTION
...()

**Root cause**:
the CapsLock key element may not exist when the keyboard is shown as number for the first time.

In showKeyboard(), resetKeyboard() failed due to the above case, and then we failed to invoke inputMethod.activate().
