### PR TITLE
Bug 837055 - enable word suggestion for Spanish keyboard layout. r=djf, ...

### DIFF
--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -173,9 +173,10 @@ const Keyboards = {
     }
   },
   es: {
-    type: 'keyboard',
     label: 'Spanish',
     menuLabel: 'Español',
+    imEngine: 'latin',
+    needsCandidatePanel: 'true',
     alt: {
       a: 'áªàâäåãāæ',
       c: 'ç',
@@ -275,7 +276,6 @@ const Keyboards = {
     }
   },
   pt_BR: {
-    type: 'keyboard',
     label: 'Portuguese',
     menuLabel: 'Português',
     imEngine: 'latin',
@@ -825,7 +825,6 @@ const Keyboards = {
     ]
   },
   'zh-Hans-Pinyin-number': {
-    type: 'keyboard',
     disableAlternateLayout: true,
     hidesSwitchKey: true,
     typeInsensitive: true,
@@ -851,7 +850,6 @@ const Keyboards = {
     ]
   },
   'zh-Hans-Pinyin-symbol0': {
-    type: 'keyboard',
     disableAlternateLayout: true,
     hidesSwitchKey: true,
     typeInsensitive: true,
@@ -877,7 +875,6 @@ const Keyboards = {
     ]
   },
   'zh-Hans-Pinyin-symbol1': {
-    type: 'keyboard',
     disableAlternateLayout: true,
     hidesSwitchKey: true,
     typeInsensitive: true,
@@ -903,7 +900,6 @@ const Keyboards = {
     ]
   },
   'zh-Hans-Pinyin-symbol2': {
-    type: 'keyboard',
     disableAlternateLayout: true,
     hidesSwitchKey: true,
     typeInsensitive: true,
@@ -929,7 +925,6 @@ const Keyboards = {
     ]
   },
   ar: {
-    type: 'keyboard',
     label: 'Arabic',
     menuLabel: 'العربية',
     alternateLayoutKey: '123',
@@ -994,7 +989,6 @@ const Keyboards = {
     }
   },
   el: {
-    type: 'keyboard',
     label: 'Greek',
     menuLabel: 'Greek',
     alt: {


### PR DESCRIPTION
...a=blocking-b2g:tef+

(cherry picked from commit c0c1217639bd1adf469d4da0d05d43daca9d4c14)

Conflicts:
    apps/keyboard/js/layout.js
