### PR TITLE
Bug 874055 - [Video] Activity played videos are missplaced in Peak device

### DIFF
--- a/apps/video/index.html
+++ b/apps/video/index.html
@@ -46,7 +46,9 @@
 
     <!-- 'fullscreen' (maximized) video player -->
     <section role="region" id="fullscreen-view" class="hidden">
-      <video src="about:blank" id="player"></video>
+      <div id="crop-view">
+        <video src="about:blank" id="player"></video>
+      </div>
       <!-- video controls -->
       <div id="videoControls" class="hidden">
 

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -7,7 +7,7 @@ var ids = ['thumbnail-list-view', 'thumbnails-bottom',
            'thumbnail-select-view',
            'thumbnails-delete-button', 'thumbnails-share-button',
            'thumbnails-cancel-button', 'thumbnails-number-selected',
-           'fullscreen-view',
+           'fullscreen-view', 'crop-view',
            'thumbnails-single-delete-button', 'thumbnails-single-share-button',
            'player', 'overlay', 'overlay-title',
            'overlay-text', 'videoControls', 'videoBar', 'videoActionBar',
@@ -477,69 +477,12 @@ function playerMousedown(event) {
   }
 }
 
-// Make the video fit the container
+// Align vertically fullscreen view
 function setPlayerSize() {
-  var containerWidth = window.innerWidth;
-  var containerHeight = window.innerHeight;
-
-  // Don't do anything if we don't know our size.
-  // This could happen if we get a resize event before our metadata loads
-  if (!dom.player.videoWidth || !dom.player.videoHeight)
-    return;
-
-  var width, height; // The size the video will appear, after rotation
-  var rotation = 'metadata' in currentVideo ?
-    currentVideo.metadata.rotation : 0;
-
-  switch (rotation) {
-  case 0:
-  case 180:
-    width = dom.player.videoWidth;
-    height = dom.player.videoHeight;
-    break;
-  case 90:
-  case 270:
-    width = dom.player.videoHeight;
-    height = dom.player.videoWidth;
-  }
-
-  var xscale = containerWidth / width;
-  var yscale = containerHeight / height;
-  var scale = Math.min(xscale, yscale);
-
-  // scale large videos down and scale small videos up
-  // this might result in lower image quality for small videos
-  width *= scale;
-  height *= scale;
-
-  var left = ((containerWidth - width) / 2);
-  var top = ((containerHeight - height) / 2);
-
-  var transform;
-  switch (rotation) {
-  case 0:
-    transform = 'translate(' + left + 'px,' + top + 'px)';
-    break;
-  case 90:
-    transform =
-      'translate(' + (left + width) + 'px,' + top + 'px) ' +
-      'rotate(90deg)';
-    break;
-  case 180:
-    transform =
-      'translate(' + (left + width) + 'px,' + (top + height) + 'px) ' +
-      'rotate(180deg)';
-    break;
-  case 270:
-    transform =
-      'translate(' + left + 'px,' + (top + height) + 'px) ' +
-      'rotate(270deg)';
-    break;
-  }
-
-  transform += ' scale(' + scale + ')';
-
-  dom.player.style.transform = transform;
+  var containerHeight = (window.innerHeight > dom.player.offsetHeight) ?
+    window.innerHeight : dom.player.offsetHeight;
+  dom.cropView.style.marginTop = (containerHeight / 2) * -1 + 'px';
+  dom.cropView.style.height = containerHeight + 'px';
 }
 
 function setVideoUrl(player, video, callback) {

--- a/apps/video/js/view.js
+++ b/apps/video/js/view.js
@@ -93,7 +93,7 @@ navigator.mozSetMessageHandler('activity', function viewVideo(activity) {
     // so we'll play the video without going into fullscreen mode.
 
     // Get all the elements we use by their id
-    var ids = ['player', 'videoFrame', 'videoControls',
+    var ids = ['player', 'fullscreen-view', 'crop-view', 'videoControls',
                'close', 'play', 'playHead',
                'elapsedTime', 'video-title', 'duration-text', 'elapsed-text',
                'slider-wrapper', 'spinner-overlay',
@@ -198,34 +198,12 @@ navigator.mozSetMessageHandler('activity', function viewVideo(activity) {
     });
   }
 
-  // Make the video fit the container
+  // Align vertically fullscreen view
   function setPlayerSize() {
-    var containerWidth = window.innerWidth;
-    var containerHeight = window.innerHeight;
-
-    // Don't do anything if we don't know our size.
-    // This could happen if we get a resize event before our metadata loads
-    if (!dom.player.videoWidth || !dom.player.videoHeight)
-      return;
-
-    var width = dom.player.videoWidth;
-    var height = dom.player.videoHeight;
-    var xscale = containerWidth / width;
-    var yscale = containerHeight / height;
-    var scale = Math.min(xscale, yscale);
-
-    // scale large videos down, and scale small videos up
-    width *= scale;
-    height *= scale;
-
-    var left = ((containerWidth - width) / 2);
-    var top = ((containerHeight - height) / 2);
-
-    var transform = 'translate(' + left + 'px,' + top + 'px)';
-
-    transform += ' scale(' + scale + ')';
-
-    dom.player.style.transform = transform;
+    var containerHeight = (window.innerHeight > dom.player.offsetHeight) ?
+      window.innerHeight : dom.player.offsetHeight;
+    dom.cropView.style.marginTop = (containerHeight / 2) * -1 + 'px';
+    dom.cropView.style.height = containerHeight + 'px';
   }
 
   // show video player

--- a/apps/video/style/video.css
+++ b/apps/video/style/video.css
@@ -96,7 +96,7 @@ li .after {
 }
 
 /* All of the main views fill the screen */
-#thumbnail-list-view, #thumbnail-select-view, #fullscreen-view {
+#thumbnail-list-view, #thumbnail-select-view, #fullscreen-view, #crop-view {
   position: absolute;
   top: 0px;
   left: 0px;
@@ -175,13 +175,29 @@ li .after {
   margin-bottom: 40px;
 }
 
+/* Video align and size */
+#crop-view {
+  white-space: nowrap;
+  font-size: 0;
+  text-align: center;
+  top: 50%;
+}
+
+#crop-view:before {
+  content: "";
+  width: 1px;
+  height: 100%;
+  margin-left: -1px;
+  display: inline-block;
+  vertical-align: middle
+}
+
 #player {
   /* size and position are set in JS depending on*/
   /* video size and screen orientation */
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform-origin: 0 0;
+  display: inline-block;
+  vertical-align: middle;
+  width: 100%;
 }
 
 /*

--- a/apps/video/view.html
+++ b/apps/video/view.html
@@ -14,8 +14,10 @@
   <body role="application" class="skin-dark">
     <!-- display this at startup while we create thumbnails -->
     <div id="spinner-overlay"><div id="spinner"></div></div>
-    <div id="videoFrame">
-      <video id="player" preload="metadata"></video>
+    <div id="fullscreen-view">
+      <div id="crop-view">
+        <video id="player" preload="metadata"></video>
+      </div>
       <!-- video controls -->
       <div id="videoControls" class="hidden">
         <section role="region">


### PR DESCRIPTION
Simplified code by aligning the video with CSS with some small js help.
Added new fullscreen missing id to `view.html` (to unify code).
Also added black backround to body tag in order to avoid white flashes.

Tested on Peak and Unagi like device on both portrait and lansdcape mode using videos from sdcard and youtube.
