### PR TITLE
Configure the prod payment provider (bug 824841)

### DIFF
--- a/build/payment-prefs.js
+++ b/build/payment-prefs.js
@@ -1,5 +1,5 @@
-pref("dom.payment.provider.0.name", "mockpayprovider");
-pref("dom.payment.provider.0.description", "Mock Payment Provider");
-pref("dom.payment.provider.0.type", "mock/payments/inapp/v1");
-pref("dom.payment.provider.0.uri", "https://mockpayprovider.phpfogapp.com/?req=");
+pref("dom.payment.provider.0.name", "firefoxmarket");
+pref("dom.payment.provider.0.description", "marketplace.firefox.com");
+pref("dom.payment.provider.0.uri", "https://marketplace.firefox.com/mozpay/?req=");
+pref("dom.payment.provider.0.type", "mozilla/payments/pay/v1");
 pref("dom.payment.provider.0.requestMethod", "GET");


### PR DESCRIPTION
This also removes the mock payment provider
that was in use only for testing.

Note that when you read this pull request the configured URL will probably be inaccessible. It has not been deployed yet but will be deployed in https://bugzilla.mozilla.org/show_bug.cgi?id=825270

This patch prepares us to ship payments.
