### PR TITLE
bug 808892 - hide firmware field if the value is not defined

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1549,39 +1549,32 @@
 
       <ul>
         <li>
-          <a data-l10n-id="os-version"> OS Version
-            <span data-name="deviceinfo.os"></span>
-          </a>
+          <small data-name="deviceinfo.os"></small>
+          <a data-l10n-id="os-version"> OS Version </a>
         </li>
         <li>
-          <a data-l10n-id="firmware_revision"> Firmware Revision
-            <span data-name="deviceinfo.firmware_revision"></span>
-          </a>
+          <small data-name="deviceinfo.firmware_revision"></small>
+          <a data-l10n-id="firmware_revision"> Firmware Revision </a>
         </li>
         <li>
-          <a data-l10n-id="hardware_revision"> Hardware Revision
-            <span data-name="deviceinfo.hardware"></span>
-          </a>
+          <small data-name="deviceinfo.hardware"></small>
+          <a data-l10n-id="hardware_revision"> Hardware Revision </a>
         </li>
         <li>
-          <a data-l10n-id="macAddress"> MAC address
-            <span data-name="deviceinfo.mac"></span>
-          </a>
+          <small data-name="deviceinfo.mac"></small>
+          <a data-l10n-id="macAddress"> MAC address </a>
         </li>
         <li>
-          <a data-l10n-id="platform_version"> Platform Version
-            <span data-name="deviceinfo.platform_version"></span>
-          </a>
+          <small data-name="deviceinfo.platform_version"></small>
+          <a data-l10n-id="platform_version"> Platform Version </a>
         </li>
         <li>
-          <a data-l10n-id="build-id"> Build Identifier
-            <span data-name="deviceinfo.platform_build_id"></span>
-          </a>
+          <small data-name="deviceinfo.platform_build_id"></small>
+          <a data-l10n-id="build-id"> Build Identifier </a>
         </li>
         <li>
-          <a data-l10n-id="update-channel"> Update Channel
-            <span data-name="deviceinfo.update_channel"></span>
-          </a>
+          <small data-name="deviceinfo.update_channel"></small>
+          <a data-l10n-id="update-channel"> Update Channel </a>
         </li>
         <li>
           <label>
@@ -1726,19 +1719,16 @@
       </header>
       <ul>
         <li>
-          <a id="model-name" data-l10n-id="model-name"> Model
-            <span data-name="deviceinfo.hardware"></span>
-          </a>
+          <small data-name="deviceinfo.hardware"></small>
+          <a id="model-name" data-l10n-id="model-name"> Model </a>
         </li>
         <li>
-          <a id="os-version" data-l10n-id="software"> Software
-            <span data-name="deviceinfo.software"></span>
-          </a>
+          <small data-name="deviceinfo.software"></small>
+          <a id="os-version" data-l10n-id="software"> Software </a>
         </li>
         <li>
-          <a id="last-update-date" data-l10n-id="last-updated"> Last Updated
-            <span data-name="deviceinfo.last_updated"></span>
-          </a>
+          <small data-name="deviceinfo.last_updated"></small>
+          <a id="last-update-date" data-l10n-id="last-updated"> Last Updated </a>
         </li>
         <li>
           <label>

--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -105,6 +105,7 @@ var gWifiManager = (function(window) {
   return {
     // true if the wifi is enabled
     enabled: false,
+    macAddress: 'xx:xx:xx:xx:xx:xx',
 
     // enables/disables the wifi
     setEnabled: function fakeSetEnabled(bool) {
@@ -229,6 +230,14 @@ var Connectivity = (function(window, document, undefined) {
     document.getElementById('wifi-desc').textContent = _('fullStatus-' +
         gWifiManager.connection.status,
         gWifiManager.connection.network);
+
+    // record MAC address value here because Device Information
+    // needs this value for displaying
+    var macAddress = gWifiManager.macAddress;
+    var settings = window.navigator.mozSettings;
+    if (!settings)
+      return;
+    settings.createLock().set({'deviceinfo.mac': macAddress});
   }
 
   function updateCarrier() {

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -32,7 +32,7 @@ var Settings = {
       var value = event.settingValue;
 
       // update <span> values when the corresponding setting is changed
-      var rule = 'span[data-name="' + key + '"]:not([data-ignore])';
+      var rule = '[data-name="' + key + '"]:not([data-ignore])';
       var spanField = document.querySelector(rule);
       if (spanField) {
         // check whether this setting comes from a select option
@@ -205,10 +205,11 @@ var Settings = {
       }
 
       // preset all span with data-name fields
-      rule = 'span[data-name]:not([data-ignore])';
+      rule = '[data-name]:not([data-ignore])';
       var spanFields = panel.querySelectorAll(rule);
       for (i = 0; i < spanFields.length; i++) {
         var key = spanFields[i].dataset.name;
+
         if (key && request.result[key] != undefined) {
           // check whether this setting comes from a select option
           // (it may be in a different panel, so query the whole document)
@@ -220,6 +221,23 @@ var Settings = {
             spanFields[i].textContent = option.textContent;
           } else {
             spanFields[i].textContent = request.result[key];
+          }
+        } else { // request.result[key] is undefined
+          switch (key) {
+            //XXX bug 816899 will also provide 'deviceinfo.software' from Gecko
+            //  which is {os name + os version}
+            case 'deviceinfo.software':
+              var _ = navigator.mozL10n.get;
+              var text = _('brandShortName') + ' ' +
+                request.result['deviceinfo.os'];
+              spanFields[i].textContent = text;
+              break;
+
+            //XXX workaround request from bug 808892 comment 22
+            //  hide this field if it's undefined/empty.
+            case 'deviceinfo.firmware_revision':
+              spanFields[i].parentNode.hidden = true;
+              break;
           }
         }
       }

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -705,15 +705,6 @@ onLocalized(function wifiSettings() {
       gWifiInfoBlock.textContent = _('fullStatus-initializing');
       gNetworkList.clear(true);
 
-      // record MAC address value
-      var macAddress = gWifiManager.macAddress;
-      settings.createLock().set({'deviceinfo.mac': macAddress});
-
-      var mac = document.querySelectorAll('[data-l10n-id="macAddress"] span');
-      for (var i = 0; i < mac.length; i++) {
-         mac[i].textContent = macAddress;
-      }
-
     } else {
       gWifiInfoBlock.textContent = _('disabled');
       if (gWpsInProgress) {


### PR DESCRIPTION
also add software version value that is OS name + OS version
(although the software version needs to be added into mozSettings
 DB from Gecko side, not hard code here)
also fix MAC address is missing because of lazy-loading wifi panel
