### PR TITLE
fix bug 816227 - empty title on the contact details page

### DIFF
--- a/apps/communications/contacts/js/contacts_details.js
+++ b/apps/communications/contacts/js/contacts_details.js
@@ -153,6 +153,7 @@ contacts.Details = (function() {
   var doReloadContactDetails = function doReloadContactDetails(contact) {
 
     detailsName.textContent = contact.name;
+
     contactDetails.classList.remove('no-photo');
     contactDetails.classList.remove('up');
     listContainer.innerHTML = '';
@@ -248,7 +249,7 @@ contacts.Details = (function() {
   };
 
   var renderOrg = function cd_renderOrg(contact) {
-    if (contact.org && contact.org.length > 0 && contact.org[0] != '') {
+    if (contact.org && contact.org.length > 0 && contact.org[0] != '' && contact.org[0] != contact.name) {
       orgTitle.textContent = contact.org[0];
       orgTitle.className = '';
     } else {
@@ -476,6 +477,8 @@ contacts.Details = (function() {
       listContainer.appendChild(container);
     }
   };
+
+
 
   var renderPhoto = function cd_renderPhoto(contact) {
     contactDetails.classList.remove('up');

--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -384,19 +384,12 @@ contacts.Form = (function() {
     myContact['photo'] = currentContact['photo'] || [];
     myContact['photo'][0] = getCurrentPhoto();
 
-    if (myContact.givenName || myContact.familyName) {
-      var name = myContact.givenName || '';
-      name += ' ';
-      if (myContact.familyName) {
-        name += myContact.familyName;
-      }
-      myContact.name = [name];
-    }
-
     getPhones(myContact);
     getEmails(myContact);
     getAddresses(myContact);
     getNotes(myContact);
+
+    resetName(myContact);
 
     // Use the isEmpty function to check fields but address
     // and inspect address by it self.
@@ -564,6 +557,25 @@ contacts.Form = (function() {
 
       contact['note'] = contact['note'] || [];
       contact['note'].push(noteValue);
+    }
+  };
+
+  var resetName = function resetName(contact){
+    if (contact['givenName'] || contact['familyName'] || contact['org'] || contact['tel']) {
+      var name = contact['givenName'] || '';
+  
+      if (contact['familyName']) {
+        name += ' ' + contact['familyName'];
+      } else if (contact['org']) {
+        name = contact['org'];
+      } else if (contact['tel']) {
+        var telLength = Contacts.getLength(contact['tel']);
+        if (telLength > 0){
+          name = contact['tel'][0].value;
+        }
+      }
+
+      contact['name'] = [name];
     }
   };
 


### PR DESCRIPTION
Has been added function to reset contact name depends on the properties that contact have. 

link to the bug in Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=816227
