### PR TITLE
Bug 864516 - Refresh time displays only when they are visible r=crdlc,yurenju

### DIFF
--- a/apps/homescreen/js/landing.js
+++ b/apps/homescreen/js/landing.js
@@ -12,16 +12,18 @@ const LandingPage = (function() {
   var clockElemMeridiem = document.querySelector('#landing-clock .meridiem');
   var dateElem = document.querySelector('#landing-date');
 
-  var updateInterval;
+  var updateInterval = null;
+  var updateTimeout = null;
+
   page.addEventListener('gridpagehideend', function onPageHideEnd() {
-    window.clearInterval(updateInterval);
+    stopClock();
   });
 
   navigator.mozL10n.ready(function localize() {
     timeFormat = _('shortTimeFormat');
     dateFormat = _('longDateFormat');
-    initTime();
-    page.addEventListener('gridpageshowstart', initTime);
+    startClock();
+    page.addEventListener('gridpageshowstart', startClock);
   });
 
   var landingTime = document.querySelector('#landing-time');
@@ -31,18 +33,38 @@ const LandingPage = (function() {
 
   document.addEventListener('mozvisibilitychange', function mozVisChange() {
     if (document.mozHidden === false) {
-      initTime();
+      startClock();
+    } else {
+      stopClock();
     }
   });
 
-  function initTime() {
+  function startClock() {
     var date = updateUI();
-    setTimeout(function setUpdateInterval() {
-      updateUI();
-      updateInterval = window.setInterval(function updating() {
+
+    if (updateTimeout == null) {
+      updateTimeout = window.setTimeout(function setUpdateInterval() {
         updateUI();
-      }, 60000);
-    }, (60 - date.getSeconds()) * 1000);
+
+        if (updateInterval == null) {
+          updateInterval = window.setInterval(function updating() {
+            updateUI();
+          }, 60000);
+        }
+      }, (60 - date.getSeconds()) * 1000);
+    }
+  }
+
+  function stopClock() {
+    if (updateTimeout != null) {
+      window.clearTimeout(updateTimeout);
+      updateTimeout = null;
+    }
+
+    if (updateInterval != null) {
+      window.clearInterval(updateInterval);
+      updateInterval = null;
+    }
   }
 
   function updateUI() {

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -104,10 +104,15 @@ var LockScreen = {
   */
   HANDLE_MAX: 70,
 
+  /**
+   * Object used for handling the clock UI element, wraps all related timers
+   */
+  clock: new Clock(),
+
   /* init */
   init: function ls_init() {
     if (this.ready) { // already initialized: just trigger a translation
-      this.updateTime();
+      this.refreshClock(new Date());
       this.updateConnState();
       return;
     }
@@ -262,6 +267,8 @@ var LockScreen = {
           if (this.camera.firstElementChild)
             this.camera.removeChild(this.camera.firstElementChild);
 
+          // Stop refreshing the clock when the screen is turned off.
+          this.clock.stop();
         } else {
           var _screenOffInterval = new Date().getTime() - this._screenOffTime;
           if (_screenOffInterval > this.passCodeRequestTimeout * 1000) {
@@ -269,6 +276,9 @@ var LockScreen = {
           } else {
             this._passCodeTimeoutCheck = false;
           }
+
+          // Resume refreshing the clock when the screen is turned on.
+          this.clock.start(this.refreshClock.bind(this));
         }
 
         this.lockIfEnabled(true);
@@ -526,6 +536,9 @@ var LockScreen = {
     this.setElasticEnabled(false);
     this.mainScreen.focus();
 
+    // The lockscreen will be hidden, stop refreshing the clock.
+    this.clock.stop();
+
     var repaintTimeout = 0;
     var nextPaint = (function() {
       clearTimeout(repaintTimeout);
@@ -567,7 +580,6 @@ var LockScreen = {
     var wasAlreadyLocked = this.locked;
     this.locked = true;
 
-    navigator.mozL10n.ready(this.updateTime.bind(this));
     this.switchPanel();
 
     this.setElasticEnabled(ScreenManager.screenEnabled);
@@ -728,25 +740,19 @@ var LockScreen = {
     });
   },
 
-  updateTime: function ls_updateTime() {
+  refreshClock: function ls_refreshClock(now) {
     if (!this.locked)
       return;
 
-    var d = new Date();
     var f = new navigator.mozL10n.DateTimeFormat();
     var _ = navigator.mozL10n.get;
 
     var timeFormat = _('shortTimeFormat');
     var dateFormat = _('longDateFormat');
-    var time = f.localeFormat(d, timeFormat);
+    var time = f.localeFormat(now, timeFormat);
     this.clockNumbers.textContent = time.match(/([012]?\d).[0-5]\d/g);
     this.clockMeridiem.textContent = (time.match(/AM|PM/i) || []).join('');
-    this.date.textContent = f.localeFormat(d, dateFormat);
-
-    var self = this;
-    window.setTimeout(function ls_clockTimeout() {
-      self.updateTime();
-    }, (59 - d.getSeconds()) * 1000);
+    this.date.textContent = f.localeFormat(now, dateFormat);
   },
 
   updateConnState: function ls_updateConnState() {

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -52,6 +52,61 @@ function AnimatedIcon(element, path, frames, delay) {
   };
 }
 
+/**
+ * Creates an object used for refreshing the clock UI element. Handles all
+ * related timer manipulation (start/stop/cancel).
+ */
+function Clock() {
+  /** One-shot timer used to refresh the clock at a minute's turn */
+  this.timeoutID = null;
+
+  /** Timer used to refresh the clock every minute */
+  this.timerID = null;
+
+  /**
+   * Start the timer used to refresh the clock, will call the specified
+   * callback at every timer tick to refresh the UI. The callback used to
+   * refresh the UI will also be called immediately to ensure the UI is
+   * consistent.
+   *
+   * @param {Function} refresh Function used to refresh the UI at every timer
+   *        tick, should accept a date object as its only argument.
+   */
+  this.start = function cl_start(refresh) {
+      var date = new Date();
+      var self = this;
+
+      refresh(date);
+
+      if (this.timeoutID == null) {
+        this.timeoutID = window.setTimeout(function cl_setClockInterval() {
+          refresh(new Date());
+
+          if (self.timerID == null) {
+            self.timerID = window.setInterval(function cl_clockInterval() {
+              refresh(new Date());
+            }, 60000);
+          }
+        }, (60 - date.getSeconds()) * 1000);
+      }
+    };
+
+  /**
+   * Stops the timer used to refresh the clock
+   */
+  this.stop = function cl_stop() {
+    if (this.timeoutID != null) {
+      window.clearTimeout(this.timeoutID);
+      this.timeoutID = null;
+    }
+
+    if (this.timerID != null) {
+      window.clearInterval(this.timerID);
+      this.timerID = null;
+    }
+  };
+}
+
 var StatusBar = {
   /* all elements that are children nodes of the status bar */
   ELEMENTS: ['notification', 'time',
@@ -109,6 +164,11 @@ var StatusBar = {
   networkActivityAnimation: null,
   systemDownloadsAnimation: null,
 
+  /**
+   * Object used for handling the clock UI element, wraps all related timers
+   */
+  clock: new Clock(),
+
   /* For other modules to acquire */
   get height() {
     if (this.screen.classList.contains('fullscreen-app') ||
@@ -124,6 +184,9 @@ var StatusBar = {
 
   init: function sb_init() {
     this.getAllElements();
+
+    // Refresh the time to reflect locale changes
+    this.update.time.call(this, new Date());
 
     var settings = {
       'ril.radio.disabled': ['signal', 'data'],
@@ -169,12 +232,13 @@ var StatusBar = {
     // Listen to 'moztimechange'
     window.addEventListener('moztimechange', this);
 
-    // Listen to 'appwillclose', 'appopen', 'home', 'holdhome', 'unlock'
+    // Listen to 'appwillclose', 'appopen', 'home', 'holdhome', 'lock', 'unlock'
     // to determine the visible state of statusbar
     window.addEventListener('home', this);
     window.addEventListener('holdhome', this);
     window.addEventListener('appwillclose', this);
     window.addEventListener('appopen', this);
+    window.addEventListener('lock', this);
     window.addEventListener('unlock', this);
 
     // Listen to 'mozfullscreenchange' to see if we should hide statusbar
@@ -232,7 +296,8 @@ var StatusBar = {
         break;
 
       case 'moztimechange':
-        navigator.mozL10n.ready(this.update.time.bind(this));
+        navigator.mozL10n.ready(
+          this.clock.start.bind(this.clock, this.update.time.bind(this)));
         break;
 
       case 'mozChromeEvent':
@@ -265,6 +330,10 @@ var StatusBar = {
         this.update.networkActivity.call(this);
         break;
 
+      case 'lock':
+        this.clock.stop();
+        break;
+
       case 'appopen':
       case 'mozfullscreenchange':
       case 'unlock':
@@ -272,6 +341,8 @@ var StatusBar = {
             document.mozFullScreen) {
           this.hide();
         }
+
+        this.clock.start(this.update.time.bind(this));
         break;
 
       case 'appwillclose':
@@ -293,8 +364,6 @@ var StatusBar = {
   setActive: function sb_setActive(active) {
     this.active = active;
     if (active) {
-      navigator.mozL10n.ready(this.update.time.bind(this));
-
       var battery = window.navigator.battery;
       if (battery) {
         battery.addEventListener('chargingchange', this);
@@ -327,10 +396,11 @@ var StatusBar = {
 
       if (LockScreen.locked) {
         this.show();
+      } else {
+        // Start refreshing the clock only if it's visible
+        this.clock.start(this.update.time.bind(this));
       }
     } else {
-      clearTimeout(this._clockTimer);
-
       var battery = window.navigator.battery;
       if (battery) {
         battery.removeEventListener('chargingchange', this);
@@ -347,6 +417,9 @@ var StatusBar = {
 
       window.removeEventListener('moznetworkupload', this);
       window.removeEventListener('moznetworkdownload', this);
+
+      // Always prevent the clock from refreshing itself when the screen is off
+      this.clock.stop();
     }
   },
 
@@ -380,16 +453,10 @@ var StatusBar = {
       label.textContent = navigator.mozL10n.get('statusbarLabel', l10nArgs);
     },
 
-    time: function sb_updateTime() {
-      // Schedule another clock update when a new minute rolls around
+    time: function sb_updateTime(now) {
       var _ = navigator.mozL10n.get;
       var f = new navigator.mozL10n.DateTimeFormat();
-      var now = new Date();
       var sec = now.getSeconds();
-      if (this._clockTimer)
-        window.clearTimeout(this._clockTimer);
-      this._clockTimer =
-        window.setTimeout((this.update.time).bind(this), (59 - sec) * 1000);
 
       var formated = f.localeFormat(now, _('shortTimeFormat'));
       formated = formated.replace(/\s?(AM|PM)\s?/i, '<span>$1</span>');


### PR DESCRIPTION
- Made the homescreen, lockscreen and status-bar stop refreshing their
  time displays when the screen is off or they are invisible
- Fixed timer-leaks caused by starting the same timer twice overwriting
  the previous one without cancelling it
- Made the statusbar clock reflect locale changes immediately
