### PR TITLE
Bug 813902 - remove the workaround for 791920 to blur and refocus the

### DIFF
--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -37,14 +37,6 @@ var SimPinDialog = {
     var displayField = document.querySelector('input[name="' + name + 'Vis"]');
     var self = this;
 
-    // Workaround bug 791920 until we found the root cause.
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=791920
-    // https://github.com/mozilla-b2g/gaia/issues/4500
-    inputField.addEventListener('click', function(evt) {
-      this.blur();
-      this.focus();
-    });
-
     inputField.addEventListener('keypress', function(evt) {
       if (evt.target !== inputField)
         return;


### PR DESCRIPTION
inputfield

For [Bug 791920](https://bugzilla.mozilla.org/show_bug.cgi?id=791920), we add a workaround to blur to re-focus the input field to make sure the keyboard will pop up.

Now, this workaround would cause the keyboard to hide to show again, so we need to remove this workaround.
