### PR TITLE
Bug 829507 - Setting permission to "readwrite" for "geoloc" (test_apps)

### DIFF
--- a/test_apps/geoloc/manifest.webapp
+++ b/test_apps/geoloc/manifest.webapp
@@ -9,7 +9,7 @@
   },
   "permissions": {
     "geolocation":{},
-    "device-storage:sdcard":{ "access": "readonly" }
+    "device-storage:sdcard":{ "access": "readwrite" }
   },
   "locales": {
     "en-US": {


### PR DESCRIPTION
Without the "readwrite" permission on "device-storage:sdcard", the "Save
as GPX" feature is unusable.
