### PR TITLE
Bug 806368 - [Dialer] Comms app compliance with UX visuals reloaded

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -234,7 +234,6 @@
    
     <form id="recents-deletion-confirmation" role="dialog" data-type="confirm">
       <section>
-        <h1 data-l10n-id="confirmation">Confirmation</h1>
         <p  data-l10n-id="confirm-deletion">Clear selected calls?</p>
       </section>
       <menu>

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -59,4 +59,3 @@ clear-all-text=Clear all text
 message-successfully-sent=Message successfuly sent
 ussd-server-error=There was an error in the communication, please try it again later
 lineContactName={{ name }}... or {{ n }} other
-confirmation=Confirmation


### PR DESCRIPTION
Minimal change. The UX team prefer not to have any title in the dialog shown when the user is asked if she really wants to delete all the entries in the Call Log.
