### PR TITLE
Bug 856991 - Use equals to look up phone numbers in SMS app instead of contains

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -131,7 +131,8 @@ if (!window.location.hash.length) {
           showThreadFromSystemMessage(number);
         };
 
-        Contacts.findByString(message.sender, function gotContact(contact) {
+        Contacts.findByPhoneNumber(message.sender, function gotContact(
+                                                                contact) {
           var sender;
           if (contact.length && contact[0].name) {
             sender = Utils.escapeHTML(contact[0].name[0]);

--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -185,6 +185,13 @@
         filterOp: 'contains',
         filterValue: filterValue
       }, callback);
+    },
+    findByPhoneNumber: function contacts_findByPhone(filterValue, callback) {
+      return this.findBy({
+        filterBy: ['tel'],
+        filterOp: 'equals',
+        filterValue: filterValue
+      }, callback);
     }
   };
 

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -58,7 +58,7 @@ var ThreadListUI = {
   updateThreadWithContact:
     function thlui_updateThreadWithContact(number, thread) {
 
-    Contacts.findByString(number, function gotContact(contacts) {
+    Contacts.findByPhoneNumber(number, function gotContact(contacts) {
       var nameContainer = thread.getElementsByClassName('name')[0];
       var photo = thread.getElementsByTagName('img')[0];
       // !contacts matches null results from errors

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -375,11 +375,13 @@ var ThreadUI = {
   },
   // Method for updating the header with the info retrieved from Contacts API
   updateHeaderData: function thui_updateHeaderData(callback) {
+
     // For Desktop Testing, mozContacts it's mockuped but it's not working
     // completely. So in the case of Desktop testing we are going to execute
     // the callback directly in order to make it works!
     // https://bugzilla.mozilla.org/show_bug.cgi?id=836733
     if (!navigator.mozSms && callback) {
+      this.headerText.textContent = MessageManager.currentNum;
       setTimeout(callback);
       return;
     }
@@ -392,7 +394,7 @@ var ThreadUI = {
     // Add data to contact activity interaction
     this.headerText.dataset.phoneNumber = number;
 
-    Contacts.findByString(number, function gotContact(contacts) {
+    Contacts.findByPhoneNumber(number, function gotContact(contacts) {
       var carrierTag = document.getElementById('contact-carrier');
       /** If we have more than one contact sharing the same phone number
        *  we show the name of the first contact and how many other contacts

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -210,6 +210,13 @@ suite('SMS App Unit-Test', function() {
       }
     };
 
+    Contacts.findByPhoneNumber = function(tel, callback) {
+      // Get the contact
+      if (tel === '1977') {
+        callback(MockContact.list());
+      }
+    };
+
     // Create DOM structure
     createDOM();
 
@@ -823,6 +830,92 @@ suite('SMS App Unit-Test', function() {
       var contact = new MockContact();
       contact.tel = null;
       assert.isFalse(ThreadUI.renderContact(contact));
+    });
+  });
+
+  suite('Sending SMS from new screen', function() {
+    test('Sending to contact should put in right thread', function(done) {
+      var mock = [
+          {
+            id: 111,
+            name: ['Pietje'],
+            tel: [{
+              value: '0624710190',
+              type: 'Mobile'
+            }]
+          }
+        ];
+      Contacts.findByString = stub(function(str, callback) {
+        callback(mock);
+      });
+      Contacts.findByPhoneNumber = stub(function(str, callback) {
+        callback(mock);
+      });
+
+      MessageManager.onHashChange = stub();
+      MessageManager.send = stub();
+
+      window.location.hash = '#new';
+      ThreadUI.recipient = {
+        value: '0624710190'
+      };
+      ThreadUI.input.value = 'Jo quiro';
+      ThreadUI.sendMessage();
+
+      setTimeout(function() {
+        assert.equal(Contacts.findByString.callCount, 0);
+        assert.equal(Contacts.findByPhoneNumber.callCount, 1);
+        assert.equal(MessageManager.send.callCount, 1);
+        assert.equal(MessageManager.send.calledWith[0], '0624710190');
+        assert.equal(MessageManager.send.calledWith[1], 'Jo quiro');
+
+        assert.equal(ThreadUI.headerText.textContent, 'Pietje');
+        assert.equal(ThreadUI.headerText.dataset.isContact, 'true');
+
+        done();
+      }, 30);
+    });
+
+    test('Sending to short nr should not link to contact', function(done) {
+      // findByString does a substring find
+      Contacts.findByString = stub(function(str, callback) {
+        callback([
+          {
+            id: 111,
+            name: ['Pietje'],
+            tel: [{
+              value: '0624710190',
+              type: 'Mobile'
+            }]
+          }
+        ]);
+      });
+      Contacts.findByPhoneNumber = stub(function(str, callback) {
+        callback([]);
+      });
+
+      MessageManager.onHashChange = stub();
+      MessageManager.send = stub();
+
+      window.location.hash = '#new';
+      ThreadUI.recipient = {
+        value: '2471'
+      };
+      ThreadUI.input.value = 'Short';
+      ThreadUI.sendMessage();
+
+      setTimeout(function() {
+        assert.equal(Contacts.findByString.callCount, 0);
+        assert.equal(Contacts.findByPhoneNumber.callCount, 1);
+        assert.equal(MessageManager.send.callCount, 1);
+        assert.equal(MessageManager.send.calledWith[0], '2471');
+        assert.equal(MessageManager.send.calledWith[1], 'Short');
+
+        assert.equal(ThreadUI.headerText.textContent, '2471');
+        assert.equal(ThreadUI.headerText.dataset.isContact, undefined);
+
+        done();
+      }, 30);
     });
   });
 });


### PR DESCRIPTION
At the moment the SMS app does all lookups via a contains filter op to mozContacts. However, this is causing problems when sending (or receiving) messages to a number that is the substring of the number of an existing contact, because they will either be both matched, or if the shorter number is non-existing the wrong contact will be selected.

This patch introduces `findByEqualString` that does an `equals` op against mozContacts and replaces all calls (except the one in the find contact screen) by this call. I've added test cases.
