### PR TITLE
Bug 828751 - Remove innerHTML calls in contacts application. r=albertopq

### DIFF
--- a/apps/communications/contacts/fb_link.html
+++ b/apps/communications/contacts/fb_link.html
@@ -28,6 +28,7 @@
     <script  defer type="text/javascript" src="/facebook/js/fb_sync.js"></script>
     <script  defer type="text/javascript" src="/contacts/js/utilities/image_loader.js"></script>
     <script  defer type="text/javascript" src="js/utilities/status.js"></script>
+    <script  defer type="text/javascript" src="js/utilities/dom.js"></script>
     <script  defer type="text/javascript" src="js/fb/fb_link.js"></script>
 
     <!-- starts up the functionality -->

--- a/apps/communications/contacts/import.html
+++ b/apps/communications/contacts/import.html
@@ -26,6 +26,7 @@
     <script defer type="text/javascript" src="js/search.js"></script>
     <script defer type="text/javascript" src="js/utilities/normalizer.js"></script>
     <script defer type="text/javascript" src="js/utilities/image_square.js"></script>
+    <script defer type="text/javascript" src="js/utilities/dom.js"></script>
 
     <script defer type="text/javascript" src="js/fixed_header.js"></script>
     <script defer type="text/javascript" src="js/utilities/http_rest.js"></script>

