### PR TITLE
Bug 831457 - [Browser] JS prompt does not focus on the field r=benfrancis

### DIFF
--- a/apps/browser/js/modal_dialog.js
+++ b/apps/browser/js/modal_dialog.js
@@ -114,6 +114,7 @@ var ModalDialog = {
         elements.prompt.hidden = false;
         elements.promptInput.value = evt.detail.initialValue;
         elements.promptMessage.innerHTML = message;
+        elements.promptInput.focus();
         break;
 
       case 'custom-prompt':


### PR DESCRIPTION
Invoke elements.promptInput.focus(); to set focus and therefore a cursor on the prompt's input field.

https://bugzilla.mozilla.org/show_bug.cgi?id=831457

Signed-off-by: Rick Waldron waldron.rick@gmail.com
