### PR TITLE
Bug 861152 - [Settings] Fix alignment of .fake-select

### DIFF
--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -335,7 +335,7 @@ ul li p + select {
 .fake-select {
   position: relative;
   display: block;
-  padding: 1rem 1.5rem 1.5rem 1.5rem;
+  padding: 1.1rem 3rem;
   margin: 0;
   height: 3.8rem;
 }


### PR DESCRIPTION
The patch for Bug 802234 changes the padding for .fake-select ([Line 338](https://github.com/mozilla-b2g/gaia/commit/6fdf36c189e0963774abf44806fbfd948e16e531#L1L324) in apps/settings/style/lists.css) without actually needing it for the fix, from what I noticed. This breaks the alignment for the lock timeout select in "Phone lock" screen.
