### PR TITLE
Bug862193

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -150,11 +150,15 @@ html, body {
   position: absolute;
   right: 0;
   top: -.2rem;
+  left: calc(5.5rem + 19.5rem);
   color: #52B6CC;
   margin: 1.3rem 1.5rem 0 0;
   padding: 0;
   display: inline;
   line-height: 1.6rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .notification > img {


### PR DESCRIPTION
r=Etienne
Bug 862193 - [Buri][Notification][Language]Overlap on notification

The html span of timestamp has the absolute position, but only has the right definition. When the timestamp is long enough, it will be overlap the title of the notification.
So I add position "left" definition in the CSS, and let it show "..." when the time stamp is overflow.
