### PR TITLE
Bug 803040 - [Clock] Time picker messes up when (1) set alarm (2) kill app (3) alarm fires

### DIFF
--- a/apps/clock/js/alarm.js
+++ b/apps/clock/js/alarm.js
@@ -648,7 +648,6 @@ var AlarmEditView = {
     this.snoozeMenu.addEventListener('click', this);
     this.snoozeSelect.addEventListener('change', this);
     this.deleteButton.addEventListener('click', this);
-    this.initTimePicker();
   },
 
   initTimePicker: function aev_initTimePicker() {
@@ -762,6 +761,9 @@ var AlarmEditView = {
   },
 
   load: function aev_load(alarm) {
+    if (this.timePicker.hour == null)
+      this.initTimePicker();
+
     if (!alarm) {
       this.alarmTitle.textContent = _('newAlarm');
       alarm = this.getDefaultAlarm();


### PR DESCRIPTION
The picker got wrong value of the client height when Clock APP is launching and initial in the background.
It will make the picker messes up with wrong offset height.
We only need to initial the picker when Clock APP really goes into alarm-edit page.
