### PR TITLE
Bug 863417 - Can now set toolkit.identity.uri as pref; r=fabrice, a=tef+

### DIFF
--- a/apps/system/js/identity.js
+++ b/apps/system/js/identity.js
@@ -5,8 +5,8 @@
 
 'use strict';
 
-const kIdentityScreen = 'https://login.native-persona.org/sign_in#NATIVE';
-const kIdentityFrame = 'https://login.native-persona.org/communication_iframe';
+const kIdentityScreen = '/sign_in#NATIVE';
+const kIdentityFrame = '/communication_iframe';
 
 var Identity = (function() {
   var iframe;
@@ -20,6 +20,7 @@ var Identity = (function() {
 
     handleEvent: function onMozChromeEvent(e) {
       var chromeEventId = e.detail.id;
+      var personaUri = e.detail.uri;
       var requestId = e.detail.requestId;
       switch (e.detail.type) {
         // Chrome asks Gaia to show the identity dialog.
@@ -43,7 +44,7 @@ var Identity = (function() {
           frame.setAttribute('mozbrowser', 'true');
           frame.setAttribute('remote', true);
           frame.classList.add('screen');
-          frame.src = e.detail.showUI ? kIdentityScreen : kIdentityFrame;
+          frame.src = personaUri + (e.detail.showUI ? kIdentityScreen : kIdentityFrame);
           frame.addEventListener('mozbrowserloadstart',
               function loadStart(evt) {
             // After creating the new frame containing the identity flow, we


### PR DESCRIPTION
The gaia component of https://bugzilla.mozilla.org/show_bug.cgi?id=863417
