### PR TITLE
Bug 808818 - handle mp3 files without metadata

### DIFF
--- a/apps/music/js/blobview.js
+++ b/apps/music/js/blobview.js
@@ -95,22 +95,28 @@ var BlobView = (function() {
       return this.view.getInt8(offset);
     },
     getUint16: function(offset, le) {
-      return this.view.getUint16(offset, le || this.littleEndian);
+      return this.view.getUint16(offset,
+                                 le !== undefined ? le : this.littleEndian);
     },
     getInt16: function(offset, le) {
-      return this.view.getInt16(offset, le || this.littleEndian);
+      return this.view.getInt16(offset,
+                                le !== undefined ? le : this.littleEndian);
     },
     getUint32: function(offset, le) {
-      return this.view.getUint32(offset, le || this.littleEndian);
+      return this.view.getUint32(offset,
+                                 le !== undefined ? le : this.littleEndian);
     },
     getInt32: function(offset, le) {
-      return this.view.getInt32(offset, le || this.littleEndian);
+      return this.view.getInt32(offset,
+                                le !== undefined ? le : this.littleEndian);
     },
     getFloat32: function(offset, le) {
-      return this.view.getFloat32(offset, le || this.littleEndian);
+      return this.view.getFloat32(offset,
+                                  le !== undefined ? le : this.littleEndian);
     },
     getFloat64: function(offset, le) {
-      return this.view.getFloat64(offset, le || this.littleEndian);
+      return this.view.getFloat64(offset,
+                                  le !== undefined ? le : this.littleEndian);
     },
 
     // These "read" methods read from the current position in the view and
@@ -122,32 +128,38 @@ var BlobView = (function() {
       return this.view.getUint8(this.index++);
     },
     readShort: function(le) {
-      var val = this.view.getInt16(this.index, le || this.littleEndian);
+      var val = this.view.getInt16(this.index,
+                                   le !== undefined ? le : this.littleEndian);
       this.index += 2;
       return val;
     },
     readUnsignedShort: function(le) {
-      var val = this.view.getUint16(this.index, le || this.littleEndian);
+      var val = this.view.getUint16(this.index,
+                                    le !== undefined ? le : this.littleEndian);
       this.index += 2;
       return val;
     },
     readInt: function(le) {
-      var val = this.view.getInt32(this.index, le || this.littleEndian);
+      var val = this.view.getInt32(this.index,
+                                   le !== undefined ? le : this.littleEndian);
       this.index += 4;
       return val;
     },
     readUnsignedInt: function(le) {
-      var val = this.view.getUint32(this.index, le || this.littleEndian);
+      var val = this.view.getUint32(this.index,
+                                    le !== undefined ? le : this.littleEndian);
       this.index += 4;
       return val;
     },
     readFloat: function(le) {
-      var val = this.view.getFloat32(this.index, le || this.littleEndian);
+      var val = this.view.getFloat32(this.index,
+                                     le !== undefined ? le : this.littleEndian);
       this.index += 4;
       return val;
     },
     readDouble: function(le) {
-      var val = this.view.getFloat64(this.index, le || this.littleEndian);
+      var val = this.view.getFloat64(this.index,
+                                     le !== undefined ? le : this.littleEndian);
       this.index += 8;
       return val;
     },
@@ -191,12 +203,12 @@ var BlobView = (function() {
 
     getUint24: function(offset, le) {
       var b1, b2, b3;
-      if (le || this.littleEndian) { // little end comes first
+      if (le !== undefined ? le : this.littleEndian) {
         b1 = this.view.getUint8(offset);
         b2 = this.view.getUint8(offset + 1);
         b3 = this.view.getUint8(offset + 2);
       }
-      else {               // big end first
+      else {    // big end first
         b3 = this.view.getUint8(offset);
         b2 = this.view.getUint8(offset + 1);
         b1 = this.view.getUint8(offset + 2);

--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -527,8 +527,8 @@ var ListView = {
         var artistSpan = document.createElement('span');
         albumSpan.className = 'list-main-title';
         artistSpan.className = 'list-sub-title';
-        albumSpan.textContent = result.metadata.album;
-        artistSpan.textContent = result.metadata.artist;
+        albumSpan.textContent = result.metadata.album || unknownAlbum;
+        artistSpan.textContent = result.metadata.artist || unknownArtist;
         a.appendChild(albumSpan);
         a.appendChild(artistSpan);
 
@@ -539,7 +539,7 @@ var ListView = {
       case 'artist':
         var artistSpan = document.createElement('span');
         artistSpan.className = 'list-single-title';
-        artistSpan.textContent = result.metadata.artist;
+        artistSpan.textContent = result.metadata.artist || unknownArtist;
         a.appendChild(artistSpan);
 
         a.dataset.keyRange = result.metadata.artist;
@@ -549,7 +549,7 @@ var ListView = {
       case 'playlist':
         var titleSpan = document.createElement('span');
         titleSpan.className = 'list-single-title';
-        titleSpan.textContent = result.metadata.title;
+        titleSpan.textContent = result.metadata.title || unknownTitle;
         a.appendChild(titleSpan);
 
         a.dataset.keyRange = 'all';
@@ -588,11 +588,11 @@ var ListView = {
             SubListView.setAlbumSrc(data);
 
           if (option === 'artist') {
-            SubListView.setAlbumName(data.metadata.artist);
+            SubListView.setAlbumName(data.metadata.artist || unknownArtist);
           } else if (option === 'album') {
-            SubListView.setAlbumName(data.metadata.album);
+            SubListView.setAlbumName(data.metadata.album || unknownAlbum);
           } else {
-            SubListView.setAlbumName(data.metadata.title);
+            SubListView.setAlbumName(data.metadata.title || unknownTitle);
           }
 
           var targetOption =
@@ -981,12 +981,9 @@ var PlayerView = {
       var targetIndex = parseInt(target.dataset.index);
       var songData = this.dataSource[targetIndex];
 
-      TitleBar.changeTitleText((songData.metadata.title) ?
-        songData.metadata.title : unknownTitle);
-      this.artist.textContent = (songData.metadata.artist) ?
-        songData.metadata.artist : unknownArtist;
-      this.album.textContent = (songData.metadata.album) ?
-        songData.metadata.album : unknownAlbum;
+      TitleBar.changeTitleText(songData.metadata.title || unknownTitle);
+      this.artist.textContent = songData.metadata.artist || unknownArtist;
+      this.album.textContent = songData.metadata.album || unknownAlbum;
       this.currentIndex = targetIndex;
 
       // backgroundIndex is from the index of sublistView


### PR DESCRIPTION
This pull request fixes bug #808818: it makes the music app recognize and play mp3 files even when they do not contain any metadata.

Along the way, it also fixes some other bugs:
- blobview.js was handling the le (little endian) parameter incorrectly in many methods
- mediadb.js now remembers files that trigger the error callback during metadata parsing, and considers them corrupt files, and never returns them from enumerate() calls.
- the music app displays tracks from unknown artists and unknown albums
- this should also fix #807361: it should make the music app play raw AAC files if and when gecko supports those files.  In general, if it doesn't recognize the type of a file, it attempts to load it into an <audio> element, and if that succeeds, it assumes that it is a valid music file.  So the music app should now support whatever file formats gecko supports.
- it simplifies the handling of thumbnail creation in the metadata parser
