### PR TITLE
Bug 837590 - Change button into anchor

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -334,9 +334,9 @@
       </li>
 
       <li class="delete">
-        <button data-l10n-id="event-delete" class="danger delete-record">
+        <a role="button" data-l10n-id="event-delete" class="danger delete-record">
           Delete Event
-        </button>
+        </a>
       </li>
 
     </ol>


### PR DESCRIPTION
For some reason the first button element after a form is getting a click trigger when pressing enter. I'm not sure why this is, but I don't think it's right as it differers from the browser handling.

I'm not sure where the code is that handles that, but as this is a TEF blocker I just wanted to implement the simplest fix possible.
