### PR TITLE
Bug 833743 - Workaround: Use scale instead font size change to render

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -716,7 +716,7 @@ div.animation-on {
 }
 .picker-unit.active {
   color: #FFFFFF;
-  font-size: 3.2rem;
+  transform: scale(1.5, 1.5);
 }
 
 #picker-bar-background {


### PR DESCRIPTION
each unit of the time picker
