### PR TITLE
Bug 802600/802612 - [Apps] Cancel App Download from Notification Center

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -633,7 +633,9 @@
         </div>
       </div>
 
-      <form id="app-install-dialog" data-type="confirm" role="dialog" data-z-index-level="app-install-dialog">
+      <form id="app-install-dialog" class='app-install-dialog'
+            data-type="confirm" role="dialog"
+            data-z-index-level="app-install-dialog">
         <section>
           <h1 id="app-install-message"></h1>
           <table>
@@ -656,21 +658,9 @@
         </section>
       </form>
 
-      <form id="updates-download-dialog" data-type="confirm" role="dialog" data-z-index-level="updates-download-dialog">
-        <section>
-          <h1>
-            Updates
-          </h1>
-          <ul>
-          </ul>
-          <menu>
-            <button id="updates-later-button" type="reset" data-l10n-id="later">Later</button>
-            <button id="updates-download-button" type="submit" data-l10n-id="download">Download</button>
-          </menu>
-        </section>
-      </form>
-
-      <form id="app-install-cancel-dialog" data-type="confirm" role="dialog" data-z-index-level="app-install-dialog">
+      <form id="app-install-cancel-dialog" class='app-install-dialog'
+            data-type="confirm" role="dialog"
+            data-z-index-level="app-install-dialog">
         <section>
           <h1 data-l10n-id="cancel-install">Cancel Install</h1>
           <p>
@@ -681,6 +671,39 @@
           <menu>
             <button id="app-install-confirm-cancel-button" type="reset" data-l10n-id="cancel-install">Cancel Install</button>
             <button id="app-install-resume-button" type="submit" data-l10n-id="resume">Resume</button>
+          </menu>
+        </section>
+      </form>
+
+      <form id="app-download-cancel-dialog" class='app-install-dialog'
+        data-type="confirm" role="dialog"
+        data-z-index-level="app-install-dialog">
+        <section>
+          <h1></h1>
+          <p data-l10n-id="app-download-can-be-restarted">The download can
+          be restarted later.</p>
+          <menu>
+            <button id="app-download-stop-button" class="danger confirm"
+              data-l10n-id="app-download-stop-button">Stop Download</button>
+            <button id="app-download-continue-button" class="cancel"
+              type="reset" data-l10n-id="continue">Continue</button>
+          </menu>
+        </section>
+      </form>
+
+      <form id="updates-download-dialog" data-type="confirm" role="dialog"
+            data-z-index-level="updates-download-dialog">
+        <section>
+          <h1>
+            Updates
+          </h1>
+          <ul>
+          </ul>
+          <menu>
+            <button id="updates-later-button" type="reset"
+                    data-l10n-id="later">Later</button>
+                  <button id="updates-download-button" type="submit"
+                    data-l10n-id="download">Download</button>
           </menu>
         </section>
       </form>

--- a/apps/system/js/applications.js
+++ b/apps/system/js/applications.js
@@ -56,7 +56,7 @@ var Applications = {
       delete self.installedApps[deletedapp.manifestURL];
 
       self.fireApplicationUninstallEvent(deletedapp);
-    }
+    };
   },
 
   getByManifestURL: function a_getByManifestURL(manifestURL) {

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -531,7 +531,7 @@ var StatusBar = {
       return str.replace(/\-(.)/g, function replacer(str, p1) {
         return p1.toUpperCase();
       });
-    }
+    };
 
     this.ELEMENTS.forEach((function createElementRef(name) {
       this.icons[toCamelCase(name)] =

--- a/apps/system/js/update_manager.js
+++ b/apps/system/js/update_manager.js
@@ -173,7 +173,7 @@ var UpdateManager = {
 
   cancelPrompt: function um_cancelPrompt() {
     CustomDialog.hide();
-      this.downloadDialog.classList.remove('visible');
+    this.downloadDialog.classList.remove('visible');
   },
 
   downloadProgressed: function um_downloadProgress(bytes) {

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -68,6 +68,10 @@ apps-can-be-installed-later=Apps can be installed later from the original instal
 are-you-sure-you-want-to-cancel=Are you sure you want to cancel this install?
 cancel-install=Cancel Install
 resume=Resume
+continue=Continue
+stopDownloading=Stop downloading {{ app }}?
+app-download-can-be-restarted=The download can be restarted later.
+app-download-stop-button=Stop Download
 
 # update manager
 later=Later

--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -1,5 +1,9 @@
 /* dialog */
-#app-install-dialog, #app-install-cancel-dialog {
+/* FIXME we have to see why we need such specific style here and why
+ * the general style in confirm.css isn't sufficient */
+#app-install-dialog,
+#app-install-cancel-dialog,
+#app-download-cancel-dialog {
   display: none;
   position: absolute;
   top: 20px;
@@ -9,16 +13,22 @@
   pointer-events: none;
 }
 
-#app-install-dialog.visible, #app-install-cancel-dialog.visible {
+#app-install-dialog.visible,
+#app-install-cancel-dialog.visible,
+#app-download-cancel-dialog.visible {
   display: inline-block;
   pointer-events: auto;
 }
 
-#app-install-dialog section, #app-install-cancel-dialog section {
+#app-install-dialog section,
+#app-install-cancel-dialog section,
+#app-download-cancel-dialog section {
   height: auto;
 }
 
-#app-install-dialog h1, #app-install-cancel-dialog h1 {
+#app-install-dialog h1,
+#app-install-cancel-dialog h1,
+#app-download-cancel-dialog h1 {
   border-bottom: none;
   background: none;
 }
@@ -55,6 +65,10 @@
   background-repeat: no-repeat;
   background-position: 15px center;
   background-image: url(images/downloads.png);
+}
+
+#install-manager-notification-container > .fake-notification > * {
+  pointer-events: none;
 }
 
 #install-manager-notification-container progress {

