### PR TITLE
Bug 813495 - [settings] "check for updates" doesn't wait for the apps up...

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" type="text/css" href="style/simcard.css"/>
     <link rel="stylesheet" type="text/css" href="style/phone_lock.css"/>
     <link rel="stylesheet" type="text/css" href="style/apps.css"/>
+    <link rel="stylesheet" type="text/css" href="style/updates.css"/>
 
     <!-- Shared resources
     <link rel="resource" type="application/json" href="shared/resources/apn.json"/>
@@ -1780,7 +1781,11 @@
               data-l10n-id="check-update-now"> Check Now </button>
           </label>
         </li>
-        <li id="update-status" class="description" hidden></li>
+        <li id="update-status" class="description update-status">
+          <p class="description general-information"
+              data-l10n-id="checking-for-update">Checking for updates...</p>
+          <p class="description system-update-status"></p>
+        </li>
       </ul>
 
       <header>

--- a/apps/settings/style/updates.css
+++ b/apps/settings/style/updates.css
@@ -1,0 +1,16 @@
+.update-status {
+  display: none;
+}
+
+.update-status.visible {
+  display: block;
+}
+
+.update-status .general-information {
+  display: none;
+}
+
+.update-status.checking .general-information {
+  display: block;
+}
+

--- a/apps/settings/test/unit/mock_l10n.js
+++ b/apps/settings/test/unit/mock_l10n.js
@@ -1,0 +1,13 @@
+
+var MockL10n = {
+  get: function get(key, params) {
+    return key;
+  },
+  DateTimeFormat: function() {}
+};
+
+MockL10n.DateTimeFormat.prototype = {
+  localeFormat: function mockLocaleFormat(time, strFormat) {
+    return '' + time;
+  }
+};

--- a/apps/settings/test/unit/mock_navigator_settings.js
+++ b/apps/settings/test/unit/mock_navigator_settings.js
@@ -1,0 +1,64 @@
+(function(window) {
+  var observers = {},
+      settings = {},
+      removedObservers = {};
+
+  function mns_mLockSet(obj) {
+    for (var key in obj) {
+      settings[key] = obj[key];
+    }
+  }
+
+  function mns_addObserver(name, cb) {
+    observers[name] = observers[name] || [];
+    observers[name].push(cb);
+  }
+
+  function mns_removeObserver(name, cb) {
+    removedObservers[name] = removedObservers[name] || [];
+    removedObservers[name].push(cb);
+  }
+
+  function mns_createLock() {
+    return {
+      set: mns_mLockSet
+    };
+  }
+
+  function mns_mTriggerObservers(name, args) {
+    var theseObservers = observers[name];
+
+    if (! theseObservers) {
+      return;
+    }
+
+    theseObservers.forEach(function(func) {
+      func(args);
+    });
+  }
+
+  function mns_teardown() {
+    observers = {};
+    settings = {};
+    removedObservers = {};
+  }
+
+  window.MockNavigatorSettings = {
+    addObserver: mns_addObserver,
+    removeObserver: mns_removeObserver,
+    createLock: mns_createLock,
+
+    mTriggerObservers: mns_mTriggerObservers,
+    mTeardown: mns_teardown,
+    get mObservers() {
+      return observers;
+    },
+    get mSettings() {
+      return settings;
+    },
+    get mRemovedObservers() {
+      return removedObservers;
+    }
+  };
+
+})(this);

