### PR TITLE
Bug 856991 - Use equals to look up phone numbers in SMS app instead of contains, backport from master

### DIFF
--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -14,7 +14,7 @@ var ContactDataManager = {
     // Get contacts given a number
     var options = {
       filterBy: ['tel'],
-      filterOp: 'contains',
+      filterOp: 'equals',
       filterValue: number
     };
     var self = this;


### PR DESCRIPTION
1.0.1 compatible fix backported from #9232
