### PR TITLE
- Bug 798213 : [settings] Show "no paired" on main menu when all pairing...

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -343,6 +343,7 @@ onLocalized(function bluetoothSettings() {
         var paired = req.result.slice();
         var length = paired.length;
         if (length == 0) {
+          gBluetoothInfoBlock.textContent = _('bt-status-nopaired');
           pairList.show(false);
           return;
         }

--- a/apps/settings/style/onpair.css
+++ b/apps/settings/style/onpair.css
@@ -26,12 +26,16 @@
 
 #pair-view menu {
   padding: 0.7rem;
-  bottom: 0px;
+  position: relative;
 }
 
 #pair-view menu button {
   height: 2.8rem;
   line-height: 2.8rem;
+}
+
+#pair-view {
+  padding-bottom: 4.2rem;
 }
 
 #device-info {


### PR DESCRIPTION
... devices are removed.
- on bluetooth pairing page, correct displaying mode of buttons so that it won't block input field.
