### PR TITLE
Bug 871681 - [system] typo in ceWarningcontent: 'hight' instead of 'high...

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -321,7 +321,7 @@ captive-wifi-available=The network {{networkName}} was found. Join network?
 
 # [CE] Volume warning toast
 ceWarningtitle=Volume warning
-ceWarningcontent=To prevent possible hearing damage, do not listen at hight volume levels for long periods.
+ceWarningcontent=To prevent possible hearing damage, do not listen at high volume levels for long periods.
 
 #power saving mode
 notification-powersaving-mode-on-title=Power Saving Mode


### PR DESCRIPTION
fixed typo
