### PR TITLE
Bug 824470 - Brazil Real currency is hardcoded in the Cost Control application

### DIFF
--- a/apps/costcontrol/fte.html
+++ b/apps/costcontrol/fte.html
@@ -97,8 +97,7 @@
           <p data-l10n-id="low-balance-alert">Low Balance alert</p>
         </li>
         <li>
-          <label class="end" for="ft-balance-alert-value">
-            R$
+          <label id="currency" class="end" for="ft-balance-alert-value">
             <input class="settings-option" data-option="lowLimitThreshold" data-disable-on="lowLimit=false" type="number" id="ft-balance-alert-value">
           </label>
           <p data-l10n-id="low-balance-explanation">Alert me when I’m under</p>

--- a/apps/costcontrol/index.html
+++ b/apps/costcontrol/index.html
@@ -294,7 +294,7 @@
             </li>
             <li>
               <label class="end" for="low-limit-input">
-                <span id="settings-low-limit-currency">R$</span>
+                <span id="settings-low-limit-currency"></span>
                 <input class="settings-option" data-option="lowLimitThreshold" data-disable-on="lowLimit=false" id="low-limit-input" type="number" />
               </label>
               <p data-l10n-id="low-balance-explanation">Alert me when I am under</p>

--- a/apps/costcontrol/js/fte.js
+++ b/apps/costcontrol/js/fte.js
@@ -17,10 +17,15 @@
   var wizard, vmanager;
   var toStep2, step = 0;
   function setupFTE() {
-    ConfigManager.requestSettings(function _onSettings(settings) {
+    ConfigManager.requestAll(function _onSettings(configuration, settings) {
       wizard = document.getElementById('firsttime-view');
       vmanager = new ViewManager();
       AutoSettings.addType('data-limit', dataLimitConfigurer);
+
+      // Currency is set by config as well
+      if (configuration && configuration.credit && configuration.credit.currency) {
+        document.getElementById('currency').textContent = configuration.credit.currency;
+      }
 
       var mode = costcontrol.getApplicationMode(settings);
       if (mode === 'DATA_USAGE_ONLY') {


### PR DESCRIPTION
This PR is not just about l10n.

Also the currency can be setup via partner, so it's taken into account to be setup by config as well, but falling back to l10n just in case.
