### PR TITLE
Bug 809782 - followup to fix gray square problem

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -26,10 +26,6 @@
   </head>
 
   <body class="hidden" role="application">
-    <!-- This element gets inserted into the different view elements --> 
-    <!-- It gets styled differently depending on what its parent is -->
-    <ul id="thumbnails"></ul> <!-- Thumbnails inserted here -->
-
     <section role="region" id="thumbnail-list-view" class="hidden">
       <footer id="thumbnails-bottom">
         <a id="thumbnails-camera-button" class="button"></a>
@@ -162,6 +158,10 @@
         <a id="edit-border-button" class="button" data-l10n-id="borders"></a>
       </footer>
     </section>
+
+    <!-- This element gets positioned over different view elements -->
+    <!-- It gets styled differently depending on what it is over -->
+    <ul id="thumbnails"></ul> <!-- Thumbnails inserted here -->
 
     <!-- A thin indeterminate progress bar to indicate scanning -->
     <!-- set class to "throb" to make it go, or hidden" to make it stop -->

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -33,17 +33,6 @@ section {
   display: none;
 }
 
-/*
- * When we hide the thumbnail list, to go into single-photo fullscreen mode,
- * we need to retain thumbnail layout information so monitorChildVisibility()
- * doesn't get confused if we delete a photo while in fullscreen mode.
- * So hide them this way instead of display:none
- */
-#thumbnail-list-view.hidden {
-  display: block;
-  visibility: hidden;
-}
-
 /* All of the main views fill the screen */
 #thumbnail-list-view, #thumbnail-select-view, #fullscreen-view, #pick-view, #edit-view, #crop-view {
   position: absolute;
@@ -114,12 +103,37 @@ section {
 
 #thumbnails {
   position: absolute;
+  left: 0;
+  width: calc(100% + 1px); /* one extra pixel for the right margin */
+  /* top and bottom are set depending on view below */
   padding: 0;
   margin: 0;
   overflow-y: scroll;
   overflow-x: hidden;
-  /* Cheating! Due to margins to the right, a row of 3 thumbnails is be thicker than 100% */
-  width: 104%;
+}
+
+/* thumbnails in regular thumbnail list view */
+#thumbnails.list {
+  top: 0;
+  bottom: 0;
+}
+
+/* thumbnails in thumbnail select view where there is a top bar */
+#thumbnails.select {
+  top: 50px;
+  bottom: 0;
+}
+
+/* thumbnails in pick view where there is a top bar and no bottom */
+#thumbnails.pick {
+  top: 50px;
+  bottom: 0;
+}
+
+#thumbnails.offscreen {
+  top: 0;
+  bottom: 0;
+  transform: translate(100%, 0);
 }
 
 .thumbnail {
@@ -151,6 +165,15 @@ section {
   outline-offset: -3px;
 }
 
+/*
+ * give the very last thumbnail a large bottom margin so that it doesn't
+ * get stuck hidden behind the overlaid toolbar.
+ */
+.thumbnail:last-child {
+  margin-bottom: 40px;
+}
+
+
 /* 320x480 phones */
 @media (orientation: portrait) and (width: 320px) {
   .thumbnail {
@@ -173,30 +196,6 @@ section {
         width: 160px;
         height: 160px;
     }
-}
-
-/* thumbnails in regular thumbnail list view */
-#thumbnail-list-view > #thumbnails {
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0px;
-}
-
-/* thumbnails in thumbnail select view where there is a top bar */
-#thumbnail-select-view > #thumbnails {
-  top: 50px;
-  left: 0;
-  right: 0;
-  bottom: 0px;
-}
-
-/* thumbnails in pick view where there is a top bar and no bottom */
-#pick-view > #thumbnails {
-  top: 50px;
-  left: 0;
-  right: 0;
-  bottom: 0;
 }
 
 /* since fullscreen-view is fullscreen, it needs its own background color */

--- a/shared/js/visibility_monitor.js
+++ b/shared/js/visibility_monitor.js
@@ -152,7 +152,7 @@ function monitorChildVisibility(container, scrollmargin,
     // doesn't affect us at all.
     if (lastOnscreen &&
         after(child, lastOnscreen) &&
-        container.scrollHeight > container.clientHeight)
+        child.offsetTop > container.clientHeight + scrollmargin)
       return;
 
     // Otherwise, if this is the first element added or if it is after


### PR DESCRIPTION
My 3rd patch for bug 809782 had a couple of bugs in it that would sometimes cause thumbnails to not be displayed properly.  This is a followup to fix those bugs.

One bug was in visibility_monitor.js

The other bug has to do with how the gallery was managing its list of thumbnails when switching views. So this patch includes a minor refactoring of how the thumbnails list is managed. As part of that I had to chase down a problem with fullscreen mode, so it turned out to be a larger patch than I anticipated, but it gave me the opportunity to do a little CSS cleanup, as well.
