### PR TITLE
Bug 835795 - Don't setVisible(false) frames as soon as they're created.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1168,10 +1168,6 @@ var WindowManager = (function() {
       frame.classList.add('ftu');
     }
 
-    // A frame should start with visible false
-    if ('setVisible' in iframe)
-      iframe.setVisible(false);
-
     numRunningApps++;
 
     return app;

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1197,10 +1197,6 @@ var WindowManager = (function() {
     // Open the frame, first, store the reference
     openFrame = frame;
 
-    // set the frame to visible state
-    if ('setVisible' in iframe)
-      iframe.setVisible(true);
-
     setFrameBackground(openFrame, function gotBackground() {
       // Start the transition when this async/sync callback is called.
       openFrame.classList.add('active');


### PR DESCRIPTION
In my (rather spotty) testing, this change didn't cause any problems
(e.g. app frames sitting in fg forever).  But we should be careful.
