### PR TITLE
Bug 830239 - When scanning SD Card first time, communicate this to the user. r=dflanagan, l10n

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -250,6 +250,10 @@ function initDB(include_videos) {
   };
 
   photodb.onscanend = function onscanend() {
+    // if we're still having the scanning overlay there are no photo's
+    if (currentOverlay === 'scanning')
+      showOverlay('emptygallery');
+
     // Hide the scanning indicator
     $('progress').classList.add('hidden');
     $('throbber').classList.remove('throb');
@@ -378,7 +382,7 @@ function initThumbnails(include_videos) {
   function done() {
     flush();
     if (files.length === 0) { // If we didn't find anything
-      showOverlay('emptygallery');
+      showOverlay('scanning');
     }
     // Now that we've enumerated all the photos and videos we already know
     // about go start looking for new photos and videos.
@@ -459,7 +463,7 @@ function fileCreated(fileinfo) {
   var insertPosition;
 
   // If we were showing the 'no pictures' overlay, hide it
-  if (currentOverlay === 'emptygallery')
+  if (currentOverlay === 'emptygallery' || currentOverlay === 'scanning')
     showOverlay(null);
 
   // If this new image is newer than the first one, it goes first
@@ -964,6 +968,7 @@ var currentOverlay;  // The id of the current overlay or null if none.
 //   nocard: no sdcard is installed in the phone
 //   pluggedin: the sdcard is being used by USB mass storage
 //   emptygallery: no pictures found
+//   scanning: scanning the sdcard for photo's, but none found yet
 //
 // Localization is done using the specified id with "-title" and "-text"
 // suffixes.
@@ -971,13 +976,35 @@ var currentOverlay;  // The id of the current overlay or null if none.
 function showOverlay(id) {
   currentOverlay = id;
 
-  if (id === null) {
-    $('overlay').classList.add('hidden');
-    return;
+  var title, text;
+
+  switch (currentOverlay) {
+    case null:
+      $('overlay').classList.add('hidden');
+      return;
+    case 'nocard':
+      title = navigator.mozL10n.get('nocard2-title');
+      text = navigator.mozL10n.get('nocard2-text');
+      break;
+    case 'pluggedin':
+      title = navigator.mozL10n.get('pluggedin2-title');
+      text = navigator.mozL10n.get('pluggedin2-text');
+      break;
+    case 'scanning':
+      title = navigator.mozL10n.get('scanning-title');
+      text = navigator.mozL10n.get('scanning-text');
+      break;
+    case 'emptygallery':
+      title = navigator.mozL10n.get('emptygallery2-title');
+      text = navigator.mozL10n.get('emptygallery2-text');
+      break;
+    default:
+      console.warn('Reference to undefined overlay', currentOverlay);
+      return;
   }
 
-  $('overlay-title').textContent = navigator.mozL10n.get(id + '2-title');
-  $('overlay-text').textContent = navigator.mozL10n.get(id + '2-text');
+  $('overlay-title').textContent = title;
+  $('overlay-text').textContent = text;
   $('overlay').classList.remove('hidden');
 }
 

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -48,6 +48,9 @@ nocard2-text  = Insert a memory card to use this app.
 pluggedin2-title = Memory card in use
 pluggedin2-text  = Unplug the phone to use this app.
 
+scanning-title = Scanning
+scanning-text  = Looking for photos and videos.
+
 share-noprovider = Can not share this image file type.
 
 memorycardfull = Can not edit photos: Memory card is full.


### PR DESCRIPTION
Fix for [#830239](https://bugzilla.mozilla.org/show_bug.cgi?id=830239). When you start up your phone with an empty media database the phone tells you that there are no photo's yet. This is untrue. This adds another status message that tells the user that the SD card is being scanned when that is happening.

Redo'ing #8450.
