### PR TITLE
[Bug 815067] [Settings] Keyboard vibration should be on by default

### DIFF
--- a/build/settings.py
+++ b/build/settings.py
@@ -57,7 +57,7 @@ settings = {
  "keyboard.layouts.japanese": False,
  "keyboard.layouts.portuguese": False,
  "keyboard.layouts.spanish": False,
- "keyboard.vibration": False,
+ "keyboard.vibration": True,
  "keyboard.clicksound": False,
  "keyboard.wordsuggestion": True,
  "language.current": "en-US",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=815067
