### PR TITLE
Bug 869859 - [Video] support mimetype of video/ogg for all web activities a=tef+

### DIFF
--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -42,7 +42,7 @@
   "activities": {
     "view" : {
       "filters": {
-        "type": ["video/webm", "video/mp4", "video/3gpp", "video/youtube"]
+        "type": ["video/webm", "video/mp4", "video/3gpp", "video/youtube", "video/ogg"]
       },
       "href": "view.html",
       "disposition": "inline",


### PR DESCRIPTION
- Support filetype "video/ogg"  in Video app for "view" web-activity only.
