### PR TITLE
Bug 856546 - mozChromeEvent should not cancel overlay timer.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1569,7 +1569,7 @@ var WindowManager = (function() {
   }
 
   function overlayEventHandler(evt) {
-    if (attentionScreenTimer)
+    if (attentionScreenTimer && 'mozChromeEvent' != evt.type)
       clearTimeout(attentionScreenTimer);
     switch (evt.type) {
       case 'status-active':


### PR DESCRIPTION
Bug 856546 - mozChromeEvent should not cancel overlay timer. r=alive, a=tef+
