### PR TITLE
Bug 863899 - [email] Account Type field in settings doesn't show the account type

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -794,7 +794,7 @@
           <li>
             <span data-l10n-id="settings-account-type" class="list-text">
               AccounT TypE</span>
-            <div class="aside">
+            <div class="aside end">
               <span class="tng-account-type list-value">AccounT TypE</span>
             </div>
           </li>


### PR DESCRIPTION
rs=@asutherland over IRC
