### PR TITLE
Bug 819947 - No WiFi networks detected during FTU experience

### DIFF
--- a/apps/communications/ftu/js/tutorial.js
+++ b/apps/communications/ftu/js/tutorial.js
@@ -54,6 +54,7 @@ var Tutorial = {
 
     this.tutorialFinish.addEventListener('click', function ftuEnd() {
       self.tutorialFinish.removeEventListener('click', ftuEnd);
+      WifiManager.finish();
       window.close();
     });
     window.addEventListener('hashchange', this);

--- a/apps/communications/ftu/js/ui.js
+++ b/apps/communications/ftu/js/ui.js
@@ -81,6 +81,7 @@ var UIManager = {
     });
 
     this.skipTutorialButton.addEventListener('click', function() {
+      WifiManager.finish();
       window.close();
     });
     this.letsGoButton.addEventListener('click', function() {

--- a/apps/communications/ftu/js/wifi.js
+++ b/apps/communications/ftu/js/wifi.js
@@ -7,6 +7,10 @@ var WifiManager = {
       this.api = window.navigator.mozWifiManager;
       this.changeStatus();
       this.gCurrentNetwork = this.api.connection.network;
+
+      // Ensure that wifi is on.
+      var lock = window.navigator.mozSettings.createLock();
+      this.enable(lock);
     }
   },
   scan: function wn_scan(callback) {
@@ -55,9 +59,8 @@ var WifiManager = {
       callback(fakeNetworks);
     }
   },
-  enable: function wn_enable(firstTime) {
-    var settings = window.navigator.mozSettings;
-    settings.createLock().set({'wifi.enabled': true});
+  enable: function wn_enable(lock) {
+    lock.set({'wifi.enabled': true});
   },
   getNetwork: function wm_gn(ssid) {
     var network;

--- a/apps/communications/ftu/js/wifi.js
+++ b/apps/communications/ftu/js/wifi.js
@@ -11,6 +11,7 @@ var WifiManager = {
       // Ensure that wifi is on.
       var lock = window.navigator.mozSettings.createLock();
       this.enable(lock);
+      this.enableDebugging(lock);
     }
   },
   scan: function wn_scan(callback) {
@@ -61,6 +62,22 @@ var WifiManager = {
   },
   enable: function wn_enable(lock) {
     lock.set({'wifi.enabled': true});
+  },
+  enableDebugging: function wn_enableDebugging(lock) {
+    // For bug 819947: turn on wifi debugging output to help track down a bug
+    // in wifi. We turn on wifi output only while the FTU app is active.
+    this._prevDebuggingValue = false;
+    var req = lock.get('wifi.debugging.enabled');
+    req.onsuccess = function wn_getDebuggingSuccess() {
+      this._prevDebuggingValue = req.result['wifi.debugging.enabled'];
+    };
+    lock.set({ 'wifi.debugging.enabled': true });
+  },
+  finish: function wn_finish() {
+    if (!this._prevDebuggingValue) {
+      var resetLock = window.navigator.mozSettings.createLock();
+      resetLock.set({'wifi.debugging.enabled': false});
+    }
   },
   getNetwork: function wm_gn(ssid) {
     var network;


### PR DESCRIPTION
These two patches do two things:
- Ensure that wifi is turned on when the FTU app starts.
- Turns on debugging output to help find the underlying cause of bug 819947
