### PR TITLE
Bug 873955 - [System][Notification] Notification does not make sound whe...

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -404,7 +404,7 @@ SettingsListener.observe(
 });
 
 SettingsListener.observe('audio.volume.notification', 7, function(value) {
-  NotificationScreen.silent = (value != 0);
+  NotificationScreen.silent = (value == 0);
 });
 
 SettingsListener.observe('vibration.enabled', true, function(value) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=873955
1. Title : [System][Notification] Notification does not make sound when silent mode is off.
2. Precondition : Set volume to non-silent level.
3. Tester's Action : Receive SMS from 3rd phone.
4. Detailed Symptom (ENG.) : Notice the SMS notification does not sound.
5. Expected : The SMS notification should sound when silent mode is off.
   6.Reproducibility: Y
          1)Frequency Rate : 100%
   7.Gaia Revision: a503d9a1d0a588f3689243c1ddc0f016ede51b9d
   8.Personal email id:  hanj.kim25@gmail.com

This is a regression from Bug 867912.

The problem is in apps/system/js/notifications.js. 

The following needs to change 

NotificationScreen.silent = (value != 0);

to

NotificationScreen.silent = (value == 0);
