### PR TITLE
Bug 813147 - Add contact button in the dialer is always enabled (r=basiclines).

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -201,7 +201,7 @@
               </div>
             </section>
             <section id="keypad-callbar">
-              <span role="button" id="keypad-callbar-add-contact" data-type="action" data-value="add-contact" >
+              <span role="button" id="keypad-callbar-add-contact" data-type="action" data-value="add-contact" class="disabled">
                 <div class="icon-add-contact"></div>
               </span>
               <span role="button" id="keypad-callbar-call-action" data-type="action" data-value="make-call">

--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -471,6 +471,7 @@ var KeypadManager = {
           }
 
           self._longPress = true;
+          self.updateAddContactStatus();
           self._updatePhoneNumberView();
         }, 400, this);
       }
@@ -485,6 +486,7 @@ var KeypadManager = {
 
       if (key == 'delete') {
         this._phoneNumber = this._phoneNumber.slice(0, -1);
+        this.updateAddContactStatus();
       } else if (this.phoneNumberViewContainer.classList.
           contains('keypad-visible')) {
         if (!this._isKeypadClicked) {
@@ -497,8 +499,8 @@ var KeypadManager = {
         }
       } else {
         this._phoneNumber += key;
+        this.updateAddContactStatus();
       }
-
       this._updatePhoneNumberView();
     } else if (event.type == 'mouseup' || event.type == 'mouseleave') {
       // Stop playing the DTMF/tone after a small delay
@@ -527,6 +529,13 @@ var KeypadManager = {
 
       this._updatePhoneNumberView();
     }
+  },
+
+  updateAddContactStatus: function kh_updateAddContactStatus() {
+    if (this._phoneNumber.length === 0)
+      this.callBarAddContact.classList.add('disabled');
+    else
+      this.callBarAddContact.classList.remove('disabled');
   },
 
   updatePhoneNumber: function kh_updatePhoneNumber(number) {

--- a/apps/communications/dialer/style/keypad.css
+++ b/apps/communications/dialer/style/keypad.css
@@ -199,6 +199,12 @@ article:not(:target) #keypad-delete {
   vertical-align: middle;
 }
 
+#keypad-callbar-add-contact.disabled {
+  opacity: 0.2;
+  border: .1rem solid #2d292a;
+}
+
+
 #keypad-callbar-add-contact:active {
   background: #333333;
 }


### PR DESCRIPTION
The Add Contact button of the dial pad is enabled or disabled according to the existence of content in the phone number field. 
