### PR TITLE
Bug 835149 - [email/IMAP] folder list sync breaks if IMAP server (ex: courier) returns folders in non-hierarchy order. r=squib, a=approval-gaia-v1 by sicking.

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -17041,8 +17041,9 @@ ImapConnection.prototype.connect = function(loginCb) {
               box.parent = parent;
             }
             box.displayName = decodeModifiedUtf7(name);
-            if (!curChildren[name])
-              curChildren[name] = box;
+            if (curChildren[name])
+              box.children = curChildren[name].children;
+            curChildren[name] = box;
           }
         break;
         // QRESYNC (when successful) generates a "VANISHED (EARLIER) uids"


### PR DESCRIPTION
cherry-picked c721f35db7e372f316a162f1ec00c2d13ea8a1fb from gaia/master
which was landed in merge 622ae151f123ff2ca12d0335c40bb8e7a8442737

https://bugzilla.mozilla.org/show_bug.cgi?id=835149#c5
