### PR TITLE
Bug 840073 - [MMS][User Story] Address recipient by phone number or Contact name

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -125,8 +125,7 @@ if (!window.location.hash.length) {
           showThreadFromSystemMessage(number);
         };
 
-        ContactDataManager.getContactData(message.sender,
-        function gotContact(contact) {
+        Contacts.findByString(message.sender, function gotContact(contact) {
           var sender;
           if (contact.length && contact[0].name) {
             sender = Utils.escapeHTML(contact[0].name[0]);

--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -3,56 +3,32 @@
 
 'use strict';
 
-var ContactDataManager = {
-  contactData: {},
+var Contacts = {
+  findBy: function contacts_findBy(filter, callback) {
+    var request;
 
-  getContactData: function cm_getContactData(number, callback) {
-    // so desktop keeps working
     if (!navigator.mozContacts) {
       return;
     }
-    // Get contacts given a number
-    var options = {
-      filterBy: ['tel'],
-      filterOp: 'contains',
-      filterValue: number
-    };
-    var self = this;
-    var req = window.navigator.mozContacts.find(options);
-    req.onsuccess = function onsuccess() {
-      // TODO Add cache if it's feasible without PhoneNumberJS
-      var result = req.result;
-      callback(result);
+
+    filter.filterLimit = filter.filterLimit || 10;
+
+    request = navigator.mozContacts.find(filter);
+
+    request.onsuccess = function onsuccess() {
+      callback(this.result);
     };
 
-    req.onerror = function onerror() {
-      var msg = 'Contact finding error. Error: ' + req.error.name;
-      console.log(msg);
+    request.onerror = function onerror() {
+      console.log('Contact finding error. Error: ' + this.error.name);
       callback(null);
     };
   },
-
-  searchContactData: function cm_searchContactData(string, callback) {
-    // so desktop keeps working
-    if (!navigator.mozSms)
-      return;
-
-    var options = {
+  findByString: function contacts_findBy(filterValue, callback) {
+    return this.findBy({
       filterBy: ['tel', 'givenName', 'familyName'],
       filterOp: 'contains',
-      filterValue: string
-    };
-
-    var self = this;
-    var req = window.navigator.mozContacts.find(options);
-    req.onsuccess = function onsuccess() {
-      callback(req.result);
-    };
-
-    req.onerror = function onerror() {
-      var msg = 'Contact finding error. Error: ' + req.error.name;
-      console.log(msg);
-      callback(null);
-    };
+      filterValue: filterValue
+    }, callback);
   }
 };

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -55,8 +55,7 @@ var ThreadListUI = {
   updateThreadWithContact:
     function thlui_updateThreadWithContact(number, thread) {
 
-    ContactDataManager.getContactData(number,
-      function gotContact(contacts) {
+    Contacts.findByString(number, function gotContact(contacts) {
       if (!contacts || ! Array.isArray(contacts) || contacts.length < 1) {
         return;
       }

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -407,7 +407,7 @@ var ThreadUI = {
     // Add data to contact activity interaction
     this.title.dataset.phoneNumber = number;
 
-    ContactDataManager.getContactData(number, function gotContact(contacts) {
+    Contacts.findByString(number, function gotContact(contacts) {
       var carrierTag = document.getElementById('contact-carrier');
       /** If we have more than one contact sharing the same phone number
        *  we show the name of the first contact and how many other contacts
@@ -982,7 +982,7 @@ var ThreadUI = {
     }
     var contactsContainer = document.createElement('ul');
 
-    ContactDataManager.searchContactData(string, function gotContact(contacts) {
+    Contacts.findByString(string, function gotContact(contacts) {
       self.view.innerHTML = '';
       if (!contacts || contacts.length == 0) {
 

--- a/apps/sms/test/unit/contacts_test.js
+++ b/apps/sms/test/unit/contacts_test.js
@@ -1,0 +1,254 @@
+'use strict';
+
+requireApp('sms/test/unit/mock_contact.js');
+requireApp('sms/js/contacts.js');
+
+suite('Contacts', function(done) {
+  var nativeMozContacts = navigator.mozContacts;
+
+  suiteSetup(function() {
+    // Do not use the native API.
+    navigator.mozContacts = {
+      mHistory: [],
+      find: function(filter) {
+        // attribute DOMString     filterValue;    // e.g. "Tom"
+        // attribute DOMString     filterOp;       // e.g. "contains"
+        // attribute DOMString[]   filterBy;       // e.g. "givenName"
+        // attribute DOMString     sortBy;         // e.g. "givenName"
+        // attribute DOMString     sortOrder;      // e.g. "descending"
+        // attribute unsigned long filterLimit;
+        if (!(this instanceof navigator.mozContacts.find)) {
+          return new navigator.mozContacts.find(filter);
+        }
+        var onsuccess, onerror;
+
+        navigator.mozContacts.mHistory.push({
+          filter: filter,
+          request: this
+        });
+
+        this.result = null;
+        this.error = null;
+
+        Object.defineProperties(this, {
+
+          onsuccess: {
+            // When the success handler gets assigned:
+            //  1. Set this.result to an array containing a MockContact instance
+            //  2. Immediately call the success handler
+            // This will behave like a _REALLY_ fast DB query
+            set: function(callback) {
+              onsuccess = callback;
+              // Implement a mock that gives results that appear to
+              // match the real behaviour of filtered contacts results
+              this.result = (function() {
+                // Supports the error case
+                if (filter == null ||
+                      (!filter.filterOp || !filter.filterValue)) {
+                  return null;
+                }
+
+                // Supports two "no match" cases
+                if (filter.filterValue === '911' ||
+                    filter.filterValue === 'wontmatch') {
+                  return [];
+                }
+
+                // All other cases
+                return MockContact.list();
+              }());
+
+              if (this.result === null) {
+                this.error = {
+                  name: 'Mock missing filter params'
+                };
+                if (onerror) {
+                  setTimeout(function() {
+                    onerror.call(this);
+                    onerror = null;
+                  }.bind(this), 0);
+                }
+              } else {
+                setTimeout(function() {
+                  onsuccess.call(this);
+                  onsuccess = null;
+                }.bind(this), 0);
+              }
+            }
+          },
+
+          onerror: {
+            set: function(callback) {
+              onerror = callback;
+              if (this.result === null && this.error !== null) {
+                setTimeout(function() {
+                  onerror.call(this);
+                  onerror = null;
+                }.bind(this), 0);
+              }
+            }
+          }
+        });
+      }
+    };
+  });
+
+  teardown(function() {
+    navigator.mozContacts.mHistory.length = 0;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozContacts = nativeMozContacts;
+  });
+
+  suite('Contacts.findByString (success)', function() {
+
+    test('(string[tel,givenName,familyName], ...) Match', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('Grillo', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        assert.equal(mHistory[0].filter.filterValue, 'Grillo');
+        assert.isNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+
+    test('(string[tel,givenName,familyName], ...) No Match', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('wontmatch', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were not found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        assert.isNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+
+
+    test('(string[tel], ...) Match', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('+346578888888', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        assert.equal(mHistory[0].filter.filterValue, '+346578888888');
+        assert.isNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+
+
+    test('(string[tel], ...) No Match', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('911', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were not found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        assert.equal(mHistory[0].filter.filterValue, '911');
+        assert.isNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+  });
+
+  suite('Contacts.findBy (success)', function() {
+
+    test('(object, ...), Match', function(done) {
+      var mozContacts = navigator.mozContacts;
+      var filter = {
+        findBy: ['tel'],
+        filterOp: 'contains',
+        filterValue: '12125559999'
+      };
+
+      Contacts.findBy(filter, function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mozContacts.mHistory.length, 1);
+        assert.deepEqual(mozContacts.mHistory[0].filter, filter);
+        assert.isNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+
+    test('(object, ...), No Match', function(done) {
+      var mozContacts = navigator.mozContacts;
+      var filter = {
+        findBy: ['tel'],
+        filterOp: 'contains',
+        filterValue: '911'
+      };
+
+      Contacts.findBy(filter, function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were not found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mozContacts.mHistory.length, 1);
+        assert.deepEqual(mozContacts.mHistory[0].filter, filter);
+        assert.isNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+  });
+
+  suite('Contacts.findBy (error)', function() {
+    // This test will print:
+    // "Contact finding error. Error: Mock missing filter params"
+    // to the console
+    test('({}, ...)', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findBy({}, function(contacts) {
+        var mHistory = mozContacts.mHistory;
+        assert.equal(contacts, null);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        assert.isNotNull(mHistory[0].request.error);
+
+        done();
+      });
+    });
+  });
+});

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -24,6 +24,8 @@ requireApp('sms/js/startup.js');
 
 
 suite('SMS App Unit-Test', function() {
+  var findByString;
+
   // Mockuping l10n
   navigator.mozL10n = {
     get: function get(key) {
@@ -143,6 +145,8 @@ suite('SMS App Unit-Test', function() {
 
   // Previous setup
   suiteSetup(function() {
+    findByString = Contacts.findByString;
+
     // We mockup the method for retrieving the threads
     MessageManager.getThreads = function(callback, extraArg) {
       var threadsMockup = new MockThreadList();
@@ -166,9 +170,9 @@ suite('SMS App Unit-Test', function() {
 
     // We mockup the method for retrieving the info
     // of a contact given a number
-    ContactDataManager.getContactData = function(number, callback) {
+    Contacts.findByString = function(tel, callback) {
       // Get the contact
-      if (number === '1977') {
+      if (tel === '1977') {
         callback(MockContact.list());
       }
     };
@@ -183,6 +187,11 @@ suite('SMS App Unit-Test', function() {
     window.addEventListener('hashchange',
       MessageManager.onHashChange.bind(MessageManager));
   });
+
+  suiteTeardown(function() {
+    Contacts.findByString = findByString;
+  });
+
 
   // Let's go with tests!
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=840073
https://bugzilla.mozilla.org/show_bug.cgi?id=846844

Continues the work originally here: https://github.com/rwldrn/gaia/commits/840073

Simplifies Contact filtering with reasonable defaults for the most common lookups. Adds tests to support the updated and new behaviours. 

Tested with:
- automatted test-agent (pass existing and new)
- gjslint (passing)
- manually on unagi device (behaviour/UX confirmed)

``` bash
  [sms] Contacts
    [sms] Mock
      ✓ [sms] (mock) 
    [sms] Contacts.filterBy
      ✓ [sms] (string[tel,givenName,familyName], callback) 
      ✓ [sms] (string[tel], callback) 
      ✓ [sms] (object, callback), 1 
      ✓ [sms] (object, callback), 2
```

``` bash
$ gjslint apps/sms/js/contacts.js 
1 files checked, no errors found.

$ gjslint apps/sms/test/unit/contactdata_test.js
1 files checked, no errors found.
```

<img src="http://i.imm.io/Yw1M.jpeg">
