### PR TITLE
Bug 831682 - [Bluetooth] After clicking the notification to open a received photo, cannot open another one unless pressing back button r=timdream

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -142,6 +142,10 @@ var UtilityTray = {
       evt.initCustomEvent('utilitytrayshow', true, true, null);
       window.dispatchEvent(evt);
     }
+
+    if (WindowManager.stopInlineActivity) {
+      WindowManager.stopInlineActivity(true);
+    }
   }
 };
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -2005,7 +2005,8 @@ var WindowManager = (function() {
     hideCurrentApp: hideCurrentApp,
     restoreCurrentApp: restoreCurrentApp,
     retrieveHomescreen: retrieveHomescreen,
-    retrieveFTU: retrieveFTU
+    retrieveFTU: retrieveFTU,
+    stopInlineActivity: stopInlineActivity
   };
 }());
 


### PR DESCRIPTION
Kill the inline frames when the utility tray showing.
