### PR TITLE
Bug 861965 - remove idle time during metadata parsing

### DIFF
--- a/apps/gallery/js/frames.js
+++ b/apps/gallery/js/frames.js
@@ -148,6 +148,14 @@ function singletap(e) {
 
 // Quick zoom in and out with dbltap events
 function doubletapOnPhoto(e) {
+  // Don't allow zooming while we're still scanning for photos and
+  // have found large photos without previews on the card.  Zooming in
+  // decodes the full-size version of the photo and that can cause OOM
+  // errors if there is also metadata scanning going on with large images.
+  // XXX: Remove this when bug 854795 is fixed.
+  if (scanningBigImages)
+    return;
+
   var scale;
   if (currentFrame.fit.scale > currentFrame.fit.baseScale)   // If zoomed in
     scale = currentFrame.fit.baseScale / currentFrame.fit.scale; // zoom out
@@ -271,6 +279,14 @@ function swipeHandler(event) {
 // We also support pinch-to-zoom
 function transformHandler(e) {
   if (transitioning)
+    return;
+
+  // Don't allow zooming while we're still scanning for photos and
+  // have found large photos without previews on the card.  Zooming in
+  // decodes the full-size version of the photo and that can cause OOM
+  // errors if there is also metadata scanning going on with large images.
+  // XXX: Remove this when bug 854795 is fixed.
+  if (scanningBigImages)
     return;
 
   currentFrame.zoom(e.detail.relative.scale,

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -94,6 +94,14 @@ var visibilityMonitor;
 
 var loader = LazyLoader;
 
+// This flag is set in MetadataParser.js if we encounter images larger
+// than 2 megapixels that do not have big enough embedded
+// previews. The flag is read in frames.js where it is used to prevent
+// the user from zooming in on images at the same time (to prevent OOM
+// crashes). And it is cleared below when the scanning process ends
+// XXX: When bug 854795 is fixed, we'll be able to remove this flag
+var scanningBigImages = false;
+
 // The localized event is the main entry point for the app.
 // We don't do anything until we receive it.
 window.addEventListener('localized', function showBody() {
@@ -261,6 +269,9 @@ function initDB() {
     // Hide the scanning indicator
     $('progress').classList.add('hidden');
     $('throbber').classList.remove('throb');
+
+    // It is safe to zoom in now
+    scanningBigImages = false;
   };
 
   // One or more files was created (or was just discovered by a scan)


### PR DESCRIPTION
Don't land this yet: it still causes OOMs.  And it has a bunch of console message.
