### PR TITLE
Bug 816987 - [email/IMAP] bug in mimelib dep on consecutive base64-encoded mime encoded-words breaks IMAP synchronization due to our Buffer shim's angry base64 decoding. r=squib, a=blocking-basecamp

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -340,18 +340,65 @@ function coerce(length) {
 var ENCODER_OPTIONS = { fatal: false };
 
 /**
+ * Safe atob-variant that does not throw exceptions and just ignores characters
+ * that it does not know about.  This is an attempt to mimic node's
+ * implementation so that we can parse base64 with newlines present as well
+ * as being tolerant of complete gibberish people throw at us.  Since we are
+ * doing this by hand, we also take the opportunity to put the output directly
+ * in a typed array.
+ *
+ * In contrast, window.atob() throws Exceptions for all kinds of angry reasons.
+ */
+function safeBase64DecodeToArray(s) {
+  var bitsSoFar = 0, validBits = 0, iOut = 0,
+      arr = new Uint8Array(Math.ceil(s.length * 3 / 4));
+  for (var i = 0; i < s.length; i++) {
+    var c = s.charCodeAt(i), bits;
+    if (c >= 65 && c <= 90) // [A-Z]
+      bits = c - 65;
+    else if (c >= 97 && c <= 122) // [a-z]
+      bits = c - 97 + 26;
+    else if (c >= 48 && c <= 57) // [0-9]
+      bits = c - 48 + 52;
+    else if (c === 43) // +
+      bits = 62;
+    else if (c === 47) // /
+      bits = 63;
+    else if (c === 61) { // =
+      validBits = 0;
+      continue;
+    }
+    // ignore all other characters!
+    else
+      continue;
+    bitsSoFar = (bitsSoFar << 6) | bits;
+    validBits += 6;
+    if (validBits >= 8) {
+      validBits -= 8;
+      arr[iOut++] = bitsSoFar >> validBits;
+      if (validBits === 2)
+        bitsSoFar &= 0x3;
+      else if (validBits === 4)
+        bitsSoFar &= 0xf;
+    }
+  }
+
+  if (iOut < arr.length)
+    return arr.subarray(0, iOut);
+  return arr;
+}
+
+/**
  * Encode a unicode string into a (Uint8Array) byte array with the given
- * encoding. Wraps TextEncoder to provide hex and base64 encoding (which it does
- * not provide).
+ * encoding. Wraps TextEncoder to provide hex and base64 "encoding" (which it
+ * does not provide).
  */
 function encode(string, encoding) {
   var buf, i;
   switch (encoding) {
     case 'base64':
-      // (atob is base64 ASCII string -> binary JS string)
-      string = window.atob(string);
-      // fall through to the binary case since what we have is binary now!
-    // the stringencoding polyfill no longer implements binary, so it's up to us
+      buf = safeBase64DecodeToArray(string);
+      return buf;
     case 'binary':
       buf = new Uint8Array(string.length);
       for (i = 0; i < string.length; i++) {
@@ -7102,7 +7149,7 @@ module.exports.mimeFunctions = {
 
         for(var i=0, len = str.length; i<len; i++){
             chr = str.charAt(i);
-            if(chr == "=" && (hex = str.substr(i+1, 2).match(/[\da-fA-F]{2}/))){
+            if(chr == "=" && (hex = str.substr(i+1, 2)) && /[\da-fA-F]{2}/.test(hex)){
                 buffer[bufferPos++] = parseInt(hex, 16);
                 i+=2;
                 continue;
@@ -7210,21 +7257,9 @@ module.exports.mimeFunctions = {
         var remainder = "", lastCharset, curCharset;
         str = (str || "").toString();
 
-        while(str.match(/(\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)\s+(?=\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)/g)){
-            str = str.replace(/(\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)\s+(\=\?[\w_\-]+\?[QB]\?[^\?]+\?\=)/g,function(original, first, second){
-                var match1 = (first || "").trim().match(/^\=\?([\w_\-]+)\?([QB])\?([^\?]+)\?\=$/),
-                    match2 = (second || "").trim().match(/^\=\?([\w_\-]+)\?([QB])\?([^\?]+)\?\=$/);
-
-                if(match1[1] == match2[1] && match1[2] == match2[2]){
-                    return "=?"+match1[1]+"?"+match1[2]+"?"+match1[3] + match2[3]+"?=";
-                }else{
-                    return first+second;
-                }
-
-            });
-        }
-
-        str = str.replace(/\=\?([\w_\-]+)\?([QB])\?[^\?]+\?\=/g, (function(mimeWord, charset, encoding){
+        str = str.
+                replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g, "$1").
+                replace(/\=\?([\w_\-]+)\?([QB])\?[^\?]+\?\=/g, (function(mimeWord, charset, encoding){
 
                       curCharset = charset + encoding;
 


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/91

https://bugzilla.mozilla.org/show_bug.cgi?id=816987
