### PR TITLE
[Bug 801931] "Improve Firefox OS" settings page

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1659,18 +1659,6 @@
               data-l10n-id="licensing"> Licensing </button>
           </label>
         </li>
-        <li>
-          <label for="share-performance-data" class="description">
-            <span>
-              <input type="checkbox" id="share-performance-data" name="debug.peformancedata.shared" />
-              <span data-l10n-id="share-performance-data">
-                I want to help make Firefox OS faster and easier to use by
-                sharing information about my phone’s performance.
-              </span>
-              <a href="https://www.mozilla.org/" data-l10n-id="learn-more"> Learn More </a>
-            </span>
-          </label>
-        </li>
       </ul>
     </section>
 
@@ -1821,6 +1809,73 @@
           <a data-l10n-id="screenReader">Screen Reader</a>
         </li>
       </ul>
+    </section>
+
+    <!-- Device :: Improve Firefox OS -->
+    <section role="region" id="improve-firefox-os" data-leaf>
+      <header>
+        <a href="#root"><span class="icon icon-back">back</span></a>
+        <h1 data-l10n-id="improveFirefoxOS">Improve Firefox OS</h1>
+      </header>
+
+      <header>
+        <h2 data-l10n-id="performanceData">Performance Data</h2>
+      </header>
+      <ul>
+        <li>
+          <label for="" class="description">
+            <span data-l10n-id="performanceDataInfo">
+              Make Firefox OS faster and easier to use by sharing
+              information over Wi-Fi about your phone’s performance.
+            </span>
+            <a href="https://www.mozilla.org/" data-l10n-id="learn-more" class="link-text">Learn More</a>
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" name="debug.peformancedata.shared" />
+            <span></span>
+          </label>
+          <a data-l10n-id="sharePerformanceData">Submit performance data</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="crashReports">Crash Reports</h2>
+      </header>
+      <ul>
+        <li>
+          <label for="" class="description">
+            <span data-l10n-id="crashReportInfo">
+              Sending Mozilla a report when a crash occurs helps us fix the problem
+              for everyone. Reports are sent over Wi-Fi only.
+            </span>
+            <a href="https://www.mozilla.org/" data-l10n-id="learn-more" class="link-text">Learn More</a>
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="radio" name="app.reportCrashes" value="always"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="alwaysSendReport">Always send a report</a>
+        </li>
+        <li>
+          <label>
+            <input type="radio" name="app.reportCrashes" value="never" />
+            <span></span>
+          </label>
+          <a data-l10n-id="neverSendReport">Never send a report</a>
+        </li>
+        <li>
+          <label>
+            <input type="radio" name="app.reportCrashes" value="ask" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="askToSendReport">Ask me when a crash occurs</a>
+        </li>
+      </ul>
+      -->
     </section>
 
     <!-- Device :: Help -->
@@ -2007,6 +2062,9 @@
         </li>
         <li hidden>
           <a href="#accessibility" data-l10n-id="accessibility">Accessibility</a>
+        </li>
+        <li>
+          <a href="#improve-firefox-os" data-l10n-id="improveFirefoxOS">Improve Firefox OS</a>
         </li>
         <li>
           <a href="#help" data-l10n-id="helpAndFeedback">Help &amp; Feedback</a>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -377,7 +377,6 @@ learn-more=Learn More
 reset-phone=Reset Phone
 reset-warning-1= CAUTION: Resetting will erase all your data, including any apps you've purchased.
 reset-warning-2= The phone will be restored to its factory condition. None of your settings or data will be saved.
-share-performance-data=I want to help make Firefox OS faster and easier to use by sharing information about my phone’s performance.
 # Localization note: the about* and licensing* strings below aren’t ready for translation yet.
 about-your-rights   = About Your Rights
 about-your-rights-0 = Mozilla Firefox is free and open source software, built by a community of thousands from all over the world. There are a few things you should know:
@@ -438,6 +437,17 @@ turnOnAuto=Turn on automatically
 accessibility=Accessibility
 invertColors=Invert Colors
 screenReader=Screen Reader
+
+# Device :: Improve Firefox OS
+improveFirefoxOS=Improve Firefox OS
+performanceData=Performance Data
+performanceDataInfo=Make Firefox OS faster and easier to use by sharing information over Wi-Fi about your phone’s performance.
+sharePerformanceData=Submit performance data
+crashReports=Crash Reports
+crashReportInfo=Sending Mozilla a report when a crash occurs helps us fix the problem for everyone. Reports are sent over Wi-Fi only.
+alwaysSendReport=Always send a report
+neverSendReport=Never send a report
+askToSendReport=Ask me when a crash occurs
 
 # Device :: Help
 online-support=Online support:

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -313,3 +313,11 @@ ul li > label .range-icons.brightness {
   pointer-events: none;
 }
 
+/******************************************************************************
+ * Improve Firefox OS
+ */
+
+#improve-firefox-os .link-text {
+  white-space: nowrap;
+}
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=801931

This PR creates a "Improve Firefox OS" settings page to hold the performance data and crash reporting settings.

I worked with @lco on IRC to make sure this fit her requirements. 
