### PR TITLE
Bug 840362 - Slight performance improvement to homescreen panning.

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -88,7 +88,6 @@ const GridManager = (function() {
         next.MozTransition = '';
         next.MozTransform = 'translateX(' + windowWidth + 'px)';
 
-        var translate = 'translateX($px)';
         var startX = startEvent.pageX;
         var forward = deltaX > 0;
 
@@ -96,42 +95,42 @@ const GridManager = (function() {
         if (index === 0) {
           refresh = function(e) {
             if (deltaX <= 0) {
-              next.MozTransform = translate.replace('$', windowWidth + deltaX);
-              current.MozTransform = translate.replace('$', deltaX);
+              next.MozTransform = 'translateX(' + (windowWidth + deltaX) + 'px)';
+              current.MozTransform = 'translateX(' + deltaX + 'px)';
             }
           };
         } else if (index === pages.length - 1) {
           refresh = function(e) {
             if (deltaX >= 0) {
               previous.MozTransform =
-                translate.replace('$', -windowWidth + deltaX);
-              current.MozTransform = translate.replace('$', deltaX);
+                'translateX(' + (-windowWidth + deltaX) + 'px)';
+              current.MozTransform = 'translateX(' + deltaX + 'px)';
             }
           };
         } else {
           refresh = function(e) {
             if (deltaX >= 0) {
               previous.MozTransform =
-                translate.replace('$', -windowWidth + deltaX);
+                'translateX(' + (-windowWidth + deltaX) + 'px)';
 
               // If we change direction make sure there isn't any part
               // of the page on the other side that stays visible.
               if (!forward) {
                 forward = true;
-                next.MozTransform = translate.replace('$', windowWidth);
+                next.MozTransform = 'translateX(' + windowWidth + 'px)';
               }
             } else {
-              next.MozTransform = translate.replace('$', windowWidth + deltaX);
+              next.MozTransform = 'translateX(' + (windowWidth + deltaX) + 'px)';
 
               // If we change direction make sure there isn't any part
               // of the page on the other side that stays visible.
               if (forward) {
                 forward = false;
-                previous.MozTransform = translate.replace('$', -windowWidth);
+                previous.MozTransform = 'translateX(' + (-windowWidth) + 'px)';
               }
             }
 
-            current.MozTransform = translate.replace('$', deltaX);
+            current.MozTransform = 'translateX(' + deltaX + 'px)';
           };
         }
 


### PR DESCRIPTION
According to a perf test I just ran, we may be able to slightly improve responsiveness with a small change. The perf test is here: http://jsperf.com/test-string-replace-regexp-vs-string

This is showing me that inline string concatenation is the fastest possible operation to perform, which makes sense. Even though the gain is tiny, I'd recommend going with this as this is called rapidly within a touchmove event.
