### PR TITLE
Bug 805984 - [Dialer] Remove useless locale strings

### DIFF
--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -56,8 +56,6 @@ sending=Sending...
 ussd-services={{ operator }} services
 type-your-response.placeholder=Type your response...
 clear-all-text=Clear all text
-message-successfully-sent=Message successfuly sent
-ussd-server-error=There was an error in the communication, please try it again later
 
 ## LOCALIZATION NOTE: case `zero` is never used, no need to translate it.
 contactNameWithOthers={[ plural(n) ]}


### PR DESCRIPTION
These two strings seems to be useless. No sign of usage anywhere in gaia nor mozilla-central.
And no usage shown in revision that introduced them:
  https://github.com/mozilla-b2g/gaia/commit/6db096605d36ed904250869f131037d665388701
