### PR TITLE
Bug 809791: email: fix menu icon in header during folder transition

### DIFF
--- a/apps/email/js/mail-common.js
+++ b/apps/email/js/mail-common.js
@@ -283,8 +283,6 @@ var Cards = {
    */
   _eatingEventsUntilNextCard: false,
 
-  TRAY_GUTTER_WIDTH: 60,
-
   /**
    * Initialize and bind ourselves to the DOM which should now be fully loaded.
    */
@@ -329,9 +327,18 @@ var Cards = {
       this._popupActive.close();
       return;
     }
-    if (this._trayActive &&
-        (event.clientX >
-         this._containerNode.offsetWidth - this.TRAY_GUTTER_WIDTH)) {
+
+    // Find the card containing the event target.
+    var cardNode = event.target;
+    for (cardNode = event.target; cardNode; cardNode = cardNode.parentNode) {
+      if (cardNode.classList.contains('card'))
+        break;
+    }
+
+    // If tray is active and the click is in the card that is after
+    // current card (in the gutter), then just transition back to
+    // that card.
+    if (this._trayActive && cardNode && cardNode.classList.contains('after')) {
       event.stopPropagation();
 
       // Look for a card with a data-tray-target attribute

--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -87,11 +87,11 @@ body {
 .card.center.card-folder-picker,
 .card.center.card-account-picker,
 .card.card-account-picker {
-  width: calc(100% - 4.3em);
+  width: calc(100% - 5em);
 }
 
 .card.center.card-folder-picker + .card.after {
-  transform: translateX(calc(100% - 4.3em));
+  transform: translateX(calc(100% - 5em));
 }
 
 .form-card {
@@ -267,3 +267,4 @@ section[role="status"][title="undo"] .toaster-banner-undo,
 section[role="status"][title="retry"] .toaster-banner-retry {
   display: inline;
 }
+

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -1,5 +1,22 @@
 .card-message-list {
 }
+
+/* Show full menu icon when message list is "after" folder list card, but then
+  shrink the menu icon when the message list is the center card. */
+.card-message-list.after section[role="region"] > header > a.msg-folder-list-btn {
+  background-position: 5rem center;
+}
+.card-message-list.after section[role="region"] > header > a .icon.icon-menu {
+  padding-left: 3rem;
+  background-position: center center;
+}
+.card-message-list.after section[role="region"] > header > a .icon.icon-menu:after {
+  width: 5rem;
+}
+.card-message-list.after section[role="region"] > header > h1.msg-list-header-folder-label {
+  padding-left: 2rem;
+}
+
 .msg-listedit-header {
 }
 .msg-list-scrollouter {
@@ -33,6 +50,15 @@
   background-color: #eee;
   text-align: center;
   border-bottom: 0.1rem solid #bdbdbd;
+}
+
+/* When card is slightly shown when folder card is center,
+   be sure any inputs do not accept clicks/taps that would
+   mess up the transition back to the message list. Also
+   disable scrolling of the list */
+.card-message-list.after input,
+.card-message-list.after .msg-list-scrollouter {
+  pointer-events: none;
 }
 
 input.msg-search-text-tease {


### PR DESCRIPTION
This pull request builds on the one from @sungwoo.yoon in https://github.com/mozilla-b2g/gaia/pull/9496 and adds the following:
- Move the message-list styles to message-cards.css as the styles are specific to that kind of card.
- Adjust the width of the gutter to 5em. This makes it so just the icon box is visible, as per https://www.dropbox.com/s/ww9fjv19csjn5md/04%20Email_Drawer.png. This was tested on an Unagi device.
- Removes the hardcoded TRAY_GUTTER_WIDTH check for transitioning back to message list, and instead detects if the tap was in the message list card. So if the width of the gutter changes in the future, it will just be a CSS change.
