### PR TITLE
Use custom linter, and ignore errors about line length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ manifest.appcache
 /showcase_apps/*/test/unit/_sandbox.html
 /showcase_apps/*/test/unit/_proxy.html
 
+/linter/customrules.pyc
 /profile/
 /profile.tar.gz
 /.xulrunner-url

--- a/Makefile
+++ b/Makefile
@@ -602,8 +602,8 @@ lint:
 	@# cubevid
 	@# crystalskull
 	@# towerjelly
-	@gjslint --nojsdoc -r apps -e 'homescreen/everything.me,sms/js/ext,pdfjs/content,pdfjs/test,email/js/ext,music/js/ext,calendar/js/ext'
-	@gjslint --nojsdoc -r shared/js
+	@python ./linter/gjslint.py --nojsdoc -r apps -e 'homescreen/everything.me,sms/js/ext,pdfjs/content,pdfjs/test,email/js/ext,music/js/ext,calendar/js/ext'
+	@python ./linter/gjslint.py --nojsdoc -r shared/js
 
 # Generate a text file containing the current changeset of Gaia
 # XXX I wonder if this should be a replace-in-file hack. This would let us

--- a/linter/customrules.py
+++ b/linter/customrules.py
@@ -1,0 +1,16 @@
+from closure_linter import errors
+from closure_linter import errorrules
+
+OriginalShouldReportError = None
+
+def InjectErrorReporter():
+ global OriginalShouldReportError
+ OriginalShouldReportError = errorrules.ShouldReportError
+ errorrules.ShouldReportError = MyShouldReportError
+
+def MyShouldReportError(error):
+ global OriginalShouldReportError
+ return error not in (
+   errors.LINE_TOO_LONG,
+ ) and OriginalShouldReportError(error)
+

--- a/linter/fixjsstyle.py
+++ b/linter/fixjsstyle.py
@@ -1,0 +1,6 @@
+from closure_linter import fixjsstyle
+import customrules
+
+if __name__ == '__main__':
+  customrules.InjectErrorReporter()
+  fixjsstyle.main()

--- a/linter/gjslint.py
+++ b/linter/gjslint.py
@@ -1,0 +1,6 @@
+from closure_linter import gjslint
+import customrules
+
+if __name__ == '__main__':
+  customrules.InjectErrorReporter()
+  gjslint.main()


### PR DESCRIPTION
This is based on work done by @kewisch on the linter. I strongly disagree with a 80 character max on lines, sometimes it's much cleaner to have an 81, or 82 character limit on the line length.

I think we can implement this wrapped linter with the end goal of having 'make lint' just work.
