### PR TITLE
Bug 860607 - Delete multiple SMS by calling mozMobileMessage.delete() directly. r=julienw

### DIFF
--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -355,12 +355,9 @@ var MessageManager = {
     removed completely.
   */
   deleteMessages: function mm_deleteMessages(list, callback) {
-    if (list.length > 0) {
-      this.deleteMessage(list.shift(), function(result) {
-        this.deleteMessages(list, callback);
-      }.bind(this));
-    } else
-      callback();
+    // mozMobileMessage.delete() has been modified per bug 771458.
+    // Now deleteMessage() can take an id or an array of id.
+    this.deleteMessage(list, callback);
   },
 
   markMessagesRead: function mm_markMessagesRead(list, value, callback) {


### PR DESCRIPTION
mozMobileMessage.delete() now supports array as argument for deleting multiple SMS, so update the call.
