### PR TITLE
Bug 823669 - [B2G][Email]Activesync: Emails deleted on the web client do not sync to the device

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -33266,7 +33266,7 @@ ActiveSyncFolderConn.prototype = {
         collection.push(msg);
       });
 
-      e.addEventListener(base.concat(as.Commands, [as.Delete, as.SoftDelete]),
+      e.addEventListener(base.concat(as.Commands, [[as.Delete, as.SoftDelete]]),
                          function(node) {
         let guid;
 


### PR DESCRIPTION
This has r+ from @asutherland over at https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/105
