### PR TITLE
Bug 829616 - HTTP cache serves stale content on B2G when page reloaded

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -594,7 +594,10 @@ var Browser = {
     }
 
     if (this.urlButtonMode == this.REFRESH && !this.currentTab.crashed) {
-      this.currentTab.dom.reload(true);
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=829616
+      // Switch the hard-reload to soft-reload since hard-reload still has
+      // some issue to be fix (bug 831153).
+      this.currentTab.dom.reload(false);
       return;
     }
 


### PR DESCRIPTION
- Fix issue : https://bugzilla.mozilla.org/show_bug.cgi?id=829616
