### PR TITLE
Bug 824690 - [Call log] If a contact has two phone numbers with the same type and carrier it is not possible to distinguish them on the call log

### DIFF
--- a/apps/communications/dialer/js/utils.js
+++ b/apps/communications/dialer/js/utils.js
@@ -47,7 +47,7 @@ var Utils = {
     if (matchingTel.carrier) {
       phoneCarrier = matchingTel.carrier;
     } else {
-      additionalInfo = additionalInfo + ', ' + matchingTel.value;
+      additionalInfo = additionalInfo + ', ' + contactPhoneNumber;
     }
 
     if (phoneType && phoneCarrier) {
@@ -66,7 +66,7 @@ var Utils = {
       }
 
       if (multipleNumbersSameCarrier) {
-        additionalInfo = additionalInfo + ', ' + phoneNumber;
+        additionalInfo = additionalInfo + ', ' + contactPhoneNumber;
       } else {
         additionalInfo = additionalInfo + ', ' + phoneCarrier;
       }

--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -134,15 +134,22 @@ ul[role="tablist"][data-type="filter"] > [role="tab"].selected > a {
   pointer-events: none;
 }
 
+.log-item:not(.hasPhoto) .pack-end {
+  width: 0;
+}
+
 .log-item .primary-info {
   text-overflow: clip;
 }
 
-.log-item.hasPhoto .primary-info {
+
+.log-item.hasPhoto .primary-info,
+.log-item.hasPhoto .secondary-info {
   width: 19rem;
 }
 
-.log-item:not(.hasPhoto) .primary-info {
+.log-item:not(.hasPhoto) .primary-info,
+.log-item:not(.hasPhoto) .secondary-info {
   width: 25rem;
 }
 
@@ -185,9 +192,15 @@ ul[role="tablist"][data-type="filter"] > [role="tab"].selected > a {
   transition: all 0.4s ease;
 }
 
+.recents-edit .log-item.hasPhoto .pack-end {
+  width: 0;
+}
+
 .recents-edit .log-item.hasPhoto .primary-info,
-  .recents-edit .log-item:not(.hasPhoto) .primary-info {
-  width: 22rem; 
+.recents-edit .log-item.hasPhoto .secondary-info,
+.recents-edit .log-item:not(.hasPhoto) .primary-info,
+.recents-edit .log-item:not(.hasPhoto) .secondary-info {
+  width: 22rem;
 }
 
 .recents-edit .pack-end {


### PR DESCRIPTION
Basically we show the number instead of the carrier in case a contact has more than one number assigned to the same type and carrier. On the other hand, we allocate the whole available space to the additional contact information in the call log.
