### PR TITLE
Bug 871407 - toggle fullscreen rotate orientation include statusbar heig...

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1861,7 +1861,7 @@ var WindowManager = (function() {
   // When the status bar is active it doubles in height so we need a resize
   var appResizeEvents = ['resize', 'status-active', 'status-inactive',
                          'keyboardchange', 'keyboardhide',
-                         'attentionscreenhide'];
+                         'attentionscreenhide', 'fullscreenchange'];
   appResizeEvents.forEach(function eventIterator(event) {
     window.addEventListener(event, function on(evt) {
       var keyboardHeight = KeyboardManager.getHeight();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=871407
1. Title : [BROWSER] Video files streaming from web sites in full screen mode causes a WEB Browser bottom bar UI problems
2. Precondition : 
3. Tester's Action : 
               1) Go to soem site which contails downloadable video content
               2) Click on the link, which normally is used to download it
               3) Watch the streamed video, switch to full screen, rotate to horizontal mode, turn off full screen, next turn on full screen again and rotate to vertical, next torn off full screen
4. Detailed Symptom (ENG.) : When leaving full screen in horizontal and vertical mode there is UI error in bottom Web Browser bar 
5. Expected : No UI problems
   6.Reproducibility: Y
   1)Frequency Rate : 100%
   7.Comparison Results : 
   1)Model Comparing : 
6. Build ID : 20130421070203
7. Gaia : 5cbb19e4bb78a7ad879fbe4b9a841e1c35714f5c
8. Gecko : 950b402b6188bb2f3ce3176e620ed5249719d720
