### PR TITLE
bug 810386, regression fix

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -23,8 +23,8 @@
     <link rel="stylesheet" type="text/css" href="style/updates.css"/>
 
     <!-- Shared resources
+    <link rel="resource" type="application/json" href="shared/resources/tz.json"/>
     <link rel="resource" type="application/json" href="shared/resources/apn.json"/>
-    <link rel="resource" type="application/json" href="shared/resources/timezones.json"/>
     <link rel="resource" type="application/json" href="shared/resources/languages.json"/>
     -->
 
@@ -34,7 +34,6 @@
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini"/>
     <link rel="resource" type="application/l10n" href="shared/locales/permissions.ini"/>
     <link rel="resource" type="application/l10n" href="shared/locales/tz.ini"/>
-    <link rel="resource" type="application/json" href="shared/resources/tz.json"/>
     <script type="application/javascript" src="shared/js/l10n.js"></script>
     <script type="application/javascript" src="shared/js/l10n_date.js"></script>
 


### PR DESCRIPTION
The latest Gaia doesn’t build because I forgot to remove the `timezones.json` resource call from the Settings app. Sorry for the trouble, here’s a fix.
