### PR TITLE
Bug 832841 - [OPEN_] When save a contact which has no name in contacts, it shows abnormal in call log and in notification.(617001973097).

### DIFF
--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -71,14 +71,13 @@ var CallHandler = (function callHandler() {
   window.navigator.mozSetMessageHandler('notification', handleNotification);
 
   function handleNotificationRequest(number) {
-    Contacts.findByNumber(number, function lookup(contact) {
+    Contacts.findByNumber(number, function lookup(contact, matchingTel) {
       LazyL10n.get(function localized(_) {
         var title = _('missedCall');
-        var sender = (number && number.length) ? number : _('unknown');
 
-        if (contact && contact.name) {
-          sender = contact.name;
-        }
+        var sender = (contact == null) ? number :
+          (Utils.getPhoneNumberPrimaryInfo(matchingTel, contact) ||
+            _('unknown'));
 
         var body = _('from', {sender: sender});
 


### PR DESCRIPTION
We use the same algorithm already used application-wide in the Communications app to decide which information to show about the calling number in the missed call notifications:
- If there is no contact associated to the calling number, we show the calling phone number.
- If there is a contact associated to the calling number and the contact has a name, we show the name of the contact.
- If there is a contact associated to the calling number and the contact does not have a name but has a company, we show the company of the contact.
- If there is a contact associated to the calling number and the contact does not have either a name or a company, we show the calling phone number.
