### PR TITLE
Bug 837251 - Compose textarea doesn't occupy available screen space or show bounding box (leading to users thinking messages are truncated).

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -346,7 +346,7 @@
           </div>
           <ul class="cmp-attachments-container">
           </ul>
-          <textarea class="cmp-body-text" rows="1"></textarea>
+          <textarea class="cmp-body-text"></textarea>
           <div class="cmp-body-html">
           </div>
         </div>

--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -343,17 +343,7 @@ ComposeCard.prototype = {
    * Make our textarea grow as new lines are added...
    */
   onTextBodyDelta: function() {
-    var value = this.textBodyNode.value, newlines = 0, idx = -1;
-    while (true) {
-      idx = value.indexOf('\n', idx + 1);
-      if (idx === -1)
-        break;
-      newlines++;
-    }
-    // the last line won't have a newline
-    var neededRows = newlines + 1;
-    if (this.textBodyNode.rows !== neededRows)
-      this.textBodyNode.rows = neededRows;
+    this.textBodyNode.style.height = this.textBodyNode.scrollHeight + 'px';
   },
 
   onClickRemoveAttachment: function(node, attachment) {

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -80,9 +80,9 @@ input.cmp-subject-text {
   -moz-box-sizing: border-box;
   width: calc(100% - 4rem);
   min-height: 10rem;
+  max-height: none !important;
   margin: 1.5rem 2rem;
   display: block;
-  overflow: hidden;
   padding: 0rem;
   font: 1.4rem/2rem "MozTT", Sans-serif;
   font-weight: normal;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=837251
r? @mozsquib
