### PR TITLE
Bug 810031 - Remove ActiveSync autoconfig mapping for Gmail

### DIFF
--- a/apps/email/autoconfig/gmail.com
+++ b/apps/email/autoconfig/gmail.com
@@ -8,9 +8,6 @@
     <domain>jazztel.es</domain>
     <displayName>Google Mail</displayName>
     <displayShortName>GMail</displayShortName>
-    <incomingServer type="activesync">
-      <server>https://m.google.com</server>
-    </incomingServer>
     <incomingServer type="imap">
       <hostname>imap.googlemail.com</hostname>
       <port>993</port>

--- a/apps/email/autoconfig/google.com
+++ b/apps/email/autoconfig/google.com
@@ -8,9 +8,6 @@
     <domain>jazztel.es</domain>
     <displayName>Google Mail</displayName>
     <displayShortName>GMail</displayShortName>
-    <incomingServer type="activesync">
-      <server>https://m.google.com</server>
-    </incomingServer>
     <incomingServer type="imap">
       <hostname>imap.googlemail.com</hostname>
       <port>993</port>

--- a/apps/email/autoconfig/googlemail.com
+++ b/apps/email/autoconfig/googlemail.com
@@ -8,9 +8,6 @@
     <domain>jazztel.es</domain>
     <displayName>Google Mail</displayName>
     <displayShortName>GMail</displayShortName>
-    <incomingServer type="activesync">
-      <server>https://m.google.com</server>
-    </incomingServer>
     <incomingServer type="imap">
       <hostname>imap.googlemail.com</hostname>
       <port>993</port>


### PR DESCRIPTION
r? @asutherland: this patch is pretty simple. I've confirmed that I can set up my Gmail account as an IMAP account with this change. We may want to look into how to turn on IMAP support before we fix the bug. Likewise for detecting two-factor auth, to give people hints about why their password failed.

https://bugzilla.mozilla.org/show_bug.cgi?id=810031
