### PR TITLE
Bug 833644 - [Wi-Fi] Wi-Fi status text of Settings is wrong

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -94,11 +94,15 @@ var Connectivity = (function(window, document, undefined) {
       return; // init will call updateWifi()
     }
 
-    // network.connection.status has one of the following values:
-    // connecting, associated, connected, connectingfailed, disconnected.
-    wifiDesc.textContent = _('fullStatus-' +
-        wifiManager.connection.status,
-        wifiManager.connection.network);
+    if (wifiManager.enabled) {
+      // network.connection.status has one of the following values:
+      // connecting, associated, connected, connectingfailed, disconnected.
+      wifiDesc.textContent = _('fullStatus-' +
+          wifiManager.connection.status,
+          wifiManager.connection.network);
+    } else {
+      wifiDesc.textContent = _('disabled');
+    }
 
     // record the MAC address here because the "Device Information" panel
     // has to display it as well


### PR DESCRIPTION
After following steps, Wi-Fi status text of Settings is wrong.
Wi-Fi status is displayed "Offline". It should be displayed "Disabled" 

The following is the reproduce step:
Wi-Fi Off -> device power off and on -> Settings -> check Wi-Fi status text.

https://bugzilla.mozilla.org/show_bug.cgi?id=833644
