### PR TITLE
Bug 796739: Fix CSP in keyboard by removing inline script.

### DIFF
--- a/apps/keyboard/index.html
+++ b/apps/keyboard/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="style/keyboard.css">
 </head>
 <body>
-  <div id="keyboard" class="hide" data-hidden="true" onmousedown="this.setCapture(false); return false;"></div>
+  <div id="keyboard" class="hide" data-hidden="true"></div>
   <!-- This is to pre-load styles for keys avoiding flickering -->
   <div class="cache">
       <button class="keyboard-key"><span class="visual-wrapper"><span>C</span></span></button>

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -904,6 +904,11 @@ function onScroll(evt) {
 function onMouseDown(evt) {
   var keyCode;
 
+  // Prevent loosing focus to the currently focused app
+  // Otherwise, right after mousedown event, the app will receive a focus event.
+  IMERender.ime.setCapture(false);
+  evt.preventDefault();
+
   isPressing = true;
   currentKey = evt.target;
   if (!isNormalKey(currentKey))


### PR DESCRIPTION
If we enable strict CSP, we end up with a keyboard that disappear on touch.
