### PR TITLE
Bug 839574 - gaia HEAD stuck at "Based on Mozilla Technology" screen

### DIFF
--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -34,7 +34,10 @@ l10nDictionary.locales[GAIA_DEFAULT_LOCALE] = {};
  * whitelist by app name for javascript asset aggregation.
  */
 const JS_AGGREGATION_BLACKLIST = [
-  'communications'
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=839454
+  'communications',
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=839574
+  'system'
 ];
 
 /**


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=839574
Signed-off-by: Rick Waldron waldron.rick@gmail.com
