### PR TITLE
[Bug 801938] Crash reports information page for "What's in a crash report?" and "Learn More" links

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1970,6 +1970,20 @@
       -->
     </section>
 
+    <!-- Device :: Improve Firefox OS :: Crash Reports-->
+    <section role="region" hidden id="crashReports">
+      <!--
+      <header>
+        <a href="#improveFirefoxOS"><span class="icon icon-back">back</span></a>
+        <h1 data-l10n-id="crashReports"> Crash Reports </h1>
+      </header>
+
+      <ul>
+        <li class="description" data-l10n-id="crashReportsDescription"></li>
+      </ul>
+      -->
+    </section>
+
     <!-- Device :: Improve Firefox OS -->
     <section role="region" hidden id="improveFirefoxOS">
       <!--
@@ -2010,7 +2024,7 @@
               Sending Mozilla a report when a crash occurs helps us fix the problem
               for everyone. Reports are sent over Wi-Fi only.
             </span>
-            <a href="https://www.mozilla.org/" data-l10n-id="learn-more" class="link-text">Learn More</a>
+            <a href="#crashReports" data-l10n-id="learn-more" class="link-text">Learn More</a>
           </label>
         </li>
         <li>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -473,6 +473,11 @@ alwaysSendReport=Always send a report
 neverSendReport=Never send a report
 askToSendReport=Ask me when a crash occurs
 
+# Device :: Improve Firefox OS :: Crash Reports
+# Localization note: This string is also included in system/locales/system.properties
+# FIXME: Update this string in bug 813128
+crashReportsDescription=Crash reports description goes here
+
 # Device :: Help
 online-support=Online support:
 online-support-link=www.telefonica.com

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -398,21 +398,34 @@
         </div>
 
         <!-- Crash reporter -->
-        <form id="crash-dialog" role="dialog" data-type="confirm">
-          <section>
-            <h1 id="crash-dialog-title"></h1>
-            <p data-l10n-id="crash-dialog-message">Would you like to send Mozilla a report about the crash to help us fix the problem? (Reports are sent over Wi-Fi only)</p>
-            <p><a id="crash-info-link" data-l10n-id="crash-info-link">What's in a crash report?</a></p>
-            <p>
-              <input id="always-send" type="checkbox" checked="true"/>
-              <label for="always-send" data-l10n-id="crash-always-report">Always send Mozilla a report when a crash occurs.</label>
-            <p>
+        <div id="crash-dialog">
+          <form role="dialog" data-type="confirm">
+            <section id="crash-dialog-contents">
+              <h1 id="crash-dialog-title"></h1>
+              <p data-l10n-id="crash-dialog-message">Would you like to send Mozilla a report about the crash to help us fix the problem? (Reports are sent over Wi-Fi only)</p>
+              <p><a id="crash-info-link" data-l10n-id="crash-info-link">What's in a crash report?</a></p>
+              <p>
+                <input id="always-send" type="checkbox" checked="true"/>
+                <label for="always-send" data-l10n-id="crash-always-report">Always send Mozilla a report when a crash occurs.</label>
+              <p>
+            </section>
+            <menu>
+              <button id="dont-send-report" disabled="true" data-l10n-id="crash-dont-send">Don't Send</button>
+              <button id="send-report" class="recommend" data-l10n-id="crash-send">Send Report</button>
+            </menu>
+          </form>
+
+          <!-- "Crash Reports" information page -->
+          <section role="region" class="skin-dark">
+            <header>
+              <menu type="toolbar">
+                <button id="crash-reports-done" data-l10n-id="done">Done</button>
+              </menu>
+              <h1 data-l10n-id="crashReports">Crash Reports</h1>
+            </header>
+            <p data-l10n-id="crashReportsDescription"></p>
           </section>
-          <menu>
-            <button id="dont-send-report" disabled="true" data-l10n-id="crash-dont-send">Don't Send</button>
-            <button id="send-report" class="recommend" data-l10n-id="crash-send">Send Report</button>
-          </menu>
-        </form>
+        </div>
 
         <div id="popup-container">
           <section role="region" class="title-container skin-organic">

--- a/apps/system/js/crash_reporter.js
+++ b/apps/system/js/crash_reporter.js
@@ -57,7 +57,12 @@ var CrashReporter = (function() {
     // "What's in a crash report?" link
     var crashInfoLink = document.getElementById('crash-info-link');
     crashInfoLink.addEventListener('click', function onLearnMoreClick() {
-      //XXX Show a "Crash Reports" information page (bug 801938)
+      var dialog = document.getElementById('crash-dialog');
+      document.getElementById('crash-reports-done').addEventListener('click', function onDoneClick() {
+        this.removeEventListener('click', onDoneClick);
+        dialog.classList.remove('learn-more');
+      });
+      dialog.classList.add('learn-more');
     });
 
     screen.classList.add('crash-dialog');

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -150,6 +150,13 @@ crash-always-report=Always send Mozilla a report when a crash occurs.
 crash-dont-send=Don't Send
 crash-end=Send Report
 
+# "Crash Reports" information page
+crashReports=Crash Reports
+done=Done
+# Localization note: This string is also included in settings/locales/settings.properties
+# FIXME: Update this string in bug 813128
+crashReportsDescription=Crash reports description goes here
+
 # crash notification banner
 crash-banner-os=Firefox OS just crashed.
 crash-banner-app={{name}} just crashed.

--- a/apps/system/style/crash_reporter/crash_reporter.css
+++ b/apps/system/style/crash_reporter/crash_reporter.css
@@ -14,3 +14,30 @@
   text-decoration: underline;
   margin-top: 2rem;
 }
+
+#crash-dialog.learn-more > form {
+  display: none;
+}
+
+#crash-dialog:not(.learn-more) > section {
+  display: none;
+}
+
+/* "Crash Reports" information page */
+#crash-dialog > section {
+  font-family: "MozTT", Sans-serif;
+  background-color: #fff;
+  color: #000;
+  position: absolute;
+  z-index: 100;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+#crash-dialog > section > p {
+  padding: 1rem 3rem;
+  font-size: 1.5rem;
+  white-space: normal;
+}


### PR DESCRIPTION
These two patches are still waiting on strings for the text inside the information pages, but I'd like to get feedback on the code because this is a C1 blocker.
