### PR TITLE
Enable periodic sync only when syncable accounts are present (bug #821604)

### DIFF
--- a/apps/calendar/js/controllers/alarm.js
+++ b/apps/calendar/js/controllers/alarm.js
@@ -46,6 +46,7 @@ Calendar.ns('Controllers').Alarm = (function() {
       this.accounts.on('removeCompleted', function() {
         self._accountsChanged(false);
       });
+      this._accountsChanged(); // Check on startup in case we've missed events
     },
 
     handleAlarmMessage: function(message) {
@@ -172,6 +173,7 @@ Calendar.ns('Controllers').Alarm = (function() {
 
       var duration = this.settings.syncFrequency;
       if (duration === null || !this._nextPeriodicSync.enabled) {
+        throw 'foo!' + this._nextPeriodicSync.enabled;
         this.settings.set('syncAlarm', this._nextPeriodicSync);
         return;
       }
@@ -210,10 +212,13 @@ Calendar.ns('Controllers').Alarm = (function() {
       this._resetSyncAlarm(true);
     }, 
 
+    /**
+     * Scans account list to enable/disable periodic sync
+     */
     _accountsChanged: function(added) {
       if (
-        (added && this._nextPeriodicSync.enabled) ||
-        (!added && !this._nextPeriodicSync.enabled)
+        (added === true && this._nextPeriodicSync.enabled) ||
+        (added === false && !this._nextPeriodicSync.enabled)
       )
         return;
 
@@ -228,7 +233,7 @@ Calendar.ns('Controllers').Alarm = (function() {
         }
       }
 
-      if (this._nextPeriodicSync.enabled != enable) {
+      if (this._nextPeriodicSync.enabled !== enable) {
         this._nextPeriodicSync.enabled = enable;
         this._resetSyncAlarm(false);
       }

--- a/apps/calendar/js/controllers/alarm.js
+++ b/apps/calendar/js/controllers/alarm.js
@@ -6,6 +6,7 @@ Calendar.ns('Controllers').Alarm = (function() {
     this.app = app;
     this.store = app.store('Alarm');
     this.settings = app.store('Setting');
+    this.accounts = app.store('Account');
   }
 
   Alarm.prototype = {
@@ -37,6 +38,13 @@ Calendar.ns('Controllers').Alarm = (function() {
 
       this.settings.on('syncFrequencyChange', function() {
         self._resetSyncAlarm(false);
+      });
+
+      this.accounts.on('persist', function() {
+        self._accountsChanged(true);
+      });
+      this.accounts.on('removeCompleted', function() {
+        self._accountsChanged(false);
       });
     },
 
@@ -163,7 +171,7 @@ Calendar.ns('Controllers').Alarm = (function() {
       }
 
       var duration = this.settings.syncFrequency;
-      if (duration === null) {
+      if (duration === null || !this._nextPeriodicSync.enabled) {
         this.settings.set('syncAlarm', this._nextPeriodicSync);
         return;
       }
@@ -200,6 +208,30 @@ Calendar.ns('Controllers').Alarm = (function() {
       this._wifiLock = navigator.requestWakeLock('wifi');
       this.app.syncController.all();
       this._resetSyncAlarm(true);
+    }, 
+
+    _accountsChanged: function(added) {
+      if (
+        (added && this._nextPeriodicSync.enabled) ||
+        (!added && !this._nextPeriodicSync.enabled)
+      )
+        return;
+
+      // Search for a syncable account
+      var enable = false;
+      for (var key in this.accounts.cached) {
+        var account = this.accounts.cached[key];
+        var provider = this.app.provider(account.providerType);
+        if (provider.canSync) {
+          enable = true;
+          break;
+        }
+      }
+
+      if (this._nextPeriodicSync.enabled != enable) {
+        this._nextPeriodicSync.enabled = enable;
+        this._resetSyncAlarm(false);
+      }
     }
 
   };

--- a/apps/calendar/js/store/abstract.js
+++ b/apps/calendar/js/store/abstract.js
@@ -332,6 +332,8 @@
 
         // intentionally after the callbacks...
         self._removeFromCache(id);
+
+        self.emit('removeCompleted', id);
       });
     },
 

--- a/apps/calendar/js/store/setting.js
+++ b/apps/calendar/js/store/setting.js
@@ -15,6 +15,7 @@ Calendar.ns('Store').Setting = (function() {
     defaults: {
       syncFrequency: 15,
       syncAlarm: {
+        enabled: false, 
         alarmId: null,
         start: null,
         end: null

--- a/apps/calendar/test/unit/controllers/alarm_test.js
+++ b/apps/calendar/test/unit/controllers/alarm_test.js
@@ -17,6 +17,7 @@ suite('controllers/alarm', function() {
   var busytimeStore;
   var eventStore;
   var settingStore;
+  var accountStore;
 
   var realSyncSettings;
 
@@ -31,6 +32,7 @@ suite('controllers/alarm', function() {
     busytimeStore = app.store('Busytime');
     eventStore = app.store('Event');
     settingStore = app.store('Setting');
+    accountStore = app.store('Account');
 
     db.open(function() {
       // Suppress initial creation of sync alarms
@@ -49,7 +51,7 @@ suite('controllers/alarm', function() {
   teardown(function(done) {
     testSupport.calendar.clearStore(
       db,
-      ['accounts', 'calendars', 'events', 'busytimes'],
+      ['accounts', 'calendars', 'events', 'busytimes', 'settings'],
       done
     );
   });
@@ -381,6 +383,54 @@ suite('controllers/alarm', function() {
       subject._handleSyncMessage();
       // This test will succeed when the wifi lock is released
     });
+
+    suite('#_accountsChanged', function() {
+      var testAccount;
+      var origReset;
+      var first = true;
+      var _done;
+
+      function mockReset(triggered) {
+        assert.equal(triggered, false);
+        if (first) {
+          assert.equal(subject._nextPeriodicSync.enabled, true);
+          first = false;
+          
+          var trans = db.transaction(
+            ['accounts'],
+            'readwrite'
+          );
+          accountStore.remove(testAccount._id, trans);
+        } else {
+          assert.equal(subject._nextPeriodicSync.enabled, false);
+          _done();
+        }
+      }
+
+      setup(function() {
+        origReset = subject._resetSyncAlarm;
+        subject._resetSyncAlarm = mockReset;
+      });
+      teardown(function() {
+        subject._resetSyncAlarm = origReset;
+      });
+
+      test('sync enabled/disabled by syncable account addition/removal', function(done) {
+        _done = done;
+        var trans = db.transaction(
+          ['accounts'],
+          'readwrite'
+        );
+
+        testAccount = Factory('account', {
+          providerType: 'Caldav'
+        });
+
+        assert.equal(Object.keys(accountStore._cached).length, 0);
+        accountStore.persist(testAccount, trans);
+      });
+    });
+
   });
 
 

--- a/apps/calendar/test/unit/controllers/alarm_test.js
+++ b/apps/calendar/test/unit/controllers/alarm_test.js
@@ -39,6 +39,7 @@ suite('controllers/alarm', function() {
       realSyncSettings = [settingStore.syncFrequency, settingStore.syncAlarm];
       settingStore.set('syncFrequency', null);
       settingStore.set('syncAlarm', {
+        enabled: true, 
         alarmId: null,
         start: null,
         end: null
@@ -408,6 +409,13 @@ suite('controllers/alarm', function() {
       }
 
       setup(function() {
+        settingStore.set('syncAlarm', {
+          enabled: false, 
+          alarmId: null,
+          start: null,
+          end: null
+        });
+
         origReset = subject._resetSyncAlarm;
         subject._resetSyncAlarm = mockReset;
       });


### PR DESCRIPTION
Implement enabling/disabling sync when accounts are added and removed, as per https://bugzilla.mozilla.org/show_bug.cgi?id=821604
