### PR TITLE
Bug 870187 - [Dialer] Emergency call is displayed as a normal voice call

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -107,6 +107,14 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
     return;
   }
 
+  var isEmergencyNumber = this.call.emergency;
+  if (isEmergencyNumber) {
+    LazyL10n.get(function localized(_) {
+      node.textContent = _('emergencyNumber');
+    });
+    return;
+  }
+
   var voicemail = navigator.mozVoicemail;
   if (voicemail) {
     if (voicemail.number == number) {

--- a/apps/communications/dialer/locales/shared.en-US.properties
+++ b/apps/communications/dialer/locales/shared.en-US.properties
@@ -1,6 +1,7 @@
 callAirplaneModeMessage=To make a call you need to disable airplane mode in settings.
 callAirplaneModeBtnOk=OK
 callAirplaneModeTitle=Airplane mode activated
+emergencyNumber=Emergency number
 emergencyDialogBodyBadNumber=To make a call, the phone must be connected to a network.
 emergencyDialogBodyDeviceNotAccepted=Emergency calls are not allowed by the network.
 emergencyDialogBtnOk=OK

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -382,6 +382,15 @@ suite('dialer/handled_call', function() {
     assert.equal(numberNode.textContent, 'withheld-number');
   });
 
+  test('should display emergency number label', function() {
+    mockCall = new MockCall('112', 'dialing');
+    mockCall.emergency = true;
+    subject = new HandledCall(mockCall, fakeNode);
+
+    var numberNode = fakeNode.querySelector('.numberWrapper .number');
+    assert.equal(numberNode.textContent, 'emergencyNumber');
+  });
+
   suite('additional information', function() {
     test('check additional info updated', function() {
       mockCall = new MockCall('888', 'incoming');


### PR DESCRIPTION
Support emergency call display.

Please test the patch with using the Gecko build in mozilla-central.
Because the emergency attribute of call object haven't landed in mozilla-b2g18.

Thanks. :)

http://bugzil.la/870187
