### PR TITLE
Bug 836647 - Set newly created tabs to background by default

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1138,11 +1138,26 @@ var Browser = {
       }
     }
 
-    if (tab.dom.setVisible)
-      tab.dom.setVisible(visible);
-
+    this.setVisibleWrapper(tab, visible);
     tab.dom.style.display = visible ? 'block' : 'none';
     tab.dom.style.top = '0px';
+  },
+
+  // dom.setVisible is loaded asynchronously from BrowserElementChildPreload
+  // and may require a yield before we call it, we want to make sure to
+  // clear any previous call
+  setVisibleWrapper: function(tab, visible) {
+    if (tab.setVisibleTimeout) {
+      clearTimeout(tab.setVisibleTimeout);
+    }
+    if (tab.dom.setVisible) {
+      tab.dom.setVisible(visible);
+      return;
+    }
+    tab.setVisibleTimeout = setTimeout(function() {
+      if (tab.dom.setVisible)
+        tab.dom.setVisible(visible);
+    });
   },
 
   bindBrowserEvents: function browser_bindBrowserEvents(iframe, tab) {
@@ -1189,8 +1204,9 @@ var Browser = {
       };
     }
 
+    // Default newly created frames to the background
+    this.setVisibleWrapper(tab, false);
     this.bindBrowserEvents(iframe, tab);
-
     this.tabs[tab.id] = tab;
     this.frames.appendChild(iframe);
     return tab.id;
@@ -1679,7 +1695,8 @@ var Browser = {
     switch (activity.source.data.type) {
       case 'url':
         var url = this.getUrlFromInput(activity.source.data.url);
-        this.hideCurrentTab();
+        if (this.currentTab)
+          this.hideCurrentTab();
         this.selectTab(this.createTab(url));
         this.showPageScreen();
         break;


### PR DESCRIPTION
Newly created mozbrowsers default to foreground, if we open tabs
using the context menu we never set them to background leaving
a lot of fg processes. This sets them to background by default, we
already ensure to set them to foreground every time they are
needed to be so.
