### PR TITLE
Bug 855212 - [Contacts] Search: The search function cannot be launched when user triggers it at the first time.

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -56,6 +56,9 @@ contacts.List = (function() {
   };
 
   var initSearch = function initSearch(callback) {
+    contacts.Search.init(conctactsListView, favoriteGroup, function(e) {
+      onClickHandler(e);
+    });
     if (!loaded) {
       window.addEventListener('listRendered', function onRendered() {
         window.removeEventListener('listRendered', onRendered);
@@ -64,9 +67,6 @@ contacts.List = (function() {
     } else if (!searchLoaded) {
       lazyLoadSearch();
     }
-    contacts.Search.init(conctactsListView, favoriteGroup, function(e) {
-      onClickHandler(e);
-    });
     if (callback)
       callback();
   };


### PR DESCRIPTION
The initSearch function threw error.

Because the searchBox variable was used before it was defined.

We should define the searchBox variable before use it.
