### PR TITLE
 Bug 866109 - Camera app consumes more time between two image captures

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -144,7 +144,7 @@ var Camera = {
   _previewPaused: false,
   _previewActive: false,
 
-  PREVIEW_PAUSE: 500,
+  PREVIEW_PAUSE: 0,
   FILMSTRIP_DURATION: 5000, // show filmstrip for 5s before fading
 
   _flashState: {


### PR DESCRIPTION
As there is no auto or quick review after Image capture from camera, I am setting "PREVIEW_PAUSE" to 0 (zero).
