### PR TITLE
Bug 843485 - can't toggle wifi button from second time

### DIFF
--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -95,6 +95,10 @@ var QuickSettings = {
           (self.wifi.dataset.enabled === undefined && !value))
         return;
 
+      // return during initializing
+      if (self.wifi.dataset.initializing)
+        return;
+
       if (value) {
         self.wifi.dataset.enabled = 'true';
       } else {


### PR DESCRIPTION
1. Title : [Statusbar] can't toggle wifi button from second time
2. Precondition : Bring down the statusbar from homescreen and turn on/off wifi once.
3. Tester's Action : Try turning on/off wifi again.
4. Detailed Symptom (ENG.) : It simply does not do anything. 
5. Expected : Wifi should be turned on/off when toggled.
   6.Reproducibility: Y
   1)Frequency Rate : 100%

And the strangest thing is, once 'airplane mode' is turned on/off. Then the wifi button starts working from second time.

https://bugzilla.mozilla.org/show_bug.cgi?id=843485
