### PR TITLE
Bug 809087 - [Clock] Turn off the active alarm (screen + sound) automatically when there is a incoming phone call r=timdream

### DIFF
--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -418,8 +418,8 @@ html, body {
 
 #analog-clock-container {
   width: 100%;
-  height: -moz-calc(100% - 5.8rem);
-  margin: 5.8rem auto auto;
+  height: -moz-calc(100% - 5.9rem);
+  margin: 5.9rem auto auto;
   position: absolute;
 }
 /* These CSS styles all apply to the SVG clock elements */


### PR DESCRIPTION
Fix:
1. Bug 809087 - [Clock] Turn off the active alarm (screen + sound) automatically when there is a incoming phone call
    \* Receive mozinterruptbegin event to turn the active alarm off.
2. Bug 814632 - [Clock] Put a "silent" alarm screen underneath the oncall screen if the alarm goes off during a phone call 
    \* Do a lazily check mozHidden in init state since Bug 810431 isn't fixed yet.
    \* The workaround is used in screen off mode only.
3. Refine CSS to let the SVG clock align center point more precisely.
