### PR TITLE
[Bug 816637] [SMS] [Keyboard performance] We need to remove the 'spinner' in 'loading' in order to avoid infinite rendering.

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -66,7 +66,7 @@ var MessageManager = {
             receiverInput.value = '';
             threadMessages.classList.add('new');
             MessageManager.slide(function() {
-              messageInput.focus();
+              receiverInput.focus();
             });
             break;
           case '#thread-list':
@@ -82,6 +82,7 @@ var MessageManager = {
               });
             } else {
               MessageManager.slide(function() {
+                ThreadUI.view.innerHTML = '';
                 if (MessageManager.activityTarget) {
                   window.location.hash =
                     '#num=' + MessageManager.activityTarget;

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -653,13 +653,12 @@ form.bottom[role="search"].new-sms-form {
 /*
   Loading screen while deleting
 */
-.show-loading {
-  opacity: 1 !important;
+#loading.show-loading {
+  display: block;
 }
 
 #loading {
-  opacity: 0;
-  transition: opacity 0.3s ease-out;
+  display: none;
 }
 
 .loading-header {


### PR DESCRIPTION
Simply fix that should be in https://github.com/mozilla-b2g/gaia/pull/6720#issuecomment-10862569

This is related to https://bugzilla.mozilla.org/show_bug.cgi?id=812987 as well.
