### PR TITLE
Bug 847896 - Fix the dial and sms Web Activities. r=francisco, a=tef+

### DIFF
--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -110,7 +110,8 @@
     },
     "dial": {
       "filters": {
-        "type": "webtelephony/number"
+        "type": "webtelephony/number",
+        "number": { "regexp":"/^[\\d\\s+#*().-]{0,50}$/" }
       },
       "href": "/dialer/index.html#keyboard-view",
       "disposition": "window"

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -43,7 +43,8 @@
   "activities": {
     "new": {
       "filters": {
-        "type": "websms/sms"
+        "type": "websms/sms",
+        "number": { "regexp":"/^[\\w\\s+#*().-]{0,50}$/" }
        },
       "disposition": "window"
     }


### PR DESCRIPTION
This fix only adds a regexp for the SMS and Dial Activities so they only accept valid characters, with a maximum length of 50 chars as the number to dial/send sms to.

r? @arcturus
