### PR TITLE
Bug 813679 - *2 and *8 are phone numbers(in Venezuela) the dialer treat them as MMI/USSD (r=fcampo).

### DIFF
--- a/apps/communications/dialer/js/ussd.js
+++ b/apps/communications/dialer/js/ussd.js
@@ -151,8 +151,8 @@ var UssdManager = {
   },
 
   isUSSD: function um_isUSSD(number) {
-    // A valid USSD/MMI code is any 'number' with a '*' and/or a '#' inside.
-    return ((number.indexOf('*') != -1) || (number.indexOf('#') != -1));
+    // A valid USSD/MMI code is any 'number' ending in '#'.
+    return (number.charAt(number.length - 1) === '#');
   },
 
   handleEvent: function um_handleEvent(evt) {


### PR DESCRIPTION
The latest news by @ferjm is that USSD/MMI codes are 'phone numbers' ending in #, everything else is a phone number and should be dialed (based, of course, on the airplane mode and SIM card status).
