### PR TITLE
Bug 857964 - Timing issue in ThreadListUI.renderThreads causes double entries to appear in thread list

### DIFF
--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -198,7 +198,14 @@ var ThreadListUI = {
     window.location.hash = '#thread-list';
   },
 
+  renderCounter: 0,
   renderThreads: function thlui_renderThreads(threads, renderCallback) {
+    // Rendering happens with setTimeout()'s. So when calling this method twice
+    // we have double entry's. So we need to stop our current action if a new
+    // one is there already.
+    var self = ThreadListUI; // sorry, dirty hack
+    var renderId = ++self.renderCounter;
+
     // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=854417
     // Refactor the rendering method: do not empty the entire
     // list on every render.
@@ -231,6 +238,9 @@ var ThreadListUI = {
         }
         var thread = threads.pop();
         setTimeout(function() {
+          // a new render action was started? cancel this one.
+          if (renderId !== self.renderCounter)
+            return;
           ThreadListUI.appendThread(thread);
           appendThreads(threads, callback);
         });

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -28,6 +28,23 @@ requireApp('sms/js/startup.js');
 
 
 suite('SMS App Unit-Test', function() {
+  function stub(additionalCode, ret) {
+    if (additionalCode && typeof additionalCode !== 'function')
+      ret = additionalCode;
+
+    var nfn = function() {
+      nfn.callCount++;
+      nfn.calledWith = [].slice.call(arguments);
+
+      if (typeof additionalCode === 'function')
+        additionalCode.apply(this, arguments);
+
+      return ret;
+    };
+    nfn.callCount = 0;
+    return nfn;
+  }
+
   var findByString;
   var nativeMozL10n = navigator.mozL10n;
 
@@ -298,6 +315,33 @@ suite('SMS App Unit-Test', function() {
 
     teardown(function() {
       ThreadListUI.container.innerHTML = '';
+    });
+  });
+
+  suite('Threads-list rendering behavior', function() {
+    test('Calling without threads should not append', function(done) {
+      ThreadListUI.appendThread = stub();
+
+      ThreadListUI.renderThreads([], function() {
+        assert.equal(ThreadListUI.appendThread.callCount, 0);
+        done();
+      });
+    });
+
+    test('Calling renderThreads twice should stop one', function(done) {
+      ThreadListUI.appendThread = stub();
+
+      var first = stub(), second = stub();
+      ThreadListUI.renderThreads([{}, {}], first);
+      ThreadListUI.renderThreads([{}, {}], second);
+
+      setTimeout(function() {
+        assert.equal(first.callCount, 0);
+        assert.equal(second.callCount, 1);
+        assert.equal(ThreadListUI.appendThread.callCount, 2);
+
+        done();
+      }, 20);
     });
   });
 


### PR DESCRIPTION
Fix for [#857964](https://bugzilla.mozilla.org/show_bug.cgi?id=857964). Adds an internal ID that keeps track of the render actions that are running and thus has the ability to stop old render actions. This way there won't be any double entries in the thread list.
