### PR TITLE
Bug 850647 & 796492 

### DIFF
--- a/apps/system/js/sound_manager.js
+++ b/apps/system/js/sound_manager.js
@@ -5,17 +5,21 @@
 
 (function() {
   window.addEventListener('volumeup', function() {
-    if (onBTEarphoneConnected() && onCall()) {
-      changeVolume(1, 'bt_sco');
-    } else {
-      changeVolume(1);
+    if (ScreenManager.screenEnabled || currentChannel !== 'none' ) {
+      if (onBTEarphoneConnected() && onCall()) {
+        changeVolume(1, 'bt_sco');
+      } else {
+        changeVolume(1);
+      }
     }
   });
   window.addEventListener('volumedown', function() {
-    if (onBTEarphoneConnected() && onCall()) {
-      changeVolume(-1, 'bt_sco');
-    } else {
-      changeVolume(-1);
+    if (ScreenManager.screenEnabled || currentChannel !== 'none' ) {
+      if (onBTEarphoneConnected() && onCall()) {
+        changeVolume(-1, 'bt_sco');
+      } else {
+        changeVolume(-1);
+      }
     }
   });
 

--- a/apps/system/js/sound_manager.js
+++ b/apps/system/js/sound_manager.js
@@ -21,7 +21,7 @@
 
   // Store the current active channel;
   // change with 'audio-channel-changed' mozChromeEvent
-  var currentChannel = 'notification';
+  var currentChannel = 'none';
 
   var vibrationEnabled = true;
 


### PR DESCRIPTION
As described in the first bug, there is a trivial fix. It's essential though for a clean fix of bug 796492.
The second commit is a fix for 796492 and prevents volume level change by hw buttons if the screen is off and no audio channel is active.
