### PR TITLE
Bug 835149 - [email/IMAP] folder list sync breaks if IMAP server (ex: courier) returns folders in non-hierarchy order. r=squib

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -17041,8 +17041,9 @@ ImapConnection.prototype.connect = function(loginCb) {
               box.parent = parent;
             }
             box.displayName = decodeModifiedUtf7(name);
-            if (!curChildren[name])
-              curChildren[name] = box;
+            if (curChildren[name])
+              box.children = curChildren[name].children;
+            curChildren[name] = box;
           }
         break;
         // QRESYNC (when successful) generates a "VANISHED (EARLIER) uids"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=835149
land GELAM PR that has r=squib:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/117
