### PR TITLE
Bug 844205 - [SMS] Regression in startup time r=borjasalguero

### DIFF
--- a/apps/sms/js/sms.js
+++ b/apps/sms/js/sms.js
@@ -858,8 +858,11 @@ var ThreadUI = {
 
     // We add the infinite scroll effect for increasing performance
     this.view.addEventListener('scroll', this.manageScroll.bind(this));
+  },
+  initSentAudio: function() {
+    if (this.sentAudio)
+      return;
 
-    // Sent sound init
     this.sentAudioKey = 'message.sent-sound.enabled';
     this.sentAudio = new Audio('/sounds/sent.ogg');
     this.sentAudio.mozAudioChannelType = 'notification';
@@ -930,6 +933,7 @@ var ThreadUI = {
   },
 
   enableSend: function thui_enableSend() {
+    this.initSentAudio();
     if (this.input.value.length > 0) {
       this.updateCounter();
     }


### PR DESCRIPTION
I made a sms performance regression by introducing audio load at the start of the app.

This patch delays the audio load until we actually enable the send button. There should still be plenty of time to get the setting and load the sound before sending the message.

If you have a better place to init the audio, let me know - I just wanted to avoid anything that blocks the initial render, so this seemed like the best option.
