### PR TITLE
871449 Message Card peep bubble set wrap and ellipsis

### DIFF
--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -273,6 +273,10 @@ input.msg-search-text-tease {
   font-size: 1.3rem;
   font-family: "MozTT", Sans-serif;
   box-shadow: 0 0.1rem 0.1rem #fff inset;
+  max-width: -moz-available;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .msg-peep-bubble * {
   pointer-events: none;


### PR DESCRIPTION
Mainly issue is reported in composer screen. But .msg-peep-bubble is used for composer peep bubble since it  has all the styling.

Set Max width to -moz-available and set text-overflow; ellipsis.

Please review it.
