### PR TITLE
Bug 872445 - gaia-unit-tests TEST-UNEXPECTED-FAIL | Recipients List Reci...

### DIFF
--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -7,20 +7,17 @@ requireApp('sms/test/unit/mock_utils.js');
 requireApp('sms/js/recipients.js');
 
 
-var mocksHelper = new MocksHelper([
+var mocksHelperForRecipients = new MocksHelper([
   'Utils',
   'GestureDetector'
 ]);
 
-mocksHelper.init();
+mocksHelperForRecipients.init();
 
 suite('Recipients', function() {
   var recipients;
   var fixture;
-
-  if (typeof loadBodyHTML === 'undefined') {
-    require('/shared/test/unit/load_body_html_helper.js');
-  }
+  var mocksHelper = mocksHelperForRecipients;
 
   suiteSetup(function() {
     mocksHelper.suiteSetup();


### PR DESCRIPTION
...pients | expected undefined to be truthy r=gnarf
- removed the require for load_body_html_helper.js as we do it in setup.js now
- renamed the mocks helper to have a unique mocks helper var
