### PR TITLE
bug 821221 workaround

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -439,6 +439,7 @@ section[role="region"].new > header:first-child form {
   font-weight: 600;
   font-size: calc(7 * 0.226rem);
   color: white;
+  opacity: 0.99; /* hackaround for painting bug (bug 821221) */
 }
 
 .disabled {


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=821221#c12 , there's a non-trivial painting bug that's causing labels on SMS-app buttons to not paint, when they're enabled. I dug into it for around 2 days, and it looks like it's a cairo bug (or at least, a bug where the same display list gets painted differently depending on the conditions).

Fortunately, this workaround (adding opacity:0.99 to the buttons when they're enabled) seems to avoid the bug.
