### PR TITLE
Bug 859168 - [Settings][Bluetooth] No pairing device message when lock s...

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -35,6 +35,11 @@
 
     <!-- For perf-measurement related utilities -->
     <script defer src="/shared/js/performance_testing_helper.js"></script>
+    <script type="application/javascript" defer src="shared/js/notification_helper.js"></script>
+
+    <!-- Notifications -->
+    <link rel="stylesheet" type="text/css" href="system/style/notifications/notifications.css">
+    <script type="application/javascript" defer src="system/js/notifications.js"></script>
 
     <!-- Specific code -->
     <script defer src="js/settings.js"></script>

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -603,6 +603,14 @@ navigator.mozL10n.ready(function bluetoothSettings() {
       req.onsuccess = function bt_onGetLocksuccess() {
         if (!req.result['lockscreen.locked']) {
           showPairView();
+        } else {
+          var bticon = 'system/style/bluetooth_transfer/images/icon_bluetooth.png';
+		  NotificationHelper.send(_('notification-pair-title'),
+								  _('notification-pair-description'),
+						  		  bticon,
+								  function() {
+								    showPairView();
+			});
         }
       };
       req.onerror = function bt_onGetLockError() {

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -198,6 +198,8 @@ error-connect-title   = Unable to connect devices
 error-connect-msg     = Check that the device you’re trying to connect with is still in range and has Bluetooth turned on.
 unpair-title = Unpair a connected device?
 unpair-msg   = You are currently connected to this device. Unpairing will also disconnect from it.
+notification-pair-title = Receive pairing?
+notification-pair-description = pair incoming from another device
 
 # Connectivity :: Internet Sharing
 SSIDCannotBeEmpty=The SSID cannot be empty 


### PR DESCRIPTION
it can not receive pair message in lockscreen when another BT deviece sends a pair request.
