### PR TITLE
Bug 835750 - Validate the numbers that are passed to the RIL to dial.

### DIFF
--- a/apps/communications/dialer/js/telephony_helper.js
+++ b/apps/communications/dialer/js/telephony_helper.js
@@ -3,6 +3,11 @@
 var TelephonyHelper = (function() {
 
   var call = function(number, oncall, onconnected, ondisconnected, onerror) {
+    var sanitizedNumber = number.replace(/(\s|-|\.|\(|\))/g, '');
+    if (!isValid(sanitizedNumber)) {
+      handleInvalidNumber();
+      return;
+    }
     var settings = window.navigator.mozSettings, req;
     if (settings) {
       var settingsLock = settings.createLock();
@@ -17,23 +22,22 @@ var TelephonyHelper = (function() {
             return;
           }
 
-          startDial(number, oncall, onconnected, ondisconnected, onerror);
+          startDial(sanitizedNumber, oncall, onconnected, ondisconnected, onerror);
         } else {
           handleFlightMode();
         }
       });
     } else {
-      startDial(number, oncall, onconnected, ondisconnected, onerror);
+      startDial(sanitizedNumber, oncall, onconnected, ondisconnected, onerror);
     }
   };
 
-  var startDial = function(number, oncall, connected, disconnected, onerror) {
+  var startDial = function(sanitizedNumber, oncall, connected, disconnected, onerror) {
     var telephony = navigator.mozTelephony;
     if (telephony) {
       var conn = window.navigator.mozMobileConnection;
       var call;
       var cardState = conn.cardState;
-      var sanitizedNumber = number.replace(/-/g, '');
 
       if (cardState === 'pinRequired' || cardState === 'pukRequired') {
         call = telephony.dialEmergency(sanitizedNumber);
@@ -55,6 +59,39 @@ var TelephonyHelper = (function() {
           }
         };
       }
+    }
+  };
+
+  var isValid = function t_isValid(sanitizedNumber) {
+    if (sanitizedNumber) {
+      var matches = sanitizedNumber.match(/[0-9#+*]{1,50}/);
+      if (matches.length === 1 && matches[0].length === sanitizedNumber.length) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  var handleInvalidNumber = function t_handleInvalidNumber() {
+    var showDialog = function fm_showDialog(_) {
+      ConfirmDialog.show(
+        _('invalidNumberToDialTitle'),
+        _('invalidNumberToDialMessage'),
+        {
+          title: _('cancel'),
+          callback: function() {
+            ConfirmDialog.hide();
+          }
+        }
+      );
+    };
+
+    if (window.hasOwnProperty('LazyL10n')) {
+      LazyL10n.get(function localized(_) {
+        showDialog(_);
+      });
+    } else {
+      showDialog(_);
     }
   };
 

--- a/apps/communications/dialer/locales/shared.en-US.properties
+++ b/apps/communications/dialer/locales/shared.en-US.properties
@@ -5,3 +5,5 @@ emergencyDialogBodyBadNumber=To make a call, the phone must be connected to a ne
 emergencyDialogBodyDeviceNotAccepted=Emergency calls are not allowed by the network.
 emergencyDialogBtnOk=OK
 emergencyDialogTitle=No network connection
+invalidNumberToDialTitle=Invalid phone number
+invalidNumberToDialMessage=The phone number you are calling is not valid.

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -210,6 +210,10 @@ suite('dialer/handled_call', function() {
       assert.isTrue(MockCallScreen.mSetCallerContactImageCalled);
     });
 
+    test('primary contact info', function() {
+      assert.isTrue(MockUtils.mCalledGetPhoneNumberPrimaryInfo);
+    });
+
     test('additional contact info', function() {
       assert.isTrue(MockUtils.mCalledGetPhoneNumberAdditionalInfo);
     });

--- a/apps/communications/dialer/test/unit/mock_utils.js
+++ b/apps/communications/dialer/test/unit/mock_utils.js
@@ -2,6 +2,7 @@ var MockUtils = {
   mCalledPrettyDate: false,
   mCalledHeaderDate: false,
   mCalledGetDayDate: false,
+  mCalledGetPhoneNumberPrimaryInfo: false,
   mCalledGetPhoneNumberAdditionalInfo: false,
 
   prettyDate: function ut_prettyDate(time) {
@@ -16,6 +17,11 @@ var MockUtils = {
     this.mCalledGetDayDate = true;
   },
 
+  getPhoneNumberPrimaryInfo: function getPhoneNumberPrimaryInfo(matchingTel,
+    contact) {
+    this.mCalledGetPhoneNumberPrimaryInfo = true;
+  },
+
   getPhoneNumberAdditionalInfo: function getPhoneNumberAdditionalInfo(
     matchingTel, associatedContact) {
     this.mCalledGetPhoneNumberAdditionalInfo = true;
@@ -27,11 +33,13 @@ var MockUtils = {
     this.mCalledPrettyDate = false;
     this.mCalledHeaderDate = false;
     this.mCalledGetDayDate = false;
+    this.mCalledGetPhoneNumberPrimaryInfo = false;
     this.mCalledGetPhoneNumberAdditionalInfo = false;
   },
 
   getPhoneNumberPrimaryInfo: function ut_getPhoneNumberPrimaryInfo(matchingTel,
     contact) {
+    this.mCalledGetPhoneNumberPrimaryInfo = true;
     if (contact) {
       if (contact.name && String(contact.name) !== '') {
         return contact.name;


### PR DESCRIPTION
We include a control to avoid dialing malicious codes passed to the Comms app via the "dial" Web Activity. Basically, we only allow codes composed by numbers and the "*", "#" and "+" characters.
