### PR TITLE
Bug - 862197 - Remove unused (and questionable) bind() in ttlview.js

### DIFF
--- a/apps/system/js/ttlview.js
+++ b/apps/system/js/ttlview.js
@@ -76,6 +76,6 @@ var TTLView = {
 };
 
 SettingsListener.observe('debug.ttl.enabled', false, function(value) {
-  !!value ? TTLView.show().bind(TTLView) : TTLView.hide().bind(TTLView);
+  !!value ? TTLView.show() : TTLView.hide();
 });
 


### PR DESCRIPTION
r=alive
