### PR TITLE
Bug 838795 - [Browser] URL bar displays "[object Object]" after viewing ...

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -784,11 +784,22 @@ var Browser = {
   },
 
   setUrlBar: function browser_setUrlBar(data) {
-    if (this.currentTab.url == this.ABOUT_PAGE_URL) {
-      this.urlInput.value = '';
-    } else {
-      this.urlInput.value = data;
+    // Naively assign any value passed to urlInput
+    var urlInput = data;
+
+    // 'urlInput' is assigned to the 'data' arg's value by default.
+    // In the case where either:
+    //
+    //  1. The current tab url and the about page url are the same
+    //  2. 'data' wasn't a string
+    //
+    //  ...
+    if (this.currentTab.url === this.ABOUT_PAGE_URL || typeof data !== 'string') {
+      // ...Override the value of urlInput with an empty string.
+      urlInput = '';
     }
+
+    this.urlInput.value = urlInput;
   },
 
   setUrlButtonMode: function browser_setUrlButtonMode(mode) {


### PR DESCRIPTION
...default tab tray

Similar to https://bugzilla.mozilla.org/show_bug.cgi?id=838672, the tab.title property may be set to an object or whatever the value of event.detail is, this simply adds a logical guard against accidentally attempting to display an "object" where a string is expected.

https://bugzilla.mozilla.org/show_bug.cgi?id=838795

Signed-off-by: Rick Waldron waldron.rick@gmail.com
