### PR TITLE
Bug 818253 - don't show videos in pick image activity

### DIFF
--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -153,7 +153,7 @@ var metadataParsers = (function() {
                                      // preview blob, then fall back on
                                      // the full-size image
                                      console.warn('Error creating thumbnail' +
-                                                  'from preview:', errmsg);
+                                                  ' from preview:', errmsg);
                                      getImageSizeAndThumbnail(file,
                                                               metadataCallback,
                                                               metadataError);

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -126,11 +126,6 @@ window.addEventListener('localized', function showBody() {
 });
 
 function init() {
-  initUI();
-  initDB();
-}
-
-function initUI() {
   // Keep track of when thumbnails are onscreen and offscreen
   monitorChildVisibility(thumbnails,
                          360,                 // extra space top and bottom
@@ -249,19 +244,55 @@ function initUI() {
   previousFrame.container.addEventListener('transitionend', removeTransition);
   currentFrame.container.addEventListener('transitionend', removeTransition);
   nextFrame.container.addEventListener('transitionend', removeTransition);
+
+  // If we were not invoked by an activity, then start off in thumbnail
+  // list mode, and fire up the image and video mediadb objects.
+  if (!navigator.mozHasPendingMessage('activity')) {
+    initDB(true);
+    setView(thumbnailListView);
+  }
+
+  // Register a handler for activities. This will take care of the rest
+  // of the initialization process.
+  navigator.mozSetMessageHandler('activity', function activityHandler(a) {
+    var activityName = a.source.name;
+    switch (activityName) {
+    case 'browse':
+      // The 'browse' activity is the way we launch Gallery from Camera.
+      // If this was a cold start, then the db needs to be initialized.
+      if (!photodb)
+        initDB(true);  // Initialize both the photo and video databases
+      // Always switch to the list of thumbnails.
+      setView(thumbnailListView);
+      break;
+    case 'pick':
+      if (pendingPick) // I don't think this can really happen anymore
+        cancelPick();
+      if (!photodb)
+        initDB(false); // Don't include videos when picking photos!
+      startPick(a);
+      break;
+    }
+  });
 }
 
-
-function initDB() {
+// Initialize MediaDB objects for photos and videos, and set up their
+// event handlers.
+function initDB(include_videos) {
   photodb = new MediaDB('pictures', metadataParsers.imageMetadataParser, {
     mimeTypes: ['image/jpeg', 'image/png'],
     version: 2
   });
 
-  // For videos, this app is only interested in files under DCIM/.
-  videodb = new MediaDB('videos', metadataParsers.videoMetadataParser, {
-    directory: 'DCIM/'
-  });
+  if (include_videos) {
+    // For videos, this app is only interested in files under DCIM/.
+    videodb = new MediaDB('videos', metadataParsers.videoMetadataParser, {
+      directory: 'DCIM/'
+    });
+  }
+  else {
+    videodb = null;
+  }
 
   // This is called when DeviceStorage becomes unavailable because the
   // sd card is removed or because it is mounted for USB mass storage
@@ -281,23 +312,31 @@ function initDB() {
     if (currentOverlay === 'nocard' || currentOverlay === 'pluggedin')
       showOverlay(null);
 
-    // If the videodb is also ready, enumerate photos and videos
-    if (videodb.state === MediaDB.READY)
-      createThumbnailList();
+    // If we're including videos also, be sure that they are ready
+    if (include_videos) {
+      if (videodb.state === MediaDB.READY)
+        createThumbnailList();
+    }
+    else {
+      createPhotoThumbnailList();
+    }
   };
 
-  videodb.onready = function() {
-    // If the photodb is also ready, create thumbnails.
-    // Depending on the order of the ready events, either this code
-    // or the code above will fire and set up the thumbnails
-    if (photodb.state === MediaDB.READY)
-      createThumbnailList();
-  };
+  if (include_videos) {
+    videodb.onready = function() {
+      // If the photodb is also ready, create thumbnails.
+      // Depending on the order of the ready events, either this code
+      // or the code above will fire and set up the thumbnails
+      if (photodb.state === MediaDB.READY)
+        createThumbnailList();
+    };
+  }
 
-  // When the mediadbs are scanning, let the user know
+  // When the mediadbs are scanning, let the user know. We count scan starts
+  // and ends so we correctly display the throbber while either db is scanning.
   var scanning = 0;
 
-  photodb.onscanstart = videodb.onscanstart = function onscanstart() {
+  photodb.onscanstart = function onscanstart() {
     scanning++;
     if (scanning == 1) {
       // Show the scanning indicator
@@ -306,7 +345,7 @@ function initDB() {
     }
   };
 
-  photodb.onscanend = videodb.onscanend = function onscanend() {
+  photodb.onscanend = function onscanend() {
     scanning--;
     if (scanning == 0) {
       // Hide the scanning indicator
@@ -316,25 +355,21 @@ function initDB() {
   };
 
   // One or more files was created (or was just discovered by a scan)
-  // XXX If the array is big, we should just rebuild the UI from scratch
-  photodb.oncreated = videodb.oncreated = function(event) {
+  photodb.oncreated = function(event) {
     event.detail.forEach(fileCreated);
   };
 
   // One or more files were deleted (or were just discovered missing by a scan)
-  // XXX If the array is big, we should just rebuild the UI from scratch
-  photodb.ondeleted = videodb.ondeleted = function(event) {
+  photodb.ondeleted = function(event) {
     event.detail.forEach(fileDeleted);
   };
 
-  // Start off in thumbnail list view, unless there is a pending activity
-  // request message. In that case, the message handler will set the
-  // initial view
-  if (!navigator.mozHasPendingMessage('activity'))
-    setView(thumbnailListView);
-
-  // Register a handler for activities
-  navigator.mozSetMessageHandler('activity', webActivityHandler);
+  if (include_videos) {
+    videodb.onscanstart = photodb.onscanstart;
+    videodb.onscanend = photodb.onscanend;
+    videodb.oncreated = photodb.oncreated;
+    videodb.ondelete = photodb.oncreated;
+  }
 }
 
 function fileDeleted(filename) {
@@ -383,7 +418,8 @@ function fileDeleted(filename) {
 
   // If there are no more photos show the "no pix" overlay
   if (files.length === 0) {
-    setView(thumbnailListView);
+    if (currentView !== pickView)
+      setView(thumbnailListView);
     showOverlay('emptygallery');
   }
 }
@@ -632,6 +668,23 @@ function createThumbnailList() {
   }
 }
 
+// A simpler version of createThumbnailList that only enumerates photos.
+// This is used by the pick activity.
+function createPhotoThumbnailList() {
+  photodb.enumerate('date', null, 'prev', function(fileinfo) {
+    if (fileinfo === null) {
+      if (files.length === 0) { // If we didn't find anything
+        showOverlay('emptygallery');
+      }
+    }
+    else {
+      files.push(fileinfo);                              // Remember file
+      var thumbnail = createThumbnail(files.length - 1); // Create thumbnail
+      thumbnails.appendChild(thumbnail);                 // Display thumbnail
+    }
+  });
+}
+
 //
 // Create a thumbnail element
 //
@@ -665,31 +718,9 @@ function thumbnailOffscreen(thumbnail) {
 }
 
 //
-// Web Activities
+// Pick activity
 //
 
-// Register this with navigator.mozSetMessageHandler
-function webActivityHandler(activityRequest) {
-  var activityName = activityRequest.source.name;
-  switch (activityName) {
-  case 'browse':
-    if (launchedAsInlineActivity)
-      return;
-    // The 'browse' activity is just the way we launch the app
-    // There's nothing else to do here.
-    setView(thumbnailListView);
-    break;
-  case 'pick':
-    if (!launchedAsInlineActivity)
-      return;
-    if (pendingPick)
-      cancelPick();
-    startPick(activityRequest);
-    break;
-  }
-}
-
-var launchedAsInlineActivity = window.location.hash === '#pick';
 var pendingPick;
 var pickType;
 var pickWidth, pickHeight;

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -273,6 +273,7 @@ body.hidden *[data-l10n-id] {
   height: 3px;
   border: none;
   overflow: hidden;
+  z-index: 3; /* has to be higher than pick-top */
 }
 
 #throbber {

--- a/shared/js/media/jpeg_metadata_parser.js
+++ b/shared/js/media/jpeg_metadata_parser.js
@@ -22,7 +22,9 @@ function parseJPEGMetadata(file, metadataCallback, metadataError) {
   // Hopefully, this will be all we need and everything else will
   // be synchronous
   BlobView.get(file, 0, Math.min(16 * 1024, file.size), function(data) {
-    if (data.getUint8(0) !== 0xFF || data.getUint8(1) !== 0xD8) {
+    if (data.byteLength < 2 ||
+        data.getUint8(0) !== 0xFF ||
+        data.getUint8(1) !== 0xD8) {
       metadataError('Not a JPEG file');
       return;
     }


### PR DESCRIPTION
This changes the initialization logic of the gallery a bit so that when invoked for an image pick activity, it does not create a MediaDB object for videos and does not include videos in the list of thumbnails.
