### PR TITLE
Bug 797661 - Hotspot should have random password r=kaze

### DIFF
--- a/apps/settings/js/hotspot.js
+++ b/apps/settings/js/hotspot.js
@@ -9,6 +9,41 @@ onLocalized(function hotspot() {
   var hotspotSettingsSection =
       document.getElementById('hotspot-settings-section');
 
+  // If this is the first time that the Hotspot settings are looked
+  // at, the password will be set to null since that is hardcoded in
+  // the build. If that is the case then we generate a random but
+  // friendly password.
+
+  function generateHotspotPassword() {
+    var words = ['alberta', 'amsterdam', 'ankara',
+                 'auckland', 'belfast', 'berlin',
+                 'boston', 'calgary', 'caracas',
+                 'chicago', 'dakar', 'delhi',
+                 'dubai', 'dublin', 'houston',
+                 'jakarta', 'lagos', 'lima',
+                 'madrid', 'moscow',
+                 'mumbai', 'newyork', 'osaka',
+                 'oslo', 'paris', 'porto',
+                 'santiago', 'saopaulo', 'seattle',
+                 'stockholm', 'sydney', 'taipei',
+                 'tokyo', 'toronto'];
+    var password = words[Math.floor(Math.random() * words.length)];
+    for (var i = 0; i < 4; i++) {
+      password += Math.floor(Math.random() * 10);
+    }
+    return password;
+  }
+
+  var lock = settings.createLock();
+  var req = lock.get('tethering.wifi.security.password');
+  req.onsuccess = function onTetheringPasswordSuccess() {
+    var pwd = req.result['tethering.wifi.security.password'];
+    if (!pwd) {
+      pwd = generateHotspotPassword();
+      lock.set({ 'tethering.wifi.security.password': pwd });
+    }
+  };
+
   function setHotspotSettingsEnabled(enabled) {
     hotspotSettingsSection.hidden = enabled;
   }
@@ -26,4 +61,3 @@ onLocalized(function hotspot() {
     );
   };
 });
-

--- a/build/settings.py
+++ b/build/settings.py
@@ -122,7 +122,7 @@ settings = {
  "tethering.wifi.dhcpserver.endip": "192.168.1.30",
  "tethering.wifi.ssid": "FirefoxHotspot",
  "tethering.wifi.security.type": "open",
- "tethering.wifi.security.password": "1234567890",
+ "tethering.wifi.security.password": None,
  "tethering.wifi.connectedClients": 0,
  "tethering.usb.connectedClients": 0,
  "time.nitz.automatic-update.enabled": True,


### PR DESCRIPTION
New pull request for the same fix except with city names instead of fruit names.
