### PR TITLE
Bug 833162 - [Dialer] When choosing a white background, Incoming string is not shown during incoming call

### DIFF
--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -657,7 +657,7 @@ button[disabled] .icon-keypad-visibility {
 #call-screen[data-layout="incoming-locked"] #main-container,
 #call-screen[data-layout="incoming-locked"] #main-container:before,
 #call-screen[data-layout="incoming-locked"] {
-  background-color: transparent;
+  background-color: rgba(0, 0, 0, 0.30);
 }
 
 #call-screen[data-layout="incoming-locked"] #calls {


### PR DESCRIPTION
Because background and "Incoming" string color do not defer, "Incoming" string is not shown. So, change background color
