### PR TITLE
Bug 810105: reduce camera resolution as a temporary workaround r=daleharvey

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -108,7 +108,7 @@ var Camera = {
   RECORD_SPACE_PADDING: 1024 * 1024 * 1,
 
   // Maximum image resolution for still photos taken with camera
-  MAX_IMAGE_RES: 1920000,
+  MAX_IMAGE_RES: 1024 * 768, // was: 1600*1200
 
   get overlayTitle() {
     return document.getElementById('overlay-title');


### PR DESCRIPTION
We recently increased the camera resolution from 640x480 to 1600x1200. Now the gallery app is having OOM difficulties.  So this reduces the resolution to 1024x768.  The underlying gecko image memory management bug should still be fixed, but this should prevent the gallery crashes for now.
