### PR TITLE
bug 817748: Ensure week view event bars appear above time grid lines

### DIFF
--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -115,6 +115,7 @@
 #week-view .week-events > ol li.event {
   position: absolute;
   width: 100%;
+  z-index: 10;
 }
 
 #week-view .week-events > ol.hour-allday li.event {


### PR DESCRIPTION
Looks like a quick `z-index` addition in CSS fixes this. ATTN: @lightsofapollo
