### PR TITLE
Bug 843877 - Remove facebook.com UA override

### DIFF
--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -1,7 +1,5 @@
-
 // Send these sites a custom user-agent. Bugs to remove each override after
 // evangelism are included.
-pref("general.useragent.override.facebook.com", "\(Mobile#(Android; Mobile"); // bug 827635
 pref("general.useragent.override.youtube.com", "\(Mobile#(Android; Mobile"); // bug 827636
 pref("general.useragent.override.yelp.com", "\(Mobile#(Android; Mobile"); // bug 799884 
 pref("general.useragent.override.dailymotion.com", "\(Mobile#(Android; Mobile"); // bug 827638


### PR DESCRIPTION
Facebook recognized the B2G UA correctly in tests. Facebook confirmed from their side.

The override causes issue, as Facebook shows "Get our Android App" notifications which make no sense on Firefox OS.

This is part of the demos at MWC and is currently blocking Marketplace review.
