### PR TITLE
Bug 854324 - [Cardview] App title does not reflect language change.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1078,6 +1078,21 @@ var WindowManager = (function() {
     isOutOfProcessDisabled = value;
   });
 
+  // update app name when language setting changes
+  SettingsListener.observe('language.current', null,
+    function(value) {
+      if (!value)
+          return;
+
+      for (var origin in runningApps) {
+        var app = runningApps[origin];
+        if (!app || !app.manifest)
+          continue;
+        var manifest = app.manifest;
+        app.name = new ManifestHelper(manifest).name;
+      }
+    });
+
   function createFrame(origFrame, origin, url, name, manifest, manifestURL) {
     var iframe = origFrame || document.createElement('iframe');
     iframe.setAttribute('mozallowfullscreen', 'true');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=854324
1. Title : [Cardview] App title does not reflect language change.
2. Precondition : Go to Settings and ensure the language is set to English and notice the cardview displays app name in English.
3. Tester's Action : Go back to Settings and change language.
4. Detailed Symptom (ENG.) : Notice the cardview still displays the app name in English, not the newly changed language.
5. Expected : The app name in cardview should display in newly changed language.
6. Reproducibility: Y
   1)Frequency Rate : 100%
   7.Build: AU_LINUX_GECKO_ICS_STRAWBERRY.01.01.00.19.031, Mozilla build ID: 20130312070202
