### PR TITLE
fix Error: Web App Manifest expecting 'description'

### DIFF
--- a/apps/bluetooth/manifest.webapp
+++ b/apps/bluetooth/manifest.webapp
@@ -7,6 +7,17 @@
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"
   },
+  "permissions": {
+    "bluetooth": {},
+    "device-storage:sdcard": {
+      "access": "readonly",
+      "description": "Storing recieved Files on the SD-Card"
+    },
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember Bluetooth Settings"
+    }
+  },
   "locales": {
     "en-US": {
       "name": "Bluetooth Transfer",
@@ -27,10 +38,5 @@
       "returnValue": true,
       "href": "/transfer.html"
     }   
-  },
-  "permissions": {
-    "bluetooth":{},
-    "device-storage:sdcard":{ "access": "readonly" },
-    "settings":{ "access": "readwrite" }
   }
 }

--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -8,15 +8,27 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "browser":{},
-    "systemXHR":{},
-    "settings":{ "access": "readonly" },
-    "geolocation" : {},
+    "browser": {},
+    "systemXHR": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read Browser Settings"
+    },
+    "geolocation": {},
     "storage": {},
     "desktop-notification" : {},
-    "device-storage:pictures" : { "access": "readwrite" },
-    "device-storage:videos" : { "access": "readwrite" },
-    "device-storage:music" : { "access": "readwrite" }
+    "device-storage:pictures": {
+      "access": "readwrite",
+      "description": "Read and Store Pictures on the Device"
+    },
+    "device-storage:videos": {
+      "access": "readwrite",
+      "description": "Read and Store Videos on the Device"
+    },
+    "device-storage:music": {
+      "access": "readwrite",
+      "description": "Read and Store Music on the Device"
+    }
   },
   "locales": {
     "ar": {

--- a/apps/calendar/manifest.webapp
+++ b/apps/calendar/manifest.webapp
@@ -11,11 +11,14 @@
      { "alarm": "/index.html" }
   ],
   "permissions": {
-    "systemXHR":{},
-    "settings":{ "access": "readonly" },
-    "alarms":{},
-    "storage":{},
-    "desktop-notification":{}
+    "systemXHR": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read Calendar Settings"
+    },
+    "alarms": {},
+    "storage": {},
+    "desktop-notification": {}
   },
   "locales": {
     "ar": {

--- a/apps/camera/manifest.webapp
+++ b/apps/camera/manifest.webapp
@@ -10,13 +10,22 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "storage":{},
-    "device-storage:pictures":{ "access": "readwrite" },
-    "device-storage:videos":{ "access": "readwrite" },
-    "settings":{ "access": "readonly" },
-    "camera":{},
-    "geolocation":{},
-    "audio-channel-notification":{}
+    "storage": {},
+    "device-storage:pictures": {
+      "access": "readwrite",
+      "description": "Read and Store Pictures on the Device"
+    },
+    "device-storage:videos": {
+      "access": "readwrite",
+      "description": "Read and Store Videos on the Device"
+    },
+    "settings": {
+      "access": "readonly",
+      "description": "Read Camera Settings"
+    },
+    "camera": {},
+    "geolocation": {},
+    "audio-channel-notification": {}
   },
   "activities": {
     "record": {

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -8,11 +8,14 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "storage":{},
-    "alarms":{},
-    "settings":{ "access": "readwrite" },
-    "attention":{},
-    "audio-channel-alarm":{}
+    "storage": {},
+    "alarms": {},
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember Clock Settings"
+    },
+    "attention": {},
+    "audio-channel-alarm": {}
   },
   "locales": {
     "ar": {

--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -7,6 +7,30 @@
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"
   },
+  "permissions": {
+    "telephony": {},
+    "voicemail": {},
+    "contacts": {
+      "access": "readwrite",
+      "description": "Modify Contact Information"
+    },
+    "mobileconnection": {},
+    "attention": {},
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember Communications Settings"
+    },
+    "desktop-notification": {},
+    "alarms": {},
+    "systemXHR": {},
+    "wifi-manage": {},
+    "time": {},
+    "audio-channel-telephony": {},
+    "audio-channel-ringer": {},
+    "browser": {},
+    "idle": {},
+    "storage": {}
+  },
   "entry_points": {
     "dialer": {
       "launch_path": "/dialer/index.html#keyboard-view",
@@ -65,24 +89,6 @@
       "name": "FTU",
       "fullscreen": "true"
     }
-  },
-  "permissions": {
-    "telephony":{},
-    "voicemail":{},
-    "contacts":{ "access": "readwrite" },
-    "mobileconnection":{},
-    "attention":{},
-    "settings":{ "access": "readwrite" },
-    "desktop-notification":{},
-    "alarms": {},
-    "systemXHR": {},
-    "wifi-manage":{},
-    "time": {},
-    "audio-channel-telephony":{},
-    "audio-channel-ringer":{},
-    "browser":{},
-    "idle":{},
-    "storage": {}
   },
   "orientation": "portrait-primary",
   "activities": {

--- a/apps/costcontrol/manifest.webapp
+++ b/apps/costcontrol/manifest.webapp
@@ -8,11 +8,14 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "sms":{},
-    "mobileconnection":{},
-    "desktop-notification":{},
-    "settings":{ "access": "readonly" },
-    "networkstats-manage":{},
+    "sms": {},
+    "mobileconnection": {},
+    "desktop-notification": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read Cost Control Settings"
+    },
+    "networkstats-manage": {},
     "alarms": {},
     "telephony": {},
     "storage": {}

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -11,15 +11,24 @@
      { "alarm": "/index.html" }
   ],
   "permissions": {
-    "alarms":{},
+    "alarms": {},
     "audio-channel-notification":{},
-    "contacts":{ "access": "readcreate" },
-    "desktop-notification":{},
-    "storage":{},
-    "device-storage:sdcard":{ "access": "readcreate" },
-    "systemXHR":{},
-    "settings":{ "access": "readonly" },
-    "tcp-socket":{}
+    "contacts": {
+      "access": "readcreate",
+      "description": "Modify Contact Information"
+    },
+    "desktop-notification": {},
+    "storage": {},
+    "device-storage:sdcard": {
+      "access": "readcreate",
+      "description": "Read and Store Data on the SD-Card"
+    },
+    "systemXHR": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read E-Mail Settings"
+    },
+    "tcp-socket": {}
   },
   "locales": {
     "ar": {

--- a/apps/fm/manifest.webapp
+++ b/apps/fm/manifest.webapp
@@ -8,9 +8,12 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "storage":{},
-    "fmradio":{},
-    "settings":{ "access": "readonly" }
+    "storage": {},
+    "fmradio": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read FM Radio Settings"
+    }
   },
   "locales": {
     "ar": {

--- a/apps/gallery/manifest.webapp
+++ b/apps/gallery/manifest.webapp
@@ -9,12 +9,21 @@
   },
   "fullscreen": true,
   "permissions": {
-    "storage":{},
-    "device-storage:pictures":{ "access": "readwrite" },
-    "device-storage:videos":{ "access": "readwrite" },
-    "deprecated-hwvideo":{},
-    "audio-channel-content":{},
-    "settings":{ "access": "readonly" }
+    "storage": {},
+    "device-storage:pictures": {
+      "access": "readwrite",
+      "description": "Read and Store Pictures on the Device"
+    },
+    "device-storage:videos": {
+      "access": "readwrite",
+      "description": "Read and Store Videos on the Device"
+    },
+    "deprecated-hwvideo": {},
+    "audio-channel-content": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read Gallery Settings"
+    }
   },
   "activities": {
     "browse": {

--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -8,12 +8,18 @@
     "url": "https://github.com/andreasgal/gaia"
   },
   "permissions": {
-    "webapps-manage":{},
-    "systemXHR":{},
-    "settings":{ "access": "readwrite" },
-    "device-storage:pictures":{ "access": "readonly" },
-    "open-remote-window":{},
-    "storage":{},
+    "webapps-manage": {},
+    "systemXHR": {},
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember Homescreen Settings"
+    },
+    "storage": {},
+    "device-storage:pictures": {
+      "access": "readonly",
+      "description": "Read and Store Pictures on the Device"
+    },
+    "open-remote-window": {},
     "geolocation": {}
   },
   "locales": {

--- a/apps/keyboard/manifest.webapp
+++ b/apps/keyboard/manifest.webapp
@@ -7,9 +7,12 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "settings":{ "access": "readwrite" },
-    "keyboard":{}
-  },
+    "settings": {
+      "access": "readonly",
+      "description": "Read Keyboard Settings"
+    },
+    "keyboard": {}
+  }
   "locales": {
     "en-US": {
       "name": "Keyboard",

--- a/apps/music/manifest.webapp
+++ b/apps/music/manifest.webapp
@@ -8,11 +8,17 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "storage":{},
-    "device-storage:music":{ "access": "readwrite" },
-    "settings":{ "access": "readonly" },
-    "deprecated-hwvideo":{},
-    "audio-channel-content":{}
+    "storage": {},
+    "device-storage:music": {
+      "access": "readwrite",
+      "description": "Read and Store Music on the Device"
+    },
+    "settings": {
+      "access": "readonly",
+      "description": "Remember Music Settings"
+    },
+    "deprecated-hwvideo": {},
+    "audio-channel-content": {}
   },
   "activities": {
     "open": {

--- a/apps/pdfjs/manifest.webapp
+++ b/apps/pdfjs/manifest.webapp
@@ -6,6 +6,13 @@
     "name": "The pdf.js Team",
     "url": "https://github.com/mozilla/pdf.js"
   },
+  "permissions": {
+    "systemXHR": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read PDF Viewer Settings"
+    }
+  },
   "locales": {
     "en-US": {
       "name": "PDF Viewer",
@@ -27,9 +34,5 @@
       "href": "/content/web/viewer.html",
       "returnValue": true
     }
-  },
-  "permissions": {
-    "systemXHR":{},
-    "settings":{ "access": "readonly" }
   }
 }

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -8,25 +8,43 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "storage":{},
-    "mobileconnection":{},
-    "bluetooth":{},
-    "device-storage:pictures":{ "access": "readonly" },
-    "device-storage:music":{ "access": "readonly" },
-    "device-storage:videos":{ "access": "readonly" },
-    "device-storage:sdcard":{ "access": "readonly" },
-    "device-storage:apps":{ "access": "readonly" },
-    "webapps-manage":{},
-    "permissions":{},
-    "settings":{ "access": "readwrite" },
-    "wifi-manage":{},
-    "attention":{},
-    "time":{},
-    "desktop-notification":{},
-    "power":{},
-    "idle":{},
-    "telephony":{},
-    "audio-channel-notification":{}
+    "mobileconnection": {},
+    "bluetooth": {},
+    "storage": {},
+    "device-storage:pictures": {
+      "access": "readonly",
+      "description": "Read Pictures from the Device"
+    },
+    "device-storage:music": {
+      "access": "readonly",
+      "description": "Read Music from the Device"
+    },
+    "device-storage:videos": {
+      "access": "readonly",
+      "description": "Read Videos from the Device"
+    },
+    "device-storage:sdcard": {
+      "access": "readonly",
+      "description": "Read Data from the SD-Card"
+    },
+    "device-storage:apps": {
+      "access": "readonly",
+      "description": "Read Apps Data from the Device"
+    },
+    "webapps-manage": {},
+    "permissions": {},
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember Settings"
+    },
+    "wifi-manage": {},
+    "attention": {},
+    "time": {},
+    "desktop-notification": {},
+    "power": {},
+    "idle": {},
+    "telephony": {},
+    "audio-channel-notification": {}
   },
   "activities": {
     "configure": {

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -8,13 +8,19 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "sms":{},
-    "storage":{},
-    "contacts":{ "access": "readonly" },
-    "mobileconnection":{},
-    "settings":{ "access": "readonly" },
-    "audio-channel-notification":{},
-    "desktop-notification":{}
+    "sms": {},
+    "storage": {},
+    "contacts": {
+      "access": "readonly",
+      "description": "Read Contacts from the Device"
+    },
+    "mobileconnection": {},
+    "settings": {
+      "access": "readonly",
+      "description": "Read Messages Settings"
+    },
+    "audio-channel-notification": {},
+    "desktop-notification": {}
   },
   "locales": {
     "ar": {

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -9,33 +9,48 @@
   },
   "permissions": {
     "alarms": {},
-    "browser":{},
-    "power":{},
-    "fmradio":{},
-    "webapps-manage":{},
-    "mobileconnection":{},
-    "bluetooth":{},
-    "telephony":{},
-    "voicemail":{},
-    "device-storage:sdcard":{ "access": "readonly" },
-    "device-storage:pictures":{ "access": "readwrite" },
-    "device-storage:videos":{ "access": "readwrite" },
-    "device-storage:music":{ "access": "readcreate" },
-    "settings":{ "access": "readwrite" },
-    "storage":{},
-    "camera":{},
-    "geolocation":{},
-    "wifi-manage":{},
-    "desktop-notification":{},
-    "idle":{},
-    "network-events":{},
-    "embed-apps":{},
-    "background-sensors":{},
-    "permissions":{},
-    "audio-channel-notification":{},
-    "audio-channel-content":{},
-    "cellbroadcast":{},
-    "keyboard":{}
+    "browser": {},
+    "power": {},
+    "fmradio": {},
+    "webapps-manage": {},
+    "mobileconnection": {},
+    "bluetooth": {},
+    "telephony": {},
+    "voicemail": {},
+    "device-storage:sdcard": {
+      "access": "readonly",
+      "description": "Read and Store Data on the SD-Card"
+    },
+    "device-storage:pictures": {
+      "access": "readwrite",
+      "description": "Read and Store Pictures on the Device"
+    },
+    "device-storage:videos": {
+      "access": "readwrite",
+      "description": "Read and Store Videos on the Device"
+    },
+    "device-storage:music": {
+      "access": "readcreate",
+      "description": "Read and Store Music on the Device"
+    },
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember System Settings"
+    },
+    "storage": {},
+    "camera": {},
+    "geolocation": {},
+    "wifi-manage": {},
+    "desktop-notification": {},
+    "idle": {},
+    "network-events": {},
+    "embed-apps": {},
+    "background-sensors": {},
+    "permissions": {},
+    "audio-channel-notification": {},
+    "audio-channel-content": {},
+    "cellbroadcast": {},
+    "keyboard": {}
   },
   "locales": {
     "ar": {

--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -9,13 +9,22 @@
   },
   "fullscreen": true,
   "permissions": {
-    "storage":{},
-    "device-storage:pictures":{ "access": "readwrite" },
-    "device-storage:videos":{ "access": "readwrite" },
-    "settings":{ "access": "readonly" },
-    "deprecated-hwvideo":{},
-    "audio-channel-content":{},
-    "systemXHR":{}
+    "storage": {},
+    "device-storage:pictures": {
+      "access": "readwrite",
+      "description": "Read and Store Pictures on the Device"
+    },
+    "device-storage:videos": {
+      "access": "readwrite",
+      "description": "Read and Store Videos on the Device"
+    },
+    "settings": {
+      "access": "readonly",
+      "description": "Read Video Settings"
+    },
+    "deprecated-hwvideo": {},
+    "audio-channel-content": {},
+    "systemXHR": {}
   },
   "locales": {
     "ar": {

--- a/apps/wallpaper/manifest.webapp
+++ b/apps/wallpaper/manifest.webapp
@@ -7,7 +7,10 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "settings":{ "access": "readwrite" }
+    "settings": {
+      "access": "readwrite",
+      "description": "Remember Wallpaper Settings"
+    }
   },
   "activities": {
     "pick": {


### PR DESCRIPTION
App validator throws Error: 

Web App Manifest expecting `description`

when validating Gaia bundled apps.

That´s frustrating for "newbees" if they copy permissions from gaia bundled apps. Reading the error message, they will think of the app´s description (and not permission description).
