### PR TITLE
Bug 817491 - [Bluetooth] Strange behavior when trying to share images when bluetooth is off r=evelyn

### DIFF
--- a/apps/bluetooth/js/transfer.js
+++ b/apps/bluetooth/js/transfer.js
@@ -32,6 +32,12 @@ window.addEventListener('localized', function showPanel() {
     document.getElementById('enable-bluetooth-button-turn-on');
   var dialogAlertView = document.getElementById('alert-view');
   var alertOkButton = document.getElementById('alert-button-ok');
+  var dialogConfirmPairing =
+    document.getElementById('enable-bluetooth-settings-view');
+  var pairingCancelButton =
+    document.getElementById('enable-bluetooth-settings-button-cancel');
+  var pairingOkButton =
+    document.getElementById('enable-bluetooth-settings-button-ok');
   var deviceSelect = null;
   var dialogDeviceSelector = document.getElementById('value-selector');
   var deviceSelectorContainers =
@@ -137,6 +143,33 @@ window.addEventListener('localized', function showPanel() {
     endTransfer();
   }
 
+  function showPairingConfirmation(msg) {
+    debug(msg);
+    dialogConfirmPairing.hidden = false;
+    pairingCancelButton.addEventListener('click',
+      confirmPairingDevice.bind(this, false));
+    pairingOkButton.addEventListener('click',
+      confirmPairingDevice.bind(this, true));
+  }
+
+  function confirmPairingDevice(enabled) {
+    dialogConfirmPairing.hidden = true;
+    pairingCancelButton.removeEventListener('click', confirmPairingDevice);
+    pairingOkButton.removeEventListener('click', confirmPairingDevice);
+    if (enabled) {
+      // Launch Settings App to Bluetooth settings.
+      var activityRequest = new MozActivity({
+        name: 'configure',
+        data: {
+          target: 'device',
+          section: 'bluetooth'
+        }
+      });
+    }
+    activity.postError('cancelled');
+    endTransfer();
+  }
+
   function endTransfer() {
     bluetoothCancelButton.removeEventListener('click', cancelTransfer);
     bluetoothTurnOnButton.removeEventListener('click', turnOnBluetooth);
@@ -151,7 +184,7 @@ window.addEventListener('localized', function showPanel() {
       if (length == 0) {
         var msg = 'There is no paired device!' +
                   ' Please pair your bluetooth device first.';
-        cannotTransfer(msg);
+        showPairingConfirmation(msg);
         return;
       }
       // Put the list to value selector

--- a/apps/bluetooth/locales/bluetooth.en-US.properties
+++ b/apps/bluetooth/locales/bluetooth.en-US.properties
@@ -8,3 +8,6 @@ error-transfer-title = Bluetooth file transfer failed
 error-transfer-settings = Bluetooth file transfer failed. Check that the Bluetooth settings are correct.
 ok = OK
 choose-option = Choose your option
+no-devices-paired-title = No Bluetooth devices paired.
+no-devices-paired-settings = Would you like to pair a device now?
+pair-device = Pair device

--- a/apps/bluetooth/transfer.html
+++ b/apps/bluetooth/transfer.html
@@ -48,6 +48,18 @@
         <button class="negative" id="alert-button-ok" data-l10n-id="ok">OK</button>
       </menu>
     </section>
+    <section role="dialog" id="enable-bluetooth-settings-view" hidden>
+      <div>
+        <h3 data-l10n-id="no-devices-paired-title">No Bluetooth devices paired.</h3>
+        <p data-l10n-id="no-devices-paired-settings">
+          Would you like to pair a device now?
+        </p>
+      </div>
+      <menu data-items="2">
+        <button id="enable-bluetooth-settings-button-cancel" data-l10n-id="cancel">Cancel</button>
+        <button class="negative" id="enable-bluetooth-settings-button-ok" data-l10n-id="pair-device">Pair device</button>
+      </menu>
+    </section>
     <!-- Overwrite Value Selector -->
     <div id="value-selector" hidden>
       <form id="select-option-popup" role="dialog">


### PR DESCRIPTION
Add a pairing confirmation dialog.

User story:

The pairing confirmation dialog will pop out when there is no any devices paired.

a) User click the "Cancel" button --> Bluetooth App will return.
b) User click the "Pair device" button --> Request an activity to launch Settings APP and go into bluetooth settings. Then, Bluetooth App will return.
