### PR TITLE
bug 823450 - Add data connection warning dialog r=alive, kaze

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -732,6 +732,29 @@
       -->
     </section>
 
+    <!-- Connectivity :: Cellular & Data :: Data Connection Warnings -->
+    <section role="region" id="carrier-dc-warning">
+      <!--
+      <form role="dialog" data-type="confirm">
+        <section>
+          <h1>
+            <span data-l10n-id="dataConnection-warning-head">Turn ON data connection?</span>
+          </h1>
+          <p>
+            <small data-l10n-id="dataConnection-warning-message">
+              Applications will automatically fetch data via data connection
+               when required. Additional data charges may apply.
+            </small>
+          </p>
+        </section>
+        <menu>
+          <button type="reset" data-l10n-id="dataConnection-warning-notNow">Not now</button>
+          <button type="submit" class="recommend" data-l10n-id="dataConnection-warning-turnOn">Turn ON</button>
+        </menu>
+      </form>
+      -->
+    </section>
+
     <!-- Connectivity :: Cellular & Data -->
     <section role="region" id="carrier">
       <!--
@@ -758,6 +781,8 @@
           </label>
           <small id="dataConnection-desc"></small>
           <a data-l10n-id="dataConnection">Data Connection</a>
+        </li>
+        <li id="dataConnection-expl" class="explanation" hidden>
         </li>
         <li>
           <label>
@@ -799,7 +824,7 @@
           </label>
         </li>
       </ul>
-
+      
       <script type="application/javascript" defer src="js/carrier.js"></script>
       -->
     </section>

--- a/apps/settings/js/carrier.js
+++ b/apps/settings/js/carrier.js
@@ -173,30 +173,87 @@ var Carrier = (function newCarrier(window, document, undefined) {
     };
   }
 
