### PR TITLE
Bug 854413 - [MMS][SMS] Move all DOM element property initialization into init methods and rationalize variable names and ids r=julienw

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -49,17 +49,17 @@
             <a href="#new" id="icon-add">
               <span class="icon icon-compose"></span>
             </a>
-            <a href="#edit" id="icon-edit-threads">
+            <a href="#edit" id="threads-edit-icon">
               <span class="icon icon-edit"></span>
             </a>
           </menu>
           <h1 data-l10n-id="messages">Messages</h1>
         </header>
-        <article id="thread-list-container" class="view-body" data-type="list">
+        <article id="threads-container" class="view-body" data-type="list">
         </article>
-        <div id="threads-container" class="fixed-title"></div>
+        <div id="threads-header-container" class="fixed-title"></div>
 
-        <div id="no-messages" class="hide">
+        <div id="threads-no-messages" class="hide">
           <div id="no-result-message">
             <p data-l10n-id="noMessages-title">No messages</p>
             <p data-l10n-id="noMessages-text">Start communicating now</p>
@@ -76,14 +76,14 @@
               <menu type="toolbar">
                 <button id="threads-delete-button" data-l10n-id="delete">delete</button>
               </menu>
-              <h1 id="list-edit-title" data-l10n-id="editMode">Edit mode</h1>
+              <h1 id="threads-edit-mode" data-l10n-id="editMode">Edit mode</h1>
             </header>
           </section>
           <menu>
-            <button id="deselect-all-threads" class="edit-button disabled" data-l10n-id="deselect-all">
+            <button id="threads-uncheck-all-button" class="edit-button disabled" data-l10n-id="deselect-all">
               None
             </button>
-            <button id="select-all-threads" class="edit-button" data-l10n-id="select-all">
+            <button id="threads-check-all-button" class="edit-button" data-l10n-id="select-all">
               All
             </button>
           </menu>
@@ -92,21 +92,21 @@
 
       <section id="thread-messages" class="panel" role="region">
         <header class="view-header regular-header">
-          <a role="link" id="go-to-threadlist">
+          <a role="link" id="messages-back-button">
             <span class="icon icon-back"></span>
           </a>
           <menu type="toolbar">
-            <a id="icon-contact">
+            <a id="messages-contact-pick-button">
               <span class="icon icon-user"></span>
             </a>
             <a href="#edit" id="icon-edit">
               <span class="icon icon-edit"></span>
             </a>
           </menu>
-          <h1 id="header-text" data-l10n-id="messages" aria-hidden="true">Messages</h1>
+          <h1 id="messages-header-text" data-l10n-id="messages" aria-hidden="true">Messages</h1>
           <form id="messages-tel-form">
-            <input id="receiver-input" type="text" name="tel" class="tel" />
-            <span id="clear-search" role="button" class="icon icon-clear"></span>
+            <input id="messages-recipient" type="text" name="tel" class="tel" />
+            <span id="messages-clear-button" role="button" class="icon icon-clear"></span>
           </form>
         </header>
         <div id="contact-carrier" data-l10n-id="carrier-unknown" class="carrier-wrapper">
@@ -114,15 +114,15 @@
         </div>
         <article id="messages-container" class="view-body" data-type="list">
         </article>
-        <article id="no-results-returned" class="view-body hide" data-type="list">
+        <article id="messages-no-results" class="view-body hide" data-type="list">
           <ul>
             <li><a><p data-l10n-id="no-results">No results returned</p></a></li>
           </ul>
         </article>
-        <form role="search" id="new-sms-form" class="bottom new-sms-form">
-          <button id="send-message" disabled data-l10n-id="send" type="submit">Send</button>
+        <form role="search" id="messages-compose-form" class="bottom messages-compose-form">
+          <button id="messages-send-button" disabled data-l10n-id="send" type="submit">Send</button>
           <p>
-            <textarea type="text" id="message-to-send" name="message-to-send" placeholder="Message" data-l10n-id="composeMessage"></textarea>
+            <textarea type="text" id="messages-input" name="messages-input" placeholder="Message" data-l10n-id="composeMessage"></textarea>
           </p>
         </form>
         <form role="dialog" id="messages-edit-form" role="dialog" data-type="edit" >
@@ -132,16 +132,16 @@
                 <span data-l10n-id="cancel" class="icon icon-close">close</span>
               </button>
               <menu type="toolbar">
-                <button id="messages-delete-button"  data-l10n-id="delete">delete</button>
+                <button id="messages-delete-button" data-l10n-id="delete">delete</button>
               </menu>
-              <h1 id="messages-edit-title" data-l10n-id="editMode">Edit mode</h1>
+              <h1 id="messages-edit-mode" data-l10n-id="editMode">Edit mode</h1>
             </header>
           </section>
           <menu>
-            <button id="deselect-all-messages" class="edit-button disabled" data-l10n-id="deselect-all">
+            <button id="messages-uncheck-all-button" class="edit-button disabled" data-l10n-id="deselect-all">
               None
             </button>
