### PR TITLE
Bug 855175 - [Contacts] Add contact: After clicked an input field and switched to the Lable page directly, the keyboard did not hide.

### DIFF
--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -81,7 +81,8 @@
     "audio-channel-telephony":{},
     "audio-channel-ringer":{},
     "browser":{},
-    "idle":{}
+    "idle":{},
+    "keyboard": {}
   },
   "orientation": "portrait-primary",
   "activities": {


### PR DESCRIPTION
We used the mozKeyboard API to remove the focus in the goToSelectTag function.
See the code:
https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/js/contacts.js#L404

But we didn't defined the keyboard permission in the manifest.webapp.
See the code:
https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/manifest.webapp#L69

We need to define a keyboard permission in the manifest.webapp for using the mozKeyboard API.
