### PR TITLE
Bug 819695 - Fix clock display on lockscreen and homescreen

### DIFF
--- a/apps/homescreen/js/landing.js
+++ b/apps/homescreen/js/landing.js
@@ -59,7 +59,7 @@ const LandingPage = (function() {
     var date = new Date();
 
     var time = dateTimeFormat.localeFormat(date, timeFormat);
-    clockElemNumbers.textContent = time.match(/([01]?\d):[0-5]\d/g);
+    clockElemNumbers.textContent = time.match(/([012]?\d):[0-5]\d/g);
     clockElemMeridiem.textContent = (time.match(/AM|PM/i) || []).join('');
     dateElem.textContent = dateTimeFormat.localeFormat(date, dateFormat);
 

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -713,7 +713,7 @@ var LockScreen = {
     var timeFormat = _('shortTimeFormat') || '%H:%M';
     var dateFormat = _('longDateFormat') || '%A %e %B';
     var time = f.localeFormat(d, timeFormat);
-    this.clockNumbers.textContent = time.match(/([01]?\d):[0-5]\d/g);
+    this.clockNumbers.textContent = time.match(/([012]?\d):[0-5]\d/g);
     this.clockMeridiem.textContent = (time.match(/AM|PM/i) || []).join('');
     this.date.textContent = f.localeFormat(d, dateFormat);
 


### PR DESCRIPTION
Lockscreen and Homescreen checks validity of digits before filling the
HTML element's textContent, but it forgets to include the '2' digit
which is valid in 24h format.
