### PR TITLE
Bug 861027 - If the app behind the soon-to-be-unlocked lockscreen has an

### DIFF
--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -29,15 +29,20 @@ var AttentionScreen = {
 
   init: function as_init() {
     window.addEventListener('mozbrowseropenwindow', this.open.bind(this), true);
+
     window.addEventListener('mozbrowserclose', this.close.bind(this), true);
     window.addEventListener('mozbrowsererror', this.close.bind(this), true);
+
     window.addEventListener('keyboardchange', this.resize.bind(this), true);
     window.addEventListener('keyboardhide', this.resize.bind(this), true);
 
     this.bar.addEventListener('click', this.show.bind(this));
+
     window.addEventListener('home', this.hide.bind(this));
     window.addEventListener('holdhome', this.hide.bind(this));
     window.addEventListener('appwillopen', this.hide.bind(this));
+
+    window.addEventListener('will-unlock', this.screenUnlocked.bind(this));
   },
 
   resize: function as_resize(evt) {
@@ -270,6 +275,13 @@ var AttentionScreen = {
     if (origin === frameOrigin) {
       this.show();
     }
+  },
+
+  screenUnlocked: function as_screenUnlocked() {
+    // If the app behind the soon-to-be-unlocked lockscreen has an
+    // attention screen we should display it
+    var app = WindowManager.getCurrentDisplayedApp();
+    this.showForOrigin(app.origin);
   },
 
   getAttentionScreenOrigins: function as_getAttentionScreenOrigins() {


### PR DESCRIPTION
attention screen we should display it
r=alive
