### PR TITLE
Bug 846845 - [MMS][SMS][Tests] add tests and simplify Utils

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -2,164 +2,177 @@
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 'use strict';
-
-// Based on Resig's pretty date
 var _ = navigator.mozL10n.get;
 var dtf = new navigator.mozL10n.DateTimeFormat();
 
-var Utils = {
-  updateTimeHeaders: function ut_updateTimeHeaders() {
-    var elementsToUpdate =
-        document.querySelectorAll('header[data-time-update]');
-    if (elementsToUpdate.length > 0) {
-      for (var i = 0; i < elementsToUpdate.length; i++) {
-        var ts = elementsToUpdate[i].dataset.time;
-        var tmpHeaderDate;
-        if (elementsToUpdate[i].dataset.isThread) { // only date
-          tmpHeaderDate = Utils.getHeaderDate(ts);
-        } else {
-          elementsToUpdate[i].dataset.hourOnly ?
-            tmpHeaderDate = Utils.getFormattedHour(ts) : // only time
-            tmpHeaderDate = Utils.getHeaderDate(ts) + ' ' +
-                            Utils.getFormattedHour(ts); // date + time
-        }
-        var currentHeader = elementsToUpdate[i].innerHTML;
-        if (tmpHeaderDate != currentHeader) {
-          elementsToUpdate[i].innerHTML = tmpHeaderDate;
-        }
-      }
-    }
-  },
-  startTimeHeaderScheduler: function ut_startTimeHeaderScheduler() {
-    this.updateTimeHeaders();
-    if (this.updateTimer) {
-      clearInterval(this.updateTimer);
-    }
-    this.updateTimer = setInterval(function(self) {
-      self.updateTimeHeaders();
-    }, 50000, this);
-  },
-  escapeHTML: function ut_escapeHTML(str, escapeQuotes) {
-    if (typeof(str) !== 'string') {
-      return '';
-    }
-    var stringHTML = str;
-    stringHTML = stringHTML.replace(/\</g, '&#60;');
-    stringHTML = stringHTML.replace(/(\r\n|\n|\r)/gm, '<br/>');
-    stringHTML = stringHTML.replace(/\s\s/g, ' &nbsp;');
+(function(exports) {
+  var sharedDate = new Date();
+  var regexps = {
+    amp: /&/g,
+    lt: /</g,
+    gt: />/g,
+    br: /(\r\n|\n|\r)/gm,
+    nbsp: /\s\s/g,
+    quot: /"/g,
+    apos: /'/g
+  };
 
-    if (escapeQuotes)
-      return stringHTML.replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
-    return stringHTML;
-  },
+  var Utils = {
+    updateTimeHeaders: function ut_updateTimeHeaders() {
+      var headers = document.querySelectorAll('header[data-time-update]'),
+          length = headers.length,
+          i, ts, header, headerDate, formattedHour, newHeader;
 
-  getFormattedHour: function ut_getFormattedHour(time) {
-    switch (time.constructor) {
-      case String:
-        time = parseInt(time);
-        break;
-      case Date:
-        time = time.getTime();
-        break;
-    }
+      if (length) {
+        for (i = 0; i < length; i++) {
+          header = headers[i];
+          ts = header.dataset.time;
+          headerDate = Utils.getHeaderDate(ts);
+          formattedHour = Utils.getFormattedHour(ts);
 
-    return dtf.localeFormat(new Date(time), _('shortTimeFormat'));
-  },
-  getDayDate: function re_getDayDate(timestamp) {
-    var date = new Date(timestamp);
-    var startDate = new Date(date.getFullYear(),
-                             date.getMonth(), date.getDate());
-    return startDate.getTime();
-  },
-  getHeaderDate: function ut_giveHeaderDate(time) {
-    switch (time.constructor) {
-      case String:
-        time = new Number(time);
-        break;
-      case Date:
-        time = time.getTime();
-        break;
-    }
-    var today = Utils.getDayDate((new Date()).getTime());
-    var otherDay = Utils.getDayDate(time);
-    var dayDiff = (today - otherDay) / 86400000;
+          // only date
+          if (header.dataset.isThread) {
+            newHeader = headerDate;
 
-    if (isNaN(dayDiff))
-      return _('incorrectDate');
+          // only time
+          } else if (header.dataset.hourOnly) {
+            newHeader = formattedHour;
 
-    if (dayDiff < 0) {
-      // future time
-      return dtf.localeFormat(new Date(time), _('shortDateTimeFormat'));
-    }
+          // date + time
+          } else {
+            newHeader = headerDate + ' ' + formattedHour;
+          }
 
-    return dayDiff == 0 && _('today') ||
-      dayDiff == 1 && _('yesterday') ||
-      dayDiff < 4 && dtf.localeFormat(new Date(time), '%A') ||
-      dtf.localeFormat(new Date(time), '%x');
-  },
-  getFontSize: function ut_getFontSize() {
-    if (!this.rootFontSize) {
-      var htmlCss = window.getComputedStyle(document.documentElement, null);
-      this.rootFontSize = parseInt(htmlCss.getPropertyValue('font-size'));
-    }
-    return this.rootFontSize;
-  },
-
-  getPhoneDetails: function ut_getPhoneDetails(number, contact, callback) {
-    var details = {};
-    if (contact) { // we have a contact
-      var name = contact.name[0],
-          phone = contact.tel[0],
-          carrierToShow = phone.carrier;
-
-      // Check which of the contacts phone number are we using
-      for (var i = 0; i < contact.tel.length; i++) {
-        // Based on E.164 (http://en.wikipedia.org/wiki/E.164)
-        var tempPhoneNumber = contact.tel[i].value;
-        if (number.length > 7) {
-          var rootPhoneNumber = number.substr(-8);
-        } else {
-          var rootPhoneNumber = number;
-        }
-        if (tempPhoneNumber.indexOf(rootPhoneNumber) != -1) {
-          phone = contact.tel[i];
-          carrierToShow = phone.carrier;
-          break;
-        }
-      }
-
-      // Add data values for contact activity interaction
-      details.isContact = true;
-
-      // Add photo
-      if (contact.photo && contact.photo[0]) {
-        details.photoURL = URL.createObjectURL(contact.photo[0]);
-      }
-
-      // Carrier logic
-      if (name && name != '') { // contact with name
-        // Check if other phones with same type and carrier
-        for (var i = 0; i < contact.tel.length; i++) {
-          if (contact.tel[i].value !== phone.value &&
-              contact.tel[i].type == phone.type &&
-              contact.tel[i].carrier == phone.carrier) {
-            carrierToShow = phone.value;
+          if (newHeader !== header.textContent) {
+            header.textContent = newHeader;
           }
         }
-        details.title = name;
-        details.carrier = (carrierToShow || phone.value);
-      } else { // no name of contact
+      }
+    },
+    startTimeHeaderScheduler: function ut_startTimeHeaderScheduler() {
+      this.updateTimeHeaders();
+      if (this.updateTimer) {
+        clearInterval(this.updateTimer);
+      }
+      this.updateTimer = setInterval(function(self) {
+        self.updateTimeHeaders();
+      }, 50000, this);
+    },
+    escapeHTML: function ut_escapeHTML(str, escapeQuotes) {
+      if (typeof str !== 'string') {
+        return '';
+      }
+      // Order is vitally important: ampersands must be converted first
+      // to avoid converting the ampersands that prefix an entity later.
+      var escaped = str.replace(regexps.amp, '&amp;')
+        .replace(regexps.lt, '&lt;')
+        .replace(regexps.gt, '&gt;')
+        .replace(regexps.br, '<br/>')
+        .replace(regexps.nbsp, ' &nbsp;');
+
+      if (escapeQuotes) {
+        return escaped
+          .replace(regexps.quot, '&quot;')
+          .replace(regexps.apos, '&apos;');
+      }
+
+      return escaped;
+    },
+
+    getFormattedHour: function ut_getFormattedHour(time) {
+      sharedDate.setTime(+time);
+      return dtf.localeFormat(sharedDate, _('shortTimeFormat'));
+    },
+    getDayDate: function re_getDayDate(time) {
+      sharedDate.setTime(+time);
+      sharedDate.setHours(0, 0, 0, 0);
+      return sharedDate.getTime();
+    },
+    getHeaderDate: function ut_giveHeaderDate(time) {
+      sharedDate.setTime(+time);
+      var today = Utils.getDayDate(Date.now());
+      var otherDay = Utils.getDayDate(time);
+      var dayDiff = (today - otherDay) / 86400000;
+
+      if (isNaN(dayDiff)) {
+        return _('incorrectDate');
+      }
+
+      if (dayDiff < 0) {
+        // future time
+        return dtf.localeFormat(sharedDate, _('shortDateTimeFormat'));
+      }
+
+      return dayDiff === 0 && _('today') ||
+        dayDiff === 1 && _('yesterday') ||
+        dayDiff < 4 && dtf.localeFormat(sharedDate, '%A') ||
+        dtf.localeFormat(sharedDate, '%x');
+    },
+    getFontSize: function ut_getFontSize() {
+      if (!this.rootFontSize) {
+        var htmlCss = window.getComputedStyle(document.documentElement, null);
+        this.rootFontSize = parseInt(htmlCss.getPropertyValue('font-size'), 10);
+      }
+      return this.rootFontSize;
+    },
+
+    getPhoneDetails: function ut_getPhoneDetails(number, contact, callback) {
+      var details = {},
+          name, phone, carrier, i, length, subscriber;
+
+      if (contact) {
+        name = contact.name[0];
+        phone = contact.tel[0],
+        carrier = phone.carrier;
+        length = contact.tel.length;
+        subscriber = number.length > 7 ? number.substr(-8) : number;
+
+        // Check which of the contacts phone number are we using
+        for (i = 0; i < length; i++) {
+          // Based on E.164 (http://en.wikipedia.org/wiki/E.164)
+          if (contact.tel[i].value.indexOf(subscriber) !== -1) {
+            phone = contact.tel[i];
+            carrier = phone.carrier;
+            break;
+          }
+        }
+
+        // Add data values for contact activity interaction
+        details.isContact = true;
+
+        // Add photo
+        if (contact.photo && contact.photo[0]) {
+          details.photoURL = URL.createObjectURL(contact.photo[0]);
+        }
+
+        // Carrier logic
+        if (name) {
+          // Check if other phones with same type and carrier
+          for (i = 0; i < length; i++) {
+            if (contact.tel[i].value !== phone.value &&
+                contact.tel[i].type === phone.type &&
+                contact.tel[i].carrier === phone.carrier) {
+              carrier = phone.value;
+            }
+          }
+        }
+
+        details.title = name || number;
+        details.carrier = carrier || phone.value || '';
+
+        if (phone.type) {
+          details.carrier = phone.type + ' | ' + details.carrier;
+        }
+
+      // No contact argument was provided
+      } else {
         details.title = number;
-        details.carrier = (phone.carrier || '');
       }
 
-      if (phone.type) {
-        details.carrier = phone.type + ' | ' + details.carrier;
-      }
-
-    } else { // we don't have a contact
-      details.title = number;
+      callback(details);
     }
-    callback(details);
-  }
-};
+  };
+
+  exports.Utils = Utils;
+
+}(this));

--- a/apps/sms/test/unit/contact_mockup.js
+++ b/apps/sms/test/unit/contact_mockup.js
@@ -1,7 +1,0 @@
-'use strict';
-
-function MockContact() {
-  return [{
-    name: ['Josh']
-  }];
-}

--- a/apps/sms/test/unit/mock_contact.js
+++ b/apps/sms/test/unit/mock_contact.js
@@ -1,0 +1,57 @@
+'use strict';
+
+function MockContact() {
+  if (!(this instanceof MockContact)) {
+    return new MockContact();
+  }
+  this.id = '1';
+  this.updated = Date.now();
+
+  this.familyName = ['Grillo'];
+  this.givenName = ['Pepito'];
+  this.additionalName = [''];
+  this.name = [
+    [this.givenName, this.familyName].join(' ')
+  ];
+
+  this.bday = '1978-12-20';
+  this.jobTitle = [''];
+  this.org = ['Test'],
+
+  this.adr = [
+    {
+      countryName: 'Germany',
+      locality: 'Chemnitz',
+      postalCode: '09034',
+      streetAddress: 'Gotthardstrasse 22'
+    }
+  ];
+
+  this.email = [
+    {
+      'type': 'Personal',
+      'value': 'test@test.com'
+    }
+  ];
+
+  this.tel = [
+    {
+      'value': '+346578888888',
+      'type': 'Mobile',
+      'carrier': 'TEF'
+    },
+    {
+      'value': '+12125559999',
+      'type': 'Batphone',
+      'carrier': 'XXX'
+    }
+  ];
+
+  this.category = [
+    'favorite'
+  ];
+}
+
+MockContact.list = function() {
+  return [new MockContact()];
+};

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -9,7 +9,7 @@ requireApp('sms/js/contacts.js');
 requireApp('sms/js/fixed_header.js');
 requireApp('sms/js/search_utils.js');
 requireApp('sms/js/utils.js');
-requireApp('sms/test/unit/contact_mockup.js');
+requireApp('sms/test/unit/mock_contact.js');
 requireApp('sms/test/unit/utils_mockup.js');
 requireApp('sms/test/unit/messages_mockup.js');
 requireApp('sms/test/unit/sms_test_html_mockup.js');
@@ -168,7 +168,7 @@ suite('SMS App Unit-Test', function() {
     ContactDataManager.getContactData = function(number, callback) {
       // Get the contact
       if (number === '1977') {
-        callback(new MockContact());
+        callback(MockContact.list());
       }
     };
 
@@ -225,7 +225,7 @@ suite('SMS App Unit-Test', function() {
         var threadWithContact = document.getElementById('thread_1977');
         var contactName =
           threadWithContact.getElementsByClassName('name')[0].innerHTML;
-        assert.equal(contactName, 'Josh');
+        assert.equal(contactName, 'Pepito Grillo');
       });
     });
 

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+requireApp('sms/test/unit/mock_contact.js');
+requireApp('sms/js/utils.js');
+
+
+suite('Utils', function() {
+  suite('Utils.escapeHTML', function() {
+
+    test('valid', function() {
+      var fixture = '<div>"Hello!"&  \' </div>\r\n';
+
+      assert.equal(
+        Utils.escapeHTML(fixture),
+        '&lt;div&gt;"Hello!"&amp; &nbsp;\' &lt;/div&gt;<br/>'
+      );
+      // There are zero uses of this optional signature, testing anyway.
+      assert.equal(
+        Utils.escapeHTML(fixture, true),
+        '&lt;div&gt;&quot;Hello!&quot;&amp; &nbsp;&apos; &lt;/div&gt;<br/>'
+      );
+    });
+
+    test('invalid', function() {
+      var expect = '';
+
+      assert.equal(Utils.escapeHTML(0), expect);
+      assert.equal(Utils.escapeHTML(false), expect);
+      assert.equal(Utils.escapeHTML(true), expect);
+      assert.equal(Utils.escapeHTML(null), expect);
+      assert.equal(Utils.escapeHTML({}), expect);
+      assert.equal(Utils.escapeHTML([]), expect);
+    });
+  });
+
+  /*
+
+  Omit this test, pending:
+  Bug 847975 - [MMS][SMS] remove use of "dtf" alias from SMS
+  https://bugzilla.mozilla.org/show_bug.cgi?id=847975
+
+  suite('Utils.getFormattedHour', function() {
+    var time = 1362166084256;
+
+    test('([String|Number|Date])', function() {
+      var expect = 'Fri Mar 01 2013 14:28:04 GMT-0500 (EST)';
+      var fixtures = {
+        string: time + '',
+        number: time,
+        date: new Date(time)
+      };
+
+      assert.equal(Utils.getFormattedHour(fixtures.string), expect);
+      assert.equal(Utils.getFormattedHour(fixtures.number), expect);
+      assert.equal(Utils.getFormattedHour(fixtures.date), expect);
+    });
+  });
+  */
+
+
+  suite('Utils.getDayDate', function() {
+    test('(UTSMS)', function() {
+      var date = new Date(1362166084256);
+      var offset = (+date - date.getTimezoneOffset() * 60000) % 86400000;
+
+      assert.equal(
+        Utils.getDayDate(1362166084256),
+        date.getTime() - offset // midnight
+      );
+    });
+  });
+
+  suite('Utils.getHeaderDate', function() {
+
+    test('(today [String|Number|Date])', function() {
+      var expect = 'today';
+      var today = Date.now();
+      var fixtures = {
+        string: today + '',
+        number: today,
+        date: new Date()
+      };
+
+      assert.equal(Utils.getHeaderDate(fixtures.string), expect);
+      assert.equal(Utils.getHeaderDate(fixtures.number), expect);
+      assert.equal(Utils.getHeaderDate(fixtures.date), expect);
+    });
+
+    test('(yesterday [String|Number|Date])', function() {
+      var expect = 'yesterday';
+      var yesterday = Date.now() - 86400000;
+      var fixtures = {
+        string: yesterday + '',
+        number: yesterday,
+        date: new Date(yesterday)
+      };
+
+      assert.equal(Utils.getHeaderDate(fixtures.string), expect);
+      assert.equal(Utils.getHeaderDate(fixtures.number), expect);
+      assert.equal(Utils.getHeaderDate(fixtures.date), expect);
+    });
+
+    /*
+      Related to:
+      Bug 847975 - [MMS][SMS] remove use of "dtf" alias from SMS
+      https://bugzilla.mozilla.org/show_bug.cgi?id=847975
+
+      Needs a test for dates older then yesterday. Unfortunately,
+      there appears to be issues with l10n module when running tests
+      using the desktop automated test-agent.
+
+      test('(epoch [String|Number])', function() {
+      });
+    */
+  });
+
+  suite('Utils.getPhoneDetails', function() {
+    test('(number, contact, callback)', function() {
+      var contact = new MockContact();
+
+      Utils.getPhoneDetails('346578888888', contact, function(details) {
+        assert.deepEqual(details, {
+          isContact: true,
+          title: 'Pepito Grillo',
+          carrier: 'Mobile | TEF'
+        });
+      });
+
+      Utils.getPhoneDetails('12125559999', contact, function(details) {
+        assert.deepEqual(details, {
+          isContact: true,
+          title: 'Pepito Grillo',
+          carrier: 'Batphone | XXX'
+        });
+      });
+    });
+
+    test('(number, null, callback)', function() {
+      var contact = new MockContact();
+
+      Utils.getPhoneDetails('346578888888', null, function(details) {
+        assert.deepEqual(details, {
+          title: '346578888888'
+        });
+      });
+    });
+
+    test('(number (wrong number), contact, callback)', function() {
+      var contact = new MockContact();
+
+      Utils.getPhoneDetails('99999999', contact, function(details) {
+        assert.deepEqual(details, {
+          isContact: true,
+          title: 'Pepito Grillo',
+          carrier: 'Mobile | TEF'
+        });
+      });
+    });
+
+    test('(number, contact (blank name), callback)', function() {
+      var contact = new MockContact();
+      var name = contact.name[0];
+
+      // Remove the name value
+      contact.name[0] = '';
+
+      Utils.getPhoneDetails('346578888888', contact, function(details) {
+        assert.deepEqual(details, {
+          isContact: true,
+          title: '346578888888',
+          carrier: 'Mobile | TEF'
+        });
+
+        // Restore the name
+        contact.name[0] = name;
+      });
+    });
+  });
+});


### PR DESCRIPTION
``` bash
  [SMS] Utils
    ✓ [SMS] Utils.escapeHTML (valid) 
    ✓ [SMS] Utils.escapeHTML (invalid) 
    ✓ [SMS] Utils.getFormattedHour([String|Number|Date]) 
    ✓ [SMS] Utils.getDayDate(UTSMS) 
    ✓ [SMS] Utils.getHeaderDate(today [String|Number|Date]) 
    ✓ [SMS] Utils.getHeaderDate(yesterday [String|Number|Date]) 
    ✓ [SMS] Utils.getPhoneDetails(number, contact, callback) 
    ✓ [SMS] Utils.getPhoneDetails(number, null, callback) 
    ✓ [SMS] Utils.getPhoneDetails(number (wrong number), contact, callback) 
    ✓ [SMS] Utils.getPhoneDetails(number, contact (blank name), callback) 
```

All, with the exception of escapeHTML, will pass before and after code simplification commit. The escapeHTML implementation was incomplete and requires the middle commit that corrected the entities and completed the conversion of `<` and `>`
