### PR TITLE
[bug 805037] Fix "setup" verb use to "set up"

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -356,7 +356,7 @@
       </div>
 
       <!-- === Setup === -->
-      <!-- From hyperlink, ask the user if they want to setup now or bail. -->
+      <!-- From hyperlink, ask the user if they want to set up now or bail. -->
       <div class="card-setup-needed card">
       </div>
       <!-- Pick your service provider from popular options to save yourself
@@ -375,7 +375,7 @@
         </section>
         <h2 class="sup-pick-service-label sup-form-label"
             data-l10n-id="setup-pick-service">
-          To SenD and ReceivE email, you will need to setup an account.
+          To SenD and ReceivE email, you will need to set up an account.
         </h2>
         <div class="sup-services-container">
         </div>
@@ -419,7 +419,7 @@
         </section>
         <div class="sup-progress-region">
           <span class="sup-progress-label" data-l10n-id="setup-progress-wait">
-            PleasE WaiT WhilE I SetuP YouR AccounT
+            PleasE WaiT WhilE I SeT UP YouR AccounT
           </span>
           <span class="sup-progress-spinner"></span>
         </div>
@@ -427,7 +427,7 @@
           <span class="sup-error-message"></span>
           <button class="sup-manual-config-btn sup-form-btn recommend"
                   data-l10n-id="setup-manual-config">
-            ManuallY SetuP AccounT
+            ManuallY SeT UP AccounT
           </button>
         </div>
       </div>

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -1,7 +1,7 @@
 setup-app-name-header=Mail
 
-setup-empty-account-prompt=You are not setup to send or receive email. Would you like to do that now?
-setup-pick-service=To send and receive email, you will need to setup an account.
+setup-empty-account-prompt=You are not set up to send or receive email. Would you like to do that now?
+setup-pick-service=To send and receive email, you will need to set up an account.
 setup-account-header=New Mail Account Setup
 setup-info-header=Your login information
 
@@ -14,7 +14,7 @@ setup-info-email-placeholder=Email Address
 setup-info-password-placeholder=Password
 setup-info-next=Next
 
-setup-progress-wait=Please wait while I setup your account
+setup-progress-wait=Please wait while I set up your account
 
 setup-completed-header=Mail account setup
 setup-completed-label=All Done!
@@ -25,7 +25,7 @@ setup-error-bad-user-or-pass=Invalid username or password
 setup-error-not-authorized=The server said you're not authorized to create an account
 setup-error-unknown=An unknown error occurred
 
-setup-manual-config=Manually setup account
+setup-manual-config=Manually set up account
 
 setup-manual-config-header=Manual Setup
 setup-manual-account-type=Account Type


### PR DESCRIPTION
This changes "setup" to "set up" in places where it's not being used as a noun in the email app.

I'm pretty sure this is equivalent to a spelling mistake in the English strings, so it doesn't require id changes.

r?
