### PR TITLE
Bug 833593 - Add panda=false to test_calendary.py, r=mdas, a=test-only

### DIFF
--- a/tests/python/gaiatest/tests/manifest.ini
+++ b/tests/python/gaiatest/tests/manifest.ini
@@ -26,8 +26,8 @@ camera = false
 # Expected to fail
 xfail = false
 
-# Marketplace tests don't run on pandas
-marketplace = false
+# Flag used to disable tests on pandas pending investigation of failures
+panda = true
 
 [include:unit/manifest.ini]
 [include:marketplace/manifest.ini]
@@ -38,6 +38,8 @@ marketplace = false
 [test_calculator.py]
 disabled = Bug 822565 - Not for 1.0 release
 [test_calendar.py]
+# Bug 833416
+panda = false
 [test_call_log.py]
 disabled = Need to populate missed calls automatically - Git issue #45
 [test_camera.py]
@@ -47,8 +49,6 @@ sdcard = true
 [test_delete_app.py]
 lan = true
 [test_dialer.py]
-# Bug 827783 - click events sent by marionette are discarded in gaia
-xfail = true
 carrier = true
 [test_ftu.py]
 wifi = true

--- a/tests/python/gaiatest/tests/marketplace/manifest.ini
+++ b/tests/python/gaiatest/tests/marketplace/manifest.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 lan = true
-marketplace = true
+panda = false
 
 [test_marketplace_login.py]
 disabled = Marketplace app itself is failing to launch - Issue 238


### PR DESCRIPTION
This pulls in the latest manifest.ini from gaia-ui-tests, in particular to set panda=false for test_calendary.py, until we figure out why it's failing on the panda.
