### PR TITLE
Bug 806759 - Don't allow user to modify Wifi hotspot settings when Wifi hotspot is enabled

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -672,7 +672,7 @@
             <span data-name="tethering.wifi.security.type"></span>
           </a>
         </li>
-        <li>
+        <li id="hotspot-settings-section">
           <label>
             <button data-href="#hotspot-wifiSettings"
               data-l10n-id="hotspotSettings">Hotspot Settings</button>
@@ -695,6 +695,8 @@
           Share my phone’s Internet connection with a USB-connected device.
         </li>
       </ul>
+
+      <script type="application/javascript" src="js/hotspot.js"></script>
       -->
     </section>
 

--- a/apps/settings/js/hotspot.js
+++ b/apps/settings/js/hotspot.js
@@ -1,0 +1,28 @@
+/* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+onLocalized(function hotspot() {
+
+  var settings = window.navigator.mozSettings;
+  var hotspotSettingsSection = document.getElementById('hotspot-settings-section');
+
+  function setHotspotSettingsEnabled(enabled) {
+    hotspotSettingsSection.hidden = enabled;
+  }
+
+  settings.addObserver('tethering.wifi.enabled', function(event) {
+    setHotspotSettingsEnabled(event.settingValue);
+  });
+
+  var reqTetheringWifiEnabled =
+    settings.createLock().get('tethering.wifi.enabled');
+
+  reqTetheringWifiEnabled.onsuccess = function dt_getStatusSuccess() {
+    setHotspotSettingsEnabled(
+      reqTetheringWifiEnabled.result['tethering.wifi.enabled']
+    );
+  };
+});
+


### PR DESCRIPTION
This patch will hide the hotspot settings button when hotspot is turned on.

Adds hotspot.js.

I tried to follow the previous styles for this app, please let me know if things could be done better.

r=@evelynhung
