### PR TITLE
Bug 806003 -  Awkward GPS state is awkward

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2125,7 +2125,7 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="ril.radio.disabled" />
+            <input type="checkbox" data-type="switch" name="ril.radio.disabled" data-locks="geolocation.enabled,bluetooth.enabled,wifi.enabled" />
             <span></span>
           </label>
           <a id="menuItem-airplaneMode" class="menu-item" data-l10n-id="airplaneMode">Airplane Mode</a>

--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -118,6 +118,10 @@ ul li > label:not([for]) ~ a {
   padding-right: 6rem;
 }
 
+ul li > label.disabled {
+  opacity:0.5;
+}
+
 
 /******************************************************************************
  * Text inputs


### PR DESCRIPTION
On switch toggle, I'm now disabling the checkbox and adding a "disabled" class to the label. The disabled class will give the checkbox an opacity of 50% for a brief moment.

On setting change event, I'm looking for a "data-locks" attribute on the checkbox. I'm then getting the current setting value of the switch, as well as any identified by "data-locks". After we safely have the values, they are set and the checkboxes are enabled.
