### PR TITLE
Bug 821985 - Easying dogfooding backup/reset/restore process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ manifest.appcache
 /locales/*
 
 /outoftree_apps/
+
+/backups/

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ REPORTER?=Spec
 GAIA_APP_SRCDIRS?=apps test_apps showcase_apps
 GAIA_INSTALL_PARENT?=/data/local
 ADB_REMOUNT?=0
+BACKUP_DIR?=$(PWD)/backups/
+# activities and/or settings resetting when restoring during 'reinstall'
+RESTORE_CLEAN?=activities
+BACKUP_DATABASES?=/data/local/indexedDB/
+BACKUP_WEBAPPS?=/data/local/webapps/
 
 GAIA_ALL_APP_SRCDIRS=$(GAIA_APP_SRCDIRS)
 
@@ -625,6 +630,62 @@ install-settings-defaults: profile/settings.json
 	$(ADB) push profile/settings.json /system/b2g/defaults/settings.json
 	$(ADB) shell start b2g
 
+$(BACKUP_DIR):
+	test -d $(BACKUP_DIR) || mkdir -p $(BACKUP_DIR)/indexedDB/ $(BACKUP_DIR)/webapps/
+
+.PHONY: backup restore reset-restore reinstall
+backup: $(BACKUP_DIR)
+	$(ADB) shell stop b2g
+	$(ADB) pull $(MSYS_FIX)/$(BACKUP_DATABASES)/ $(BACKUP_DIR)/indexedDB/
+	$(ADB) pull $(MSYS_FIX)/$(BACKUP_WEBAPPS)/ $(BACKUP_DIR)/webapps/
+	$(ADB) shell start b2g
+
+restore: $(BACKUP_DIR)
+	$(ADB) shell stop b2g
+	$(ADB) push $(BACKUP_DIR)/indexedDB/ $(MSYS_FIX)/$(BACKUP_DATABASES)/
+	$(ADB) push $(BACKUP_DIR)/webapps/ $(MSYS_FIX)/$(BACKUP_WEBAPPS)/
+	$(ADB) shell start b2g
+
+RESET_DATABASES =
+ifneq (,$(findstring activities,$(RESTORE_CLEAN)))
+RESET_DATABASES += 3104902905ascetiitvi.sqlite
+endif
+ifneq (,$(findstring settings,$(RESTORE_CLEAN)))
+RESET_DATABASES += 2588645841ssegtnti.sqlite
+endif
+ifneq (,$(findstring sms,$(RESTORE_CLEAN)))
+RESET_DATABASES += 226660312ssm.sqlite
+endif
+ifneq (,$(findstring netstats,$(RESTORE_CLEAN)))
+RESET_DATABASES += 3249156127nsetta_ts.sqlite
+endif
+ifneq (,$(findstring contacts,$(RESTORE_CLEAN)))
+RESET_DATABASES += 3406066227csotncta.sqlite
+endif
+ifneq (,$(findstring alarms,$(RESTORE_CLEAN)))
+RESET_DATABASES += 4045445992aslmar.sqlite
+endif
+
+reset-restore: reset-gaia
+	$(ADB) shell stop b2g
+	# Save new databases from reset-gaia before reinstalling
+	if [ ! -z "$(RESET_DATABASES)" ]; then \
+		for db in $(RESET_DATABASES); do \
+			$(ADB) shell mv $(MSYS_FIX)/$(BACKUP_DATABASES)/chrome/$$db $(MSYS_FIX)/$(BACKUP_DATABASES)/chrome/$$db.reset ;\
+		done; \
+	fi;
+	$(ADB) push $(BACKUP_DIR)/indexedDB/ $(MSYS_FIX)/$(BACKUP_DATABASES)/
+	$(ADB) push $(BACKUP_DIR)/webapps/ $(MSYS_FIX)/$(BACKUP_WEBAPPS)/
+	# Copy-back reset-gaia database before restarting
+	if [ ! -z "$(RESET_DATABASES)" ]; then \
+		for db in $(RESET_DATABASES); do \
+			$(ADB) shell rm $(MSYS_FIX)/$(BACKUP_DATABASES)/chrome/$$db ; \
+			$(ADB) shell mv $(MSYS_FIX)/$(BACKUP_DATABASES)/chrome/$$db.reset $(MSYS_FIX)/$(BACKUP_DATABASES)/chrome/$$db ;\
+		done; \
+	fi;
+	$(ADB) shell start b2g
+
+reinstall: backup reset-restore
 
 # clean out build products
 clean:


### PR DESCRIPTION
This commit introduces new Makefile targets:
- backup, which performs the backup of user data
  (/data/local/indexedDB/) to a BACKUP_DIR (by default
  $PWD/device-backup)
- restore, which performs the inverse operation
- reset-restore, which performs a reset-gaia before restoring
- reinstall, which does a backup then a reset-restore

The reset-restore can be configured to not restore some databases,
thought the RESTORE_CLEAN variable. By default, activities only will not
be restored, but one can also ask for: settings, sms, netstats,
contacts and alarms. This is useful when dogfooding and debugging, to
recover the full phone data while restarting on good basis for some
parts.
