### PR TITLE
Bug 796743 - Store parsed icalComponents separately from the main event

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -78,6 +78,8 @@
   <script defer src="/js/store/calendar.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/store/setting.js" type="text/javascript" charset="utf-8"></script>
   <script defer src="/js/store/alarm.js" type="text/javascript" charset="utf-8"></script>
+  <script defer src="/js/store/ical_component.js" type="text/javascript" charset="utf-8"></script>
+  <script defer src="/js/event_mutations.js" type="text/javascript" charset="utf-8"></script>
 
   <!--- models -->
   <script defer src="/js/models/account.js" type="text/javascript" charset="utf-8"></script>

--- a/apps/calendar/js/event_mutations.js
+++ b/apps/calendar/js/event_mutations.js
@@ -1,0 +1,134 @@
+/**
+ * EventMutations are a simple wrapper for a
+ * set of idb transactions that span multiple
+ * stores and calling out to the time controller
+ * at appropriate times so it can cache the information.
+ *
+ *
+ * Examples:
+ *
+ *
+ *    // create an event
+ *    var mutation = Calendar.EventMutations.create({
+ *      // this class does not handle/process events
+ *      // only persisting the records. Busytimes will
+ *      // automatically be recreated.
+ *      event: event
+ *    });
+ *
+ *    // add an optional component
+ *    // mutation.icalComponent = component;
+ *
+ *    mutation.commit(function(err) {
+ *      if (err) {
+ *        // handle it
+ *      }
+ *
+ *      // success event/busytime/etc.. has been created
+ *    });
+ *
+ *
+ *    // update an event:
+ *    // update shares an identical api but will
+ *    // destroy/recreate associated busytimes with event.
+ *    var mutation = Calendar.EventMutations.update({
+ *      event: event
+ *    });
+ *
+ *    mutation.commit(function() {
+ *
+ *    });
+ *
+ *
+ */
+Calendar.EventMutations = (function() {
+
+  function Create(options) {
+    if (options) {
+      for (var key in options) {
+        if (options.hasOwnProperty(key)) {
+          this[key] = options[key];
+        }
+      }
+    }
+  }
+
+  Create.prototype = {
+
+    commit: function(callback) {
+      var eventStore = Calendar.App.store('Event');
+      var busytimeStore = Calendar.App.store('Busytime');
+      var componentStore = Calendar.App.store('IcalComponent');
+
+      var controller = Calendar.App.timeController;
+
+      var trans = eventStore.db.transaction(
+        eventStore._dependentStores,
+        'readwrite'
+      );
+
+      trans.oncomplete = function commitComplete() {
+        callback(null);
+      };
+
+      trans.onerror = function commitError(e) {
+        callback(e.target.error);
+      };
+
+
+      eventStore.persist(this.event, trans);
+
+      if (!this.busytime) {
+        this.busytime = busytimeStore.factory(
+          this.event
+        );
+      }
+
+      busytimeStore.persist(this.busytime, trans);
+
+      if (this.icalComponent) {
+        componentStore.persist(this.icalComponent, trans);
+      }
+
+      controller.cacheEvent(this.event);
+      controller.cacheBusytime(
+        busytimeStore.initRecord(this.busytime)
+      );
+    }
+
+  };
+
+  function Update() {
+    Create.apply(this, arguments);
+  }
+
+  Update.prototype = {
+    commit: function(callback) {
+      var busytimeStore = Calendar.App.store('Busytime');
+
+      var self = this;
+
+      // required so UI knows to refresh even in the
+      // case where the start/end times are the same.
+      busytimeStore.removeEvent(this.event._id, function(err) {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        Create.prototype.commit.call(self, callback);
+      });
+    }
+  };
+
+  return {
+    create: function createMutation(option) {
+      return new Create(option);
+    },
+
+    update: function updateMutation(option) {
+      return new Update(option);
+    }
+  };
+
+}());

