### PR TITLE
Bug 838486 - [Lockscreen] Lock screen bounce animation not running r=tim...

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -716,16 +716,21 @@ var LockScreen = {
       return;
     }
 
-    var overlay = this.overlay;
-    var self = this;
     panel = panel || 'main';
+    var overlay = this.overlay;
+    var currentPanel = overlay.dataset.panel;
+
+    if (currentPanel && currentPanel === panel) {
+      return;
+    }
+
+    var self = this;
 
     this._switchingPanel = true;
     this.loadPanel(panel, function panelLoaded() {
       self.unloadPanel(overlay.dataset.panel, panel,
         function panelUnloaded() {
-          if (overlay.dataset.panel !== panel)
-            self.dispatchEvent('lockpanelchange');
+          self.dispatchEvent('lockpanelchange');
 
           overlay.dataset.panel = panel;
           self._switchingPanel = false;


### PR DESCRIPTION
...dream

Before Bug 830480, a callback was called sometimes synchronously and sometimes
asynchronously. In Bug 830480 it was made always asynchronous.

As a result, when switching panels, the "cleaning" code for the unloaded panel
is now always done after the "initializing" code for the loaded panel.

The "main" panel is enabling the bounce animation at initialization and
disabling at unload. Therefore it was disabled right after being enabled.

Note that the bounce animation is also enabled at lock, and disabled at unlock.

This patch skip the loading/unloading command when we ask to switch to the panel
that is already displayed. This should also make the performance better, because
it was actually called several times.
