### PR TITLE
Bug 803407 - Removed onmouseout event for listening drag event of slider...

### DIFF
--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -206,7 +206,6 @@ function bug344618_polyfill() {
     slider.onmousedown = onClick;
     thumb.onmousedown = onDragStart;
     label.onmousemove = onDragMove;
-    label.onmouseout = onDragStop;
     label.onmouseup = onDragStop;
 
     // expose the 'refresh' method on <input>


### PR DESCRIPTION
Bug 803407 - Removed onmouseout event for listening drag event of slider thumb even outside it.

@evelynhung, could you please to review it? thanks!
