### PR TITLE
Bug 804544 - [Clock] Our alarm feature need to ignore time zone. r=timdream

### DIFF
--- a/apps/clock/js/alarm.js
+++ b/apps/clock/js/alarm.js
@@ -463,7 +463,7 @@ var AlarmManager = {
     } else {
       nextAlarmFireTime = getNextAlarmFireTime(alarm);
     }
-    var request = navigator.mozAlarms.add(nextAlarmFireTime, 'honorTimezone',
+    var request = navigator.mozAlarms.add(nextAlarmFireTime, 'ignoreTimezone',
                   { id: alarm.id }); // give the alarm id for the request
     var self = this;
     request.onsuccess = function(e) {


### PR DESCRIPTION
Change the parameter "honorTimezone" to "ignoreTimezone".
