### PR TITLE
Bug 832269 - Clean up calendar styles.

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -305,28 +305,40 @@
       </li>
 
       <li class="start-date">
-        <input name="startDate" data-l10n-id="event-start-date" placeholder="Date" type="date" />
+        <span class="button icon icon-dialog">
+          <input name="startDate" data-l10n-id="event-start-date" placeholder="Date" type="date" />
+        </span>
       </li>
 
       <li class="start-time">
-        <input type="time" data-l10n-id="event-start-time" placeholder="Start Time" name="startTime" />
+        <span class="button icon icon-dialog">
+          <input type="time" data-l10n-id="event-start-time" placeholder="Start Time" name="startTime" />
+        </span>
       </li>
 
       <li class="end-date">
-        <input name="endDate" data-l10n-id="event-end-date" placeholder="Date" type="date" />
+        <span class="button icon icon-dialog">
+          <input name="endDate" data-l10n-id="event-end-date" placeholder="Date" type="date" />
+        </span>
       </li>
 
       <li class="end-time">
-        <input type="time" data-l10n-id="event-end-time" placeholder="End Time" name="endTime" />
+        <span class="button icon icon-dialog">
+          <input type="time" data-l10n-id="event-end-time" placeholder="End Time" name="endTime" />
+        </span>
       </li>
 
       <li class="current-calendar">
-        <input name="currentCalendar" />
+        <span class="button icon icon-dialog" aria-disabled="true">
+          <input name="currentCalendar" />
+        </span>
       </li>
 
       <li class="calendar-id">
-        <select name="calendarId">
-        </select>
+        <span class="button icon icon-dialog">
+          <select name="calendarId">
+          </select>
+        </span>
       </li>
 
       <li class="notes">

