### PR TITLE
Bug 861758 - [Notification] Hard to click or tap

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -40,6 +40,7 @@ html, body {
 }
 
 #toaster-title {
+  pointer-events: none;
   position: absolute;
   top: 0.3rem;
   color: #52b8cc;
@@ -48,6 +49,7 @@ html, body {
 }
 
 #toaster-detail {
+  pointer-events: none;
   position: absolute;
   top: 2.2rem;
   color: white;


### PR DESCRIPTION
When user tap notification bar, the 'notificationNode' element should be always tapped.

http://bugzil.la/861758
