### PR TITLE
Bug 863610 - [email] Accounts in the Account Setup can take two lines

### DIFF
--- a/apps/email/style/setup-cards.css
+++ b/apps/email/style/setup-cards.css
@@ -139,6 +139,7 @@ input:focus:invalid {
 }
 
 .tng-account-item-label {
+  white-space: nowrap;
   margin: 0;
 }
 


### PR DESCRIPTION
r? @asutherland: This is a simple fix. It just makes sure we don't wrap the account name in the setup card.

https://bugzilla.mozilla.org/show_bug.cgi?id=863610
