### PR TITLE
Bug 834931 - add a uitest for fullscreen controls

### DIFF
--- a/test_apps/uitest/index.html
+++ b/test_apps/uitest/index.html
@@ -36,6 +36,7 @@
       <li><a href="#test=inputmode">text inputmode tests</a></li>
       <li><a href="#test=audiotag">audio tag tests</a></li>
       <li><a href="#test=identity">navigator.mozId tests</a></li>
+      <li><a href="#test=fullscreen_controls">Fullscreen Controls</a></li>
     </ul>
   </div>
   <div id="test-panel" class="panel">

--- a/test_apps/uitest/tests/fullscreen_controls.html
+++ b/test_apps/uitest/tests/fullscreen_controls.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fullscreen Controls</title>
+  </head>
+
+  <body>
+    <p>The video element should have controls for entering and exiting
+    fullscreen, but the audio element should not</p>
+    <video src="../data/video/meetthecubs.webm" preload controls width=300>
+    </video>
+    <br>
+    <audio src="../style/ringtones/classic.ogg" preload controls>
+    </audio>
+  </body>
+
+</html>


### PR DESCRIPTION
This PR adds a new test panel to the UI Tests app for testing that video element controls include buttons to go in and out of fullscreen mode and for testing that audio elements do not.
