### PR TITLE
Bug 862146: unable to add attachments to an email

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -351,22 +351,9 @@
                 <div class="cmp-bcc-add cmp-contact-add"></div>
               </div>
             </div>
-            <div class="cmp-envelope-line cmp-combo">
-              <span class="cmp-attachment-label cmp-addr-label"
-                     data-l10n-id="compose-attachments[zero]">AttachmentS:</span>
-              <div class="cmp-attachment-container cmp-addr-container">
-                <div class="cmp-attachments-size">
-                </div>
-                <!-- commenting instead of removing to make the life of future
-                uplifters easier by providing more context: we don't want this
-                in v1.0.1 -->
-                <!--
-                <div class="cmp-attachment-add cmp-file-add"></div>
-                -->
-              </div>
-            </div>
-            <ul class="cmp-attachments-container">
-            </ul>
+            <!-- v1.0.1 can only handle a single attachment.
+            v1.1 uses a list for cmp-attachments-container -->
+            <div class="cmp-attachments-container"></div>
             <div class="cmp-envelope-line cmp-subject">
               <span class="cmp-subject-label"
                      data-l10n-id="compose-subject">SubjecT:</span>
@@ -1062,12 +1049,12 @@
           <button id="cmp-send-failed-ok" class="recommend" data-l10n-id="dialog-button-ok">OK</button>
         </menu>
       </form>
-      <li class="cmp-attachment-item">
+      <div class="cmp-attachment-item">
         <span class="cmp-attachment-icon"></span>
         <span class="cmp-attachment-filename"></span>
         <span class="cmp-attachment-filesize"></span>
         <button class="cmp-attachment-remove">X</span>
-      </li>
+      </div>
       <form role="dialog" data-type="confirm" class="cmp-sending-container">
         <section class="cmp-messages-sending">
           <h1 data-l10n-id="compose-sending-message">Sending messagE</h1>

--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -375,7 +375,8 @@ ComposeCard.prototype = {
                               this, attachmentNode, attachment));
       }
 
-      this.updateAttachmentsSize();
+      // Only one attachment for v1.0.1 so we should't update header information
+      // this.updateAttachmentsSize();
 
       attachmentsContainer.classList.remove('collapsed');
     }
@@ -418,7 +419,8 @@ ComposeCard.prototype = {
     node.parentNode.removeChild(node);
     this.composer.removeAttachment(attachment);
 
-    this.updateAttachmentsSize();
+    // Only one attachment for v1.0.1 so we should't update header information
+    // this.updateAttachmentsSize();
   },
 
   /**

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -15,7 +15,7 @@
   content: ':';
 }
 
-.cmp-addr-container, .cmp-subject-text {
+.cmp-addr-container, input.cmp-subject-text {
   display: table-cell;
   width: -moz-available;
 }
@@ -97,12 +97,13 @@ input.cmp-subject-text {
 
 /* Attachment */
 .cmp-attachments-container {
-  padding: 0 1rem;
+  position: relative;
+  margin: 0 2rem;
+  padding: 0.4rem 0;
   font-size: 1.2rem;
   line-height: 4rem;
 }
 .cmp-attachment-item {
-  list-style-type: none;
   height: 4rem;
 }
 .cmp-attachment-icon {


### PR DESCRIPTION
Changing from li to div removed li css rule from setup-card.css

Still an issue (regression) where input fields are positioned higher than on 1.1. Separate issue?
