### PR TITLE
Bug 853425 - Get rid of innerHTML in Keyboard app

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -497,8 +497,6 @@ function mapInputType(type) {
     return 'number';
     break;
   }
-
-  return null;
 }
 
 //
@@ -812,8 +810,7 @@ function getUpperCaseValue(key) {
     return key.value;
 
   var upperCase = currentLayout.upperCase || {};
-  var v = upperCase[key.value] || key.value.toUpperCase();
-  return v;
+  return upperCase[key.value] || key.value.toUpperCase();
 }
 
 function setMenuTimeout(target, coords, touchId) {

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -13,7 +13,7 @@
 // attributes.
 const IMERender = (function() {
 
-  var ime, menu, pendingSymbolPanel, candidatePanel, candidatePanelToggleButton;
+  var ime, menu;
   var getUpperCaseValue, isSpecialKey;
 
   var _menuKey, _altContainer;
@@ -22,7 +22,7 @@ const IMERender = (function() {
 
   var inputMethodName; // used as a CSS class on the candidatePanel
 
-  // Initiaze the render. It needs some business logic to determine:
+  // Initialize the render. It needs some business logic to determine:
   //   1- The uppercase for a key object
   //   2- When a key is a special key
   var init = function kr_init(uppercaseFunction, keyTest) {
@@ -82,7 +82,6 @@ const IMERender = (function() {
     // and use it for multipling changeScale deppending on the value of pixel
     // density used in media queries
 
-    var content = '';
     layoutWidth = layout.width || 10;
     var totalWidth = document.getElementById('keyboard').clientWidth;
     var placeHolderWidth = totalWidth / layoutWidth;
@@ -92,6 +91,7 @@ const IMERender = (function() {
 
     var first = true;
 
+    var content = document.createDocumentFragment();
     layout.keys.forEach((function buildKeyboardRow(row, nrow) {
 
       var firstRow = '';
@@ -100,7 +100,8 @@ const IMERender = (function() {
         first = false;
       }
 
-      content += '<div class="keyboard-row' + firstRow + '">';
+      var kbRow = document.createElement('div');
+      kbRow.className = 'keyboard-row' + firstRow;
       row.forEach((function buildKeyboardColumns(key, ncolumn) {
 
         var keyChar = key.value;
@@ -140,19 +141,29 @@ const IMERender = (function() {
           dataset.push({'key': 'compositekey', 'value': key.compositeKey});
         }
 
-        content += buildKey(keyChar, className, keyWidth + 'px',
-                            dataset, key.altNote);
+        kbRow.appendChild(buildKey(keyChar, className, keyWidth + 'px',
+          dataset, key.altNote));
 
       }));
-      content += '</div>';
+      content.appendChild(kbRow);
     }));
 
-    // Append empty accent char menu and key highlight into content HTML
-    content += '<span id="keyboard-accent-char-menu-out">' +
-               '<span id="keyboard-accent-char-menu"></span></span>';
-    content += '<span id="keyboard-key-highlight"></span>';
+    // Append empty accent char menu and key highlight into content
+    var accentMenuContainer = document.createElement('span');
+    accentMenuContainer.setAttribute('id', 'keyboard-accent-char-menu-out');
+    var accentMenu = document.createElement('span');
+    accentMenu.setAttribute('id', 'keyboard-accent-char-menu');
+    var highlight = document.createElement('span');
+    highlight.setAttribute('id', 'keyboard-key-highlight');
 
-    this.ime.innerHTML = content;
+    accentMenuContainer.appendChild(accentMenu);
+
+    this.ime.innerHTML = '';
+
+    content.appendChild(accentMenuContainer);
+    content.appendChild(highlight);
+
+    this.ime.appendChild(content);
     this.menu = document.getElementById('keyboard-accent-char-menu');
 
     // Builds candidate panel
@@ -196,9 +207,9 @@ const IMERender = (function() {
 
   // Show pending symbols with highlight (selection) if provided
   var showPendingSymbols = function km_showPendingSymbols(symbols,
-                                                            highlightStart,
-                                                            highlightEnd,
-                                                            highlightState) {
+                                                          highlightStart,
+                                                          highlightEnd,
+                                                          highlightState) {
     var HIGHLIGHT_COLOR_TABLE = {
       'red': 'keyboard-pending-symbols-highlight-red',
       'green': 'keyboard-pending-symbols-highlight-green',
@@ -212,35 +223,31 @@ const IMERender = (function() {
     if (pendingSymbolPanel) {
 
       if (typeof highlightStart === 'undefined' ||
-          typeof highlightEnd === 'undefined' ||
-          typeof highlightState === 'undefined') {
+        typeof highlightEnd === 'undefined' ||
+        typeof highlightState === 'undefined') {
         pendingSymbolPanel.textContent = symbols;
         return;
       }
 
-      pendingSymbolPanel.innerHTML = "<span class='" +
-                                     HIGHLIGHT_COLOR_TABLE[highlightState] +
-                                     "'>" +
-                                     symbols.slice(
-                                       highlightStart, highlightEnd) +
-                                     '</span>' +
-                                     symbols.substr(highlightEnd);
+      var span = document.createElement('span');
+      span.className = HIGHLIGHT_COLOR_TABLE[highlightState];
+      span.textContent = symbols.slice(highlightStart, highlightEnd);
+
+      pendingSymbolPanel.innerHTML = '';
+      pendingSymbolPanel.appendChild(span);
+      pendingSymbolPanel.appendChild(
+        document.createTextNode(symbols.substr(highlightEnd)));
     }
   };
 
   // Show candidates
   // Each candidate is a string or an array of two strings
   var showCandidates = function(candidates, noWindowHeightUpdate) {
-
-    var ime = document.getElementById('keyboard');
     // TODO: Save the element
     var candidatePanel = document.getElementById('keyboard-candidate-panel');
-    var isFullView = ime.classList.contains('full-candidate-panel');
-
 
     if (candidatePanel) {
       candidatePanel.innerHTML = '';
-
       candidatePanel.scrollTop = candidatePanel.scrollLeft = 0;
 
       // If there were too many candidate
@@ -267,7 +274,8 @@ const IMERender = (function() {
 
   // Show keyboard alternatives
   var showKeyboardAlternatives = function(key, keyboards, current, switchCode) {
-    var dataset, className, content = '';
+    var content = document.createDocumentFragment();
+    var dataset, className;
     var menu = this.menu;
 
     var cssWidth = key.style.width;
@@ -287,15 +295,17 @@ const IMERender = (function() {
         {key: 'keyboard', value: kbr},
         {key: 'keycode', value: switchCode}
       ];
-      content += buildKey(
+
+      content.appendChild(buildKey(
         Keyboards[kbr].menuLabel,
         className, cssWidth + 'px',
-        dataset
+        dataset)
       );
 
       alreadyAdded[kbr] = true;
     }
-    menu.innerHTML = content;
+    menu.innerHTML = '';
+    menu.appendChild(content);
 
     // Replace with the container
     _altContainer = document.createElement('div');
@@ -314,8 +324,7 @@ const IMERender = (function() {
 
   // Show char alternatives.
   var showAlternativesCharMenu = function(key, altChars) {
-    var content = '';
-
+    var content = document.createDocumentFragment();
     var left = (window.innerWidth / 2 > key.offsetLeft);
 
     // Place the menu to the left
@@ -330,8 +339,7 @@ const IMERender = (function() {
     // How wide (in characters) is the key that we're displaying
     // these alternatives for?
     var keycharwidth = key.dataset.compositeKey ?
-      key.dataset.compositeKey.length :
-      1;
+      key.dataset.compositeKey.length : 1;
 
     // Build a key for each alternative
     altChars.forEach(function(alt) {
@@ -348,9 +356,10 @@ const IMERender = (function() {
       if (altChars.length === 1)
         width = Math.max(width, key.offsetWidth);
 
-      content += buildKey(alt, '', width + 'px', dataset);
+      content.appendChild(buildKey(alt, '', width + 'px', dataset));
     });
-    this.menu.innerHTML = content;
+    this.menu.innerHTML = '';
+    this.menu.appendChild(content);
 
     // Replace with the container
     _altContainer = document.createElement('div');
@@ -372,17 +381,18 @@ const IMERender = (function() {
     var alternativesLeft = getWindowLeft(this.menu);
     var alternativesRight = alternativesLeft + this.menu.offsetWidth;
 
+    var offset;
     // It overflows on the right
     if (left && alternativesRight > window.innerWidth) {
       console.log('overflowing right');
-      var offset = window.innerWidth - alternativesRight;
+      offset = window.innerWidth - alternativesRight;
       console.log(offset);
       this.menu.style.left = offset + 'px';
 
-    // It overflows on the left
+      // It overflows on the left
     } else if (!left && alternativesLeft < 0) {
       console.log('overflowing left');
-      var offset = alternativesLeft;
+      offset = alternativesLeft;
       console.log(offset);
       this.menu.style.right = offset + 'px';
     }
@@ -391,9 +401,9 @@ const IMERender = (function() {
   // Hide the alternative menu
   var hideAlternativesCharMenu = function km_hideAlternativesCharMenu() {
     this.menu = document.getElementById('keyboard-accent-char-menu');
-    this.menu.innerHTML = '';
-    this.menu.className = '';
     this.menu.style.display = 'none';
+    this.menu.className = '';
+    this.menu.innerHTML = '';
 
     if (_altContainer)
       _altContainer.parentNode.replaceChild(_menuKey, _altContainer);
@@ -406,7 +416,7 @@ const IMERender = (function() {
 
   // Recalculate dimensions for the current render
   var resizeUI = function(layout) {
-    var changeScale, scale;
+    var changeScale;
 
     // Font size recalc
     var ime = document.getElementById('keyboard');
@@ -483,7 +493,7 @@ const IMERender = (function() {
 
   var candidatePanelToggleButtonCode = function() {
     var toggleButton = document.createElement('span');
-    toggleButton.innerHTML = '⇪';
+    toggleButton.textContent = '⇪';
     toggleButton.id = 'keyboard-candidate-panel-toggle-button';
     if (inputMethodName)
       toggleButton.classList.add(inputMethodName);
@@ -492,21 +502,34 @@ const IMERender = (function() {
   };
 
   var buildKey = function buildKey(label, className, width, dataset, altNote) {
-
-    var altNoteHTML = '';
+    var altNoteNode;
     if (altNote) {
-      altNoteHTML = '<div class="alt-note">' + altNote + '</div>';
+      altNoteNode = document.createElement('div');
+      altNoteNode.textContent = altNote;
     }
 
-
-    var content = '<button class="keyboard-key ' + className + '"';
+    var contentNode = document.createElement('button');
+    contentNode.className = 'keyboard-key ' + className;
+    contentNode.setAttribute('style', 'width: ' + width + ';');
     dataset.forEach(function(data) {
-      content += ' data-' + data.key + '="' + data.value + '" ';
+      contentNode.dataset[data.key] = data.value;
     });
-    content += ' style="width: ' + width + '"';
-    content += '><span class="visual-wrapper"><span>' +
-               label + '</span>' + altNoteHTML + '</span></button>';
-    return content;
+
+    var vWrapperNode = document.createElement('span');
+    vWrapperNode.className = 'visual-wrapper';
+
+    var labelNode = document.createElement('span');
+    // Using innerHTML here because some labels (so far only the &nbsp; in the
+    // space key) can be HTML entities.
+    labelNode.innerHTML = label;
+
+    vWrapperNode.appendChild(labelNode);
+    if (altNoteNode) {
+      vWrapperNode.appendChild(altNoteNode);
+    }
+    contentNode.appendChild(vWrapperNode);
+
+    return contentNode;
   };
 
   var getWidth = function getWidth() {
@@ -540,8 +563,6 @@ const IMERender = (function() {
 
     this.ime.clientHeight;
     var rows = document.querySelectorAll('.keyboard-row');
-
-
     var rowCount = rows.length || 3;
     return Math.ceil(this.ime.clientHeight / rowCount);
   };


### PR DESCRIPTION
This patch takes care of sanitising innerHTML as per issue https://bugzilla.mozilla.org/show_bug.cgi?id=837740. It makes use of textContent and DocumentFragment in some cases, which also improves the speed of these operations. Some other small fixes in code and comments have been made.

This patch makes https://github.com/mozilla-b2g/gaia/pull/8791 obsolete.
