### PR TITLE
Bug 865025 - [B2G] [Clock] The Alarm page scrolls if the user adjusts the time rollers while the Label textbox has focus r=timdream

### DIFF
--- a/apps/clock/js/utils.js
+++ b/apps/clock/js/utils.js
@@ -293,6 +293,7 @@ var ValuePicker = (function() {
   }
 
   function vp_mousemove(event) {
+    event.preventDefault();
     event.stopPropagation();
     currentEvent = cloneEvent(event);
 
@@ -313,6 +314,7 @@ var ValuePicker = (function() {
   }
 
   function vp_mouseup(event) {
+    event.preventDefault();
     event.stopPropagation();
     this.removeEventListeners();
 
@@ -330,6 +332,7 @@ var ValuePicker = (function() {
   }
 
   function vp_mousedown(event) {
+    event.preventDefault();
     event.stopPropagation();
     event.target.setCapture(true);
     MouseEventShim.setCapture();


### PR DESCRIPTION
Need to prevenDefault() for time picker when received mousedown/mousemove/mouseup event.
