### PR TITLE
PerApp test helpers a=test-only r=etienne_s

### DIFF
--- a/test_apps/test-agent/common/test/agent_proxy.js
+++ b/test_apps/test-agent/common/test/agent_proxy.js
@@ -21,9 +21,14 @@
   worker.on({
 
     'sandbox': function() {
-      /* Load your fav assertion engine */
-      /* expect.js
-      */
+      /**
+       * Important will not cause failures if missing.
+       * Allows each app to have its own setup.js file that will execute
+       * before any tests are loaded so we can utilize helpers outside
+       * of setup blocks. Any files require from setup.js should also
+       * block loading of any tests...
+       */
+      worker.loader.require('/test/unit/setup.js');
     },
 
     'run tests': function() {


### PR DESCRIPTION
Allows each much more flexibility when it comes to reusing code across tests.

a quick is example is like this:

``` js
// in setup.js
function mockEverything() {
  suiteSetup(function() {
     // do stuff
  });
}

suiteSetup(function() {
 // before all tests etc...
});

suiteTeardown(function() {
 // after all tests...
});


// in tests

suite('my test', function() {
  // this was impossible before
  mockEverything();
});

```
