### PR TITLE
Bug 871907 - [Contacts][SMS] When selecting a contact in 'Send Message' page, the wrong pop-up is displayed.

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -587,7 +587,7 @@ contacts.List = (function() {
   var toggleNoContactsScreen = function cl_toggleNoContacs(show) {
     if (show && ActivityHandler.currentlyHandling) {
       var actName = ActivityHandler.activityName;
-      if (actName == 'pick' || actName == 'update') {
+      if (actName == 'update') {
         showNoContactsAlert();
         return;
       }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=871907
