### PR TITLE
Bug 848916 - back out new strings for just 1.0.1 to keep string freeze

### DIFF
--- a/apps/gallery/js/open.js
+++ b/apps/gallery/js/open.js
@@ -41,7 +41,8 @@ window.addEventListener('localized', function() {
 
       // Report errors if we're passed an invalid image
       frame.onerror = function invalid() {
-        displayError('imageinvalid');
+        // 1.0.1 only, ignore error
+        // displayError('imageinvalid');
       };
     }
 
@@ -80,7 +81,8 @@ window.addEventListener('localized', function() {
 
       // If the image is too large, display an error
       if (pixels > MAX_IMAGE_SIZE) {
-        displayError('imagetoobig');
+        // 1.0.1 only, ignore error
+        // displayError('imagetoobig');
         return;
       }
 
@@ -130,7 +132,8 @@ window.addEventListener('localized', function() {
         frame.displayImage(blob);
       }
       else {
-        displayError('imagetoobig');
+        // 1.0.1 only, ignore error
+        // displayError('imagetoobig');
       }
     }
   }

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -51,6 +51,3 @@ pluggedin2-text  = Unplug the phone to use this app.
 share-noprovider = Can not share this image file type.
 
 memorycardfull = Can not edit photos: Memory card is full.
-
-imagetoobig = Image is too large to display on this device.
-imageinvalid = Image is invalid or corrupt and cannot be displayed.


### PR DESCRIPTION
We should try hard to not take the strings in bug 848916 for 1.0.1.
Doing this by disabling the calls to displayError, and then remove the strings again.

This PR is for 1.0.1 only, the new strings should stay on master and v1-train.
