### PR TITLE
Bug 848195 - Enlarge select element hit-state also

### DIFF
--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -296,7 +296,7 @@ Calendar.ns('Views').ModifyEvent = (function() {
      * Enlarges focus areas for .button controls
      */
     focusHandler: function(e) {
-      var input = e.target.querySelector('input');
+      var input = e.target.querySelector('input, select');
       if (input && e.target.classList.contains('button')) {
         input.focus();
       }


### PR DESCRIPTION
In the calendar view we have both <input> and <select> elements inside of .button wrappers. Due to the difficulty of styling the height of these elements properly, along with building blocks, we enlarge the focus area with javascript.
