### PR TITLE
Bug 841251 - Implement a simple shared lazy loader. (alternative design)

### DIFF
--- a/apps/gallery/test/unit/lazy_loader_test.js
+++ b/apps/gallery/test/unit/lazy_loader_test.js
@@ -79,6 +79,25 @@ suite('lazy loader', function() {
     }
   });
 
+  test('append non existent script', function(done) {
+    var req = utils.script.load('js/js/non_existent_file.js');
+
+    req.onsuccess = function() {
+      assert.fail('success callback not invoked', 'success callback invoked');
+      done();
+    }
+
+    req.onerror = function(e) {
+      assert.equal(e.target.resourceInError,'non_existent_file.js');
+      done();
+    }
+
+    req.onresourceloaded = function() {
+       assert.fail('resource loaded callback not invoked',
+                   'resource loaded callback invoked');
+    }
+  });
+
   test('append the same css script', function(done) {
     var numStyles = countSytles();
     var req = utils.script.load('support/styles.css');

--- a/apps/gallery/test/unit/lazy_loader_test.js
+++ b/apps/gallery/test/unit/lazy_loader_test.js
@@ -1,0 +1,120 @@
+/**
+ * Tests for the shared lazy loader code
+ * TODO: Shared code unit tests should not be in gallery
+ * Bug #841422 has been filed to move these tests
+ */
+require('/shared/js/script_loader.js');
+
+mocha.setup({globals: ['jsCount']});
+
+suite('lazy loader', function() {
+
+  function countSytles() {
+    return document.querySelectorAll('link').length;
+  }
+
+  suiteSetup(function() {
+    window.jsCount = 0;
+  });
+
+  suiteTeardown(function() {
+    delete window.jsCount;
+  });
+
+  test('everything looks ok', function() {
+    assert.equal(window.jsCount, 0);
+    assert.typeOf(utils.script, 'object');
+    assert.typeOf(utils.script.load, 'function');
+  });
+
+  test('append single js script', function(done) {
+    var req = utils.script.load('support/inc.js');
+    req.onsuccess = function() {
+      assert.equal(window.jsCount, 1);
+      done();
+    };
+
+    req.onerror = function() {
+      assert.fail('no error expected', 'there was error');
+      done();
+    }
+
+    req.onresourceloaded = function(e) {
+      assert.equal(e.target.resourceSrc,'inc.js');
+    }
+  });
+
+  test('append the same js script', function(done) {
+    var req = utils.script.load('support/inc.js');
+    req.onsuccess = function() {
+      assert.equal(window.jsCount, 1);
+      done();
+    };
+
+    req.onerror = function() {
+      assert.fail('no error expected', 'there was error');
+      done();
+    }
+
+    req.onresourceloaded = function(e) {
+      assert.equal(e.target.resourceSrc,'inc.js');
+    }
+  });
+
+  test('append css script', function(done) {
+    var numStyles = countSytles();
+    var req = utils.script.load('support/styles.css');
+    req.onsuccess = function() {
+      assert.equal(countSytles(), (numStyles+1));
+      done();
+    };
+
+    req.onerror = function() {
+      assert.fail('no error expected', 'there was error');
+      done();
+    }
+
+    req.onresourceloaded = function(e) {
+      assert.equal(e.target.resourceSrc,'styles.css');
+    }
+  });
+
+  test('append the same css script', function(done) {
+    var numStyles = countSytles();
+    var req = utils.script.load('support/styles.css');
+    req.onsuccess = function() {
+      assert.equal(countSytles(), numStyles);
+      done();
+    };
+
+    req.onerror = function() {
+      assert.fail('no error expected', 'there was error');
+      done();
+    }
+
+    req.onresourceloaded = function(e) {
+      assert.equal(e.target.resourceSrc,'styles.css');
+    }
+  });
+
+  test('append multiple scripts', function(done) {
+    var numStyles = countSytles();
+
+    var req = utils.script.load(['support/styles.css', 'support/inc.js']);
+    req.onsuccess = function() {
+      assert.equal(window.jsCount, 1);
+      assert.equal(countSytles(), (numStyles));
+      done();
+    };
+
+    req.onerror = function() {
+      assert.fail('no error expected', 'there was error');
+      done();
+    }
+
+    req.onresourceloaded = function(e) {
+      assert.isTrue(e.target.resourceSrc === 'styles.css' ||
+                    e.target.resourceSrc === 'inc.js');
+    }
+  });
+});

--- a/shared/js/script_loader.js
+++ b/shared/js/script_loader.js
@@ -1,0 +1,217 @@
+'use strict';
+
+var utils = this.utils || {};
+
+(function() {
+  var scr = utils.script = {};
+
+  function getFileId(resourceSrc) {
+    var fileIdSplit = resourceSrc.split('/');
+    return fileIdSplit[fileIdSplit.length - 1];
+  }
+
+  // order can be one of 'sequential', 'concurrent'
+  utils.script.Loader = function(psources, porder) {
+    var numLoaded = 0;
+    var self = this;
+    var nextToBeLoaded = 0;
+    var sourcesArray = Array.isArray(psources) ? psources : [psources];
+    var totalToBeLoaded = sourcesArray.length;
+    var order = porder || 'concurrent';
+
+    function addEventListeners(node) {
+      node.addEventListener('load', resourceLoaded);
+      node.addEventListener('error', resourceError);
+    }
+
+    function removeEventListeners(node) {
+      node.removeEventListener('load', resourceLoaded);
+      node.removeEventListener('error', resourceError);
+    }
+
+    function loadScript(scriptSrc) {
+      var scriptNode = document.createElement('script');
+      scriptNode.src = scriptSrc;
+      addEventListeners(scriptNode);
+
+      document.head.appendChild(scriptNode);
+    }
+
+    function loadStyle(styleSrc) {
+      var styleNode = document.createElement('link');
+      styleNode.href = styleSrc;
+      styleNode.rel = 'stylesheet';
+      styleNode.type = 'text/css';
+
+      addEventListeners(styleNode);
+      document.head.appendChild(styleNode);
+    }
+
+    function loadResource(resourceSrc) {
+      var extension = resourceSrc.match(/\.(.*?)$/)[1];
+      if(extension === 'js') {
+        var node = document.head.querySelector('script[src=' + '"' +
+                                               resourceSrc + '"]');
+        if(node) {
+          // Would be nice if Firefox would have a readyState attribute as IE
+          addEventListeners(node);
+        }
+        else {
+          loadScript(resourceSrc);
+        }
+      }
+      else if(extension === 'css') {
+        var node = document.head.querySelector('link[href=' + '"'
+                                               + resourceSrc + '"]');
+        if(node) {
+          // Would be nice if Firefox would have a readyState attribute as IE
+          addEventListeners(node);
+        }
+        else {
+          loadStyle(resourceSrc);
+        }
+      }
+    }
+
+    function resourceLoaded(e) {
+      removeEventListeners(e.target);
+      numLoaded++;
+      if(typeof self.onresourceloaded === 'function') {
+        window.setTimeout(function cb_loaded() {
+          self.onresourceloaded(e.target.src || e.target.href);
+        }, 0);
+      }
+      nextToBeLoaded++;
+      if(order === 'sequential' && nextToBeLoaded < totalToBeLoaded) {
+        loadResource(sourcesArray[nextToBeLoaded]);
+      }
+      else {
+        // Order is concurrent (just check for the number of resources loaded)
+        if(numLoaded === totalToBeLoaded) {
+          if(typeof self.onfinish === 'function') {
+            window.setTimeout(self.onfinish, 0);
+          }
+        }
+      }
+    }
+
+    function resourceError(e) {
+      removeEventListeners(e.target);
+
+      if(typeof self.onerror === 'function') {
+        window.setTimeout(function cb_error() {
+          self.onerror(e.target.src);
+        }, 0);
+      }
+    }
+
+    this.start = function() {
+      if(order === 'sequential') {
+        loadResource(sourcesArray[0]);
+      }
+      else {
+        // All of them are loaded concurrently
+        sourcesArray.forEach(function(aSource) {
+          loadResource(aSource);
+        });
+      }
+    }
+  }
+
+
+  var resourcesLoaded = {};
+
+  utils.script.load = function(psources, order) {
+    var outReq = new Request();
+    var sourcesArray = Array.isArray(psources) ? psources : [psources];
+
+    window.setTimeout(function do_load() {
+      var toBeLoaded = getToBeLoaded(sourcesArray, outReq);
+      if(toBeLoaded.length > 0) {
+        var loader = new utils.script.Loader(toBeLoaded, order);
+        loader.onfinish = function() {
+          outReq.done();
+        }
+        loader.onerror = function(e) {
+          outReq.failed(getFiledId(e.target.src || e.target.href));
+        }
+        loader.onresourceloaded = function(resourceSrc) {
+          window.console.log('!!!Resource Loaded!!!', resourceSrc);
+          var fileId = getFileId(resourceSrc);
+          resourcesLoaded[fileId] = true;
+          outReq.resourceLoaded(fileId);
+        }
+        loader.start();
+      }
+      else {
+        outReq.done();
+      }
+    }, 0);
+
+    return outReq;
+  }
+
+  function getToBeLoaded(requestedSources, outReq) {
+    var realToBeLoaded = [];
+
+    requestedSources.forEach(function(aSource) {
+      var fileId = getFileId(aSource);
+      if(resourcesLoaded[fileId] !== true) {
+        realToBeLoaded.push(aSource);
+      }
+      else {
+        // Immediately fire onresourceloaded on all ready loaded
+        if(typeof outReq.onresourceloaded === 'function') {
+          outReq.resourceLoaded(fileId);
+        }
+      }
+    });
+
+    window.console.log('!!!!', realToBeLoaded.length, '!!!!');
+
+    return realToBeLoaded;
+  }
+
+  utils.script.isLoaded = function(resourceSrc) {
+    return resourcesLoaded[resourceSrc] === true;
+  }
+
+  /**
+  *   Request auxiliary object to support asynchronous calls
+  *
+  */
+  var Request = function() {
+    this.done = function(result) {
+      this.result = result;
+      if (typeof this.onsuccess === 'function') {
+        var ev = {};
+        ev.target = this;
+        window.setTimeout(function() {
+          this.onsuccess(ev);
+        }.bind(this), 0);
+      }
+    };
+
+    this.resourceLoaded = function(resourceSrc) {
+      this.resourceSrc = resourceSrc;
+      if(typeof this.onresourceloaded === 'function') {
+        var ev = {};
+        ev.target = this;
+        window.setTimeout(function() {
+          this.onresourceloaded(ev);
+        }.bind(this), 0);
+      }
+    }
+
+    this.failed = function(error) {
+      this.error = error;
+      if (typeof this.onerror === 'function') {
+        var ev = {};
+        ev.target = this;
+        window.setTimeout(function() {
+          this.onerror(ev);
+        }.bind(this), 0);
+      }
+    };
+  };
+})();


### PR DESCRIPTION
This PR intends to propose an alternative design for Bug 841251, provided in PR #8088 by @KevinGrandon. It has been partially inspired on #8088 but provides the following improvements:
- DOMRequest-based interface avoiding hierarchical callbacks in the code
- It cleanly manages errors during loading
- Callers can be notified of individual resource loading and of the full load of all the resources
- Callers can load resources in parallel or sequentially as requested 
- Checks presence on the DOM by using querySelector as requested by @vingtetun 
