### PR TITLE
Bug 827842 - [Call log] Deleting all entries when there are more than one entry from the same number is not working (r=borjasalguero)

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -361,7 +361,7 @@ var Recents = {
     if (end > limit) {
       for (var i = limit; i < end; i++) {
         var visibleCallParentNode = visibleCalls[i].parentNode;
-        visibleCallParentNode.removeChild(visibleCalls[i]);
+        visibleCalls[i].classList.add('hide');
         // Remove the day header if no more entries.
         if (visibleCallParentNode.getElementsByTagName('*').length === 0) {
           visibleCallParentNode.parentNode.parentNode.
@@ -846,7 +846,7 @@ var Recents = {
   },
 
   groupCalls: function re_groupCalls(olderCallEl, newerCallEl, count, inc) {
-    olderCallEl.parentNode.removeChild(olderCallEl);
+    olderCallEl.classList.add('hide');
     count += inc;
     var entryCountNode = newerCallEl.querySelector('.entry-count');
     entryCountNode.innerHTML = '&#160;(' + count + ')';


### PR DESCRIPTION
We cannot delete the call log entries HTML elements included in a group of calls but hide them since when the group wants to be deleted, the existent but hidden entries corresponding to the selected group/s have to be available (but hidden) ;-)
