### PR TITLE
Bug 863417 - toolkit.identity.uri pref; resolved conflicts from v1-train

### DIFF
--- a/apps/system/js/identity.js
+++ b/apps/system/js/identity.js
@@ -5,9 +5,8 @@
 
 'use strict';
 
-const kIdentityScreen = 'https://login.native-persona.org/sign_in#NATIVE';
-const kIdentityFrame =
-    'https://login.native-persona.org/communication_iframe';
+const kIdentityScreen = '/sign_in#NATIVE';
+const kIdentityFrame = '/communication_iframe';
 
 var Identity = (function() {
   var iframe;
@@ -21,6 +20,7 @@ var Identity = (function() {
 
     handleEvent: function onMozChromeEvent(e) {
       var chromeEventId = e.detail.id;
+      var personaUri = e.detail.uri;
       var requestId = e.detail.requestId;
       switch (e.detail.type) {
         // Chrome asks Gaia to show the identity dialog.
@@ -44,7 +44,8 @@ var Identity = (function() {
           frame.setAttribute('mozbrowser', 'true');
           frame.setAttribute('remote', true);
           frame.classList.add('screen');
-          frame.src = e.detail.showUI ? kIdentityScreen : kIdentityFrame;
+          frame.src = personaUri +
+            (e.detail.showUI ? kIdentityScreen : kIdentityFrame);
           frame.addEventListener('mozbrowserloadstart',
               function loadStart(evt) {
             // After creating the new frame containing the identity flow, we


### PR DESCRIPTION
Bug 863417 - Can now set toolkit.identity.uri as pref; r=fabrice, a=tef+
(cherry picked from commit 9dbb2d9ee919ea75d33be495ff710b7c3a3b24d9)

Bug 863417 - pref for identity ui, fix line too long; a=tef+
(cherry picked from commit f48d569231583b91118f1c9c848796259e35aa7b)

Conflicts:
    apps/system/js/identity.js

(Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=863417#c47)
