### PR TITLE
Bug 867909 - [email/IMAP] attachment filenames encoded using rfc 2231 character set encodings instead of mime-words are not decoded. r=squib

### DIFF
--- a/apps/email/js/ext/mailapi/chewlayer.js
+++ b/apps/email/js/ext/mailapi/chewlayer.js
@@ -3745,6 +3745,17 @@ define('mailapi/imap/imapchew',
     exports
   ) {
 
+function parseRfc2231CharsetEncoding(s) {
+  // charset'lang'url-encoded-ish
+  var match = /^([^']*)'([^']*)'(.+)$/.exec(s);
+  if (match) {
+    // we can convert the dumb encoding into quoted printable.
+    return $mimelib.parseMimeWords(
+      '=?' + (match[1] || 'us-ascii') + '?Q?' +
+        match[3].replace(/%/g, '=') + '?=');
+  }
+  return null;
+}
 
 /**
  * Process the headers and bodystructure of a message to build preliminary state
@@ -3828,13 +3839,30 @@ function chewStructure(msg) {
         filename, disposition;
 
     // - Detect named parts; they could be attachments
-    if (partInfo.params && partInfo.params.name)
-      filename = partInfo.params.name;
+    // filename via content-type 'name' parameter
+    if (partInfo.params && partInfo.params.name) {
+      filename = $mimelib.parseMimeWords(partInfo.params.name);
+    }
+    // filename via content-type 'name' with charset/lang info
+    else if (partInfo.params && partInfo.params['name*']) {
+      filename = parseRfc2231CharsetEncoding(
+                   partInfo.params['name*']);
+    }
+    // rfc 2231 stuff:
+    // filename via content-disposition filename without charset/lang info
     else if (partInfo.disposition && partInfo.disposition.params &&
-             partInfo.disposition.params.filename)
-      filename = partInfo.disposition.params.filename;
-    else
+             partInfo.disposition.params.filename) {
+      filename = $mimelib.parseMimeWords(partInfo.disposition.params.filename);
+    }
+    // filename via content-disposition filename with charset/lang info
+    else if (partInfo.disposition && partInfo.disposition.params &&
+             partInfo.disposition.params['filename*']) {
+      filename = parseRfc2231CharsetEncoding(
+                   partInfo.disposition.params['filename*']);
+    }
+    else {
       filename = null;
+    }
 
     // - Start from explicit disposition, make attachment if non-displayable
     if (partInfo.disposition)
@@ -3873,8 +3901,7 @@ function chewStructure(msg) {
     function makePart(partInfo, filename) {
 
       return {
-        name: $mimelib.parseMimeWords(filename) ||
-              'unnamed-' + (++unnamedPartCounter),
+        name: filename || 'unnamed-' + (++unnamedPartCounter),
         contentId: partInfo.id ? stripArrows(partInfo.id) : null,
         type: (partInfo.type + '/' + partInfo.subtype).toLowerCase(),
         part: partInfo.partID,

--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -11449,13 +11449,16 @@ define('encoding',['require','exports','module'],function(require, exports, modu
  */
 function checkEncoding(name){
     name = (name || "").toString().trim().toLowerCase().
+        // this handles aliases with dashes and underscores too; built-in
+        // aliase are only for latin1, latin2, etc.
         replace(/^latin[\-_]?(\d+)$/, "iso-8859-$1").
-        replace(/^win(?:dows)?[\-_]?(\d+)$/, "windows-$1").
+        // win949, win-949, ms949 => windows-949
+        replace(/^(?:(?:win(?:dows)?)|ms)[\-_]?(\d+)$/, "windows-$1").
         replace(/^utf[\-_]?(\d+)$/, "utf-$1").
-        replace(/^ks_c_5601\-1987$/, "windows-949"). // maps to euc-kr
         replace(/^us_?ascii$/, "ascii"); // maps to windows-1252
     return name;
 }
+exports.checkEncoding = checkEncoding;
 
 var ENCODER_OPTIONS = { fatal: false };
 


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/196
