### PR TITLE
Bug 859159 - Fix broken keyboard layout for 'tel' and 'number' inputs

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -505,6 +505,7 @@ const IMERender = (function() {
     var altNoteNode;
     if (altNote) {
       altNoteNode = document.createElement('div');
+      altNoteNode.className = 'alt-note';
       altNoteNode.textContent = altNote;
     }
 


### PR DESCRIPTION
The patch for Bug 853425 introduces an error at [line 507](https://github.com/mozilla-b2g/gaia/pull/8935/files#L1R507) in apps/keyboard/render.js by not setting the className, thus breaking the keyboard layout for 'tel' and 'number' inputs.
