### PR TITLE
Bug 846901: Use a separate card for account listing, instead of nested translateX

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -77,17 +77,6 @@
        into them. -->
   <div id="templates" class="collapsed">
     <div id="templ-card">
-      <div class="card-account-picker card">
-        <div class="fld-accounts-header top-header">
-          <h2 class="fld-accounts-header-label header-label"
-              data-l10n-id="accounts-header">AccountS</h2>
-        </div>
-        <div class="scrollregion-below-header">
-          <div class="fld-accounts-container">
-          </div>
-        </div>
-      </div>
-
       <!-- Shows folders for navigation or move targeting.
            The navigation mode is less than full-width so we can see the
            messages display to its right.  -->
@@ -100,10 +89,8 @@
             <h1 class="fld-folders-header-account-label"></h1>
           </header>
         </section>
-        <div class="scrollregion-below-header folder-scoller-region">
-          <div class="fld-accounts-container">
-          </div>
-          <div class="fld-folders-container show">
+        <div class="scrollregion-below-header folder-scroller-region">
+          <div class="fld-folders-container">
           </div>
           <div class="bottom-toolbar-spacer"></div>
         </div>
@@ -119,8 +106,30 @@
           <span class="fld-nav-account-problem icon collapsed">!</span>
         </div>
       </div>
+      <!-- Shows accounts, to the left of folder list.
+           The navigation mode is less than full-width so we can see the
+           messages display to its right.  -->
+      <div class="card-account-picker card anim-overlay">
+        <section class="acct-picker-header skin-organic" role="region">
+          <header>
+            <a href="#" class="fld-accounts-btn">
+              <span class="icon icon-back"></span>
+            </a>
+            <h1 class="acct-picker-header-label"
+                data-l10n-id="settings-account-section"></h1>
+          </header>
+        </section>
+        <div class="scrollregion-below-header acct-scroller-region">
+          <div class="acct-list-container">
+          </div>
+          <div class="bottom-toolbar-spacer"></div>
+        </div>
+        <div class="fld-nav-toolbar bottom-toolbar">
+          <button class="fld-nav-settings-btn bottom-btn"></button>
+        </div>
+      </div>
       <!-- Lists the messages in a folder -->
-      <div class="card-message-list card">
+      <div class="card-message-list card" data-tray-target>
         <!-- Non-search header -->
         <section class="msg-list-header msg-nonsearch-only" role="region">
           <header>

--- a/apps/email/js/setup-cards.js
+++ b/apps/email/js/setup-cards.js
@@ -537,8 +537,7 @@ console.log('  CONFIG CURRENTLY:', JSON.stringify(MailAPI.config));//HACK
 }
 SettingsMainCard.prototype = {
   onClose: function() {
-    Cards.removeCardAndSuccessors(this.domNode, 'animate', 1,
-                                  ['folder-picker', 'navigation']);
+    Cards.removeCardAndSuccessors(this.domNode, 'animate', 1, 1);
   },
 
   onAccountsSplice: function(index, howMany, addedItems,

--- a/apps/email/style/folder-cards.css
+++ b/apps/email/style/folder-cards.css
@@ -32,38 +32,30 @@
   display: none;
 }
 
-.card-folder-picker {
+.card-folder-picker,
+.card-account-picker {
   box-shadow: inset 0 0 1rem black;
   background-color: rgba(0, 0, 0, 0.6);
   color: white;
 }
 
-.folder-scoller-region {
+.folder-scroller-region,
+.acct-scroller-region {
   background-color: white;
   background: url(images/pattern.png) repeat left top #3a4446;
   background-size: auto auto, 100% 100%;
-  overflow: hidden;
-}
-
-.fld-accounts-container, .fld-folders-container {
-  -moz-transition: transform .2s ease-in;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
+.folder-scroller-region.scrollregion-below-header,
+.acct-scroller-region.scrollregion-below-header {
+  height: calc(100% - 5rem);
+}
+
 .fld-folders-container {
-  -moz-transform: translateX(100%);
-  height: calc(100% - 4.8rem);
-}
-
-.fld-accounts-container {
-  position: absolute;
-  width: 100%;
-  -moz-transform: translateX(-100%);
-  height: calc(100% - 9.8rem);
-}
-
-.folder-scoller-region .show {
-  -moz-transform: translateX(0px);
+  -moz-transition: transform .2s ease-in;
+  overflow-y: auto;
 }
 
 .fld-accounts-btn {

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -90,12 +90,20 @@ body {
 }
 
 
-.card.center.card-folder-picker {
+.card.center.card-folder-picker,
+.card.center.card-account-picker,
+.card.card-account-picker {
   width: calc(100% - 4.3em);
 }
 
 .card.center.card-folder-picker + .card.after {
   transform: translateX(calc(100% - 4.3em));
+}
+
+/* Override animation for card list, should appear
+ * to just be under the message list */
+.card.before.card-folder-picker {
+  transform: translateX(0);
 }
 
 .form-card {


### PR DESCRIPTION
Splits out the account picker to a different card with an "overlay" animation, to avoid the nested translateX usage from before. Notable code changes:
- There is an AccountPickerCard in folder-cards.js now, and the parts of the account picker that FolderPickerCard used to do are now in that separate card. index.html now has
  a card template for account-picker too.
- zindex for overlaid card decks are now incremented by just 10, instad of 100, because the shared dialog class only has a z-index of 100, and with two overlay decks (one for AccountPicker and one for the account config) that placed it under the zindex of 200, hiding the confirmation dialog. With increments of 10 it is now 100 vs 20. This should be fine as the 100 increment was arbitrary before, and probably too much of a jump.
- AccountPicker card shows the account config gear, but not last sync: since it seemed to make less sense in a listing of accounts.
- Clicking on the "Inbox" header in the far upper right, when AccountPicker is shown, results in a "navigate two cards back" navigation. So, two navigations stacked back to back. The _afterTransitionAction changes in mail-common.js are related to this. While it looks kind of neat, it is new, and may be undesirable. If this is not a desirable behavior, it will require a more invasive change to card navigation to sort out, as it was designed more around adjacent card navigation.

Because of the UX changes mentioned above, it should have a UX review, but I am not sure how to specify that for gaia code.
