### PR TITLE
Bug 830572 - MAC address label overlaps value

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -256,9 +256,8 @@
       <div>
         <ul>
           <li>
-            <a data-l10n-id="macAddress"> MAC address
-              <span data-name="deviceinfo.mac"></span>
-            </a>
+            <small data-name="deviceinfo.mac"></small>
+            <a data-l10n-id="macAddress"> MAC address </a>
           </li>
         </ul>
 


### PR DESCRIPTION
Displays MAC address label and value in two lines just like in the 'More information' view of 'Device information'
