### PR TITLE
Define mocks based on document domain

### DIFF
--- a/tools/extensions/desktop-helper/content/content.js
+++ b/tools/extensions/desktop-helper/content/content.js
@@ -84,9 +84,7 @@ var LoadListener = {
     currentWindow.alreadyMocked = true;
 
     try {
-      let currentDomain = currentWindow.location.toString();
-      if (currentDomain == 'about:blank')
-        return;
+      let currentDomain = currentWindow.document.domain;
 
       debug('loading scripts for app: ' + currentDomain);
       for (let domain in kScriptsPerDomain) {


### PR DESCRIPTION
Instead of inferring the document's domain from the location object,
query the global `document.domain` string. This approach acheives the
desired behavior for iFrames that do not declare a `src` attribute (in
such cases, `location.toString()` yeilds `undefined`, but
`document.domain` correctly returns the domain of the parent document.
