### PR TITLE
Bug 821770 - don't scroll sideways in crop and edit screens r=daleharvey a=bb+

### DIFF
--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -166,7 +166,7 @@ section {
 #thumbnails.offscreen {
   top: 0;
   bottom: 0;
-  transform: translate(100%, 0);
+  visibility: hidden;
 }
 
 .thumbnail {


### PR DESCRIPTION
A new pull request to deal with my broken tree. This is still the same 1-line fix for bug 821770, but now with just one commit.
