### PR TITLE
Remove duplicate link to confirm.css

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -26,7 +26,6 @@
     <link rel="stylesheet" type="text/css" href="shared/style/confirm.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>
-    <link rel="stylesheet" type="text/css" href="shared/style/confirm.css"/>
     <link rel="stylesheet" type="text/css" href="style/fake-notification.css"/>
 
     <!-- applications.js must not be deferred


### PR DESCRIPTION
This was accidentally added by https://github.com/mozilla-b2g/gaia/commit/253892155b6fe6627b3b70d6f728024a4abd14a9.
