### PR TITLE
Bug 820268 - Add PIN keyboard to input digits only. r=rudyl

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -481,6 +481,7 @@ function mapInputType(type) {
   case 'tel':
   case 'email':
   case 'text':
+  case 'pin':
     return type;
     break;
 
@@ -523,7 +524,8 @@ function modifyLayout(keyboardName) {
   }
 
   var altLayoutName;
-  if (currentInputType === 'number' || currentInputType === 'tel')
+  if (currentInputType === 'number' || currentInputType === 'tel' ||
+      currentInputType === 'pin')
     altLayoutName = currentInputType + 'Layout';
   else if (layoutPage === LAYOUT_PAGE_SYMBOLS_I)
     altLayoutName = 'alternateLayout';
@@ -825,9 +827,10 @@ function setMenuTimeout(target, coords, touchId) {
     if (isShowingAlternativesMenu || touchCount > 1)
       return;
 
-    // The telLayout and numberLayout do not show an alternative key
+    // The telLayout, numberLayout and pinLayout do not show an alternative key
     // menu, instead they send the alternative key and ignore the endPress.
-    if (currentInputType === 'number' || currentInputType === 'tel') {
+    if (currentInputType === 'number' || currentInputType === 'tel' ||
+        currentInputType === 'pin') {
 
       // Does the key have an altKey?
       var r = target.dataset.row, c = target.dataset.column;
@@ -1196,7 +1199,7 @@ function endPress(target, coords, touchId) {
 
   IMERender.unHighlightKey(target);
 
-  // The alternate keys of telLayout and numberLayout do not
+  // The alternate keys of telLayout, numberLayout and pinLayout do not
   // trigger keypress on key release.
   if (target.dataset.ignoreEndPress) {
     delete target.dataset.ignoreEndPress;

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -69,6 +69,19 @@ const Keyboards = {
       '0' : '-'
     }
   },
+  pinLayout: {
+    width: 9,
+    keys: [
+      [{ value: '1', ratio: 3},{ value: '2', ratio: 3},{ value: '3', ratio: 3}],
+      [{ value: '4', ratio: 3},{ value: '5', ratio: 3},{ value: '6', ratio: 3}],
+      [{ value: '7', ratio: 3},{ value: '8', ratio: 3},{ value: '9', ratio: 3}],
+      [
+        { value: '', ratio: 3},
+        { value: '0', ratio: 3},
+        { value: '⌫', ratio: 3, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ]
+    ]
+  },
   telLayout: {
     width: 9,
     keys: [

--- a/test_apps/uitest/tests/keyboard.html
+++ b/test_apps/uitest/tests/keyboard.html
@@ -15,6 +15,8 @@
   <body>
     <ul>
       <li>Input type=text: <input type="text" /></li>
+      <li>PIN(type=text, pattern="\d*"): <input type="text" pattern="\d*" /></li>
+      <li>PIN(type=text, pattern="[0-9]*"): <input type="text" pattern="[0-9]*" /></li>
       <li>Input type=password: <input type="password" /></li>
       <li>Input type=number: <input type="number" /></li>
       <li>Input type=range: <input type="range" /></li>


### PR DESCRIPTION
Add the keyboard layout of PIN, which shows digits only. 
Open the PIN keyboard if user focuses a text field of type "pin".
Add PIN keyboard tests.
