### PR TITLE
Bug 815932 - Only ever start a single timer to cancel our worker. r=dflanagan

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -143,12 +143,13 @@
   }
 
   function deactivate() {
-    if (!worker)
+    if (!worker || idleTimer)
       return;
     idleTimer = setTimeout(function onIdleTimeout() {
       // Let's terminate the worker.
       worker.terminate();
       worker = null;
+      idleTimer = null;
     }, workerTimeout);
   }
 


### PR DESCRIPTION
This is a simple fix to avoid JS error spam in logcat.
