### PR TITLE
Bug 842558 - Tapping the top of the screen causes the utility tray to appear and slide out immediately. r=timdream

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -87,8 +87,8 @@ var UtilityTray = {
   },
 
   onTouchStart: function ut_onTouchStart(touch) {
-    this.startX = touch.pageX;
     this.startY = touch.pageY;
+
     this.screen.classList.add('utility-tray');
     this.onTouchMove({ pageY: touch.pageY + this.statusbar.offsetHeight });
   },
@@ -121,6 +121,8 @@ var UtilityTray = {
     style.MozTransition = instant ? '' : '-moz-transform 0.2s linear';
     style.MozTransform = 'translateY(0)';
     this.shown = false;
+    this.lastY = undefined;
+    this.startY = undefined;
     if (instant)
       this.screen.classList.remove('utility-tray');
 


### PR DESCRIPTION
Fix for [#842558](https://bugzilla.mozilla.org/show_bug.cgi?id=842558). This patch adds the `utility-tray` class to the screen only when actually making a drag movement from the top of the screen rather than from `onTouchStart`.
