### PR TITLE
Bug 812934 [Browser] back button not available while in a call

### DIFF
--- a/apps/browser/style/browser.css
+++ b/apps/browser/style/browser.css
@@ -974,14 +974,14 @@ li[role="listitem"] small {
  * then the keyboard is likely activated
  */
 /* For the Otoro, 320x480 */
-@media (device-height: 480px) and (max-height: 450px),
-       (device-height: 320px) and (max-height: 290px) {
+@media (device-height: 480px) and (max-height: 430px),
+       (device-height: 320px) and (max-height: 270px) {
   .page-screen #toolbar-end { display: none; }
   .page-screen #frames { bottom: 0; }
 }
 /* For the Galaxy SII, 640x480 */
-@media (device-height: 480px) and (max-height: 450px),
-       (device-height: 640px) and (max-height: 610px) {
+@media (device-height: 480px) and (max-height: 430px),
+       (device-height: 640px) and (max-height: 590px) {
   .page-screen #toolbar-end { display: none; }
   .page-screen #frames { bottom: 0; }
 }

--- a/apps/browser/style/browser.css
+++ b/apps/browser/style/browser.css
@@ -970,7 +970,8 @@ li[role="listitem"] small {
 }
 
 /* This is a dirty hack to hide the bottom toolbar while
- * the keyboard is active, than device-height - 20px (for status bar),
+ * the keyboard is active, than device-height - 40px 
+ * (for status bar/mini attention screen),
  * then the keyboard is likely activated
  */
 /* For the Otoro, 320x480 */


### PR DESCRIPTION
The hack deepens...

This media query hack to not display the bottom bar when the keyboard is displayed needs to not only take into account the 20px high status bar, but also the 40px high mini in-call and alarm attention screens. Adding another 20 pixels of hack.

Tested with keyboard in portrait & landscape orientations.
