### PR TITLE
Merge pull request #8970 from Archaeopteryx/patch-1

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -250,9 +250,8 @@
       <div>
         <ul>
           <li>
-            <a data-l10n-id="macAddress"> MAC address
-              <span data-name="deviceinfo.mac"></span>
-            </a>
+            <small data-name="deviceinfo.mac"></small>
+            <a data-l10n-id="macAddress"> MAC address </a>
           </li>
         </ul>
 


### PR DESCRIPTION
Bug 830572 - MAC address label overlaps value, r=kaze (cherry picked from commit d0d350489a63bd01c57c1e2ce38c758739073221)
