### PR TITLE
Bug 859719 - [Dialer] Follow up to bug 835750 - Validate the numbers that are passed to the RIL to dial.

### DIFF
--- a/apps/communications/dialer/js/telephony_helper.js
+++ b/apps/communications/dialer/js/telephony_helper.js
@@ -72,14 +72,8 @@ var TelephonyHelper = (function() {
   }
 
   var isValid = function t_isValid(sanitizedNumber) {
-    if (sanitizedNumber) {
-      var matches = sanitizedNumber.match(/[0-9#+*]{1,50}/);
-      if (matches.length === 1 &&
-          matches[0].length === sanitizedNumber.length) {
-        return true;
-      }
-    }
-    return false;
+    var validExp = /^[0-9#+*]{1,50}$/;
+    return validExp.test(sanitizedNumber);
   };
 
   var displayMessage = function t_displayMessage(message) {


### PR DESCRIPTION
The code included in the patch to bug 835750 is not correct regarding the isValid() function in telephony_helper.js. The case where the match() function of the String object returns null is not properly dealt. Instead, Antonio suggests using the RegExp.test() function.
