### PR TITLE
Bug 868600 - Safeguard alarm check

### DIFF
--- a/apps/calendar/js/views/day_child.js
+++ b/apps/calendar/js/views/day_child.js
@@ -19,7 +19,7 @@ Calendar.ns('Views').DayChild = (function() {
       var attendees;
       var classes;
 
-      if (event.remote.alarms.length) {
+      if (event.remote.alarms && event.remote.alarms.length) {
         classes = 'has-alarms';
       }
 

--- a/apps/calendar/test/unit/views/day_child_test.js
+++ b/apps/calendar/test/unit/views/day_child_test.js
@@ -93,4 +93,20 @@ suiteGroup('Views.DayChild', function() {
 
     assert.ok(result.indexOf('has-alarms') === -1);
   });
+
+  test('#_renderEvent undefined alarms, bug 868600', function() {
+    var event = Factory('event', {
+      remote: {
+        title: '|rendercheck|'
+      }
+    });
+    delete event.remote.alarms;
+
+    var busytime = Factory('busytime');
+
+    var result = subject._renderEvent(busytime, event);
+    assert.ok(result);
+
+    assert.include(result, '|rendercheck|');
+  });
 });


### PR DESCRIPTION
IMO - safeguarding the alarm check is a more simple approach for the time being than resyncing the entire database.
