### PR TITLE
Bug 830901 - [App Updates] Disabling all checkboxes in the update prompt...

### DIFF
--- a/apps/system/js/update_manager.js
+++ b/apps/system/js/update_manager.js
@@ -267,6 +267,7 @@ var UpdateManager = {
     }, this);
 
     this.downloadDialog.classList.add('visible');
+    this.updateDownloadButton();
   },
 
   updateDownloadButton: function() {

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -962,6 +962,29 @@ suite('system/UpdateManager', function() {
               assert.isFalse(downloadButton.disabled);
             });
           });
+
+          // Bug 830901 - Disabling all checkboxes in the update prompt...
+          suite('cancel and reopen', function() {
+            setup(function() {
+              // cancel
+              UpdateManager.cancelPrompt();
+
+              // reopen
+              UpdateManager.containerClicked();
+            });
+
+            test('should check all checkboxes', function() {
+              var checkboxes = dialog.querySelectorAll('input[type="checkbox"]');
+              for (var i = 0; i < checkboxes.length; i++) {
+                var checkbox = checkboxes[i];
+                assert.isTrue(checkbox.checked);
+              }
+            });
+
+            test('should enable the download button', function() {
+              assert.isFalse(downloadButton.disabled);
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
This showDownloadPrompt is call when update is selected from notification panel. 
Let's refresh the Download button when the showDownloadPrompt is called.
