### PR TITLE
Bug 816306: Handle system updater check-error-* events, and accompanying tests

### DIFF
--- a/apps/settings/js/about.js
+++ b/apps/settings/js/about.js
@@ -114,6 +114,8 @@ var About = {
        *   - already-latest-version
        *   - check-complete
        *   - retry-when-online
+       *   - check-error-$nsresult
+       *   - check-error-http-$code
        *
        * - for apps updates:
        *   - check-complete
@@ -124,7 +126,8 @@ var About = {
        */
 
       if (value !== 'check-complete') {
-        systemStatus.textContent = _(value, null, value);
+        systemStatus.textContent = _(value, null, _('check-error'));
+        console.error('Error checking for system update:', value);
       }
 
       checkIfStatusComplete();

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -424,6 +424,7 @@ checking-for-update    = Checking for updates…
 no-updates             = No updates were found
 retry-when-online      = Network is offline. Will check again when the network is online.
 already-latest-version = This is already the latest version of {{brandShortName}}
+check-error            = There was an error when checking for updates.
 aboutBrowserOS  = About {{brandShortName}}
 browser-os-desc = {{brandShortName}} is the free and open source operating system from Mozilla. Our mission is to promote openness, innovation and opportunity by keeping the power of the Web in your hands.
 learn-more=Learn More

--- a/apps/settings/test/unit/settings_test.js
+++ b/apps/settings/test/unit/settings_test.js
@@ -1,6 +1,7 @@
 requireApp('settings/test/unit/mock_l10n.js');
 requireApp('settings/test/unit/mock_navigator_settings.js');
 requireApp('settings/js/settings.js');
+requireApp('settings/js/about.js');
 
 suite('settings >', function() {
   var realL10n, realNavigatorSettings;
@@ -57,7 +58,7 @@ suite('settings >', function() {
         geckoUpdateHandlers, appsUpdateHandlers;
 
     setup(function() {
-      Settings.checkForUpdates();
+      About.checkForUpdates();
 
       geckoUpdateSetting = 'gecko.updateStatus';
       appsUpdateSetting = 'apps.updateStatus';
@@ -130,6 +131,17 @@ suite('settings >', function() {
         assert.equal(systemStatus.textContent, 'retry-when-online');
       });
 
+      test('check-error', function() {
+        var errors = ['check-error-http-200', 'check-error-http-403',
+                      'check-error-http-404', 'check-error-http-500',
+                      'check-error-2152398878'];
+        for (var i = 0; i < errors.length; i++) {
+          MockNavigatorSettings.mTriggerObservers(geckoUpdateSetting, {
+            settingValue: errors[i]
+          });
+          assert.equal(systemStatus.textContent, errors[i]);
+        }
+      });
     });
 
     suite('getting response for app update >', function() {
@@ -201,7 +213,7 @@ suite('settings >', function() {
 
         suite('starting an update again >', function() {
           setup(function() {
-            Settings.checkForUpdates();
+            About.checkForUpdates();
           });
 
           test('should remove the text', function() {


### PR DESCRIPTION
This is gaia support for new update checking errors, and is safe to merge before the platform support lands.
https://bugzilla.mozilla.org/show_bug.cgi?id=816306

r+ from @julienw
