### PR TITLE
Bug 828174: Track Bluetooth discovery state in Settings app [r=ehung]

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -593,7 +593,7 @@ onLocalized(function bluetoothSettings() {
     }
 
     function startDiscovery() {
-      if (!bluetooth.enabled || !defaultAdapter)
+      if (!bluetooth.enabled || !defaultAdapter || discoverTimeout)
         return;
 
       var req = defaultAdapter.startDiscovery();
@@ -616,7 +616,7 @@ onLocalized(function bluetoothSettings() {
     }
 
     function stopDiscovery() {
-      if (!bluetooth.enabled || !defaultAdapter)
+      if (!bluetooth.enabled || !defaultAdapter || !discoverTimeout)
         return;
       var req = defaultAdapter.stopDiscovery();
       req.onsuccess = function bt_discoveryStopped() {


### PR DESCRIPTION
The settings app unconditionally stops Bluetooth discovery when
processing incoming events. Stopping discovery when no discovery
is actually running will make the Bluetooth daemon generate an
error.

This patch prevents this by tracking the discovery state in the
settings application and only stopping discovery if it's currently
running. We reuse the value 'discoverTimeout' for this purpose,
because it exposes the required behaviour.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
