### PR TITLE
Bug 813841 - HTML scrolling fix (alternate impl). bustage fix for HTML reply. a=blocking-basecamp a=bustage-fix

### DIFF
--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -30,6 +30,9 @@ function ComposeCard(domNode, mode, args) {
   this.htmlBodyContainer = domNode.getElementsByClassName('cmp-body-html')[0];
   this.htmlIframeNode = null;
 
+  this.scrollContainer =
+    domNode.getElementsByClassName('scrollregion-below-header')[0];
+
   // Add input event listener for handling the bubble creation/deletion.
   this.toNode.addEventListener('keydown', this.onAddressKeydown.bind(this));
   this.ccNode.addEventListener('keydown', this.onAddressKeydown.bind(this));
@@ -120,7 +123,8 @@ ComposeCard.prototype = {
       // able to see what they are sending, so reusing the viewing functionality
       // is desirable.
       this.htmlIframeNode = createAndInsertIframeForContent(
-        this.composer.body.html, this.htmlBodyContainer, /* append */ null,
+        this.composer.body.html, this.scrollContainer,
+        this.htmlBodyContainer, /* append */ null,
         'noninteractive',
         /* no click handler because no navigation desired */ null);
     }


### PR DESCRIPTION
Quickly hack-fix oversight on https://github.com/mozilla-b2g/gaia/pull/6676 that broke the reply functionality for HTML messages.
