### PR TITLE
Bug 840943: Display correct status for connected Bluetooth devices

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -546,7 +546,9 @@ navigator.mozL10n.ready(function bluetoothSettings() {
       };
       connectingAddress = device.address;
       var item = pairList.index[connectingAddress][1];
-      item.querySelector('small').textContent = _('device-status-connecting');
+      item.querySelector('small').textContent = (device.connected) ?
+        _('device-status-connected') :
+        _('device-status-connecting');
     }
 
     function showDeviceConnected(deviceAddress, connected) {


### PR DESCRIPTION
The Bluetooth UI sometimes gets confused about the connection status
of a device, if user repeatedly taps the connect button. The button
then displays 'Connecting...' even though phone and Bluetooth device
are already connected. With this patch, the interface tests the
device's 'connected' attribute when setting the displayed string.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
