### PR TITLE
remove ftuStarting if FTU is skipped for any reason

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -767,6 +767,7 @@ var WindowManager = (function() {
   }
 
   function skipFTU() {
+    document.getElementById('screen').classList.remove('ftuStarting');
     handleInitlogo();
     setDisplayedApp(homescreen);
     // Eventually ask for SIM code, but only when we do not show FTU,
@@ -779,11 +780,11 @@ var WindowManager = (function() {
   // reference to the app and launch it.
   function retrieveFTU() {
     window.asyncStorage.getItem('ftu.enabled', function getItem(launchFTU) {
+      document.getElementById('screen').classList.add('ftuStarting');
       if (launchFTU === false) {
         skipFTU();
         return;
       }
-      document.getElementById('screen').classList.add('ftuStarting');
       var lock = navigator.mozSettings.createLock();
       var req = lock.get('ftu.manifestURL');
       req.onsuccess = function() {


### PR DESCRIPTION
There are four conditions under which the FTU is skipped, but the ftuStarting class is only removed from the screen for one of them, which causes visual (and behavioral?) glitches when the FTU is skipped for one of the other reasons.

(I found this because Firefox OS Simulator unsets ftu.manifestURL in order to skip the FTU when B2G is run in the Simulator, which causes those glitches to appear, since ftuStarting never gets removed in that case.)

ftuStarting should be removed from the screen if the FTU is skipped for any reason.  Here's a patch that does that.
