### PR TITLE
Bug 840147 - [System] fix orientation problem on open/close app animation

### DIFF
--- a/apps/system/js/cards_view.js
+++ b/apps/system/js/cards_view.js
@@ -201,11 +201,9 @@ var CardsView = (function() {
       card.classList.add('card');
       card.dataset.origin = origin;
 
-      var orientation = WindowManager.getOrientationForApp(origin) || '';
-      var landscape = orientation.indexOf('landscape') !== -1;
-      if (landscape) {
-        card.classList.add(orientation);
-      }
+      var screenshotView = document.createElement('div');
+      screenshotView.classList.add('screenshotView');
+      card.appendChild(screenshotView);
 
       //display app icon on the tab
       if (DISPLAY_APP_ICON) {
@@ -267,22 +265,34 @@ var CardsView = (function() {
 
       card.addEventListener('onviewport', function onviewport() {
         card.style.display = 'block';
-
-        if (card.style.backgroundImage) {
+        if (screenshotView.style.backgroundImage) {
           return;
+        }
+
+        // Handling cards in different orientations
+        var orientation = app.frame.dataset.orientation;
+        var isLandscape = false;
+        if (orientation == 'landscape-primary' ||
+            orientation == 'landscape-secondary') {
+          isLandscape = true;
+        }
+        // Rotate screenshotView if needed
+        screenshotView.classList.add(orientation);
+        if (isLandscape) {
+          // We must exchange width and height if it's landscape mode
+          var width = card.clientHeight;
+          var height = card.clientWidth;
+          screenshotView.style.width = width + 'px';
+          screenshotView.style.height = height + 'px';
+          screenshotView.style.left = ((height - width) / 2) + 'px';
+          screenshotView.style.top = ((width - height) / 2) + 'px';
         }
 
         // If we have a cached screenshot, use that first
         // We then 'res-in' the correctly sized version
         var cachedLayer = WindowManager.screenshots[origin];
         if (cachedLayer) {
-          card.style.backgroundImage = 'url(' + cachedLayer + ')';
-        }
-
-        // We cannot take a screenshot here for landscape apps because the
-        // mobile is on portrait
-        if (landscape) {
-          return;
+          screenshotView.style.backgroundImage = 'url(' + cachedLayer + ')';
         }
 
         // And then switch it with screenshots when one will be ready
@@ -293,13 +303,15 @@ var CardsView = (function() {
           origin === displayedApp)) {
           // rect is the final size (considering CSS transform) of the card.
           var rect = card.getBoundingClientRect();
-          frameForScreenshot.getScreenshot(rect.width, rect.height).onsuccess =
+          var width = isLandscape ? rect.height : rect.width;
+          var height = isLandscape ? rect.width : rect.height;
+          frameForScreenshot.getScreenshot(width, height).onsuccess =
             function gotScreenshot(screenshot) {
               if (screenshot.target.result) {
                 var objectURL = URL.createObjectURL(screenshot.target.result);
 
                 // Overwrite the cached image to prevent flickering
-                card.style.backgroundImage =
+                screenshotView.style.backgroundImage =
                   'url(' + objectURL + '), url(' + cachedLayer + ')';
 
                 // setTimeout is needed to ensure that the image is fully drawn

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -34,6 +34,7 @@ var KeyboardManager = (function() {
   var previousHash = '';
 
   var urlparser = document.createElement('a');
+  var appClosing = false;
   keyboard.addEventListener('mozbrowserlocationchange', function(e) {
     urlparser.href = e.detail;
     if (previousHash == urlparser.hash)
@@ -43,6 +44,12 @@ var KeyboardManager = (function() {
     var type = urlparser.hash.split('=');
     switch (type[0]) {
       case '#show':
+
+        // If an app is closing, we should ignore any #show triggered by
+        // resize events which come from orientation change events.
+        if (appClosing) {
+          return;
+        }
 
         //XXX: The url will contain the info for keyboard height
         keyboardHeight = parseInt(type[1]);
@@ -100,7 +107,14 @@ var KeyboardManager = (function() {
       keyboardHeight = 0;
       dispatchEvent(new CustomEvent('keyboardhide'));
       container.classList.add('hide');
+      if (eventType == 'appwillclose') {
+        appClosing = true;
+      }
     });
+  });
+
+  window.addEventListener('appclose', function appClose() {
+    appClosing = false;
   });
 
   return {

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -39,18 +39,32 @@
   margin: 0;
   margin-top: 2rem;
   position: absolute;
-  background-size: contain;
-  background-position: center center;
-  background-repeat: no-repeat;
   opacity: 0;
   pointer-events: none;
   transform: scale(0.8);
 }
 
-#cards-view .card.landscape, #cards-view .card.landscape-primary,
-#cards-view .card.landscape-secondary {
-  height: 43%;
-  margin-top: calc(43% + 2rem);
+#cards-view .screenshotView {
+  background-size: cover;
+  background-position: left top;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+#cards-view .screenshotView.landscape,
+#cards-view .screenshotView.landscape-primary {
+  transform: rotate(90deg);
+}
+
+#cards-view .screenshotView.landscape-secondary {
+  transform: rotate(270deg);
+}
+
+#cards-view .screenshotView.portrait-secondary {
+  transform: rotate(180deg);
+  transform-origin: 50% 50%;
 }
 
 #cards-view .card h1 {

--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -271,16 +271,43 @@ body {
 }
 
 #windows > .appWindow.opening {
-  animation: openApp .3s forwards ease;
   pointer-events: auto;
+}
+
+#windows > .appWindow.opening[data-orientation='portrait-primary'] {
+  animation: openApp-portrait-primary 0.3s forwards ease;
+}
+
+#windows > .appWindow.opening[data-orientation='portrait-secondary'] {
+  animation: openApp-portrait-secondary 0.3s forwards ease;
+}
+
+#windows > .appWindow.opening[data-orientation='landscape-primary'] {
+  animation: openApp-landscape-primary 0.3s forwards ease;
+}
+
+#windows > .appWindow.opening[data-orientation='landscape-secondary'] {
+  animation: openApp-landscape-secondary 0.3s forwards ease;
 }
 
 #windows.slow-transition > .appWindow.opening {
   animation-duration: 3s;
 }
 
-#screen.cards-view > #windows > .appWindow.opening {
-  animation: openAppFromCardView 0.15s forwards ease;
+#screen.cards-view > #windows > .appWindow.opening[data-orientation='portrait-primary'] {
+  animation: openAppFromCardView-portrait-primary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.opening[data-orientation='portrait-secondary'] {
+  animation: openAppFromCardView-portrait-secondary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.opening[data-orientation='landscape-primary'] {
+  animation: openAppFromCardView-landscape-primary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.opening[data-orientation='landscape-secondary'] {
+  animation: openAppFromCardView-landscape-secondary 0.15s forwards ease;
 }
 
 #screen.cards-view > #windows.slow-transition > .appWindow.opening {
@@ -288,9 +315,24 @@ body {
 }
 
 /* Opacity increases start up time then we don't use it anymore for opening */
-@keyframes openApp {
-  0%   { transform: scale(0.1) }
-  100% { transform: scale(1.0) }
+@keyframes openApp-portrait-primary {
+  0%   { transform: scale(0.1); }
+  100% { transform: scale(1.0); }
+}
+
+@keyframes openApp-portrait-secondary {
+  0%   { transform: scale(0.1) rotate(180deg); }
+  100% { transform: scale(1.0) rotate(180deg); }
+}
+
+@keyframes openApp-landscape-primary {
+  0%   { transform: scale(0.1) rotate(90deg);}
+  100% { transform: scale(1.0) rotate(90deg);}
+}
+
+@keyframes openApp-landscape-secondary {
+  0%   { transform: scale(0.1) rotate(270deg); }
+  100% { transform: scale(1.0) rotate(270deg); }
 }
 
 #windows > .appWindow.homescreen.zoom-in > iframe {
@@ -312,7 +354,7 @@ body {
   100% { transform: scale(1.8); }
 }
 
-@keyframes openAppFromCardView {
+@keyframes openAppFromCardView-portrait-primary {
   0%   { transform: scale(0.8); }
   100% { transform: scale(1.0); }
 }
@@ -321,6 +363,29 @@ body {
   /* The background color is black behind the switch app animation
    * (the homescreen is hidden) */
   background: #000;
+}
+
+@keyframes openAppFromCardView-portrait-secondary {
+  0%   { transform: scale(0.8) rotate(180deg); }
+  100% { transform: scale(1.0) rotate(180deg); }
+}
+
+@keyframes openAppFromCardView-landscape-primary {
+  0%   { transform: scale(0.8) rotate(90deg); }
+  100% { transform: scale(1.0) rotate(90deg); }
+}
+
+@keyframes openAppFromCardView-landscape-secondary {
+  0%   { transform: scale(0.8) rotate(270deg); }
+  100% { transform: scale(1.0) rotate(270deg); }
+}
+
+#screen.switch-app > #windows > .appWindow.opening,
+#screen.switch-app > #windows > .appWindow.closing {
+  transition: transform 0.25s ease;
+  visibility: inherit;
+  opacity: 1;
+  animation: none;
 }
 
 #screen.switch-app > #windows > .appWindow.opening > iframe {
@@ -365,10 +430,64 @@ body {
 }
 
 #windows > .appWindow.closing {
-  animation: closeApp 0.3s forwards ease;
   /* The animation takes .3 seconds so users cannot touch the app while the
    * closing animation is performing */
   pointer-events: none;
+}
+
+#windows > .appWindow[data-orientation='portrait-secondary'] {
+  transform: rotate(180deg);
+  margin-top: -2rem;
+  overflow: visible;
+}
+
+#windows > .appWindow[data-orientation='landscape-primary'] {
+  transform: rotate(90deg);
+  overflow: visible;
+}
+
+#windows > .appWindow[data-orientation='landscape-secondary'] {
+  transform: rotate(270deg);
+  margin-left: 2rem;
+  overflow: visible;
+}
+
+#windows > .appWindow.fullscreen-app[data-orientation='portrait-secondary'],
+#windows > .appWindow.fullscreen-app[data-orientation='landscape-primary'],
+#windows > .appWindow.fullscreen-app[data-orientation='landscape-secondary'] {
+  margin: 0;
+}
+
+/* placeholder for status bar of previous orientation */
+#windows > .appWindow[data-orientation='landscape-primary']:not(.fullscreen-app):after,
+#windows > .appWindow[data-orientation='landscape-secondary']:not(.fullscreen-app):after,
+#windows > .appWindow[data-orientation='portrait-secondary']:not(.fullscreen-app):after {
+  display: block;
+  height: 2rem;
+  width: 100%;
+  left: 0;
+  top: -2rem;
+  position: absolute;
+  content: ' ';
+  font-size: 1.8rem;
+  background: #000000;
+}
+
+
+#windows > .appWindow.closing[data-orientation='portrait-primary'] {
+  animation: closeApp-portrait-primary 0.3s forwards ease;
+}
+
+#windows > .appWindow.closing[data-orientation='portrait-secondary'] {
+  animation: closeApp-portrait-secondary 0.3s forwards ease;
+}
+
+#windows > .appWindow.closing[data-orientation='landscape-primary'] {
+  animation: closeApp-landscape-primary 0.3s forwards ease;
+}
+
+#windows > .appWindow.closing[data-orientation='landscape-secondary'] {
+  animation: closeApp-landscape-secondary 0.3s forwards ease;
 }
 
 #windows.slow-transition > .appWindow.closing {
