### PR TITLE
Bug 873762 - [Email] "message-download-images" locale is not displayed completely in other languages. r=asuth

### DIFF
--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -400,7 +400,7 @@ input.msg-search-text-tease {
   left: 0;
   bottom: 4.8rem;
   width: 100%;
-  height: 2.2rem;
+  /*height: 2.2rem; Lengthy strings are not displayed, by deafult made auto*/
   line-height: 2.2rem;
   padding: 0.8rem 1.6rem;
   background-color: #424242;;

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -395,12 +395,14 @@ input.msg-search-text-tease {
 
 .msg-reader-load-infobar {
   position: absolute;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
   color: white;
   font-size: 1.2rem;
   left: 0;
   bottom: 4.8rem;
   width: 100%;
-  /*height: 2.2rem; Lengthy strings are not displayed, by deafult made auto*/
+  /* we do not specify a height because text may be more than 1 line high */
   line-height: 2.2rem;
   padding: 0.8rem 1.6rem;
   background-color: #424242;;


### PR DESCRIPTION
includes fix from https://github.com/mozilla-b2g/gaia/pull/9864 plus review fix
