### PR TITLE
Bug 799682 - [email] Card implementation needs to be redone to support acceleration...

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -165,7 +165,7 @@
         <div class="msg-list-scrollouter">
           <!-- exists so we can force a minimum height -->
           <div class="msg-list-scrollinner">
-            <!-- The search textbox hides under the lip of the messages. 
+            <!-- The search textbox hides under the lip of the messages.
                  As soon as any typing happens in it, we push the search
                  controls card. -->
             <div class="msg-search-tease-bar msg-nonsearch-only">
@@ -507,7 +507,7 @@
       </div>
 
       <!-- Main settings menu, root of all (mail) settings -->
-      <section class="card-settings-main card skin-organic" role="region">
+      <section class="card-settings-main card anim-vertical anim-overlay skin-organic" role="region">
         <header class="tng-main-header">
           <menu type="toolbar" class="tng-close-btn">
             <button data-l10n-id="settings-done">Done</button>
@@ -823,7 +823,7 @@
           <progress></progress>
           <span class="cmp-sending-text" data-l10n-id="compose-sending-message">Sending messagE
           </span>
-        </p>        
+        </p>
       </div>
     </div>
     <!-- Widget nodes for the setup cards; styles use the sup prefix -->

--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -43,6 +43,18 @@ function populateTemplateNodes() {
   tngNodes = processTemplNodes('tng');
 }
 
