### PR TITLE
fix Bug 808893 - Dock is empty after recent OTA update

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -415,11 +415,14 @@ const GridManager = (function() {
           }
 
           HomeState.getHiddens(function(hidden) {
-            var len = hidden.length;
-            for (var i = 0; i < len; i++) {
-              var origin = hidden[i].origin || hidden[i];
-              if (origin in installedApps) {
-                delete installedApps[origin];
+
+            if (hidden) {
+              var len = hidden.length;
+              for (var i = 0; i < len; i++) {
+                var origin = hidden[i].origin || hidden[i];
+                if (origin in installedApps) {
+                  delete installedApps[origin];
+                }
               }
             }
 

--- a/apps/homescreen/js/state.js
+++ b/apps/homescreen/js/state.js
@@ -7,7 +7,7 @@ const HomeState = (function() {
   const DOCK_STORE_NAME = 'Dock';
   const HIDDEN_STORE_NAME = 'Hiddens';
   const BOOKMARKS_STORE_NAME = 'Bookmarks';
-  const VERSION = 3;
+  const VERSION = 4;
 
   var database = null;
 
@@ -40,22 +40,32 @@ const HomeState = (function() {
 
       request.onupgradeneeded = function(event) {
         var db = event.target.result;
-        var gridStore = db.createObjectStore(GRID_STORE_NAME,
-                                             { keyPath: 'id' });
-        gridStore.createIndex('byPage', 'id', { unique: true });
 
-        var dockStore = db.createObjectStore(DOCK_STORE_NAME,
-                                             { keyPath: 'id' });
-        dockStore.createIndex('byId', 'id', { unique: true });
+        if (!db.objectStoreNames.contains(GRID_STORE_NAME)) {
+            var gridStore = db.createObjectStore(GRID_STORE_NAME,
+                                                 { keyPath: 'id' });
+            gridStore.createIndex('byPage', 'id', { unique: true });
+        }
 
-        var hiddenStore = db.createObjectStore(HIDDEN_STORE_NAME,
-                                                { keyPath: 'id' });
-        hiddenStore.createIndex('byId', 'id', { unique: true });
+        if (!db.objectStoreNames.contains(DOCK_STORE_NAME)) {
+            var dockStore = db.createObjectStore(DOCK_STORE_NAME,
+                                                 { keyPath: 'id' });
+            dockStore.createIndex('byId', 'id', { unique: true });
+        }
 
-        var bookmarksStore = db.createObjectStore(BOOKMARKS_STORE_NAME,
-                                                  { keyPath: 'origin' });
-        bookmarksStore.createIndex('byOrigin', 'origin', { unique: true });
+        if (!db.objectStoreNames.contains(HIDDEN_STORE_NAME)) {
+            var hiddenStore = db.createObjectStore(HIDDEN_STORE_NAME,
+                                                    { keyPath: 'id' });
+            hiddenStore.createIndex('byId', 'id', { unique: true });
+        }
 
+        if (!db.objectStoreNames.contains(BOOKMARKS_STORE_NAME)) {
+            var bookmarksStore =
+                db.createObjectStore(BOOKMARKS_STORE_NAME,
+                                     { keyPath: 'origin' });
+            bookmarksStore.createIndex('byOrigin', 'origin',
+                                       { unique: true });
+        }
 
         onUpgradeNeeded = true;
       };


### PR DESCRIPTION
The problems were :
- we have to trigger a versionchange transaction by incrementing the IDB version
- we need to create the new object stores only if they don't exist already
- we need to take care that the hidden apps array could be null if we're in the case where users updated their software without doing a full reset (ie: dogfood users), because in that case we don't init the IDB.
