### PR TITLE
Bug 828226 - [Dialer] Call logs doesn't show nothing (r=albertopq)

### DIFF
--- a/apps/communications/dialer/js/lazy_l10n.js
+++ b/apps/communications/dialer/js/lazy_l10n.js
@@ -13,11 +13,11 @@ var LazyL10n = {
       return;
     }
 
-
     // Adding the l10n JS files to the DOM
     // the l10n resources
     var l10nScript = document.createElement('script');
     l10nScript.src = '/shared/js/l10n.js';
+    l10nScript.onload = this._finalize.bind(this, callback);
     document.head.appendChild(l10nScript);
 
     var l10nDateScript = document.createElement('script');
@@ -25,20 +25,20 @@ var LazyL10n = {
     document.head.appendChild(l10nDateScript);
 
     this._inDOM = true;
-
-    this._waitForLoad(callback);
   },
 
   _waitForLoad: function ll10n_waitForLoad(callback) {
-    var self = this;
+    var finalize = this._finalize.bind(this);
     window.addEventListener('localized', function onLocalized() {
       window.removeEventListener('localized', onLocalized);
-
-      document.documentElement.lang = navigator.mozL10n.language.code;
-      document.documentElement.dir = navigator.mozL10n.language.direction;
-
-      self._loaded = true;
-      callback(navigator.mozL10n.get);
+      finalize(callback);
     });
+  },
+
+  _finalize: function ll10n_finalize(callback) {
+    document.documentElement.lang = navigator.mozL10n.language.code;
+    document.documentElement.dir = navigator.mozL10n.language.direction;
+    this._loaded = true;
+    callback(navigator.mozL10n.get);
   }
 };

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -278,8 +278,9 @@ var Recents = {
       return;
     }
     var action = event.target.dataset.action;
-    var noMissedCallsSelector = '.log-item[data-type^=dialing],' +
-      '.log-item[data-type=incoming-connected]';
+    var noMissedCallsSelector = '.log-item[data-type^=dialing]' +
+      ':not(.collapsed), ' +
+      '.log-item[data-type=incoming-connected]:not(.collapsed)';
     var noMissedCallsItems = document.querySelectorAll(noMissedCallsSelector);
     var noMissedCallsLength = noMissedCallsItems.length;
     var i;
@@ -670,6 +671,7 @@ var Recents = {
         '</div>';
       navigator.mozL10n.translate(this.recentsContainer);
       this.recentsIconEdit.parentNode.setAttribute('aria-disabled', 'true');
+      this.allFilter.classList.add('selected');
       return;
     }
 
@@ -847,6 +849,7 @@ var Recents = {
 
   groupCalls: function re_groupCalls(olderCallEl, newerCallEl, count, inc) {
     olderCallEl.classList.add('hide');
+    olderCallEl.classList.add('collapsed');
     count += inc;
     var entryCountNode = newerCallEl.querySelector('.entry-count');
     entryCountNode.innerHTML = '&#160;(' + count + ')';


### PR DESCRIPTION
There was a problem with the lazy loading of the localization library which cause the usage of the navigator.mozL10n object before it was really created.

The PR also fixes another issue found regarding the filtering of all and missed calls in the Call Log.
