### PR TITLE
Bug 870235 - [Contacts] When adding only a picture in 'Add contact' page, the 'Done' button is enabled.

### DIFF
--- a/apps/communications/contacts/js/contacts_form.js
+++ b/apps/communications/contacts/js/contacts_form.js
@@ -766,7 +766,8 @@ contacts.Form = (function() {
 
     activity.onsuccess = function success() {
       addRemoveIconToPhoto();
-      saveButton.removeAttribute('disabled');
+      if (!emptyForm())
+        saveButton.removeAttribute('disabled');
       // XXX
       // this.result.blob is valid now, but it won't stay valid
       // (see https://bugzilla.mozilla.org/show_bug.cgi?id=806503)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=870235
