### PR TITLE
Bug 826468 - [Email] Change in XHR behaviour makes autoconfig fail on "L.ooking in local file store" for all domains not in gaia/apps/email/autoconfig/ (workaround)

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -35944,7 +35944,14 @@ Autoconfigurator.prototype = {
       callback('no-config-info', null, { status: 'error' });
     };
 
-    xhr.send();
+    // Gecko currently throws in send() if the file we're opening doesn't exist.
+    // This is almost certainly wrong, but let's just work around it for now.
+    try {
+      xhr.send();
+    }
+    catch(e) {
+      callback('no-config-info', null, { status: 404 });
+    }
   },
 
   /**


### PR DESCRIPTION
This has r+ from @asutherland and is blocking-basecamp+, so merging...
