### PR TITLE
Bug 867649 - Switch the SMS app from using the high-priority wake lock t...

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -102,14 +102,15 @@ window.navigator.mozSetMessageHandler('activity', function actHandle(activity) {
 if (!window.location.hash.length) {
   window.navigator.mozSetMessageHandler('sms-received',
     function smsReceived(message) {
-      // Acquire the "high-priority" wake lock when we receive an SMS.  This
-      // raises the priority of this process above vanilla background apps,
-      // making it less likely to be killed on OOM.
+      // Acquire the cpu wake lock when we receive an SMS.  This raises the
+      // priority of this process above vanilla background apps, making it less
+      // likely to be killed on OOM.  It also prevents the device from going to
+      // sleep before the user is notified of the new message.
       //
       // We'll release it once we display a notification to the user.  We also
       // release the lock after 30s, in case we never run the notification code
       // for some reason.
-      var wakeLock = navigator.requestWakeLock('high-priority');
+      var wakeLock = navigator.requestWakeLock('cpu');
       var wakeLockReleased = false;
       var timeoutID = null;
       function releaseWakeLock() {


### PR DESCRIPTION
...o the CPU wake lock.

Without this patch, I think it's possible for us not to notify the user
of an incoming SMS, failing for the same reason that we sometimes don't
ring alarms: The device goes to sleep before we play the sound.
