### PR TITLE
Bug 861206 - Don't prompt for SIM PIN entry if Settings app is opened

### DIFF
--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -49,6 +49,13 @@ var SimLock = {
               'sms' in app.manifest.permissions))
           return;
 
+        // If the Settings app will open, don't prompt for SIM PIN entry
+        // although it has 'telephony' permission (Bug 861206)
+        var settingsManifestURL =
+          'app://settings.gaiamobile.org/manifest.webapp';
+        if (app.manifestURL == settingsManifestURL)
+          return;
+
         // Ignore second 'appwillopen' event when showIfLocked eventually opens
         // the app on valid PIN code
         var origin = evt.target.dataset.frameOrigin;


### PR DESCRIPTION
I'm not sure if this is the best approach to check if the app dispatching 'appwillopen' event is the Settings app, however, it seems quite unlikely that there will be any other app with 'telephony' or 'sms' permissions whose name is 'Settings' (in the manifest).
