### PR TITLE
[865273] Fix for Utils.Template to not throw on non-exisiting-id

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -234,17 +234,24 @@
   var priv = new WeakMap();
 
   function extract(node) {
-    if (!node) {
-      return '';
-    }
-
+    var nodeId;
     // Received an ID string? Find the appropriate node to continue
     if (typeof node === 'string') {
+      nodeId = node;
       node = document.getElementById(node);
+    } else if (node) {
+      nodeId = node.id;
+    }
+
+    if (!node) {
+      console.error('Can not find the node passed to Utils.Template', nodeId);
+      return '';
     }
 
     // No firstChild means no comment node.
     if (!node.firstChild) {
+      console.error(
+        'Node passed to Utils.Template should have a comment node', nodeId);
       return '';
     }
 
@@ -260,6 +267,9 @@
       // a comment node, it's likely a text node, so hop to
       // the nextSibling and repeat the operation.
     } while ((node = node.nextSibling));
+
+    console.error(
+      'Nodes passed to Utils.Template should have a comment node', nodeId);
     return '';
   }
 

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -315,6 +315,22 @@ suite('Utils.Message', function() {
 suite('Utils.Template', function() {
 
   suite('extracted template strings', function() {
+
+    var domElement;
+    suiteSetup(function() {
+      domElement = document.createElement('div');
+      domElement.id = 'existing-id';
+      domElement.appendChild(document.createComment('testing'));
+      document.body.appendChild(domElement);
+    });
+
+    suiteTeardown(function() {
+      if (domElement && domElement.parentNode) {
+        document.body.removeChild(domElement);
+        domElement = null;
+      }
+    });
+
     test('extract(node)', function() {
       var node = document.createElement('div');
       var comment = document.createComment('<span>${str}</span>');
@@ -331,13 +347,23 @@ suite('Utils.Template', function() {
         Utils.Template(node).toString(), ''
       );
     });
+
     test('extract(null)', function() {
       assert.equal(Utils.Template(null), '');
     });
+
     test('extract(non-element)', function() {
       assert.equal(Utils.Template(document), '');
       assert.equal(Utils.Template(window), '');
       assert.equal(Utils.Template(document.createComment('')), '');
+    });
+
+    test('extract("non-existing-id")', function() {
+      assert.equal(Utils.Template('non-existing-id'), '');
+    });
+
+    test('extract("existing-id")', function() {
+      assert.equal(Utils.Template('existing-id').toString(), 'testing');
     });
   });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=865273
