### PR TITLE
[Bug 807187] Update URL for "Learn More" link in "Share Performacne Data"

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2018,7 +2018,7 @@
               Make Firefox OS faster and easier to use by sharing
               information over Wi-Fi about your phone’s performance.
             </span>
-            <a href="https://www.mozilla.org/" data-l10n-id="learn-more" class="link-text">Learn More</a>
+            <a href="https://support.mozilla.org/kb/how-can-i-help-submitting-mobile-performance-data" data-l10n-id="learn-more" class="link-text">Learn More</a>
           </label>
         </li>
         <li>


### PR DESCRIPTION
I confirmed that this redirects to the page for the correct locale when it opens in the browser.
