### PR TITLE
Bug 809608 - Tracking data usage in a more accurate way

### DIFF
--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -100,6 +100,7 @@ function setupApp() {
 
   // Initializes the cost control module: basic parameters, automatic and manual
   // updates.
+  var _initialized = false;
   function _init() {
     var status = Service.getServiceStatus();
     if (status.fte) {
@@ -131,12 +132,6 @@ function setupApp() {
     // Keep the left tab synchronized with the plantype
     Service.settings.observe('plantype', _setLeftTab);
 
-    // Update UI when localized
-    window.addEventListener('localized', function ccapp_onLocalized() {
-      for (var viewid in Views) if (Views.hasOwnProperty(viewid))
-        Views[viewid].localize();
-    });
-
     // Adapt tab visibility according to available functionality
     if (!status.enabledFunctionalities.balance &&
         !status.enabledFunctionalities.telephony) {
@@ -150,7 +145,17 @@ function setupApp() {
       viewManager.changeViewTo(TAB_DATA_USAGE);
       dataUsageTab.classList.add('standalone');
     }
+
+    _initialized = true;
   }
 
-  _init();
+  // Update UI when localized
+  window.addEventListener('localized', function ccapp_onLocalized() {
+    if (!_initialized)
+      _init();
+
+    for (var viewid in Views) if (Views.hasOwnProperty(viewid))
+      Views[viewid].localize();
+  });
+
 }

--- a/apps/costcontrol/js/service/cost_control_service.js
+++ b/apps/costcontrol/js/service/cost_control_service.js
@@ -14,7 +14,7 @@ setService(function cc_setupCostControlService() {
   var WAITING_TIMEOUT = 5 * 60 * 1000; // 5 minutes
   var REQUEST_BALANCE_UPDATE_INTERVAL = 1 * 60 * 60 * 1000; // 1 hour
   var REQUEST_BALANCE_MAX_DELAY = 2 * 60 * 1000; // 2 minutes
-  var REQUEST_DATA_USAGE_UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
+  var REQUEST_DATA_USAGE_UPDATE_INTERVAL = 2 * 60 * 1000; // 2 minutes
   var REQUEST_DATA_USAGE_MAX_DELAY = 1 * 60 * 1000; // 1 minute
 
   // Data usage limits
@@ -397,7 +397,8 @@ setService(function cc_setupCostControlService() {
 
     // Recalculate with month period
     if (trackingPeriod === TRACKING_MONTHLY) {
-      var month, year, monthday = parseInt(_appSettings.option('reset_time'));
+      var month, year;
+      var monthday = parseInt(_appSettings.option('reset_time'), 10);
       month = today.getMonth();
       year = today.getFullYear();
       if (today.getDate() >= monthday) {
@@ -410,7 +411,7 @@ setService(function cc_setupCostControlService() {
     // Recalculate with week period
     } else if (trackingPeriod === TRACKING_WEEKLY) {
       var oneDay = 24 * 60 * 60 * 1000;
-      var weekday = parseInt(_appSettings.option('reset_time'));
+      var weekday = parseInt(_appSettings.option('reset_time'), 10);
       var daysToTarget = weekday - today.getDay();
       if (daysToTarget <= 0)
         daysToTarget = 7 + daysToTarget;

--- a/apps/costcontrol/js/utils/formatting.js
+++ b/apps/costcontrol/js/utils/formatting.js
@@ -42,36 +42,34 @@ function formatData(dataArray) {
 }
 
 // Return a fixed point data value in MG/GB
-function roundData(value) {
-  if (value < 1000000000)
-    return [(value / 1000000).toFixed(2), 'MB'];
+function roundData(value, positions) {
+  positions = (typeof positions === 'undefined') ? 2 : positions;
+  if (value < 1000)
+    return [value.toFixed(positions), 'B'];
 
-  return [(value / 1000000000).toFixed(2), 'GB'];
+  if (value < 1000000)
+    return [(value / 1000).toFixed(positions), 'KB'];
+
+  if (value < 1000000000)
+    return [(value / 1000000).toFixed(positions), 'MB'];
+
+  return [(value / 1000000000).toFixed(positions), 'GB'];
 }
 
 // Return a padded data value in MG/GB
 function padData(value) {
-  if (value === 0)
-    return ['0', 'MB'];
-
-  value = value / 1000000;
-
-  var unit = 'GB';
-  if (value < 1000) {
-    var floorValue = value < 10 ? Math.floor(value) :
-                                  Math.floor(10 * value) / 10;
-    unit = 'MB';
-    var str = floorValue.toFixed() + '';
-    switch (str.length + 1 + unit.length) {
-      case 2:
-        return ['00' + str, unit];
-      case 3:
-        return ['0' + str, unit];
-      default:
-        return [str, unit];
-    }
+  var rounded = roundData(value, 0);
+  var value = rounded[0];
+  var len = value.length;
+  switch (len) {
+    case 1:
+      value = '00' + value;
+      break;
+    case 2:
+      value = '0' + value;
+      break;
   }
-
-  return [(value / 1000).toFixed(1), unit];
+  rounded[0] = parseInt(value, 10) ? value : '0';
+  return rounded;
 }
 

--- a/apps/costcontrol/js/views/data_usage.js
+++ b/apps/costcontrol/js/views/data_usage.js
@@ -61,7 +61,8 @@ viewManager.tabs[TAB_DATA_USAGE] = (function cc_setUpDataUsage() {
     });
   }
 
-  // Show the dialog for setting data limit (this reuses the )
+  // Show the dialog for setting data limit
+  // (this reuses the dialog from settings)
   function _showSetDataLimit() {
     var settingsWindow = document.getElementById('settings-view').contentWindow;
     var dialog = settingsWindow.document.getElementById('data-limit-dialog');
@@ -233,10 +234,6 @@ viewManager.tabs[TAB_DATA_USAGE] = (function cc_setUpDataUsage() {
         }
       );
 
-      debug('Installing observers 1');
-      // XXX: here is a trick. In settings, when unit is changed, the
-      // option data_limit_value is "touched" so it suffices to observe
-      // data_limit_value to be aware about both changes in value or unit
       Service.settings.observe('data_limit_value',
         function ccapp_onDataLimitValueChanged(value) {
           _model.limits.value = Service.dataLimitInBytes;
@@ -245,7 +242,6 @@ viewManager.tabs[TAB_DATA_USAGE] = (function cc_setUpDataUsage() {
         }
       );
 
-      debug('Installing observers 2');
       // X axis
       Service.settings.observe('lastdatareset',
         function ccapp_onLastResetValueChanged(value) {
@@ -256,7 +252,6 @@ viewManager.tabs[TAB_DATA_USAGE] = (function cc_setUpDataUsage() {
         }
       );
 
-      debug('Installing observers 3');
       Service.settings.observe('next_reset',
         function ccapp_onNextResetChanged(value) {
           _model.axis.X.upper = value ? new Date(value) :

--- a/apps/costcontrol/js/views/limit_dialog.js
+++ b/apps/costcontrol/js/views/limit_dialog.js
@@ -13,7 +13,7 @@ function dataLimitConfigurer(guiWidget, settings, viewManager) {
   var dialog = document.getElementById('data-limit-dialog');
   var switchUnitButton = document.getElementById('switch-unit-button');
   var dataLimitInput = dialog.querySelector('input');
-  var format = function ccas_formatterDataUnit(value) {
+  var format = function ccal_formatterDataUnit(value) {
     var unit = settings.option('data_limit_unit');
     return formatData([value, unit]);
   };

--- a/apps/costcontrol/js/views/settings.js
+++ b/apps/costcontrol/js/views/settings.js
@@ -210,6 +210,7 @@ function setupSettings() {
   }
 
   // Configure each settings' control and paint the interface
+  var _initialized = false;
   function _init() {
     _configureUI();
 
@@ -222,8 +223,7 @@ function setupSettings() {
       parent.settingsVManager.closeCurrentView();
     });
 
-    // Localize interface
-    window.addEventListener('localized', _localize);
+    _initialized = true;
   }
 
   // Repaint settings interface reading from local settings and localizing
@@ -233,10 +233,15 @@ function setupSettings() {
   }
 
   // Updates the UI to match the localization
+  // First time the application runs, it also initializes the settings module
   function _localize() {
+    if (!_initialized)
+      _init();
+
     _updateUI();
   }
 
-  _init();
+  // Delay the initialization until `localized` event is triggered
+  window.addEventListener('localized', _localize);
 
 }

--- a/apps/costcontrol/js/widget.js
+++ b/apps/costcontrol/js/widget.js
@@ -118,11 +118,13 @@ function setupWidget() {
       }
     );
 
-    // ...when the utility tray shows.
-    window.addEventListener('message', function ccwidget_utilityTray(evt) {
-      if (evt.data.type === 'utilitytrayshow')
-        _updateDataUsageUI();
-    });
+    document.addEventListener('mozvisibilitychange',
+      function ccwidget_visibility(evt) {
+        if (!document.mozHidden)
+          Service.requestDataUsage();
+      }
+    );
+
   }
 
   // Attach event listeners for manual updates

--- a/apps/costcontrol/style/app.css
+++ b/apps/costcontrol/style/app.css
@@ -240,7 +240,7 @@ section.content .error-messages {
 .settings li > .end button {
   display: inline-block;
   vertical-align: middle;
-  width: 8.5rem;
+  width: 10.0rem;
   margin: 0;
   padding-left: 0.5rem;
 }

--- a/apps/system/js/cost_control.js
+++ b/apps/system/js/cost_control.js
@@ -11,12 +11,13 @@
 
   var widgetContainer = document.getElementById('cost-control-widget');
 
+  var widgetFrame;
   function _ensureWidget() {
 
     if (Applications.ready) {
 
       // Check widget is there
-      var widgetFrame = widgetContainer.querySelector('iframe');
+      widgetFrame = widgetContainer.querySelector('iframe');
       if (widgetFrame && !widgetFrame.dataset.killed)
         return;
 
@@ -50,7 +51,19 @@
     }
   }
 
+  function _showWidget() {
+    if (widgetFrame)
+      widgetFrame.setVisible(true);
+  }
+
+  function _hideWidget() {
+    if (widgetFrame)
+      widgetFrame.setVisible(false);
+  }
+
   // Listen to utilitytray show
   window.addEventListener('utilitytrayshow', _ensureWidget);
+  window.addEventListener('utilitytrayshow', _showWidget);
+  window.addEventListener('utilitytrayhide', _hideWidget);
   window.addEventListener('applicationready', _ensureWidget);
 }());


### PR DESCRIPTION
The change improves the way in which rounding is performed over data amounts increasing the scale to take in counts bytes and kilobytes.

Furthermore, it keeps the synchronization every two minutes and after showing the widget. The problem here is Gecko does not provide live values or system messages to keep this values up to date in real time so it is necessary  to poll the data. See [bug 810057](https://bugzilla.mozilla.org/show_bug.cgi?id=810057).
