### PR TITLE
Bug 871990 - Make multi-line messages show up as a single line

### DIFF
--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -338,7 +338,7 @@ var ThreadListUI = {
     }
 
     if (lastMessageType === 'sms' && body) {
-      body = Utils.Message.format(body).split('\n')[0];
+      body = Utils.escapeHTML(body);
     }
 
     // Render markup with thread data


### PR DESCRIPTION
Turn newlines into spaces when prepping elements for the main view so that multi-line messages show up as a single line and do not overflow into the following message.