-            <button id="select-all-messages" class="edit-button" data-l10n-id="select-all">
+            <button id="messages-check-all-button" class="edit-button" data-l10n-id="select-all">
               All
             </button>
           </menu>

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -21,7 +21,7 @@ var MessageManager = {
     window.addEventListener('hashchange', this.onHashChange.bind(this));
     document.addEventListener('mozvisibilitychange',
                               this.onVisibilityChange.bind(this));
-    this.fullHeight = ThreadListUI.view.offsetHeight;
+
     // Callback if needed
     if (callback && typeof callback === 'function') {
       callback();
@@ -82,7 +82,7 @@ var MessageManager = {
       Utils.updateTimeHeaders();
     } else {
       var threadMockup = this.createThreadMockup(message);
-      if (ThreadListUI.view.getElementsByTagName('ul').length === 0) {
+      if (ThreadListUI.container.getElementsByTagName('ul').length === 0) {
         ThreadListUI.renderThreads([threadMockup]);
       } else {
         var num = threadMockup.senderOrReceiver;
@@ -102,8 +102,8 @@ var MessageManager = {
             // If it's the last one we should remove the container
             var oldThreadContainer = previousThread.parentNode;
             var oldHeaderContainer = oldThreadContainer.previousSibling;
-            ThreadListUI.view.removeChild(oldThreadContainer);
-            ThreadListUI.view.removeChild(oldHeaderContainer);
+            ThreadListUI.container.removeChild(oldThreadContainer);
+            ThreadListUI.container.removeChild(oldHeaderContainer);
           } else {
             var threadsContainerID = 'threadsContainer_' +
                               Utils.getDayDate(threadMockup.timestamp);
@@ -155,10 +155,10 @@ var MessageManager = {
     var threadMessages = document.getElementById('thread-messages');
     switch (window.location.hash) {
       case '#new':
-        var messageInput = document.getElementById('message-to-send');
-        var receiverInput = document.getElementById('receiver-input');
+        var input = document.getElementById('messages-input');
+        var receiverInput = document.getElementById('messages-recipient');
         //Keep the  visible button the :last-child
-        var contactButton = document.getElementById('icon-contact');
+        var contactButton = document.getElementById('messages-contact-pick-button');
         contactButton.parentNode.appendChild(contactButton);
         document.getElementById('messages-container').innerHTML = '';
         ThreadUI.cleanFields();
@@ -190,7 +190,7 @@ var MessageManager = {
           });
         } else {
           MessageManager.slide(function() {
-            ThreadUI.view.innerHTML = '';
+            ThreadUI.container.innerHTML = '';
             if (MessageManager.activityTarget) {
               window.location.hash =
                 '#num=' + MessageManager.activityTarget;
@@ -209,7 +209,7 @@ var MessageManager = {
         var num = this.getNumFromHash();
         if (num) {
           var filter = this.createFilter(num);
-          var messageInput = document.getElementById('message-to-send');
+          var input = document.getElementById('messages-input');
           MessageManager.currentNum = num;
           if (mainWrapper.classList.contains('edit')) {
             mainWrapper.classList.remove('edit');
@@ -358,5 +358,3 @@ var MessageManager = {
     };
   }
 };
-
-

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -4,40 +4,6 @@
 'use strict';
 
 var ThreadListUI = {
-  get view() {
-    delete this.view;
-    return this.view = document.getElementById('thread-list-container');
-  },
-  get selectAllButton() {
-    delete this.selectAllButton;
-    return this.selectAllButton = document.getElementById('select-all-threads');
-  },
-  get deselectAllButton() {
-    delete this.deselectAllButton;
-    return this.deselectAllButton =
-                                document.getElementById('deselect-all-threads');
-  },
-  get deleteButton() {
-    delete this.deleteButton;
-    return this.deleteButton = document.getElementById('threads-delete-button');
-  },
-  get cancelButton() {
-    delete this.cancelButton;
-    return this.cancelButton = document.getElementById('threads-cancel-button');
-  },
-  get iconEdit() {
-    delete this.iconEdit;
-    return this.iconEdit = document.getElementById('icon-edit-threads');
-  },
-  get pageHeader() {
-    delete this.pageHeader;
-    return this.pageHeader = document.getElementById('list-edit-title');
-  },
-  get editForm() {
-    delete this.editForm;
-    return this.editForm = document.getElementById('threads-edit-form');
-  },
-
   // Used to track the current number of rendered
   // threads. Updated in ThreadListUI.renderThreads
   count: 0,
@@ -46,21 +12,42 @@ var ThreadListUI = {
     var _ = navigator.mozL10n.get;
 
     // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=854413
-    ['threads-container', 'no-messages'].forEach(function(id) {
-      this[Utils.camelCase(id)] = document.getElementById(id);
+    [
+      'container', 'no-messages',
+      'check-all-button', 'uncheck-all-button',
+      'delete-button', 'cancel-button',
+      'edit-icon', 'edit-mode', 'edit-form'
+    ].forEach(function(id) {
+      this[Utils.camelCase(id)] = document.getElementById('threads-' + id);
     }, this);
 
     this.delNumList = [];
-    this.selectedInputList = [];
-    this.selectAllButton.addEventListener('click',
-                                          this.selectAllThreads.bind(this));
-    this.deselectAllButton.addEventListener('click',
-                                            this.deselectAllThreads.bind(this));
-    this.deleteButton.addEventListener('click',
-                                       this.executeDeletion.bind(this));
-    this.cancelButton.addEventListener('click', this.cancelEditMode.bind(this));
-    this.view.addEventListener('click', this);
-    this.editForm.addEventListener('submit', this);
+    this.selectedInputs = [];
+    this.fullHeight = this.container.offsetHeight;
+
+    this.checkAllButton.addEventListener(
+      'click', this.toggleCheckedAll.bind(this, true)
+    );
+
+    this.uncheckAllButton.addEventListener(
+      'click', this.toggleCheckedAll.bind(this, false)
+    );
+
+    this.deleteButton.addEventListener(
+      'click', this.delete.bind(this)
+    );
+
+    this.cancelButton.addEventListener(
+      'click', this.cancelEditMode.bind(this)
+    );
+
+    this.container.addEventListener(
+      'click', this
+    );
+
+    this.editForm.addEventListener(
+      'submit', this
+    );
   },
 
   updateThreadWithContact:
@@ -117,35 +104,35 @@ var ThreadListUI = {
 
   clickInput: function thlui_clickInput(target) {
     if (target.checked) {
-      ThreadListUI.selectedInputList.push(target);
+      ThreadListUI.selectedInputs.push(target);
     } else {
-      ThreadListUI.selectedInputList.splice(
-        ThreadListUI.selectedInputList.indexOf(target), 1);
+      ThreadListUI.selectedInputs.splice(
+        ThreadListUI.selectedInputs.indexOf(target), 1);
     }
   },
 
   checkInputs: function thlui_checkInputs() {
     var _ = navigator.mozL10n.get;
-    var selected = ThreadListUI.selectedInputList.length;
+    var selected = ThreadListUI.selectedInputs.length;
 
     if (selected === ThreadListUI.count) {
-      ThreadListUI.selectAllButton.classList.add('disabled');
+      this.checkAllButton.classList.add('disabled');
     } else {
-      ThreadListUI.selectAllButton.classList.remove('disabled');
+      this.checkAllButton.classList.remove('disabled');
     }
     if (selected) {
-      ThreadListUI.deselectAllButton.classList.remove('disabled');
-      ThreadListUI.deleteButton.classList.remove('disabled');
-      this.pageHeader.innerHTML = _('selected', {n: selected});
+      this.uncheckAllButton.classList.remove('disabled');
+      this.deleteButton.classList.remove('disabled');
+      this.editMode.innerHTML = _('selected', {n: selected});
     } else {
-      ThreadListUI.deselectAllButton.classList.add('disabled');
-      ThreadListUI.deleteButton.classList.add('disabled');
-      this.pageHeader.innerHTML = _('editMode');
+      this.uncheckAllButton.classList.add('disabled');
+      this.deleteButton.classList.add('disabled');
+      this.editMode.innerHTML = _('editMode');
     }
   },
 
   cleanForm: function thlui_cleanForm() {
-    var inputs = this.view.querySelectorAll(
+    var inputs = this.container.querySelectorAll(
       'input[type="checkbox"]'
     );
     var length = inputs.length;
@@ -154,40 +141,32 @@ var ThreadListUI = {
       inputs[i].parentNode.parentNode.classList.remove('undo-candidate');
     }
     this.delNumList = [];
-    this.selectedInputList = [];
-    this.pageHeader.textContent = navigator.mozL10n.get('editMode');
+    this.selectedInputs = [];
+    this.editMode.textContent = navigator.mozL10n.get('editMode');
     this.checkInputs();
   },
 
-  selectAllThreads: function thlui_selectAllThreads() {
-    var inputs = this.view.querySelectorAll(
-      'input[type="checkbox"]:not(:checked)'
+  toggleCheckedAll: function thlui_select(value) {
+    var inputs = this.container.querySelectorAll(
+      'input[type="checkbox"]' +
+      // value ?
+      //   true : query for currently unselected threads
+      //   false: query for currently selected threads
+      (value ? ':not(:checked)' : ':checked')
     );
     var length = inputs.length;
     for (var i = 0; i < length; i++) {
-      inputs[i].checked = true;
-      ThreadListUI.clickInput(inputs[i]);
+      inputs[i].checked = value;
+      this.clickInput(inputs[i]);
     }
-    ThreadListUI.checkInputs();
+    this.checkInputs();
   },
 
-  deselectAllThreads: function thlui_deselectAllThreads() {
-    var inputs = this.view.querySelectorAll(
-      'input[type="checkbox"]:checked'
-    );
-    var length = inputs.length;
-    for (var i = 0; i < length; i++) {
-      inputs[i].checked = false;
-      ThreadListUI.clickInput(inputs[i]);
-    }
-    ThreadListUI.checkInputs();
-  },
-
-  executeDeletion: function thlui_executeDeletion() {
+  delete: function thlui_delete() {
     var question = navigator.mozL10n.get('deleteThreads-confirmation2');
     if (confirm(question)) {
       WaitingScreen.show();
-      var inputs = ThreadListUI.selectedInputList;
+      var inputs = this.selectedInputs;
       var nums = inputs.map(function(input) {
         return input.value;
       });
@@ -223,20 +202,20 @@ var ThreadListUI = {
     // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=854417
     // Refactor the rendering method: do not empty the entire
     // list on every render.
-    ThreadListUI.view.innerHTML = '';
+    ThreadListUI.container.innerHTML = '';
     ThreadListUI.count = threads.length;
 
     if (threads.length) {
       // There are messages to display.
-      //  1. Add the "hide" class to the no-messages display
+      //  1. Add the "hide" class to the threads-no-messages display
       //  2. Remove the "hide" class from the view
       //
       ThreadListUI.noMessages.classList.add('hide');
-      ThreadListUI.view.classList.remove('hide');
-      ThreadListUI.iconEdit.classList.remove('disabled');
+      ThreadListUI.container.classList.remove('hide');
+      ThreadListUI.editIcon.classList.remove('disabled');
 
-      FixedHeader.init('#thread-list-container',
-                       '#threads-container',
+      FixedHeader.init('#threads-container',
+                       '#threads-header-container',
                        'header');
       // Edit mode available
 
@@ -267,12 +246,12 @@ var ThreadListUI = {
       });
     } else {
       // There are no messages to display.
-      //  1. Remove the "hide" class from no-messages display
+      //  1. Remove the "hide" class from threads-no-messages display
       //  2. Add the "hide" class to the view
       //
       ThreadListUI.noMessages.classList.remove('hide');
-      ThreadListUI.view.classList.add('hide');
-      ThreadListUI.iconEdit.classList.add('disabled');
+      ThreadListUI.container.classList.add('hide');
+      ThreadListUI.editIcon.classList.add('disabled');
 
       // Callback if exist
       if (renderCallback) {
@@ -320,17 +299,17 @@ var ThreadListUI = {
   insertThreadContainer:
     function thlui_insertThreadContainer(fragment, timestamp) {
     // We look for placing the group in the right place.
-    var headers = ThreadListUI.view.getElementsByTagName('header');
+    var headers = ThreadListUI.container.getElementsByTagName('header');
     var groupFound = false;
     for (var i = 0; i < headers.length; i++) {
       if (timestamp >= headers[i].dataset.time) {
         groupFound = true;
-        ThreadListUI.view.insertBefore(fragment, headers[i]);
+        ThreadListUI.container.insertBefore(fragment, headers[i]);
         break;
       }
     }
     if (!groupFound) {
-      ThreadListUI.view.appendChild(fragment);
+      ThreadListUI.container.appendChild(fragment);
     }
   },
   appendThread: function thlui_appendThread(thread) {
@@ -395,7 +374,7 @@ var ThreadListUI = {
   // Method for updating all contact info after creating a contact
   updateContactsInfo: function mm_updateContactsInfo() {
     // Retrieve all 'li' elements and getting the phone numbers
-    var threads = ThreadListUI.view.getElementsByTagName('li');
+    var threads = ThreadListUI.container.getElementsByTagName('li');
     for (var i = 0; i < threads.length; i++) {
       var thread = threads[i];
       var num = thread.id.replace('thread_', '');

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -7,148 +7,121 @@ var ThreadUI = {
   // Time buffer for the 'last-messages' set. In this case 10 min
   LAST_MESSSAGES_BUFFERING_TIME: 10 * 60 * 1000,
   CHUNK_SIZE: 10,
-  get view() {
-    delete this.view;
-    return this.view = document.getElementById('messages-container');
-  },
-
-  get contactInput() {
-    delete this.contactInput;
-    return this.contactInput = document.getElementById('receiver-input');
-  },
-
-  get backButton() {
-    delete this.backButton;
-    return this.backButton = document.getElementById('go-to-threadlist');
-  },
-
-  get clearButton() {
-    delete this.clearButton;
-    return this.clearButton = document.getElementById('clear-search');
-  },
-
-  get title() {
-    delete this.title;
-    return this.title = document.getElementById('header-text');
-  },
-
-  get input() {
-    delete this.input;
-    return this.input = document.getElementById('message-to-send');
-  },
-
-  get sendButton() {
-    delete this.sendButton;
-    return this.sendButton = document.getElementById('send-message');
-  },
-
-  get pickButton() {
-    delete this.pickButton;
-    return this.pickButton = document.getElementById('icon-contact');
-  },
-
-  get selectAllButton() {
-    delete this.deleteAllButton;
-    return this.deleteAllButton =
-                                document.getElementById('select-all-messages');
-  },
-
-  get deselectAllButton() {
-    delete this.deselectAllButton;
-    return this.deselectAllButton =
-                              document.getElementById('deselect-all-messages');
-  },
-
-  get deleteButton() {
-    delete this.doneButton;
-    return this.doneButton = document.getElementById('messages-delete-button');
-  },
-
-  get cancelButton() {
-    delete this.cancelButton;
-    return this.cancelButton =
-                              document.getElementById('messages-cancel-button');
-  },
-
-  get pageHeader() {
-    delete this.pageHeader;
-    return this.pageHeader = document.getElementById('messages-edit-title');
-  },
-
-  get editForm() {
-    delete this.editForm;
-    return this.editForm = document.getElementById('messages-edit-form');
-  },
-
-  get telForm() {
-    delete this.telForm;
-    return this.telForm = document.getElementById('messages-tel-form');
-  },
-
-  get sendForm() {
-    delete this.sendForm;
-    return this.sendForm = document.getElementById('new-sms-form');
-  },
 
   init: function thui_init() {
     var _ = navigator.mozL10n.get;
 
-    // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=854413
-    ['no-results-returned'].forEach(function(id) {
-      this[Utils.camelCase(id)] = document.getElementById(id);
+    [
+      'container', 'no-results',
+      'header-text', 'recipient', 'input', 'compose-form',
+      'check-all-button', 'uncheck-all-button',
+      'contact-pick-button', 'back-button', 'clear-button', 'send-button',
+      'delete-button', 'cancel-button',
+      'edit-mode', 'edit-form', 'tel-form'
+    ].forEach(function(id) {
+      this[Utils.camelCase(id)] = document.getElementById('messages-' + id);
     }, this);
 
-    this.sendButton.addEventListener('click', this.sendMessage.bind(this));
     // Allow for stubbing in environments that do not implement the
     // `navigator.mozSms` API
     this._mozSms = navigator.mozSms || window.MockNavigatormozSms;
 
     // Prevent sendbutton to hide the keyboard:
-    this.sendButton.addEventListener('mousedown',
-      function btnDown(event) {
+    this.sendButton.addEventListener(
+      'mousedown', function mouseDown(event) {
         event.preventDefault();
         event.target.classList.add('active');
       }
     );
-    this.sendButton.addEventListener('mouseup',
-      function btnUp(event) {
+
+    this.sendButton.addEventListener(
+      'mouseup', function mouseUp(event) {
         event.target.classList.remove('active');
       }
     );
-    this.sendButton.addEventListener('mouseout',
-      function mouseOut(event) {
+
+    this.sendButton.addEventListener(
+      'mouseout', function mouseOut(event) {
         event.target.classList.remove('active');
       }
     );
-    this.backButton.addEventListener('click',
-      this.onBackAction.bind(this));
-    this.pickButton.addEventListener('click', this.pickContact.bind(this));
-    this.selectAllButton.addEventListener('click',
-      this.selectAllMessages.bind(this));
-    this.deselectAllButton.addEventListener('click',
-      this.deselectAllMessages.bind(this));
-    this.cancelButton.addEventListener('click', this.cancelEditMode.bind(this));
-    this.input.addEventListener('input', this.updateInputHeight.bind(this));
-    this.input.addEventListener('input', this.enableSend.bind(this));
-    this.contactInput.addEventListener('input', this.searchContact.bind(this));
-    this.contactInput.addEventListener('input', this.enableSend.bind(this));
-    this.deleteButton.addEventListener('click',
-                                       this.executeDeletion.bind(this));
-    this.title.addEventListener('click', this.activateContact.bind(this));
-    this.clearButton.addEventListener('click', this.clearContact.bind(this));
-    this.view.addEventListener('click', this);
-    this.view.addEventListener('contextmenu', this);
-    this.editForm.addEventListener('submit', this);
-    this.telForm.addEventListener('submit', this);
-    this.sendForm.addEventListener('submit', this);
+
+    this.sendButton.addEventListener(
+      'click', this.sendMessage.bind(this)
+    );
+
+    this.container.addEventListener(
+      'scroll', this.manageScroll.bind(this)
+    );
+
+    this.backButton.addEventListener(
+      'click', this.back.bind(this)
+    );
+
+    this.contactPickButton.addEventListener(
+      'click', this.pick.bind(this)
+    );
+
+    this.checkAllButton.addEventListener(
+      'click', this.toggleCheckedAll.bind(this, true)
+    );
+
+    this.uncheckAllButton.addEventListener(
+      'click', this.toggleCheckedAll.bind(this, false)
+    );
+
+    this.cancelButton.addEventListener(
+      'click', this.cancelEdit.bind(this)
+    );
+
+    this.deleteButton.addEventListener(
+      'click', this.delete.bind(this)
+    );
+
+    this.headerText.addEventListener(
+      'click', this.activateContact.bind(this)
+    );
+
+    this.clearButton.addEventListener(
+      'click', this.clear.bind(this)
+    );
+
+    this.input.addEventListener(
+      'input', function() {
+        this.updateInputHeight();
+        this.enableSend();
+      }.bind(this)
+    );
+
+    this.recipient.addEventListener(
+      'input', function() {
+        this.searchContact();
+        this.enableSend();
+      }.bind(this)
+    );
+
+    // Delegate to |this.handleEvent|
+    this.container.addEventListener(
+      'click', this
+    );
+    this.container.addEventListener(
+      'contextmenu', this
+    );
+    this.editForm.addEventListener(
+      'submit', this
+    );
+    this.telForm.addEventListener(
+      'submit', this
+    );
+    this.composeForm.addEventListener(
+      'submit', this
+    );
+
 
     Utils.startTimeHeaderScheduler();
 
     // Initialized here, but used in ThreadUI.cleanFields
     this.previousHash = null;
-
-    // We add the infinite scroll effect for increasing performance
-    this.view.addEventListener('scroll', this.manageScroll.bind(this));
   },
 
   initSentAudio: function() {
@@ -177,29 +150,29 @@ var ThreadUI = {
   manageScroll: function thui_manageScroll(oEvent) {
     // kEdge will be the limit (in pixels) for showing the next chunk
     var kEdge = 30;
-    var currentScroll = this.view.scrollTop;
+    var currentScroll = this.container.scrollTop;
     if (currentScroll < kEdge) {
-      var previous = this.view.scrollHeight;
+      var previous = this.container.scrollHeight;
       this.showChunkOfMessages(this.CHUNK_SIZE);
       // We update the scroll to the previous position
       // taking into account the previous offset to top
       // and the current height due to we have added a new
       // chunk of visible messages
-      this.view.scrollTop =
-        (this.view.scrollHeight - previous) + currentScroll;
+      this.container.scrollTop =
+        (this.container.scrollHeight - previous) + currentScroll;
     }
   },
   setInputMaxHeight: function thui_setInputMaxHeight() {
     // Method for initializing the maximum height
     var fontSize = Utils.getFontSize();
-    var viewHeight = this.view.offsetHeight / fontSize;
+    var viewHeight = this.container.offsetHeight / fontSize;
     var inputHeight = this.input.offsetHeight / fontSize;
     var barHeight =
-      document.getElementById('new-sms-form').offsetHeight / fontSize;
+      document.getElementById('messages-compose-form').offsetHeight / fontSize;
     var adjustment = barHeight - inputHeight;
     this.input.style.maxHeight = (viewHeight - adjustment) + 'rem';
   },
-  onBackAction: function thui_onBackAction() {
+  back: function thui_back() {
     var goBack = function() {
       ThreadUI.stopRendering();
       if (ThreadUI.input.value.length == 0) {
@@ -213,7 +186,9 @@ var ThreadUI = {
     };
 
     // We're waiting for the keyboard to disappear before animating back
-    if (MessageManager.fullHeight !== this.view.offsetHeight) {
+    if (ThreadListUI.fullHeight !==
+        this.container.offsetHeight) {
+
       window.addEventListener('resize', function keyboardHidden() {
         window.removeEventListener('resize', keyboardHidden);
         goBack();
@@ -228,7 +203,7 @@ var ThreadUI = {
     if (this.input.value.length) {
       this.updateCounter();
     }
-    if (window.location.hash == '#new' && !this.contactInput.value.length) {
+    if (window.location.hash == '#new' && !this.recipient.value.length) {
       this.sendButton.disabled = true;
       return;
     }
@@ -237,7 +212,7 @@ var ThreadUI = {
   },
 
   scrollViewToBottom: function thui_scrollViewToBottom() {
-    this.view.scrollTop = this.view.scrollHeight;
+    this.container.scrollTop = this.container.scrollHeight;
   },
 
   updateCounter: function thui_updateCount(evt) {
@@ -273,7 +248,7 @@ var ThreadUI = {
     var buttonHeight = 30;
 
     // Retrieve elements useful in growing method
-    var bottomBar = document.getElementById('new-sms-form');
+    var bottomBar = document.getElementById('messages-compose-form');
 
     // Updating the height if scroll is bigger that height
     // This is when we have reached the header (UX requirement)
@@ -313,7 +288,7 @@ var ThreadUI = {
     this.sendButton.style.marginTop = buttonOffset;
 
     // Last adjustment to view taking into account the new height of the bar
-    this.view.style.bottom = bottomBarHeight;
+    this.container.style.bottom = bottomBarHeight;
     this.scrollViewToBottom();
   },
   // Adds a new grouping header if necessary (today, tomorrow, ...)
@@ -365,14 +340,14 @@ var ThreadUI = {
     // Where do I have to append the Container?
     // If is the first block or is the 'last-messages' one should be the
     // most recent one.
-    if (isLastMessagesBlock || !ThreadUI.view.firstElementChild) {
-      ThreadUI.view.appendChild(header);
-      ThreadUI.view.appendChild(messageContainer);
+    if (isLastMessagesBlock || !ThreadUI.container.firstElementChild) {
+      ThreadUI.container.appendChild(header);
+      ThreadUI.container.appendChild(messageContainer);
       return messageContainer;
     }
     // In other case we have to look for the right place for appending
     // the message
-    var messageContainers = ThreadUI.view.getElementsByTagName('ul');
+    var messageContainers = ThreadUI.container.getElementsByTagName('ul');
     var insertBeforeContainer;
     for (var i = 0, l = messageContainers.length; i < l; i++) {
       if (normalizedTimestamp < messageContainers[i].dataset.timestamp) {
@@ -386,12 +361,12 @@ var ThreadUI = {
     }
     // Finally we append the container & header in the right position
     if (insertBeforeContainer) {
-      ThreadUI.view.insertBefore(messageContainer,
+      ThreadUI.container.insertBefore(messageContainer,
         insertBeforeContainer.previousSibling);
-      ThreadUI.view.insertBefore(header, messageContainer);
+      ThreadUI.container.insertBefore(header, messageContainer);
     } else {
-      ThreadUI.view.appendChild(header);
-      ThreadUI.view.appendChild(messageContainer);
+      ThreadUI.container.appendChild(header);
+      ThreadUI.container.appendChild(messageContainer);
     }
     return messageContainer;
   },
@@ -412,7 +387,7 @@ var ThreadUI = {
     }
 
     // Add data to contact activity interaction
-    this.title.dataset.phoneNumber = number;
+    this.headerText.dataset.phoneNumber = number;
 
     Contacts.findByString(number, function gotContact(contacts) {
       var carrierTag = document.getElementById('contact-carrier');
@@ -422,10 +397,10 @@ var ThreadUI = {
        *  this mess with the agenda.
        */
       if (contacts.length > 1) {
-        this.title.dataset.isContact = true;
+        this.headerText.dataset.isContact = true;
         var contactName = contacts[0].name[0];
         var numOthers = contacts.length - 1;
-        this.title.textContent = navigator.mozL10n.get('others', {
+        this.headerText.textContent = navigator.mozL10n.get('others', {
           name: contactName,
           n: numOthers
         });
@@ -435,11 +410,11 @@ var ThreadUI = {
                               contacts[0],
                               function returnedDetails(details) {
           if (details.isContact) {
-            this.title.dataset.isContact = true;
+            this.headerText.dataset.isContact = true;
           } else {
-            delete this.title.dataset.isContact;
+            delete this.headerText.dataset.isContact;
           }
-          this.title.textContent = details.title || number;
+          this.headerText.textContent = details.title || number;
           if (details.carrier) {
             carrierTag.textContent = details.carrier;
             carrierTag.classList.remove('hide');
@@ -460,7 +435,7 @@ var ThreadUI = {
     this.cleanFields();
     this.checkInputs();
     // Clean list of messages
-    this.view.innerHTML = '';
+    this.container.innerHTML = '';
     // Update header index
     this.dayHeaderIndex = 0;
     this.timeHeaderIndex = 0;
@@ -613,9 +588,9 @@ var ThreadUI = {
   },
 
   showChunkOfMessages: function thui_showChunkOfMessages(number) {
-    var hiddenElements = ThreadUI.view.getElementsByClassName('hidden');
-    for (var i = hiddenElements.length - 1; i >= 0; i--) {
-      hiddenElements[i].classList.remove('hidden');
+    var elements = ThreadUI.container.getElementsByClassName('hidden');
+    for (var i = elements.length - 1; i >= 0; i--) {
+      elements[i].classList.remove('hidden');
     }
   },
 
@@ -634,7 +609,7 @@ var ThreadUI = {
 
   cleanForm: function thui_cleanForm() {
     // Reset all inputs
-    var inputs = this.view.querySelectorAll('input[type="checkbox"]');
+    var inputs = this.container.querySelectorAll('input[type="checkbox"]');
     for (var i = 0; i < inputs.length; i++) {
       inputs[i].checked = false;
       inputs[i].parentNode.parentNode.classList.remove('undo-candidate');
@@ -643,38 +618,35 @@ var ThreadUI = {
     this.checkInputs();
   },
 
-  clearContact: function thui_clearContact() {
-    this.contactInput.value = '';
-    this.view.innerHTML = '';
+  clear: function thui_clear() {
+    this.recipient.value = '';
+    this.container.innerHTML = '';
   },
 
-  selectAllMessages: function thui_selectAllMessages() {
-    var inputs =
-            this.view.querySelectorAll('input[type="checkbox"]:not(:checked)');
-    for (var i = 0; i < inputs.length; i++) {
-      inputs[i].checked = true;
-      ThreadUI.chooseMessage(inputs[i]);
+  toggleCheckedAll: function thui_select(value) {
+    var inputs = this.container.querySelectorAll(
+      'input[type="checkbox"]' +
+      // value ?
+      //   true : query for currently unselected threads
+      //   false: query for currently selected threads
+      (value ? ':not(:checked)' : ':checked')
+    );
+    var length = inputs.length;
+    for (var i = 0; i < length; i++) {
+      inputs[i].checked = value;
+      this.chooseMessage(inputs[i]);
     }
-    ThreadUI.checkInputs();
+    this.checkInputs();
   },
 
-  deselectAllMessages: function thui_deselectAllMessages() {
-    var inputs =
-            this.view.querySelectorAll('input[type="checkbox"]:checked');
-    for (var i = 0; i < inputs.length; i++) {
-      inputs[i].checked = false;
-      ThreadUI.chooseMessage(inputs[i]);
-    }
-    ThreadUI.checkInputs();
-  },
-
-  executeDeletion: function thui_executeDeletion() {
+  delete: function thui_delete() {
     var question = navigator.mozL10n.get('deleteMessages-confirmation');
     if (confirm(question)) {
       WaitingScreen.show();
       var delNumList = [];
-      var inputs =
-        ThreadUI.view.querySelectorAll('input[type="checkbox"]:checked');
+      var inputs = ThreadUI.container.querySelectorAll(
+        'input[type="checkbox"]:checked'
+      );
       for (var i = 0; i < inputs.length; i++) {
         delNumList.push(+inputs[i].value);
       }
@@ -691,9 +663,9 @@ var ThreadUI = {
             // Is the last message in the container?
             if (messagesContainer.childNodes.length == 1) {
               var header = messagesContainer.previousSibling;
-              ThreadUI.view.removeChild(header);
-              ThreadUI.view.removeChild(messagesContainer);
-              if (!ThreadUI.view.childNodes.length) {
+              ThreadUI.container.removeChild(header);
+              ThreadUI.container.removeChild(messagesContainer);
+              if (!ThreadUI.container.childNodes.length) {
                 var mainWrapper = document.getElementById('main-wrapper');
                 mainWrapper.classList.remove('edit');
                 window.location.hash = '#thread-list';
@@ -716,7 +688,7 @@ var ThreadUI = {
     }
   },
 
-  cancelEditMode: function thlui_cancelEditMode() {
+  cancelEdit: function thlui_cancelEdit() {
     window.history.go(-1);
   },
 
@@ -732,21 +704,25 @@ var ThreadUI = {
 
   checkInputs: function thui_checkInputs() {
     var _ = navigator.mozL10n.get;
-    var selected = this.view.querySelectorAll('input[type="checkbox"]:checked');
-    var allInputs = this.view.querySelectorAll('input[type="checkbox"]');
+    var selected = this.container.querySelectorAll(
+      'input[type="checkbox"]:checked'
+    );
+    var allInputs = this.container.querySelectorAll(
+      'input[type="checkbox"]'
+    );
     if (selected.length == allInputs.length) {
-      ThreadUI.selectAllButton.classList.add('disabled');
+      this.checkAllButton.classList.add('disabled');
     } else {
-      ThreadUI.selectAllButton.classList.remove('disabled');
+      this.checkAllButton.classList.remove('disabled');
     }
     if (selected.length > 0) {
-      ThreadUI.deselectAllButton.classList.remove('disabled');
-      ThreadUI.deleteButton.classList.remove('disabled');
-      this.pageHeader.innerHTML = _('selected', {n: selected.length});
+      this.uncheckAllButton.classList.remove('disabled');
+      this.deleteButton.classList.remove('disabled');
+      this.editMode.innerHTML = _('selected', {n: selected.length});
     } else {
-      ThreadUI.deselectAllButton.classList.add('disabled');
-      ThreadUI.deleteButton.classList.add('disabled');
-      this.pageHeader.innerHTML = _('editMode');
+      this.uncheckAllButton.classList.add('disabled');
+      this.deleteButton.classList.add('disabled');
+      this.editMode.innerHTML = _('editMode');
     }
   },
 
@@ -780,7 +756,7 @@ var ThreadUI = {
       self.input.value = '';
       self.sendButton.disabled = true;
       self.sendButton.dataset.counter = '';
-      self.contactInput.value = '';
+      self.recipient.value = '';
       self.updateInputHeight();
     };
 
@@ -799,8 +775,8 @@ var ThreadUI = {
   sendMessage: function thui_sendMessage(resendText) {
     var num, text;
 
-    this.noResultsReturned.classList.add('hide');
-    this.view.classList.remove('hide');
+    this.noResults.classList.add('hide');
+    this.container.classList.remove('hide');
 
     if (resendText && typeof resendText === 'string') {
       num = MessageManager.currentNum;
@@ -810,7 +786,7 @@ var ThreadUI = {
       var hash = window.location.hash;
       // Depending where we are, we get different num
       if (hash == '#new') {
-        num = this.contactInput.value;
+        num = this.recipient.value;
         if (!num) {
           return;
         }
@@ -908,15 +884,15 @@ var ThreadUI = {
     if (messagesContainer.childNodes.length == 1) {
       // If it is, we remove header & container
       var header = messagesContainer.previousSibling;
-      ThreadUI.view.removeChild(header);
-      ThreadUI.view.removeChild(messagesContainer);
+      ThreadUI.container.removeChild(header);
+      ThreadUI.container.removeChild(messagesContainer);
     } else {
       // If not we only have to remove the message
       messageDOM.parentNode.removeChild(messageDOM);
     }
 
     // Have we more elements in the view?
-    if (!ThreadUI.view.childNodes.length) {
+    if (!ThreadUI.container.childNodes.length) {
       // Update header index
       ThreadUI.dayHeaderIndex = 0;
       ThreadUI.timeHeaderIndex = 0;
@@ -944,7 +920,7 @@ var ThreadUI = {
         var name = Utils.escapeHTML((contact.name[0] || details.title));
         //TODO ask UX if we should use type+carrier or just number
         var number = tels[i].value.toString();
-        var input = self.contactInput.value;
+        var input = self.recipient.value;
         // For name, as long as we do a startsWith on API,
         // we want only to show
         // highlight of the startsWith also
@@ -986,16 +962,16 @@ var ThreadUI = {
       });
     }
 
-    ThreadUI.view.appendChild(contactsContainer);
+    ThreadUI.container.appendChild(contactsContainer);
   },
 
   searchContact: function thui_searchContact() {
-    var input = this.contactInput;
+    var input = this.recipient;
     var string = input.value;
 
     // TODO: Investigate why view.innerHTML is cleared
     // here and later in the results callback
-    this.view.innerHTML = '';
+    this.container.innerHTML = '';
     if (!string) {
       return;
     }
@@ -1005,26 +981,26 @@ var ThreadUI = {
       // !contacts.length matches empty arrays from unmatches filters
       if (!contacts || !contacts.length) {
         // There are no contacts that match the input.
-        //  1. Remove the "hide" class from no-results-returned display
+        //  1. Remove the "hide" class from messages-no-results display
         //  2. Add the "hide" class to the view
         //
-        this.noResultsReturned.classList.remove('hide');
-        this.view.classList.add('hide');
+        this.noResults.classList.remove('hide');
+        this.container.classList.add('hide');
         return;
       }
 
       // There are contacts that match the input.
-      //  1. Add the "hide" class to the no-results-returned display
+      //  1. Add the "hide" class to the messages-no-results display
       //  2. Remove the "hide" class from the view
       //
-      this.noResultsReturned.classList.add('hide');
-      this.view.classList.remove('hide');
+      this.noResults.classList.add('hide');
+      this.container.classList.remove('hide');
 
       contacts.forEach(this.renderContactData.bind(this));
     }.bind(this));
   },
 
-  pickContact: function thui_pickContact() {
+  pick: function thui_pick() {
     try {
       var activity = new MozActivity({
         name: 'pick',
@@ -1045,9 +1021,9 @@ var ThreadUI = {
 
   activateContact: function thui_activateContact() {
     var _ = navigator.mozL10n.get;
-    var phoneNumber = this.title.dataset.phoneNumber;
+    var phoneNumber = this.headerText.dataset.phoneNumber;
     // Call to 'option menu' or 'dialer' depending on existence of contact
-    if (this.title.dataset.isContact == 'true') {
+    if (this.headerText.dataset.isContact == 'true') {
       ActivityPicker.call(phoneNumber);
     } else {
       var options = new OptionMenu({

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -32,7 +32,7 @@ form.bottom[role="search"] {
   z-index: 3;
 }
 
-#receiver-input {
+#messages-recipient {
   padding-right: 3rem;
   font-size: 1.8rem;
 }
@@ -126,16 +126,16 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
   transition: all 0.3s ease;
 }
 
-.edit #thread-list-container[data-type="list"] aside.pack-end {
+.edit #threads-container[data-type="list"] aside.pack-end {
   margin: 0 0 0 -3rem;
 }
 
-.edit #thread-list-container[data-type="list"] aside.pack-end img {
+.edit #threads-container[data-type="list"] aside.pack-end img {
   transform: translateX(7.5rem);
   transition: all 0.3s ease;
 }
 
-.edit #thread-list-container[data-type="list"] aside.pack-end img[src=""] {
+.edit #threads-container[data-type="list"] aside.pack-end img[src=""] {
   width: 6.5rem;
 }
 
@@ -186,12 +186,12 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
   transform: translateX(0%);
 }
 
-#thread-list,#thread-messages {
+#threads-container,#thread-messages {
   z-index: 10;
   background: white;
 }
 
-#icon-contact {
+#messages-contact-pick-button {
   display: none;
 }
 
@@ -203,7 +203,7 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
   transform: translateY(0);
 }
 
-.edit .new-sms-form {
+.edit .messages-compose-form {
   transform: translateY(3.6rem);
 }
 
@@ -211,16 +211,16 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
   transform: translateY(0);
 }
 
-.edit #thread-list-container .item > a {
+.edit #threads-container .item > a {
   transform: translateX(3rem);
   pointer-events: none;
 }
 
-.edit #thread-list-container .item > a.unread .unread-tag {
+.edit #threads-container .item > a.unread .unread-tag {
   opacity: 0;
 }
 
-.edit #thread-list-container .checkbox-container {
+.edit #threads-container .checkbox-container {
   pointer-events:auto;
   opacity: 1;
   transform: translateX(0);
@@ -259,7 +259,7 @@ section[role="region"].new > header:first-child form {
   display: none;
 }
 
-.new #icon-contact {
+.new #messages-contact-pick-button {
   display: block;
 }
 
@@ -451,22 +451,22 @@ section[role="region"].new > header:first-child form {
   Bottom bar for sending SMS
 */
 
-.new-sms-form {
+.messages-compose-form {
   transition: transform .2s ease-in;
 }
 
-form.bottom[role="search"].new-sms-form {
+form.bottom[role="search"].messages-compose-form {
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
 }
 
-#send-message.active {
+#messages-send-button.active {
   background: #008aaa;
 }
 
-#send-message:before {
+#messages-send-button:before {
   content: attr(data-counter);
   color: #666;
   font-weight: normal;
@@ -476,7 +476,7 @@ form.bottom[role="search"].new-sms-form {
   top: -0.2rem;
 }
 
-#message-to-send {
+#messages-input {
   padding: 0.4rem 0.2rem 0.2rem 0.6rem;
   line-height: 1.8rem !important;
   font-size: 1.8rem;
@@ -513,7 +513,7 @@ form.bottom[role="search"].new-sms-form {
   No result container
 */
 
-#no-messages {
+#threads-no-messages {
   background-image: url('images/SMS_200x200_bubble.png');
   background-repeat: no-repeat;
   background-attachment: fixed;

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -79,16 +79,16 @@ suite('SMS App Unit-Test', function() {
     threadListHeader.innerHTML = renderThreadListHeader();
 
     // Thread-list container
-    var threadListContainer = document.createElement('article');
-    threadListContainer.id = 'thread-list-container';
+    var threadsContainer = document.createElement('article');
+    threadsContainer.id = 'threads-container';
 
     // Thread-list fixed-header
-    var fixedHeader = document.createElement('div');
-    fixedHeader.id = 'threads-container';
+    var threadsHeaderContainer = document.createElement('div');
+    threadsHeaderContainer.id = 'threads-header-container';
 
-    // no-messages
+    // threads-no-messages
     var noMessages = document.createElement('div');
-    noMessages.id = 'no-messages';
+    noMessages.id = 'threads-no-messages';
 
     // Thread-list Edit form
     var threadListEditForm = document.createElement('form');
@@ -98,8 +98,8 @@ suite('SMS App Unit-Test', function() {
     threadListEditForm.innerHTML = renderThreadListEdit();
     // Append all elemnts to thread-list view
     threadList.appendChild(threadListHeader);
-    threadList.appendChild(threadListContainer);
-    threadList.appendChild(fixedHeader);
+    threadList.appendChild(threadsContainer);
+    threadList.appendChild(threadsHeaderContainer);
     threadList.appendChild(noMessages);
     threadList.appendChild(threadListEditForm);
 
@@ -129,7 +129,7 @@ suite('SMS App Unit-Test', function() {
 
     // Thread-messages input form
     var threadMsgInputForm = document.createElement('form');
-    threadMsgInputForm.id = 'new-sms-form';
+    threadMsgInputForm.id = 'messages-compose-form';
     threadMsgInputForm.innerHTML = renderThreadMsgInputBar();
 
     threadMessages.appendChild(threadMsgHeader);
@@ -187,12 +187,17 @@ suite('SMS App Unit-Test', function() {
     // Create DOM structure
     createDOM();
 
-    // We render all elements
-    ThreadUI.view.innerHTML = '';
+    // Clear if necessary...
+    if (ThreadUI.container) {
+      ThreadUI.container.innerHTML = '';
+    }
+
+    // ...And render
     ThreadUI.init();
     ThreadListUI.init();
-    window.addEventListener('hashchange',
-      MessageManager.onHashChange.bind(MessageManager));
+    window.addEventListener(
+      'hashchange', MessageManager.onHashChange.bind(MessageManager)
+    );
   });
 
   suiteTeardown(function() {
@@ -216,12 +221,12 @@ suite('SMS App Unit-Test', function() {
         // Check the HTML structure, and if it fits with Building Blocks
 
         // Given our mockup, we should have 4 grous UL/HEADER
-        assertNumberOfElementsInContainerByTag(ThreadListUI.view, 3, 'ul');
-        assertNumberOfElementsInContainerByTag(ThreadListUI.view, 3, 'header');
+        assertNumberOfElementsInContainerByTag(ThreadListUI.container, 3, 'ul');
+        assertNumberOfElementsInContainerByTag(ThreadListUI.container, 3, 'header');
 
         // We know as well that we have, in total, 5 threads
-        assertNumberOfElementsInContainerByTag(ThreadListUI.view, 4, 'li');
-        assertNumberOfElementsInContainerByTag(ThreadListUI.view, 4, 'a');
+        assertNumberOfElementsInContainerByTag(ThreadListUI.container, 4, 'li');
+        assertNumberOfElementsInContainerByTag(ThreadListUI.container, 4, 'a');
 
         // In our mockup we shoul group the threads following day criteria
         // In the second group, we should have 2 threads
@@ -234,7 +239,7 @@ suite('SMS App Unit-Test', function() {
 
       test('Render unread style properly', function() {
         // We know that only one thread is unread
-        assertNumOfElementsByClass(ThreadListUI.view, 1, 'unread');
+        assertNumOfElementsByClass(ThreadListUI.container, 1, 'unread');
       });
 
       test('Update thread with contact info', function() {
@@ -251,21 +256,21 @@ suite('SMS App Unit-Test', function() {
 
       test('Check edit mode form', function() {
         // Do we have all inputs ready?
-        assertNumberOfElementsInContainerByTag(ThreadListUI.view, 4, 'input');
+        assertNumberOfElementsInContainerByTag(ThreadListUI.container, 4, 'input');
       });
 
       test('Select all/Deselect All buttons', function() {
         // Retrieve all inputs
-        var inputs = ThreadListUI.view.getElementsByTagName('input');
+        var inputs = ThreadListUI.container.getElementsByTagName('input');
         // Activate all inputs
         for (var i = inputs.length - 1; i >= 0; i--) {
           inputs[i].checked = true;
           ThreadListUI.clickInput(inputs[i]);
         }
         ThreadListUI.checkInputs();
-        assert.isTrue(document.getElementById('select-all-threads')
+        assert.isTrue(document.getElementById('threads-check-all-button')
           .classList.contains('disabled'));
-        assert.isFalse(document.getElementById('deselect-all-threads')
+        assert.isFalse(document.getElementById('threads-uncheck-all-button')
           .classList.contains('disabled'));
         // Deactivate all inputs
         for (var i = inputs.length - 1; i >= 0; i--) {
@@ -273,23 +278,23 @@ suite('SMS App Unit-Test', function() {
           ThreadListUI.clickInput(inputs[i]);
         }
         ThreadListUI.checkInputs();
-        assert.isFalse(document.getElementById('select-all-threads')
+        assert.isFalse(document.getElementById('threads-check-all-button')
           .classList.contains('disabled'));
-        assert.isTrue(document.getElementById('deselect-all-threads')
+        assert.isTrue(document.getElementById('threads-uncheck-all-button')
           .classList.contains('disabled'));
         // Activate only one
         inputs[0].checked = true;
         ThreadListUI.clickInput(inputs[0]);
         ThreadListUI.checkInputs();
-        assert.isFalse(document.getElementById('select-all-threads')
+        assert.isFalse(document.getElementById('threads-check-all-button')
           .classList.contains('disabled'));
-        assert.isFalse(document.getElementById('deselect-all-threads')
+        assert.isFalse(document.getElementById('threads-uncheck-all-button')
           .classList.contains('disabled'));
       });
     });
 
     teardown(function() {
-      ThreadListUI.view.innerHTML = '';
+      ThreadListUI.container.innerHTML = '';
     });
   });
 
@@ -303,17 +308,17 @@ suite('SMS App Unit-Test', function() {
     suite('Thread-messages rendering (bubbles view)', function() {
       test('Check HTML structure', function() {
         // It should have 3 bubbles
-        assertNumberOfElementsInContainerByTag(ThreadUI.view, 5, 'li');
+        assertNumberOfElementsInContainerByTag(ThreadUI.container, 5, 'li');
         // Grouped in 2 sets
-        assertNumberOfElementsInContainerByTag(ThreadUI.view, 3, 'header');
-        assertNumberOfElementsInContainerByTag(ThreadUI.view, 3, 'ul');
+        assertNumberOfElementsInContainerByTag(ThreadUI.container, 3, 'header');
+        assertNumberOfElementsInContainerByTag(ThreadUI.container, 3, 'ul');
       });
 
       test('Check message status & styles', function() {
-        assertNumOfElementsByClass(ThreadUI.view, 1, 'sending');
-        assertNumOfElementsByClass(ThreadUI.view, 1, 'sent');
-        assertNumOfElementsByClass(ThreadUI.view, 1, 'received');
-        assertNumOfElementsByClass(ThreadUI.view, 2, 'error');
+        assertNumOfElementsByClass(ThreadUI.container, 1, 'sending');
+        assertNumOfElementsByClass(ThreadUI.container, 1, 'sent');
+        assertNumOfElementsByClass(ThreadUI.container, 1, 'received');
+        assertNumOfElementsByClass(ThreadUI.container, 2, 'error');
       });
 
       test('Check input form & send button', function() {
@@ -330,7 +335,7 @@ suite('SMS App Unit-Test', function() {
         // In '#new' I need the contact as well, so it should be disabled
         assert.isTrue(ThreadUI.sendButton.disabled);
         // Adding a contact should enable the button
-        ThreadUI.contactInput.value = '123123123';
+        ThreadUI.recipient.value = '123123123';
         ThreadUI.enableSend();
         assert.isFalse(ThreadUI.sendButton.disabled);
         // Finally we clean the form
@@ -348,20 +353,20 @@ suite('SMS App Unit-Test', function() {
       });
 
       test('Check edit mode form', function() {
-        assertNumberOfElementsInContainerByTag(ThreadUI.view, 5, 'input');
+        assertNumberOfElementsInContainerByTag(ThreadUI.container, 5, 'input');
       });
 
       test('Select/Deselect all', function() {
-        var inputs = ThreadUI.view.getElementsByTagName('input');
+        var inputs = ThreadUI.container.getElementsByTagName('input');
         // Activate all inputs
         for (var i = inputs.length - 1; i >= 0; i--) {
           inputs[i].checked = true;
           ThreadUI.chooseMessage(inputs[i]);
         }
         ThreadUI.checkInputs();
-        assert.isTrue(document.getElementById('select-all-messages')
+        assert.isTrue(document.getElementById('messages-check-all-button')
           .classList.contains('disabled'));
-        assert.isFalse(document.getElementById('deselect-all-messages')
+        assert.isFalse(document.getElementById('messages-uncheck-all-button')
           .classList.contains('disabled'));
         // Deactivate all inputs
         for (var i = inputs.length - 1; i >= 0; i--) {
@@ -369,23 +374,23 @@ suite('SMS App Unit-Test', function() {
           ThreadUI.chooseMessage(inputs[i]);
         }
         ThreadUI.checkInputs();
-        assert.isFalse(document.getElementById('select-all-messages')
+        assert.isFalse(document.getElementById('messages-check-all-button')
           .classList.contains('disabled'));
-        assert.isTrue(document.getElementById('deselect-all-messages')
+        assert.isTrue(document.getElementById('messages-uncheck-all-button')
           .classList.contains('disabled'));
         // Activate only one
         inputs[0].checked = true;
         ThreadUI.chooseMessage(inputs[0]);
         ThreadUI.checkInputs();
-        assert.isFalse(document.getElementById('select-all-messages')
+        assert.isFalse(document.getElementById('messages-check-all-button')
           .classList.contains('disabled'));
-        assert.isFalse(document.getElementById('deselect-all-messages')
+        assert.isFalse(document.getElementById('messages-uncheck-all-button')
           .classList.contains('disabled'));
       });
     });
 
     teardown(function() {
-      ThreadUI.view.innerHTML = '';
+      ThreadUI.container.innerHTML = '';
     });
   });
 
@@ -537,4 +542,3 @@ suite('SMS App Unit-Test', function() {
     });
   });
 });
-

--- a/apps/sms/test/unit/sms_test_html_mockup.js
+++ b/apps/sms/test/unit/sms_test_html_mockup.js
@@ -5,7 +5,7 @@ function renderThreadListHeader() {
             '<a href="#new" id="icon-add">' +
               '<span class="icon icon-compose"></span>' +
             '</a>' +
-            '<a href="#edit" id="icon-edit-threads">' +
+            '<a href="#edit" id="threads-edit-icon">' +
               '<span class="icon icon-edit"></span>' +
             '</a>' +
           '</menu>';
@@ -22,16 +22,16 @@ function renderThreadListEdit() {
                 '<button id="threads-delete-button" data-l10n-id="delete">' +
                   'delete</button>' +
               '</menu>' +
-              '<h1 id="list-edit-title" data-l10n-id="editMode">' +
+              '<h1 id="threads-edit-mode" data-l10n-id="editMode">' +
                   'Edit mode</h1>' +
             '</header>' +
           '</section>' +
           '<menu>' +
-            '<button id="deselect-all-threads" class="edit-button disabled" ' +
+            '<button id="threads-uncheck-all-button" class="edit-button disabled" ' +
               'data-l10n-id="deselect-all">' +
               'None' +
             '</button>' +
-            '<button id="select-all-threads" class="edit-button" ' +
+            '<button id="threads-check-all-button" class="edit-button" ' +
               'data-l10n-id="select-all">' +
               'All' +
             '</button>' +
@@ -39,22 +39,22 @@ function renderThreadListEdit() {
 }
 
 function renderThreadMsgHeader() {
-  return '<a role="link" id="go-to-threadlist">' +
+  return '<a role="link" id="messages-back-button">' +
             '<span class="icon icon-back"></span>' +
           '</a>' +
           '<menu type="toolbar">' +
-            '<a id="icon-contact">' +
+            '<a id="messages-contact-pick-button">' +
               '<span class="icon icon-user"></span>' +
             '</a>' +
             '<a href="#edit" id="icon-edit">' +
               '<span class="icon icon-edit"></span>' +
             '</a>' +
           '</menu>' +
-          '<h1 id="header-text" data-l10n-id="messages" aria-hidden="true">' +
+          '<h1 id="messages-header-text" data-l10n-id="messages" aria-hidden="true">' +
             'Messages</h1>' +
           '<form id="messages-tel-form">' +
-            '<input id="receiver-input" type="text" name="tel" class="tel" />' +
-            '<span id="clear-search" role="button" class="icon icon-clear">' +
+            '<input id="messages-recipient" type="text" name="tel" class="tel" />' +
+            '<span id="messages-clear-button" role="button" class="icon icon-clear">' +
               '</span>' +
           '</form>';
 }
@@ -70,16 +70,16 @@ function renderThreadMsgEdit() {
                 '<button id="messages-delete-button"  data-l10n-id="delete">' +
                   'delete</button>' +
               '</menu>' +
-              '<h1 id="messages-edit-title" data-l10n-id="editMode">' +
+              '<h1 id="messages-edit-mode" data-l10n-id="editMode">' +
                 'Edit mode</h1>' +
             '</header>' +
           '</section>' +
           '<menu>' +
-            '<button id="deselect-all-messages" class="edit-button disabled"' +
+            '<button id="messages-uncheck-all-button" class="edit-button disabled"' +
               ' data-l10n-id="deselect-all">' +
               'None' +
             '</button>' +
-            '<button id="select-all-messages" class="edit-button"' +
+            '<button id="messages-check-all-button" class="edit-button"' +
               ' data-l10n-id="select-all">' +
               'All' +
             '</button>' +
@@ -87,11 +87,11 @@ function renderThreadMsgEdit() {
 }
 
 function renderThreadMsgInputBar() {
-  return '<button id="send-message" disabled data-l10n-id="send"' +
+  return '<button id="messages-send-button" disabled data-l10n-id="send"' +
             ' type="submit">Send</button>' +
           '<p>' +
-            '<textarea type="text" id="message-to-send"' +
-              ' name="message-to-send" placeholder="Message"' +
+            '<textarea type="text" id="messages-input"' +
+              ' name="messages-input" placeholder="Message"' +
               ' data-l10n-id="composeMessage"></textarea>' +
           '</p>';
 }


### PR DESCRIPTION
- Moved initialization into init() methods
- Rename element properties to match disambiguated element ids (sans prefix: threads|messages)
- Shift code lines to avoid lint complaints

https://bugzilla.mozilla.org/show_bug.cgi?id=854413
