### PR TITLE
Bug 805360 - [MMI] Force long MMI/USSD replies to wrap; r=basiclines, a=vingtetun

### DIFF
--- a/apps/communications/dialer/style/ussd.css
+++ b/apps/communications/dialer/style/ussd.css
@@ -20,18 +20,12 @@ html, body {
 }
 
 #message-container {
-  width: 100%;
   height: -moz-calc(100% - 5rem - 5rem);
-  display: -moz-box;
-  -moz-box-orient: horizontal;
-  -moz-box-pack: center;
-  -moz-box-align: center;
 }
 
 #message {
   font-size: 2rem;
   padding: 1rem;
-  -moz-box-flex: 1;
   white-space: pre-line;
   word-wrap: break-word;
   overflow: auto;


### PR DESCRIPTION
Some message restyling in the USSD screen to adapt it to the:
html \* {
   overflow: hidden;
}
deletion ;-)
