### PR TITLE
Bug 834542 - Display time in the statusbar for the Emergency Call screen

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -735,7 +735,7 @@ var LockScreen = {
     this.loadPanel(panel, function panelLoaded() {
       self.unloadPanel(overlay.dataset.panel, panel,
         function panelUnloaded() {
-          self.dispatchEvent('lockpanelchange');
+          self.dispatchEvent('lockpanelchange', { 'panel': panel });
 
           overlay.dataset.panel = panel;
           self._switchingPanel = false;
@@ -956,9 +956,10 @@ var LockScreen = {
     this.mainScreen = document.getElementById('screen');
   },
 
-  dispatchEvent: function ls_dispatchEvent(name) {
+  dispatchEvent: function ls_dispatchEvent(name, detail) {
     var evt = document.createEvent('CustomEvent');
-    evt.initCustomEvent(name, true, true, null);
+    var evtDetail = detail ? detail : null;
+    evt.initCustomEvent(name, true, true, evtDetail);
     window.dispatchEvent(evt);
   },
 

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -135,6 +135,10 @@ var StatusBar = {
   init: function sb_init() {
     this.getAllElements();
 
+    // Hide clock when initializing since this is handled by the event
+    // listeners for 'lock', 'unlock', and 'lockpanelchange'
+    this.icons.time.hidden = true;
+
     var settings = {
       'ril.radio.disabled': ['signal', 'data'],
       'ril.data.enabled': ['data'],
@@ -179,6 +183,13 @@ var StatusBar = {
     // Listen to 'moztimechange'
     window.addEventListener('moztimechange', this);
 
+    // Listen to 'lock', 'unlock', and 'lockpanelchange' from lockscreen.js in
+    // order to correctly set the visibility of the statusbar clock depending
+    // on the active lockscreen panel
+    window.addEventListener('lock', this);
+    window.addEventListener('unlock', this);
+    window.addEventListener('lockpanelchange', this);
+
     this.systemDownloadsCount = 0;
 
     // Create the objects used to animate the statusbar-network-activity and
@@ -195,6 +206,24 @@ var StatusBar = {
     switch (evt.type) {
       case 'screenchange':
         this.setActive(evt.detail.screenEnabled);
+        break;
+
+      case 'lock':
+        // Hide the clock in the statusbar when screen is locked
+        this.icons.time.hidden = true;
+        break;
+
+      case 'unlock':
+        // Display the clock in the statusbar when screen is unlocked
+        this.icons.time.hidden = false;
+        break;
+
+      case 'lockpanelchange':
+        if (this.screen.classList.contains('locked')) {
+          // Display the clock in the statusbar if on Emergency Call screen
+          var isHidden = (evt.detail.panel == 'emergency-call') ? false : true;
+          this.icons.time.hidden = isHidden;
+        }
         break;
 
       case 'chargingchange':

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -84,10 +84,6 @@ body, html {
   font-size: 1rem;
 }
 
-#screen.locked #statusbar-time {
-  display: none;
-}
-
 .sb-icon {
   width: 1.6rem;
   height: 1.6rem;


### PR DESCRIPTION
Add event listeners for lockscreen events in the StatusBar in order to correctly display the statusbar clock according to the lockscreen panel:
- main: hide clock
- passcode: hide clock
- emergency-call: show clock
