### PR TITLE
Bug 806048 - Don't reset the lock timeout every time the screen turns off

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -52,7 +52,7 @@ var LockScreen = {
   /*
   * Check the timeout of passcode lock
   */
-  _passcodeTimeoutCheck: false,
+  _passCodeTimeoutCheck: false,
 
   /*
   * passcode to enable the smiley face easter egg.

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -45,7 +45,7 @@ var LockScreen = {
   passCodeRequestTimeout: 0,
 
   /*
-  * Store the time that screen is off
+  * Store the first time the screen went off since unlocking.
   */
   _screenOffTime: 0,
 
@@ -195,7 +195,11 @@ var LockScreen = {
         // we would need to lock the screen again
         // when it's being turned back on
         if (!evt.detail.screenEnabled) {
-          this._screenOffTime = new Date().getTime();
+          // Don't update the time after we're already locked otherwise turning
+          // the screen off again will bypass the passcode before the timeout.
+          if (!this.locked) {
+            this._screenOffTime = new Date().getTime();
+          }
         } else {
           var _screenOffInterval = new Date().getTime() - this._screenOffTime;
           if (_screenOffInterval > this.passCodeRequestTimeout * 1000) {


### PR DESCRIPTION
I can try writing a test if this patch is acceptable.
