### PR TITLE
Bug 853756 - [Buri][WIFI]The icon display wrong after connected to AP

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -504,6 +504,9 @@ var StatusBar = {
         case 'connected':
           icon.hidden = false;
 
+          if (icon.dataset.connecting) {
+            delete icon.dataset.connecting;
+          }
           var relSignalStrength =
             wifiManager.connectionInformation.relSignalStrength;
           icon.dataset.level = Math.floor(relSignalStrength / 25);


### PR DESCRIPTION
r = Etienne
Bug 853756 - [Buri][WIFI]The icon display wrong after connected to AP
add "delete icon.dataset.connecting"  if "delete icon.dataset.connecting === true" when wifi signal level equals 0 after connected and before wif level change
