### PR TITLE
bug 820166 stop discover nearby devices when Settings app is pushed to the background

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -230,8 +230,6 @@ var Connectivity = (function(window, document, undefined) {
 
     // this listener is replaced when bluetooth.js is loaded
     gBluetooth.onadapteradded = updateBluetooth;
-    // these listeners are not cleared by bluetooth.js
-    gBluetooth.onenabled = updateBluetooth;
     gBluetooth.ondisabled = updateBluetooth;
     updateBluetooth();
     initSystemMessageHandler();


### PR DESCRIPTION
do more error checking: detect bluetooth isn't ready or been turned off.
remove the hook of onenabled event, it's useless.
clean up when bluetooth is turned off, delete defaultAdapter
