### PR TITLE
Bug 799601 - Use busytime instance date/time when event is recurring

### DIFF
--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -463,17 +463,18 @@ Calendar.ns('Views').ModifyEvent = (function() {
 
       this.getField('location').value = model.location;
 
+      var dateSrc = model;
+      if (model.remote.isRecurring && this.busytime) {
+          dateSrc = this.busytime;
+      }
       this.getField('startDate').value =
-        InputParser.exportDate(model.startDate);
-
+        InputParser.exportDate(dateSrc.startDate);
       this.getField('endDate').value =
-        InputParser.exportDate(model.endDate);
-
+        InputParser.exportDate(dateSrc.endDate);
       this.getField('startTime').value =
-        InputParser.exportTime(model.startDate);
-
+        InputParser.exportTime(dateSrc.startDate);
       this.getField('endTime').value =
-          InputParser.exportTime(model.endDate);
+        InputParser.exportTime(dateSrc.endDate);
 
       this.getField('description').textContent =
         model.description;

--- a/apps/calendar/test/unit/provider/caldav_test.js
+++ b/apps/calendar/test/unit/provider/caldav_test.js
@@ -291,7 +291,7 @@ suite('provider/caldav', function() {
         calledWith = arguments;
         var cb = calledWith[calledWith.length - 1];
         setTimeout(cb, 0, null);
-      }
+      };
 
       var trans = db.transaction(
         ['accounts', 'calendars'],
@@ -306,7 +306,7 @@ suite('provider/caldav', function() {
 
       trans.oncomplete = function() {
         done();
-      }
+      };
 
       accountStore.persist(account, trans);
       calendarStore.persist(calendar, trans);

--- a/apps/calendar/test/unit/service/caldav_test.js
+++ b/apps/calendar/test/unit/service/caldav_test.js
@@ -92,7 +92,7 @@ suite('service/caldav', function() {
 
       subject[event] = function() {
         calledWith = arguments;
-      }
+      };
 
       service.emit(event, 1, 2, 3, 4);
 
@@ -617,7 +617,7 @@ suite('service/caldav', function() {
       };
 
       // This test assumes PST TZ
-      var expectedDate = new Date("Sun, 01 Jan 2012 00:00:00 PST");
+      var expectedDate = new Date('Sun, 01 Jan 2012 00:00:00 PST');
 
       var result = subject.formatInputTime(input);
       assert.deepEqual(new Date(result.toJSDate()), expectedDate);
@@ -863,7 +863,7 @@ suite('service/caldav', function() {
         assetReq[method] = cb;
 
         return assetReq;
-      }
+      };
     }
 
     function mockXhr() {

--- a/apps/calendar/test/unit/views/modify_event_test.js
+++ b/apps/calendar/test/unit/views/modify_event_test.js
@@ -10,7 +10,6 @@ suite('views/modify_event', function() {
 
   var subject;
   var controller;
-  var event;
   var app;
   var fmt;
 
@@ -65,6 +64,7 @@ suite('views/modify_event', function() {
     div.innerHTML = [
       '<div id="modify-event-view">',
         '<button class="save">save</button>',
+        '<button class="cancel">cancel</button>',
         '<button class="delete-record">delete</button>',
         '<section role="status">',
           '<div class="errors"></div>',
@@ -160,11 +160,11 @@ suite('views/modify_event', function() {
 
       controller.findAssociated = function() {
         calledLoad = arguments;
-      }
+      };
 
       subject._displayModel = function() {
         calledUpdate = arguments;
-      }
+      };
     });
 
     test('when change token is same', function() {
@@ -296,6 +296,34 @@ suite('views/modify_event', function() {
 
     });
 
+    test('use busytime instance when isRecurring', function() {
+      var eventRecurring = Factory('event', {
+        calendarId: 'foo',
+        remote: {
+          isRecurring: true,
+          startDate: new Date(2012, 1, 1),
+          endDate: new Date(2012, 1, 5)
+        }
+      });
+      var busytimeRecurring = Factory('busytime', {
+        eventId: eventRecurring._id,
+        startDate: new Date(2012, 10, 30),
+        endDate: new Date(2012, 10, 31)
+      });
+
+      subject.useModel(busytimeRecurring, eventRecurring);
+
+      var expected = {
+        startDate: busytimeRecurring.startDate,
+        endDate: busytimeRecurring.endDate
+      };
+
+      assert.hasProperties(
+        subject.formData(),
+        expected
+      );
+    });
+
     test('when start & end times are 00:00:00', function() {
       remote.startDate = new Date(2012, 0, 1);
       remote.endDate = new Date(2012, 0, 2);
@@ -373,7 +401,7 @@ suite('views/modify_event', function() {
       setup(function() {
         subject._loadModel = function() {
           calledWith = arguments;
-        }
+        };
       });
 
       test('existing model', function() {
@@ -558,7 +586,7 @@ suite('views/modify_event', function() {
 
         subject.displayErrors = function() {
           displayedErrors = arguments;
-        }
+        };
 
         event.validationErrors = function() {
           return errors;
@@ -575,7 +603,7 @@ suite('views/modify_event', function() {
       setup(function() {
         provider.updateEvent = function() {
           calledWith = arguments;
-        }
+        };
 
         subject.onfirstseen();
         subject.useModel(busytime, event);
@@ -843,7 +871,7 @@ suite('views/modify_event', function() {
 
       provider.createEvent = function() {
         calledWith = arguments;
-      }
+      };
 
       triggerEvent(subject.form, 'submit');
       assert.ok(calledWith);
@@ -856,7 +884,7 @@ suite('views/modify_event', function() {
 
       provider.deleteEvent = function() {
         done();
-      }
+      };
 
       triggerEvent(subject.deleteButton, 'click');
     });
@@ -870,7 +898,7 @@ suite('views/modify_event', function() {
 
       provider.createEvent = function() {
         calledWith = arguments;
-      }
+      };
 
       triggerEvent(subject.saveButton, 'click');
       assert.ok(calledWith);


### PR DESCRIPTION
ATTN: @lightsofapollo - Here's my first stab at the recurring time display problem.

It's a bit funky. Rather than switching over to `busytime` for all `{start,end}Date` needs, I'm only using it when the event is recurring. I found all kinds of test breakage when I did the former. 

I think that's because `busytime` isn't created or initialized consistently through all the tests. But, I wanted to get something practical working, before I went down the rabbit hole of working out how to fix all that. :)
