### PR TITLE
Bug 858118 - [system] fix and reenable unit tests for update manager r=e...

### DIFF
--- a/apps/system/test/unit/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen_test.js
@@ -63,22 +63,27 @@ suite('lockscreen', function() {
         setTimeout(checkCanvas, 10);
         return;
       }
-      var ctx = canvas.getContext('2d');
-      var top_pixel = ctx.getImageData(0, 0, 1, 1).data;
 
-      assert.equal(top_pixel[0], 77);
-      assert.equal(top_pixel[1], 0);
-      assert.equal(top_pixel[2], 0);
+      try {
+        var ctx = canvas.getContext('2d');
+        var top_pixel = ctx.getImageData(0, 0, 1, 1).data;
 
-      var center_width = Math.floor(canvas.width / 2);
-      var center_height = Math.floor(canvas.height / 2);
-      var center_pixel = ctx.getImageData(center_width, center_height,
-                                          1 , 1).data;
-      assert.equal(center_pixel[0], 251);
-      assert.equal(center_pixel[1], 0);
-      assert.equal(center_pixel[2], 0);
+        assert.equal(top_pixel[0], 77);
+        assert.equal(top_pixel[1], 0);
+        assert.equal(top_pixel[2], 0);
 
-      done();
+        var center_width = Math.floor(canvas.width / 2);
+        var center_height = Math.floor(canvas.height / 2);
+        var center_pixel = ctx.getImageData(center_width, center_height,
+                                            1 , 1).data;
+        assert.ok(center_pixel[0] <= 251 || center_pixel[0] >= 250);
+        assert.equal(center_pixel[1], 0);
+        assert.equal(center_pixel[2], 0);
+
+        done();
+      } catch (e) {
+        done(e);
+      }
     })();
 
   });

--- a/apps/system/test/unit/mocks_helper.js
+++ b/apps/system/test/unit/mocks_helper.js
@@ -1,9 +1,19 @@
+'use strict';
+
 var MocksHelper = function(mocks) {
   this.mocks = mocks;
   this.realWindowObjects = {};
 };
 
 MocksHelper.prototype = {
+
+  init: function mh_init() {
+    this.mocks.forEach(function(objName) {
+      if (! window[objName]) {
+        window[objName] = null;
+      }
+    });
+  },
 
   setup: function mh_setup() {
     this._forEachMock('mSetup');
@@ -13,7 +23,8 @@ MocksHelper.prototype = {
     this.mocks.forEach(function(objName) {
       var mockName = 'Mock' + objName;
       if (!window[mockName]) {
-        throw 'Mock ' + mockName + ' has not been loaded into the test';
+        var errMsg = 'Mock ' + mockName + ' has not been loaded into the test';
+        throw new Error(errMsg);
       }
 
       this.realWindowObjects[objName] = window[objName];

--- a/apps/system/test/unit/setup.js
+++ b/apps/system/test/unit/setup.js
@@ -1,0 +1,5 @@
+'use strict';
+
+requireApp('system/test/unit/mocks_helper.js');
+
+

--- a/apps/system/test/unit/updatable_test.js
+++ b/apps/system/test/unit/updatable_test.js
@@ -14,20 +14,16 @@ requireApp('system/test/unit/mock_manifest_helper.js');
 requireApp('system/test/unit/mocks_helper.js');
 
 
-var mocksForUpdatable = [
+var mocksHelperForUpdatable = new MocksHelper([
   'CustomDialog',
   'UpdateManager',
   'WindowManager',
   'UtilityTray',
   'ManifestHelper',
   'asyncStorage'
-];
+]);
 
-mocksForUpdatable.forEach(function(mockName) {
-  if (!window[mockName]) {
-    window[mockName] = null;
-  }
-});
+mocksHelperForUpdatable.init();
 
 suite('system/Updatable', function() {
   var subject;
@@ -35,8 +31,9 @@ suite('system/Updatable', function() {
 
   var realDispatchEvent;
   var realL10n;
+  var realMozApps;
 
-  var mocksHelper;
+  var mocksHelper = mocksHelperForUpdatable;
 
   var lastDispatchedEvent = null;
   var fakeDispatchEvent;
@@ -49,19 +46,26 @@ suite('system/Updatable', function() {
       }
     };
 
-    mocksHelper = new MocksHelper(mocksForUpdatable);
+    // we used to set subject._mgmt in setup
+    // but now, this seems to work and feels cleaner
+    realMozApps = navigator.mozApps;
+    navigator.mozApps = { mgmt: MockAppsMgmt };
+
     mocksHelper.suiteSetup();
   });
 
   suiteTeardown(function() {
     navigator.mozL10n = realL10n;
+    navigator.mozApps = realMozApps;
     mocksHelper.suiteTeardown();
   });
 
   setup(function() {
     mockApp = new MockApp();
     subject = new AppUpdatable(mockApp);
-    subject._mgmt = MockAppsMgmt;
+
+    // keeping this line here, we might need to use it again in the future
+    //subject._mgmt = MockAppsMgmt;
 
     fakeDispatchEvent = function(type, value) {
       lastDispatchedEvent = {
@@ -137,19 +141,21 @@ suite('system/Updatable', function() {
       subject = new AppUpdatable(mockApp);
     });
 
-/*
-// These tests are currently failing and have been temporarily disabled as per
-// Bug 838993. They should be fixed and re-enabled as soon as possible as per
-// Bug 840500.
-    test('should apply update if downloaded', function() {
-      mockApp.readyToApplyDownload = true;
-      subject = new AppUpdatable(mockApp);
-      // We cannot test for this._mgmt methods because it's created in
-      // a constructor, so we check if the window is killed because
-      // WindowManager.kill() is also called in applyUpdate() method
-      assert.equal(MockWindowManager.mLastKilledOrigin, subject.app.origin);
+    suite('applyDownload', function() {
+      setup(function() {
+        mockApp.readyToApplyDownload = true;
+        subject = new AppUpdatable(mockApp);
+      });
+
+      test('should apply update if downloaded', function() {
+        assert.equal(MockAppsMgmt.mLastAppApplied, mockApp);
+      });
+
+      test('should kill the app if downloaded', function() {
+        assert.equal(MockWindowManager.mLastKilledOrigin, mockApp.origin);
+      });
     });
-*/
+
   });
 
   suite('infos', function() {

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -38,13 +38,6 @@ mocksForUpdateManager.forEach(function(mockName) {
   }
 });
 
-/*
-// These tests are currently failing and have been temporarily disabled as per
-// Bug 838993. They should be fixed and re-enabled as soon as possible as per
-// Bug 840500.
-// Please also note: the outcome of this test suite is non-deterministic.
-// Failures occur inconsistently, so potential fixes should be thoroughly
-// vetted.
 suite('system/UpdateManager', function() {
   var realL10n;
   var realWifiManager;
@@ -1479,4 +1472,3 @@ suite('system/UpdateManager', function() {
     });
   });
 });
-*/


### PR DESCRIPTION
...tienne

fix updatable tests and use the new mocks helper
reenable update tests without any more change as I couldn't make them fail
fix lockscreen test for various firefox versions
