### PR TITLE
Bug 833708: Correctly handle update errors that happen in-stack while sending a download event

### DIFF
--- a/apps/system/js/updatable.js
+++ b/apps/system/js/updatable.js
@@ -146,9 +146,9 @@ SystemUpdatable.prototype.download = function() {
 
   this.downloading = true;
   this.paused = false;
-  this._dispatchEvent('update-available-result', 'download');
   UpdateManager.addToDownloadsQueue(this);
   this.progress = 0;
+  this._dispatchEvent('update-available-result', 'download');
 };
 
 SystemUpdatable.prototype.cancelDownload = function() {

--- a/apps/system/test/unit/mock_update_manager.js
+++ b/apps/system/test/unit/mock_update_manager.js
@@ -3,6 +3,7 @@
 var MockUpdateManager = {
   addToUpdatesQueue: function mum_addtoUpdateQueue(updatable) {
     this.mLastUpdatesAdd = updatable;
+    this.mUpdates.push(updatable);
   },
   addToUpdatableApps: function mum_addToUpdatableApps(updatable) {
     this.mLastUpdatableAdd = updatable;
@@ -10,15 +11,24 @@ var MockUpdateManager = {
 
   removeFromUpdatesQueue: function mum_removeFromUpdateQueue(updatable) {
     this.mLastUpdatesRemoval = updatable;
+    var index = this.mUpdates.indexOf(updatable);
+    if (index >= 0) {
+      this.mUpdates.splice(index, 1);
+    }
   },
 
   addToDownloadsQueue: function mum_addtoActiveDownloads(updatable) {
     this.mLastDownloadsAdd = updatable;
+    this.mDownloads.push(updatable);
   },
   removeFromDownloadsQueue:
     function mum_removeFromActiveDownloads(updatable) {
 
     this.mLastDownloadsRemoval = updatable;
+    var index = this.mDownloads.indexOf(updatable);
+    if (index >= 0) {
+      this.mDownloads.splice(index, 1);
+    }
   },
 
   downloadProgressed: function mum_downloadProgressed(bytes) {
@@ -38,6 +48,8 @@ var MockUpdateManager = {
   },
 
   mErrorBannerRequested: false,
+  mUpdates: [],
+  mDownloads: [],
   mLastUpdatesAdd: null,
   mLastUpdatableAdd: null,
   mLastUpdatesRemoval: null,
@@ -56,5 +68,7 @@ var MockUpdateManager = {
     this.mProgressCalledWith = null;
     this.mCheckForUpdatesCalledWith = null;
     this.mStartedUncompressingCalled = false;
+    this.mUpdates = [];
+    this.mDownloads = [];
   }
 };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=833708

I have r+ from @etiennesegonzac, and tef+