@@ -394,22 +513,80 @@ body {
   100% { transform: scale(1); }
 }
 
-#screen.cards-view > #windows > .appWindow.closing {
-  animation: closeAppTowardsCardView 0.15s forwards ease;
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='portrait-primary'] {
+  animation: closeAppTowardsCardView-landscape-primary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='portrait-secondary'] {
+  animation: closeAppTowardsCardView-landscape-secondary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='landscape-primary'] {
+  animation: closeAppTowardsCardView-portrait-primary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='landscape-secondary'] {
+  animation: closeAppTowardsCardView-portrait-secondary 0.15s forwards ease;
 }
 
 #screen.cards-view > #windows.slow-transition > .appWindow.closing {
   animation: closeAppTowardsCardView 1.5s forwards ease;
 }
 
-@keyframes closeApp {
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='portrait-primary'] {
+  animation: closeAppTowardsCardView-portrait-primary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='portrait-secondary'] {
+  animation: closeAppTowardsCardView-portrait-secondary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='landscape-primary'] {
+  animation: closeAppTowardsCardView-landscape-primary 0.15s forwards ease;
+}
+
+#screen.cards-view > #windows > .appWindow.closing[data-orientation='landscape-secondary'] {
+  animation: closeAppTowardsCardView-landscape-secondary 0.15s forwards ease;
+}
+
+@keyframes closeApp-landscape-primary {
+  0%   { transform: scale(1.0) rotate(90deg); opacity: 1; }
+  100% { transform: scale(0.1) rotate(90deg); opacity: 0; }
+}
+
+@keyframes closeApp-landscape-secondary {
+  0%   { transform: scale(1.0) rotate(270deg); opacity: 1; }
+  100% { transform: scale(0.1) rotate(270deg); opacity: 0; }
+}
+
+@keyframes closeApp-portrait-primary {
   0%   { transform: scale(1.0); opacity: 1; }
   100% { transform: scale(0.1); opacity: 0; }
 }
 
