### PR TITLE
Bug 824287 - Use mozbrowser to load privacy page

### DIFF
--- a/apps/communications/ftu/index.html
+++ b/apps/communications/ftu/index.html
@@ -289,7 +289,6 @@
         </p>
       </section>
       <section role="region" id="external-url-loader" class='external'>
-        <iframe src='about:blank' class='external'></iframe>
       </section>
 
       <section role="region" id="browser_privacy">

--- a/apps/communications/ftu/js/navigation.js
+++ b/apps/communications/ftu/js/navigation.js
@@ -56,8 +56,14 @@ var Navigation = {
     UIManager.activationScreen.addEventListener('click',
         this.handleExternalLinksClick.bind(this));
 
-    this.externalIframe = document.querySelector(
-        this.externalUrlLoaderSelector + ' iframe');
+    var browserFrame = document.createElement('iframe');
+    browserFrame.setAttribute('mozbrowser', 'true');
+    browserFrame.classList.add('external');
+
+    var container = document.querySelector(this.externalUrlLoaderSelector);
+    container.appendChild(browserFrame);
+
+    this.externalIframe = browserFrame;
 
     // this will be called by setTimeout, so it's easier if it's already bound
     this.backFromIframe = this.backFromIframe.bind(this);
@@ -127,7 +133,7 @@ var Navigation = {
 
     e.preventDefault();
     var href = link.href,
-        title = link.getAttribute('title') || link.textContent;
+        title = link.getAttribute('title') || link.textContent;
 
     if (navigator.onLine) {
       this.displayExternalLink(href, title);

--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -79,7 +79,8 @@
     "wifi-manage":{},
     "time": {},
     "audio-channel-telephony":{},
-    "audio-channel-ringer":{}
+    "audio-channel-ringer":{},
+    "browser":{}
   },
   "orientation": "portrait-primary",
   "activities": {


### PR DESCRIPTION
**Root cause**
Failed to load privacy page because:
[JavaScript Error: "Load denied by X-Frame-Options: http://www.mozilla.org/en-US/privacy/ does not permit framing."]

**Solution**
Use mozbrowser iframe to load the privacy page.
