### PR TITLE
Bug 843512 - Make tap target area of keyboard buttons larger

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -56,7 +56,6 @@ button::-moz-focus-inner {
 /* Rows */
 .keyboard-row {
   width: 100%;
-  margin-bottom: 0.5rem;
   white-space: nowrap;
 }
 
@@ -69,11 +68,12 @@ button::-moz-focus-inner {
 .keyboard-key {
   -moz-box-sizing: border-box;
   padding: 0 0.1rem;
-  border: none;
   background: url(images/key-shadow.png) no-repeat center -1px;
   background-size: 100% 100%;
   min-width: 2.6rem;
   display: inline-block;
+  border: none;
+  border-bottom: 0.5rem solid transparent; /* enlarge click area */
 }
 
 /* Visible keys */
@@ -681,3 +681,4 @@ bubble above the key when you tap and hold. */
   visibility: visible;
   color: #555;
 }
+


### PR DESCRIPTION
Fix for [#843512](https://bugzilla.mozilla.org/show_bug.cgi?id=843512). An issue (I have seen it on the GeeksPhone a couple of times, and easy to reproduce on the emulator) is that between every row on the keyboard there is 'dead' space, and the same goes for a couple of pixels below the bottom row. For example, trying to click the ABC/123 button in the lower left corner will fail every now and then because there is a dead spot located there.

This PR makes every button as high as the row, thus eliminating dead spots on the keyboard. The padding and margin cannot be used for this because this will change the button visibly. However, by adding a transparent 0.5rem bottom border to the keys, they will have a larger target area, without any visual change.
