### PR TITLE
bug 830905 - Set the name to the iframe object r=alive kuo, a=tef+

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1125,7 +1125,11 @@ var WindowManager = (function() {
     var iframe = frame.firstChild;
     frame.id = 'appframe' + nextAppId++;
     iframe.dataset.frameType = 'window';
-    frame.name = 'main';
+
+    // Give a name to the frame for differentiating between main frame and 
+    // inline frame. With the name we can get frames of the same app using the
+    // window.open method. 
+    iframe.name = 'main';
 
     // If this frame corresponds to the homescreen, set mozapptype=homescreen
     // so we're less likely to kill this frame's process when we're running low
@@ -1175,6 +1179,10 @@ var WindowManager = (function() {
     var iframe = frame.firstChild;
     frame.classList.add('inlineActivity');
     iframe.dataset.frameType = 'inline-activity';
+
+    // Give a name to the frame for differentiating between main frame and 
+    // inline frame. With the name we can get frames of the same app using the
+    // window.open method.
     iframe.name = 'inline';
 
     // Save the reference


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=830905
