### PR TITLE
Bug 853659 - [email/activesync] Fix sending mail on Exchange 2007 and lower

### DIFF
--- a/apps/email/js/ext/mailapi/activesync/configurator.js
+++ b/apps/email/js/ext/mailapi/activesync/configurator.js
@@ -2931,8 +2931,12 @@ ActiveSyncAccount.prototype = {
         });
       }
       else { // ActiveSync 12.x and lower
+        var encoder = new TextEncoder('UTF-8');
+
+        // On B2G 18, XHRs expect ArrayBuffers and will barf on Uint8Arrays. In
+        // the future, we can remove the last |.buffer| bit below.
         this.conn.postData('SendMail', 'message/rfc822',
-                           mimeBuffer,
+                           encoder.encode(mimeBuffer).buffer,
                            function(aError, aResponse) {
           if (aError) {
             console.error(aError);

--- a/apps/email/js/ext/mailapi/composer.js
+++ b/apps/email/js/ext/mailapi/composer.js
@@ -330,7 +330,6 @@ module.exports = function(address){
     });
 };
 });
-
 define('mailcomposer/lib/dkim',['require','exports','module','crypto','mimelib','./punycode'],function (require, exports, module) {
 var crypto = require('crypto'),
     mimelib = require('mimelib'),
@@ -550,7 +549,6 @@ function hasUTFChars(str){
     return !!rforeign.test(str);
 }
 });
-
 define('http',['require','exports','module'],function(require, exports, module) {
 });
 
@@ -633,7 +631,6 @@ function openUrlStream(url, options){
     return stream; 
 }
 });
-
 define('fs',['require','exports','module'],function(require, exports, module) {
 });
 
@@ -1879,7 +1876,6 @@ MailComposer.prototype._getMimeType = function(filename){
     return extension && mimelib.contentTypes[extension] || defaultMime;
 };
 });
-
 define('mailcomposer',['./mailcomposer/lib/mailcomposer'], function (main) {
     return main;
 });
@@ -3893,11 +3889,21 @@ Composer.prototype = {
    * Request that a body be produced as a single buffer with the given options.
    * Multiple calls to this method can be made and they may overlap.
    *
+   * XXX: Currently, the callback is invoked with a String instead of an
+   * ArrayBuffer/node-like Buffer; consumers that do not use TextEncoder to
+   * produce a utf-8 encoding probably need to and we might want to change this
+   * here.
+   *
    * @args[
    *   @param[opts @dict[
    *     @key[includeBcc Boolean]{
    *       Should we include the BCC data in the headers?
    *     }
+   *   ]]
+   *   @param[callback @func[
+   *     @args[
+   *       @param[messageBuffer String]
+   *     ]
    *   ]]
    * ]
    */


### PR DESCRIPTION
This has r+ from @asutherland over at https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/154

Note that the newline changes are because OS X's `sed` is bad, but that will be permanently fixed in the near future (by not using `sed`).
