### PR TITLE
Bug 864516 - Do not refresh time displays when they are invisible

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -95,6 +95,8 @@ var DCFApi = (function() {
 
 })();
 
+var screenLock = null;
+var returnToCamera = true;
 var Camera = {
   _cameras: null,
   _camera: 0,
@@ -269,10 +271,7 @@ var Camera = {
 
     // Dont let the phone go to sleep while the camera is
     // active, user must manually close it
-    if (navigator.requestWakeLock) {
-      navigator.requestWakeLock('screen');
-    }
-
+    this.screenWakeLock();
     this.setToggleCameraStyle();
 
     // We lock the screen orientation and deal with rotating
@@ -342,6 +341,24 @@ var Camera = {
 
     this.previewEnabled();
     DCFApi.init();
+  },
+
+  screenTimeout: function camera_screenTimeout() {
+    if (screenLock) {
+      screenLock.unlock();
+      screenLock = null;
+    }
+  },
+  screenWakeLock: function camera_screenWakeLock() {
+    if ((!screenLock) && (returnToCamera === true)) {
+      screenLock = navigator.requestWakeLock('screen');
+    }
+  },
+  setReturnToCamera: function camera_setReturnToCamera() {
+    returnToCamera = true;
+  },
+  resetReturnToCamera: function camera_resetReturnToCamera() {
+    returnToCamera = false;
   },
 
   enableButtons: function camera_enableButtons() {
@@ -725,6 +742,7 @@ var Camera = {
   },
 
   startPreview: function camera_startPreview() {
+    this.screenWakeLock();
     this.viewfinder.play();
     this.loadCameraPreview(this._camera, this.previewEnabled.bind(this));
     this._previewActive = true;
@@ -736,6 +754,7 @@ var Camera = {
   },
 
   stopPreview: function camera_stopPreview() {
+    this.screenTimeout();
     if (this._recording) {
       this.stopRecording();
     }

--- a/apps/camera/js/filmstrip.js
+++ b/apps/camera/js/filmstrip.js
@@ -99,6 +99,8 @@ var Filmstrip = (function() {
   };
 
   function previewItem(index) {
+    Camera.resetReturnToCamera();
+    Camera.screenTimeout();
     // Don't redisplay the item if it is already displayed
     if (currentItemIndex === index)
       return;
@@ -128,6 +130,8 @@ var Filmstrip = (function() {
   }
 
   function returnToCameraMode() {
+    Camera.setReturnToCamera();
+    Camera.screenWakeLock();
     Camera.viewfinder.play();        // Restart the viewfinder
     show(Camera.FILMSTRIP_DURATION); // Fade the filmstrip after a delay
     preview.classList.add('offscreen');

--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -306,7 +306,7 @@ contacts.List = (function() {
     var searchable = ['givenName', 'familyName', 'org'];
     searchable.forEach(function(field) {
       if (contact[field] && contact[field][0]) {
-        var value = contact[field][0].trim();
+        var value = String(contact[field][0]).trim();
         if (value.length > 0) {
           searchInfo.push(value);
         }
@@ -759,7 +759,7 @@ contacts.List = (function() {
     if (!hasName(contact)) {
       contact.givenName = [];
       if (contact.org && contact.org.length > 0) {
-        contact.givenName.push(contact.org);
+        contact.givenName.push(contact.org[0]);
       } else if (contact.tel && contact.tel.length > 0) {
         contact.givenName.push(contact.tel[0].value);
       } else if (contact.email && contact.email.length > 0) {

--- a/apps/communications/contacts/test/unit/contacts_list_test.js
+++ b/apps/communications/contacts/test/unit/contacts_list_test.js
@@ -451,7 +451,7 @@ suite('Render contacts list', function() {
       newContact.givenName = null;
       newContact.name = null;
       newContact.category = null;
-      newContact.org = 'AD';
+      newContact.org = ['AD'];
       subject.refresh(newContact);
       assert.isTrue(noContacts.classList.contains('hide'));
       assertNoGroup(groupFav, containerFav);

--- a/apps/costcontrol/js/views/balance.js
+++ b/apps/costcontrol/js/views/balance.js
@@ -46,6 +46,7 @@ var BalanceTab = (function() {
       document.addEventListener('mozvisibilitychange', updateWhenVisible);
       updateButton.addEventListener('click', lockAndUpdateUI);
       ConfigManager.observe('lowLimit', toogleLimits, true);
+      ConfigManager.observe('lowLimitThreshold', resetNotification, true);
       ConfigManager.observe('lastBalance', onBalance, true);
       ConfigManager.observe('errors', onBalanceTimeout, true);
 
@@ -77,6 +78,7 @@ var BalanceTab = (function() {
     document.removeEventListener('mozvisibilitychange', updateWhenVisible);
     updateButton.removeEventListener('click', lockAndUpdateUI);
     ConfigManager.removeObserver('lowLimit', toogleLimits);
+    ConfigManager.removeObserver('lowLimitThreshold', resetNotification);
     ConfigManager.removeObserver('lastBalance', onBalance);
     ConfigManager.removeObserver('errors', onBalanceTimeout);
 
@@ -111,6 +113,11 @@ var BalanceTab = (function() {
   function toogleLimits(isEnabled, old, key, settings) {
     updateBalance(settings.lastBalance,
                   isEnabled && settings.lowLimitThreshold);
+  }
+
+  // On changing the threshold for low limit
+  function resetNotification() {
+    ConfigManager.setOption({ 'lowLimitNotified': false });
   }
 
   // On balance update received

--- a/apps/homescreen/js/landing.js
+++ b/apps/homescreen/js/landing.js
@@ -12,16 +12,18 @@ const LandingPage = (function() {
   var clockElemMeridiem = document.querySelector('#landing-clock .meridiem');
   var dateElem = document.querySelector('#landing-date');
 
-  var updateInterval;
+  var updateInterval = null;
+  var updateTimeout = null;
+
   page.addEventListener('gridpagehideend', function onPageHideEnd() {
-    window.clearInterval(updateInterval);
+    stopClock();
   });
 
   navigator.mozL10n.ready(function localize() {
     timeFormat = _('shortTimeFormat');
     dateFormat = _('longDateFormat');
-    initTime();
-    page.addEventListener('gridpageshowstart', initTime);
+    startClock();
+    page.addEventListener('gridpageshowstart', startClock);
   });
 
   var landingTime = document.querySelector('#landing-time');
@@ -31,18 +33,38 @@ const LandingPage = (function() {
 
   document.addEventListener('mozvisibilitychange', function mozVisChange() {
     if (document.mozHidden === false) {
-      initTime();
+      startClock();
+    } else {
+      stopClock();
     }
   });
 
-  function initTime() {
+  function startClock() {
     var date = updateUI();
-    setTimeout(function setUpdateInterval() {
-      updateUI();
-      updateInterval = window.setInterval(function updating() {
+
+    if (updateTimeout == null) {
+      updateTimeout = window.setTimeout(function setUpdateInterval() {
         updateUI();
-      }, 60000);
-    }, (60 - date.getSeconds()) * 1000);
+
+        if (updateInterval == null) {
+          updateInterval = window.setInterval(function updating() {
+            updateUI();
+          }, 60000);
+        }
+      }, (60 - date.getSeconds()) * 1000);
+    }
+  }
+
+  function stopClock() {
+    if (updateTimeout != null) {
+      window.clearTimeout(updateTimeout);
+      updateTimeout = null;
+    }
+
+    if (updateInterval != null) {
+      window.clearInterval(updateInterval);
+      updateInterval = null;
+    }
   }
 
   function updateUI() {

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -171,7 +171,7 @@ const REPEAT_RATE = 100;
 const REPEAT_TIMEOUT = 700;
 
 // How long to wait for more focuschange events before processing
-const FOCUS_CHANGE_DELAY = 20;
+const FOCUS_CHANGE_DELAY = 100;
 
 // Taps the shift key twice within CAPS_LOCK_TIMEOUT
 // to lock the keyboard at upper case state.
@@ -401,13 +401,13 @@ function initKeyboard() {
     // We can get multiple focuschange events in rapid succession
     // so wait a bit before responding to see if we get another.
     clearTimeout(focusChangeTimeout);
-    focusChangeTimeout = setTimeout(function switchKeyboard() {
-      if (type === 'blur') {
+    if (type === 'blur') {
+      focusChangeTimeout = setTimeout(function switchKeyboard() {
         hideKeyboard();
-      } else {
-        showKeyboard(state);
-      }
-    }, FOCUS_CHANGE_DELAY);
+      }, FOCUS_CHANGE_DELAY);
+    } else {
+      showKeyboard(state);
+    }
   };
 
   // Handle resize events

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -447,7 +447,7 @@ var LockScreen = {
             return;
           }
 
-          self.unlock();
+          self.unlock(/* instant */ null, /* detail */ { areaCamera: true });
 
           var a = new MozActivity({
             name: 'record',
@@ -516,7 +516,7 @@ var LockScreen = {
     }
   },
 
-  unlock: function ls_unlock(instant) {
+  unlock: function ls_unlock(instant, detail) {
     var currentApp = WindowManager.getDisplayedApp();
     WindowManager.setOrientationForApp(currentApp);
 
@@ -543,7 +543,7 @@ var LockScreen = {
       if (!wasAlreadyUnlocked) {
         // Any changes made to this,
         // also need to be reflected in apps/system/js/storage.js
-        this.dispatchEvent('unlock');
+        this.dispatchEvent('unlock', detail);
         this.writeSetting(false);
 
         if (instant)
@@ -942,9 +942,14 @@ var LockScreen = {
     this.mainScreen = document.getElementById('screen');
   },
 
-  dispatchEvent: function ls_dispatchEvent(name) {
-    var evt = document.createEvent('CustomEvent');
-    evt.initCustomEvent(name, true, true, null);
+  dispatchEvent: function ls_dispatchEvent(name, detail) {
+    var evt = new CustomEvent(name, {
+      'bubbles': true,
+      'cancelable': true,
+      // Set event detail if needed for the specific event 'name' (relevant for
+      // passing which button triggered the event)
+      'detail': detail
+    });
     window.dispatchEvent(evt);
   },
 

--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -26,6 +26,12 @@ var SimLock = {
   handleEvent: function sl_handleEvent(evt) {
     switch (evt.type) {
       case 'unlock':
+        // Check whether the lock screen was unlocked from the camera or not.
+        // If the former is true, the SIM PIN dialog should not displayed after
+        // unlock, because the camera will be opened (Bug 849718)
+        if (evt.detail && evt.detail.areaCamera)
+          return;
+
         this.showIfLocked();
         break;
       case 'appwillopen':

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -109,6 +109,61 @@ var StatusBar = {
   networkActivityAnimation: null,
   systemDownloadsAnimation: null,
 
+  /**
+   * Object used for handling the clock, includes functions to automatically
+   * refresh the clock when shown and suspend the refreshes when hidden.
+   */
+  clock: {
+    /** One-shot timer used to refresh the clock at a minute's turn */
+    timeoutID: null,
+
+    /** Timer used to refresh the clock every minute */
+    timerID: null,
+
+    /**
+     * Start the timer used to refresh the clock, will call the specified
+     * callback at every timer tick to refresh the UI. The callback used to
+     * refresh the UI will also be called immediately to ensure the UI is
+     * consistent.
+     *
+     * @param {Function} Function used to refresh the UI at every timer tick,
+     *                   should accept a date object as its only argument
+     */
+    start: function cl_start(refresh) {
+      var date = new Date();
+      var self = this;
+
+      refresh(date);
+
+      if (this.timeoutID == null) {
+        this.timeoutID = window.setTimeout(function cl_setClockInterval() {
+          refresh(new Date());
+
+          if (self.timerID == null) {
+            self.timerID = window.setInterval(function cl_clockInterval() {
+              refresh(new Date());
+            }, 60000);
+          }
+        }, (60 - date.getSeconds()) * 1000);
+      }
+    },
+
+    /**
+     * Stops the timer used to refresh the clock
+     */
+    stop: function cl_stop() {
+      if (this.timeoutID != null) {
+        window.clearTimeout(this.timeoutID);
+        this.timeoutID = null;
+      }
+
+      if (this.timerID != null) {
+        window.clearInterval(this.timerID);
+        this.timerID = null;
+      }
+    }
+  },
+
   /* For other modules to acquire */
   get height() {
     if (this.screen.classList.contains('fullscreen-app') ||
@@ -124,6 +179,9 @@ var StatusBar = {
 
   init: function sb_init() {
     this.getAllElements();
+
+    // Refresh the time to reflect locale changes
+    this.update.time.call(this, new Date());
 
     var settings = {
       'ril.radio.disabled': ['signal', 'data'],
@@ -169,12 +227,13 @@ var StatusBar = {
     // Listen to 'moztimechange'
     window.addEventListener('moztimechange', this);
 
-    // Listen to 'appwillclose', 'appopen', 'home', 'holdhome', 'unlock'
+    // Listen to 'appwillclose', 'appopen', 'home', 'holdhome', 'lock', 'unlock'
     // to determine the visible state of statusbar
     window.addEventListener('home', this);
     window.addEventListener('holdhome', this);
     window.addEventListener('appwillclose', this);
     window.addEventListener('appopen', this);
+    window.addEventListener('lock', this);
     window.addEventListener('unlock', this);
 
     // Listen to 'mozfullscreenchange' to see if we should hide statusbar
@@ -265,6 +324,10 @@ var StatusBar = {
         this.update.networkActivity.call(this);
         break;
 
+      case 'lock':
+        this.clock.stop();
+        break;
+
       case 'appopen':
       case 'mozfullscreenchange':
       case 'unlock':
@@ -272,6 +335,8 @@ var StatusBar = {
             document.mozFullScreen) {
           this.hide();
         }
+
+        this.clock.start(this.update.time.bind(this));
         break;
 
       case 'appwillclose':
@@ -293,8 +358,6 @@ var StatusBar = {
   setActive: function sb_setActive(active) {
     this.active = active;
     if (active) {
-      this.update.time.call(this);
-
       var battery = window.navigator.battery;
       if (battery) {
         battery.addEventListener('chargingchange', this);
@@ -321,10 +384,11 @@ var StatusBar = {
 
       if (LockScreen.locked) {
         this.show();
+      } else {
+        // Start refreshing the clock only if it's visible
+        this.clock.start(this.update.time.bind(this));
       }
     } else {
-      clearTimeout(this._clockTimer);
-
       var battery = window.navigator.battery;
       if (battery) {
         battery.removeEventListener('chargingchange', this);
@@ -341,6 +405,9 @@ var StatusBar = {
 
       window.removeEventListener('moznetworkupload', this);
       window.removeEventListener('moznetworkdownload', this);
+
+      // Always prevent the clock from refreshing itself when the screen is off
+      this.clock.stop();
     }
   },
 
@@ -374,16 +441,10 @@ var StatusBar = {
       label.textContent = navigator.mozL10n.get('statusbarLabel', l10nArgs);
     },
 
-    time: function sb_updateTime() {
-      // Schedule another clock update when a new minute rolls around
+    time: function sb_updateTime(now) {
       var _ = navigator.mozL10n.get;
       var f = new navigator.mozL10n.DateTimeFormat();
-      var now = new Date();
       var sec = now.getSeconds();
-      if (this._clockTimer)
-        window.clearTimeout(this._clockTimer);
-      this._clockTimer =
-        window.setTimeout((this.update.time).bind(this), (59 - sec) * 1000);
 
       var formated = f.localeFormat(now, _('shortTimeFormat'));
       formated = formated.replace(/\s?(AM|PM)\s?/i, '<span>$1</span>');

--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -192,7 +192,7 @@ init = getFile(GAIA_DIR, 'apps', 'costcontrol', 'js', 'config.json');
 
 content = {
   provider: 'Vivo',
-  enable_on: { 724: [6, 10, 11, 23] }, // { MCC: [ MNC1, MNC2, ...] }
+  enable_on: { "724": ["6", "10", "11", "23"] }, // { MCC: [ MNC1, MNC2, ...] }
   is_free: true,
   is_roaming_free: true,
   credit: { currency : 'R$' },


### PR DESCRIPTION
Both the homescreen and the lockscreen kept refreshing their time
displays even when another application was in the foreground or the
screen was off, both were fixed. The timers used for refreshing could
also be leaked, this was also fixed.
