### PR TITLE
Bug 823025 - Call Log: Returning from contact details should go back to call log, not contact list.

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -472,6 +472,18 @@ var Contacts = (function() {
     }
   };
 
+  var handleDetailsBack = function handleDetailsBack() {
+    var hasParams = window.location.hash.split('?');
+    var params = hasParams.length > 1 ?
+      extractParams(hasParams[1]) : -1;
+
+    navigation.back();
+    // post message to parent page included Contacts app.
+    if (params['send_message_from_iframe'] === '1') {
+      window.parent.postMessage({ 'type': 'iframe', 'message': 'back' }, '*');
+    }
+  };
+
   var sendEmailOrPick = function sendEmailOrPick(address) {
     if (ActivityHandler.currentlyHandling) {
       // Placeholder for the email app if we want to
@@ -607,7 +619,7 @@ var Contacts = (function() {
           handler: contacts.Search.enterSearchMode
         }
       ],
-      '#details-back': handleBack, // Details
+      '#details-back': handleDetailsBack, // Details
       '#edit-contact-button': showEditContact,
       '#toggle-favorite': contacts.Details.toggleFavorite,
       '#contact-form button[data-field-type]': contacts.Form.onNewFieldClicked,

--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -82,7 +82,7 @@
       </article>
       <article class="view" role="tab" id="contacts-view">
         <a id="option-contacts" href="#contacts-view" class="icon icon-contacts">contacts</a>
-        <iframe role="tabpanel" id="iframe-contacts" frameBorder="no" class="grid-wrapper"></iframe>
+        <iframe role="tabpanel" id="iframe-contacts" name="iframe-contacts" frameBorder="no" class="grid-wrapper"></iframe>
       </article>
       <article id="keyboard-view" role="tab">
         <a id="option-keypad" href="#keyboard-view" class="icon icon-keypad">keypad</a>

--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -98,6 +98,17 @@ var CallHandler = (function callHandler() {
     });
   }
 
+  /* === Handle messages recevied from iframe === */
+  function handleIframeRequest(message) {
+    switch (message) {
+      case 'back':
+        // disable the function of receiving the messages posted from the iframe
+        window.frames['iframe-contacts'].window.history.pushState(null, null, '/contacts/index.html');
+        window.location.hash = '#recents-view';
+        break;
+    }
+  }
+
   /* === Incoming and STK calls === */
   function newCall() {
     // We need to query mozTelephony a first time here
@@ -177,6 +188,8 @@ var CallHandler = (function callHandler() {
       handleNotificationRequest(data.number);
     } else if (data.type && data.type === 'recent') {
       handleRecentAddRequest(data.entry);
+    } else if (data.type && data.type === 'iframe') {
+      handleIframeRequest(data.message);
     }
   }
   window.addEventListener('message', handleMessage);

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -597,6 +597,8 @@ var Recents = {
     if (contactId) {
       src += '#view-contact-details?id=' + contactId;
       src += '&tel=' + phoneNumber;
+      // enable the function of receiving the messages posted from the iframe
+      src += '&send_message_from_iframe=1';
       var timestamp = new Date().getTime();
       contactsIframe.src = src + '&timestamp=' + timestamp;
       window.location.hash = '#contacts-view';


### PR DESCRIPTION
http://bugzil.la/823025

Root Cause:
When user switches Contacts tap in Dialer app in some conditions, the Dialer app will have a iframe just included Contacts app.

Dialer app and Contacts app are individual.And the two apps have no function to communicate each other.

So when user clicks back button in Contact Details Section of Contacts app, the app will go back to Contacts List Section, and never go back to Call log Section of Dialer app.

Then the Bug 823025 will happen.

Solution:
When user click back button in contact details page in iframe, the iframe will post message to Dialer app. After receive back message, Dialer app will show Call log page.
