### PR TITLE
bug 854031: missing l10n-id attributes for the “Confirm New PIN” message

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1689,7 +1689,9 @@
           </div>
 
           <div id="confirmPinArea" class="sim-code-area">
-            <div>Confirm New PIN</div>
+            <div data-l10n-id="confirmNewSimPinMsg">
+              Confirm New PIN
+            </div>
             <div class="input-wrapper">
               <input type="number" x-inputmode="digits" name="confirmNewSimpin" size="8" maxlength="8" />
               <input type="text" name="confirmNewSimpinVis" size="8" maxlength="8" />

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -456,7 +456,9 @@
               </div>
               <!-- confirm new sim pin input field -->
               <div id="confirmPinArea" hidden>
-                <div>Confirm New PIN</div>
+                <div data-l10n-id="confirmNewSimPinMsg">
+                  Confirm New PIN
+                </div>
                 <div class="input-wrapper">
                   <input name="confirmNewSimpin" type="number" x-inputmode="digits" size="8" maxlength="8" />
                   <input name="confirmNewSimpinVis" type="text" size="8" maxlength="8" />


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=854031
