### PR TITLE
Bug 829510 - When a contact name has no name and no lastname we show an empty string in the call log (r=albertopq)

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -114,8 +114,15 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
 
   var self = this;
   Contacts.findByNumber(number, function lookupContact(contact, matchingTel) {
-    if (contact && contact.name) {
-      node.textContent = contact.name;
+    if (contact) {
+      var primaryInfo = Utils.getPhoneNumberPrimaryInfo(matchingTel, contact);
+      if (primaryInfo) {
+        node.textContent = primaryInfo;
+      } else {
+        LazyL10n.get(function (_) {
+          node.textContent = _('unknown');
+        });
+      }
       KeypadManager.formatPhoneNumber('end', true);
       var additionalInfo = Utils.getPhoneNumberAdditionalInfo(matchingTel,
                                                               contact);

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -750,8 +750,15 @@ var Recents = {
         phoneNumber = logItem.dataset.num.trim(),
         count = logItem.dataset.count;
     if (contact !== null) {
-      primaryInfoMainNode.textContent = (contact.name && contact.name !== '') ?
-        contact.name : this._('unknown');
+      var primaryInfo = Utils.getPhoneNumberPrimaryInfo(
+        matchingTel, contact);
+      if (primaryInfo) {
+        primaryInfoMainNode.textContent = primaryInfo;
+      } else {
+        LazyL10n.get(function (_) {
+          primaryInfoMainNode.textContent = _('unknown');
+        });
+      }
       manyContactsNode.innerHTML = contactsWithSameNumber ?
         '&#160;' + this._('contactNameWithOthersSuffix',
           {n: contactsWithSameNumber}) : '';

--- a/apps/communications/dialer/js/utils.js
+++ b/apps/communications/dialer/js/utils.js
@@ -32,6 +32,21 @@ var Utils = {
     return startDate.getTime();
   },
 
+  getPhoneNumberPrimaryInfo: function ut_getPhoneNumberPrimaryInfo(matchingTel,
+    contact) {
+    if (contact) {
+      if (contact.name && String(contact.name) !== '') {
+        return contact.name;
+      } else if (contact.org && String(contact.org) !== '') {
+        return  contact.org;
+      }
+    }
+    if (matchingTel) {
+      return matchingTel.value;
+    }
+    return null;
+  },
+
   // XXX: this is way too complex for the task accomplished
   getPhoneNumberAdditionalInfo: function ut_getPhoneNumberAdditionalInfo(
     matchingTel, associatedContact) {


### PR DESCRIPTION
According to UX guidelines, if a contact has no name or surname set:
- In case the company is set is it shown as the primary information associated to the phone number.
  - In case the company is not set, the phone number itself is shown as the primary information associated to the phone number.
