### PR TITLE
Bug 859185 - [Dialer] When calling number that device isn't saved, call screen shows similar number.

### DIFF
--- a/apps/communications/dialer/js/contacts.js
+++ b/apps/communications/dialer/js/contacts.js
@@ -95,7 +95,7 @@ var Contacts = {
 
       options = {
         filterBy: ['tel'],
-        filterOp: 'contains',
+        filterOp: 'match',
         filterValue: variants[0] // matching the shortest variant
       };
     }


### PR DESCRIPTION
Use the new 'match' option for incoming and outgoing calls.
All blocking bugs of 859185 have to be uplifted if we want to uplift this patch.
