### PR TITLE
Bug 805829 - Add test-container app to launch test harnesses from an oop...

### DIFF
--- a/test_apps/test-container/index.html
+++ b/test_apps/test-container/index.html
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <style type="text/css">
+            #test-container {
+                width: 100%;
+                height: 100%;
+                padding: 0;
+                margin: 0;
+                border: 0;
+                frameborder: "0";
+            }
+        </style>
+    </head>
+    <body>
+        <iframe id="test-container" remote="true" mozbrowser></iframe>
+    </body>
+</html>

--- a/test_apps/test-container/manifest.webapp
+++ b/test_apps/test-container/manifest.webapp
@@ -1,0 +1,39 @@
+{
+  "name": "Test Container",
+  "type": "certified",
+  "description": "Test framework container",
+  "launch_path": "/index.html",
+  "developer": {
+    "name": "The Ateam",
+    "url": "https://wiki.mozilla.org/Auto-tools"
+  },
+  "permissions": {
+    "alarms": {},
+    "browser":{},
+    "power":{},
+    "webapps-manage":{},
+    "mobileconnection":{},
+    "mozBluetooth":{},
+    "bluetooth":{},
+    "telephony":{},
+    "voicemail":{},
+    "device-storage:pictures":{},
+    "settings":{},
+    "storage":{},
+    "camera":{},
+    "geolocation":{},
+    "wifi-manage":{},
+    "wifi":{},
+    "desktop-notification":{},
+    "idle":{},
+    "network-events":{},
+    "embed-apps":{}
+  },
+  "locales": {
+    "en-US": {
+      "name": "Test Container",
+      "description": "Test framework container"
+    }
+  },
+  "default_locale": "en-US"
+}


### PR DESCRIPTION
... iframe, r=fabrice

See: https://bugzilla.mozilla.org/show_bug.cgi?id=805829

This got reviewed in bugzilla.
