### PR TITLE
Bug 797792 - [Clock] If next alarm comes more than 24 HOURS, it should display in DAYS instead of HOURS in countdown indicator

### DIFF
--- a/apps/clock/js/alarm.js
+++ b/apps/clock/js/alarm.js
@@ -297,10 +297,17 @@ var BannerView = {
       innerHTML = _('countdown-lessThanAnHour', {
         minutes: _('nMinutes', { n: this._remainMinutes })
       });
-    } else {
+    } else if (this._remainHours < 24) {
       innerHTML = _('countdown-moreThanAnHour', {
-        hours: _('nRemainHours', { n: this._remainHours }),
+        hours: _('nHours', { n: this._remainHours }),
         minutes: _('nRemainMinutes', { n: this._remainMinutes })
+      });
+    } else {
+      var remainDays = Math.floor(this._remainHours / 24);
+      var remainHours = this._remainHours - (remainDays * 24);
+      innerHTML = _('countdown-moreThanADay', {
+        days: _('nRemainDays', { n: remainDays }),
+        hours: _('nRemainHours', { n: remainHours })
       });
     }
     this.bannerCountdown.innerHTML = '<p>' + innerHTML + '</p>';

--- a/apps/clock/locales/clock.ar.properties
+++ b/apps/clock/locales/clock.ar.properties
@@ -52,6 +52,12 @@ nRemainHours[few] = <strong>{{n}} ساعات</strong>
 nRemainHours[many] = <strong>{{n}} ساعات</strong>
 nRemainHours[other] = <strong>{{n}} ساعات</strong>
 
+#TODO: nHours={[ plural(n) ]}
+nHours[zero]  =
+
+#TODO: nRemainDays={[ plural(n) ]}
+nRemainDays[zero]  =
+
 nRemainMinutes={[ plural(n) ]}
 nRemainMinutes[zero]  =
 nRemainMinutes[one]   = و <strong>{{n}} دقيقة</strong>

--- a/apps/clock/locales/clock.en-US.properties
+++ b/apps/clock/locales/clock.en-US.properties
@@ -35,6 +35,7 @@ dateFormat = %A, %B %e
 
 countdown-lessThanAnHour = The alarm is set for <strong>{{minutes}}</strong> from now.
 countdown-moreThanAnHour = The alarm is set for {{hours}} {{minutes}} from now.
+countdown-moreThanADay = The alarm is set for {{days}} {{hours}} from now.
 
 nMinutes={[ plural(n) ]}
 nMinutes[zero]  = less than a minute
@@ -44,13 +45,29 @@ nMinutes[few] = {{n}} minutes
 nMinutes[many] = {{n}} minutes
 nMinutes[other] = {{n}} minutes
 
+nHours={[ plural(n) ]}
+nHours[zero] =
+nHours[one] = <strong>{{n}} hour</strong>
+nHours[two] = <strong>{{n}} hours</strong>
+nHours[few] = <strong>{{n}} hours</strong>
+nHours[many] = <strong>{{n}} hours</strong>
+nHours[other] = <strong>{{n}} hours</strong>
+
 nRemainHours={[ plural(n) ]}
-nRemainHours[zero]  =
-nRemainHours[one]   = <strong>{{n}} hour</strong>
-nRemainHours[two] = <strong>{{n}} hours</strong>
-nRemainHours[few] = <strong>{{n}} hours</strong>
-nRemainHours[many] = <strong>{{n}} hours</strong>
-nRemainHours[other] = <strong>{{n}} hours</strong>
+nRemainHours[zero] =
+nRemainHours[one] = and <strong>{{n}} hour</strong>
+nRemainHours[two] = and <strong>{{n}} hours</strong>
+nRemainHours[few] = and <strong>{{n}} hours</strong>
+nRemainHours[many] = and <strong>{{n}} hours</strong>
+nRemainHours[other] = and <strong>{{n}} hours</strong>
+
+nRemainDays={[ plural(n) ]}
+nRemainDays[zero] =
+nRemainDays[one] = <strong>{{n}} day</strong>
+nRemainDays[two] = <strong>{{n}} days</strong>
+nRemainDays[few] = <strong>{{n}} days</strong>
+nRemainDays[many] = <strong>{{n}} days</strong>
+nRemainDays[other] = <strong>{{n}} days</strong>
 
 nRemainMinutes={[ plural(n) ]}
 nRemainMinutes[zero]  =

--- a/apps/clock/locales/clock.fr.properties
+++ b/apps/clock/locales/clock.fr.properties
@@ -35,6 +35,7 @@ dateFormat = %A %e %B
 
 countdown-lessThanAnHour = L’alarme est réglée pour dans <strong>{{minutes}}</strong>.
 countdown-moreThanAnHour = L’alarme est réglée pour dans {{hours}} {{minutes}}.
+countdown-moreThanADay = L’alarme est réglée pour dans {{days}} {{hours}}.
 
 nMinutes={[ plural(n) ]}
 nMinutes[zero]  = moins d’une minute
@@ -44,13 +45,29 @@ nMinutes[few] = {{n}} minutes
 nMinutes[many] = {{n}} minutes
 nMinutes[other] = {{n}} minutes
 
+nHours={[ plural(n) ]}
+nHours[zero] =
+nHours[one] = <strong>{{n}} heure</strong>
+nHours[two] = <strong>{{n}} heures</strong>
+nHours[few] = <strong>{{n}} heures</strong>
+nHours[many] = <strong>{{n}} heures</strong>
+nHours[other] = <strong>{{n}} heures</strong>
+
 nRemainHours={[ plural(n) ]}
 nRemainHours[zero]  =
-nRemainHours[one]   = <strong>{{n}} heure</strong>
-nRemainHours[two] = <strong>{{n}} heures</strong>
-nRemainHours[few] = <strong>{{n}} heures</strong>
-nRemainHours[many] = <strong>{{n}} heures</strong>
-nRemainHours[other] = <strong>{{n}} heures</strong>
+nRemainHours[one]   = et <strong>{{n}} heure</strong>
+nRemainHours[two] = et <strong>{{n}} heures</strong>
+nRemainHours[few] = et <strong>{{n}} heures</strong>
+nRemainHours[many] = et <strong>{{n}} heures</strong>
+nRemainHours[other] = et <strong>{{n}} heures</strong>
+
+nRemainDays={[ plural(n) ]}
+nRemainDays[zero] =
+nRemainDays[one] = <strong>{{n}} jour</strong>
+nRemainDays[two] = <strong>{{n}} jours</strong>
+nRemainDays[few] = <strong>{{n}} jours</strong>
+nRemainDays[many] = <strong>{{n}} jours</strong>
+nRemainDays[other] = <strong>{{n}} jours</strong>
 
 nRemainMinutes={[ plural(n) ]}
 nRemainMinutes[zero]  =


### PR DESCRIPTION
Fixes bug [797792](https://bugzilla.mozilla.org/show_bug.cgi?id=797792).

This fix expresses the remaining time for the alarm to fire in days and hours only in cas that the remaining time is longer than 24 hours. I've added extra locale strings for en-US and fr, but ar and zh-TW should be eventually completed.
