### PR TITLE
Bug 857942 - Select All button in Edit Messages screen is not enabled when we receive a new sms

### DIFF
--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -22,7 +22,12 @@ var ThreadListUI = {
     }, this);
 
     this.delNumList = [];
-    this.selectedInputs = [];
+    Object.defineProperty(this, 'selectedInputs', {
+      get: function() {
+          return [].slice.call(this.container.querySelectorAll(
+                        'input[type=checkbox]:checked'));
+        }
+    });
     this.fullHeight = this.container.offsetHeight;
 
     this.checkAllButton.addEventListener(
@@ -95,22 +100,12 @@ var ThreadListUI = {
         // a target with a |type| property, then assume it could've
         // been a checkbox and proceed w/ validation condition
         if (evt.target.type && evt.target.type === 'checkbox') {
-          ThreadListUI.clickInput(evt.target);
           ThreadListUI.checkInputs();
         }
         break;
       case 'submit':
         evt.preventDefault();
         break;
-    }
-  },
-
-  clickInput: function thlui_clickInput(target) {
-    if (target.checked) {
-      ThreadListUI.selectedInputs.push(target);
-    } else {
-      ThreadListUI.selectedInputs.splice(
-        ThreadListUI.selectedInputs.indexOf(target), 1);
     }
   },
 
@@ -144,7 +139,6 @@ var ThreadListUI = {
       inputs[i].parentNode.parentNode.classList.remove('undo-candidate');
     }
     this.delNumList = [];
-    this.selectedInputs = [];
     this.editMode.textContent = navigator.mozL10n.get('editMode');
     this.checkInputs();
   },
@@ -160,7 +154,6 @@ var ThreadListUI = {
     var length = inputs.length;
     for (var i = 0; i < length; i++) {
       inputs[i].checked = value;
-      this.clickInput(inputs[i]);
     }
     this.checkInputs();
   },
