### PR TITLE
Bug 835642 - [Call log] Dotted line is shown on deselect all button

### DIFF
--- a/apps/communications/dialer/style/dialer.css
+++ b/apps/communications/dialer/style/dialer.css
@@ -16,6 +16,10 @@ a:hover, a:active, a:focus {
   outline: 0;
 }
 
+button::-moz-focus-inner {
+  border: 0;
+}
+
 .hide {
   display: none !important;
 }


### PR DESCRIPTION
[Call log] In edit mode, when press delete button, and then press cancel button, looks a Deselect all button on the dotted line
