### PR TITLE
Bug 873711 - [bluetooth] pincode screen should not allow the symbol for ...

### DIFF
--- a/apps/settings/onpair.html
+++ b/apps/settings/onpair.html
@@ -35,11 +35,11 @@
         </span>
 
         <span id="pin-input-method" hidden>
-          <input type="number" id="pin-input" size="4" maxlength="4" />
+          <input type="number" id="pin-input" x-inputmode="digits" size="4" maxlength="4" />
         </span>
 
         <span id="passkey-input-method" hidden>
-          <input type="number" id="passkey-input" size="6" maxlength="6" />
+          <input type="number" id="passkey-input" x-inputmode="digits" size="6" maxlength="6" />
         </span>
       </section>
       <menu>


### PR DESCRIPTION
...bluetooth pairing
