### PR TITLE
Bug 855369 Added link to MDN to supplement the wiki link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and talk to us on IRC:
 
 See INSTALL file in B2G repository for instructions on building and running B2G. To try out Gaia on desktop, see
 
+  https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Building_and_installing_Firefox_OS
   https://wiki.mozilla.org/Gaia/Hacking
 
 # Installing on different devices resolution


### PR DESCRIPTION
The MDN page has better and more detailed information on getting B2G and Gaia running on the desktop so I added a link to it's landing page. 
