### PR TITLE
bug 823783 - change wifi.js in both System and Settings app

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -215,6 +215,16 @@ var Connectivity = (function(window, document, undefined) {
   var wifiStatusChangeListeners = [updateWifi];
   var settings = Settings.mozSettings;
 
+  //
+  // Set wifi.enabled so that it mirrors the state of the hardware.
+  // wifi.enabled is not an ordinary user setting because the system
+  // turns it on and off when wifi goes up and down.
+  //
+  settings.createLock().set({'wifi.enabled': gWifiManager.enabled});
+
+  //
+  // Now register callbacks to track the state of the wifi hardware
+  //
   gWifiManager.onenabled = wifiEnabled;
   gWifiManager.ondisabled = wifiDisabled;
   gWifiManager.onstatuschange = wifiStatusChange;

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -81,33 +81,14 @@ onLocalized(function wifiSettings() {
   };
 
   Connectivity.wifiEnabled = function onWifiEnabled() {
-    // enable UI toggle
-    if (!lastMozSettingValue) {
-      // Wifi just came up, but the last known value of the setting was false.
-      // This either means that some external force turned it on (in which
-      // case we need to update the setting) or we simply haven't received the
-      // settings change event. Do that now and update our
-      // lastMozSettingValue. This will have the side-effect of not disabling
-      // the checkbox.
-      settings.createLock().set({ 'wifi.enabled': true });
-      lastMozSettingValue = true;
-      setMozSettingsEnabled(lastMozSettingValue);
-    }
-
+    // Re-enable UI toggle
     gWifiCheckBox.disabled = false;
     updateNetworkState();
     gNetworkList.scan();
   };
 
   Connectivity.wifiDisabled = function onWifiDisabled() {
-    // enable UI toggle
-    if (lastMozSettingValue) {
-      // See the comment in onWifiEnabled for why we do this.
-      settings.createLock().set({ 'wifi.enabled': false });
-      lastMozSettingValue = false;
-      setMozSettingsEnabled(lastMozSettingValue);
-    }
-
+    // Re-enable UI toggle
     gWifiCheckBox.disabled = false;
     gWifiInfoBlock.textContent = _('disabled');
     gNetworkList.clear(false);
@@ -750,9 +731,6 @@ onLocalized(function wifiSettings() {
   settings.addObserver('wifi.enabled', function(event) {
     if (lastMozSettingValue == event.settingValue)
       return;
-
-    // lock UI toggle
-    gWifiCheckBox.disabled = true;
 
     lastMozSettingValue = event.settingValue;
     setMozSettingsEnabled(event.settingValue);

--- a/apps/system/js/wifi.js
+++ b/apps/system/js/wifi.js
@@ -48,8 +48,18 @@ var Wifi = {
 
     var self = this;
     var wifiManager = window.navigator.mozWifiManager;
+
+    // Set wifi.enabled so that it mirrors the state of the hardware.
+    // wifi.enabled is not an ordinary user setting because the system
+    // turns it on and off when wifi goes up and down.
+    SettingsListener.getSettingsLock().set({'wifi.enabled': wifiManager.enabled});
+
     // when wifi is really enabled, emit event to notify QuickSettings
     wifiManager.onenabled = function onWifiEnabled() {
+      // Keep the setting in sync with the hardware state.
+      // We need to do this because b2g/dom/wifi/WifiWorker.js can turn
+      // the hardware on and off
+      SettingsListener.getSettingsLock().set({'wifi.enabled': true});
       var evt = document.createEvent('CustomEvent');
       evt.initCustomEvent('wifi-enabled',
         /* canBubble */ true, /* cancelable */ false, null);
@@ -58,6 +68,8 @@ var Wifi = {
 
     // when wifi is really disabled, emit event to notify QuickSettings
     wifiManager.ondisabled = function onWifiDisabled() {
+      // Keep the setting in sync with the hardware state.
+      SettingsListener.getSettingsLock().set({'wifi.enabled': false});
       var evt = document.createEvent('CustomEvent');
       evt.initCustomEvent('wifi-disabled',
         /* canBubble */ true, /* cancelable */ false, null);


### PR DESCRIPTION
System app:
- keep the hardware and the setting in sync even when the settings app isn't running
  Settings app:
- initial wifi.enabled so that it mirrors the state of the hardware.
- won't set wifi.enabled when wifi is really on enabled, it's moved to
  System app.
