### PR TITLE
Bug 810725  - Update time earlier so the clock never disappears (r/a=gal)

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -565,6 +565,8 @@ var LockScreen = {
     var wasAlreadyLocked = this.locked;
     this.locked = true;
 
+    this.updateTime();
+
     this.switchPanel();
 
     this.overlay.focus();
@@ -576,8 +578,6 @@ var LockScreen = {
     this.mainScreen.classList.add('locked');
 
     screen.mozLockOrientation('portrait-primary');
-
-    this.updateTime();
 
     if (!wasAlreadyLocked) {
       if (document.mozFullScreen)


### PR DESCRIPTION
The clock takes a moment before appearing on the lock screen when the screen is turned on. This fixes that.
