### PR TITLE
after completion of video playing in landscape mode time stamps for video files in list view are not displayed

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -1237,11 +1237,6 @@ window.addEventListener('resize', function() {
     setPlayerSize();
   }
 
-  // reTruncate text
-  var texts = document.querySelectorAll('.details');
-  for (var i = 0; i < texts.length; i++) {
-    textTruncate(texts[i]);
-  }
 });
 
 dom.player.addEventListener('timeupdate', timeUpdated);


### PR DESCRIPTION
After completion of video playing in landscape mode time stamps for video files in list view are not displayed
