### PR TITLE
Bug 813506 - [Call Log. UX VD] The 'no communications' scenario has the wrong spacing and type (r=basiclines).

### DIFF
--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -544,8 +544,8 @@ var Recents = {
       this.recentsContainer.innerHTML =
         '<div id="no-result-container">' +
         ' <div id="no-result-message">' +
-        ' <p data-l10n-id="no-logs-msg-1">no calls recorded</p>' +
-        ' <p data-l10n-id="no-logs-msg-2">start communicating now</p>' +
+        '   <p data-l10n-id="no-logs-msg-1">no calls recorded</p>' +
+        '   <p data-l10n-id="no-logs-msg-2">start communicating now</p>' +
         ' </div>' +
         '</div>';
       navigator.mozL10n.translate(this.recentsContainer);

--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -219,24 +219,24 @@ ul[role="tablist"][data-type="filter"] > [role="tab"].selected > a {
 /*
   No result container
 */
+
 #no-result-container {
   height: 100%;
-  width: 100%;
-  background: url('images/ComLog_200x200_clock.png') no-repeat 50% 50%;
+  background: url('images/ComLog_200x200_clock.png') fixed no-repeat center / 20rem;
 }
 
 #no-result-message {
   position: relative;
-  top: 14rem;
+  top: 11.5rem;
+  border-top: .1rem solid rgba(96,96,96,.5);
   padding: 1rem 0.5rem;
-  color: #606060;
-  line-height: 3rem;
-  font-weight: 300;
-  font-size: -moz-calc(10 * 0.226rem);
-  text-align: left;
-  border-top: 0.1rem solid rgba(96,96,96,.5);
 }
 
 #no-result-message > p {
+  text-align: left;
+  line-height: 3rem;
+  font-size: 2.2rem;
+  font-weight: 300;
+  color: #606060;
   margin: 0;
 }


### PR DESCRIPTION
Readjusting the "no communications" image and text when there are no entries in the Call Log according to @VictoriaGerchinhoren guidelines.
