### PR TITLE
Bug 817850 - Correctly parse number out of hash after contact picking in...

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -195,7 +195,7 @@ var MessageManager = {
   },
 
   getNumFromHash: function mm_getNumFromHash() {
-    var num = /\bnum=(.+)(&|$)/.exec(window.location.hash);
+    var num = /\bnum=(\S+)(\s|&|$)/.exec(window.location.hash);
     return num ? num[1] : null;
   },
 
@@ -528,7 +528,7 @@ var ThreadListUI = {
           ThreadListUI.appendThread(thread);
           appendThreads(threads, callback);
         });
-      }
+      };
 
       appendThreads(threads, function at_callback() {
         // Boot update of headers


### PR DESCRIPTION
... SMS

**Root Cause**
The number returned from contact picking may contain space, like "0916xxxxxx " or "0916xxxxxx CarrierName". (This format is from Contact apps. value selector logic)
SMS could not handle this form of number in hashchange function.

**Solution**
Refine the RegExp in SMS to correctly parse the number out.
The assumption is that the number itself should not contain space.
