### PR TITLE
Bug 799832 - when swiping between days & weeks visible hour should be the same

### DIFF
--- a/apps/calendar/js/views/day_based.js
+++ b/apps/calendar/js/views/day_based.js
@@ -637,6 +637,17 @@ Calendar.ns('Views').DayBased = (function() {
       if (el && el.parentNode) {
         el.parentNode.removeChild(el);
       }
+    },
+
+    getScrollTop: function() {
+      var scroll = this.element.querySelectorAll('.day-events')[1];
+      var scrollTop = scroll.scrollTop;
+      return scrollTop;
+    },
+
+    setScrollTop: function(scrollTop) {
+      var scroll = this.element.querySelectorAll('.day-events')[1];
+      scroll.scrollTop = scrollTop;
     }
 
   };

--- a/apps/calendar/js/views/month_child.js
+++ b/apps/calendar/js/views/month_child.js
@@ -442,7 +442,11 @@
         this.element.parentNode.removeChild(this.element);
         this.element = undefined;
       }
-    }
+    },
+
+    getScrollTop: function() {},
+
+    setScrollTop: function(scrollTop) {}
 
   };
 

--- a/apps/calendar/js/views/time_parent.js
+++ b/apps/calendar/js/views/time_parent.js
@@ -169,8 +169,11 @@ Calendar.ns('Views').TimeParent = (function() {
      * @param {Date} time center point to activate.
      */
     changeDate: function(time) {
+      var prevScrollTop = 0;
+
       // deactivate previous frame
       if (this.currentFrame) {
+        prevScrollTop = this.currentFrame.getScrollTop();
         this.currentFrame.deactivate();
       }
 
@@ -186,6 +189,7 @@ Calendar.ns('Views').TimeParent = (function() {
       // create & activate current frame
       var cur = this.currentFrame = this.addFrame(time);
       cur.activate();
+      cur.setScrollTop(prevScrollTop);
 
       // add next frame
       this.addFrame(next);

--- a/apps/calendar/js/views/week.js
+++ b/apps/calendar/js/views/week.js
@@ -99,6 +99,17 @@ Calendar.ns('Views').Week = (function() {
       this.element = null;
     },
 
+    getScrollTop: function() {
+      var scroll = this.element.querySelector('.scroll');
+      var scrollTop = scroll.scrollTop;
+      return scrollTop;
+    },
+
+    setScrollTop: function(scrollTop) {
+      var scroll = this.element.querySelector('.scroll');
+      scroll.scrollTop = scrollTop;
+    },
+
     _appendSidebarHours: function() {
       var element = this.element.querySelector('.sidebar');
 

--- a/apps/calendar/test/unit/views/time_parent_test.js
+++ b/apps/calendar/test/unit/views/time_parent_test.js
@@ -8,6 +8,7 @@ suiteGroup('Views.TimeParent', function() {
   var app;
   var subject;
   var id;
+  var scrollTop;
   var controller;
 
   var TimeParent;
@@ -50,6 +51,14 @@ suiteGroup('Views.TimeParent', function() {
       el.id = this.id;
       this.element = el;
       return el;
+    },
+
+    getScrollTop: function() {
+      return this.scrollTop;
+    },
+
+    setScrollTop: function(scrollTop) {
+      this.scrollTop = scrollTop;
     }
   };
 
@@ -254,6 +263,16 @@ suiteGroup('Views.TimeParent', function() {
 
       // verify other children where removed
       assert.length(subject.frameContainer.children, 3);
+    });
+
+    test('the same scrollTop between day ane week views', function() {
+      subject.currentFrame.setScrollTop(100);
+
+      var next = subject._nextTime(date);
+      subject.changeDate(next);
+      var scrollTop = subject.currentFrame.getScrollTop();
+
+      assert.equal(scrollTop, 100, 'same scrollTop');
     });
   });
 


### PR DESCRIPTION
The scrollTop of a day/week view is always as same as the scrollTop in the previous view.

http://bugzil.la/799832