--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -50,6 +50,7 @@ Calendar.ns('Views').ModifyEvent = (function() {
       this.saveButton.addEventListener('click', this.save);
       this.deleteButton.addEventListener('click', this.deleteRecord);
       this.cancelButton.addEventListener('click', this.cancel);
+      this.form.addEventListener('click', this.focusHandler);
       this.form.addEventListener('submit', this.save);
 
       var allday = this.getField('allday');
@@ -327,6 +328,16 @@ Calendar.ns('Views').ModifyEvent = (function() {
      */
     cancel: function() {
       window.back();
+    },
+
+    /**
+     * Enlarges focus areas for .button controls
+     */
+    focusHandler: function(e) {
+      var input = e.target.querySelector('input');
+      if (input && e.target.classList.contains('button')) {
+        input.focus();
+      }
     },
 
     /**

--- a/apps/calendar/style/modify_event_view.css
+++ b/apps/calendar/style/modify_event_view.css
@@ -2,6 +2,14 @@
   margin: 1rem 1rem 0 1rem;
 }
 
+#modify-event-view .button {
+  margin-bottom: 0;
+}
+
+#modify-event-view .button input {
+  width: 100%;
+}
+
 #modify-event-view form ol li {
   margin: 0rem;
 }
@@ -29,8 +37,10 @@
 }
 
 #modify-event-view li.allday {
-  padding: 1rem;
+  padding: 0 1rem;
   position: relative;
+  font-size: 1.4rem;
+  line-height: 3rem;
 }
 
 #modify-event-view li.allday > label {
@@ -57,6 +67,15 @@
 
 #modify-event-view.create .current-calendar {
   display: none;
+}
+
+#modify-event-view .calendar-id,
+#modify-event-view .current-calendar {
+  clear: both;
+}
+
+#modify-event-view .calendar-id select {
+  font-size: 1.4rem;
 }
 
 #modify-event-view.readonly menu,

--- a/shared/style/buttons.css
+++ b/shared/style/buttons.css
@@ -2,6 +2,7 @@
  * Buttons
  * ---------------------------------- */
 
+.button::-moz-focus-inner,
 a[role="button"]::-moz-focus-inner,
 button::-moz-focus-inner {
   border: none;
@@ -9,7 +10,8 @@ button::-moz-focus-inner {
 }
 
 button,
-a[role="button"] {
+a[role="button"],
+.button {
   width: 100%;
   height: 3.8rem;
   margin: 0 0 1rem;
@@ -51,7 +53,8 @@ a[role="button"].recommend {
 
 /* Danger */
 button.danger,
-a.danger[role="button"] {
+a.danger[role="button"],
+span.danger[role="button"] {
   background-image: url(buttons/images/ui/danger.png);
   background-color: #b70404;
   color: #fff;
@@ -61,7 +64,8 @@ a.danger[role="button"] {
 
 /* Danger Press */
 button.danger:active,
-a[role="button"].danger:active {
+a[role="button"].danger:active,
+.button.danger:active {
   background-image: url(buttons/images/ui/danger-press.png);
   background-color: #890707;
 }
@@ -69,8 +73,10 @@ a[role="button"].danger:active {
 /* Disabled (default & recommend) */
 button[disabled],
 a[role="button"][aria-disabled="true"],
+.button[aria-disabled="true"],
 button[disabled].recommend,
-a[role="button"][aria-disabled="true"].recommend {
+a[role="button"][aria-disabled="true"].recommend,
+.button[aria-disabled="true"].recommend {
   background: #e7e7e7;
   border-color: #c7c7c7;
   color: #c7c7c7;
@@ -80,6 +86,7 @@ a[role="button"][aria-disabled="true"].recommend {
 
 /* Danger disabled */
 button[disabled].danger,
+.button[aria-disabled="true"].danger,
 a[role="button"][aria-disabled="true"].danger {
   background: #c68484;
   border-color: #a56464;
@@ -90,6 +97,7 @@ a[role="button"][aria-disabled="true"].danger {
 
 /* Disabled with dark background */
 .dark button[disabled],
+.dark .button[aria-disabled="true"],
 .dark a[role="button"][aria-disabled="true"] {
   background: #5f5f5f;
   color: #4d4d4d;
@@ -104,7 +112,8 @@ a[role="button"][aria-disabled="true"].danger {
  * ---------------------------------- */
 
 li button,
-li a[role="button"] {
+li a[role="button"],
+li .button {
   position: relative;
   background: #e7e7e7;
   text-align: left;
@@ -115,7 +124,8 @@ li a[role="button"] {
 
 /* Hacking box-shadow */
 li button:after,
-li a[role="button"]:after {
+li a[role="button"]:after,
+li .button:after {
   content: "";
   position: absolute;
   bottom: -0.3rem;
@@ -127,24 +137,28 @@ li a[role="button"]:after {
 
 /* Press */
 li a[role="button"]:active:after,
+li .button:active:after,
 li button:active:after {
   opacity: 0;
 }
 
 /* Disabled */
 li button[disabled]:after,
-li a[role="button"][aria-disabled="true"]:after {
+li a[role="button"][aria-disabled="true"]:after,
+li .button[aria-disabled="true"]:after {
   background: none;
 }
 
 /* Icons */
 li button.icon,
-li a[role="button"].icon {
+li a[role="button"].icon,
+li .button.icon {
   padding-right: 3rem;
 }
 
 li button.icon:before,
-li a[role="button"].icon:before {
+li a[role="button"].icon:before,
+li .button.icon:before {
   content: "";
   width: 3rem;
   height: 3rem;
@@ -172,19 +186,22 @@ li a[role="button"][aria-disabled="true"].icon-view:before {
 }
 
 li button.icon-dialog:before,
-li a[role="button"].icon-dialog:before {
+li a[role="button"].icon-dialog:before,
+li .button.icon-dialog:before {
   background: url(buttons/images/icons/dialog.png) no-repeat 1.6rem 0 / 1rem 9rem;
   top: 100%;
   margin-top: -2.4rem;
 }
 
 li button.icon-dialog:active:before,
-li a[role="button"].icon-dialog:active:before {
+li a[role="button"].icon-dialog:active:before,
+li .button.icon-dialog:active:before {
   background-position: 1.6rem -3rem;
 }
 
 li button.icon-dialog:disabled:before,
-li a[role="button"][aria-disabled="true"].icon-dialog:before {
+li a[role="button"][aria-disabled="true"].icon-dialog:before,
+li .button[aria-disabled="true"].icon-dialog:before {
   background-position: 1.6rem -6rem;
 }
 
@@ -227,4 +244,16 @@ ol.compact {
 .compact > li a[role="button"][aria-disabled="true"] {
   color: #a6a6a6;
   border-color: #a6a6a6;
+}
+
+/* Inputs inside of .button */
+.button input,
+body[role="application"] .button input {
+  border: 0;
+  background: none;
+}
+
+/* Hides dropdown arrow until bug #649849 is fixed */
+.button.icon select {
+   width: 130%;
 }


### PR DESCRIPTION
This change request implements the minimum changes necessary to support updates to the modify event flow in calendar.

In order to do this in a way that I thought was re-useable, without too much JS - I needed to modify building blocks. If we are unable to land the building blocks changes, then we will need to copy/paste a lot of it into calendar, and I wanted to avoid that.

This patch introduces changes to buttons.css and allows a wrapping <span> tag around inputs for styling. We have support for anchors, but it seems wrong to wrap an anchor around an input. Here is an example of the implementation:

```
 <span role="button" class="icon icon-dialog">
  <input type="date" />
</span>
```
