### PR TITLE
install mochi.test as an external app

### DIFF
--- a/external-apps/mochitest/manifest.webapp
+++ b/external-apps/mochitest/manifest.webapp
@@ -1,0 +1,38 @@
+{
+  "name": "Mochitest",
+  "description": "Mochitests",
+  "type": "certified",
+  "developer": {
+    "name": "The Ateam",
+    "url": "https://wiki.mozilla.org/Auto-tools"
+  },
+  "permissions": {
+    "alarms": {},
+    "browser":{},
+    "power":{},
+    "webapps-manage":{},
+    "mobileconnection":{},
+    "mozBluetooth":{},
+    "bluetooth":{},
+    "telephony":{},
+    "voicemail":{},
+    "device-storage:pictures":{ "access": "readwrite" },
+    "settings":{ "access": "readwrite" },
+    "storage":{},
+    "camera":{},
+    "geolocation":{},
+    "wifi-manage":{},
+    "wifi":{},
+    "desktop-notification":{},
+    "idle":{},
+    "network-events":{},
+    "embed-apps":{}
+  },
+  "locales": {
+    "en-US": {
+      "name": "Mochitest",
+      "description": "Mochitests"
+    }
+  },
+  "default_locale": "en-US"
+}

--- a/external-apps/mochitest/origin
+++ b/external-apps/mochitest/origin
@@ -1,0 +1,1 @@
+http://mochi.test:8888/


### PR DESCRIPTION
A patch to install mochi.test as an external app. 
The concept here is there are already test apps that won't be deployed inside the external directory. 

This is a low risk patch to take. 

There is another effort that should be made to split the external apps directory into 

--> external apps that are for test & dev 
--> external apps that are shipping on device. 
