### PR TITLE
Bug 825046 - delete videos correctly

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -366,7 +366,7 @@ function initDB(include_videos) {
     videodb.onscanstart = photodb.onscanstart;
     videodb.onscanend = photodb.onscanend;
     videodb.oncreated = photodb.oncreated;
-    videodb.ondelete = photodb.oncreated;
+    videodb.ondeleted = photodb.ondeleted;
   }
 }
 


### PR DESCRIPTION
This is a one-line fix to an embarassing copy/paste error that prevented videos from being deleted.
