### PR TITLE
fix bug 863527 by updating text instead of parsing untrusted input

### DIFF
--- a/apps/system/js/window.js
+++ b/apps/system/js/window.js
@@ -40,11 +40,10 @@
       console.warn(
         'app of [' + self.app.origin + '] got a mozbrowsererror event.');
 
-      if (self.injected) {
-        self.update();
-      } else {
+      if (!self.injected) {
         self.render();
       }
+      self.update();
       self.show();
       self.injected = true;
     });
@@ -116,11 +115,9 @@
     return '<div id="' + this.id() + '" class="' +
         AppError.className + ' visible" role="dialog">' +
       '<div class="modal-dialog-message-container inner">' +
-        '<h3 data-l10n-id="error-title" class="title">' +
-          this.getTitle() + '</h3>' +
+        '<h3 data-l10n-id="error-title" class="title"></h3>' +
         '<p>' +
-         '<span data-l10n-id="error-message" class="message">' +
-            this.getMessage() + '</span>' +
+         '<span data-l10n-id="error-message" class="message"></span>' +
         '</p>' +
       '</div>' +
       '<menu data-items="2">' +


### PR DESCRIPTION
self.update() is safe, so create blank template, then set textContent, rather than setting the values prior to the template being parsed by insertAdjecentHTML.
