### PR TITLE
Bug 806003 -  Wait for components ready before enabling airplane mode

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -47,6 +47,7 @@
     <!-- Specific code -->
     <script type="application/javascript" defer src="js/utils.js"></script>
     <script type="application/javascript" defer src="js/settings.js"></script>
+    <script type="application/javascript" defer src="js/airplane_mode.js"></script>
 
     <!-- Required to update the status of the root panel -->
     <script type="application/javascript" defer src="js/battery.js"></script>

--- a/apps/settings/js/airplane_mode.js
+++ b/apps/settings/js/airplane_mode.js
@@ -1,0 +1,173 @@
+/* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
+/**
+ * This file manages airplane mode interaction within the settings app.
+ * The airplane mode button is disabled when the user taps it.
+ * We then determine the number of components that need to change,
+ * and fire off an event only when all components are ready.
+ */
+
+'use strict';
+
+var AirplaneMode = {
+
+  /**
+   * Counter for operstions before radiosafe event
+   * Updated when we toggle radio mode
+   * @private
+   */
+  _ops: 0,
+
+  /**
+   * Whether or not we are firing the event for airplane mode
+   * @private
+   */
+  _doNotify: false,
+
+  element: document.querySelector('input[name="ril.radio.disabled"]'),
+
+  /**
+   * Enable the radio state
+   */
+  enableRadioSwitch: function() {
+    this.element.disabled = false;
+  },
+
+  /**
+   * Notifies apps that components are in a stable state
+   * This waits until all components are enabled after changing airplane mode
+   * @param {String} the setting name.
+   */
+  notify: function(name) {
+    if (!this._doNotify)
+      return;
+
+    this._ops--;
+    if (this._ops === 0) {
+      this._doNotify = false;
+      this.enableRadioSwitch();
+    }
+  },
+
+  /**
+   * Called when the user interacts with the airplane_mode switch
+   */
+  handleEvent: function(e) {
+    this.element.disabled = true;
+  },
+
+  init: function apm_init() {
+    var settings = Settings.mozSettings;
+    if (!settings)
+      return;
+
+    var self = this;
+
+    // Disable airplane mode when we interact with it
+    this.element.addEventListener('change', this);
+
+    var mobileDataEnabled = false;
+    settings.addObserver('ril.data.enabled', function(e) {
+      mobileDataEnabled = e.settingValue;
+      self.notify('ril.data.enabled');
+    });
+
+    var bluetoothEnabled = false;
+    var wifiEnabled = false;
+    var geolocationEnabled = false;
+    settings.addObserver('geolocation.enabled', function(e) {
+      geolocationEnabled = e.settingValue;
+      self.notify('geolocation.enabled');
+    });
+
+    // when wifi is really enabled, notify if needed
+    window.addEventListener('wifi-enabled', function() {
+      wifiEnabled = true;
+      self.notify('wifi.enabled');
+    });
+
+    // when wifi is really disabled, notify if needed
+    window.addEventListener('wifi-disabled', function() {
+      wifiEnabled = false;
+      self.notify('wifi.enabled');
+    });
+
+    if (window.gBluetooth) {
+      // when bluetooth is really enabled, notify if needed
+      window.addEventListener('bluetooth-adapter-added', function() {
+        bluetoothEnabled = true;
+        self.notify('bluetooth.enabled');
+      });
+
+      // when bluetooth is really disabled, notify if needed
+      window.addEventListener('bluetooth-disabled', function() {
+        bluetoothEnabled = false;
+        self.notify('bluetooth.enabled');
+      });
+    }
+
+    var restoreMobileData = false;
+    var restoreBluetooth = false;
+    var restoreWifi = false;
+    var restoreGeolocation = false;
+
+    settings.addObserver('ril.radio.disabled', function(value) {
+
+      self.status = value;
+
+      // Reset notification params
+      self._ops = 0;
+      self._doNotify = true;
+
+      if (value) {
+
+        if (window.gMobileConnection) {
+          restoreMobileData = mobileDataEnabled;
+          if (mobileDataEnabled)
+            self._ops++;
+        }
+
+        // Bluetooth.
+        if (window.gBluetooth) {
+          restoreBluetooth = bluetoothEnabled;
+          if (bluetoothEnabled)
+            self._ops++;
+        }
+
+        // Wifi.
+        if (window.gWifiManager) {
+          restoreWifi = wifiEnabled;
+          if (wifiEnabled)
+            self._ops++;
+        }
+
+        // Geolocation
+        restoreGeolocation = geolocationEnabled;
+        if (geolocationEnabled)
+          self._ops++;
+
+      } else {
+        // Don't count mobile data if it's already on
+        if (window.gMobileConnection && !mobileDataEnabled && restoreMobileData)
+          self._ops++;
+
+        // Don't count Bluetooth if it's already on
+        if (window.gBluetooth && !gBluetooth.enabled && restoreBluetooth)
+          self._ops++;
+
+        // Don't count Wifi if it's already on
+        if (window.gWifiManager && !gWifiManager.enabled && restoreWifi)
+          self._ops++;
+
+        // Don't count Geolocation if it's already on
+        if (!geolocationEnabled && restoreGeolocation)
+          self._ops++;
+      }
+
+      // If we have zero operations to perform, enable the radio switch
+      if (self._ops === 0)
+        self.enableRadioSwitch();
+    });
+  }
+};
+
+AirplaneMode.init();

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -716,10 +716,12 @@ onLocalized(function bluetoothSettings() {
     // enable UI toggle
     gBluetoothCheckBox.disabled = false;
     initialDefaultAdapter();
+    dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
   };
   bluetooth.ondisabled = function bt_onDisabled() {
     gBluetoothCheckBox.disabled = false;  // enable UI toggle
     defaultAdapter = null;  // clear defaultAdapter
+    dispatchEvent(new CustomEvent('bluetooth-disabled'));    
   };
 });
 

