### PR TITLE
Bug 828266:  [email] black flash / email flickers when transitioning from list to email and back

### DIFF
--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -785,6 +785,12 @@ var Cards = {
     else {
       this._transitionCount = (beginNode && endNode) ? 2 : 1;
       this._eatingEventsUntilNextCard = true;
+
+      // Show a sliver of the next card, to kickstart
+      // platform for a smooth, non-black transition: 828266
+      addClass(endNode, 'start');
+      // Kick the reflow
+      cardsNode.clientWidth;
     }
 
     if (this.activeCardIndex === cardIndex) {
@@ -857,6 +863,9 @@ var Cards = {
       if (endNode.classList.contains('disabled-anim-vertical')) {
         removeClass(endNode, 'disabled-anim-vertical');
         addClass(endNode, 'anim-vertical');
+      } else {
+        // Remove hack for 828266
+        removeClass(endNode, 'start');
       }
     }
   },

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -71,6 +71,11 @@ body {
 .card.before {
   transform: translateX(-100%);
 }
+/* Show a sliver of the next card, to kickstart
+platform for a smooth, non-black transition: 828266 */
+.card.before.start {
+  transform: translateX(-99%);
+}
 
 .card.before.anim-vertical {
   transform: translateY(100%);
@@ -79,10 +84,16 @@ body {
 .card.after {
   transform: translateX(100%);
 }
+/* Show a sliver of the next card, to kickstart
+platform for a smooth, non-black transition: 828266 */
+.card.after.start {
+  transform: translateX(99%);
+}
 
 .card.after.anim-vertical {
   transform: translateY(-100%);
 }
+
 
 .card.center.card-folder-picker {
   width: calc(100% - 4.3em);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=828266

This seems to do the trick for me on an unagi phone. I tried before this change and saw the black flash, after this change I do not see it.

I still see some dropping of animations for some transitions. I believe this is due to the size/complexity of the DOM for one of the cards. I will investigate a fix for that, but this change is the bare minimum for removing the black transition.
