### PR TITLE
Bug 821447 - Show "(no subject)" if a message has an empty subject

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -27718,7 +27718,7 @@ exports.chewBodyParts = function chewBodyParts(rep, bodyPartContents,
     date: rep.msg.date,
     flags: rep.msg.flags,
     hasAttachments: rep.attachments.length > 0,
-    subject: rep.msg.msg.subject,
+    subject: rep.msg.msg.subject || null,
     snippet: snippet,
   };
 

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -14,6 +14,25 @@ const SCROLL_MIN_BUFFER_SCREENS = 2;
 const SCROLL_MAX_RETENTION_SCREENS = 7;
 
 /**
+ * Format the message subject appropriately.  This means ensuring that if the
+ * subject is empty, we use a placeholder string instead.
+ *
+ * @param subjectNode the DOM node for the message's subject
+ * @param message the message object
+ */
+function displaySubject(subjectNode, message) {
+  var subject = message.subject.trim();
+  if (subject) {
+    subjectNode.textContent = subject;
+    subjectNode.classList.remove('msg-no-subject');
+  }
+  else {
+    subjectNode.textContent = mozL10n.get('message-no-subject');
+    subjectNode.classList.add('msg-no-subject');
+  }
+}
+
+/**
  * List messages for listing the contents of folders ('nonsearch' mode) and
  * searches ('search' mode).  Multi-editing is just a state of the card.
  *
@@ -582,8 +601,8 @@ MessageListCard.prototype = {
       dateNode.dataset.time = message.date.valueOf();
       dateNode.textContent = prettyDate(message.date);
       // subject
-      msgNode.getElementsByClassName('msg-header-subject')[0]
-        .textContent = message.subject;
+      displaySubject(msgNode.getElementsByClassName('msg-header-subject')[0],
+                     message);
       // snippet
       msgNode.getElementsByClassName('msg-header-snippet')[0]
         .textContent = message.snippet;
@@ -638,7 +657,7 @@ MessageListCard.prototype = {
       if (matches.subject)
         appendMatchItemTo(matches.subject[0], subjectNode);
       else
-        subjectNode.textContent = message.subject;
+        displaySubject(subjectNode, message);
 
       // snippet
       var snippetNode = msgNode.getElementsByClassName('msg-header-snippet')[0];
@@ -1151,10 +1170,10 @@ MessageReaderCard.prototype = {
     dateNode.dataset.time = header.date.valueOf();
     dateNode.textContent = prettyDate(header.date);
 
-    domNode.getElementsByClassName('msg-reader-header-label')[0]
-      .textContent = header.subject;
-    domNode.getElementsByClassName('msg-envelope-subject')[0]
-      .textContent = header.subject;
+    displaySubject(domNode.getElementsByClassName('msg-reader-header-label')[0],
+                   header);
+    displaySubject(domNode.getElementsByClassName('msg-envelope-subject')[0],
+                   header);
 
     // -- Bodies
     var rootBodyNode = domNode.getElementsByClassName('msg-body-container')[0],

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -129,6 +129,8 @@ attachment-size-kib={{kilobytes}}K
 
 message-attachment-view.textContent=View
 
+message-no-subject=(no subject)
+
 message-edit-menu-star=Star
 message-edit-menu-unstar=Unstar
 message-edit-menu-mark-read=Mark as read

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -42,6 +42,10 @@
   margin: 0.5rem 0;
 }
 
+.msg-no-subject {
+  font-style: italic;
+}
+
 /* Sections horizontally chop up the item: unread, details, icons, avatar.
  * We have 320 horizontal pixels to play with.
  */


### PR DESCRIPTION
r? @asutherland. This is pretty self-explanatory. Empty subjects say "(no subject)" in italics now.
