### PR TITLE
Bug 818003 - correct the 3G network type settings to "wcdma"

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -488,9 +488,9 @@
         <li>
           <span data-l10n-id="operator-networkType">Network Type
             <select name="ril.radio.preferredNetworkType" id="preferredNetworkType">
-              <option data-l10n-id="operator-networkType-auto" value="wcmda/gsm">Automatic</option>
+              <option data-l10n-id="operator-networkType-auto" value="wcdma/gsm">Automatic</option>
               <option data-l10n-id="operator-networkType-2G" value="gsm">2G only</option>
-              <option data-l10n-id="operator-networkType-3G" value="wcmda">3G only</option>
+              <option data-l10n-id="operator-networkType-3G" value="wcdma">3G only</option>
             </select>
           </span>
         </li>


### PR DESCRIPTION
To resolve the following 2 bugs,
https://bugzilla.mozilla.org/show_bug.cgi?id=818003
https://bugzilla.mozilla.org/show_bug.cgi?id=817977
