### PR TITLE
Bug 869811 - [Clock] The alarm goes off page is broken and overlapping after attention screen switched between full/status bar mode. patch2 r=alive

### DIFF
--- a/apps/clock/style/onring.css
+++ b/apps/clock/style/onring.css
@@ -183,13 +183,14 @@ html, body {
 
   #ring-alarm-label {
     position: absolute;
-    top: 0.6rem;
+    top: 0.46rem;
     left: 4rem;
-    font: bolder 1.38rem/1.38rem 'MozTT',sans-serif;
+    font: bolder 1.38rem/1.44rem 'MozTT',sans-serif;
     color: #00aac8;
     margin-top: 0;
     margin-left: 0;
     margin-right: 0;
+    height: 1.5rem;
   }
 
   #footer-button-container {


### PR DESCRIPTION
Revise height/line-height of alarm label in mini attention screen.
