### PR TITLE
Bug 845243 - Gallery uses gesture detector, prevent click bubbling when cancelling scroll

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -11,7 +11,7 @@
     <link rel="resource" type="application/l10n" href="locales/locales.ini" />
     <!-- Shared code -->
     <script defer src="shared/js/l10n.js"></script>
-    <script defer src="shared/js/mouse_event_shim.js"></script>
+    <script defer src="shared/js/gesture_detector.js"></script>
     <script defer src="shared/js/mediadb.js"></script>
     <script defer src="shared/js/lazy_loader.js"></script>
     <script defer src="shared/js/visibility_monitor.js"></script>

--- a/shared/js/gesture_detector.js
+++ b/shared/js/gesture_detector.js
@@ -415,6 +415,8 @@ var GestureDetector = (function() {
       // pan actually started at a point along the path between the
       // first touch and this current touch.
       d.start = d.last = between(d.start, coordinates(e, t));
+      
+      d.emitEvent('panstart', d.start);
 
       // If we transition into this state with a touchmove event,
       // then process it with that handler. If we don't do this then
@@ -795,6 +797,8 @@ var GestureDetector = (function() {
       // starting point to a point between the start point and this
       // current point
       d.start = d.last = between(d.start, mouseCoordinates(e));
+      
+      d.emitEvent('panstart', d.start);
 
       // If we transition into this state with a mousemove event,
       // then process it with that handler. If we don't do this then


### PR DESCRIPTION
Fix for [#845243](https://bugzilla.mozilla.org/show_bug.cgi?id=845243).

This patch removes the use of the mouse event shim from the gallery, and replaces it by the gesture_detector. This was need to fix an issue with click/tap bubbling. When you swipe down the list of photo's (pan and let go to swipe), you can tap the screen to stop the automated scrolling. However, the tap event bubbled through to the thumbnail and thus the detail view got opened. This patch stops bubbling through (with a threshold of 200 ms. because scroll and tap aren't in sync). The threshold is enough for the simulator and the Unagi phone to keep behaving properly with existing UI flows, and I haven't seen any false positives so far.
