### PR TITLE
Bug 809979 - [email/IMAP] syncFolderList will duplicate folders. r=squib, a=blocking-basecamp.

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -29741,7 +29741,8 @@ ImapAccount.prototype = {
     }
 
     // - build a map of known existing folders
-    var folderPubsByPath = {}, folderPub;
+    const folderPubsByPath = {};
+    var folderPub;
     for (var iFolder = 0; iFolder < this.folders.length; iFolder++) {
       folderPub = this.folders[iFolder];
       folderPubsByPath[folderPub.path] = folderPub;
@@ -29762,7 +29763,7 @@ ImapAccount.prototype = {
             meta.delim = box.delim;
 
           // mark it with true to show that we've seen it.
-          folderPubsByPath = true;
+          folderPubsByPath[path] = true;
         }
         // - new to us!
         else {
@@ -31006,8 +31007,9 @@ ActiveSyncFolderConn.prototype = {
       e.run(aResponse);
 
       if (folderConn.syncKey === '0') {
-        // XXX we should re-sync the entire folder list from scratch and compute
-        // the deltas.
+        // We should never actually hit this, since it would mean that the
+        // server is refusing to give us a sync key. On the off chance that we
+        // do hit it, just bail.
         console.error('Unable to get sync key for folder');
         callback('unknown');
       }


### PR DESCRIPTION
land the changes from https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/77

https://bugzilla.mozilla.org/show_bug.cgi?id=809979
