### PR TITLE
Bug 848247 - [Toolbar] button in toolbar shifts to right once when press...

### DIFF
--- a/shared/style/headers.css
+++ b/shared/style/headers.css
@@ -146,7 +146,6 @@ section[role="region"] > header:first-child menu[type="toolbar"] a:not([aria-dis
 section[role="region"] > header:first-child menu[type="toolbar"] button:not(:disabled):active  {
   background: #008aaa !important;
   transition: background 0.2s ease;
-  border-bottom: solid 0.1rem rgba(0, 0, 0, 0.2) !important;
 }
 
 /* Disabled state */


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=848247
1. Title : [Toolbar] button in toolbar shifts to right once when pressed
2. Precondition : Go to a page where it has a toolbar with a button, such as 'Edit Contact', , 'Contacts->Settings' page, 'Wifi Setup' page on FTU, etc.
3. Tester's Action : Press and hold the button on toolbar, 'Update', 'Done' or 'Refresh'.
4. Detailed Symptom (ENG.) : The button shifts to right a little once on touch. It only moves once.
5. Expected : The button shouldn't move.
   6.Reproducibility: Y
   1)Frequency Rate : 100%
   7.Build: AU_LINUX_GECKO_ICS_STRAWBERRY_V1.01.00.01.19.018, Mozilla build ID: 20130219070201
