### PR TITLE
Bug 829110 - add tests for navigator.mozId.request oncancel() callback; r=ferjm

### DIFF
--- a/test_apps/uitest/index.html
+++ b/test_apps/uitest/index.html
@@ -35,7 +35,7 @@
       <li><a href="#test=pay">navigator.mozPay tests</a></li>
       <li><a href="#test=inputmode">text inputmode tests</a></li>
       <li><a href="#test=audiotag">audio tag tests</a></li>
-      <li><a href="#test=identity">navigator.id tests</a></li>
+      <li><a href="#test=identity">navigator.mozId tests</a></li>
     </ul>
   </div>
   <div id="test-panel" class="panel">

--- a/test_apps/uitest/tests/identity.html
+++ b/test_apps/uitest/tests/identity.html
@@ -20,6 +20,7 @@
       <p>Tests</p>
       <ul>
         <li><button id="t-request">Request</button> (Standard, verified email)</li>
+        <li><button id="t-request-withOnCancel">Request</button> (With <code>oncancel</code> handler)</li>
         <li><button id="t-request-allowUnverified">Request</button> (Unverified)</li>
         <li><button id="t-request-forceIssuer">Request</button> (Force issuer)</li>
         <li><button id="t-request-forceIssuer-allowUnverified">Request</button> (Force issuer; unverified)</li>
@@ -35,7 +36,6 @@
     </div>
 
     <script type="text/javascript" src="../js/identity.js"></script>
-    <script src="https://notoriousb2g.personatest.org/include.js"></script>
   </body>
 
 </html>


### PR DESCRIPTION
This provides a marionette-testable way to prove recent changes to the native identity implementation.  This will be helpful in marketplace testing.

The main addition is a test for the persona `oncancel()` callback.

The tests have been re-written to exercise the newly-renamed `navigator.mozId` instead of `navigator.id`.
