### PR TITLE
after completion of video playing in landscape mode time stamps for video files in list view are not displayed

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -1255,9 +1255,11 @@ window.addEventListener('resize', function() {
   }
 
   // reTruncate text
-  var texts = document.querySelectorAll('.details');
-  for (var i = 0; i < texts.length; i++) {
-    textTruncate(texts[i]);
+  if (!playing) {
+    var texts = document.querySelectorAll('.details');
+    for (var i = 0; i < texts.length; i++) {
+      textTruncate(texts[i]);
+    }
   }
 });
 


### PR DESCRIPTION
after completion of video playing in landscape mode time stamps for video files in list view are not displayed
