### PR TITLE
Bug 855569 - [Buri][Shira-48042][Email] Message shown when bad certificates are used is not the right one. r=squib, a=blocking-b2g=tef+

### DIFF
--- a/apps/email/js/ext/mailapi/activesync/configurator.js
+++ b/apps/email/js/ext/mailapi/activesync/configurator.js
@@ -3374,6 +3374,7 @@ define('mailapi/activesync/configurator',
     '../accountcommon',
     '../a64',
     './account',
+    'require',
     'exports'
   ],
   function(
@@ -3381,8 +3382,56 @@ define('mailapi/activesync/configurator',
     $accountcommon,
     $a64,
     $asacct,
+    require,
     exports
   ) {
+
+function checkServerCertificate(url, callback) {
+  var match = /^https:\/\/([^:/]+)(?::(\d+))?/.exec(url);
+  // probably unit test http case?
+  if (!match) {
+    callback(null);
+    return;
+  }
+  var port = match[2] ? parseInt(match[2], 10) : 443,
+      host = match[1];
+
+  console.log('checking', host, port, 'for security problem');
+
+  require(['tls'], function($tls) {
+    var sock = $tls.connect(port, host);
+    function reportAndClose(err) {
+      if (sock) {
+        var wasSock = sock;
+        sock = null;
+        try {
+          wasSock.end();
+        }
+        catch (ex) {
+        }
+        callback(err);
+      }
+    }
+    // this is a little dumb, but since we don't actually get an event right now
+    // that tells us when our secure connection is established, and connect always
+    // happens, we write data when we connect to help trigger an error or have us
+    // receive data to indicate we successfully connected.
+    // so, the deal is that connect is going to happen.
+    sock.on('connect', function() {
+      sock.write(new Buffer('GET /images/logo.png HTTP/1.1\n\n'));
+    });
+    sock.on('error', function(err) {
+      var reportErr = null;
+      if (err && typeof(err) === 'object' &&
+          /^Security/.test(err.name))
+        reportErr = 'bad-security';
+      reportAndClose(reportErr);
+    });
+    sock.on('data', function(data) {
+      reportAndClose(null);
+    });
+  });
+}
 
 exports.account = $asacct;
 exports.configurator = {
@@ -3424,9 +3473,20 @@ exports.configurator = {
             }
           }
           else {
-            // We didn't talk to the server, so let's call it an unresponsive
-            // server.
-            failureType = 'unresponsive-server';
+            // We didn't talk to the server, so it's either an unresponsive
+            // server or a server with a bad certificate.  (We require https
+            // outside of unit tests so there's no need to branch here.)
+            checkServerCertificate(
+              domainInfo.incoming.server,
+              function(securityError) {
+                var failureType;
+                if (securityError)
+                  failureType = 'bad-security';
+                else
+                  failureType = 'unresponsive-server';
+                callback(failureType, null, failureDetails);
+              });
+            return;
           }
           callback(failureType, null, failureDetails);
           return;
@@ -3516,4 +3576,5 @@ exports.configurator = {
   },
 };
 
-}); // end define;
+}); // end define
+;

--- a/apps/email/js/ext/mailapi/imap/probe.js
+++ b/apps/email/js/ext/mailapi/imap/probe.js
@@ -956,8 +956,9 @@ ImapConnection.prototype.connect = function(loginCb) {
       var errType;
       // (only do error probing on things we can safely use 'in' on)
       if (err && typeof(err) === 'object') {
-        // detect an nsISSLStatus instance by an unusual property.
-        if ('isNotValidAtThisTime' in err) {
+        // XXX just map all security errors as indicated by the name into
+        // security errors.
+        if (/^Security/.test(err.name)) {
           err = new Error('SSL error');
           errType = err.type = 'bad-security';
         }
@@ -2525,7 +2526,7 @@ ImapProber.prototype = {
   onError: function ImapProber_onError(err) {
     if (!this.onresult)
       return;
-    console.warn('PROBE:IMAP sad', err && err.name, '|', err && err.type, '|',
+    console.warn('PROBE:IMAP sad.', err && err.name, '|', err && err.type, '|',
                  err && err.message, '|', err && err.serverResponse);
 
     var normErr = normalizeError(err);

--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -3954,14 +3954,9 @@ define('mailapi/worker-support/net-main',[],function() {
       if (err && typeof(err) === 'object') {
         wrappedErr = {
           name: err.name,
+          type: err.type,
           message: err.message
         };
-        // Propagate the SSL error detecting heuristic used elsewhere.  This is
-        // an XPCOM interface that we do not expect to structured clone across
-        // so well.
-        if ('isNotValidAtThisTime' in err) {
-          wrappedErr.isNotValidAtThisTime = err.isNotValidAtThisTime;
-        }
       }
       else {
         wrappedErr = err;

--- a/apps/email/js/ext/mailapi/smtp/probe.js
+++ b/apps/email/js/ext/mailapi/smtp/probe.js
@@ -1170,8 +1170,8 @@ SmtpProber.prototype = {
     if (!this.onresult)
       return;
     if (err && typeof(err) === 'object') {
-      // detect an nsISSLStatus instance by an unusual property.
-      if ('isNotValidAtThisTime' in err) {
+      // XXX just map all security errors as indicated by name
+      if (err.name && /^Security/.test(err.name)) {
         err = 'bad-security';
       }
       else {
@@ -1189,7 +1189,8 @@ SmtpProber.prototype = {
 
     this.error = err;
     if (err)
-      console.warn('PROBE:SMTP sad. error: |' + (err && err.message) + '|');
+      console.warn('PROBE:SMTP sad. error: | ' + (err && err.name || err) +
+                   ' | '  + (err && err.message || '') + ' |');
     else
       console.log('PROBE:SMTP happy');
 

--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -1393,6 +1393,10 @@ require.config({
     'mailapi/imap/protocol/snippetparser': 'mailapi/imap/protocollayer',
     'mailapi/imap/protocol/bodyfetcher': 'mailapi/imap/protocollayer',
 
+    // 'tls' is actually in both the SMTP probe and IMAP probe, but the SMTP
+    // probe is much smaller, so if someone requests it outright, just use that.
+    'tls': 'mailapi/smtp/probe',
+
     // The imap probe layer also contains the imap module
     'imap': 'mailapi/imap/probe',
 
@@ -13441,6 +13445,15 @@ var autoconfigByDomain = exports._autoconfigByDomain = {
       // This string may be clobbered with the correct port number when
       // running as a unit test.
       server: 'http://localhost:8880',
+      username: '%EMAILADDRESS%',
+    },
+  },
+  // like slocalhost, really just exists to generate a test failure
+  'saslocalhost': {
+    type: 'activesync',
+    displayName: 'Test',
+    incoming: {
+      server: 'https://localhost:443',
       username: '%EMAILADDRESS%',
     },
   },


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/188
