### PR TITLE
Bug 837001 - Disable remote debugging by default. r=fabrice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,10 +654,6 @@ ifeq ($(NOFTU), 1)
 SETTINGS_ARG=--noftu
 endif
 
-ifneq ($(TARGET_BUILD_VARIANT),user)
-SETTINGS_ARG += --enable-debugger
-endif
-
 profile/settings.json: build/settings.py build/wallpaper.jpg
 	python build/settings.py $(SETTINGS_ARG) --console --locale $(GAIA_DEFAULT_LOCALE) --homescreen $(SCHEME)homescreen.$(GAIA_DOMAIN)$(GAIA_PORT)/manifest.webapp --ftu $(SCHEME)communications.$(GAIA_DOMAIN)$(GAIA_PORT)/manifest.webapp --wallpaper build/wallpaper.jpg --override build/custom-settings.json --output $@
 

--- a/build/settings.py
+++ b/build/settings.py
@@ -150,7 +150,7 @@ def main():
     parser.add_option("-v", "--verbose", help="increase output verbosity", action="store_true")
     parser.add_option(      "--noftu", help="bypass the ftu app", action="store_true")
     parser.add_option(      "--locale", help="specify the default locale to use")
-    parser.add_option(      "--enable-debugger", help="enable remote debugger and ADB", action="store_true")
+    parser.add_option(      "--enable-debugger", help="enable remote debugger (and ADB for VARIANT=user builds)", action="store_true")
     (options, args) = parser.parse_args(sys.argv[1:])
 
     verbose = options.verbose


### PR DESCRIPTION
Marionette requires that remote debugging be disabled, so this changes
remote debugging to be off by default.
