### PR TITLE
Bug 812123 - [Dialer] [UX Incomming call] The incoming and outgoing call should not show a generic avatar

### DIFF
--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -556,4 +556,11 @@ window.addEventListener('localized', function callSetup(evt) {
   CallScreen.init();
   CallScreen.syncSpeakerEnabled();
   OnCallHandler.setup();
+  if (navigator.mozSettings) {
+    var req = navigator.mozSettings.createLock().get('wallpaper.image');
+    req.onsuccess = function cs_wi_onsuccess() {
+      CallScreen.mainContainer.style.backgroundImage =
+        'url(' + req.result['wallpaper.image'] + ')';
+    };
+  }
 });

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -138,10 +138,7 @@ body.hidden *[data-l10n-id] {
 #main-container {
   position: relative;
   height: 100%;
-  background-image: url("images/Generic_image.png");
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center top;
+  background: rgba(0, 0, 0, 0.8) no-repeat center top/cover;
 }
 
 #actions-container {


### PR DESCRIPTION
UX states that instead of the "anonymous contact" image, the wallpaper should be shown in cases the number is associated to a contact with no image or to no contact at all.
