### PR TITLE
Bug 832246 - [clock] Alarm label displays in multiline in onring screen and maximum length set for 75. r=ian-liu

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -106,7 +106,7 @@
         </li>
         <li class="singleline field">
           <span class="view-alarm-lbl" data-l10n-id="label">Label</span>
-          <input type="text" class="right" data-l10n-id="alarm" name="alarm.label" placeholder="Alarm"/>
+          <input type="text" class="right" data-l10n-id="alarm" name="alarm.label" placeholder="Alarm" maxLength="75"/>
         </li>
         <li class="singleline field">
           <span class="view-alarm-lbl" data-l10n-id="repeat">Repeat</span>

--- a/apps/clock/style/onring.css
+++ b/apps/clock/style/onring.css
@@ -56,7 +56,7 @@ html, body {
 #ring-alarm-label {
   font: lighter 2.50rem 'MozTT',sans-serif;
   line-height: 6.25rem;
-  white-space: nowrap; 
+  white-space: normal;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=832246
