### PR TITLE
Bug 863310 - Show the stack traces for failing tests, r=lightsofapollo, ...

### DIFF
--- a/tests/python/gaia-unit-tests/gaia_unit_test/reporters/tbpl.py
+++ b/tests/python/gaia-unit-tests/gaia_unit_test/reporters/tbpl.py
@@ -11,7 +11,13 @@ class TBPLLogger(Base):
         self.logger.testPass(data['fullTitle'])
 
     def on_fail(self, data):
-        self.logger.testFail(data['fullTitle'])
+        msg = data['fullTitle']
+        if 'err' in data:
+            if 'message' in data['err']:
+                msg += " | %s" % data['err']['message']
+        self.logger.testFail(msg)
+        if 'err' in data and 'stack' in data['err']:
+            self.logger.info('stack trace:\n%s' % '\n'.join('    %s' % x for x in data['err']['stack'].split('\n')))
 
     def on_suite(self, data):
         self.logger.testStart(data['title'])


### PR DESCRIPTION
...a=test-only

Stack traces now appear!
