### PR TITLE
Bug 796509 - [phone] Need an asset for 'Airplane Mode' dialog when emiti.ng a call while the phone is in airplane mode (r=fcampo).

### DIFF
--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -232,9 +232,9 @@ var CallHandler = (function callHandler() {
   function handleFlightMode() {
     ConfirmDialog.show(
       _('callAirplaneModeTitle'),
-      _('callAirplaneModeBody'),
+      _('callAirplaneModeMessage'),
       {
-        title: _('callAirplaneModeBtnOk'),
+        title: _('cancel'),
         callback: function() {
           ConfirmDialog.hide();
 
@@ -242,6 +242,20 @@ var CallHandler = (function callHandler() {
             currentActivity.postError('canceled');
             currentActivity = null;
           }
+        }
+      },
+      {
+        title: _('settings'),
+        callback: function() {
+          var activity = new MozActivity({
+            name: 'configure',
+              data: {
+                target: 'device',
+                section: 'root'
+              }
+            }
+          );
+          ConfirmDialog.hide();
         }
       }
     );

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -1,7 +1,7 @@
 addNewNumber=Add new number
 addToExistingContact=Add to existing contact
 all=All
-callAirplaneModeBody=To make a call, disable Airplane Mode.
+callAirplaneModeMessage=To make a call you need to disable airplane mode in settings.
 callAirplaneModeBtnOk=OK
 callAirplaneModeTitle=Airplane Mode is on
 callLog=Call log
@@ -70,3 +70,5 @@ contactNameWithOthers[two]={{ name }}… or {{ n }} other
 contactNameWithOthers[few]={{ name }}… or {{ n }} other
 contactNameWithOthers[many]={{ name }}… or {{ n }} other
 contactNameWithOthers[other]={{ name }}… or {{ n }} other
+
+settings=Settings


### PR DESCRIPTION
Basically, implementation of the new dialog shown when the user tries to make a call and the airplane mode is enabled according to this: https://www.dropbox.com/s/9r1iwp8ud2huj2i/OWD_00_airplanemode.png
