### PR TITLE
Bug 859281:[Video Player]After completion of video playing slider goes to 25% of total video time before resetting to zero.

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -923,7 +923,6 @@ function playerEnded() {
     endedTimer = null;
   }
 
-  dom.player.currentTime = 0;
   hidePlayer();
 }
 


### PR DESCRIPTION
After completion of video playing slider goes to 25% of total video time before resetting to zero.
