### PR TITLE
Fix typo to add ' to dvorak keyboard.

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -625,7 +625,7 @@ function modifyLayout(keyboardName) {
 
         // adds . and , to both sides of the space bar
       case 'text':
-        var overwrites = layout.textLayoutOverwrites || {};
+        var overwrites = layout.textLayoutOverwrite || {};
         var next = c + 1;
         if (overwrites['.'] !== false) {
           space.ratio -= 1;

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -697,7 +697,7 @@ const Keyboards = {
       S: 'ŚŠŞ',
       n: 'ńñň'
     },
-    textLayoutOverwrite: {
+    textLayoutOverwrites: {
       ',': "'",
       '.': false
     },

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -697,7 +697,7 @@ const Keyboards = {
       S: 'ŚŠŞ',
       n: 'ńñň'
     },
-    textLayoutOverwrites: {
+    textLayoutOverwrite: {
       ',': "'",
       '.': false
     },


### PR DESCRIPTION
I noticed that there wasn't a single quote key on the dvorak keyboard. Diving down into the code, I noticed this typo.
