### PR TITLE
Bug 863417 - pref for identity ui, fix line too long; a=tef+

### DIFF
--- a/apps/system/js/identity.js
+++ b/apps/system/js/identity.js
@@ -44,7 +44,8 @@ var Identity = (function() {
           frame.setAttribute('mozbrowser', 'true');
           frame.setAttribute('remote', true);
           frame.classList.add('screen');
-          frame.src = personaUri + (e.detail.showUI ? kIdentityScreen : kIdentityFrame);
+          frame.src = personaUri +
+            (e.detail.showUI ? kIdentityScreen : kIdentityFrame);
           frame.addEventListener('mozbrowserloadstart',
               function loadStart(evt) {
             // After creating the new frame containing the identity flow, we


### PR DESCRIPTION
This fixes https://github.com/mozilla-b2g/gaia/pull/9490, which broke the linter with a line too long
