### PR TITLE
Bug 802981 - UA override for maps.google.ca.

### DIFF
--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -7,6 +7,7 @@ pref("general.useragent.override.yelp.com", "\(Mobile#(Android; Mobile"); // bug
 pref("general.useragent.override.dailymotion.com", "\(Mobile#(Android; Mobile"); // bug 827638
 pref("general.useragent.override.accounts.google.com", "\(Mobile#(Android; Mobile"); // bug 805164 
 pref("general.useragent.override.maps.google.com", "\(Mobile#(Android; Mobile"); // bug 802981
+pref("general.useragent.override.maps.google.ca", "\(Mobile#(Android; Mobile"); // bug 802981
 pref("general.useragent.override.uol.com.br", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826330
 pref("general.useragent.override.live.com", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826332
 pref("general.useragent.override.globo.com", "\(Mobile#(Android; Mobile"); // bug 826335


### PR DESCRIPTION
We already have an override for maps.google.com to prevent
bad sniffing redirecting us to the search page. This commit
adds it for the .ca domain as well.

https://bugzilla.mozilla.org/show_bug.cgi?id=802981
