### PR TITLE
Bug 869830 - [System] Receiving SMS during video recording should not pl...

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -305,7 +305,7 @@ var NotificationScreen = {
                                this.lockScreenContainer.firstElementChild);
     }
 
-    if (!this.silent) {
+    if (!this.silent && !StatusBar.recordingActive) {
       var ringtonePlayer = new Audio();
       ringtonePlayer.src = this._sound;
       ringtonePlayer.mozAudioChannelType = 'notification';


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=869830
1. Title : [System] Receiving SMS during video recording should not play notification sound.
2. Precondition : Run Video app and start recording.
3. Tester's Action : Receive SMS.
4. Detailed Symptom (ENG.) : It plays the notification sound.
5. Expected : It should not play the notification sound during video recording.
   6.Reproducibility: Y
          1)Frequency Rate : 100%
   7.Gaia Master/v1-train : Reproduced
   8.Gaia Revision: 5cbb19e4bb78a7ad879fbe4b9a841e1c35714f5c
   9.Personal email id:  hanj.kim25@gmail.com
