### PR TITLE
Bug 812974, remove mozAudioChannelType assignment in ringtone

### DIFF
--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -186,7 +186,6 @@ var OnCallHandler = (function onCallHandler() {
   }
 
   var ringtonePlayer = new Audio();
-  ringtonePlayer.mozAudioChannelType = 'ring';
   ringtonePlayer.src = selectedPhoneSound;
   ringtonePlayer.loop = true;
 


### PR DESCRIPTION
Root cause: undefined channel string assignment causes gecko error.
