### PR TITLE
Bug 873936 - [clock]stored Alarm hold and press then complet area not highlighted

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -295,7 +295,7 @@ ul li > a, ul li > span, ul li > small { /* text ellipsis */
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: -moz-calc(100% - 8.13rem);
+  width: -moz-calc(100% - 4.5rem);
 }
 
 ul li > span {


### PR DESCRIPTION
Subtract the width of the checkbox element from the width of the a element.

http://bugzil.la/873936
