### PR TITLE
Bug 813200 - [Dialer. UX VD] The icon pad should have transparency and affordance by tiny bevel effect (r=basiclines).

### DIFF
--- a/apps/communications/dialer/style/keypad.css
+++ b/apps/communications/dialer/style/keypad.css
@@ -22,7 +22,7 @@
 
 #phone-number-view-container {
   width: 100%;
-  height: -moz-calc(100% - 35rem);
+  height: -moz-calc(100% - 34.5rem);
   background: #242B36;
   text-align: center;
   display: table;
@@ -33,7 +33,7 @@
 }
 
 #phone-number-view-container.keypad-visible {
-  height: -moz-calc(100% - 35rem);
+  height: -moz-calc(100% - 34.5rem);
   visibility: hidden;
 }
 
@@ -83,17 +83,21 @@ article:not(:target) #keypad-delete {
 
 .keypad-cell {
   display: table-cell;
-  border-right: 1px solid #6F6F6F;
-  border-top: 1px solid #6F6F6F;;
 }
 
-.keypad-cell:last-child {
+.keypad-cell:first-child .keypad-key {
+  border-left: 0;
+}
+
+.keypad-cell:last-child .keypad-key {
   border-right: 0;
 }
 
 .keypad-key {
-  border: 0;
-  border-bottom: 1px solid #6F6F6F;
+  border: solid 0.1rem rgba(255, 255, 255, 0.2);
+  border-right-color: rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(0, 0, 0, 0.4);
+  -moz-box-sizing: border-box;
   height: 7rem;
   vertical-align: middle;
   position: relative;
@@ -190,6 +194,11 @@ article:not(:target) #keypad-delete {
   display: table;
   table-layout: fixed;
   border-spacing: 1rem 1rem;
+  border: solid 0.1rem rgba(255, 255, 255, 0.2);
+  border-right-color: rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(0, 0, 0, 0.4);
+  border-left: 0;
+  -moz-box-sizing: border-box;
 }
 
 #keypad-callbar-add-contact,
@@ -261,7 +270,12 @@ article:not(:target) #keypad-delete {
 }
 
 #keypad-hidebar {
-  background: rgba(0,0,0,.92);
+  background: rgba(24,24,24,.92);
+  border: solid 0.1rem rgba(255, 255, 255, 0.2);
+  border-right-color: rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(0, 0, 0, 0.4);
+  border-left: 0;
+  -moz-box-sizing: border-box;
 }
 
 #keypad-hidebar-hang-up-action-wrapper {

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -101,7 +101,7 @@ body.showKeypad #views {
 }
 
 body.showKeypad #keyboard-container {
-  height: 35rem;
+  height: 34.5rem;
 }
 
 body.showKeypad .duration {
@@ -187,11 +187,11 @@ body.hidden *[data-l10n-id] {
 .co-advanced-option {
   height: 9.5rem;
   width: 100%;
-  background: rgba(0,0,0,.92);
-  border: 0;
-  border-top: 1px solid #3A3A3A;
-  border-bottom: 1px solid #3A3A3A;
-  border-right: 1px solid #3A3A3A;
+  background: rgba(24,24,24,.92);
+  border: solid 0.1rem rgba(255, 255, 255, 0.2);
+  border-right-color: rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(0, 0, 0, 0.4);
+  -moz-box-sizing: border-box;
   border-radius: 0;
 }
 
@@ -199,8 +199,13 @@ body.hidden *[data-l10n-id] {
   background: #00aacc;
 }
 
+
+#co-advanced span.grid-cell:first-child .co-advanced-option {
+  border-left: 0;
+}
+
 #co-advanced span.grid-cell:last-child .co-advanced-option {
-  border-right: 0px;
+  border-right: 0;
 }
 
 #mute > span {
@@ -239,7 +244,12 @@ button[disabled] .icon-keypad-visibility {
 }
 
 #callbar {
-  background: rgba(0,0,0,.92);
+  background: rgba(24,24,24,.92);
+  border: solid 0.1rem rgba(255, 255, 255, 0.2);
+  border-right-color: rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(0, 0, 0, 0.4);
+  border-left: 0;
+  -moz-box-sizing: border-box;
 }
 
 #callbar-hang-up {


### PR DESCRIPTION
Adding transparency to the keypad keys and toolbars as well as some relief to the buttons.
