### PR TITLE
Bug 851457 - [Settings] Enforce correct script direction when Arabic (or...

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -619,7 +619,19 @@ window.addEventListener('load', function loadSettings() {
           for (var lang in languages) {
             var option = document.createElement('option');
             option.value = lang;
-            option.textContent = languages[lang];
+            // Right-to-Left (RTL) languages:
+            // (http://www.w3.org/International/questions/qa-scripts)
+            // Arabic, Hebrew, Farsi, Pashto, Urdu
+            var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
+            // Use script direction control-characters to wrap the text labels
+            // since markup (i.e. <bdo>) does not work inside <option> tags
+            // http://www.w3.org/International/tutorials/bidi-xhtml/#nomarkup
+            var lEmbedBegin =
+                (rtlList.indexOf(lang) >= 0) ? '&#x202B;' : '&#x202A;';
+            var lEmbedEnd = '&#x202C;';
+            // The control-characters enforce the language-specific script
+            // direction to correctly display the text label (Bug #851457)
+            option.innerHTML = lEmbedBegin + languages[lang] + lEmbedEnd;
             option.selected = (lang == document.documentElement.lang);
             langSel.appendChild(option);
           }


### PR DESCRIPTION
... any RTL language) is selected

Since markup is not allowed inside 'option' tags, the strongly-typed Unicode control characters Left-to-Right Embedding (LRE - U+202A), Right-to-Left Embedding (RLE - U+202B) and Pop Directional Formatting (PDF - U+202C) were used to wrap the language labels.
