### PR TITLE
Bug 828266 - [email] black flash / email flickers when transitioning from list to email and back - part 2

### DIFF
--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -785,12 +785,6 @@ var Cards = {
     else {
       this._transitionCount = (beginNode && endNode) ? 2 : 1;
       this._eatingEventsUntilNextCard = true;
-
-      // Show a sliver of the next card, to kickstart
-      // platform for a smooth, non-black transition: 828266
-      addClass(endNode, 'start');
-      // Kick the reflow
-      cardsNode.clientWidth;
     }
 
     if (this.activeCardIndex === cardIndex) {
@@ -863,9 +857,6 @@ var Cards = {
       if (endNode.classList.contains('disabled-anim-vertical')) {
         removeClass(endNode, 'disabled-anim-vertical');
         addClass(endNode, 'anim-vertical');
-      } else {
-        // Remove hack for 828266
-        removeClass(endNode, 'start');
       }
     }
   },

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -69,12 +69,10 @@ body {
 }
 
 .card.before {
-  transform: translateX(-100%);
-}
-/* Show a sliver of the next card, to kickstart
-platform for a smooth, non-black transition: 828266 */
-.card.before.start {
-  transform: translateX(-99%);
+  /* Show a sliver of the before card, to kickstart
+  platform for a smooth, non-black transition: 828266.
+  Otherwise, this would just be -100% */
+  transform: translateX(calc(-100% + 0.5px));
 }
 
 .card.before.anim-vertical {
@@ -82,12 +80,10 @@ platform for a smooth, non-black transition: 828266 */
 }
 
 .card.after {
-  transform: translateX(100%);
-}
-/* Show a sliver of the next card, to kickstart
-platform for a smooth, non-black transition: 828266 */
-.card.after.start {
-  transform: translateX(99%);
+  /* Show a sliver of the after card, to kickstart
+  platform for a smooth, non-black transition: 828266.
+  Otherwise, this would just be 100% */
+  transform: translateX(calc(100% - 0.5px));
 }
 
 .card.after.anim-vertical {


### PR DESCRIPTION
What I believe to be a slight improvement over the current fix for this bug:

https://github.com/mozilla-b2g/gaia/commit/5c1050aeab1cc04ed49f4759b308b35f1852eadd

This fix does not require an extra intermediate "start" style applied with a reflow kick. Instead, it uses calc() to place the non visible cards onscreen by half a pixel, and that is the style they keep when inserted/ended animation. 

The cards do not show visibly on the screen, and it avoids the black flashing. I believe this approach helps with the loss of animation when going back to the message list. But I have probably been staring at this for too long.

With this patch, I only see a loss of animation frames if the platform-provided vertical scrollbar is on screen or on its way to disappearing when the animation starts. 

So to improve the animation for those cases, I believe it will need some platform help/guidance.
