### PR TITLE
Bug 830730 - [CONTACTS][DIALER] The contacts added from the dialer app are not displayed

### DIFF
--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -349,6 +349,18 @@ var KeypadManager = {
           }
         }
       });
+      // If we created the contact let's invalidated the contacts
+      // tab within the dialer.
+      activity.onsuccess = function contactCreated() {
+        var contactsIframe = document.getElementById('iframe-contacts');
+        var src = contactsIframe.src;
+        // Only perform this refresh if we DID open the contacts tab
+        if (src && src.length > 0) {
+          var timestamp = new Date().getTime();  
+          contactsIframe.contentWindow.location.search =
+            '?timestamp=' + timestamp;
+        }
+      }
     } catch (e) {
       console.log('WebActivities unavailable? : ' + e);
     }


### PR DESCRIPTION
When we return from an activity of creating a new contact, if we were displaying the contacts tab, we will make the tab to reset to load the new contact
