### PR TITLE
Bug 835484 - Localized complete and failed strings are not used in BT file transfer notification status r=kaze

### DIFF
--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -358,7 +358,7 @@ var BluetoothTransfer = {
 
   showBanner: function bt_showBanner(isComplete) {
     var _ = navigator.mozL10n.get;
-    var status = (isComplete) ? 'complete' : 'failed';
+    var status = (isComplete) ? _('complete') : _('failed');
     this.banner.addEventListener('animationend', function animationend() {
       this.banner.removeEventListener('animationend', animationend);
       this.banner.classList.remove('visible');


### PR DESCRIPTION
Add localized method for the status string.
