### PR TITLE
Bug 837269 - Remove "Sent from my Firefox OS" tag line from email app. r=squib

### DIFF
--- a/apps/email/js/ext/gaia-email-opt.js
+++ b/apps/email/js/ext/gaia-email-opt.js
@@ -35233,10 +35233,6 @@ const PIECE_ACCOUNT_TYPE_TO_CLASS = {
   //'gmail-imap': GmailAccount,
 };
 
-// A boring signature that conveys the person was probably typing on a touch
-// screen, helping to explain typos and short replies.
-const DEFAULT_SIGNATURE = exports.DEFAULT_SIGNATURE =
-  'Sent from my Firefox OS device.';
 
 // The number of milliseconds to wait for various (non-ActiveSync) XHRs to
 // complete during the autoconfiguration process. This value is intentionally
@@ -35653,7 +35649,7 @@ Configurators['imap+smtp'] = {
           name: userDetails.displayName,
           address: userDetails.emailAddress,
           replyTo: null,
-          signature: DEFAULT_SIGNATURE
+          signature: null
         },
       ],
       tzOffset: tzOffset,
@@ -35716,7 +35712,7 @@ Configurators['fake'] = {
           name: userDetails.displayName,
           address: userDetails.emailAddress,
           replyTo: null,
-          signature: DEFAULT_SIGNATURE
+          signature: null
         },
       ]
     };
@@ -35838,7 +35834,7 @@ Configurators['activesync'] = {
             name: userDetails.displayName || domainInfo.displayName,
             address: userDetails.emailAddress,
             replyTo: null,
-            signature: DEFAULT_SIGNATURE
+            signature: null
           },
         ]
       };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=837269
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/123
