### PR TITLE
Bug 815979 - Remove "Everything.me" verbiage from loading screen [r=ving...

### DIFF
--- a/apps/homescreen/index.html
+++ b/apps/homescreen/index.html
@@ -84,8 +84,8 @@
       <div class="page" id="evmePage">
           <article id="loading-overlay">
             <section class="loading-container">
-              <header class="loading-header" data-l10n-id="loadingEvme">
-                Everything.me
+              <header class="loading-header" data-l10n-id="loadingEvme2">
+                Loading&hellip;
               </header>
               <p role="status">
                 <progress class="loading-icon frozen small"></progress>

--- a/apps/homescreen/locales/homescreen.en-US.properties
+++ b/apps/homescreen/locales/homescreen.en-US.properties
@@ -22,7 +22,7 @@ remove-body=Remove {{name}} from the homescreen?
 remove=Remove
 
 # Evme
-loadingEvme=Everything.me
+loadingEvme2=Loading…
 
 # Landing
 longDateFormat=%A, %B %e


### PR DESCRIPTION
...tetun]
