### PR TITLE
Bug 813676 - While on a call a long press on 0 should not generate a '+' since the DTMF sent will always be 0 (r=fcampo).

### DIFF
--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -413,7 +413,7 @@ var KeypadManager = {
       }
 
       // Manage long press
-      if (key == '0' || key == 'delete') {
+      if ((key == '0' && !this._onCall) || key == 'delete') {
         this._holdTimer = setTimeout(function(self) {
           if (key == 'delete') {
             self._phoneNumber = '';

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -312,7 +312,7 @@
                 <div class="keypad-key-label-container">
                   <div class="keypad-key-label" data-value="0">
                     <span class="keypad-number font-regular">0</span>
-                    <span class="keypad-text font-size-plus">+</span>
+                    <span class="keypad-text font-size-plus"></span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Basically, we delete the '+' from the 0 key and avoid including a '+' in the number area when long pressing on it
