### PR TITLE
Bug 843855: reduce the time between unlock tap and unlock transition from 1000ms to 500ms

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -531,8 +531,6 @@ var LockScreen = {
 
     var wasAlreadyUnlocked = !this.locked;
     this.locked = false;
-    this.setElasticEnabled(false);
-    this.mainScreen.focus();
 
     var repaintTimeout = 0;
     var nextPaint = (function() {
@@ -567,14 +565,16 @@ var LockScreen = {
       }
     }).bind(this);
 
-    this.dispatchEvent('will-unlock');
-
     if (currentFrame)
       currentFrame.addNextPaintListener(nextPaint);
 
     repaintTimeout = setTimeout(function ensureUnlock() {
       nextPaint();
-    }, 400);
+    }, 200);
+
+    this.setElasticEnabled(false);
+    this.mainScreen.focus();
+    this.dispatchEvent('will-unlock');
   },
 
   lock: function ls_lock(instant) {

--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -24,8 +24,6 @@
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-
-  transition-delay: 0.3s;
 }
 
 #screen.screenoff > #lockscreen,


### PR DESCRIPTION
remove:
- transition-delay
- reduce timeout (we're hitting it after 100ms without noticable difference because the transition takes 500ms anyway)
  move some function post setting nextFramePaintListener
