### PR TITLE
Bug 837236 - add deprecated-hwvideo permission to Gallery app

### DIFF
--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -11,6 +11,7 @@
   "permissions": {
     "device-storage:pictures":{ "access": "readwrite" },
     "device-storage:videos":{ "access": "readwrite" },
+    "deprecated-hwvideo":{},
     "audio-channel-content":{},
     "settings":{ "access": "readonly" }
   },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=837236
