### PR TITLE
Bug 861227 - recipients search results are hidden message input text takes available screen

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -112,7 +112,9 @@
         <div id="contact-carrier" data-l10n-id="carrier-unknown" class="carrier-wrapper">
           Carrier unknown
         </div>
-        <article id="messages-container" class="view-body" data-type="list">
+        <article id="messages-recipient-results" class="view-body article-list" data-type="list">
+        </article>
+        <article id="messages-container" class="view-body article-list" data-type="list">
         </article>
         <form role="search" id="messages-compose-form" class="bottom messages-compose-form">
           <button id="messages-send-button" disabled data-l10n-id="send" type="submit">Send</button>

--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -112,7 +112,7 @@
         <div id="contact-carrier" data-l10n-id="carrier-unknown" class="carrier-wrapper">
           Carrier unknown
         </div>
-        <article id="messages-recipient-results" class="view-body article-list" data-type="list">
+        <article id="messages-recipient-results" class="view-body article-list hide" data-type="list">
         </article>
         <article id="messages-container" class="view-body article-list" data-type="list">
         </article>

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -169,7 +169,10 @@ var MessageManager = {
             'messages-contact-pick-button'
         );
         contactButton.parentNode.appendChild(contactButton);
-        document.getElementById('messages-container').innerHTML = '';
+        ThreadUI.container.innerHTML = '';
+        ThreadUI.innerHTML = '';
+        ThreadUI.recipientResults.classList.add('hide');
+
         ThreadUI.cleanFields();
         // If the message has a body, use it to popuplate the input field.
         if (MessageManager.activityBody) {
@@ -209,6 +212,9 @@ var MessageManager = {
         } else {
           MessageManager.slide(function() {
             ThreadUI.container.innerHTML = '';
+            ThreadUI.recipientResults.innerHTML = '';
+            ThreadUI.recipientResults.classList.add('hide');
+
             if (MessageManager.activityTarget) {
               window.location.hash =
                 '#num=' + MessageManager.activityTarget;

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -169,9 +169,8 @@ var MessageManager = {
             'messages-contact-pick-button'
         );
         contactButton.parentNode.appendChild(contactButton);
-        ThreadUI.container.innerHTML = '';
-        ThreadUI.recipientResults.innerHTML = '';
-        ThreadUI.recipientResults.classList.add('hide');
+        ThreadUI.container.textContent = '';
+        ThreadUI.recipientSearch.discard();
 
         ThreadUI.cleanFields();
         // If the message has a body, use it to popuplate the input field.
@@ -211,9 +210,8 @@ var MessageManager = {
           });
         } else {
           MessageManager.slide(function() {
-            ThreadUI.container.innerHTML = '';
-            ThreadUI.recipientResults.innerHTML = '';
-            ThreadUI.recipientResults.classList.add('hide');
+            ThreadUI.container.textContent = '';
+            ThreadUI.recipientSearch.discard();
 
             if (MessageManager.activityTarget) {
               window.location.hash =

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -170,7 +170,7 @@ var MessageManager = {
         );
         contactButton.parentNode.appendChild(contactButton);
         ThreadUI.container.innerHTML = '';
-        ThreadUI.innerHTML = '';
+        ThreadUI.recipientResults.innerHTML = '';
         ThreadUI.recipientResults.classList.add('hide');
 
         ThreadUI.cleanFields();

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -198,7 +198,7 @@ var ThreadListUI = {
     // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=854417
     // Refactor the rendering method: do not empty the entire
     // list on every render.
-    ThreadListUI.container.innerHTML = '';
+    ThreadListUI.container.textContent = '';
     ThreadListUI.count = threads.length;
 
     if (threads.length) {

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1002,8 +1002,10 @@ var ThreadUI = {
       // that was actually a "delete" that removed the last
       // character in the recipient input field,
       // eg. type "a", then delete it.
-      // Always remove the the existing results.
+      // Always remove the the existing results and hide
+      // the recipient results container
       this.recipientResults.innerHTML = '';
+      this.recipientResults.classList.add('hide');
       return;
     }
 

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -13,7 +13,7 @@ var ThreadUI = {
 
     [
       'container',
-      'header-text', 'recipient', 'input', 'compose-form',
+      'header-text', 'recipient', 'recipient-results', 'input', 'compose-form',
       'check-all-button', 'uncheck-all-button',
       'contact-pick-button', 'back-button', 'clear-button', 'send-button',
       'delete-button', 'cancel-button',
@@ -51,6 +51,10 @@ var ThreadUI = {
     );
 
     this.container.addEventListener(
+      'scroll', this.manageScroll.bind(this)
+    );
+
+    this.recipientResults.addEventListener(
       'scroll', this.manageScroll.bind(this)
     );
 
@@ -105,6 +109,12 @@ var ThreadUI = {
       'click', this
     );
     this.container.addEventListener(
+      'contextmenu', this
+    );
+    this.recipientResults.addEventListener(
+      'click', this
+    );
+    this.recipientResults.addEventListener(
       'contextmenu', this
     );
     this.editForm.addEventListener(
@@ -441,6 +451,8 @@ var ThreadUI = {
     this.checkInputs();
     // Clean list of messages
     this.container.innerHTML = '';
+    // Clean list of recipient results
+    this.recipientResults.innerHTML = '';
     // Update header index
     this.dayHeaderIndex = 0;
     this.timeHeaderIndex = 0;
@@ -631,7 +643,8 @@ var ThreadUI = {
 
   clear: function thui_clear() {
     this.recipient.value = '';
-    this.container.innerHTML = '';
+    this.recipientResults.innerHTML = '';
+    this.recipientResults.classList.add('hide');
   },
 
   toggleCheckedAll: function thui_select(value) {
@@ -978,9 +991,7 @@ var ThreadUI = {
       }.bind(this));
     }
 
-    ThreadUI.container.appendChild(contactsUl);
-
-    return true;
+    ThreadUI.recipientResults.appendChild(contactsUl);
   },
 
   searchContact: function thui_searchContact() {
@@ -992,13 +1003,23 @@ var ThreadUI = {
       // character in the recipient input field,
       // eg. type "a", then delete it.
       // Always remove the the existing results.
-      this.container.innerHTML = '';
+      this.recipientResults.innerHTML = '';
       return;
     }
 
     Contacts.findByString(filterValue, function gotContact(contacts) {
+      // !contacts matches null results from errors
+      // !contacts.length matches empty arrays from unmatches filters
+      if (!contacts || !contacts.length) {
+        this.recipientResults.classList.add('hide');
+        return;
+      }
+
       // There are contacts that match the input.
-      this.container.innerHTML = '';
+      this.recipientResults.innerHTML = '';
+      this.recipientResults.classList.remove('hide');
+
+      // There are contacts that match the input.
       contacts.forEach(this.renderContact, this);
     }.bind(this));
   },

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -643,7 +643,7 @@ var ThreadUI = {
 
   clear: function thui_clear() {
     this.recipient.value = '';
-    ThreadUI.recipientSearch.discard();
+    this.recipientSearch.discard();
   },
 
   toggleCheckedAll: function thui_select(value) {
@@ -1003,7 +1003,7 @@ var ThreadUI = {
       // eg. type "a", then delete it.
       // Always remove the the existing results and hide
       // the recipient results container
-      ThreadUI.recipientSearch.discard();
+      this.recipientSearch.discard();
       return;
     }
 
@@ -1011,7 +1011,7 @@ var ThreadUI = {
       // !contacts matches null results from errors
       // !contacts.length matches empty arrays from unmatches filters
       if (!contacts || !contacts.length) {
-        ThreadUI.recipientSearch.discard();
+        this.recipientSearch.discard();
         return;
       }
 

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -99,7 +99,7 @@ var ThreadUI = {
 
     this.recipient.addEventListener(
       'input', function() {
-        this.searchContact();
+        this.recipientSearch();
         this.enableSend();
       }.bind(this)
     );
@@ -450,9 +450,9 @@ var ThreadUI = {
     this.cleanFields();
     this.checkInputs();
     // Clean list of messages
-    this.container.innerHTML = '';
+    this.container.textContent = '';
     // Clean list of recipient results
-    this.recipientResults.innerHTML = '';
+    this.recipientResults.textContent = '';
     // Update header index
     this.dayHeaderIndex = 0;
     this.timeHeaderIndex = 0;
@@ -643,8 +643,7 @@ var ThreadUI = {
 
   clear: function thui_clear() {
     this.recipient.value = '';
-    this.recipientResults.innerHTML = '';
-    this.recipientResults.classList.add('hide');
+    ThreadUI.recipientSearch.discard();
   },
 
   toggleCheckedAll: function thui_select(value) {
@@ -867,7 +866,7 @@ var ThreadUI = {
 
     // Remove only the spinner
     var spinnerContainer = aElement.querySelector('aside');
-    spinnerContainer.innerHTML = '';
+    spinnerContainer.textContent = '';
 
     ThreadUI.addResendHandler(message, messageDOM);
 
@@ -994,18 +993,17 @@ var ThreadUI = {
     ThreadUI.recipientResults.appendChild(contactsUl);
   },
 
-  searchContact: function thui_searchContact() {
+  recipientSearch: function thui_recipientSearch() {
     var filterValue = this.recipient.value;
 
     if (!filterValue.trim()) {
-      // In cases where searchContact was invoked for "input"
+      // In cases where recipientSearch was invoked for "input"
       // that was actually a "delete" that removed the last
       // character in the recipient input field,
       // eg. type "a", then delete it.
       // Always remove the the existing results and hide
       // the recipient results container
-      this.recipientResults.innerHTML = '';
-      this.recipientResults.classList.add('hide');
+      ThreadUI.recipientSearch.discard();
       return;
     }
 
@@ -1013,12 +1011,12 @@ var ThreadUI = {
       // !contacts matches null results from errors
       // !contacts.length matches empty arrays from unmatches filters
       if (!contacts || !contacts.length) {
-        this.recipientResults.classList.add('hide');
+        ThreadUI.recipientSearch.discard();
         return;
       }
 
       // There are contacts that match the input.
-      this.recipientResults.innerHTML = '';
+      this.recipientResults.textContent = '';
       this.recipientResults.classList.remove('hide');
 
       // There are contacts that match the input.
@@ -1096,6 +1094,11 @@ var ThreadUI = {
       ThreadUI.updateHeaderData();
     }
   }
+};
+
+ThreadUI.recipientSearch.discard = function() {
+  ThreadUI.recipientResults.textContent = '';
+  ThreadUI.recipientResults.classList.add('hide');
 };
 
 window.confirm = window.confirm; // allow override in unit tests

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -31,6 +31,11 @@ section[role="region"] > header:first-child form {
 form.bottom[role="search"] {
   z-index: 3;
 }
+/* recipient search results must appear over the input message form */
+#messages-recipient-results {
+  position: absolute;
+  z-index: 4;
+}
 
 #messages-recipient {
   padding-right: 3rem;
@@ -267,17 +272,17 @@ section[role="region"].new > header:first-child form {
   Messages Style as 'bubbles'
 */
 
-#messages-container {
+.article-list  {
   -moz-box-sizing: border-box;
   background: none repeat scroll 0 0 #F4F4F4;
   text-align: left;
 }
 
-#messages-container header:first-child {
+.article-list header:first-child {
   margin-top: 2rem;
 }
 
-#messages-container header {
+.article-list header {
   border-bottom: 0.1rem solid #A6A6A6;
   color: #606060;
   font-size: 1.3rem;
@@ -287,11 +292,11 @@ section[role="region"].new > header:first-child form {
   text-transform: uppercase;
 }
 
-#messages-container[data-type="list"] > ul:last-child {
+.article-list[data-type="list"] > ul:last-child {
   margin-bottom: 7rem;
 }
 
-#messages-container[data-type="list"] li.bubble {
+.article-list[data-type="list"] li.bubble {
   border-bottom: 0.1rem solid transparent;
   display: block;
   overflow: hidden;
@@ -302,23 +307,23 @@ section[role="region"].new > header:first-child form {
   height: auto;
 }
 
-#messages-container[data-type="list"] li.hidden {
+.article-list[data-type="list"] li.hidden {
   display: none;
 }
 
-#messages-container[data-type="list"] header.hidden {
+.article-list[data-type="list"] header.hidden {
   display: none;
 }
 
-#messages-container[data-type="list"] li.bubble:first-child {
+.article-list[data-type="list"] li.bubble:first-child {
   padding: 0 0 0.5rem 0;
 }
 
-#messages-container[data-type="list"] li.bubble a {
+.article-list[data-type="list"] li.bubble a {
   height: 100%;
 }
 
-#messages-container[data-type="list"] li.bubble p {
+.article-list[data-type="list"] li.bubble p {
   text-align: right;
   overflow: visible;
   white-space: normal;
@@ -336,7 +341,7 @@ section[role="region"].new > header:first-child form {
   float: right;
 }
 
-#messages-container[data-type="list"] li.bubble p:after {
+.article-list[data-type="list"] li.bubble p:after {
   content: '';
   width: 1.1rem;
   height: 1rem;
@@ -348,7 +353,7 @@ section[role="region"].new > header:first-child form {
   top: 1rem;
 }
 
-#messages-container[data-type="list"] li.bubble .received p {
+.article-list[data-type="list"] li.bubble .received p {
   float: left;
   background: #FBEAE0;
   border: 0.2rem solid #FF4E00;
@@ -356,41 +361,41 @@ section[role="region"].new > header:first-child form {
   float: left;
 }
 
-#messages-container[data-type="list"] li.bubble .received p:after {
+.article-list[data-type="list"] li.bubble .received p:after {
   background-position: 0 0;
   left: -1.1rem;
   margin-top: 0;
 }
 
-#messages-container[data-type="list"] li.bubble .sending p {
+.article-list[data-type="list"] li.bubble .sending p {
   border: 0.2rem solid #5f5f5f;
   color: #5f5f5f;
 }
 
-#messages-container[data-type="list"] li.bubble .sending p:after {
+.article-list[data-type="list"] li.bubble .sending p:after {
   background-position: -3.3rem 0;
   right: -1.1rem;
 }
 
-#messages-container[data-type="list"] li.bubble .error p {
+.article-list[data-type="list"] li.bubble .error p {
   border: 0.2rem solid #B90000;
 }
-#messages-container[data-type="list"] li.bubble .error p:after {
+.article-list[data-type="list"] li.bubble .error p:after {
   background-position: -4.4rem 0;
   right: -1.1rem;
 }
 
-#messages-container[data-type="list"] li.bubble .error aside.pack-end {
+.article-list[data-type="list"] li.bubble .error aside.pack-end {
   background: url('images/icons/exclamation.png') no-repeat center center;
   background-size: 2.2rem;
   width: 3.2rem;
   height: 4.5rem;
 }
-#messages-container[data-type="list"] li.bubble aside progress {
+.article-list[data-type="list"] li.bubble aside progress {
   margin-top: 0.4rem;
 }
 
-#messages-container[data-type="list"] li.bubble aside {
+.article-list[data-type="list"] li.bubble aside {
   overflow: hidden;
 }
 
@@ -398,11 +403,11 @@ section[role="region"].new > header:first-child form {
   Styles for Edit mode in Messages Container
 */
 
-.edit #messages-container[data-type="list"] li {
+.edit .article-list[data-type="list"] li {
   border-color: #e7e7e7;
 }
 
-.edit #messages-container[data-type="list"] li:last-child {
+.edit .article-list[data-type="list"] li:last-child {
   border-color: transparent;
 }
 
@@ -410,24 +415,24 @@ section[role="region"].new > header:first-child form {
   pointer-events: none;
 }
 
-.edit #messages-container[data-type="list"] li p {
+.edit .article-list[data-type="list"] li p {
   transform: translateX(0);
 }
 
-.edit #messages-container[data-type="list"] li .received p {
+.edit .article-list[data-type="list"] li .received p {
   transform: translateX(4rem);
   transition: all 0.3s ease 0s;
 }
 
-.edit #messages-container[data-type="list"] li.selected p {
+.edit .article-list[data-type="list"] li.selected p {
   border: 0.2rem solid #B90000;
 }
 
-.edit #messages-container[data-type="list"] li.selected p:after {
+.edit .article-list[data-type="list"] li.selected p:after {
   background-position: -4.4rem 0;
 }
 
-.edit #messages-container[data-type="list"] li.selected .received p:after {
+.edit .article-list[data-type="list"] li.selected .received p:after {
   background-position: -1.1rem 0;
 }
 

--- a/apps/sms/test/unit/contacts_test.js
+++ b/apps/sms/test/unit/contacts_test.js
@@ -1,137 +1,14 @@
 'use strict';
 
 requireApp('sms/test/unit/mock_contact.js');
+requireApp('sms/test/unit/mock_mozcontacts.js');
 requireApp('sms/js/contacts.js');
 
 suite('Contacts', function(done) {
   var nativeMozContacts = navigator.mozContacts;
 
   suiteSetup(function() {
-    // Do not use the native API.
-    navigator.mozContacts = {
-      mHistory: [],
-      find: function(filter) {
-        // attribute DOMString     filterValue;    // e.g. "Tom"
-        // attribute DOMString     filterOp;       // e.g. "contains"
-        // attribute DOMString[]   filterBy;       // e.g. "givenName"
-        // attribute DOMString     sortBy;         // e.g. "givenName"
-        // attribute DOMString     sortOrder;      // e.g. "descending"
-        // attribute unsigned long filterLimit;
-        if (!(this instanceof navigator.mozContacts.find)) {
-          return new navigator.mozContacts.find(filter);
-        }
-        var onsuccess, onerror;
-
-        navigator.mozContacts.mHistory.push({
-          // make a "copy" of the filter object
-          filter: Object.keys(filter).reduce(function(copy, key) {
-            return (copy[key] = filter[key]) && copy;
-          }, {}),
-          request: this
-        });
-
-        this.result = null;
-        this.error = null;
-
-        Object.defineProperties(this, {
-
-          onsuccess: {
-            // When the success handler gets assigned:
-            //  1. Set this.result to an array containing a MockContact instance
-            //  2. Immediately call the success handler
-            // This will behave like a _REALLY_ fast DB query
-            set: function(callback) {
-              onsuccess = callback;
-              if (callback !== null) {
-                // Implement a mock that gives results that appear to
-                // match the real behaviour of filtered contacts results
-                this.result = (function() {
-                  // Supports the error case
-                  if (filter == null ||
-                        (!filter.filterOp || !filter.filterValue)) {
-                    return null;
-                  }
-
-                  // Supports two "no match" cases
-                  if (filter.filterValue === '911' ||
-                      filter.filterValue === 'wontmatch') {
-                    return [];
-                  }
-
-                  if (filter.filterValue === 'jane') {
-                    return MockContact.list([
-                      // true
-                      { givenName: ['Jane'], familyName: ['D'] },
-                      // false
-                      { givenName: ['jane'], familyName: ['austen'] },
-                      // true
-                      { givenName: ['jane'], familyName: ['doe'] },
-                      // false
-                      { givenName: ['jane'], familyName: ['fonda'] },
-                      // true
-                      { givenName: ['jane'], familyName: ['dow'] },
-                      // false
-                      { givenName: ['janet'], familyName: [''] }
-                    ]);
-                  }
-
-                  if (filter.filterValue === 'do') {
-                    return MockContact.list([
-                      // true
-                      { givenName: ['Jane'], familyName: ['Doozer'] },
-                      // false
-                      { givenName: ['doug'], familyName: ['dooley'] },
-                      // true
-                      { givenName: ['jane'], familyName: ['doe'] },
-                      // false
-                      { givenName: ['jerry'], familyName: ['doe'] },
-                      // true
-                      { givenName: ['j'], familyName: ['dow'] },
-                      // true
-                      { givenName: ['john'], familyName: ['doland'] }
-                    ]);
-                  }
-
-                  // All other cases
-                  return MockContact.list();
-                }());
-
-                if (this.result === null) {
-                  this.error = {
-                    name: 'Mock missing filter params'
-                  };
-                  if (onerror) {
-                    setTimeout(function() {
-                      onerror.call(this);
-                      onerror = null;
-                    }.bind(this), 0);
-                  }
-                } else {
-                  setTimeout(function() {
-                    onsuccess.call(this);
-                    onsuccess = null;
-                  }.bind(this), 0);
-                }
-              }
-            }
-          },
-
-          onerror: {
-            set: function(callback) {
-              onerror = callback;
-              if (callback !== null) {
-                if (this.result === null && this.error !== null) {
-                  setTimeout(function() {
-                    onerror.call(this);
-                    onerror = null;
-                  }.bind(this), 0);
-                }
-              }
-            }
-          }
-        });
-      }
-    };
+    navigator.mozContacts = MockMozContacts;
   });
 
   teardown(function() {

--- a/apps/sms/test/unit/mock_mozcontacts.js
+++ b/apps/sms/test/unit/mock_mozcontacts.js
@@ -1,0 +1,125 @@
+// Do not use the native API.
+var MockMozContacts = {
+  mHistory: [],
+  find: function(filter) {
+    // attribute DOMString     filterValue;    // e.g. "Tom"
+    // attribute DOMString     filterOp;       // e.g. "contains"
+    // attribute DOMString[]   filterBy;       // e.g. "givenName"
+    // attribute DOMString     sortBy;         // e.g. "givenName"
+    // attribute DOMString     sortOrder;      // e.g. "descending"
+    // attribute unsigned long filterLimit;
+    if (!(this instanceof navigator.mozContacts.find)) {
+      return new navigator.mozContacts.find(filter);
+    }
+    var onsuccess, onerror;
+
+    navigator.mozContacts.mHistory.push({
+      // make a "copy" of the filter object
+      filter: Object.keys(filter).reduce(function(copy, key) {
+        return (copy[key] = filter[key]) && copy;
+      }, {}),
+      request: this
+    });
+
+    this.result = null;
+    this.error = null;
+
+    Object.defineProperties(this, {
+
+      onsuccess: {
+        // When the success handler gets assigned:
+        //  1. Set this.result to an array containing a MockContact instance
+        //  2. Immediately call the success handler
+        // This will behave like a _REALLY_ fast DB query
+        set: function(callback) {
+          onsuccess = callback;
+          if (callback !== null) {
+            // Implement a mock that gives results that appear to
+            // match the real behaviour of filtered contacts results
+            this.result = (function() {
+              // Supports the error case
+              if (filter == null ||
+                    (!filter.filterOp || !filter.filterValue)) {
+                return null;
+              }
+
+              // Supports two "no match" cases
+              if (filter.filterValue === '911' ||
+                  filter.filterValue === 'wontmatch') {
+                return [];
+              }
+
+              if (filter.filterValue === 'jane') {
+                return MockContact.list([
+                  // true
+                  { givenName: ['Jane'], familyName: ['D'] },
+                  // false
+                  { givenName: ['jane'], familyName: ['austen'] },
+                  // true
+                  { givenName: ['jane'], familyName: ['doe'] },
+                  // false
+                  { givenName: ['jane'], familyName: ['fonda'] },
+                  // true
+                  { givenName: ['jane'], familyName: ['dow'] },
+                  // false
+                  { givenName: ['janet'], familyName: [''] }
+                ]);
+              }
+
+              if (filter.filterValue === 'do') {
+                return MockContact.list([
+                  // true
+                  { givenName: ['Jane'], familyName: ['Doozer'] },
+                  // false
+                  { givenName: ['doug'], familyName: ['dooley'] },
+                  // true
+                  { givenName: ['jane'], familyName: ['doe'] },
+                  // false
+                  { givenName: ['jerry'], familyName: ['doe'] },
+                  // true
+                  { givenName: ['j'], familyName: ['dow'] },
+                  // true
+                  { givenName: ['john'], familyName: ['doland'] }
+                ]);
+              }
+
+              // All other cases
+              return MockContact.list();
+            }());
+
+            if (this.result === null) {
+              this.error = {
+                name: 'Mock missing filter params'
+              };
+              if (onerror) {
+                setTimeout(function() {
+                  onerror.call(this);
+                  onerror = null;
+                }.bind(this), 0);
+              }
+            } else {
+              setTimeout(function() {
+                onsuccess.call(this);
+                onsuccess = null;
+              }.bind(this), 0);
+            }
+          }
+        }
+      },
+
+      onerror: {
+        set: function(callback) {
+          onerror = callback;
+          if (callback !== null) {
+            if (this.result === null && this.error !== null) {
+              setTimeout(function() {
+                onerror.call(this);
+                onerror = null;
+              }.bind(this), 0);
+            }
+          }
+        }
+      }
+    });
+  }
+};

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -962,7 +962,7 @@ suite('SMS App Unit-Test', function() {
       // textContent should not be cleared and container not hidden.
       ThreadUI.recipientResults.textContent = 'hello';
       ThreadUI.recipient.value = 'foo';
-      ThreadUI.searchContact();
+      ThreadUI.recipientSearch();
     });
 
     test('no value, is cleared and hidden', function(done) {
@@ -970,14 +970,29 @@ suite('SMS App Unit-Test', function() {
       // textContent should be cleared.
       ThreadUI.recipientResults.textContent = 'hello';
       ThreadUI.recipient.value = '';
-      ThreadUI.searchContact();
+      ThreadUI.recipientSearch();
 
-      // ThreadUI.searchContact is optimized to avoid calling
+      // ThreadUI.recipientSearch is optimized to avoid calling
       // Contacts.findByString if there is no value to search for;
       // check the state of recipientResults immediately.
       assert.equal(ThreadUI.recipientResults.textContent, '');
       assert.isTrue(ThreadUI.recipientResults.classList.contains('hide'));
       done();
+    });
+
+    test('ThreadUI.recipientSearch.discard', function() {
+      ThreadUI.recipientResults.classList.remove('hide');
+      ThreadUI.recipientResults.textContent = 'hello';
+      ThreadUI.recipient.value = 'foo';
+
+      ThreadUI.recipientSearch.discard();
+
+      assert.isTrue(
+        ThreadUI.recipientResults.classList.contains('hide')
+      );
+      assert.equal(
+        ThreadUI.recipientResults.textContent, ''
+      );
     });
   });
 });

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -826,7 +826,6 @@ suite('SMS App Unit-Test', function() {
     });
   });
 
-<<<<<<< HEAD
   suite('Defensive Contact Rendering', function() {
     test('has tel number', function() {
       var contact = new MockContact();

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -138,6 +138,10 @@ suite('SMS App Unit-Test', function() {
     var threadMsgContainer = document.createElement('article');
     threadMsgContainer.id = 'messages-container';
 
+    var recipientResults = document.createElement('article');
+    recipientResults.id = 'messages-recipient-results';
+
+
     // Thread-messages edit form
     var threadMsgEditForm = document.createElement('form');
     threadMsgEditForm.id = 'messages-edit-form';
@@ -151,6 +155,7 @@ suite('SMS App Unit-Test', function() {
     threadMessages.appendChild(threadMsgHeader);
     threadMessages.appendChild(threadMsgSubHeader);
     threadMessages.appendChild(threadMsgContainer);
+    threadMessages.appendChild(recipientResults);
     threadMessages.appendChild(threadMsgEditForm);
     threadMessages.appendChild(threadMsgInputForm);
 

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -8,6 +8,7 @@ require('/shared/js/l10n.js');
 require('/shared/js/l10n_date.js');
 
 requireApp('sms/test/unit/mock_contact.js');
+requireApp('sms/test/unit/mock_mozcontacts.js');
 requireApp('sms/test/unit/mock_l10n.js');
 
 requireApp('sms/js/link_helper.js');
@@ -825,6 +826,7 @@ suite('SMS App Unit-Test', function() {
     });
   });
 
+<<<<<<< HEAD
   suite('Defensive Contact Rendering', function() {
     test('has tel number', function() {
       var contact = new MockContact();
@@ -921,6 +923,62 @@ suite('SMS App Unit-Test', function() {
 
         done();
       }, 30);
+    });
+  });
+
+  suite('Recipient Results', function() {
+    var nativeMozContacts = navigator.mozContacts;
+    var findByString;
+
+    suiteSetup(function() {
+      findByString = Contacts.findByString;
+      navigator.mozContacts = MockMozContacts;
+    });
+
+    teardown(function() {
+      navigator.mozContacts.mHistory.length = 0;
+      ThreadUI.recipient.value = '';
+    });
+
+    suiteTeardown(function() {
+      Contacts.findByString = findByString;
+      navigator.mozContacts = nativeMozContacts;
+    });
+
+    test('has value, is not cleared or hidden', function(done) {
+      Contacts.findByString = function(value, callback) {
+        assert.equal(value, 'foo');
+        assert.equal(ThreadUI.recipientResults.textContent, 'hello');
+
+        callback(MockContact.list());
+
+        setTimeout(function() {
+          assert.isFalse(
+            ThreadUI.recipientResults.classList.contains('hide')
+          );
+          done();
+        });
+      };
+      // If there is any value in ThreadUI.recipient, this
+      // textContent should not be cleared and container not hidden.
+      ThreadUI.recipientResults.textContent = 'hello';
+      ThreadUI.recipient.value = 'foo';
+      ThreadUI.searchContact();
+    });
+
+    test('no value, is cleared and hidden', function(done) {
+      // Since there is no value in ThreadUI.recipient, this
+      // textContent should be cleared.
+      ThreadUI.recipientResults.textContent = 'hello';
+      ThreadUI.recipient.value = '';
+      ThreadUI.searchContact();
+
+      // ThreadUI.searchContact is optimized to avoid calling
+      // Contacts.findByString if there is no value to search for;
+      // check the state of recipientResults immediately.
+      assert.equal(ThreadUI.recipientResults.textContent, '');
+      assert.isTrue(ThreadUI.recipientResults.classList.contains('hide'));
+      done();
     });
   });
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=861227
- create dedicated recipient results element
- shift logic from previously shared container to new dedicated element
- innerHTML => textContent
- Rename ThreadUI.searchContact => ThreadUI.recipientSearch (matches the ThreadUI.reci
- Wrap the recipient search result discarding operations (clear and hide) in a functio
- Tests display of ThreadUI.recipientResults by ThreadUI.recipient.value
  - has value, is not cleared or hidden
  - no value, is cleared and hidden
- Tests discarding results with ThreadUI.recipientSearch.discard()
