### PR TITLE
Bug 805230 - [email] Remove 3 and 6 month filter ranges

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -647,10 +647,6 @@
                   2 WeekS</option>
                 <option value="1m" data-l10n-id="settings-synchronize-one-month">
                   1 MontH</option>
-                <option value="3m" data-l10n-id="settings-synchronize-three-months">
-                  3 MonthS</option>
-                <option value="6m" data-l10n-id="settings-synchronize-six-months">
-                  6 MonthS</option>
                 <option value="all" data-l10n-id="settings-synchronize-all">
                   AlL MessageS</option>
               </select>

--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -30773,15 +30773,14 @@ const DESIRED_SNIPPET_LENGTH = 100;
 const FILTER_TYPE = $ascp.AirSync.Enums.FilterType;
 
 // Map our built-in sync range values to their corresponding ActiveSync
-// FilterType values.
+// FilterType values. We exclude 3 and 6 months, since they aren't valid for
+// email.
 const SYNC_RANGE_TO_FILTER_TYPE = {
    '1d': FILTER_TYPE.OneDayBack,
    '3d': FILTER_TYPE.ThreeDaysBack,
    '1w': FILTER_TYPE.OneWeekBack,
    '2w': FILTER_TYPE.TwoWeeksBack,
    '1m': FILTER_TYPE.OneMonthBack,
-   '3m': FILTER_TYPE.ThreeMonthsBack,
-   '6m': FILTER_TYPE.SixMonthsBack,
   'all': FILTER_TYPE.NoFilter,
 };
 

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -86,8 +86,6 @@ settings-synchronize-three-days=3 days
 settings-synchronize-one-week=1 week
 settings-synchronize-two-weeks=2 weeks
 settings-synchronize-one-month=1 month
-settings-synchronize-three-months=3 months
-settings-synchronize-six-months=6 months
 settings-synchronize-all=All messages
 
 accounts-header=Accounts


### PR DESCRIPTION
r? @asutherland

Corresponds to https://bugzilla.mozilla.org/show_bug.cgi?id=805230 and mozilla-b2g/gaia-email-libs-and-more#73. The diff should be self-explanatory.
