### PR TITLE
Bug 817912 - [Settings-Phone Lock] "confirm passcode" field accepts char...

### DIFF
--- a/apps/settings/js/phone_lock.js
+++ b/apps/settings/js/phone_lock.js
@@ -164,7 +164,7 @@ var PhoneLock = {
             this._passcodeBuffer = this._passcodeBuffer.substring(0,
                 this._passcodeBuffer.length - 1);
           }
-        } else {
+        } else if(this._passcodeBuffer.length < 8){ 
           this._passcodeBuffer += key;
         }
 


### PR DESCRIPTION
Bug 817912 - [Settings-Phone Lock] "confirm passcode" field accepts characters beyond the first 4 