--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -379,7 +379,7 @@ var Contacts = (function() {
 
   var fillTagOptions = function fillTagOptions(options, tagList, update) {
     var container = document.getElementById('tags-list');
-    container.innerHTML = '';
+    utils.dom.removeChildNodes(container);
     contactTag = update;
 
     var selectedLink;
@@ -729,6 +729,7 @@ var Contacts = (function() {
       '/contacts/js/utilities/normalizer.js',
       '/contacts/js/utilities/status.js',
       '/contacts/js/utilities/overlay.js',
+      '/contacts/js/utilities/dom.js',
       '/contacts/js/search.js',
       '/shared/style_unstable/progress_activity.css',
       '/shared/style/status.css',

--- a/apps/communications/contacts/js/contacts_details.js
+++ b/apps/communications/contacts/js/contacts_details.js
@@ -156,7 +156,7 @@ contacts.Details = (function() {
     contactDetails.classList.remove('no-photo');
     contactDetails.classList.remove('fb-contact');
     contactDetails.classList.remove('up');
-    listContainer.innerHTML = '';
+    utils.dom.removeChildNodes(listContainer);
 
     renderFavorite(contact);
     renderOrg(contact);

--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -169,7 +169,7 @@ contacts.Form = (function() {
     saveButton.textContent = _('update');
     currentContact = contact;
     deleteContactButton.parentNode.classList.remove('hide');
-    formTitle.innerHTML = _('editContact');
+    formTitle.textContent = _('editContact');
     currentContactId.value = contact.id;
     givenName.value = contact.givenName || '';
     familyName.value = contact.familyName || '';
@@ -228,7 +228,7 @@ contacts.Form = (function() {
     saveButton.setAttribute('disabled', 'disabled');
     saveButton.textContent = _('done');
     deleteContactButton.parentNode.classList.add('hide');
-    formTitle.innerHTML = _('addContact');
+    formTitle.textContent = _('addContact');
 
     params = params || {};
 
@@ -590,10 +590,9 @@ contacts.Form = (function() {
     var emails = dom.querySelector('#contacts-form-emails');
     var addresses = dom.querySelector('#contacts-form-addresses');
     var notes = dom.querySelector('#contacts-form-notes');
-    phones.innerHTML = '';
-    emails.innerHTML = '';
-    addresses.innerHTML = '';
-    notes.innerHTML = '';
+
+    [phones, emails, addresses, notes].forEach(utils.dom.removeChildNodes);
+
     counters = {
       'tel': 0,
       'email': 0,

--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 var contacts = window.contacts || {};
 contacts.List = (function() {
@@ -147,8 +147,12 @@ contacts.List = (function() {
     var title = document.createElement('header');
     title.id = 'group-' + group;
     title.className = 'hide';
-    title.innerHTML = '<abbr title="Contacts listed ' + group + '">';
-    title.innerHTML += letter + '</abbr>';
+
+    var letterAbbr = document.createElement('abbr');
+    letterAbbr.setAttribute('title', 'Contacts listed ' + group);
+    letterAbbr.textContent = letter;
+    title.appendChild(letterAbbr);
+
     var contactsContainer = document.createElement('ol');
     contactsContainer.id = 'contacts-list-' + group;
     contactsContainer.dataset.group = group;
@@ -209,9 +213,7 @@ contacts.List = (function() {
     contactContainer.dataset.updated = timestampDate.getTime();
     // contactInner is a link with 3 p elements:
     // name, socaial marks and org
-    var contactInner = '<p>' + getHighlightedName(contact);
-    contactInner += '</p>';
-    contactContainer.innerHTML = contactInner;
+    contactContainer.appendChild(getHighlightedName(contact));
     contactsCache[contact.id] = {
       contact: contact,
       container: contactContainer
@@ -246,20 +248,28 @@ contacts.List = (function() {
     return utils.text.normalize(escapedValue);
   };
 
-  var getHighlightedName = function getHighlightedName(contact) {
-    var givenName = '';
-    var familyName = '';
-    if (contact.givenName && contact.givenName.length)
-      givenName = utils.text.escapeHTML(contact.givenName[0]);
-    if (contact.familyName && contact.familyName.length)
-      familyName = utils.text.escapeHTML(contact.familyName[0]);
+  function getHighlightedName(contact, ele) {
+    if (!ele) {
+      ele = document.createElement('p');
+    }
+    var givenName = (contact.givenName && contact.givenName[0]) || '';
+    var familyName = (contact.familyName && contact.familyName[0]) || '';
+
+    function createStrongTag(content) {
+      var fs = document.createElement('strong');
+      fs.textContent = content;
+      return fs;
+    }
 
     if (orderByLastName) {
-      return givenName + ' <strong>' + familyName + '</strong>';
+      ele.appendChild(document.createTextNode(givenName + ' '));
+      ele.appendChild(createStrongTag(familyName));
     } else {
-      return '<strong>' + givenName + '</strong> ' + familyName;
+      ele.appendChild(createStrongTag(givenName));
+      ele.appendChild(document.createTextNode(' ' + familyName));
     }
-  };
+    return ele;
+  }
 
   function buildSocialMarks(category) {
     var marks = [];
@@ -463,7 +473,7 @@ contacts.List = (function() {
             }
             var fbContact = new fb.Contact(contact);
             contact = fbContact.merge(fbReq.result[fbContact.uid]);
-            elements[0].innerHTML = getHighlightedName(contact);
+            getHighlightedName(contact, elements[0]);
             var mark = markAsFb(createSocialMark());
             var org = meta.querySelector('span.org');
             meta.insertBefore(mark, org);
@@ -835,7 +845,7 @@ contacts.List = (function() {
   // Reset the content of the list to 0
   var resetDom = function resetDom() {
     contactsPhoto = [];
-    groupsList.innerHTML = '';
+    utils.dom.removeChildNodes(groupsList);
     loaded = false;
 
     initHeaders();

--- a/apps/communications/contacts/js/contacts_settings.js
+++ b/apps/communications/contacts/js/contacts_settings.js
@@ -192,11 +192,15 @@ contacts.Settings = (function() {
       var position = totalsMsgContent.indexOf('(');
       if (position != -1) {
         msgPart1 = totalsMsgContent.substring(0, position - 1);
-        msgPart2 = '<span>' + totalsMsgContent.substring(position) + '</span>';
+        msgPart2 = totalsMsgContent.substring(position);
       }
     }
-
-    fbTotalsMsg.innerHTML = msgPart1 + (msgPart2 || '');
+    fbTotalsMsg.appendChild(document.createTextNode(msgPart1));
+    if (msgPart2) {
+      var span = document.createElement('span');
+      span.textContent = msgPart2;
+      fbTotalsMsg.appendChild(span);
+    }
   };
 
   var onFbImport = function onFbImportClick(evt) {

--- a/apps/communications/contacts/js/fb/fb_link.js
+++ b/apps/communications/contacts/js/fb/fb_link.js
@@ -404,7 +404,7 @@ if (!fb.link) {
       }
       var template = friendsList.querySelector('[data-template]');
 
-      friendsList.innerHTML = '';
+      utils.dom.removeChildNodes(friendsList);
       friendsList.appendChild(template);
     }
 

--- a/apps/communications/contacts/js/fb/friends_list.js
+++ b/apps/communications/contacts/js/fb/friends_list.js
@@ -66,7 +66,8 @@ var FriendListRenderer = (function() {
     // # group
     renderGroup(fragment, groupsList, '#', groups['#']);
 
-    groupsList.innerHTML = ''; // Deleting template
+    // Deleting template
+    utils.dom.removeChildNodes(groupsList);
     groupsList.appendChild(fragment);
 
     if (typeof cb === 'function') {

--- a/apps/communications/contacts/js/importer_ui.js
+++ b/apps/communications/contacts/js/importer_ui.js
@@ -627,7 +627,7 @@ if (typeof window.importer === 'undefined') {
     function clearList() {
       var template = contactList.querySelector('[data-template]');
 
-      contactList.innerHTML = '';
+      utils.dom.removeChildNodes(contactList);
       contactList.appendChild(template);
     }
 

--- a/apps/communications/contacts/js/search.js
+++ b/apps/communications/contacts/js/search.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 var contacts = window.contacts || {};
 
@@ -86,7 +86,6 @@ contacts.Search = (function() {
       searchBox.value = '';
       // Resetting state
       contactNodes = null;
-      searchList.innerHTML = '';
       searchTextCache = {};
       resetState();
 
@@ -104,7 +103,7 @@ contacts.Search = (function() {
     currentSet = {};
     // We don't know if the user will launch a new search later
     theClones = {};
-    searchList.innerHTML = '';
+    utils.dom.removeChildNodes(searchList);
     emptySearch = true;
     remainingPending = true;
   }
@@ -367,7 +366,7 @@ contacts.Search = (function() {
         prevText.length > 0 && newText.indexOf(prevText) === 0) {
       out = searchableNodes || getContactsDom();
     } else {
-      searchList.innerHTML = '';
+      utils.dom.removeChildNodes(searchList);
       currentSet = {};
       out = getContactsDom();
       canReuseSearchables = false;

--- a/apps/communications/contacts/js/utilities/dom.js
+++ b/apps/communications/contacts/js/utilities/dom.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var utils = window.utils || {};
+
+if (!utils.dom) {
+  (function(document) {
+    var Dom = utils.dom = {};
+
+    // remove all children of a given parent node
+    Dom.removeChildNodes = function(node) {
+      while (node.hasChildNodes()) {
+        node.removeChild(node.firstChild);
+      }
+    };
+
+  })(document);
+}

--- a/apps/communications/contacts/test/unit/contacts_list_test.js
+++ b/apps/communications/contacts/test/unit/contacts_list_test.js
@@ -2,6 +2,7 @@ requireApp('communications/contacts/test/unit/mock_asyncstorage.js');
 requireApp('communications/contacts/js/search.js');
 requireApp('communications/contacts/js/contacts_list.js');
 requireApp('communications/contacts/js/utilities/normalizer.js');
+requireApp('communications/contacts/js/utilities/dom.js');
 requireApp('communications/contacts/js/utilities/templates.js');
 requireApp('communications/contacts/test/unit/mock_contacts.js');
 requireApp('communications/contacts/test/unit/mock_contact_all_fields.js');


### PR DESCRIPTION
This is a proposed fix for [#828751](https://bugzilla.mozilla.org/show_bug.cgi?id=828751). Removal of all `innerHTML` calls within the contacts app.

Open for debate: clearing elements happens through `innerHTML = ''`, I've changed it to do this via DOM. Perhaps gaia already has taken a stand on that. For that sake I have most of those changes in a separate commit, so please first review before I squash everything into one single commit.
