### PR TITLE
Bug 810487 - [email] No messages overlay is on top of the search filters after searching for a word that doesn't exist in the filter

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -207,7 +207,7 @@
         </div>
         <div class="msg-list-empty-container collapsed">
           <div class="msg-list-empty-message">
-            <p data-l10n-id="messages-folder-empty">No messagE</p>
+            <p class="msg-list-empty-message-text" data-l10n-id="messages-folder-empty">No messagE</p>
           </div>
         </div>
       </div>

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -378,6 +378,10 @@ MessageListCard.prototype = {
   },
 
   showEmptyLayout: function() {
+    var text = this.domNode.
+      getElementsByClassName('msg-list-empty-message-text')[0];
+    text.textContent = this.mode == 'search' ?
+      mozL10n.get('messages-search-empty'):mozL10n.get('messages-folder-empty');
     this.messageEmptyContainer.classList.remove('collapsed');
     this.toolbar.editBtn.classList.add('disabled');
     this.toolbar.searchBtn.classList.add('disabled');

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -165,6 +165,7 @@ message-search-cancel-accessible=cancel search
 messages-syncing=Loading messages
 messages-sync-more=Load more messages from server
 messages-folder-empty=No Mail in this Folder
+messages-search-empty=No matches in locally cached messages
 messages-folder-select=Select folder
 
 message-contact-menu-view=View contact

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -414,10 +414,10 @@
   background-image: url('images/mail_watermark.png');
   background-repeat:no-repeat;
   background-position: 50% 40%;
-  height: 100%;
+  height: 20rem;
   width: 100%;
   position: absolute;
-  top: 0;
+  top: 10rem;
   left: 0;
 }
 
@@ -425,7 +425,7 @@
   text-align: center;
   line-height: 3rem;
   position: relative;
-  top: 50%;
+  top: 12rem;
   border-top: .1rem solid rgba(96,96,96,.5);
   width: 27rem;
   margin: -7rem auto;


### PR DESCRIPTION
- Fix bug : https://bugzilla.mozilla.org/show_bug.cgi?id=810487
