### PR TITLE
Bug 860595 - video decoder not released while power on

### DIFF
--- a/apps/system/js/init_logo_handler.js
+++ b/apps/system/js/init_logo_handler.js
@@ -100,9 +100,19 @@ var InitLogoHandler = {
       if (elem.tagName == 'VIDEO' && !elem.ended) {
         elem.onended = function() {
           elem.classList.add('hide');
+          // XXX workaround of bug 831747
+          // Unload the video. This releases the video decoding hardware
+          // so other apps can use it.
+          elem.removeAttribute('src');
+          elem.load();
         };
       } else {
         elem.classList.add('hide');
+        // XXX workaround of bug 831747
+        // Unload the video. This releases the video decoding hardware
+        // so other apps can use it.
+        elem.removeAttribute('src');
+        elem.load();
       }
 
       self.carrierLogo.addEventListener('transitionend',

--- a/apps/system/js/sleep_menu.js
+++ b/apps/system/js/sleep_menu.js
@@ -245,10 +245,20 @@ var SleepMenu = {
       if (elem.tagName == 'VIDEO' && !elem.ended) {
         elem.onended = function() {
           elem.classList.add('hide');
+          // XXX workaround of bug 831747
+          // Unload the video. This releases the video decoding hardware
+          // so other apps can use it.
+          elem.removeAttribute('src');
+          elem.load();
         };
       } else {
         div.addEventListener('animationend', function() {
           elem.classList.add('hide');
+          // XXX workaround of bug 831747
+          // Unload the video. This releases the video decoding hardware
+          // so other apps can use it.
+          elem.removeAttribute('src');
+          elem.load();
         });
       }
 


### PR DESCRIPTION
The initial phenomenon is 'power off animation' with video for customization doesn't work

I found the  video decoder not released while power on, which cause video app can't decode and power off animation can't decode, too.

Sotaro Ikeda suggest not apply gecko patch in 1.0.1, and use workaround in gallery app instead. 

With 

```
elem.removeAttribute('src');
elem.load(); 
```

we can release hardware decorder. 

do it in elem.onended not cover all edge cases. adding in 'else' section will release all video/picture src elements.
