### PR TITLE
Bug 834174 - [Calendar] UI break in Bottom bar in calendar. r=KevinGrandon

### DIFF
--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -18,7 +18,7 @@
 }
 
 #week-view {
-  position: relative;
+  position: static;
 }
 
 #week-view .sidebar {
@@ -51,7 +51,7 @@
 }
 
 #week-view > .scroll {
-  height: calc(100% - 8rem);
+  height: calc(100% - 8.1rem);
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=834174
