### PR TITLE
Removing keyboard when selecting a label

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -360,6 +360,7 @@ var Contacts = (function() {
     var options = TAG_OPTIONS[tagList];
     fillTagOptions(options, tagList, target);
     navigation.go('view-select-tag', 'right-left');
+    window.navigator.mozKeyboard.removeFocus();
   };
 
   var fillTagOptions = function fillTagOptions(options, tagList, update) {


### PR DESCRIPTION
The disappearing keyboard issue is fixed by removing keyboard when selecting a label.
