### PR TITLE
Bug 874330 - CostControl Widget in utility tray does not ellipsis a over...

### DIFF
--- a/apps/costcontrol/style/widget.css
+++ b/apps/costcontrol/style/widget.css
@@ -86,6 +86,9 @@ p.meta {
 
 #fte-view p.meta {
   font-size:1.4em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 #fte-view p:not(.meta) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=874330
1. Title : [CostControl] Widget in utility tray should ellipsis long text.
2. Precondition : Make the cost control widget display a very long text.
                 1) Remove SIM card
                 2) Change language to Brazilian Portuguese
3. Tester's Action : Expand the utility tray and observe the very long text.
4. Detailed Symptom (ENG.) : The very long text is not well-trimmed.
5. Expected : The very long text would better ellipsis in a single line.
   6.Reproducibility: Y
          1)Frequency Rate : 100%
   7.Gaia Revision: a503d9a1d0a588f3689243c1ddc0f016ede51b9d
   8.Personal email id:  hanj.kim25@gmail.com
