### PR TITLE
Bug 861097 - [Buri][Beetle lite FF]The phone display date on status after power off animate  r=Alive

### DIFF
--- a/apps/system/js/sleep_menu.js
+++ b/apps/system/js/sleep_menu.js
@@ -312,15 +312,13 @@ var SleepMenu = {
   _actualPowerOff: function sm_actualPowerOff(isReboot) {
     var power = navigator.mozPower;
 
-    setTimeout(function() {
-      if (isReboot) {
-        power.reboot();
-      } else {
-        power.powerOff();
-      }
-    });
     // Paint screen to black before reboot/poweroff
     ScreenManager.turnScreenOff(true);
+    if (isReboot) {
+      power.reboot();
+    } else {
+      power.powerOff();
+    }
   }
 };
 


### PR DESCRIPTION
r=Alive

After "ScreenManager.turnScreenOff(true)" it will fire screenchange event, So the icon for notification or date in status bar showed after 3-rings animation.

I remove the reboot or poweroff code out the setTimeout in order to reboot or poweroff immediately.
