### PR TITLE
Merge pull request #8879 from fabi1cazenave/confirmPIN-bug854031

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1654,7 +1654,9 @@
           </div>
 
           <div id="confirmPinArea" class="sim-code-area">
-            <div>Confirm New PIN</div>
+            <div data-l10n-id="confirmNewSimPinMsg">
+              Confirm New PIN
+            </div>
             <div class="input-wrapper">
               <input type="number" name="confirmNewSimpin" size="8" maxlength="8" />
               <input type="text" name="confirmNewSimpinVis" size="8" maxlength="8" />

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -453,7 +453,9 @@
               </div>
               <!-- confirm new sim pin input field -->
               <div id="confirmPinArea" hidden>
-                <div>Confirm New PIN</div>
+                <div data-l10n-id="confirmNewSimPinMsg">
+                  Confirm New PIN
+                </div>
                 <div class="input-wrapper">
                   <input name="confirmNewSimpin" type="number" size="8" maxlength="8" />
                   <input name="confirmNewSimpinVis" type="text" size="8" maxlength="8" />


### PR DESCRIPTION
bug 854031: missing l10n-id attributes for the “Confirm New PIN” message, r=etienne (cherry picked from commit 452eaff2d2f25eda3addee8833df2aaaf7cbcdd3)
