### PR TITLE
Bug 799153 - Add UI for toggling the debugger server in Firefox OS

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1420,6 +1420,13 @@
           </label>
           <a data-l10n-id="oop-disabled">Disable Out-Of-Process</a>
         </li>
+        <li>
+          <label>
+            <input type="checkbox" name="devtools.debugger.remote-enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="remote-debugging">Remote Debugging</a>
+        </li>
        </ul>
     </section>
 

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -354,6 +354,7 @@ paint-flashing=Flash repainted area
 log-animations=Log slow animations
 dev-mode=Developer Mode
 oop-disabled=Disable Out-Of-Process
+remote-debugging=Remote Debugging
 ttl-monitor=Show time to load
 model-name=Model
 os-version=OS Version


### PR DESCRIPTION
There is a complementary change in gecko for this to work, which I'll attach in the bug.
