### PR TITLE
Bug 826901 - Mirror gaia-ui-tests to gaia, r=lightsofapollo, a=test-only

### DIFF
--- a/tests/atoms/gaia_data_layer.js
+++ b/tests/atoms/gaia_data_layer.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
- var GaiaDataLayer = {
+var GaiaDataLayer = {
 
   insertContact: function(cdata) {
     contact = new mozContact();
@@ -46,7 +46,7 @@
     var req = window.navigator.mozSettings.createLock().get(aName);
     req.onsuccess = function() {
       console.log('setting retrieved');
-      result = aName === '*' ? req.result : req.result[aName];
+      let result = aName === '*' ? req.result : req.result[aName];
       marionetteScriptFinished(result);
     };
     req.onerror = function() {
@@ -186,7 +186,8 @@
       console.log("success forgetting network with ssid '" +
                   aNetwork.ssid + "'");
       if (waitForStatus !== false) {
-        console.log("waiting for connection status '" + waitForStatus + "'");
+        console.log("waiting for connection status '" +
+                    waitForStatus + "'");
         waitFor(
           function() { callback(true); },
           function() {
@@ -221,13 +222,13 @@
     var manager = window.navigator.mozMobileConnection;
 
     if (!manager.data.connected) {
-      manager.ondatachange = function() {
-        if (manager.data.connected) {
+      waitFor(
+        function() {
           console.log('cell data enabled');
-          manager.ondatachange = null;
           marionetteScriptFinished(true);
-        }
-      };
+        },
+        function() { return manager.data.connected; }
+      );
       this.setSetting('ril.data.enabled', true, false);
     }
     else {
@@ -240,27 +241,18 @@
     var manager = window.navigator.mozMobileConnection;
 
     if (manager.data.connected) {
-      manager.ondatachange = function() {
-        if (!manager.data.connected) {
+      waitFor(
+        function() {
           console.log('cell data disabled');
-          manager.ondatachange = null;
           marionetteScriptFinished(true);
-        }
-      };
+        },
+        function() { return !manager.data.connected; }
+      );
       this.setSetting('ril.data.enabled', false, false);
     }
     else {
       console.log('cell data already disabled');
       marionetteScriptFinished(true);
     }
-  },
-
-  getFMHardwareState: function() {
-    return window.navigator.mozFMRadio.enabled;
-  },
-
-  getFMHardwareFrequency: function() {
-    return this.getFMHardwareState() &&
-           window.navigator.mozFMRadio.frequency;
   }
 };

--- a/tests/atoms/gaia_lock_screen.js
+++ b/tests/atoms/gaia_lock_screen.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict';
+
 var GaiaLockScreen = {
 
   unlock: function() {

--- a/tests/python/README.md
+++ b/tests/python/README.md
@@ -1,4 +1,3 @@
-
 Introduction
 ============
 
@@ -85,14 +84,16 @@ Variables:
 }
 `
 
-` WPA-EAP:
-"wifi": {
-    "ssid": "MyNetwork",
-    "keyManagement": "WPA-EAP",
-    "password": "MyPassword",
-    "identity": "MyIdentity"
-}
-`
+__Note__: Due to [Bug 775499](http://bugzil.la/775499), WiFi connections via WPA-EAP are not capable at this time.
+
+Test data Prerequisites
+=======================
+
+Occasionally a test will need data on the hardware that cannot be set during the test setUp.
+The following tests need data set up before they can be run successfully:
+
+`test_ftu` Requires a single record/contact saved onto the SIM card to test the SIM contact import
+
 
 Writing Tests
 =============

--- a/tests/python/gaiatest/mocks/mock_contact.py
+++ b/tests/python/gaiatest/mocks/mock_contact.py
@@ -22,7 +22,7 @@ class MockContact(dict):
         self['name'] = self['givenName'] + " " + self['familyName']
         self['email'] = '%s@restmail.net' % self['givenName']
         # TODO this will only support one phone number
-        self['tel'] = {'type':'Mobile','value':"555%s" % curr_time[:8]}
+        self['tel'] = {'type':'Mobile','value':"555%s" % curr_time[8:]}
         self['street'] = "101 Testing street"
         self['zip'] = "90210"
         self['city'] = "London"

--- a/tests/python/gaiatest/tests/__init__.py
+++ b/tests/python/gaiatest/tests/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/python/gaiatest/tests/clock/__init__.py
+++ b/tests/python/gaiatest/tests/clock/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/python/gaiatest/tests/clock/clock_object.py
+++ b/tests/python/gaiatest/tests/clock/clock_object.py
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from gaiatest import GaiaTestCase
+from marionette import MarionetteTestCase
+from marionette import Marionette
+import time
+
+_alarm_create_new_locator = ('id', 'alarm-new')
+
+_clock_day_date = ('id', 'clock-day-date')
+_analog_clock_display = ('id', 'analog-clock-svg')
+_digital_clock_display = ('id', 'digital-clock-display')
+_digital_clock_hour24_state = ('id', 'clock-hour24-state')
+    
+_all_alarms = ('css selector', '#alarms li')
+_alarm_save_locator = ('id', 'alarm-done')
+_banner_countdown_notification_locator = ('id', 'banner-countdown')
+_picker_container = ('id', 'picker-container')
+_alarm_name = ('xpath', "//input[@placeholder='Alarm']")
+_repeat_menu = ('id', 'repeat-menu')
+_sound_menu = ('id', 'sound-menu')
+_snooze_menu = ('id', 'snooze-menu')
+_new_alarm_label = ('name', 'alarm.label')
+_alarm_label = ('css selector', "div.alarmList-detail div.label")
+_alarm_checked_status = ('css selector', 'li label.alarmList #input-enable')
+_alarm_checked_status_button = ('css selector', 'li label.alarmList')
+_alarm_item = ('id', 'alarm-item')
+_alarm_delete_button = ('id', 'alarm-delete')
+
+def create_alarm(self):
+    """ create a new alarm for test """
+    self.wait_for_element_displayed(*_alarm_create_new_locator)
+    # find the origin alarms' number
+    initial_alarms_count = len(self.marionette.find_elements(*_all_alarms))
+    self.marionette.find_element(*_alarm_create_new_locator).click()
+    self.marionette.find_element(*_alarm_save_locator).click()
+    self.wait_for_element_displayed(*_alarm_create_new_locator)
+    self.wait_for_condition(lambda m: len(m.find_elements(*_all_alarms)) > initial_alarms_count)
+
+def delete_alarm(self):
+    """ delete the new alarm """
+    self.wait_for_element_displayed(*_alarm_create_new_locator)
+    # find the origin alarms' number
+    initial_alarms_count = len(self.marionette.find_elements(*_all_alarms))
+    self.marionette.find_element(*_alarm_item).click()
+    self.marionette.find_element(*_alarm_delete_button).click()
+    self.wait_for_element_displayed(*_alarm_create_new_locator)
+    self.wait_for_condition(lambda m: len(m.find_elements(*_all_alarms)) < initial_alarms_count)
+    

--- a/tests/python/gaiatest/tests/clock/manifest.ini
+++ b/tests/python/gaiatest/tests/clock/manifest.ini
@@ -1,0 +1,9 @@
+[DEFAULT]
+# Test requires B2G
+b2g = true
+
+[test_clock_all_items_present_new_alarm.py]
+[test_clock_create_new_alarm.py]
+[test_clock_delete_alarm.py]
+[test_clock_switch_clock_type.py]
+[test_clock_turn_on_off_alarm.py]

--- a/tests/python/gaiatest/tests/clock/test_clock_all_items_present_new_alarm.py
+++ b/tests/python/gaiatest/tests/clock/test_clock_all_items_present_new_alarm.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.tests.clock import clock_object
+
+
+class TestClockTestAllItemsPresentNewAlarm(GaiaTestCase):
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+        self.app = self.apps.launch('Clock')
+
+    def test_all_items_present_new_alarm(self):
+        # Wait for the new alarm screen to load
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+        self.marionette.find_element(*clock_object._alarm_create_new_locator).click()
+
+        # Ensure the picker is displayed
+        picker = self.marionette.find_element(*clock_object._picker_container)
+        self.assertTrue(picker.is_displayed(), 'Picker container not displayed.')
+
+        # Ensure label has the default placeholder and text
+        label = self.marionette.find_element(*clock_object._alarm_name)
+        self.assertEquals(label.get_attribute('placeholder'), 'Alarm')
+        self.assertEquals(label.text, '')
+
+        # Ensure repeat has the default value
+        repeat = self.marionette.find_element(*clock_object._repeat_menu)
+        self.assertEquals(repeat.text, 'Never')
+
+        # Ensure sound has the default value
+        sound = self.marionette.find_element(*clock_object._sound_menu)
+        self.assertEquals(sound.text, 'Classic Buzz')
+
+        # Ensure snooze has the default value
+        snooze = self.marionette.find_element(*clock_object._snooze_menu)
+        self.assertEquals(snooze.text, '5 minutes')

--- a/tests/python/gaiatest/tests/clock/test_clock_create_new_alarm.py
+++ b/tests/python/gaiatest/tests/clock/test_clock_create_new_alarm.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.tests.clock import clock_object
+import time
+
+class TestClockCreateNewAlarm(GaiaTestCase):
+    
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # unlock the lockscreen if it's locked
+        self.lockscreen.unlock()
+
+        # launch the Clock app
+        self.app = self.apps.launch('Clock')
+
+    
+    def test_clock_create_new_alarm(self):
+        """ Add a alarm
+        
+        https://moztrap.mozilla.org/manage/case/1772/ 
+        
+        """
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+
+        # Get the number of alarms set, before adding the new alarm
+        initial_alarms_count = len(self.marionette.find_elements(*clock_object._all_alarms))
+
+        # create a new alarm with the default values that are available
+        self.marionette.find_element(*clock_object._alarm_create_new_locator).click()
+        self.marionette.find_element(*clock_object._alarm_save_locator).click()
+
+        # verify the banner-countdown message appears
+        self.wait_for_element_displayed(*clock_object._banner_countdown_notification_locator)
+        alarm_msg = self.marionette.find_element(*clock_object._banner_countdown_notification_locator).text
+        self.assertTrue('The alarm is set for' in alarm_msg, 'Actual banner message was: "' + alarm_msg + '"')
+
+        # Get the number of alarms set after the new alarm was added
+        new_alarms_count = len(self.marionette.find_elements(*clock_object._all_alarms))
+
+        # Ensure the new alarm has been added and is displayed
+        self.assertTrue(initial_alarms_count < new_alarms_count,
+            'Alarms count did not increment')
+        
+        
+    def test_clock_set_alarm_label(self):
+        """ Set label of the new alarm
+        
+        https://moztrap.mozilla.org/manage/case/1775/
+        
+        """
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+        
+        # create a new alarm
+        self.marionette.find_element(*clock_object._alarm_create_new_locator).click()
+        
+        # set label
+        alarm_label = self.marionette.find_element(*clock_object._new_alarm_label)
+        alarm_label.click()
+        alarm_label.send_keys("\b\b\b\b\btest4321")
+        
+        # save the alarm
+        self.marionette.find_element(*clock_object._alarm_save_locator).click()
+
+        # verify the label of alarm
+        self.wait_for_element_displayed(*clock_object._alarm_label)
+        alarm_label = self.marionette.find_element(*clock_object._alarm_label).text
+        self.assertTrue("test4321" == alarm_label, 'Actual label was: "' + alarm_label + '", not "test4321".')
+        
+        
+    def tearDown(self):
+        # delete the new alarm
+        clock_object.delete_alarm(self)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/clock/test_clock_delete_alarm.py
+++ b/tests/python/gaiatest/tests/clock/test_clock_delete_alarm.py
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from gaiatest import GaiaTestCase
+from gaiatest.tests.clock import clock_object
+import time
+
+class TestClockDeleteAlarm(GaiaTestCase):
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # unlock the lockscreen if it's locked
+        self.lockscreen.unlock()
+
+        # launch the Clock app
+        self.app = self.apps.launch('Clock')
+        
+        # create a new alarm for test
+        clock_object.create_alarm(self)
+
+    
+    def test_clock_delete_alarm(self):
+        """ Delete alarm 
+        
+        https://moztrap.mozilla.org/manage/case/1783/
+        
+        """
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+
+        # find the origin alarms' number
+        initial_alarms_count = len(self.marionette.find_elements(*clock_object._all_alarms))
+        
+        # edit alarm
+        self.marionette.find_element(*clock_object._alarm_item).click()
+        # delete alarm
+        self.marionette.find_element(*clock_object._alarm_delete_button).click()
+        
+        # wait alarm item not displayed
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+        self.wait_for_condition(lambda m: len(m.find_elements(*clock_object._all_alarms)) != initial_alarms_count)
+
+        # find the new alarms' number
+        new_alarms_count = len(self.marionette.find_elements(*clock_object._all_alarms))
+        
+        self.assertEqual(initial_alarms_count, new_alarms_count+1, "delete alarm failed.")

--- a/tests/python/gaiatest/tests/clock/test_clock_switch_clock_type.py
+++ b/tests/python/gaiatest/tests/clock/test_clock_switch_clock_type.py
@@ -1,0 +1,59 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.tests.clock import clock_object
+import time
+
+class TestClockSwitchClockType(GaiaTestCase):
+    
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # unlock the lockscreen if it's locked
+        self.lockscreen.unlock()
+
+        # launch the Clock app
+        self.app = self.apps.launch('Clock')
+
+    
+    def test_clock_switch_clock_type(self):
+        """ Switch the clock type
+        
+        https://moztrap.mozilla.org/manage/case/1770 
+        
+        """
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+        
+        # switch to digital clock
+        self.marionette.find_element(*clock_object._analog_clock_display).click()
+        self.wait_for_element_displayed(*clock_object._digital_clock_display)
+        self.assertTrue(self.marionette.find_element(*clock_object._digital_clock_display).is_displayed(), "The digital clock should be displayed.")
+        
+        # switch to analog clock
+        self.marionette.find_element(*clock_object._digital_clock_display).click()
+        self.wait_for_element_displayed(*clock_object._analog_clock_display)
+        self.assertTrue(self.marionette.find_element(*clock_object._analog_clock_display).is_displayed(), "The analog clock should be displayed.")
+        
+        
+    def test_clock_show_time_date(self):
+        """ Show the time, date
+        
+        https://moztrap.mozilla.org/manage/case/1771
+        
+        """
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+        
+        # check the date, time, state for digital clock
+        self.marionette.find_element(*clock_object._analog_clock_display).click()
+        self.wait_for_element_displayed(*clock_object._digital_clock_display)
+        self.assertTrue(self.marionette.find_element(*clock_object._clock_day_date).is_displayed(), "The date of digital clock should be displayed.")
+        self.assertTrue(self.marionette.find_element(*clock_object._digital_clock_display).is_displayed(), "The time of digital clock should be displayed.")
+        self.assertTrue(self.marionette.find_element(*clock_object._digital_clock_hour24_state).is_displayed(), "The hour24-state of digital clock should be displayed.")
+        
+        # check the date, time for analog clock
+        self.marionette.find_element(*clock_object._digital_clock_display).click()
+        self.wait_for_element_displayed(*clock_object._analog_clock_display)
+        self.assertTrue(self.marionette.find_element(*clock_object._clock_day_date).is_displayed(), "The date should be displayed.")
+        self.assertTrue(self.marionette.find_element(*clock_object._analog_clock_display).is_displayed(), "The date should be displayed.")

--- a/tests/python/gaiatest/tests/clock/test_clock_turn_on_off_alarm.py
+++ b/tests/python/gaiatest/tests/clock/test_clock_turn_on_off_alarm.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.tests.clock import clock_object
+import time
+
+class TestClockTurnOnOffAlarm(GaiaTestCase):
+    
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # unlock the lockscreen if it's locked
+        self.lockscreen.unlock()
+
+        # launch the Clock app
+        self.app = self.apps.launch('Clock')
+
+        # create a new alarm for test
+        clock_object.create_alarm(self)
+        
+    
+    def test_clock_turn_on_off_alarm(self):
+        """ Turn on/off the alarm
+        
+        https://moztrap.mozilla.org/manage/case/1779/ 
+        
+        """
+        self.wait_for_element_displayed(*clock_object._alarm_create_new_locator)
+        
+        # turn on the alarm
+        origin_alarm_checked = self.marionette.find_element(*clock_object._alarm_checked_status).get_attribute('checked')
+        self.marionette.find_element(*clock_object._alarm_checked_status_button).click()
+        time.sleep(2)
+        new_alarm_checked = self.marionette.find_element(*clock_object._alarm_checked_status).get_attribute('checked')
+        self.assertTrue(origin_alarm_checked != new_alarm_checked, 'user should be able to turn on the alarm.')
+        
+        # turn off the alarm
+        origin_alarm_checked = self.marionette.find_element(*clock_object._alarm_checked_status).get_attribute('checked')
+        self.marionette.find_element(*clock_object._alarm_checked_status_button).click()
+        time.sleep(2)
+        new_alarm_checked = self.marionette.find_element(*clock_object._alarm_checked_status).get_attribute('checked')
+        self.assertTrue(origin_alarm_checked != new_alarm_checked, 'user should be able to turn off the alarm.')
+
+
+    def tearDown(self):
+        # delete the new alarm
+        clock_object.delete_alarm(self)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/contacts/manifest.ini
+++ b/tests/python/gaiatest/tests/contacts/manifest.ini
@@ -1,10 +1,7 @@
 [test_add_new_contact.py]
-disabled = Bug 818455 - Done button not enabling while run with marionette
 [test_call_contact.py]
-disabled = Bug 816641 - Call app crashes after 2nd run
 carrier = true
+disabled = Requires remote phone number to dial - github issue #156
 [test_edit_contact.py]
-disabled = Bug 818455 - Done button not enabling while run with marionette
 [test_sms_contact.py]
-disabled = Bug 816057 - Marionette does not click button correctly
 carrier = true

--- a/tests/python/gaiatest/tests/contacts/test_add_new_contact.py
+++ b/tests/python/gaiatest/tests/contacts/test_add_new_contact.py
@@ -74,9 +74,3 @@ class TestContacts(GaiaTestCase):
 
         contact_locator = self.create_contact_locator(self.contact['givenName'])
         self.wait_for_element_displayed(*contact_locator)
-
-
-    def tearDown(self):
-
-        # close all apps
-        self.apps.kill_all()

--- a/tests/python/gaiatest/tests/contacts/test_call_contact.py
+++ b/tests/python/gaiatest/tests/contacts/test_call_contact.py
@@ -81,5 +81,4 @@ class TestContacts(GaiaTestCase):
             self.marionette.switch_to_frame(self.app.frame_id)
             self.data_layer.remove_contact(self.contact)
 
-        # close all apps
-        self.apps.kill_all()
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/contacts/test_edit_contact.py
+++ b/tests/python/gaiatest/tests/contacts/test_edit_contact.py
@@ -109,5 +109,4 @@ class TestContacts(GaiaTestCase):
             self.marionette.switch_to_frame(self.app.frame_id)
             self.data_layer.remove_contact(self.contact)
 
-        # close all apps
-        self.apps.kill_all()
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/contacts/test_sms_contact.py
+++ b/tests/python/gaiatest/tests/contacts/test_sms_contact.py
@@ -19,6 +19,7 @@ class TestContacts(GaiaTestCase):
 
     #SMS app locators
     _sms_app_header_locator = ('id', 'header-text')
+    _contact_carrier_locator = ('id', 'contact-carrier')
 
     def setUp(self):
 
@@ -52,7 +53,8 @@ class TestContacts(GaiaTestCase):
         sms_iframe = self.marionette.find_element(*self._sms_app_iframe_locator)
         self.marionette.switch_to_frame(sms_iframe)
 
-        self.wait_for_element_displayed(*self._sms_app_header_locator)
+        self.wait_for_condition(lambda m: m.find_element(*self._contact_carrier_locator).text
+                                    != "Carrier unknown")
 
         header_element = self.marionette.find_element(*self._sms_app_header_locator)
         expected_name = self.contact['givenName'] + " " + self.contact['familyName']
@@ -70,5 +72,4 @@ class TestContacts(GaiaTestCase):
             self.marionette.switch_to_frame(self.app.frame_id)
             self.data_layer.remove_contact(self.contact)
 
-        # close all apps
-        self.apps.kill_all()
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/fmradio/__init__.py
+++ b/tests/python/gaiatest/tests/fmradio/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/python/gaiatest/tests/fmradio/manifest.ini
+++ b/tests/python/gaiatest/tests/fmradio/manifest.ini
@@ -1,0 +1,11 @@
+[DEFAULT]
+# Test requires B2G
+b2g = true
+
+# Test requires antenna (headphones)
+antenna = true
+
+[test_fmradio_add_to_favorite.py]
+[test_fmradio_find_stations.py]
+[test_fmradio_remove_from_favorite.py]
+[test_fmradio_turn_on_off.py]

--- a/tests/python/gaiatest/tests/fmradio/test_fmradio_add_to_favorite.py
+++ b/tests/python/gaiatest/tests/fmradio/test_fmradio_add_to_favorite.py
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+
+class TestFMRadioAddToFavorite(GaiaTestCase):
+
+    _frequency_display_locator = ('id', 'frequency')
+    _favorite_button_locator = ('id', 'bookmark-button')
+    _favorite_list_locator = ('css selector', "div[class='fav-list-frequency']")
+    _favorite_remove_locator = ('css selector', "div[class='fav-list-remove-button']")
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # launch the FM Radio app
+        self.app = self.apps.launch('FM Radio')
+
+    def test_add_to_favorite(self):
+        """ Add a frequency to favorite list
+
+        https://moztrap.mozilla.org/manage/case/1923/
+
+        """
+        # check the headphone is plugged-in or not
+        self.assertTrue(self.data_layer.is_antenna_available, 'Antenna (headphones) not plugged in')
+
+        # wait for the radio start-up
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # save the initial count of favorite stations
+        initial_favorite_count = len(self.marionette.find_elements(*self._favorite_list_locator))
+
+        # save the current frequency
+        current_frequency = self.marionette.find_element(*self._frequency_display_locator).text
+
+        # check the ui value and the system value
+        self.assertEqual(current_frequency, str(self.data_layer.fm_radio_frequency))
+
+        # add the current frequency to favorite list
+        self.marionette.find_element(*self._favorite_button_locator).click()
+
+        # verify the change of favorite list
+        favorite_list = self.marionette.find_elements(*self._favorite_list_locator)
+        new_favorite_count = len(favorite_list)
+        self.assertEqual(initial_favorite_count, new_favorite_count - 1)
+
+        # verify the favorite frequency is equal to the current frequency
+        favorite_frequency = favorite_list[0].text
+        self.assertEqual(current_frequency, favorite_frequency)
+
+    def tearDown(self):
+        # remove the station from favorite list
+        self.wait_for_element_displayed(*self._favorite_remove_locator)
+        self.marionette.find_element(*self._favorite_remove_locator).click()
+
+        # close the app
+        if self.app:
+            self.apps.kill(self.app)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/fmradio/test_fmradio_find_stations.py
+++ b/tests/python/gaiatest/tests/fmradio/test_fmradio_find_stations.py
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+
+class TestFMRadioFindStations(GaiaTestCase):
+
+    _frequency_display_locator = ('id', 'frequency')
+    _next_button_locator = ('id', 'frequency-op-seekup')
+    _prev_button_locator = ('id', 'frequency-op-seekdown')
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # launch the FM Radio app
+        self.app = self.apps.launch('FM Radio')
+
+    def test_find_next_station(self):
+        """ Find next station
+
+        https://moztrap.mozilla.org/manage/case/1928/
+
+        """
+        # check the headphone is plugged-in or not
+        self.assertTrue(self.data_layer.is_antenna_available, 'Antenna (headphones) not plugged in')
+
+        # wait for the radio start-up
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # save the current frequency
+        current_frequency = self.marionette.find_element(*self._frequency_display_locator).text
+
+        # check the ui value and the system value
+        self.assertEqual(current_frequency, str(self.data_layer.fm_radio_frequency))
+
+        # search next station
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_condition(lambda m: m.find_element(*self._frequency_display_locator).text != current_frequency)
+
+        next_frequency = self.marionette.find_element(*self._frequency_display_locator).text
+
+        # check the ui value and the system value
+        self.assertEqual(next_frequency, str(self.data_layer.fm_radio_frequency))
+
+        # check the change of the frequency
+        self.assertNotEqual(current_frequency, next_frequency)
+
+    def test_find_prev_station(self):
+        """ Find previous station
+
+        https://moztrap.mozilla.org/manage/case/1929/
+
+        """
+        # check the headphone is plugged-in or not
+        self.assertTrue(self.data_layer.is_antenna_available, 'Antenna (headphones) not plugged in')
+
+        # wait for the radio start-up
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # save the current frequency
+        current_frequency = self.marionette.find_element(*self._frequency_display_locator).text
+
+        # check the ui value and the system value
+        self.assertEqual(current_frequency, str(self.data_layer.fm_radio_frequency))
+
+        # search next station
+        self.marionette.find_element(*self._prev_button_locator).click()
+        self.wait_for_condition(lambda m: m.find_element(*self._frequency_display_locator).text != current_frequency)
+
+        prev_frequency = self.marionette.find_element(*self._frequency_display_locator).text
+
+        # check the ui value and the system value
+        self.assertEqual(prev_frequency, str(self.data_layer.fm_radio_frequency))
+
+        # check the change of the frequency
+        self.assertNotEqual(current_frequency, prev_frequency)
+
+    def tearDown(self):
+        # close the app
+        if self.app:
+            self.apps.kill(self.app)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/fmradio/test_fmradio_remove_from_favorite.py
+++ b/tests/python/gaiatest/tests/fmradio/test_fmradio_remove_from_favorite.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+
+class TestFMRadioRemoveFromFavorite(GaiaTestCase):
+
+    _favorite_button_locator = ('id', 'bookmark-button')
+    _favorite_list_locator = ('css selector', "div[class='fav-list-frequency']")
+    _favorite_remove_locator = ('css selector', "div[class='fav-list-remove-button']")
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # launch the FM Radio app
+        self.app = self.apps.launch('FM Radio')
+
+    def test_remove_from_favorite(self):
+        """ Remove a station from favorite list
+
+        https://moztrap.mozilla.org/manage/case/1926/
+
+        """
+        # check the headphone is plugged-in or not
+        self.assertTrue(self.data_layer.is_antenna_available, 'Antenna (headphones) not plugged in')
+
+        # wait for the radio start-up
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # save the initial count of favorite stations
+        initial_favorite_count = len(self.marionette.find_elements(*self._favorite_list_locator))
+
+        # add the current frequency to favorite list
+        self.wait_for_element_displayed(*self._favorite_button_locator)
+        self.marionette.find_element(*self._favorite_button_locator).click()
+
+        # verify the change of favorite list after add
+        after_add_favorite_count = len(self.marionette.find_elements(*self._favorite_list_locator))
+        self.assertEqual(initial_favorite_count, after_add_favorite_count - 1)
+
+        # remove the station from favorite list
+        self.wait_for_element_displayed(*self._favorite_remove_locator)
+        self.marionette.find_element(*self._favorite_remove_locator).click()
+
+        # verify the chage of favorite after remove
+        self.wait_for_element_not_displayed(*self._favorite_remove_locator)
+        after_remove_favorite_count = len(self.marionette.find_elements(*self._favorite_list_locator))
+        self.assertEqual(after_add_favorite_count - 1, after_remove_favorite_count)
+
+    def tearDown(self):
+        # close the app
+        if self.app:
+            self.apps.kill(self.app)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/fmradio/test_fmradio_turn_on_off.py
+++ b/tests/python/gaiatest/tests/fmradio/test_fmradio_turn_on_off.py
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+
+class TestFMRadioTurnOnOff(GaiaTestCase):
+
+    _power_button_locator = ('id', 'power-switch')
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # launch the FM Radio app
+        self.app = self.apps.launch('FM Radio')
+
+    def test_turn_radio_on_off(self):
+        """ Turn off and then Turn on the radio
+
+        https://moztrap.mozilla.org/manage/case/1930/
+        https://moztrap.mozilla.org/manage/case/1931/
+
+        """
+        # check the headphone is plugged-in or not
+        self.assertTrue(self.data_layer.is_antenna_available, 'Antenna (headphones) not plugged in')
+
+        # wait for the radio start-up
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # turn the radio off
+        power_button = self.marionette.find_element(*self._power_button_locator)
+        power_button.click()
+
+        # check the radio is off
+        self.assertEqual(power_button.get_attribute('data-enabled'), 'false')
+        self.assertFalse(self.data_layer.is_fm_radio_enabled)
+
+        # turn the radio on
+        power_button.click()
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # check the radio is on
+        self.assertEqual(power_button.get_attribute('data-enabled'), 'true')
+        self.assertTrue(self.data_layer.is_fm_radio_enabled)
+
+    def tearDown(self):
+        # turn off the radio
+        self.marionette.find_element(*self._power_button_locator).click()
+
+        # close the app
+        if self.app:
+            self.apps.kill(self.app)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/manifest.ini
+++ b/tests/python/gaiatest/tests/manifest.ini
@@ -2,6 +2,9 @@
 # Test requires B2G
 b2g = true
 
+# Test requires antenna (headphones)
+antenna = false
+
 # Test requires a SIM/Carrier connection
 carrier = false
 
@@ -27,12 +30,15 @@ xfail = false
 [include:unit/manifest.ini]
 [include:marketplace/manifest.ini]
 [include:contacts/manifest.ini]
+[include:clock/manifest.ini]
 
 [test_browser_cell_data.py]
 carrier = true
+disabled = No SIM/data plan on CI
 [test_browser_lan.py]
 lan = true
 [test_calculator.py]
+disabled = Bug 822565 - Not for 1.0 release
 [test_calendar.py]
 [test_call_log.py]
 disabled = Need to populate missed calls automatically - Git issue #45
@@ -40,10 +46,12 @@ disabled = Need to populate missed calls automatically - Git issue #45
 camera = true
 sdcard = true
 [test_cards_view.py]
-[test_clock.py]
 [test_dialer.py]
-carrier = true
+carrier=true
 disabled = Requires remote phone number to dial - github issue #156
+[test_ftu.py]
+wifi=true
+carrier=true
 [test_gallery.py]
 sdcard = true
 [test_launch_app.py]
@@ -51,12 +59,13 @@ lan = true
 [test_lockscreen.py]
 [test_music.py]
 sdcard = true
-# Bug 818433 - Gaia Music app is indexing non-Music audio files
-xfail = true
 [test_radio.py]
+antenna = true
 [test_sms.py]
 carrier = true
 [test_updater.py]
 disabled = TODO
 [test_video_player.py]
 sdcard = true
+[test_wallpaper.py]
+disabled = Occasionally fails to select a wallpaper - Github issue #221

--- a/tests/python/gaiatest/tests/marketplace/test_marketplace_login.py
+++ b/tests/python/gaiatest/tests/marketplace/test_marketplace_login.py
@@ -3,13 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from gaiatest import GaiaTestCase
-
+import time
 
 class TestMarketplaceLogin(GaiaTestCase):
 
+    # Marketplace locators
     _login_button = ('css selector', 'a.button.browserid')
-    _persona_frame = ('css selector', "iframe[name='__persona_dialog']")
-    _search_result = ('css selector', '#search-results li.item')
+    _logged_in_locator = ('css selector', 'div.account.authenticated')
+    _settings_cog_locator = ('css selector', 'a.header-button.settings')
+    _settings_form_locator = ('css selector', 'form.form-grid')
+    _email_account_field_locator = ('id', 'email')
+    _logout_button = ('css selector', 'a.logout')
 
     def setUp(self):
         GaiaTestCase.setUp(self)
@@ -18,38 +22,93 @@ class TestMarketplaceLogin(GaiaTestCase):
             self.data_layer.enable_wifi()
             self.data_layer.connect_to_wifi(self.testvars['wifi'])
 
-        # launch the app
+        # Launch the app
         self.app = self.apps.launch('Marketplace')
 
     def test_login_marketplace(self):
         # https://moztrap.mozilla.org/manage/case/4134/
 
         self.wait_for_element_displayed(*self._login_button)
+
         self.marionette.find_element(*self._login_button).click()
 
-        # switch to top level frame
+        self._login_to_persona(self.testvars['marketplace']['username'],
+                                self.testvars['marketplace']['password'])
+
+        # Switch back to marketplace and verify that user is logged in
         self.marionette.switch_to_frame()
+        self.marionette.switch_to_frame(self.app.frame_id)
 
-        #switch to persona frame
+        # If you go too fast here marionette seems to crash the marketplace app
+        time.sleep(5)
+        self.wait_for_element_present(*self._logged_in_locator)
 
-        self.wait_for_element_present(*self._persona_frame)
-        #persona_frame = self.marionette.find_element(*self._persona_frame)
-        #self.marionette.switch_to_frame(persona_frame)
+        # Click the cog
+        self.marionette.find_element(*self._settings_cog_locator).click()
 
-        #TODO switch to Persona frame and wait for throbber to clear
+        self.wait_for_element_displayed(*self._settings_form_locator)
 
-        #TODO complete Persona login
-        #self.testvars['marketplace_username']
-        #self.testvars['marketplace_password']
-        #TODO Switch back to marketplace and verify that user is logged in
+        self.assertEqual(self.testvars['marketplace']['username'],
+            self.marionette.find_element(*self._email_account_field_locator).get_attribute('value'))
+
+        self.marionette.find_element(*self._logout_button).click()
+        self.wait_for_element_not_present(*self._logged_in_locator)
+
+
+    def _login_to_persona(self, username, password):
+
+        persona_frame_locator = ('css selector', "iframe[name='__persona_dialog']")
+
+        # Persona dialog
+        waiting_locator = ('css selector', 'body.waiting')
+        email_input_locator = ('id', 'authentication_email')
+        password_input_locator = ('id', 'authentication_password')
+        next_button_locator = ('css selector', 'button.start')
+        returning_button_locator = ('css selector', 'button.returning')
+        sign_in_button_locator = ('id', 'signInButton')
+
+        # Switch to top level frame then Persona frame
+        self.marionette.switch_to_frame()
+        persona_frame = self.wait_for_element_present(*persona_frame_locator, timeout=20)
+        self.marionette.switch_to_frame(persona_frame)
+
+        # Wait for the loading to complete
+        self.wait_for_element_not_present(*waiting_locator)
+
+        if self.marionette.find_element(*email_input_locator).is_displayed():
+            # Persona has no memory of your details ie after device flash
+            email_field = self.marionette.find_element(*email_input_locator)
+            email_field.send_keys(username)
+
+            self.marionette.find_element(*next_button_locator).click()
+
+            self.wait_for_element_displayed(*password_input_locator)
+            password_field = self.marionette.find_element(*password_input_locator)
+            password_field.send_keys(password)
+
+            self.wait_for_element_displayed(*returning_button_locator)
+            self.marionette.find_element(*returning_button_locator).click()
+
+        else:
+            # Persona remembers your username and password
+            self.marionette.find_element(*sign_in_button_locator).click()
+
 
     def tearDown(self):
+        # In the event that the test fails, a 2nd attempt
+        # switch to marketplace frame and if we are logged in attempt to log out again
+        self.marionette.switch_to_frame()
+        self.marionette.switch_to_frame(self.app.frame_id)
 
-        # close the app
-        if self.app:
-            self.apps.kill(self.app)
+        if self.is_element_present(*self._logged_in_locator):
+            # Refresh to get back to the marketplace main page
+            self.marionette.refresh()
+
+            # click the cog
+            self.marionette.find_element(*self._settings_cog_locator).click()
+            self.wait_for_element_displayed(*self._settings_form_locator)
+            self.marionette.find_element(*self._logout_button).click()
 
         if self.wifi:
             self.data_layer.disable_wifi()
-
         GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/marketplace/test_search_marketplace_and_install_app.py
+++ b/tests/python/gaiatest/tests/marketplace/test_search_marketplace_and_install_app.py
@@ -80,13 +80,7 @@ class TestSearchMarketplaceAndInstallApp(GaiaTestCase):
         self.wait_for_element_present(*self._app_icon_locator)
 
     def tearDown(self):
-
-        # close the app
-        if self.app:
-            self.apps.kill(self.app)
-
         if self.wifi:
             self.data_layer.disable_wifi()
-
         self.apps.uninstall(APP_NAME)
         GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_browser_cell_data.py
+++ b/tests/python/gaiatest/tests/test_browser_cell_data.py
@@ -43,13 +43,7 @@ class TestBrowserCellData(GaiaTestCase):
         self.assertEqual(heading.text, 'We believe that the internet should be public, open and accessible.')
 
     def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'app'):
-            self.apps.kill(self.app)
-
         self.data_layer.disable_cell_data()
-
         GaiaTestCase.tearDown(self)
 
     def is_throbber_visible(self):

--- a/tests/python/gaiatest/tests/test_browser_lan.py
+++ b/tests/python/gaiatest/tests/test_browser_lan.py
@@ -12,6 +12,7 @@ class TestBrowserLAN(GaiaTestCase):
     _url_button_locator = ("id", "url-button")
     _throbber_locator = ("id", "throbber")
     _browser_frame_locator = ('css selector', 'iframe[mozbrowser]')
+    _page_title_locator = ("id", "page-title")
 
     def setUp(self):
         GaiaTestCase.setUp(self)
@@ -32,25 +33,21 @@ class TestBrowserLAN(GaiaTestCase):
 
         self.marionette.find_element(*self._url_button_locator).click()
 
-        self.wait_for_condition(lambda m: not self.is_throbber_visible())
+        # TODO see if we can reduce this timeout in the future. >10 seconds is poor UX
+        self.wait_for_condition(lambda m: not self.is_throbber_visible(), timeout=20)
 
         browser_frame = self.marionette.find_element(
             *self._browser_frame_locator)
 
         self.marionette.switch_to_frame(browser_frame)
 
-        heading = self.marionette.find_element('id', 'page-title')
+        self.wait_for_element_present(*self._page_title_locator)
+        heading = self.marionette.find_element(*self._page_title_locator)
         self.assertEqual(heading.text, 'We believe that the internet should be public, open and accessible.')
 
     def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'app'):
-            self.apps.kill(self.app)
-
         if self.wifi:
             self.data_layer.disable_wifi()
-
         GaiaTestCase.tearDown(self)
 
     def is_throbber_visible(self):

--- a/tests/python/gaiatest/tests/test_calculator.py
+++ b/tests/python/gaiatest/tests/test_calculator.py
@@ -38,11 +38,3 @@ class TestCalculator(GaiaTestCase):
         # verify the result
         display = self.marionette.find_element(*self._display_locator)
         self.assertEquals(display.text, '15', 'wrong calculated value!')
-
-    def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'app'):
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_calendar.py
+++ b/tests/python/gaiatest/tests/test_calendar.py
@@ -51,17 +51,13 @@ class TestCalendar(GaiaTestCase):
         month_title = self.marionette.find_element(
             *self._current_month_year_locator)
 
-        # Get today's date - month, year, weekday
-        today = datetime.datetime.today()
-        month = calendar.month_name[today.month]
-        year = today.year
-        weekday = DAYS_OF_WEEK[today.weekday()]
+        # Get today's date from the phone
+        today = self.marionette.execute_script('return new Date().toUTCString();')
+        date = datetime.datetime.strptime(today, "%a, %d %b %Y %H:%M:%S %Z")
 
         # validate month title and selected day aligns with today's date
-        self.assertEquals(month_title.text, '%s %s' % (month, year),
-            "wrong month title for today");
-        self.assertEquals(selected_day.text, '%s %s %s' % (weekday,
-            month.upper(), year), "wrong selected day for today")
+        self.assertEquals(month_title.text, date.strftime('%B %Y'))
+        self.assertEquals(selected_day.text, date.strftime('%A %B %Y').upper())
 
     def test_that_new_event_appears_on_all_calendar_views(self):
         # https://github.com/mozilla/gaia-ui-tests/issues/102
@@ -99,7 +95,7 @@ class TestCalendar(GaiaTestCase):
         self.marionette.find_element(*self._save_event_button_locator).click()
 
         # wait for the default calendar display
-        self.wait_for_element_displayed(*self._event_list_locator)
+        self.wait_for_element_displayed(*this_event_time_slot_locator)
 
         # assert that the event is displayed as expected
         self.assertTrue(self.marionette.find_element(*this_event_time_slot_locator).is_displayed(),
@@ -110,13 +106,13 @@ class TestCalendar(GaiaTestCase):
 
         # switch to the week display
         self.marionette.find_element(*self._week_display_button_locator).click()
-        self.wait_for_element_displayed(*self._week_view_locator)
+        self.wait_for_element_displayed(*week_view_time_slot_all_events_locator)
         displayed_events = self.marionette.find_element(*week_view_time_slot_all_events_locator).text
         self.assertIn(event_title, displayed_events)
 
         # switch to the day display
         self.marionette.find_element(*self._day_display_button_locator).click()
-        self.wait_for_element_displayed(*self._day_view_locator)
+        self.wait_for_element_displayed(*day_view_time_slot_all_events_locator)
         displayed_events = self.marionette.find_element(*day_view_time_slot_all_events_locator).text
         self.assertIn(event_title, displayed_events)
         self.assertIn(event_location, displayed_events)
@@ -129,12 +125,3 @@ class TestCalendar(GaiaTestCase):
             self.marionette.find_element(*self._delete_event_button_locator).click()
             self.wait_for_element_displayed(*self._day_view_locator)
             all_events = self.marionette.find_elements(*day_view_time_slot_individual_events_locator)
-
-    def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'app'):
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)
-

--- a/tests/python/gaiatest/tests/test_call_log.py
+++ b/tests/python/gaiatest/tests/test_call_log.py
@@ -77,11 +77,3 @@ class TestCallLog(GaiaTestCase):
 
         # Check that the first one is displayed. this is only a smoke test after all
         self.assertTrue(missed_calls[0].is_displayed())
-
-    def tearDown(self):
-
-        # close the app
-        if self.app:
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_camera.py
+++ b/tests/python/gaiatest/tests/test_camera.py
@@ -35,7 +35,9 @@ class TestCamera(GaiaTestCase):
         # The focus state will be either 'focused' or 'fail'
         self.assertEqual(focus_state, 'focused', "Camera failed to focus with error: %s" % focus_state)
 
-        self.wait_for_element_displayed(*self._film_strip_image_locator) #wait for image to be added in to filmstrip
+        # Wait for image to be added in to filmstrip
+        # TODO investigate lowering this timeout in the future
+        self.wait_for_element_displayed(*self._film_strip_image_locator, timeout=20)
 
         # Find the new picture in the film strip
         self.assertTrue(self.marionette.find_element(*self._film_strip_image_locator).is_displayed())
@@ -61,8 +63,12 @@ class TestCamera(GaiaTestCase):
 
         self.wait_for_element_not_displayed(*self._video_timer_locator)
 
-        # TODO
-        # Validate the recorded video somehow
+        # Wait for image to be added in to filmstrip
+        self.wait_for_element_displayed(*self._film_strip_image_locator)
+
+        # Find the new film thumbnail in the film strip
+        self.assertTrue(self.marionette.find_element(*self._film_strip_image_locator).is_displayed())
+
 
     def wait_for_capture_ready(self):
         self.marionette.set_script_timeout(10000)
@@ -72,11 +78,3 @@ class TestCamera(GaiaTestCase):
                 function () { return document.getElementById('viewfinder').readyState > 1; }
             );
         """)
-
-    def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'app'):
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_cards_view.py
+++ b/tests/python/gaiatest/tests/test_cards_view.py
@@ -6,22 +6,18 @@ from gaiatest import GaiaTestCase
 
 class TestCardsView(GaiaTestCase):
 
+    _app_under_test = "Clock"
+
     # Home/Cards view locators
     _cards_view_locator = ('id', 'cards-view')
-    _calculator_card_locator = ('xpath', "//li[@class='card']/h1[text()='Calculator']")
-
-    # Calculator locators
-    _clear_button_locator = ('xpath', "//input[@value='C']")
+    _app_card_locator = ('xpath', "//li[@class='card']/h1[text()='%s']" % _app_under_test)
 
     def setUp(self):
         GaiaTestCase.setUp(self)
 
-        # launch the Calculator app as a basic, reliable
+        # launch the Clock app as a basic, reliable
         # app to test against in Cards View
-        self.calculator = self.apps.launch('Calculator')
-
-        # wait for the Calculator to load
-        self.wait_for_element_displayed(*self._clear_button_locator)
+        self.app = self.apps.launch(self._app_under_test)
 
     def test_cards_view(self):
 
@@ -38,8 +34,8 @@ class TestCardsView(GaiaTestCase):
         self.assertTrue(card_view_element.is_displayed(),
             "Card view expected to be visible")
 
-        calculator_card = self.marionette.find_element(*self._calculator_card_locator)
-        self.assertTrue(calculator_card.is_displayed())
+        app_card = self.marionette.find_element(*self._app_card_locator)
+        self.assertTrue(app_card.is_displayed())
 
         self._touch_home_button()
         self.wait_for_element_not_displayed(*self._cards_view_locator)
@@ -53,29 +49,19 @@ class TestCardsView(GaiaTestCase):
         # go to the home screen
         self.marionette.switch_to_frame()
         self._touch_home_button()
-        self.wait_for_element_not_displayed(*self._clear_button_locator)
 
         # pull up the cards view
         self.marionette.switch_to_frame()
         self._hold_home_button()
         self.wait_for_element_displayed(*self._cards_view_locator)
 
-        # launch the calculator from the cards view
-        calc_card = self.marionette.find_element(*self._calculator_card_locator)
-        calc_card.click()
-        self.marionette.switch_to_frame(self.calculator.frame_id)
-        self.wait_for_element_displayed(*self._clear_button_locator)
+        # launch the app from the cards view
+        app_card = self.marionette.find_element(*self._app_card_locator)
+        app_card.click()
+        self.marionette.switch_to_frame(self.app.frame_id)
 
     def _hold_home_button(self):
         self.marionette.execute_script("window.wrappedJSObject.dispatchEvent(new Event('holdhome'));")
 
     def _touch_home_button(self):
         self.marionette.execute_script("window.wrappedJSObject.dispatchEvent(new Event('home'));")
-
-    def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'calculator'):
-            self.apps.kill(self.calculator)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_dialer_verify.py
+++ b/tests/python/gaiatest/tests/test_dialer_verify.py
@@ -50,6 +50,19 @@ class TestDialer(GaiaTestCase):
         # Now press call!
         self.marionette.find_element(*self._call_bar_locator).click()
 
+        outgoing_number = self.marionette.execute_async_script("""
+            waitFor(
+                function() {
+                    let call = window.navigator.mozTelephony.calls[0];
+                    marionetteScriptFinished(call.number);
+                },
+                function() {
+                    return window.navigator.mozTelephony.calls.length > 0;
+                }
+            );
+        """)
+        self.assertEqual(outgoing_number, self._test_phone_number)
+
         # Switch to top level frame
         self.marionette.switch_to_frame()
 
@@ -70,6 +83,11 @@ class TestDialer(GaiaTestCase):
 
         # hang up before the person answers ;)
         self.marionette.find_element(*self._hangup_bar_locator).click()
+
+    def tearDown(self):
+
+        self.apps.kill_all()
+        GaiaTestCase.tearDown(self)
 
     def _dial_number(self, phone_number):
         '''

--- a/tests/python/gaiatest/tests/test_ftu.py
+++ b/tests/python/gaiatest/tests/test_ftu.py
@@ -1,0 +1,196 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+import time
+
+class TestFtu(GaiaTestCase):
+
+    _activation_section_locator = ('id', 'activation')
+    _main_title_locator = ('id', 'main_title')
+
+    _next_button_locator = ('id', 'forward')
+
+    # Step Languages section
+    _section_languages_locator = ('id', 'languages')
+    _listed_languages_locator = ('css selector', "#languages ul li input[name='language.current']")
+
+    # Step Cell data section
+    _section_cell_data_locator = ('id', 'data_3g')
+    _enable_data_checkbox_locator = ('id', 'data-connection-switch')
+
+    # Step Wifi
+    _section_wifi_locator = ('id', 'wifi')
+    _found_wifi_networks_locator = ('css selector', 'ul#networks li')
+    _network_state_locator = ('xpath', 'p[2]')
+
+    # Step Date & Time
+    _section_date_time_locator = ('id', 'date_and_time')
+    _timezone_continent_locator = ('id', 'tz-continent')
+    _timezone_city_locator = ('id', 'tz-city')
+    _time_zone_title_locator = ('id', 'time-zone-title')
+
+    # Section Import contacts
+    _section_import_contacts_locator = ('id', 'import_contacts')
+    _import_from_sim_locator = ('id', 'sim_import')
+    _sim_import_feedback_locator = ('id', 'sim_import_feedback')
+
+    # Section About Your rights
+    _section_ayr_locator = ('id', 'about-your-rights')
+
+    # Section Welcome Browser
+    _section_welcome_browser_locator = ('id', 'welcome_browser')
+    _enable_statistic_checkbox_locator = ('id', 'share-performance')
+
+    # Section Privacy Choices
+    _section_browser_privacy_locator = ('id', 'browser_privacy')
+    _email_field_locator = ('css selector', 'input[type="email"]')
+
+    # Section Finish
+    _section_finish_locator = ('id', 'finish-screen')
+    _skip_tour_button_locator = ('id', 'skip-tutorial-button')
+
+    # Section Tutorial Finish
+    _section_tutorial_finish_locator = ('id', 'tutorialFinish')
+    _lets_go_button_locator = ('id', 'tutorialFinished')
+
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # We need WiFi enabled but not connected to a network
+        self.data_layer.enable_wifi()
+        self.data_layer.forget_all_networks()
+
+        # Cell data must be off so we can switch it on again
+        self.data_layer.disable_cell_data()
+
+        # launch the First Time User app
+        self.app = self.apps.launch('FTU')
+
+
+    def test_ftu(self):
+        # https://moztrap.mozilla.org/manage/case/3876/
+        # 3876, 3879
+
+        self.wait_for_element_displayed(*self._section_languages_locator)
+
+        # FTU is not properly localized yet so let's just check some are listed
+        # TODO enhance this to include lang selection when FTU is localized
+        listed_languages = self.marionette.find_elements(*self._listed_languages_locator)
+        self.assertGreater(len(listed_languages), 0, "No languages listed on screen")
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_cell_data_locator)
+
+        # Click enable data
+        self.marionette.find_element(*self._enable_data_checkbox_locator).click()
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_wifi_locator)
+
+        # Wait for some networks to be found
+        self.wait_for_condition(lambda m: len(m.find_elements(*self._found_wifi_networks_locator)) > 0,
+                message="No networks listed on screen")
+
+        # TODO This will only work on Mozilla Guest or unsecure network
+        wifi_network = self.marionette.find_element('id', self.testvars['wifi']['ssid'])
+        wifi_network.click()
+
+        self.wait_for_condition(lambda m:
+            wifi_network.find_element(*self._network_state_locator).text == "Connected")
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_date_time_locator)
+
+        # Set timezone
+        continent_select = self.marionette.find_element(*self._timezone_continent_locator)
+        # Click to activate the b2g select element
+        continent_select.click()
+        self._select("Europe")
+
+        city_select = self.marionette.find_element(*self._timezone_city_locator)
+        # Click to activate the b2g select element
+        city_select.click()
+        self._select("London")
+
+        self.assertEqual(self.marionette.find_element(*self._time_zone_title_locator).text,
+                        "UTC+00:00 Europe/London")
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_import_contacts_locator)
+
+        # Commenting out SIM import for now
+
+#        # Click import from SIM
+#        # You can do this as many times as you like without db conflict
+#        self.marionette.find_element(*self._import_from_sim_locator).click()
+#
+#        # TODO What if Sim has two contacts?
+#        self.wait_for_condition(lambda m: m.find_element(*self._sim_import_feedback_locator).text ==
+#                        "Imported one contact", message="Contact did not import from sim before timeout")
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_welcome_browser_locator)
+
+        # Click the statistics box and check that it sets a setting
+        # TODO assert via settings API that this is set. Currently it is not used
+        self.marionette.find_element(*self._enable_statistic_checkbox_locator).click()
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_browser_privacy_locator)
+
+        # Enter a dummy email address and check it set inside the os
+        # TODO assert that this is preserved in the system somewhere. Currently it is not used
+        self.marionette.find_element(*self._email_field_locator).send_keys("testuser@mozilla.com")
+
+        # Click next
+        self.marionette.find_element(*self._next_button_locator).click()
+        self.wait_for_element_displayed(*self._section_finish_locator)
+
+       # The tour appears to be empty so let's skip it
+        self.marionette.find_element(*self._skip_tour_button_locator).click()
+
+        # Switch back to top level now that FTU app is gone
+        self.marionette.switch_to_frame()
+
+        self.assertTrue(self.data_layer.get_setting("ril.data.enabled"), "Cell data was not enabled by FTU app")
+        self.assertTrue(self.data_layer.is_wifi_connected(self.testvars['wifi']), "WiFi was not connected via FTU app")
+
+    def tearDown(self):
+
+        # TODO flush any settings set by the FTU app
+        self.data_layer.disable_cell_data()
+
+        self.data_layer.disable_wifi()
+
+        GaiaTestCase.tearDown(self)
+
+    def _select(self, match_string):
+        # Cheeky Select wrapper until Marionette has its own
+        # Due to the way B2G wraps the app's select box we match on text
+
+        # Have to go back to top level to get the B2G select box wrapper
+        self.marionette.switch_to_frame()
+
+        options = self.marionette.find_elements('css selector', '#value-selector-container li')
+        close_button = self.marionette.find_element('css selector', 'button.value-option-confirm')
+
+        # Loop options until we find the match
+        for li in options:
+            if li.text == match_string:
+                li.click()
+                break
+
+        close_button.click()
+
+        # Now back to app
+        self.marionette.switch_to_frame(self.app.frame_id)

--- a/tests/python/gaiatest/tests/test_gallery.py
+++ b/tests/python/gaiatest/tests/test_gallery.py
@@ -36,11 +36,3 @@ class TestGallery(GaiaTestCase):
         # Add steps to view picture full screen
         # TODO
         # Repeat test with landscape orientation
-
-    def tearDown(self):
-
-        # close the app
-        if self.app:
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_launch_app.py
+++ b/tests/python/gaiatest/tests/test_launch_app.py
@@ -30,7 +30,11 @@ class TestLaunchApp(GaiaTestCase):
         self.wait_for_element_displayed(*self._yes_button_locator)
         yes = self.marionette.find_element(*self._yes_button_locator)
         yes.click()
+
         self.marionette.switch_to_frame(self.homescreen.frame_id)
+        # TODO: Should use swipe/flick once this works reliably
+        self._go_to_next_page()
+
         self.wait_for_element_displayed(*self._icon_locator)
 
     def test_launch_app(self):
@@ -43,8 +47,10 @@ class TestLaunchApp(GaiaTestCase):
         self.wait_for_element_displayed(*self._header_locator, timeout=20)
         self.assertEqual(self.marionette.find_element(*self._header_locator).text, TITLE)
 
+    def _go_to_next_page(self):
+        self.marionette.execute_script('window.wrappedJSObject.GridManager.goToNextPage()')
+
     def tearDown(self):
-        self.apps.kill_all()
         self.apps.uninstall(APP_NAME)
         if self.wifi:
             self.data_layer.disable_wifi()

--- a/tests/python/gaiatest/tests/test_lockscreen.py
+++ b/tests/python/gaiatest/tests/test_lockscreen.py
@@ -9,13 +9,19 @@ class TestLockScreen(GaiaTestCase):
 
     # Lockscreen area locators
     _lockscreen_locator = ('id', 'lockscreen')
+    _lockscreen_area_locator = ('id', 'lockscreen-area')
     _lockscreen_handle_locator = ('id', 'lockscreen-area-handle')
     _unlock_button_locator = ('id', 'lockscreen-area-unlock')
-    _lockscreen_animation_locator = ('css selector', 'animate.lockscreen-start-animation[attributeName="y"]')
+    _camera_button_locator = ('id', 'lockscreen-area-camera')
 
     # Homescreen locators
     _homescreen_frame_locator = ('css selector', 'iframe.homescreen')
     _homescreen_landing_locator = ('id', 'landing-page')
+
+    # Camera locators
+    _camera_frame_locator = ('css selector', 'iframe[src="app://camera.gaiamobile.org/index.html"]')
+    _capture_button_locator = ('id', 'capture-button')
+
 
     def setUp(self):
         GaiaTestCase.setUp(self)
@@ -31,6 +37,8 @@ class TestLockScreen(GaiaTestCase):
         unlock_button.click()
 
         lockscreen_element = self.marionette.find_element(*self._lockscreen_locator)
+        self.wait_for_condition(lambda m: not lockscreen_element.is_displayed())
+
         self.assertFalse(lockscreen_element.is_displayed(), "Lockscreen still visible after unlock")
 
         hs_frame = self.marionette.find_element(*self._homescreen_frame_locator)
@@ -42,6 +50,28 @@ class TestLockScreen(GaiaTestCase):
 
         self.assertTrue(landing_element.is_displayed(), "Landing element not displayed after unlocking")
 
+
+    def test_unlock_swipe_to_camera(self):
+        # https://moztrap.mozilla.org/manage/case/2460/
+        self._swipe_and_unlock()
+
+        camera_button = self.marionette.find_element(*self._camera_button_locator)
+        camera_button.click()
+
+        lockscreen_element = self.marionette.find_element(*self._lockscreen_locator)
+        self.wait_for_condition(lambda m: not lockscreen_element.is_displayed())
+
+        self.assertFalse(lockscreen_element.is_displayed(), "Lockscreen still visible after unlock")
+
+        camera_frame = self.marionette.find_element(*self._camera_frame_locator)
+
+        # TODO I would prefer to check visibility of the the frame at this point but bug 813583
+        self.marionette.switch_to_frame(camera_frame)
+
+        # Wait fot the capture button displayed. no need to take a photo.
+        self.wait_for_element_displayed(*self._capture_button_locator)
+
+
     def _swipe_and_unlock(self):
 
         unlock_handle = self.marionette.find_element(*self._lockscreen_handle_locator)
@@ -49,7 +79,8 @@ class TestLockScreen(GaiaTestCase):
         unlock_handle_y_centre = int(unlock_handle.size['height']/2)
 
         # Get the end position from the demo animation
-        end_animation_position = int(self.marionette.find_element(*self._lockscreen_animation_locator).get_attribute('to'))
+        lockscreen_area = self.marionette.find_element(*self._lockscreen_area_locator)
+        end_animation_position = lockscreen_area.size['height'] - unlock_handle.size['height']
 
         # Flick from unlock handle to (0, -end_animation_position) over 800ms duration
         self.marionette.flick(unlock_handle, unlock_handle_x_centre, unlock_handle_y_centre, 0, 0 - end_animation_position, 800)

--- a/tests/python/gaiatest/tests/test_music.py
+++ b/tests/python/gaiatest/tests/test_music.py
@@ -64,10 +64,3 @@ class TestMusic(GaiaTestCase):
 
       # validate stopped playback
       self.assertEqual(audiotag.get_attribute('paused'), 'true')
-
-  def tearDown(self):
-      # close the app
-      if hasattr(self, 'app'):
-          self.apps.kill(self.app)
-
-      GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_radio.py
+++ b/tests/python/gaiatest/tests/test_radio.py
@@ -4,11 +4,13 @@
 
 from gaiatest import GaiaTestCase
 
+
 class TestRadio(GaiaTestCase):
 
     # Radio
     _frequency_dialer_locator = ('id', 'frequency-dialer')
     _frequency_indicator_locator = ('id', 'frequency')
+    _power_button_locator = ('id', 'power-switch')
 
     def setUp(self):
         GaiaTestCase.setUp(self)
@@ -17,21 +19,24 @@ class TestRadio(GaiaTestCase):
         self.app = self.apps.launch('FM Radio')
 
     def test_radio(self):
-
         # https://moztrap.mozilla.org/manage/case/2461/
 
-        # Access to the FM hardware radio requires the use of 
-        # headphones plugged into an actual device
+        # Access to the FM hardware radio requires the use of headphones
+        self.assertTrue(self.data_layer.is_antenna_available, 'Antenna (headphones) not plugged in')
 
         # Determine if the FM hardware radio is enabled; wait for hardware init
-        ## This will fail if headphones are not plugged in
-        self.wait_for_condition(lambda m: self.data_layer.fm_state is True)
+        self.wait_for_condition(lambda m: self.data_layer.is_fm_radio_enabled)
+
+        # Check if the radio is on
+        power_button = self.marionette.find_element(*self._power_button_locator)
+        self.assertEqual(power_button.get_attribute('data-enabled'), 'true')
+        self.assertTrue(self.data_layer.is_fm_radio_enabled)
 
         frequency_indicator = self.marionette.find_element(*self._frequency_indicator_locator)
         dialer = self.marionette.find_element(*self._frequency_dialer_locator)
 
         # Check that the FM radio has tuned in to the default channel frequency (lower bound)
-        channel = str(self.data_layer.fm_frequency)
+        channel = str(self.data_layer.fm_radio_frequency)
 
         self.assertEqual(frequency_indicator.text, channel)
 
@@ -39,17 +44,20 @@ class TestRadio(GaiaTestCase):
         for station in range(0, 20):
 
             # Get new coordinates for realistic flinging
-            dialer_x_center = int(dialer.size['width']/2)
-            dialer_y_center = int(dialer.size['height']/2)
+            dialer_x_center = int(dialer.size['width'] / 2)
+            dialer_y_center = int(dialer.size['height'] / 2)
 
             self.marionette.flick(dialer, dialer_x_center, dialer_y_center, 0, 300, 800)
 
         # Check that the FM radio has tuned in to a higher default frequency (upper bound)
-        self.assertNotEqual(channel, str(self.data_layer.fm_frequency))
+        self.assertNotEqual(channel, str(self.data_layer.fm_radio_frequency))
         self.assertNotEqual(frequency_indicator.text, channel)
 
     def tearDown(self):
-        if hasattr(self, 'app'):
+        # Turn off the radio
+        self.marionette.find_element(*self._power_button_locator).click()
+
+        if self.app:
             self.apps.kill(self.app)
 
         GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_sms.py
+++ b/tests/python/gaiatest/tests/test_sms.py
@@ -11,7 +11,7 @@ class TestSms(GaiaTestCase):
     # Summary page
     _summary_header_locator = ('xpath', "//h1[text()='Messages']")
     _create_new_message_locator = ('id', 'icon-add')
-    _unread_message_locator = ('css selector', 'div.item > a.unread')
+    _unread_message_locator = ('css selector', 'li > a.unread')
 
     # Message composition
     _receiver_input_locator = ('id', 'receiver-input')
@@ -22,9 +22,8 @@ class TestSms(GaiaTestCase):
         "img[src='style/images/spinningwheel_small_animation.gif']")
 
     # Conversation view
-    _all_messages_locator = ('css selector', 'div.message-block')
-    _received_message_content_locator = ('xpath',
-         "//div[@class='message-block'][span[@class='bubble-container received']]")
+    _all_messages_locator = ('css selector', 'li.bubble')
+    _received_message_content_locator = ('xpath', "//li[@class='bubble'][a[@class='received']]")
 
     def setUp(self):
         GaiaTestCase.setUp(self)
@@ -88,11 +87,3 @@ class TestSms(GaiaTestCase):
         # Check that most recent message is also the most recent received message
         self.assertEqual(received_message.get_attribute('id'),
             last_message.get_attribute('id'))
-
-    def tearDown(self):
-
-        # close the app
-        if self.app:
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_updater.py
+++ b/tests/python/gaiatest/tests/test_updater.py
@@ -28,11 +28,3 @@ class TestUpdater(GaiaTestCase):
         # wait for 'Checking for updates' to clear
 
         # Confirm that ui journey is complete
-
-    def tearDown(self):
-
-        # close the app
-        if hasattr(self, 'app'):
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_video_player.py
+++ b/tests/python/gaiatest/tests/test_video_player.py
@@ -57,11 +57,3 @@ class TestVideoPlayer(GaiaTestCase):
         # Check the name too. This will only work if the toolbar is visible
         self.assertEqual(first_video_name,
                         self.marionette.find_element(*self._video_title_locator).text)
-
-    def tearDown(self):
-
-        # close the app
-        if self.app:
-            self.apps.kill(self.app)
-
-        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/test_wallpaper.py
+++ b/tests/python/gaiatest/tests/test_wallpaper.py
@@ -1,0 +1,77 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+class TestWallpaper(GaiaTestCase):
+
+    _display_locator = ('id', 'menuItem-display')
+    _wallpaper_preview_locator = ('id', 'wallpaper-preview')
+    _wallpaper_button_locator = ('css selector', "a[data-value='0']")
+    _wallpaper_title_locator = ('css selector', "h1[data-l10n-id='select-wallpaper']")
+    _pick_wallpapers_locator = ('css selector', "img[class='wallpaper']")
+    _wallpaper_frame_locator = ('css selector', "iframe[src='app://wallpaper.gaiamobile.org/pick.html']")
+    _settings_frame_locator = ('css selector', "iframe[src='app://settings.gaiamobile.org/index.html#root']")
+
+    # default wallpaper 
+    _default_wallpaper_src = None
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # unlock the lockscreen if it's locked
+        self.lockscreen.unlock()
+
+    def test_change_wallpaper(self):
+        # https://moztrap.mozilla.org/manage/case/3449/
+        # launch the Settings app
+        self.app = self.apps.launch('Settings')
+
+        self.wait_for_element_displayed(*self._display_locator)
+        self.marionette.find_element(*self._display_locator).click()
+
+        self.wait_for_element_displayed(*self._wallpaper_preview_locator)
+
+        # save the default wallpaper's src
+        wallpaper_preview = self.marionette.find_element(*self._wallpaper_preview_locator)
+        self._default_wallpaper_src = wallpaper_preview.get_attribute('src')
+
+        # Send the pick event to system
+        wallpaper_preview.click()
+        
+        # switch to the system app
+        self.marionette.switch_to_frame()
+
+        # choose the source as wallpaper app
+        self.wait_for_element_displayed(*self._wallpaper_button_locator)
+        self.marionette.find_element(*self._wallpaper_button_locator).click()
+        
+        # switch to the wallpaper app
+        self.wait_for_element_displayed(*self._wallpaper_frame_locator)
+        self.marionette.switch_to_frame(self.marionette.find_element(*self._wallpaper_frame_locator))
+
+        # pick a wallpaper
+        self.wait_for_condition(lambda m: m.find_element(*self._wallpaper_title_locator).text != "")
+        pick_wallpapers = self.marionette.find_elements(*self._pick_wallpapers_locator)
+        self.wait_for_element_displayed(*self._pick_wallpapers_locator)
+        pick_wallpapers[3].click()
+
+        # switch to the system app
+        self.marionette.switch_to_frame()
+        
+        # switch to the setting app
+        self.marionette.switch_to_frame(self.marionette.find_element(*self._settings_frame_locator))
+        self.wait_for_element_displayed(*self._wallpaper_preview_locator)
+
+        # save the new wallpaper's src
+        new_wallpaper = self.marionette.find_element(*self._wallpaper_preview_locator).get_attribute('src')
+
+        # verify the change of wallpaper
+        self.assertFalse(new_wallpaper == self._default_wallpaper_src, 'Wallpaper has not changed from default.')
+
+    def tearDown(self):
+        # reset to the default wallpaper
+        self.marionette.execute_script("navigator.mozSettings.createLock().set({'wallpaper.image' : arguments[0]});", [self._default_wallpaper_src])
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaiatest/tests/unit/manifest.ini
+++ b/tests/python/gaiatest/tests/unit/manifest.ini
@@ -4,6 +4,7 @@ carrier = false
 
 [include:settings/manifest.ini]
 
+[test_debug.py]
 [test_initial_state.py]
 [test_kill.py]
 [test_killall.py]

--- a/tests/python/gaiatest/tests/unit/test_debug.py
+++ b/tests/python/gaiatest/tests/unit/test_debug.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import unittest
+
+from gaiatest import GaiaTestCase
+
+
+class TestDebug(GaiaTestCase):
+
+    expect_debug = False
+
+    @unittest.expectedFailure
+    def test_debug_expected(self):
+        self.expect_debug = True
+        self.lockscreen.unlock()
+        self.assertTrue(False)
+
+    def test_debug_not_expected(self):
+        self.expect_debug = False
+        self.assertTrue(True)
+
+    def tearDown(self):
+        GaiaTestCase.tearDown(self)
+        debug_path = os.path.join('debug', self.__class__.__name__, self._testMethodName)
+        for file_name in ['screenshot.png']:
+            file_exists = os.path.isfile(os.path.join(debug_path, file_name))
+            if self.expect_debug:
+                self.assertTrue(file_exists)
+            else:
+                self.assertFalse(file_exists)

--- a/tests/python/gaiatest/tests/unit/test_kill.py
+++ b/tests/python/gaiatest/tests/unit/test_kill.py
@@ -15,7 +15,7 @@ class TestKill(GaiaTestCase):
     def test_kill_multiple(self):
         running_apps = []
 
-        for app in ['Calculator', 'Clock']:
+        for app in ['Calendar', 'Clock']:
             running_apps.append(self.apps.launch(app))
 
         for app in running_apps:

--- a/tests/python/gaiatest/tests/unit/test_killall.py
+++ b/tests/python/gaiatest/tests/unit/test_killall.py
@@ -8,7 +8,7 @@ from gaiatest import GaiaTestCase
 class TestKillAll(GaiaTestCase):
 
     def test_kill_all(self):
-        for app in ['Calculator', 'Clock']:
+        for app in ['Calendar', 'Clock']:
             self.apps.launch(app)
 
         self.apps.kill_all()
@@ -20,7 +20,7 @@ class TestKillAll(GaiaTestCase):
         self.check_no_apps_running()
 
     def test_kill_all_twice(self):
-        apps = ['Calculator', 'Clock']
+        apps = ['Calendar', 'Clock']
         for app in apps:
             self.apps.launch(app)
 

--- a/tests/python/gaiatest/testvars_template.json
+++ b/tests/python/gaiatest/testvars_template.json
@@ -1,9 +1,13 @@
 {
-    "marketplace_user": "",
-    "marketplace_password": "",
     "remote_phone_number": "",
     "this_phone_number": "",
+
     "wifi": {
         "ssid": ""
+    },
+
+    "marketplace": {
+        "username": "",
+        "password": ""
     }
 }


### PR DESCRIPTION
JS files pass gjslint, and tests pass except as noted by the xfail or disabled manifest keys.
