### PR TITLE
Bug 857795 - Convert bluetooth VTS command to keypad press. r=etienne, a=leo+.

### DIFF
--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -596,6 +596,18 @@ var KeypadManager = {
     this._updatePhoneNumberView(ellipsisSide, maxFontSize);
   },
 
+  press: function(value) {
+    var telephony = navigator.mozTelephony;
+
+    telephony.stopTone();
+    telephony.startTone(value);
+    TonePlayer.start(gTonesFrequencies[value], true);
+    setTimeout(function nextTick() {
+      telephony.stopTone();
+      TonePlayer.stop();
+    });
+  },
+
   _updatePhoneNumberView: function kh_updatePhoneNumberview(ellipsisSide,
     maxFontSize) {
     var phoneNumber = this._phoneNumber;

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -499,6 +499,12 @@ var OnCallHandler = (function onCallHandler() {
       case 'CHLD+ATA':
         holdAndAnswer();
         break;
+      default:
+        var partialCommand = message.substring(0, 3);
+        if (partialCommand === 'VTS') {
+          KeypadManager.press(message.substring(4));
+        }
+        break;
     }
   }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=857795