-  // 'Data Roaming' message
-  var settings = Settings.mozSettings;
-  if (settings) {
-    var _ = window.navigator.mozL10n.get;
-    var dataRoamingSetting = 'ril.data.roaming_enabled';
+  // initialize 'Data Connection' warnings
+  function initDataConnectionWarning() {
+    // 'Data Roaming' message and data connection messaging
+    var settings = Settings.mozSettings;
+    if (settings) {
+      var _ = window.navigator.mozL10n.get;
+      var dataRoamingSetting = 'ril.data.roaming_enabled';
+      var dataConnectionSetting = 'ril.data.enabled';
+      var dataConnectionSettingWarning = 'ril.data.enabled.warning.shown';
 
-    var displayDataRoamingMessage = function(enabled) {
-      var messageID = 'dataRoaming-' + (enabled ? 'enabled' : 'disabled');
-      document.getElementById('dataRoaming-expl').textContent = _(messageID);
+      var dcExplanation = document.getElementById('dataConnection-expl');
+      var drExplanation = document.getElementById('dataRoaming-expl');
+
+      var setDataConnectionState = function(state) {
+        var cset = {};
+        cset[dataConnectionSetting] = !!state;
+        settings.createLock().set(cset);
+      };
+
+      var displayDataRoamingMessage = function(enabled) {
+        var messageID = 'dataRoaming-' + (enabled ? 'enabled' : 'disabled');
+        drExplanation.textContent = _(messageID);
+      };
+
+      var onSubmit = function() {
+        var warningIsShown = true;
+        window.asyncStorage.setItem(dataConnectionSettingWarning,
+          warningIsShown);
+      };
+
+      var onReset = function() {
+        var warningIsShown = false;
+        window.asyncStorage.setItem(dataConnectionSettingWarning,
+          warningIsShown);
+        setDataConnectionState(false);
+      };
+
+      var displayDataConnectionMessage = function(enabled) {
+        window.asyncStorage.getItem(dataConnectionSettingWarning,
+          function(warningIsShown) {
+            warningIsShown = warningIsShown || false;
+            if (enabled && warningIsShown) {
+              dcExplanation.hidden = false;
+              dcExplanation.textContent = _('dataConnection-warning-message');
+            } else if (enabled) {
+              dcExplanation.hidden = true;
+              openDialog('carrier-dc-warning', onSubmit, onReset);
+            } else {
+              dcExplanation.hidden = true;
+            }
+        });
+      };
+
+      // register an observer to monitor setting changes
+      settings.addObserver(dataRoamingSetting, function(event) {
+        displayDataRoamingMessage(event.settingValue);
+      });
+
+      settings.addObserver(dataConnectionSetting, function(event) {
+        displayDataConnectionMessage(event.settingValue);
+      });
+
+      // get the initial setting value
+      var req = settings.createLock().get(dataRoamingSetting);
+      req.onsuccess = function roaming_getStatusSuccess() {
+        var enabled = req.result && req.result[dataRoamingSetting];
+        displayDataRoamingMessage(enabled);
+      };
+
+      var dataConnectionSettingRequest =
+          settings.createLock().get(dataConnectionSetting);
+      dataConnectionSettingRequest.onsuccess =
+          function connection_getStatusSuccess() {
+        var enabled = dataConnectionSettingRequest.result &&
+            dataConnectionSettingRequest.result[dataConnectionSetting];
+        displayDataConnectionMessage(enabled);
+      };
+    } else {
+      drExplanation.hidden = true;
+      dcExplanation.hidden = true;
     }
-
-    // register an observer to monitor setting changes
-    settings.addObserver(dataRoamingSetting, function(event) {
-      displayDataRoamingMessage(event.settingValue);
-    });
-
-    // get the initial setting value
-    var req = settings.createLock().get(dataRoamingSetting);
-    req.onsuccess = function roaming_getStatusSuccess() {
-      var enabled = req.result && req.result[dataRoamingSetting];
-      displayDataRoamingMessage(enabled);
-    };
-  } else {
-    document.getElementById('dataRoaming-expl').hidden = true;
   }
 
   // network operator selection: auto/manual
@@ -324,6 +381,7 @@ var Carrier = (function newCarrier(window, document, undefined) {
     init: function carrier_init() {
       Connectivity.updateCarrier(); // see connectivity.js
       updateSelectionMode();
+      initDataConnectionWarning();
       // XXX this should be done later -- not during init()
       this.fillAPNList('data');
       this.fillAPNList('mms');

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -138,6 +138,10 @@ autoConfigure=Auto-configure
 httpProxyHost=HTTP proxy host
 httpProxyPort=HTTP proxy port
 custom=(custom settings)
+dataConnection-warning-head=Turn ON data connection?
+dataConnection-warning-message=Applications will automatically fetch data via data connection when required. Additional data charges may apply.
+dataConnection-warning-notNow=Not now
+dataConnection-warning-turnOn=Turn ON
 
 # Connectivity :: Bluetooth
 bluetooth = Bluetooth
@@ -533,3 +537,5 @@ operatorServices=Operator Services
 operatorServices-help=Help
 operatorServices-helpmenu=Help menu
 operatorService-invalid-url=Cannot access the URL
+stkAppsNotAvailable=SIM card applications not available.
+simToolkit=SIM toolkit

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -216,6 +216,7 @@ section li.password > p {
   height: 2.7rem;
 }
 
+
 /******************************************************************************
  * Cellular and Data
  */
@@ -223,6 +224,17 @@ section li.password > p {
 .carrier-disabled a {
   opacity: 0.6;
   color: #797e80;
+}
+
+#carrier-dc-warning h1 > span:before {
+  content: "";
+  position: relative;
+  display: inline-block;
+  background: -moz-image-rect(url(images/icons_sprite.png), 0, 120, 30, 90) no-repeat scroll 0 50% transparent;
+  top: 0.9rem;
+  margin: 0.5rem;
+  width: 3rem;
+  height: 3rem;
 }
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=823450

The original patch has been reviewed by Kaze (https://github.com/mozilla-b2g/gaia/pull/7106) and alive (https://github.com/mozilla-b2g/gaia/pull/7749). Create a new pull request here for requesting to merge to the master branch.

A few modifications have been made to address their comments:
- Use a div to show the warning dialog instead of an attention screen.
- Use async storage for recording if the warning dialog has been shown before.
- Remove the the CSS styles overriding the default confirm dialog style. 
