### PR TITLE
Bug 817571 - [Contacts] Import contacts option is not working when using  a SIM Card with the PIN code enabled

### DIFF
--- a/apps/communications/contacts/js/contacts_settings.js
+++ b/apps/communications/contacts/js/contacts_settings.js
@@ -100,14 +100,7 @@ contacts.Settings = (function() {
       return;
     }
 
-    var req = conn.getCardLock('pin');
-    req.onsuccess = function onsucces(evt) {
-      enableSIMImport(!req.result.enabled);
-    };
-    req.onerror = function onerror(evt) {
-      console.error('Could not check if we have SIM');
-      enableSIMImport(false);
-    };
+    enableSIMImport(conn.cardState == 'ready');
   };
 
   // Disables/Enables the actions over the sim import functionality


### PR DESCRIPTION
Checking for the card state. 

If carState is ready, means, we have sim card and it's not locked.
