### PR TITLE
Bug 837475 - HTML tags rendered in SMS overview

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -591,6 +591,7 @@ var ThreadListUI = {
 
     // Retrieving params from thread
     var bodyText = (thread.body || '').split('\n')[0];
+    var bodyHTML = Utils.escapeHTML(bodyText);
     var formattedDate = Utils.getFormattedHour(timestamp);
     // Create HTML Structure
     var structureHTML = '<label class="danger">' +
@@ -606,7 +607,7 @@ var ThreadListUI = {
                           '</aside>' +
                           '<p class="name">' + num + '</p>' +
                           '<p><time>' + formattedDate +
-                          '</time>' + bodyText + '</p>' +
+                          '</time>' + bodyHTML + '</p>' +
                         '</a>';
 
     // Update HTML


### PR DESCRIPTION
Escape HTML of SMS bodies when displaying threads
