### PR TITLE
Bug 829040 - [CALL LOG] If you delete a contact with editing it from call log, contact name disappear but photo is still there, until you close the app and open it again

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -769,7 +769,7 @@ var Recents = {
       logItem.classList.add('isContact');
       logItem.dataset['contactId'] = contact.id;
     } else {
-      contactPhoto.classList.add('unknownContact');
+      logItem.classList.remove('hasPhoto');
       delete logItem.dataset['contactId'];
       var isContact = logItem.classList.contains('isContact');
       if (isContact) {


### PR DESCRIPTION
In case the contact is deleted, his/her photo should not appear next to its phone number in the call log.
