### PR TITLE
Bug 812924 - rotate videos according to embedded rotation metadata

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -74,7 +74,7 @@ var Camera = {
 
   _previewConfigVideo: {
     profile: 'cif',
-    rotation: 90,
+    rotation: 0,
     width: 352,
     height: 288
   },
@@ -279,6 +279,7 @@ var Camera = {
       this._cameraObj.getPreviewStream(this._previewConfig,
                                        gotPreviewStream.bind(this));
     } else {
+      this._previewConfigVideo.rotation = this._phoneOrientation;
       this._cameraObj.getPreviewStreamVideoMode(this._previewConfigVideo,
                                                 gotPreviewStream.bind(this));
     }
@@ -352,7 +353,7 @@ var Camera = {
       }
 
       var config = {
-        rotation: 90,
+        rotation: this._phoneOrientation,
         maxFileSizeBytes: freeBytes - this.RECORD_SPACE_PADDING
       };
       this._cameraObj.startRecording(config,
@@ -362,14 +363,17 @@ var Camera = {
 
     this.createDCFFilename('video', '3gp', (function(filename) {
       this._videoPath = filename;
+
       // The CameraControl API will not automatically create directories
-      // for the new file if they do not exist, so write a stub file
-      // via the deviceStorage API which will, then start recording
-      // over it
-      var stub = new Blob([''], {'type': 'video\/3gpp'});
-      var req = this._videoStorage.addNamed(stub, filename);
+      // for the new file if they do not exist, so write a dummy file
+      // to the same directory via DeviceStorage to ensure that the directory
+      // exists before recording starts.
+      var dummyblob = new Blob([''], {type: 'video/3gpp'});
+      var dummyfilename = filename + '.dummy.3gp';
+      var req = this._videoStorage.addNamed(dummyblob, dummyfilename);
       req.onerror = onerror;
       req.onsuccess = (function fileCreated() {
+        this._videoStorage.delete(dummyfilename); // No need to wait for success
         // Determine the number of bytes available on disk.
         var stat = this._videoStorage.stat();
         stat.onerror = onerror;
@@ -554,7 +558,7 @@ var Camera = {
     }
 
     // Launch the gallery with an open activity to view this specific photo
-    var storage =  isVideo ? this._videoStorage : this._pictureStorage;
+    var storage = isVideo ? this._videoStorage : this._pictureStorage;
     var isVideo = /video/.test(filetype);
     var activity;
 

--- a/apps/camera/manifest.webapp
+++ b/apps/camera/manifest.webapp
@@ -10,8 +10,8 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "device-storage:pictures":{ "access": "readcreate" },
-    "device-storage:videos":{ "access": "readcreate" },
+    "device-storage:pictures":{ "access": "readwrite" },
+    "device-storage:videos":{ "access": "readwrite" },
     "settings":{ "access": "readonly" },
     "camera":{},
     "geolocation":{}

--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -16,6 +16,7 @@
     <script type="text/javascript" defer src="shared/js/blobview.js"></script>
     <!-- Specific code -->
     <script type="text/javascript" defer src="js/JPEGMetadataParser.js"></script>
+    <script type="text/javascript" defer src="js/MP4Parser.js"></script>
     <script type="text/javascript" defer src="js/MetadataParser.js"></script>
     <script type="text/javascript" defer src="js/ImageEditor.js"></script>
     <script type="text/javascript" defer src="js/VideoPlayer.js"></script>

--- a/apps/gallery/js/Frame.js
+++ b/apps/gallery/js/Frame.js
@@ -203,7 +203,9 @@ Frame.prototype._switchToPreviewImage = function _switchToPreviewImage() {
   }
 };
 
-Frame.prototype.displayVideo = function displayVideo(blob, width, height) {
+Frame.prototype.displayVideo = function displayVideo(blob, width, height,
+                                                     rotation)
+{
   if (!this.video)
     return;
 
@@ -221,34 +223,10 @@ Frame.prototype.displayVideo = function displayVideo(blob, width, height) {
   // Get a new URL for this blob
   this.url = URL.createObjectURL(blob);
 
-  // Display it in the video element
-  this.video.player.src = this.url;
-
-  // If we have the width and height, position the video element now.
-  // Otherwise, register an event handler to position it when loaded.
-  // The gallery app always has the dimensions but the open activity doesn't.
-  // Note that the video controls don't need to be positioned; they
-  // always go at the bottom of the container.
-  if (width && height) {
-    this.itemWidth = width;
-    this.itemHeight = height;
-    this.video.player.style.width = width + 'px';
-    this.video.player.style.height = height + 'px';
-    this.computeFit();
-    this.setPosition();
-  }
-  else {
-    var self = this;
-    this.video.player.addEventListener('loadedmetadata', function onload() {
-      this.removeEventListener('loadedmetadata', onload);
-      self.itemWidth = this.videoWidth;
-      self.itemHeight = this.videoHeight;
-      this.style.width = this.videoWidth + 'px';
-      this.style.height = this.videoHeight + 'px';
-      self.computeFit();
-      self.setPosition();
-    });
-  }
+  // Display it in the video element.
+  // The VideoPlayer class takes care of positioning itself, so we
+  // don't have to do anything here with computeFit() or setPosition()
+  this.video.load(this.url, rotation || 0);
 };
 
 // Reset the frame state, release any urls and and hide everything

--- a/apps/gallery/js/MP4Parser.js
+++ b/apps/gallery/js/MP4Parser.js
@@ -1,0 +1,81 @@
+'use strict';
+
+function MP4Parser(blob, handlers) {
+  // Start off with a 4kb chunk from the start of the blob.
+  BlobView.get(blob, 0, 4096, function(data, error) {
+    // Make sure that the blob is, in fact, some kind of MP4 file
+    if (data.getASCIIText(4, 4) !== 'ftyp') {
+      handlers.errorHandler('not an MP4 file');
+      return;
+    }
+    parseAtom(data);
+  });
+
+
+  // Call this with a BlobView object that includes the first 16 bytes of
+  // an atom. It doesn't matter whether the body of the atom is included.
+  function parseAtom(data) {
+    var offset = data.sliceOffset + data.viewOffset; // atom position in blob
+    var size = data.readUnsignedInt();               // atom length
+    var type = data.readASCIIText(4);                // atom type
+    var contentOffset = 8;                           // position of atom content
+
+    if (size === 0) {
+      // Zero size means the rest of the file
+      size = blob.size - offset;
+    }
+    else if (size === 1) {
+      // A size of 1 means the size is in bytes 8-15
+      size = data.readUnsignedInt() * 4294967296 + data.readUnsignedInt();
+      contentOffset = 16;
+    }
+
+    var handler = handlers[type] || handlers.defaultHandler;
+    if (typeof handler === 'function') {
+      // If the handler is a function, pass that function a
+      // DataView object that contains the entire atom
+      // including size and type.  Then use the return value
+      // of the function as instructions on what to do next.
+      data.getMore(data.sliceOffset + data.viewOffset, size, function(atom) {
+        // Pass the entire atom to the handler function
+        var rv = handler(atom);
+
+        // If the return value is 'done', stop parsing.
+        // Otherwise, continue with the next atom.
+        // XXX: For more general parsing we need a way to pop some
+        // stack levels.  A return value that is an atom name should mean
+        // pop back up to this atom type and go on to the next atom
+        // after that.
+        if (rv !== 'done') {
+          parseAtomAt(data, offset + size);
+        }
+      });
+    }
+    else if (handler === 'children') {
+      // If the handler is this string, then assume that the atom is
+      // a container atom and do its next child atom next
+      var skip = (type === 'meta') ? 4 : 0; // special case for meta atoms
+      parseAtomAt(data, offset + contentOffset + skip);
+    }
+    else if (handler === 'skip' || !handler) {
+      // Skip the atom entirely and go on to the next one.
+      // If there is no next one, call the eofHandler or just return
+      parseAtomAt(data, offset + size);
+    }
+    else if (handler === 'done') {
+      // Stop parsing
+      return;
+    }
+  }
+
+  function parseAtomAt(data, offset) {
+    if (offset >= blob.size) {
+      if (handlers.eofHandler)
+        handlers.eofHandler();
+      return;
+    }
+    else {
+      data.getMore(offset, 8, parseAtom);
+    }
+  }
+}

--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -26,7 +26,7 @@ var metadataParsers = (function() {
   // cropping the edges as needed to make it fit, and then extract the
   // thumbnail image as a blob and pass it to the callback.
   // This utility function is used by both the image and video metadata parsers
-  function createThumbnailFromElement(elt, video, callback) {
+  function createThumbnailFromElement(elt, video, rotation, callback) {
     // Create a thumbnail image
     var canvas = document.createElement('canvas');
     var context = canvas.getContext('2d');
@@ -47,9 +47,33 @@ var metadataParsers = (function() {
     var x = Math.round((eltwidth - w) / 2);
     var y = Math.round((eltheight - h) / 2);
 
+    // If a rotation is specified, rotate the canvas context
+    if (rotation) {
+      context.save();
+      switch (rotation) {
+      case 90:
+        context.translate(THUMBNAIL_WIDTH, 0);
+        context.rotate(Math.PI / 2);
+        break;
+      case 180:
+        context.translate(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+        context.rotate(Math.PI);
+        break;
+      case 270:
+        context.translate(0, THUMBNAIL_HEIGHT);
+        context.rotate(-Math.PI / 2);
+        break;
+      }
+    }
+
     // Draw that region of the image into the canvas, scaling it down
     context.drawImage(elt, x, y, w, h,
                       0, 0, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+    // Restore the default rotation so the play arrow comes out correctly
+    if (rotation) {
+      context.restore();
+    }
 
     // If this is a video, superimpose a translucent play button over
     // the captured video frame to distinguish it from a still photo thumbnail
@@ -198,7 +222,7 @@ var metadataParsers = (function() {
         callback(metadata);
       }
       else {
-        createThumbnailFromElement(offscreenImage, false,
+        createThumbnailFromElement(offscreenImage, false, 0,
                                    function(thumbnail) {
                                      metadata.thumbnail = thumbnail;
                                      offscreenImage.src = null;
@@ -235,25 +259,108 @@ var metadataParsers = (function() {
         metadata.duration = offscreenVideo.duration;
         metadata.width = offscreenVideo.videoWidth;
         metadata.height = offscreenVideo.videoHeight;
+        metadata.rotation = 0;
 
-        offscreenVideo.currentTime = 1; // read 1 second into video
-        offscreenVideo.onseeked = function() {
-          createThumbnailFromElement(offscreenVideo, true,
-                                     function(thumbnail) {
-                                       URL.revokeObjectURL(url);
-                                       offscreenVideo.onerror = null;
-                                       offscreenVideo.onseeked = null;
-                                       offscreenVideo.src = null;
-                                       metadata.thumbnail = thumbnail;
-                                       metadataCallback(metadata);
-                                     });
-        };
+        // If this is a .3gp video file, look for its rotation matrix and
+        // then create the thumbnail. Otherwise set rotation to 0 and
+        // create the thumbnail.
+        if (file.name.substring(file.name.lastIndexOf('.') + 1) === '3gp') {
+          getVideoRotation(file, function(rotation) {
+            console.log(file.name, 'rotation:', rotation);
+            if (typeof rotation === 'number')
+              metadata.rotation = rotation;
+            else if (typeof rotation === 'string')
+              console.warn('Video rotation:', rotation);
+            createThumbnail();
+          });
+        }
+        else {
+          createThumbnail();
+        }
+
+        function createThumbnail() {
+          offscreenVideo.currentTime = 1; // read 1 second into video
+          offscreenVideo.onseeked = function onseeked() {
+            createThumbnailFromElement(offscreenVideo, true, metadata.rotation,
+                                       function(thumbnail) {
+                                         URL.revokeObjectURL(url);
+                                         offscreenVideo.onerror = null;
+                                         offscreenVideo.onseeked = null;
+                                         offscreenVideo.removeAttribute('src');
+                                         offscreenVideo.load();
+                                         metadata.thumbnail = thumbnail;
+                                         metadataCallback(metadata);
+                                       });
+          };
+        }
       };
     }
     catch (e) {
       console.error('Exception in videoMetadataParser', e, e.stack);
       errorCallback('Exception in videoMetadataParser');
     }
+  }
+
+  //
+  // Given an MP4/Quicktime based video file as a blob, read through its
+  // atoms to find the track header "tkhd" atom and extract the rotation
+  // matrix from it. Convert the matrix value to rotation in degrees and
+  // pass that number to the specified callback function. If no value is
+  // found but the video file is valid, pass null to the callback. If
+  // any errors occur, pass an error message (a string) callback.
+  //
+  // See also:
+  // http://androidxref.com/4.0.4/xref/frameworks/base/media/libstagefright/MPEG4Writer.cpp
+  // https://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFChap2/qtff2.html
+  //
+  function getVideoRotation(blob, rotationCallback) {
+
+    // We want to loop through the top-level atoms until we find the 'moov'
+    // atom. Then, within this atom, there are one or more 'trak' atoms.
+    // Each 'trak' should begin with a 'tkhd' atom. The tkhd atom has
+    // a transformation matrix at byte 48.  The matrix is 9 32 bit integers.
+    // We'll interpret those numbers as a rotation of 0, 90, 180 or 270.
+    // If the video has more than one track, we expect all of them to have
+    // the same rotation, so we'll only look at the first 'trak' atom that
+    // we find.
+    MP4Parser(blob, {
+      errorHandler: function(msg) { rotationCallback(msg); },
+      eofHandler: function() { rotationCallback(null); },
+      defaultHandler: 'skip',  // Skip all atoms other than those listed below
+      moov: 'children',        // Enumerate children of the moov atom
+      trak: 'children',        // Enumerate children of the trak atom
+      tkhd: function(data) {   // Pass the tkhd atom to this function
+        // The matrix begins at byte 48
+        data.advance(48);
+
+        var a = data.readUnsignedInt();
+        var b = data.readUnsignedInt();
+        data.advance(4); // we don't care about this number
+        var c = data.readUnsignedInt();
+        var d = data.readUnsignedInt();
+
+        if (a === 0 && d === 0) { // 90 or 270 degrees
+          if (b === 0x00010000 && c === 0xFFFF0000)
+            rotationCallback(90);
+          else if (b === 0xFFFF0000 && c === 0x00010000)
+            rotationCallback(270);
+          else
+            rotationCallback('unexpected rotation matrix');
+        }
+        else if (b === 0 && c === 0) { // 0 or 180 degrees
+          if (a === 0x00010000 && d === 0x00010000)
+            rotationCallback(0);
+          else if (a === 0xFFFF0000 && d === 0xFFFF0000)
+            rotationCallback(180);
+          else
+            rotationCallback('unexpected rotation matrix');
+        }
+        else {
+          rotationCallback('unexpected rotation matrix');
+        }
+        return 'done';
+      }
+    });
   }
 
   return {

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -1133,7 +1133,8 @@ function setupFrameContent(n, frame) {
     videodb.getFile(fileinfo.name, function(file) {
       frame.displayVideo(file,
                          fileinfo.metadata.width,
-                         fileinfo.metadata.height);
+                         fileinfo.metadata.height,
+                         fileinfo.metadata.rotation || 0);
     });
   }
   else {

--- a/apps/gallery/style/VideoPlayer.css
+++ b/apps/gallery/style/VideoPlayer.css
@@ -1,6 +1,9 @@
 /* styles for the video element itself */
 .videoPlayer {
   position: absolute;
+  left: 0; /* we position it with a transform */
+  top:0;
+  transform-origin: 0 0;
 }
 
 /* video player controls */


### PR DESCRIPTION
This pull request modifies the camera app to pass the phone orientation to the video recorder.

Then it modifies the gallery app video metadata parser to extract the rotation from the .3gp video files and it also modifies the metadata parser to use the rotation when creating a video thumbnail.

Then it modifies the gallery app video player module to use that rotation value when playing back the video.
