### PR TITLE
Bug 869823 - [Contacts] Scroll doesn't work when touch starts from the label area in 'Add contact' page.

### DIFF
--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -336,7 +336,7 @@ contacts.Form = (function() {
     // Add event listeners
     var boxTitle = rendered.querySelector('legend.action');
     if (boxTitle) {
-      boxTitle.addEventListener(touchstart, onGoToSelectTag);
+      boxTitle.addEventListener('click', onGoToSelectTag);
     }
 
     container.appendChild(rendered);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=869823
