### PR TITLE
Bug 837236 - share video decoding hardware among Camera, Gallery and Video

### DIFF
--- a/apps/camera/js/filmstrip.js
+++ b/apps/camera/js/filmstrip.js
@@ -116,7 +116,9 @@ var Filmstrip = (function() {
       frame.displayImage(item.blob, item.width, item.height, item.preview);
     }
     else if (item.isVideo) {
-      frame.displayVideo(item.blob, item.width, item.height, item.rotation);
+      frame.displayVideo(item.blob, item.poster,
+                         item.width, item.height,
+                         item.rotation);
     }
 
     preview.classList.remove('offscreen');
@@ -328,18 +330,17 @@ var Filmstrip = (function() {
 
         offscreenImage.src = URL.createObjectURL(previewBlob);
         offscreenImage.onload = function() {
-          createThumbnailFromElement(offscreenImage, false, 0,
-                                     function(thumbnail) {
-                                       addItem({
-                                         isImage: true,
-                                         filename: filename,
-                                         thumbnail: thumbnail,
-                                         blob: blob,
-                                         width: metadata.width,
-                                         height: metadata.height,
-                                         preview: metadata.preview
-                                       });
-                                     });
+          createThumbnailFromImage(offscreenImage, function(thumbnail) {
+            addItem({
+              isImage: true,
+              filename: filename,
+              thumbnail: thumbnail,
+              blob: blob,
+              width: metadata.width,
+              height: metadata.height,
+              preview: metadata.preview
+            });
+          });
           URL.revokeObjectURL(offscreenImage.src);
           offscreenImage.onload = null;
           offscreenImage.src = null;
@@ -378,18 +379,19 @@ var Filmstrip = (function() {
         }
 
         offscreenVideo.onloadedmetadata = function() {
-          createThumbnailFromElement(offscreenVideo, true, rotation,
-                                     function(thumbnail) {
-                                       addItem({
-                                         isVideo: true,
-                                         filename: filename,
-                                         thumbnail: thumbnail,
-                                         blob: blob,
-                                         width: offscreenVideo.videoWidth,
-                                         height: offscreenVideo.videoHeight,
-                                         rotation: rotation
-                                       });
+          createThumbnailFromVideo(offscreenVideo, rotation, filename,
+                                   function(thumbnail, poster) {
+                                     addItem({
+                                       isVideo: true,
+                                       filename: filename,
+                                       thumbnail: thumbnail,
+                                       poster: poster,
+                                       blob: blob,
+                                       width: offscreenVideo.videoWidth,
+                                       height: offscreenVideo.videoHeight,
+                                       rotation: rotation
                                      });
+                                   });
           URL.revokeObjectURL(url);
           offscreenVideo.onerror = null;
           offscreenVideo.onloadedmetadata = null;
@@ -444,16 +446,16 @@ var Filmstrip = (function() {
   // Create a thumbnail size canvas, copy the <img> or <video> into it
   // cropping the edges as needed to make it fit, and then extract the
   // thumbnail image as a blob and pass it to the callback.
-  function createThumbnailFromElement(elt, video, rotation, callback) {
+  function createThumbnailFromImage(img, callback) {
     // Create a thumbnail image
     var canvas = document.createElement('canvas');
     var context = canvas.getContext('2d');
     canvas.width = THUMBNAIL_WIDTH;
     canvas.height = THUMBNAIL_HEIGHT;
-    var eltwidth = video ? elt.videoWidth : elt.width;
-    var eltheight = video ? elt.videoHeight : elt.height;
-    var scalex = canvas.width / eltwidth;
-    var scaley = canvas.height / eltheight;
+    var imgwidth = img.width;
+    var imgheight = img.height;
+    var scalex = canvas.width / imgwidth;
+    var scaley = canvas.height / imgheight;
 
     // Take the larger of the two scales: we crop the image to the thumbnail
     var scale = Math.max(scalex, scaley);
@@ -462,69 +464,116 @@ var Filmstrip = (function() {
     // canvas to create the thumbnail
     var w = Math.round(THUMBNAIL_WIDTH / scale);
     var h = Math.round(THUMBNAIL_HEIGHT / scale);
-    var x = Math.round((eltwidth - w) / 2);
-    var y = Math.round((eltheight - h) / 2);
+    var x = Math.round((imgwidth - w) / 2);
+    var y = Math.round((imgheight - h) / 2);
+
+    // Draw that region of the image into the canvas, scaling it down
+    context.drawImage(img, x, y, w, h,
+                      0, 0, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+    canvas.toBlob(callback, 'image/jpeg');
+  }
+
+  // Create a thumbnail size canvas, copy the <img> or <video> into it
+  // cropping the edges as needed to make it fit, and then extract the
+  // thumbnail image as a blob and pass it to the callback.
+  function createThumbnailFromVideo(video, rotation, filename, callback) {
+    var videowidth = video.videoWidth;
+    var videoheight = video.videoHeight;
+
+    // First, create a full-size unrotated poster image
+    var postercanvas = document.createElement('canvas');
+    var postercontext = postercanvas.getContext('2d');
+    postercanvas.width = videowidth;
+    postercanvas.height = videoheight;
+    postercontext.drawImage(video, 0, 0);
+
+    // Now create a thumbnail
+    var thumbnailcanvas = document.createElement('canvas');
+    var thumbnailcontext = thumbnailcanvas.getContext('2d');
+    thumbnailcanvas.width = THUMBNAIL_WIDTH;
+    thumbnailcanvas.height = THUMBNAIL_HEIGHT;
+
+    var scalex = THUMBNAIL_WIDTH / videowidth;
+    var scaley = THUMBNAIL_HEIGHT / videoheight;
+
+    // Take the larger of the two scales: we crop the image to the thumbnail
+    var scale = Math.max(scalex, scaley);
+
+    // Calculate the region of the image that will be copied to the
+    // canvas to create the thumbnail
+    var w = Math.round(THUMBNAIL_WIDTH / scale);
+    var h = Math.round(THUMBNAIL_HEIGHT / scale);
+    var x = Math.round((videowidth - w) / 2);
+    var y = Math.round((videoheight - h) / 2);
 
     // If a rotation is specified, rotate the canvas context
     if (rotation) {
-      context.save();
+      thumbnailcontext.save();
       switch (rotation) {
       case 90:
-        context.translate(THUMBNAIL_WIDTH, 0);
-        context.rotate(Math.PI / 2);
+        thumbnailcontext.translate(THUMBNAIL_WIDTH, 0);
+        thumbnailcontext.rotate(Math.PI / 2);
         break;
       case 180:
-        context.translate(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
-        context.rotate(Math.PI);
+        thumbnailcontext.translate(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+        thumbnailcontext.rotate(Math.PI);
         break;
       case 270:
-        context.translate(0, THUMBNAIL_HEIGHT);
-        context.rotate(-Math.PI / 2);
+        thumbnailcontext.translate(0, THUMBNAIL_HEIGHT);
+        thumbnailcontext.rotate(-Math.PI / 2);
         break;
       }
     }
 
-    // Draw that region of the image into the canvas, scaling it down
-    context.drawImage(elt, x, y, w, h,
-                      0, 0, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+    // Draw that region of the poster into the thumbnail, scaling it down
+    thumbnailcontext.drawImage(postercanvas, x, y, w, h,
+                               0, 0, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
 
     // Restore the default rotation so the play arrow comes out correctly
     if (rotation) {
-      context.restore();
+      thumbnailcontext.restore();
     }
 
     // If this is a video, superimpose a translucent play button over
-    // the captured video frame to distinguish it from a still photo thumbnail
-    if (video) {
-      // First draw a transparent gray circle
-      context.fillStyle = 'rgba(0, 0, 0, .3)';
-      context.beginPath();
-      context.arc(THUMBNAIL_WIDTH / 2, THUMBNAIL_HEIGHT / 2,
-                  THUMBNAIL_HEIGHT / 3, 0, 2 * Math.PI, false);
-      context.fill();
+    // the captured video frame to distinguish it from a still photo
+    // thumbnail. First draw a transparent gray circle
+    thumbnailcontext.fillStyle = 'rgba(0, 0, 0, .3)';
+    thumbnailcontext.beginPath();
+    thumbnailcontext.arc(THUMBNAIL_WIDTH / 2, THUMBNAIL_HEIGHT / 2,
+                         THUMBNAIL_HEIGHT / 3, 0, 2 * Math.PI, false);
+    thumbnailcontext.fill();
 
-      // Now outline the circle in white
-      context.strokeStyle = 'rgba(255,255,255,.6)';
-      context.lineWidth = 2;
-      context.stroke();
+    // Now outline the circle in white
+    thumbnailcontext.strokeStyle = 'rgba(255,255,255,.6)';
+    thumbnailcontext.lineWidth = 2;
+    thumbnailcontext.stroke();
 
-      // And add a white play arrow.
-      context.beginPath();
-      context.fillStyle = 'rgba(255,255,255,.6)';
-      // The height of an equilateral triangle is sqrt(3)/2 times the side
-      var side = THUMBNAIL_HEIGHT / 3;
-      var triangle_height = side * Math.sqrt(3) / 2;
-      context.moveTo(THUMBNAIL_WIDTH / 2 + triangle_height * 2 / 3,
-                     THUMBNAIL_HEIGHT / 2);
-      context.lineTo(THUMBNAIL_WIDTH / 2 - triangle_height / 3,
-                     THUMBNAIL_HEIGHT / 2 - side / 2);
-      context.lineTo(THUMBNAIL_WIDTH / 2 - triangle_height / 3,
-                     THUMBNAIL_HEIGHT / 2 + side / 2);
-      context.closePath();
-      context.fill();
+    // And add a white play arrow.
+    thumbnailcontext.beginPath();
+    thumbnailcontext.fillStyle = 'rgba(255,255,255,.6)';
+    // The height of an equilateral triangle is sqrt(3)/2 times the side
+    var side = THUMBNAIL_HEIGHT / 3;
+    var triangle_height = side * Math.sqrt(3) / 2;
+    thumbnailcontext.moveTo(THUMBNAIL_WIDTH / 2 + triangle_height * 2 / 3,
+                            THUMBNAIL_HEIGHT / 2);
+    thumbnailcontext.lineTo(THUMBNAIL_WIDTH / 2 - triangle_height / 3,
+                            THUMBNAIL_HEIGHT / 2 - side / 2);
+    thumbnailcontext.lineTo(THUMBNAIL_WIDTH / 2 - triangle_height / 3,
+                            THUMBNAIL_HEIGHT / 2 + side / 2);
+    thumbnailcontext.closePath();
+    thumbnailcontext.fill();
+
+    // Save the poster image to storage, then call the callback
+    postercanvas.toBlob(savePosterImage, 'image/jpeg');
+
+    // The Gallery app depends on this poster image being saved here
+    function savePosterImage(poster) {
+      Camera._pictureStorage.addNamed(poster, filename.replace('.3gp', '.jpg'));
+      thumbnailcanvas.toBlob(function(thumbnail) {
+        callback(thumbnail, poster);
+      }, 'image/jpeg');
     }
-
-    canvas.toBlob(callback, 'image/jpeg');
   }
 
   function setOrientation(orientation) {

--- a/apps/camera/style/VideoPlayer.css
+++ b/apps/camera/style/VideoPlayer.css
@@ -1,5 +1,5 @@
 /* styles for the video element itself */
-.videoPlayer {
+.videoPoster, .videoPlayer {
   position: absolute;
   left: 0; /* we position it with a transform */
   top:0;

--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -7,7 +7,7 @@
 //
 // This file depends on JPEGMetadataParser.js and blobview.js
 //
-var metadataParsers = (function() {
+var metadataParser = (function() {
   // If we generate our own thumbnails, aim for this size
   var THUMBNAIL_WIDTH = 120;
   var THUMBNAIL_HEIGHT = 120;
@@ -18,9 +18,8 @@ var metadataParsers = (function() {
   // Don't try to open images with more pixels than this
   var MAX_IMAGE_PIXEL_SIZE = 5 * 1024 * 1024; // 5 megapixels
 
-  // <img> and <video> elements for loading images and videos
+  // An <img> element for loading images
   var offscreenImage = new Image();
-  var offscreenVideo = document.createElement('video');
 
   // Create a thumbnail size canvas, copy the <img> or <video> into it
   // cropping the edges as needed to make it fit, and then extract the
@@ -32,8 +31,8 @@ var metadataParsers = (function() {
     var context = canvas.getContext('2d');
     canvas.width = THUMBNAIL_WIDTH;
     canvas.height = THUMBNAIL_HEIGHT;
-    var eltwidth = video ? elt.videoWidth : elt.width;
-    var eltheight = video ? elt.videoHeight : elt.height;
+    var eltwidth = elt.width;
+    var eltheight = elt.height;
     var scalex = canvas.width / eltwidth;
     var scaley = canvas.height / eltheight;
 
@@ -106,17 +105,19 @@ var metadataParsers = (function() {
       context.fill();
     }
 
-    canvas.toBlob(function(blob) {
-      // This setTimeout is here in the hopes that it gives gecko a bit
-      // of time to release the memory that holds the decoded image before
-      // we start creating the next thumbnail.
-      setTimeout(function() {
-        callback(blob);
-      });
-    }, 'image/jpeg');
+    canvas.toBlob(callback, 'image/jpeg');
   }
 
-  function imageMetadataParser(file, metadataCallback, metadataError) {
+  var VIDEOFILE = /DCIM\/\d{3}MZLLA\/VID_\d{4}\.jpg/;
+
+  function metadataParser(file, metadataCallback, metadataError) {
+    // If the file is a poster image for a video file, then we've want
+    // video metadata, not image metadata
+    if (VIDEOFILE.test(file.name)) {
+      videoMetadataParser(file, metadataCallback, metadataError);
+      return;
+    }
+
     if (file.type !== 'image/jpeg') {
       // For any kind of image other than JPEG, we just have to get
       // our metadata with an <img> tag
@@ -228,76 +229,54 @@ var metadataParsers = (function() {
   }
 
   function videoMetadataParser(file, metadataCallback, errorCallback) {
-    try {
-      if (file.type && !offscreenVideo.canPlayType(file.type)) {
-        errorCallback("can't play video file type: " + file.type);
-        return;
-      }
+    var metadata = {};
+    var videofilename = file.name.replace('.jpg', '.3gp');
+    metadata.video = videofilename;
 
-      var url = URL.createObjectURL(file);
-
-      offscreenVideo.preload = 'metadata';
-      offscreenVideo.style.width = THUMBNAIL_WIDTH + 'px';
-      offscreenVideo.style.height = THUMBNAIL_HEIGHT + 'px';
-      offscreenVideo.src = url;
-
-      offscreenVideo.onerror = function() {
-        URL.revokeObjectURL(url);
-        offscreenVideo.onerror = null;
-        offscreenVideo.src = null;
-        errorCallback('not a video file');
-      }
-
-      offscreenVideo.onloadedmetadata = function() {
-        var metadata = {};
-        metadata.video = true;
-        metadata.duration = offscreenVideo.duration;
-        metadata.width = offscreenVideo.videoWidth;
-        metadata.height = offscreenVideo.videoHeight;
-        metadata.rotation = 0;
-
-        // If this is a .3gp video file, look for its rotation matrix and
-        // then create the thumbnail. Otherwise set rotation to 0 and
-        // create the thumbnail.
-        // getVideoRotation is defined in shared/js/media/get_video_rotation.js
-        if (file.name.substring(file.name.lastIndexOf('.') + 1) === '3gp') {
-          getVideoRotation(file, function(rotation) {
-            if (typeof rotation === 'number')
-              metadata.rotation = rotation;
-            else if (typeof rotation === 'string')
-              console.warn('Video rotation:', rotation);
-            createThumbnail();
-          });
-        }
-        else {
-          createThumbnail();
-        }
-
-        function createThumbnail() {
-          offscreenVideo.currentTime = 1; // read 1 second into video
-          offscreenVideo.onseeked = function onseeked() {
-            createThumbnailFromElement(offscreenVideo, true, metadata.rotation,
-                                       function(thumbnail) {
-                                         URL.revokeObjectURL(url);
-                                         offscreenVideo.onerror = null;
-                                         offscreenVideo.onseeked = null;
-                                         offscreenVideo.removeAttribute('src');
-                                         offscreenVideo.load();
-                                         metadata.thumbnail = thumbnail;
-                                         metadataCallback(metadata);
-                                       });
-          };
-        }
-      };
+    var getreq = videostorage.get(videofilename);
+    getreq.onerror = function() {
+      errorCallback('cannot get video file: ' + videofilename);
     }
-    catch (e) {
-      console.error('Exception in videoMetadataParser', e, e.stack);
-      errorCallback('Exception in videoMetadataParser');
+    getreq.onsuccess = function() {
+      var videofile = getreq.result;
+      getVideoRotation(videofile, function(rotation) {
+        if (typeof rotation === 'number') {
+          metadata.rotation = rotation;
+          getVideoThumbnailAndSize();
+        }
+        else if (typeof rotation === 'string') {
+          errorCallback('Video rotation:', rotation);
+        }
+      });
+    }
+
+    function getVideoThumbnailAndSize() {
+      var url = URL.createObjectURL(file);
+      offscreenImage.src = url;
+
+      offscreenImage.onerror = function() {
+        URL.revokeObjectURL(url);
+        offscreenImage.removeAttribute('src');
+        errorCallback('getVideoThumanailAndSize: Image failed to load');
+      };
+
+      offscreenImage.onload = function() {
+        URL.revokeObjectURL(url);
+
+        // We store the unrotated size of the poster image, which we
+        // require to have the same size and rotation as the video
+        metadata.width = offscreenImage.width;
+        metadata.height = offscreenImage.height;
+
+        createThumbnailFromElement(offscreenImage, true, metadata.rotation,
+                                   function(thumbnail) {
+                                     metadata.thumbnail = thumbnail;
+                                     offscreenImage.removeAttribute('src');
+                                     metadataCallback(metadata);
+                                   });
+      };
     }
   }
 
-  return {
-    imageMetadataParser: imageMetadataParser,
-    videoMetadataParser: videoMetadataParser
-  };
+  return metadataParser;
 }());

--- a/apps/gallery/js/frames.js
+++ b/apps/gallery/js/frames.js
@@ -293,22 +293,25 @@ function setupFrameContent(n, frame) {
   // Remember what file we're going to display
   frame.filename = fileinfo.name;
 
-  if (fileinfo.metadata.video) {
-    videodb.getFile(fileinfo.name, function(file) {
-      frame.displayVideo(file,
-                         fileinfo.metadata.width,
-                         fileinfo.metadata.height,
-                         fileinfo.metadata.rotation || 0);
-    });
-  }
-  else {
-    photodb.getFile(fileinfo.name, function(file) {
-      frame.displayImage(file,
+  photodb.getFile(fileinfo.name, function(imagefile) {
+    if (fileinfo.metadata.video) {
+      // If this is a video, then the file we just got is the poster image
+      // and we still have to fetch the actual video
+      getVideoFile(fileinfo.metadata.video, function(videofile) {
+        frame.displayVideo(videofile, imagefile,
+                           fileinfo.metadata.width,
+                           fileinfo.metadata.height,
+                           fileinfo.metadata.rotation || 0);
+      });
+    }
+    else {
+      // Otherwise, just display the image
+      frame.displayImage(imagefile,
                          fileinfo.metadata.width,
                          fileinfo.metadata.height,
                          fileinfo.metadata.preview);
-    });
-  }
+    }
+  });
 }
 
 var FRAME_BORDER_WIDTH = 3;
@@ -356,9 +359,10 @@ function nextFile(time) {
   if (currentFileIndex === files.length - 1)
     return;
 
-  // Don't pan a playing video!
-  if (currentFrame.displayingVideo && !currentFrame.video.player.paused)
-    currentFrame.video.pause();
+  // If the current frame is using a <video> element instead of just
+  // displaying a poster image, reset it back to just the image
+  if (currentFrame.displayingVideo && currentFrame.video.playerShowing)
+    currentFrame.video.init();
 
   // Set a flag to ignore pan and zoom gestures during the transition.
   transitioning = true;
@@ -405,9 +409,10 @@ function previousFile(time) {
   if (currentFileIndex === 0)
     return;
 
-  // Don't pan a playing video!
-  if (currentFrame.displayingVideo && !currentFrame.video.player.paused)
-    currentFrame.video.pause();
+  // If the current frame is using a <video> element instead of just
+  // displaying a poster image, reset it back to just the image.
+  if (currentFrame.displayingVideo && currentFrame.video.playerShowing)
+    currentFrame.video.init();
 
   // Set a flag to ignore pan and zoom gestures during the transition.
   transitioning = true;

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -82,9 +82,13 @@ var editedPhotoIndex;
 var selectedFileNames = [];
 var selectedFileNamesToBlobs = {};
 
-// The MediaDB objects that manage the filesystem and the database of metadata
-// See init()
-var photodb, videodb;
+// The MediaDB object that manages the filesystem and the database of metadata
+var photodb;
+
+// We manage videos through their poster images, which are photos and so get
+// listed in the photodb above. But when we need to access the actual video
+// file, we have to get that from a device storage object for videos.
+var videostorage;
 
 var visibilityMonitor;
 
@@ -180,7 +184,7 @@ function init() {
 // Initialize MediaDB objects for photos and videos, and set up their
 // event handlers.
 function initDB(include_videos) {
-  photodb = new MediaDB('pictures', imageMetadataParser, {
+  photodb = new MediaDB('pictures', metadataParserWrapper, {
     mimeTypes: ['image/jpeg', 'image/png'],
     version: 2,
     autoscan: false,     // We're going to call scan() explicitly
@@ -189,40 +193,19 @@ function initDB(include_videos) {
   });
 
   if (include_videos) {
-    // For videos, this app is only interested in files under DCIM/.
-    videodb = new MediaDB('videos', videoMetadataParser, {
-      directory: 'DCIM/',
-      autoscan: false,     // We're going to call scan() explicitly
-      batchHoldTime: 150,  // Batch files during scanning
-      batchSize: PAGE_SIZE // Max batch size: one screenful
-    });
-  }
-  else {
-    videodb = null;
+    videostorage = navigator.getDeviceStorage('videos');
   }
 
   var loaded = false;
-  function imageMetadataParser(file, onsuccess, onerror) {
+  function metadataParserWrapper(file, onsuccess, onerror) {
     if (loaded) {
-      metadataParsers.imageMetadataParser(file, onsuccess, onerror);
+      metadataParser(file, onsuccess, onerror);
       return;
     }
 
     loader.load('js/metadata_scripts.js', function() {
       loaded = true;
-      metadataParsers.imageMetadataParser(file, onsuccess, onerror);
-    });
-  }
-
-  function videoMetadataParser(file, onsuccess, onerror) {
-    if (loaded) {
-      metadataParsers.videoMetadataParser(file, onsuccess, onerror);
-      return;
-    }
-
-    loader.load('js/metadata_scripts.js', function() {
-      loaded = true;
-      metadataParsers.videoMetadataParser(file, onsuccess, onerror);
+      metadataParser(file, onsuccess, onerror);
     });
   }
 
@@ -244,46 +227,19 @@ function initDB(include_videos) {
     if (currentOverlay === 'nocard' || currentOverlay === 'pluggedin')
       showOverlay(null);
 
-    // If we're including videos also, be sure that they are ready
-    if (include_videos) {
-      if (videodb.state === MediaDB.READY)
-        initThumbnails();
-    }
-    else {
-      initThumbnails();
-    }
+    initThumbnails(include_videos);
   };
 
-  if (include_videos) {
-    videodb.onready = function() {
-      // If the photodb is also ready, create thumbnails.
-      // Depending on the order of the ready events, either this code
-      // or the code above will fire and set up the thumbnails
-      if (photodb.state === MediaDB.READY)
-        initThumbnails();
-    };
-  }
-
-  // When the mediadbs are scanning, let the user know. We count scan starts
-  // and ends so we correctly display the throbber while either db is scanning.
-  var scanning = 0;
-
   photodb.onscanstart = function onscanstart() {
-    scanning++;
-    if (scanning == 1) {
-      // Show the scanning indicator
-      $('progress').classList.remove('hidden');
-      $('throbber').classList.add('throb');
-    }
+    // Show the scanning indicator
+    $('progress').classList.remove('hidden');
+    $('throbber').classList.add('throb');
   };
 
   photodb.onscanend = function onscanend() {
-    scanning--;
-    if (scanning == 0) {
-      // Hide the scanning indicator
-      $('progress').classList.add('hidden');
-      $('throbber').classList.remove('throb');
-    }
+    // Hide the scanning indicator
+    $('progress').classList.add('hidden');
+    $('throbber').classList.remove('throb');
   };
 
   // One or more files was created (or was just discovered by a scan)
@@ -295,12 +251,17 @@ function initDB(include_videos) {
   photodb.ondeleted = function(event) {
     event.detail.forEach(fileDeleted);
   };
+}
 
-  if (include_videos) {
-    videodb.onscanstart = photodb.onscanstart;
-    videodb.onscanend = photodb.onscanend;
-    videodb.oncreated = photodb.oncreated;
-    videodb.ondeleted = photodb.ondeleted;
+// Pass the filename of the poster image and get the video file back
+function getVideoFile(filename, callback) {
+  // We get videos directly through the video device storage
+  var req = videostorage.get(filename);
+  req.onsuccess = function() {
+    callback(req.result);
+  };
+  req.onerror = function() {
+    console.error('Failed to get video file', filename);
   }
 }
 
@@ -315,7 +276,7 @@ function compareFilesByDate(a, b) {
 }
 
 //
-// Enumerate existing entries in the photo and video databases in reverse
+// Enumerate existing entries in the media database in reverse
 // chronological order (most recent first) and display thumbnails for them all.
 // After the thumbnails are displayed, scan for new files.
 //
@@ -323,7 +284,7 @@ function compareFilesByDate(a, b) {
 // when the sdcard becomes available again after a USB mass storage
 // session or an sdcard replacement.
 //
-function initThumbnails() {
+function initThumbnails(include_videos) {
   // If we've already been called once, then we've already got thumbnails
   // displayed. There is no need to re-enumerate them, so we just go
   // straight to scanning for new files
@@ -370,63 +331,29 @@ function initThumbnails() {
   // from most recent to least recent.
 
   // Temporary arrays to hold enumerated files
-  var photos = [], videos = [], interleaved = [];
+  var batch = [];
   var batchsize = PAGE_SIZE;
 
   photodb.enumerate('date', null, 'prev', function(fileinfo) {
-    photos.push(fileinfo);
-    merge();
+    if (fileinfo) {
+      // For a pick activity, don't display videos
+      if (!include_videos && fileinfo.metadata.video)
+        return;
+
+      batch.push(fileinfo);
+      if (batch.length >= batchsize) {
+        flush();
+        batchsize *= 2;
+      }
+    }
+    else {
+      done();
+    }
   });
 
-  if (videodb) {
-    videodb.enumerate('date', null, 'prev', function(fileinfo) {
-      videos.push(fileinfo);
-      merge();
-    });
-  }
-  else {
-    videos.push(null); // This means we're done enumerating videos
-  }
-
-  // Create thumbnails for as many of the files in the photos and videos arrays
-  // as we can. This is the tricky bit of the algorithm for ensuring that
-  // they are sorted by date
-  function merge() {
-    // If we don't have at least one of each, we don't know what the newest is
-    while (photos.length > 0 && videos.length > 0) {
-      if (photos[0] === null && videos[0] === null) {
-        // Both enumerations are done
-        done();
-        break;
-      }
-
-      // If we've finished enumerating photos, then videos[0] is next
-      if (photos[0] === null) {
-        batch(videos.shift());
-      }
-      else if (videos[0] === null) {
-        batch(photos.shift());
-      }
-      else if (videos[0].date > photos[0].date) {
-        batch(videos.shift());
-      }
-      else {
-        batch(photos.shift());
-      }
-    }
-  }
-
-  function batch(fileinfo) {
-    interleaved.push(fileinfo);
-    if (interleaved.length >= batchsize) {
-      flush();
-      batchsize *= 2;
-    }
-  }
-
   function flush() {
-    interleaved.forEach(thumb);
-    interleaved.length = 0;
+    batch.forEach(thumb);
+    batch.length = 0;
   }
 
   function thumb(fileinfo) {
@@ -442,14 +369,8 @@ function initThumbnails() {
     }
     // Now that we've enumerated all the photos and videos we already know
     // about go start looking for new photos and videos.
-    scan();
+    photodb.scan();
   }
-}
-
-function scan() {
-  photodb.scan();
-  if (videodb)
-    videodb.scan();
 }
 
 function fileDeleted(filename) {
@@ -512,10 +433,13 @@ function deleteFile(n) {
   // deletes the file in device storage. This will generate an change
   // event which will call imageDeleted()
   var fileinfo = files[n];
-  if (fileinfo.metadata.video)
-    videodb.deleteFile(fileinfo.name);
-  else
-    photodb.deleteFile(files[n].name);
+  photodb.deleteFile(files[n].name);
+
+  // If it is a video, however, we can't just delete the poster image, but
+  // must also delete the video file.
+  if (fileinfo.metadata.video) {
+    videostorage.delete(fileinfo.metadata.video);
+  }
 }
 
 function fileCreated(fileinfo) {
@@ -851,10 +775,17 @@ function updateSelection(thumbnail) {
 
   if (selected) {
     selectedFileNames.push(filename);
-    var db = files[index].metadata.video ? videodb : photodb;
-    db.getFile(filename, function(file) {
-      selectedFileNamesToBlobs[filename] = file;
-    });
+    if (files[index].metadata.video) {
+      getVideoFile(files[index].metadata.video, function(file) {
+        selectedFileNamesToBlobs[filename] = file;
+      });
+    }
+    else {
+      // We get photos through the photo db
+      photodb.getFile(filename, function(file) {
+        selectedFileNamesToBlobs[filename] = file;
+      });
+    }
   }
   else {
     delete selectedFileNamesToBlobs[filename];

--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -11,6 +11,7 @@
   "permissions": {
     "device-storage:pictures":{ "access": "readwrite" },
     "device-storage:videos":{ "access": "readwrite" },
+    "deprecated-hwvideo":{},
     "audio-channel-content":{},
     "settings":{ "access": "readonly" }
   },

--- a/apps/gallery/style/VideoPlayer.css
+++ b/apps/gallery/style/VideoPlayer.css
@@ -1,5 +1,5 @@
-/* styles for the video element itself */
-.videoPlayer {
+/* styles for the video player and poster image */
+.videoPoster, .videoPlayer {
   position: absolute;
   left: 0; /* we position it with a transform */
   top:0;

--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -8,6 +8,7 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
+    "device-storage:pictures":{ "access": "readwrite" },
     "device-storage:videos":{ "access": "readwrite" },
     "settings":{ "access": "readonly" },
     "deprecated-hwvideo":{},


### PR DESCRIPTION
This is a big last-minute pull request to resolve the tef+ blocking bug 837236. The issue is that we are no longer allowing software decoding of videos, so only one <video> element can have its src specfied at a time, anywhere in the system. Only Camera, Gallery, and Video have permission to use the hardware, so these are the three that need to cooperate. This is tricky because both Gallery and Video used to create  a <video> element to parse metadata as soon as the Camera recorded a new video.

I've kept the commits separate because I think it might be easier to review in chunks.

I'll squash them before landing it though.
