### PR TITLE
Bug 826229 - [Calendar] The settings button in calendar menu view will be highlighted when clicked. r=kevinGrandon

### DIFF
--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -120,6 +120,9 @@ body[data-path^='/settings'] #time-views {
   display: block;
 }
 
+#settings .settings:active {
+  background-color: #008aaa;
+}
 
 #settings .calendars > li label {
   text-transform: none;


### PR DESCRIPTION
The UI highlight issue with the settings icon in the menu view of calendar is fixed by adding a highlight color on click.
