### PR TITLE
Bug 834696 - Implementing new tab transitions and avoiding disturbing blank flash when disposing settings

### DIFF
--- a/apps/costcontrol/index.html
+++ b/apps/costcontrol/index.html
@@ -79,7 +79,7 @@
     </ul>
 
     <!-- BALANCE TAB -->
-    <section role="region" id="balance-tab" class="view" data-viewport="behind">
+    <section role="region" id="balance-tab" class="view" data-viewport="left">
 
       <section class="content">
 
@@ -129,7 +129,7 @@
     </section>
 
     <!-- TELEPHONY TAB -->
-    <section role="region" id="telephony-tab" class="view" data-viewport="behind">
+    <section role="region" id="telephony-tab" class="view" data-viewport="left">
       <section class="settings">
         <ul>
           <li>
@@ -210,7 +210,7 @@
     </section>
 
     <!-- DATA USAGE TAB -->
-    <section id="datausage-tab" role="region" class="view" data-viewport="behind">
+    <section id="datausage-tab" role="region" class="view" data-viewport="right">
       <div class="view-scroll">
         <section class="content">
           <section id="graphic-area" class="graph">

--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -64,7 +64,7 @@ var CostControlApp = (function() {
   function setupApp() {
     // View managers for dialogs and settings
     tabmanager = new ViewManager(
-      ['balance-tab', 'telephony-tab', 'datausage-tab']
+      ['balance-tab', 'telephony-tab', { id:'datausage-tab', tab:'right' }]
     );
     settingsVManager = new ViewManager();
 

--- a/apps/costcontrol/js/utils/debug.js
+++ b/apps/costcontrol/js/utils/debug.js
@@ -1,4 +1,4 @@
-var DEBUGGING = false;
+var DEBUGGING = true;
 
 var debug = (function() {
   var SEQ_ID = 0;

--- a/apps/costcontrol/js/view_manager.js
+++ b/apps/costcontrol/js/view_manager.js
@@ -3,109 +3,125 @@
 
 'use strict';
 
-// The ViewManager is in charge of simply manage the different views of the
-// applications. ViewManager.changeViewTo() valid values are listed above
-// these lines.
-var ViewManager = function ViewManager(tabs) {
-  tabs = tabs || [];
+var ViewManager = (function () {
 
-  this._tabs = {};
-  tabs.forEach(function _registerTab(tabId) {
-    this._tabs[tabId] = true;
-  }, this);
+  // The ViewManager is in charge of simply manage the different views of the
+  // applications. ViewManager.changeViewTo() valid values are listed above
+  // these lines.
+  function ViewManager(tabs) {
+    tabs = tabs || [];
 
-  this._currentView = null;
-  this._currentTab = null;
+    this._tabs = {};
+    tabs.forEach(function _registerTab(tabItem) {
+      if (typeof tabItem !== 'object') {
+        tabItem = { id:tabItem };
+      }
+      this._tabs[tabItem.id] = tabItem.tab || 'left';
+    }, this);
 
-};
+    this._currentView = null;
+    this._currentTab = null;
 
-// Return true if the passed view is a tab
-ViewManager.prototype._isTab = function _isTab(view) {
-  return this._tabs.hasOwnProperty(view);
-};
+  };
 
-// Make target enter screen's main area and call callback after, passing as
-// arguments if the new view is a tab, the new view id and a third parameter
-// depending on if the view was a tab or not:
-//   If it is a tab: it returns the current overlay view id or null
-//   If it is not a tab: it returns the previous ovrlay view or null
-ViewManager.prototype.changeViewTo = function _changeViewTo(viewId, callback) {
-  this.closeCurrentView();
+  // Return true if the passed view is a tab
+  ViewManager.prototype._isTab = function _isTab(view) {
+    return this._tabs.hasOwnProperty(view);
+  };
 
-  var previousViewId, currentViewId;
-
-  // Note here how we set the same value with different semantincs.
-  // This is used at the end of the function and the names are the correct
-  // because, depending on if the view is a tab or not, semantics may change.
-  previousViewId = currentViewId = this._currentView ?
-                                   this._currentView.id : null;
-  var isTab = this._isTab(viewId);
-
-  // Tabs are treated in a different way than overlay views
-  if (isTab) {
-    // Hide all
-    for (var tabId in this._tabs) if (this._tabs.hasOwnProperty(tabId)) {
-      document.getElementById(tabId).dataset.viewport = 'behind';
-      document.getElementById(tabId + '-filter')
-        .setAttribute('aria-selected', 'false');
+  // Make target enter screen's main area and call callback after, passing as
+  // arguments if the new view is a tab, the new view id and a third parameter
+  // depending on if the view was a tab or not:
+  //   If it is a tab: it returns the current overlay view id or null
+  //   If it is not a tab: it returns the previous ovrlay view or null
+  ViewManager.prototype.changeViewTo = function _changeViewTo(viewId,
+                                                              callback) {
+    if (this.isCurrentView(viewId)) {
+      return;
     }
 
-    // Show the proper one
-    document.getElementById(viewId).dataset.viewport = '';
-    document.getElementById(viewId + '-filter')
-      .setAttribute('aria-selected', 'true');
+    // Note here how we set the same value with different semantincs.
+    // This is used at the end of the function and the names are the correct
+    // because, depending on if the view is a tab or not, semantics may change.
+    var previousViewId, currentViewId;
+    previousViewId = currentViewId = this._currentView ?
+                                     this._currentView.id : null;
 
-    this._currentTab = viewId;
+    // Tabs are treated in a different way than overlay views
+    var isTab = this._isTab(viewId);
+    if (isTab) {
 
-  // Overlay view
-  } else {
-    var view = document.getElementById(viewId);
-    var previousViewId = this._currentView ? this._currentView.id : '';
-    this._currentView = {
-      id: viewId,
-      defaultViewport: view.dataset.viewport
-    };
+      // Disposing the current view
+      var disposingTab = null;
+      if (this._currentTab) {
+        disposingTab = document.getElementById(this._currentTab);
+      }
+      if (disposingTab) {
+        disposingTab.dataset.viewport = this._tabs[disposingTab.id];
+        document.getElementById(disposingTab.id + '-filter')
+          .setAttribute('aria-selected', 'false');
+      }
 
-    // With a combination of CSS, we actually animate and display the view
-    view.dataset.viewport = '';
-  }
+      // Showing the new one
+      var enteringTab = document.getElementById(viewId);
+      enteringTab.dataset.viewport = '';
+      document.getElementById(enteringTab.id + '-filter')
+        .setAttribute('aria-selected', 'true');
 
-  if (callback) {
-    callback(isTab, viewId, isTab ? currentViewId : previousViewId);
-  }
-};
+      this._currentTab = viewId;
 
-// Close the current view returning to the previous one
-ViewManager.prototype.closeCurrentView = function _closeCurrentView() {
-  // Tabs can not be closed
-  if (!this._currentView || this._isTab(this._currentView.id)) {
-    return;
-  }
+    // Overlay view
+    } else {
+      this.closeCurrentView();
+      var view = document.getElementById(viewId);
+      var previousViewId = this._currentView ? this._currentView.id : '';
+      this._currentView = {
+        id: viewId,
+        defaultViewport: view.dataset.viewport
+      };
 
-  var view = document.getElementById(this._currentView.id);
+      // With a combination of CSS, we actually animate and display the view
+      delete view.dataset.viewport;
+    }
 
-  // With a combination of CSS, Restoring the last viewport we actually
-  // animate and hide the current view
-  view.dataset.viewport = this._currentView.defaultViewport;
-  this._currentView = null;
-};
+    if (callback) {
+      callback(isTab, viewId, isTab ? currentViewId : previousViewId);
+    }
+  };
 
-// Test if the current view is the one passed as parameter
-ViewManager.prototype.isCurrentView = function _isCurrentView(view) {
-  return this._currentView && this._currentView.id === view;
-};
+  // Close the current view returning to the previous one
+  ViewManager.prototype.closeCurrentView = function _closeCurrentView() {
+    if (!this._currentView) {
+      return;
+    }
 
-// Return the current view id or null if not current view
-ViewManager.prototype.getCurrentView = function _getCurrentView() {
-  return this._currentView ? this._currentView.id : null;
-};
+    var view = document.getElementById(this._currentView.id);
 
-// Return true if the tab id passed is the current tab
-ViewManager.prototype.isCurrentTab = function _isCurrentTab(tab) {
-  return this._currentTab && this._currentTab === tab;
-};
+    // With a combination of CSS, Restoring the last viewport we actually
+    // animate and hide the current view
+    view.dataset.viewport = this._currentView.defaultViewport;
+    this._currentView = null;
+  };
 
-// Return the current tab
-ViewManager.prototype.getCurrentTab = function _getCurrentTab() {
-  return this._currentTab;
-};
+  // Test if the current view is the one passed as parameter
+  ViewManager.prototype.isCurrentView = function _isCurrentView(view) {
+    return this._currentView && this._currentView.id === view;
+  };
+
+  // Return the current view id or null if not current view
+  ViewManager.prototype.getCurrentView = function _getCurrentView() {
+    return this._currentView ? this._currentView.id : null;
+  };
+
+  // Return true if the tab id passed is the current tab
+  ViewManager.prototype.isCurrentTab = function _isCurrentTab(tab) {
+    return this._currentTab && this._currentTab === tab;
+  };
+
+  // Return the current tab
+  ViewManager.prototype.getCurrentTab = function _getCurrentTab() {
+    return this._currentTab;
+  };
+
+  return ViewManager;
+}());

--- a/apps/costcontrol/style/app.css
+++ b/apps/costcontrol/style/app.css
@@ -55,7 +55,8 @@ input.error {
 .view {
   top: 9.1rem;
   background: url(images/app/ui/pattern.png) repeat left top;
-  -moz-transition: -moz-transform 0.3s ease;
+  transform: translate(0, 0);
+  transition: transform 0.3s ease;
 }
 
 .view.standalone {
@@ -82,23 +83,23 @@ input.error {
 }
 
 .view[data-viewport="bottom"] {
-  -moz-transform: translateY(100%);
+  transform: translateY(100%);
 }
 
 .view[data-viewport="top"] {
-  -moz-transform: translateY(-100%);
+  transform: translateY(-100%);
 }
 
 .view[data-viewport="left"] {
-  -moz-transform: translateX(-100%);
+  transform: translateX(-100%);
 }
 
 .view[data-viewport="right"] {
-  -moz-transform: translateX(100%);
+  transform: translateX(100%);
 }
 
 .view[data-viewport="inside"] {
-  -moz-transform: scale(0.3);
+  transform: scale(0.3);
   opacity: 0;
   pointer-events: none;
 }


### PR DESCRIPTION
There is a big indentation change so please add ?w=1 to the URL to ignore whitespaces when reviewing the PR.
