### PR TITLE
[Bug 826278] Fixed bookmark icon bug [r=crdlc]

### DIFF
--- a/apps/homescreen/everything.me/js/etmmanager.js
+++ b/apps/homescreen/everything.me/js/etmmanager.js
@@ -56,9 +56,9 @@ var EvmeManager = (function EvmeManager() {
     }
 
     function getAppIcon(app) {
-        var iconsForApp = GridManager.getIconsForApp(app);
-        for (var entryPoint in iconsForApp) {
-          return iconsForApp[entryPoint].descriptor.icon;
+        var object = GridManager.getIcon(app);
+        if (object && 'descriptor' in object && 'icon' in object.descriptor) {
+            return object.descriptor.icon;
         }
     }
     function getAppName(app) {


### PR DESCRIPTION
In Evme, relevant grid apps appear on top of results. Bookmarks didn't show the correct icon (defaulted). https://bug826278.bugzilla.mozilla.org/attachment.cgi?id=697483

Now using GridManager.getIcon instead of GridManager.getIconsForApp, the correct image appears.

https://bugzilla.mozilla.org/show_bug.cgi?id=826278
