### PR TITLE
bug 842215 - some tweaks to improve performance

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -38,7 +38,6 @@
     <!-- shared helper library -->
     <!--<script defer src="shared/js/mouse_event_shim.js"></script>-->
     <!--<script defer src="shared/js/mobile_operator.js"></script>-->
-    <!--<script defer src="shared/js/settings_listener.js"></script>-->
 
     <!-- all non-#root panels will lazy-load their own scripts -->
   </head>
@@ -286,7 +285,7 @@
       <ul>
         <li id="wifi-enabled">
           <label>
-            <input type="checkbox" data-type="switch" />
+            <input type="checkbox" data-type="switch" data-ignore/>
             <span></span>
           </label>
           <a data-l10n-id="wifi">Wi-Fi</a>
@@ -465,7 +464,7 @@
       <ul>
         <li id="menuItem-callWaiting" data-state="off">
           <label class="checkbox-label">
-            <input type="checkbox" data-type="switch"/>
+            <input type="checkbox" data-type="switch" data-ignore/>
             <span></span>
           </label>
           <label class="alert-label" hidden>
@@ -505,7 +504,7 @@
           </p>
           <p class="cw-alert-sub-p">
             <label class="cw-alert-checkbox-label">
-              <input type="checkbox" data-type="switch"/>
+              <input type="checkbox" data-type="switch" data-ignore/>
               <span></span>
             </label>
             <span data-l10n-id="callWaiting">Call Waiting</span>
@@ -545,7 +544,7 @@
         </li>
         <li id="operator-autoSelect">
           <label>
-            <input type="checkbox" data-type="switch" />
+            <input type="checkbox" data-type="switch" data-ignore/>
             <span></span>
           </label>
           <small></small>
@@ -804,7 +803,7 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="ril.data.enabled"/>
+            <input type="checkbox" data-type="switch" name="ril.data.enabled" class="uninit"/>
             <span></span>
           </label>
           <small id="dataConnection-desc"></small>
@@ -814,7 +813,7 @@
         </li>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="ril.data.roaming_enabled"/>
+            <input type="checkbox" data-type="switch" name="ril.data.roaming_enabled" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="dataRoaming">Data Roaming</a>
@@ -870,7 +869,7 @@
       <ul>
         <li id="bluetooth-status">
           <label>
-            <input type="checkbox" data-type="switch" />
+            <input type="checkbox" data-type="switch" data-ignore/>
             <span></span>
           </label>
           <a data-l10n-id="bluetooth">Bluetooth</a>
@@ -983,7 +982,7 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="tethering.wifi.enabled"/>
+            <input type="checkbox" data-type="switch" name="tethering.wifi.enabled" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="wifi-hotspot">Wi-Fi Hotspot</a>
@@ -1020,7 +1019,7 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="tethering.usb.enabled"/>
+            <input type="checkbox" data-type="switch" name="tethering.usb.enabled" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="usb-tethering">USB Tethering</a>
@@ -1075,7 +1074,7 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="vibration.enabled" checked />
+            <input type="checkbox" data-type="switch" name="vibration.enabled" checked class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="vibrate">Vibrate</a>
@@ -1257,7 +1256,7 @@
       <ul id="time-auto" data-state="auto" hidden>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="time.nitz.automatic-update.enabled"/>
+            <input type="checkbox" data-type="switch" name="time.nitz.automatic-update.enabled" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="setTimeAutomatically">Set Automatically</a>
@@ -1515,14 +1514,14 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="lockscreen.enabled" id="lockscreen-enable" />
+            <input type="checkbox" data-type="switch" name="lockscreen.enabled" id="lockscreen-enable" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="lockScreen">Lock Screen</a>
         </li>
         <li class="lockscreen-enabled">
           <label>
-            <input type="checkbox" data-type="switch" name="lockscreen.passcode-lock.enabled" id="passcode-enable" />
+            <input type="checkbox" data-type="switch" name="lockscreen.passcode-lock.enabled" id="passcode-enable" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="passcode-lock">Passcode Lock</a>
@@ -1624,7 +1623,7 @@
       <ul>
         <li id="simpin-enabled">
           <label>
-            <input type="checkbox" data-type="switch" />
+            <input type="checkbox" data-type="switch" data-ignore/>
             <span></span>
           </label>
           <a data-l10n-id="simPin">SIM PIN</a>
@@ -2211,7 +2210,7 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="powersave.enabled" />
+            <input type="checkbox" data-type="switch" name="powersave.enabled" class="uninit"/>
             <span></span>
           </label>
           <a data-l10n-id="powerSaveMode">Power Save Mode</a>
@@ -2543,14 +2542,14 @@
       <ul>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="ril.radio.disabled" />
