### PR TITLE
Bug 828830 - [CALL LOG] A half of last contact is covered with deselect all and select all popup

### DIFF
--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -181,6 +181,10 @@ ul[role="tablist"][data-type="filter"] > [role="tab"].selected > a {
 }
 
 /* Edit mode state */
+.recents-edit #recents-container {
+  height: -moz-calc(100% - 2.5rem);
+}
+
 .recents-edit form[role="dialog"][data-type="edit"] header,
 .recents-edit form[role="dialog"][data-type="edit"] > menu {
   transform: translateY(0);


### PR DESCRIPTION
In edit mode of call log, a half of last contact is covered with edit mode popup.
