### PR TITLE
Bug 844426 - [email] Limit JS syntax to legal ES5 syntax (but not semantics). r=asuth, rs=squib

### DIFF
--- a/apps/email/js/ext/mailapi/activesync/configurator.js
+++ b/apps/email/js/ext/mailapi/activesync/configurator.js
@@ -23,9 +23,9 @@
 }(this, function() {
   'use strict';
 
-  let exports = {};
+  var exports = {};
 
-  const Tokens = {
+  var Tokens = {
     SWITCH_PAGE: 0x00,
     END:         0x01,
     ENTITY:      0x02,
@@ -96,8 +96,8 @@
     this.strings = [];
     this.offsets = {};
 
-    let start = 0;
-    for (let i = 0; i < data.length; i++) {
+    var start = 0;
+    for (var i = 0; i < data.length; i++) {
       if (data[i] === 0) {
         this.offsets[start] = this.strings.length;
         this.strings.push(decoder.decode( data.subarray(start, i) ));
@@ -114,8 +114,8 @@
         if (offset < 0)
           throw new ParseError('offset must be >= 0');
 
-        let curr = 0;
-        for (let i = 0; i < this.strings.length; i++) {
+        var curr = 0;
+        for (var i = 0; i < this.strings.length; i++) {
           // Add 1 to the current string's length here because we stripped a
           // null-terminator earlier.
           if (offset < curr + this.strings[i].length + 1)
@@ -132,20 +132,24 @@
     codepages.__tagnames__ = {};
     codepages.__attrdata__ = {};
 
-    for (let [name, page] in Iterator(codepages)) {
+    for (var iter in Iterator(codepages)) {
+      var name = iter[0], page = iter[1];
       if (name.match(/^__/))
         continue;
 
       if (page.Tags) {
-        let [,v] = Iterator(page.Tags).next();
-        codepages.__nsnames__[v >> 8] = name;
+        var v = Iterator(page.Tags).next();
+        codepages.__nsnames__[v[1] >> 8] = name;
 
-        for (let [tag, value] in Iterator(page.Tags))
+        for (var iter2 in Iterator(page.Tags)) {
+          var tag = iter2[0], value = iter2[1];
           codepages.__tagnames__[value] = tag;
+        }
       }
 
       if (page.Attrs) {
-        for (let [attr, data] in Iterator(page.Attrs)) {
+        for (var iter3 in Iterator(page.Attrs)) {
+          var attr = iter3[0], data = iter3[1];
           if (!('name' in data))
             data.name = attr;
           codepages.__attrdata__[data.value] = data;
@@ -156,7 +160,7 @@
   }
   exports.CompileCodepages = CompileCodepages;
 
-  const mib2str = {
+  var mib2str = {
       3: 'US-ASCII',
       4: 'ISO-8859-1',
       5: 'ISO-8859-2',
@@ -173,9 +177,10 @@
 
   // TODO: Really, we should build our own map here with synonyms for the
   // various encodings, but this is a step in the right direction.
-  const str2mib = {};
-  for (let [k, v] in Iterator(mib2str))
-    str2mib[v] = k;
+  var str2mib = {};
+  for (var iter in Iterator(mib2str)) {
+    str2mib[iter[1]] = iter[0];
+  }
 
   function Element(ownerDocument, type, tag) {
     this.ownerDocument = ownerDocument;
@@ -183,10 +188,13 @@
     this._attrs = {};
 
     if (typeof tag === 'string') {
-      let pieces = tag.split(':');
-      if (pieces.length === 1)
+      var pieces = tag.split(':');
+      if (pieces.length === 1) {
         this.localTagName = pieces[0];
-      else        [this.namespaceName, this.localTagName] = pieces;
+      } else {
+        this.namespaceName = pieces[0];
+        this.localTagName = pieces[1];
+      }
     }
     else {
       this.tag = tag;
@@ -205,17 +213,20 @@
   exports.Element = Element;
   Element.prototype = {
     get tagName() {
-      let ns = this.namespaceName;
+      var ns = this.namespaceName;
       ns = ns ? ns + ':' : '';
       return ns + this.localTagName;
     },
 
-    get attributes() {
-      for (let [name, pieces] in Iterator(this._attrs)) {
-        let [namespace, localName] = name.split(':');
-        yield { name: name, namespace: namespace, localName: localName,
-                value: this._getAttribute(pieces) };
+    getAttributes: function() {
+      var attributes = [];
+      for (var iter in Iterator(this._attrs)) {
+        var name = iter[0], pieces = iter[1];
+        var data = name.split(':');
+        attributes.push({ name: name, namespace: data[0], localName: data[1],
+                          value: this._getAttribute(pieces) });
       }
+      return attributes;
     },
 
     getAttribute: function(attr) {
@@ -228,10 +239,11 @@
     },
 
     _getAttribute: function(pieces) {
-      let strValue = '';
-      let array = [];
+      var strValue = '';
+      var array = [];
 
-      for (let [,hunk] in Iterator(pieces)) {
+      for (var iter in Iterator(pieces)) {
+        var hunk = iter[1];
         if (hunk instanceof Extension) {
           if (strValue) {
             array.push(strValue);
@@ -260,13 +272,13 @@
         return this._attrs[attr] = [];
       }
       else {
-        let namespace = attr >> 8;
-        let localAttr = attr & 0xff;
+        var namespace = attr >> 8;
+        var localAttr = attr & 0xff;
 
-        let localName = this.ownerDocument._codepages.__attrdata__[localAttr]
+        var localName = this.ownerDocument._codepages.__attrdata__[localAttr]
                             .name;
-        let nsName = this.ownerDocument._codepages.__nsnames__[namespace];
-        let name = nsName + ':' + localName;
+        var nsName = this.ownerDocument._codepages.__nsnames__[namespace];
+        var name = nsName + ':' + localName;
 
         if (name in this._attrs)
           throw new ParseError('attribute '+name+' is repeated');
@@ -354,8 +366,8 @@
     },
 
     _get_mb_uint32: function() {
-      let b;
-      let result = 0;
+      var b;
+      var result = 0;
       do {
         b = this._get_uint8();
         result = result*128 + (b & 0x7f);
@@ -364,27 +376,33 @@
     },
 
     _get_slice: function(length) {
-      let start = this._index;
+      var start = this._index;
       this._index += length;
       return this._data.subarray(start, this._index);
     },
 
     _get_c_string: function() {
-      let start = this._index;
+      var start = this._index;
       while (this._get_uint8());
       return this._data.subarray(start, this._index - 1);
     },
 
     rewind: function() {
+      // Although in theory we could cache this.document since we no longer use
+      // iterators, there is clearly some kind of rep exposure that goes awry
+      // for us, so I'm having us re-do our work.  This does not matter in the
+      // normal use-case, just for debugging and just for our test server, which
+      // both rely on rewind().
+
       this._index = 0;
 
-      let v = this._get_uint8();
+      var v = this._get_uint8();
       this.version = ((v & 0xf0) + 1).toString() + '.' + (v & 0x0f).toString();
       this.pid = this._get_mb_uint32();
       this.charset = mib2str[this._get_mb_uint32()] || 'unknown';
       this._decoder = TextDecoder(this.charset);
 
-      let tbl_len = this._get_mb_uint32();
+      var tbl_len = this._get_mb_uint32();
       this.strings = new StringTable(this._get_slice(tbl_len), this._decoder);
 
       this.document = this._getDocument();
@@ -424,20 +442,21 @@
     // zero         = u_int8                // containing the value zero (0).
     _getDocument: function() {
       // Parser states
-      const States = {
+      var States = {
         BODY: 0,
         ATTRIBUTES: 1,
         ATTRIBUTE_PI: 2,
       };
 
-      let state = States.BODY;
-      let currentNode;
-      let currentAttr;
-      let codepage = 0;
-      let depth = 0;
-      let foundRoot = false;
+      var state = States.BODY;
+      var currentNode;
+      var currentAttr;
+      var codepage = 0;
+      var depth = 0;
+      var foundRoot = false;
+      var doc = [];
 
-      let appendString = (function(s) {
+      var appendString = (function(s) {
         if (state === States.BODY) {
           if (!currentNode)
             currentNode = new Text(this, s);
@@ -452,25 +471,25 @@
       }).bind(this);
 
       try { while (true) {
-        let tok = this._get_uint8();
+        var tok = this._get_uint8();
 
         if (tok === Tokens.SWITCH_PAGE) {
           codepage = this._get_uint8();
           if (!(codepage in this._codepages.__nsnames__))
-            throw new ParseError('unknown codepage '+codepage)
+            throw new ParseError('unknown codepage '+codepage);
         }
         else if (tok === Tokens.END) {
           if (state === States.BODY && depth-- > 0) {
             if (currentNode) {
-              yield currentNode;
+              doc.push(currentNode);
               currentNode = null;
             }
-            yield new EndTag(this);
+            doc.push(new EndTag(this));
           }
           else if (state === States.ATTRIBUTES || state === States.ATTRIBUTE_PI) {
             state = States.BODY;
 
-            yield currentNode;
+            doc.push(currentNode);
             currentNode = null;
             currentAttr = null;
           }
@@ -481,7 +500,7 @@
         else if (tok === Tokens.ENTITY) {
           if (state === States.BODY && depth === 0)
             throw new ParseError('unexpected ENTITY token');
-          let e = this._get_mb_uint32();
+          var e = this._get_mb_uint32();
           appendString('&#'+e+';');
         }
         else if (tok === Tokens.STR_I) {
@@ -495,32 +514,32 @@
           state = States.ATTRIBUTE_PI;
 
           if (currentNode)
-            yield currentNode;
+            doc.push(currentNode);
           currentNode = new ProcessingInstruction(this);
         }
         else if (tok === Tokens.STR_T) {
           if (state === States.BODY && depth === 0)
             throw new ParseError('unexpected STR_T token');
-          let r = this._get_mb_uint32();
+          var r = this._get_mb_uint32();
           appendString(this.strings.get(r));
         }
         else if (tok === Tokens.OPAQUE) {
           if (state !== States.BODY)
             throw new ParseError('unexpected OPAQUE token');
-          let len = this._get_mb_uint32();
-          let data = this._get_slice(len);
+          var len = this._get_mb_uint32();
+          var data = this._get_slice(len);
 
           if (currentNode) {
-            yield currentNode;
+            doc.push(currentNode);
             currentNode = null;
           }
-          yield new Opaque(this, data);
+          doc.push(new Opaque(this, data));
         }
         else if (((tok & 0x40) || (tok & 0x80)) && (tok & 0x3f) < 3) {
-          let hi = tok & 0xc0;
-          let lo = tok & 0x3f;
-          let subtype;
-          let value;
+          var hi = tok & 0xc0;
+          var lo = tok & 0x3f;
+          var subtype;
+          var value;
 
           if (hi === Tokens.EXT_I_0) {
             subtype = 'string';
@@ -535,13 +554,13 @@
             value = null;
           }
 
-          let ext = new Extension(this, subtype, lo, value);
+          var ext = new Extension(this, subtype, lo, value);
           if (state === States.BODY) {
             if (currentNode) {
-              yield currentNode;
+              doc.push(currentNode);
               currentNode = null;
             }
-            yield ext;
+            doc.push(ext);
           }
           else { // if (state === States.ATTRIBUTES || state === States.ATTRIBUTE_PI)
             currentAttr.push(ext);
@@ -554,14 +573,14 @@
             foundRoot = true;
           }
 
-          let tag = (codepage << 8) + (tok & 0x3f);
+          var tag = (codepage << 8) + (tok & 0x3f);
           if ((tok & 0x3f) === Tokens.LITERAL) {
-            let r = this._get_mb_uint32();
+            var r = this._get_mb_uint32();
             tag = this.strings.get(r);
           }
 
           if (currentNode)
-            yield currentNode;
+            doc.push(currentNode);
           currentNode = new Element(this, (tok & 0x40) ? 'STAG' : 'TAG', tag);
           if (tok & 0x40)
             depth++;
@@ -572,15 +591,15 @@
           else {
             state = States.BODY;
 
-            yield currentNode;
+            doc.push(currentNode);
             currentNode = null;
           }
         }
         else { // if (state === States.ATTRIBUTES || state === States.ATTRIBUTE_PI)
-          let attr = (codepage << 8) + tok;
+          var attr = (codepage << 8) + tok;
           if (!(tok & 0x80)) {
             if (tok === Tokens.LITERAL) {
-              let r = this._get_mb_uint32();
+              var r = this._get_mb_uint32();
               attr = this.strings.get(r);
             }
             if (state === States.ATTRIBUTE_PI) {
@@ -600,17 +619,18 @@
         if (!(e instanceof StopIteration))
           throw e;
       }
+      return doc;
     },
 
     dump: function(indentation, header) {
-      let result = '';
+      var result = '';
 
       if (indentation === undefined)
         indentation = 2;
-      let indent = function(level) {
+      var indent = function(level) {
         return new Array(level*indentation + 1).join(' ');
       };
-      let tagstack = [];
+      var tagstack = [];
 
       if (header) {
         result += 'Version: ' + this.version + '\n';
@@ -620,12 +640,17 @@
                   this.strings.strings.join('"\n  "') + '"\n\n';
       }
 
-      let newline = false;
-      for (let node in this.document) {
+      var newline = false;
+      var doc = this.document;
+      var doclen = doc.length;
+      for (var iNode = 0; iNode < doclen; iNode++) {
+        var node = doc[iNode];
         if (node.type === 'TAG' || node.type === 'STAG') {
           result += indent(tagstack.length) + '<' + node.tagName;
 
-          for (let attr in node.attributes) {
+          var attributes = node.getAttributes();
+          for (var i = 0; i < attributes.length; i++) {
+            var attr = attributes[i];
             result += ' ' + attr.name + '="' + attr.value + '"';
           }
 
@@ -637,7 +662,7 @@
             result += '/>\n';
         }
         else if (node.type === 'ETAG') {
-          let tag = tagstack.pop();
+          var tag = tagstack.pop();
           result += indent(tagstack.length) + '</' + tag + '>\n';
         }
         else if (node.type === 'TEXT') {
@@ -668,27 +693,29 @@
     this._codepage = 0;
     this._tagStack = [];
 
-    let [major, minor] = version.split('.').map(function(x) {
+    var infos = version.split('.').map(function(x) {
       return parseInt(x);
     });
-    let v = ((major - 1) << 4) + minor;
+    var major = infos[0], minor = infos[1];
+    var v = ((major - 1) << 4) + minor;
 
-    let charsetNum = charset;
+    var charsetNum = charset;
     if (typeof charset === 'string') {
       charsetNum = str2mib[charset];
       if (charsetNum === undefined)
         throw new Error('unknown charset '+charset);
     }
-    let encoder = this._encoder = TextEncoder(charset);
+    var encoder = this._encoder = TextEncoder(charset);
 
     this._write(v);
     this._write(pid);
     this._write(charsetNum);
     if (strings) {
-      let bytes = strings.map(function(s) { return encoder.encode(s); });
-      let len = bytes.reduce(function(x, y) { return x + y.length + 1; }, 0);
+      var bytes = strings.map(function(s) { return encoder.encode(s); });
+      var len = bytes.reduce(function(x, y) { return x + y.length + 1; }, 0);
       this._write_mb_uint32(len);
-      for (let [,b] in Iterator(bytes)) {
+      for (var iter in Iterator(bytes)) {
+        var b = iter[1];
         this._write_bytes(b);
         this._write(0x00);
       }
@@ -716,7 +743,7 @@
   };
 
   Writer.Extension = function(subtype, index, data) {
-    const validTypes = {
+    var validTypes = {
       'string':  { value:     Tokens.EXT_I_0,
                    validator: function(data) {
                      return typeof data === 'string';
@@ -731,7 +758,7 @@
                    } },
     };
 
-    let info = validTypes[subtype];
+    var info = validTypes[subtype];
     if (!info)
       throw new Error('Invalid WBXML Extension type');
     if (!info.validator(data))
@@ -755,9 +782,9 @@
       // Expand the buffer by a factor of two if we ran out of space.
       if (this._pos === this._buffer.length - 1) {
         this._rawbuf = new ArrayBuffer(this._rawbuf.byteLength * 2);
-        let buffer = new Uint8Array(this._rawbuf);
+        var buffer = new Uint8Array(this._rawbuf);
 
-        for (let i = 0; i < this._buffer.length; i++)
+        for (var i = 0; i < this._buffer.length; i++)
           buffer[i] = this._buffer[i];
 
         this._buffer = buffer;
@@ -767,19 +794,19 @@
     },
 
     _write_mb_uint32: function(value) {
-      let bytes = [];
+      var bytes = [];
       bytes.push(value % 0x80);
       while (value >= 0x80) {
         value >>= 7;
         bytes.push(0x80 + (value % 0x80));
       }
 
-      for (let i = bytes.length - 1; i >= 0; i--)
+      for (var i = bytes.length - 1; i >= 0; i--)
         this._write(bytes[i]);
     },
 
     _write_bytes: function(bytes) {
-      for (let i = 0; i < bytes.length; i++)
+      for (var i = 0; i < bytes.length; i++)
         this._write(bytes[i]);
     },
 
@@ -799,7 +826,7 @@
       if (tag === undefined)
         throw new Error('unknown tag');
 
-      let flags = 0x00;
+      var flags = 0x00;
       if (stag)
         flags += 0x40;
       if (attrs.length)
@@ -815,8 +842,10 @@
       }
 
       if (attrs.length) {
-        for (let [,attr] in Iterator(attrs))
+        for (var iter in Iterator(attrs)) {
+          var attr = iter[1];
           this._writeAttr(attr);
+        }
         this._write(Tokens.END);
       }
     },
@@ -840,8 +869,10 @@
 
     _writeText: function(value, inAttr) {
       if (Array.isArray(value)) {
-        for (let [,piece] in Iterator(value))
+        for (var iter in Iterator(value)) {
+          var piece = iter[1];
           this._writeText(piece, inAttr);
+        }
       }
       else if (value instanceof Writer.StringTableRef) {
         this._write(Tokens.STR_T);
@@ -878,14 +909,14 @@
     },
 
     tag: function(tag) {
-      let tail = arguments.length > 1 ? arguments[arguments.length - 1] : null;
+      var tail = arguments.length > 1 ? arguments[arguments.length - 1] : null;
       if (tail === null || tail instanceof Writer.Attribute) {
-        let rest = Array.prototype.slice.call(arguments, 1);
+        var rest = Array.prototype.slice.call(arguments, 1);
         this._writeTag(tag, false, rest);
         return this;
       }
       else {
-        let head = Array.prototype.slice.call(arguments, 0, -1);
+        var head = Array.prototype.slice.call(arguments, 0, -1);
         return this.stag.apply(this, head)
                      .text(tail)
                    .etag();
@@ -893,7 +924,7 @@
     },
 
     stag: function(tag) {
-      let rest = Array.prototype.slice.call(arguments, 1);
+      var rest = Array.prototype.slice.call(arguments, 1);
       this._writeTag(tag, true, rest);
       this._tagStack.push(tag);
       return this;
@@ -902,7 +933,7 @@
     etag: function(tag) {
       if (this._tagStack.length === 0)
         throw new Error('Spurious etag() call!');
-      let expectedTag = this._tagStack.pop();
+      var expectedTag = this._tagStack.pop();
       if (tag !== undefined && tag !== expectedTag)
         throw new Error('Closed the wrong tag');
 
@@ -933,7 +964,7 @@
         this._write_str(data);
       }
       else {
-        for (let i = 0; i < data.length; i++)
+        for (var i = 0; i < data.length; i++)
           this._write(data[i]);
       }
       return this;
@@ -966,14 +997,18 @@
     },
 
     run: function(reader) {
-      let fullPath = [];
-      let recPath = [];
-      let recording = 0;
+      var fullPath = [];
+      var recPath = [];
+      var recording = 0;
 
-      for (let node in reader.document) {
+      var doc = reader.document;
+      var doclen = doc.length;
+      for (var iNode = 0; iNode < doclen; iNode++) {
+        var node = doc[iNode];
         if (node.type === 'TAG') {
           fullPath.push(node.tag);
-          for (let [,listener] in Iterator(this.listeners)) {
+          for (var iter in Iterator(this.listeners)) {
+            var listener = iter[1];
             if (this._pathMatches(fullPath, listener.path)) {
               node.children = [];
               try {
@@ -991,14 +1026,16 @@
         else if (node.type === 'STAG') {
           fullPath.push(node.tag);
 
-          for (let [,listener] in Iterator(this.listeners)) {
+          for (var iter in Iterator(this.listeners)) {
+            var listener = iter[1];
             if (this._pathMatches(fullPath, listener.path)) {
               recording++;
             }
           }
         }
         else if (node.type === 'ETAG') {
-          for (let [,listener] in Iterator(this.listeners)) {
+          for (var iter in Iterator(this.listeners)) {
+            var listener = iter[1];
             if (this._pathMatches(fullPath, listener.path)) {
               recording--;
               try {
@@ -1062,7 +1099,7 @@
 }(this, function(WBXML) {
   'use strict';
 
-  let codepages = {
+  var codepages = {
     Common: {
       Enums: {
         Status: {
@@ -2261,8 +2298,8 @@
   exports.HttpError = HttpError;
 
   function nsResolver(prefix) {
-    const baseUrl = 'http://schemas.microsoft.com/exchange/autodiscover/';
-    const ns = {
+    var baseUrl = 'http://schemas.microsoft.com/exchange/autodiscover/';
+    var ns = {
       rq: baseUrl + 'mobilesync/requestschema/2006',
       ad: baseUrl + 'responseschema/2006',
       ms: baseUrl + 'mobilesync/responseschema/2006',
@@ -2270,9 +2307,11 @@
     return ns[prefix] || null;
   }
 
-  function Version(str) {    [this.major, this.minor] = str.split('.').map(function(x) {
+  function Version(str) {
+    var details = str.split('.').map(function(x) {
       return parseInt(x);
     });
+    this.major = details[0], this.minor = details[1];
   }
   exports.Version = Version;
   Version.prototype = {
@@ -2315,7 +2354,7 @@
    * @param password the user's password
    */
   function setAuthHeader(xhr, username, password) {
-    let authorization = 'Basic ' + btoa(username + ':' + password);
+    var authorization = 'Basic ' + btoa(username + ':' + password);
     xhr.setRequestHeader('Authorization', authorization);
   }
 
@@ -2334,14 +2373,15 @@
   function autodiscover(aEmailAddress, aPassword, aTimeout, aCallback,
                         aNoRedirect) {
     if (!aCallback) aCallback = nullCallback;
-    let domain = aEmailAddress.substring(aEmailAddress.indexOf('@') + 1);
+    var domain = aEmailAddress.substring(aEmailAddress.indexOf('@') + 1);
 
     // The first time we try autodiscovery, we should try to recover from
-    // AutodiscoverDomainErrors. The second time, *all* errors should be
-    // reported to the callback.
+    // AutodiscoverDomainErrors and HttpErrors. The second time, *all* errors
+    // should be reported to the callback.
     do_autodiscover(domain, aEmailAddress, aPassword, aTimeout, aNoRedirect,
                     function(aError, aConfig) {
-      if (aError instanceof AutodiscoverDomainError)
+      if (aError instanceof AutodiscoverDomainError ||
+          aError instanceof HttpError)
         do_autodiscover('autodiscover.' + domain, aEmailAddress, aPassword,
                         aTimeout, aNoRedirect, aCallback);
       else
@@ -2365,7 +2405,7 @@
    */
   function do_autodiscover(aHost, aEmailAddress, aPassword, aTimeout,
                            aNoRedirect, aCallback) {
-    let xhr = new XMLHttpRequest({mozSystem: true, mozAnon: true});
+    var xhr = new XMLHttpRequest({mozSystem: true, mozAnon: true});
     xhr.open('POST', 'https://' + aHost + '/autodiscover/autodiscover.xml',
              true);
     setAuthHeader(xhr, aEmailAddress, aPassword);
@@ -2380,7 +2420,7 @@
       if (xhr.status < 200 || xhr.status >= 300)
         return aCallback(new HttpError(xhr.statusText, xhr.status));
 
-      let doc = new DOMParser().parseFromString(xhr.responseText, 'text/xml');
+      var doc = new DOMParser().parseFromString(xhr.responseText, 'text/xml');
 
       function getNode(xpath, rel) {
         return doc.evaluate(xpath, rel, nsResolver,
@@ -2400,30 +2440,30 @@
         return aCallback(new AutodiscoverDomainError(
           'Error parsing autodiscover response'));
 
-      let responseNode = getNode('/ad:Autodiscover/ms:Response', doc);
+      var responseNode = getNode('/ad:Autodiscover/ms:Response', doc);
       if (!responseNode)
         return aCallback(new AutodiscoverDomainError(
           'Missing Autodiscover Response node'));
 
-      let error = getNode('ms:Error', responseNode) ||
+      var error = getNode('ms:Error', responseNode) ||
                   getNode('ms:Action/ms:Error', responseNode);
       if (error)
         return aCallback(new AutodiscoverError(
           getString('ms:Message/text()', error)));
 
-      let redirect = getNode('ms:Action/ms:Redirect', responseNode);
+      var redirect = getNode('ms:Action/ms:Redirect', responseNode);
       if (redirect) {
         if (aNoRedirect)
           return aCallback(new AutodiscoverError(
             'Multiple redirects occurred during autodiscovery'));
 
-        let redirectedEmail = getString('text()', redirect);
+        var redirectedEmail = getString('text()', redirect);
         return autodiscover(redirectedEmail, aPassword, aTimeout, aCallback,
                             true);
       }
 
-      let user = getNode('ms:User', responseNode);
-      let config = {
+      var user = getNode('ms:User', responseNode);
+      var config = {
         culture: getString('ms:Culture/text()', responseNode),
         user: {
           name:  getString('ms:DisplayName/text()',  user),
@@ -2432,8 +2472,8 @@
         servers: [],
       };
 
-      let servers = getNodes('ms:Action/ms:Settings/ms:Server', responseNode);
-      let server;
+      var servers = getNodes('ms:Action/ms:Settings/ms:Server', responseNode);
+      var server;
       while ((server = servers.iterateNext())) {
         config.servers.push({
           type:       getString('ms:Type/text()',       server),
@@ -2444,7 +2484,8 @@
       }
 
       // Try to find a MobileSync server from Autodiscovery.
-      for (let [,server] in Iterator(config.servers)) {
+      for (var iter in Iterator(config.servers)) {
+        var server = iter[1];
         if (server.type === 'MobileSync') {
           config.mobileSyncServer = server;
           break;
@@ -2464,7 +2505,7 @@
 
     // TODO: use something like
     // http://ejohn.org/blog/javascript-micro-templating/ here?
-    let postdata =
+    var postdata =
     '<?xml version="1.0" encoding="utf-8"?>\n' +
     '<Autodiscover xmlns="' + nsResolver('rq') + '">\n' +
     '  <Request>\n' +
@@ -2519,8 +2560,10 @@
       if (aError)
         this.disconnect();
 
-      for (let [,callback] in Iterator(this._connectionCallbacks))
+      for (var iter in Iterator(this._connectionCallbacks)) {
+        var callback = iter[1];
         callback.apply(callback, arguments);
+      }
       this._connectionCallbacks = [];
     },
 
@@ -2614,8 +2657,8 @@
      *        WBXML response
      */
     provision: function(aCallback) {
-      const pv = ASCP.Provision.Tags;
-      let w = new WBXML.Writer('1.3', 1, 'UTF-8');
+      var pv = ASCP.Provision.Tags;
+      var w = new WBXML.Writer('1.3', 1, 'UTF-8');
       w.stag(pv.Provision)
         .etag();
       this.postCommand(w, aCallback);
@@ -2630,8 +2673,8 @@
     getOptions: function(aCallback) {
       if (!aCallback) aCallback = nullCallback;
 
-      let conn = this;
-      let xhr = new XMLHttpRequest({mozSystem: true, mozAnon: true});
+      var conn = this;
+      var xhr = new XMLHttpRequest({mozSystem: true, mozAnon: true});
       xhr.open('OPTIONS', this.baseUrl, true);
       setAuthHeader(xhr, this._username, this._password);
       xhr.timeout = this.timeout;
@@ -2648,7 +2691,7 @@
           return;
         }
 
-        let result = {
+        var result = {
           versions: xhr.getResponseHeader('MS-ASProtocolVersions').split(','),
           commands: xhr.getResponseHeader('MS-ASProtocolCommands').split(','),
         };
@@ -2657,7 +2700,7 @@
       };
 
       xhr.ontimeout = xhr.onerror = function() {
-        let error = new Error('Error getting OPTIONS URL');
+        var error = new Error('Error getting OPTIONS URL');
         console.error(error);
         aCallback(error);
       };
@@ -2713,15 +2756,15 @@
      */
     postCommand: function(aCommand, aCallback, aExtraParams, aExtraHeaders,
                           aProgressCallback) {
-      const contentType = 'application/vnd.ms-sync.wbxml';
+      var contentType = 'application/vnd.ms-sync.wbxml';
 
       if (typeof aCommand === 'string' || typeof aCommand === 'number') {
         this.postData(aCommand, contentType, null, aCallback, aExtraParams,
                       aExtraHeaders);
       }
       else {
-        let r = new WBXML.Reader(aCommand, ASCP);
-        let commandName = r.document.next().localTagName;
+        var r = new WBXML.Reader(aCommand, ASCP);
+        var commandName = r.document[0].localTagName;
         this.postData(commandName, contentType, aCommand.buffer, aCallback,
                       aExtraParams, aExtraHeaders, aProgressCallback);
       }
@@ -2753,7 +2796,7 @@
         aCommand = ASCP.__tagnames__[aCommand];
 
       if (!this.supportsCommand(aCommand)) {
-        let error = new Error("This server doesn't support the command " +
+        var error = new Error("This server doesn't support the command " +
                               aCommand);
         console.error(error);
         aCallback(error);
@@ -2761,26 +2804,27 @@
       }
 
       // Build the URL parameters.
-      let params = [
+      var params = [
         ['Cmd', aCommand],
         ['User', this._email],
         ['DeviceId', this._deviceId],
         ['DeviceType', this._deviceType]
       ];
       if (aExtraParams) {
-        for (let [,param] in Iterator(params)) {
+        for (var iter in Iterator(params)) {
+          var param = iter[1];
           if (param[0] in aExtraParams)
             throw new TypeError('reserved URL parameter found');
         }
-        for (let kv in Iterator(aExtraParams))
+        for (var kv in Iterator(aExtraParams))
           params.push(kv);
       }
-      let paramsStr = params.map(function(i) {
+      var paramsStr = params.map(function(i) {
         return encodeURIComponent(i[0]) + '=' + encodeURIComponent(i[1]);
       }).join('&');
 
       // Now it's time to make our request!
-      let xhr = new XMLHttpRequest({mozSystem: true, mozAnon: true});
+      var xhr = new XMLHttpRequest({mozSystem: true, mozAnon: true});
       xhr.open('POST', this.baseUrl + '?' + paramsStr, true);
       setAuthHeader(xhr, this._username, this._password);
       xhr.setRequestHeader('MS-ASProtocolVersion', this.currentVersion);
@@ -2788,8 +2832,10 @@
 
       // Add extra headers if we have any.
       if (aExtraHeaders) {
-        for (let [key, value] in Iterator(aExtraHeaders))
+        for (var iter in Iterator(aExtraHeaders)) {
+          var key = iter[0], key = iter[1];
           xhr.setRequestHeader(key, value);
+        }
       }
 
       xhr.timeout = this.timeout;
@@ -2802,8 +2848,8 @@
           aProgressCallback(event.loaded, event.total);
       };
 
-      let conn = this;
-      let parentArgs = arguments;
+      var conn = this;
+      var parentArgs = arguments;
       xhr.onload = function() {
         // This status code is a proprietary Microsoft extension used to
         // indicate a redirect, not to be confused with the draft-standard
@@ -2822,14 +2868,14 @@
           return;
         }
 
-        let response = null;
+        var response = null;
         if (xhr.response.byteLength > 0)
           response = new WBXML.Reader(new Uint8Array(xhr.response), ASCP);
         aCallback(null, response);
       };
 
       xhr.ontimeout = xhr.onerror = function() {
-        let error = new Error('Error getting command URL');
+        var error = new Error('Error getting command URL');
         console.error(error);
         aCallback(error);
       };
@@ -2873,16 +2919,16 @@ define('mailapi/activesync/folder',
   ) {
 'use strict';
 
-const DESIRED_SNIPPET_LENGTH = 100;
+var DESIRED_SNIPPET_LENGTH = 100;
 
 /**
  * This is minimum number of messages we'd like to get for a folder for a given
  * sync range. It's not exact, since we estimate from the number of messages in
  * the past two weeks, but it's close enough.
  */
-const DESIRED_MESSAGE_COUNT = 50;
+var DESIRED_MESSAGE_COUNT = 50;
 
-const FILTER_TYPE = $ascp.AirSync.Enums.FilterType;
+var FILTER_TYPE = $ascp.AirSync.Enums.FilterType;
 
 /**
  * Map our built-in sync range values to their corresponding ActiveSync
@@ -2891,7 +2937,7 @@ const FILTER_TYPE = $ascp.AirSync.Enums.FilterType;
  *
  * Also see SYNC_RANGE_ENUMS_TO_MS in `syncbase.js`.
  */
-const SYNC_RANGE_TO_FILTER_TYPE = {
+var SYNC_RANGE_TO_FILTER_TYPE = {
   'auto': null,
     '1d': FILTER_TYPE.OneDayBack,
     '3d': FILTER_TYPE.ThreeDaysBack,
@@ -2904,7 +2950,7 @@ const SYNC_RANGE_TO_FILTER_TYPE = {
 /**
  * This mapping is purely for logging purposes.
  */
-const FILTER_TYPE_TO_STRING = {
+var FILTER_TYPE_TO_STRING = {
   0: 'all messages',
   1: 'one day',
   2: 'three days',
@@ -2944,9 +2990,9 @@ ActiveSyncFolderConn.prototype = {
    * elsewhere (see _inferFilterType()).
    */
   get filterType() {
-    let syncRange = this._account.accountDef.syncRange;
+    var syncRange = this._account.accountDef.syncRange;
     if (SYNC_RANGE_TO_FILTER_TYPE.hasOwnProperty(syncRange)) {
-      let accountFilterType = SYNC_RANGE_TO_FILTER_TYPE[syncRange];
+      var accountFilterType = SYNC_RANGE_TO_FILTER_TYPE[syncRange];
       if (accountFilterType)
         return accountFilterType;
       else
@@ -2967,11 +3013,11 @@ ActiveSyncFolderConn.prototype = {
    * @param {function} callback A callback to be run when the operation finishes
    */
   _getSyncKey: function asfc__getSyncKey(filterType, callback) {
-    let folderConn = this;
-    let account = this._account;
-    const as = $ascp.AirSync.Tags;
+    var folderConn = this;
+    var account = this._account;
+    var as = $ascp.AirSync.Tags;
 
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(as.Sync)
        .stag(as.Collections)
          .stag(as.Collection)
@@ -2999,7 +3045,7 @@ ActiveSyncFolderConn.prototype = {
       // response.
       folderConn.syncKey = '0';
 
-      let e = new $wbxml.EventParser();
+      var e = new $wbxml.EventParser();
       e.addEventListener([as.Sync, as.Collections, as.Collection, as.SyncKey],
                          function(node) {
         folderConn.syncKey = node.children[0].textContent;
@@ -3029,10 +3075,10 @@ ActiveSyncFolderConn.prototype = {
    * @param {function} callback A callback to be run when the operation finishes
    */
   _getItemEstimate: function asfc__getItemEstimate(filterType, callback) {
-    const ie = $ascp.ItemEstimate.Tags;
-    const as = $ascp.AirSync.Tags;
+    var ie = $ascp.ItemEstimate.Tags;
+    var as = $ascp.AirSync.Tags;
 
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(ie.GetItemEstimate)
        .stag(ie.Collections)
          .stag(ie.Collection)
@@ -3052,10 +3098,10 @@ ActiveSyncFolderConn.prototype = {
         return;
       }
 
-      let e = new $wbxml.EventParser();
-      const base = [ie.GetItemEstimate, ie.Response];
+      var e = new $wbxml.EventParser();
+      var base = [ie.GetItemEstimate, ie.Response];
 
-      let status, estimate;
+      var status, estimate;
       e.addEventListener(base.concat(ie.Status), function(node) {
         status = node.children[0].textContent;
       });
@@ -3092,10 +3138,10 @@ ActiveSyncFolderConn.prototype = {
    *  picked
    */
   _inferFilterType: function asfc__inferFilterType(callback) {
-    let folderConn = this;
-    const Type = $ascp.AirSync.Enums.FilterType;
+    var folderConn = this;
+    var Type = $ascp.AirSync.Enums.FilterType;
 
-    let getEstimate = function(filterType, onSuccess) {
+    var getEstimate = function(filterType, onSuccess) {
       folderConn._getSyncKey(filterType, function(error) {
         if (error) {
           callback('unknown');
@@ -3114,8 +3160,8 @@ ActiveSyncFolderConn.prototype = {
     };
 
     getEstimate(Type.TwoWeeksBack, function(estimate) {
-      let messagesPerDay = estimate / 14; // Two weeks. Twoooo weeeeeeks.
-      let filterType;
+      var messagesPerDay = estimate / 14; // Two weeks. Twoooo weeeeeeks.
+      var filterType;
 
       if (estimate < 0)
         filterType = Type.ThreeDaysBack;
@@ -3131,7 +3177,7 @@ ActiveSyncFolderConn.prototype = {
         filterType = Type.OneMonthBack;
       else {
         getEstimate(Type.NoFilter, function(estimate) {
-          let filterType;
+          var filterType;
           if (estimate > DESIRED_MESSAGE_COUNT) {
             filterType = Type.OneMonthBack;
             // Reset the sync key since we're changing filter types. This avoids
@@ -3170,7 +3216,7 @@ ActiveSyncFolderConn.prototype = {
    */
   _enumerateFolderChanges: function asfc__enumerateFolderChanges(callback,
                                                                  progress) {
-    let folderConn = this, storage = this._storage;
+    var folderConn = this, storage = this._storage;
 
     if (!this._account.conn.connected) {
       this._account.conn.connect(function(error) {
@@ -3205,12 +3251,12 @@ ActiveSyncFolderConn.prototype = {
       return;
     }
 
-    const as = $ascp.AirSync.Tags;
-    const asEnum = $ascp.AirSync.Enums;
-    const asb = $ascp.AirSyncBase.Tags;
-    const asbEnum = $ascp.AirSyncBase.Enums;
+    var as = $ascp.AirSync.Tags;
+    var asEnum = $ascp.AirSync.Enums;
+    var asb = $ascp.AirSyncBase.Tags;
+    var asbEnum = $ascp.AirSyncBase.Enums;
 
-    let w;
+    var w;
 
     // If the last sync was ours and we got an empty response back, we can send
     // an empty request to repeat our request. This saves a little bandwidth.
@@ -3252,11 +3298,11 @@ ActiveSyncFolderConn.prototype = {
     }
 
     this._account.conn.postCommand(w, function(aError, aResponse) {
-      let added   = [];
-      let changed = [];
-      let deleted = [];
-      let status;
-      let moreAvailable = false;
+      var added   = [];
+      var changed = [];
+      var deleted = [];
+      var status;
+      var moreAvailable = false;
 
       folderConn._account._syncsInProgress--;
 
@@ -3277,8 +3323,8 @@ ActiveSyncFolderConn.prototype = {
       }
 
       folderConn._account._lastSyncResponseWasEmpty = false;
-      let e = new $wbxml.EventParser();
-      const base = [as.Sync, as.Collections, as.Collection];
+      var e = new $wbxml.EventParser();
+      var base = [as.Sync, as.Collections, as.Collection];
 
       e.addEventListener(base.concat(as.SyncKey), function(node) {
         folderConn.syncKey = node.children[0].textContent;
@@ -3294,9 +3340,10 @@ ActiveSyncFolderConn.prototype = {
 
       e.addEventListener(base.concat(as.Commands, [[as.Add, as.Change]]),
                          function(node) {
-        let id, guid, msg;
+        var id, guid, msg;
 
-        for (let [,child] in Iterator(node.children)) {
+        for (var iter in Iterator(node.children)) {
+          var child = iter[1];
           switch (child.tag) {
           case as.ServerId:
             guid = child.children[0].textContent;
@@ -3322,15 +3369,16 @@ ActiveSyncFolderConn.prototype = {
         msg.header.srvid = guid;
         // XXX need to get the message's message-id header value!
 
-        let collection = node.tag === as.Add ? added : changed;
+        var collection = node.tag === as.Add ? added : changed;
         collection.push(msg);
       });
 
       e.addEventListener(base.concat(as.Commands, [[as.Delete, as.SoftDelete]]),
                          function(node) {
-        let guid;
+        var guid;
 
-        for (let [,child] in Iterator(node.children)) {
+        for (var iter in Iterator(node.children)) {
+          var child = iter[1];
           switch (child.tag) {
           case as.ServerId:
             guid = child.children[0].textContent;
@@ -3388,11 +3436,11 @@ ActiveSyncFolderConn.prototype = {
    * @return {object} An object containing the header and body for the message
    */
   _parseMessage: function asfc__parseMessage(node, isAdded) {
-    const em = $ascp.Email.Tags;
-    const asb = $ascp.AirSyncBase.Tags;
-    const asbEnum = $ascp.AirSyncBase.Enums;
+    var em = $ascp.Email.Tags;
+    var asb = $ascp.AirSyncBase.Tags;
+    var asbEnum = $ascp.AirSyncBase.Enums;
 
-    let header, body, flagHeader;
+    var header, body, flagHeader;
 
     if (isAdded) {
       header = {
@@ -3431,20 +3479,22 @@ ActiveSyncFolderConn.prototype = {
         flags: [],
         mergeInto: function(o) {
           // Merge flags
-          for (let [,flagstate] in Iterator(this.flags)) {
+          for (var iter in Iterator(this.flags)) {
+            var flagstate = iter[1];
             if (flagstate[1]) {
               o.flags.push(flagstate[0]);
             }
             else {
-              let index = o.flags.indexOf(flagstate[0]);
+              var index = o.flags.indexOf(flagstate[0]);
               if (index !== -1)
                 o.flags.splice(index, 1);
             }
           }
 
           // Merge everything else
-          const skip = ['mergeInto', 'suid', 'srvid', 'guid', 'id', 'flags'];
-          for (let [key, value] in Iterator(this)) {
+          var skip = ['mergeInto', 'suid', 'srvid', 'guid', 'id', 'flags'];
+          for (var iter in Iterator(this)) {
+            var key = iter[0], value = iter[1];
             if (skip.indexOf(key) !== -1)
               continue;
 
@@ -3455,7 +3505,8 @@ ActiveSyncFolderConn.prototype = {
 
       body = {
         mergeInto: function(o) {
-          for (let [key, value] in Iterator(this)) {
+          for (var iter in Iterator(this)) {
+            var key = iter[0], value = iter[1];
             if (key === 'mergeInto') continue;
             o[key] = value;
           }
@@ -3467,10 +3518,11 @@ ActiveSyncFolderConn.prototype = {
       }
     }
 
-    let bodyType, bodyText;
+    var bodyType, bodyText;
 
-    for (let [,child] in Iterator(node.children)) {
-      let childText = child.children.length ? child.children[0].textContent :
+    for (var iter in Iterator(node.children)) {
+      var child = iter[1];
+      var childText = child.children.length ? child.children[0].textContent :
                                               null;
 
       switch (child.tag) {
@@ -3496,13 +3548,15 @@ ActiveSyncFolderConn.prototype = {
         flagHeader('\\Seen', childText === '1');
         break;
       case em.Flag:
-        for (let [,grandchild] in Iterator(child.children)) {
+        for (var iter2 in Iterator(child.children)) {
+          var grandchild = iter2[1];
           if (grandchild.tag === em.Status)
             flagHeader('\\Flagged', grandchild.children[0].textContent !== '0');
         }
         break;
       case asb.Body: // ActiveSync 12.0+
-        for (let [,grandchild] in Iterator(child.children)) {
+        for (var iter2 in Iterator(child.children)) {
+          var grandchild = iter2[1];
           switch (grandchild.tag) {
           case asb.Type:
             bodyType = grandchild.children[0].textContent;
@@ -3519,12 +3573,13 @@ ActiveSyncFolderConn.prototype = {
         break;
       case asb.Attachments: // ActiveSync 12.0+
       case em.Attachments:  // pre-ActiveSync 12.0
-        for (let [,attachmentNode] in Iterator(child.children)) {
+        for (var iter2 in Iterator(child.children)) {
+          var attachmentNode = iter2[1];
           if (attachmentNode.tag !== asb.Attachment &&
               attachmentNode.tag !== em.Attachment)
             continue;
 
-          let attachment = {
+          var attachment = {
             name: null,
             contentId: null,
             type: null,
@@ -3534,10 +3589,11 @@ ActiveSyncFolderConn.prototype = {
             file: null,
           };
 
-          let isInline = false;
-          for (let [,attachData] in Iterator(attachmentNode.children)) {
-            let dot, ext;
-            let attachDataText = attachData.children.length ?
+          var isInline = false;
+          for (var iter3 in Iterator(attachmentNode.children)) {
+            var attachData = iter3[1];
+            var dot, ext;
+            var attachDataText = attachData.children.length ?
                                  attachData.children[0].textContent : null;
 
             switch (attachData.tag) {
@@ -3585,13 +3641,13 @@ ActiveSyncFolderConn.prototype = {
 
     // Process the body as needed.
     if (bodyType === asbEnum.Type.PlainText) {
-      let bodyRep = $quotechew.quoteProcessTextBody(bodyText);
+      var bodyRep = $quotechew.quoteProcessTextBody(bodyText);
       header.snippet = $quotechew.generateSnippet(bodyRep,
                                                   DESIRED_SNIPPET_LENGTH);
       body.bodyReps = ['plain', bodyRep];
     }
     else if (bodyType === asbEnum.Type.HTML) {
-      let htmlNode = $htmlchew.sanitizeAndNormalizeHtml(bodyText);
+      var htmlNode = $htmlchew.sanitizeAndNormalizeHtml(bodyText);
       header.snippet = $htmlchew.generateSnippet(htmlNode,
                                                  DESIRED_SNIPPET_LENGTH);
       body.bodyReps = ['html', htmlNode.innerHTML];
@@ -3602,7 +3658,7 @@ ActiveSyncFolderConn.prototype = {
 
   syncDateRange: function asfc_syncDateRange(startTS, endTS, accuracyStamp,
                                              doneCallback, progressCallback) {
-    let folderConn = this,
+    var folderConn = this,
         addedMessages = 0,
         changedMessages = 0,
         deletedMessages = 0;
@@ -3610,7 +3666,7 @@ ActiveSyncFolderConn.prototype = {
     this._LOG.syncDateRange_begin(null, null, null, startTS, endTS);
     this._enumerateFolderChanges(function (error, added, changed, deleted,
                                            moreAvailable) {
-      let storage = folderConn._storage;
+      var storage = folderConn._storage;
 
       if (error === 'badkey') {
         folderConn._account._recreateFolder(storage.folderId, function(s) {
@@ -3626,7 +3682,8 @@ ActiveSyncFolderConn.prototype = {
         return;
       }
 
-      for (let [,message] in Iterator(added)) {
+      for (var iter in Iterator(added)) {
+        var message = iter[1];
         // If we already have this message, it's probably because we moved it as
         // part of a local op, so let's assume that the data we already have is
         // ok. XXX: We might want to verify this, to be safe.
@@ -3638,7 +3695,8 @@ ActiveSyncFolderConn.prototype = {
         addedMessages++;
       }
 
-      for (let [,message] in Iterator(changed)) {
+      for (var iter in Iterator(changed)) {
+        var message = iter[1];
         // If we don't know about this message, just bail out.
         if (!storage.hasMessageWithServerId(message.header.srvid))
           continue;
@@ -3652,7 +3710,8 @@ ActiveSyncFolderConn.prototype = {
         // XXX: update bodies
       }
 
-      for (let [,messageGuid] in Iterator(deleted)) {
+      for (var iter in Iterator(deleted)) {
+        var messageGuid = iter[1];
         // If we don't know about this message, it's probably because we already
         // deleted it.
         if (!storage.hasMessageWithServerId(messageGuid))
@@ -3663,7 +3722,7 @@ ActiveSyncFolderConn.prototype = {
       }
 
       if (!moreAvailable) {
-        let messagesSeen = addedMessages + changedMessages + deletedMessages;
+        var messagesSeen = addedMessages + changedMessages + deletedMessages;
 
         // Note: For the second argument here, we report the number of messages
         // we saw that *changed*. This differs from IMAP, which reports the
@@ -3678,7 +3737,7 @@ ActiveSyncFolderConn.prototype = {
   },
 
   performMutation: function(invokeWithWriter, callWhenDone) {
-    let folderConn = this;
+    var folderConn = this;
     if (!this._account.conn.connected) {
       this._account.conn.connect(function(error) {
         if (error) {
@@ -3690,9 +3749,9 @@ ActiveSyncFolderConn.prototype = {
       return;
     }
 
-    const as = $ascp.AirSync.Tags;
+    var as = $ascp.AirSync.Tags;
 
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(as.Sync)
        .stag(as.Collections)
          .stag(as.Collection);
@@ -3732,10 +3791,10 @@ ActiveSyncFolderConn.prototype = {
         return;
       }
 
-      let e = new $wbxml.EventParser();
-      let syncKey, status;
+      var e = new $wbxml.EventParser();
+      var syncKey, status;
 
-      const base = [as.Sync, as.Collections, as.Collection];
+      var base = [as.Sync, as.Collections, as.Collection];
       e.addEventListener(base.concat(as.SyncKey), function(node) {
         syncKey = node.children[0].textContent;
       });
@@ -3768,7 +3827,7 @@ ActiveSyncFolderConn.prototype = {
   // XXX: take advantage of multipart responses here.
   // See http://msdn.microsoft.com/en-us/library/ee159875%28v=exchg.80%29.aspx
   downloadMessageAttachments: function(uid, partInfos, callback, progress) {
-    let folderConn = this;
+    var folderConn = this;
     if (!this._account.conn.connected) {
       this._account.conn.connect(function(error) {
         if (error) {
@@ -3781,13 +3840,14 @@ ActiveSyncFolderConn.prototype = {
       return;
     }
 
-    const io = $ascp.ItemOperations.Tags;
-    const ioStatus = $ascp.ItemOperations.Enums.Status;
-    const asb = $ascp.AirSyncBase.Tags;
+    var io = $ascp.ItemOperations.Tags;
+    var ioStatus = $ascp.ItemOperations.Enums.Status;
+    var asb = $ascp.AirSyncBase.Tags;
 
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(io.ItemOperations);
-    for (let [,part] in Iterator(partInfos)) {
+    for (var iter in Iterator(partInfos)) {
+      var part = iter[1];
       w.stag(io.Fetch)
          .tag(io.Store, 'Mailbox')
          .tag(asb.FileReference, part.part)
@@ -3802,18 +3862,19 @@ ActiveSyncFolderConn.prototype = {
         return;
       }
 
-      let globalStatus;
-      let attachments = {};
+      var globalStatus;
+      var attachments = {};
 
-      let e = new $wbxml.EventParser();
+      var e = new $wbxml.EventParser();
       e.addEventListener([io.ItemOperations, io.Status], function(node) {
         globalStatus = node.children[0].textContent;
       });
       e.addEventListener([io.ItemOperations, io.Response, io.Fetch],
                          function(node) {
-        let part = null, attachment = {};
+        var part = null, attachment = {};
 
-        for (let [,child] in Iterator(node.children)) {
+        for (var iter in Iterator(node.children)) {
+          var child = iter[1];
           switch (child.tag) {
           case io.Status:
             attachment.status = child.children[0].textContent;
@@ -3824,8 +3885,9 @@ ActiveSyncFolderConn.prototype = {
           case io.Properties:
             var contentType = null, data = null;
 
-            for (let [,grandchild] in Iterator(child.children)) {
-              let textContent = grandchild.children[0].textContent;
+            for (var iter2 in Iterator(child.children)) {
+              var grandchild = iter2[1];
+              var textContent = grandchild.children[0].textContent;
 
               switch (grandchild.tag) {
               case asb.ContentType:
@@ -3848,9 +3910,10 @@ ActiveSyncFolderConn.prototype = {
       });
       e.run(aResult);
 
-      let error = globalStatus !== ioStatus.Success ? 'unknown' : null;
-      let bodies = [];
-      for (let [,part] in Iterator(partInfos)) {
+      var error = globalStatus !== ioStatus.Success ? 'unknown' : null;
+      var bodies = [];
+      for (var iter in Iterator(partInfos)) {
+        var part = iter[1];
         if (attachments.hasOwnProperty(part.part) &&
             attachments[part.part].status === ioStatus.Success) {
           bodies.push(attachments[part.part].data);
@@ -3934,7 +3997,7 @@ ActiveSyncFolderSyncer.prototype = {
       return;
     }
 
-    let storage = this.folderStorage;
+    var storage = this.folderStorage;
 
     console.log("Sync Completed!", messagesSeen, "messages synced");
 
@@ -4077,7 +4140,7 @@ ActiveSyncJobDriver.prototype = {
 
   do_modtags: function(op, jobDoneCallback, undo) {
     // Note: this method is derived from the IMAP implementation.
-    let addTags = undo ? op.removeTags : op.addTags,
+    var addTags = undo ? op.removeTags : op.addTags,
         removeTags = undo ? op.addTags : op.removeTags;
 
     function getMark(tag) {
@@ -4088,13 +4151,13 @@ ActiveSyncJobDriver.prototype = {
       return undefined;
     }
 
-    let markRead = getMark('\\Seen');
-    let markFlagged = getMark('\\Flagged');
+    var markRead = getMark('\\Seen');
+    var markFlagged = getMark('\\Flagged');
 
-    const as = $ascp.AirSync.Tags;
-    const em = $ascp.Email.Tags;
+    var as = $ascp.AirSync.Tags;
+    var em = $ascp.Email.Tags;
 
-    let aggrErr = null;
+    var aggrErr = null;
 
     this._partitionAndAccessFoldersSequentially(
       op.messages, true,
@@ -4122,7 +4185,7 @@ ActiveSyncJobDriver.prototype = {
 
         folderConn.performMutation(
           function withWriter(w) {
-            for (let i = 0; i < serverIds.length; i++) {
+            for (var i = 0; i < serverIds.length; i++) {
               w.stag(as.Change)
                  .tag(as.ServerId, serverIds[i])
                  .stag(as.ApplicationData);
@@ -4184,10 +4247,10 @@ ActiveSyncJobDriver.prototype = {
      * disappear and then show up again. XXX we are not currently enforcing this
      * yet.
      */
-    let aggrErr = null, account = this.account,
+    var aggrErr = null, account = this.account,
         targetFolderStorage = this.account.getFolderStorageForFolderId(
                                 op.targetFolder);
-    const mo = $ascp.Move.Tags;
+    var mo = $ascp.Move.Tags;
 
     this._partitionAndAccessFoldersSequentially(
       op.messages, true,
@@ -4210,9 +4273,9 @@ ActiveSyncJobDriver.prototype = {
           return;
         }
 
-        let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+        var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
         w.stag(mo.MoveItems);
-        for (let i = 0; i < serverIds.length; i++) {
+        for (var i = 0; i < serverIds.length; i++) {
           w.stag(mo.Move)
              .tag(mo.SrcMsgId, serverIds[i])
              .tag(mo.SrcFldId, storage.folderMeta.serverId)
@@ -4254,9 +4317,9 @@ ActiveSyncJobDriver.prototype = {
   local_do_delete: $jobmixins.local_do_delete,
 
   do_delete: function(op, jobDoneCallback) {
-    let aggrErr = null;
-    const as = $ascp.AirSync.Tags;
-    const em = $ascp.Email.Tags;
+    var aggrErr = null;
+    var as = $ascp.AirSync.Tags;
+    var em = $ascp.Email.Tags;
 
     this._partitionAndAccessFoldersSequentially(
       op.messages, true,
@@ -4272,7 +4335,7 @@ ActiveSyncJobDriver.prototype = {
 
         folderConn.performMutation(
           function withWriter(w) {
-            for (let i = 0; i < serverIds.length; i++) {
+            for (var i = 0; i < serverIds.length; i++) {
               w.stag(as.Delete)
                  .tag(as.ServerId, serverIds[i])
                .etag(as.Delete);
@@ -4460,9 +4523,9 @@ define('mailapi/activesync/account',
   ) {
 'use strict';
 
-const bsearchForInsert = $util.bsearchForInsert;
+var bsearchForInsert = $util.bsearchForInsert;
 
-const DEFAULT_TIMEOUT_MS = exports.DEFAULT_TIMEOUT_MS = 30 * 1000;
+var DEFAULT_TIMEOUT_MS = exports.DEFAULT_TIMEOUT_MS = 30 * 1000;
 
 function ActiveSyncAccount(universe, accountDef, folderInfos, dbConn,
                            receiveProtoConn, _parentLog) {
@@ -4587,17 +4650,18 @@ ActiveSyncAccount.prototype = {
 
   saveAccountState: function asa_saveAccountState(reuseTrans, callback,
                                                   reason) {
-    let account = this;
-    let perFolderStuff = [];
-    for (let [,folder] in Iterator(this.folders)) {
-      let folderStuff = this._folderStorages[folder.id]
+    var account = this;
+    var perFolderStuff = [];
+    for (var iter in Iterator(this.folders)) {
+      var folder = iter[1];
+      var folderStuff = this._folderStorages[folder.id]
                            .generatePersistenceInfo();
       if (folderStuff)
         perFolderStuff.push(folderStuff);
     }
 
     this._LOG.saveAccountState(reason);
-    let trans = this._db.saveAccountFolderStates(
+    var trans = this._db.saveAccountFolderStates(
       this.id, this._folderInfos, perFolderStuff, this._deadFolderIds,
       function stateSaved() {
         if (callback)
@@ -4621,7 +4685,7 @@ ActiveSyncAccount.prototype = {
 
   sliceFolderMessages: function asa_sliceFolderMessages(folderId,
                                                         bridgeHandle) {
-    let storage = this._folderStorages[folderId],
+    var storage = this._folderStorages[folderId],
         slice = new $mailslice.MailSlice(bridgeHandle, storage, this._LOG);
 
     storage.sliceOpenFromNow(slice);
@@ -4637,10 +4701,10 @@ ActiveSyncAccount.prototype = {
   syncFolderList: function asa_syncFolderList(callback) {
     // We can assume that we already have a connection here, since jobs.js
     // ensures it.
-    let account = this;
+    var account = this;
 
-    const fh = $ascp.FolderHierarchy.Tags;
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var fh = $ascp.FolderHierarchy.Tags;
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(fh.FolderSync)
        .tag(fh.SyncKey, this.meta.syncKey)
      .etag();
@@ -4650,8 +4714,8 @@ ActiveSyncAccount.prototype = {
         callback(aError);
         return;
       }
-      let e = new $wbxml.EventParser();
-      let deferredAddedFolders = [];
+      var e = new $wbxml.EventParser();
+      var deferredAddedFolders = [];
 
       e.addEventListener([fh.FolderSync, fh.SyncKey], function(node) {
         account.meta.syncKey = node.children[0].textContent;
@@ -4659,9 +4723,11 @@ ActiveSyncAccount.prototype = {
 
       e.addEventListener([fh.FolderSync, fh.Changes, [fh.Add, fh.Delete]],
                          function(node) {
-        let folder = {};
-        for (let [,child] in Iterator(node.children))
+        var folder = {};
+        for (var iter in Iterator(node.children)) {
+          var child = iter[1];
           folder[child.localTagName] = child.children[0].textContent;
+        }
 
         if (node.tag === fh.Add) {
           if (!account._addedFolder(folder.ServerId, folder.ParentId,
@@ -4687,8 +4753,9 @@ ActiveSyncAccount.prototype = {
       // folders before their parents). Keep trying to add folders until we're
       // done.
       while (deferredAddedFolders.length) {
-        let moreDeferredAddedFolders = [];
-        for (let [,folder] in Iterator(deferredAddedFolders)) {
+        var moreDeferredAddedFolders = [];
+        for (var iter in Iterator(deferredAddedFolders)) {
+          var folder = iter[1];
           if (!account._addedFolder(folder.ServerId, folder.ParentId,
                                     folder.DisplayName, folder.Type))
             moreDeferredAddedFolders.push(folder);
@@ -4736,25 +4803,25 @@ ActiveSyncAccount.prototype = {
     if (!(typeNum in this._folderTypes))
       return true; // Not a folder type we care about.
 
-    const folderType = $ascp.FolderHierarchy.Enums.Type;
+    var folderType = $ascp.FolderHierarchy.Enums.Type;
 
-    let path = displayName;
-    let parentFolderId = null;
-    let depth = 0;
+    var path = displayName;
+    var parentFolderId = null;
+    var depth = 0;
     if (parentServerId !== '0') {
       parentFolderId = this._serverIdToFolderId[parentServerId];
       // We haven't learned about the parent folder. Just return, and wait until
       // we do.
       if (parentFolderId === undefined)
         return null;
-      let parent = this._folderInfos[parentFolderId];
+      var parent = this._folderInfos[parentFolderId];
       path = parent.$meta.path + '/' + path;
       depth = parent.$meta.depth + 1;
     }
 
     // Handle sentinel Inbox.
     if (typeNum === folderType.DefaultInbox) {
-      let existingInboxMeta = this.getFirstFolderWithType('inbox');
+      var existingInboxMeta = this.getFirstFolderWithType('inbox');
       if (existingInboxMeta) {
         // Update the server ID to folder ID mapping.
         delete this._serverIdToFolderId[existingInboxMeta.serverId];
@@ -4769,8 +4836,8 @@ ActiveSyncAccount.prototype = {
       }
     }
 
-    let folderId = this.id + '/' + $a64.encodeInt(this.meta.nextFolderNum++);
-    let folderInfo = this._folderInfos[folderId] = {
+    var folderId = this.id + '/' + $a64.encodeInt(this.meta.nextFolderNum++);
+    var folderInfo = this._folderInfos[folderId] = {
       $meta: {
         id: folderId,
         serverId: serverId,
@@ -4800,8 +4867,8 @@ ActiveSyncAccount.prototype = {
                                    $asfolder.ActiveSyncFolderSyncer, this._LOG);
     this._serverIdToFolderId[serverId] = folderId;
 
-    let folderMeta = folderInfo.$meta;
-    let idx = bsearchForInsert(this.folders, folderMeta, function(a, b) {
+    var folderMeta = folderInfo.$meta;
+    var idx = bsearchForInsert(this.folders, folderMeta, function(a, b) {
       return a.path.localeCompare(b.path);
     });
     this.folders.splice(idx, 0, folderMeta);
@@ -4821,7 +4888,7 @@ ActiveSyncAccount.prototype = {
    *   listeners of this addition
    */
   _deletedFolder: function asa__deletedFolder(serverId, suppressNotification) {
-    let folderId = this._serverIdToFolderId[serverId],
+    var folderId = this._serverIdToFolderId[serverId],
         folderInfo = this._folderInfos[folderId],
         folderMeta = folderInfo.$meta;
 
@@ -4851,7 +4918,7 @@ ActiveSyncAccount.prototype = {
    */
   _recreateFolder: function asa__recreateFolder(folderId, callback) {
     this._LOG.recreateFolder(folderId);
-    let folderInfo = this._folderInfos[folderId];
+    var folderInfo = this._folderInfos[folderId];
     folderInfo.$impl = {
       nextId: 0,
       nextHeaderBlock: 0,
@@ -4866,13 +4933,14 @@ ActiveSyncAccount.prototype = {
       this._deadFolderIds = [];
     this._deadFolderIds.push(folderId);
 
-    let self = this;
+    var self = this;
     this.saveAccountState(null, function() {
-      let newStorage =
+      var newStorage =
         new $mailslice.FolderStorage(self, folderId, folderInfo, self._db,
                                      $asfolder.ActiveSyncFolderSyncer,
                                      self._LOG);
-      for (let [,slice] in Iterator(self._folderStorages[folderId]._slices)) {
+      for (var iter in Iterator(self._folderStorages[folderId]._slices)) {
+        var slice = iter[1];
         slice._storage = newStorage;
         slice._resetHeadersBecauseOfRefreshExplosion(true);
         newStorage.sliceOpenFromNow(slice);
@@ -4922,7 +4990,7 @@ ActiveSyncAccount.prototype = {
    */
   createFolder: function asa_createFolder(parentFolderId, folderName,
                                           containOnlyOtherFolders, callback) {
-    let account = this;
+    var account = this;
     if (!this.conn.connected) {
       this.conn.connect(function(error) {
         if (error) {
@@ -4935,14 +5003,14 @@ ActiveSyncAccount.prototype = {
       return;
     }
 
-    let parentFolderServerId = parentFolderId ?
+    var parentFolderServerId = parentFolderId ?
       this._folderInfos[parentFolderId] : '0';
 
-    const fh = $ascp.FolderHierarchy.Tags;
-    const fhStatus = $ascp.FolderHierarchy.Enums.Status;
-    const folderType = $ascp.FolderHierarchy.Enums.Type.Mail;
+    var fh = $ascp.FolderHierarchy.Tags;
+    var fhStatus = $ascp.FolderHierarchy.Enums.Status;
+    var folderType = $ascp.FolderHierarchy.Enums.Type.Mail;
 
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(fh.FolderCreate)
        .tag(fh.SyncKey, this.meta.syncKey)
        .tag(fh.ParentId, parentFolderServerId)
@@ -4951,8 +5019,8 @@ ActiveSyncAccount.prototype = {
      .etag();
 
     this.conn.postCommand(w, function(aError, aResponse) {
-      let e = new $wbxml.EventParser();
-      let status, serverId;
+      var e = new $wbxml.EventParser();
+      var status, serverId;
 
       e.addEventListener([fh.FolderCreate, fh.Status], function(node) {
         status = node.children[0].textContent;
@@ -4975,7 +5043,7 @@ ActiveSyncAccount.prototype = {
       }
 
       if (status === fhStatus.Success) {
-        let folderMeta = account._addedFolder(serverId, parentFolderServerId,
+        var folderMeta = account._addedFolder(serverId, parentFolderServerId,
                                               folderName, folderType);
         callback(null, folderMeta);
       }
@@ -4995,7 +5063,7 @@ ActiveSyncAccount.prototype = {
    * Callback is like the createFolder one, why not.
    */
   deleteFolder: function asa_deleteFolder(folderId, callback) {
-    let account = this;
+    var account = this;
     if (!this.conn.connected) {
       this.conn.connect(function(error) {
         if (error) {
@@ -5007,21 +5075,21 @@ ActiveSyncAccount.prototype = {
       return;
     }
 
-    let folderMeta = this._folderInfos[folderId].$meta;
+    var folderMeta = this._folderInfos[folderId].$meta;
 
-    const fh = $ascp.FolderHierarchy.Tags;
-    const fhStatus = $ascp.FolderHierarchy.Enums.Status;
-    const folderType = $ascp.FolderHierarchy.Enums.Type.Mail;
+    var fh = $ascp.FolderHierarchy.Tags;
+    var fhStatus = $ascp.FolderHierarchy.Enums.Status;
+    var folderType = $ascp.FolderHierarchy.Enums.Type.Mail;
 
-    let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+    var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
     w.stag(fh.FolderDelete)
        .tag(fh.SyncKey, this.meta.syncKey)
        .tag(fh.ServerId, folderMeta.serverId)
      .etag();
 
     this.conn.postCommand(w, function(aError, aResponse) {
-      let e = new $wbxml.EventParser();
-      let status;
+      var e = new $wbxml.EventParser();
+      var status;
 
       e.addEventListener([fh.FolderDelete, fh.Status], function(node) {
         status = node.children[0].textContent;
@@ -5052,7 +5120,7 @@ ActiveSyncAccount.prototype = {
   },
 
   sendMessage: function asa_sendMessage(composer, callback) {
-    let account = this;
+    var account = this;
     if (!this.conn.connected) {
       this.conn.connect(function(error) {
         if (error) {
@@ -5070,8 +5138,8 @@ ActiveSyncAccount.prototype = {
       // ActiveSync 14.0 has a completely different API for sending email. Make
       // sure we format things the right way.
       if (this.conn.currentVersion.gte('14.0')) {
-        const cm = $ascp.ComposeMail.Tags;
-        let w = new $wbxml.Writer('1.3', 1, 'UTF-8');
+        var cm = $ascp.ComposeMail.Tags;
+        var w = new $wbxml.Writer('1.3', 1, 'UTF-8');
         w.stag(cm.SendMail)
            .tag(cm.ClientId, Date.now().toString()+'@mozgaia')
            .tag(cm.SaveInSentItems)

--- a/apps/email/js/ext/mailapi/composite/configurator.js
+++ b/apps/email/js/ext/mailapi/composite/configurator.js
@@ -2775,7 +2775,7 @@ var normalizeError = exports.normalizeError = function normalizeError(err) {
  *
  * XXX DST issue, maybe vary this.
  */
-const DEFAULT_TZ_OFFSET = -7 * 60 * 60 * 1000;
+var DEFAULT_TZ_OFFSET = -7 * 60 * 60 * 1000;
 
 var extractTZFromHeaders = exports._extractTZFromHeaders =
     function extractTZFromHeaders(allHeaders) {
@@ -2952,34 +2952,34 @@ define('mailapi/imap/jobs',
 /**
  * The evidence suggests the job has not yet been performed.
  */
-const CHECKED_NOTYET = 'checked-notyet';
+var CHECKED_NOTYET = 'checked-notyet';
 /**
  * The operation is idempotent and atomic, just perform the operation again.
  * No checking performed.
  */
-const UNCHECKED_IDEMPOTENT = 'idempotent';
+var UNCHECKED_IDEMPOTENT = 'idempotent';
 /**
  * The evidence suggests that the job has already happened.
  */
-const CHECKED_HAPPENED = 'happened';
+var CHECKED_HAPPENED = 'happened';
 /**
  * The job is no longer relevant because some other sequence of events
  * have mooted it.  For example, we can't change tags on a deleted message
  * or move a message between two folders if it's in neither folder.
  */
-const CHECKED_MOOT = 'moot';
+var CHECKED_MOOT = 'moot';
 /**
  * A transient error (from the checker's perspective) made it impossible to
  * check.
  */
-const UNCHECKED_BAILED = 'bailed';
+var UNCHECKED_BAILED = 'bailed';
 /**
  * The job has not yet been performed, and the evidence is that the job was
  * not marked finished because our database commits are coherent.  This is
  * appropriate for retrieval of information, like the downloading of
  * attachments.
  */
-const UNCHECKED_COHERENT_NOTYET = 'coherent-notyet';
+var UNCHECKED_COHERENT_NOTYET = 'coherent-notyet';
 
 /**
  * @typedef[MutationState @dict[
@@ -3118,7 +3118,7 @@ ImapJobDriver.prototype = {
    */
   _acquireConnWithoutFolder: function(label, callback, deathback) {
     this._LOG.acquireConnWithoutFolder_begin(label);
-    const self = this;
+    var self = this;
     this.account.__folderDemandsConnection(
       null, label,
       function(conn) {
@@ -3941,8 +3941,8 @@ define('mailapi/imap/account',
     $module,
     exports
   ) {
-const bsearchForInsert = $util.bsearchForInsert;
-const allbackMaker = $allback.allbackMaker;
+var bsearchForInsert = $util.bsearchForInsert;
+var allbackMaker = $allback.allbackMaker;
 
 function cmpFolderPubPath(a, b) {
   return a.path.localeCompare(b.path);
@@ -4733,7 +4733,7 @@ ImapAccount.prototype = {
     }
 
     // - build a map of known existing folders
-    const folderPubsByPath = {};
+    var folderPubsByPath = {};
     var folderPub;
     for (var iFolder = 0; iFolder < this.folders.length; iFolder++) {
       folderPub = this.folders[iFolder];

--- a/apps/email/js/ext/mailapi/fake/configurator.js
+++ b/apps/email/js/ext/mailapi/fake/configurator.js
@@ -21,7 +21,7 @@ define('mailapi/fake/account',
  *  reversible names.  To keep things easily reversible, if you add names, make
  *  sure they have no spaces in them!
  */
-const FIRST_NAMES = [
+var FIRST_NAMES = [
   "Andy", "Bob", "Chris", "David", "Emily", "Felix",
   "Gillian", "Helen", "Idina", "Johnny", "Kate", "Lilia",
   "Martin", "Neil", "Olof", "Pete", "Quinn", "Rasmus",
@@ -34,7 +34,7 @@ const FIRST_NAMES = [
  *  reversible names.  To keep things easily reversible, if you add names, make
  *  sure they have no spaces in them!
  */
-const LAST_NAMES = [
+var LAST_NAMES = [
   "Anway", "Bell", "Clarke", "Davol", "Ekberg", "Flowers",
   "Gilbert", "Hook", "Ivarsson", "Jones", "Kurtz", "Lowe",
   "Morris", "Nagel", "Orzabal", "Price", "Quinn", "Rolinski",
@@ -48,7 +48,7 @@ const LAST_NAMES = [
  *  make sure they have no spaces in them!  Also, make sure your additions
  *  don't break the secret Monty Python reference!
  */
-const SUBJECT_ADJECTIVES = [
+var SUBJECT_ADJECTIVES = [
   "Big", "Small", "Huge", "Tiny",
   "Red", "Green", "Blue", "My",
   "Happy", "Sad", "Grumpy", "Angry",
@@ -61,7 +61,7 @@ const SUBJECT_ADJECTIVES = [
  *  make sure they have no spaces in them!  Also, make sure your additions
  *  don't break the secret Monty Python reference!
  */
-const SUBJECT_NOUNS = [
+var SUBJECT_NOUNS = [
   "Meeting", "Party", "Shindig", "Wedding",
   "Document", "Report", "Spreadsheet", "Hovercraft",
   "Aardvark", "Giraffe", "Llama", "Velociraptor",
@@ -73,7 +73,7 @@ const SUBJECT_NOUNS = [
  *  by MessageGenerator.  These can (clearly) have spaces in them.  Make sure
  *  your additions don't break the secret Monty Python reference!
  */
-const SUBJECT_SUFFIXES = [
+var SUBJECT_SUFFIXES = [
   "Today", "Tomorrow", "Yesterday", "In a Fortnight",
   "Needs Attention", "Very Important", "Highest Priority", "Full Of Eels",
   "In The Lobby", "On Your Desk", "In Your Car", "Hiding Behind The Door",
@@ -615,7 +615,7 @@ function FakeAccount(universe, accountDef, folderInfo, receiveProtoConn, _LOG) {
     address: ourIdentity.address,
   };
 
-  const HOURS_MS = 60 * 60 * 1000;
+  var HOURS_MS = 60 * 60 * 1000;
   var inboxFolder = {
     id: this.id + '/0',
     name: 'Inbox',

--- a/apps/email/js/ext/mailapi/same-frame-setup.js
+++ b/apps/email/js/ext/mailapi/same-frame-setup.js
@@ -1468,7 +1468,7 @@ MessageComposition.prototype = {
 };
 
 
-const LEGAL_CONFIG_KEYS = ['syncCheckIntervalEnum'];
+var LEGAL_CONFIG_KEYS = ['syncCheckIntervalEnum'];
 
 /**
  * Error reporting helper; we will probably eventually want different behaviours
@@ -4702,7 +4702,7 @@ define('mailapi/util',
  * and messages with higher UIDs (newer-ish) before those with lower UIDs
  * (when the date is the same.)
  */
-const cmpHeaderYoungToOld = exports.cmpHeaderYoungToOld =
+var cmpHeaderYoungToOld = exports.cmpHeaderYoungToOld =
     function cmpHeaderYoungToOld(a, b) {
   var delta = b.date - a.date;
   if (delta)
@@ -4721,7 +4721,7 @@ const cmpHeaderYoungToOld = exports.cmpHeaderYoungToOld =
  *   range [0, arr.length].
  * }
  */
-const bsearchForInsert = exports.bsearchForInsert =
+var bsearchForInsert = exports.bsearchForInsert =
     function bsearchForInsert(list, seekVal, cmpfunc) {
   if (!list.length)
     return 0;
@@ -4863,90 +4863,90 @@ define('mailapi/quotechew',
 /**
  * Actual content of the message written by the user.
  */
-const CT_AUTHORED_CONTENT = 0x1;
+var CT_AUTHORED_CONTENT = 0x1;
 /**
  * Niceties like greetings/thanking someone/etc.  These are things that we want to
  * show when displaying the message, but that arguably are of lower importance and
  * might want to be elided for snippet purposes, etc.
  */
-const CT_AUTHORED_NICETIES = 0x11;
+var CT_AUTHORED_NICETIES = 0x11;
 /**
  * The signature of the message author; might contain useful information in it.
  */
-const CT_SIGNATURE = 0x2;
+var CT_SIGNATURE = 0x2;
 
 /**
  * The line that says "Blah wrote:" that precedes a quote.  It's not part of the
  * user content, but it's also not part of the quote.
  */
-const CT_LEADIN_TO_QUOTE = 0x3;
+var CT_LEADIN_TO_QUOTE = 0x3;
 
-const CT_QUOTED_TYPE = 0x4;
+var CT_QUOTED_TYPE = 0x4;
 
 /**
  * A quoted reply; eligible for collapsing.  Depth of quoting will also be
  * encoded in the actual integer value.
  */
-const CT_QUOTED_REPLY = 0x14;
+var CT_QUOTED_REPLY = 0x14;
 /**
  * A quoted forwarded message; we would guess that the user has not previously seen
  * the message and the quote wants to be displayed.
  */
-const CT_QUOTED_FORWARD = 0x24;
+var CT_QUOTED_FORWARD = 0x24;
 /**
  * Quoted content that has not been pruned.  Aspirational!
  */
-const CT_QUOTED_IN_ENTIRETY = 0x40;
+var CT_QUOTED_IN_ENTIRETY = 0x40;
 /**
  * The quote has been subjected to some level of manual intervention. Aspirational!
  */
-const CT_QUOTED_GARDENED = 0x80;
+var CT_QUOTED_GARDENED = 0x80;
 
-const CT_QUOTE_DEPTH_MASK = 0xff00;
+var CT_QUOTE_DEPTH_MASK = 0xff00;
 
 /**
  * Legal-ish boilerplate about how it's only for the recipient, etc. etc.
  * Generally going to be long and boring.
  */
-const CT_BOILERPLATE_DISCLAIMER = 0x5;
+var CT_BOILERPLATE_DISCLAIMER = 0x5;
 /**
  * Boilerplate about the message coming from a mailing list, info about the
  * mailing list.
  */
-const CT_BOILERPLATE_LIST_INFO = 0x6;
+var CT_BOILERPLATE_LIST_INFO = 0x6;
 /**
  * Product branding boilerplate that may or may not indicate that the composing
  * device was a mobile device (which is useful).
  */
-const CT_BOILERPLATE_PRODUCT = 0x7;
+var CT_BOILERPLATE_PRODUCT = 0x7;
 /**
  * Advertising automatically inserted by the mailing list or free e-mailing service,
  * etc.  This is assumed to be boring.
  */
-const CT_BOILERPLATE_ADS = 0x8;
+var CT_BOILERPLATE_ADS = 0x8;
 
-const CHARCODE_GT = ('>').charCodeAt(0),
-      CHARCODE_SPACE = (' ').charCodeAt(0),
-      CHARCODE_NBSP = ('\xa0').charCodeAt(0),
-      CHARCODE_NEWLINE = ('\n').charCodeAt(0);
+var CHARCODE_GT = ('>').charCodeAt(0),
+    CHARCODE_SPACE = (' ').charCodeAt(0),
+    CHARCODE_NBSP = ('\xa0').charCodeAt(0),
+    CHARCODE_NEWLINE = ('\n').charCodeAt(0);
 
-const RE_ORIG_MESAGE_DELIM = /^-{5} Original Message -{5}$/;
+var RE_ORIG_MESAGE_DELIM = /^-{5} Original Message -{5}$/;
 
-const RE_ALL_WS = /^\s+$/;
+var RE_ALL_WS = /^\s+$/;
 
-const RE_SECTION_DELIM = /^[_-]{6,}$/;
+var RE_SECTION_DELIM = /^[_-]{6,}$/;
 
-const RE_LIST_BOILER = /mailing list$/;
+var RE_LIST_BOILER = /mailing list$/;
 
-const RE_WROTE_LINE = /wrote/;
+var RE_WROTE_LINE = /wrote/;
 
-const RE_SIGNATURE_LINE = /^-- $/;
+var RE_SIGNATURE_LINE = /^-- $/;
 
 /**
  * The maximum number of lines that can be in a boilerplate chunk.  We expect
  * disclaimer boilerplate to be what drives this.
  */
-const MAX_BOILERPLATE_LINES = 20;
+var MAX_BOILERPLATE_LINES = 20;
 
 /**
  * Catch various common well-known product branding lines:
@@ -4957,9 +4957,9 @@ const MAX_BOILERPLATE_LINES = 20;
  *     that match the prefix.
  * - "Sent from Mobile"
  */
-const RE_PRODUCT_BOILER = /^(?:Sent from (?:Mobile|my .+))$/;
+var RE_PRODUCT_BOILER = /^(?:Sent from (?:Mobile|my .+))$/;
 
-const RE_LEGAL_BOILER_START = /^(?:This message|Este mensaje)/;
+var RE_LEGAL_BOILER_START = /^(?:This message|Este mensaje)/;
 
 function indexOfDefault(string, search, startIndex, defVal) {
   var idx = string.indexOf(search, startIndex);
@@ -4968,7 +4968,7 @@ function indexOfDefault(string, search, startIndex, defVal) {
   return idx;
 }
 
-const NEWLINE = '\n', RE_NEWLINE = /\n/g;
+var NEWLINE = '\n', RE_NEWLINE = /\n/g;
 
 function countNewlinesInRegion(string, startIndex, endIndex) {
   var idx = startIndex - 1, count = 0;
@@ -5367,9 +5367,9 @@ exports.quoteProcessTextBody = function quoteProcessTextBody(fullBodyText) {
  * whitespace boundary.  If it would take more characters than this, we just
  * do a hard truncation and hope things work out visually.
  */
-const MAX_WORD_SHRINK = 8;
+var MAX_WORD_SHRINK = 8;
 
-const RE_NORMALIZE_WHITESPACE = /\s+/g;
+var RE_NORMALIZE_WHITESPACE = /\s+/g;
 
 /**
  * Derive the snippet for a message from its processed body representation.  We
@@ -5409,25 +5409,25 @@ exports.generateSnippet = function generateSnippet(rep, desiredLength) {
  * We accept depth levels up to 5 mainly because a quick perusal of mozilla lists
  * shows cases where 5 levels of nesting were used to provide useful context.
  */
-const MAX_QUOTE_REPEAT_DEPTH = 5;
+var MAX_QUOTE_REPEAT_DEPTH = 5;
 // we include a few more than we need for forwarded text regeneration
-const replyQuotePrefixStrings = [
+var replyQuotePrefixStrings = [
   '> ', '>> ', '>>> ', '>>>> ', '>>>>> ', '>>>>>> ', '>>>>>>> ', '>>>>>>>> ',
   '>>>>>>>>> ',
 ];
-const replyQuotePrefixStringsNoSpace = [
+var replyQuotePrefixStringsNoSpace = [
   '>', '>>', '>>>', '>>>>', '>>>>>', '>>>>>>', '>>>>>>>', '>>>>>>>>',
   '>>>>>>>>>',
 ];
-const replyQuoteNewlineReplaceStrings = [
+var replyQuoteNewlineReplaceStrings = [
   '\n> ', '\n>> ', '\n>>> ', '\n>>>> ', '\n>>>>> ', '\n>>>>>> ', '\n>>>>>>> ',
   '\n>>>>>>>> ',
 ];
-const replyQuoteNewlineReplaceStringsNoSpace = [
+var replyQuoteNewlineReplaceStringsNoSpace = [
   '\n>', '\n>>', '\n>>>', '\n>>>>', '\n>>>>>', '\n>>>>>>', '\n>>>>>>>',
   '\n>>>>>>>>',
 ];
-const replyPrefix = '> ', replyNewlineReplace = '\n> ';
+var replyPrefix = '> ', replyNewlineReplace = '\n> ';
 
 function expandQuotedPrefix(s, depth) {
   if (s.charCodeAt(0) === CHARCODE_NEWLINE)
@@ -6188,13 +6188,13 @@ var LEGAL_STYLES = [
  *
  * ignore-case is not required; the value is checked against the lower-cased tag.
  */
-const RE_NODE_NEEDS_TRANSFORM = /^(?:a|area|img)$/;
+var RE_NODE_NEEDS_TRANSFORM = /^(?:a|area|img)$/;
 
-const RE_CID_URL = /^cid:/i;
-const RE_HTTP_URL = /^http(?:s)?/i;
-const RE_MAILTO_URL = /^mailto:/i;
+var RE_CID_URL = /^cid:/i;
+var RE_HTTP_URL = /^http(?:s)?/i;
+var RE_MAILTO_URL = /^mailto:/i;
 
-const RE_IMG_TAG = /^img$/;
+var RE_IMG_TAG = /^img$/;
 
 /**
  * Transforms src tags, ensure that links are http and transform them too so
@@ -6271,9 +6271,9 @@ exports.sanitizeAndNormalizeHtml = function sanitizeAndNormalize(htmlString) {
   return sanitizedNode;
 };
 
-const ELEMENT_NODE = 1, TEXT_NODE = 3;
+var ELEMENT_NODE = 1, TEXT_NODE = 3;
 
-const RE_NORMALIZE_WHITESPACE = /\s+/g;
+var RE_NORMALIZE_WHITESPACE = /\s+/g;
 
 /**
  * Derive snippet text from the already-sanitized HTML representation.
@@ -6381,7 +6381,7 @@ exports.wrapTextIntoSafeHTMLString = function(text, wrapTag,
   return wrapNode.outerHTML;
 };
 
-const RE_QUOTE_CHAR = /"/g;
+var RE_QUOTE_CHAR = /"/g;
 
 /**
  * Make an HTML attribute value safe.
@@ -6420,7 +6420,7 @@ define('mailapi/mailchew',
     $htmlchew
   ) {
 
-const RE_RE = /^[Rr][Ee]: /;
+var RE_RE = /^[Rr][Ee]: /;
 
 /**
  * Generate the reply subject for a message given the prior subject.  This is
@@ -6629,9 +6629,9 @@ exports.generateForwardMessage = function generateForwardMessage(
   };
 };
 
-const HTML_WRAP_TOP =
+var HTML_WRAP_TOP =
   '<html><body><body bgcolor="#FFFFFF" text="#000000">';
-const HTML_WRAP_BOTTOM =
+var HTML_WRAP_BOTTOM =
   '</body></html>';
 
 /**
@@ -8330,7 +8330,6 @@ module.exports = function(address){
     });
 };
 });
-
 define('crypto',['require','exports','module'],function(require, exports, module) {
 
 exports.createHash = function(algorithm) {
@@ -8956,7 +8955,6 @@ function hasUTFChars(str){
     return !!rforeign.test(str);
 }
 });
-
 define('http',['require','exports','module'],function(require, exports, module) {
 });
 
@@ -9039,7 +9037,6 @@ function openUrlStream(url, options){
     return stream; 
 }
 });
-
 define('fs',['require','exports','module'],function(require, exports, module) {
 });
 
@@ -10285,7 +10282,6 @@ MailComposer.prototype._getMimeType = function(filename){
     return extension && mimelib.contentTypes[extension] || defaultMime;
 };
 });
-
 define('mailcomposer',['./mailcomposer/lib/mailcomposer'], function (main) {
     return main;
 });
@@ -10502,14 +10498,14 @@ define('mailapi/mailbridge',
     $module,
     exports
   ) {
-const bsearchForInsert = $imaputil.bsearchForInsert,
-      bsearchMaybeExists = $imaputil.bsearchMaybeExists;
+var bsearchForInsert = $imaputil.bsearchForInsert,
+    bsearchMaybeExists = $imaputil.bsearchMaybeExists;
 
 function toBridgeWireOn(x) {
   return x.toBridgeWire();
 }
 
-const FOLDER_TYPE_TO_SORT_PRIORITY = {
+var FOLDER_TYPE_TO_SORT_PRIORITY = {
   account: 'a',
   inbox: 'c',
   starred: 'e',
@@ -11529,7 +11525,7 @@ define('mailapi/a64',
  * JS coders) ordering which makes it tractable to eyeball an encoded value and
  * not be completely confused/misled.
  */
-const ORDERED_ARBITRARY_BASE64_CHARS = [
+var ORDERED_ARBITRARY_BASE64_CHARS = [
   '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
   'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
   'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
@@ -11542,7 +11538,7 @@ const ORDERED_ARBITRARY_BASE64_CHARS = [
  * Zero padding to get us up to the maximum encoding length of a 64-bit value in
  * our encoding (11) or for decimal re-conversion (16).
  */
-const ZERO_PADDING = '0000000000000000';
+var ZERO_PADDING = '0000000000000000';
 
 /**
  * Encode a JS int in our base64 encoding.
@@ -11568,7 +11564,7 @@ exports.encodeInt = encodeInt;
  * 10^14 >> 14 so that its 'lowest' binary 1 ends up in the one's place.  It
  * is encoded in 33 bits itself.
  */
-const E10_14_RSH_14 = Math.pow(10, 14) / Math.pow(2, 14),
+var E10_14_RSH_14 = Math.pow(10, 14) / Math.pow(2, 14),
       P2_14 = Math.pow(2, 14),
       P2_22 = Math.pow(2, 22),
       P2_32 = Math.pow(2, 32),
@@ -11771,14 +11767,14 @@ define('mailapi/date',
  *
  * !BEFORE(a, b) === SINCE(a, b)
  */
-const BEFORE = exports.BEFORE =
+var BEFORE = exports.BEFORE =
       function BEFORE(testDate, comparisonDate) {
   // testDate is numerically less than comparisonDate, so it is chronologically
   // before it.
   return testDate < comparisonDate;
 };
 
-const ON_OR_BEFORE = exports.ON_OR_BEFORE =
+var ON_OR_BEFORE = exports.ON_OR_BEFORE =
       function ON_OR_BEFORE(testDate, comparisonDate) {
   return testDate <= comparisonDate;
 };
@@ -11789,19 +11785,19 @@ const ON_OR_BEFORE = exports.ON_OR_BEFORE =
  *
  * !SINCE(a, b) === BEFORE(a, b)
  */
-const SINCE = exports.SINCE =
+var SINCE = exports.SINCE =
       function SINCE(testDate, comparisonDate) {
   // testDate is numerically greater-than-or-equal-to comparisonDate, so it
   // chronologically after/since it.
   return testDate >= comparisonDate;
 };
 
-const STRICTLY_AFTER = exports.STRICTLY_AFTER =
+var STRICTLY_AFTER = exports.STRICTLY_AFTER =
       function STRICTLY_AFTER(testDate, comparisonDate) {
   return testDate > comparisonDate;
 };
 
-const IN_BS_DATE_RANGE = exports.IN_BS_DATE_RANGE =
+var IN_BS_DATE_RANGE = exports.IN_BS_DATE_RANGE =
       function IN_BS_DATE_RANGE(testDate, startTS, endTS) {
   return testDate >= startTS && testDate < endTS;
 };
@@ -11809,8 +11805,8 @@ const IN_BS_DATE_RANGE = exports.IN_BS_DATE_RANGE =
 //function DATE_RANGES_OVERLAP(A_startTS, A_endTS, B_startTS, B_endTS) {
 //}
 
-const HOUR_MILLIS = exports.HOUR_MILLIS = 60 * 60 * 1000;
-const DAY_MILLIS = exports.DAY_MILLIS = 24 * 60 * 60 * 1000;
+var HOUR_MILLIS = exports.HOUR_MILLIS = 60 * 60 * 1000;
+var DAY_MILLIS = exports.DAY_MILLIS = 24 * 60 * 60 * 1000;
 
 /**
  * Testing override that when present replaces use of Date.now().
@@ -11835,11 +11831,11 @@ exports.TEST_LetsDoTheTimewarpAgain = function(fakeNow) {
   FUTURE_TIME_WARPED_NOW = quantizeDate(fakeNow + DAY_MILLIS);
 };
 
-const NOW = exports.NOW =
+var NOW = exports.NOW =
       function NOW() {
   return TIME_WARPED_NOW || Date.now();
 };
-const FUTURE = exports.FUTURE =
+var FUTURE = exports.FUTURE =
       function FUTURE() {
   return FUTURE_TIME_WARPED_NOW || null;
 };
@@ -11849,7 +11845,7 @@ const FUTURE = exports.FUTURE =
  * that day.  This results in rounding up; if it's noon right now and you
  * ask for 2 days ago, you really get 2.5 days worth of time.
  */
-const makeDaysAgo = exports.makeDaysAgo =
+var makeDaysAgo = exports.makeDaysAgo =
       function makeDaysAgo(numDays) {
   var //now = quantizeDate(TIME_WARPED_NOW || Date.now()),
       //past = now - numDays * DAY_MILLIS;
@@ -11857,14 +11853,14 @@ const makeDaysAgo = exports.makeDaysAgo =
                (numDays + 1) * DAY_MILLIS;
   return past;
 };
-const makeDaysBefore = exports.makeDaysBefore =
+var makeDaysBefore = exports.makeDaysBefore =
       function makeDaysBefore(date, numDaysBefore) {
   return quantizeDate(date) - numDaysBefore * DAY_MILLIS;
 };
 /**
  * Quantize a date to midnight on that day.
  */
-const quantizeDate = exports.quantizeDate =
+var quantizeDate = exports.quantizeDate =
       function quantizeDate(date) {
   if (typeof(date) === 'number')
     date = new Date(date);
@@ -12143,7 +12139,7 @@ exports.CHECK_INTERVALS_ENUMS_TO_MS = {
  */
 exports.DEFAULT_CHECK_INTERVAL_ENUM = 'manual';
 
-const DAY_MILLIS = 24 * 60 * 60 * 1000;
+var DAY_MILLIS = 24 * 60 * 60 * 1000;
 
 /**
  * Map the ActiveSync-limited list of sync ranges to milliseconds.  Do NOT
@@ -12260,7 +12256,7 @@ else {
  * Bumping to 17 because we changed the folder representation to store
  * hierarchy.
  */
-const CUR_VERSION = exports.CUR_VERSION = 17;
+var CUR_VERSION = exports.CUR_VERSION = 17;
 
 /**
  * What is the lowest database version that we are capable of performing a
@@ -12270,17 +12266,17 @@ const CUR_VERSION = exports.CUR_VERSION = 17;
  * Note that this type of upgrade can still be EXTREMELY DANGEROUS because it
  * may blow away user actions that haven't hit a server yet.
  */
-const FRIENDLY_LAZY_DB_UPGRADE_VERSION = 5;
+var FRIENDLY_LAZY_DB_UPGRADE_VERSION = 5;
 
 /**
  * The configuration table contains configuration data that should persist
  * despite implementation changes. Global configuration data, and account login
  * info.  Things that would be annoying for us to have to re-type.
  */
-const TBL_CONFIG = 'config',
-      CONFIG_KEY_ROOT = 'config',
-      // key: accountDef:`AccountId`
-      CONFIG_KEYPREFIX_ACCOUNT_DEF = 'accountDef:';
+var TBL_CONFIG = 'config',
+    CONFIG_KEY_ROOT = 'config',
+    // key: accountDef:`AccountId`
+    CONFIG_KEYPREFIX_ACCOUNT_DEF = 'accountDef:';
 
 /**
  * The folder-info table stores meta-data about the known folders for each
@@ -12296,7 +12292,7 @@ const TBL_CONFIG = 'config',
  *
  * key: `AccountId`
  */
-const TBL_FOLDER_INFO = 'folderInfo';
+var TBL_FOLDER_INFO = 'folderInfo';
 
 /**
  * Stores time-clustered information about messages in folders.  Message bodies
@@ -12314,7 +12310,7 @@ const TBL_FOLDER_INFO = 'folderInfo';
  * globally unique identifier (ex: gmail's X-GM-MSGID values).  The values are
  * the info on the message; see `ImapFolderStorage` for details.
  */
-const TBL_HEADER_BLOCKS = 'headerBlocks';
+var TBL_HEADER_BLOCKS = 'headerBlocks';
 /**
  * Stores time-clustered information about message bodies.  Body details include
  * the list of attachments, as well as the body payloads and the embedded inline
@@ -12330,7 +12326,7 @@ const TBL_HEADER_BLOCKS = 'headerBlocks';
  * globally unique identifier (ex: gmail's X-GM-MSGID values).  The values are
  * the info on the message; see `ImapFolderStorage` for details.
  */
-const TBL_BODY_BLOCKS = 'bodyBlocks';
+var TBL_BODY_BLOCKS = 'bodyBlocks';
 
 /**
  * DB helper methods for Gecko's IndexedDB implementation.  We are assuming
@@ -12768,19 +12764,19 @@ define('mailapi/cronsync',
 /**
  * Sanity demands we do not check more frequently than once a minute.
  */
-const MINIMUM_SYNC_INTERVAL_MS = 60 * 1000;
+var MINIMUM_SYNC_INTERVAL_MS = 60 * 1000;
 
 /**
  * How long should we let a synchronization run before we give up on it and
  * potentially try and kill it (if we can)?
  */
-const MAX_SYNC_DURATION_MS = 3 * 60 * 1000;
+var MAX_SYNC_DURATION_MS = 3 * 60 * 1000;
 
 /**
  * Caps the number of notifications we generate per account.  It would be
  * sitcom funny to let this grow without bound, but would end badly in reality.
  */
-const MAX_MESSAGES_TO_REPORT_PER_ACCOUNT = 5;
+var MAX_MESSAGES_TO_REPORT_PER_ACCOUNT = 5;
 
 /**
  * Implements the interface of `MailSlice` as presented to `FolderStorage`, but
@@ -13272,8 +13268,9 @@ var autoconfigByDomain = exports._autoconfigByDomain = {
  * @return the new identities
  */
 function recreateIdentities(universe, accountId, oldIdentities) {
-  let identities = [];
-  for (let [,oldIdentity] in Iterator(oldIdentities)) {
+  var identities = [];
+  for (var iter in Iterator(oldIdentities)) {
+    var oldIdentity = iter[1];
     identities.push({
       id: accountId + '/' + $a64.encodeInt(universe.config.nextIdentityNum++),
       name: oldIdentity.name,
@@ -13387,7 +13384,7 @@ Autoconfigurator.prototype = {
    *        info, formatted as JSON
    */
   _getXmlConfig: function getXmlConfig(url, callback) {
-    let xhr = new XMLHttpRequest({mozSystem: true});
+    var xhr = new XMLHttpRequest({mozSystem: true});
     xhr.open('GET', url, true);
     xhr.timeout = this.timeout;
 
@@ -13402,31 +13399,35 @@ Autoconfigurator.prototype = {
       // issue), trying to use responseXML results in a SecurityError when
       // running XPath queries. So let's just do an end-run around the
       // "security".
-      let doc = new DOMParser().parseFromString(xhr.responseText, 'text/xml');
+      var doc = new DOMParser().parseFromString(xhr.responseText, 'text/xml');
       function getNode(xpath, rel) {
         return doc.evaluate(xpath, rel || doc, null,
                             XPathResult.FIRST_ORDERED_NODE_TYPE, null)
                   .singleNodeValue;
       }
 
-      let provider = getNode('/clientConfig/emailProvider');
+      var provider = getNode('/clientConfig/emailProvider');
       // Get the first incomingServer we can use (we assume first == best).
-      let incoming = getNode('incomingServer[@type="imap"] | ' +
+      var incoming = getNode('incomingServer[@type="imap"] | ' +
                              'incomingServer[@type="activesync"]', provider);
-      let outgoing = getNode('outgoingServer[@type="smtp"]', provider);
+      var outgoing = getNode('outgoingServer[@type="smtp"]', provider);
 
       if (incoming) {
-        let config = { type: null, incoming: {}, outgoing: {} };
-        for (let [,child] in Iterator(incoming.children))
+        var config = { type: null, incoming: {}, outgoing: {} };
+        for (var iter in Iterator(incoming.children)) {
+          var child = iter[1];
           config.incoming[child.tagName] = child.textContent;
+        }
 
         if (incoming.getAttribute('type') === 'activesync') {
           config.type = 'activesync';
         }
         else if (outgoing) {
           config.type = 'imap+smtp';
-          for (let [,child] in Iterator(outgoing.children))
+          for (var iter in Iterator(outgoing.children)) {
+            var child = iter[1];
             config.outgoing[child.tagName] = child.textContent;
+          }
 
           // We do not support unencrypted connections outside of unit tests.
           if (config.incoming.socketType !== 'SSL' ||
@@ -13511,7 +13512,7 @@ Autoconfigurator.prototype = {
           return;
         }
 
-        let autoconfig = {
+        var autoconfig = {
           type: 'activesync',
           displayName: config.user.name,
           incoming: {
@@ -13536,10 +13537,10 @@ Autoconfigurator.prototype = {
    */
   _getConfigFromDomain: function getConfigFromDomain(userDetails, domain,
                                                      callback) {
-    let suffix = '/mail/config-v1.1.xml?emailaddress=' +
+    var suffix = '/mail/config-v1.1.xml?emailaddress=' +
                  encodeURIComponent(userDetails.emailAddress);
-    let url = 'http://autoconfig.' + domain + suffix;
-    let self = this;
+    var url = 'http://autoconfig.' + domain + suffix;
+    var self = this;
 
     this._getXmlConfig(url, function(error, config, errorDetails) {
       if (self._isSuccessOrFatal(error)) {
@@ -13548,7 +13549,7 @@ Autoconfigurator.prototype = {
       }
 
       // See <http://tools.ietf.org/html/draft-nottingham-site-meta-04>.
-      let url = 'http://' + domain + '/.well-known/autoconfig' + suffix;
+      var url = 'http://' + domain + '/.well-known/autoconfig' + suffix;
       self._getXmlConfig(url, function(error, config, errorDetails) {
         if (self._isSuccessOrFatal(error)) {
           callback(error, config, errorDetails);
@@ -13582,7 +13583,7 @@ Autoconfigurator.prototype = {
    *        domain
    */
   _getMX: function getMX(domain, callback) {
-    let xhr = new XMLHttpRequest({mozSystem: true});
+    var xhr = new XMLHttpRequest({mozSystem: true});
     xhr.open('GET', 'https://live.mozillamessaging.com/dns/mx/' +
              encodeURIComponent(domain), true);
     xhr.timeout = this.timeout;
@@ -13613,7 +13614,7 @@ Autoconfigurator.prototype = {
    *        info, formatted as JSON
    */
   _getConfigFromMX: function getConfigFromMX(domain, callback) {
-    let self = this;
+    var self = this;
     this._getMX(domain, function(error, mxDomain, errorDetails) {
       if (error)
         return callback(error, null, errorDetails);
@@ -13655,8 +13656,9 @@ Autoconfigurator.prototype = {
    *        info, formatted as JSON
    */
   getConfig: function getConfig(userDetails, callback) {
-    let [emailLocalPart, emailDomainPart] = userDetails.emailAddress.split('@');
-    let domain = emailDomainPart.toLowerCase();
+    var details = userDetails.emailAddress.split('@');
+    var emailLocalPart = details[0], emailDomainPart = details[1];
+    var domain = emailDomainPart.toLowerCase();
     console.log('Attempting to get autoconfiguration for', domain);
 
     var placeholderFields = {
@@ -13676,12 +13678,14 @@ Autoconfigurator.prototype = {
 
       // Fill any placeholder strings in the configuration object we retrieved.
       if (config) {
-        for (let [serverType, fields] in Iterator(placeholderFields)) {
+        for (var iter in Iterator(placeholderFields)) {
+          var serverType = iter[0], fields = iter[1];
           if (!config.hasOwnProperty(serverType))
             continue;
 
-          let server = config[serverType];
-          for (let [,field] in Iterator(fields)) {
+          var server = config[serverType];
+          for (var iter2 in Iterator(fields)) {
+            var field = iter2[1];
             if (server.hasOwnProperty(field))
               server[field] = fillPlaceholder(server[field]);
           }
@@ -13697,7 +13701,7 @@ Autoconfigurator.prototype = {
       return;
     }
 
-    let self = this;
+    var self = this;
     console.log('  Looking in local file store');
     this._getConfigFromLocalFile(domain, function(error, config, errorDetails) {
       if (self._isSuccessOrFatal(error)) {
@@ -13739,7 +13743,7 @@ Autoconfigurator.prototype = {
    *        info, formatted as JSON
    */
   tryToCreateAccount: function(universe, userDetails, callback) {
-    let self = this;
+    var self = this;
     this.getConfig(userDetails, function(error, config, errorDetails) {
       if (error)
         return callback(error, null, errorDetails);
@@ -13817,13 +13821,13 @@ define('mailapi/mailuniverse',
  *
  * This limit obviously is not used to discard operations not yet performed!
  */
-const MAX_MUTATIONS_FOR_UNDO = 10;
+var MAX_MUTATIONS_FOR_UNDO = 10;
 
 /**
  * When debug logging is enabled, how many second's worth of samples should
  * we keep?
  */
-const MAX_LOG_BACKLOG = 30;
+var MAX_LOG_BACKLOG = 30;
 
 /**
  * The MailUniverse is the keeper of the database, the root logging instance,
@@ -17427,7 +17431,7 @@ exports.chewHeaderAndBodyStructure = function chewStructure(msg) {
   };
 };
 
-const DESIRED_SNIPPET_LENGTH = 100;
+var DESIRED_SNIPPET_LENGTH = 100;
 
 /**
  * Call once the body parts requested by `chewHeaderAndBodyStructure` have been
@@ -17548,18 +17552,18 @@ define('mailapi/imap/folder',
     $module,
     exports
   ) {
-const allbackMaker = $allback.allbackMaker,
-      bsearchForInsert = $util.bsearchForInsert,
-      bsearchMaybeExists = $util.bsearchMaybeExists,
-      cmpHeaderYoungToOld = $util.cmpHeaderYoungToOld,
-      DAY_MILLIS = $date.DAY_MILLIS,
-      NOW = $date.NOW,
-      FUTURE = $date.FUTURE,
-      BEFORE = $date.BEFORE,
-      ON_OR_BEFORE = $date.ON_OR_BEFORE,
-      SINCE = $date.SINCE,
-      makeDaysBefore = $date.makeDaysBefore,
-      quantizeDate = $date.quantizeDate;
+var allbackMaker = $allback.allbackMaker,
+    bsearchForInsert = $util.bsearchForInsert,
+    bsearchMaybeExists = $util.bsearchMaybeExists,
+    cmpHeaderYoungToOld = $util.cmpHeaderYoungToOld,
+    DAY_MILLIS = $date.DAY_MILLIS,
+    NOW = $date.NOW,
+    FUTURE = $date.FUTURE,
+    BEFORE = $date.BEFORE,
+    ON_OR_BEFORE = $date.ON_OR_BEFORE,
+    SINCE = $date.SINCE,
+    makeDaysBefore = $date.makeDaysBefore,
+    quantizeDate = $date.quantizeDate;
 
 /**
  * Compact an array in-place with nulls so that the nulls are removed.  This
@@ -17589,7 +17593,7 @@ function compactArray(arr) {
  * us with an upper bound on the messages in the folder since we are blinding
  * ourselves to deleted messages.
  */
-const BASELINE_SEARCH_OPTIONS = ['!DELETED'];
+var BASELINE_SEARCH_OPTIONS = ['!DELETED'];
 
 /**
  * Fetch parameters to get the headers / bodystructure; exists to reuse the
@@ -17606,7 +17610,7 @@ const BASELINE_SEARCH_OPTIONS = ['!DELETED'];
  * right now either, but that's a lesser issue.  We probably don't want to trust
  * that data, however, if we don't want to trust normal ENVELOPE.
  */
-const INITIAL_FETCH_PARAMS = {
+var INITIAL_FETCH_PARAMS = {
   request: {
     headers: ['FROM', 'TO', 'CC', 'BCC', 'SUBJECT', 'REPLY-TO', 'MESSAGE-ID',
               'REFERENCES'],
@@ -17619,7 +17623,7 @@ const INITIAL_FETCH_PARAMS = {
  * Fetch parameters to just get the flags, which is no parameters because
  * imap.js always fetches them right now.
  */
-const FLAG_FETCH_PARAMS = {
+var FLAG_FETCH_PARAMS = {
   request: {
     struct: false,
     headers: false,
@@ -17974,11 +17978,11 @@ console.log("backoff! had", serverUIDs.length, "from", curDaysDelta,
 console.log("_commonSync", 'newUIDs', newUIDs.length, 'knownUIDs',
             knownUIDs.length, 'knownHeaders', knownHeaders.length);
     // See the `ImapFolderConn` block comment for rationale.
-    const KNOWN_HEADERS_AGGR_COST = 20,
-          KNOWN_HEADERS_PER_COST = 1,
-          NEW_HEADERS_AGGR_COST = 20,
-          NEW_HEADERS_PER_COST = 5,
-          NEW_BODIES_PER_COST = 30;
+    var KNOWN_HEADERS_AGGR_COST = 20,
+        KNOWN_HEADERS_PER_COST = 1,
+        NEW_HEADERS_AGGR_COST = 20,
+        NEW_HEADERS_PER_COST = 5,
+        NEW_BODIES_PER_COST = 30;
     var progressCost =
           (knownUIDs.length ? KNOWN_HEADERS_AGGR_COST : 0) +
           KNOWN_HEADERS_PER_COST * knownUIDs.length +
@@ -18220,6 +18224,7 @@ console.warn('  FLAGS: "' + header.flags.toString() + '" VS "' +
 
   downloadMessageAttachments: function(uid, partInfos, callback, progress) {
     var conn = this._conn;
+    var self = this;
     var mparser = new $mailparser.MailParser();
 
     // I actually implemented a usable shim for the checksum purposes, but we
@@ -18936,22 +18941,22 @@ define('mailapi/mailslice',
     $module,
     exports
   ) {
-const bsearchForInsert = $util.bsearchForInsert,
-      bsearchMaybeExists = $util.bsearchMaybeExists,
-      cmpHeaderYoungToOld = $util.cmpHeaderYoungToOld,
-      allbackMaker = $allback.allbackMaker,
-      BEFORE = $date.BEFORE,
-      ON_OR_BEFORE = $date.ON_OR_BEFORE,
-      SINCE = $date.SINCE,
-      STRICTLY_AFTER = $date.STRICTLY_AFTER,
-      IN_BS_DATE_RANGE = $date.IN_BS_DATE_RANGE,
-      HOUR_MILLIS = $date.HOUR_MILLIS,
-      DAY_MILLIS = $date.DAY_MILLIS,
-      NOW = $date.NOW,
-      FUTURE = $date.FUTURE,
-      makeDaysAgo = $date.makeDaysAgo,
-      makeDaysBefore = $date.makeDaysBefore,
-      quantizeDate = $date.quantizeDate;
+var bsearchForInsert = $util.bsearchForInsert,
+    bsearchMaybeExists = $util.bsearchMaybeExists,
+    cmpHeaderYoungToOld = $util.cmpHeaderYoungToOld,
+    allbackMaker = $allback.allbackMaker,
+    BEFORE = $date.BEFORE,
+    ON_OR_BEFORE = $date.ON_OR_BEFORE,
+    SINCE = $date.SINCE,
+    STRICTLY_AFTER = $date.STRICTLY_AFTER,
+    IN_BS_DATE_RANGE = $date.IN_BS_DATE_RANGE,
+    HOUR_MILLIS = $date.HOUR_MILLIS,
+    DAY_MILLIS = $date.DAY_MILLIS,
+    NOW = $date.NOW,
+    FUTURE = $date.FUTURE,
+    makeDaysAgo = $date.makeDaysAgo,
+    makeDaysBefore = $date.makeDaysBefore,
+    quantizeDate = $date.quantizeDate;
 
 // What do we think the post-snappy compression overhead of the structured clone
 // persistence rep will be for various things?  These are total guesses right
@@ -18959,10 +18964,10 @@ const bsearchForInsert = $util.bsearchForInsert,
 // cases and we just hope it will compress a bit.  For the attributes we are
 // including the attribute name as well as any fixed-overhead for its payload,
 // especially numbers which may or may not be zig-zag encoded/etc.
-const OBJ_OVERHEAD_EST = 2, STR_ATTR_OVERHEAD_EST = 5,
-      NUM_ATTR_OVERHEAD_EST = 10, LIST_ATTR_OVERHEAD_EST = 4,
-      NULL_ATTR_OVERHEAD_EST = 2, LIST_OVERHEAD_EST = 4,
-      NUM_OVERHEAD_EST = 8, STR_OVERHEAD_EST = 4;
+var OBJ_OVERHEAD_EST = 2, STR_ATTR_OVERHEAD_EST = 5,
+    NUM_ATTR_OVERHEAD_EST = 10, LIST_ATTR_OVERHEAD_EST = 4,
+    NULL_ATTR_OVERHEAD_EST = 2, LIST_OVERHEAD_EST = 4,
+    NUM_OVERHEAD_EST = 8, STR_OVERHEAD_EST = 4;
 
 /**
  * Intersects two objects each defining tupled ranges of the type
@@ -18970,7 +18975,7 @@ const OBJ_OVERHEAD_EST = 2, STR_ATTR_OVERHEAD_EST = 5,
  * This is exported for unit testing purposes and because no state is closed
  * over.
  */
-const tupleRangeIntersectsTupleRange = exports.tupleRangeIntersectsTupleRange =
+var tupleRangeIntersectsTupleRange = exports.tupleRangeIntersectsTupleRange =
     function tupleRangeIntersectsTupleRange(a, b) {
   if (BEFORE(a.endTS, b.startTS) ||
       STRICTLY_AFTER(a.startTS, b.endTS))
@@ -18985,7 +18990,7 @@ const tupleRangeIntersectsTupleRange = exports.tupleRangeIntersectsTupleRange =
  * What is the maximum number of bytes a block should store before we split
  * it?
  */
-const MAX_BLOCK_SIZE = 96 * 1024,
+var MAX_BLOCK_SIZE = 96 * 1024,
 /**
  * How many bytes should we target for the small part when splitting 1:2?
  */
@@ -22711,7 +22716,7 @@ RecipientFilter.prototype = {
   needsBody: true,
 
   testMessage: function(header, body, match) {
-    const phrase = this.phrase, stopAfter = this.stopAfter;
+    var phrase = this.phrase, stopAfter = this.stopAfter;
     var matches = [];
     function checkRecipList(list) {
       var ret;
@@ -22816,16 +22821,16 @@ exports.SubjectFilter = SubjectFilter;
 SubjectFilter.prototype = {
   needsBody: false,
   testMessage: function(header, body, match) {
-    const subject = header.subject;
+    var subject = header.subject;
     // Empty subjects can't match *anything*; no empty regexes allowed, etc.
     if (!subject)
       return false;
-    const phrase = this.phrase,
-          slen = subject.length,
-          stopAfter = this.stopAfter,
-          contextBefore = this.contextBefore, contextAfter = this.contextAfter,
-          matches = [];
-    var idx = 0;
+    var phrase = this.phrase,
+        slen = subject.length,
+        stopAfter = this.stopAfter,
+        contextBefore = this.contextBefore, contextAfter = this.contextAfter,
+        matches = [],
+        idx = 0;
 
     while (idx < slen && matches.length < stopAfter) {
       var ret = matchRegexpOrString(phrase, subject, idx);
@@ -22849,9 +22854,9 @@ SubjectFilter.prototype = {
 };
 
 // stable value from quotechew.js; full export regime not currently required.
-const CT_AUTHORED_CONTENT = 0x1;
+var CT_AUTHORED_CONTENT = 0x1;
 // HTML DOM constants
-const ELEMENT_NODE = 1, TEXT_NODE = 3;
+var ELEMENT_NODE = 1, TEXT_NODE = 3;
 
 /**
  * Searches the body of the message, it can ignore quoted stuff or not.
@@ -22874,12 +22879,12 @@ exports.BodyFilter = BodyFilter;
 BodyFilter.prototype = {
   needsBody: true,
   testMessage: function(header, body, match) {
-    const phrase = this.phrase,
-          stopAfter = this.stopAfter,
-          contextBefore = this.contextBefore, contextAfter = this.contextAfter,
-          matches = [],
-          matchQuotes = this.matchQuotes;
-    var idx;
+    var phrase = this.phrase,
+        stopAfter = this.stopAfter,
+        contextBefore = this.contextBefore, contextAfter = this.contextAfter,
+        matches = [],
+        matchQuotes = this.matchQuotes,
+        idx;
 
     for (var iBodyRep = 0; iBodyRep < body.bodyReps.length; iBodyRep += 2) {
       var bodyType = body.bodyReps[iBodyRep],
@@ -23013,7 +23018,7 @@ MessageFilterer.prototype = {
     //console.log('sf: testMessage(', header.suid, header.author.address,
     //            header.subject, 'body?', !!body, ')');
     var matched = false, matchObj = {};
-    const filters = this.filters;
+    var filters = this.filters;
     try {
       for (var i = 0; i < filters.length; i++) {
         var filter = filters[i];
@@ -23032,8 +23037,8 @@ MessageFilterer.prototype = {
   },
 };
 
-const CONTEXT_CHARS_BEFORE = 16;
-const CONTEXT_CHARS_AFTER = 40;
+var CONTEXT_CHARS_BEFORE = 16;
+var CONTEXT_CHARS_AFTER = 40;
 
 /**
  *
@@ -23352,7 +23357,7 @@ exports.local_undo_modtags = function(op, callback) {
 exports.local_do_move = function(op, doneCallback, targetFolderId) {
   // create a scratch field to store the guid's for check purposes
   op.guids = {};
-  const nukeServerIds = !this.resilientServerIds;
+  var nukeServerIds = !this.resilientServerIds;
 
   var stateDelta = this._stateDelta, addWait = 0, self = this;
   if (!stateDelta.moveMap)
@@ -23874,7 +23879,7 @@ exports.runOp = function runOp(op, mode, callback) {
  * if no such folder exists.
  */
 exports.getFirstFolderWithType = function(type) {
-  const folders = this.folders;
+  var folders = this.folders;
   for (var iFolder = 0; iFolder < folders.length; iFolder++) {
     if (folders[iFolder].type === type)
       return folders[iFolder];


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/130
