### PR TITLE
Bug 832878 - [Bluetooth] Unable to open image with MIME type image/* r=djf

### DIFF
--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -417,7 +417,7 @@ var BluetoothTransfer = {
       // use the file.type to replace the empty fileType which is given by API
       var fileType = '';
       var fileName = file.name;
-      if (contentType != '') {
+      if (contentType != '' && contentType != 'image/*') {
         fileType = contentType;
       } else {
         var fileNameExtension =


### PR DESCRIPTION
Galaxy Nexus will provide the content type with "image/*". We need to consider and add the judgement for the case.
