### PR TITLE
Bug 797633 [browser] Gaia work to prevent bouncing address bar bug

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -443,7 +443,8 @@ var Browser = {
       this.mainScreen.addEventListener('transitionend', addressBarVisible);
       this.addressBarState = this.TRANSITIONING;
       this.mainScreen.classList.remove('address-hidden');
-    } else if (evt.detail.top > this.UPPER_SCROLL_THRESHOLD) {
+    } else if (evt.detail.top > this.UPPER_SCROLL_THRESHOLD 
+      && evt.detail.bottom > this.UPPER_SCROLL_THRESHOLD) {
       if (this.addressBarState == this.HIDDEN ||
         this.addressBarState == this.TRANSITIONING) {
         return;


### PR DESCRIPTION
Only hide the address bar if there's enough page to scroll to not cause the iframe resizing to move the content past the threshold to trigger showing it again, and getting into an infinite loop.

Try reading that sentence after a couple of beers!
