### PR TITLE
Bug 852003 - [email] ActiveSync mimetype-guessing fails for files with non-lowercase extensions (e.g. foo.PNG)

### DIFF
--- a/apps/email/js/ext/mailapi/activesync/configurator.js
+++ b/apps/email/js/ext/mailapi/activesync/configurator.js
@@ -1339,7 +1339,8 @@ ActiveSyncFolderConn.prototype = {
               // Get the file's extension to look up a mimetype, but ignore it
               // if the filename is of the form '.bashrc'.
               dot = attachment.name.lastIndexOf('.');
-              ext = dot > 0 ? attachment.name.substring(dot + 1) : '';
+              ext = dot > 0 ? attachment.name.substring(dot + 1).toLowerCase() :
+                              '';
               attachment.type = $mimelib.contentTypes[ext] ||
                                 'application/octet-stream';
               break;


### PR DESCRIPTION
r=@asutherland from https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/187

https://bugzilla.mozilla.org/show_bug.cgi?id=852003
