### PR TITLE
Bug 835481 - add whitespace between 'privacy policy' link and text left of it

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -574,7 +574,7 @@ crash-reports-description-1=A crash report contains some details about the crash
 crash-reports-description-2=This may include things like open pages and apps, text typed into forms and the content of open messages, recent browsing history, or geolocation used by an open app.
 # LOCALIZATION NOTE (crash-reports-description-3-*): these strings are a paragraph, with a "privacy policy"
 # link in the middle. Include trailing spaces as needed.
-crash-reports-description-3-start=We use crash reports to try to fix problems and improve our products. We handle your information as we describe in our
+crash-reports-description-3-start=We use crash reports to try to fix problems and improve our products. We handle your information as we describe in our 
 crash-reports-description-3-privacy=privacy policy
 crash-reports-description-3-end=.
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=835481
