### PR TITLE
every nearbyKey was holding itself in the list which caused unneccesary ...

### DIFF
--- a/apps/keyboard/js/imes/latin/predictions.js
+++ b/apps/keyboard/js/imes/latin/predictions.js
@@ -87,6 +87,8 @@ var Predictions = function() {
       var list = {};
       for (var m = 0; m < keyArray.length; ++m) {
         var key2 = keyArray[m];
+        if (key1.code == key2.code)
+          continue;
         if (SpecialKey(key2))
           continue;
         if (SquaredDistanceToEdge(/* key dimensions */


### PR DESCRIPTION
...double insertions of candidates
