### PR TITLE
a little correction typo in link shared css file

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="shared/style/confirm.css">
     <link rel="stylesheet" type="text/css" href="shared/style_unstable/progress_activity.css">
     <link rel="stylesheet" type="text/css" href="shared/style_unstable/lists.css">
-    <link rel="stylesheet" type="text/css" href="/shared/style_unstable/tabs.css">
+    <link rel="stylesheet" type="text/css" href="shared/style_unstable/tabs.css">
 
     <!-- App styles -->
     <link rel="stylesheet" type="text/css" href="style/root.css">


### PR DESCRIPTION
Fix the leading slash in the css link.
