### PR TITLE
Bug 869817 - [Email] "Last Sync:" value at folder screen is not displayed properly with IMAP accounts. r=asuth

### DIFF
--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -8133,7 +8133,9 @@ FolderStorage.prototype = {
 
     aranges.splice.apply(aranges, [newInfo[0], delCount].concat(insertions));
 
-    this.folderMeta.lastSyncedAt = endTS;
+    /*lastSyncedAt depends on current timestamp of the client device
+     should not be added timezone offset*/
+    this.folderMeta.lastSyncedAt = NOW();
     if (this._account.universe)
       this._account.universe.__notifyModifiedFolder(this._account,
                                                     this.folderMeta);

--- a/apps/email/js/folder-cards.js
+++ b/apps/email/js/folder-cards.js
@@ -136,8 +136,8 @@ FolderPickerCard.prototype = {
       self.updateFolderDom(folder, true);
       foldersContainer.insertBefore(folderNode, insertBuddy);
 
-      if (this.mostRecentSyncTimestamp < folder.lastSyncedAt) {
-        this.mostRecentSyncTimestamp = folder.lastSyncedAt;
+      if (self.mostRecentSyncTimestamp < folder.lastSyncedAt) {
+        self.mostRecentSyncTimestamp = folder.lastSyncedAt;
         dirtySyncTime = true;
       }
     });


### PR DESCRIPTION
Land:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/203

This includes a required review fix of changing erroneous use of 'this' in a
forEach in FolderPickerCard.onFoldersSplice to 'self'.  This corrects the
problem where the value is not displayed at startup.
