### PR TITLE
[Bug 815381] Don't animate the root panel when the settings app launches

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2135,7 +2135,7 @@
     </section>
 
     <!-- Main List -->
-    <section role="region" id="root">
+    <section role="region" id="root" class="current">
       <header>
         <h1 data-l10n-id="settings"> Settings </h1>
       </header>

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -637,8 +637,7 @@ window.addEventListener('load', function loadSettings() {
       document.location.hash = 'root';
       break;
     case '#root':
-      document.getElementById('root').className = 'current';
-      showPanel();
+      // do nothing
       break;
     default:
       document.getElementById('root').className = 'previous';


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=815381
