### PR TITLE
Bug 813811 - Localized login title for identity signin

### DIFF
--- a/apps/system/js/identity.js
+++ b/apps/system/js/identity.js
@@ -54,7 +54,7 @@ var Identity = (function() {
 
           if (e.detail.showUI) {
             // The identity flow is shown within the trusted UI.
-            TrustedUIManager.open('IdentityFlow', frame, this.chromeEventId);
+            TrustedUIManager.open(navigator.mozL10n.get('persona-signin'), frame, this.chromeEventId);
           } else {
             var container = document.getElementById('screen');
             container.appendChild(frame);
@@ -79,5 +79,11 @@ var Identity = (function() {
   };
 })();
 
-Identity.init();
+// Make sure L10n is ready before init
+if (navigator.mozL10n.readyState == 'complete' ||
+    navigator.mozL10n.readyState == 'interactive') {
+  Identity.init();
+} else {
+  window.addEventListener('localized', Identity.init.bind(Identity));
+}
 

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -263,6 +263,9 @@ activity-browse=Browse with:
 activity-configure=Configure with:
 activity-dial=Dial from:
 
+# Persona dialog and Identity
+persona-signin=Sign In
+
 # Remote Debugger Connection Dialog
 remoteDebuggerMessage=An incoming request to permit remote debugging connection was detected. Allow connection?
 


### PR DESCRIPTION
The title for the Trusty UI just says "IdentityFlow".  This is awful.  Created a localized string for it.

NB, I got the Persona "Sign In" string from the source: http://svn.mozilla.org/projects/l10n-misc/trunk/browserid/locale
