### PR TITLE
Bug 862590: Grammar nit: s/is/are/ in bluetooth/transfer.html

### DIFF
--- a/apps/bluetooth/transfer.html
+++ b/apps/bluetooth/transfer.html
@@ -43,7 +43,7 @@
       <div>
         <h3 data-l10n-id="error-transfer-title">Bluetooth file transfer failed</h3>
         <p data-l10n-id="error-transfer-settings">
-          Bluetooth file transfer failed. Check that the Bluetooth settings is correct.
+          Bluetooth file transfer failed. Check that the Bluetooth settings are correct.
         </p>
       </div>
       <menu data-items="1">


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=862590
