### PR TITLE
Bug 831429 - [Settings] Device Information "Phone Number" field has title positioned too low to start out, nearly overlapping phone number

### DIFF
--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -95,6 +95,7 @@ ul li > label:not([for]) + small {
 ul li > small:not(:empty) + a,
 ul li > small:not(:empty) + span {
   line-height: 4.4rem;
+  overflow: inherit; /* see Bug 831429 */
 }
 
 


### PR DESCRIPTION
Bug [#831429](https://bugzilla.mozilla.org/show_bug.cgi?id=831429)
