### PR TITLE
Bug 823025 - Call Log: Returning from contact details should go back to call log, not contact list.

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -466,6 +466,18 @@ var Contacts = (function() {
     }
   };
 
+  var handleDetailsBack = function handleDetailsBack() {
+    var hasParams = window.location.hash.split('?');
+    var params = hasParams.length > 1 ?
+      extractParams(hasParams[1]) : -1;
+
+    navigation.back();
+    // post message to parent page included Contacts app.
+    if (params['back_to_previous_tab'] === '1') {
+      window.parent.postMessage({ 'type': 'contactsiframe', 'message': 'back' }, '*');
+    }
+  };
+
   var sendEmailOrPick = function sendEmailOrPick(address) {
     if (ActivityHandler.currentlyHandling) {
       // Placeholder for the email app if we want to
@@ -601,7 +613,7 @@ var Contacts = (function() {
           handler: contacts.Search.enterSearchMode
         }
       ],
-      '#details-back': handleBack, // Details
+      '#details-back': handleDetailsBack, // Details
       '#edit-contact-button': showEditContact,
       '#toggle-favorite': contacts.Details.toggleFavorite,
       '#contact-form button[data-field-type]': contacts.Form.onNewFieldClicked,

--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -98,6 +98,18 @@ var CallHandler = (function callHandler() {
     });
   }
 
+  /* === Handle messages recevied from iframe === */
+  function handleContactsIframeRequest(message) {
+    switch (message) {
+      case 'back':
+        var contactsIframe = document.getElementById('iframe-contacts');
+        // disable the function of receiving the messages posted from the iframe
+        contactsIframe.contentWindow.history.pushState(null, null, '/contacts/index.html');
+        window.location.hash = '#recents-view';
+        break;
+    }
+  }
+
   /* === Incoming and STK calls === */
   function newCall() {
     // We need to query mozTelephony a first time here
@@ -177,6 +189,8 @@ var CallHandler = (function callHandler() {
       handleNotificationRequest(data.number);
     } else if (data.type && data.type === 'recent') {
       handleRecentAddRequest(data.entry);
+    } else if (data.type && data.type === 'contactsiframe') {
+      handleContactsIframeRequest(data.message);
     }
   }
   window.addEventListener('message', handleMessage);

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -598,6 +598,8 @@ var Recents = {
     if (contactId) {
       src += '#view-contact-details?id=' + contactId;
       src += '&tel=' + phoneNumber;
+      // enable the function of receiving the messages posted from the iframe
+      src += '&back_to_previous_tab=1';
       var timestamp = new Date().getTime();
       contactsIframe.src = src + '&timestamp=' + timestamp;
       window.location.hash = '#contacts-view';


### PR DESCRIPTION
http://bugzil.la/823025

Root Cause:
When user switches Contacts tap in Dialer app in some conditions, the Dialer app will have a iframe just included Contacts app.

Dialer app and Contacts app are individual.And the two apps have no function to communicate each other.

So when user clicks back button in Contact Details Section of Contacts app, the app will go back to Contacts List Section, and never go back to Call log Section of Dialer app.

Then the Bug 823025 will happen.

Solution:
When user click back button in contact details page in iframe, the iframe will post message to Dialer app. After receive back message, Dialer app will show Call log page.
