### PR TITLE
Removed "pulse" from the name string as the name was slightly too large

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -191,7 +191,7 @@
           <select id="sound-select" class="abstract-menu">
             <option value="classic_buzz.ogg">Classic Buzz</option>
             <option value="classic_pulse.ogg">Classic Pulse</option>
-            <option value="classic_pulse_progressive.ogg">Classic Pulse Progressive</option>
+            <option value="classic_pulse_progressive.ogg">Classic Progressive</option>
             <option value="alarm_gem_echoes.ogg">Gem Echoes</option>
             <option value="alarm_into_the_void.ogg">Into the Void</option>
             <option value="alarm_ringing_strings.ogg">Ringing Strings</option>


### PR DESCRIPTION
Removed "pulse" from the name string as the name was slightly too large and overlapped with the selected checkmark.
