### PR TITLE
Bug 826621 - when we clear a media frame, remember that we cleared it r=daleharvey a=blocking+

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -711,6 +711,9 @@ function setView(view) {
     previousFrame.clear();
     currentFrame.clear();
     nextFrame.clear();
+    delete previousFrame.filename;
+    delete currentFrame.filename;
+    delete nextFrame.filename;
     break;
   }
 


### PR DESCRIPTION
At some point relatively recently I started clearing media frames when leaving fullscreen mode so we don't keep decoded images around in memory. And I started setting the photo's filename on the frame object so  that I would know whether I needed to reload the photo.

But I didn't always delete the filename when I cleared the frame, so bug 826621 happens when I go back to an empty frame, but the frame thinks it already has the photo I want in it and I get a blank gray screen.
