### PR TITLE
Bug 842750 - [B2G] [Clock] Default alarm name not localized r=timdream

### DIFF
--- a/apps/clock/js/alarm.js
+++ b/apps/clock/js/alarm.js
@@ -407,6 +407,7 @@ var AlarmList = {
     d.setHours(alarm.hour);
     d.setMinutes(alarm.minute);
     var time = getLocaleTime(d);
+    var label = (alarm.label === '') ? _('alarm') : escapeHTML(alarm.label);
     content = '<label class="alarmList">' +
               '  <input id="input-enable"' +
                    '" data-id="' + alarm.id +
@@ -421,10 +422,8 @@ var AlarmList = {
               '      <span class="hour24-state">' + time.p + '</span>' +
               '    </div>' +
               '    <div class="alarmList-detail">' +
-              '      <div class="label">' +
-                       escapeHTML(alarm.label) + '</div>' +
-              '      <div class="repeat">' +
-                       summaryRepeat + '</div>' +
+              '      <div class="label">' + label + '</div>' +
+              '      <div class="repeat">' + summaryRepeat + '</div>' +
               '    </div>' +
               '  </div>' +
               '</a>';
@@ -447,6 +446,7 @@ var AlarmList = {
       d.setHours(alarm.hour);
       d.setMinutes(alarm.minute);
       var time = getLocaleTime(d);
+      var label = (alarm.label === '') ? _('alarm') : escapeHTML(alarm.label);
       content += '<li>' +
                  '  <label class="alarmList">' +
                  '    <input id="input-enable"' +
@@ -462,10 +462,8 @@ var AlarmList = {
                  '        <span class="hour24-state">' + time.p + '</span>' +
                  '      </div>' +
                  '      <div class="alarmList-detail">' +
-                 '        <div class="label">' +
-                            escapeHTML(alarm.label) + '</div>' +
-                 '        <div class="repeat">' +
-                            summaryRepeat + '</div>' +
+                 '        <div class="label">' + label + '</div>' +
+                 '        <div class="repeat">' + summaryRepeat + '</div>' +
                  '      </div>' +
                  '    </div>' +
                  '  </a>' +
@@ -1011,8 +1009,7 @@ var AlarmEditView = {
     }
     var error = false;
 
-    var label = this.labelInput.value;
-    this.alarm.label = (label) ? label : 'Alarm';
+    this.alarm.label = this.labelInput.value;
     this.alarm.enabled = true;
     // Get alarm time from time picker.
     if (this.timePicker.is12hFormat) {

--- a/apps/clock/js/onring.js
+++ b/apps/clock/js/onring.js
@@ -2,6 +2,8 @@
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 'use strict';
 
+var _ = navigator.mozL10n.get;
+
 var RingView = {
 
   _ringtonePlayer: null,
@@ -88,7 +90,8 @@ var RingView = {
   },
 
   setAlarmLabel: function rv_setAlarmLabel() {
-    this.alarmLabel.textContent = this.getAlarmLabel();
+    var label = this.getAlarmLabel();
+    this.alarmLabel.textContent = (label === '') ? _('alarm') : label;
   },
 
   ring: function rv_ring() {


### PR DESCRIPTION
- Set '' to be default alarm label if user don't type in any label.
- If the alarm label is '' in alarm-list/onring page, localize it.
- Since the localization of placeholder works fine, we don't need to anything in alarm-edit page. Sync the default input behavior with Contacts app.
