### PR TITLE
Bug 826872 - Optimize XHR

### DIFF
--- a/apps/calendar/js/service/caldav.js
+++ b/apps/calendar/js/service/caldav.js
@@ -5,7 +5,8 @@ Calendar.ns('Service').Caldav = (function() {
   /* TODO: ugly hack to enable system XHR fix upstream in Caldav lib */
   var xhrOpts = {
     mozSystem: true,
-    mozAnon: true
+    mozAnon: true,
+    useMozChunkedText: true
   };
 
   Caldav.Xhr.prototype.globalXhrOptions = xhrOpts;

--- a/apps/calendar/test/unit/service/caldav_test.js
+++ b/apps/calendar/test/unit/service/caldav_test.js
@@ -81,7 +81,8 @@ suite('service/caldav', function() {
     var xhr = Caldav.Xhr;
     var expected = {
       mozSystem: true,
-      mozAnon: true
+      mozAnon: true,
+      useMozChunkedText: true
     };
 
     assert.deepEqual(xhr.prototype.globalXhrOptions, expected);


### PR DESCRIPTION
Uses responseType=moz-chunked-text so XHR objects don't accumulate all data sent by servers. 
