### PR TITLE
[Bug 815066] Spelling suggestions should be on by default

### DIFF
--- a/build/settings.py
+++ b/build/settings.py
@@ -59,7 +59,7 @@ settings = {
  "keyboard.layouts.spanish": False,
  "keyboard.vibration": False,
  "keyboard.clicksound": False,
- "keyboard.wordsuggestion": False,
+ "keyboard.wordsuggestion": True,
  "language.current": "en-US",
  "lockscreen.passcode-lock.code": "0000",
  "lockscreen.passcode-lock.timeout": 0,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=815066