--- a/apps/calendar/js/provider/caldav.js
+++ b/apps/calendar/js/provider/caldav.js
@@ -15,6 +15,7 @@ Calendar.ns('Provider').Caldav = (function() {
     this.service = this.app.serviceController;
     this.busytimes = this.app.store('Busytime');
     this.events = this.app.store('Event');
+    this.icalComponents = this.app.store('IcalComponent');
   }
 
   CaldavProvider.prototype = {
@@ -202,8 +203,27 @@ Calendar.ns('Provider').Caldav = (function() {
             calendarId: calendar._id
           };
 
+          var component = {
+            eventId: event._id,
+            data: remote.icalComponent
+          }
+
+          delete remote.icalComponent;
           event.remote = remote;
-          Local.createEvent.call(self, event, callback);
+
+          var create = Calendar.EventMutations.create({
+            event: event,
+            icalComponent: component
+          });
+
+          create.commit(function(err) {
+            if (err) {
+              callback(err);
+              return;
+            }
+
+            callback(null, create.busytime, create.event);
+          });
         }
       );
     },
@@ -218,22 +238,56 @@ Calendar.ns('Provider').Caldav = (function() {
       var account = this.events.accountFor(event);
       var self = this;
 
-      this.service.request(
-        'caldav',
-        'updateEvent',
-        account,
-        calendar.remote,
-        event.remote,
-        function handleUpdate(err, remote) {
+      function handleUpdate(err, remote) {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        var component = {
+          eventId: event._id,
+          data: remote.icalComponent
+        }
+
+        delete remote.icalComponent;
+        event.remote = remote;
+
+        var update = Calendar.EventMutations.update({
+          event: event,
+          icalComponent: component
+        });
+
+        update.commit(function(err) {
           if (err) {
             callback(err);
             return;
           }
+          callback(null, update.busytime, update.event);
+        });
 
-          event.remote = remote;
-          Local.updateEvent.call(self, event, busytime, callback);
+      }
+
+      // get the raw ical component
+      this.icalComponents.get(event._id, function(err, ical) {
+        if (err) {
+          callback(err);
+          return;
         }
-      );
+
+        var details = {
+          event: event.remote,
+          icalComponent: ical.data
+        };
+
+        self.service.request(
+          'caldav',
+          'updateEvent',
+          account,
+          calendar.remote,
+          details,
+          handleUpdate
+        );
+      });
     },
 
     deleteEvent: function(event, busytime, callback) {

--- a/apps/calendar/js/service/caldav.js
+++ b/apps/calendar/js/service/caldav.js
@@ -704,17 +704,31 @@ Calendar.ns('Service').Caldav = (function() {
 
     },
 
-    updateEvent: function(account, calendar, event, callback) {
+    /**
+     * Updates a single caldav event.
+     * Will handle updating both primary events and exceptions.
+     *
+     * @param {Object} account full account details.
+     * @param {Object} calendar full calendar details.
+     * @param {Object} eventDetails details to update the event.
+     * @param {Object} eventDetails.event modified remote event details.
+     * @param {Object} eventDetails.icalComponent
+     *  unmodified parsed ical component. (VCALENDAR).
+     */
+    updateEvent: function(account, calendar, eventDetails, callback) {
       var connection = new Caldav.Connection(
         account
       );
+
+      var icalComponent = eventDetails.icalComponent;
+      var event = eventDetails.event;
 
       var self = this;
       var req = this._assetRequest(connection, event.url);
       var etag = event.syncToken;
 
       // parse event
-      this.parseEvent(event.icalComponent, function(err, icalEvent) {
+      this.parseEvent(icalComponent, function(err, icalEvent) {
         var target = icalEvent;
 
         // find correct event

--- a/apps/calendar/js/store/abstract.js
+++ b/apps/calendar/js/store/abstract.js
@@ -85,14 +85,12 @@
       var model;
 
       var putReq;
-      var reqType;
+      var reqType = this._detectPersistType(object);
 
       // determine type of event
-      if (object._id) {
-        reqType = 'update';
+      if (reqType === 'update') {
         putReq = store.put(data);
       } else {
-        reqType = 'add';
         this._assignId(data);
         putReq = store.add(data);
       }
@@ -175,6 +173,10 @@
 
     _addDependents: function() {},
     _removeDependents: function(trans) {},
+
+    _detectPersistType: function(object) {
+      return ('_id' in object) ? 'update' : 'add';
+    },
 
     _parseId: function(id) {
       return parseInt(id);

--- a/apps/calendar/js/store/account.js
+++ b/apps/calendar/js/store/account.js
@@ -39,7 +39,8 @@
      * related to it must be removed.
      */
     _dependentStores: [
-      'accounts', 'calendars', 'events', 'busytimes', 'alarms'
+      'accounts', 'calendars', 'events',
+      'busytimes', 'alarms', 'icalComponents'
     ],
 
     _removeDependents: function(id, trans) {

--- a/apps/calendar/js/store/calendar.js
+++ b/apps/calendar/js/store/calendar.js
@@ -21,7 +21,8 @@
     _store: 'calendars',
 
     _dependentStores: [
-      'calendars', 'events', 'busytimes', 'alarms'
+      'calendars', 'events', 'busytimes',
+      'alarms', 'icalComponents'
     ],
 
     _parseId: function(id) {

--- a/apps/calendar/js/store/event.js
+++ b/apps/calendar/js/store/event.js
@@ -7,7 +7,7 @@
   Events.prototype = {
     __proto__: Calendar.Store.Abstract.prototype,
     _store: 'events',
-    _dependentStores: ['events', 'busytimes', 'alarms'],
+    _dependentStores: ['events', 'busytimes', 'alarms', 'icalComponents'],
 
     /** disable caching */
     _addToCache: function() {},
@@ -36,6 +36,9 @@
 
       var busy = this.db.getStore('Busytime');
       busy.removeEvent(id, trans);
+
+      var component = this.db.getStore('IcalComponent');
+      component.remove(id, trans);
     },
 
     /**

--- a/apps/calendar/js/store/ical_component.js
+++ b/apps/calendar/js/store/ical_component.js
@@ -1,0 +1,29 @@
+Calendar.ns('Store').IcalComponent = (function() {
+
+  function IcalComponent() {
+    Calendar.Store.Abstract.apply(this, arguments);
+  }
+
+  IcalComponent.prototype = {
+    __proto__: Calendar.Store.Abstract.prototype,
+
+    _store: 'icalComponents',
+
+    _createModel: function(object) {
+      return object;
+    },
+
+    _detectPersistType: function(object) {
+      // always fire update.
+      return 'update';
+    },
+
+    _parseId: function(id) {
+      return id;
+    }
+
+  };
+
+  return IcalComponent;
+}());
+

--- a/apps/calendar/test/unit/event_mutations_test.js
+++ b/apps/calendar/test/unit/event_mutations_test.js
@@ -1,0 +1,229 @@
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('timespan.js');
+  requireLib('event_mutations.js');
+});
+
+suite('event_mutations', function() {
+  var subject;
+  var app;
+  var db;
+
+  var controller;
+
+  var eventStore;
+  var busytimeStore;
+  var alarmStore;
+  var componentStore;
+
+  setup(function(done) {
+    this.timeout(5000);
+
+    subject = Calendar.EventMutations;
+    app = testSupport.calendar.app();
+    db = app.db;
+    controller = app.timeController;
+
+    eventStore = db.getStore('Event');
+    busytimeStore = db.getStore('Busytime');
+    alarmStore = db.getStore('Alarm');
+    componentStore = db.getStore('IcalComponent');
+
+    db.open(function(err) {
+      assert.ok(!err);
+      done();
+    });
+  });
+
+  teardown(function(done) {
+    testSupport.calendar.clearStore(
+      db,
+      [
+       'events',
+       'busytimes',
+       'alarms',
+       'icalComponents'
+      ],
+      done
+    );
+  });
+
+  var addTime;
+  var addEvent;
+  var removeTime;
+
+  setup(function() {
+    addTime = null;
+    addEvent = null;
+    removeTime = null;
+
+    var span = new Calendar.Timespan(
+      0, Infinity
+    );
+
+    controller.observe();
+    controller.observeTime(span, function(e) {
+      switch (e.type) {
+        case 'add':
+          addTime = e.data;
+          addEvent = controller._eventsCache[addTime.eventId];
+          break;
+        case 'remove':
+          removeTime = e.data;
+          break;
+      }
+    });
+  });
+
+  suite('#create', function() {
+
+    var event;
+    var component;
+
+    setup(function(done) {
+      event = Factory('event');
+      component = Factory('icalComponent', {
+        eventId: event._id
+      });
+
+      var mutation = subject.create({
+        event: event,
+        icalComponent: component
+      });
+
+      mutation.commit(done);
+
+      // verify that we sent to controller
+      assert.ok(addEvent, 'sent controller event');
+      assert.ok(addTime, 'sent controller time');
+
+      // check we sent the right event over.
+      assert.hasProperties(addEvent, event, 'controller event');
+      assert.equal(addTime.eventId, event._id, 'controller time');
+    });
+
+    test('event', function(done) {
+      eventStore.get(event._id, function(err, value) {
+        done(function() {
+          assert.ok(value);
+        });
+      });
+    });
+
+    test('busytime', function(done) {
+      var expectedBusytime = busytimeStore.factory(
+        event
+      );
+
+      busytimeStore.get(expectedBusytime._id, function(err, value) {
+        done(function() {
+          assert.hasProperties(value, {
+            eventId: event._id,
+            start: event.remote.start,
+            end: event.remote.end
+          });
+        });
+      });
+    });
+
+    test('icalComponent', function(done) {
+      componentStore.get(event._id, function(err, value) {
+        done(function() {
+          assert.deepEqual(value, component);
+        });
+      });
+    });
+
+  });
+
+  suite('#update', function() {
+    var event;
+    var component;
+
+    setup(function(done) {
+      event = Factory('event');
+      component = Factory('icalComponent', {
+        eventId: event._id
+      });
+
+      var create = subject.create({
+        event: event,
+        icalComponent: component
+      });
+
+      create.commit(done);
+    });
+
+    setup(function(done) {
+      event.remote.foo = true;
+      event.remote.start = Calendar.Calc.dateToTransport(
+        new Date(2012, 7, 7)
+      );
+
+      event.remote.end = Calendar.Calc.dateToTransport(
+        new Date(2012, 8, 8)
+      );
+
+      component.data = { changed: true };
+
+      var update = subject.update({
+        event: event,
+        icalComponent: component
+      });
+
+      addTime = addEvent = removeTime = null;
+      update.commit(done);
+    });
+
+    test('controller events', function() {
+      // verify we sent the controller stuff before
+      // fully sending to the db.
+      assert.ok(addTime, 'controller time');
+      assert.ok(addEvent, 'controller event');
+      assert.ok(removeTime, 'controller removed time');
+
+      assert.hasProperties(addTime, {
+        start: event.remote.start,
+        end: event.remote.end
+      });
+    });
+
+    test('event', function(done) {
+      eventStore.get(event._id, function(err, value) {
+        done(function() {
+          assert.hasProperties(
+            value.remote,
+            {
+              start: event.remote.start,
+              end: event.remote.end
+            }
+          );
+        });
+      });
+    });
+
+    test('busytime', function(done) {
+      var expectedBusytime = busytimeStore.factory(
+        event
+      );
+
+      busytimeStore.get(expectedBusytime._id, function(err, value) {
+        done(function() {
+          assert.hasProperties(value, {
+            eventId: event._id,
+            start: event.remote.start,
+            end: event.remote.end
+          });
+        });
+      });
+    });
+
+    test('icalComponent', function(done) {
+      componentStore.get(event._id, function(err, value) {
+        done(function() {
+          assert.deepEqual(value, component);
+        });
+      });
+    });
+  });
+
+});

--- a/apps/calendar/test/unit/helper.js
+++ b/apps/calendar/test/unit/helper.js
@@ -185,8 +185,10 @@
   requireLib('store/busytime.js');
   requireLib('store/calendar.js');
   requireLib('store/event.js');
+  requireLib('store/ical_component.js');
   requireLib('store/setting.js');
   requireLib('store/alarm.js');
+  requireLib('event_mutations.js');
   requireLib('view.js');
   requireLib('router.js');
   requireLib('controllers/alarm.js');

--- a/apps/calendar/test/unit/provider/caldav_test.js
+++ b/apps/calendar/test/unit/provider/caldav_test.js
@@ -16,6 +16,7 @@ suite('provider/caldav', function() {
 
   var accountStore;
   var calendarStore;
+  var componentStore;
   var eventStore;
 
   var calendar;
@@ -36,6 +37,7 @@ suite('provider/caldav', function() {
 
     calendarStore = app.store('Calendar');
     accountStore = app.store('Account');
+    componentStore = app.store('IcalComponent');
 
     accountStore.cached[account._id] = account;
     calendarStore.cached[calendar._id] = calendar;
@@ -47,7 +49,11 @@ suite('provider/caldav', function() {
   teardown(function(done) {
     testSupport.calendar.clearStore(
       db,
-      ['accounts', 'calendars', 'events', 'busytimes'],
+      [
+        'accounts', 'calendars',
+        'events', 'busytimes',
+        'icalComponents'
+      ],
       done
     );
   });
@@ -155,8 +161,11 @@ suite('provider/caldav', function() {
     });
 
     suite('#createEvent', function() {
-      test('success', function(done) {
-        var event = Factory('event', {
+      var event;
+      var id;
+
+      setup(function(done) {
+        event = Factory('event', {
           calendarId: calendar._id
         });
 
@@ -165,41 +174,98 @@ suite('provider/caldav', function() {
         result.syncToken = 'hit';
         result.icalComponent = 'xfoo';
 
-        var id = calendar._id + '-foo';
+        id = calendar._id + '-foo';
 
-        subject.createEvent(event, function() {
-          eventStore.get(id, function(err, result) {
-            var remote = result.remote;
-            assert.equal(remote.id, 'foo');
-            assert.equal(remote.syncToken, 'hit');
-            assert.equal(remote.icalComponent, 'xfoo');
-            done();
+        subject.createEvent(event, done);
+      });
+
+      test('icalComponent', function(done) {
+        componentStore.get(id, function(err, result) {
+          done(function() {
+            assert.deepEqual(result, {
+              eventId: id,
+              data: 'xfoo'
+            });
           });
         });
       });
+
+      test('event', function(done) {
+        eventStore.get(id, function(err, result) {
+          var remote = result.remote;
+          assert.equal(remote.id, 'foo');
+          assert.equal(remote.syncToken, 'hit');
+          assert.ok(!remote.icalComponent, 'does not have icalComponent');
+          done();
+        });
+      });
+
     });
 
     suite('#updateEvent', function() {
       var event;
+      var component;
 
       setup(function(done) {
+        var trans = eventStore.db.transaction(
+          ['events', 'icalComponents'],
+          'readwrite'
+        );
+
+        trans.oncomplete = function() {
+          done();
+        };
+
         event = Factory('event', {
           calendarId: calendar._id
         });
+
+        component = Factory('icalComponent', {
+          eventId: event._id,
+          data: 'original'
+        });
+
         eventStore.persist(event, done);
+        componentStore.persist(component, done);
       });
 
-      test('simple event', function(done) {
+      setup(function(done) {
         result = Factory.create('event').remote;
         result.icalComponent = 'xfooo';
+        result.syncToken = 'changedmefoo';
+        subject.updateEvent(event, done);
+      });
 
-        subject.updateEvent(event, function(err, data) {
-          eventStore.get(event._id, function(err, result) {
-            done(function() {
-              assert.equal(result.remote.icalComponent, 'xfooo');
-            });
+      test('sent data', function() {
+        var details = calledWith[calledWith.length - 2];
+
+        assert.ok(details.event, 'sends event');
+
+        assert.equal(
+          details.icalComponent,
+          'original',
+          'icalComponent'
+        );
+      });
+
+      test('component', function(done) {
+        componentStore.get(event._id, function(err, item) {
+          done(function() {
+            assert.deepEqual(
+              item,
+              { eventId: event._id, data: 'xfooo' }
+            );
           });
         });
+      });
+
+      test('event', function(done) {
+        eventStore.get(event._id, function(err, item) {
+          done(function() {
+            assert.equal(item.remote.syncToken, result.syncToken);
+          });
+        });
+
       });
 
     });
@@ -241,6 +307,7 @@ suite('provider/caldav', function() {
         var event = Factory('event', {
           calendarId: calendar._id,
           remote: {
+            id: i,
             url: 'some_foo_' + i + '.ics',
             syncToken: i
           }

--- a/apps/calendar/test/unit/provider/local_test.js
+++ b/apps/calendar/test/unit/provider/local_test.js
@@ -1,6 +1,7 @@
 requireApp('calendar/test/unit/helper.js', function() {
   requireLib('ext/uuid.js');
   requireLib('timespan.js');
+  requireLib('event_mutations.js');
   requireLib('provider/abstract.js');
   requireLib('provider/local.js');
 });

--- a/apps/calendar/test/unit/service/caldav_test.js
+++ b/apps/calendar/test/unit/service/caldav_test.js
@@ -984,8 +984,12 @@ suite('service/caldav', function() {
           }
         });
 
-        update.remote.icalComponent = ICAL.parse(fixtures.singleEvent);
         update = update.remote;
+
+        var eventDetails = {
+          event: update,
+          icalComponent: ICAL.parse(fixtures.singleEvent)
+        };
 
         mockAsset('put', function() {
           var args = Array.prototype.slice.call(arguments);
@@ -993,7 +997,9 @@ suite('service/caldav', function() {
           cb(null, null, mockXhr());
         });
 
-        subject.updateEvent(account, calendar, update, function(err, result) {
+        subject.updateEvent(account, calendar, eventDetails,
+                            function(err, result) {
+
           subject.parseEvent(result.icalComponent,
                              function(parseErr, newEvent) {
 

--- a/apps/calendar/test/unit/store/ical_component_test.js
+++ b/apps/calendar/test/unit/store/ical_component_test.js
@@ -1,0 +1,44 @@
+requireApp('calendar/test/unit/helper.js', function() {
+  requireLib('db.js');
+  requireLib('store/abstract.js');
+  requireLib('store/ical_component.js');
+});
+
+suite('store/account', function() {
+
+  var subject;
+  var db;
+  var app;
+
+  setup(function(done) {
+    this.timeout(5000);
+    app = testSupport.calendar.app();
+    db = testSupport.calendar.db();
+    subject = db.getStore('IcalComponent');
+
+    db.open(function(err) {
+      assert.ok(!err);
+      done();
+    });
+  });
+
+  teardown(function(done) {
+    testSupport.calendar.clearStore(
+      subject.db,
+      ['icalComponents'],
+      done
+    );
+  });
+
+  teardown(function() {
+    db.close();
+  });
+
+  test('initialization', function() {
+    assert.instanceOf(subject, Calendar.Store.Abstract);
+    assert.equal(subject.db, db);
+    assert.deepEqual(subject._cached, {});
+  });
+
+});
+

--- a/apps/calendar/test/unit/support/factories/all.js
+++ b/apps/calendar/test/unit/support/factories/all.js
@@ -190,4 +190,10 @@
     }
   });
 
+  Factory.define('icalComponent', {
+    properties: {
+      data: { icalData: true }
+    }
+  });
+
 }(this));

--- a/apps/calendar/test/unit/views/create_account_test.js
+++ b/apps/calendar/test/unit/views/create_account_test.js
@@ -20,6 +20,7 @@ suite('views/create_account', function() {
     div.id = 'test';
     div.innerHTML = [
       '<div id="create-account-view">',
+        '<button class="cancel">cancel</button>',
         '<ul id="create-account-presets"></ul>',
       '</div>'
     ].join('');

--- a/apps/calendar/test/unit/views/modify_account_test.js
+++ b/apps/calendar/test/unit/views/modify_account_test.js
@@ -41,6 +41,8 @@ suite('views/modify_account', function() {
     div.innerHTML = [
       '<div id="modify-account-view">',
         '<button class="save">save</button>',
+        '<button class="cancel">cancel</button>',
+        '<button class="delete-cancel">cancel</button>',
         '<div class="errors"></div>',
         '<form>',
           '<input name="user" />',


### PR DESCRIPTION
Changes the way the parsed ical component is stored. Instead of keeping it on event.remote.icalComponent it is stored in a separate object store.

This is largely for performance/memory reasons _after_ sync it does not greatly effect sync performance but it is the part 1 of 2 for incremental recurring event expansion bug (which will greatly effect sync performance).
