### PR TITLE
Bug 824190 - [email] once attachments are downloaded, the file size shows NaN. r=squib, a=blocking-basecamp

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -29558,7 +29558,7 @@ exports.do_download = function(op, callback) {
           storeTo = storePartsTo[i];
 
       if (blob) {
-        partInfo.sizeEstimate = blob.length;
+        partInfo.sizeEstimate = blob.size;
         partInfo.type = blob.type;
         if (storeTo === 'idb')
           partInfo.file = blob;


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/107
https://bugzilla.mozilla.org/show_bug.cgi?id=824190
