### PR TITLE
Bug 810746 - [keyboard]Cannot delete the text in a text field with Chinese Pinyin Keyboard

### DIFF
--- a/apps/keyboard/js/imes/jspinyin/jspinyin.js
+++ b/apps/keyboard/js/imes/jspinyin/jspinyin.js
@@ -454,7 +454,6 @@ IMEngine.prototype = {
           this._historyText = '';
 
           this._updateCandidateList(this._next.bind(this));
-          return;
         }
         // pass the key to IMEManager for default action
         debug('Default action.');


### PR DESCRIPTION
Fix a jspinyin IME bug that the backspace key doesn't work when the pending symbols are cleared.
