### PR TITLE
Bug 820648 - Print the name of the error instead of [object DOMError].

### DIFF
--- a/apps/communications/ftu/js/wifi.js
+++ b/apps/communications/ftu/js/wifi.js
@@ -18,7 +18,7 @@ var WifiManager = {
         callback(self.networks);
       };
       req.onerror = function onScanError() {
-        console.log('Error reading networks: ' + req.error);
+        console.log('Error reading networks: ' + req.error.name);
       };
     } else {
       var fakeNetworks = [


### PR DESCRIPTION
This has r=jst in the bug and a=blocking-basecamp+ I'll merge this right away.
