### PR TITLE
Bug 829003 - [CALL LOG] Fixed headers are not working fine in call log

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -144,7 +144,7 @@ var Recents = {
 
       // All the scripts are now loaded
       if (scriptLoadCount === scripts.length) {
-        var headerSelector = '#recents-container h2';
+        var headerSelector = '#recents-container header';
         FixedHeader.init('#recents-container',
                          '#fixed-container', headerSelector);
 


### PR DESCRIPTION
The renaming of an HTML element was causing the fixed headers to crash. Simple fix ;)
