### PR TITLE
Fix Error:  CSP Violation Detected

### DIFF
--- a/shared/style/action_menu/index.html
+++ b/shared/style/action_menu/index.html
@@ -24,7 +24,7 @@
 </head>
 <body role="application">
 
-  <form role="dialog" data-type="action" onsubmit="return false;">
+  <form role="dialog" data-type="action">
     <header> Title </header> <!-- this header is optional -->
     <menu>
       <button> Action 1 </button>


### PR DESCRIPTION
If you copy the ActionMenu Buildingblock into your app and you´re trying to upload it, the application validator will throw an error:

```
Error:  CSP Violation Detected
It appears that your code may be performing an action which violates the CSP (content security policy) for privileged apps.
You can find more information about what is and is not allowed by the CSP on the Mozilla Developers website. https://developer.mozilla.org/en-US/docs/Security/CSP
        Tier:   2
        File:   shared/style/action_menu/index.html
        Line:   27
        Context:
        >
        > <form role="dialog" data-type="action" onsubmit="return false;">
```
