### PR TITLE
Bug 806229 - [Cost Control] "WIFI" is used instead of "Wi-Fi"

### DIFF
--- a/apps/costcontrol/fte.html
+++ b/apps/costcontrol/fte.html
@@ -240,7 +240,7 @@
             <li id="toggleWifi">
               <label for="wifiCheck">
                 <input type="checkbox" checked="checked" id="wifiCheck">
-                <span>WIFI <em id="wifiOverview">--</em></span>
+                <span>Wi-Fi <em id="wifiOverview">--</em></span>
               </label>
             </li>
           </ul>

--- a/apps/costcontrol/index.html
+++ b/apps/costcontrol/index.html
@@ -209,7 +209,7 @@
             <li id="toggleWifi">
               <label for="wifiCheck">
                 <input type="checkbox" checked="checked" id="wifiCheck">
-                <span>WIFI <em id="wifiOverview">--</em></span>
+                <span>Wi-Fi <em id="wifiOverview">--</em></span>
               </label>
             </li>
           </ul>


### PR DESCRIPTION
Changed the text string for consistency throughout the OS
