### PR TITLE
Bug 838672 [Browser] Default tab title "[object Object]"

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1424,12 +1424,19 @@ var Browser = {
   },
 
   generateTabLi: function browser_generateTabLi(tab, multipleTabs) {
-    var title = tab.title || tab.url || _('new-tab');
     var a = document.createElement('a');
     var li = document.createElement('li');
     var span = document.createElement('span');
     var preview = document.createElement('div');
-    var text = document.createTextNode(title);
+
+    // #838672 Certain browser event (ie. mozbrowsertitlechange) objects
+    // will have an object as the value of the 'detail' property. Avoid
+    // naively assigning an object (as the displayed text) where a string is expected.
+    // TODO: Investigate whether or not to isolate and abstract this logic
+    // for reuse throughout the Browser application.
+    span.innerHTML = tab.title && typeof tab.title === 'string' ?
+      tab.title :  ( tab.url ? tab.url : _('new-tab') );
+
 
     if (multipleTabs) {
       var close = document.createElement('button');
@@ -1442,7 +1449,6 @@ var Browser = {
     a.setAttribute('data-id', tab.id);
     preview.classList.add('preview');
 
-    span.appendChild(text);
     a.appendChild(preview);
     a.appendChild(span);
     li.appendChild(a);
@@ -1755,4 +1761,3 @@ function actHandle(activity) {
 if (window.navigator.mozSetMessageHandler) {
   window.navigator.mozSetMessageHandler('activity', actHandle);
 }
-


### PR DESCRIPTION
Ensure that the value being used to set the display text of a tab is a string (certain event handler logic appear to set the property value to an object).

Remove unnecessary text node creation, assign display text directly to innerHTML of container span node.

https://bugzilla.mozilla.org/show_bug.cgi?id=838672

Signed-off-by: Rick Waldron waldron.rick@gmail.com
