### PR TITLE
Bug 831453 - [Clock] If I change an alarm time and then hit back (canceling the change) and then return to alarm, the dials spin from my canceled time to correct time r=timdream

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -151,9 +151,9 @@
                 <div id="value-indicator-hover-time">:</div>
                 <div id="value-indicator-hover"></div>
               </div>
-
-              <div id="value-picker-hours" class="animation-on"></div>
-              <div id="value-picker-minutes" class="animation-on"></div>
+ 
+              <div id="value-picker-hours"></div>
+              <div id="value-picker-minutes"></div>
               <div id="right-picker-separator"></div>
               <div id="value-picker-hour24-state" class="animation-on"></div>
             </div>

--- a/apps/clock/js/utils.js
+++ b/apps/clock/js/utils.js
@@ -196,6 +196,7 @@ var ValuePicker = (function() {
     this.mousedonwHandler = vp_mousedown.bind(this);
     this.mousemoveHandler = vp_mousemove.bind(this);
     this.mouseupHandler = vp_mouseup.bind(this);
+    this.transitionendHandler = vp_transitionend.bind(this);
     this.addEventListeners();
   };
 
@@ -240,7 +241,7 @@ var ValuePicker = (function() {
   };
 
   VP.prototype.resetUI = function() {
-    var actives = this.element.querySelectorAll(".active");
+    var actives = this.element.querySelectorAll('.active');
     for (var i = 0; i < actives.length; i++) {
       actives[i].classList.remove('active');
     }
@@ -286,6 +287,12 @@ var ValuePicker = (function() {
     return reValue;
   }
 
+  function vp_transitionend() {
+    this.element.classList.remove('animation-on');
+    this.element.removeEventListener('transitionend',
+                                     this.transitionendHandler);
+  }
+
   function vp_mousemove(event) {
     event.stopPropagation();
     currentEvent = cloneEvent(event);
@@ -311,6 +318,7 @@ var ValuePicker = (function() {
     this.removeEventListeners();
 
     // Add animation back
+    this.element.addEventListener('transitionend', this.transitionendHandler);
     this.element.classList.add('animation-on');
 
     // Add momentum if speed is higher than a given threshold.


### PR DESCRIPTION
1. Remove class animation-on when the picker init.
2. Remove class animation-on when received transitionend event.
