### PR TITLE
Bug 810465 - [calendar]Month title in calendar squashed after resuming the calendar app

### DIFF
--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -89,7 +89,6 @@ ol.link-list a {
 
 #time-header h1 {
   max-width: calc(100% - 5rem);
-  direction:rtl;
 }
 
 #progress-indicator {


### PR DESCRIPTION
- Fix issue: https://bugzilla.mozilla.org/show_bug.cgi?id=810465
