### PR TITLE
Bug 837583 - Need a switch in Settings app for enabling/disabling Bluetooth log r=evelyn

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1781,6 +1781,13 @@
         </li>
         <li>
           <label>
+            <input type="checkbox" name="bluetooth.debugging.enabled" />
+            <span></span>
+          </label>
+          <a data-l10n-id="bluetooth-debugging">Bluetooth output in adb</a>
+        </li>
+        <li>
+          <label>
             <input type="checkbox" name="debug.console.enabled"/>
             <span></span>
           </label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -417,6 +417,7 @@ paint-flashing=Flash repainted area
 log-animations=Log slow animations
 remote-debugging=Remote debugging
 wifi-debugging=Wi-Fi output in adb
+bluetooth-debugging=Bluetooth output in adb
 ttl-monitor=Show time to load
 console-enabled=Console enabled
 model-name=Model

--- a/build/settings.py
+++ b/build/settings.py
@@ -24,6 +24,7 @@ settings = {
  "audio.volume.tts": 15,
  "audio.volume.telephony": 5,
  "bluetooth.enabled": False,
+ "bluetooth.debugging.enabled": False,
  "camera.shutter.enabled": True,
  "clear.remote-windows.data": False,
  "debug.grid.enabled": False,


### PR DESCRIPTION
Add a key "bluetooth.debugging.enabled" for enabling/disabling Bluetooth log in Settings app.
