### PR TITLE
Bug 829008 - [Settings] Don't use a divider under the last item in a list

### DIFF
--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -18,6 +18,10 @@ ul li {
   min-height: 6rem;
 }
 
+ul li:last-child {
+  border-bottom-color: transparent;
+}
+
 ul li.active,
 ul li:active {
   background-color: #b2f2ff;


### PR DESCRIPTION
Bug [#829008](https://bugzilla.mozilla.org/show_bug.cgi?id=829008)
