### PR TITLE
Bug 824783 - Don't show the "empty folder" and "loading" indicators at the same time

### DIFF
--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -401,6 +401,7 @@ MessageListCard.prototype = {
     if (newStatus === 'synchronizing') {
       this.syncingNode.classList.remove('collapsed');
       this.syncMoreNode.classList.add('collapsed');
+      this.hideEmptyLayout();
 
       this.progressNode.value = this.messagesSlice ?
                                 this.messagesSlice.syncProgress : 0;


### PR DESCRIPTION
r? @asutherland: This ties in with https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/104 and hides the "empty folder" display when we're loading. The two should never be visible at the same time, since that's just silly.
