### PR TITLE
Bug 807418 - [Clock] No way to preview an alarm tone r=rlu r=alive

### DIFF
--- a/apps/clock/js/alarm.js
+++ b/apps/clock/js/alarm.js
@@ -593,6 +593,7 @@ var AlarmEditView = {
     hour24State: null,
     is12hFormat: false
   },
+  previewRingtonePlayer: null,
 
   get element() {
     delete this.element;
@@ -674,6 +675,7 @@ var AlarmEditView = {
     this.repeatSelect.addEventListener('change', this);
     this.soundMenu.addEventListener('click', this);
     this.soundSelect.addEventListener('change', this);
+    this.soundSelect.addEventListener('blur', this);
     this.snoozeMenu.addEventListener('click', this);
     this.snoozeSelect.addEventListener('change', this);
     this.deleteButton.addEventListener('click', this);
@@ -753,6 +755,10 @@ var AlarmEditView = {
         switch (evt.type) {
           case 'change':
             this.refreshSoundMenu(this.getSoundSelect());
+            this.previewSound();
+            break;
+          case 'blur':
+            this.stopPreviewSound();
             break;
         }
         break;
@@ -857,9 +863,30 @@ var AlarmEditView = {
   },
 
   refreshSoundMenu: function aev_refreshSoundMenu(sound) {
-    // XXX: Refresh and paser the name of sound file for sound menu.
+    // Refresh and paser the name of sound file for sound menu.
     var sound = (sound) ? this.getSoundSelect() : this.alarm.sound;
     this.soundMenu.innerHTML = _(sound.slice(0, sound.lastIndexOf('.')));
+  },
+
+  previewSound: function aev_previewSound() {
+    var ringtonePlayer = this.previewRingtonePlayer;
+    if (!ringtonePlayer) {
+      this.previewRingtonePlayer = new Audio();
+      ringtonePlayer = this.previewRingtonePlayer;
+    } else {
+      ringtonePlayer.pause();
+    }
+
+    var ringtoneName = this.getSoundSelect();
+    var previewRingtone = 'style/ringtones/' + ringtoneName;
+    ringtonePlayer.mozAudioChannelType = 'alarm';
+    ringtonePlayer.src = previewRingtone;
+    ringtonePlayer.play();
+  },
+
+  stopPreviewSound: function aev_stopPreviewSound() {
+    if (this.previewRingtonePlayer)
+      this.previewRingtonePlayer.pause();
   },
 
   initSnoozeSelect: function aev_initSnoozeSelect() {


### PR DESCRIPTION
I suppose that we can receive "onchange" event when the value selector is showing and user selecting on it.
So, we can preview the alarm tone by the event.
