### PR TITLE
Bug 847311 - [Dialer] Don't animate layout properties. Animate transforms (r=basiclines)

### DIFF
--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -86,8 +86,8 @@ button::-moz-focus-inner {
 }
 
 body.showKeypad #views {
-  transition: top 0.3s ease;
-  top: 0;
+  transition: transform 0.3s ease;
+  transform: translateY(-100%);
   z-index: 500;
 }
 


### PR DESCRIPTION
Removal of layout properties animations and substitution by transform ones.
