### PR TITLE
bug 854023: allow line wrapping on the “PUK Code” panel labels

### DIFF
--- a/apps/system/style/simcard.css
+++ b/apps/system/style/simcard.css
@@ -10,9 +10,14 @@
   bottom: 0;
   right: 0;
 }
+
 #simpin-dialog .container {
   padding-left: 2rem;
   font-size: 1.5rem;
+}
+
+#simpin-dialog .container div {
+  white-space: normal;
 }
 
 #simpin-dialog .container > div {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=854023
