### PR TITLE
Bug 822440 - create new gaia languages file for basecamp

### DIFF
--- a/shared/resources/languages-basecamp.json
+++ b/shared/resources/languages-basecamp.json
@@ -1,0 +1,5 @@
+{
+  "en-US"     : "English (US)",
+  "es"        : "Español",
+  "pt-BR"     : "Português (do Brasil)"
+}


### PR DESCRIPTION
After this lands, we can point b2g18 otoro builds at this gaia languages file, which will then only include the required languages in the build manifest.  Without this, we'll add all 6 languages to the build manifest for handoff.
