### PR TITLE
Bug 826249 - Thumbs redraw on applying effect or border

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -76,7 +76,7 @@
         <img id="crop-image"></img>
       </div>
     </section>
-    
+
     <section role="region" id="edit-view" class="hidden skin-organic">
       <header id="edit-header">
         <button id="edit-cancel-button"><span class="icon icon-close"></span></button>
@@ -110,7 +110,7 @@
           </div>
         </div>
 
-        <div id="edit-crop-options" class="edit-options-bar hidden"> 
+        <div id="edit-crop-options" class="edit-options-bar hidden">
           <a id="edit-crop-none" class="button"></a>
           <a id="edit-crop-aspect-free" class="selected radio button"></a>
           <a id="edit-crop-aspect-portrait" class="radio button"></a>
@@ -118,30 +118,30 @@
           <a id="edit-crop-aspect-square" class="radio button"></a>
         </div>
 
-        <div id="edit-effect-options" class="edit-options-bar hidden"> 
+        <div id="edit-effect-options" class="edit-options-bar hidden">
           <a id="edit-effect-none" class="selected radio button bgimage"
-             data-effect="none"></a>
+             data-effect="none"><canvas/></a>
           <a id="edit-effect-bw" class="radio button filter-bw bgimage"
-             data-effect="bw"></a>
+             data-effect="bw"><canvas/></a>
           <a id="edit-effect-sepia" class="radio button filter-sepia bgimage"
-             data-effect="sepia"></a>
+             data-effect="sepia"><canvas/></a>
           <a id="edit-effect-bluesteel" class="radio button filter-bluesteel bgimage"
-             data-effect="bluesteel"></a>
+             data-effect="bluesteel"><canvas/></a>
           <a id="edit-effect-faded" class="radio button filter-faded bgimage"
-             data-effect="faded"></a>
+             data-effect="faded"><canvas/></a>
         </div>
 
-        <div id="edit-border-options" class="edit-options-bar hidden"> 
+        <div id="edit-border-options" class="edit-options-bar hidden">
           <a id="edit-border-none" class="selected radio button bgimage"
-             data-border-width="0"></a>
+             data-border-width="0"><canvas/></a>
           <a id="edit-border-thin-white" class="radio button bgimage"
-             data-border-width=".015" data-border-color="white"></a>
+             data-border-width=".015" data-border-color="white"><canvas/></a>
           <a id="edit-border-thick-white" class="radio button bgimage"
-             data-border-width=".03" data-border-color="white"></a>
+             data-border-width=".03" data-border-color="white"><canvas/></a>
           <a id="edit-border-thin-black" class="radio button bgimage"
-             data-border-width=".015" data-border-color="black"></a>
+             data-border-width=".015" data-border-color="black"><canvas/></a>
           <a id="edit-border-thick-black" class="radio button bgimage"
-             data-border-width=".03" data-border-color="black"></a>
+             data-border-width=".03" data-border-color="black"><canvas/></a>
         </div>
       </div>
 

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -100,7 +100,7 @@ section {
 
 #overlay-text {
   padding: 10px 5px 0 5px;
-  border-top: 1px solid #686868;	
+  border-top: 1px solid #686868;
   font-weight: 300;
   font-size: 2.5rem;
   color: #ebebeb;
@@ -110,7 +110,7 @@ section {
  * Thumbnails are implemented as <li> elements in a <ul> with background-image
  * set to display the image. We use background-size: cover to automatically
  * resize the image as needed.
- * The thumbnail list appears in regular browsing mode, in selection mode, 
+ * The thumbnail list appears in regular browsing mode, in selection mode,
  * and in pick mode.
  */
 
@@ -495,7 +495,7 @@ footer {
   height: calc(100% - 20px)  /* can't just set bottom: 10px here */
 }
 
-#edit-crop-canvas { 
+#edit-crop-canvas {
   position: absolute;
   left: 0;
   right: 0;
@@ -611,7 +611,6 @@ footer {
 /* All the effects radio buttons share these styles */
 #edit-effect-options > a.radio.button {
   width: 20%;
-  padding-top: 15px;
 }
 
 #edit-effect-none {
@@ -629,6 +628,7 @@ footer {
 #edit-effect-faded {
   left:80%
 }
+
 a.filter-bw {
   filter: url(../index.html#filter-bw);
 }
@@ -661,11 +661,11 @@ a.filter-faded {
 
 #edit-border-none {
   left: calc(0% + 3px);
-  border: 2px solid white;  
+  border: 2px solid white;
 }
 #edit-border-thin-white {
   left: calc(20% + 3px);
-  border: 2px solid white;  
+  border: 2px solid white;
 }
 #edit-border-thick-white {
   left: calc(40% + 3px);
@@ -673,11 +673,11 @@ a.filter-faded {
 }
 #edit-border-thin-black {
   left: calc(60% + 3px);
-  border: 2px solid black;  
+  border: 2px solid black;
 }
 #edit-border-thick-black {
   left: calc(80% + 3px);
-  border: 4px solid black;  
+  border: 4px solid black;
 }
 
 /* all buttons in the toolbar share these styles */


### PR DESCRIPTION
Fix for [#826249](https://bugzilla.mozilla.org/show_bug.cgi?id=826249).

When you apply an effect or a border to an image in the gallery all thumbs get redrawn. This is very easy to spot on the Unagi or GeeksPhone, but takes a large image (e.g. grab a 3 MB one from your photo camera) to see in the emulator.

After quite some testing I tracked this down to the moment that the filter is applied (through WebGL, `gl.texImage2D` line). During this moment (which runs on the main thread, can't offload GL to a worker at the moment) the background images of the buttons disappear as well, even though there is no actual change on them. This is not only due to buttons or anything, but seem to happen on all background-images on the current view. Maybe a gecko flake or anything.

I worked around the above by writing the image information to a canvas object embedded within the button, as an <img/> tag crashes B2G desktop there. This works great, the effects are also faster applied on the Unagi and no redraws are triggered. Also I now delay the rendering of these elements until the panel is actually used.
