### PR TITLE
Bug 825615 - scale small videos up to screen size when playing them. r=daleharvey a=blocking+

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -415,11 +415,10 @@ function setPlayerSize() {
   var yscale = containerHeight / height;
   var scale = Math.min(xscale, yscale);
 
-  // scale large videos down, but don't scale small videos up
-  if (scale < 1) {
-    width *= scale;
-    height *= scale;
-  }
+  // scale large videos down and scale small videos up
+  // this might result in lower image quality for small videos
+  width *= scale;
+  height *= scale;
 
   var left = ((containerWidth - width) / 2);
   var top = ((containerHeight - height) / 2);
@@ -446,9 +445,7 @@ function setPlayerSize() {
     break;
   }
 
-  if (scale < 1) {
-    transform += ' scale(' + scale + ')';
-  }
+  transform += ' scale(' + scale + ')';
 
   dom.player.style.transform = transform;
 }

--- a/apps/video/js/view.js
+++ b/apps/video/js/view.js
@@ -160,20 +160,16 @@ navigator.mozSetMessageHandler('activity', function viewVideo(activity) {
     var yscale = containerHeight / height;
     var scale = Math.min(xscale, yscale);
 
-    // scale large videos down, but don't scale small videos up
-    if (scale < 1) {
-      width *= scale;
-      height *= scale;
-    }
+    // scale large videos down, and scale small videos up
+    width *= scale;
+    height *= scale;
 
     var left = ((containerWidth - width) / 2);
     var top = ((containerHeight - height) / 2);
 
     var transform = 'translate(' + left + 'px,' + top + 'px)';
 
-    if (scale < 1) {
-      transform += ' scale(' + scale + ')';
-    }
+    transform += ' scale(' + scale + ')';
 
     dom.player.style.transform = transform;
   }

--- a/shared/js/media/video_player.js
+++ b/shared/js/media/video_player.js
@@ -215,11 +215,10 @@ function VideoPlayer(container) {
     var yscale = containerHeight / height;
     var scale = Math.min(xscale, yscale);
 
-    // scale large videos down, but don't scale small videos up
-    if (scale < 1) {
-      width *= scale;
-      height *= scale;
-    }
+    // Scale large videos down, and scale small videos up.
+    // This might reduce image quality for small videos.
+    width *= scale;
+    height *= scale;
 
     var left = ((containerWidth - width) / 2);
     var top = ((containerHeight - height) / 2);
@@ -246,9 +245,7 @@ function VideoPlayer(container) {
       break;
     }
 
-    if (scale < 1) {
-      transform += ' scale(' + scale + ')';
-    }
+    transform += ' scale(' + scale + ')';
 
     player.style.transform = transform;
   }


### PR DESCRIPTION
The Camera, Gallery and Video apps (and the video view activity handler) all have special case code that scales down videos larger than the screen, but keeps videos that are smaller than the screen at actual size.

This pull request removes that special case code, so that all videos are scaled to fit the screen.
