### PR TITLE
force Gaia build to be a non-parallel build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -45,6 +45,6 @@ $(LOCAL_PATH)/profile.tar.gz:
 ifeq ($(CLEAN_PROFILE), 1)
 	rm -rf $(GAIA_PATH)/profile $(GAIA_PATH)/profile.tar.gz
 endif
-	$(MAKE) $(GAIA_MAKE_FLAGS) profile
+	$(MAKE) -j1 $(GAIA_MAKE_FLAGS) profile
 	cd $(GAIA_PATH)/profile && tar cfz $(abspath $@) webapps
 


### PR DESCRIPTION
The gaia makefile doesn't like being run with a -j setting higher than one.  Because we are using $(MAKE) in the Android.mk file, we are passing through whatever -j setting that is figured out during config.sh.
