### PR TITLE
Bug 830659 - The apps permissions UI does not list the system and homesc...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ manifest.appcache
 /apps/settings/resources/gaia_commit.txt
 /apps/homescreen/js/init.json
 /apps/homescreen/js/hiddenapps.js
+/apps/settings/js/hiddenapps.js
 /apps/costcontrol/js/config.json
 /apps/sms/js/blacklist.json
 /test_apps/test-agent/test/config.json

--- a/apps/settings/js/hiddenapps.js
+++ b/apps/settings/js/hiddenapps.js
@@ -1,8 +1,0 @@
-var HIDDEN_APPS = [
-  "app://homescreen.gaiamobile.org/manifest.webapp",
-  "app://keyboard.gaiamobile.org/manifest.webapp",
-  "app://wallpaper.gaiamobile.org/manifest.webapp",
-  "app://bluetooth.gaiamobile.org/manifest.webapp",
-  "app://system.gaiamobile.org/manifest.webapp",
-  "app://pdfjs.gaiamobile.org/manifest.webapp"
-]

--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -128,15 +128,23 @@ let content = customize.homescreens.map(
 init = getFile(GAIA_DIR, GAIA_CORE_APP_SRCDIR, 'homescreen', 'js', 'init.json');
 writeContent(init, JSON.stringify(content));
 
-// Apps that should never appear as icons in the homescreen grid or dock.
+// Apps that should never appear in settings > app permissions
+// bug 830659: We want homescreen to appear in order to remove e.me geolocation permission
 let hidden_apps = [
-  gaiaManifestURL('homescreen'),
   gaiaManifestURL('keyboard'),
   gaiaManifestURL('wallpaper'),
   gaiaManifestURL('bluetooth'),
-  gaiaManifestURL('system'),
   gaiaManifestURL('pdfjs')
 ];
+
+init = getFile(GAIA_DIR, GAIA_CORE_APP_SRCDIR, 'settings', 'js', 'hiddenapps.js');
+writeContent(init, "var HIDDEN_APPS = " + JSON.stringify(hidden_apps));
+
+// Apps that should never appear as icons in the homescreen grid or dock
+hidden_apps = hidden_apps.concat([
+  gaiaManifestURL('homescreen'),
+  gaiaManifestURL('system')
+]);
 
 init = getFile(GAIA_DIR, GAIA_CORE_APP_SRCDIR, 'homescreen', 'js', 'hiddenapps.js');
 writeContent(init, "var HIDDEN_APPS = " + JSON.stringify(hidden_apps));


### PR DESCRIPTION
...reen apps, even though they call out support for geolocation
https://bugzilla.mozilla.org/show_bug.cgi?id=830659
