### PR TITLE
Bug 867064 - Fix homescreen panning test due  r=crdlc

### DIFF
--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -95,10 +95,7 @@ suite('grid.js >', function() {
     suite('ensurePanning >', function() {
       var realRequestAnimationFrame;
 
-      setup(function() {
-        GridManager.ensurePanning();
-        MockPage.mTeardown();
-
+      suiteSetup(function() {
         realRequestAnimationFrame = window.mozRequestAnimationFrame;
         window.mozRequestAnimationFrame = function(func) {
           setTimeout(function() {
@@ -107,23 +104,51 @@ suite('grid.js >', function() {
         };
       });
 
-      teardown(function() {
+      setup(function() {
+        GridManager.ensurePanning();
+        MockPage.mTeardown();
+      });
+
+      suiteTeardown(function() {
         window.mozRequestAnimationFrame = realRequestAnimationFrame;
         realRequestAnimationFrame = null;
       });
 
-      test('should be able to pan', function(done) {
+      function sendTouchEvent(type, node, coords) {
+        var touch = document.createTouch(window, node, 1,
+          coords.x, coords.y, coords.x, coords.y);
+        var touchList = document.createTouchList(touch);
+
+        var evt = document.createEvent('TouchEvent');
+        evt.initTouchEvent(type, true, true, window,
+          0, false, false, false, false,
+          touchList, touchList, touchList);
+        node.dispatchEvent(evt);
+      }
+
+      function sendMouseEvent(type, node, coords) {
         var evt = document.createEvent('MouseEvent');
 
-        evt.initMouseEvent('mousedown', true, true, window,
-          0, 100, 100, 100, 100, false, false, false, false, 0, null);
+        evt.initMouseEvent(type, true, true, window,
+          0, coords.x, coords.y, coords.x, coords.y,
+          false, false, false, false, 0, null);
         containerNode.dispatchEvent(evt);
+      }
 
-        evt = document.createEvent('MouseEvent');
+      test('should be able to pan', function(done) {
+        var start = { x: 100, y: 100 };
+        var move = { x: 200, y: 100 };
 
-        evt.initMouseEvent('mousemove', true, true, window,
-          0, 200, 100, 200, 100, false, false, false, false, 0, null);
-        containerNode.dispatchEvent(evt);
+        // sending both events because depending on the context we may listen to
+        // one or the other
+        // the real code is listening only to one of those so we can safely send
+        // both (this might change but it's unlikely)
+
+        sendTouchEvent('touchstart', containerNode, start);
+        sendMouseEvent('mousedown', containerNode, start);
+
+        sendTouchEvent('touchmove', containerNode, move);
+        sendMouseEvent('mousemove', containerNode, move);
 
         assert.equal(document.body.dataset.transitioning, 'true');
 


### PR DESCRIPTION
Move from mouse events to touch events.
Send both event types so that we won't fail in some situations.

also mock requestAnimationFrame in the suiteSetup instead of setup.
