### PR TITLE
Bug 825202 - Ensure check SIM is done before initializing APP or Widget

### DIFF
--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -29,14 +29,15 @@ var CostControlApp = (function() {
   });
 
   function _startApp() {
-    checkSIMChange();
-    CostControl.getInstance(function _onCostControlReady(instance) {
-      if (ConfigManager.option('fte')) {
-        window.location = '/fte.html';
-        return;
-      }
-      costcontrol = instance;
-      setupApp();
+    checkSIMChange(function _onSIMChecked() {
+      CostControl.getInstance(function _onCostControlReady(instance) {
+        if (ConfigManager.option('fte')) {
+          window.location = '/fte.html';
+          return;
+        }
+        costcontrol = instance;
+        setupApp();
+      });
     });
   }
 

--- a/apps/costcontrol/js/common.js
+++ b/apps/costcontrol/js/common.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // Checks for a SIM change
-function checkSIMChange() {
+function checkSIMChange(callback) {
   asyncStorage.getItem('lastSIM', function _compareWithCurrent(lastSIM) {
     var currentSIM = window.navigator.mozMobileConnection.iccInfo.iccid;
     if (lastSIM !== currentSIM) {
@@ -10,8 +10,13 @@ function checkSIMChange() {
       MindGap.updateTagList(currentSIM);
     }
     ConfigManager.requestSettings(function _onSettings(settings) {
-      if (settings.nextReset)
+      if (settings.nextReset) {
         setNextReset(settings.nextReset);
+      }
+
+      if (callback) {
+        callback();
+      }
     });
   });
 }

--- a/apps/costcontrol/js/widget.js
+++ b/apps/costcontrol/js/widget.js
@@ -36,10 +36,11 @@
   });
 
   function _startWidget() {
-    checkSIMChange();
-    CostControl.getInstance(function _onCostControlReady(instance) {
-      costcontrol = instance;
-      setupWidget();
+    checkSIMChange(function _onSIMChecked() {
+      CostControl.getInstance(function _onCostControlReady(instance) {
+        costcontrol = instance;
+        setupWidget();
+      });
     });
   }
 
@@ -92,8 +93,8 @@
       }
     );
 
-    updateUI();
     initialized = true;
+    updateUI();
   }
 
   // BALANCE ACTIONS
@@ -146,8 +147,10 @@
 
     document.getElementById('fte-icon').className = 'icon ' + simKey;
 
-    fte.querySelector('p:first-child').innerHTML = navigator.mozL10n.get(simKey + '-heading', { provider: provider });
-    fte.querySelector('p:last-child').innerHTML = navigator.mozL10n.get(simKey + '-meta');
+    fte.querySelector('p:first-child').innerHTML =
+      navigator.mozL10n.get(simKey + '-heading', { provider: provider });
+    fte.querySelector('p:last-child').innerHTML =
+      navigator.mozL10n.get(simKey + '-meta');
   }
 
   var currentMode;
@@ -156,15 +159,6 @@
     ConfigManager.requestAll(function _onInfo(configuration, settings) {
       var mode = costcontrol.getApplicationMode(settings);
       debug('Widget UI mode:', mode);
-
-      // Show 'fte' widget
-      if (ConfigManager.option('fte')) {
-        setupFte(configuration.provider, mode);
-        return;
-      }
-      fte.setAttribute('aria-hidden', true);
-      leftPanel.setAttribute('aria-hidden', false);
-      rightPanel.setAttribute('aria-hidden', false);
 
       var isPrepaid = (mode === 'PREPAID');
       var isDataUsageOnly = (mode === 'DATA_USAGE_ONLY');
@@ -175,6 +169,15 @@
       views.limitedDataUsage.setAttribute('aria-hidden', !isLimited);
 
       if (currentMode !== mode) {
+
+        // Show fte mode widget
+        if (settings.fte) {
+          setupFte(configuration.provider, mode);
+          return;
+        } else {
+          fte.setAttribute('aria-hidden', true)
+        }
+
         // Always data usage
         leftPanel.setAttribute('aria-hidden', isDataUsageOnly);
 


### PR DESCRIPTION
Making checkSIM accept a callback to ensure initialization only happens when check SIM is done

Avoiding not available message when non authorized SIM inserted
