### PR TITLE
Bug 847908 - [Gallery] Remove mouse event shim in favor of GestureDetector

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -16,7 +16,6 @@
     <link rel="resource" type="application/l10n" href="locales/locales.ini" />
     <!-- Shared code -->
     <script defer src="shared/js/l10n.js"></script>
-    <script defer src="shared/js/mouse_event_shim.js"></script>
     <script defer src="shared/js/mediadb.js"></script>
     <script defer src="shared/js/lazy_loader.js"></script>
     <script defer src="shared/js/visibility_monitor.js"></script>

--- a/apps/gallery/js/ImageEditor.js
+++ b/apps/gallery/js/ImageEditor.js
@@ -5,6 +5,9 @@ var editedPhotoURL; // The blob URL of the photo we're currently editing
 var editSettings;
 var imageEditor;
 
+var gestureDetector = new GestureDetector($('edit-view'));
+gestureDetector.startDetecting();
+
 var editOptionButtons =
   Array.slice($('edit-options').querySelectorAll('a.radio.button'), 0);
 
@@ -140,33 +143,21 @@ var exposureSlider = (function() {
   var bar = document.getElementById('sliderbar');
   var thumb = document.getElementById('sliderthumb');
 
-  thumb.addEventListener('mousedown', sliderStartDrag);
-
-  var currentExposure;
-  var sliderStartPixel;
-  var sliderStartExposure;
-
-  function sliderStartDrag(e) {
-    document.addEventListener('mousemove', sliderDrag, true);
-    document.addEventListener('mouseup', sliderEndDrag, true);
-    sliderStartPixel = e.clientX;
+  thumb.addEventListener('pan', sliderDrag);
+  thumb.addEventListener('swipe', function(e) {
+    // when stopping we init the start to be at the current level
+    // this way we avoid a 'panstart' event
     sliderStartExposure = currentExposure;
     e.preventDefault();
-  }
+  });
+
+  var currentExposure; // will be set by the initial setExposure call
+  var sliderStartExposure = 0;
 
   function sliderDrag(e) {
-    var delta = e.clientX - sliderStartPixel;
-    var exposureDelta = delta / (parseInt(bar.clientWidth) * .8) * 6;
-    var oldExposure = currentExposure;
+    var delta = e.detail.absolute.dx;
+    var exposureDelta = delta / (parseInt(bar.clientWidth, 10) * .8) * 6;
     setExposure(sliderStartExposure + exposureDelta);
-    if (currentExposure !== oldExposure)
-      slider.dispatchEvent(new Event('change', {bubbles: true}));
-    e.preventDefault();
-  }
-
-  function sliderEndDrag(e) {
-    document.removeEventListener('mousemove', sliderDrag, true);
-    document.removeEventListener('mouseup', sliderEndDrag, true);
     e.preventDefault();
   }
 
@@ -192,8 +183,8 @@ var exposureSlider = (function() {
   }
 
   function forceSetExposure(exposure) {
-    var barWidth = parseInt(bar.clientWidth);
-    var thumbWidth = parseInt(thumb.clientWidth);
+    var barWidth = parseInt(bar.clientWidth, 10);
+    var thumbWidth = parseInt(thumb.clientWidth, 10);
 
     // Remember the new exposure value
     currentExposure = exposure;
@@ -212,6 +203,9 @@ var exposureSlider = (function() {
 
     // Display exposure value in thumb
     thumb.textContent = exposure;
+
+    // Dispatch an event to actually change the image
+    slider.dispatchEvent(new Event('change', {bubbles: true}));
   }
 
   return {
@@ -220,7 +214,7 @@ var exposureSlider = (function() {
     setExposure: setExposure,
     getExposure: function() { return currentExposure; }
   };
-}());
+})();
 
 $('exposure-slider').onchange = function() {
   var stops = exposureSlider.getExposure();
@@ -606,6 +600,8 @@ ImageEditor.prototype.hasBeenCropped = function() {
 // Display cropping controls
 // XXX: have to handle rotate/resize
 ImageEditor.prototype.showCropOverlay = function showCropOverlay(newRegion) {
+  var self = this;
+
   var canvas = this.cropCanvas = document.createElement('canvas');
   var context = this.cropContext = canvas.getContext('2d');
   canvas.id = 'edit-crop-canvas'; // for stylesheet
@@ -638,7 +634,16 @@ ImageEditor.prototype.showCropOverlay = function showCropOverlay(newRegion) {
 
   this.drawCropControls();
 
-  canvas.addEventListener('mousedown', this.cropStart.bind(this));
+  var isCropping = false;
+  this.cropCanvas.addEventListener('pan', function(ev) {
+    if (!isCropping) {
+      self.cropStart(ev);
+      isCropping = true;
+    }
+  });
+  this.cropCanvas.addEventListener('swipe', function() {
+    isCropping = false;
+  });
 };
 
 ImageEditor.prototype.hideCropOverlay = function hideCropOverlay() {
@@ -778,14 +783,14 @@ ImageEditor.prototype.drawCropControls = function(handle) {
   }
 };
 
-// Called on mousedown in the crop overlay canvas
-ImageEditor.prototype.cropStart = function(startEvent) {
+// Called when the first pan event comes in on the crop canvas
+ImageEditor.prototype.cropStart = function(ev) {
   var self = this;
   var region = this.cropRegion;
   var dest = this.dest;
   var rect = this.previewCanvas.getBoundingClientRect();
-  var x0 = startEvent.clientX - rect.left - dest.x;
-  var y0 = startEvent.clientY - rect.top - dest.y;
+  var x0 = ev.detail.position.screenX - rect.left - dest.x;
+  var y0 = ev.detail.position.screenY - rect.top - dest.y;
   var left = region.left;
   var top = region.top;
   var right = region.right;
@@ -826,14 +831,14 @@ ImageEditor.prototype.cropStart = function(startEvent) {
     drag(); // pan
 
   function drag(handle) {
-    window.addEventListener('mousemove', move, true);
-    window.addEventListener('mouseup', up, true);
+    window.addEventListener('pan', move, true);
+    window.addEventListener('swipe', up, true);
 
     self.drawCropControls(handle); // highlight drag handle
 
     function move(e) {
-      var dx = e.clientX - startEvent.clientX;
-      var dy = e.clientY - startEvent.clientY;
+      var dx = e.detail.absolute.dx;
+      var dy = e.detail.absolute.dy;
 
       var newleft = region.left;
       var newright = region.right;
@@ -956,9 +961,11 @@ ImageEditor.prototype.cropStart = function(startEvent) {
     }
 
     function up(e) {
-      window.removeEventListener('mousemove', move, true);
-      window.removeEventListener('mouseup', up, true);
+      window.removeEventListener('pan', move, true);
+      window.removeEventListener('swipe', up, true);
       self.drawCropControls(); // erase drag handle highlight
+
+      e.preventDefault();
     }
   }
 

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -119,9 +119,6 @@ navigator.mozL10n.ready(function showBody() {
 });
 
 function init() {
-  // We only need clicks and move event coordinates
-  MouseEventShim.trackMouseMoves = false;
-
   // Clicking on the select button goes to thumbnail select mode
   $('thumbnails-select-button').onclick =
     setView.bind(null, thumbnailSelectView);
@@ -381,7 +378,7 @@ function initThumbnails() {
 
 
   // Handle clicks on the thumbnails we're about to create
-  thumbnails.onclick = thumbnailClickHandler;
+  thumbnails.addEventListener('click', thumbnailClickHandler);
 
   // We need to enumerate both the photo and video dbs and interleave
   // the files they return so that everything is in chronological order
@@ -852,7 +849,6 @@ window.addEventListener('mozvisibilitychange', function() {
 //
 // Event handlers
 //
-
 
 // Clicking on a thumbnail does different things depending on the view.
 // In thumbnail list mode, it displays the image. In thumbanilSelect mode


### PR DESCRIPTION
Fix for [#847908](https://bugzilla.mozilla.org/show_bug.cgi?id=847908). This patch removes the use of the mouse event shim from the gallery, and replaces it by the gesture_detector, following discussion in #8333.
