### PR TITLE
Browse to URL Email is truncated modified overflow property

### DIFF
--- a/shared/style/confirm.css
+++ b/shared/style/confirm.css
@@ -10,7 +10,7 @@ form[role="dialog"][data-type="confirm"] {
   background-size: auto auto, 100% 100%;
   /* We can't use shortand with background size because is not implemented yet:
   https://bugzilla.mozilla.org/show_bug.cgi?id=570326; */
-  overflow: hidden;
+  overflow: visible;
   position: absolute;
   z-index: 100;
   top: 0;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=838139
