### PR TITLE
Bug 820648 - Output the error for better debugging output. r=ferjm

### DIFF
--- a/apps/communications/ftu/js/wifi.js
+++ b/apps/communications/ftu/js/wifi.js
@@ -18,7 +18,7 @@ var WifiManager = {
         callback(self.networks);
       };
       req.onerror = function onScanError() {
-        console.log('Error reading networks');
+        console.log('Error reading networks: ' + req.error);
       };
     } else {
       var fakeNetworks = [


### PR DESCRIPTION
This is blocking-basecamp+ for a small debug-only (and hopefully rare-error-condition only) change.
