### PR TITLE
Bug 807006 - [BB][Clock] Apply building blocks [headers]

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" type="text/css" href="style/clock.css">
     <link rel="stylesheet" type="text/css" href="style/alarm.css">
 
+    <!-- Shared styles -->
+    <link rel="stylesheet" type="text/css" href="shared/style/headers.css">
+
     <!-- Localization -->
     <link rel="resource" type="application/l10n" href="/shared/locales/date.ini">
     <link rel="resource" type="application/l10n" href="locales/locales.ini">
@@ -138,14 +141,13 @@
     </div>
 
     <!-- Alarm -->
-    <div id="alarm" class="view" data-title="Alarm">
+    <section id="alarm" class="view skin-organic" role="region" data-title="Alarm">
       <header>
-        <a href="#alarm-view" class="left button close">
-          <div class="background-close"></div>
-          <div class="icon-close"></div>
-        </a>
-        <h1 id="alarm-title" class="label"></h1>
-        <a id="alarm-done" href="#alarm-view" class="right button done-button" data-l10n-id="done">Done</a>
+        <a href="#alarm-view"><span class="icon icon-back">back</span></a>
+        <menu type="toolbar">
+          <a id="alarm-done" href="#alarm-view" data-l10n-id="done">Done</a>
+        </menu>
+        <h1 id="alarm-title"></h1>
       </header>
       <ul id="edit-alarm" class="tableView">
         <li class="picker">
@@ -216,7 +218,7 @@
           <a id="alarm-delete" href="#alarm-view" data-l10n-id="delete">Delete</a>
         </li>
       </ul>
-    </div>
+    </section>
   </body>
 </html>
 

--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -4,32 +4,20 @@ html, body {
   overflow: hidden !important;
 }
 
