### PR TITLE
Bug 836654 - Process priority fixes

### DIFF
--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -240,10 +240,13 @@ var CallHandler = (function callHandler() {
     var protocol = document.location.protocol;
     var urlBase = protocol + '//' + host + '/dialer/oncall.html';
 
+    var highPriorityWakeLock = navigator.requestWakeLock('high-priority');
     var openWindow = function dialer_openCallScreen(state) {
       callScreenWindow = window.open(urlBase + '#' + state,
                   'call_screen', 'attention');
+
       callScreenWindow.onload = function onload() {
+        highPriorityWakeLock.unlock();
         callScreenWindowLoaded = true;
         if (openCallback) {
           openCallback();

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -210,7 +210,18 @@ var OnCallHandler = (function onCallHandler() {
   }
 
   /* === Handled calls === */
+  var highPriorityWakeLock = null;
   function onCallsChanged() {
+    // Acquire or release the high-priority wake lock, as necessary.  This
+    // (mostly) prevents this process from being killed while we're on a call.
+    if (!highPriorityWakeLock && telephony.calls.length > 0) {
+      highPriorityWakeLock = navigator.requestWakeLock('high-priority');
+    }
+    if (highPriorityWakeLock && telephony.calls.length == 0) {
+      highPriorityWakeLock.unlock();
+      highPriorityWakeLock = null;
+    }
+
     // Adding any new calls to handledCalls
     telephony.calls.forEach(function callIterator(call) {
       var alreadyAdded = handledCalls.some(function hcIterator(hc) {


### PR DESCRIPTION
Bug 836654 - Put the expecting-system-message and mozapptype=critical attributes on frames, and hold the "high-priority" wake lock in the phone app.

Combined with the Gecko changes in the bug, this should make is much less likely to kill processes we actually want to keep around.

This is like PR 8053, except it is against gaia/master, which is the right thing to do, aiui.
