### PR TITLE
Bug 847566 - Shim for mozSetMessageHandler and mozNotification. r=kgrandon

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -144,6 +144,12 @@ if (!window.location.hash.length) {
             sender = message.sender;
           }
 
+          if (MessageManager._mozSms === window.MockNavigatormozSms) {
+            MessageManager._mozSms.addMessageToDb(
+              message.sender, message.body);
+            MessageManager.getThreads(ThreadListUI.renderThreads);
+          }
+
           NotificationHelper.send(sender, message.body, iconURL, goToMessage);
         });
       };

--- a/apps/sms/js/sms_mock.js
+++ b/apps/sms/js/sms_mock.js
@@ -287,7 +287,7 @@
         idx += 1;
         request.continue = continueCursor;
         if (typeof request.onsuccess === 'function') {
-          request.onsuccess.call(null);
+          request.onsuccess.call(request);
         }
       }
 
@@ -356,10 +356,11 @@
         }
       } else {
         request.result = msgs[idx];
+        request.done = !request.result;
         idx += 1;
         request.continue = continueCursor;
         if (typeof request.onsuccess === 'function') {
-          request.onsuccess.call(null);
+          request.onsuccess.call(request);
         }
       }
 
@@ -409,11 +410,43 @@
       }
 
       if (typeof request.onsuccess === 'function') {
-        request.onsuccess.call(null);
+        request.onsuccess.call(request);
       }
     }, simulation.delay());
 
     return request;
+  };
+
+  MockNavigatormozSms.addMessageToDb = function(number, body) {
+    var thread = messagesDb.threads.filter(function(t) {
+      return t.participants[0] === number;
+    })[0];
+    if (thread) {
+      thread.unreadCount++;
+      thread.body = body;
+      thread.timestamp = new Date();
+    }
+    else {
+      thread = {
+        id: messagesDb.id++,
+        participants: [number],
+        body: body,
+        timestamp: new Date(),
+        unreadCount: 1
+      };
+      messagesDb.threads.push(thread);
+    }
+
+    var message = {
+      sender: number,
+      receiver: null,
+      delivery: 'received',
+      body: body,
+      id: messagesDb.id++,
+      timestamp: new Date(),
+      threadId: thread.id
+    };
+    messagesDb.messages.push(message);
   };
 
 }(this));

