### PR TITLE
Uses the new .button class we've recently created in buttons.css

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -176,14 +176,15 @@
         </li>
         <li>
           <p data-l10n-id="security">Security</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select>
-              <option data-l10n-id="securityNone">none</option>
-              <option>WEP</option>
-              <option selected>WPA-PSK</option>
-              <option>WPA-EAP</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select>
+                <option data-l10n-id="securityNone">none</option>
+                <option>WEP</option>
+                <option selected>WPA-PSK</option>
+                <option>WPA-EAP</option>
+              </select>
+            </span>
           </p>
         </li>
         <li class="identity">
@@ -541,13 +542,14 @@
       <ul>
         <li>
           <p data-l10n-id="operator-networkType">Network Type</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select name="ril.radio.preferredNetworkType" id="preferredNetworkType">
-              <option data-l10n-id="operator-networkType-auto" value="wcdma/gsm">Automatic</option>
-              <option data-l10n-id="operator-networkType-2G" value="gsm">2G only</option>
-              <option data-l10n-id="operator-networkType-3G" value="wcdma">3G only</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="ril.radio.preferredNetworkType" id="preferredNetworkType">
+                <option data-l10n-id="operator-networkType-auto" value="wcdma/gsm">Automatic</option>
+                <option data-l10n-id="operator-networkType-2G" value="gsm">2G only</option>
+                <option data-l10n-id="operator-networkType-3G" value="wcdma">3G only</option>
+              </select>
+            </span>
           </p>
         </li>
         <li id="operator-autoSelect">
@@ -950,13 +952,14 @@
         </li>
         <li>
           <p data-l10n-id="wifi-security">Security</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">Security</button>
-            <select class="security-selector" data-setting="tethering.wifi.security.type">
-              <option value="open" data-l10n-id="hotspot-open">open</option>
-              <option value="wpa-psk" data-l10n-id="hotspot-wpa-psk">WPA (TKIP)</option>
-              <option value="wpa2-psk" data-l10n-id="hotspot-wpa2-psk">WPA2 (AES)</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select class="security-selector" data-setting="tethering.wifi.security.type">
+                <option value="open" data-l10n-id="hotspot-open">open</option>
+                <option value="wpa-psk" data-l10n-id="hotspot-wpa-psk">WPA (TKIP)</option>
+                <option value="wpa2-psk" data-l10n-id="hotspot-wpa2-psk">WPA2 (AES)</option>
+              </select>
+            </span>
           </p>
         </li>
       </ul>
@@ -1101,8 +1104,8 @@
       <ul>
         <li>
           <p data-l10n-id="ringer">Ringer</p>
-          <p class="fake-select">
-            <button id="call-tone-selection" class="tone-select" data-l10n-id="change"></button>
+          <p>
+            <button id="call-tone-selection" class="tone-select icon icon-dialog" data-l10n-id="change"></button>
           </p>
         </li>
       </ul>
@@ -1179,15 +1182,16 @@
         </li>
         <li id="screen-timeout">
           <p data-l10n-id="screen-timeout">Screen Timeout</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select name="screen.timeout" data-value-type="integer">
-              <option value="60"  data-l10n-id="one-minute" selected>1 minute</option>
-              <option value="120" data-l10n-id="two-minutes"> 2 minutes</option>
-              <option value="300" data-l10n-id="five-minutes">5 minutes</option>
-              <option value="600" data-l10n-id="ten-minutes">10 minutes</option>
-              <option value="0"   data-l10n-id="never">Never</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="screen.timeout" data-value-type="integer">
+                <option value="60"  data-l10n-id="one-minute" selected>1 minute</option>
+                <option value="120" data-l10n-id="two-minutes"> 2 minutes</option>
+                <option value="300" data-l10n-id="five-minutes">5 minutes</option>
+                <option value="600" data-l10n-id="ten-minutes">10 minutes</option>
+                <option value="0"   data-l10n-id="never">Never</option>
+              </select>
+            </span>
           </p>
         </li>
       </ul>
@@ -1272,16 +1276,18 @@
       <ul id="timezone">
         <li>
           <p data-l10n-id="tz-region">Region</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select id="timezone-region"></select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select id="timezone-region"></select>
+            </span>
           </p>
         </li>
         <li>
           <p data-l10n-id="tz-city">City</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select id="timezone-city"></select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select id="timezone-city"></select>
+            </span>
           </p>
         </li>
       </ul>
@@ -1304,26 +1310,28 @@
       <ul>
         <li>
           <p data-l10n-id="language">Language</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">Language</button>
-            <select name="language.current"></select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="language.current"></select>
+            </span>
           </p>
         </li>
         <li hidden>
           <p data-l10n-id="region">Region</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select name="region.current">
-              <option value="BR">Brasil</option>
-              <option value="CO">Columbia</option>
-              <option value="ES">España</option>
-              <option value="FR">France</option>
-              <option value="PT">Portugal</option>
-              <option value="TW">Taiwan</option>
-              <option value="UK">United Kingdom</option>
-              <option value="US">United States</option>
-              <option value="VZ">Venezuela</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="region.current">
+                <option value="BR">Brasil</option>
+                <option value="CO">Columbia</option>
+                <option value="ES">España</option>
+                <option value="FR">France</option>
+                <option value="PT">Portugal</option>
+                <option value="TW">Taiwan</option>
+                <option value="UK">United Kingdom</option>
+                <option value="US">United States</option>
+                <option value="VZ">Venezuela</option>
+              </select>
+            </span>
           </p>
         </li>
       </ul>
