### PR TITLE
Bug 814441 - Email text has no formatting applied. r=asuth

### DIFF
--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -207,6 +207,8 @@
 .msg-body-container {
   font-family: monospace;
   white-space: pre-wrap;
+  font-size: 1.9rem;
+  line-height: 2.6rem;
 }
 
 .msg-attachments-container {


### PR DESCRIPTION
- Fix bug : https://bugzilla.mozilla.org/show_bug.cgi?id=814441. Based on https://bugzilla.mozilla.org/show_bug.cgi?id=814441#c1
