### PR TITLE
Bug 827780 - Apply hit state to keyboard buttons in lockscreen passcode entry.

### DIFF
--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -499,8 +499,14 @@ button::-moz-focus-inner {
 }
 
 #lockscreen-passcode-pad > a:active {
-  background-color: rgb(0, 0, 0);
-  color: #ccc;
+  background-color: #00aacd;
+  color: #fff;
+  text-shadow: none;
+}
+
+#lockscreen-passcode-pad > a:active > span {
+  color: #fff;
+  text-shadow: none;
 }
 
 #lockscreen-passcode-pad > a.lockscreen-passcode-pad-func {


### PR DESCRIPTION
Bug [#827780](https://bugzilla.mozilla.org/show_bug.cgi?id=827780)
