### PR TITLE
871449 adding composer bubble style seperately

### DIFF
--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -198,6 +198,7 @@ ComposeCard.prototype = {
   createBubbleNode: function(name, address) {
     var bubble = cmpNodes['peep-bubble'].cloneNode(true);
     bubble.classList.add('msg-peep-bubble');
+    bubble.classList.add('cmp-peep-bubble');
     bubble.setAttribute('data-address', address);
     bubble.setAttribute('data-name', name);
     bubble.querySelector('.cmp-peep-address').textContent = address;

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -27,7 +27,10 @@
 
 .cmp-peep-bubble {
   float: left;
-  margin-left: 0.3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: -moz-available;
+  white-space: nowrap;
 }
 
 .cmp-to-text-container {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=871449

I have tried the below two approaches

1) having common peep-bubble in mail.css
but ended up with many regressions, may be I did in wrong way.
so I left that approach

2) Tried with separate text-overflow:ellipsis;  styling for .cmp-peep-bubble  and added this class to the peep node along with .msg-peep-bubble.

I tested thoroughly in both composer and message reader screens.
If this approach is okay , please accept the patch.

Thanks.
