### PR TITLE
Arabic letters being shown out of the key's limits

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -105,7 +105,7 @@ button::-moz-focus-inner {
   bottom: -1px;
   left: -1px;
   right: -1px;
-  font: 2.4rem/3.5rem MozTT, Sans-serif;
+  font: 2rem/3.1rem MozTT, Sans-serif;
   font-weight: 500;
   text-align: center;
   color: #fff;


### PR DESCRIPTION
Reducing font size of the keyboard characters
in ".keyboard-key > .visual-wrapper > span"
from 2.4rem/3.5rem to 2rem/3.1rem so that letters such as
ض ص
don't get out of the key's limits.
