### PR TITLE
Bug 845660 - [Call] Proximity sensor shouldn't work on speaker/BT SCO mode in call.

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -219,6 +219,13 @@ var ScreenManager = {
         break;
 
       case 'userproximity':
+        var bluetooth = navigator.mozBluetooth;
+        var telephony = window.navigator.mozTelephony;
+        // 0x111E is for querying earphone type.
+        if ((bluetooth && bluetooth.isConnected(0x111E)) ||
+            telephony.speakerEnabled)
+          break;
+
         this._screenOffByProximity = evt.near;
         if (evt.near) {
           this.turnScreenOff(true);


### PR DESCRIPTION
Bug 845660 - [Call] Proximity sensor shouldn't work on speaker/BT SCO mode in call.
r=timdream, a=leo+.
