### PR TITLE
use platform-specific path separators so build scripts work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ ifneq ($(GAIA_OUTOFTREE_APP_SRCDIRS),)
 endif
 
 GAIA_LOCALES_PATH?=locales
-LOCALES_FILE?=shared/resources/languages.json
+LOCALES_FILE?=shared$(SEP)resources$(SEP)languages.json
 GAIA_LOCALE_SRCDIRS=shared $(GAIA_APP_SRCDIRS)
 GAIA_DEFAULT_LOCALE?=en-US
 GAIA_INLINE_LOCALES?=1
@@ -220,12 +220,12 @@ ifneq ($(LOCALE_BASEDIR),)
 		targets="$$targets --target $$appdir"; \
 	done; \
 	python $(CURDIR)/build/multilocale.py \
-		--config $(LOCALES_FILE) \
-		--source $(LOCALE_BASEDIR) \
+		--config '$(LOCALES_FILE)' \
+		--source '$(LOCALE_BASEDIR)' \
 		$$targets;
 	@echo "Done"
-ifneq ($(LOCALES_FILE),shared/resources/languages.json)
-	cp $(LOCALES_FILE) shared/resources/languages.json
+ifneq ($(LOCALES_FILE),shared$(SEP)resources$(SEP)languages.json)
+	cp '$(LOCALES_FILE)' shared$(SEP)resources$(SEP)languages.json
 endif
 endif
 
@@ -381,7 +381,7 @@ define run-js-command
 	const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)";       \
 	const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)";                             \
 	const GAIA_LOCALES_PATH = "$(GAIA_LOCALES_PATH)";                           \
-	const LOCALES_FILE = "$(LOCALES_FILE)";                                     \
+	const LOCALES_FILE = "$(subst \,\\,$(LOCALES_FILE))";                       \
 	const BUILD_APP_NAME = "$(BUILD_APP_NAME)";                                 \
 	const PRODUCTION = "$(PRODUCTION)";                                         \
 	const GAIA_OPTIMIZE = "$(GAIA_OPTIMIZE)";                                   \

--- a/build/multilocale.py
+++ b/build/multilocale.py
@@ -115,7 +115,7 @@ def copy_properties(source, locales, ini_file):
             target_path = os.path.join(ini_dirname, path)
             # apps/browser/locales/browser.fr.properties becomes
             # apps/browser/browser.properties
-            source_path = target_path.replace('/locales', '') \
+            source_path = target_path.replace(os.sep + 'locales', '') \
                                      .replace('.%s' % locale, '')
             source_path = os.path.join(source, locale, source_path)
             if not os.path.exists(source_path):

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -362,8 +362,9 @@ if (GAIA_INLINE_LOCALES === '1') {
 
   // LOCALES_FILE is a relative path by default: shared/resources/languages.json
   // -- but it can be an absolute path when doing a multilocale build.
-  // LOCALES_FILE is using unix separator, ensure working fine on win32
-  let abs_path_chunks = [GAIA_DIR].concat(LOCALES_FILE.split('/'));
+  let os = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).OS;
+  let separator = os == "WINNT" ? "\\" : "/";
+  let abs_path_chunks = [GAIA_DIR].concat(LOCALES_FILE.split(separator));
   let file = getFile.apply(null, abs_path_chunks);
   if (!file.exists()) {
     file = getFile(LOCALES_FILE);


### PR DESCRIPTION
This is the reviewed, commit-ready patch for [bug 858640](https://bugzilla.mozilla.org/show_bug.cgi?id=858640).
