### PR TITLE
Bug 816260 - Hotspot Settings: No error message is displayed when Wi-Fi hotspot SSID is blank

### DIFF
--- a/apps/settings/js/hotspot.js
+++ b/apps/settings/js/hotspot.js
@@ -134,20 +134,36 @@ var Hotspot = {
     // validate all settings in the dialog box
     function submit() {
       if (settings) {
-        var ignorePassword = (securityTypeSelector.value == 'open');
 
-        // mozSettings does not support multiple keys in the cset object
-        // with one set() call,
-        // see https://bugzilla.mozilla.org/show_bug.cgi?id=779381
-        var lock = settings.createLock();
-        for (var i = 0; i < fields.length; i++) {
-          var input = fields[i];
-          var cset = {};
-          var key = input.dataset.setting;
+        var tethering_ssid_element = '[data-setting="tethering.wifi.ssid"]';
+        var tethering_password = 'tethering.wifi.security.password';
 
-          if (!(ignorePassword && key == 'tethering.wifi.security.password')) {
-            cset[key] = input.value;
-            lock.set(cset);
+        var tethering_ssid = dialog.querySelector(tethering_ssid_element);
+
+        // Check if SSID is set
+        // if (tethering_ssid.value == '') {
+          if (/^\s*$/.test(tethering_ssid.value)) {
+
+          var _ = navigator.mozL10n.get;
+          var error_msg = _('SSIDCannotBeEmpty');
+          alert(error_msg);
+          reset(); // Reset to original values if ssid is null.
+        } else {
+          var ignorePassword = (securityTypeSelector.value == 'open');
+
+          // mozSettings does not support multiple keys in the cset object
+          // with one set() call,
+          // see https://bugzilla.mozilla.org/show_bug.cgi?id=779381
+          var lock = settings.createLock();
+          for (var i = 0; i < fields.length; i++) {
+            var input = fields[i];
+            var cset = {};
+            var key = input.dataset.setting;
+
+            if (!(ignorePassword && key == tethering_password)) {
+              cset[key] = input.value;
+              lock.set(cset);
+            }
           }
         }
       }

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -196,6 +196,7 @@ unpair-title = Unpair a connected device?
 unpair-msg   = You are currently connected to this device. Unpairing will also disconnect from it.
 
 # Connectivity :: Internet Sharing
+SSIDCannotBeEmpty=The SSID cannot be empty 
 internetSharing=Internet sharing
 internetSharing-usb=USB
 internetSharing-usb-desc=Share my phone’s Internet connection with a USB-connected device.


### PR DESCRIPTION
Fixed [Bug 816260] Hotspot Settings: No error message is displayed when Wi-Fi hotspot SSID is blank
 https://bugzilla.mozilla.org/show_bug.cgi?id=816260

An error message is displayed and changes are reverted.

![Screenshot from 2013-02-24 02:15:12](https://f.cloud.github.com/assets/1485255/188591/fca1d238-7df9-11e2-89d6-6a938a2f1e6f.png)
