### PR TITLE
Bug 811640 - [KEYBOARD] Long press on 0 or p or }, the keyboard would shift left a little bit

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -135,6 +135,10 @@ button::-moz-focus-inner {
   background: url(images/dark-alpha.png) repeat left top;
   border-radius: 0.6rem;
 }
+.keyboard-key:not(.special-key).highlighted:last-child > .visual-wrapper:after {
+  right: -0.2rem;
+  border-radius: 0.6rem 0 0 0.6rem; 
+}
 .keyboard-key:not(.special-key).highlighted > .visual-wrapper:before {
   content: "";
   position: absolute;
@@ -169,6 +173,10 @@ button::-moz-focus-inner {
   z-index: -1;
   background: url(images/dark-alpha.png) repeat left top;
   border-radius: 0.6rem;
+}
+.keyboard-key:not(.special-key).highlighted:last-child > .visual-wrapper > span:after {
+  right: -0.2rem;
+  border-radius: 0.6rem 0 0 0.6rem;
 }
 
 .keyboard-key:not(.special-key).highlighted:last-child  > .visual-wrapper > span {


### PR DESCRIPTION
Fix it by reducing the width of highlight key at the right end of the keyboard.
