### PR TITLE
Bug 851146 - make path to lazy loader absolute in camera

### DIFF
--- a/apps/camera/index.html
+++ b/apps/camera/index.html
@@ -18,7 +18,7 @@
     <!-- <script defer src="/shared/js/media/video_player.js"></script> -->
     <!-- <script defer src="/shared/js/media/media_frame.js"></script> -->
     <!-- <script defer src="/shared/js/gesture_detector.js"></script> -->
-    <script defer src="shared/js/lazy_loader.js"></script>
+    <script defer src="/shared/js/lazy_loader.js"></script>
     <script defer src="js/camera.js"></script>
   </head>
   <body>


### PR DESCRIPTION
The relative path works in the camera app, but the lockscreen camera needs an absolute path to locate the shared module.
