### PR TITLE
Bug 869346 - [System] [Video] [Bluetooth] String message is half-hidden when Share->Bluetooth is selected on a video.

### DIFF
--- a/apps/bluetooth/style/transfer.css
+++ b/apps/bluetooth/style/transfer.css
@@ -175,10 +175,3 @@ button.affirmative:active {
     font-size: 10px;
   }
 }
-
-/* 480x800 phones */
-@media screen and (min-width: 480px) {
-  html {
-    font-size: 13.3px;
-  }
-}


### PR DESCRIPTION
The base font size 13.3px makes the message truncated in landscape mode.
Remove media query for 480x800 phones. We don't support multi-resolution in v1-train.
