### PR TITLE
Bug 866378 - [OPEN_]It does not have ringtone when receiving an Unknown number call and can not answer this call (r=jmcanterafonseca)

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -100,7 +100,7 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
   var node = this.numberNode;
   var additionalInfoNode = this.additionalInfoNode;
 
-  if (!number.length) {
+  if (!number) {
     LazyL10n.get(function localized(_) {
       node.textContent = _('withheld-number');
     });


### PR DESCRIPTION
We need to include a control to check if number is null before accessing to its length property since right now using the commercial RIL it can be null when the calling party has withheld his number.
