### PR TITLE
Bug 828197 - make the onpair screen of bluescreen properly handle home key

### DIFF
--- a/apps/settings/js/onpair.js
+++ b/apps/settings/js/onpair.js
@@ -129,8 +129,13 @@ var PairView = {
         }
         break;
       case 'resize':
-        this.close();
+      // XXX: this is hack that we have to close the attention in this case,
+      // while in most other cases, we would just change it into an active
+      // status bar
+        if (window.innerHeight < 200)
+          this.close();
         break;
+
       default:
         break;
     }

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -40,14 +40,17 @@ var AttentionScreen = {
   },
 
   resize: function as_resize(evt) {
-    if (!this.isFullyVisible())
-      return;
-
     if (evt.type == 'keyboardchange') {
+      if (!this.isFullyVisible())
+        return;
+
       this.attentionScreen.style.height =
         window.innerHeight - evt.detail.height + 'px';
     } else if (evt.type == 'keyboardhide') {
-      this.attentionScreen.style.height = window.innerHeight + 'px';
+      // We still need to reset the height property even when the attention
+      // screen is not fully visible, or it will overrides the height
+      // we defined with #attention-screen.status-mode
+      this.attentionScreen.style.height = '';
     }
   },
 


### PR DESCRIPTION
[Root Cause]
The on pair screen will disappear once the keyboard is shown up because we listen to 'resize' event and close the window.
What we want is to close the window when [Home] button is pressed but not for keyboard change.

[Solution]
The only (hacky) way we can know the home screen is pressed is still from window "resize" event, and here we check window.innerHeight to be < 200, because it is 40px when the attentation screen is in active status bar mode.