+            <input type="checkbox" data-type="switch" name="ril.radio.disabled" class="uninit"/>
             <span></span>
           </label>
           <a id="menuItem-airplaneMode" class="menu-item" data-l10n-id="airplaneMode">Airplane Mode</a>
         </li>
         <li>
           <label>
-            <input type="checkbox" data-type="switch" name="geolocation.enabled" />
+            <input type="checkbox" data-type="switch" name="geolocation.enabled" class="uninit"/>
             <span></span>
           </label>
           <a id="menuItem-gps" class="menu-item" data-l10n-id="gps">GPS</a>
@@ -2674,17 +2673,16 @@
       </ul>
 
       <!-- Main :: SIM Toolkit -->
-      <header id="icc-mainheader" hidden>
+      <header id="icc-mainheader">
         <h2 data-l10n-id="operatorServices">Operator Services</h2>
       </header>
-      <ul id="icc-mainentry" hidden>
+      <ul id="icc-mainentry">
         <li>
           <small id="icc-desc" class="menu-item-desc"></small>
           <a id="menuItem-icc" class="menu-item" href="#icc">SIM Toolkit</a>
         </li>
       </ul>
     </section>
-
   </body>
 </html>
 

--- a/apps/settings/js/app_storage.js
+++ b/apps/settings/js/app_storage.js
@@ -35,6 +35,8 @@ var AppStorage = (function AppStorage() {
       _callback();
   }
 
+  //XXX we really don't need this callback because nobody invoke this method
+  //with a callback function.
   function getSpaceInfo(callback) {
     var callbackFunc = callback ? callback : _callback;
     DeviceStorageHelper.getStat('apps', callbackFunc);

--- a/apps/settings/js/icc.js
+++ b/apps/settings/js/icc.js
@@ -99,16 +99,18 @@
     // Load STK apps
     updateMenu();
 
+    // XXX https://bugzilla.mozilla.org/show_bug.cgi?id=844727
+    // We should use Settings.settingsCache first
+    var settings = Settings.mozSettings;
+    var lock = settings.createLock();
     // Update displayTextTimeout with settings parameter
-    var reqDisplayTimeout =
-      window.navigator.mozSettings.createLock().get('icc.displayTextTimeout');
+    var reqDisplayTimeout = lock.get('icc.displayTextTimeout');
     reqDisplayTimeout.onsuccess = function icc_getDisplayTimeout() {
       displayTextTimeout = reqDisplayTimeout.result['icc.displayTextTimeout'];
     };
 
     // Update inputTimeout with settings parameter
-    var reqInputTimeout =
-      window.navigator.mozSettings.createLock().get('icc.inputTextTimeout');
+    var reqInputTimeout = lock.get('icc.inputTextTimeout');
     reqInputTimeout.onsuccess = function icc_getInputTimeout() {
       inputTimeout = reqInputTimeout.result['icc.inputTextTimeout'];
     };
@@ -745,7 +747,7 @@
       clearTimeout(timeoutId);
       alertbox.classList.add('hidden');
       stkResGoBack();
-    }
+    };
 
     alertbox_btnclose.onclick = function() {
       clearTimeout(timeoutId);
@@ -833,7 +835,7 @@
         closeToneAlert();
         iccLastCommandProcessed = true;
         responseSTKCommand({ resultCode: icc.STK_RESULT_OK });
-      }
+      };
       alertbox_btnback.onclick = function() {
         closeToneAlert();
         stkResGoBack();

--- a/apps/settings/js/icc_menu.js
+++ b/apps/settings/js/icc_menu.js
@@ -25,8 +25,12 @@
 
   setTimeout(function updateStkMenu() {
     debug('Showing STK main menu');
-    var reqApplications =
-      window.navigator.mozSettings.createLock().get('icc.applications');
+    // XXX https://bugzilla.mozilla.org/show_bug.cgi?id=844727
+    // We should use Settings.settingsCache first
+    var settings = Settings.mozSettings;
+    var lock = settings.createLock();
+
+    var reqApplications = lock.get('icc.applications');
     reqApplications.onsuccess = function icc_getApplications() {
       var json = reqApplications.result['icc.applications'];
       var menu = json && JSON.parse(json);
@@ -38,29 +42,28 @@
         return;
       }
 
-      // Show the entry in settings
-      document.getElementById('icc-mainheader').hidden = false;
-      document.getElementById('icc-mainentry').hidden = false;
-
+      // update and show the entry in settings
       debug('STK Main App Menu title: ' + menu.title);
       document.getElementById('menuItem-icc').textContent = menu.title;
+      document.getElementById('icc-mainheader').hidden = false;
+      document.getElementById('icc-mainentry').hidden = false;
     };
 
-    var reqIccData = window.navigator.mozSettings.createLock().get('icc.data');
+    var reqIccData = lock.get('icc.data');
     reqIccData.onsuccess = function icc_getIccData() {
       var cmd = reqIccData.result['icc.data'];
       if (cmd) {
         debug('ICC async command (launcher)');
         executeICCCmd(JSON.parse(cmd));
       }
-    }
+    };
 
-    SettingsListener.observe('icc.data', null, function(value) {
-      if(!value)
-        return;
-
-      debug('ICC async command while settings running: ', value);
-      executeICCCmd(JSON.parse(value));
+    settings.addObserver('icc.data', function(event) {
+      var value = event.settingValue;
+      if (value) {
+        debug('ICC async command while settings running: ', value);
+        executeICCCmd(JSON.parse(value));
+      }
     });
   });
 })();

