### PR TITLE
Bug 817694 - [Dialer UX VD] Call screen. Make buttons in call pad with no rounded corners (r=basiclines).

### DIFF
--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -174,6 +174,7 @@ body.hidden *[data-l10n-id] {
   border-top: 1px solid #3A3A3A;
   border-bottom: 1px solid #3A3A3A;
   border-right: 1px solid #3A3A3A;
+  border-radius: 0;
 }
 
 #co-advanced span.grid-cell:last-child .co-advanced-option {


### PR DESCRIPTION
The on call screen toolbar buttons (mute, speaker and keypad) should not have rounded corners ;-)
