### PR TITLE
Bug 802605 / Bug 802611 : app downloading icon in status bar

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -46,8 +46,10 @@ var StatusBar = {
 
   headphonesActive: false,
 
-  // JW: this keeps how many current installs/updates we do
-  // JW: it triggers the icon "systemDownloads"
+  /**
+   * this keeps how many current installs/updates we do
+   * it triggers the icon "systemDownloads"
+   */
   systemDownloadsCount: 0,
 
   /* For other app to acquire */

--- a/apps/system/test/unit/app_install_manager_test.js
+++ b/apps/system/test/unit/app_install_manager_test.js
@@ -1,11 +1,17 @@
-requireApp('system/js/app_install_manager.js');
-
 requireApp('system/test/unit/mock_app.js');
 requireApp('system/test/unit/mock_chrome_event.js');
+requireApp('system/test/unit/mock_statusbar.js');
+requireApp('system/js/app_install_manager.js');
+
+// prevent Mocha to choke on "leaks" that are not leaks
+if (!window.StatusBar) {
+  window.StatusBar = null;
+}
 
 suite('system/AppInstallManager', function() {
   var realL10n;
   var realDispatchResponse;
+  var realStatusBar;
 
   var fakeDialog;
 
@@ -28,6 +34,9 @@ suite('system/AppInstallManager', function() {
         type: type
       };
     };
+
+    realStatusBar = window.StatusBar;
+    window.StatusBar = MockStatusBar;
   });
 
   suiteTeardown(function() {
@@ -43,6 +52,9 @@ suite('system/AppInstallManager', function() {
 
     navigator.mozL10n = realL10n;
     AppInstallManager.dispatchResponse = realDispatchResponse;
+
+    window.StatusBar = realStatusBar;
+    realStatusBar = null;
   });
 
   setup(function() {
@@ -254,6 +266,119 @@ suite('system/AppInstallManager', function() {
         });
       });
     });
+  });
+
+  suite('duringInstall', function() {
+    var mockApp, e;
+
+    setup(function() {
+      e = new CustomEvent('applicationinstall', { detail: {} });
+    });
+
+
+    function dispatchEvent() {
+        e.detail.application = mockApp;
+        window.dispatchEvent(e);
+    }
+
+    suite('hosted app without cache', function() {
+      setup(function() {
+        mockApp = new MockApp({
+          manifest: {
+            name: 'Fake app',
+            size: 5245678,
+            developer: {
+              name: 'Fake dev',
+              url: 'http://fakesoftware.com'
+            },
+            updateManifest: null
+          },
+          installState: 'installed'
+        });
+
+        dispatchEvent();
+      });
+
+      test('should not show the icon', function() {
+        assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
+      });
+
+      test('should do nothing if we get downloadsuccess', function() {
+        mockApp.mTriggerDownloadSuccess();
+        assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
+      });
+
+      test('should do nothing if we get downloaderror', function() {
+        mockApp.mTriggerDownloadError();
+        assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
+      });
+    });
+
+    suite('hosted app with cache', function() {
+      setup(function() {
+        mockApp = new MockApp({
+          manifest: {
+            name: 'Fake app',
+            developer: {
+              name: 'Fake dev',
+              url: 'http://fakesoftware.com'
+            }
+          },
+          updateManifest: null,
+          installState: 'pending'
+        });
+
+        dispatchEvent();
+      });
+
+      test('should show the icon', function() {
+        assert.ok(MockStatusBar.wasMethodCalled['incSystemDownloads']);
+      });
+
+      test('should remove the icon if we get downloadsuccess', function() {
+        mockApp.mTriggerDownloadSuccess();
+        assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
+      });
+
+      test('should remove the icon if we get downloaderror', function() {
+        mockApp.mTriggerDownloadError();
+        assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
+      });
+    });
+
+    suite('packaged app', function() {
+      setup(function() {
+        mockApp = new MockApp({
+          manifest: null,
+          updateManifest: {
+            name: 'Fake app',
+            size: 5245678,
+            developer: {
+              name: 'Fake dev',
+              url: 'http://fakesoftware.com'
+            }
+          },
+          installState: 'pending'
+        });
+
+        dispatchEvent();
+      });
+
+      test('should show the icon', function() {
+        assert.ok(MockStatusBar.wasMethodCalled['incSystemDownloads']);
+      });
+
+      test('should remove the icon if we get downloadsuccess', function() {
+        mockApp.mTriggerDownloadSuccess();
+        assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
+      });
+
+      test('should remove the icon if we get downloaderror', function() {
+        mockApp.mTriggerDownloadError();
+        assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
+      });
+    });
+
   });
 
   suite('humanizeSize', function() {

--- a/apps/system/test/unit/mock_app.js
+++ b/apps/system/test/unit/mock_app.js
@@ -1,12 +1,14 @@
 var idGen = 0;
 
-function MockApp() {
+function MockApp(opts) {
+  /* default values */
   this.origin = 'https://testapp.gaiamobile.org';
   this.manifest = {
     name: 'Mock app'
   };
   this.updateManifest = {
-    size: 42
+    size: 42,
+    name: 'Mock packaged app'
   };
 
   this.removable = true;
@@ -16,6 +18,13 @@ function MockApp() {
   this.mId = idGen++;
   this.mDownloadCalled = false;
   this.mCancelCalled = false;
+
+  /* overwrite default values with whatever comes in "opts" from the test */
+  if (opts) {
+    for (var key in opts) {
+      this[key] = opts[key];
+    }
+  }
 }
 
 MockApp.prototype.download = function() {

--- a/apps/system/test/unit/mock_statusbar.js
+++ b/apps/system/test/unit/mock_statusbar.js
@@ -1,6 +1,13 @@
 var MockStatusBar = {
   notificationsCount: null,
 
+  wasMethodCalled: {},
+
+  methodCalled: function msb_methodCalled(name) {
+    this.wasMethodCalled[name] =
+        this.wasMethodCalled[name] ? this.wasMethodCalled[name]++ : 1;
+  },
+
   updateNotification: function(count) {
     var number = new Number(count);
     this.notificationsCount = number.toString();
@@ -17,5 +24,12 @@ var MockStatusBar = {
     this.notificationsCount = null;
     this.mNotificationsUpdated = false;
     this.mNotificationUnread = false;
+  },
+  incSystemDownloads: function msb_incSystemDownloads() {
+    this.methodCalled("incSystemDownloads");
+  },
+
+  decSystemDownloads: function msb_decSystemDownloads() {
+    this.methodCalled("decSystemDownloads");
   }
 };

--- a/apps/system/test/unit/updatable_test.js
+++ b/apps/system/test/unit/updatable_test.js
@@ -195,7 +195,13 @@ suite('system/Updatable', function() {
       });
 
       suite('ondownloadsuccess', function() {
-        test('should remove self from active downloads', function() {
+        test('should not remove self from active downloads when not updating', function() {
+          mockApp.mTriggerDownloadSuccess();
+          assert.isNull(MockUpdateManager.mLastDownloadsRemoval);
+        });
+
+        test('should remove self from active downloads after downloading', function() {
+          subject.download();
           mockApp.mTriggerDownloadSuccess();
           assert.isNotNull(MockUpdateManager.mLastDownloadsRemoval);
           assert.equal(MockUpdateManager.mLastDownloadsRemoval.app.mId,
@@ -204,6 +210,7 @@ suite('system/Updatable', function() {
 
         suite('application of the download', function() {
           test('should apply if the app is not in foreground', function() {
+            subject.download();
             MockWindowManager.mDisplayedApp =
               'http://homescreen.gaiamobile.org';
             mockApp.mTriggerDownloadSuccess();
@@ -215,6 +222,8 @@ suite('system/Updatable', function() {
             var origin = 'http://testapp.gaiamobile.org';
             mockApp.origin = origin;
             MockWindowManager.mDisplayedApp = origin;
+
+            subject.download();
             mockApp.mTriggerDownloadSuccess();
             assert.isNull(MockAppsMgmt.mLastAppApplied);
 
@@ -228,6 +237,7 @@ suite('system/Updatable', function() {
           });
 
           test('should kill the app before applying the update', function() {
+            subject.download();
             mockApp.mTriggerDownloadSuccess();
             assert.equal('https://testapp.gaiamobile.org',
                          MockWindowManager.mLastKilledOrigin);
@@ -237,6 +247,7 @@ suite('system/Updatable', function() {
 
       suite('ondownloaderror', function() {
         setup(function() {
+          subject.download();
           mockApp.mTriggerDownloadError();
         });
 
@@ -253,6 +264,7 @@ suite('system/Updatable', function() {
 
       suite('ondownloadapplied', function() {
         setup(function() {
+          subject.download();
           mockApp.mTriggerDownloadApplied();
         });
 


### PR DESCRIPTION
[Apps] Show app download icon in status bar if app(s) downloading
[Apps] Remove app downloading icon from status bar once download(s) complete

Also rewrote how callbacks for applications lifecycle management
are set and removed in the AppUpdatable object (part of the update
manager) so that it doesn't conflict with the install functionality.
