### PR TITLE
Bug 853420 - Use absolute path for the optimized js file. r=vingtetun, a=tef+

### DIFF
--- a/apps/camera/index.html
+++ b/apps/camera/index.html
@@ -18,7 +18,7 @@
     <!-- <script defer src="/shared/js/media/video_player.js"></script> -->
     <!-- <script defer src="/shared/js/media/media_frame.js"></script> -->
     <!-- <script defer src="/shared/js/gesture_detector.js"></script> -->
-    <script defer src="shared/js/lazy_loader.js"></script>
+    <script defer src="/shared/js/lazy_loader.js"></script>
     <script defer src="js/camera.js"></script>
   </head>
   <body>

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -170,7 +170,7 @@ function optimize_aggregateJsResources(doc, webapp, htmlFile) {
 
   // find the absolute root of the app's html file.
   let rootUrl = htmlFile.parent.path;
-  rootUrl = rootUrl.replace(webapp.manifestFile.parent.path, '');
+  rootUrl = rootUrl.replace(webapp.manifestFile.parent.path, '') || '.';
   // the above will yield something like: '', '/facebook/', '/contacts/', etc...
 
   function writeAggregatedScript(config) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=853420
