### PR TITLE
Bug 812115 - keyboard manager would hide the keyboard when it receives

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -271,8 +271,7 @@ var eventHandlers = {
   'mouseover': onMouseOver,
   'mouseleave': onMouseLeave,
   'mouseup': onMouseUp,
-  'mousemove': onMouseMove,
-  'transitionend': keyboardTransitionEnd
+  'mousemove': onMouseMove
 };
 
 // The first thing we do when the keyboard app loads is query all the
@@ -375,9 +374,7 @@ function initKeyboard() {
   }
 
   dimensionsObserver = new MutationObserver(function() {
-    // Not to update the app window height until the transition is complete
-    if (IMERender.ime.dataset.transitioncomplete)
-      updateTargetWindowHeight();
+    updateTargetWindowHeight();
   });
 
   // And observe mutation events on the renderer element
@@ -902,22 +899,6 @@ function isNormalKey(key) {
 // Event Handlers
 //
 
-// This transition end handler is triggered when the keyboard is dismissed
-function keyboardTransitionEnd() {
-  updateTargetWindowHeight();
-
-  if (IMERender.ime.dataset.hidden) {
-    // The keyboard just closed. Delete the flag we use on opening
-    // And let the system know that the keyboard has closed.
-    delete IMERender.ime.dataset.transitioncomplete;
-    notifyShowKeyboard(false);
-  } else {
-    // The keyboard just opened. Set this flag so that futures
-    // changes to the keyboard size call updateTargetWindowHeight()
-    IMERender.ime.dataset.transitioncomplete = true;
-  }
-}
-
 // When user scrolls over IME's candidate or alternatives panels
 function onScroll(evt) {
   if (!isPressing || !currentKey)
@@ -1330,7 +1311,6 @@ function showKeyboard(state) {
   }
   IMERender.ime.classList.remove('full-candidate-panel');
 
-  notifyShowKeyboard(true);
 }
 
 // Hide keyboard

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -50,12 +50,7 @@ button::-moz-focus-inner {
   width: 100%;
   background: #6a6f73;
   border-top: solid 1px #000;
-  -moz-transition: -moz-transform 0.3s ease;
   pointer-events: auto;
-}
-
-#keyboard.hide{
-  -moz-transform: translateY(100%);
 }
 
 /* Rows */

--- a/apps/system/style/system/keyboard.css
+++ b/apps/system/style/system/keyboard.css
@@ -12,10 +12,6 @@
   -moz-transition: visibility 0.2s ease, -moz-transform 0.2s ease;
 }
 
-#keyboard-frame.visible {
-  visibility: visible;
-}
-
 #keyboard-frame.hide {
   visibility: hidden;
 


### PR DESCRIPTION
appwillclose event
1.  Hide the keyboard when keyboard manager receives `appwillclose` event.
2.  Remove redundant transition code in keyboard app.
