### PR TITLE
[Bug 802908] Update help links and add button to submit feedback to Mozilla

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1999,6 +1999,14 @@
         <h1 data-l10n-id="improveFirefoxOS">Improve Firefox OS</h1>
       </header>
 
+      <ul>
+        <li>
+          <label>
+            <button data-href="http://input.mozilla.org/feedback" data-l10n-id="sendMozillaFeedback"></button>
+          </label>
+        </li>
+      </ul>
+
       <header>
         <h2 data-l10n-id="performanceData">Performance Data</h2>
       </header>
@@ -2064,19 +2072,23 @@
       <!--
       <header>
         <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="helpAndFeedback"> Help </h1>
+        <h1 data-l10n-id="help"></h1>
       </header>
 
       <ul>
         <li>
-          <a href="#" data-href="http://www.telefonica.com/" data-l10n-id="online-support"> Online Support:
-            <span class="link-text" data-l10n-id="online-support-link">www.telefonica.com</span>
+          <a data-l10n-id="online-support"> Online Support:
+            <span class="link-text" data-l10n-id="online-support-link-text"></span>
           </a>
         </li>
         <li>
-          <a href="#" data-href="tel:+16509030800" data-l10n-id="call-support"> Call Support:
-            <span class="tel-text" data-l10n-id="call-support-number">+1 650-903-0800</span>
-          </a>
+          <span data-l10n-id="call-support"> Call Support:
+            <span id="call-support-numbers">
+              <a class="tel-text" data-l10n-id="call-support-link-1"></a>
+              <span data-l10n-id="call-support-link-or"></span>
+              <a class="tel-text" data-l10n-id="call-support-link-2"></a>
+            </span>
+          </span>
         </li>
         <li>
           <label>
@@ -2252,10 +2264,10 @@
           <a id="menuItem-accessibility" class="menu-item" href="#accessibility" data-l10n-id="accessibility">Accessibility</a>
         </li>
         <li>
-          <a id="menuItem-helpAndFeedback" class="menu-item" href="#improveFirefoxOS" data-l10n-id="improveFirefoxOS">Improve Firefox OS</a>
+          <a id="menuItem-improveFirefoxOS" class="menu-item" href="#improveFirefoxOS" data-l10n-id="improveFirefoxOS">Improve Firefox OS</a>
         </li>
         <li>
-          <a id="menuItem-helpAndFeedback" class="menu-item" href="#help" data-l10n-id="helpAndFeedback">Help &amp; Feedback</a>
+          <a id="menuItem-help" class="menu-item" href="#help" data-l10n-id="help">Help</a>
         </li>
       </ul>
 

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -91,7 +91,7 @@ var Settings = {
 
     // activate all links
     var self = this;
-    var links = panel.querySelectorAll('a[href^="http"], [data-href]');
+    var links = panel.querySelectorAll('a[href^="http"], a[href^="tel"], [data-href]');
     for (i = 0; i < links.length; i++) {
       var link = links[i];
       if (!link.dataset.href) {

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -354,7 +354,7 @@ doNotTrack-dd2=Turning on Do Not Track won’t affect your ability to sign in to
 
 device=Device
 storage=Storage
-helpAndFeedback=Help & Feedback
+help=Help
 
 # Device :: Information
 deviceInfo=Device information
@@ -463,6 +463,7 @@ screenReader=Screen reader
 
 # Device :: Improve Firefox OS
 improveFirefoxOS=Improve Firefox OS
+sendMozillaFeedback=Send Mozilla Feedback
 performanceData=Performance data
 performanceDataInfo=Make Firefox OS faster and easier to use by sharing information over Wi-Fi about your phone’s performance.
 sharePerformanceData=Submit performance data
@@ -484,9 +485,20 @@ crash-reports-description-3-end=.
 
 # Device :: Help
 online-support=Online support:
-online-support-link=www.telefonica.com
+# Localization note (online-support.href): This is the URL for the online support page.
+online-support.href=http://www.vivo.com.br/portalweb/appmanager/env/web?_nfls=false&_nfpb=true&_pageLabel=vcAtendMovelBook&WT.ac=portal.atendimento.movel
+# Localization note (online-support-link-text): This text will appear as a link.
+online-support-link-text=Vivo
 call-support=Call support:
-call-support-number=+1 650-903-0800
+# Localization note (call-support-link-1): This text will appear as a link.
+call-support-link-1=*8486
+# Localization note (call-support-link-1.href): Include the "tel:" protocol before the call support
+# number so that it will open in the dialer app.
+call-support-link-1.href=tel:*8486
+# Localization note: If your locale only has one support phone number, leave the next 3 strings empty.
+call-support-link-2=1058
+call-support-link-2.href=tel:1058
+call-support-link-or=or
 user-guide=User guide
 
 # Device :: SIM toolkit

--- a/apps/settings/style/icons.css
+++ b/apps/settings/style/icons.css
@@ -105,7 +105,11 @@
   background-image: -moz-image-rect(url(images/icons_sprite.png), 120, 90, 150, 60);
 }
 
-#menuItem-helpAndFeedback {
+#menuItem-improveFirefoxOS {
+  background-image: -moz-image-rect(url(images/icons_sprite.png), 120, 120, 150, 90);
+}
+
+#menuItem-help {
   background-image: -moz-image-rect(url(images/icons_sprite.png), 120, 120, 150, 90);
 }
 

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -236,6 +236,19 @@ ul li > label .range-icons.brightness {
   white-space: nowrap;
 }
 
+/******************************************************************************
+ * Help
+ */
+
+#call-support-numbers {
+  position: absolute;
+  right: 2rem;
+}
+
+html[dir="rtl"] #call-support-numbers {
+  right: inherit;
+  left: 2rem;
+}
 
 /******************************************************************************
  * Right-To-Left layout


### PR DESCRIPTION
This pull request:
- Adds "Send Mozilla Feedback" button to the top of "Improve Firefox OS" http://cl.ly/image/1F2G2p0o1P2Y
- Renames "Help & Feedback" section to "Help"
- Updates links in "Help" section

See the bug for full conversation:
https://bugzilla.mozilla.org/show_bug.cgi?id=802908
