### PR TITLE
Bug 846127 Notification Touch effect of Clear all button does not work h...

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
@@ -341,7 +341,7 @@
         <!-- notifications -->
         <div id="notification-bar">
           <span data-l10n-id="notifications">Notifications</span>
-          <button id="notification-clear" data-l10n-id="clear-all">Clear all</button>
+          <a href="#" id="notification-clear" data-l10n-id="clear-all">Clear all</a>
         </div>
 
         <div id="notifications-container">

--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -77,22 +77,25 @@ html, body {
   line-height: 30px;
 }
 
-#notification-bar button {
+#notification-clear {
   float: right;
   margin-right: 15px;
   width: 30%;
   height: 30px;
+  line-height: 30px;
   padding: 0;
   border: 0;
   background: none;
   text-align: right;
+  text-decoration: none;
   font-size: 1.4rem;
   font-weight: 500;
+  outline: none;
+  color: #666;
 }
 
-/* remove ugly dotted outline when focus */
-#notification-bar button::-moz-focus-inner {
-  border: 0;
+#notification-clear:active { 
+  color: #1b3f46;
 }
 
 #notifications-container {


### PR DESCRIPTION
1. Title : [Notification] Touch effect of 'Clear all' button does not work half times.
2. Precondition : None
3. Tester's Action : Bring down the notification and touch 'Clear all' button.
4. Detailed Symptom (ENG.) : Half the times, the 'Clear all' button text darkens on touch and half the times it doesn't
5. Expected : The 'Clear all' button text should darken every touch.
6. Reproducibility: Y
   1)Frequency Rate : 50%
7. Gaia revision : 6916e18d1f72936e892543cf4a104a7d457f78ad

When the problem does not occur easily, touch an empty area of the notification list many times. and repeat.
