### PR TITLE
Bug 865469 - check mozMobileConnection.voice.network.mcc before access in

### DIFF
--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -189,7 +189,7 @@ var OnCallHandler = (function onCallHandler() {
 
   // Setting up the SimplePhoneMatcher
   var conn = window.navigator.mozMobileConnection;
-  if (conn && conn.voice && conn.voice.network) {
+  if (conn && conn.voice && conn.voice.network && conn.voice.network.mcc) {
     SimplePhoneMatcher.mcc = conn.voice.network.mcc.toString();
   }
 


### PR DESCRIPTION
"no network" case. r=etienne.

Please note that this pull request is targeted at "v1.0.1" branch, since this issue would not occur on master/v1-train.
