### PR TITLE
Bug 854417 - Smarter redraw of SMS list

### DIFF
--- a/apps/sms/test/unit/thread_list_mockup.js
+++ b/apps/sms/test/unit/thread_list_mockup.js
@@ -29,7 +29,7 @@ function MockThreadList() {
             id: 4,
             participants: ['1977436979'],
             body: 'Nothing :)',
-            timestamp: getMockupedDate(2),
+            timestamp: new Date(getMockupedDate(2) - 1),
             unreadCount: 2
           }
         ];


### PR DESCRIPTION
This is my experiment that I have been working on a bit. It brings initial rendering time of a list of 1,000 items down by a factor two. Subsequent redraws are infinite faster because it redraws based on a hash.

It doesn't lint at the moment, but I want some feedback first before continueing. @borjasalguero @rwldrn @fcampo 

FYI, I'm aware that this might block on the real device on large lists but it makes dev a lot easier without all the setTimeout's.
