### PR TITLE
Bug 859596 - When closing the paring window, fire a blur event to the in...

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -469,8 +469,10 @@ navigator.mozL10n.ready(function bluetoothSettings() {
         }
       } else {
         // if the attention screen still open, close it
-        if (childWindow)
+        if (childWindow) {
+          childWindow.PairView.closeInput();
           childWindow.close();
+        }
         // display failure only when active request
         if (pairingMode === 'active' && !userCanceledPairing) {
           // show pair process fail.

--- a/apps/settings/js/onpair.js
+++ b/apps/settings/js/onpair.js
@@ -92,6 +92,15 @@ var PairView = {
     window.close();
   },
 
+  closeInput: function() {
+    if (!this.pinInputItem.hidden) {
+      this.pinInput.blur();
+    }
+    if (!this.passkeyInputItem.hidden) {
+      this.passkeyInput.blur();
+    }
+  },
+
   handleEvent: function pv_handleEvent(evt) {
     var _ = navigator.mozL10n.get;
     if (!evt.target)


### PR DESCRIPTION
The forms.js did receive blur events when closing the child window, but somehow the Keyboard.jsm fail to receive any message. Though additionally firing a blur event to the input element of child window solves the problem.
