### PR TITLE
Bug 815168 - [Homescreen] Race condition showing/hiding the progress indicator while downloading

### DIFF
--- a/apps/homescreen/js/page.js
+++ b/apps/homescreen/js/page.js
@@ -78,9 +78,6 @@ Icon.prototype = {
 
     // Icon container
     var icon = this.icon = document.createElement('div');
-    if (this.downloading) {
-      icon.classList.add('loading');
-    }
 
     // Image
     var img = this.img = new Image();
@@ -122,6 +119,13 @@ Icon.prototype = {
     }
 
     target.appendChild(container);
+
+    if (this.downloading) {
+      //XXX: Bug 816043 We need to force the repaint to show the span
+      // with the label and the animation (associated to the span)
+      container.style.visibility = 'visible';
+      icon.classList.add('loading');
+    }
   },
 
   fetchImageData: function icon_fetchImageData() {

--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -127,10 +127,6 @@ body[data-transitioning] .loading:after {
   margin-left: -0.4rem;
 }
 
-.loading span {
-  margin-top: 0.4rem;
-}
-
 @keyframes rotate {
   from {
     transform: rotate(1deg)


### PR DESCRIPTION
Finally the problem is gecko wasn't doing a repaint when adding the new element. Forcing that repaint in the case we add a icon that is downloading

r=@benfrancis
