### PR TITLE
Bug 859736 - Speaker is disabled when rejecting an incoming call during an established call (r=etiennesegonzac)

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -222,8 +222,6 @@ HandledCall.prototype.disconnected = function hc_disconnected() {
   if (!this.node)
     return;
 
-  CallScreen.unmute();
-  CallScreen.turnSpeakerOff();
   this.remove();
 };
 

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -380,6 +380,9 @@ var OnCallHandler = (function onCallHandler() {
   }
 
   function handleFirstIncoming(call) {
+    unmute();
+    turnSpeakerOff();
+
     var vibrateInterval = 0;
     if (activateVibration != false) {
       vibrateInterval = window.setInterval(function vibrate() {

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -239,14 +239,6 @@ suite('dialer/handled_call', function() {
       assert.equal(subject.recentsEntry, MockOnCallHandler.mLastEntryAdded);
     });
 
-    test('mute off after call', function() {
-      assert.isFalse(MockCallScreen.mMuteOn);
-    });
-
-    test('speaker off after call', function() {
-      assert.isFalse(MockCallScreen.mSpeakerOn);
-    });
-
     test('remove listener', function() {
       assert.isTrue(mockCall._listenerRemoved);
     });

--- a/apps/communications/dialer/test/unit/mock_call_screen.js
+++ b/apps/communications/dialer/test/unit/mock_call_screen.js
@@ -15,10 +15,10 @@ var MockCallScreen = {
     this.mMuteOn = false;
   },
   turnSpeakerOff: function() {
-    this.speakerOn = false;
+    this.mSpeakerOn = false;
   },
   turnSpeakerOn: function() {
-    this.speakerOn = true;
+    this.mSpeakerOn = true;
   },
   render: function(mode) {
     this.mLastRenderMode = mode;


### PR DESCRIPTION
To avoid weird behaviors regarding the speaker and mute functionality, we reset them when handling the first incoming call. For the proposed patch we have considered the case when a busy tone is played in which case, although the call is disconnected, the call screen is shown. If while the busy tone is played, a new call reaches the phone, it is properly reset to not muted and the speaker off.
