### PR TITLE
Bug 853757 - [Buri][Email/IMAP] Attachment names are not being MIME-word decoded. r=squib. a=blocking-b2g=tef+

### DIFF
--- a/apps/email/js/ext/mailapi/chewlayer.js
+++ b/apps/email/js/ext/mailapi/chewlayer.js
@@ -3412,11 +3412,13 @@ exports.escapeAttrValue = function(s) {
 
 define('mailapi/imap/imapchew',
   [
+    'mimelib',
     '../quotechew',
     '../htmlchew',
     'exports'
   ],
   function(
+    $mimelib,
     $quotechew,
     $htmlchew,
     exports
@@ -3548,8 +3550,10 @@ function chewStructure(msg) {
     }
 
     function makePart(partInfo, filename) {
+
       return {
-        name: filename || 'unnamed-' + (++unnamedPartCounter),
+        name: $mimelib.parseMimeWords(filename) ||
+              'unnamed-' + (++unnamedPartCounter),
         contentId: partInfo.id ? stripArrows(partInfo.id) : null,
         type: (partInfo.type + '/' + partInfo.subtype).toLowerCase(),
         part: partInfo.partID,


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/174

does require copy-into-gaia.js fixup from:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/175