@@ -352,6 +345,9 @@ var ThreadListUI = {
     if (!threadFound) {
       threadsContainer.appendChild(threadDOM);
     }
+
+    if (document.getElementById('main-wrapper').classList.contains('edit'))
+      this.checkInputs();
   },
   // Adds a new grouping header if necessary (today, tomorrow, ...)
   createThreadContainer: function thlui_createThreadContainer(timestamp) {

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -183,7 +183,7 @@ var ThreadUI = {
         window.location.hash = '#thread-list';
         return;
       }
-      if (confirm(navigator.mozL10n.get('discard-sms'))) {
+      if (window.confirm(navigator.mozL10n.get('discard-sms'))) {
         ThreadUI.cleanFields(true);
         window.location.hash = '#thread-list';
       }
@@ -591,6 +591,9 @@ var ThreadUI = {
         messageContainer.appendChild(messageDOM);
       }
     }
+
+    if (document.getElementById('main-wrapper').classList.contains('edit'))
+      this.checkInputs();
   },
 
   showChunkOfMessages: function thui_showChunkOfMessages(number) {
@@ -605,7 +608,7 @@ var ThreadUI = {
     aElement.addEventListener('click', function resend(e) {
       var hash = window.location.hash;
       if (hash != '#edit') {
-        if (confirm(navigator.mozL10n.get('resend-confirmation'))) {
+        if (window.confirm(navigator.mozL10n.get('resend-confirmation'))) {
           messageDOM.removeEventListener('click', resend);
           ThreadUI.resendMessage(message, messageDOM);
         }
@@ -647,7 +650,7 @@ var ThreadUI = {
 
   delete: function thui_delete() {
     var question = navigator.mozL10n.get('deleteMessages-confirmation');
-    if (confirm(question)) {
+    if (window.confirm(question)) {
       WaitingScreen.show();
       var delNumList = [];
       var inputs = ThreadUI.container.querySelectorAll(
@@ -1069,6 +1072,8 @@ var ThreadUI = {
     }
   }
 };
+
+window.confirm = window.confirm; // allow override in unit tests
 
 window.addEventListener('resize', function resize() {
   ThreadUI.setInputMaxHeight();

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -27,6 +27,23 @@ requireApp('sms/js/startup.js');
 
 
 suite('SMS App Unit-Test', function() {
+  function stub(additionalCode, ret) {
+    if (additionalCode && typeof additionalCode !== 'function')
+      ret = additionalCode;
+
+    var nfn = function() {
+      nfn.callCount++;
+      nfn.calledWith = [].slice.call(arguments);
+
+      if (typeof additionalCode === 'function')
+        additionalCode.apply(this, arguments);
+
+      return ret;
+    };
+    nfn.callCount = 0;
+    return nfn;
+  }
+
   var findByString;
   var nativeMozL10n = navigator.mozL10n;
 
@@ -218,10 +235,12 @@ suite('SMS App Unit-Test', function() {
 
   // First suite it's related to review Thread-View
   suite('Threads-list', function() {
+    var _tci;
     // Setup. We need an async. way due to threads are rendered
     // async.
     setup(function(done) {
       MessageManager.getThreads(ThreadListUI.renderThreads, done);
+      _tci = ThreadListUI.checkInputs;
     });
     // We are gonna review the HTML structure with this suite
     suite('Threads-list rendering', function() {
@@ -272,12 +291,12 @@ suite('SMS App Unit-Test', function() {
       });
 
       test('Select all/Deselect All buttons', function() {
+        document.getElementById('main-wrapper').classList.add('edit');
         // Retrieve all inputs
         var inputs = ThreadListUI.container.getElementsByTagName('input');
         // Activate all inputs
         for (var i = inputs.length - 1; i >= 0; i--) {
           inputs[i].checked = true;
-          ThreadListUI.clickInput(inputs[i]);
         }
 
         var checkAllButton =
@@ -291,30 +310,105 @@ suite('SMS App Unit-Test', function() {
         // Deactivate all inputs
         for (var i = inputs.length - 1; i >= 0; i--) {
           inputs[i].checked = false;
-          ThreadListUI.clickInput(inputs[i]);
         }
         ThreadListUI.checkInputs();
         assert.isFalse(checkAllButton.disabled);
         assert.isTrue(uncheckAllButton.disabled);
         // Activate only one
         inputs[0].checked = true;
-        ThreadListUI.clickInput(inputs[0]);
         ThreadListUI.checkInputs();
         assert.isFalse(checkAllButton.disabled);
         assert.isFalse(uncheckAllButton.disabled);
+      });
+
+      test('Select all while receiving new thread', function(done) {
+        document.getElementById('main-wrapper').classList.add('edit');
+        ThreadListUI.toggleCheckedAll(true);
+
+        var checkboxes =
+          ThreadListUI.container.querySelectorAll('input[type=checkbox]');
+        assert.equal(4,
+          [].slice.call(checkboxes).filter(function(i) {
+            return i.checked;
+          }).length, 'All items should be checked');
+
+        // now a new message comes in for a new thread...
+        ThreadListUI.count++;
+        ThreadListUI.appendThread({
+          participants: ['287138'],
+          body: 'Recibidas!',
+          id: 9999,
+          timestamp: new Date(),
+          channel: 'sms'
+        });
+
+        checkboxes =
+          ThreadListUI.container.querySelectorAll('input[type=checkbox]');
+
+        assert.equal(checkboxes.length, 5);
+        assert.equal(ThreadListUI.count, 5, '.count should be in sync');
+        assert.equal(checkboxes[4].checked, true);
+        assert.equal(checkboxes[2].checked, true);
+        // new checkbox should have been added
+        assert.equal(checkboxes[0].checked, false);
+
+        // Select all and Deselect all should both be enabled
+        assert.isFalse(document.getElementById('threads-check-all-button')
+          .hasAttribute('disabled'), 'Check all enabled');
+        assert.isFalse(document.getElementById('threads-uncheck-all-button')
+          .hasAttribute('disabled'), 'Uncheck all enabled');
+
+        done();
+      });
+
+      test('checkInputs should fire in edit mode', function(done) {
+        document.getElementById('main-wrapper').classList.add('edit');
+        ThreadListUI.checkInputs = stub();
+
+        ThreadListUI.counter++;
+        ThreadListUI.appendThread({
+          participants: ['287138'],
+          body: 'Recibidas!',
+          id: 9999,
+          timestamp: new Date(),
+          channel: 'sms'
+        });
+
+        assert.equal(ThreadListUI.checkInputs.callCount, 1);
+        done();
+      });
+
+      test('checkInputs should not fire in normal mode', function(done) {
+        document.getElementById('main-wrapper').classList.remove('edit');
+        ThreadListUI.checkInputs = stub();
+
+        ThreadListUI.counter++;
+        ThreadListUI.appendThread({
+          participants: ['287138'],
+          body: 'Recibidas!',
+          id: 9999,
+          timestamp: new Date(),
+          channel: 'sms'
+        });
+
+        assert.equal(ThreadListUI.checkInputs.callCount, 0);
+        done();
       });
     });
 
     teardown(function() {
       ThreadListUI.container.innerHTML = '';
+      ThreadListUI.checkInputs = _tci;
     });
   });
 
   // Suite for reviewing Thread-view ("bubbles" view)
   suite('Messages given a thread', function() {
+    var _tci;
     // Setup for getting all messages rendered before every test
     setup(function(done) {
       ThreadUI.renderMessages({}, done);
+      _tci = ThreadUI.checkInputs;
     });
 
     suite('Thread-messages rendering (bubbles view)', function() {
@@ -401,10 +495,103 @@ suite('SMS App Unit-Test', function() {
         assert.isFalse(checkAllButton.disabled);
         assert.isFalse(uncheckAllButton.disabled);
       });
+
+      test('Select all while receiving new message', function(done) {
+        document.getElementById('main-wrapper').classList.add('edit');
+        ThreadUI.toggleCheckedAll(true);
+
+        var checkboxes =
+          ThreadUI.container.querySelectorAll('input[type=checkbox]');
+        assert.equal(checkboxes.length,
+          [].slice.call(checkboxes).filter(function(i) {
+            return i.checked;
+          }).length, 'All items should be checked');
+
+        // now a new message comes in...
+        ThreadUI.appendMessage({
+          sender: '197746797',
+          body: 'Recibidas!',
+          delivery: 'received',
+          id: 9999,
+          timestamp: new Date(),
+          channel: 'sms'
+        });
+
+        // new checkbox should have been added
+        checkboxes =
+          ThreadUI.container.querySelectorAll('input[type=checkbox]');
+        assert.equal(checkboxes.length, 6);
+        assert.equal(checkboxes[2].checked, true);
+        assert.equal(checkboxes[5].checked, false);
+
+        // Select all and Deselect all should both be enabled
+        assert.isFalse(document.getElementById('messages-check-all-button')
+          .hasAttribute('disabled'), 'Check all enabled');
+        assert.isFalse(document.getElementById('messages-uncheck-all-button')
+          .hasAttribute('disabled'), 'Uncheck all enabled');
+
+        // now delete the selected messages...
+        MessageManager.deleteMessages = stub(function(list, itCb) {
+          setTimeout(itCb);
+        });
+
+        window.confirm = stub(true);
+
+        setTimeout(function() {
+          assert.equal(window.confirm.callCount, 1);
+          assert.equal(MessageManager.deleteMessages.callCount, 1);
+          assert.equal(MessageManager.deleteMessages.calledWith[0].length, 5);
+          assert.equal(ThreadUI.container.querySelectorAll('li').length, 1);
+          assert.equal(
+            ThreadUI.container.querySelector('#message-9999 p').textContent,
+            'Recibidas!');
+
+          done();
+        }, 1500); // only the last one is slow. What is blocking?
+
+        ThreadUI.delete();
+      });
+
+      test('checkInputs should fire in edit mode', function(done) {
+        document.getElementById('main-wrapper').classList.add('edit');
+        ThreadUI.checkInputs = stub();
+
+        // now a new message comes in...
+        ThreadUI.appendMessage({
+          sender: '197746797',
+          body: 'Recibidas!',
+          delivery: 'received',
+          id: 9999,
+          timestamp: new Date(),
+          channel: 'sms'
+        });
+
+        assert.equal(ThreadUI.checkInputs.callCount, 1);
+        done();
+      });
+
+      test('checkInputs should not fire in normal mode', function(done) {
+        document.getElementById('main-wrapper').classList.remove('edit');
+        ThreadUI.checkInputs = stub();
+
+        // now a new message comes in...
+        ThreadUI.appendMessage({
+          sender: '197746797',
+          body: 'Recibidas!',
+          delivery: 'received',
+          id: 9999,
+          timestamp: new Date(),
+          channel: 'sms'
+        });
+
+        assert.equal(ThreadUI.checkInputs.callCount, 0);
+        done();
+      });
     });
 
     teardown(function() {
       ThreadUI.container.innerHTML = '';
+      ThreadUI.checkInputs = _tci;
     });
   });
 


### PR DESCRIPTION
Fix for [#857942](https://bugzilla.mozilla.org/show_bug.cgi?id=857942). Do a `checkInputs` call after appending messages. Also added tests for this scenario.
