### PR TITLE
[Bug 805738] Launching any app as 'first-running-app'

### DIFF
--- a/apps/system/js/applications.js
+++ b/apps/system/js/applications.js
@@ -18,6 +18,7 @@ var Applications = {
         var apps = evt.target.result;
         apps.forEach(function(app) {
           self.installedApps[app.manifestURL] = app;
+          // TODO Followup for retrieving homescreen & comms app
         });
 
         self.ready = true;

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -4,12 +4,17 @@
 'use strict';
 
 window.addEventListener('load', function startup() {
+  function firstAppManager(homescreenApp) {
+    // TODO Include algorith for handling which app is the first running app
+    // By now will be homescreen until merging #5883
+    homescreenApp.launch();
+  }
   if (Applications.ready) {
-    WindowManager.launchHomescreen();
+    WindowManager.retrieveHomescreen(firstAppManager);
   } else {
     window.addEventListener('applicationready', function appListReady(event) {
       window.removeEventListener('applicationready', appListReady);
-      WindowManager.launchHomescreen();
+      WindowManager.retrieveHomescreen(firstAppManager);
     });
   }
 


### PR DESCRIPTION
This code is needed in order to launch any app as 'first-running-app'. We need it in order to launch FTU ensuring Homescreen. In this approach 'Homescreen' is launched as an App instead of an activity, so probably we could https://bugzilla.mozilla.org/show_bug.cgi?id=801995 as fixed with this code.
