### PR TITLE
Bug 796739: [uitest] Change default CSP.

### DIFF
--- a/test_apps/uitest/manifest.webapp
+++ b/test_apps/uitest/manifest.webapp
@@ -1,7 +1,6 @@
 {
   "name": "UI tests",
   "launch_path": "/index.html",
-  "type": "certified",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"
@@ -15,5 +14,6 @@
     "contacts":{ "access": "readwrite" },
     "settings":{ "access": "readwrite" },
     "desktop-notification":{}
-  }
+  },
+  "csp": "options inline-script eval-script; default-src *; script-src 'self'; object-src 'none'; style-src 'self'"
 }


### PR DESCRIPTION
Try to change default CSP for UITest app that has various CSP violations, but it isn't worth making this app "secure".
Unfortunately, the `csp` field doesn't seem to work.
