### PR TITLE
[Bug 813128] Final text for "Crash Reports" information page

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1979,7 +1979,13 @@
       </header>
 
       <ul>
-        <li class="description" data-l10n-id="crashReportsDescription"></li>
+        <li class="description" data-l10n-id="crash-reports-description-1"></li>
+        <li class="description" data-l10n-id="crash-reports-description-2"></li>
+        <li>
+          <label for="" class="description">
+            <span data-l10n-id="crash-reports-description-3-start"></span><a href="https://www.mozilla.org/privacy/" data-l10n-id="crash-reports-description-3-privacy" class="link-text"></a><span data-l10n-id="crash-reports-description-3-end"></span>
+          </label>
+        </li>
       </ul>
       -->
     </section>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -473,9 +473,14 @@ neverSendReport=Never send a report
 askToSendReport=Ask me when a crash occurs
 
 # Device :: Improve Firefox OS :: Crash Reports
-# Localization note: This string is also included in system/locales/system.properties
-# FIXME: Update this string in bug 813128
-crashReportsDescription=Crash reports description goes here
+# Localization note (crash-reports-description-*): These strings are also included in system.properties
+crash-reports-description-1=A crash report contains some details about the crash and your device, as well as a snapshot of the state of your device when it crashed.
+crash-reports-description-2=This may include things like open pages and apps, text typed into forms and the content of open messages, recent browsing history, or geolocation used by an open app.
+# Localization note (crash-reports-description-3-*): These strings are a paragraph, with a "privacy policy"
+# link in the middle. Include trailing spaces as needed.
+crash-reports-description-3-start=We use crash reports to try to fix problems and improve our products. We handle your information as we describe in our 
+crash-reports-description-3-privacy=privacy policy
+crash-reports-description-3-end=.
 
 # Device :: Help
 online-support=Online support:

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -423,7 +423,11 @@
               </menu>
               <h1 data-l10n-id="crashReports">Crash Reports</h1>
             </header>
-            <p data-l10n-id="crashReportsDescription"></p>
+            <p data-l10n-id="crash-reports-description-1"></p>
+            <p data-l10n-id="crash-reports-description-2"></p>
+            <p>
+              <span data-l10n-id="crash-reports-description-3-start"></span><span data-l10n-id="crash-reports-description-3-privacy"></span><span data-l10n-id="crash-reports-description-3-end"></span>
+            </p>
           </section>
         </div>
 

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -158,9 +158,14 @@ crash-end=Send Report
 # "Crash Reports" information page
 crashReports=Crash Reports
 done=Done
-# Localization note: This string is also included in settings/locales/settings.properties
-# FIXME: Update this string in bug 813128
-crashReportsDescription=Crash reports description goes here
+# Localization note (crash-reports-description-*): These strings are also included in settings.properties
+crash-reports-description-1=A crash report contains some details about the crash and your device, as well as a snapshot of the state of your device when it crashed.
+crash-reports-description-2=This may include things like open pages and apps, text typed into forms and the content of open messages, recent browsing history, or geolocation used by an open app.
+# Localization note (crash-reports-description-3-*): These strings are a paragraph, with a "privacy policy"
+# link in the middle. Include trailing spaces as needed.
+crash-reports-description-3-start=We use crash reports to try to fix problems and improve our products. We handle your information as we describe in our 
+crash-reports-description-3-privacy=privacy policy
+crash-reports-description-3-end=.
 
 # crash notification banner
 crash-banner-os=Firefox OS just crashed.


### PR DESCRIPTION
This patch adds the final strings for the "Crash Reports" information page in both the crash dialog (system app) and the settings app. I didn't make the "privacy policy" link in the crash dialog into an actual link for now because I haven't sorted out the behavior of what a link in a modal dialog should do. However, this will get the strings landed, which is the important part!
