### PR TITLE
Bug 822959 - [Clock] Deleting in the alarm label will reprint the label you deleted r=timdream

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -424,6 +424,10 @@ input.right {
   height: 2.8rem;
   color: black;
 }
+
+input.right:-moz-placeholder {
+  color: gray;
+}
 /* ----------- Input Error ---------- */
 input ~ * {
   color:#E00;


### PR DESCRIPTION
Set the color 'gray' for the property placeholder.
