### PR TITLE
Bug 807846 - punctuation alternatives

### DIFF
--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -5,8 +5,10 @@
 const Keyboards = {
   alternateLayout: {
     alt: {
-        '0': 'º',
-        '$': '€ £ ¥ R$'
+      '0': 'º',
+      '$': '€ £ ¥ R$',
+      '?': '¿',
+      '!': '¡'
     },
     keys: [
       [
@@ -103,7 +105,8 @@ const Keyboards = {
       l: 'ł£',
       y: 'ÿ¥',
       z: 'žźż',
-      r: 'R$ '
+      r: 'R$ ',
+      '.': ',?!;:'
     },
     keys: [
       [
@@ -129,6 +132,247 @@ const Keyboards = {
     },
     emailOverrides: {
       "'": '_'
+    },
+    alternateLayout: {
+      alt: {
+        '0': 'º',
+        '1': '1st ',
+        '2': '2nd ',
+        '3': '3rd ',
+        '4': '4th ',
+        '5': '5th ',
+        '6': '6th ',
+        '7': '7th ',
+        '8': '8th ',
+        '9': '9th ',
+        '$': '€ £ ¥ R$',
+        '?': '¿',
+        '!': '¡'
+      },
+      keys: [
+        [
+          { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
+          { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
+          { value: '9' }, { value: '0' }
+        ], [
+          { value: '@' }, { value: '#' }, { value: '$' }, { value: '%' },
+          { value: '&' } , { value: '*' }, { value: '-' }, { value: '+' },
+          { value: '(' }, { value: ')' }
+        ], [
+          { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+          { value: '!' }, { value: '\"' }, { value: "'" }, { value: ':' },
+          { value: ';' }, { value: '/' }, { value: '?' },
+          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+        ], [
+          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+        ]
+      ]
+    }
+  },
+  es: {
+    type: 'keyboard',
+    label: 'Spanish',
+    menuLabel: 'Español',
+    alt: {
+      a: 'áªàâäåãāæ',
+      c: 'ç',
+      e: 'é€èêëēęɛ',
+      i: 'íïìîīį',
+      o: 'óºöòôōœøɵ',
+      u: 'üúùûū',
+      s: '$ßš',
+      l: '£',
+      n: 'ń',
+      y: '¥',
+      r: 'R$ ',
+      '.': ',¿?¡!;:',
+      ':)': ':) :D :( ;D :* :/'
+//      '.com': '.es .org .eu' XXX: commented to avoid overflows for the demo
+    },
+    keys: [
+      [
+        { value: 'q' }, { value: 'w' }, { value: 'e' } , { value: 'r' },
+        { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
+        { value: 'o' }, { value: 'p' }
+      ], [
+        { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
+        { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
+        { value: 'l' }, { value: 'ñ' }
+      ], [
+        { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+        { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
+        { value: 'b' }, { value: 'n' }, { value: 'm' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+//        { value: ':)', compositeKey:':)', ratio: 2 },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ],
+    urlOverrides: {
+      'ñ': ':'
+    },
+    emailOverrides: {
+      'ñ': '_'
+    },
+    alternateLayout: {
+      alt: {
+        '€': '$ £ ¥ R$',
+        '0': 'º',
+        '1': '1º 1ª',
+        '2': '2º 2ª',
+        '3': '3º 3ª',
+        '4': '4º 4ª',
+        '5': '5º 5ª',
+        '6': '6º 6ª',
+        '7': '7º 7ª',
+        '8': '8º 8ª',
+        '9': '9º 9ª'
+      },
+      keys: [
+        [
+          { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
+          { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
+          { value: '9' }, { value: '0' }
+        ], [
+          { value: '-' }, { value: '/' }, { value: ':' }, { value: ';' },
+          { value: '(' } , { value: ')' }, { value: '€' }, { value: '&' },
+          { value: '@' }, { value: '%' }
+        ], [
+          { value: '#+=', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+          { value: '¿' }, { value: '?' }, { value: '¡' }, { value: '!' },
+          { value: '\"' }, { value: '\'' }, { value: '*' },
+          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+        ], [
+          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+        ]
+      ]
+    },
+    symbolLayout: {
+      keys: [
+        [
+          { value: '[' }, { value: ']' }, { value: '{' }, { value: '}' },
+          { value: '#' }, { value: '%' }, { value: '^' }, { value: '+' },
+          { value: '=' }, { value: '°' }
+        ], [
+          { value: '_' }, { value: '\\' }, { value: '|' }, { value: '~' },
+          { value: '<' }, { value: '>' }, { value: '$' }, { value: '£' },
+          { value: '¥' }, { value: '•' }
+        ], [
+          { value: '123', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+          { value: '¿' }, { value: '?' }, { value: '¡' }, { value: '!' },
+          { value: '\"' }, { value: '\'' }, {value: '*' },
+          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+        ], [
+          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+        ]
+      ]
+    }
+  },
+  pt_BR: {
+    type: 'keyboard',
+    label: 'Portuguese',
+    menuLabel: 'Português',
+    imEngine: 'latin',
+    needsCandidatePanel: 'true',
+    alt: {
+      a: 'áãàâäåæª',
+      e: 'éêèęėēëɛ',
+      i: 'íîìïįī',
+      o: 'óõôòöœøōɵ',
+      u: 'úüùûū',
+      s: '$ßš',
+      l: '£',
+      n: 'ñń',
+      y: '¥ÿ',
+      r: 'R$ ',
+      '.': ',?!;:'
+    },
+    keys: [
+      [
+        { value: 'q' }, { value: 'w' }, { value: 'e' } , { value: 'r' },
+        { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
+        { value: 'o' }, { value: 'p' }
+      ], [
+        { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
+        { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
+        { value: 'l' }, { value: 'ç' }
+      ], [
+        { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+        { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
+        { value: 'b' }, { value: 'n' }, { value: 'm' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ],
+    urlOverrides: {
+      'ç': ':'
+    },
+    emailOverrides: {
+      'ç': '_'
+    },
+    alternateLayout: {
+      alt: {
+        'R$': '€$£¥',
+        '0': 'º',
+        '1': '1º 1ª',
+        '2': '2º 2ª',
+        '3': '3º 3ª',
+        '4': '4º 4ª',
+        '5': '5º 5ª',
+        '6': '6º 6ª',
+        '7': '7º 7ª',
+        '8': '8º 8ª',
+        '9': '9º 9ª',
+        '?': '¿',
+        '!': '¡'
+      },
+      keys: [
+        [
+          { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
+          { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
+          { value: '9' }, { value: '0' }
+        ], [
+          { value: '-' }, { value: '/' }, { value: ':' }, { value: ';' },
+          { value: '(' } , { value: ')' },
+          { value: 'R$', compositeKey: 'R$' }, { value: '&' }, { value: '@' },
+          { value: '%' }
+        ], [
+          { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+          { value: '?' }, {value: '!' }, { value: '«' }, { value: '»' },
+          { value: '\"' }, { value: '\'' }, { value: '*' },
+          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+        ], [
+          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+        ]
+      ]
+    },
+    symbolLayout: {
+      keys: [
+        [
+          { value: '[' }, { value: ']' }, { value: '{' }, { value: '}' },
+          { value: '#' }, { value: '%' }, { value: '^' }, { value: '+' },
+          { value: '=' }, { value: '°' }
+        ], [
+          { value: '_' }, { value: '\\' }, { value: '|' }, { value: '~' },
+          { value: '<' }, { value: '>' }, { value: '€' }, { value: '$' },
+          { value: '£' }, { value: '•' }
+        ], [
+          { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+          { value: '?' }, {value: '!' }, { value: '«' }, { value: '»' },
+          { value: '\"' }, { value: '\'' }, { value: '*' },
+          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+        ], [
+          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+        ]
+      ]
     }
   },
   cz: {
@@ -782,208 +1026,6 @@ const Keyboards = {
         { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
       ]
     ]
-  },
-  es: {
-    type: 'keyboard',
-    label: 'Spanish',
-    menuLabel: 'Español',
-    alt: {
-      a: 'áªàâäåãāæ',
-      c: 'ç',
-      e: 'é€èêëēęɛ',
-      i: 'íïìîīį',
-      o: 'óºöòôōœøɵ',
-      u: 'üúùûū',
-      s: '$ßš',
-      l: '£',
-      n: 'ń',
-      y: '¥',
-      r: 'R$ ',
-      '.': ',¿?¡!;:',
-      ':)': ':) :D :( ;D :* :/'
-//      '.com': '.es .org .eu' XXX: commented to avoid overflows for the demo
-    },
-    keys: [
-      [
-        { value: 'q' }, { value: 'w' }, { value: 'e' } , { value: 'r' },
-        { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
-        { value: 'o' }, { value: 'p' }
-      ], [
-        { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
-        { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
-        { value: 'l' }, { value: 'ñ' }
-      ], [
-        { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
-        { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
-        { value: 'b' }, { value: 'n' }, { value: 'm' },
-        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-      ], [
-        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-//        { value: ':)', compositeKey:':)', ratio: 2 },
-        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-      ]
-    ],
-    urlOverrides: {
-      'ñ': ':'
-    },
-    emailOverrides: {
-      'ñ': '_'
-    },
-    alternateLayout: {
-      alt: {
-        '€': '$ £ ¥ R$',
-        '0': 'º',
-        '1': '1º 1ª',
-        '2': '2º 2ª',
-        '3': '3º 3ª',
-        '4': '4º 4ª',
-        '5': '5º 5ª',
-        '6': '6º 6ª',
-        '7': '7º 7ª',
-        '8': '8º 8ª',
-        '9': '9º 9ª'
-      },
-      keys: [
-        [
-          { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
-          { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
-          { value: '9' }, { value: '0' }
-        ], [
-          { value: '-' }, { value: '/' }, { value: ':' }, { value: ';' },
-          { value: '(' } , { value: ')' }, { value: '€' }, { value: '&' },
-          { value: '@' }, { value: '%' }
-        ], [
-          { value: '#+=', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
-          { value: '¿' }, { value: '?' }, { value: '¡' }, { value: '!' },
-          { value: '\"' }, { value: '\'' }, { value: '*' },
-          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-        ], [
-          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-        ]
-      ]
-    },
-    symbolLayout: {
-      keys: [
-        [
-          { value: '[' }, { value: ']' }, { value: '{' }, { value: '}' },
-          { value: '#' }, { value: '%' }, { value: '^' }, { value: '+' },
-          { value: '=' }, { value: '°' }
-        ], [
-          { value: '_' }, { value: '\\' }, { value: '|' }, { value: '~' },
-          { value: '<' }, { value: '>' }, { value: '$' }, { value: '£' },
-          { value: '¥' }, { value: '•' }
-        ], [
-          { value: '123', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
-          { value: '¿' }, { value: '?' }, { value: '¡' }, { value: '!' },
-          { value: '\"' }, { value: '\'' }, {value: '*' },
-          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-        ], [
-          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-        ]
-      ]
-    }
-  },
-  pt_BR: {
-    type: 'keyboard',
-    label: 'Portuguese',
-    menuLabel: 'Português',
-    imEngine: 'latin',
-    needsCandidatePanel: 'true',
-    alt: {
-      a: 'áãàâäåæª',
-      e: 'éêèęėēëɛ',
-      i: 'íîìïįī',
-      o: 'óõôòöœøōɵ',
-      u: 'úüùûū',
-      s: '$ßš',
-      l: '£',
-      n: 'ñń',
-      y: '¥ÿ',
-      r: 'R$ '
-    },
-    keys: [
-      [
-        { value: 'q' }, { value: 'w' }, { value: 'e' } , { value: 'r' },
-        { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
-        { value: 'o' }, { value: 'p' }
-      ], [
-        { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
-        { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
-        { value: 'l' }, { value: 'ç' }
-      ], [
-        { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
-        { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
-        { value: 'b' }, { value: 'n' }, { value: 'm' },
-        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-      ], [
-        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-      ]
-    ],
-    urlOverrides: {
-      'ç': ':'
-    },
-    emailOverrides: {
-      'ç': '_'
-    },
-    alternateLayout: {
-      alt: {
-        'R$': '€$£¥',
-        '0': 'º',
-        '1': '1º 1ª',
-        '2': '2º 2ª',
-        '3': '3º 3ª',
-        '4': '4º 4ª',
-        '5': '5º 5ª',
-        '6': '6º 6ª',
-        '7': '7º 7ª',
-        '8': '8º 8ª',
-        '9': '9º 9ª'
-      },
-      keys: [
-        [
-          { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
-          { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
-          { value: '9' }, { value: '0' }
-        ], [
-          { value: '-' }, { value: '/' }, { value: ':' }, { value: ';' },
-          { value: '(' } , { value: ')' },
-          { value: 'R$', compositeKey: 'R$' }, { value: '&' }, { value: '@' },
-          { value: '%' }
-        ], [
-          { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
-          { value: '?' }, {value: '!' }, { value: '«' }, { value: '»' },
-          { value: '\"' }, { value: '\'' }, { value: '*' },
-          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-        ], [
-          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-        ]
-      ]
-    },
-    symbolLayout: {
-      keys: [
-        [
-          { value: '[' }, { value: ']' }, { value: '{' }, { value: '}' },
-          { value: '#' }, { value: '%' }, { value: '^' }, { value: '+' },
-          { value: '=' }, { value: '°' }
-        ], [
-          { value: '_' }, { value: '\\' }, { value: '|' }, { value: '~' },
-          { value: '<' }, { value: '>' }, { value: '€' }, { value: '$' },
-          { value: '£' }, { value: '•' }
-        ], [
-          { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
-          { value: '?' }, {value: '!' }, { value: '«' }, { value: '»' },
-          { value: '\"' }, { value: '\'' }, { value: '*' },
-          { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-        ], [
-          { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-          { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-        ]
-      ]
-    }
   },
   'jp-kanji': {
     label: 'Japanese - Kanji',

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -306,45 +306,43 @@ const IMERender = (function() {
     menu.style.display = 'block';
   };
 
-  // Show char alternatives. The first element of altChars is ALWAYS the
-  // original char.
+  // Show char alternatives.
   var showAlternativesCharMenu = function(key, altChars) {
     var content = '';
 
-    var original = altChars[0];
-    altChars = altChars.slice(1);
-
-    var altCharsCurrent = [];
     var left = (window.innerWidth / 2 > key.offsetLeft);
 
-    // Place the menu to the left and adds the original key at the end
+    // Place the menu to the left
     if (left) {
       this.menu.classList.add('kbr-menu-left');
-      altCharsCurrent.push(original);
-      altCharsCurrent = altCharsCurrent.concat(altChars);
-
-    // Place menu on the right and adds the original key at the beginning
+    // Place menu on the right and reverse key order
     } else {
       this.menu.classList.add('kbr-menu-right');
-      altCharsCurrent = altChars.reverse();
-      altCharsCurrent.push(original);
+      altChars = altChars.reverse();
     }
 
+    // How wide (in characters) is the key that we're displaying
+    // these alternatives for?
+    var keycharwidth = key.dataset.compositeKey ?
+      key.dataset.compositeKey.length :
+      1;
+
     // Build a key for each alternative
-    altCharsCurrent.forEach(function(keyChar) {
-      var keyCode = keyChar.keyCode || keyChar.charCodeAt(0);
-      var dataset = [{'key': 'keycode', 'value': keyCode}];
-      var label = keyChar.label || keyChar;
+    altChars.forEach(function(alt) {
+      var dataset = alt.length == 1 ?
+        [{'key': 'keycode', 'value': alt.charCodeAt(0)}] :
+        [{'key': 'compositekey', 'value': alt}];
 
-      var cssWidth = key.offsetWidth;
-      if (altCharsCurrent.length != 1) {
-        cssWidth = key.offsetWidth *
-                   (0.9 + 0.5 * (label.length - original.length));
-      }
+      // Make each of these alternative keys 75% as wide as the key that
+      // it is an alternative for, but adjust for the relative number of
+      // characters in the original and the alternative
+      var width = 0.75 * key.offsetWidth / keycharwidth * alt.length;
+      // If there is only one alternative, then display it at least as
+      // wide as the original key.
+      if (altChars.length === 1)
+        width = Math.max(width, key.offsetWidth);
 
-      if (label.length > 1)
-        dataset.push({'key': 'compositekey', 'value': label});
-      content += buildKey(label, '', cssWidth + 'px', dataset);
+      content += buildKey(alt, '', width + 'px', dataset);
     });
     this.menu.innerHTML = content;
 


### PR DESCRIPTION
This PR patches the keyboard to add alternative punctuation characters to the . key of the english and portuguese keyboards, per https://docs.google.com/spreadsheet/ccc?key=0Aho3t5kX1TtRdFFOS25rZFNXcncxZm9LRUtzaDlKLVE#gid=0 and the discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=807846

It also adds 1st, 2nd, 3rd, etc. to the english keyboard numbers, also according to the spreadsheet above. In order to ensure that these only appear in the english keyboard and not all layouts that inherit the default, it gives the english keyboard its own alt layout.

This PR moves the portuguese and spanish keyboard layouts from the bottom of layout.js to the top, since they are two of our most important targets for v1.

Finally, there were bugs in render.js that made wide alternatives like "1st" and "R$" appear in menus that were too narrow, so this patch rewrites showAlternativesCharMenu)_.  Part of the problem was the no-longer valid assumption that the first alternative passed in was the original key that the user pressed on.
