### PR TITLE
Bug 849165 - [SMS] Vibration occurs when SMS is received even when the v...

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -52,6 +52,7 @@ var NotificationScreen = {
   silent: false,
   alerts: true,
   vibrates: true,
+  vibrationEnabled: true,
 
   init: function ns_init() {
     window.addEventListener('mozChromeEvent', this);
@@ -317,7 +318,8 @@ var NotificationScreen = {
       }, 2000);
     }
 
-    if (this.vibrates) {
+    var vibrate = !this.silent ? this.vibrates : this.vibrates && this.vibrationEnabled;
+    if (vibrate) {
       if (document.mozHidden) {
         window.addEventListener('mozvisibilitychange', function waitOn() {
           window.removeEventListener('mozvisibilitychange', waitOn);
@@ -414,4 +416,8 @@ SettingsListener.observe('ring.enabled', true, function(value) {
 
 SettingsListener.observe('alert-vibration.enabled', true, function(value) {
   NotificationScreen.vibrates = value;
+});
+
+SettingsListener.observe('vibration.enabled', true, function(value) {
+  NotificationScreen.vibrationEnabled = value;
 });


### PR DESCRIPTION
1. Title : Vibration occurs when sms is received even when the vibration setting is disabled.
2. Precondition : Receiving of a new message should be possible.
3. Tester's Action : settings - sound - vibrate off - Receive sms 
4. Detailed Symptom (ENG.) : Device is vibrating when sms is receieved even though vibrate setting is off.
5. Expected :The vibration should not occur if the vibration setting is off
   6.Reproducibility: Y
   1)Frequency Rate : 100%
   7.Gaia Revision: 7b8dea7e7ec377a2143151bbe5e9998d87f7b36d

https://bugzilla.mozilla.org/show_bug.cgi?id=849165
