### PR TITLE
Bug 864516 - Refresh time displays only when they are visible r=crdlc,yurenju

### DIFF
--- a/apps/homescreen/js/landing.js
+++ b/apps/homescreen/js/landing.js
@@ -12,16 +12,18 @@ const LandingPage = (function() {
   var clockElemMeridiem = document.querySelector('#landing-clock .meridiem');
   var dateElem = document.querySelector('#landing-date');
 
-  var updateInterval;
+  var updateInterval = null;
+  var updateTimeout = null;
+
   page.addEventListener('gridpagehideend', function onPageHideEnd() {
-    window.clearInterval(updateInterval);
+    stopClock();
   });
 
   navigator.mozL10n.ready(function localize() {
     timeFormat = _('shortTimeFormat');
     dateFormat = _('longDateFormat');
-    initTime();
-    page.addEventListener('gridpageshowstart', initTime);
+    startClock();
+    page.addEventListener('gridpageshowstart', startClock);
   });
 
   var landingTime = document.querySelector('#landing-time');
@@ -31,18 +33,38 @@ const LandingPage = (function() {
 
   document.addEventListener('mozvisibilitychange', function mozVisChange() {
     if (document.mozHidden === false) {
-      initTime();
+      startClock();
+    } else {
+      stopClock();
     }
   });
 
-  function initTime() {
+  function startClock() {
     var date = updateUI();
-    setTimeout(function setUpdateInterval() {
-      updateUI();
-      updateInterval = window.setInterval(function updating() {
+
+    if (updateTimeout == null) {
+      updateTimeout = window.setTimeout(function setUpdateInterval() {
         updateUI();
-      }, 60000);
-    }, (60 - date.getSeconds()) * 1000);
+
+        if (updateInterval == null) {
+          updateInterval = window.setInterval(function updating() {
+            updateUI();
+          }, 60000);
+        }
+      }, (60 - date.getSeconds()) * 1000);
+    }
+  }
+
+  function stopClock() {
+    if (updateTimeout != null) {
+      window.clearTimeout(updateTimeout);
+      updateTimeout = null;
+    }
+
+    if (updateInterval != null) {
+      window.clearInterval(updateInterval);
+      updateInterval = null;
+    }
   }
 
   function updateUI() {

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -104,10 +104,15 @@ var LockScreen = {
   */
   HANDLE_MAX: 70,
 
+  /**
+   * Object used for handling the clock UI element, wraps all related timers
+   */
+  clock: new Clock(),
+
   /* init */
   init: function ls_init() {
     if (this.ready) { // already initialized: just trigger a translation
-      this.updateTime();
+      this.refreshClock(new Date());
       this.updateConnState();
       return;
     }
@@ -262,6 +267,8 @@ var LockScreen = {
           if (this.camera.firstElementChild)
             this.camera.removeChild(this.camera.firstElementChild);
 
+          // Stop refreshing the clock when the screen is turned off.
+          this.clock.stop();
         } else {
           var _screenOffInterval = new Date().getTime() - this._screenOffTime;
           if (_screenOffInterval > this.passCodeRequestTimeout * 1000) {
@@ -269,6 +276,9 @@ var LockScreen = {
           } else {
             this._passCodeTimeoutCheck = false;
           }
+
+          // Resume refreshing the clock when the screen is turned on.
+          this.clock.start(this.refreshClock.bind(this));
         }
 
         this.lockIfEnabled(true);
@@ -581,13 +591,15 @@ var LockScreen = {
     this.setElasticEnabled(false);
     this.mainScreen.focus();
     this.dispatchEvent('will-unlock');
+
+    // The lockscreen will be hidden, stop refreshing the clock.
+    this.clock.stop();
   },
 
   lock: function ls_lock(instant) {
     var wasAlreadyLocked = this.locked;
     this.locked = true;
 
-    navigator.mozL10n.ready(this.updateTime.bind(this));
     this.switchPanel();
 
     this.setElasticEnabled(ScreenManager.screenEnabled);
@@ -748,25 +760,19 @@ var LockScreen = {
     });
   },
 
-  updateTime: function ls_updateTime() {
+  refreshClock: function ls_refreshClock(now) {
     if (!this.locked)
       return;
 
-    var d = new Date();
     var f = new navigator.mozL10n.DateTimeFormat();
     var _ = navigator.mozL10n.get;
 
     var timeFormat = _('shortTimeFormat');
     var dateFormat = _('longDateFormat');
-    var time = f.localeFormat(d, timeFormat);
+    var time = f.localeFormat(now, timeFormat);
     this.clockNumbers.textContent = time.match(/([012]?\d).[0-5]\d/g);
     this.clockMeridiem.textContent = (time.match(/AM|PM/i) || []).join('');
-    this.date.textContent = f.localeFormat(d, dateFormat);
-
-    var self = this;
-    window.setTimeout(function ls_clockTimeout() {
-      self.updateTime();
-    }, (59 - d.getSeconds()) * 1000);
+    this.date.textContent = f.localeFormat(now, dateFormat);
   },
 
   updateConnState: function ls_updateConnState() {


### PR DESCRIPTION
- Made the homescreen, lockscreen and status-bar stop refreshing their
  time displays when the screen is off or they are invisible
- Fixed timer-leaks caused by starting the same timer twice overwriting
  the previous one without cancelling it
- Made the statusbar clock reflect locale changes immediately
