### PR TITLE
Bug 804916 - [Email] Refine toaster and hide undo button for move operation. r=asuth, a=bustage-fix

### DIFF
--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -328,7 +328,7 @@ ComposeCard.prototype = {
     // XXX well-formedness-check (ideally just handle by not letting you send
     // if you haven't added anyone...)
 
-    this.composer.finishCompositionSendMessage(Toaster.trackSendMessage());
+    this.composer.finishCompositionSendMessage();
     if (this.shareActivity) {
       // XXX: Return value under window mode will cause crash easily, disable
       //      return and stay in email until inline mode is stable.


### PR DESCRIPTION
Fix minor sending bustage caused by the interaction of https://github.com/mozilla-b2g/gaia/pull/5826 and a related patch.
