### PR TITLE
Bug 830865 - Mirror gaia_app.js from gaia-ui-tests to gaia, r=lightsofap...

### DIFF
--- a/tests/atoms/gaia_apps.js
+++ b/tests/atoms/gaia_apps.js
@@ -10,6 +10,23 @@ var GaiaApps = {
     return name.replace(/[- ]+/g, '').toLowerCase();
   },
 
+  getRunningApps: function() {
+    let runningApps = window.wrappedJSObject.WindowManager.getRunningApps();
+    // Return a simplified version of the runningApps object which can be
+    // JSON-serialized.
+    let apps = {};
+    for (let app in runningApps) {
+        let anApp = {};
+        for (let key in runningApps[app]) {
+            if (['name', 'origin', 'manifest'].indexOf(key) > -1) {
+                anApp[key] = runningApps[app][key];
+            }
+        }
+        apps[app] = anApp;
+    }
+    return apps;
+  },
+
   getRunningAppOrigin: function(name) {
     let runningApps = window.wrappedJSObject.WindowManager.getRunningApps();
     let origin;
@@ -155,7 +172,7 @@ var GaiaApps = {
         waitFor(
           function() {
             let app = runningApps[origin];
-            let result = {frame: app.frame.firstChild.id,
+            let result = {frame: app.frame.firstChild,
                           src: app.iframe.src,
                           name: app.name,
                           origin: origin};
@@ -166,7 +183,7 @@ var GaiaApps = {
             }
             else {
               // wait until the new iframe sends the mozbrowserfirstpaint event
-              let frame = runningApps[origin].frame;
+              let frame = runningApps[origin].frame.firstChild;
               if (frame.dataset.unpainted) {
                 window.addEventListener('mozbrowserfirstpaint',
                     function firstpaint() {
@@ -193,7 +210,7 @@ var GaiaApps = {
   },
 
   /**
-   * Uninstalls the app with the speciifed name.
+   * Uninstalls the app with the specified name.
    */
   uninstallWithName: function(name) {
     GaiaApps.locateWithName(name, function uninstall(app) {


### PR DESCRIPTION
...ollo, a=test-only

This merges the work done in bug 830240 (to adapt Gaia UI Tests to recent window_manager changes) from gaia-ui-tests to gaia.

The primary difference from an earlier merged PR is to add a new method, getRunningApps(), that can return a version of the runningApps object that is JSON-serializable, and to change the return value of launchWithName so that the 'frame' attribute of the returned object specifies the actual application frame, and not just its id.  We needed to make this change because app iframes do not always have an id now.

AFAICT, this should work with the Gaia integration tests (at e.g., https://github.com/mozilla-b2g/gaia/blob/master/tests/js/app_integration.js#L243)  without further changes.  However, they fail for me on an unagi with and without this patch for apparently unrelated reasons.
