### PR TITLE
Bug 829397 - Need a way to clear all storage for everything.me apps and bookmarks added to the homescreen

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1621,8 +1621,31 @@
           App permissions
         </h1>
       </header>
+
+      <ul></ul>
+
       <ul>
+        <li>
+          <button id="clear-bookmarks-app" class="icon icon-dialog"
+                  style="visibility: hidden"
+                  data-l10n-id="clearBookmarkAppsData">
+            Clear bookmarks data
+          </button>
+        </li>
       </ul>
+
+      <form role="dialog" data-type="confirm" hidden class="cb-alert">
+        <section>
+          <h1 data-l10n-id="confirmClearBookmarkAppsDataTitle">Clear private data from bookmarks</h1>
+          <p>
+            <strong data-l10n-id="confirmClearBookmarkAppsDataDesc">This clear private data from bookmarks that have been added to the home screen. This cannot be undone.</strong>
+          </p>
+        </section>
+        <menu>
+          <button class="cb-alert-cancel" data-l10n-id="cancel">Cancel</button>
+          <button class="cb-alert-clear recommend danger" data-l10n-id="clear">Clear</button>
+        </menu>
+      </form>
 
       <script type="application/javascript" src="js/hiddenapps.js"></script>
       <script type="application/javascript" src="js/apps.js"></script>

--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -19,6 +19,13 @@ var ApplicationsList = {
   detailPermissionsHeader: document.getElementById('permissionsListHeader'),
   uninstallButton: document.getElementById('uninstall-app'),
 
+  bookmarksClear: {
+    dialog: document.querySelector('#appPermissions .cb-alert'),
+    goButton: document.querySelector('#appPermissions .cb-alert-clear'),
+    cancelButton: document.querySelector('#appPermissions .cb-alert-cancel'),
+    mainButton: document.getElementById('clear-bookmarks-app')
+  },
+
   init: function al_init() {
     var appsMgmt = navigator.mozApps.mgmt;
     appsMgmt.oninstall = this.oninstall.bind(this);
@@ -40,6 +47,25 @@ var ApplicationsList = {
       }
     }).bind(this);
     xhr.send();
+
+    // Implement clear bookmarks apps button and its confirm dialog
+    var confirmDialog = this.bookmarksClear.dialog;
+    this.bookmarksClear.goButton.onclick = function cb_confirmGoClicked(event) {
+      var settings = navigator.mozSettings;
+      var lock = settings.createLock();
+      lock.set({'clear.remote-windows.data': true});
+
+      confirmDialog.hidden = true;
+    };
+
+    this.bookmarksClear.cancelButton.onclick =
+      function cb_confirmCancelClicked(event) {
+        confirmDialog.hidden = true;
+      };
+
+    this.bookmarksClear.mainButton.onclick = function clearBookmarksData() {
+      confirmDialog.hidden = false;
+    };
   },
 
   initExplicitPermissionsTable: function al_initExplicitPermissionsTable() {
@@ -163,6 +189,10 @@ var ApplicationsList = {
     }, this);
 
     this.container.appendChild(listFragment);
+
+    // Unhide clear bookmarks button only after app list is populated
+    // otherwise it would appear solely during loading
+    this.bookmarksClear.mainButton.style.visibility = '';
   },
 
   oninstall: function al_oninstall(evt) {

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -324,6 +324,12 @@ allow=Grant
 uninstallApp=Uninstall app
 uninstallConfirm=Are you sure you want to uninstall {{ app }}?
 
+# Bookmarks/Everything.me app data
+clearBookmarkAppsData=Clear bookmarks data
+confirmClearBookmarkAppsDataTitle=Clear private data from bookmarks?
+confirmClearBookmarkAppsDataDesc=This clears private data from bookmarks that have been added to the home screen. This cannot be undone.
+clear=Clear
+
 # Security :: Phone Lock
 phone=Phone
 messages=Messages

--- a/apps/settings/style/apps.css
+++ b/apps/settings/style/apps.css
@@ -39,3 +39,7 @@
   height: calc(6rem - 2rem);
 }
 
+#appPermissions .cb-alert {
+  position: fixed;
+}
+

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1606,6 +1606,25 @@ var WindowManager = (function() {
     return (value === 'allow');
   }
 
+  // Use a setting in order to be "called" by settings app
+  navigator.mozSettings.addObserver(
+    'clear.remote-windows.data',
+    function clearRemoteWindowsData(setting) {
+      var shouldClear = setting.settingValue;
+      if (!shouldClear)
+        return;
+
+      // Delete all storage and cookies from our content processes
+      var request = navigator.mozApps.getSelf();
+      request.onsuccess = function() {
+        request.result.clearBrowserData();
+      };
+
+      // Reset the setting value to false
+      var lock = navigator.mozSettings.createLock();
+      lock.set({'clear.remote-windows.data': false});
+    });
+
   // Watch for window.open usages in order to open wrapper frames
   window.addEventListener('mozbrowseropenwindow', function handleWrapper(evt) {
     var detail = evt.detail;

--- a/build/settings.py
+++ b/build/settings.py
@@ -25,6 +25,7 @@ settings = {
  "audio.volume.telephony": 5,
  "bluetooth.enabled": False,
  "camera.shutter.enabled": True,
+ "clear.remote-windows.data": False,
  "debug.grid.enabled": False,
  "debug.oop.disabled": False,
  "debug.fps.enabled": False,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=829397
