### PR TITLE
Bug 842143 - fix gallery share activity r=daleharvey a=tef+

### DIFF
--- a/apps/gallery/js/frames.js
+++ b/apps/gallery/js/frames.js
@@ -105,7 +105,7 @@ function deleteSingleItem() {
 
 // In fullscreen mode, the share button shares the current item
 function shareSingleItem() {
-  share([currentFrame.blob]);
+  share([currentFrame.imageblob || currentFrame.videoblob]);
 }
 
 // In order to distinguish single taps from double taps, we have to


### PR DESCRIPTION
One line fix. I updated shared/js/media/media_frame.js without updating the gallery code that used it and didn't test my patch sufficiently.
