### PR TITLE
Bug 818056 - Workaround for setting panel layering

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -133,9 +133,6 @@ var Settings = {
         };
       }
     }
-
-    // display panel if required
-    panel.hidden = false;
   },
 
   presetPanel: function settings_presetPanel(panel) {
@@ -679,6 +676,7 @@ window.addEventListener('load', function loadSettings() {
 
     // load panel (+ dependencies) if necessary -- this should be synchronous
     lazyLoad(newPanel);
+    newPanel.hidden = false;
 
     // switch previous/current classes -- the timeout is required to make the
     // transition smooth after lazy-loading a panel
@@ -701,6 +699,17 @@ window.addEventListener('load', function loadSettings() {
 
       setTimeout(function setInit() {
         document.body.classList.remove('uninit');
+      });
+
+      // Bug 818056 - When multiple visible panels are present,
+      // they are not painted correctly. This appears to fix the issue.
+      // Only do this after the first load
+      if (oldPanel.className === 'current')
+        return;
+
+      oldPanel.addEventListener('transitionend', function onTransitionEnd() {
+        oldPanel.removeEventListener('transitionend', onTransitionEnd);
+        oldPanel.hidden = true;
       });
     });
   }


### PR DESCRIPTION
It appears that the nature of transitioning the entire page off screen is causing strange repaint issues. This was one workaround I found to fix navigation around the settings app. I'm not sure if it's the most ideal, but it appeared to be the simplest fix - and navigation seems to be improved. I can try to gather some test cases and open a gecko bug for this.

With this change there are only no more than two panels displayed at a single time. Once the panel is transitioned away from, we hide it again.
