### PR TITLE
Bug 833710 - [Music] Avoid displaying '-00:00' for song remaining time 

### DIFF
--- a/apps/music/js/Player.js
+++ b/apps/music/js/Player.js
@@ -524,7 +524,11 @@ var PlayerView = {
     this.seekIndicator.style.transform = 'translateX(' + x + ')';
 
     this.seekElapsed.textContent = formatTime(currentTime);
-    this.seekRemaining.textContent = '-' + formatTime(endTime - currentTime);
+    var remainingTime = endTime - currentTime;
+    // Check if there is remaining time to show, avoiding to display "-00:00"
+    // while song is loading (Bug 833710)
+    this.seekRemaining.textContent =
+        (remainingTime > 0) ? '-' + formatTime(remainingTime) : '---:--';
   },
 
   handleEvent: function pv_handleEvent(evt) {


### PR DESCRIPTION
Add check for song remaining time greater than 0 in order to avoid displaying "-00:00" (replace with "--:--") when song is loading.
