### PR TITLE
Bug 818234 - Add disabled style to switch of building blocks

### DIFF
--- a/shared/style/switches.css
+++ b/shared/style/switches.css
@@ -95,6 +95,21 @@ label input[data-type="switch"] + span:after {
   transform: translateX(-5.4rem);
 }
 
+/* switch: disabled state */
+label input[data-type="switch"]:disabled + span:before,
+label input[data-type="switch"]:disabled + span:after {
+  opacity: 0.2;
+}
+
+label input[data-type="switch"]:disabled + span {
+  opacity: 0.3;
+}
+
+label input[data-type="switch"]:checked:disabled + span {
+  opacity: 1;
+  border: solid 1px #A7DBE6;
+}
+
 /* 'ON' state */
 
 label input[data-type="switch"]:checked + span {


### PR DESCRIPTION
This is a follow-up patch for Bug 818234, needed by #6875.
Should be ok to be merged first without #6875
