### PR TITLE
set javascript.options.strict to false r=vingtetun

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -20,7 +20,7 @@ Gaia.webapps.forEach(function (webapp) {
 
 // Probably wont be needed when https://bugzilla.mozilla.org/show_bug.cgi?id=768440 lands
 prefs.push(["dom.send_after_paint_to_content", true]);
-
+prefs.push(["javascript.options.strict", false]);
 prefs.push(["network.http.max-connections-per-server", 15]);
 
 if (LOCAL_DOMAINS) {
@@ -34,7 +34,6 @@ if (DEBUG) {
   prefs.push(["javascript.options.showInConsole", true]);
   prefs.push(["nglayout.debug.disable_xul_cache", true]);
   prefs.push(["browser.dom.window.dump.enabled", true]);
-  prefs.push(["javascript.options.strict", true]);
   prefs.push(["dom.report_all_js_exceptions", true]);
   prefs.push(["nglayout.debug.disable_xul_fastload", true]);
   prefs.push(["extensions.autoDisableScopes", 0]);


### PR DESCRIPTION
I tried removing the line but it was still set to true in prefs after starting b2g (which means its always enabled even in non-debug mode).
