### PR TITLE
Bug 870237 - [Gaia][Contacts] use navigator.mozIccManager to access SIM Contact functionality.

### DIFF
--- a/apps/communications/contacts/js/utilities/import_sim_contacts.js
+++ b/apps/communications/contacts/js/utilities/import_sim_contacts.js
@@ -48,10 +48,18 @@ function SimContactsImporter() {
   }
 
   this.start = function() {
+    // See bug 870237
+    // To have the backward compatibility for bug 859220.
+    // If we could not get iccManger from navigator,
+    // try to get it from mozMobileConnection.
+    // 'window.navigator.mozMobileConnection.icc' can be dropped
+    // after bug 859220 is landed.
+    var icc = navigator.mozIccManager || navigator.mozMobileConnection.icc;
+
     // request contacts with readContacts() -- valid types are:
     //   'adn': Abbreviated Dialing Numbers
     //   'fdn': Fixed Dialing Numbers
-    var request = navigator.mozMobileConnection.icc.readContacts('adn');
+    var request = icc.readContacts('adn');
 
     request.onsuccess = function onsuccess() {
       self.items = request.result; // array of mozContact elements


### PR DESCRIPTION
Please see [bug 870237](https://bugzilla.mozilla.org/show_bug.cgi?id=870237).

I add a checking for IccManager in this patch.
In this way we can make sure it won't break 'import SIM contacts' function no matter [bug 859220](https://bugzilla.mozilla.org/show_bug.cgi?id=859220) is landed or not. Otherwise, 'import SIM contacts' function may fail until both bugs are landed. ([bug 870237](https://bugzilla.mozilla.org/show_bug.cgi?id=870237) and [bug 859220](https://bugzilla.mozilla.org/show_bug.cgi?id=859220))

Thanks
