### PR TITLE
bug 839552 - ignore generated file icc.json; r=fabrice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ manifest.appcache
 /apps/*/test/unit/_proxy.html
 /apps/*/shared
 /apps/settings/resources/support.json
+/apps/settings/resources/icc.json
 /test_apps/*/test/unit/_sandbox.html
 /test_apps/*/test/unit/_proxy.html
 /showcase_apps/*/test/unit/_sandbox.html


### PR DESCRIPTION
_build/applications-data.js_ generates _apps/settings/resources/icc.json_, so _.gitignore_ should ignore it to suppress spurious "untracked files" warnings by Git after building Gaia:

```
02-08 09:45 > git status
# On branch master
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#   apps/settings/resources/icc.json
nothing added to commit but untracked files present (use "git add" to track)
```
