### PR TITLE
Bug 853788 - [SMS] support the "full name search" use case r=julienw

### DIFF
--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -1,34 +1,192 @@
 /* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+(function(exports) {
+  'use strict';
 
-'use strict';
+  /**
+   * isMatch
+   *
+   * Validate a contact record against a list of terms by specified fields
+   *
+   * @param {Object} contact a contact record object.
+   *
+   * @param {Object} criteria fields and terms to validate a contact.
+   *        - fields (fields of a contact record).
+   *        - terms (terms to validate against contact record field values).
+   */
+  function isMatch(contact, criteria) {
+    /**
+     * Validation Strategy
+     *
+     * 1. Let _found_ be a register of confirmed terms
+     * 2. Let _contact_ be a contact record.
+     * 3. For each _term_ [...input list], with the label _outer_
+     *   - For each _field_ of [givenName, familyName]
+     *     - For each _value_ in _contact_[ _field_ ]
+     *       - Let _found_[ _term_ ] be the result of calling
+     *           _value_.startsWith( _term_ )
+     *         - If _found_[ _term_ ] is **true**, continue to
+     *           loop labelled _outer_
+     * 4. If every value of _key_ in _found_ is **true** return **true**,
+     *    else return **false**
+    */
+    var found = {};
 
-var Contacts = {
-  findBy: function contacts_findBy(filter, callback) {
-    var request;
-
-    if (!navigator.mozContacts) {
-      return;
+    // The outer loop is specifically labelled to allow the
+    // nested condition a way out of the second and third loop.
+    outer:
+    for (var i = 0, ilen = criteria.terms.length; i < ilen; i++) {
+      var term = criteria.terms[i];
+      for (var j = 0, jlen = criteria.fields.length; j < jlen; j++) {
+        var field = criteria.fields[j];
+        for (var k = 0, klen = contact[field].length; k < klen; k++) {
+          var value = contact[field][k];
+          if (found[term] = value.toLowerCase().startsWith(term)) {
+            continue outer;
+          }
+        }
+      }
     }
 
-    filter.filterLimit = filter.filterLimit || 10;
-
-    request = navigator.mozContacts.find(filter);
-
-    request.onsuccess = function onsuccess() {
-      callback(this.result);
-    };
-
-    request.onerror = function onerror() {
-      console.log('Contact finding error. Error: ' + this.error.name);
-      callback(null);
-    };
-  },
-  findByString: function contacts_findBy(filterValue, callback) {
-    return this.findBy({
-      filterBy: ['tel', 'givenName', 'familyName'],
-      filterOp: 'contains',
-      filterValue: filterValue
-    }, callback);
+    // Pending the publication of a list of ES6 features available in Firefox
+    // and deemed "safe enough" for FirefoxOS development, the above code is a
+    // stand-in for what should be written as:
+    // outer:
+    // for (var term of criteria.terms) {
+    //   for (var field of criteria.fields) {
+    //     for (var value of contact[field]) {
+    //       if (found[term] = value.toLowerCase().startsWith(term)) {
+    //         continue outer;
+    //       }
+    //     }
+    //   }
+    // }
+    return Object.keys(found).every(function(key) {
+      return found[key];
+    });
   }
-};
+
+  var rspaces = /\s+/;
+
+  var Contacts = {
+    findBy: function contacts_findBy(filter, callback) {
+      var lower = [];
+      var filterValue = (filter.filterValue || '').trim();
+      var terms, request;
+
+      if (!navigator.mozContacts || !filterValue.length) {
+        setTimeout(function() {
+          callback(
+            /**
+             * Bailout Strategy
+             *
+             * 1. A _missing_ filter.filterValue will results in an
+             *    error when passed to mozContacts.find, bailing out
+             *    early avoids the additional overhead of making a
+             *    request that we know will fail.
+             *
+             * 2. Missing navigator.mozContacts API or empty but
+             *    present filter.filterValue make the app useless,
+             *    so prevent unpredictable state by making the
+             *    result a no-op.
+             *
+             */
+            typeof filter.filterValue === 'undefined' ? null : []
+          );
+        });
+        return;
+      }
+
+      /**
+       * Lookup Strategy
+       *
+       * 1. Create a list of terms from the filterValue string
+       *
+       * 2. If only 1 term, set filterValue to that term.
+       *
+       * 3. If more than 1 term, find the length predominate term.
+       *     a. let initial be an empty string
+       *       (Do not use default first item in terms, or it will not
+       *       be pushed into the lowercase list)
+       *     b. For each term of terms
+       *         i. Push lowercased term into a list of lowercased terms
+       *         ii. If the current term.length is greater then initial.length,
+       *             return the term, otherwise return the initial.
+       *
+       * 4. If filterValue.length is < 3, set the filterLimit to 10
+       *
+       * 5. Remove the length predominate term from the list of validation terms
+       *
+       * 6. Make a mozContact.find request with the length predominate term
+       *     as the filter.filterValue.
+       *
+       * 7. In the mozContacts.find request success handler, filter the
+       *     results by evaluating each contact record against
+       *     the list of validation terms.
+       */
+
+      // Step 1
+      terms = filterValue.split(rspaces);
+
+      filter.filterValue = terms.length === 1 ?
+        // Step 2
+        terms[0] :
+        // Step 3
+        terms.reduce(function(initial, term) {
+          // Step 3.b.i
+          // (used as a criteria list for isMatch)
+          lower.push(term.toLowerCase());
+          // Step 3.b.ii
+          return term.length > initial.length ? term : initial;
+        // Step 3.a
+        }, '');
+
+      // Step 4
+      if (filter.filterValue.length < 3) {
+        filter.filterLimit = 10;
+      }
+
+      // Step 5
+      lower.splice(lower.indexOf(filter.filterValue.toLowerCase()), 1);
+
+      // Step 6
+      request = navigator.mozContacts.find(filter);
+
+      request.onsuccess = function onsuccess() {
+        var contacts = this.result.slice();
+        var fields = ['givenName', 'familyName'];
+        var results = [];
+        var contact;
+
+        // Step 7
+        if (terms.length > 1) {
+          while ((contact = contacts.pop())) {
+            if (isMatch(contact, { fields: fields, terms: lower })) {
+              results.push(contact);
+            }
+          }
+        } else {
+          results = contacts;
+        }
+        callback(results);
+      };
+
+      request.onerror = function onerror() {
+        // When an error occurs, regardless of completed count,
+        // clear the onsuccess handler from this request and immediately
+        // invoke the callback with a `null` argument.
+        this.onsuccess = this.onerror = null;
+        callback(null);
+      };
+    },
+    findByString: function contacts_findBy(filterValue, callback) {
+      return this.findBy({
+        filterBy: ['tel', 'givenName', 'familyName'],
+        filterOp: 'contains',
+        filterValue: filterValue
+      }, callback);
+    }
+  };
+
+  exports.Contacts = Contacts;
+}(this));

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -927,13 +927,15 @@ var ThreadUI = {
         var regName = new RegExp('\\b' + input, 'ig');
         // For number we search in any position to avoid country code issues
         var regNumber = new RegExp(input, 'ig');
-        if (!(name.match(regName) || number.match(regNumber))) {
-          return;
-        }
-        var nameHTML =
-            SearchUtils.createHighlightHTML(name, regName, 'highlight');
-        var numHTML =
-            SearchUtils.createHighlightHTML(number, regNumber, 'highlight');
+
+        var nameHTML = name.match(regName) ?
+              SearchUtils.createHighlightHTML(name, regName, 'highlight') :
+              name;
+
+        var numHTML = number.match(regNumber) ?
+              SearchUtils.createHighlightHTML(number, regNumber, 'highlight') :
+              number;
+
         // Create DOM element
         var contactDOM = document.createElement('li');
 
@@ -966,17 +968,19 @@ var ThreadUI = {
   },
 
   searchContact: function thui_searchContact() {
-    var input = this.recipient;
-    var string = input.value;
+    var filterValue = this.recipient.value;
 
-    // TODO: Investigate why view.innerHTML is cleared
-    // here and later in the results callback
-    this.container.innerHTML = '';
-    if (!string) {
+    if (!filterValue.trim()) {
+      // In cases where searchContact was invoked for "input"
+      // that was actually a "delete" that removed the last
+      // character in the recipient input field,
+      // eg. type "a", then delete it.
+      // Always remove the the existing results.
+      this.container.innerHTML = '';
       return;
     }
 
-    Contacts.findByString(string, function gotContact(contacts) {
+    Contacts.findByString(filterValue, function gotContact(contacts) {
       // !contacts matches null results from errors
       // !contacts.length matches empty arrays from unmatches filters
       if (!contacts || !contacts.length) {
@@ -990,9 +994,11 @@ var ThreadUI = {
       }
 
       // There are contacts that match the input.
-      //  1. Add the "hide" class to the messages-no-results display
-      //  2. Remove the "hide" class from the view
+      //  1. Clear the existing container html
+      //  2. Add the "hide" class to the messages-no-results display
+      //  3. Remove the "hide" class from the container
       //
+      this.container.innerHTML = '';
       this.noResults.classList.add('hide');
       this.container.classList.remove('hide');
 

--- a/apps/sms/test/unit/contacts_test.js
+++ b/apps/sms/test/unit/contacts_test.js
@@ -23,7 +23,10 @@ suite('Contacts', function(done) {
         var onsuccess, onerror;
 
         navigator.mozContacts.mHistory.push({
-          filter: filter,
+          // make a "copy" of the filter object
+          filter: Object.keys(filter).reduce(function(copy, key) {
+            return (copy[key] = filter[key]) && copy;
+          }, {}),
           request: this
         });
 
@@ -39,40 +42,76 @@ suite('Contacts', function(done) {
             // This will behave like a _REALLY_ fast DB query
             set: function(callback) {
               onsuccess = callback;
-              // Implement a mock that gives results that appear to
-              // match the real behaviour of filtered contacts results
-              this.result = (function() {
-                // Supports the error case
-                if (filter == null ||
-                      (!filter.filterOp || !filter.filterValue)) {
-                  return null;
-                }
+              if (callback !== null) {
+                // Implement a mock that gives results that appear to
+                // match the real behaviour of filtered contacts results
+                this.result = (function() {
+                  // Supports the error case
+                  if (filter == null ||
+                        (!filter.filterOp || !filter.filterValue)) {
+                    return null;
+                  }
 
-                // Supports two "no match" cases
-                if (filter.filterValue === '911' ||
-                    filter.filterValue === 'wontmatch') {
-                  return [];
-                }
+                  // Supports two "no match" cases
+                  if (filter.filterValue === '911' ||
+                      filter.filterValue === 'wontmatch') {
+                    return [];
+                  }
 
-                // All other cases
-                return MockContact.list();
-              }());
+                  if (filter.filterValue === 'jane') {
+                    return MockContact.list([
+                      // true
+                      { givenName: ['Jane'], familyName: ['D'] },
+                      // false
+                      { givenName: ['jane'], familyName: ['austen'] },
+                      // true
+                      { givenName: ['jane'], familyName: ['doe'] },
+                      // false
+                      { givenName: ['jane'], familyName: ['fonda'] },
+                      // true
+                      { givenName: ['jane'], familyName: ['dow'] },
+                      // false
+                      { givenName: ['janet'], familyName: [''] }
+                    ]);
+                  }
 
-              if (this.result === null) {
-                this.error = {
-                  name: 'Mock missing filter params'
-                };
-                if (onerror) {
+                  if (filter.filterValue === 'do') {
+                    return MockContact.list([
+                      // true
+                      { givenName: ['Jane'], familyName: ['Doozer'] },
+                      // false
+                      { givenName: ['doug'], familyName: ['dooley'] },
+                      // true
+                      { givenName: ['jane'], familyName: ['doe'] },
+                      // false
+                      { givenName: ['jerry'], familyName: ['doe'] },
+                      // true
+                      { givenName: ['j'], familyName: ['dow'] },
+                      // true
+                      { givenName: ['john'], familyName: ['doland'] }
+                    ]);
+                  }
+
+                  // All other cases
+                  return MockContact.list();
+                }());
+
+                if (this.result === null) {
+                  this.error = {
+                    name: 'Mock missing filter params'
+                  };
+                  if (onerror) {
+                    setTimeout(function() {
+                      onerror.call(this);
+                      onerror = null;
+                    }.bind(this), 0);
+                  }
+                } else {
                   setTimeout(function() {
-                    onerror.call(this);
-                    onerror = null;
+                    onsuccess.call(this);
+                    onsuccess = null;
                   }.bind(this), 0);
                 }
-              } else {
-                setTimeout(function() {
-                  onsuccess.call(this);
-                  onsuccess = null;
-                }.bind(this), 0);
               }
             }
           },
@@ -80,11 +119,13 @@ suite('Contacts', function(done) {
           onerror: {
             set: function(callback) {
               onerror = callback;
-              if (this.result === null && this.error !== null) {
-                setTimeout(function() {
-                  onerror.call(this);
-                  onerror = null;
-                }.bind(this), 0);
+              if (callback !== null) {
+                if (this.result === null && this.error !== null) {
+                  setTimeout(function() {
+                    onerror.call(this);
+                    onerror = null;
+                  }.bind(this), 0);
+                }
               }
             }
           }
@@ -101,7 +142,7 @@ suite('Contacts', function(done) {
     navigator.mozContacts = nativeMozContacts;
   });
 
-  suite('Contacts.findByString (success)', function() {
+  suite('Contacts.findByString, single-term', function() {
 
     test('(string[tel,givenName,familyName], ...) Match', function(done) {
       var mozContacts = navigator.mozContacts;
@@ -160,7 +201,6 @@ suite('Contacts', function(done) {
       });
     });
 
-
     test('(string[tel], ...) No Match', function(done) {
       var mozContacts = navigator.mozContacts;
 
@@ -181,12 +221,175 @@ suite('Contacts', function(done) {
     });
   });
 
+  suite('Contacts.findByString, multi-term', function() {
+
+    test('no predominate', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('Pepito Grillo', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+        // contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('no predominate, reversed', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('Grillo Pepito', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('predominate first, upper', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('Pepi G', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('predominate last, upper', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('G Pepi', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+
+    test('predominate first, lower', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('pepi g', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('predominate last, lower', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('g pepi', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 1);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('no matches, predominate first, upper', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('Pepito S', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('no matches, predominate last, upper', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('S Pepito', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('no matches, predominate first, lower', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('pepi s', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+
+    test('no matches, predominate last, lower', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByString('s pepi', function(contacts) {
+        var mHistory = mozContacts.mHistory;
+
+        // No contacts were found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 0);
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+  });
+
   suite('Contacts.findBy (success)', function() {
 
     test('(object, ...), Match', function(done) {
       var mozContacts = navigator.mozContacts;
       var filter = {
-        findBy: ['tel'],
+        filterBy: ['tel'],
         filterOp: 'contains',
         filterValue: '12125559999'
       };
@@ -210,7 +413,7 @@ suite('Contacts', function(done) {
     test('(object, ...), No Match', function(done) {
       var mozContacts = navigator.mozContacts;
       var filter = {
-        findBy: ['tel'],
+        filterBy: ['tel'],
         filterOp: 'contains',
         filterValue: '911'
       };
@@ -242,10 +445,59 @@ suite('Contacts', function(done) {
       Contacts.findBy({}, function(contacts) {
         var mHistory = mozContacts.mHistory;
         assert.equal(contacts, null);
+        done();
+      });
+    });
+  });
+
+  suite('Contacts validation', function() {
+    test('Contact validation, predominate first', function(done) {
+      Contacts.findByString('jane d', function(contacts) {
+        var mozContacts = navigator.mozContacts;
+
+        // contacts were not found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 3);
+
+        /**
+         * The three matching contacts are:
+         *
+         * { givenName: ['Jane'], familyName: ['D'] }
+         * { givenName: ['jane'], familyName: ['doe'] }
+         * { givenName: ['jane'], familyName: ['dow'] }
+         *
+         */
 
         // navigator.mozContacts.find was called?
-        assert.equal(mHistory.length, 1);
-        assert.isNotNull(mHistory[0].request.error);
+        assert.equal(mozContacts.mHistory.length, 1);
+        assert.deepEqual(mozContacts.mHistory[0].filter.filterValue, 'jane');
+
+        done();
+      });
+    });
+
+    test('Contact validation, predominate last', function(done) {
+      Contacts.findByString('j do', function(contacts) {
+        var mozContacts = navigator.mozContacts;
+
+        // contacts were not found
+        assert.ok(Array.isArray(contacts));
+        assert.equal(contacts.length, 5);
+
+        /**
+         * The five matching contacts are:
+         *
+         * { givenName: ['Jane'], familyName: ['Doozer'] }
+         * { givenName: ['jane'], familyName: ['doe'] }
+         * { givenName: ['jerry'], familyName: ['doe'] }
+         * { givenName: ['j'], familyName: ['dow'] }
+         * { givenName: ['john'], familyName: ['doland'] }
+         *
+         */
+
+        // navigator.mozContacts.find was called?
+        assert.equal(mozContacts.mHistory.length, 1);
+        assert.deepEqual(mozContacts.mHistory[0].filter.filterValue, 'do');
 
         done();
       });

--- a/apps/sms/test/unit/mock_contact.js
+++ b/apps/sms/test/unit/mock_contact.js
@@ -1,37 +1,20 @@
 'use strict';
 
-function MockContact() {
+
+function MockContact(name) {
+  name = typeof name !== 'undefined' ? name : {
+    familyName: ['Grillo'],
+    givenName: ['Pepito']
+  };
   if (!(this instanceof MockContact)) {
-    return new MockContact();
+    return new MockContact(name);
   }
   this.id = '1';
-  this.updated = Date.now();
 
-  this.familyName = ['Grillo'];
-  this.givenName = ['Pepito'];
-  this.additionalName = [''];
+  this.familyName = name.familyName;
+  this.givenName = name.givenName;
   this.name = [
     [this.givenName, this.familyName].join(' ')
-  ];
-
-  this.bday = '1978-12-20';
-  this.jobTitle = [''];
-  this.org = ['Test'],
-
-  this.adr = [
-    {
-      countryName: 'Germany',
-      locality: 'Chemnitz',
-      postalCode: '09034',
-      streetAddress: 'Gotthardstrasse 22'
-    }
-  ];
-
-  this.email = [
-    {
-      'type': 'Personal',
-      'value': 'test@test.com'
-    }
   ];
 
   this.tel = [
@@ -52,6 +35,26 @@ function MockContact() {
   ];
 }
 
-MockContact.list = function() {
-  return [new MockContact()];
+/*
+
+  MockContact.list([names])
+
+  Create contacts lists
+
+  MockContact.list();
+
+  MockContact.list([
+    { givenName: ['Jane'], familyName: ['Doozer'] },
+    { givenName: ['doug'], familyName: ['dooley'] }
+  ]);
+ */
+
+MockContact.list = function(names) {
+  if (names && names.length) {
+    return names.map(function(name) {
+      return new MockContact(name);
+    });
+  } else {
+    return [new MockContact()];
+  }
 };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=853788
- Bug 853788 - [SMS] support the "full name search" use case …  05c0217
- Make multi-term searches match on both fields. Fixes display of match… …  db02b1c
- Add clarification of contact match validation. Set handlers to null (… …  870b7b6
- Change contact lookup and filter strategy …   037bd66
- Finalize Validation and Lookup strategies …   6a6b441
- Fix early bailouts on missing inbound filterValues. Update Lookup Str… …  578cfba
- Clarifies bailout strategy for avoiding known errors …  e1d70b7
- Failing tests: multi-term lookups where predominate term is the first… …  142c5cf
- Fixes: multi-term lookups where predominate term is the first in the … …  49c3938
- gjslint line length nits …  5ed2251
- Devolve the isMatch implementation …  99bf4eb
- Prevent duplicates appearing as a result of fast-typing. Reduces list… …  4ba9a8a
- Modify MockContact to accept explicit givenName, familyName; Modify M… …  41abe0a
- Update MockMozContacts.find to support multi-term search result mocks …   d0cba06
- Update multi-term search validation and matching tests …  d35624e
- Always remove the previously existing results. …  d3804b0
- Don't expose isMatch on the Contacts object

Bailout Strategy
1. A _missing_ filter.filterValue will results in an
   error when passed to mozContacts.find, bailing out
   early avoids the additional overhead of making a
   request that we know will fail.
2. Missing navigator.mozContacts API or empty but
   present filter.filterValue make the app useless,
   so prevent unpredictable state by making the
   result a no-op.

Validation Strategy
1. Let _found_ be a register of confirmed terms
2. Let _contact_ be a contact record.
3. For each _term_ [...input list], with the label _outer_
- For each _field_ of [givenName, familyName]
  - For each _value_ in _contact_[ _field_ ]
    - Let _found_[ _term_ ] be the result of calling
      _value_.startsWith( _term_ )
    - If _found_[ _term_ ] is **true**, continue to
      loop labelled _outer_
  - If every value of _key_ in _found_ is **true** return **true**,
    else return **false**

Lookup Strategy
1. If only 1 term, set filterValue to that term.
2. If more than 1 term, find the length predominate term.
3. If filterValue.length is < 3, set the filterLimit to 10
4. Remove the length predominate term from the list of validation terms
5. Make a mozContact.find request with the length predominate term
   as the filter.filterValue.
6. In the mozContacts.find request success handler, filter the
   results by evaluating each contact record against
   the list of validation terms.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
