### PR TITLE
Bug 862061 - [SMS][MMS] contacts without a phone number entry will break the SMS app

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -864,6 +864,10 @@ var ThreadUI = {
   },
 
   renderContactData: function thui_renderContactData(contact) {
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=862061
+    if (contact.tel === null) {
+      return;
+    }
     // Retrieve info from thread
     var self = this;
     var tels = contact.tel;

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -106,7 +106,12 @@ var Utils = {
     var details = {};
     if (contact) { // we have a contact
       var name = contact.name[0],
-          phone = contact.tel[0],
+          length = contact.tel ? contact.tel.length : 0,
+          phone = length && contact.tel[0].value ? contact.tel[0] : {
+            value: '',
+            type: '',
+            carrier: ''
+          };
           carrierToShow = phone.carrier;
 
       // Check which of the contacts phone number are we using


### PR DESCRIPTION
Per request here https://bugzilla.mozilla.org/show_bug.cgi?id=862061#c12

The tests cannot be easily ported because they require mocks that don't exist in this v1.0.1 world and I was asked to keep it minimal.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
