### PR TITLE
Bug 815083 - Replace gallery delete confirm() call by CSS based window

### DIFF
--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -76,7 +76,7 @@
         <img id="crop-image"></img>
       </div>
     </section>
-    
+
     <section role="region" id="edit-view" class="hidden skin-organic">
       <header id="edit-header">
         <button id="edit-cancel-button"><span class="icon icon-close"></span></button>
@@ -110,7 +110,7 @@
           </div>
         </div>
 
-        <div id="edit-crop-options" class="edit-options-bar hidden"> 
+        <div id="edit-crop-options" class="edit-options-bar hidden">
           <a id="edit-crop-none" class="button"></a>
           <a id="edit-crop-aspect-free" class="selected radio button"></a>
           <a id="edit-crop-aspect-portrait" class="radio button"></a>
@@ -118,7 +118,7 @@
           <a id="edit-crop-aspect-square" class="radio button"></a>
         </div>
 
-        <div id="edit-effect-options" class="edit-options-bar hidden"> 
+        <div id="edit-effect-options" class="edit-options-bar hidden">
           <a id="edit-effect-none" class="selected radio button bgimage"
              data-effect="none"></a>
           <a id="edit-effect-bw" class="radio button filter-bw bgimage"
@@ -131,7 +131,7 @@
              data-effect="faded"></a>
         </div>
 
-        <div id="edit-border-options" class="edit-options-bar hidden"> 
+        <div id="edit-border-options" class="edit-options-bar hidden">
           <a id="edit-border-none" class="selected radio button bgimage"
              data-border-width="0"></a>
           <a id="edit-border-thin-white" class="radio button bgimage"
@@ -171,6 +171,16 @@
         <p id="overlay-text"><p>
       </div>
     </div>
+
+    <form id="confirm-dialog" role="dialog" data-type="confirm" class="hidden">
+      <section>
+        <p id="confirm-msg"></p>
+      </section>
+      <menu>
+        <button id="confirm-cancel"></button>
+        <button id="confirm-ok"></button>
+      </menu>
+    </form>
 
     <!-- Some SVG filters we use -->
     <svg id="filters" width="0" height="0">

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -904,18 +904,75 @@ function deleteSelectedItems() {
   if (selected.length === 0)
     return;
 
-  var msg = navigator.mozL10n.get('delete-n-items?', {n: selected.length});
-  if (confirm(msg)) {
-    // XXX
+  showConfirmDialog({
+    message: navigator.mozL10n.get('delete-n-items?', {n: selected.length}),
+    cancelText: navigator.mozL10n.get('cancel'),
+    confirmText: navigator.mozL10n.get('delete'),
+    danger: true
+  }, function() { // onSuccess
     // deleteFile is O(n), so this loop is O(n*n). If used with really large
     // selections, it might have noticably bad performance.  If so, we
     // can write a more efficient deleteFiles() function.
     for (var i = 0; i < selected.length; i++) {
       selected[i].classList.toggle('selected');
-      deleteFile(parseInt(selected[i].dataset.index));
+      deleteFile(parseInt(selected[i].dataset.index, 10));
     }
     clearSelection();
-  }
+  });
+}
+
+// show a confirm dialog
+function showConfirmDialog(options, onConfirm, onCancel) {
+  LazyLoader.load('shared/style/confirm.css', function() {
+    var dialog = $('confirm-dialog');
+    var msgEle = $('confirm-msg');
+    var cancelButton = $('confirm-cancel');
+    var confirmButton = $('confirm-ok');
+
+    // set up the dialog based on the options
+    msgEle.textContent = options.message;
+    cancelButton.textContent = options.cancelText ||
+      navigator.mozL10n.get('cancel');
+    confirmButton.textContent = options.confirmText ||
+      navigator.mozL10n.get('ok');
+
+    if (options.danger) {
+      confirmButton.classList.add('danger');
+    }
+    else {
+      confirmButton.classList.remove('danger');
+    }
+
+    // show the confirm dialog
+    dialog.classList.remove('hidden');
+
+    // attach event handlers
+    var onCancelClick = function(ev) {
+      close(ev);
+      if (onCancel) {
+        onCancel();
+      }
+      return false;
+    };
+    var onConfirmClick = function(ev) {
+      close(ev);
+      if (onConfirm) {
+        onConfirm();
+      }
+      return false;
+    };
+    cancelButton.addEventListener('click', onCancelClick);
+    confirmButton.addEventListener('click', onConfirmClick);
+
+    function close(ev) {
+      dialog.classList.add('hidden');
+      cancelButton.removeEventListener('click', onCancelClick);
+      confirmButton.removeEventListener('click', onConfirmClick);
+      ev.preventDefault();
+      ev.stopPropagation();
+      return false;
+    }
+  });
 }
 
 

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -23,6 +23,8 @@ pickoneimage2 = Select
 cropimage = Crop
 
 cancel   = Cancel
+delete   = Delete
+ok       = OK
 edit     = Edit
 save     = Save
 exposure = Exposure


### PR DESCRIPTION
Patch for [#815083](https://bugzilla.mozilla.org/show_bug.cgi?id=815083). At the moment the normal `confirm()` dialog is used to get confirmation for deletion of photo's in the gallery. This patch replaces it with the standard HTML/CSS dialog, adds the right text to it and adds a danger class to the delete button.

In terms of localisation, the `Delete` term is used in a variety of places, do I need to really add it here as well for all locales or do we have a shared way for terms like this?
