### PR TITLE
Bug_849759 [Email] Contact + icon overlapped with Email id in the composer screen r=Andrew Sutherland

### DIFF
--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -48,6 +48,7 @@ input.cmp-addr-text {
   margin-top: 2px;
   float: left;
   width: 0.5rem;
+  max-width: 100%;
 }
 
 input.cmp-subject-text {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=849759 
