### PR TITLE
Bug 796729 - convert share image activity to use blobs

### DIFF
--- a/apps/email/js/mail-app.js
+++ b/apps/email/js/mail-app.js
@@ -183,7 +183,7 @@ if ('mozSetMessageHandler' in window.navigator) {
     }
     var activityName = activity.source.name;
     if (activityName === 'share') {
-      var attachmentUrls = activity.source.data.urls,
+      var attachmentBlobs = activity.source.data.blobs,
           attachmentNames = activity.source.data.filenames;
     } else if (activityName === 'new') {
       var [to, subject, body, cc, bcc] = queryURI(activity.source.data.URI);
@@ -226,32 +226,14 @@ if ('mozSetMessageHandler' in window.navigator) {
             composer.cc = cc;
           if (bcc)
             composer.bcc = bcc;
-          if (attachmentUrls) {
-            for (var iUrl = 0; iUrl < attachmentUrls.length; iUrl++) {
-              // our data URIs look like:
-              // data:image/png;base64,CONTENT
-              // 012345        012345678
-              var url = attachmentUrls[iUrl],
-                  filename = attachmentNames[iUrl],
-                  idxSemicolon = url.indexOf(';'),
-                  mimeType = url.substring(5, idxSemicolon),
-                  imageString = url.substring(idxSemicolon + 8),
-                  imageData = window.atob(imageString),
-                  imageArr = new Uint8Array(imageData.length);
-              for (var i = 0; i < imageData.length; i++) {
-                imageArr[i] = imageData.charCodeAt(i);
-              }
-              var blob = new Blob([imageArr],
-                                  { type: mimeType });
+          if (attachmentBlobs) {
+            for (var iBlob = 0; iBlob < attachmentBlobs.length; iBlob++) {
               composer.addAttachment({
-                name: filename,
-                blob: blob
+                name: attachmentNames[iBlob],
+                blob: attachmentBlobs[iBlob]
               });
             }
           }
-          // TODO: We may need to add attachments here:
-          // if (attachments)
-          //   composer.attachments = attachments;
           Cards.pushCard('compose',
             'default', 'immediate', { composer: composer,
             activity: (activityName == 'share' ? activity : null) });

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -883,54 +883,41 @@ $('thumbnails-share-button').onclick = function() {
  * Image data is passed as data: URLs because we can't pass blobs
  */
 function shareFiles(filenames) {
-  var urls = [], justnames = [];
-  getDataURLForNextFile();
+  var blobs = [], basenames = [];
+  getBlobForNextFile();
 
-  function getDataURLForNextFile() {
-    if (urls.length === filenames.length) {
-      shareURLs(urls, justnames);
+  function getBlobForNextFile() {
+    if (blobs.length === filenames.length) {
+      shareBlobs(blobs, basenames);
     }
     else {
-      var i = urls.length;
+      var i = blobs.length;
       var filename = filenames[i];
       photodb.getFile(filename, function(file) {
+        blobs.push(file);
         // filename is identical to file.name, both of which may contain path
         // information.  We want to let the recipient know the name of the
         // file, but not the path components.
-        justnames.push(filename.substring(filename.lastIndexOf('/') + 1));
-        var reader = new FileReader();
-        reader.readAsBinaryString(file);
-        reader.onload = function() {
-          urls[i] = 'data:' + file.type + ';base64,' + btoa(reader.result);
-          getDataURLForNextFile();
-        };
+        basenames.push(filename.substring(filename.lastIndexOf('/') + 1));
+        getBlobForNextFile();
       });
     }
   }
 }
 
-// This is called by shareFile once the filenames have
-// been converted to data URLs
-function shareURLs(urls, filenames) {
+// This is called by shareFiles() once the filenames have
+// been converted to blobs
+function shareBlobs(blobs, filenames) {
   var a = new MozActivity({
     name: 'share',
     data: {
       type: 'image/*',
-      number: urls.length,
-      urls: urls,
+      number: blobs.length,
+      blobs: blobs,
       filenames: filenames
     }
   });
 
-  function reopen() {
-    navigator.mozApps.getSelf().onsuccess = function(e) {
-      e.target.result.launch();
-    };
-  }
-
-  a.onsuccess = function() {
-    reopen();
-  };
   a.onerror = function(e) {
     if (a.error.name === 'NO_PROVIDER') {
       var msg = navigator.mozL10n.get('share-noprovider');
@@ -939,7 +926,6 @@ function shareURLs(urls, filenames) {
     else {
       console.warn('share activity error:', a.error.name);
     }
-    reopen();
   };
 }
 

--- a/apps/wallpaper/style/wallpaper.css
+++ b/apps/wallpaper/style/wallpaper.css
@@ -40,3 +40,10 @@ html, body {
   width: 50%;
   height: 100%;
 }
+
+#cancel {
+  position: absolute;
+  left: 0;
+  width: 50%;
+  height: 100%;
+}

--- a/showcase_apps/twittershare/js/activities.js
+++ b/showcase_apps/twittershare/js/activities.js
@@ -7,13 +7,13 @@ var ActivityHandler = (function Handler() {
   var handleActivity = function handleActivity(activity) {
     this._currentActivity = activity;
 
-    if (!activity.source.data.urls ||
-      activity.source.data.urls.length == 0) {
+    if (!activity.source.data.blobs ||
+      activity.source.data.blobs.length == 0) {
       this.postCancel();
       return;
     }
 
-    this._image = activity.source.data.urls[0];
+    this._image = activity.source.data.blobs[0];
     var event = new CustomEvent('onImageReceived', {
       detail: {
         data: this._image

--- a/showcase_apps/twittershare/js/twittershare.js
+++ b/showcase_apps/twittershare/js/twittershare.js
@@ -45,10 +45,10 @@ var twitter = (function() {
 
     // Add event listener to catch images through activity
     document.addEventListener('onImageReceived', function(e) {
-
       var img = document.createElement('img');
-      img.src = e.detail.data;
-      imgToShare = dataURItoBlob(img.src);
+      imgToShare = e.detail.data;
+      img.src = URL.createObjectURL(imgToShare);
+      img.onload = function() { URL.revokeObjectURL(img.src); };
 
       var imgContainer = document.querySelector('#img_container');
       imgContainer.innerHTML = '';
@@ -325,24 +325,6 @@ var twitter = (function() {
 
     xhr.send(data);
   };
-
-  function dataURItoBlob(dataURI) {
-    // convert base64 to raw binary data held in a string
-    // doesn't handle URLEncoded DataURIs
-    var byteString = atob(dataURI.split(',')[1]);
-
-    // separate out the mime component
-    var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
-
-    // write the bytes of the string to an ArrayBuffer
-    var ab = new ArrayBuffer(byteString.length);
-    var ia = new Uint8Array(ab);
-    for (var i = 0; i < byteString.length; i++) {
-        ia[i] = byteString.charCodeAt(i);
-    }
-
-    return new Blob([ab], {'type': mimeString});
-  }
 
   var linkDomElements = function() {
     // # Setup input

--- a/test_apps/share-receiver/js/share-receiver.js
+++ b/test_apps/share-receiver/js/share-receiver.js
@@ -16,15 +16,17 @@ function done() {
 }
 
 function addImages(data) {
-  var urls = data.urls, filenames = data.filenames;
-  console.log('share receiver: got', urls.length, 'images');
-  urls.forEach(function(url, iUrl) {
+  var blobs = data.blobs, filenames = data.filenames;
+  console.log('share receiver: got', blobs.length, 'images');
+  blobs.forEach(function(blob, index) {
+    var url = URL.createObjectURL(blob);
     var img = document.createElement('img');
     img.style.width = '100px';
     img.src = url;
+    img.onload = function() { URL.revokeObjectURL(url); };
     document.body.appendChild(img);
     var label = document.createElement('span');
-    label.textContent = filenames[iUrl];
+    label.textContent = filenames[index];
     document.body.appendChild(label);
   });
 }


### PR DESCRIPTION
Now that web activities allow blobs to be transferred between apps, and as a first step for the "sanitize web activities" bug, this pull request converts the image share activity to use blobs instead of data URLs.

The gallery is the only app that launches this activity, but a number of other apps handle it, so this pull request includes minor changes to a number of apps.
