### PR TITLE
Bug 864516 - Do not refresh the date when the screen is turned off

### DIFF
--- a/apps/homescreen/js/landing.js
+++ b/apps/homescreen/js/landing.js
@@ -12,9 +12,11 @@ const LandingPage = (function() {
   var clockElemMeridiem = document.querySelector('#landing-clock .meridiem');
   var dateElem = document.querySelector('#landing-date');
 
-  var updateInterval;
+  var updateInterval = null;
+  var updateTimeout = null;
+
   page.addEventListener('gridpagehideend', function onPageHideEnd() {
-    window.clearInterval(updateInterval);
+    clearTime();
   });
 
   navigator.mozL10n.ready(function localize() {
@@ -32,17 +34,37 @@ const LandingPage = (function() {
   document.addEventListener('mozvisibilitychange', function mozVisChange() {
     if (document.mozHidden === false) {
       initTime();
+    } else {
+      clearTime();
     }
   });
 
   function initTime() {
     var date = updateUI();
-    setTimeout(function setUpdateInterval() {
-      updateUI();
-      updateInterval = window.setInterval(function updating() {
+
+    if (updateTimeout == null) {
+      updateTimeout = window.setTimeout(function setUpdateInterval() {
         updateUI();
-      }, 60000);
-    }, (60 - date.getSeconds()) * 1000);
+
+        if (updateInterval == null) {
+          updateInterval = window.setInterval(function updating() {
+            updateUI();
+          }, 60000);
+        }
+      }, (60 - date.getSeconds()) * 1000);
+    }
+  }
+
+  function clearTime() {
+    if (updateTimeout != null) {
+      window.clearTimeout(updateTimeout);
+      updateTimeout = null;
+    }
+
+    if (updateInterval != null) {
+      window.clearInterval(updateInterval);
+      updateInterval = null;
+    }
   }
 
   function updateUI() {


### PR DESCRIPTION
This patch disables the timers responsible for updating the clock/date on the homescreen whenever it becomes invisible including when the homescreen is turned off. The patch also ensures that the timers are properly cleared and do not accidentally pile up.
