### PR TITLE
Bug 852541 - fixed reference-workload dialer history to determine appID correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,84 +297,25 @@ contacts: install-xulrunner-sdk
 # Create webapps
 offline: webapp-manifests webapp-optimize webapp-zip optimize-clean
 
-DIALER_SEARCH_STRING=/data/local/indexedDB/*communications.*
-# Disabled on suspicion of causing intermittent build failures - bug 852299
-# DIALER_HISTORY_DIR=$(shell adb shell 'echo -n $(DIALER_SEARCH_STRING)')
-ifeq ($(DIALER_HISTORY_DIR),$(DIALER_SEARCH_STRING))
-	DIALER_HISTORY_DIR=
-endif
-
 # Create a light reference workload
 .PHONY: reference-workload-light
 reference-workload-light:
-	@echo "Populate Databases - Light Workload"
-	$(ADB) shell stop b2g
-	test_media/reference-workload/generateImages.sh 20
-	test_media/reference-workload/generateMusicFiles.sh 20
-	test_media/reference-workload/generateVideos.sh 5
-	$(ADB) push  test_media/reference-workload/contactsDb-200.sqlite /data/local/indexedDB/chrome/3406066227csotncta.sqlite
-	$(ADB) push  test_media/reference-workload/smsDb-200.sqlite /data/local/indexedDB/chrome/226660312ssm.sqlite
-ifneq ($(DIALER_HISTORY_DIR),)
-	$(ADB) push  test_media/reference-workload/dialerDb-50.sqlite $(DIALER_HISTORY_DIR)/2584670174dsitanleecreR.sqlite
-else
-	@echo "Skipped dialer history - no communications DB directory found..."
-endif
-	$(ADB) shell start b2g
-	@echo "Done"
+	test_media/reference-workload/makeReferenceWorkload.sh light
 
 # Create a medium reference workload
 .PHONY: reference-workload-medium
 reference-workload-medium:
-	@echo "Populate Databases - Medium Workload"
-	$(ADB) shell stop b2g
-	test_media/reference-workload/generateImages.sh 50
-	test_media/reference-workload/generateMusicFiles.sh 50
-	test_media/reference-workload/generateVideos.sh 10
-	$(ADB) push  test_media/reference-workload/contactsDb-500.sqlite /data/local/indexedDB/chrome/3406066227csotncta.sqlite
-	$(ADB) push  test_media/reference-workload/smsDb-500.sqlite /data/local/indexedDB/chrome/226660312ssm.sqlite
-ifneq ($(DIALER_HISTORY_DIR),)
-	$(ADB) push  test_media/reference-workload/dialerDb-100.sqlite $(DIALER_HISTORY_DIR)/2584670174dsitanleecreR.sqlite
-else
-	@echo "Skipped dialer history - no communications DB directory found..."
-endif
-	$(ADB) shell start b2g
-	@echo "Done"
+	test_media/reference-workload/makeReferenceWorkload.sh medium
 
 # Create a heavy reference workload
 .PHONY: reference-workload-heavy
 reference-workload-heavy:
-	@echo "Populate Databases - Heavy Workload"
-	$(ADB) shell stop b2g
-	test_media/reference-workload/generateImages.sh 100
-	test_media/reference-workload/generateMusicFiles.sh 100
-	test_media/reference-workload/generateVideos.sh 20
-	$(ADB) push  test_media/reference-workload/contactsDb-1000.sqlite /data/local/indexedDB/chrome/3406066227csotncta.sqlite
-	$(ADB) push  test_media/reference-workload/smsDb-1000.sqlite /data/local/indexedDB/chrome/226660312ssm.sqlite
-ifneq ($(DIALER_HISTORY_DIR),)
-	$(ADB) push  test_media/reference-workload/dialerDb-200.sqlite $(DIALER_HISTORY_DIR)/2584670174dsitanleecreR.sqlite
-else
-	@echo "Skipped dialer history - no communications DB directory found..."
-endif
-	$(ADB) shell start b2g
-	@echo "Done"
+	test_media/reference-workload/makeReferenceWorkload.sh heavy
 
 # Create an extra heavy reference workload
 .PHONY: reference-workload-x-heavy
 reference-workload-x-heavy:
-	@echo "Populate Databases - Extra Heavy Workload"
-	$(ADB) shell stop b2g
-	test_media/reference-workload/generateImages.sh 250
-	test_media/reference-workload/generateMusicFiles.sh 250
-	test_media/reference-workload/generateVideos.sh 50
-	$(ADB) push  test_media/reference-workload/contactsDb-2000.sqlite /data/local/indexedDB/chrome/3406066227csotncta.sqlite
-	$(ADB) push  test_media/reference-workload/smsDb-2000.sqlite /data/local/indexedDB/chrome/226660312ssm.sqlite
-ifneq ($(DIALER_HISTORY_DIR),)
-	$(ADB) push  test_media/reference-workload/dialerDb-500.sqlite $(DIALER_HISTORY_DIR)/2584670174dsitanleecreR.sqlite
-else
-	@echo "Skipped dialer history - no communications DB directory found..."
-endif
-	$(ADB) shell start b2g
-	@echo "Done"
+	test_media/reference-workload/makeReferenceWorkload.sh x-heavy
 
 
 # The install-xulrunner target arranges to get xulrunner downloaded and sets up

--- a/test_media/reference-workload/generateImages.sh
+++ b/test_media/reference-workload/generateImages.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 if [ -z "$1" ]; then 
   echo Must provide number of iterations
+  exit
 fi
 
 adb push ${SCRIPT_DIR}/MasterGalleryImage.jpg /mnt/sdcard/DCIM/100MZLLA/IMG_0001.jpg

--- a/test_media/reference-workload/generateMusicFiles.sh
+++ b/test_media/reference-workload/generateMusicFiles.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 if [ -z "$1" ]; then 
   echo "Must provide number of iterations"
+  exit
 fi
 
 if ! type mid3v2 > /dev/null 2>&1; then

--- a/test_media/reference-workload/generateVideos.sh
+++ b/test_media/reference-workload/generateVideos.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 if [ -z "$1" ]; then 
   echo Must provide number of iterations
+  exit
 fi
 
 adb push ${SCRIPT_DIR}/MasterVideo.3gp /mnt/sdcard/Movies/VID_0001.3gp

--- a/test_media/reference-workload/makeReferenceWorkload.sh
+++ b/test_media/reference-workload/makeReferenceWorkload.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+if [ -z "$1" ]; then 
+  echo "Must provide size parameter (light/medium/heavy/x-heavy)"
+  exit
+fi
+
+case $1 in
+
+  light)
+    IMAGE_COUNT=20
+    MUSIC_COUNT=20
+    VIDEO_COUNT=5
+    CONTACT_COUNT=200
+    SMS_COUNT=200
+    DIALER_COUNT=50
+  ;;
+
+  medium)
+    IMAGE_COUNT=50
+    MUSIC_COUNT=50
+    VIDEO_COUNT=10
+    CONTACT_COUNT=500
+    SMS_COUNT=500
+    DIALER_COUNT=100
+  ;;
+
+  heavy)
+    IMAGE_COUNT=100
+    MUSIC_COUNT=100
+    VIDEO_COUNT=20
+    CONTACT_COUNT=1000
+    SMS_COUNT=1000
+    DIALER_COUNT=200
+  ;;
+
+  x-heavy)
+    IMAGE_COUNT=250
+    MUSIC_COUNT=250
+    VIDEO_COUNT=50
+    CONTACT_COUNT=2000
+    SMS_COUNT=2000
+    DIALER_COUNT=500
+  ;;
+
+  *)
+    echo "Size parameter must be one of (light/medium/heavy/x-heavy)"
+    exit
+
+esac
+
+echo "Populate Databases - $1 Workload"
+
+adb pull /data/local/webapps/webapps.json $SCRIPT_DIR/webapps.json
+DIALER_ID=$(python $SCRIPT_DIR/readJSON.py $SCRIPT_DIR/webapps.json "communications.gaiamobile.org/localId")
+DIALER_DIR="$DIALER_ID+f+app+++communications.gaiamobile.org"
+rm $SCRIPT_DIR/webapps.json
+
+adb shell stop b2g
+$SCRIPT_DIR/generateImages.sh $IMAGE_COUNT
+$SCRIPT_DIR/generateMusicFiles.sh $MUSIC_COUNT
+$SCRIPT_DIR/generateVideos.sh $VIDEO_COUNT
+adb push  $SCRIPT_DIR/contactsDb-$CONTACT_COUNT.sqlite /data/local/indexedDB/chrome/3406066227csotncta.sqlite
+adb push  $SCRIPT_DIR/smsDb-$SMS_COUNT.sqlite /data/local/indexedDB/chrome/226660312ssm.sqlite
+if [ -z "$DIALER_ID" ]; then
+  echo "Unable to determine communications application ID - skipping dialer history..."
+else
+  adb push  $SCRIPT_DIR/dialerDb-$DIALER_COUNT.sqlite /data/local/indexedDB/$DIALER_DIR/2584670174dsitanleecreR.sqlite
+fi
+adb shell start b2g
+
+echo ""
+echo "Images:         $(printf "%4d" $IMAGE_COUNT)"
+echo "Songs:          $(printf "%4d" $MUSIC_COUNT)"
+echo "Videos:         $(printf "%4d" $VIDEO_COUNT)"
+echo "Contacts:       $(printf "%4d" $CONTACT_COUNT)"
+echo "Sms Messages:   $(printf "%4d" $SMS_COUNT)"
+echo "Dialer History: $(printf "%4d" $DIALER_COUNT)"
+
+echo "Done"

--- a/test_media/reference-workload/readJSON.py
+++ b/test_media/reference-workload/readJSON.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+#
+# This script parses json files, and extracts a value from a provided key
+# The value is printed to stdout
+
+import json
+import os
+import sys
+
+json_data=open(sys.argv[1])
+data = json.load(json_data)
+json_data.close()
+
+keyString = sys.argv[2]
+keys = keyString.split('/')
+
+result = data
+for key in keys:
+  result = result[key]
+
+print result


### PR DESCRIPTION
Fixed reference-workload dialer history to determine the communications app ID correctly by reading and parsing the webapps.json file from the phone. Also fixed a minor omission in the image/music/video generate scripts, and moved most processing out of the makefile and into a central script.
