### PR TITLE
Bug 815988 - SIM PUK dialog misses the input label r=alive

### DIFF
--- a/apps/system/style/simcard.css
+++ b/apps/system/style/simcard.css
@@ -1,5 +1,6 @@
 #simpin-dialog {
   background: white;
+  color: #000;
 }
 
 #simpin-dialog section[role="region"] {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=815988
