### PR TITLE
Bug 838871 - Revert "Bug 808650 - Implement filtering by contact email."

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -440,16 +440,6 @@ contacts.List = (function() {
       sortBy: sortBy,
       sortOrder: 'ascending'
     };
-
-    // We use an empty string here for now because the WebContacts API
-    // is really performing a "startswith" instead of "contains".
-    // We should look at implementing a "nonempty" filter in the future.
-    if (ActivityHandler.activityDataType === 'webcontacts/email') {
-      options.filterBy = ['email'];
-      options.filterOp = 'contains';
-      options.filterValue = '';
-    }
-
     var request = navigator.mozContacts.find(options);
     request.onsuccess = function findCallback() {
       successCb(request.result);


### PR DESCRIPTION
This reverts commit 493b0d71879d033c2c16a6c5044ac34a509e08a5. This is for bug: https://bugzilla.mozilla.org/show_bug.cgi?id=838871

The original fix as implemented for Bug 808650 does not work with how we currently handle imported facebook contacts. We would need to change our approach to handle these, so opening this up in case we want to revert.
