### PR TITLE
Bug 821447 - Email with no subject displays "undefined" (fix fallout from original commit)

### DIFF
--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -21,7 +21,7 @@ const SCROLL_MAX_RETENTION_SCREENS = 7;
  * @param message the message object
  */
 function displaySubject(subjectNode, message) {
-  var subject = message.subject.trim();
+  var subject = message.subject && message.subject.trim();
   if (subject) {
     subjectNode.textContent = subject;
     subjectNode.classList.remove('msg-no-subject');


### PR DESCRIPTION
r? @asutherland: This PR fixes a boneheaded mistake in the previous PR for this. Now, things won't implode when a subject is null!
