### PR TITLE
mochitest app needs a metadata.json file

### DIFF
--- a/external-apps/mochitest/origin
+++ b/external-apps/mochitest/origin
@@ -1,1 +1,0 @@
-http://mochi.test:8888/


### PR DESCRIPTION
without this the app is no longer installed. 
