### PR TITLE
Bug 799723, 799715 - [email] Automatically linkify URLs and e-mail addresses in plaintext and HTML e-mails. r=asuth, a=blocking-basecamp

### DIFF
--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -1012,7 +1012,9 @@ MessageReaderCard.prototype = {
     }
   },
 
-  onHyperlinkClick: function() {
+  onHyperlinkClick: function(event, linkNode, linkUrl, linkText) {
+    if(confirm(mozL10n.get('browse-to-url-prompt', { url: linkUrl })))
+      window.open(linkUrl, '_blank');
   },
 
   _populatePlaintextBodyNode: function(bodyNode, rep) {
@@ -1032,7 +1034,11 @@ MessageReaderCard.prototype = {
       }
       if (cname)
         node.setAttribute('class', cname);
-      node.textContent = rep[i + 1];
+
+      var subnodes = MailAPI.utils.linkifyPlain(rep[i + 1], document);
+      for(var i in subnodes)
+        node.appendChild(subnodes[i]);
+
       bodyNode.appendChild(node);
     }
   },
@@ -1084,6 +1090,10 @@ MessageReaderCard.prototype = {
         hasExternalImages = false,
         showEmbeddedImages = body.embeddedImageCount &&
                              body.embeddedImagesDownloaded;
+
+    bindSanitizedClickHandler(rootBodyNode, this.onHyperlinkClick.bind(this),
+                              rootBodyNode);
+
     for (var iRep = 0; iRep < reps.length; iRep += 2) {
       var repType = reps[iRep], rep = reps[iRep + 1];
       if (repType === 'plain') {
@@ -1094,6 +1104,7 @@ MessageReaderCard.prototype = {
           rep, rootBodyNode, null,
           'interactive', this.onHyperlinkClick.bind(this));
         var bodyNode = iframe.contentDocument.body;
+        MailAPI.utils.linkifyHTML(iframe.contentDocument);
         this.htmlBodyNodes.push(bodyNode);
         if (body.checkForExternalImages(bodyNode))
           hasExternalImages = true;

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -136,6 +136,8 @@ message-multiedit-header[few]   = {{ n }} selected
 message-multiedit-header[many]  = {{ n }} selected
 message-multiedit-header[other] = {{ n }} selected
 
+browse-to-url-prompt = Browse to URL?: {{ url }}
+
 message-download-images={[ plural(n) ]}
 message-download-images[one]   = This email contains one image. Click to download.
 message-download-images[two]   = This email contains {{ n }} images. Click to download.

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -283,6 +283,11 @@
   right: 0rem;
 }
 
+.moz-external-link {
+  color: blue;
+  cursor: pointer;
+}
+
 .msg-body-content {
   color: black;
   margin: 4px 0px;


### PR DESCRIPTION
Land changes from https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/79 with minor UI hookup scaffolding.
