### PR TITLE
Bug 825653 - Power save mode turns off by itself

### DIFF
--- a/apps/system/js/battery_manager.js
+++ b/apps/system/js/battery_manager.js
@@ -232,7 +232,7 @@ var PowerSaveHandler = (function PowerSaveHandler() {
           return;
         }
 
-        if (battery.level > value && _powerSaveEnabled) {
+        if (value != 0 && battery.level > value && _powerSaveEnabled) {
           setMozSettings({'powersave.enabled' : false});
           return;
         }


### PR DESCRIPTION
We would disable the power save mode when the battery level goes to be > "powersave.threshold".
However, we should NOT to disable the power save mode when "powersave.threshold" is set to 0.
