### PR TITLE
Bug 829610 - When updating a packaged app with different sizes in the old vs. new packaged app, we always show the old size in the app update confirmation prompt

### DIFF
--- a/apps/homescreen/test/unit/mock_app.js
+++ b/apps/homescreen/test/unit/mock_app.js
@@ -16,6 +16,7 @@ function MockApp(opts) {
   this.installState = 'installed';
   this.downloadAvailable = false;
   this.downloadError = null;
+  this.downloadSize = null;
 
   this.mId = idGen++;
   this.mDownloadCalled = false;
@@ -39,6 +40,7 @@ MockApp.prototype.cancelDownload = function() {
 
 MockApp.prototype.mTriggerDownloadAvailable = function() {
   this.downloadAvailable = true;
+  this.downloadSize = 42;
   if (this.ondownloadavailable) {
     this.ondownloadavailable({
         application: this
@@ -48,6 +50,7 @@ MockApp.prototype.mTriggerDownloadAvailable = function() {
 
 MockApp.prototype.mTriggerDownloadSuccess = function() {
   this.downloadAvailable = false;
+  this.downloadSize = null;
   if (this.ondownloadsuccess) {
     this.ondownloadsuccess({
         application: this
@@ -57,6 +60,7 @@ MockApp.prototype.mTriggerDownloadSuccess = function() {
 
 MockApp.prototype.mTriggerDownloadError = function(error) {
   this.downloadAvailable = true;
+  this.downloadSize = null;
 
   this.downloadError = {
     name: error || 'NETWORK_ERROR'
@@ -80,6 +84,8 @@ MockApp.prototype.mTriggerDownloadProgress = function(progress) {
 
 MockApp.prototype.mTriggerDownloadApplied = function() {
   this.downloadAvailable = false;
+  this.downloadSize = null;
+
   if (this.ondownloadapplied) {
     this.ondownloadapplied({
         application: this

--- a/apps/system/js/updatable.js
+++ b/apps/system/js/updatable.js
@@ -19,7 +19,7 @@ function AppUpdatable(app) {
   var manifest = app.manifest ? app.manifest : app.updateManifest;
   this.name = new ManifestHelper(manifest).name;
 
-  this.size = app.updateManifest ? app.updateManifest.size : null;
+  this.size = app.downloadSize;
   this.progress = null;
 
   UpdateManager.addToUpdatableApps(this);
@@ -56,8 +56,7 @@ AppUpdatable.prototype.clean = function() {
 };
 
 AppUpdatable.prototype.availableCallBack = function() {
-  this.size = this.app.updateManifest ?
-    this.app.updateManifest.size : null;
+  this.size = this.app.downloadSize;
 
   if (this.app.installState === 'installed') {
     UpdateManager.addToUpdatesQueue(this);

--- a/apps/system/test/unit/mock_app.js
+++ b/apps/system/test/unit/mock_app.js
@@ -10,15 +10,12 @@ function MockApp(opts) {
   this.manifest = {
     name: 'Mock app'
   };
-  this.updateManifest = {
-    size: 42,
-    name: 'Mock packaged app'
-  };
 
   this.removable = true;
   this.installState = 'installed';
   this.downloadAvailable = false;
   this.downloadError = null;
+  this.downloadSize = null;
 
   this.mId = idGen++;
   this.mDownloadCalled = false;
@@ -40,8 +37,9 @@ MockApp.prototype.cancelDownload = function() {
   this.mCancelCalled = true;
 };
 
-MockApp.prototype.mTriggerDownloadAvailable = function() {
+MockApp.prototype.mTriggerDownloadAvailable = function(size) {
   this.downloadAvailable = true;
+  this.downloadSize = size;
   if (this.ondownloadavailable) {
     this.ondownloadavailable({
         application: this
@@ -51,6 +49,7 @@ MockApp.prototype.mTriggerDownloadAvailable = function() {
 
 MockApp.prototype.mTriggerDownloadSuccess = function() {
   this.downloadAvailable = false;
+  this.downloadSize = null;
   if (this.ondownloadsuccess) {
     this.ondownloadsuccess({
         application: this
@@ -60,6 +59,7 @@ MockApp.prototype.mTriggerDownloadSuccess = function() {
 
 MockApp.prototype.mTriggerDownloadError = function(error) {
   this.downloadAvailable = true;
+  this.downloadSize = null;
 
   this.downloadError = {
     name: error || 'UNKNOWN_ERROR'
@@ -84,6 +84,7 @@ MockApp.prototype.mTriggerDownloadProgress = function(progress) {
 
 MockApp.prototype.mTriggerDownloadApplied = function() {
   this.downloadAvailable = false;
+  this.downloadSize = null;
   if (this.ondownloadapplied) {
     this.ondownloadapplied({
         application: this

--- a/apps/system/test/unit/updatable_test.js
+++ b/apps/system/test/unit/updatable_test.js
@@ -152,7 +152,7 @@ suite('system/Updatable', function() {
 
     suite('size', function() {
       test('should give packaged app update size', function() {
-        assert.equal(42, subject.size);
+        assert.equal(null, subject.size);
       });
 
       test('should return null for hosted apps', function() {
@@ -166,10 +166,7 @@ suite('system/Updatable', function() {
         subject = new AppUpdatable(mockApp);
         assert.isNull(subject.size);
 
-        mockApp.updateManifest = {
-          size: 45678
-        };
-        mockApp.mTriggerDownloadAvailable();
+        mockApp.mTriggerDownloadAvailable(45678);
         assert.equal(45678, subject.size);
       });
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=829610
