### PR TITLE
Bug 866690 - [Dialer] Call Log broken due to mcc being null if no SIM (r=etiennesegonzac).

### DIFF
--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -190,7 +190,7 @@ var OnCallHandler = (function onCallHandler() {
   // Setting up the SimplePhoneMatcher
   var conn = window.navigator.mozMobileConnection;
   if (conn && conn.voice && conn.voice.network && conn.voice.network.mcc) {
-    SimplePhoneMatcher.mcc = conn.voice.network.mcc.toString();
+    SimplePhoneMatcher.mcc = conn.voice.network.mcc;
   }
 
   var ringtonePlayer = new Audio();

--- a/apps/communications/dialer/js/recents.js
+++ b/apps/communications/dialer/js/recents.js
@@ -165,7 +165,7 @@ var Recents = {
     // Setting up the SimplePhoneMatcher
     var conn = window.navigator.mozMobileConnection;
     if (conn && conn.voice && conn.voice.network) {
-      SimplePhoneMatcher.mcc = conn.voice.network.mcc.toString();
+      SimplePhoneMatcher.mcc = conn.voice.network.mcc;
     }
 
     LazyL10n.get(function localized(_) {


### PR DESCRIPTION
If we start the device with no SIM, the Call Log does start correctly since mozMobileConnection.voice.network.mcc is null and the toString() function is invoked on it -> https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/dialer/js/recents.js#L168

The problem is due to mcc being a string and not a number anymore. No need to call .toString() on it.
