### PR TITLE
Bug 824783 - [email] "No mail in this Folder" overlaps the actual emails...

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -28261,13 +28261,6 @@ function ImapFolderConn(account, storage, _parentLog) {
 }
 ImapFolderConn.prototype = {
   /**
-   * Can we grow this sync range?  IMAP always lets us do this.
-   */
-  get canGrowSync() {
-    return true;
-  },
-
-  /**
    * Acquire a connection and invoke the callback once we have it and we have
    * entered the folder.  This method should only be called when running
    * inside `runMutexed`.
@@ -28946,6 +28939,13 @@ ImapFolderSyncer.prototype = {
    * synchronize.  The errbackoff is just a question of when we will retry.
    */
   syncable: true,
+
+  /**
+   * Can we grow this sync range?  IMAP always lets us do this.
+   */
+  get canGrowSync() {
+    return true;
+  },
 
   syncDateRange: function(startTS, endTS, syncCallback, doneCallback,
                           progressCallback) {


### PR DESCRIPTION
... in the sent folder if the phone times out. regression fix, a=bustage-fix

land regression fix:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/111
