### PR TITLE
bug 817755: Further tweak calendar week event bar height calculation

### DIFF
--- a/apps/calendar/js/views/week_child.js
+++ b/apps/calendar/js/views/week_child.js
@@ -46,7 +46,11 @@ Calendar.ns('Views').WeekChild = (function() {
      */
     _assignHeight: function(element, hoursDuration) {
       var percHeight = hoursDuration * 100;
-      var pxHeight = hoursDuration * 2;
+ 
+      // TODO: This is a magic calculation based on current CSS. Fix this so
+      // that it can be dynamic based on CSS, or fix CSS to not need this.
+      var pxHeight = (hoursDuration * 2) - 5;
+
       element.style.height = 'calc(' + percHeight + '% + ' + pxHeight + 'px)';
     },
 

--- a/apps/calendar/test/unit/views/week_child_test.js
+++ b/apps/calendar/test/unit/views/week_child_test.js
@@ -69,7 +69,7 @@ suite('views/week_child', function() {
       subject.date = new Date(2012, 0, 1);
       subject._assignPosition(busy, el);
 
-      assert.equal(el.style.height, 'calc(325% + 6.5px)', 'height');
+      assert.equal(el.style.height, 'calc(325% + 1.5px)', 'height');
   });
 
   test('#create', function() {


### PR DESCRIPTION
Seems like CSS changes from the overlap stuff made borders & margins apply differently. This tweak to the previous bar height calculation looks like it accounts for it.

ATTN: @lightsofapollo
