### PR TITLE
Bug 873762 - [Email] message-download-images locale is not displayed completely...

### DIFF
--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -400,7 +400,7 @@ input.msg-search-text-tease {
   left: 0;
   bottom: 4.8rem;
   width: 100%;
-  height: 2.2rem;
+  /*height: 2.2rem; Lengthy strings are not displayed, by deafult made auto*/
   line-height: 2.2rem;
   padding: 0.8rem 1.6rem;
   background-color: #424242;;


### PR DESCRIPTION
... in other languages

Removed height of the msg-reader-load-infobar

which makes height auto by default.

Please review.
Thanks
