### PR TITLE
Bug 807182 - Add a setting to enable wifi output. r=kaze

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1403,6 +1403,13 @@
           </label>
           <a data-l10n-id="remote-debugging">Remote Debugging</a>
         </li>
+        <li>
+          <label>
+            <input type="checkbox" name="wifi.debugging.enabled" />
+            <span></span>
+          </label>
+          <a data-l10n-id="wifi-debugging">Wi-Fi output in adb</a>
+        </li>
       </ul>
 
       <header>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -355,6 +355,7 @@ log-animations=Log slow animations
 dev-mode=Developer Mode
 oop-disabled=Disable Out-Of-Process
 remote-debugging=Remote Debugging
+wifi-debugging=Wi-Fi output in adb
 ttl-monitor=Show time to load
 model-name=Model
 os-version=OS Version


### PR DESCRIPTION
With this patch, people who are having problems with wifi can enable wifi debugging output and use adb to give useful information for debugging.

Note that this patch depends on https://bugzilla.mozilla.org/show_bug.cgi?id=806611 ... Until that patch lands, no functionality should be broken but the newly added setting will have no effect.
