### PR TITLE
Update b2g bin location for bot.io

### DIFF
--- a/tools/ci/unit/b2g-desktop.sh
+++ b/tools/ci/unit/b2g-desktop.sh
@@ -20,7 +20,7 @@ echo "Starting B2G Desktop";
 echo "Test Agent URL: $DOMAIN"
 echo
 
-B2G=`which b2g`;
+B2G=`which b2g-bin`;
 
 if [ ! -x $B2G ];
 then


### PR DESCRIPTION
Note: test is still broken the b2g-desktop instance crashes every time with this error:

1356906119156   Marionette  INFO    MarionetteComponent loaded
1356906119157   Marionette  INFO    marionette enabled, loadearly: false
### !!! ABORT: failed to construct LayersChild: file ../../../widget/xpwidgets/nsBaseWidget.cpp, line 879
### !!! ABORT: failed to construct LayersChild: file ../../../widget/xpwidgets/nsBaseWidget.cpp, line 879

---

Also: I have refactored the server setup using chef so we can re-deploy to a different server later on.
