### PR TITLE
bug 811235 - [Status Bar] display AM/PM indicators when in 12hr mode

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -269,8 +269,7 @@ var StatusBar = {
       this._clockTimer =
         window.setTimeout((this.update.time).bind(this), (59 - sec) * 1000);
 
-      this.icons.time.textContent =
-          f.localeFormat(now, _('statusbarTimeFormat'));
+      this.icons.time.textContent = f.localeFormat(now, _('shortTimeFormat'));
 
       var label = this.icons.label;
       var l10nArgs = JSON.parse(label.dataset.l10nArgs || '{}');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=811235

We’re just dropping the specific time format that used to be requested by UX on the status bar, and use the locale-specific time format instead (see `shortTimeFormat` in /shared/locales/date.*.properties).

@stasm, I’ve removed a line in the system.*.properties file, is that OK with you?
