### PR TITLE
Bug 861252 - [email] to/recipients local search filter broken by lazy body fetching. r=asuth, a=blocking-b2g=tef+

### DIFF
--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -9222,12 +9222,12 @@ RecipientFilter.prototype = {
       }
     }
 
-    if (this.checkTo && body.to)
-      checkRecipList(body.to);
-    if (this.checkCc && body.cc && matches.length < stopAfter)
-      checkRecipList(body.cc);
-    if (this.checkBcc && body.bcc && matches.length < stopAfter)
-      checkRecipList(body.bcc);
+    if (this.checkTo && header.to)
+      checkRecipList(header.to);
+    if (this.checkCc && header.cc && matches.length < stopAfter)
+      checkRecipList(header.cc);
+    if (this.checkBcc && header.bcc && matches.length < stopAfter)
+      checkRecipList(header.bcc);
 
     if (matches.length) {
       match.recipients = matches;


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/179
