### PR TITLE
Bug 823431 - [Clock] No ringtone and vibration when alarm goes off from screen off mode. r=timdream

### DIFF
--- a/apps/clock/js/onring.js
+++ b/apps/clock/js/onring.js
@@ -35,23 +35,12 @@ var RingView = {
 
   init: function rv_init() {
     document.addEventListener('mozvisibilitychange', this);
+    // If mozHidden is true in init state,
+    // it means that the incoming call happens before the alarm.
+    // We should just put a "silent" alarm screen
+    // underneath the oncall screen
     if (!document.mozHidden) {
       this.startAlarmNotification();
-    } else {
-      // The setTimeout() is used to workaround
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=810431
-      // The workaround is used in screen off mode.
-      // mozHidden will be true in init() state.
-      var self = this;
-      window.setTimeout(function rv_checkMozHidden() {
-        // If mozHidden is true in init state,
-        // it means that the incoming call happens before the alarm.
-        // We should just put a "silent" alarm screen
-        // underneath the oncall screen
-        if (!document.mozHidden) {
-          self.startAlarmNotification();
-        }
-      }, 0);
     }
 
     this.setAlarmTime();
@@ -190,5 +179,9 @@ var RingView = {
 
 };
 
-RingView.init();
+window.addEventListener('localized', function showBody() {
+  window.removeEventListener('localized', showBody);
+  RingView.init();
+});
+
 


### PR DESCRIPTION
Listening "localized" event to replace setTimeout checking mozHidden in init() state.
Because of the timing to check mozHidden is safer.
The patch also fixed Bug 819244 - [Clock] The alarm attention screen uses 24H format but the time picker uses 12H format, which is not consistent.

E/GeckoConsole(  585): Content JS WARN at app://clock.gaiamobile.org/shared/js/l10n.js:52 in consoleWarn: [l10n] #dateTimeFormat_%X is undefined.
We need to listen 'localized' event to prevent the warn.
