### PR TITLE
Bug 853845 - use setAttribute('mozbrowser', true) in browser app

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1385,7 +1385,7 @@ var Browser = {
   createTab: function browser_createTab(url, iframe, tab) {
     if (!iframe) {
       iframe = document.createElement('iframe');
-      iframe.mozbrowser = true;
+      iframe.setAttribute('mozbrowser', true);
       iframe.setAttribute('mozallowfullscreen', true);
       iframe.classList.add('browser-tab');
 


### PR DESCRIPTION
Change .mozbrowser = true to .setAttribute('mozbrowser', true) in Browser app after moving HTMLIFrameElement to WebIDL.
