### PR TITLE
Bug 811528 - pref native identity on; r=ferjm

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -69,6 +69,9 @@ if (DEBUG) {
                      webapp.sourceDirectoryName);
   });
   prefs.push(["extensions.gaia.app_relative_path", appPathList.join(' ')]);
+
+  // Identity debug messages
+  prefs.push(["toolkit.identity.debug", true]);
 }
 
 function writePrefs() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=811528

The native implementation of Persona needs to be enabled in b2g.

@ferjm points out that the proper place to pref identity on is on the gecko side: http://mxr.mozilla.org/mozilla-central/source/b2g/app/b2g.js

This PR is then only to enable identity debugging if `DEBUG=1`.  Merging this PR does not depend on landing the rest of Bug 811528 in gecko.
