### PR TITLE
[821657] Scroll to input when focus

### DIFF
--- a/apps/communications/ftu/css/style.css
+++ b/apps/communications/ftu/css/style.css
@@ -638,6 +638,7 @@ html, body {
   padding: 1.5rem 3rem 0 3rem;
   width: calc(100% - 6rem);
   height: calc(100% - 3.5rem);
+  margin-top: 2rem;
 }
 
 #browser_privacy img {
@@ -651,9 +652,7 @@ html, body {
   font-size: 1.35rem;
   line-height: 1.8rem;
 }
-#browser_privacy p:first-child {
-  margin-top: 2rem;
-}
+
 
 #browser_privacy p a {
   margin-left: 0.3rem;

--- a/apps/communications/ftu/js/ui.js
+++ b/apps/communications/ftu/js/ui.js
@@ -110,6 +110,18 @@ var UIManager = {
       event.preventDefault();
     });
 
+    // Input scroll workaround
+    var top = this.newsletterInput.offsetTop;
+    this.newsletterInput.addEventListener('focus', function() {
+      window.addEventListener('resize', function resize() {
+        window.removeEventListener('resize', resize);
+        // Need to wait till resize is done
+        setTimeout(function() {
+          document.getElementById('browser_privacy').scrollTop = top;
+        }, 30);
+      });
+    });
+
     // Browser privacy newsletter subscription
     var basketCallback = function(err, data) {
       this.loadingOverlay.classList.remove('show-overlay');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=821657

workaround for email input covered by navigation bar on resize events when keyboard pops out
Should be fixed in gecko, though

r? @borjasalguero 
