### PR TITLE
Bug 833279 - [Calendar] Second field for time selector in calendar new event removed

### DIFF
--- a/apps/calendar/js/utils/input_parser.js
+++ b/apps/calendar/js/utils/input_parser.js
@@ -53,13 +53,11 @@ Calendar.ns('Utils').InputParser = (function() {
     exportTime: function(value) {
       var hour = value.getHours();
       var minute = value.getMinutes();
-      var second = value.getSeconds();
 
       var result = '';
 
       result += InputParser.padNumber(hour) + ':';
-      result += InputParser.padNumber(minute) + ':';
-      result += InputParser.padNumber(second);
+      result += InputParser.padNumber(minute);
 
       return result;
     },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=833279
