### PR TITLE
Bug 863196 - Workaround on FTU and active audio channel to avoid the power-on clip is too short.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1718,6 +1718,10 @@ var WindowManager = (function() {
           if (normalAudioChannelActive && evt.detail.channel !== 'normal' &&
               LockScreen.locked) {
             deviceLockedTimer = setTimeout(function setVisibility() {
+              // XXX: Check FTU status again to avoid the power-on video
+              // is too short.
+              if (isRunningFirstRunApp)
+                return;
               setVisibilityForCurrentApp(false);
             }, 3000);
           }


### PR DESCRIPTION
power-on clip is too short.
