### PR TITLE
Remove line that was left from a bad rebase

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2007,7 +2007,6 @@
           <a data-l10n-id="askToSendReport">Ask me when a crash occurs</a>
         </li>
       </ul>
-      -->
     </section>
 
     <!-- Device :: Help -->


### PR DESCRIPTION
This was introduced by a bad rebase of the patch for the crash reporter settings UI.

https://github.com/mozilla-b2g/gaia/commit/ec8f31707e168d4654906e4a4e6b11234b5e7265
