### PR TITLE
Bug_847817 [Cost Control] Datalimitinput_Wrong_Cursor_Position r=lodr

### DIFF
--- a/apps/costcontrol/js/settings/limitdialog.js
+++ b/apps/costcontrol/js/settings/limitdialog.js
@@ -101,6 +101,7 @@ function dataLimitConfigurer(guiWidget, settings, viewManager) {
   guiWidget.addEventListener('click', function ccld_onWidgetClick() {
     viewManager.changeViewTo(dialog.id);
     dataLimitInput.focus();
+    dataLimitInput.setSelectionRange(dataLimitInput.value.length, dataLimitInput.value.length);
     oldUnitValue = settings.option('dataLimitUnit');
     switchUnitButton.querySelector('span.tag').textContent = oldUnitValue;
   });


### PR DESCRIPTION
Mozilla URL:
https://bugzilla.mozilla.org/show_bug.cgi?id=847817
