### PR TITLE
Bug 827893 - [Gallery] Add a contact photo from an empty gallery

### DIFF
--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -78,7 +78,7 @@ section {
   https://bugzilla.mozilla.org/show_bug.cgi?id=570326; */
   overflow: hidden;
   position: absolute;
-  z-index: 100;
+  z-index: 1;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
- Fix bug : https://bugzilla.mozilla.org/show_bug.cgi?id=827893