-header {
-  height: 8rem;
-  text-align: left;
-  border-bottom: solid 0.3rem;
-  -moz-border-bottom-colors: #e9e9e9 #cdcdcd #a3a3a3;
-  font: normal 1.3rem/4.5rem 'MozTT',sans-serif;
-  line-height: 4.5rem;
-  padding-left: 4rem;
-  background: url(images/edit_header.png) repeat scroll left top transparent;
-  background-size: 100% 100%;
-}
-
 /* ------------- Button ------------- */
 a.button, span.button {
-  margin: 0.4rem;
-  padding: 1.2rem 1.2rem 1rem 1.2rem;
-  border: 0.4rem solid;
-  border-radius: 1rem;
+  margin: 0.25rem;
+  padding: 0.75rem 0.75rem 0.63rem 0.75rem;
+  border: 0.25rem solid;
+  border-radius: 0.63rem;
   background: transparent;
   color: #000000;
   display: inline-block;
   text-align: center;
   text-decoration: none;
   cursor: pointer;
-  font: bold 2rem 'MozTT', sans-serif;
-  line-height: 2.2rem;
+  font: bold 1.25rem 'MozTT', sans-serif;
+  line-height: 1.38rem;
   -moz-border-top-colors: #6F6F6F #4D4D4D #4D4D4D #6F6F6F;
   -moz-border-right-colors: #6F6F6F #4D4D4D #4D4D4D #6F6F6F;
   -moz-border-left-colors: #6F6F6F #4D4D4D #4D4D4D #6F6F6F;
@@ -37,7 +25,7 @@ a.button, span.button {
 }
 
 a.button.left.close {
-  background: url(images/separator_close.png) no-repeat scroll 2rem center transparent;
+  background: url(images/separator_close.png) no-repeat scroll 1.25rem center transparent;
   background-size: auto 100%;
   border: none;
   cursor: pointer;
@@ -45,15 +33,15 @@ a.button.left.close {
   left: 0;
   overflow: visible;
   position: absolute;
-  width: 6rem;
-  height: 5rem;
+  width: 3.75rem;
+  height: 3.13rem;
 }
 
 .background-close {
   position: fixed;
   background-color: rgba(0, 0, 0, 0.13);
-  width: 2.54rem;
-  height: 8rem;
+  width: 1.59rem;
+  height: 5rem;
   top: 0;
   left: 0;
 }
@@ -61,32 +49,32 @@ a.button.left.close {
 .icon-close {
   display: inline-block;
   background: url(images/edit_close.png) no-repeat;
-  background-position: left 1rem;
+  background-position: left 0.63rem;
   background-repeat: no-repeat;
   background-size: 60% 60%;
   display: inline-block;
-  width: 4rem;
-  height: 4rem;
-  margin-left: -5rem;
+  width: 2.50rem;
+  height: 2.50rem;
+  margin-left: -3.13rem;
   overflow: visible;
   overflow: visible;
 }
 
 a.button.left {
   position: absolute;
-  top: 0.6rem;
-  left: 0.1rem;
+  top: 0.37rem;
+  left: 0.06rem;
 }
 
 a.button.right {
   position: absolute;
-  top: 1rem;
-  right: 1rem;
+  top: 0.63rem;
+  right: 0.63rem;
 }
 
 a.button.right.plus {
-  width: 4.4rem;
-  height: 4.4rem;
+  width: 2.75rem;
+  height: 2.75rem;
   background-image: url(images/add_alarm.png);
   background-size: 100%;
   background-repeat: no-repeat;
@@ -98,29 +86,29 @@ a.button.right.done-button {
   border: none;
   background-size: auto 100%;
   cursor: pointer;
-  height: 5rem;
+  height: 3.13rem;
   top: 0;
   right: 0;
   overflow: visible;
   position: absolute;
   color: white;
   font-weight: normal;
-  line-height: 5.2rem;
+  line-height: 3.25rem;
 }
 
 a.abstract-menu {
   display: block;
-  height:      auto; /* 5.4rem; -moz-calc(100% - 4rem); */
-  line-height: normal; /* 5.4rem; -moz-calc(100% - 4rem); */
-  width: -moz-calc(100% - 12rem);
+  height:      auto; /* 3.38rem; -moz-calc(100% - 2.50rem); */
+  line-height: normal; /* 3.38rem; -moz-calc(100% - 2.50rem); */
+  width: -moz-calc(100% - 7.50rem);
   text-decoration: none;
   text-align: left;
-  padding-left: 12rem;
+  padding-left: 7.50rem;
   outline: 0;
   color: black;
-  font: 2.4rem/2.9rem 'MozTT',sans-serif;
-  padding-top: 2rem;
-  padding-bottom: 2rem;
+  font: 1.50rem/1.81rem 'MozTT',sans-serif;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
 }
 
 select.abstract-menu {
@@ -130,7 +118,7 @@ select.abstract-menu {
 
 #alarm-delete {
   color: #F2F2F2;
-  font: 2.4rem/2.4rem 'MozTT',sans-serif;
+  font: 1.50rem/1.50rem 'MozTT',sans-serif;
   text-align: center;
   text-decoration: none;
   width: 100%;
@@ -139,12 +127,11 @@ select.abstract-menu {
 #alarm-delete-button {
   background: -moz-linear-gradient(bottom, #900010, #c90010);
   border: none;
-  width: 90%;
-  height: 5.5rem;
-  margin-left: auto;
-  margin-right: auto;
+  height: 3.44rem;
+  overflow: hidden;
+  margin: 1.5rem 1.5rem 1rem;
   text-shadow: -1px -1px 0 #830B0B;
-  border-radius: 0.3rem 0.3rem 0.3rem 0.3rem;
+  border-radius: 0.19rem 0.19rem 0.19rem 0.19rem;
 }
 
 #alarm-delete-button:active {
@@ -153,25 +140,20 @@ select.abstract-menu {
 
 .view label.text {
   text-align: right;
-  padding: 2rem 0;
-  text-indent: 2rem;
+  padding: 1.25rem 0;
+  text-indent: 1.25rem;
   direction: rtl;
 }
 
 /* View */
 .view {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   border: 0;
   width: 100%;
   height: 100%;
-  /* XXX: The below overflow property is being ignored by B2G Phone
-    https://bugzilla.mozilla.org/show_bug.cgi?id=777672
-    It is a workaround to set overflow-y: scroll.
-    It should be refined to overflow: hidden when the bug fixed.
-  */
-  overflow-y: scroll;
+  overflow: hidden;
 }
 
 /* View - Slide Horizontal Transition */
@@ -220,18 +202,19 @@ body.hidden #alarm-view {
 }
 
 li.singleline {
-  height: 6.4rem;
+  height: 4rem;
   border-top: none;
-  border-bottom: 0.1rem solid #cbcbcc;
+  border-bottom: 0.06rem solid #cbcbcc;
   padding-left: 5%;
   padding-right: 5%;
-  width: 90%;
+  overflow: hidden;
+  -moz-box-sizing: border-box;
 }
 
 li.multiline {
-  height: 35.5rem;
+  height: 22.19rem;
   border-top: none;
-  border-bottom: 0.1rem solid #cbcbcc;
+  border-bottom: 0.06rem solid #cbcbcc;
 }
 
 li.multiline:active {
@@ -241,8 +224,8 @@ li.multiline:active {
 }
 
 li.picker {
-  height: 35rem;
-  padding-top: 0.5rem;
+  height: 21.88rem;
+  padding-top: 0.31rem;
   border-top: none;
   border-bottom: none;
 }
@@ -254,10 +237,9 @@ li.picker:active {
 
 .view-alarm-lbl {
   color: #7d7d7d;
-  font: 2.4rem/2.4rem 'MozTT',sans-serif;
-  top: 2.2rem;
+  font: 1.50rem/1.50rem 'MozTT',sans-serif;
+  top: 1.38rem;
   height: auto;
-  width: 100%;
   pointer-events: none;
 }
 
@@ -269,30 +251,29 @@ li.picker:active {
 ul {
   margin: 0;
   padding: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: auto;
   list-style: none;
 }
 
-ul li { /* 9.6rem, including a 0.2rem border */
+ul li { /* 6rem, including a 0.13rem border */
   position: relative;
-  height: 10rem;
-  border-top: 0.1rem solid #cbcbcc;
+  height: 6.25rem;
+  border-top: 0.06rem solid #cbcbcc;
   color: #555;
 }
 
 ul li:active {
   background-color: rgba(0, 0, 0, .07);
-  text-shadow: #999 0 -0.1rem 0;
+  text-shadow: #999 0 -0.06rem 0;
   color: #222;
 }
 
 ul li > a {
   display: block;
-  padding-top: 1.6rem;
-  padding-bottom: 1.6rem;
-  height:      6.8rem; /* -moz-calc(100% - 4rem); */
-  line-height: 6.8rem; /* -moz-calc(100% - 4rem); */
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  height:      4.25rem; /* -moz-calc(100% - 2.50rem); */
+  line-height: 4.25rem; /* -moz-calc(100% - 2.50rem); */
   text-decoration: none;
   outline: 0;
   color: #555;
@@ -304,7 +285,7 @@ ul li > a, ul li > span, ul li > small { /* text ellipsis */
   text-overflow: ellipsis;
   white-space: nowrap;
   position: absolute;
-  width: -moz-calc(100% - 13rem);
+  width: -moz-calc(100% - 8.13rem);
 }
 
 ul li > span {
@@ -313,7 +294,7 @@ ul li > span {
 
 ul li > small {
   position: absolute;
-  left: 2rem;
+  left: 1.25rem;
   top: 50%;
   font-size: 0.9em;
   color: #888;
@@ -322,7 +303,7 @@ ul li > small {
 .alarmList-time {
   float: left;
   width: 41%;
-  padding-top: 1.2rem;
+  padding-top: 0.75rem;
   text-align: left;
 }
 
@@ -330,7 +311,7 @@ ul li > small {
   float: left;
   width: 50%;
   text-align: left;
-  margin-left: -0.3rem;
+  margin-left: -0.19rem;
 }
 
 /* fake input boxes for checkboxes & radio buttons */
@@ -343,7 +324,7 @@ ul li > small {
 }
 
 .view label.alarmList {
-  width: -moz-calc(13rem);
+  width: -moz-calc(8.13rem);
 }
 
 .view label > input {
@@ -352,11 +333,11 @@ ul li > small {
 
 .view label > span {
   position: absolute;
-  top: -moz-calc(50% - 1.7rem);
-  right: 1.4rem;
+  top: -moz-calc(50% - 1.06rem);
+  right: 0.87rem;
   display: block;
-  width: 6.4rem;
-  height: 6.4rem;
+  width: 4rem;
+  height: 4rem;
   border: none;
 }
 
@@ -370,10 +351,10 @@ ul li > small {
 
 /* ----------- Alarm Set Repeat Button ------------- */
 .view label > input[type=checkbox] + span.setRepeat {
-  width: 4.6rem;
-  height: 4.6rem;
-  border: 0.4rem solid;
-  border-radius: 1.3rem;
+  width: 2.87rem;
+  height: 2.87rem;
+  border: 0.25rem solid;
+  border-radius: 0.81rem;
   -moz-border-top-colors: #696969 #4D4D4D #4D4D4D #696969;
   -moz-border-right-colors: #696969 #4D4D4D #4D4D4D #696969;
   -moz-border-bottom-colors: #696969 #4D4D4D #4D4D4D #696969;
@@ -388,20 +369,20 @@ ul li > small {
 
 /* ----------- Alarm Set Enabled Button ------------- */
 .view label > input[type=checkbox] + span.setEnabledBtn {
-  width: 13rem;
-  height: 4.4rem;
+  width: 8.13rem;
+  height: 2.75rem;
   margin: 0rem;
   right: 0rem;
-  top: calc(50% - 2.2rem);
+  top: calc(50% - 1.38rem);
   background: url(images/set_enabled_btn_off.png) no-repeat scroll center center;
   background-size: 100% 100%;
 }
 
 .view label > input[type=checkbox] + span.setEnabledBtn:after {
-  font: 2.15rem/4.4rem 'MozTT',sans-serif;
+  font: 1.4rem/2.9rem 'MozTT',sans-serif;
   color: #7a7a7a;
   position: absolute;
-  left: 6rem;
+  left: 3.75rem;
   content: attr(data-unchecked);
 }
 
@@ -411,10 +392,10 @@ ul li > small {
 }
 
 .view label > input[type=checkbox]:checked + span.setEnabledBtn:after {
-  font: 2.25rem/4.4rem 'MozTT',sans-serif;
+  font: 1.4rem/2.9rem 'MozTT',sans-serif;
   color: #0088a3;
   position: absolute;
-  left: 3.3rem;
+  left: 2.06rem;
   content: attr(data-checked);
 }
 
@@ -422,8 +403,8 @@ ul li > small {
 select, input, textarea {
   clear: both;
   background:none;
-  border:0.2rem solid white;
-  border-radius: 0.5rem;
+  border:0.13rem solid white;
+  border-radius: 0.31rem;
   font-size: 1em;
 }
 
@@ -432,20 +413,20 @@ select:focus, input:focus, textarea:focus {
 }
 
 select.right {
-  width: 7rem;
+  width: 4.38rem;
 }
 
 input.right {
-  width: -moz-calc(100% - 20rem);
-  margin: 0.6rem 0.8rem 0.3rem 12rem;
-  height: 5rem;
-  font: 2.4rem/3rem 'MozTT',sans-serif;
+  width: -moz-calc(100% - 12.50rem);
+  margin: 0.37rem 0.50rem 0.19rem 7.50rem;
+  height: 3.13rem;
+  font: 1.50rem/1.88rem 'MozTT',sans-serif;
   color: black;
 }
 /* ----------- Input Error ---------- */
 input ~ * {
   color:#E00;
-  margin: -1rem 0rem 0rem 2rem;
+  margin: -0.63rem 0rem 0rem 1.25rem;
 }
 
 input ~ *:empty {
@@ -455,11 +436,11 @@ input ~ *:empty {
 /* ----------- TableView ---------- */
 .tableView p {
   padding: 0;
-  margin-right: 2.8rem;
+  margin-right: 1.75rem;
 }
 
 .tableView {
-  height: -moz-calc(100% - 8rem - 0.3rem);
+  height: -moz-calc(100% - 5rem - 0.19rem);
   background-color: #ffffff;
   padding-left: 5%;
   padding-right: 5%;
@@ -490,7 +471,7 @@ input ~ *:empty {
 li img {
   position: absolute;
   vertical-align: middle;
-  margin-right:1rem;
+  margin-right:0.63rem;
 }
 
 .description {
@@ -504,32 +485,32 @@ li img {
 
 .alarmList-time span.time {
   height: auto;
-  font: 4rem/4rem 'MozTT', sans-serif;
+  font: 2.50rem/2.50rem 'MozTT', sans-serif;
   color: black;
 }
 
 .alarmList-time span.hour24-state {
   height: auto;
-  font: 2.2rem/2.2rem 'MozTT', sans-serif;
+  font: 1.38rem/1.38rem 'MozTT', sans-serif;
   color: #25292a;
-  margin-left: -0.4rem;
+  margin-left: -0.25rem;
   text-transform:lowercase;
 }
 
 .alarmList-detail .label {
   height: auto;
-  font: 2.4rem/2.4rem 'MozTT', sans-serif;
+  font: 1.50rem/1.50rem 'MozTT', sans-serif;
   color: black;
   text-overflow: ellipsis;
-  padding-top: 0.5rem;
+  padding-top: 0.31rem;
 }
 
 .alarmList-detail .repeat {
   height: auto;
-  font: 2.4rem/2.4rem 'MozTT', sans-serif;
+  font: 1.50rem/1.50rem 'MozTT', sans-serif;
   color: #646768;
   text-overflow: ellipsis;
-  padding-top: 0.7rem;
+  padding-top: 0.44rem;
 }
 
 .alarmList-detail .hiddenSummary {
@@ -537,7 +518,7 @@ li img {
 }
 
 .alarmList-detail .paddingTop {
-  padding-top: 1.9rem;
+  padding-top: 1.19rem;
 }
 
 .lebal {
@@ -547,10 +528,11 @@ li img {
 /* ----------- TimeSelectorView ---------- */
 #picker-bar {
   position: relative;
-  height: -moz-calc(100% - 0.2rem);
+  overflow: hidden;
+  height: -moz-calc(100% - 0.13rem);
   margin-left: auto;
   margin-right: auto;
-  border-bottom: solid 0.2rem;
+  border-bottom: solid 0.13rem;
   -moz-border-bottom-colors: #CBCBCC #FFFFFF; 
 }
 
@@ -573,8 +555,8 @@ li img {
     rgba(0, 0, 0, 0.12) rgba(0, 0, 0, 0.07)  rgba(0, 0, 0, 0.05)
     rgba(0, 0, 0, 0.04) rgba(0, 0, 0, 0.03)  rgba(0, 0, 0, 0.02);
 
-  border-top: solid 1rem;
-  border-bottom: solid 1rem;
+  border-top: solid 0.63rem;
+  border-bottom: solid 0.63rem;
   border-left:  1px solid #CCC;
   border-right: 1px solid #CCC;
 
@@ -590,7 +572,7 @@ li img {
   width: 100%;
   height: 100%;
   position: relative;
-  padding-top: 13.25rem;
+  padding-top: 8.28rem;
 }
 
 #value-indicator-wrapper {
@@ -604,10 +586,10 @@ li img {
     rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.25) rgba(0, 0, 0, 0.3)
     rgba(0, 0, 0, 0.35);
 
-  border-top: solid 0.7rem;
-  border-bottom: solid 0.7rem;
+  border-top: solid 0.44rem;
+  border-bottom: solid 0.44rem;
   position: absolute;
-  height: 7.2rem;
+  height: 4.50rem;
   width: 100%;
   pointer-events: none;
 }
@@ -618,7 +600,7 @@ li img {
   color: #FFF;
   position: absolute;
   height: 100%;
-  font: 3rem/6rem 'MozTT',sans-serif;
+  font: 1.88rem/3.75rem 'MozTT',sans-serif;
   text-align: center;
 }
 
@@ -697,12 +679,12 @@ div.animation-on {
 
 .picker-unit {
   position: relative;
-  font: 3.4rem/8.5rem 'MozTT',sans-serif;
+  font: 2.13rem/5.3rem 'MozTT',sans-serif;
   color: black;
   text-align: center;
   vertical-align: middle;
   width: 100%;
-  height: 8.5rem;
+  height: 5.3rem;
   pointer-events: none;
 }
 
@@ -761,7 +743,7 @@ div.animation-on {
 /* 320x480 phones */
 @media screen and (width: 320px) {
   html {
-    font-size: 6px;
+    font-size: 10px;
   }
 }
 
@@ -771,19 +753,19 @@ div.animation-on {
     font-size: 10px;
   }
   .alarmList-detail {
-    margin-left: 0.5rem; 
+    margin-left: 0.31rem; 
   }
   .alarmList-time span.time {
-    font: 3.6rem/3.6rem 'MozTT', sans-serif;
+    font: 2.25rem/2.25rem 'MozTT', sans-serif;
   }
   .alarmList-time span.hour24-state {
-    font: 1.6rem/1.6rem 'MozTT', sans-serif;
-    margin-left: -0.3rem;
+    font: 1rem/1rem 'MozTT', sans-serif;
+    margin-left: -0.19rem;
   }
   .alarmList-detail .label {
-    font: 2rem/2rem 'MozTT', sans-serif;
+    font: 1.25rem/1.25rem 'MozTT', sans-serif;
   }
   .alarmList-detail .repeat {
-    font: 1.8rem/1.8rem 'MozTT', sans-serif;
+    font: 1.13rem/1.13rem 'MozTT', sans-serif;
   }
 }

--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -7,10 +7,6 @@ html, body {
   background: url(images/home_texture.png) repeat scroll 2% 50% #666666;
 }
 
-html * {
-  overflow: hidden;
-}
-
 @media all and (min-resolution: 200dpi) {
   html, body {
     font-size: 2mozmm;
@@ -22,42 +18,42 @@ html * {
   position: absolute;
   width: 100%;
   bottom: 0;
-  padding: 2rem 0rem 1.5rem 0rem;
+  padding: 1.25rem 0rem 0.94rem 0rem;
   -moz-transition: bottom 0.3s ease;
   /* === Disable Tab Controller in V1 === */
   display: none;
 }
 
 #tabs {
-  width: -moz-calc(100% - 3.8rem);
-  padding: 0.9rem 0.9rem 0.7rem 0.9rem;
+  width: -moz-calc(100% - 2.37rem);
+  padding: 0.56rem 0.56rem 0.44rem 0.56rem;
   margin: auto;
   background-color: rgba(0,0,0,.3);
-  border-radius: 0.5rem;
+  border-radius: 0.31rem;
 }
 
 #tabs fieldset {
   list-style: none;
-  width: -moz-calc(100% - 0.2rem);
-  height: 6.6rem;
+  width: -moz-calc(100% - 0.13rem);
+  height: 4.12rem;
   padding: 0;
   margin: 0;
   display: -moz-box;
   -moz-box-orient: horizontal;
-  border: 0.1rem solid #333333;
-  border-radius: 0.3rem;
-  background:-moz-linear-gradient(top, hsl(0,0%,65%) 0, hsl(0,0%,56%) 1rem, hsl(0,0%,37%) 100%);
+  border: 0.06rem solid #333333;
+  border-radius: 0.19rem;
+  background:-moz-linear-gradient(top, hsl(0,0%,65%) 0, hsl(0,0%,56%) 0.63rem, hsl(0,0%,37%) 100%);
 }
 
 #tabs label {
   float: left;
   display: block;
-  width: -moz-calc(100% / 3 - 0.2rem);
+  width: -moz-calc(100% / 3 - 0.13rem);
   height: 100%;
   padding: 0;
   margin: 0;
-  border-right: 0.1rem solid rgb(29,29,29);
-  border-left: 0.1rem solid rgb(123,123,123);
+  border-right: 0.06rem solid rgb(29,29,29);
+  border-left: 0.06rem solid rgb(123,123,123);
   background-position: 50% 50%;
   background-repeat: no-repeat;
 }
@@ -67,36 +63,36 @@ html * {
 
 #tabs label:first-child {
   border-left-color: transparent;
-  border-radius: 0.3rem 0 0 0.3rem;
+  border-radius: 0.19rem 0 0 0.19rem;
 }
 #tabs label:last-child {
   border-right-color: transparent;
-  border-radius: 0 0.3rem 0.3rem 0;
+  border-radius: 0 0.19rem 0.19rem 0;
 }
 
 #alarm-label {
   background-image: url(images/alarm.png);
 }
 #alarm-label[data-active] {
-  background: url(images/alarm.png) no-repeat 50% 50%, -moz-linear-gradient(top, hsl(0,0%,44%) 0, hsl(0,0%,37%) 0.1rem, hsl(0,0%,56%) 100%);
+  background: url(images/alarm.png) no-repeat 50% 50%, -moz-linear-gradient(top, hsl(0,0%,44%) 0, hsl(0,0%,37%) 0.06rem, hsl(0,0%,56%) 100%);
 }
 
 #stopwatch-label {
   background-image: url(images/stopwatch.png);
 }
 #stopwatch-label[data-active] {
-  background: url(images/stopwatch.png) no-repeat 50% 50%, -moz-linear-gradient(top, hsl(0,0%,44%) 0, hsl(0,0%,37%) 0.1rem, hsl(0,0%,56%) 100%);
+  background: url(images/stopwatch.png) no-repeat 50% 50%, -moz-linear-gradient(top, hsl(0,0%,44%) 0, hsl(0,0%,37%) 0.06rem, hsl(0,0%,56%) 100%);
 }
 
 #timer-label {
   background-image: url(images/timer.png);
 }
 #timer-label[data-active] {
-  background: url(images/timer.png) no-repeat 50% 50%, -moz-linear-gradient(top, hsl(0,0%,44%) 0, hsl(0,0%,37%) 0.1rem, hsl(0,0%,56%) 100%);
+  background: url(images/timer.png) no-repeat 50% 50%, -moz-linear-gradient(top, hsl(0,0%,44%) 0, hsl(0,0%,37%) 0.06rem, hsl(0,0%,56%) 100%);
 }
 
 #views {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -109,26 +105,26 @@ html * {
 }
 
 .chrono-view-container {
-  width: -moz-calc(100% - 3.8rem);
-  height: -moz-calc(100% - 2rem - 3mozmm - 9.4rem);
-  margin: 2rem auto;
-  padding: 0.9rem;
-  border-radius: 0.5rem;
+  width: -moz-calc(100% - 2.37rem);
+  height: -moz-calc(100% - 1.25rem - 3mozmm - 5.88rem);
+  margin: 1.25rem auto;
+  padding: 0.56rem;
+  border-radius: 0.31rem;
   background:rgba(0,0,0,0.3);
 }
 
 .chrono-view-container > div:first-child {
   position: relative;
   display: block;
-  height: -moz-calc(100% - 2rem);
+  height: -moz-calc(100% - 1.25rem);
   margin: auto;
   border: medium none;
-  border-radius: 0.5rem;
-  box-shadow: 0 0 0.8rem rgba(0, 0, 0, 0.3) inset;
+  border-radius: 0.31rem;
+  box-shadow: 0 0 0.50rem rgba(0, 0, 0, 0.3) inset;
   text-align: center;
   font-size: 0.4em;
   text-overflow: ellipsis;
-  text-shadow:0 0 0.3rem rgba(0,0,0,.5);
+  text-shadow:0 0 0.19rem rgba(0,0,0,.5);
   white-space: nowrap;
 }
 
@@ -145,11 +141,11 @@ html * {
 }
 
 .ticker-view {
-  height: 1rem;
-  margin-top: 1rem;
+  height: 0.63rem;
+  margin-top: 0.63rem;
   background: #A7DD11;
-  border-radius: 0.5rem;
-  box-shadow: 0 0 0.3rem 0.3rem rgba(167, 221, 17, 0.3);
+  border-radius: 0.31rem;
+  box-shadow: 0 0 0.19rem 0.19rem rgba(167, 221, 17, 0.3);
   visibility: hidden;
 }
 
@@ -180,34 +176,34 @@ html * {
 
 .button-container {
   position: absolute;
-  left: 1rem;
-  width: -moz-calc(100% - 3.8rem);
-  padding: 0.9rem;
+  left: 0.63rem;
+  width: -moz-calc(100% - 2.37rem);
+  padding: 0.56rem;
   background-color: rgba(0, 0, 0, 0.3);
-  border-radius: 0.5rem;
+  border-radius: 0.31rem;
   text-align: center;
 }
 
 .button-container > div > span {
   display: block;
-  width: -moz-calc(100% - 0.2rem);
+  width: -moz-calc(100% - 0.13rem);
   height: 1.5mozmm;
-  border-radius: 0.3rem;
-  background: -moz-linear-gradient(center top , #A5A5A5 0pt, #878787 0.1rem, #545454 100%) repeat scroll 0 0 transparent;
+  border-radius: 0.19rem;
+  background: -moz-linear-gradient(center top , #A5A5A5 0pt, #878787 0.06rem, #545454 100%) repeat scroll 0 0 transparent;
   line-height: 15mozmm;
   font-size: 0.2em;
   font-weight: bold;
-  text-shadow: 0 0 0.3rem rgba(0, 0, 0, 0.5);
+  text-shadow: 0 0 0.19rem rgba(0, 0, 0, 0.5);
 }
 
 .button-container:active > div > span {
-  background: -moz-linear-gradient(center bottom , #A5A5A5 0pt, #878787 0.1rem, #545454 100%) repeat scroll 0 0 transparent;
+  background: -moz-linear-gradient(center bottom , #A5A5A5 0pt, #878787 0.06rem, #545454 100%) repeat scroll 0 0 transparent;
 }
 
 /* === Stop watch === */
 
 #reset-button {
-  bottom: -moz-calc(15mozmm + 3.8rem);
+  bottom: -moz-calc(15mozmm + 2.37rem);
 }
 
 #stopwatch-action-button {
@@ -215,10 +211,10 @@ html * {
 }
 
 #stopwatch-action-button > div > span {
-  background: -moz-linear-gradient(top, rgb(177,214,0) 1rem, rgb(143,195,0) 2rem, rgb(82,107,23) 100%);
+  background: -moz-linear-gradient(top, rgb(177,214,0) 0.63rem, rgb(143,195,0) 1.25rem, rgb(82,107,23) 100%);
 }
 #stopwatch-action-button > div > span:last-child {
-  background: -moz-linear-gradient(top, hsl(355,93%,42%) 0, hsl(356,94%,37%) 1rem, hsl(353,100%,22%) 100%);
+  background: -moz-linear-gradient(top, hsl(355,93%,42%) 0, hsl(356,94%,37%) 0.63rem, hsl(353,100%,22%) 100%);
 }
 
 #stopwatch-action-button:active span:first-child {
@@ -253,10 +249,10 @@ html * {
 }
 
 #timer-action-button > div > span {
-  background: -moz-linear-gradient(top, rgb(177,214,0) 0.1rem, rgb(143,195,0) 0.2rem, rgb(82,107,23) 100%);
+  background: -moz-linear-gradient(top, rgb(177,214,0) 0.06rem, rgb(143,195,0) 0.13rem, rgb(82,107,23) 100%);
 }
 #timer-action-button > div > span:last-child {
-  background: -moz-linear-gradient(top, hsl(355,93%,42%) 0, hsl(356,94%,37%) 0.1rem, hsl(353,100%,22%) 100%);
+  background: -moz-linear-gradient(top, hsl(355,93%,42%) 0, hsl(356,94%,37%) 0.06rem, hsl(353,100%,22%) 100%);
 }
 
 #timer-action-button:active span:first-child {
@@ -297,7 +293,7 @@ html * {
   text-align: center;
   font-size: 2em;
   font-weight: bold;
-  text-shadow: 0 0 0.3rem rgba(0, 0, 0, 0.5);
+  text-shadow: 0 0 0.19rem rgba(0, 0, 0, 0.5);
 }
 
 #duration-field:invalid {
@@ -307,12 +303,12 @@ html * {
 
 #clock-view {
   width: 100%;
-  height: -moz-calc(100% - 0.2rem);
+  height: -moz-calc(100% - 0.13rem);
   color: black;
   background-image: url(images/clock_background.png);
   background-size: cover;
   background-position: center;
-  border-bottom: 0.2rem solid #ACACAC;
+  border-bottom: 0.13rem solid #ACACAC;
   text-align: center;
 }
 
@@ -360,6 +356,7 @@ html * {
 
 #digital-clock-background {
   height: 100%;
+  overflow: hidden;
   background-image: none;
   display: none;
 }
@@ -368,12 +365,12 @@ html * {
   height: 48%;
   background-size: 100% 100%;
   background-image: url(images/digital_clock_bg.png);
-  box-shadow: 0 0.4rem 0.6rem -0.6rem black;
+  box-shadow: 0 0.25rem 0.37rem -0.37rem black;
   display: block;
 }
 
 #digital-clock {
-  margin-top: 10.4rem;
+  margin-top: 6.50rem;
   display: none;
 }
 
@@ -388,13 +385,13 @@ html * {
 }
 
 #clock-time {
-  font: 100 15rem/19rem 'MozTT', sans-serif;
+  font: 100 9.38rem/11.88rem 'MozTT', sans-serif;
   color: #26292a;
   pointer-events: none;
 }
 
 #clock-hour24-state {
-  font: 100 5rem/5rem 'MozTT', sans-serif;
+  font: 100 3.13rem/3.13rem 'MozTT', sans-serif;
   color: #313334;
   text-transform:lowercase;
   pointer-events: none;
@@ -405,24 +402,24 @@ html * {
   content: "";
   background-image: url("images/alarm_indicator.png");
   background-size: 100% auto;
-  width: 5.5rem;
-  height: 5.5rem;
-  margin-top: 2.6rem;
-  margin-left: -4rem;
+  width: 3.44rem;
+  height: 3.44rem;
+  margin-top: 1.63rem;
+  margin-left: -2.50rem;
 }
 
 #clock-day-date {
   position: absolute;
   width: 100%;
   margin: auto;
-  font: normal 2.5rem 'MozTT', sans-serif;
-  line-height: 9.8rem;
+  font: normal 1.56rem 'MozTT', sans-serif;
+  line-height: 6.13rem;
 }
 
 #analog-clock-container {
   width: 100%;
-  height: -moz-calc(100% - 9.8rem);
-  margin: 9.8rem auto auto;
+  height: -moz-calc(100% - 5.8rem);
+  margin: 5.8rem auto auto;
   position: absolute;
 }
 /* These CSS styles all apply to the SVG clock elements */
@@ -435,16 +432,16 @@ html * {
   pointer-events: none;
 }
 #secondhand { /* narrow blue second hand */
-  stroke-width: 0.08rem; 
+  stroke-width: 0.05rem; 
   stroke: #00abcd;
 }
 #minutehandCentralPoint { /* dark-gray central point*/
-  stroke-width: 0.005rem; 
+  stroke-width: 0rem; 
   stroke: #4f5b5f; 
   fill: #4f5b5f;
 }
 #secondhandCentralPoint { /* blue central point */
-  stroke-width: 0.005rem; 
+  stroke-width: 0rem; 
   stroke: #00abcd; 
   fill: #00abcd;
 }
@@ -453,7 +450,7 @@ html * {
   position: absolute;
   background: orange;
   width: 100%;
-  height: 13rem;
+  height: 8.13rem;
   bottom: 0;
   vertical-align: middle;
   text-align: center;
@@ -491,8 +488,8 @@ html * {
 }
 .banner > p {
   display: inline-block;
-  font-size: 2.5rem;
-  line-height: 3.75rem;
+  font-size: 1.56rem;
+  line-height: 2.34rem;
   max-width: 75%;
   vertical-align: middle;
   white-space: normal;
@@ -513,7 +510,7 @@ body.hidden *[data-l10n-id] {
 /* 320x480 phones */
 @media screen and (width: 320px) {
   html {
-    font-size: 6px;
+    font-size: 10px;
   }
   #analog-clock-svg-body.alarm1 {
     transform: matrix(1,0,0,1,0,0);

--- a/apps/clock/style/onring.css
+++ b/apps/clock/style/onring.css
@@ -8,10 +8,10 @@ html, body {
 }
 
 .ring-display {
-  padding: 1.2rem 1.2rem 1rem;
-  width: -moz-calc(100% - 2.4rem);
-  height: -moz-calc(100% - 2.2rem);
-  position: absolute;
+  padding: 0.75rem 0.75rem 0.63rem;
+  width: -moz-calc(100% - 1.50rem);
+  height: -moz-calc(100% - 1.38rem);
+  position: fixed;
 }
 
 #ring-icon {
@@ -36,33 +36,33 @@ html, body {
 #ring-clock-display {
   width: 86%;
   margin-top: 44%;
-  border-bottom: 0.2rem solid rgba(122, 122, 122, 0.65);
+  border-bottom: 0.13rem solid rgba(122, 122, 122, 0.65);
   margin-left: auto;
   margin-right: auto;
 }
 
 #ring-clock-time {
-  font: lighter 5rem 'MozTT', sans-serif;
-  line-height: 9rem;
+  font: lighter 3.13rem 'MozTT', sans-serif;
+  line-height: 5.63rem;
   width: 100%;
 }
 
 #ring-clock-hour24-state {
-  font: lighter 5rem 'MozTT', sans-serif;
-  line-height: 8rem;
-  padding-left: 1.5rem;
+  font: lighter 3.13rem 'MozTT', sans-serif;
+  line-height: 5rem;
+  padding-left: 0.94rem;
 }
 
 #ring-alarm-label {
-  font: lighter 4rem 'MozTT',sans-serif;
-  line-height: 10rem;
+  font: lighter 2.50rem 'MozTT',sans-serif;
+  line-height: 6.25rem;
   white-space: nowrap; 
   text-overflow: ellipsis;
 }
 
 #footer-button-container {
   width: 100%;
-  height: 11.5rem;
+  height: 7.19rem;
   left: 0;
   bottom: 0;
   background: url(images/attention_button_container.png);
@@ -73,19 +73,19 @@ html, body {
 
 #ring-button-close {
   float: left;
-  width: -moz-calc((100% - 6.5rem) / 2 );
+  width: -moz-calc((100% - 4.06rem) / 2 );
   -moz-box-sizing: border-box;
   background: url("images/ring_button_snooze.png") repeat-x scroll left bottom #FAFAFA;
   border: 1px solid #9F9F9F;
-  border-radius: 0.4rem 0.4rem 0.4rem 0.4rem;
+  border-radius: 0.25rem 0.25rem 0.25rem 0.25rem;
   color: #333333;
   display: inline-block;
-  font: 600 2.6rem/6.5rem 'MozTT', sans-serif;
-  height: 6.6rem;
-  margin: 2.4rem 0 0 2.5rem;
+  font: 600 1.63rem/4.06rem 'MozTT', sans-serif;
+  height: 4.12rem;
+  margin: 1.50rem 0 0 1.56rem;
   outline: medium none;
   overflow: hidden;
-  padding: 0 1.5rem;
+  padding: 0 0.94rem;
   text-align: center;
   text-decoration: none;
   text-overflow: ellipsis;
@@ -102,20 +102,20 @@ html, body {
 
 #ring-button-snooze {
   float: left;
-  width: -moz-calc((100% - 6.5rem) / 2 );
+  width: -moz-calc((100% - 4.06rem) / 2 );
   -moz-box-sizing: border-box;
   background: url("images/ring_button_close.png") repeat-x scroll left bottom #FAFAFA;
   background-color: #00CAF2;
   border: 1px solid #00ACCE;
-  border-radius: 0.4rem 0.4rem 0.4rem 0.4rem;
+  border-radius: 0.25rem 0.25rem 0.25rem 0.25rem;
   color: #333333;
   display: inline-block;
-  font: 600 2.6rem/6.5rem 'MozTT', sans-serif;
-  height: 6.6rem;
-  margin: 2.4rem 2.5rem 0 1.5rem;
+  font: 600 1.63rem/4.06rem 'MozTT', sans-serif;
+  height: 4.12rem;
+  margin: 1.50rem 1.56rem 0 0.94rem;
   outline: medium none;
   overflow: hidden;
-  padding: 0 1.5rem;
+  padding: 0 0.94rem;
   text-align: center;
   text-decoration: none;
   text-overflow: ellipsis;
@@ -134,7 +134,7 @@ html, body {
 @media (orientation: portrait) and (width: 320px),
        (orientation: landscape) and (width: 480px) {
   html {
-    font-size: 6px;
+    font-size: 10px;
   }
 }
 
@@ -142,7 +142,7 @@ html, body {
 @media (orientation: portrait) and (width: 480px),
        (orientation: landscape) and (width: 800px) {
   html {
-    font-size: 10px;
+    font-size: 14px;
   }
 }
 
@@ -171,7 +171,7 @@ html, body {
   }
   
   #ring-clock-time {
-    font: bolder 2.2rem/2.2rem 'MozTT', sans-serif;
+    font: bolder 1.38rem/1.38rem 'MozTT', sans-serif;
   }
   
   #ring-clock-hour24-state {
@@ -182,7 +182,7 @@ html, body {
     position: absolute;
     top: 6px;
     left: 40px;
-    font: bolder 2.2rem/2.2rem 'MozTT',sans-serif;
+    font: bolder 1.38rem/1.38rem 'MozTT',sans-serif;
     color: #00aac8;
   }
   

--- a/shared/style/headers.css
+++ b/shared/style/headers.css
@@ -125,6 +125,7 @@ section[role="region"] > header:first-child button {
   font: 600 1.4rem/1.1em "MozTT", Sans-serif;
   color: #fff;
   border-radius: 0;
+  text-decoration: none;
 }
 
 


### PR DESCRIPTION
Applied `headers.css` from `shared/style` folder.

> There is a **huge drawback** in the Clock app: 
> It is using 6px as base font-size for their rem units, so any BB applied will be seen smaller as 10px is the base unit for all the building blocks and Gaia apps.
> 
> I encourage to change all the sizes ASAP for being synced with Gaia apps base font size.
> The change is easy but takes time to do, you only need a basic math operation and some patience :D 

**EDIT**: I've fixed **all** the units in the 3 css files in the application for getting work with 10px base font-size, i've also removed as in others applications the rule `html * { overflow: hidden; }` because of obvious performances problems and visual issues with building blocks.

Also i've added a missing rule to `headers.css` for avoiding text-decoration on links inside bb headers.

Please @arcturus @ian-liu @fabi1cazenave  take a look!
