### PR TITLE
Bug 799828 - [email] Add a missing parameter to scheduleMessagePurge. r=asuth, a=blocking-basecamp

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -34547,7 +34547,7 @@ ActiveSyncAccount.prototype = {
       callback();
   },
 
-  scheduleMessagePurge: function(callback) {
+  scheduleMessagePurge: function(folderId, callback) {
     // ActiveSync servers have no incremental folder growth, so message purging
     // makes no sense for them.
     if (callback)


### PR DESCRIPTION
Land squib's fix from:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/98
