### PR TITLE
Bug 829339 - reject mp4 files with codecs other than mp4a

### DIFF
--- a/apps/music/js/metadata.js
+++ b/apps/music/js/metadata.js
@@ -586,10 +586,11 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
     }
 
     function findChildAtom(data, atom) {
+      var start = data.index;
       var length = data.readUnsignedInt();
       data.advance(4);
 
-      while (data.index < length) {
+      while (data.index < start + length) {
         var size = data.readUnsignedInt();
         var type = data.readASCIIText(4);
         if (type === atom) {


### PR DESCRIPTION
I'm surpised that the metadata parser was working at all with this bug in it. It now properly detects trak atoms for non-audio tracks and rejects movies.
