### PR TITLE
Bug 859712 - [Gaia][STK] Use new WebAPI to access STK functionality, r=frsela

### DIFF
--- a/apps/settings/js/icc.js
+++ b/apps/settings/js/icc.js
@@ -62,11 +62,12 @@
    * Init STK UI
    */
   function init() {
-    if (!window.navigator.mozMobileConnection) {
-      return;
-    }
-
-    icc = window.navigator.mozMobileConnection.icc;
+    // See bug 859712
+    // To have the backward compatibility for bug 859220.
+    // If we could not get iccManager from navigator,
+    // try to get it from mozMobileConnection.
+    // 'window.navigator.mozMobileConnection.icc' can be dropped after bug 859220 is landed.
+    icc = window.navigator.mozIccManager || window.navigator.mozMobileConnection.icc;
 
     icc.onstksessionend = function handleSTKSessionEnd(event) {
       updateMenu();

--- a/apps/system/js/icc_cache.js
+++ b/apps/system/js/icc_cache.js
@@ -26,7 +26,13 @@
     return;
   }
 
-  var icc = window.navigator.mozMobileConnection.icc;
+  // See bug 859712
+  // To have the backward compatibility for bug 859220.
+  // If we could not get iccManager from navigator,
+  // try to get it from mozMobileConnection.
+  // 'window.navigator.mozMobileConnection.icc' can be dropped after bug 859220 is landed.
+  var icc = window.navigator.mozIccManager || window.navigator.mozMobileConnection.icc;
+
   // Remove previous menu
   var resetApplications = window.navigator.mozSettings.createLock().set({
     'icc.applications': '{}'


### PR DESCRIPTION
Please see [bug 859712](https://bugzilla.mozilla.org/show_bug.cgi?id=859712).

I add a checking for IccManager in this patch.
In this way we can make sure it won't break STK function no matter [bug 859220](bug 859712](https://bugzilla.mozilla.org/show_bug.cgi?id=859220) is landed or not. Otherwise, STK function may fail until both bugs are landed. ([bug 859712](https://bugzilla.mozilla.org/show_bug.cgi?id=859712) and [bug 859220](bug 859712]%28https://bugzilla.mozilla.org/show_bug.cgi?id=859220%29).

Thanks
