### PR TITLE
Bug 861424 - Bump maxVersion in gaia extension install.rdf's, r=vingtetun

### DIFF
--- a/tools/extensions/desktop-helper/install.rdf
+++ b/tools/extensions/desktop-helper/install.rdf
@@ -12,7 +12,7 @@
       <Description>
        <em:id>toolkit@mozilla.org</em:id>
        <em:minVersion>6.0</em:minVersion>
-       <em:maxVersion>22.0.*</em:maxVersion>
+       <em:maxVersion>32.0.*</em:maxVersion>
      </Description>
     </em:targetApplication>
     <em:unpack>true</em:unpack>

--- a/tools/extensions/httpd/install.rdf
+++ b/tools/extensions/httpd/install.rdf
@@ -12,12 +12,12 @@
       <Description>
        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
        <em:minVersion>6.0</em:minVersion>
-       <em:maxVersion>22.0.*</em:maxVersion>
+       <em:maxVersion>32.0.*</em:maxVersion>
      </Description>
       <Description>
        <em:id>{3c2e2abc-06d4-11e1-ac3b-374f68613e61}</em:id>
        <em:minVersion>6.0</em:minVersion>
-       <em:maxVersion>22.0.*</em:maxVersion>
+       <em:maxVersion>32.0.*</em:maxVersion>
      </Description>
     </em:targetApplication>
     <em:unpack>true</em:unpack>

--- a/tools/extensions/keyboard/install.rdf
+++ b/tools/extensions/keyboard/install.rdf
@@ -12,7 +12,7 @@
       <Description>
        <em:id>toolkit@mozilla.org</em:id>
        <em:minVersion>6.0</em:minVersion>
-       <em:maxVersion>22.0.*</em:maxVersion>
+       <em:maxVersion>32.0.*</em:maxVersion>
      </Description>
     </em:targetApplication>
     <em:unpack>true</em:unpack>


### PR DESCRIPTION
This bumps all the extension rdf's to a maxVersion of 32.0, to prevent this problem from recurring again in the near future.
