### PR TITLE
Bug 805685 - [camera] video recording does not work since bug 795379

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -88,16 +88,11 @@ var Camera = {
 
   _pendingPick: null,
 
-  // How many seconds we wait between collecting available disk space
-  DISK_SAMPLE_RATE: 1,
-  // How many disk samples we store, we dont want to just average 2 samples
-  // as they might spike
-  DISK_SAMPLE_SIZE: 10,
-  // Amount of seconds of streaming the disk can support before we
-  // stop recording
-  DISK_BUFFER: 10,
+  // The minimum available disk space to start recording a video.
+  RECORD_SPACE_MIN: 1024 * 1024 * 2,
 
-  _diskSpace: [],
+  // Number of bytes left on disk to let us stop recording.
+  RECORD_SPACE_PADDING: 1024 * 1024 * 1,
 
   get overlayTitle() {
     return document.getElementById('overlay-title');
@@ -161,6 +156,7 @@ var Camera = {
     this._orientationRule = this._styleSheet.insertRule(css, insertId);
     window.addEventListener('deviceorientation', this.orientChange.bind(this));
 
+    this.overlay.addEventListener('click', this.showOverlay.bind(this, null));
     this.toggleButton.addEventListener('click', this.toggleCamera.bind(this));
     this.toggleFlashBtn.addEventListener('click', this.toggleFlash.bind(this));
     this.viewfinder.addEventListener('click', this.toggleFilmStrip.bind(this));
@@ -302,6 +298,7 @@ var Camera = {
     var switchButton = this.switchButton;
     this._videoPath = this.createVideoFilename();
 
+    var onerror = function() handleError('error-recording');
     var onsuccess = (function onsuccess() {
       captureButton.removeAttribute('disabled');
       document.body.classList.add('capturing');
@@ -313,15 +310,40 @@ var Camera = {
       }
     }).bind(this);
 
-    var onerror = function onerror(e) {
+    var handleError = (function handleError(id) {
       captureButton.removeAttribute('disabled');
       switchButton.removeAttribute('disabled');
-    };
+      this.showOverlay(id);
+    }).bind(this);
 
     switchButton.setAttribute('disabled', 'disabled');
     captureButton.setAttribute('disabled', 'disabled');
-    this._cameraObj.startRecording(this._videoStorage, this._videoPath,
-                                   onsuccess, onerror);
+
+    // Determine the number of bytes available on disk.
+    var stat = this._videoStorage.stat();
+    stat.onerror = onerror;
+    stat.onsuccess = (function() {
+      var freeBytes = stat.result.freeBytes;
+
+      // Determine the size of the file we might be overwriting.
+      var get = this._videoStorage.get(this._videoPath);
+      get.onerror = function() startRecording(freeBytes);
+      get.onsuccess = function() startRecording(freeBytes - get.result.size);
+    }).bind(this);
+
+    var startRecording = (function startRecording(freeBytes) {
+      if (freeBytes < this.RECORD_SPACE_MIN) {
+        handleError('nospace');
+        return;
+      }
+
+      var config = {
+        rotation: 90,
+        maxFileSizeBytes: freeBytes - this.RECORD_SPACE_PADDING
+      };
+      this._cameraObj.startRecording(config, this._videoStorage, this._videoPath,
+                                     onsuccess, onerror);
+    }).bind(this);
   },
 
   addToFilmStrip: function camera_addToFilmStrip(name, thumbnail, type) {
@@ -372,7 +394,6 @@ var Camera = {
   },
 
   startRecordingTimer: function camera_startRecordingTimer() {
-    this._diskSpace = [];
     this._videoStart = new Date().getTime();
     this.videoTimer.textContent = this.formatTimer(0);
     this._videoTimer =
@@ -383,37 +404,6 @@ var Camera = {
     var videoLength =
       Math.round((new Date().getTime() - this._videoStart) / 1000);
     this.videoTimer.textContent = this.formatTimer(videoLength);
-
-    if (videoLength % this.DISK_SAMPLE_RATE !== 0) {
-      return;
-    }
-
-    // Check the amount of storage we have available and stop recording
-    // before we fill the sdcard
-    this._videoStorage.stat().onsuccess = (function(e) {
-      var freeBytes = e.target.result.freeBytes;
-      this._diskSpace.push(freeBytes);
-      if (this._diskSpace.length > this.DISK_SAMPLE_SIZE) {
-        this._diskSpace.shift();
-      }
-
-      if (this._diskSpace.length < 2) {
-        return;
-      }
-
-      // Find the average amount of diskspace we are consuming per second
-      // If we are overwriting a file, freeBytes will stay constant until
-      // we start exceeding the original filesize, so we need to handle
-      // 0 bytes used
-      var diskUsed = this._diskSpace[0] - freeBytes;
-      var diskRate = diskUsed > 0 ?
-        diskUsed / (this._diskSpace.length * this.DISK_SAMPLE_RATE) : 0;
-
-      if ((freeBytes - (diskRate * this.DISK_BUFFER)) < 0) {
-        this.stopRecording();
-      }
-
-    }).bind(this);
   },
 
   stopRecording: function camera_stopRecording() {

--- a/apps/camera/locales/camera.en-US.properties
+++ b/apps/camera/locales/camera.en-US.properties
@@ -4,6 +4,9 @@ nospace-text  = Try freeing up space by deleting media.
 error-saving-title = Picture not saved
 error-saving-text  = An error prevented Camera from saving the picture.
 
+error-recording-title = Video not recorded
+error-recording-text  = An error prevented Camera from recording the video.
+
 nocard-title = No memory card found
 nocard-text  = Insert a memory card to take pictures.
 


### PR DESCRIPTION
There's a couple of changes here:

1) The overlay does now disappear if you click it. I don't know if it's supposed to fade away automatically but I didn't find any code for that so I just assumed we need that.

2) As soon as I got this._cameraObj.startRecording() working again it always failed - because of https://bugzilla.mozilla.org/show_bug.cgi?id=805777 I figured it would be better to have an error message than nothing happening.

3) startRecording() does now support a maxFileSizeBytes parameter which I think we should use to constraint used disk space by videos. I replaced the old code that periodically checks with a one-time check before the recording starts.
