### PR TITLE
[Bug 828948] display shortcuts with proper sentence case [r=crdlc]

### DIFF
--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -1186,29 +1186,32 @@ Evme.Brain = new function Evme_Brain() {
                 }
                 
                 Evme.ShortcutsCustomize.Loading.show();
-
+    
                 // load user/default shortcuts from API
                 Evme.DoATAPI.Shortcuts.get(null, function onSuccess(data){
                     var loadedResponse = data.response,
                         currentIcons = loadedResponse.icons,
-                        arrShortcuts = [],
-                        shortcutsToFavorite = {};
-                        
+                        arrCurrentShortcuts = [],
+                        shortcutsToSelect = {};
+    
                     for (var i=0, shortcut, query; shortcut=loadedResponse.shortcuts[i++];) {
                         query = shortcut.query;
                         if (!query && shortcut.experienceId) {
                             query = Evme.Utils.l10n('shortcut', 'id-' + Evme.Utils.shortcutIdToKey(shortcut.experienceId));
                         }
-                        arrShortcuts.push(query.toLowerCase());
+                        
+                        if (query) {
+                            arrCurrentShortcuts.push(query.toLowerCase());
+                        }
                     }
-
+    
                     // load suggested shortcuts from API
                     requestSuggest = Evme.DoATAPI.Shortcuts.suggest({
-                        "existing": arrShortcuts
+                        "existing": arrCurrentShortcuts
                     }, function onSuccess(data) {
                         var suggestedShortcuts = data.response.shortcuts,
                             icons = data.response.icons;
-                            
+    
                         for (var id in icons) {
                             currentIcons[id] = icons[id];
                         }
@@ -1217,11 +1220,13 @@ Evme.Brain = new function Evme_Brain() {
                             "shortcuts": suggestedShortcuts,
                             "icons": currentIcons
                         });
-                        
+    
                         isFirstShow = false;
                         isRequesting = false;
                         Evme.ShortcutsCustomize.show();
-                        Evme.ShortcutsCustomize.Loading.hide();
+                        // setting timeout to give the select box enough time to show
+                        // otherwise there's visible flickering
+                        window.setTimeout(Evme.ShortcutsCustomize.Loading.hide, 300);
                     });
                 });
             });

--- a/apps/homescreen/everything.me/modules/Shortcuts/Shortcuts.css
+++ b/apps/homescreen/everything.me/modules/Shortcuts/Shortcuts.css
@@ -123,7 +123,6 @@
             display: block;
             font-size: 12px;
             margin-top: 12px;
-            text-transform: capitalize;
             z-index: 50;
             color: #fff;
             font-weight: 600;
@@ -140,10 +139,6 @@
             -moz-transform: scale(.7) !important;
             transform: scale(.7) !important;
         }
-
-    #evmeContainer #category-page-name {
-        text-transform: capitalize;
-    }
 
 #evmeContainer #category-page-screen {
     position: absolute;

--- a/apps/homescreen/everything.me/modules/ShortcutsCustomize/ShortcutsCustomize.css
+++ b/apps/homescreen/everything.me/modules/ShortcutsCustomize/ShortcutsCustomize.css
@@ -1,4 +1,4 @@
-#shortcuts-select {
+#evmeContainer #shortcuts-select {
     position: absolute;
     top: 0;
     left: 0;
@@ -22,7 +22,7 @@
     }
 }
 
-#shortcuts-customize-loading {
+#evmeContainer #shortcuts-customize-loading {
     position: absolute;
     top: 0;
     left: 0;
@@ -34,7 +34,7 @@
       url(../../images/shared/pattern.png) repeat left top,
       url(../../images/shared/gradient.png) no-repeat left top / 100% 100%;
 }
-    #shortcuts-customize-loading b {
+    #evmeContainer #shortcuts-customize-loading b {
         position: absolute;
         top: 50%;
         left: 0;
@@ -47,7 +47,7 @@
         font-weight: 300;
         font-size: 38px;
     }
-    #shortcuts-customize-loading .loading-wrapper {
+    #evmeContainer #shortcuts-customize-loading .loading-wrapper {
         position: absolute;
         top: 50%;
         left: 0;
@@ -56,7 +56,7 @@
     }
     
     
-#shortcuts-customize-loading menu {
+#evmeContainer #shortcuts-customize-loading menu {
   margin: 0;
   padding: 0;
   width: auto;
@@ -67,7 +67,7 @@
   right: 0;
   bottom: 0;
 }
-    #shortcuts-customize-loading menu button {
+    #evmeContainer #shortcuts-customize-loading menu button {
       width: calc(100% - 5rem);
       height: 4rem;
       -moz-box-sizing: border-box;
@@ -90,7 +90,7 @@
       border: solid 1px rgba(0, 0, 0, 0.25);
     }
 
-    #shortcuts-customize-loading menu button:last-child {
+    #evmeContainer #shortcuts-customize-loading menu button:last-child {
       text-shadow: 1px 1px 0 rgba(255,255,255,0.3);
       color: #333;
       background-image: url(action_menu/images/ui/default.png);
@@ -101,7 +101,7 @@
       text-align: center;
       font-size: 1.6rem;
     }
-        #shortcuts-customize-loading menu button:last-child:before {
+        #evmeContainer #shortcuts-customize-loading menu button:last-child:before {
           content: '';
           position: absolute;
           width: 100%;
@@ -114,12 +114,12 @@
         }
 
 /* Press state */
-#shortcuts-customize-loading menu button:active {
+#evmeContainer #shortcuts-customize-loading menu button:active {
   background-color: #006f86;
   color: #333;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.25);
 }
-#shortcuts-customize-loading menu button:last-child:active {
+#evmeContainer #shortcuts-customize-loading menu button:last-child:active {
   border: solid 1px #008aaa;
   background: #008aaa;
   color: #333;

--- a/apps/homescreen/everything.me/modules/ShortcutsCustomize/ShortcutsCustomize.js
+++ b/apps/homescreen/everything.me/modules/ShortcutsCustomize/ShortcutsCustomize.js
@@ -51,17 +51,23 @@ Evme.ShortcutsCustomize = new function Evme_ShortcutsCustomize() {
     };
     
     this.add = function add(shortcuts) {
-        var html = '';
+        var html = '',
+            shortcutsAdded = {};
         
-        for (var i=0,shortcut,query; shortcut=shortcuts[i++];) {
+        for (var i=0,shortcut,query,queryKey; shortcut=shortcuts[i++];) {
             query = shortcut.query;
+            queryKey = query.toLowerCase();
             
-            html += '<option ' +
-                        'value="' + query.replace(/"/g, '&quot;') + '" ' +
-                        'data-experience="' + (shortcut.experienceId || '') + '"' +
-                    '>' +
-                        query.replace(/</g, '&lt;') +
-                    '</option>';
+            if (!shortcutsAdded[queryKey]) {
+                html += '<option ' +
+                            'value="' + query.replace(/"/g, '&quot;') + '" ' +
+                            'data-experience="' + (shortcut.experienceId || '') + '"' +
+                        '>' +
+                            query.replace(/</g, '&lt;') +
+                        '</option>';
+                
+                shortcutsAdded[queryKey] = true;
+            }
         }
         
         elList.innerHTML = html;


### PR DESCRIPTION
removing all text normalization and manipulation, so the user now sees exactly what comes from the API (correct case).

https://bugzilla.mozilla.org/show_bug.cgi?id=828948
