### PR TITLE
Bug 800017 - Implement killAll method, a=test-only, r=lightsofapollo

### DIFF
--- a/tests/python/gaiatest/gaia_test.py
+++ b/tests/python/gaiatest/gaia_test.py
@@ -67,6 +67,17 @@ class GaiaApps(object):
         self.marionette.execute_script("window.wrappedJSObject.WindowManager.kill('%s');"
                                         % app.origin)
 
+    def killAll(self):
+        self.marionette.switch_to_frame()
+        js = os.path.abspath(os.path.join(__file__, os.path.pardir, 'atoms', "gaia_apps.js"))
+        self.marionette.import_script(js)
+        self.marionette.execute_async_script("GaiaApps.killAll()")
+
+    def runningApps(self):
+        apps = self.marionette.execute_script("""
+return window.wrappedJSObject.WindowManager.getRunningApps();
+            """)
+        return apps
 
 class GaiaTestCase(MarionetteTestCase):
 

--- a/tests/python/gaiatest/tests/test_killall.py
+++ b/tests/python/gaiatest/tests/test_killall.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+import time
+
+
+class TestKillAll(GaiaTestCase):
+    def test_kill_all(self):
+        # unlock the lockscreen if it's locked
+        self.assertTrue(self.lockscreen.unlock())
+
+        # launch the Calculator app
+        app = self.apps.launch('Calculator')
+        self.assertTrue(app.frame_id is not None)
+
+        # launch the Clock app
+        app = self.apps.launch('Clock')
+        self.assertTrue(app.frame_id is not None)
+
+        # kill all the apps
+        self.apps.killAll()
+
+        # verify no apps are active
+        runningApps = self.apps.runningApps()
+        for origin in runningApps.keys():
+            if 'homescreen' not in origin:
+                self.assertTrue(False, "%s still running" % origin)


### PR DESCRIPTION
This patch adds a 'killAll' method to the GaiaTest apps object that can be used to kill all running apps, except for the homescreen app.
