### PR TITLE
Bug 823496 - [CONTACTS][FACEBOOK] If you link a contact with company fil...

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -158,8 +158,10 @@ contacts.List = (function() {
         });
       }
     }
-    //Add organization name
-    meta.innerHTML += utils.text.escapeHTML(contact.org, true);
+    // Add organization name
+    if (contact.org && contact.org.length > 0 && contact.org[0] !== '') {
+      meta.innerHTML += utils.text.escapeHTML(contact.org[0], true);
+    }
 
     //Final item structure
     link.appendChild(name);


### PR DESCRIPTION
...led with a facebook contact with company filled, you see both in contact list but not in contact details [r=jmcanterafonseca]
