### PR TITLE
Bug 868762 - [Settings] Cannot set the system time as 12:xx PM in the Date & Time panel.

### DIFF
--- a/shared/js/l10n_date.js
+++ b/shared/js/l10n_date.js
@@ -63,7 +63,7 @@ navigator.mozL10n.DateTimeFormat = function(locales, options) {
 
         // like %d, without any leading zero
         case '%p':
-          value = d.getHours() <= 12 ? 'AM' : 'PM';
+          value = d.getHours() < 12 ? 'AM' : 'PM';
           break;
 
         // localized date/time strings


### PR DESCRIPTION
The hour value of time is between 0 to 23 in HTML spec.

http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#valid-time-string

http://bugzil.la/868762
