### PR TITLE
Bug 829472 - [COST CONTROL] Telephony widget is showing 119 mins in call.s although Telephony details only shows 1 min

### DIFF
--- a/apps/costcontrol/js/settings/settings.js
+++ b/apps/costcontrol/js/settings/settings.js
@@ -191,7 +191,7 @@ var Settings = (function() {
     var calltimeSpan = document.getElementById('calltime');
     var smscountSpan = document.getElementById('smscount');
     calltimeSpan.innerHTML = _('magnitude', {
-      value: Math.ceil(activity.calltime / 60000),
+      value: computeTelephonyMinutes(activity),
       unit: 'min.'
     });
     smscountSpan.innerHTML = _('magnitude', {

--- a/apps/costcontrol/js/utils/formatting.js
+++ b/apps/costcontrol/js/utils/formatting.js
@@ -100,3 +100,9 @@ function padData(v) {
   return rounded;
 }
 
+// Given the API information compute the human friendly minutes
+function computeTelephonyMinutes(activity) {
+  // Right now the activity for telephony is computed in milliseconds
+  return Math.ceil(activity.calltime / 60000);
+}
+

--- a/apps/costcontrol/js/views/telephony.js
+++ b/apps/costcontrol/js/views/telephony.js
@@ -92,7 +92,7 @@ var TelephonyTab = (function() {
       unit: 'SMS'
     });
     calltime.innerHTML = _('magnitude', {
-      value: Math.ceil(activity.calltime / 60000),
+      value: computeTelephonyMinutes(activity),
       unit: 'min.'
     });
   }

--- a/apps/costcontrol/js/widget.js
+++ b/apps/costcontrol/js/widget.js
@@ -273,7 +273,7 @@
             var activity = result.data;
             document.getElementById('telephony-calltime').innerHTML =
               _('magnitude', {
-                value: (activity.calltime / 60).toFixed(0),
+                value: computeTelephonyMinutes(activity),
                 unit: 'min'
               }
             );


### PR DESCRIPTION
We were expecting the api to return seconds, but is returning milliseconds.

No setup the correct transform as in the normal cost control all
