### PR TITLE
Bug 873477 - [SMS][MMS] Group participants string formatting update per v8.0

### DIFF
--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -101,7 +101,7 @@ var ThreadListUI = {
         };
       }
 
-      name.textContent = navigator.mozL10n.get('contact-title-text', {
+      name.textContent = navigator.mozL10n.get('thread-header-text', {
         name: title,
         n: others
       });

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -678,9 +678,9 @@ var ThreadUI = global.ThreadUI = {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=836733
     if (!navigator.mozMobileMessage && callback) {
       this.headerText.textContent = navigator.mozL10n.get(
-        'contact-title-text', {
-          name: number,
-          n: others
+        'thread-header-text', {
+        name: number,
+        n: others
       });
       setTimeout(callback);
       return;
@@ -706,7 +706,7 @@ var ThreadUI = global.ThreadUI = {
 
       this.headerText.dataset.isContact = !!details.isContact;
       this.headerText.textContent = navigator.mozL10n.get(
-        'contact-title-text', {
+        'thread-header-text', {
           name: contactName,
           n: others
       });

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -3,13 +3,13 @@ messages           = Messages
 editMode           = Edit messages
 
 # Contact title
-contact-title-text        = {[ plural(n) ]}
-contact-title-text[zero]  = {{name}}
-contact-title-text[one]   = {{name}} and {{n}} other
-contact-title-text[two]   = {{name}} and {{n}} others
-contact-title-text[few]   = {{name}} and {{n}} others
-contact-title-text[many]  = {{name}} and {{n}} others
-contact-title-text[other] = {{name}} and {{n}} others
+thread-header-text        = {[ plural(n) ]}
+thread-header-text[zero]  = {{name}}
+thread-header-text[one]   = {{name}} (+{{n}})
+thread-header-text[two]   = {{name}} (+{{n}})
+thread-header-text[few]   = {{name}} (+{{n}})
+thread-header-text[many]  = {{name}} (+{{n}})
+thread-header-text[other] = {{name}} (+{{n}})
 
 
 

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -241,8 +241,9 @@ suite('SMS App Unit-Test', function() {
         var threadWithContact = document.getElementById('thread-1');
         var contactName =
           threadWithContact.getElementsByClassName('name')[0].innerHTML;
-        assert.equal(contactName,
-                     'contact-title-text{"name":"Pepito Grillo","n":0}');
+        assert.equal(
+          contactName, 'thread-header-text{"name":"Pepito Grillo","n":0}'
+        );
       });
     });
 


### PR DESCRIPTION
I believe this is incomplete and need someone with more i18n experience to review
- Renames `contact-title-text` => `others` to match other locales
- Updates en-US locale with correct displayed text

Other locales aren't updated because I'm not sure it's a 1-to-1 change

Signed-off-by: Rick Waldron waldron.rick@gmail.com
