### PR TITLE
871454  Provided Overflow to the Contact Form Header to show long email id

### DIFF
--- a/apps/email/style/mail.css
+++ b/apps/email/style/mail.css
@@ -230,6 +230,11 @@ body {
   height: 100%;
 }
 
+/*Adding horizontal scroll to the form header*/
+form[role='dialog'] > header {
+  overflow: auto;
+}
+
 /*Disabled a tag style extend*/
 section[role="region"] > header:first-child menu[type="toolbar"] a[aria-disabled="true"] {
   pointer-events: none;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=871454

Provided overflow to the header text, because at composer peep bubble we are showing long email id using ellipsis as part of the fix 871449. 

So at this form dialog showing complete email id. 

Please review it.
