### PR TITLE
bug 803378: Tweaks for layout of non-overlapping partial-hour events in calendar day view

### DIFF
--- a/apps/calendar/js/views/day_based.js
+++ b/apps/calendar/js/views/day_based.js
@@ -297,6 +297,12 @@ Calendar.ns('Views').DayBased = (function() {
       var hoursDuration = (endHour - startHour) +
                           ((endMin - startMin) / MINUTES_IN_HOUR);
 
+      // If this event is less than a full hour, tweak the classname so that
+      // some alternate styles for a tiny event can apply (eg. hide details)
+      if (hoursDuration < 1) {
+        element.className += ' partial-hour';
+      }
+
       return this._assignHeight(element, hoursDuration);
     },
 

--- a/apps/calendar/style/day_views.css
+++ b/apps/calendar/style/day_views.css
@@ -47,7 +47,7 @@
 }
 
 .day-events .event {
-  position: relative;
+  position: absolute;
   height: 6rem;
   top: 0;
   z-index: 10;
@@ -79,12 +79,10 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  position: absolute;
 }
 
 .day-events .event .details {
   width: calc(100% - 1rem - 6px);
-  position: absolute;
   min-height: 2rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -94,6 +92,10 @@
   color: #535353;
   font-size: 1.1rem;
   top: 3rem;
+}
+
+.day-events .event.partial-hour .details {
+  display: none;
 }
 
 .attendee {

--- a/apps/calendar/test/unit/views/day_based_test.js
+++ b/apps/calendar/test/unit/views/day_based_test.js
@@ -249,6 +249,7 @@ suite('views/day_based', function() {
 
       assert.equal(el.style.top, '83.3333%', 'top');
       assert.equal(el.style.height, '50%', 'height');
+      assert.ok(/\bpartial-hour\b/.test(el.className));
     });
 
     test('top of hour 1.5 hours', function() {


### PR DESCRIPTION
A few tweaks, here:
- When an event takes up less than an hour, I hide the details (ie. location) because they don't fit.
- Relative positioning on events caused the `top` style not to work correctly, with respect to the top of the hour. That caused multiple events in the same hour to push each other down
- But, when relative positioning was removed, absolute positioning on event title and details worked badly.
