### PR TITLE
bug 808803: Tweaks to correct view of overlapping events in calendar week view

### DIFF
--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -101,14 +101,16 @@
   margin: 1px;
   height: 6rem;
   width: 7rem;
-}
-
-#week-view .week-events > ol {
-  width: 7rem;
+  position: relative;
 }
 
 #week-view .days-3 .week-events > ol {
   width: 9.5rem;
+}
+
+#week-view .week-events > ol li.event {
+    position: absolute;
+    width: 100%;
 }
 
 #week-view .week-events .container {


### PR DESCRIPTION
Used these events for testing:
1. 11/8, 1:00 - 2:00
2. 11/8, 1:15 - 1:45

Before:
![Before](http://dl.dropbox.com/u/2798055/Screenshots/r.png)

After:
![After](http://dl.dropbox.com/u/2798055/Screenshots/q.png)
