### PR TITLE
Bug 869287 - [Bluetooth][File-Transfer] Remove the transfer restriction on the number of files

### DIFF
--- a/apps/bluetooth/js/transfer.js
+++ b/apps/bluetooth/js/transfer.js
@@ -274,17 +274,19 @@ window.addEventListener('localized', function showPanel() {
       // we could refine following code to pass blob to API directly.
       var filepaths = activity.source.data.filepaths;
       var storage = navigator.getDeviceStorage('sdcard');
-      var getRequest = storage.get(filepaths[0]);
+      filepaths.forEach(function(filepath) {
+        var getRequest = storage.get(filepath);
+        getRequest.onsuccess = function() {
+          defaultAdapter.sendFile(targetDevice.address, getRequest.result);
+        };
+        getRequest.onerror = function() {
+          var errmsg = getRequest.error && getRequest.error.name;
+          console.error('Bluetooth.getFile:', errmsg);
+        };
+      });
 
-      getRequest.onsuccess = function() {
-        defaultAdapter.sendFile(targetDevice.address, getRequest.result);
-        activity.postResult('transferred');
-        endTransfer();
-      };
-      getRequest.onerror = function() {
-        var errmsg = getRequest.error && getRequest.error.name;
-        console.error('Bluetooth.getFile:', errmsg);
-      };
+      activity.postResult('transferred');
+      endTransfer();
     };
 
     transferRequest.onerror = function bt_connError() {

--- a/apps/bluetooth/manifest.webapp
+++ b/apps/bluetooth/manifest.webapp
@@ -20,9 +20,6 @@
   "orientation": "portrait-primary",
   "activities": {
     "share": {
-      "filters": {
-      	"number": 1
-       },
       "disposition": "inline",
       "returnValue": true,
       "href": "/transfer.html"


### PR DESCRIPTION
- Remove the filter of sharing number.
- Use a for loop to send all sharing files.
- This patch won't change the UX anymore.
