### PR TITLE
Bug 828936 - make video deletion work r=daleharvey a=blocking+

### DIFF
--- a/apps/video/index.html
+++ b/apps/video/index.html
@@ -12,12 +12,8 @@
 
     <div id="throbber"><div></div></div>
 
-    <menu type="context" id="thumbnail-menu">
-      <menuitem label="Delete Video" data-l10n-id="delete-video" id="delete-confirmation-button"></menuitem>
-    </menu>
-
     <!-- title bar + thumbnail list -->
-    <ul id="thumbnails" contextmenu="thumbnail-menu"></ul>
+    <ul id="thumbnails"></ul>
 
     <!-- 'fullscreen' (maximized) video player -->
     <div id="videoFrame" class="hidden">


### PR DESCRIPTION
Gets rid of the contextmenu that wasn't working right with the event shim and just uses a confirm() dialog from the oncontextmenu event.
