### PR TITLE
Bug 862704 - Fix failing MobileOperaror unit tests r=alive

### DIFF
--- a/apps/system/test/unit/mock_mobile_operator.js
+++ b/apps/system/test/unit/mock_mobile_operator.js
@@ -11,5 +11,9 @@ var MockMobileOperator = {
 
   mOperator: '',
   mCarrier: '',
-  mRegion: ''
+  mRegion: '',
+
+  mTeardown: function() {
+    this.mOperator = this.mCarrier = this.mRegion = '';
+  }
 };

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -1,6 +1,4 @@
 'use strict';
-// Ignore leak, otherwise an error would occur when using MockMozActivity.
-mocha.setup({ignoreLeaks: true});
 
 requireApp('system/test/unit/mock_settings_listener.js');
 requireApp('system/test/unit/mock_l10n.js');
@@ -15,7 +13,7 @@ requireApp('system/js/lockscreen.js');
 var mocksForStatusBar = ['SettingsListener', 'MobileOperator'];
 
 mocksForStatusBar.forEach(function(mockName) {
-  if (window[mockName]) {
+  if (!window[mockName]) {
     window[mockName] = null;
   }
 });
@@ -38,8 +36,6 @@ suite('system/Statusbar', function() {
     navigator.mozMobileConnection = MockNavigatorMozMobileConnection;
     realMozTelephony = navigator.mozTelephony;
     navigator.mozTelephony = MockNavigatorMozTelephony;
-    realMobileOperator = window.MobileOperator;
-    window.MobileOperator = MockMobileOperator;
   });
 
   suiteTeardown(function() {
@@ -47,8 +43,6 @@ suite('system/Statusbar', function() {
     navigator.mozL10n = realMozL10n;
     navigator.mozMobileConnection = realMozMobileConnection;
     navigator.mozTelephony = realMozTelephony;
-    window.SettingsListener = realSettingsListener;
-    window.MobileOperator = realMobileOperator;
   });
 
   setup(function() {
@@ -437,5 +431,3 @@ suite('system/Statusbar', function() {
     });
   });
 });
-
-mocha.setup({ignoreLeaks: false});


### PR DESCRIPTION
The errors really come from a bad status bar test teardown. So this patch is
adding a teardown operation to the mock for MobileOperator, and is fixing the
teardown of the tests for status bar.

Sadly, we were really testing the mock for MobileOperator because of that.

This is also reverting part of Bug 844738.
