### PR TITLE
Bug 815379 - [email/activesync] Support usernames that aren't the email address

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -493,6 +493,8 @@
               ActivesynC SettingS</h2>
             <input class="sup-manual-activesync-hostname sup-form-text"
                    type="text" placeholder="HostnamE" />
+            <input class="sup-manual-activesync-username sup-form-text"
+                   type="text" placeholder="UsernamE" />
           </div>
 
           <button class="sup-manual-next-btn sup-form-btn recommend"

--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -34030,6 +34030,7 @@ var autoconfigByDomain = exports._autoconfigByDomain = {
       // This string may be clobbered with the correct port number when
       // running as a unit test.
       server: 'http://localhost:8880',
+      username: '%EMAILADDRESS%',
     },
   },
   // Mapping for a nonexistent domain for testing a bad domain without it being
@@ -34328,7 +34329,7 @@ Configurators['activesync'] = {
   tryToCreateAccount: function cfg_as_ttca(universe, userDetails, domainInfo,
                                            callback, _LOG) {
     var credentials = {
-      username: userDetails.emailAddress,
+      username: domainInfo.incoming.username,
       password: userDetails.password,
     };
 
@@ -34617,6 +34618,7 @@ Autoconfigurator.prototype = {
         displayName: config.user.name,
         incoming: {
           server: config.mobileSyncServer.url,
+          username: config.user.email
         },
       };
       callback(null, autoconfig);

--- a/apps/email/js/setup-cards.js
+++ b/apps/email/js/setup-cards.js
@@ -237,6 +237,11 @@ function SetupManualConfig(domNode, mode, args) {
     'sup-manual-activesync-hostname')[0];
   this.activeSyncHostnameNode.setAttribute('placeholder',
      mozL10n.get('setup-manual-hostname-placeholder'));
+
+  this.activeSyncUsernameNode = domNode.getElementsByClassName(
+    'sup-manual-activesync-username')[0];
+  this.activeSyncUsernameNode.setAttribute('placeholder',
+     mozL10n.get('setup-manual-username-placeholder'));
 }
 SetupManualConfig.prototype = {
   onBack: function(event) {
@@ -262,7 +267,8 @@ SetupManualConfig.prototype = {
     }
     else { // config.type === 'activesync'
       config.incoming = {
-        server: 'https://' + this.activeSyncHostnameNode.value
+        server: 'https://' + this.activeSyncHostnameNode.value,
+        username: this.activeSyncUsernameNode.value
       };
     }
 


### PR DESCRIPTION
r? @asutherland: These are the front-end changes to let us manually specify a username for ActiveSync. Remember to remove the autoconfig file I mentioned in mozilla-b2g/gaia-email-libs-and-more#88 (assuming you added it in the first place).
