### PR TITLE
bug 860530: add a “LOCALIZATION NOTE” to the email.en-US.properties file, r=stas

### DIFF
--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -254,6 +254,7 @@ folder-list-header=Folders
 account-last-synced-label=Last sync:
 account-never-synced=Never
 
+# LOCALIZATION NOTE: do not translate {name}
 reply-quoting-wrote={name} wrote
 forward-original-message=Original message
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=860530
