### PR TITLE
Bug 798696 - Gallery back button, move the button to a header element

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -40,7 +40,11 @@
       </footer>
     </section>
 
-    <section role="region" id="fullscreen-view" class="hidden">
+    <section role="region" id="fullscreen-view" class="hidden skin-dark">
+      <header>
+        <button id="fullscreen-back-button"><span class='icon icon-back'></span></button>
+        <h1></h1>
+      </header>
       <div id="frames">
         <!-- the current photo plus next and previous waiting in the wings -->
         <div id="frame1" class="frame"></div>
@@ -49,7 +53,6 @@
       </div>
 
       <footer id="fullscreen-toolbar">
-        <a id="fullscreen-back-button" class="button"></a>
         <a id="fullscreen-camera-button" class="button"></a>
         <a id="fullscreen-edit-button" class="button"></a>
         <a id="fullscreen-share-button" class="button"></a>

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -392,47 +392,47 @@ footer {
   transition: transform 100ms linear;
 }
 
+#fullscreen-view header {
+  opacity: 0.75;
+  transform: translate(0, 0);
+  transition: transform 100ms linear;
+}
+
 #fullscreen-view.toolbarhidden #fullscreen-toolbar {
   transform: translate(0, 40px);
 }
-
-#fullscreen-back-button {
-  position: absolute;
-  width: 20%;
-  height: 100%;
-  left: 0;
-  background-image: url('images/iconaction_camera_gridview_30x30.png');
+#fullscreen-view.toolbarhidden header {
+  transform: translate(0, -5rem);
 }
 
 #fullscreen-camera-button {
   position: absolute;
-  width: 20%;
+  width: 25%;
   height: 100%;
-  left: 20%;
   background-image: url('images/iconaction_camera_30x30.png');
 }
 
 #fullscreen-edit-button {
   position: absolute;
-  width: 20%;
+  width: 25%;
   height: 100%;
-  left: 40%;
+  left: 25%;
   background-image: url('images/iconaction_camera_editphoto_30x30.png');
 }
 
 #fullscreen-share-button {
   position: absolute;
-  width: 20%;
+  width: 25%;
   height: 100%;
-  left: 60%;
+  left: 50%;
   background-image: url('images/iconaction_share_30x30.png');
 }
 
 #fullscreen-delete-button {
   position: absolute;
-  width: 20%;
+  width: 25%;
   height: 100%;
-  left: 80%;
+  left: 75%;
   background-image: url('images/iconaction_delete_30x30.png');
 }
 


### PR DESCRIPTION
Fix for [#798696](https://bugzilla.mozilla.org/show_bug.cgi?id=798696). At the moment it is not clear how to get back to the photo list from the photo detail page. The button has a different icon than normally and is at a different place. Also all the icons in the footer are used to do an _action_ on the current image, and the back button should have no place there.

This patch is a proposal on how to fix this. I have moved the back button to a 0.75 opacity dark header element (that goes away if you tap the photo). It looks pretty good actually, and it is way more clear on how to go back.
