### PR TITLE
Bug 829018 - [FTU] Going back to initial screen after pressing 'Next' quickly

### DIFF
--- a/apps/communications/ftu/js/sim_manager.js
+++ b/apps/communications/ftu/js/sim_manager.js
@@ -79,9 +79,12 @@ var SimManager = {
     UIManager.pincodeScreen.classList.remove('show');
     UIManager.pukcodeScreen.classList.remove('show');
     UIManager.activationScreen.classList.add('show');
-    window.location.hash = '#languages';
-    Navigation.currentStep = 1;
-    Navigation.manageStep();
+    if (Navigation.currentStep == 1) {
+      // Ensure first screen after pin unlock
+      window.location.hash = '#languages';
+      Navigation.currentStep = 1;
+      Navigation.manageStep();
+    }
   },
 
   skip: function sm_skip() {


### PR DESCRIPTION
Ensuring language selection after we setup the ping if we didn't move from the first page of the ftu.
