### PR TITLE
Bug 811890: camera doesn't work from locked home screen when you set a passcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ ifneq ($(DEBUG),1)
 	@echo "Packaged webapps"
 	@rm -rf apps/system/camera
 	@cp -r apps/camera apps/system/camera
+	@cat apps/camera/index.html | sed -e 's:shared/:../shared/:' > apps/system/camera/index.html
 	@rm apps/system/camera/manifest.webapp
 	@mkdir -p profile/webapps
 	@$(call run-js-command, webapp-zip)


### PR DESCRIPTION
The problem was that this triggered access to asyncStorage, and that, due to
the way the camera app was copied into the system app's dir, the shared file
async-storage.js was not referenced correctly.

Since all references to `shared/` are from the index.html, this simply uses sed to
update them to `../shared/` when the camera app is copied. Not terribly robust
(people might try to add new references to shared stuff from other files), but no
worse than copying that app over like this in the first place.
