### PR TITLE
[Bug 829661] Fix same page navigation [r=crdlc]

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -218,7 +218,9 @@ const GridManager = (function() {
         page = page - 1;
       }
     }
-    goToPage(page);
+    if (currentPage !== page) {
+      goToPage(page);
+    }
   }
 
   function attachEvents() {


### PR DESCRIPTION
goToPage shouldn't be triggered if the user is already on that page. Causes a bug in Evme.

https://bugzilla.mozilla.org/show_bug.cgi?id=829661
