### PR TITLE
Bug 853457 - Keep the address bar visible while loading

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -50,6 +50,10 @@ var Browser = {
   waitingActivities: [],
   hasLoaded: false,
 
+  // store the current scroll position, so we can re-calculate whether
+  // we need to show the addressbar when loading the page is complete
+  lastScrollOffset: 0,
+
   init: function browser_init() {
     this.getAllElements();
 
@@ -377,7 +381,6 @@ var Browser = {
   // Each browser gets their own listener
   handleBrowserEvent: function browser_handleBrowserEvent(tab) {
     return (function(evt) {
-
       var isCurrentTab = this.currentTab.id === tab.id;
       switch (evt.type) {
 
@@ -430,9 +433,14 @@ var Browser = {
           Places.setAndLoadIconForPage(tab.url, iconUrl);
         }
 
+        // We always show the address bar when loading
+        // After loading we might need to hide it
+        this.handleScroll({ detail: { top: this.lastScrollOffset } });
+
         break;
 
       case 'mozbrowserlocationchange':
+        this.lastScrollOffset = 0;
         if (evt.detail === 'about:blank') {
           return;
         }
@@ -529,22 +537,25 @@ var Browser = {
   },
 
   handleScroll: function browser_handleScroll(evt) {
+    this.lastScrollOffset = evt.detail.top;
+
     if (evt.detail.top < this.LOWER_SCROLL_THRESHOLD) {
-      if (this.addressBarState === this.VISIBLE ||
-          this.addressBarState === this.TRANSITIONING) {
-        return;
-      }
       this.showAddressBar();
     } else if (evt.detail.top > this.UPPER_SCROLL_THRESHOLD) {
-      if (this.addressBarState === this.HIDDEN ||
-          this.addressBarState === this.TRANSITIONING) {
-        return;
-      }
       this.hideAddressBar();
     }
   },
 
   hideAddressBar: function browser_hideAddressBar() {
+    if (this.addressBarState === this.HIDDEN ||
+        this.addressBarState === this.TRANSITIONING) {
+      return;
+    }
+
+    // don't hide the address bar when loading
+    if (this.currentTab.loading)
+      return;
+
     var addressBarHidden = (function browser_addressBarHidden() {
       this.addressBarState = this.HIDDEN;
       this.mainScreen.removeEventListener('transitionend', addressBarHidden);
@@ -557,6 +568,11 @@ var Browser = {
   },
 
   showAddressBar: function browser_showAddressBar() {
+    if (this.addressBarState === this.VISIBLE ||
+        this.addressBarState === this.TRANSITIONING) {
+      return;
+    }
+
     var addressBarVisible = (function browser_addressBarVisible() {
       this.mainScreen.classList.remove('expanded');
       this.addressBarState = this.VISIBLE;


### PR DESCRIPTION
Fix for [#853457](https://bugzilla.mozilla.org/show_bug.cgi?id=853457). At the moment the address bar becomes visible (including the loading indicator) when you navigate away on a page. However when a scroll event comes in the address bar hides immediately, which is not nice.

This patch takes this into account and keeps the address bar visible until a page is fully loaded, hiding it afterwards if we are passed the scroll threshold.
