### PR TITLE
Bug 804916 -  [email] Remove UI for Undo email move and delete.

### DIFF
--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -882,8 +882,9 @@ var Toaster = {
       var undoBtn = this.body.querySelector('.toaster-banner-undo');
       text = mozL10n.get(textId, { n: this.undoableOp.affectedCount });
       // https://bugzilla.mozilla.org/show_bug.cgi?id=804916
-      // Remove undo email move UI for V1.
-      if (this.undoableOp.operation == 'move') {
+      // Remove undo email move/delete UI for V1.
+      if (this.undoableOp.operation == 'move' ||
+          this.undoableOp.operation == 'delete') {
         undoBtn.classList.add('collapsed');
       } else {
         undoBtn.classList.remove('collapsed');

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -239,6 +239,10 @@ section[role="status"].fadeout {
   opacity: 0;
 }
 
+section[role="status"][title="undo"] p {
+  max-width: 65% !important;
+}
+
 section[role="status"] .toaster-cancel-btn {
   height: 8rem;
 }


### PR DESCRIPTION
- Fix bug : https://bugzilla.mozilla.org/show_bug.cgi?id=804916. Remove delete undo button patch.
- Reduce the toaster text title width for undo button
