### PR TITLE
Bug 832246 - [clock] Alarm label doesnt display completely when alarm rings r=timdream

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -107,7 +107,7 @@
         </li>
         <li class="singleline field">
           <span class="view-alarm-lbl" data-l10n-id="label">Label</span>
-          <input type="text" class="right" data-l10n-id="alarm" name="alarm.label" placeholder="Alarm"/>
+          <input type="text" class="right" data-l10n-id="alarm" name="alarm.label" placeholder="Alarm" maxLength="50"/>
         </li>
         <li class="singleline field">
           <span class="view-alarm-lbl" data-l10n-id="repeat">Repeat</span>

--- a/apps/clock/style/onring.css
+++ b/apps/clock/style/onring.css
@@ -30,11 +30,10 @@ html, body {
   height: 100%;
   color: #fbfbfb;
   text-align: center;
-  text-shadow: 0.1rem 0.1rem 0 rgba(255, 255, 255, 0.25);
 }
 
 #ring-clock-display {
-  width: 86%;
+  width: 95%;
   margin-top: 44%;
   border-bottom: 0.13rem solid rgba(122, 122, 122, 0.65);
   margin-left: auto;
@@ -55,9 +54,13 @@ html, body {
 
 #ring-alarm-label {
   font: lighter 2.50rem 'MozTT',sans-serif;
-  line-height: 6.25rem;
-  white-space: nowrap;
+  line-height: 3.25rem;
   text-overflow: ellipsis;
+  overflow: hidden;
+  height: 6.5rem; /* span 2 lines, twice the line-height */
+  margin-top: 1.2rem;
+  margin-left: 0.7rem;
+  margin-right: 0.7rem;
 }
 
 #footer-button-container {


### PR DESCRIPTION
- Add maxLength = 50 for input alarm label.
- Refine the layout of onring label.
