### PR TITLE
Bug 821663 - [MMI/USSD] USSD is sent in a wrong USSD session if the dial...

### DIFF
--- a/apps/communications/dialer/js/ussd.js
+++ b/apps/communications/dialer/js/ussd.js
@@ -27,6 +27,9 @@ var UssdManager = {
     this._origin = document.location.protocol + '//' +
       document.location.host;
     if (this._conn) {
+      // We cancel any active session if one exists to avoid sending any new
+      // USSD message within an invalid session.
+      this._conn.cancelMMI();
       this._conn.addEventListener('ussdreceived', this);
       window.addEventListener('message', this);
     }


### PR DESCRIPTION
...er is killed while an USSD session is opened; r=etienne, a=bb+
