### PR TITLE
Bug 863127 - Dont show SPN if same as network name

### DIFF
--- a/apps/system/test/unit/mobile_operator_test.js
+++ b/apps/system/test/unit/mobile_operator_test.js
@@ -52,6 +52,15 @@ suite('shared/MobileOperator', function() {
       assert.isUndefined(infos.carrier);
       assert.isUndefined(infos.region);
     });
+    test('Connection with same SPN and network name', function() {
+      MockMobileConnection.iccInfo.isDisplaySpnRequired = true;
+      MockMobileConnection.iccInfo.spn = 'Fake short';
+      MockMobileConnection.iccInfo.isDisplayNetworkNameRequired = true;
+      var infos = MobileOperator.userFacingInfo(MockMobileConnection);
+      assert.equal(infos.operator, 'Fake short');
+      assert.isUndefined(infos.carrier);
+      assert.isUndefined(infos.region);
+    });
     test('Connection with roaming', function() {
       MockMobileConnection.voice.roaming = true;
       var infos = MobileOperator.userFacingInfo(MockMobileConnection);

--- a/shared/js/mobile_operator.js
+++ b/shared/js/mobile_operator.js
@@ -11,7 +11,7 @@ var MobileOperator = {
 
     if (iccInfo.isDisplaySpnRequired && iccInfo.spn &&
         !mobileConnection.voice.roaming) {
-      if (iccInfo.isDisplayNetworkNameRequired) {
+      if (iccInfo.isDisplayNetworkNameRequired && operator !== iccInfo.spn) {
         operator = operator + ' ' + iccInfo.spn;
       } else {
         operator = iccInfo.spn;


### PR DESCRIPTION
Proposed fix for [#863127](https://bugzilla.mozilla.org/show_bug.cgi?id=863127). If SPN and network name are required but they are the same then we get weird results here, like `movistar movistar`. This patch omits the SPN if it's the same as the network name.
