### PR TITLE
Bug 827753 - [DIALER] When using the keypad during a call to a contact with a long name, name shown changes (r=fcampo).

### DIFF
--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -28,7 +28,7 @@ var CallHandler = (function callHandler() {
     var number = activity.source.data.number;
     var fillNumber = function actHandleDisplay() {
       if (number) {
-        KeypadManager.updatePhoneNumber(number);
+        KeypadManager.updatePhoneNumber(number, 'begin', false);
         if (window.location.hash != '#keyboard-view') {
           window.location.hash = '#keyboard-view';
         }
@@ -194,7 +194,7 @@ var CallHandler = (function callHandler() {
     }.bind(this);
 
     var connected, disconnected = function clearPhoneView() {
-      KeypadManager.updatePhoneNumber('');
+      KeypadManager.updatePhoneNumber('', 'begin', true);
     };
 
     TelephonyHelper.call(number, oncall, connected, disconnected);

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -116,6 +116,7 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
   Contacts.findByNumber(number, function lookupContact(contact, matchingTel) {
     if (contact && contact.name) {
       node.textContent = contact.name;
+      KeypadManager.formatPhoneNumber('end', true);
       var additionalInfo = Utils.getPhoneNumberAdditionalInfo(matchingTel,
                                                               contact);
       KeypadManager.updateAdditionalContactInfo(additionalInfo);
@@ -127,6 +128,7 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
     }
 
     node.textContent = number;
+    KeypadManager.formatPhoneNumber('end', true);
   });
 };
 

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -95,9 +95,8 @@ var CallScreen = {
   },
 
   hideKeypad: function cs_hideKeypad() {
-    KeypadManager.restorePhoneNumber();
+    KeypadManager.restorePhoneNumber('end', true);
     KeypadManager.restoreAdditionalContactInfo();
-    KeypadManager.formatPhoneNumber();
     this.body.classList.remove('showKeypad');
   },
 

--- a/apps/communications/dialer/test/unit/mock_keypad.js
+++ b/apps/communications/dialer/test/unit/mock_keypad.js
@@ -5,7 +5,7 @@ var MockKeypadManager = {
   },
   mFormatPhoneNumberCalled: false,
   updateAdditionalContactInfo:
-    function khm_updateAdditionalContactInfo(ellipsisSide) {
+    function khm_updateAdditionalContactInfo(ellipsisSide, maxFontSize) {
     this.mUpdateAdditionalContactInfo = true;
   },
   mUpdateAdditionalContactInfo: false,


### PR DESCRIPTION
According to UX guidelines, the font sizes of the phone number or contact name have been adjusted. In case that during a call, the keypad is expanded, tones sent and the keypad is hidden, the font size is also restored.
