### PR TITLE
Bug 820206 - Validate "Webapps:*" message parameters in the parent process (part 2, call .uninstall() from mozIDOMApplicationMgmt in Gaia). r=sicking, a=blocking-basecamp

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -84,7 +84,7 @@ const Homescreen = (function() {
       var confirm = {
         callback: function onAccept() {
           ConfirmDialog.hide();
-          app.uninstall();
+          navigator.mozApps.mgmt.uninstall(app);
         },
         applyClass: 'danger'
       };

--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -323,7 +323,7 @@ var ApplicationsList = {
     var name = new ManifestHelper(this._displayedApp.manifest).name;
 
     if (confirm(_('uninstallConfirm', {app: name}))) {
-      this._displayedApp.uninstall();
+      navigator.mozApps.mgmt.uninstall(this._displayedApp);
       this._displayedApp = null;
     }
   },

--- a/tests/atoms/gaia_apps.js
+++ b/tests/atoms/gaia_apps.js
@@ -197,7 +197,7 @@ var GaiaApps = {
    */
   uninstallWithName: function(name) {
     GaiaApps.locateWithName(name, function uninstall(app) {
-      app.uninstall();
+      navigator.mozApps.mgmt.uninstall(app);
       marionetteScriptFinished(false);
     });
   }


### PR DESCRIPTION
Bug 820206 - Validate "Webapps:*" message parameters in the parent process (part 2, call .uninstall() from mozIDOMApplicationMgmt in Gaia). r=sicking, a=blocking-basecamp
