### PR TITLE
Fixed maximum URL length in the browser web activity

### DIFF
--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -42,7 +42,7 @@
     "view": {
       "filters": {
         "type": "url",
-        "url": { "required":true, "regexp":"/^https?:/" }
+        "url": { "required":true, "regexp":"/^https?:.{1,16384}$/" }
       }
     }
   }


### PR DESCRIPTION
Restricted the length of the http(s) URL to 16K. This fixes the crashing.
