### PR TITLE
[Bug 809580] Get rid of invalid CSS declaration in crash_reporter.css

### DIFF
--- a/apps/system/style/crash_reporter/crash_reporter.css
+++ b/apps/system/style/crash_reporter/crash_reporter.css
@@ -1,7 +1,3 @@
-#crash-dialog section {
-  vertical-align: center;
-}
-
 #crash-dialog h1 {
   border-bottom: none;
 }


### PR DESCRIPTION
This declaration is invalid, so let's just get rid of it.

E/GeckoConsole(  780): [JavaScript Warning: "Error in parsing value for 'vertical-align'.  Declaration dropped." {file: "app://system.gaiamobile.org/style/crash_reporter/crash_reporter.css" line: 2}]
