### PR TITLE
Bug 858908 - Class 0 SMSes get cleared when opening SMS app

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -83,7 +83,7 @@ if (!window.location.hash.length) {
       // progress to the user. Se blackllist.js for more information.
       var number = message.sender;
       // Class 0 handler:
-      if (message.messageClass == 'class-0') {
+      if (message.messageClass === 'class-0') {
         // XXX: Hack hiding the message class in the icon URL
         // Should use the tag element of the notification once the final spec
         // lands:
@@ -95,16 +95,11 @@ if (!window.location.hash.length) {
           // XXX: Add params to Icon URL.
           iconURL += '?class0';
           var messageBody = number + '\n' + message.body;
-          var showMessage = function() {
-            app.launch();
-            alert(messageBody);
-          };
 
           // We have to remove the SMS due to it does not have to be shown.
           MessageManager.deleteMessage(message.id, function() {
-            // Once we remove the sms from DB we launch the notification
-            NotificationHelper.send(message.sender, message.body,
-                                      iconURL, showMessage);
+            app.launch();
+            alert(messageBody);
           });
 
         };

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -69,8 +69,10 @@ var MessageManager = {
 
   onMessageReceived: function mm_onMessageReceived(e) {
     var message = e.message;
+    if (message.messageClass === 'class-0') {
+      return;
+    }
 
-    var sender = message.sender;
     var threadId = message.threadId;
     if (threadId && threadId === this.currentThread) {
       //Append message and mark as unread


### PR DESCRIPTION
Fix for [#858908](https://bugzilla.mozilla.org/show_bug.cgi?id=858908). The problem lies herein:
1. Class 0 SMSes are handled by the SMS app. When the SMS app encounters a class 0 sms it shows a notification.
2. When clicking a notification the respective application will launch
3. All notifications for this application will be removed
4. If you had two class 0 SMSes, or one in notifications that you didn't read yet, it will be purged, because these SMSes don't show up in the SMS app (on purpose).

This patch introduces a way for notifications to avoid getting cleared when opening their parent application. The behaviour when clicking the notification (goes away) or 'clear all' is not affected.

So I took maybe a bit of an unusual approach, but that's because I didn't want to touch Gecko on this part (and change the API of mozNotification), probably mainly because this is a FFOS only problem so far. If you prefix the title line of the notification with a zero width space it will become a 'persistent' notification. 

The reason for this is that it doesn't matter if a bug is introduced here, because the character will never be shown. In theory it could cause problems if you create people in your contacts that have a name that starts with a zero width space, but a la.
