### PR TITLE
bug 803378, bug 808803: Rework layout for conflicts and partial-hour events

### DIFF
--- a/apps/calendar/js/views/day_based.js
+++ b/apps/calendar/js/views/day_based.js
@@ -297,6 +297,12 @@ Calendar.ns('Views').DayBased = (function() {
       var hoursDuration = (endHour - startHour) +
                           ((endMin - startMin) / MINUTES_IN_HOUR);
 
+      // If this event is less than a full hour, tweak the classname so that
+      // some alternate styles for a tiny event can apply (eg. hide details)
+      if (hoursDuration < 1) {
+        element.className += ' partial-hour';
+      }
+
       return this._assignHeight(element, hoursDuration);
     },
 

--- a/apps/calendar/style/day_views.css
+++ b/apps/calendar/style/day_views.css
@@ -47,7 +47,7 @@
 }
 
 .day-events .event {
-  position: relative;
+  position: absolute;
   height: 6rem;
   top: 0;
   z-index: 10;
@@ -79,12 +79,10 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  position: absolute;
 }
 
 .day-events .event .details {
   width: calc(100% - 1rem - 6px);
-  position: absolute;
   min-height: 2rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -96,27 +94,15 @@
   top: 3rem;
 }
 
+.day-events .event.partial-hour .details {
+  display: none;
+}
+
 .attendee {
   padding-right: 0.3rem;
 }
 
-/* overlap & conflicts */
-
-.event[data-conflicts] {
-  float: left;
-}
-
-/** generic conflict stuff / overlap */
-.event[data-conflicts="1"] { width: 50%; }
-.event[data-conflicts="2"] { width: 33.3%; }
-.event[data-conflicts="3"] { width: 25%; }
-.event[data-conflicts="4"] { width: 20%; }
-.event[data-conflicts="5"] { width: 16.66%; }
-.event[data-conflicts="6"] { width: 14.285%; }
-.event[data-conflicts="7"] { width: 12.5%; }
-.event[data-conflicts="8"] { width: 11.111%; }
-.event[data-conflicts="9"] { width: 10%; }
-.event[data-conflicts="10"] { width: 9.09%; }
+/* overlap */
 
 .event[data-overlaps="1"] { padding-left: 6px; z-index: 11; }
 .event[data-overlaps="2"] { padding-left: 12px; z-index: 12; }

--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -101,6 +101,7 @@
   margin: 1px;
   height: 6rem;
   width: 7rem;
+  position: relative;
 }
 
 #week-view .week-events > ol {
@@ -109,6 +110,11 @@
 
 #week-view .days-3 .week-events > ol {
   width: 9.5rem;
+}
+
+#week-view .week-events > ol li.event {
+  position: absolute;
+  width: 100%;
 }
 
 #week-view .week-events .container {

--- a/apps/calendar/test/unit/views/day_based_test.js
+++ b/apps/calendar/test/unit/views/day_based_test.js
@@ -249,6 +249,7 @@ suite('views/day_based', function() {
 
       assert.equal(el.style.top, '83.3333%', 'top');
       assert.equal(el.style.height, '50%', 'height');
+      assert.match(el.className, /\bpartial-hour\b/, 'partial-hour found');
     });
 
     test('top of hour 1.5 hours', function() {


### PR DESCRIPTION
Okay, let's see if this works. ATTN: @lightsofapollo & @mmccollow
- Location on events spanning less than an hour is hidden in the day view, because there's no room in the UI (was #6293)
- Calculation of both width and left position of conflicting event is now done in JS
  - A set of conflict IDs is maintained for affected events, as events are added and removed from the overlap manager
  - Event element width is 100% / number of conflicts
  - Event element left position is derived by sorting the conflict IDs, finding the index of an event in that sorted list, and then multiplying that by the width. This ensures a unique position for each conflicting event

I couldn't quite make this work with just CSS - floats and absolute positioning don't work together, and flexbox doesn't seem to help with things that overlap. In the end, it just seemed cleaner to slap absolute positioning on everything and control size & positioning programmatically in JS.

The per-event conflict IDs list also seems redundant, but it was the simplest thing I could come up with to derive a unique position for each event in a conflict. Could probably invent some kind of Conflict class to abstract things further, but I suspect that would accumulate a pile of additional code.
