### PR TITLE
Bug 847635 - [B2G][Contacts] Grayed out Facebook fields become editable ...

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -820,11 +820,12 @@ var Contacts = (function() {
           currentContact.id == event.contactID) {
           contactsList.getContactById(event.contactID,
             function success(contact, enrichedContact) {
-            currentContact = enrichedContact || contact;
-            contactsDetails.render(currentContact, false,
+            currentContact = contact;
+            var mergedContact = enrichedContact || contact;
+            contactsDetails.render(mergedContact, false,
                                    enrichedContact ? true : false);
-            contactsList.refresh(currentContact, checkPendingChanges,
-              event.reason);
+            contactsList.refresh(mergedContact, checkPendingChanges,
+                                 event.reason);
           });
         } else {
           contactsList.refresh(event.contactID, checkPendingChanges,

--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -135,6 +135,12 @@ contacts.Form = (function() {
         checkDisableButton();
       }
     });
+
+    thumbAction.addEventListener('mousedown', function click(event) {
+      // Removing current photo
+      if (event.target.tagName == 'BUTTON')
+        saveButton.removeAttribute('disabled');
+    });
   };
 
   var render = function cf_render(contact, callback, pFbContactData) {
@@ -157,6 +163,7 @@ contacts.Form = (function() {
       return;
     }
     formView.classList.add('skin-organic');
+    saveButton.setAttribute('disabled', 'disabled');
     saveButton.textContent = _('update');
     currentContact = contact;
     deleteContactButton.parentNode.classList.remove('hide');
@@ -662,7 +669,7 @@ contacts.Form = (function() {
 
     activity.onsuccess = function success() {
       addRemoveIconToPhoto();
-
+      saveButton.removeAttribute('disabled');
       // XXX
       // this.result.blob is valid now, but it won't stay valid
       // (see https://bugzilla.mozilla.org/show_bug.cgi?id=806503)


### PR DESCRIPTION
...after editing any field in a Facebook/ linked contact.
