### PR TITLE
Bug 827708 - [music] the seeking position is not always the same as the users tapping position

### DIFF
--- a/apps/music/style/music.css
+++ b/apps/music/style/music.css
@@ -658,6 +658,7 @@ button::-moz-focus-inner {
 }
 
 #player-seek-bar-progress {
+  pointer-events: none;
   -moz-appearance: none;
   position: absolute;
   top: calc(50% - 0.15rem);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=827708

Root Cause:
There are two elements called #player-seek-bar and #player-seek-bar-progress will trigger seek event. It let users sometimes touch #player-seek-bar and sometimes touch #player-seek-bar-progress.

And the width size of these two elements are different. So the seek function will return wrong result, and this bug will happen.

Solution:
Disable event trigger function of #player-seek-bar-progress element.
