### PR TITLE
bug 858640: use platform-specific path separators so build scripts work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,12 +220,12 @@ ifneq ($(LOCALE_BASEDIR),)
 		targets="$$targets --target $$appdir"; \
 	done; \
 	python $(CURDIR)/build/multilocale.py \
-		--config $(LOCALES_FILE) \
-		--source $(LOCALE_BASEDIR) \
+		--config '$(LOCALES_FILE)' \
+		--source '$(LOCALE_BASEDIR)' \
 		$$targets;
 	@echo "Done"
 ifneq ($(LOCALES_FILE),shared/resources/languages.json)
-	cp $(LOCALES_FILE) shared/resources/languages.json
+	cp '$(LOCALES_FILE)' shared/resources/languages.json
 endif
 endif
 
@@ -386,7 +386,7 @@ define run-js-command
 	const HOMESCREEN = "$(HOMESCREEN)"; const GAIA_PORT = "$(GAIA_PORT)";       \
 	const GAIA_APP_SRCDIRS = "$(GAIA_APP_SRCDIRS)";                             \
 	const GAIA_LOCALES_PATH = "$(GAIA_LOCALES_PATH)";                           \
-	const LOCALES_FILE = "$(LOCALES_FILE)";                                     \
+	const LOCALES_FILE = "$(subst \,\\,$(LOCALES_FILE))";                       \
 	const BUILD_APP_NAME = "$(BUILD_APP_NAME)";                                 \
 	const PRODUCTION = "$(PRODUCTION)";                                         \
 	const GAIA_OPTIMIZE = "$(GAIA_OPTIMIZE)";                                   \

--- a/build/multilocale.py
+++ b/build/multilocale.py
@@ -115,7 +115,7 @@ def copy_properties(source, locales, ini_file):
             target_path = os.path.join(ini_dirname, path)
             # apps/browser/locales/browser.fr.properties becomes
             # apps/browser/browser.properties
-            source_path = target_path.replace('/locales', '') \
+            source_path = target_path.replace(os.sep + 'locales', '') \
                                      .replace('.%s' % locale, '')
             source_path = os.path.join(source, locale, source_path)
             if not os.path.exists(source_path):

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -362,8 +362,7 @@ if (GAIA_INLINE_LOCALES === '1') {
 
   // LOCALES_FILE is a relative path by default: shared/resources/languages.json
   // -- but it can be an absolute path when doing a multilocale build.
-  // LOCALES_FILE is using unix separator, ensure working fine on win32
-  let abs_path_chunks = [GAIA_DIR].concat(LOCALES_FILE.split('/'));
+  let abs_path_chunks = [GAIA_DIR].concat(LOCALES_FILE.split(/\/|\\/));
   let file = getFile.apply(null, abs_path_chunks);
   if (!file.exists()) {
     file = getFile(LOCALES_FILE);


### PR DESCRIPTION
Revised patch that fixes bug 858640 by using platform-specific path separators so build scripts work on Windows when a build configuration includes an absolute LOCALES_FILE path.

Tested with the following commands on Windows:

```
make
LOCALES_FILE=locales/languages_dev.json make
LOCALES_FILE='locales\languages_dev.json' make
LOCALES_FILE='C:\Users\myk\Mozilla\gaia\locales\languages_dev.json' make
```

And these on Mac and Linux:

```
make
LOCALES_FILE=locales/languages_dev.json make
LOCALES_FILE=$(PWD)/locales/languages_dev.json make
```
