### PR TITLE
Bug 809782 - display image previews instead of full size

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -111,7 +111,7 @@ var Camera = {
   RECORD_SPACE_PADDING: 1024 * 1024 * 1,
 
   // Maximum image resolution for still photos taken with camera
-  MAX_IMAGE_RES: 1024 * 768, // was: 1600*1200
+  MAX_IMAGE_RES: 1600 * 1200, // Just under 2 megapixels
 
   get overlayTitle() {
     return document.getElementById('overlay-title');

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -499,6 +499,13 @@ function setView(view) {
     if (document.mozFullScreenElement === fullscreenView) {
       document.mozCancelFullScreen();
     }
+
+    // Clear the frames to release the memory they're holding and
+    // so that we don't see a flash of the old image when we return
+    // to fullscreen view
+    previousFrame.clear();
+    currentFrame.clear();
+    nextFrame.clear();
     break;
   }
 
@@ -1133,7 +1140,8 @@ function setupFrameContent(n, frame) {
     photodb.getFile(fileinfo.name, function(file) {
       frame.displayImage(file,
                          fileinfo.metadata.width,
-                         fileinfo.metadata.height);
+                         fileinfo.metadata.height,
+                         fileinfo.metadata.preview);
     });
   }
 }

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -216,6 +216,19 @@ section {
   -moz-user-select: none;
 }
 
+/*
+ * these styles apply when we're swapping out a preview image to replace
+ * it with a full-resolution image, but the full image isn't ready yet.
+ * This happens when the user starts to zoom in on the image. We need
+ * some sort of simple visual effect to fill ~500ms of dead time so the
+ * user doesn't think the app has frozen up
+ */
+.frame > img.swapping {
+  opacity: 0.8;
+  outline: dashed #0ac 4px;
+  outline-offset: -4px;
+}
+
 .frame > video {
   transform-origin: 0px 0px;
 }


### PR DESCRIPTION
This pull request modifies the Frame class used by the Gallery app so that when displaying an image, if the image has an embedded preview, and the preview is big enough, it display that preview instead of decoding the full image.

The tricky part here is handling zooms, because in order to zoom in we have to switch from the preview image to the full-size image. And doing this smoothly without having the screen flash or go blank turns out to be kind of hard. The solution here ends up relying on MozAfterPaint events.

@dominickuo will you review, please
