### PR TITLE
[Bug 850004] - SMS - Resend message clickable area to icon only r= borjasalguero

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -549,7 +549,6 @@ var ThreadUI = {
     switch (message.delivery) {
       case 'error':
         asideHTML = '<aside class="pack-end"></aside>';
-        ThreadUI.addResendHandler(message, messageDOM);
         break;
       case 'sending':
         asideHTML = '<aside class="pack-end">' +
@@ -566,6 +565,10 @@ var ThreadUI = {
     messageHTML += asideHTML;
     messageHTML += '<p>' + bodyHTML + '</p></a>';
     messageDOM.innerHTML = messageHTML;
+
+    if (message.delivery === 'error')
+      ThreadUI.addResendHandler(message, messageDOM);
+
     // Add to the right position
     var messageContainer = ThreadUI.getMessageContainer(timestamp, hidden);
     if (!messageContainer.firstElementChild) {
@@ -594,7 +597,8 @@ var ThreadUI = {
   },
 
   addResendHandler: function thui_addResendHandler(message, messageDOM) {
-    messageDOM.addEventListener('click', function resend(e) {
+    var aElement = messageDOM.querySelector('aside');
+    aElement.addEventListener('click', function resend(e) {
       var hash = window.location.hash;
       if (hash != '#edit') {
         var resendConfirmStr = _('resend-confirmation');

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -384,8 +384,7 @@ section[role="region"].new > header:first-child form {
   background: url('images/icons/exclamation.png') no-repeat center center;
   background-size: 2.2rem;
   width: 3.2rem;
-  height: 2.2rem;
-  margin-top: 1rem;
+  height: 4.5rem;
 }
 #messages-container[data-type="list"] li.bubble aside progress {
   margin-top: 0.4rem;


### PR DESCRIPTION
Fix for moving the 'clickable' area to the icon only in order to have the text inside the bubbles free for new 'action links' (for example urls','email', 'phone number')
On send message failure, click on icon show resend message prompt.
