### PR TITLE
Bug 823401 [System] Strict mode exceptions when launching any app

### DIFF
--- a/apps/system/js/value_selector/spin_date_picker.js
+++ b/apps/system/js/value_selector/spin_date_picker.js
@@ -64,10 +64,8 @@ var SpinDatePicker = (function SpinDatePicker() {
 
   /**
    * Get the order of date components.
-   *
-   * @param {String} date format.
    */
-  function getDateComponentOrder(format) {
+  function getDateComponentOrder() {
     var format = navigator.mozL10n.get('dateTimeFormat_%x');
     var order = '';
     var tokens = format.match(/(%E.|%O.|%.)/g);


### PR DESCRIPTION
Removed the unused "format" parameter from getDateComponentOrder() in SpinDatePicker. The parameter has not been used by any code since its introduction in commit f0c430c478b2893379446fa1076d801d91726c6c

Signed-off-by: Rick Waldron waldron.rick@gmail.com
