### PR TITLE
Bug 832263 - [Calendar] The account name in calendar not displayed properly

### DIFF
--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -60,7 +60,7 @@ body[data-path^='/settings'] #time-views {
 
 #settings .calendars label > span {
   display: block;
-  overflow: hidden;
+  overflow: visible;
   white-space: nowrap;
   text-overflow: ellipsis;
   width: -moz-calc(100% - 20px);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=832263