--- a/apps/settings/js/media_storage.js
+++ b/apps/settings/js/media_storage.js
@@ -11,6 +11,7 @@
  * In this case, the user has to unplug the USB cable in order to actually turn
  * off UMS, and we put some text to that effect on the settings screen.
  */
+
 var MediaStorage = {
   init: function mediaStorage_init() {
     this.deviceStorage = navigator.getDeviceStorage('pictures');
@@ -146,7 +147,6 @@ var MediaStorage = {
 
   updateStorageInfo: function mediaStorage_updateStorageInfo() {
     var _ = navigator.mozL10n.get;
-
     function formatSize(element, size, l10nId) {
       if (!element)
         return;
@@ -165,26 +165,39 @@ var MediaStorage = {
         unit: _('byteUnit-' + sizeInfo.unit)
       });
     }
-    
+
+    DeviceStorageHelper.getFreeSpace(function(freeSize) {
+      var element = document.getElementById('media-storage-desc');
+      formatSize(element, freeSize, 'availableSize');
+    });
+
+    // XXX https://bugzilla.mozilla.org/show_bug.cgi?id=844709
+    // if the sub-menu hasn't been loaded because of lazy-loading
+    // we don't need to update these fields
+    var element = document.querySelector('#music-space .size');
+    if (!element)
+      return;
+
     // Update the storage details
     stackedBar.reset();
-    
-    DeviceStorageHelper.getStats(['music', 'pictures', 'videos'], function(sizes) {
-      var element = document.querySelector('#music-space .size');
-      formatSize(element, sizes['music']);
-      stackedBar.add(new StackBarItem('music', sizes['music']));
-      element = document.querySelector('#pictures-space .size');
-      formatSize(element, sizes['pictures']);
-      stackedBar.add(new StackBarItem('pictures', sizes['pictures']));
-      element = document.querySelector('#videos-space .size');
-      formatSize(element, sizes['videos']);
-      stackedBar.add(new StackBarItem('videos', sizes['videos']));
-      element = document.querySelector('#media-free-space .size');
-      formatSize(element, sizes['music']);
-      stackedBar.add(new StackBarItem('free', sizes['free']));
-      element = document.getElementById('media-storage-desc');
-      formatSize(element, sizes['free'], 'availableSize');
-      stackedBar.refreshUI();
+    DeviceStorageHelper.getStats(['music', 'pictures', 'videos'],
+      function(sizes) {
+        formatSize(element, sizes['music']);
+        stackedBar.add(new StackBarItem('music', sizes['music']));
+
+        element = document.querySelector('#pictures-space .size');
+        formatSize(element, sizes['pictures']);
+        stackedBar.add(new StackBarItem('pictures', sizes['pictures']));
+
+        element = document.querySelector('#videos-space .size');
+        formatSize(element, sizes['videos']);
+        stackedBar.add(new StackBarItem('videos', sizes['videos']));
+
+        element = document.querySelector('#media-free-space .size');
+        formatSize(element, sizes['free']);
+        stackedBar.add(new StackBarItem('free', sizes['free']));
+
+        stackedBar.refreshUI();
     });
   }
 };
@@ -198,33 +211,31 @@ function StackBarItem(id, value) {
 }
 
 var stackedBar = {
-  
   _targetId: null,
-  
   _items: [],
-  
   _total: 0,
-  
+
   _initUI: function sb_initui(targetId) {
-    this._targetId = targetId
+    this._targetId = targetId;
   },
-  
+
   init: function sb_init(targetId) {
     this._initUI(targetId);
   },
-  
+
   add: function sb_add(item) {
     this._total = this._total + item.value;
     this._items.push(item);
   },
-  
+
   refreshUI: function sb_refreshUI() {
     var container = document.getElementById(this._targetId);
-    if(!container)
+    if (!container)
       return;
     for (var i = 0; i < this._items.length; i++) {
-      var item = document.getElementById('stackedbar-item-' + this._items[i].id);
-      if(!item)
+      var item = document.getElementById('stackedbar-item-' +
+          this._items[i].id);
+      if (!item)
         item = document.createElement('span');
       item.className = 'stackedbar-item';
       item.id = 'stackedbar-item-' + this._items[i].id;
@@ -232,12 +243,11 @@ var stackedBar = {
       container.appendChild(item);
     }
   },
-  
+
   reset: function sb_reset() {
     this._items = [];
     this._total = 0;
   }
-  
-}
+};
 
 navigator.mozL10n.ready(MediaStorage.init.bind(MediaStorage));

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -124,7 +124,7 @@ var Settings = {
     // activate all scripts
     var scripts = panel.querySelectorAll('script');
     for (var i = 0; i < scripts.length; i++) {
-      var src = scripts[i].getAttribute('src')
+      var src = scripts[i].getAttribute('src');
       if (document.head.querySelector('script[src="' + src + '"]')) {
         continue;
       }
@@ -183,6 +183,10 @@ var Settings = {
   // without these, so we keep this around most of the time.
   _settingsCache: null,
 
+  get settingsCache() {
+    return this._settingsCache;
+  },
+
   // True when a request has already been made to fill the settings
   // cache.  When this is true, no further get("*") requests should be
   // made; instead, pending callbacks should be added to
@@ -192,7 +196,7 @@ var Settings = {
   // There can be race conditions in which we need settings values,
   // but haven't filled the cache yet.  This array tracks those
   // listeners.
-  _pendingSettingsCallbacks: [ ],
+  _pendingSettingsCallbacks: [],
 
   // Invoke |callback| with a request object for a successful fetch of
   // settings values, when those values are ready.
@@ -243,6 +247,16 @@ var Settings = {
           checkboxes[i].checked = !!result[key];
         }
       }
+
+      // remove initial class so the swich animation will apply
+      // on these toggles if user interact with it.
+      setTimeout(function() {
+        for (var i = 0; i < checkboxes.length; i++) {
+          if (checkboxes[i].classList.contains('initial')) {
+            checkboxes[i].classList.remove('initial');
+          }
+        }
+      }, 0);
 
       // preset all radio buttons
       rule = 'input[type="radio"]:not([data-ignore])';
@@ -549,7 +563,6 @@ window.addEventListener('load', function loadSettings() {
       'shared/js/mobile_operator.js',
       'js/connectivity.js',
       'js/security_privacy.js',
-      'shared/js/settings_listener.js',
       'js/icc_menu.js'
     ];
     scripts.forEach(function attachScripts(src) {
@@ -694,7 +707,7 @@ window.addEventListener('load', function loadSettings() {
 
       if (disabled) {
         item.classList.add('carrier-disabled');
-        link.onclick = function() { return false; }
+        link.onclick = function() { return false; };
       } else {
         item.classList.remove('carrier-disabled');
         link.onclick = null;
@@ -771,3 +784,5 @@ window.addEventListener('localized', function showLanguages() {
 // Do initialization work that doesn't depend on the DOM, as early as
 // possible in startup.
 Settings.preInit();
+
+MouseEventShim.trackMouseMoves = false;

--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -174,12 +174,25 @@ var DeviceStorageHelper = (function DeviceStorageHelper() {
           
       });
     }
+  }
 
+  function getFreeSpace(callback) {
+    var deviceStorage = navigator.getDeviceStorage('sdcard');
+
+    if (!deviceStorage) {
+      console.error('Cannot get free space size in sdcard');
+      return;
+    }
+    deviceStorage.freeSpace().onsuccess = function(e) {
+      var freeSpace = e.target.result;
+      callback(freeSpace);
+    };
   }
 
   return {
     getStat: getStat,
-    getStats: getStats
+    getStats: getStats,
+    getFreeSpace: getFreeSpace
   };
 
 })();

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -13,6 +13,7 @@
     "device-storage:pictures":{ "access": "readonly" },
     "device-storage:music":{ "access": "readonly" },
     "device-storage:videos":{ "access": "readonly" },
+    "device-storage:sdcard":{ "access": "readonly" },
     "device-storage:apps":{ "access": "readonly" },
     "webapps-manage":{},
     "permissions":{},

--- a/shared/style/switches.css
+++ b/shared/style/switches.css
@@ -125,3 +125,8 @@ label input[data-type="switch"]:checked + span:after {
   transform: translateX(0);
 }
 
+label input[type="checkbox"][data-type="switch"].uninit + span,
+label input[type="checkbox"][data-type="switch"].uninit + span:before,
+label input[type="checkbox"][data-type="switch"].uninit + span:after {
+  transition: none;
+}


### PR DESCRIPTION
1.remove initial animation on toggles
2.remove extra device states queries from media_storage.js
   because these states are displayed only on the sub-menu which
   is lazy-loaded
3.icc menu should be default visible to prevent extra reflow. (Most
   of the time, we have a SIM card in the phone, the menu has higher
   probability needs to be displayed.)
4. Don't track mousemove targets in Settings (patch from Chris Jones)
5. Don't query settings database multiple times when initialing. (patch from Chris Jones)
