### PR TITLE
Bug 815126 - [Dialer] The Call Log appearance breaks if more than 1 call to a very long name contact (r=fcampo).

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -539,11 +539,11 @@ var Recents = {
       '        <span class="entry-count">' +
       '        </span>' +
       '      </section>' +
-      '      <section class="secondary-info">' +
+      '      <section class="secondary-info ellipsis">' +
       '        <span class="call-time">' +
                  Utils.prettyDate(recent.date) +
       '        </span>' +
-      '        <span class="call-additional-info ellipsis">' +
+      '        <span class="call-additional-info">' +
       '        </span>' +
       '      </section>' +
       '    </div>' +
@@ -766,7 +766,7 @@ var Recents = {
     if (!isNaN(primaryInfoNodeWidth) && !isNaN(primaryInfoMainNodeWidth) &&
       !isNaN(entryCountNodeWidth) &&
       (primaryInfoNodeWidth < primaryInfoMainNodeWidth + entryCountNodeWidth)) {
-      var newWidth = primaryInfoNodeWidth - entryCountNodeWidth - 4;
+      var newWidth = primaryInfoNodeWidth - entryCountNodeWidth - 5;
       primaryInfoMainNode.classList.add('ellipsed');
       primaryInfoMainNode.style.width = newWidth + 'px';
     }

--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -200,10 +200,7 @@ ul[role="tablist"][data-type="filter"] > [role="tab"].selected > a {
 }
 
 .primary-info-main {
-  overflow: hidden;
-  text-overflow: ellipsis;
   display: inline-block;
-  white-space: nowrap;
   padding-right: 0.6rem;
 }
 


### PR DESCRIPTION
As a consequence of the new MozTT font, we had to minimally adjust the code to reserve space in the Call Log to certain entries (several calls to/from contacts with very long names which should be rendered as "A very very very long name... (17)" in one line).
