### PR TITLE
bug 826119 - Change the default value of ril.callwaiting.enabled to null r=yuren a=tef+

### DIFF
--- a/build/settings.py
+++ b/build/settings.py
@@ -75,7 +75,7 @@ settings = {
  "powersave.enabled": False,
  "powersave.threshold": 0,
  "privacy.donottrackheader.enabled": False,
- "ril.callwaiting.enabled": True,
+ "ril.callwaiting.enabled": None,
  "ril.data.enabled": False,
  "ril.data.apn": "",
  "ril.data.carrier": "",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=826119

Change the default value of ril.callwaiting.enabled to null because the call waiting setting on startup is unknown.
