### PR TITLE
Bug 811605 - add preference for ril debug with false value by default

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -23,6 +23,9 @@ prefs.push(["dom.send_after_paint_to_content", true]);
 
 prefs.push(["network.http.max-connections-per-server", 15]);
 
+// for https://bugzilla.mozilla.org/show_bug.cgi?id=811605 to let user know what prefs is for ril debugging
+prefs.push(["ril.debugging.enabled", false]);
+
 if (LOCAL_DOMAINS) {
   prefs.push(["network.dns.localDomains", domains.join(",")]);
 }


### PR DESCRIPTION
Please reference https://bugzilla.mozilla.org/show_bug.cgi?id=811605
Bug 811605 - B2G RIL: enable ril debugging output in run-time

There is a mechanism to enable ril debug output in runtime.
Add "ril.debugging.enabled" in user.js with false value by default.
This will be convenient for users to know what prefs values they can change.