-@keyframes closeAppTowardsCardView {
+@keyframes closeApp-portrait-secondary {
+  0%   { transform: scale(1.0) rotate(180deg); opacity: 1; }
+  100% { transform: scale(0.1) rotate(180deg); opacity: 0; }
+}
+
+@keyframes closeAppTowardsCardView-landscape-primary {
+  0%   { transform: scale(1.0) rotate(90deg); }
+  100% { transform: scale(0.8) rotate(90deg); }
+}
+
+@keyframes closeAppTowardsCardView-landscape-secondary {
+  0%   { transform: scale(1.0) rotate(270deg); }
+  100% { transform: scale(0.8) rotate(270deg); }
+}
+
+@keyframes closeAppTowardsCardView-portrait-primary {
   0%   { transform: scale(1.0); }
   100% { transform: scale(0.8); }
+}
+
+@keyframes closeAppTowardsCardView-portrait-secondary {
+  0%   { transform: scale(1.0) rotate(180deg); }
+  100% { transform: scale(0.8) rotate(180deg); }
 }
 
 #windows > .appWindow.inlineActivity,

--- a/apps/system/test/unit/cards_view_test.js
+++ b/apps/system/test/unit/cards_view_test.js
@@ -63,42 +63,56 @@ suite('cards view >', function() {
 
   setup(function() {
     mocksHelper.setup();
+    var frameCreator = function(orientation) {
+      var frame = document.createElement('div');
+      frame.dataset.orientation = orientation;
+      return frame;
+    };
 
     MockWindowManager.mRunningApps = {
       'http://sms.gaiamobile.org': {
-        launchTime: 4,
+        launchTime: 5,
         name: 'SMS',
-        frame: document.createElement('div'),
+        frame: frameCreator('portrait-primary'),
         iframe: document.createElement('iframe'),
         manifest: {
           orientation: 'portrait-primary'
         }
       },
       'http://game.gaiamobile.org': {
-        launchTime: 3,
+        launchTime: 4,
         name: 'GAME',
-        frame: document.createElement('div'),
+        frame: frameCreator('landscape-primary'),
         iframe: document.createElement('iframe'),
         manifest: {
           orientation: 'landscape-primary'
         }
       },
       'http://game2.gaiamobile.org': {
-        launchTime: 2,
+        launchTime: 3,
         name: 'GAME2',
-        frame: document.createElement('div'),
+        frame: frameCreator('landscape-secondary'),
         iframe: document.createElement('iframe'),
         manifest: {
           orientation: 'landscape-secondary'
         }
       },
       'http://game3.gaiamobile.org': {
-        launchTime: 1,
+        launchTime: 2,
         name: 'GAME3',
-        frame: document.createElement('div'),
+        frame: frameCreator('landscape-primary'),
         iframe: document.createElement('iframe'),
         manifest: {
           orientation: 'landscape'
+        }
+      },
+      'http://game4.gaiamobile.org': {
+        launchTime: 1,
+        name: 'GAME4',
+        frame: frameCreator('portrait-secondary'),
+        iframe: document.createElement('iframe'),
+        manifest: {
+          orientation: 'portrait-secondary'
         }
       }
     };
@@ -170,29 +184,34 @@ suite('cards view >', function() {
       CardsView.hideCardSwitcher();
     });
 
+    var testCardOrientation = function(origin, orientation) {
+      var card = cardsView.querySelector('li[data-origin="' + origin + '"]');
+      card.dispatchEvent(new CustomEvent('onviewport'));
+      return card.querySelector('.screenshotView')
+          .classList.contains(orientation);
+    };
+
     test('cardsview defines a landscape-primary app', function() {
-      assert.isTrue(cardsView.
-        querySelector('li[data-origin="http://game.gaiamobile.org"]').classList.
-        contains('landscape-primary'));
+      assert.isTrue(testCardOrientation('http://game.gaiamobile.org',
+                                        'landscape-primary'));
     });
-
     test('cardsview defines a landscape-secondary app', function() {
-      assert.isTrue(cardsView.
-        querySelector('li[data-origin="http://game2.gaiamobile.org"]').
-        classList.contains('landscape-secondary'));
+      assert.isTrue(testCardOrientation('http://game2.gaiamobile.org',
+                                        'landscape-secondary'));
+    });
+    test('cardsview defines a landscape app in landscape-primary', function() {
+      assert.isTrue(testCardOrientation('http://game3.gaiamobile.org',
+                                        'landscape-primary'));
+    });
+    test('cardsview defines a portrait app in portrait-primary', function() {
+      assert.isTrue(testCardOrientation('http://sms.gaiamobile.org',
+                                        'portrait-primary'));
+    });
+    test('cardsview defines a portrait-secondary app', function() {
+      assert.isTrue(testCardOrientation('http://game4.gaiamobile.org',
+                                        'portrait-secondary'));
     });
 
-    test('cardsview defines a landscape app', function() {
-      assert.isTrue(cardsView.
-        querySelector('li[data-origin="http://game3.gaiamobile.org"]').
-        classList.contains('landscape'));
-    });
-
-    test('cardsview defines a portrait app', function() {
-      assert.isFalse(cardsView.
-        querySelector('li[data-origin="http://sms.gaiamobile.org"]').classList.
-        contains('landscape'));
-    });
   });
 });
 


### PR DESCRIPTION
This patch aims for:
- when user presses home to go from app back to homescreen, the app keeps its original orientation.
- when user opens/returns to an app with its direction locked, the app opens directly in its orientation.

These are implemented by css rotation to make app orientates different from homescreen possible.
