### PR TITLE
Bug 828732 - "Add to existing contacts" should not be available if no contacts exist

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -15,7 +15,6 @@
     -->
 
     <!-- Call log resources -->
-    <script defer type="application/javascript" src="/dialer/js/recents.js"></script>
     <!-- Making sure the shared resources will be copy into the zip
     <link rel="stylesheet" type="text/css" href="/shared/style/headers.css">
     <link rel="stylesheet" type="text/css" href="/shared/style/switches.css">
@@ -46,6 +45,7 @@
     <script defer type="application/javascript" src="/contacts/js/confirm_dialog.js"></script>
     <script defer type="application/javascript" src="/shared/js/simple_phone_matcher.js"></script>
     <script defer type="application/javascript" src="/dialer/js/contacts.js"></script>
+    <script defer type="application/javascript" src="/dialer/js/recents.js"></script>
     <script defer type="application/javascript" src="/dialer/js/keypad.js"></script>
     <script defer type="application/javascript" src="/dialer/js/ussd.js"></script>
     <script defer type="application/javascript" src="/dialer/js/dialer.js"></script>

--- a/apps/communications/dialer/js/contacts.js
+++ b/apps/communications/dialer/js/contacts.js
@@ -157,5 +157,16 @@ var Contacts = {
     request.onerror = function findError() {
       callback(null);
     };
+  },
+
+  getCount: function getCount(callback) {
+    var request = navigator.mozContacts.find({});
+    request.onsuccess = function getCountCallback() {
+      callback(request.result.length);
+    };
+
+    request.onerror = function getCountError() {
+      callback(null);
+    };
   }
 };

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -682,6 +682,9 @@ var Recents = {
       if (!total) {
         self.addToExistingContactMenuItem.style.display = "none";
       }
+      else {
+        self.addToExistingContactMenuItem.style.display = null;
+      }
     });
 
     window.asyncStorage.getItem('latestCallLogVisit', function getItem(value) {

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -303,7 +303,7 @@ var Recents = {
         var selectedCalls = this.recentsContainer.
           querySelectorAll('.log-item:not(.hide) input:checked');
         var selectedCallsLength = selectedCalls.length;
-        if (selectedCallsLength == 0) {
+        if (selectedCallsLength === 0) {
           this.headerEditModeText.textContent = this._('edit');
         } else {
           this.headerEditModeText.textContent = this._('edit-selected',
@@ -322,13 +322,13 @@ var Recents = {
         var noMissedCallsItemParent = noMissedCallsItem.parentNode;
         var notHiddenCalls = noMissedCallsItemParent.
           querySelectorAll('.log-item:not(.hide)');
-        if (notHiddenCalls.length == 0) {
+        if (notHiddenCalls.length === 0) {
           var notHiddenCallsDay = noMissedCallsItemParent.parentNode;
           notHiddenCallsDay.classList.add('hide');
         }
         var visibleCalls = this.recentsContainer.
           querySelectorAll('.log-item:not(.hide)');
-        if (visibleCalls.length == 0) {
+        if (visibleCalls.length === 0) {
           this.recentsIconEdit.parentNode.setAttribute('aria-disabled', 'true');
         } else {
           this.recentsIconEdit.parentNode.removeAttribute('aria-disabled');
@@ -337,7 +337,7 @@ var Recents = {
           var selectedCalls = this.recentsContainer.
             querySelectorAll('.log-item:not(.hide) input:checked');
           var selectedCallsLength = selectedCalls.length;
-          if (selectedCallsLength == 0) {
+          if (selectedCallsLength === 0) {
             this.headerEditModeText.textContent = this._('edit');
           } else {
             this.headerEditModeText.textContent = this._('edit-selected',
@@ -536,7 +536,7 @@ var Recents = {
         event.stopPropagation();
       }
       var count = this.getSelectedEntries().length;
-      if (count == 0) {
+      if (count === 0) {
         this.headerEditModeText.textContent = this._('edit');
         this.recentsIconDelete.classList.add('disabled');
         this.deselectAllThreads.setAttribute('disabled', 'disabled');
@@ -661,7 +661,7 @@ var Recents = {
     if (!this.recentsContainer)
       return;
 
-    if (recents.length == 0) {
+    if (recents.length === 0) {
       this.recentsContainer.innerHTML =
         '<div id="no-result-container">' +
         ' <div id="no-result-message">' +
@@ -678,6 +678,12 @@ var Recents = {
     this.recentsIconEdit.parentNode.removeAttribute('aria-disabled');
 
     var self = this;
+    Contacts.getCount(function(total) {
+      if (!total) {
+        self.addToExistingContactMenuItem.style.display = "none";
+      }
+    });
+
     window.asyncStorage.getItem('latestCallLogVisit', function getItem(value) {
       var content = '',
         currentDay = '';


### PR DESCRIPTION
Fixes [828732](https://bugzilla.mozilla.org/show_bug.cgi?id=828732)
### Steps to reproduce
1. Go to your call history and click on a phone number without a contact associated.

Expect: Options to call or create a new contact
Actual: "Add to existing contacts" is also available despite 0 contacts in my address book
### Caveats

This patch will check for the existence of any number of contacts at the startup of the dialer app, and it will hide the `Add to existing contacts` accordingly.

Please note that if a contact is added or deleted from the communications app itself or while the communications app is loaded, that won't have any effect. In order to be able to implement a proper dynamic reaction to adding or deleting contacts, some kind of event that reacts to contact addition/deletion would be necessary. Some advice of what would be a standard solution would be very helpful.
