### PR TITLE
Bug 823399 - [Clock] After cancel an incoming call when there is an active alarm, the alarm will keep ringing with no alarm page r=timdream

### DIFF
--- a/apps/clock/js/onring.js
+++ b/apps/clock/js/onring.js
@@ -163,6 +163,7 @@ var RingView = {
       // event on the 'alarm' channel audio element.
       // If the incoming call happens after the alarm rings,
       // we need to close ourselves.
+      this.stopAlarmNotification();
       window.opener.AlarmManager.cancelHandler();
       window.close();
       break;


### PR DESCRIPTION
Since window.close() does not pause the audio tag, we turn off the ringtone and vibration by itself in Clock app.
