### PR TITLE
Bug 796681 - Adjust the delay time of alternative char menu

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -920,14 +920,8 @@ function onMouseDown(evt) {
 
     // redirect mouse over event so that the first key in menu
     // would be highlighted
-    if (isShowingAlternativesMenu &&
-        menuLockedArea &&
-        evt.pageY >= menuLockedArea.top &&
-        evt.pageY <= menuLockedArea.bottom &&
-        evt.pageX >= menuLockedArea.left &&
-        evt.pageX <= menuLockedArea.right) {
+    if (inMenuLockedArea(evt))
       redirectMouseOver(evt);
-    }
 
   }), ACCENT_CHAR_MENU_TIMEOUT);
 
@@ -952,6 +946,16 @@ function onMouseDown(evt) {
   }
 }
 
+
+function inMenuLockedArea(evt) {
+  return (isShowingAlternativesMenu &&
+          menuLockedArea &&
+          evt.pageY >= menuLockedArea.top &&
+          evt.pageY <= menuLockedArea.bottom &&
+          evt.pageX >= menuLockedArea.left &&
+          evt.pageX <= menuLockedArea.right);
+}
+
 // [LOCKED_AREA] TODO:
 // This is an agnostic way to improve the usability of the alternatives.
 // It consists into compute an area where the user movement is redirected
@@ -959,13 +963,7 @@ function onMouseDown(evt) {
 // with better performance.
 function onMouseMove(evt) {
   // Control locked zone for menu
-  if (isShowingAlternativesMenu &&
-      menuLockedArea &&
-      evt.pageY >= menuLockedArea.top &&
-      evt.pageY <= menuLockedArea.bottom &&
-      evt.pageX >= menuLockedArea.left &&
-      evt.pageX <= menuLockedArea.right) {
-
+  if (inMenuLockedArea(evt)) {
     clearTimeout(hideMenuTimeout);
     redirectMouseOver(evt);
   }
@@ -1003,10 +1001,10 @@ function onMouseOver(evt) {
   clearTimeout(menuTimeout);
 
   // Control hide of alternatives menu
-  if (target.parentNode === IMERender.menu) {
+  if (target.parentNode === IMERender.menu || inMenuLockedArea(evt)) {
     clearTimeout(hideMenuTimeout);
   } else {
-    hideAlternatives(true);
+    hideAlternatives(false);
   }
 
   // Control showing alternatives menu
@@ -1060,7 +1058,7 @@ function onMouseUp(evt) {
   clearInterval(deleteInterval);
   clearTimeout(menuTimeout);
 
-  hideAlternatives(true);
+  hideAlternatives(false);
 
   var target = currentKey;
   var keyCode = parseInt(target.dataset.keycode);
@@ -1452,7 +1450,7 @@ function getSettings(settings, callback) {
     // If settings is broken, just return the default values
     console.warn('Exception in mozSettings.createLock():', e,
                  '\nUsing default values');
-    for (p in settings)
+    for (var p in settings)
       results[p] = settings[p];
     callback(results);
   }


### PR DESCRIPTION
Now the alternative char menu would disappear when,
1. mouseUp
2. mouseOver to another key which is beyond the menu touch area (menu locked area).
