### PR TITLE
Bug 808650 - Implement filtering by contact email.

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -440,6 +440,16 @@ contacts.List = (function() {
       sortBy: sortBy,
       sortOrder: 'ascending'
     };
+
+    // We use an empty string here for now because the WebContacts API
+    // is really performing a "startswith" instead of "contains".
+    // We should look at implementing a "nonempty" filter in the future.
+    if (ActivityHandler.activityDataType === 'webcontacts/email') {
+      options.filterBy = ['email'];
+      options.filterOp = 'contains';
+      options.filterValue = '';
+    }
+
     var request = navigator.mozContacts.find(options);
     request.onsuccess = function findCallback() {
       successCb(request.result);


### PR DESCRIPTION
Only show contacts for a webcontacts/email activity if the contact email contains an empty string. r=asuth
