### PR TITLE
Bug 882799 - Add radix parameter to minutes and hours

### DIFF
--- a/apps/music/js/utils.js
+++ b/apps/music/js/utils.js
@@ -15,8 +15,8 @@ function formatTime(secs) {
 
   var formatedTime;
   var seconds = parseInt(secs % 60, 10);
-  var minutes = parseInt(secs / 60) % 60;
-  var hours = parseInt(secs / 3600) % 24;
+  var minutes = parseInt(secs / 60, 10) % 60;
+  var hours = parseInt(secs / 3600, 10) % 24;
 
   if (hours === 0) {
     formatedTime =


### PR DESCRIPTION
Although not likely to cause problems here, we should always specify the radix when using a stock `parseInt` function for the sake of good coding practices.
