### PR TITLE
Bug 857574 - Contacts app takes long time the first time to enter in sea...

### DIFF
--- a/apps/communications/contacts/js/search.js
+++ b/apps/communications/contacts/js/search.js
@@ -35,13 +35,34 @@ contacts.Search = (function() {
       imgLoader,
       searchEnabled = false;
 
+  var onLoad = function onLoad() {
+    searchView = document.getElementById('search-view');
+    searchList = document.getElementById('search-list');
+  };
+
+  onLoad();
+
   var init = function load(_conctactsListView, _groupFavorites, _clickHandler,
                            defaultEnabled) {
     conctactsListView = _conctactsListView;
-
-    searchView = document.getElementById('search-view');
-
     favoriteGroup = _groupFavorites;
+
+    if (typeof _clickHandler === 'function') {
+      searchList.addEventListener('click', _clickHandler);
+    }
+
+    if (defaultEnabled)
+      searchEnabled = true;
+  };
+
+  var initialized = false;
+
+  var doInit = function doInit() {
+    if (initialized) {
+      return;
+    }
+
+    initialized = true;
     searchBox = document.getElementById('search-contact');
     var resetButton = searchBox.nextElementSibling;
     resetButton.addEventListener('mousedown', function() {
@@ -51,10 +72,6 @@ contacts.Search = (function() {
       window.setTimeout(fillInitialSearchPage, 0);
     });
 
-    searchList = document.getElementById('search-list');
-    if (typeof _clickHandler === 'function') {
-      searchList.addEventListener('click', _clickHandler);
-    }
     searchList.parentNode.addEventListener('touchstart', function() {
       blurList = true;
     });
@@ -71,9 +88,6 @@ contacts.Search = (function() {
 
     imgLoader = new ImageLoader('#groups-list-search', 'li');
     imgLoader.setResolver(fb.resolver);
-
-    if (defaultEnabled)
-      searchEnabled = true;
   };
 
   //Search mode instructions
@@ -209,6 +223,7 @@ contacts.Search = (function() {
     if (!inSearchMode) {
       window.addEventListener('input', onInput);
       searchView.classList.add('insearchmode');
+      doInit();
       fillInitialSearchPage();
       inSearchMode = true;
       emptySearch = true;
@@ -296,9 +311,14 @@ contacts.Search = (function() {
     if (searchEnabled) {
       return;
     }
+
     searchEnabled = true;
-    invalidateCache();
-    search();
+    // We perform the search when all the info have been loaded and the
+    // user wrote something in the entry field
+    if (searchBox.value.trim()) {
+      invalidateCache();
+      search();
+    }
   };
 
   var search = function performSearch(searchDoneCb) {
@@ -416,6 +436,8 @@ contacts.Search = (function() {
     'enterSearchMode': enterSearchMode,
     'exitSearchMode': exitSearchMode,
     'isInSearchMode': isInSearchMode,
-    'enableSearch': enableSearch
+    'enableSearch': enableSearch,
+    // The purpose of this method is only for unit tests
+    'load': onLoad
   };
 })();

--- a/apps/communications/contacts/test/unit/contacts_list_test.js
+++ b/apps/communications/contacts/test/unit/contacts_list_test.js
@@ -1,4 +1,4 @@
-requireApp('/shared/lazy_loader.js');
+require('/shared/js/lazy_loader.js');
 requireApp('communications/contacts/test/unit/mock_asyncstorage.js');
 requireApp('communications/contacts/js/search.js');
 requireApp('communications/contacts/js/contacts_list.js');
@@ -792,19 +792,18 @@ suite('Render contacts list', function() {
       var contact = mockContacts[contactIndex];
 
       subject.load(mockContacts);
-      window.setTimeout(function() {
-        contacts.List.initSearch(function onInit() {
-          searchBox.value = contact.familyName[0];
-          contacts.Search.search(function search_finished() {
-            assertContactFound(contact);
-            done();
-          });
-        });
-      }, 100);
+
+      contacts.Search.load();
+      contacts.List.initSearch(function onInit() {
+        searchBox.value = contact.familyName[0];
+        contacts.Search.enterSearchMode({preventDefault: function() {}});
+        done();
+      });
     });
 
     test('check empty search', function(done) {
       mockContacts = new MockContactsList();
+      subject.resetSearch();
       subject.load(mockContacts);
       searchBox.value = 'YYY';
       contacts.Search.search(function search_finished() {
@@ -841,6 +840,7 @@ suite('Render contacts list', function() {
       var contactIndex = Math.floor(Math.random() * mockContacts.length);
       var contact = mockContacts[contactIndex];
 
+      subject.resetSearch();
       subject.load(mockContacts);
 
       searchBox.value = '(';
@@ -858,6 +858,7 @@ suite('Render contacts list', function() {
       mockContacts[contactIndex].givenName[0] =
         '(' + contact.givenName[0] + ')';
 
+      subject.resetSearch();
       subject.load(mockContacts);
 
       window.setTimeout(function() {


### PR DESCRIPTION
...rch mode when the list is already loaded

This patch implements:

1) Users can enter in search mode when they click on the search box the first time
2) The algorithm that creates the search info avoids querySelectors in a loop -> less time for calculate search data
3) This algorithm is performed once although an user gets crazy and clicks several times very fast on the search box
4) Entering in search mode is almost immediately because the search-data calculation is put off after search mode view appears
5) The search library is initialized once and not always that an user enters in search mode
