### PR TITLE
Bug 833140 - [Settings] Text overlap between device name and switch icon...

### DIFF
--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -91,7 +91,7 @@ ul li > small {
 }
 
 ul li > label:not([for]) + small {
-  right: 6rem;
+  right: 9rem; 
 }
 
 /* required for empty elements like Bluetooth */
@@ -444,7 +444,7 @@ html[dir="rtl"] ul li a[role="button"] {
 
 html[dir="rtl"] ul li > label:not([for]) > span,
 html[dir="rtl"] ul li > label:not([for]) > input[data-type="switch"] + span {
-  left: 6rem; /* XXX we use "right: 3rem" for LTR layouts... */
+  left: 9rem; /* XXX we use "right: 3rem" for LTR layouts... */
   right: inherit;
 }
 


### PR DESCRIPTION
... on BT menu
