### PR TITLE
Bug 852647 - Remove duplicate in from translation

### DIFF
--- a/apps/calendar/js/controllers/alarm.js
+++ b/apps/calendar/js/controllers/alarm.js
@@ -85,7 +85,7 @@ Calendar.ns('Controllers').Alarm = (function() {
 
       // TODO: verify this is all we need to handle.
       var type = (begins > now) ?
-        'alarm-starting-notice' :
+        'alarm-start-notice' :
         'alarm-started-notice';
 
       var title = navigator.mozL10n.get(type, {

--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -106,7 +106,7 @@ alarm-weeks-after={{value}} weeks after
 
 # alarms
 
-alarm-starting-notice={{title}} starting in {{distance}}
+alarm-start-notice={{title}} starting {{distance}}
 alarm-started-notice={{title}} started {{distance}}
 
 # Date formatting details (http://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html)


### PR DESCRIPTION
Date localization content already has the 'in' text, such as:
inMinutes-long[one]   = in a minute
inMinutes-long[two]   = in {{m}} minutes

This removes the duplicate text and changes the key which I believe is needed for new translations.
