### PR TITLE
Bug 804448 - remove overscroll effect

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -1626,6 +1626,12 @@ PhotoState.prototype.pan = function(dx, dy) {
     }
   }
 
+  // Don't swipe past the end of the last photo or past the start of the first
+  if ((currentPhotoIndex === 0 && this.swipe > 0) ||
+      (currentPhotoIndex === images.length - 1 && this.swipe < 0)) {
+    this.swipe = 0;
+  }
+
   this._reposition();
 };
 


### PR DESCRIPTION
The gallery used to let you try to pan past the first or last photo, and would then transition the photo back onto the screen. This fixes it so that it doesn't let you pan past the start or end.