--- a/apps/system/test/unit/identity_test.js
+++ b/apps/system/test/unit/identity_test.js
@@ -34,7 +34,7 @@ suite('identity', function() {
   setup(function() {});
 
   teardown(function() {
-    MockTrustedUIManager.mTearDown();
+    MockTrustedUIManager.mTeardown();
   });
 
   suite('open popup', function() {

--- a/apps/system/test/unit/mock_app.js
+++ b/apps/system/test/unit/mock_app.js
@@ -3,6 +3,7 @@ var idGen = 0;
 function MockApp(opts) {
   /* default values */
   this.origin = 'https://testapp.gaiamobile.org';
+  this.manifestURL = 'https://testapp.gaiamobile.org/manifest.webapp';
   this.manifest = {
     name: 'Mock app'
   };

--- a/apps/system/test/unit/mock_applications.js
+++ b/apps/system/test/unit/mock_applications.js
@@ -1,0 +1,26 @@
+var MockApplications = (function() {
+  var mockApps = {};
+
+  function getByManifestURL(url) {
+    return mockApps[url];
+  }
+
+  function mRegisterMockApp(mockApp) {
+    mockApps[mockApp.manifestURL] = mockApp;
+  }
+
+  function mUnregisterMockApp(mockApp) {
+    mockApps[mockApp.manifestURL] = null;
+  }
+
+  function mTeardown() {
+    mockApps = {};
+  }
+
+  return {
+    getByManifestURL: getByManifestURL,
+    mRegisterMockApp: mRegisterMockApp,
+    mUnregisterMockApp: mUnregisterMockApp,
+    mTeardown: mTeardown
+  };
+})();

--- a/apps/system/test/unit/mock_custom_dialog.js
+++ b/apps/system/test/unit/mock_custom_dialog.js
@@ -16,7 +16,7 @@ var MockCustomDialog = {
   mShowedMsg: null,
   mShowedCancel: null,
   mShowedConfirm: null,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.mShown = false;
     this.mShowedTitle = null;
     this.mShowedMsg = null;

--- a/apps/system/test/unit/mock_notification_helper.js
+++ b/apps/system/test/unit/mock_notification_helper.js
@@ -12,7 +12,7 @@ var MockNotificationHelper = {
   mIcon: null,
   mClickCB: null,
   mCloseCB: null,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.mTitle = null;
     this.mBody = null;
     this.mIcon = null;

--- a/apps/system/test/unit/mock_notification_screen.js
+++ b/apps/system/test/unit/mock_notification_screen.js
@@ -8,25 +8,29 @@ var MockNotificationScreen = {
   ],
 
   mockPopulate: function mockPopulate() {
-    this.mockMethods.forEach((function(methodName) {
+    this.mockMethods.forEach(function(methodName) {
       // we could probably put this method outside if we had a closure
       this[methodName] = function mns_method() {
         this.methodCalled(methodName);
       };
-    }).bind(this));
+    }, this);
   },
 
   init: function mns_init() {
     this.wasMethodCalled = {};
+    this.mockMethods.forEach(function(methodName) {
+      this[methodName].wasCalled = false;
+    }, this);
   },
 
   methodCalled: function mns_methodCalled(name) {
     this.wasMethodCalled[name] =
         this.wasMethodCalled[name] ? this.wasMethodCalled[name]++ : 1;
+    this[name].wasCalled = true;
   },
 
-  mTearDown: function mns_mTearDown() {
-    this.wasMethodCalled = {};
+  mTeardown: function mns_mTeardown() {
+    this.init();
   }
 };
 

--- a/apps/system/test/unit/mock_settings_listener.js
+++ b/apps/system/test/unit/mock_settings_listener.js
@@ -8,7 +8,7 @@ var MockSettingsListener = {
   mName: null,
   mDefaultValue: null,
   mCallback: null,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.mName = null;
     this.mDefaultValue = null;
     this.mDefaultCallback = null;

--- a/apps/system/test/unit/mock_statusbar.js
+++ b/apps/system/test/unit/mock_statusbar.js
@@ -19,7 +19,7 @@ var MockStatusBar = {
   },
 
   mNotificationUnread: false,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.notificationsCount = null;
     this.mNotificationsUpdated = false;
     this.mNotificationUnread = false;

--- a/apps/system/test/unit/mock_system_banner.js
+++ b/apps/system/test/unit/mock_system_banner.js
@@ -6,7 +6,7 @@ var MockSystemBanner = {
 
   mShowCount: 0,
   mMessage: null,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.mShowCount = 0;
     this.mMessage = null;
   }

--- a/apps/system/test/unit/mock_trusted_ui_manager.js
+++ b/apps/system/test/unit/mock_trusted_ui_manager.js
@@ -14,7 +14,7 @@ var MockTrustedUIManager = {
   mName: null,
   mFrame: null,
   mOrigin: null,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.mOpened = false;
     this.mName = null;
     this.mFrame = null;

--- a/apps/system/test/unit/mock_utility_tray.js
+++ b/apps/system/test/unit/mock_utility_tray.js
@@ -8,7 +8,7 @@ var MockUtilityTray = {
   },
 
   mShown: false,
-  mTearDown: function tearDown() {
+  mTeardown: function teardown() {
     this.mShown = false;
   }
 };

--- a/apps/system/test/unit/mock_window_manager.js
+++ b/apps/system/test/unit/mock_window_manager.js
@@ -9,7 +9,7 @@ var MockWindowManager = {
 
   mDisplayedApp: '',
   mLastKilledOrigin: '',
-  mTearDown: function() {
+  mTeardown: function() {
     this.mDisplayedApp = '';
     this.mLastKilledOrigin = '';
   }

--- a/apps/system/test/unit/mocks_helper.js
+++ b/apps/system/test/unit/mocks_helper.js
@@ -1,0 +1,40 @@
+var MocksHelper = function(mocks) {
+  this.mocks = mocks;
+  this.realWindowObjects = {};
+};
+
+MocksHelper.prototype = {
+
+  setup: function mh_setup() {
+  },
+
+  suiteSetup: function mh_suiteSetup() {
+    this.mocks.forEach(function(objName) {
+      var mockName = 'Mock' + objName;
+      if (!window[mockName]) {
+        throw 'Mock ' + mockName + ' has not been loaded into the test';
+      }
+
+      this.realWindowObjects[objName] = window[objName];
+      window[objName] = window[mockName];
+    }, this);
+  },
+
+  suiteTeardown: function mh_suiteTeardown() {
+    this.mocks.forEach(function(objName) {
+      window[objName] = this.realWindowObjects[objName];
+    }, this);
+  },
+
+  teardown: function mh_teardown() {
+    this.mocks.forEach(function(objName) {
+      var mockName = 'Mock' + objName;
+      var mock = window[mockName];
+
+      if (mock.mTeardown) {
+        mock.mTeardown();
+      }
+    });
+  }
+};
+

--- a/apps/system/test/unit/notifications_test.js
+++ b/apps/system/test/unit/notifications_test.js
@@ -1,36 +1,30 @@
 requireApp('system/test/unit/mock_statusbar.js');
 requireApp('system/test/unit/mock_gesture_detector.js');
+requireApp('system/test/unit/mocks_helper.js');
 
 requireApp('system/js/notifications.js');
 
-var mocks = ['StatusBar', 'GestureDetector'];
+var mocksForNotificationScreen = ['StatusBar', 'GestureDetector'];
 
-mocks.forEach(function(objName) {
-  if (! window[objName]) {
-    window[objName] = null;
+mocksForNotificationScreen.forEach(function(mockName) {
+  if (! window[mockName]) {
+    window[mockName] = null;
   }
 });
 
-suite('system/NotificationScreen', function() {
+
+suite('system/NotificationScreen >', function() {
   var fakeNotifContainer, fakeLockScreenContainer, fakeToaster, fakeButton;
-  var realWindowObjects = {};
+
+  var mocksHelper;
 
   suiteSetup(function() {
-    mocks.forEach(function(objName) {
-      var mockName = 'Mock' + objName;
-      if (!window[mockName]) {
-        throw 'Mock ' + mockName + ' has not been loaded into the test';
-      }
-
-      realWindowObjects[objName] = window[objName];
-      window[objName] = window[mockName];
-    });
+    mocksHelper = new MocksHelper(mocksForNotificationScreen);
+    mocksHelper.suiteSetup();
   });
 
   suiteTeardown(function() {
-    mocks.forEach(function(objName) {
-      window[objName] = realWindowObjects[objName];
-    });
+    mocksHelper.suiteTeardown();
   });
 
   setup(function() {
@@ -55,6 +49,8 @@ suite('system/NotificationScreen', function() {
     document.body.appendChild(fakeLockScreenContainer);
     document.body.appendChild(fakeButton);
 
+    mocksHelper.setup();
+
     NotificationScreen.init();
   });
 
@@ -63,9 +59,11 @@ suite('system/NotificationScreen', function() {
     fakeLockScreenContainer.parentNode.removeChild(fakeLockScreenContainer);
     fakeToaster.parentNode.removeChild(fakeToaster);
     fakeButton.parentNode.removeChild(fakeButton);
+
+    mocksHelper.teardown();
   });
 
-  suite('updateStatusBarIcon', function() {
+  suite('updateStatusBarIcon >', function() {
     setup(function() {
       NotificationScreen.updateStatusBarIcon();
     });

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -9,7 +9,7 @@ if (!this.SettingsListener) {
 
 suite('system/Statusbar', function() {
   var fakeStatusBarNode;
-  var realSettingsListener, realMozL10n;
+  var realSettingsListener, realMozL10n,
       fakeIcons = [];
 
   suiteSetup(function() {

--- a/apps/system/test/unit/updatable_test.js
+++ b/apps/system/test/unit/updatable_test.js
@@ -84,9 +84,9 @@ suite('system/Updatable', function() {
   teardown(function() {
     MockUpdateManager.mTeardown();
     MockAppsMgmt.mTeardown();
-    MockCustomDialog.mTearDown();
-    MockWindowManager.mTearDown();
-    MockUtilityTray.mTearDown();
+    MockCustomDialog.mTeardown();
+    MockWindowManager.mTeardown();
+    MockUtilityTray.mTeardown();
 
     subject._dispatchEvent = realDispatchEvent;
     lastDispatchedEvent = null;

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -209,12 +209,12 @@ suite('system/UpdateManager', function() {
     UpdateManager.downloadDialogList = null;
 
     MockAppsMgmt.mTeardown();
-    MockCustomDialog.mTearDown();
-    MockUtilityTray.mTearDown();
-    MockSystemBanner.mTearDown();
-    MockSettingsListener.mTearDown();
-    MockStatusBar.mTearDown();
-    MockNotificationScreen.mTearDown();
+    MockCustomDialog.mTeardown();
+    MockUtilityTray.mTeardown();
+    MockSystemBanner.mTeardown();
+    MockSettingsListener.mTeardown();
+    MockStatusBar.mTeardown();
+    MockNotificationScreen.mTeardown();
 
     fakeNode.parentNode.removeChild(fakeNode);
     fakeToaster.parentNode.removeChild(fakeToaster);


### PR DESCRIPTION
Tapping on the notification triggers a confirmation screen to stop the
currently running download. This confirmation screen has 2 buttons,
one to cancel this cancel order, and one to confirm this cancel order.

This patch also introduces a mocks helper to helps developers using
mocks correctly.
