### PR TITLE
Bug 836710 - E.me apps added from the wrapper do not show the 62x62 icon...

### DIFF
--- a/apps/system/js/wrapper.js
+++ b/apps/system/js/wrapper.js
@@ -159,7 +159,8 @@ var Launcher = (function() {
           url: url,
           name: name,
           icon: dataset.icon,
-          useAsyncPanZoom: dataset.useAsyncPanZoom
+          useAsyncPanZoom: dataset.useAsyncPanZoom,
+          iconable: false
         }
       });
 


### PR DESCRIPTION
... but a small one within the default bookmark circle [r=arcturus]