+function addClass(domNode, name) {
+  if (domNode) {
+    domNode.classList.add(name);
+  }
+}
+
+function removeClass(domNode, name) {
+  if (domNode) {
+    domNode.classList.remove(name);
+  }
+}
+
 function batchAddClass(domNode, searchClass, classToAdd) {
   var nodes = domNode.getElementsByClassName(searchClass);
   for (var i = 0; i < nodes.length; i++) {
@@ -186,7 +198,13 @@ var Cards = {
    * }
    */
   _cardStack: [],
-  activeCardIndex: null,
+  activeCardIndex: -1,
+
+  /**
+   * Cards can stack on top of each other, make sure the stacked set is
+   * visible over the lower sets.
+   */
+  _zIndex: 0,
 
   /**
    * The DOM node that contains the _containerNode ("#cardContainer") and which
@@ -216,6 +234,13 @@ var Cards = {
    */
   _animatingDeadDomNodes: [],
 
+  /**
+   * Tracks the number of transition events per card animation. Since each
+   * animation ends up with two transitionend events since two cards are
+   * moving, need to wait for the last one to be finished before doing
+   * cleanup, like DOM removal.
+   */
+  _transitionCount: 0,
 
   /**
    * Annoying logic related to contextmenu event handling; search for the uses
@@ -259,9 +284,6 @@ var Cards = {
                                          this._onMaybeIntercept.bind(this),
                                          true);
 
-    this._adjustCardSizes();
-    window.addEventListener('resize', this._adjustCardSizes.bind(this), false);
-
     // XXX be more platform detecty. or just add more events. unless the
     // prefixes are already gone with webkit and opera?
     this._cardsNode.addEventListener('transitionend',
@@ -294,32 +316,7 @@ var Cards = {
         (event.clientX >
          this._containerNode.offsetWidth - this.TRAY_GUTTER_WIDTH)) {
       event.stopPropagation();
-      this.moveToCard(this.activeCardIndex + 1);
-    }
-  },
-
-  _adjustCardSizes: function(evt) {
-    var cardWidth = this._containerNode.offsetWidth,
-        cardHeight = this._containerNode.offsetHeight,
-        totalWidth = 0;
-
-    for (var i = 0; i < this._cardStack.length; i++) {
-      var cardInst = this._cardStack[i];
-      var targetWidth = cardWidth;
-      if (cardInst.modeDef.tray)
-        targetWidth -= this.TRAY_GUTTER_WIDTH;
-      cardInst.domNode.style.width = targetWidth + 'px';
-      cardInst.domNode.style.height = cardHeight + 'px';
-
-      cardInst.left = totalWidth;
-      totalWidth += targetWidth;
-    }
-    this._cardsNode.style.width = totalWidth + 'px';
-    this._cardsNode.style.height = cardHeight + 'px';
-
-    // Reset cards' position when container resized.
-    if (evt && evt.type == 'resize') {
-      this._showCard(this.activeCardIndex, 'immediate');
+      this.moveToCard(this.activeCardIndex + 1, 'animate', 'forward');
     }
   },
 
@@ -405,10 +402,12 @@ var Cards = {
     if (!placement) {
       cardIndex = this._cardStack.length;
       insertBuddy = null;
+      domNode.classList.add(cardIndex === 0 ? 'before': 'after');
     }
     else if (placement === 'left') {
       cardIndex = this.activeCardIndex++;
       insertBuddy = this._cardsNode.children[cardIndex];
+      domNode.classList.add('before');
     }
     else if (placement === 'right') {
       cardIndex = this.activeCardIndex + 1;
@@ -416,21 +415,19 @@ var Cards = {
         insertBuddy = null;
       else
         insertBuddy = this._cardsNode.children[cardIndex];
+      domNode.classList.add('after');
     }
     this._cardStack.splice(cardIndex, 0, cardInst);
     this._cardsNode.insertBefore(domNode, insertBuddy);
-    this._adjustCardSizes();
     if ('postInsert' in cardImpl)
       cardImpl.postInsert();
 
     if (showMethod !== 'none') {
-      // If we want to animate and we just inserted the card to the left, then
-      // we need to update our position so that the user perceives animation.
-      // (Otherwise our offset is already showing the new card.)
-      if (showMethod === 'animate' && placement === 'left')
-        this._showCard(this.activeCardIndex, 'immediate');
+      // make sure the reflow sees the new node so that the animation
+      // later is smooth.
+      domNode.clientWidth;
 
-      this._showCard(cardIndex, showMethod);
+      this._showCard(cardIndex, showMethod, 'forward');
     }
   },
 
@@ -667,6 +664,25 @@ var Cards = {
     if (!numCards)
       numCards = this._cardStack.length - firstIndex;
 
+    if (showMethod !== 'none') {
+      var nextCardIndex = null;
+      if (nextCardSpec)
+        nextCardIndex = this._findCard(nextCardSpec);
+      else if (this._cardStack.length)
+        nextCardIndex = Math.min(firstIndex - 1, this._cardStack.length - 1);
+
+      this._showCard(nextCardIndex, showMethod, 'back');
+    }
+
+    // Update activeCardIndex if nodes were removed that would affect its
+    // value.
+    if (firstIndex <= this.activeCardIndex) {
+      this.activeCardIndex -= numCards;
+      if (this.activeCardIndex < -1) {
+        this.activeCardIndex = -1;
+      }
+    }
+
     var deadCardInsts = this._cardStack.splice(
                           firstIndex, numCards);
     for (iCard = 0; iCard < deadCardInsts.length; iCard++) {
@@ -687,51 +703,115 @@ var Cards = {
           break;
       }
     }
-    if (showMethod !== 'none') {
-      var nextCardIndex = null;
-      if (nextCardSpec)
-        nextCardIndex = this._findCard(nextCardSpec);
-      else if (this._cardStack.length)
-        nextCardIndex = Math.min(firstIndex - 1, this._cardStack.length - 1);
-      this._showCard(nextCardIndex, showMethod);
-    }
   },
 
-  _showCard: function(cardIndex, showMethod) {
+  _showCard: function(cardIndex, showMethod, navDirection) {
+    // Do not do anything if this is a show card for the current card.
+    if (cardIndex === this.activeCardIndex) {
+      return;
+    }
+
+    if (cardIndex > this._cardStack.length - 1) {
+      // Some cards were removed, adjust.
+      cardIndex = this._cardStack.length - 1;
+    }
+    if (this.activeCardIndex > this._cardStack.length - 1) {
+      this.activeCardIndex = -1;
+    }
+
+    if (this.activeCardIndex === -1) {
+      this.activeCardIndex = cardIndex === 0 ? cardIndex : cardIndex - 1;
+    }
+
     var cardInst = (cardIndex !== null) ? this._cardStack[cardIndex] : null;
+    var beginNode = this._cardStack[this.activeCardIndex].domNode;
+    var endNode = this._cardStack[cardIndex].domNode;
+    var isForward = navDirection === 'forward';
 
-    var targetLeft;
-    if (cardInst)
-      targetLeft = 'translateX(' + (-cardInst.left) + 'px)';
-    else
-      targetLeft = 'translateX(0px)';
+    if (this._cardStack.length === 1) {
+      // Reset zIndex so that it does not grow ever higher when all but
+      // one card are removed
+      this._zIndex = 0;
+    }
 
-    var cardsNode = this._cardsNode;
-    if (cardsNode.style.MozTransform !== targetLeft) {
-      if (showMethod === 'immediate') {
-        // XXX cross-platform support.
-        cardsNode.style.MozTransitionProperty = 'none';
-        // make sure the reflow sees the transition is turned off.
-        cardsNode.clientWidth;
-        // explicitly clear since there will be no animation
-        this._eatingEventsUntilNextCard = false;
-      }
-      else {
-        this._eatingEventsUntilNextCard = true;
-      }
-      cardsNode.style.MozTransform = targetLeft;
+    // If going forward and it is an overlay node, then do not animate the
+    // beginning node, it will just sit under the overlay.
+    if (isForward && endNode.classList.contains('anim-overlay')) {
+      beginNode = null;
 
-      if (showMethod === 'immediate') {
-        // make sure the instantaneous transition is seen before we turn
-        // transitions back on.
-        cardsNode.clientWidth;
-        // CROSS-BROWSER-TODO
-        cardsNode.style.MozTransitionProperty = '-moz-transform';
+      // anim-overlays are the transitions to new layers in the stack. If
+      // starting a new one, it is forward movement and needs a new zIndex.
+      // Otherwise, going back to
+      this._zIndex += 100;
+    }
+
+    // If going back and the beginning node was an overlay, do not animate
+    // the end node, since it should just be hidden under the overlay.
+    if (beginNode && beginNode.classList.contains('anim-overlay')) {
+      if (isForward) {
+        // If a forward animation and overlay had a vertical transition,
+        // disable it, use normal horizontal transition.
+        if (showMethod !== 'immediate' &&
+            beginNode.classList.contains('anim-vertical')) {
+          removeClass(beginNode, 'anim-vertical');
+          addClass(beginNode, 'disabled-anim-vertical');
+        }
+      } else {
+        endNode = null;
+        this._zIndex -= 100;
       }
     }
-    else {
+
+    // If the zindex is not zero, then in an overlay stack, adjust zindex
+    // accordingly.
+    if (endNode && isForward && this._zIndex) {
+      endNode.style.zIndex = this._zIndex;
+    }
+
+    var cardsNode = this._cardsNode;
+
+    if (showMethod === 'immediate') {
+      addClass(beginNode, 'no-anim');
+      addClass(endNode, 'no-anim');
+
+      // make sure the reflow sees the transition is turned off.
+      cardsNode.clientWidth;
       // explicitly clear since there will be no animation
       this._eatingEventsUntilNextCard = false;
+    }
+    else {
+      this._transitionCount = (beginNode && endNode) ? 2 : 1;
+      this._eatingEventsUntilNextCard = true;
+    }
+
+    if (this.activeCardIndex === cardIndex) {
+      // same node, no transition, just bootstrapping UI.
+      removeClass(beginNode, 'before');
+      removeClass(beginNode, 'after');
+      addClass(beginNode, 'center');
+    } else if (this.activeCardIndex > cardIndex) {
+      // back
+      removeClass(beginNode, 'center');
+      addClass(beginNode, 'after');
+
+      removeClass(endNode, 'before');
+      addClass(endNode, 'center');
+    } else {
+      // forward
+      removeClass(beginNode, 'center');
+      addClass(beginNode, 'before');
+
+      removeClass(endNode, 'after');
+      addClass(endNode, 'center');
+    }
+
+    if (showMethod === 'immediate') {
+      // make sure the instantaneous transition is seen before we turn
+      // transitions back on.
+      cardsNode.clientWidth;
+
+      removeClass(beginNode, 'no-anim');
+      removeClass(endNode, 'no-anim');
     }
 
     // Hide toaster while active card index changed:
@@ -749,17 +829,32 @@ var Cards = {
   },
 
   _onTransitionEnd: function(event) {
-    if (this._eatingEventsUntilNextCard)
-      this._eatingEventsUntilNextCard = false;
-    if (this._animatingDeadDomNodes.length) {
-      this._animatingDeadDomNodes.forEach(function(domNode) {
-        if (domNode.parentNode)
-          domNode.parentNode.removeChild(domNode);
-      });
-      // Our coordinate space may have been affected, so update and re-show
-      // the current card.
-      this._adjustCardSizes();
-      this._showCard(this.activeCardIndex, 'immediate');
+    // Multiple cards can animate, so there can be multiple transitionend
+    // events. Only do the end work when all have finished animating.
+    if (this._transitionCount > 0)
+      this._transitionCount -= 1;
+
+    if (this._transitionCount === 0) {
+      if (this._eatingEventsUntilNextCard)
+        this._eatingEventsUntilNextCard = false;
+      if (this._animatingDeadDomNodes.length) {
+        // Use a setTimeout to give the animation some space to settle.
+        setTimeout(function () {
+          this._animatingDeadDomNodes.forEach(function(domNode) {
+            if (domNode.parentNode)
+              domNode.parentNode.removeChild(domNode);
+          });
+          this._animatingDeadDomNodes = [];
+        }.bind(this), 100);
+      }
+
+      // If an vertical overlay transition was was disabled, if
+      // current node index is an overlay, enable it again.
+      var endNode = this._cardStack[this.activeCardIndex].domNode;
+      if (endNode.classList.contains('disabled-anim-vertical')) {
+        removeClass(endNode, 'disabled-anim-vertical');
+        addClass(endNode, 'anim-vertical');
+      }
     }
   },
 

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -28,38 +28,68 @@ body {
   background-color: black;
 }
 
-#cardContainer {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-  -moz-transform: translateX(0px);
-}
+#cardContainer,
 #cards {
   position: absolute;
   top: 0;
   left: 0;
-  -moz-transition-property: -moz-transform;
-  -moz-transition-duration: 300ms;
-  -moz-transition-timing-function: ease;
-  -webkit-transition-property: -webkit-transform;
-  -webkit-transition-duration: 300ms;
-  -webkit-transition-timing-function: ease;
-  -o-transition-property: -o-transform;
-  -o-transition-duration: 300ms;
-  -otransition-timing-function: ease;
-
-  /* To trigger hardward acceleration for webkit:
-     http://www.html5rocks.com/en/tutorials/speed/quick/#toc-hwaccel
-     May need to remove */
-  -webkit-transform: translateZ(0);
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 .card {
-  float: left;
-  position: relative;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
   background-color: white;
+  -moz-transition-property: transform;
+  -moz-transition-duration: 0.3s;
+  -moz-transition-timing-function: ease;
+  -moz-transition-delay: 0;
+
+}
+
+.card.anim-up center {
+  transition: translateX(0);
+}
+
+.card.no-anim {
+  -moz-transition-property: none;
+}
+
+.card.center {
+  transform: translateX(0);
+}
+
+.card.center.anim-vertical {
+  transform: translateY(0);
+}
+
+.card.before {
+  transform: translateX(-100%);
+}
+
+.card.before.anim-vertical {
+  transform: translateY(100%);
+}
+
+.card.after {
+  transform: translateX(100%);
+}
+
+.card.after.anim-vertical {
+  transform: translateY(-100%);
+}
+
+.card.center.card-folder-picker {
+  width: calc(100% - 4.3em);
+}
+
+.card.center.card-folder-picker + .card.after {
+  transform: translateX(calc(100% - 4.3em));
 }
 
 .form-card {
@@ -93,7 +123,7 @@ body {
 .header-btn, .header-left-btn, .header-right-btn {
   position: absolute;
   top: 0px;
-  height: 5.2rem; 
+  height: 5.2rem;
   width: 3.2rem;
   border: none;
   background: none;


### PR DESCRIPTION
Bug link: https://bugzilla.mozilla.org/show_bug.cgi?id=799682

Instead of using a wide horizontal div that holds div "cards" with navigation done by adjusting that horizontal div's scroll location, switch to a model where there is space only for two divs, and their "left" coordinate for each card is adjusted, with a CSS transition used to animate the change in "left" values.

Since the two animating card divs are the size of the screen, it should fit better into the heuristics used to allow faster rendering/scroll animation.

With this change, the card divs are no longer manually sized via a resize handler, but just CSS with percentages are used, so it may also help with https://bugzilla.mozilla.org/show_bug.cgi?id=798695, although I have not tried since I do not have a device available/set up.

Notes on this pull request:
- Not tested on an actual phone. I just used Firefox desktop with a Gaia profile. Although I turned on repaint display, and it seemed to not have a bunch of stripes for the animation.
- It currently has the #cardContainer and #cards divs, although now, just one of those outer divs is enough. I can look at removing one if this approach seems good in general. 
- I considered removing hidden card divs when they were scrolled off to the right, and just holding on to the DOM nodes in the Cards JS object, to help reduce the in-document DOM size. I am not sure that would help though, so I opted to keep it simple. However, that capability could be added if there was more data that it might help. The stack of cards may not get deep enough though for it to matter.
- I was using the "test data" path, so I am not sure I exercised enough of the UI paths. Suggestions on tricky ones to try are welcome.
