### PR TITLE
Bug 847851 - change event hook to addEventListener, r=kaze

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -13,21 +13,18 @@ var gDeviceList = null;
 // handle Bluetooth settings
 navigator.mozL10n.ready(function bluetoothSettings() {
   var _ = navigator.mozL10n.get;
-  var settings = window.navigator.mozSettings;
-  var bluetooth = window.navigator.mozBluetooth;
+  var settings = Settings.mozSettings;
+  var bluetooth = getBluetooth();
   var defaultAdapter = null;
 
   if (!settings || !bluetooth) {
     return;
   }
 
-  var gBluetoothInfoBlock = document.getElementById('bluetooth-desc');
   var gBluetoothCheckBox = document.querySelector('#bluetooth-status input');
 
   // display Bluetooth power state
   function updateBluetoothState(value) {
-    gBluetoothInfoBlock.textContent =
-      value ? _('bt-status-nopaired') : _('bt-status-turnoff');
     gBluetoothCheckBox.checked = value;
   }
 
@@ -343,6 +340,7 @@ navigator.mozL10n.ready(function bluetoothSettings() {
 
       navigator.mozSetMessageHandler('bluetooth-pairedstatuschanged',
         function bt_getPairedMessage(message) {
+          dispatchEvent(new CustomEvent('bluetooth-pairedstatuschanged'));
           showDevicePaired(message.paired, 'Authentication Failed');
         }
       );
@@ -377,7 +375,6 @@ navigator.mozL10n.ready(function bluetoothSettings() {
         var paired = req.result.slice();
         var length = paired.length;
         if (length == 0) {
-          gBluetoothInfoBlock.textContent = _('bt-status-nopaired');
           pairList.show(false);
           return;
         }
@@ -408,11 +405,6 @@ navigator.mozL10n.ready(function bluetoothSettings() {
             }
           })(paired[i]);
         }
-        var text = _('bt-status-paired', {
-          name: paired[0].name,
-          n: length - 1
-        });
-        gBluetoothInfoBlock.textContent = text;
         pairList.show(true);
         // the callback function now is for restoring the connected device
         // when the bluetooth is turned on.
@@ -714,16 +706,16 @@ navigator.mozL10n.ready(function bluetoothSettings() {
     gMyDeviceInfo.update(lastMozSettingValue);
   };
 
-  bluetooth.onadapteradded = function bt_adapterAdded() {
+  bluetooth.addEventListener('adapteradded', function() {
     // enable UI toggle
     gBluetoothCheckBox.disabled = false;
     initialDefaultAdapter();
     dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
-  };
-  bluetooth.ondisabled = function bt_onDisabled() {
+  });
+  bluetooth.addEventListener('disabled', function() {
     gBluetoothCheckBox.disabled = false;  // enable UI toggle
     defaultAdapter = null;  // clear defaultAdapter
     dispatchEvent(new CustomEvent('bluetooth-disabled'));
-  };
+  });
 });
 

--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -8,21 +8,23 @@
  * requiring the full `wifi.js' + `carrier.js' + `bluetooth.js' libraries.
  */
 
-var gBluetooth = (function(window) {
-  var navigator = window.navigator;
-  if ('mozBluetooth' in navigator)
-    return navigator.mozBluetooth;
-  return null;
-})(this);
-
-
 // TODO: handle hotspot status
 
 // display connectivity status on the main panel
 var Connectivity = (function(window, document, undefined) {
   var _initialized = false;
   var _ = navigator.mozL10n.get;
+
+  // in util.js, we fake these device interfaces if they are not exist.
   var wifiManager = getWifiManager();
+  var bluetooth = getBluetooth();
+  var mobileConnection = getMobileConnection();
+
+  mobileConnection.addEventListener('datachange', updateCarrier);
+  mobileConnection.addEventListener('cardstatechange', updateCallSettings);
+
+  // XXX if wifiManager implements addEventListener function
+  // we can remove these listener lists.
   var wifiEnabledListeners = [updateWifi];
   var wifiDisabledListeners = [updateWifi];
   var wifiStatusChangeListeners = [updateWifi];
@@ -48,16 +50,25 @@ var Connectivity = (function(window, document, undefined) {
   };
   wifiManager.onstatuschange = wifiStatusChange;
 
+  // Register callbacks to track the state of the bluetooth hardware
+  bluetooth.addEventListener('adapteradded', function() {
+    dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
+    updateBluetooth();
+  });
+  bluetooth.addEventListener('disabled', function() {
+    dispatchEvent(new CustomEvent('bluetooth-disabled'));
+    updateBluetooth();
+  });
+
+  window.addEventListener('bluetooth-pairedstatuschanged', updateBluetooth);
+
+  // called when localization is done
   function init() {
     if (_initialized) {
       return;
     }
     _initialized = true;
 
-    var mobileConnection = getMobileConnection();
-    updateWifi();
-
-    // this event listener is not cleared by carrier.js
     kCardState = {
       'pinRequired' : _('simCardLockedMsg'),
       'pukRequired' : _('simCardLockedMsg'),
@@ -66,21 +77,12 @@ var Connectivity = (function(window, document, undefined) {
       'absent' : _('noSimCard'),
       'null' : _('simCardNotReady')
     };
-    mobileConnection.addEventListener('datachange', updateCarrier);
-    updateCarrier();
-    mobileConnection.addEventListener('cardstatechange', updateCallSettings);
-    updateCallSettings();
 
-    // these listeners are replaced when bluetooth.js is loaded
-    gBluetooth.onadapteradded = function() {
-      dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
-      updateBluetooth();
-    };
-    gBluetooth.ondisabled = function() {
-      dispatchEvent(new CustomEvent('bluetooth-disabled'));
-      updateBluetooth();
-    };
+    updateCarrier();
+    updateCallSettings();
+    updateWifi();
     updateBluetooth();
+    // register blutooth system message handler
     initSystemMessageHandler();
   }
 
@@ -153,12 +155,11 @@ var Connectivity = (function(window, document, undefined) {
   var dataDesc = document.getElementById('data-desc');
 
   function updateCarrier() {
+    // if 'datachange' event happens before init
     if (!_initialized) {
       init();
       return; // init will call updateCarrier()
     }
-
-    var mobileConnection = getMobileConnection();
 
     var setCarrierStatus = function(msg) {
       var operator = msg.operator || '';
@@ -237,15 +238,20 @@ var Connectivity = (function(window, document, undefined) {
    * Bluetooth Manager
    */
 
-  var bluetoothDesc = document.getElementById('bluetooth-desc');
 
   function updateBluetooth() {
-    bluetoothDesc.textContent = gBluetooth.enabled ?
+    var bluetoothDesc = document.getElementById('bluetooth-desc');
+    // if 'adapteradd' or 'disabled' event happens before init
+    if (!_initialized) {
+      init();
+      return; // init will call updateBluetooth()
+    }
+    bluetoothDesc.textContent = bluetooth.enabled ?
       _('bt-status-nopaired') : _('bt-status-turnoff');
-    if (!gBluetooth.enabled) {
+    if (!bluetooth.enabled) {
       return;
     }
-    var req = gBluetooth.getDefaultAdapter();
+    var req = bluetooth.getDefaultAdapter();
     req.onsuccess = function bt_getAdapterSuccess() {
       var defaultAdapter = req.result;
       var reqPaired = defaultAdapter.getPairedDevices();
@@ -269,6 +275,7 @@ var Connectivity = (function(window, document, undefined) {
   }
 
   function initSystemMessageHandler() {
+    // XXX this is not a good way to interact with bluetooth.js
     var handlePairingRequest = function(message, method) {
       window.location.hash = '#bluetooth';
       setTimeout(function() {
@@ -305,14 +312,6 @@ var Connectivity = (function(window, document, undefined) {
     updateWifi: updateWifi,
     updateCarrier: updateCarrier,
     updateBluetooth: updateBluetooth,
-    get statusText() {
-      return {
-        wifi: document.getElementById('wifi-desc').textContent,
-        carrier: document.getElementById('data-desc').textContent,
-        hotspot: document.getElementById('hotspot-desc').textContent,
-        bluetooth: document.getElementById('bluetooth-desc').textContent
-      };
-    },
     set wifiEnabled(listener) { wifiEnabledListeners.push(listener) },
     set wifiDisabled(listener) { wifiDisabledListeners.push(listener); },
     set wifiStatusChange(listener) { wifiStatusChangeListeners.push(listener); }

--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -361,6 +361,20 @@ var getMobileConnection = function() {
   };
 };
 
+var getBluetooth = function() {
+  var navigator = window.navigator;
+  if ('mozBluetooth' in navigator)
+    return navigator.mozBluetooth;
+  return {
+    enabled: false,
+    addEventListener: function(type, callback, bubble) {},
+    onenabled: function(event) {},
+    onadapteradded: function(event) {},
+    ondisabled: function(event) {},
+    getDefaultAdapter: function() {}
+  };
+};
+
 // create a fake mozWifiManager if required (e.g. desktop browser)
 var getWifiManager = function() {
   var navigator = window.navigator;

--- a/apps/settings/style/onpair.css
+++ b/apps/settings/style/onpair.css
@@ -34,6 +34,7 @@ html {
 }
 
 .bluetooth-default {
-  background-image: -moz-image-rect(url(images/icons_sprite.png), 0, 150, 30, 120);
+  /* https://bugzilla.mozilla.org/show_bug.cgi?id=853693 */
+  /* need a transparent background of icons_sprite.gif */
 }
 


### PR DESCRIPTION
when bluetooth.js is loaded before connectivity.js, the hook will be overwritten. we should avoid using event hook but registering event listener instead.
