### PR TITLE
Bug 836109 - speed up jpeg metadata parsing

### DIFF
--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -168,7 +168,7 @@ var metadataParsers = (function() {
       }, function(errmsg) {
         // If we couldn't parse the JPEG file, then try again with
         // an <img> element. This will probably fail, too.
-        console.warn('In parseJPEGMetadata:', errmsg);
+        console.warn('In parseJPEGMetadata: for file', file.name, errmsg);
         getImageSizeAndThumbnail(file, metadataCallback, metadataError);
       });
     }


### PR DESCRIPTION
This pull request fixes error messages that were appearing in the console when parsing JPEG files with malformed EXIF data.  And it also speeds up jpeg metadata parsing by skipping some EXIF tags and just drilling down directly to the embedded preview image, which is the only EXIF metadata we need.
