### PR TITLE
Bug 835410 - [Email UX] Wrong use of spinner when sending an email

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -195,11 +195,11 @@
                  regardless of their displayed status so we don't scroll them
                  out of the way -->
             <div class="msg-messages-sync-container">
-              <p role="status" class="msg-messages-syncing collapsed">
+              <p class="msg-messages-syncing collapsed">
                 <progress class="small"></progress>
                 <span data-l10n-id="messages-syncing">Message loadinG</span>
               </p>
-              <p role="status" class="msg-messages-sync-more collapsed">
+              <p class="msg-messages-sync-more collapsed">
                 <span data-l10n-id="messages-sync-more">SynC MorE</span>
               </p>
             </div>
@@ -1031,13 +1031,14 @@
         <span class="cmp-attachment-filesize"></span>
         <button class="cmp-attachment-remove">X</span>
       </li>
-      <div class="cmp-sending-container">
-        <p role="status" class="cmp-messages-sending">
-          <progress></progress>
-          <span class="cmp-sending-text" data-l10n-id="compose-sending-message">Sending messagE
-          </span>
-        </p>
-      </div>
+      <form role="dialog" data-type="confirm" class="cmp-sending-container">
+        <section class="cmp-messages-sending">
+          <h1 data-l10n-id="compose-sending-message">Sending messagE</h1>
+          <p style="text-align: center">
+            <progress></progress>
+          </p>   
+        </section>
+      </form>
     </div>
     <!-- Widget nodes for the setup cards; styles use the sup prefix -->
     <div id="templ-sup">

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -35,7 +35,7 @@
 }
 
 input.cmp-addr-text, input.cmp-subject-text {
-  border: 0;
+  border: 0 !important;
   background: none;
   padding: 0;
   height: auto;
@@ -91,28 +91,6 @@ input.cmp-subject-text {
   background: #fff;
 }
 
-.cmp-sending-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 20;
-  background: rgba(0,0,0,.8);
-}
-
-.cmp-messages-sending {
-  position: absolute;
-  top:40%;
-  width: 80%;
-  padding: 0 10% !important;
-}
-
-.cmp-sending-text {
-  color: white;
-  font: 600 2.3rem/1em "MozTT",Sans-serif;
-  padding: 0 1rem;
-}
 /* Attachment */
 .cmp-attachments-container {
   padding: 0 1rem;

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -450,15 +450,19 @@ input.msg-search-text-tease {
 }
 
 /* PROGRESS LABEL BUILDING BLOCKS EXTENSION */
-.msg-messages-sync-container > p[role="status"],
+.msg-messages-sync-container > p,
 .msg-list-empty {
   width: 80%;
   padding: 2rem 10%;
   text-align: center;
+  font: 500 1.3rem/1em "MozTT", Sans-serif;
 }
 .msg-list-empty {
   position: absolute;
   top: 40%;
+}
+.msg-messages-syncing > span {
+  margin: 0 1rem;
 }
 .msg-messages-sync-more {
   margin: 3rem 0;
@@ -466,7 +470,7 @@ input.msg-search-text-tease {
   border-bottom: 1px solid lightgray;
 }
 .msg-messages-sync-more > span {
-  margin: 0 !important;
+  margin: 0;
 }
 
 /* Filters selected state */


### PR DESCRIPTION
- Fix the UX issue : https://bugzilla.mozilla.org/show_bug.cgi?id=835410
- Fix the regression caused by building-block change: Remove the BB style on message syncing/sync more block sine the status style changed a lot and not suitable for these blocks.
- Fix the compose view input regression in setup page layout fixing.