@@ -1507,16 +1515,17 @@
         </li>
         <li class="passcode-enabled" id="passcode-timeout-row">
           <p data-l10n-id="require-passcode">Require passcode</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select name="lockscreen.passcode-lock.timeout">
-              <option value="0" data-l10n-id="immediately" selected>Immediately</option>
-              <option value="60" data-l10n-id="after-one-minute">After 1 minute</option>
-              <option value="300" data-l10n-id="after-five-minutes">After 5 minutes</option>
-              <option value="900" data-l10n-id="after-fifteen-minutes">After 15 minutes</option>
-              <option value="3600" data-l10n-id="after-one-hour">After 1 hour</option>
-              <option value="14400" data-l10n-id="after-four-hours">After 4 hours</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="lockscreen.passcode-lock.timeout">
+                <option value="0" data-l10n-id="immediately" selected>Immediately</option>
+                <option value="60" data-l10n-id="after-one-minute">After 1 minute</option>
+                <option value="300" data-l10n-id="after-five-minutes">After 5 minutes</option>
+                <option value="900" data-l10n-id="after-fifteen-minutes">After 15 minutes</option>
+                <option value="3600" data-l10n-id="after-one-hour">After 1 hour</option>
+                <option value="14400" data-l10n-id="after-four-hours">After 4 hours</option>
+              </select>
+            </span>
           </p>
         </li>
         <li class="passcode-enabled">
@@ -2099,13 +2108,14 @@
       <ul>
         <li>
           <p data-l10n-id="check-for-updates">Check for Updates</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select name="app.update.interval">
-              <option value="86400"   data-l10n-id="check-update-daily" selected>Daily</option>
-              <option value="604800"  data-l10n-id="check-update-weekly">Weekly</option>
-              <option value="2592000" data-l10n-id="check-update-monthly">Monthly</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="app.update.interval">
+                <option value="86400"   data-l10n-id="check-update-daily" selected>Daily</option>
+                <option value="604800"  data-l10n-id="check-update-weekly">Weekly</option>
+                <option value="2592000" data-l10n-id="check-update-monthly">Monthly</option>
+              </select>
+            </span>
           </p>
         </li>
         <li>
@@ -2183,14 +2193,15 @@
         </li>
         <li>
           <p data-l10n-id="turnOnAuto">Turn on automatically</p>
-          <p class="fake-select">
-            <button class="icon icon-dialog">empty</button>
-            <select name="powersave.threshold">
-              <option value="0.05" data-l10n-id="powerSave-threshold" data-l10n-args='{"level":  "5"}'> 5% battery left</option>
-              <option value="0.15" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "15"}'>15% battery left</option>
-              <option value="0.25" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "25"}'>25% battery left</option>
-              <option value="0" data-l10n-id="never">Never</option>
-            </select>
+          <p>
+            <span class="button icon icon-dialog">
+              <select name="powersave.threshold">
+                <option value="0.05" data-l10n-id="powerSave-threshold" data-l10n-args='{"level":  "5"}'> 5% battery left</option>
+                <option value="0.15" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "15"}'>15% battery left</option>
+                <option value="0.25" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "25"}'>25% battery left</option>
+                <option value="0" data-l10n-id="never">Never</option>
+              </select>
+            </span>
           </p>
         </li>
         <li class="description" data-l10n-id="powerSave-expl">

--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -241,7 +241,7 @@ ul li select {
 }
 
 /* half-width select boxes */
-ul li span select {
+ul li span:not(.button) select {
   display: inline-block;
   position: absolute;
   top: 1.5rem;
@@ -257,41 +257,18 @@ ul li p + select {
 }
 
 /******************************************************************************
- * Fake select boxes
+ * Select boxes
  */
-.fake-select {
-  position: relative;
-  display: block;
-  padding: 1.1rem 3rem;
-  margin: 0;
-  height: 3.8rem;
-}
 
-.fake-select.small {
-  display: inline-block;
-  vertical-align: top;
-}
-
-.fake-select > button {
-  display: block;
-  top: 0;
-  left: 0;
-  width: 100%;
-}
-
-.fake-select > select {
-  position: absolute;
-  top: 0;
-  left: 3rem;
-  width: calc(100% - 6rem);
-  height: 3.8rem;
-  border: none;
-  background: red;
-  opacity: 0;
+.button > select {
+  border: 0;
+  background: 0;
+  text-align: left;
+  width: 150% !important;
 }
 
 /* */
-section[role="region"] > ul > li > p + .fake-select {
+section[role="region"] > ul > li > p #preferredNetworkType {
   padding-top: 0;
   margin-top: -0.8rem;
 }


### PR DESCRIPTION
This slightly refactors settings to use the new method of button styles around <select> and <input> elements.

This feels more natural to me, instead of shimming a select on top of a button with absolute positioning. This also allows us to keep most of the css code inside of shared.
