### PR TITLE
Bug 820268 - Add PIN keyboard to input digits only. r=rudyl

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -159,6 +159,7 @@ var touchEventsPresent = false;
 var touchedKeys = {};
 var touchCount = 0;
 var currentInputType = null;
+var currentInputMode = null;
 var menuLockedArea = null;
 
 // Show accent char menu (if there is one) after ACCENT_CHAR_MENU_TIMEOUT
@@ -523,8 +524,11 @@ function modifyLayout(keyboardName) {
   }
 
   var altLayoutName;
-  if (currentInputType === 'number' || currentInputType === 'tel')
+  if (currentInputType === 'tel')
     altLayoutName = currentInputType + 'Layout';
+  else if (currentInputType === 'number')
+    altLayoutName =
+      currentInputMode === 'digits' ? 'pinLayout' : 'numberLayout';
   else if (layoutPage === LAYOUT_PAGE_SYMBOLS_I)
     altLayoutName = 'alternateLayout';
   else if (layoutPage === LAYOUT_PAGE_SYMBOLS_II)
@@ -1400,6 +1404,7 @@ function showKeyboard(state) {
 
   IMERender.showIME();
 
+  currentInputMode = state.inputmode;
   currentInputType = mapInputType(state.type);
   resetKeyboard();
 

--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -69,6 +69,19 @@ const Keyboards = {
       '0' : '-'
     }
   },
+  pinLayout: {
+    width: 9,
+    keys: [
+      [{ value: '1', ratio: 3},{ value: '2', ratio: 3},{ value: '3', ratio: 3}],
+      [{ value: '4', ratio: 3},{ value: '5', ratio: 3},{ value: '6', ratio: 3}],
+      [{ value: '7', ratio: 3},{ value: '8', ratio: 3},{ value: '9', ratio: 3}],
+      [
+        { value: '', ratio: 3},
+        { value: '0', ratio: 3},
+        { value: '⌫', ratio: 3, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ]
+    ]
+  },
   telLayout: {
     width: 9,
     keys: [

--- a/test_apps/uitest/tests/inputmode.html
+++ b/test_apps/uitest/tests/inputmode.html
@@ -21,6 +21,10 @@
       differences as well (in word suggestions, for example) but for
       now, inputmode is just controlling auto capitalization
     </p>
+    <p>
+      The special inputmode "digits" for the number field will allow the
+      keyboard to enter digits(0-9) only.
+    </p>
 
     none: <input type="text"><br>
     latin: <input type="text" x-inputmode="latin"><br>
@@ -33,5 +37,7 @@
     verbatim: <textarea x-inputmode="verbatim"></textarea><br>
     latin-prose: <textarea x-inputmode="latin-prose"></textarea><br>
     latin-name: <textarea x-inputmode="latin-name"></textarea><br>
+
+    digits: <input type="number" x-inputmode="digits"><br>
   </body>
 </html>

--- a/test_apps/uitest/tests/keyboard.html
+++ b/test_apps/uitest/tests/keyboard.html
@@ -17,6 +17,7 @@
       <li>Input type=text: <input type="text" /></li>
       <li>Input type=password: <input type="password" /></li>
       <li>Input type=number: <input type="number" /></li>
+      <li>Input type=number(x-inputmode="digits"): <input type="number" x-inputmode="digits" /></li>
       <li>Input type=range: <input type="range" /></li>
       <li>Input type=search: <input type="search" /></li>
       <li>Input type=tel: <input type="tel" /></li>


### PR DESCRIPTION
Add the keyboard layout of PIN, which shows digits only.
Add the new x-inputmode "digits".
Open the PIN keyboard if user focuses a number field of  x-inputmode "digits".
