### PR TITLE
Bug 807368 - [email] UI: Update mesage reader to always show all information

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -259,7 +259,7 @@
                      data-l10n-id="envelope-from">FroM</span>
             </div>
             <!-- the details starts out collapsed, but can be toggled -->
-            <div class="msg-envelope-details collapsed">
+            <div class="msg-envelope-details">
               <div class="msg-envelope-to-line msg-envelope-line">
                 <span class="msg-envelope-key"
                        data-l10n-id="envelope-to">tO</span>

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -862,23 +862,15 @@ MessageReaderCard.prototype = {
   },
 
   /**
-   * Distinguish clicks on contacts from clicks on the envelope to toggle its
-   * expanded state and then do the right thing.
+   * Handle peep bubble click event and trigger context menu.
    */
   onEnvelopeClick: function(event) {
     var target = event.target;
-    while (target !== this.envelopeNode &&
-           !target.classList.contains('msg-peep-bubble')) {
-      target = target.parentNode;
-    }
-    // - envelope click
-    if (target === this.envelopeNode) {
-      this.envelopeDetailsNode.classList.toggle('collapsed');
+    if (!target.classList.contains('msg-peep-bubble')) {
+      return;
     }
     // - peep click
-    else {
-      this.onPeepClick(target);
-    }
+    this.onPeepClick(target);
   },
 
   onPeepClick: function(target) {

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -30,10 +30,6 @@
   margin-left: 0.3rem;
 }
 
-.cmp-peep-name, .cmp-peep-address {
-  pointer-events: none;
-}
-
 .cmp-to-text-container {
   overflow: hidden;
 }

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -211,6 +211,9 @@
   padding: 2px 0.8rem;
   font-size: 80%;
 }
+.msg-peep-bubble * {
+  pointer-events: none;
+}
 .msg-peep-name {
 }
 .msg-peep-address {
@@ -255,6 +258,7 @@
 .msg-body-content {
   color: black;
   margin: 4px 0px;
+  word-wrap: break-word;
 }
 .msg-body-signature {
   color: blue;


### PR DESCRIPTION
- Fix bug : https://bugzilla.mozilla.org/show_bug.cgi?id=807368
- Fix message read view UI bug : When message body contain a string that over the container width, message read view y-axis will become scrollable. Set word-wrap style to break long word for preventing this bug.
