### PR TITLE
Bug 823894 - [USSD/MMI] Home button is not properly handled while MMI screen is shown (r=fcampo)

### DIFF
--- a/apps/communications/dialer/js/ussd.js
+++ b/apps/communications/dialer/js/ussd.js
@@ -180,18 +180,21 @@ var UssdManager = {
     this._popup.ready = true;
     if (this._closedOnVisibilityChange) {
       this.notifyLast();
+    } else {
+      this.notifyPending();
     }
-    this.notifyPending();
   },
 
   notifyPending: function um_notifyPending() {
-    if (this._pendingNotification)
+    if (this._pendingNotification) {
       this.postMessage(this._pendingNotification);
+    }
   },
 
-  notifyLast: function um_notifyPending() {
-    if (this._lastMessage)
+  notifyLast: function um_notifyLast() {
+    if (this._lastMessage) {
       this.postMessage(this._lastMessage);
+    }
   },
 
   isUSSD: function um_isUSSD(number) {
@@ -201,7 +204,11 @@ var UssdManager = {
 
   postMessage: function um_postMessage(message) {
     if (this._popup && this._popup.ready) {
-      this._popup.postMessage(this._lastMessage = message, this._origin);
+      this._popup.postMessage(message, this._origin);
+      this._pendingNotification = null;
+      if (message.type !== 'voicechange') {
+        this._lastMessage = message;
+      }
     } else {
       this._pendingNotification = message;
     }


### PR DESCRIPTION
To recover the correct status of the USSD/MMI screen in case it has been hidden (due to clicking on the Home button or switching to any other app), we have to store the last messages shown on this screen. This does not include the update of the screen header as a consequence of an operator change (change of SIM card, etc.).
