### PR TITLE
Bug 863778 - Incorrect message content when launching Usage without a SIM

### DIFF
--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -39,9 +39,6 @@ var CostControlApp = (function() {
 
   'use strict';
 
-  // XXX: This is the point of entry, check common.js for more info
-  waitForDOMAndMessageHandler(window, onReady);
-
   var costcontrol, initialized = false;
   function onReady() {
     var mobileConnection = window.navigator.mozMobileConnection;
@@ -163,6 +160,8 @@ var CostControlApp = (function() {
   }
 
   window.addEventListener('localized', function _onLocalize() {
+    // XXX: This is the point of entry, check common.js for more info
+    waitForDOMAndMessageHandler(window, onReady);
     if (initialized) {
       updateUI();
     }


### PR DESCRIPTION
We should use locales functions after localized event was triggered.

http://bugzil.la/863778
