### PR TITLE
Bug 813473 - [email] Allow autoconfiguration of Hotmail accounts, no matter their domain

### DIFF
--- a/apps/email/autoconfig/hotmail.co.jp
+++ b/apps/email/autoconfig/hotmail.co.jp
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.co.uk
+++ b/apps/email/autoconfig/hotmail.co.uk
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.com
+++ b/apps/email/autoconfig/hotmail.com
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.com.br
+++ b/apps/email/autoconfig/hotmail.com.br
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.de
+++ b/apps/email/autoconfig/hotmail.de
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.es
+++ b/apps/email/autoconfig/hotmail.es
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.fr
+++ b/apps/email/autoconfig/hotmail.fr
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/hotmail.it
+++ b/apps/email/autoconfig/hotmail.it
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.co.jp
+++ b/apps/email/autoconfig/live.co.jp
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.co.uk
+++ b/apps/email/autoconfig/live.co.uk
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.com
+++ b/apps/email/autoconfig/live.com
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.de
+++ b/apps/email/autoconfig/live.de
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.fr
+++ b/apps/email/autoconfig/live.fr
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.it
+++ b/apps/email/autoconfig/live.it
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/live.jp
+++ b/apps/email/autoconfig/live.jp
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>

--- a/apps/email/autoconfig/msn.com
+++ b/apps/email/autoconfig/msn.com
@@ -1,0 +1,26 @@
+<clientConfig version="1.1">
+  <emailProvider id="hotmail.com">
+    <domain>hotmail.com</domain>
+    <domain>hotmail.co.uk</domain>
+    <domain>hotmail.co.jp</domain>
+    <domain>hotmail.com.br</domain>
+    <domain>hotmail.de</domain>
+    <domain>hotmail.fr</domain>
+    <domain>hotmail.it</domain>
+    <domain>hotmail.es</domain>
+    <domain>live.com</domain>
+    <domain>live.co.uk</domain>
+    <domain>live.co.jp</domain>
+    <domain>live.de</domain>
+    <domain>live.fr</domain>
+    <domain>live.it</domain>
+    <domain>live.jp</domain>
+    <domain>msn.com</domain>
+    <displayName>Microsoft Live Hotmail</displayName>
+    <displayShortName>Hotmail</displayShortName>
+    <incomingServer type="activesync">
+      <server>https://m.hotmail.com</server>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+  </emailProvider>
+</clientConfig>


### PR DESCRIPTION
r? @asutherland: I'm keeping this simple. All the added files are exact copies of each other. In reality, we'd want to use symlinks or some other wizbang feature like that, but we're not at the point where the number of autoconfig files is overwhelming us.

I also changed my mind about adding hotmail.com now. I added it in, since I have autodiscovery unit tests in the jsas repo, and I can always remove hotmail.com from our local store if I need to test it in Gaia.

I've manually tested this with @hotmail.com, @live.com, and @hotmail.es.
