### PR TITLE
Bug 867427 - workaround bug 867421: use unique names for the dialer mock...

### DIFF
--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -41,7 +41,12 @@ suite('dialer/handled_call', function() {
   var realUtils;
   var phoneNumber;
 
+  var MockContacts;
+
   suiteSetup(function() {
+    // FIXME workaround for Bug 867421
+    MockContacts = MockContactsForDialer;
+
     realContacts = window.Contacts;
     window.Contacts = MockContacts;
 

--- a/apps/communications/dialer/test/unit/mock_contacts.js
+++ b/apps/communications/dialer/test/unit/mock_contacts.js
@@ -1,4 +1,5 @@
-var MockContacts = {
+// FIXME workaround for Bug 867421
+var MockContactsForDialer = {
   findByNumber: function findByNumber(number, callback) {
     this.mCalledWith = number;
     this.mPhoto = 'test';

--- a/apps/communications/dialer/test/unit/mock_utils.js
+++ b/apps/communications/dialer/test/unit/mock_utils.js
@@ -1,3 +1,4 @@
+// FIXME workaround for Bug 867421
 var MockUtils = {
   mCalledPrettyDate: false,
   mCalledHeaderDate: false,
@@ -15,11 +16,6 @@ var MockUtils = {
 
   getDayDate: function re_getDayDate(timestamp) {
     this.mCalledGetDayDate = true;
-  },
-
-  getPhoneNumberPrimaryInfo: function getPhoneNumberPrimaryInfo(matchingTel,
-    contact) {
-    this.mCalledGetPhoneNumberPrimaryInfo = true;
   },
 
   getPhoneNumberAdditionalInfo: function getPhoneNumberAdditionalInfo(

--- a/apps/communications/dialer/test/unit/suggestion_bar_test.js
+++ b/apps/communications/dialer/test/unit/suggestion_bar_test.js
@@ -29,6 +29,8 @@ suite('suggestion Bar', function() {
   var domSuggestionCount;
   var domOverlay;
 
+  var MockContacts;
+
   var subject;
 
   var mockResult1 = [{
@@ -60,6 +62,11 @@ suite('suggestion Bar', function() {
     event.initEvent(eventName, true, true);
     element.dispatchEvent(event);
   };
+
+  suiteSetup(function() {
+    // FIXME workaround for Bug 867421
+    MockContacts = MockContactsForDialer;
+  });
 
   setup(function() {
     subject = SuggestionBar;

--- a/apps/communications/dialer/test/unit/utils_test.js
+++ b/apps/communications/dialer/test/unit/utils_test.js
@@ -1,5 +1,7 @@
-requireApp('communications/dialer/js/utils.js');
+'use strict';
+
 requireApp('communications/dialer/test/unit/mock_contacts.js');
+requireApp('communications/dialer/js/utils.js');
 
 if (!this.SettingsListener) {
   this.SettingsListener = null;
@@ -7,6 +9,8 @@ if (!this.SettingsListener) {
 
 suite('dialer/utils', function() {
   var realPhoneMatcher;
+
+  var MockContacts;
 
   // Mock the mozL10n api for the Utils class
   navigator.mozL10n = {
@@ -18,6 +22,8 @@ suite('dialer/utils', function() {
   var number = '555-555-555-555';
 
   suiteSetup(function() {
+    // FIXME workaround for Bug 867421
+    MockContacts = MockContactsForDialer;
     subject = Utils;
   });
 


### PR DESCRIPTION
...s r=etienne

In this patch we rename the conflicting mock names. Also fixes mock_utils which
had twice the same properties.