--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -99,7 +99,10 @@ var NotificationScreen = {
         this.addNotification(detail);
         break;
       case 'tap':
-        var target = evt.target;
+        var target = evt.target.dataset.notificationID
+          ? evt.target
+          : evt.currentTarget;
+
         this.tap(target);
         break;
       case 'mousedown':

--- a/tools/extensions/desktop-helper/content/content.js
+++ b/tools/extensions/desktop-helper/content/content.js
@@ -29,6 +29,7 @@ const kScriptsPerDomain = {
     'lib/idle.js',
     'lib/keyboard.js',
     'lib/mobile_connection.js',
+    'lib/notification.js',
     'lib/power.js',
     'lib/set_message_handler.js',
     'lib/wifi.js'

--- a/tools/extensions/desktop-helper/content/data/ffos_runtime.js
+++ b/tools/extensions/desktop-helper/content/data/ffos_runtime.js
@@ -23,7 +23,8 @@ FFOS_RUNTIME = {
    * Creates a navigator shim on the window
    * @param {String} property name.
    * @param {Object} property definition.
-   * @param {Boolean} if true, makes a navigator setter for this object. Useful for testing.
+   * @param {Boolean} if true, makes a navigator setter for this object.
+   *                  Useful for testing.
    */
   makeNavigatorShim: function(property, definition, makeSetter) {
     try {
@@ -104,7 +105,8 @@ FFOS_RUNTIME.getAppWindow(function(win) {
   /**
    * Remove the nextPaintListener
    **/
-  win.HTMLIFrameElement.prototype.removeNextPaintListener = function(callback) {
+  win.HTMLIFrameElement.prototype.removeNextPaintListener =
+        function(callback) {
 
   };
 });

--- a/tools/extensions/desktop-helper/content/data/ffos_runtime.js
+++ b/tools/extensions/desktop-helper/content/data/ffos_runtime.js
@@ -49,23 +49,19 @@ FFOS_RUNTIME = {
    * @param {Object} The e.detail object passed to the event.
    */
   sendFrameEvent: function(data) {
-
     var eventDetail = {
       detail: data
     };
 
-    var targetFrame;
     if (/system.gaiamobile.org/.test(location.href)) {
-      targetFrame = window;
       var evtObject = new CustomEvent('mozChromeEvent', eventDetail);
+      evtObject.source = window;
       window.dispatchEvent(evtObject);
 
       return;
     }
 
-    targetFrame = parent;
-
-    targetFrame.postMessage({
+    parent.postMessage({
       action: 'dispatchMessage',
       payload: eventDetail
     }, 'http://system.gaiamobile.org:8080');
@@ -87,6 +83,7 @@ var debug = FFOS_RUNTIME.debug;
     if (e.data.action == 'dispatchMessage') {
       FFOS_RUNTIME.getAppWindow(function(win) {
         var evtObject = new CustomEvent('mozChromeEvent', e.data.payload);
+        evtObject.source = e.source;
         win.dispatchEvent(evtObject);
       });
     }

--- a/tools/extensions/desktop-helper/content/data/lib/activity.js
+++ b/tools/extensions/desktop-helper/content/data/lib/activity.js
@@ -41,7 +41,10 @@
               if (activityKey != self.config.name) { continue }
 
               // Verify we match a filter
-              if (app.manifest.activities[activityKey].filters.type.indexOf(self.config.data.type) === -1) { continue }
+              if (app.manifest.activities[activityKey].filters.type
+                .indexOf(self.config.data.type) === -1) {
+                  continue;
+              }
 
               // We found the activity
               activityFound = true;

--- a/tools/extensions/desktop-helper/content/data/lib/alarm.js
+++ b/tools/extensions/desktop-helper/content/data/lib/alarm.js
@@ -35,7 +35,8 @@
   var realMsgHandler = navigator.mozSetMessageHandler;
 
   // do the override
-  FFOS_RUNTIME.makeNavigatorShim('mozSetMessageHandler', function(type, callback) {
+  FFOS_RUNTIME.makeNavigatorShim('mozSetMessageHandler', function(type,
+                                                                  callback) {
     if (type === 'alarm') {
       messageHandler = callback;
     } else if (realMsgHandler) {

--- a/tools/extensions/desktop-helper/content/data/lib/apps.js
+++ b/tools/extensions/desktop-helper/content/data/lib/apps.js
@@ -47,7 +47,11 @@
         scope.onsuccess({
           target: {
             result: {
-              installOrigin: 'http://' + app + '.gaiamobile.org:8080'
+              installOrigin: 'http://' + app + '.gaiamobile.org:8080',
+              manifest: {},
+              launch: function() {
+                // todo!
+              }
             }
           }
         });

--- a/tools/extensions/desktop-helper/content/data/lib/cameras.js
+++ b/tools/extensions/desktop-helper/content/data/lib/cameras.js
@@ -60,7 +60,8 @@
       cnvs.width = config.pictureSize.width;
       cnvs.height = config.pictureSize.height;
       var ctx = cnvs.getContext('2d');
-      ctx.drawImage(window.document.querySelector('video'), 0, 0, cnvs.width, cnvs.height);
+      ctx.drawImage(window.document.querySelector('video'), 0, 0,
+                      cnvs.width, cnvs.height);
       cnvs.toBlob(function(blob) {
           onSuccess(blob);
       }, 'image/jpeg');

--- a/tools/extensions/desktop-helper/content/data/lib/getdevicestorage.js
+++ b/tools/extensions/desktop-helper/content/data/lib/getdevicestorage.js
@@ -62,7 +62,9 @@
                 });
                 return proxy;
             }
-            var decoded = new Blob([convertBase64ToBinary(blob)], { type: 'image/png' });
+            var decoded = new Blob([convertBase64ToBinary(blob)], {
+              type: 'image/png'
+            });
             decoded.name = name;
             decoded.lastModifiedDate = new Date();
 
@@ -110,7 +112,8 @@
                 this.results = {};
 
                 this.__defineGetter__('result', function() {
-                    console.log('DeviceStorage.enumerate.result', typeof self.results[self.ix]);
+                    console.log('DeviceStorage.enumerate.result',
+                      typeof self.results[self.ix]);
                     return self.results[self.ix];
                 });
 
@@ -128,14 +131,17 @@
                     }
 
                     // decode the base64 blob to a normal Blob thingy
-                    var decoded = new Blob([convertBase64ToBinary(blob)], { type: 'image/png' });
+                    var decoded = new Blob([convertBase64ToBinary(blob)], {
+                      type: 'image/png'
+                    });
                     decoded.name = 'file' + ix + '.png';
                     decoded.lastModifiedDate = new Date();
                     this.results[ix] = decoded;
 
+                    // if you need to simulate sd card speed, add timeout here
                     setTimeout(function() {
                         self.onsuccess();
-                    }); // if you need to simulate sd card speed, add a timeout here
+                    });
                 };
             })();
 

--- a/tools/extensions/desktop-helper/content/data/lib/idle.js
+++ b/tools/extensions/desktop-helper/content/data/lib/idle.js
@@ -1,9 +1,9 @@
 !function() {
-  FFOS_RUNTIME.makeNavigatorShim('addIdleObserver', function addIdleObserver(callback) {
+  FFOS_RUNTIME.makeNavigatorShim('addIdleObserver', function(callback) {
     console.log('Adding idle observer');
   });
 
-  FFOS_RUNTIME.makeNavigatorShim('removeIdleObserver', function removeIdleObserver(callback) {
+  FFOS_RUNTIME.makeNavigatorShim('removeIdleObserver', function(callback) {
     console.log('Removing idle observer');
   });
 }();

--- a/tools/extensions/desktop-helper/content/data/lib/keyboard.js
+++ b/tools/extensions/desktop-helper/content/data/lib/keyboard.js
@@ -3,7 +3,12 @@
   // Invoke the keyboard if we're viewing that page
   if (/keyboard.gaiamobile.org/.test(location.href) && parent == window) {
     setTimeout(function() {
-      window.navigator.mozKeyboard.onfocuschange({detail: {type: 'text', value: 'foo'}});
+      window.navigator.mozKeyboard.onfocuschange({
+        detail: {
+          type: 'text',
+          value: 'foo'
+        }
+      });
     }, 300);
   }
 

--- a/tools/extensions/desktop-helper/content/data/lib/notification.js
+++ b/tools/extensions/desktop-helper/content/data/lib/notification.js
@@ -1,44 +1,99 @@
 !function() {
-  function sendChromeEvent(detail) {
-      var customEvt = document.createEvent('CustomEvent');
-      customEvt.initCustomEvent('mozChromeEvent', true, true, detail);
-      window.dispatchEvent(customEvt);
-  }
 
-  var nid = 0;
-  var listeners = {};
-
-  window.addEventListener('mozContentEvent', function(ev) {
-    var px;
-
-    if (ev.detail.type === 'desktop-notification-click') {
-      px = listeners[ev.detail.id];
-      px.onclick && px.onclick();
+  function system() {
+    function sendChromeEvent(detail) {
+        var customEvt = document.createEvent('CustomEvent');
+        customEvt.initCustomEvent('mozChromeEvent', true, true, detail);
+        window.dispatchEvent(customEvt);
     }
-    else if (ev.detail.type === 'desktop-notification-close') {
-      px = listeners[ev.detail.id];
-      px.onclose && px.onclose();
-    }
-  });
 
-  function Notification() {
-    this.createNotification = function(title, body, icon) {
-      var px = {};
-      px.show = function() {
+    // someone interacted with the notification (from the system app)
+    window.addEventListener('mozContentEvent', function(ev) {
+      var px;
+
+      if (ev.detail.type === 'desktop-notification-click') {
+        px = listeners[ev.detail.id];
+
+        px.source.postMessage({
+          action: 'notification-click',
+          id: px.sourceId
+        }, px.origin);
+      }
+      else if (ev.detail.type === 'desktop-notification-close') {
+        px = listeners[ev.detail.id];
+
+        px.source.postMessage({
+          action: 'notification-close',
+          id: px.sourceId
+        }, px.origin);
+      }
+    });
+
+    var nid = 0;
+    var listeners = {};
+    window.addEventListener('mozChromeEvent', function(e) {
+      var detail = e.detail;
+      if (detail.type === 'notification') {
+
         var id = ++nid;
+        // show notification
         sendChromeEvent({
           type: 'desktop-notification',
           id: id,
-          title: title,
-          text: body,
-          manifestURL: 'http://sytem.gaiamobile.org:8080/manifest.webapp'
+          title: detail.title,
+          text: detail.text,
+          manifestURL: detail.manifestURL,
+          icon: detail.icon
         });
 
-        listeners[id] = px;
-      };
-      return px;
-    };
+        listeners[id] = {
+          source: e.source,
+          sourceId: detail.id,
+          origin: detail.origin
+        };
+      }
+    });
+  }
+  if (/system.gaiamobile.org/.test(location.href)) {
+    system();
   }
 
-  FFOS_RUNTIME.makeNavigatorShim('mozNotification', new Notification());
+  // SHIM!
+  (function() {
+    var nid = 0;
+    var listeners = {};
+    function Notification() {
+      this.createNotification = function(title, body, icon) {
+        var px = {};
+        px.show = function() {
+          var id = ++nid;
+
+          FFOS_RUNTIME.sendFrameEvent({
+            type: 'notification',
+            id: id,
+            title: title,
+            text: body,
+            manifestURL: 'http://sytem.gaiamobile.org:8080/manifest.webapp',
+            origin: window.location + '',
+            icon: icon
+          });
+
+          listeners[id] = px;
+        };
+        return px;
+      };
+    }
+
+    window.addEventListener('message', function(e) {
+      var px = (listeners[e.data.id] || []);
+      if (e.data.action === 'notification-click') {
+        px.onclick && px.onclick();
+      }
+      else if (e.data.action === 'notification-close') {
+        px.onclose && px.onclose();
+      }
+    });
+
+    FFOS_RUNTIME.makeNavigatorShim('mozNotification', new Notification());
+  })();
 }();

--- a/tools/extensions/desktop-helper/content/data/lib/notification.js
+++ b/tools/extensions/desktop-helper/content/data/lib/notification.js
@@ -1,0 +1,19 @@
+!function() {
+  function Notification() {
+    this.createNotification = function(title, body, icon) {
+      var px = {};
+      px.show = function() {
+        var text = 'NOTIFICATION!\n\n' + title + '\n\n' + body + '\n' + icon;
+        if (confirm(text)) {
+          px.onclick && px.onclick();
+        }
+        else {
+          px.onclose && px.onclose();
+        }
+      };
+      return px;
+    };
+  }
+
+  FFOS_RUNTIME.makeNavigatorShim('mozNotification', new Notification());
+}();

--- a/tools/extensions/desktop-helper/content/data/lib/notification.js
+++ b/tools/extensions/desktop-helper/content/data/lib/notification.js
@@ -1,15 +1,40 @@
 !function() {
+  function sendChromeEvent(detail) {
+      var customEvt = document.createEvent('CustomEvent');
+      customEvt.initCustomEvent('mozChromeEvent', true, true, detail);
+      window.dispatchEvent(customEvt);
+  }
+
+  var nid = 0;
+  var listeners = {};
+
+  window.addEventListener('mozContentEvent', function(ev) {
+    var px;
+
+    if (ev.detail.type === 'desktop-notification-click') {
+      px = listeners[ev.detail.id];
+      px.onclick && px.onclick();
+    }
+    else if (ev.detail.type === 'desktop-notification-close') {
+      px = listeners[ev.detail.id];
+      px.onclose && px.onclose();
+    }
+  });
+
   function Notification() {
     this.createNotification = function(title, body, icon) {
       var px = {};
       px.show = function() {
-        var text = 'NOTIFICATION!\n\n' + title + '\n\n' + body + '\n' + icon;
-        if (confirm(text)) {
-          px.onclick && px.onclick();
-        }
-        else {
-          px.onclose && px.onclose();
-        }
+        var id = ++nid;
+        sendChromeEvent({
+          type: 'desktop-notification',
+          id: id,
+          title: title,
+          text: body,
+          manifestURL: 'http://sytem.gaiamobile.org:8080/manifest.webapp'
+        });
+
+        listeners[id] = px;
       };
       return px;
     };

--- a/tools/extensions/desktop-helper/content/data/lib/set_message_handler.js
+++ b/tools/extensions/desktop-helper/content/data/lib/set_message_handler.js
@@ -1,5 +1,62 @@
 !function() {
-  FFOS_RUNTIME.makeNavigatorShim('mozSetMessageHandler', function(name, callback) {
-    console.log('navigator.mozSetMessageHandler');
+
+
+  if (/system.gaiamobile.org/.test(location.href)) {
+    var frameListeners = {};
+
+    // Receive a setMessageHandler from the app
+    window.addEventListener('message', function(e) {
+      if (e.data.action == 'dispatchMessage' &&
+            e.data.payload.detail.type === 'setMessageHandler') {
+        var detail = e.data.payload.detail;
+        frameListeners[detail.eventName] =
+          frameListeners[detail.eventName] || [];
+
+        frameListeners[detail.eventName].push(e.source);
+      }
+    });
+
+    // Fake a message handler. I thought of the name myself as there is no
+    // alternative in the real Gaia (only through Gecko).
+    FFOS_RUNTIME.makeNavigatorShim('mozTriggerMessageHandler', function(name,
+                                                                  detail) {
+      (frameListeners[name] || []).forEach(function(l) {
+        l.postMessage({
+          action: 'triggerMessageHandler',
+          evName: name,
+          payload: detail
+        }, '*');
+      });
+    }, true);
+  }
+
+  // so this is how it works:
+  // 1. When registering with mozSetMessageHandler we have an EventEmitter
+  //    like object that lives in the app iFrame context;
+  //    additionally we tell the system app that we're interested in this event
+  // 2. An event gets fired via mozTriggerMessageHandler,
+  //    the system app checks which apps are interested and does a
+  //    `postMessage` to them
+  // 3. App grabs the listeners and invokes them based on this data
+  var messageListeners = {};
+
+  // React on events from the system app regarding message handlers
+  window.addEventListener('message', function(e) {
+    if (e.data.action === 'triggerMessageHandler') {
+      (messageListeners[e.data.evName] || []).forEach(function(fn) {
+        fn(e.data.payload);
+      });
+    }
+  });
+
+  // mozSetMessageHandler called from within the app
+  FFOS_RUNTIME.makeNavigatorShim('mozSetMessageHandler', function(evName, cb) {
+    FFOS_RUNTIME.sendFrameEvent({
+      type: 'setMessageHandler',
+      eventName: evName
+    });
+
+    messageListeners[evName] = messageListeners[evName] || [];
+    messageListeners[evName].push(cb);
   }, true);
 }();

--- a/tools/extensions/desktop-helper/content/panel/controls.js
+++ b/tools/extensions/desktop-helper/content/panel/controls.js
@@ -1,16 +1,5 @@
 !function() {
 
-function sendChromeEvent(detail) {
-    var contentDetail = Components.utils.createObjectIn(tab);
-    for (var i in detail) {
-        contentDetail[i] = detail[i];
-    }
-    Components.utils.makeObjectPropsNormal(contentDetail);
-    var customEvt = tab.document.createEvent('CustomEvent');
-    customEvt.initCustomEvent('mozChromeEvent', true, true, contentDetail);
-    tab.dispatchEvent(customEvt);
-}
-
 function HardwareButtons() {
 
 }
@@ -52,15 +41,25 @@ function Emulation() {
 }
 
 Emulation.prototype = {
-    notification: function() {
-        sendChromeEvent({
-            type: 'desktop-notification',
-            id: 123,
-            title: 'Some Notification',
-            text: 'I love notifications.',
-            manifestURL: 'http://sytem.gaiamobile.org:8080/manifest.webapp'
-         });
-    }
+  nid: 0,
+  notification: function() {
+    var id = ++this.nid;
+    var n = tab.wrappedJSObject.navigator.mozNotification.createNotification(
+      'Some Notification',
+      'I love notifications. #' + id);
+
+    n.onclick = function() {
+      document.querySelector('#log').textContent =
+        'You clicked notification #' + id + '!';
+    };
+
+    n.onclose = function() {
+      document.querySelector('#log').textContent =
+        'You closed notification #' + id + '!';
+    };
+
+    n.show();
+  }
 };
 window.emulation = new Emulation();
 }();

--- a/tools/extensions/desktop-helper/content/panel/controls.js
+++ b/tools/extensions/desktop-helper/content/panel/controls.js
@@ -59,6 +59,20 @@ Emulation.prototype = {
     };
 
     n.show();
+  },
+  receiveSMS: function() {
+    try {
+      // execute this on the context of the window because that has CORS
+      // acceptance to send stuff to the consuming party
+      tab.wrappedJSObject.eval("navigator.mozTriggerMessageHandler('sms-received', {\
+          sender: '52656642666',\
+          body: 'Hola supermercado!'\
+        });");
+    }
+    catch(ex) {
+      document.querySelector('#log').textContent =
+        'receive sms ' + ex;
+    }
   }
 };
 window.emulation = new Emulation();

--- a/tools/extensions/desktop-helper/content/panel/index.html
+++ b/tools/extensions/desktop-helper/content/panel/index.html
@@ -15,4 +15,5 @@
 <h3>Emulation</h3>
 <section>
 	<button onclick="emulation.notification()">Notification</button>
+  <div id="log"></div>
 </section>

--- a/tools/extensions/desktop-helper/content/panel/index.html
+++ b/tools/extensions/desktop-helper/content/panel/index.html
@@ -15,5 +15,6 @@
 <h3>Emulation</h3>
 <section>
 	<button onclick="emulation.notification()">Notification</button>
+  <button onclick="emulation.receiveSMS()">Receive SMS</button>
   <div id="log"></div>
 </section>


### PR DESCRIPTION
Yet another addition to the shims. This adds mozSetMessageHandlers and mozNotification. To trigger a message handler execute:

``` javascript
navigator.mozTriggerMessageHandler('eventname', { payload: 'data' })
```

Note that handlers aren't auto-added. You have to start up the app once (f.e. SMS app), then you can go back to the homescreen, trigger the event and see the notification pop up that originates from the SMS application.

@vingtetun @kevingrandon
