### PR TITLE
Bug 813841 - HTML scrolling fix (alternate impl)

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -242,7 +242,7 @@
               data-l10n-id="reader-header">ReaD</h1>
           </header>
         </section>
-        <div class="scrollregion-below-header">
+        <div class="scrollregion-below-header scrollregion-horizontal-too">
           <div class="msg-envelope-bar">
             <div class="msg-envelope-date"></div>
             <div class="msg-envelope-from-line msg-envelope-line">

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -843,6 +843,9 @@ function MessageReaderCard(domNode, mode, args) {
   domNode.getElementsByClassName('msg-forward-btn')[0]
     .addEventListener('click', this.onForward.bind(this), false);
 
+  this.scrollContainer =
+    domNode.getElementsByClassName('scrollregion-below-header')[0];
+
   this.envelopeNode = domNode.getElementsByClassName('msg-envelope-bar')[0];
   this.envelopeNode
     .addEventListener('click', this.onEnvelopeClick.bind(this), false);
@@ -1167,7 +1170,7 @@ MessageReaderCard.prototype = {
       }
       else if (repType === 'html') {
         var iframe = createAndInsertIframeForContent(
-          rep, rootBodyNode, null,
+          rep, this.scrollContainer, rootBodyNode, null,
           'interactive', this.onHyperlinkClick.bind(this));
         var bodyNode = iframe.contentDocument.body;
         MailAPI.utils.linkifyHTML(iframe.contentDocument);

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -123,6 +123,9 @@ body {
   height: -webkit-calc(100% - 5.8rem + 5px);
   height: calc(100% - 5.8rem + 5px);
 }
+.scrollregion-below-header.scrollregion-horizontal-too {
+  overflow-x: auto !important;
+}
 
 .bottom-toolbar {
   position: absolute;

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -166,6 +166,7 @@
 .msg-envelope-bar {
   border-bottom: 1px solid gray;
   font-size: 1.5rem;
+  width: 100%;
 }
 
 .msg-envelope-date {


### PR DESCRIPTION
@steveck-chung Here's what I've got so far, as mentioned on https://github.com/mozilla-b2g/gaia/pull/6628

I believe I have addressed the scrolling problem and zooming should work for newsletter-mode, but the centering logic for zooming is currently pretty broken.  Visible in the patch is my ugly hackery that shows how sleepy I am right now.  Such things are best done with a clear head!

The key thing in this patch is that we try and make the iframe entirely seamless, but we do keep it inside a viewport that simply exists to clip the excess off.  Namely, when we have used transform to scale the iframe to display at 0.5x, the iframe's size is still 1x, so we need the viewport that holds it to size itself to 0.5x to clip down so scrolling does not get messed up.

I did have to disable pointer-events again, so for link purposes, we will probably want to use document.elementFromPoint.
