### PR TITLE
Bug 835329 - [DIALER] Timer is not appearing during an outgoing call (r=@etiennesegonzac)

### DIFF
--- a/apps/communications/dialer/js/lazy_l10n.js
+++ b/apps/communications/dialer/js/lazy_l10n.js
@@ -17,14 +17,13 @@ var LazyL10n = {
     // the l10n resources
     var l10nScript = document.createElement('script');
     l10nScript.src = '/shared/js/l10n.js';
-    l10nScript.onload = this._finalize.bind(this, callback);
     document.head.appendChild(l10nScript);
+    this._waitForLoad(callback);
+    this._inDOM = true;
 
     var l10nDateScript = document.createElement('script');
     l10nDateScript.src = '/shared/js/l10n_date.js';
     document.head.appendChild(l10nDateScript);
-
-    this._inDOM = true;
   },
 
   _waitForLoad: function ll10n_waitForLoad(callback) {

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -947,7 +947,8 @@
 
   // the B2G build system doesn't expose any `document'...
   if (typeof(document) !== 'undefined') {
-    if (document.readyState === 'complete') {
+    if (document.readyState === 'complete' ||
+      document.readyState === 'interactive') {
       window.setTimeout(l10nStartup);
     } else {
       document.addEventListener('DOMContentLoaded', l10nStartup);


### PR DESCRIPTION
The localization feature was not working in the Comms incoming and outgoing attention screens due to a problem in the lazy loading of this feature.

The source of the problem in this code snippet: https://github.com/mozilla-b2g/gaia/blob/master/shared/js/l10n.js#L949

More concretely, in the case of the incoming/outgoing attention screen, the lazy loading of the localization feature in the Comms app caused the previously mentioned code snippet to be executed with document.readyState equal to 'interactive' and consequently the listener added via document.addEventListener('DOMContentLoaded', l10nStartup) never ran (since the DOMContentLoaded has been already fired, if not the document.readyState wouldn't be 'interactive') and consequently the l10nStartup function was never executed which was causing the localization capabilities to fail ;-999
