### PR TITLE
Bug 805189 - [video] typo in error message

### DIFF
--- a/apps/video/locales/video.en-US.properties
+++ b/apps/video/locales/video.en-US.properties
@@ -6,5 +6,5 @@ empty-text  = Load videos on to the memory card.
 nocard-title = No memory card found
 nocard-text  = Insert a memory card to watch videos.
 
-pluggedin-title = Video cannot be watch while plugged in
+pluggedin-title = Video cannot be watched while plugged in
 pluggedin-text  = Unplug the phone to watch videos.


### PR DESCRIPTION
There is no need to change the key for this translation as it is just a typo correction
