### PR TITLE
Bug 851692 - clock on homescreen is out of date from when screen turned ...

### DIFF
--- a/apps/homescreen/js/landing.js
+++ b/apps/homescreen/js/landing.js
@@ -29,6 +29,12 @@ const LandingPage = (function() {
     evt.stopImmediatePropagation();
   });
 
+  document.addEventListener('mozvisibilitychange', function mozVisChange() {
+    if (document.mozHidden === false) {
+      initTime();
+    }
+  });
+
   function initTime() {
     var date = updateUI();
     setTimeout(function setUpdateInterval() {


### PR DESCRIPTION
...on until next minute ticks (or a little sooner)
