### PR TITLE
Bug 830468 - Rotate images in gallery

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -76,7 +76,7 @@
         <img id="crop-image"></img>
       </div>
     </section>
-    
+
     <section role="region" id="edit-view" class="hidden skin-organic">
       <header id="edit-header">
         <button id="edit-cancel-button"><span class="icon icon-close"></span></button>
@@ -110,7 +110,7 @@
           </div>
         </div>
 
-        <div id="edit-crop-options" class="edit-options-bar hidden"> 
+        <div id="edit-crop-options" class="edit-options-bar hidden">
           <a id="edit-crop-none" class="button"></a>
           <a id="edit-crop-aspect-free" class="selected radio button"></a>
           <a id="edit-crop-aspect-portrait" class="radio button"></a>
@@ -118,7 +118,7 @@
           <a id="edit-crop-aspect-square" class="radio button"></a>
         </div>
 
-        <div id="edit-effect-options" class="edit-options-bar hidden"> 
+        <div id="edit-effect-options" class="edit-options-bar hidden">
           <a id="edit-effect-none" class="selected radio button bgimage"
              data-effect="none"></a>
           <a id="edit-effect-bw" class="radio button filter-bw bgimage"
@@ -131,7 +131,7 @@
              data-effect="faded"></a>
         </div>
 
-        <div id="edit-border-options" class="edit-options-bar hidden"> 
+        <div id="edit-border-options" class="edit-options-bar hidden">
           <a id="edit-border-none" class="selected radio button bgimage"
              data-border-width="0"></a>
           <a id="edit-border-thin-white" class="radio button bgimage"
@@ -143,6 +143,11 @@
           <a id="edit-border-thick-black" class="radio button bgimage"
              data-border-width=".03" data-border-color="black"></a>
         </div>
+
+        <div id="edit-rotate-options" class="edit-options-bar hidden">
+          <a id="edit-rotate-counter" class="radio button">Counter</a>
+          <a id="edit-rotate-clock" class="radio button">Clockwise</a>
+        </div>
       </div>
 
       <!-- buttons for selecting the type of edit to perform -->
@@ -151,6 +156,7 @@
         <a id="edit-crop-button" class="button" data-l10n-id="crop"></a>
         <a id="edit-effect-button" class="button" data-l10n-id="effects"></a>
         <a id="edit-border-button" class="button" data-l10n-id="borders"></a>
+        <a id="edit-rotate-button" class="button" data-l10n-id="rotate"></a>
       </footer>
     </section>
 

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -29,6 +29,7 @@ exposure = Exposure
 crop     = Crop
 effects  = Effects
 borders  = Borders
+rotate   = Rotate
 
 original      = Original
 blackandwhite = B&W

--- a/apps/gallery/locales/gallery.fr.properties
+++ b/apps/gallery/locales/gallery.fr.properties
@@ -29,6 +29,7 @@ exposure = Exposition
 crop     = Découper
 effects  = Effets
 borders  = Bords
+rotate   = Tourner
 
 original      = Original
 blackandwhite = Noir et blanc

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -491,8 +491,8 @@ footer {
   position: absolute;
   top: 10px;
   left: 10px;
-  width: 300px;  /* I can't do right: 10px here. Bug? */
-  height: calc(100% - 20px)  /* can't just set bottom: 10px here */
+  width: calc(100% - 20px);
+  height: calc(100% - 20px);
 }
 
 #edit-crop-canvas {
@@ -814,3 +814,4 @@ a.filter-faded {
 #slider3 {
   left: calc(10% + 6 * 80%/6);
 }
+.thumbnail {width:120px;height:120px}

--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -100,7 +100,7 @@ section {
 
 #overlay-text {
   padding: 10px 5px 0 5px;
-  border-top: 1px solid #686868;	
+  border-top: 1px solid #686868;
   font-weight: 300;
   font-size: 2.5rem;
   color: #ebebeb;
@@ -110,7 +110,7 @@ section {
  * Thumbnails are implemented as <li> elements in a <ul> with background-image
  * set to display the image. We use background-size: cover to automatically
  * resize the image as needed.
- * The thumbnail list appears in regular browsing mode, in selection mode, 
+ * The thumbnail list appears in regular browsing mode, in selection mode,
  * and in pick mode.
  */
 
@@ -495,7 +495,7 @@ footer {
   height: calc(100% - 20px)  /* can't just set bottom: 10px here */
 }
 
-#edit-crop-canvas { 
+#edit-crop-canvas {
   position: absolute;
   left: 0;
   right: 0;
@@ -533,7 +533,7 @@ footer {
   outline-offset: -3px;
 }
 
-#edit-crop-options a.button {
+#edit-crop-options a.button, #edit-rotate-options a.button {
   position: absolute;
   display: block;
   top: 0;
@@ -549,7 +549,7 @@ footer {
   background-position: center;
 }
 
-#edit-crop-options a.selected.radio.button {
+#edit-crop-options a.selected.radio.button, #edit-rotate-options a.selected.radio.button {
   outline: solid #00aacc 2px;
   outline-offset: -2px;
 }
@@ -661,11 +661,11 @@ a.filter-faded {
 
 #edit-border-none {
   left: calc(0% + 3px);
-  border: 2px solid white;  
+  border: 2px solid white;
 }
 #edit-border-thin-white {
   left: calc(20% + 3px);
-  border: 2px solid white;  
+  border: 2px solid white;
 }
 #edit-border-thick-white {
   left: calc(40% + 3px);
@@ -673,17 +673,17 @@ a.filter-faded {
 }
 #edit-border-thin-black {
   left: calc(60% + 3px);
-  border: 2px solid black;  
+  border: 2px solid black;
 }
 #edit-border-thick-black {
   left: calc(80% + 3px);
-  border: 4px solid black;  
+  border: 4px solid black;
 }
 
 /* all buttons in the toolbar share these styles */
 #edit-toolbar > .button {
   position: absolute;
-  width: 25%;
+  width: 20%;
   height: 100%;
   font-size: 1.4rem;
 }
@@ -698,15 +698,26 @@ a.filter-faded {
 }
 
 #edit-crop-button {
-  left: 25%;
+  left: 20%;
 }
 
 #edit-effect-button {
-  left: 50%
+  left: 40%
 }
 
 #edit-border-button {
-  left: 75%
+  left: 60%
+}
+
+#edit-rotate-button {
+  left: 80%;
+}
+
+#edit-rotate-counter {
+  left: 30%;
+}
+#edit-rotate-clock {
+  left: 50%;
 }
 
 /*


### PR DESCRIPTION
Fix for [#830468](https://bugzilla.mozilla.org/show_bug.cgi?id=830468). This patch adds a Rotation function in the 'edit' feature of the gallery.

The approach I took is to redraw the image when someone rotates, as this is by far the easiest way to rotate an image. Thereafter I update all the references to the image so that the other effects now use this canvas. Works pretty neat. Tested on B2G desktop and the Unagi device.

As you can see I have terrible design skills, so I'd like someone from UX to give some feedback as well (plus design some nice icon for the clockwise / counterclockwise rotation).
