### PR TITLE
Bug 819893 - [Gaia::Clock] Unable to close or snooze alarm after an user kills Clock app by Window Manager

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -254,6 +254,16 @@ var AttentionScreen = {
     }
   },
 
+  getAttentionScreenOrigins: function as_getAttentionScreenOrigins() {
+    var attentionScreen = this.attentionScreen;
+    var frames = this.attentionScreen.querySelectorAll('iframe');
+    var attentiveApps = [];
+    Array.prototype.forEach.call(frames, function pushFrame(frame) {
+      attentiveApps.push(frame.dataset.frameOrigin);
+    });
+    return attentiveApps;
+  },
+
   _hasAttentionPermission: function as_hasAttentionPermission(app) {
     var mozPerms = navigator.mozPermissionSettings;
     if (!mozPerms)

--- a/apps/system/js/cards_view.js
+++ b/apps/system/js/cards_view.js
@@ -27,6 +27,8 @@ var CardsView = (function() {
   var cardsList = cardsView.firstElementChild;
   var displayedApp;
   var runningApps;
+  // Unkillable apps which have attention screen now
+  var attentionScreenApps = [];
   // Card which we are re-ordering now
   var reorderedCard = null;
   var currentDisplayed = 0;
@@ -94,7 +96,6 @@ var CardsView = (function() {
 
     // events to handle
     window.addEventListener('lock', CardsView);
-    window.addEventListener('attentionscreenshow', CardsView);
 
     // Close utility tray if it is opened.
     UtilityTray.hide(true);
@@ -316,7 +317,6 @@ var CardsView = (function() {
 
     // events to handle
     window.removeEventListener('lock', CardsView);
-    window.removeEventListener('attentionscreenshow', CardsView);
 
     // Make the cardsView overlay inactive
     cardsView.classList.remove('active');
@@ -490,7 +490,10 @@ var CardsView = (function() {
     ) {
 
       draggingCardUp = false;
-      if (-eventDetail.dy > removeCardThreshold) {
+      // Prevent user from closing the app with a attention screen
+      if (-eventDetail.dy > removeCardThreshold &&
+        attentionScreenApps.indexOf(element.dataset.origin) == -1
+      ) {
 
         // remove the app also from the ordering list
         if (
@@ -605,7 +608,12 @@ var CardsView = (function() {
 
       case 'lock':
       case 'attentionscreenshow':
+        attentionScreenApps = AttentionScreen.getAttentionScreenOrigins();
         hideCardSwitcher();
+        break;
+
+      case 'attentionscreenhide':
+        attentionScreenApps = AttentionScreen.getAttentionScreenOrigins();
         break;
 
       case 'holdhome':
@@ -628,6 +636,8 @@ var CardsView = (function() {
   };
 })();
 
+window.addEventListener('attentionscreenshow', CardsView);
+window.addEventListener('attentionscreenhide', CardsView);
 window.addEventListener('holdhome', CardsView);
 window.addEventListener('home', CardsView);
 window.addEventListener('appwillopen', CardsView);


### PR DESCRIPTION
Maintain an unkillable array of origins in the CardsView module by listening to the attentionscreenshow/attentionscreenhide events.
