### PR TITLE
Bug 869367 - [Settings] The screen of Date & Time panel has redundant space when NITZ is NOT available.

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -447,10 +447,6 @@ ul li > label .range-icons.brightness {
   display: none;
 }
 
-#dateTime ul[hidden] + header {
-  margin-top: 5rem;
-}
-
 #time-manual span {
   pointer-events: none;
 }


### PR DESCRIPTION
It shouldn't use the margin-top style in the dateTime section.

http://bugzil.la/869367
