### PR TITLE
Bug 810773 - Initial drop shadow for all day row

### DIFF
--- a/apps/calendar/style/day_views.css
+++ b/apps/calendar/style/day_views.css
@@ -156,4 +156,7 @@
 
 #day-view .day-events.allday {
   height: 6rem;
+  box-shadow: 0px 5px 5px 0px rgba(1, 1, 1, 0.2);
+  position: relative;
+  z-index: 11;
 }

--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -144,6 +144,9 @@
   border-bottom: 1px solid #2A2A2A;
   height: 8rem;
   overflow: hidden;
+  box-shadow: 0px 5px 5px 0px rgba(1, 1, 1, 0.2);
+  position: relative;
+  z-index: 11;
 }
 
 #week-view .all-day {


### PR DESCRIPTION
This adds a simple drop shadow for each all day row. The position relative/z-index rules are to get the top row to pop-out over the events in the below container.
