### PR TITLE
Bug 833517 - to clear the ended timer after setting a new audio source. ...

### DIFF
--- a/apps/music/js/Player.js
+++ b/apps/music/js/Player.js
@@ -296,6 +296,11 @@ var PlayerView = {
     // due to b2g cannot get some mp3's duration
     // and the seekBar can still show 00:00 to -00:00
     this.setSeekBar(0, 0, 0);
+
+    if (this.endedTimer) {
+      clearTimeout(this.endedTimer);
+      this.endedTimer = null;
+    }
   },
 
   play: function pv_play(targetIndex, backgroundIndex) {
@@ -305,10 +310,6 @@ var PlayerView = {
     if (!cpuLock)
       cpuLock = navigator.requestWakeLock('cpu');
 
-    if (this.endedTimer) {
-      clearTimeout(this.endedTimer);
-      this.endedTimer = null;
-    }
 
     this.showInfo();
 
@@ -652,7 +653,6 @@ var PlayerView = {
             this.endedTimer == null) {
           var timeToNext = (this.audio.duration - this.audio.currentTime + 1);
           this.endedTimer = setTimeout(function() {
-                                         this.endedTimer = null;
                                          this.next(true);
                                        }.bind(this),
                                        timeToNext * 1000);


### PR DESCRIPTION
...r=Dominic

See https://bugzilla.mozilla.org/show_bug.cgi?id=833517 for details.