--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -225,8 +225,14 @@ var Connectivity = (function(window, document, undefined) {
   //
   // Now register callbacks to track the state of the wifi hardware
   //
-  gWifiManager.onenabled = wifiEnabled;
-  gWifiManager.ondisabled = wifiDisabled;
+  gWifiManager.onenabled = function() {
+    dispatchEvent(new CustomEvent('wifi-enabled'));
+    wifiEnabled();
+  };
+  gWifiManager.ondisabled = function() {
+    dispatchEvent(new CustomEvent('wifi-disabled'));
+    wifiDisabled();
+  };
   gWifiManager.onstatuschange = wifiStatusChange;
 
   function init() {
@@ -241,9 +247,15 @@ var Connectivity = (function(window, document, undefined) {
     gMobileConnection.addEventListener('datachange', updateCarrier);
     updateCarrier();
 
-    // this listener is replaced when bluetooth.js is loaded
-    gBluetooth.onadapteradded = updateBluetooth;
-    gBluetooth.ondisabled = updateBluetooth;
+    // these listeners are replaced when bluetooth.js is loaded
+    gBluetooth.onadapteradded = function() {
+      dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
+      updateBluetooth();
+    };
+    gBluetooth.ondisabled = function() {
+      dispatchEvent(new CustomEvent('bluetooth-disabled'));
+      updateBluetooth();
+    };
     updateBluetooth();
     initSystemMessageHandler();
   }


### PR DESCRIPTION
This patch will disable and enable the airplane mode switch only when the device is ready to do so.

We check on the following events to determine "Readiness", please let me know if there is a better event to check on, but this was as late as I could find:

geolocation: addObserver('geolocation.enabled')
wifi: WifiManager.onenabled || WifiManager.ondisabled
bluetooth: Bluetooth.ondisabled || Bluetooth.onadapteradded
