### PR TITLE
Bug 812584: Remove a failed system update from the update queue so it isn't offered again

### DIFF
--- a/apps/system/js/updatable.js
+++ b/apps/system/js/updatable.js
@@ -148,6 +148,7 @@ SystemUpdatable.prototype.handleEvent = function(evt) {
 SystemUpdatable.prototype.errorCallBack = function() {
   UpdateManager.requestErrorBanner();
   UpdateManager.removeFromDownloadsQueue(this);
+  UpdateManager.removeFromUpdatesQueue(this);
 };
 
 SystemUpdatable.prototype.showApplyPrompt = function() {

--- a/apps/system/test/unit/updatable_test.js
+++ b/apps/system/test/unit/updatable_test.js
@@ -399,6 +399,11 @@ suite('system/Updatable', function() {
           assert.isNotNull(MockUpdateManager.mLastDownloadsRemoval);
           assert.equal(subject, MockUpdateManager.mLastDownloadsRemoval);
         });
+
+        test('should remove self from update queue', function() {
+          assert.isNotNull(MockUpdateManager.mLastUpdatesRemoval);
+          assert.equal(subject, MockUpdateManager.mLastUpdatesRemoval);
+        });
       });
 
       suite('update-progress', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=812584

This is needed so failed system updates aren't offered again unless another check happens.
