### PR TITLE
Bug 860681 - Icons revert to default in 3rd party apps r=vivien

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -729,13 +729,13 @@ var GridManager = (function() {
    */
 
   // Map 'bookmarkURL' -> Icon object.
-  var bookmarkIcons = Object.create(null);
+  var bookmarkIcons;
   // Map 'manifestURL' + 'entry_point' to Icon object.
-  var appIcons = Object.create(null);
+  var appIcons;
   // Map 'origin' -> app object.
-  var appsByOrigin = Object.create(null);
+  var appsByOrigin;
   // Map 'origin' for bookmarks -> bookmark object.
-  var bookmarksByOrigin = Object.create(null);
+  var bookmarksByOrigin;
 
   function rememberIcon(icon) {
     var descriptor = icon.descriptor;
@@ -973,6 +973,7 @@ var GridManager = (function() {
     var existingIcon = getIcon(descriptor);
     if (existingIcon) {
       existingIcon.update(descriptor, app);
+      markDirtyState();
       return;
     }
 
@@ -1092,6 +1093,11 @@ var GridManager = (function() {
 
   function doInit(options, callback) {
     pages = [];
+    bookmarkIcons = Object.create(null);
+    appIcons = Object.create(null);
+    appsByOrigin = Object.create(null);
+    bookmarksByOrigin = Object.create(null);
+
     initUI(options.gridSelector);
 
     tapThreshold = options.tapThreshold;

--- a/apps/homescreen/test/unit/mock_hidden_apps.js
+++ b/apps/homescreen/test/unit/mock_hidden_apps.js
@@ -1,0 +1,4 @@
+'use strict';
+
+var MockHIDDEN_APPS = [];
+

--- a/apps/homescreen/test/unit/mock_home_state.js
+++ b/apps/homescreen/test/unit/mock_home_state.js
@@ -1,11 +1,19 @@
 'use strict';
 
 var MockHomeState = {
-  init: function(eachPageCallback, onSuccessCallback, onErrorCallback) {
+  init: function mhs_init(eachPageCallback, successCallback, errorCallback) {
     // first page is the dock, let's say it's empty
     eachPageCallback({ index: 0, icons: [] });
-    onSuccessCallback();
+    successCallback();
   },
-  saveGrid: function() {
+
+  saveGrid: function mhs_saveGrid(state) {
+    this.mLastSavedGrid = state;
+  },
+
+  mLastSavedGrid: null,
+
+  mTeardown: function mhs_mTeardown() {
+    this.mLastSavedGrid = null;
   }
 };

--- a/apps/homescreen/test/unit/mock_icon.js
+++ b/apps/homescreen/test/unit/mock_icon.js
@@ -1,0 +1,21 @@
+'use strict';
+
+function MockIcon(descriptor, app) {
+  this.descriptor = descriptor;
+  this.app = app;
+}
+
+MockIcon.prototype = {
+  remove: function mi_remove() {
+  },
+
+  update: function mi_update() {
+  }
+};
+
+MockIcon.mDefaultIcon = 'http://inexistant.name/default_icon.png';
+
+function MockgetDefaultIcon(app) {
+  return MockIcon.mDefaultIcon;
+}
+

--- a/apps/homescreen/test/unit/mock_manifest_helper.js
+++ b/apps/homescreen/test/unit/mock_manifest_helper.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function MockManifestHelper(manifest) {
+  return manifest;
+}

--- a/apps/homescreen/test/unit/mock_page.js
+++ b/apps/homescreen/test/unit/mock_page.js
@@ -9,10 +9,15 @@ MockPage.prototype = {
     // at least 1 or it will be removed
     return 1;
   },
+
   getIconDescriptors: function() {
   },
+
   moveByWithEffect: function mp_moveByWithEffect() {
     MockPage.mMoveByWithEffectCalled = true;
+  },
+
+  appendIcon: function mp_appendIcon() {
   }
 };
 
@@ -21,3 +26,4 @@ MockPage.mTeardown = function mp_mTeardown() {
 };
 
 var MockDock = MockPage;
+


### PR DESCRIPTION
- hopefully finally fix reliably the "ensure panning" test by mocking
  `requestAnimationFrame`
- call `markDirtyState` in all situations ensure that our state is saved in
  IndexedDB
- add tests to ensure the state is saved in these situations. Had to move the
  initialization of some objects to `doInit` so that we can correctly reset the
  object state.
- don't try to load a default icon if we already have an icon
