### PR TITLE
Bug 813469 - [E-Mail] Can't open an e-mail from the Inbox email list.

### DIFF
--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -1102,8 +1102,9 @@ MessageReaderCard.prototype = {
         node.setAttribute('class', cname);
 
       var subnodes = MailAPI.utils.linkifyPlain(rep[i + 1], document);
-      for (var i in subnodes)
-        node.appendChild(subnodes[i]);
+      for (var iNode = 0; iNode < subnodes.length; iNode++) {
+        node.appendChild(subnodes[iNode]);
+      }
 
       bodyNode.appendChild(node);
     }


### PR DESCRIPTION
r? @mozsquib

https://bugzilla.mozilla.org/show_bug.cgi?id=813469

The problem was that there's an outer for loop over 'i'.

I'm still looking into the IMAP fake-server-in-integration tests thing, but it's not an entirely trivial undertaking and I figured I'd put the bugfix up first since this should ideally land ASAP-ish.
