### PR TITLE
Bug 866660 - [Dialer] Call Log not rendering correctly (follow up of 845097) (r=basiclines)

### DIFF
--- a/apps/communications/dialer/style/commslog.css
+++ b/apps/communications/dialer/style/commslog.css
@@ -144,6 +144,10 @@ ul[role="tablist"][data-type="filter"] > [role="tab"].selected > a {
   background-image: url('images/CallLog_30x30_missed_grey.png');
 }
 
+[data-type="list"] .log-item {
+  padding: 0;
+}
+
 .log-item * {
   pointer-events: none;
 }


### PR DESCRIPTION
This is a follow up of bug 845097 due to the inclusion of a left padding (https://github.com/mozilla-b2g/gaia/blob/817939fc85f8f81c287ee958db497a964817cae0/shared/style_unstable/lists.css#L43) which is not expected in the Call Log rendering :-) This left padding breaks the rendering of the Call Log.
