### PR TITLE
Bug 833285 - [Calendar] Title text for calendar events overflows

### DIFF
--- a/apps/calendar/style/day_views.css
+++ b/apps/calendar/style/day_views.css
@@ -64,7 +64,7 @@
   border-style: solid;
   border-left-width: 6px;
   height: 100%;
-  padding: 1rem;
+  padding: 0.8rem 1rem 2.2rem;
 }
 
 .day-events .hour .display-hour {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=833285
