### PR TITLE
Bug 829362 - don't use mozRequestFullScreen() in the Gallery

### DIFF
--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -7,6 +7,7 @@
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"
   },
+  "fullscreen": true,
   "permissions": {
     "device-storage:pictures":{ "access": "readwrite" },
     "device-storage:videos":{ "access": "readwrite" },


### PR DESCRIPTION
This sets the fullscreen flag in the gallery app's manifest, and removes the calls to mozRequestFullScreen() and all the stuff that goes along with that.
