### PR TITLE
Bug 814355 - l10n_date.js / pretty dates: support compact formats

### DIFF
--- a/shared/locales/date/date.en-US.properties
+++ b/shared/locales/date/date.en-US.properties
@@ -97,10 +97,13 @@ inDays-long[other] = in {{d}} days
 # Relative time ("pretty dates"), short variant
 # LOCALIZATION NOTE: the time unit should be as short as possible,
 # and the whole string should not exceed a length of ~10 latin characters.
+# LOCALIZATION NOTE: the prime (’) can be used to represent minutes for most
+# locales, but we use “m” instead for the English locale to prevent a possible
+# confusion (35’ ago ≠ 35 feet ago).
 
 minutesAgo-short={[ plural(m) ]}
 minutesAgo-short[zero]  = just now
-minutesAgo-short[other] = {{m}}’ ago
+minutesAgo-short[other] = {{m}}m ago
 
 hoursAgo-short={[ plural(h) ]}
 hoursAgo-short[zero]  = just now
@@ -112,7 +115,7 @@ daysAgo-short[other] = {{d}}d ago
 
 inMinutes-short={[ plural(m) ]}
 inMinutes-short[zero]  = now
-inMinutes-short[other] = in {{m}}’
+inMinutes-short[other] = in {{m}}m
 
 inHours-short={[ plural(h) ]}
 inHours-short[zero]  = now


### PR DESCRIPTION
l10n follow-up: use 'm' instead of prime for the en-US locale
