### PR TITLE
Bug 822507 - fix Gallery's Open activity r=daleharvey

### DIFF
--- a/apps/gallery/js/open.js
+++ b/apps/gallery/js/open.js
@@ -4,7 +4,7 @@ window.onload = function() {
 
 function handleOpenActivity(request) {
   var blob = request.source.data.blob;
-  var frame = new Frame(document.getElementById('open-frame'), false);
+  var frame = new MediaFrame(document.getElementById('open-frame'), false);
   var backButton = document.getElementById('open-back-button');
   var toolbar = document.getElementById('open-toolbar');
   var cameraButton = document.getElementById('open-camera-button');

--- a/apps/gallery/open.html
+++ b/apps/gallery/open.html
@@ -11,8 +11,8 @@
     <!-- Shared code -->
     <script type="text/javascript" src="shared/js/l10n.js"></script>
     <script type="text/javascript" defer src="shared/js/gesture_detector.js"></script>
+    <script type="text/javascript" defer src="shared/js/media/media_frame.js"></script>
     <!-- Specific code -->
-    <script type="text/javascript" defer src="js/Frame.js"></script>
     <script type="text/javascript" defer src="js/open.js"></script>
   </head>
 


### PR DESCRIPTION
A two line fix to restore the Open activity, which I broke when I added native previews to the Camera.

This is needed to enable image previews after bluetooth file transfer.
