### PR TITLE
Bug 802362 - Switch to common fromNow() date function for relative dates

### DIFF
--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -926,42 +926,12 @@ function prettyFileSize(sizeInBytes) {
   return mozL10n.get('attachment-size-kib', { kilobytes: kilos });
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Pretty date logic; copied from the SMS app.
-// Based on Resig's pretty date
-
+/**
+ * Display a human-readable relative timestamp.
+ */
 function prettyDate(time) {
-
-  switch (time.constructor) {
-    case String:
-      time = parseInt(time);
-      break;
-    case Date:
-      time = time.getTime();
-      break;
-  }
-
-  var f = new navigator.mozL10n.DateTimeFormat();
-  var diff = (Date.now() - time) / 1000;
-  var day_diff = Math.floor(diff / 86400);
-
-  if (isNaN(day_diff))
-    return '(incorrect date)';
-
-  if (day_diff < 0 || diff < 0) {
-    // future time
-    return f.localeFormat(new Date(time), _('shortDateTimeFormat'));
-  }
-
-  return day_diff == 0 && (
-    diff < 60 && 'Just Now' ||
-    diff < 120 && '1 Minute Ago' ||
-    diff < 3600 && Math.floor(diff / 60) + ' Minutes Ago' ||
-    diff < 7200 && '1 Hour Ago' ||
-    diff < 86400 && Math.floor(diff / 3600) + ' Hours Ago') ||
-    day_diff == 1 && 'Yesterday' ||
-    day_diff < 7 && f.localeFormat(new Date(time), '%A') ||
-    f.localeFormat(new Date(time), '%x');
+  var f = new mozL10n.DateTimeFormat();
+  return f.fromNow(time);
 }
 
 (function() {


### PR DESCRIPTION
r? @asutherland. This fixes handling of future dates, which eliminates some errors that caused such messages to not show up in the message list. I keep bumping into this when testing, since it seems Hotmail's clock is slightly ahead of mine (and then I entered the wrong timezone on my Unagi).

Who do I ask to get approval to land this, as the original bug is not blocking?

https://bugzilla.mozilla.org/show_bug.cgi?id=802362
