### PR TITLE
Bug 826122: Provide meaningful error message if pairing is refused [r=kaze,ehung]

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -337,13 +337,13 @@ onLocalized(function bluetoothSettings() {
 
       navigator.mozSetMessageHandler('bluetooth-cancel',
         function bt_gotCancelMessage(message) {
-          showDevicePaired(false);
+          showDevicePaired(false, null);
         }
       );
 
       navigator.mozSetMessageHandler('bluetooth-pairedstatuschanged',
         function bt_getPairedMessage(message) {
-          showDevicePaired(message.paired);
+          showDevicePaired(message.paired, 'Authentication Failed');
         }
       );
 
@@ -437,8 +437,8 @@ onLocalized(function bluetoothSettings() {
         pairingMode = 'active';
         pairingAddress = device.address;
         stopDiscovery();
-        req.onerror = function bt_pairError() {
-          showDevicePaired(false);
+        req.onerror = function bt_pairError(error) {
+          showDevicePaired(false, req.error.name);
         };
 
       };
@@ -446,7 +446,7 @@ onLocalized(function bluetoothSettings() {
       openList.index[device.address] = [device, aItem];
     }
 
-    function showDevicePaired(paired) {
+    function showDevicePaired(paired, errorMessage) {
       // if we are in a pairing process, update found device list
       // or do error handling.
       if (pairingAddress) {
@@ -466,7 +466,12 @@ onLocalized(function bluetoothSettings() {
           // display failure only when active request
           if (pairingMode === 'active' && !userCanceledPairing) {
             // show pair process fail.
-            var msg = _('error-pair-title') + '\n' + _('error-pair-pincode');
+            var msg = _('error-pair-title');
+            if (errorMessage === 'Repeated Attempts') {
+              msg = msg + '\n' + _('error-pair-toofast');
+            } else if (errorMessage === 'Authentication Failed') {
+              msg = msg + '\n' + _('error-pair-pincode');
+            }
             window.alert(msg);
           }
           userCanceledPairing = false;
@@ -493,7 +498,7 @@ onLocalized(function bluetoothSettings() {
       // backend takes responsibility to disconnect first.
       var req = defaultAdapter.unpair(device);
       req.onerror = function bt_pairError() {
-        showDevicePaired(true);
+        showDevicePaired(true, null);
       };
     }
 

--- a/apps/settings/locales/settings.ar.properties
+++ b/apps/settings/locales/settings.ar.properties
@@ -128,6 +128,7 @@ bluetooth=بلوتوث
 #TODO: passive-pair-passkey      = {{device}} would like to pair with this phone. To accept, enter the Passkey on the device.
 #TODO: error-pair-title      = Unable to Pair Devices 
 #TODO: error-pair-pincode    = Unable to pair with the device. Check that the PIN is correct.
+#TODO: error-pair-toofast    = Unable to pair with the device. Too many requests.
 #TODO: error-connect-title   = Unable to Connect Devices
 #TODO: error-connect-msg     = Check that the device you're trying to connect with is still in range and has Bluetooth turned on.
 #TODO: unpair-title = Unpair a connected device?

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -179,6 +179,7 @@ passive-pair-pincode      = {{device}} would like to pair with this phone. To ac
 passive-pair-passkey      = {{device}} would like to pair with this phone. To accept, enter the passkey on the device.
 error-pair-title      = Unable to pair devices
 error-pair-pincode    = Unable to pair with the device. Check that the PIN is correct.
+error-pair-toofast    = Unable to pair with the device. Too many requests.
 error-connect-title   = Unable to connect devices
 error-connect-msg     = Check that the device you’re trying to connect with is still in range and has Bluetooth turned on.
 unpair-title = Unpair a connected device?

--- a/apps/settings/locales/settings.fr.properties
+++ b/apps/settings/locales/settings.fr.properties
@@ -175,6 +175,7 @@ passive-pair-pincode      = {{device}} voudrait s’associer avec ce téléphone
 passive-pair-passkey      = {{device}} voudrait s’associer avec ce téléphone. Pour accepter, saisissez la phrase-clé sur l’appareil.
 error-pair-title      = Impossible d’associer cet appareil
 error-pair-pincode    = Impossible d’associer cet appareil. Vérifiez que le code PIN est correct.
+#TODO: error-pair-toofast    = Unable to pair with the device. Too many requests.
 error-connect-title   = Impossible de connecter des appareils
 error-connect-msg     = Vérifiez que l’appareil avec lequel vous essayez de vous connecter est toujours à portée et que le Bluetooth est activé.
 unpair-title = Dissocier un appareil connecté ?

--- a/apps/settings/locales/settings.zh-TW.properties
+++ b/apps/settings/locales/settings.zh-TW.properties
@@ -172,6 +172,7 @@ passive-pair-pincode      = {{device}} 想要與這支手機配對。若要接�
 passive-pair-passkey      = {{device}} 想要與這支手機配對。若要接受配對請求，請在裝置上輸入配對金鑰。
 error-pair-title      = 無法與裝置配對
 error-pair-pincode    = 無法與裝置配對。請確定 PIN 正確。
+#TODO: error-pair-toofast    = Unable to pair with the device. Too many requests.
 error-connect-title   = 無法連線到裝置
 error-connect-msg     = 請確定您想要連線到的裝置還在附近，藍牙也仍然開啟。
 unpair-title = 取消已連線裝置的配對？


### PR DESCRIPTION
Bluetooth peer devices can refuse to pair if the initiator tries too
often. In this case we now print a more meaningful error message.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
