### PR TITLE
Bug 802121 - [System] Configure cell broadcast service through operator-variant software. r=kaze

### DIFF
--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -37,7 +37,9 @@
         !cset['operatorvariant.mnc']) {
       return;
     }
-    if (gNetwork.mcc == 0 && gNetwork.mnc == 0) {
+
+    var cardState = mobileConnection.cardState;
+    if (gNetwork.mcc == 0 && gNetwork.mnc == 0 && cardState == 'ready') {
       return;
     }
     if ((gNetwork.mcc == cset['operatorvariant.mcc']) &&
@@ -79,7 +81,8 @@
         },
         'operatorvariant': {
           'ril.iccInfo.mbdn': 'voicemail',
-          'ril.sms.strict7BitEncoding.enabled': 'enableStrict7BitEncodingForSms'
+          'ril.sms.strict7BitEncoding.enabled': 'enableStrict7BitEncodingForSms',
+          'ril.cellbroadcast.searchlist': 'cellBroadcastSearchList'
         }
       };
 
@@ -92,7 +95,7 @@
       for (var type in apnPrefNames) {
         var apn = {};
         for (var i = 0; i < result.length; i++) {
-          if (result[i].type.indexOf(type) != -1) {
+          if (result[i] && result[i].type.indexOf(type) != -1) {
             apn = result[i];
             break;
           }

--- a/build/settings.py
+++ b/build/settings.py
@@ -71,6 +71,7 @@ settings = {
  "operatorvariant.mnc": 0,
  "ril.iccInfo.mbdn":"",
  "ril.sms.strict7BitEncoding.enabled": False,
+ "ril.cellbroadcast.searchlist": "",
  "phone.ring.keypad": True,
  "powersave.enabled": False,
  "powersave.threshold": 0,

--- a/shared/resources/apn.json
+++ b/shared/resources/apn.json
@@ -2970,7 +2970,7 @@
   ],
   "6": [
     {"carrier":"Vivo MMS","apn":"mms.vivo.com.br","user":"vivo","password":"vivo","mmsc":"http://termnat.vivomms.com.br:8088/mms","mmsproxy":"200.142.130.104","mmsport":"80","authtype":"1","type":["mms"]},
-    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"type":["operatorvariant"]},
+    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"cellBroadcastSearchList":"50","type":["operatorvariant"]},
     {"carrier":"Vivo Internet","apn":"zap.vivo.com.br","user":"vivo","password":"vivo","authtype":"1","type":["default","supl"]}
   ],
   "7": [
@@ -2980,12 +2980,12 @@
   ],
   "10": [
     {"carrier":"Vivo Internet","apn":"zap.vivo.com.br","user":"vivo","password":"vivo","type":["default","supl"]},
-    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"type":["operatorvariant"]},
+    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"cellBroadcastSearchList":"50","type":["operatorvariant"]},
     {"carrier":"Vivo MMS","apn":"mms.vivo.com.br","user":"vivo","password":"vivo","mmsc":"http://termnat.vivomms.com.br:8088/mms","mmsproxy":"200.142.130.104","mmsport":"80","authtype":"1","type":["mms"]}
   ],
   "11": [
     {"carrier":"Vivo MMS","apn":"mms.vivo.com.br","user":"vivo","password":"vivo","mmsc":"http://termnat.vivomms.com.br:8088/mms","mmsproxy":"200.142.130.104","mmsport":"80","authtype":"1","type":["mms"]},
-    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"type":["operatorvariant"]},
+    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"cellBroadcastSearchList":"50","type":["operatorvariant"]},
     {"carrier":"Vivo Internet","apn":"zap.vivo.com.br","user":"vivo","password":"vivo","authtype":"1","type":["default","supl"]}
   ],
   "16": [
@@ -3000,7 +3000,7 @@
   ],
   "23": [
     {"carrier":"Vivo Internet","apn":"zap.vivo.com.br","user":"vivo","password":"vivo","authtype":"1","type":["default","supl"]},
-    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"type":["operatorvariant"]},
+    {"voicemail":"*555","enableStrict7BitEncodingForSms":true,"cellBroadcastSearchList":"50","type":["operatorvariant"]},
     {"carrier":"Vivo MMS","apn":"mms.vivo.com.br","user":"vivo","password":"vivo","mmsc":"http://termnat.vivomms.com.br:8088/mms","mmsproxy":"200.142.130.104","mmsport":"80","authtype":"1","type":["mms"]}
   ],
   "24": [

--- a/shared/resources/apn/operator-variant.xml
+++ b/shared/resources/apn/operator-variant.xml
@@ -269,6 +269,7 @@
        mcc="724"
        mnc="06"
        enableStrict7BitEncodingForSms="true"
+       cellBroadcastSearchList="50"
    />
    <operator
        name="SCTL GPRS"
@@ -281,12 +282,14 @@
        mcc="724"
        mnc="10"
        enableStrict7BitEncodingForSms="true"
+       cellBroadcastSearchList="50"
    />
    <operator
        name="Vivo Internet"
        mcc="724"
        mnc="11"
        enableStrict7BitEncodingForSms="true"
+       cellBroadcastSearchList="50"
    />
    <operator
        name="BrT Modem"
@@ -305,6 +308,7 @@
        mcc="724"
        mnc="23"
        enableStrict7BitEncodingForSms="true"
+       cellBroadcastSearchList="50"
    />
    <operator
        name="AmazôniaC GPRS"

--- a/shared/resources/apn/query.js
+++ b/shared/resources/apn/query.js
@@ -72,7 +72,6 @@ document.addEventListener('DOMContentLoaded', function onload() {
   function queryGnomeDB(mcc, mnc, setting) {
     var query = '//gsm[network-id' + '[@mcc=' + mcc + '][@mnc=' + mnc + ']' +
         ']/' + setting;
-    console.log(query);
     var result = queryXML(gGnomeDB, query);
     var node = result.iterateNext();
     return node ? node.textContent : '';
@@ -131,6 +130,12 @@ document.addEventListener('DOMContentLoaded', function onload() {
               operatorVariantSettings.enableStrict7BitEncodingForSms =
                 enableStrict7BitEncodingForSms == 'true';
             }
+            var cellBroadcastSearchList =
+              otherSettings['cellBroadcastSearchList'];
+            if (cellBroadcastSearchList) {
+              operatorVariantSettings.cellBroadcastSearchList =
+                cellBroadcastSearchList;
+            }
           }
 
           delete(result[i].mcc);
@@ -146,7 +151,7 @@ document.addEventListener('DOMContentLoaded', function onload() {
             country[mnc].push(result[i]);
           } else {
             country[mnc] = [result[i]];
-            if (voicemail || otherSettings) {
+            if (voicemail || otherSettings || cellBroadcastSearchList) {
               operatorVariantSettings.type = [];
               operatorVariantSettings.type.push('operatorvariant');
               country[mnc].push(operatorVariantSettings);
@@ -196,7 +201,8 @@ document.addEventListener('DOMContentLoaded', function onload() {
     },
     'operatorvariant': {
       'ril.iccInfo.mbdn': 'voicemail',
-      'ril.sms.strict7BitEncoding.enabled': 'enableStrict7BitEncodingForSms'
+      'ril.sms.strict7BitEncoding.enabled': 'enableStrict7BitEncodingForSms',
+      'ril.cellbroadcast.searchlist': 'cellBroadcastSearchList'
     }
   };
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=802121.

Going ahead with this PR but Waiting for a response from Vicamo. Please don't land until cell broadcast support gets landed.

It seems this PR doesn't broke anything. See some logcat output bellow:

I/Gecko   (  109): -*- RadioInterfaceLayer: 'ril.cellbroadcast.searchlist' is now 50
I/Gecko   (  109): RIL Worker: Received DOM message {"rilMessageType":"setCellBroadcastSearchList","searchListStr":"50"}
I/Gecko   (  109): RIL Worker: Cell Broadcast search lists: {"MMI":[50,51],"CBMIR":null,"CBMI":[]}
I/Gecko   (  109): RIL Worker: Cell Broadcast search lists(merged): [50,51]
