### PR TITLE
Bug 816687 - Add option for forcing gaia apps to install to /system r=fabrice

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -22,6 +22,11 @@ CLEAN_PROFILE := 0
 # In user (production) builds we put gaia apps in /system/b2g/webapps
 ifneq ($(filter user userdebug, $(TARGET_BUILD_VARIANT)),)
 GAIA_MAKE_FLAGS += PRODUCTION=1
+B2G_SYSTEM_APPS := 1
+endif
+
+ifeq ($(B2G_SYSTEM_APPS),1)
+GAIA_MAKE_FLAGS += B2G_SYSTEM_APPS=1
 GAIA_APP_INSTALL_PARENT := $(TARGET_OUT)/b2g
 CLEAN_PROFILE := 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,17 @@ GAIA_DOMAIN=thisdomaindoesnotexist.org
 GAIA_APP_SRCDIRS=apps showcase_apps
 else ifeq ($(MAKECMDGOALS), production)
 PRODUCTION=1
+B2G_SYSTEM_APPS=1
 endif
 
 # PRODUCTION is also set for user and userdebug B2G builds
 ifeq ($(PRODUCTION), 1)
 GAIA_APP_SRCDIRS=apps
-GAIA_INSTALL_PARENT=/system/b2g
 ADB_REMOUNT=1
+endif
+
+ifeq ($(B2G_SYSTEM_APPS), 1)
+GAIA_INSTALL_PARENT=/system/b2g
 endif
 
 ifneq ($(GAIA_OUTOFTREE_APP_SRCDIRS),)


### PR DESCRIPTION
Setting B2G_SYSTEM_APPS=1 will force all gaia apps to be installed
to /system

This was r+ 'ed by @fabricedesre

https://bugzilla.mozilla.org/show_bug.cgi?id=816687
