### PR TITLE
Bug 804907 - [email] Create dialog to notify of send failure

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -836,6 +836,13 @@
         <span class="cmp-attachment-filesize"></span>
         <button class="cmp-attachment-remove">X</span>
       </li>
+      <div class="cmp-sending-container">
+        <p role="status" class="cmp-messages-sending">
+          <progress></progress>
+          <span class="cmp-sending-text" data-l10n-id="compose-sending-message">Sending messagE
+          </span>
+        </p>        
+      </div>
     </div>
     <!-- Widget nodes for the setup cards; styles use the sup prefix -->
     <div id="templ-sup">

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -107,6 +107,10 @@ compose-bcc=bcc
 compose-subject=Subject
 compose-discard-message=Discard Email?
 compose-discard-confirm=Discard
+compose-sending-message=Sending Email
+compose-send-message-failed=Send email failed
+
+dialog-button-ok=Ok
 
 attachment-size-kib={{kilobytes}}K
 
@@ -176,8 +180,6 @@ forward-header-cc=CC
 
 toaster-undo=Undo
 toaster-retry=Try again
-toaster-message-send-success=Message sent
-toaster-message-send-failed=Send Message failed
 toaster-message-star={[ plural(n) ]}
 toaster-message-star[one]=1 message flag set
 toaster-message-star[other]={{ n }} messages flag set

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -98,6 +98,28 @@
   background: #fff;
 }
 
+.cmp-sending-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 20;
+  background: rgba(0,0,0,.8);
+}
+
+.cmp-messages-sending{
+  position: absolute;
+  top:40%;
+  width: 80%;
+  padding: 0 10% !important;
+}
+
+.cmp-sending-text {
+  color: white;
+  font: 600 2.3rem/1em "MozTT",Sans-serif;
+  padding: 0 1rem;
+}
 /* Attachment */
 .cmp-attachments-container {
   padding: 0 1rem;


### PR DESCRIPTION
- Fix bug : https://bugzilla.mozilla.org/show_bug.cgi?id=804907 (https://bugzilla.mozilla.org/show_bug.cgi?id=798715) 
- There exist some limitation when sent failed. We could not preform resend action now, so user could only click ok to go back to message list view(or switch back to originated activity).
