### PR TITLE
Bug 869811 - [Clock] The alarm goes off page is broken and overlapping after attention screen switched between full/status bar mode. r=alive

### DIFF
--- a/apps/clock/style/onring.css
+++ b/apps/clock/style/onring.css
@@ -150,7 +150,7 @@ html, body {
 }
 
 /* Handling the status bar mode */
-@media screen and (max-height: 4rem) {
+@media screen and (max-height: 4em) {
   #ring-icon {
     width: 4rem;
     height: 4rem;
@@ -187,6 +187,9 @@ html, body {
     left: 4rem;
     font: bolder 1.38rem/1.38rem 'MozTT',sans-serif;
     color: #00aac8;
+    margin-top: 0;
+    margin-left: 0;
+    margin-right: 0;
   }
 
   #footer-button-container {


### PR DESCRIPTION
- Because of Bug 725879 - Broken support for rem unit in Media Queries, refine the unit from rem to em in media query.
- Reset the margin for alarm label when attention screen in status bar mode.