--- a/apps/settings/test/unit/settings_test.js
+++ b/apps/settings/test/unit/settings_test.js
@@ -1,0 +1,214 @@
+requireApp('settings/test/unit/mock_l10n.js');
+requireApp('settings/test/unit/mock_navigator_settings.js');
+requireApp('settings/js/settings.js');
+
+suite('settings >', function() {
+  var realL10n, realNavigatorSettings;
+  var updateStatusNode, systemStatus, generalInfo;
+
+  suiteSetup(function() {
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = MockL10n;
+
+    realNavigatorSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozL10n = realL10n;
+    realL10n = null;
+
+    navigator.mozSettings = realNavigatorSettings;
+    realNavigatorSettings = null;
+  });
+
+  setup(function() {
+    var updateNodes =
+      '<section id="root" role="region"></section>' +
+      '<ul>' +
+        '<li>' +
+          '<label>' +
+            '<button id="check-update-now">Check Now</button>' +
+          '</label>' +
+        '</li>' +
+        '<li id="update-status" class="description">' +
+          '<p class="general-information description">' +
+            'Checking for update...</p>' +
+          '<p class="system-update-status description"></p>' +
+        '</li>' +
+      '</ul>';
+
+    document.body.insertAdjacentHTML('beforeend', updateNodes);
+
+    updateStatusNode = document.getElementById('update-status');
+    systemStatus = updateStatusNode.querySelector('.system-update-status');
+    generalInfo = updateStatusNode.querySelector('.general-information');
+
+    Settings.init();
+
+  });
+
+  teardown(function() {
+    MockNavigatorSettings.mTeardown();
+  });
+
+  suite('checkForUpdates >', function() {
+    var geckoUpdateSetting, appsUpdateSetting,
+        geckoUpdateHandlers, appsUpdateHandlers;
+
+    setup(function() {
+      Settings.checkForUpdates();
+
+      geckoUpdateSetting = 'gecko.updateStatus';
+      appsUpdateSetting = 'apps.updateStatus';
+      geckoUpdateHandlers =
+        MockNavigatorSettings.mObservers[geckoUpdateSetting];
+      appsUpdateHandlers =
+        MockNavigatorSettings.mObservers[appsUpdateSetting];
+    });
+
+    test('triggers the updates', function() {
+      var setting = 'gaia.system.checkForUpdates';
+      assert.isTrue(MockNavigatorSettings.mSettings[setting]);
+    });
+
+    test('register handlers', function() {
+      assert.isFunction(geckoUpdateHandlers[0]);
+      assert.isFunction(appsUpdateHandlers[0]);
+    });
+
+    test('displays the checking updates text', function() {
+      assert.isTrue(updateStatusNode.classList.contains('checking'));
+      assert.isTrue(updateStatusNode.classList.contains('visible'));
+      assert.notEqual(generalInfo.textContent.length, 0);
+    });
+
+
+    suite('getting response for system update >', function() {
+      suite('successful >', function() {
+        setup(function() {
+          MockNavigatorSettings.mTriggerObservers(geckoUpdateSetting, {
+            settingValue: 'check-complete'
+          });
+        });
+
+        test('does not hide the status', function() {
+          assert.isTrue(updateStatusNode.classList.contains('visible'));
+        });
+
+        test('does not hide the checking updates text', function() {
+          assert.isTrue(updateStatusNode.classList.contains('checking'));
+        });
+
+        test('remove the handler', function() {
+          var removedObservers = MockNavigatorSettings.mRemovedObservers;
+          var removedObserver = removedObservers[geckoUpdateSetting][0];
+          assert.isFunction(removedObserver);
+          assert.equal(removedObserver, geckoUpdateHandlers[0]);
+        });
+      });
+
+
+      test('no-updates', function() {
+        MockNavigatorSettings.mTriggerObservers(geckoUpdateSetting, {
+          settingValue: 'no-updates'
+        });
+        assert.equal(systemStatus.textContent, 'no-updates');
+      });
+
+      test('already-latest-version', function() {
+        MockNavigatorSettings.mTriggerObservers(geckoUpdateSetting, {
+          settingValue: 'already-latest-version'
+        });
+        assert.equal(systemStatus.textContent, 'already-latest-version');
+      });
+
+      test('retry-when-online', function() {
+        MockNavigatorSettings.mTriggerObservers(geckoUpdateSetting, {
+          settingValue: 'retry-when-online'
+        });
+        assert.equal(systemStatus.textContent, 'retry-when-online');
+      });
+
+    });
+
+    suite('getting response for app update >', function() {
+      suite('successful >', function() {
+        setup(function() {
+          MockNavigatorSettings.mTriggerObservers(appsUpdateSetting, {
+            settingValue: 'check-complete'
+          });
+        });
+
+        test('does not hide the status', function() {
+          assert.isTrue(updateStatusNode.classList.contains('visible'));
+        });
+
+        test('does not hide the checking updates text', function() {
+          assert.isTrue(updateStatusNode.classList.contains('checking'));
+        });
+
+        test('remove the handler', function() {
+          var removedObservers = MockNavigatorSettings.mRemovedObservers;
+          var removedObserver = removedObservers[appsUpdateSetting][0];
+          assert.isFunction(removedObserver);
+          assert.equal(removedObserver, appsUpdateHandlers[0]);
+        });
+      });
+    });
+
+    suite('getting response for both updates >', function() {
+      suite('both successful >', function() {
+        setup(function() {
+          MockNavigatorSettings.mTriggerObservers('gecko.updateStatus', {
+            settingValue: 'check-complete'
+          });
+          MockNavigatorSettings.mTriggerObservers('apps.updateStatus', {
+            settingValue: 'check-complete'
+          });
+        });
+
+        test('hides the status', function() {
+          assert.isFalse(updateStatusNode.classList.contains('visible'));
+        });
+
+        test('removes the text in the system description', function() {
+          assert.equal(systemStatus.textContent.length, 0);
+        });
+
+        test('hide the checking updates text', function() {
+          assert.isFalse(updateStatusNode.classList.contains('checking'));
+        });
+      });
+
+      suite('not both successful >', function() {
+        setup(function() {
+          MockNavigatorSettings.mTriggerObservers('gecko.updateStatus', {
+            settingValue: 'no-updates'
+          });
+          MockNavigatorSettings.mTriggerObservers('apps.updateStatus', {
+            settingValue: 'check-complete'
+          });
+        });
+
+        test('do not hide the status', function() {
+          assert.isTrue(updateStatusNode.classList.contains('visible'));
+        });
+
+        test('hide the checking updates text', function() {
+          assert.isFalse(updateStatusNode.classList.contains('checking'));
+        });
+
+        suite('starting an update again >', function() {
+          setup(function() {
+            Settings.checkForUpdates();
+          });
+
+          test('should remove the text', function() {
+            assert.equal(systemStatus.textContent.length, 0);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
...dates r=etienne

Now we keeps the text "Checking for updates" until we get both
notifications from the platform for both updates.

We still show the error message as soon as we get it.
