### PR TITLE
Bug 832258 - [Calendar] sync option removed if no calendar account is added. r=KevinGrandon

### DIFF
--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -131,6 +131,7 @@ Calendar.App = (function(window) {
     _mozTimeRefreshTimeout: 3000,
 
     pendingClass: 'pending-operation',
+    syncDisabledClass: 'sync-disabled',
 
     // Dependency map for loading
     cssBase: '/style/',
@@ -221,6 +222,7 @@ Calendar.App = (function(window) {
 
       var self = this;
       this._pendingManger.oncomplete = function onpending() {
+        document.body.classList.remove(self.syncDisabledClass);
         document.body.classList.remove(self.pendingClass);
       };
 

--- a/apps/calendar/js/views/settings.js
+++ b/apps/calendar/js/views/settings.js
@@ -14,6 +14,13 @@
     __proto__: _super,
 
     /**
+     * Keeps the count of calendar accounts added
+     * used to enable/disable the sync operation of
+     * external calendars
+     */
+    _accountCount: 0,
+
+    /**
      * Local update is a flag
      * used to indicate that the incoming
      * update was made by this view and
@@ -135,7 +142,11 @@
       var el = document.getElementById(htmlId);
       if (el) {
         el.parentNode.removeChild(el);
+        this._accountCount = this._accountCount - 1;
       }
+
+      if (this._accountCount <= 1)
+        document.body.classList.add(this.app.syncDisabledClass);
     },
 
     render: function() {
@@ -143,12 +154,18 @@
       var store = this.app.store('Calendar');
       var key;
       var html = '';
+      var lCalCount = 0;
 
       for (key in store.cached) {
         html += template.item.render(
           store.cached[key]
         );
+        lCalCount ++;
       }
+      this._accountCount = lCalCount;
+
+      if (this._accountCount <= 1)
+        document.body.classList.add(this.app.syncDisabledClass);
 
       list.innerHTML = html;
     },

--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -112,6 +112,10 @@ body[data-path^='/settings'] #time-views {
   display: none;
 }
 
+.sync-disabled #settings .sync {
+  display: none;
+}
+
 #settings .settings {
   width: 5.5rem;
   height: 4rem;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=832258
