### PR TITLE
Bug 836276 - remove "alert-sound.enabled" and "alert-vibration.enabled"

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1288,20 +1288,6 @@
             </label>
             <a data-l10n-id="lockscreen-notifications">Show on Lock Screen</a>
           </li>
-          <li>
-            <label>
-              <input type="checkbox" name="alert-sound.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="ring">Ring</a>
-          </li>
-          <li>
-            <label>
-              <input type="checkbox" name="alert-vibration.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="vibrate">Vibrate</a>
-          </li>
         </ul>
       </div>
       -->

--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -50,7 +50,6 @@ var NotificationScreen = {
 
   lockscreenPreview: true,
   silent: false,
-  alerts: true,
   vibrates: true,
 
   init: function ns_init() {
@@ -306,7 +305,7 @@ var NotificationScreen = {
                                this.lockScreenContainer.firstElementChild);
     }
 
-    if (this.alerts && !this.silent) {
+    if (!this.silent) {
       var ringtonePlayer = new Audio();
       ringtonePlayer.src = this._sound;
       ringtonePlayer.mozAudioChannelType = 'notification';
@@ -404,14 +403,10 @@ SettingsListener.observe(
   NotificationScreen.lockscreenPreview = value;
 });
 
-SettingsListener.observe('alert-sound.enabled', true, function(value) {
-  NotificationScreen.alerts = value;
-});
-
 SettingsListener.observe('ring.enabled', true, function(value) {
   NotificationScreen.silent = !value;
 });
 
-SettingsListener.observe('alert-vibration.enabled', true, function(value) {
+SettingsListener.observe('vibration.enabled', true, function(value) {
   NotificationScreen.vibrates = value;
 });

--- a/build/settings.py
+++ b/build/settings.py
@@ -12,8 +12,6 @@ settings = {
  "accessibility.invert": False,
  "accessibility.screenreader": False,
  "alarm.enabled": False,
- "alert-sound.enabled": True,
- "alert-vibration.enabled": True,
  "app.reportCrashes": "ask",
  "app.update.interval": 86400,
  "audio.volume.alarm": 15,


### PR DESCRIPTION
System app fires notification by looking "ring.enabled" and "vibration.enabled" instead.
