### PR TITLE
Bug 851016 - [Statusbar] recording icon is still visible even after stop...

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -560,6 +560,10 @@ var StatusBar = {
         // Geolocation is currently active, show the active icon.
         icon.hidden = false;
         return;
+      } else if (!this.recordingActive && !icon.hidden) {
+        // Recording is now stopped, hide the icon.
+        icon.hidden = true;
+        return;
       }
 
       // Geolocation is currently inactive.


### PR DESCRIPTION
1. Title : [Statusbar] recording icon is still visible even after stopped.
2. Precondition : Launch Camera app and start recording.
3. Tester's Action : Stop recording and press Home key.
4. Detailed Symptom (ENG.) : The recording icon on statusbar is still visible.
5. Expected : The recording icon on statusbar must be hidden on stop.
   6.Reproducibility: Y
   1)Frequency Rate : 100%

This happens on all builds I have. And I am currently on the following build.

AU_LINUX_GECKO_ICS_STRAWBERRY_V1.01.00.01.19.037
Mozilla build ID: 20130310070203

Also, just by looking at the codes, the same fix might apply to 'geolocationActive' as well. I will create a separate bug once this fix is approved.
