### PR TITLE
Bug 819136 - Check application types when granting audio-* permissions (part 1). r=alive, a=blocking-basecamp

### DIFF
--- a/apps/camera/manifest.webapp
+++ b/apps/camera/manifest.webapp
@@ -15,7 +15,7 @@
     "settings":{ "access": "readonly" },
     "camera":{},
     "geolocation":{},
-    "audio":{ "channels": ["publicnotification"] }
+    "audio-channel-publicnotification":{}
   },
   "activities": {
     "record": {

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -11,7 +11,7 @@
     "alarms":{},
     "settings":{ "access": "readwrite" },
     "attention":{},
-    "audio":{ "channels": ["alarm"] }
+    "audio-channel-alarm":{}
   },
   "locales": {
     "ar": {

--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -78,7 +78,8 @@
     "systemXHR": {},
     "wifi-manage":{},
     "time": {},
-    "audio":{ "channels": ["telephony", "ringer"] }
+    "audio-channel-telephony":{},
+    "audio-channel-ringer":{}
   },
   "orientation": "portrait-primary",
   "activities": {

--- a/apps/music/manifest.webapp
+++ b/apps/music/manifest.webapp
@@ -10,7 +10,7 @@
   "permissions": {
     "device-storage:music":{ "access": "readwrite" },
     "settings":{ "access": "readonly" },
-    "audio":{ "channels": ["content"] }
+    "audio-channel-content":{}
   },
   "locales": {
     "ar": {

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -31,7 +31,8 @@
     "embed-apps":{},
     "background-sensors":{},
     "permissions":{},
-    "audio":{ "channels": ["publicnotification", "notification"] }
+    "audio-channel-publicnotification":{},
+    "audio-channel-notification":{}
   },
   "locales": {
     "ar": {

--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -10,7 +10,7 @@
   "permissions": {
     "device-storage:videos":{ "access": "readwrite" },
     "deprecated-hwvideo":{},
-    "audio":{ "channels": ["content"] }
+    "audio-channel-content":{}
   },
   "locales": {
     "ar": {


### PR DESCRIPTION
We're hoping to adjust the audio permission syntax by https://bugzilla.mozilla.org/show_bug.cgi?id=819136#c6.
