### PR TITLE
Bug 843736 - [sms] Application broken when running with FF18

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -865,7 +865,9 @@ var ThreadUI = {
     this.sentAudio.mozAudioChannelType = 'notification';
     this.sentAudioEnabled = false;
 
-    if ('mozSettings' in navigator) {
+    // navigator.mozSettings will always be defined, but in some environments,
+    // it may be set to `null`.
+    if (navigator.mozSettings !== null) {
       var req = navigator.mozSettings.createLock().get(this.sentAudioKey);
       req.onsuccess = (function onsuccess() {
         this.sentAudioEnabled = req.result[this.sentAudioKey];


### PR DESCRIPTION
In FireFox 18, the global `navigator` object has a `mozSettings`
attribute, but it is set to `null`. In order to properly test with
FireFox, code that attempts to reference properties of
`navigator.mozSettings` should check that this value is non-null.

r=kgrandon
