### PR TITLE
Bug 875271 - Remove alt camera button

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -827,9 +827,6 @@
             <div id="lockscreen-header">
               <div id="lockscreen-connstate" hidden><span></span><span></span></div>
               <div id="lockscreen-mute" hidden></div>
-              <div id="lockscreen-alt-camera" class="lockscreen-icon">
-                <div role="button" id="lockscreen-alt-camera-button" class="lockscreen-icon-a11y-button" data-l10n-id="camera-a11y-button" aria-label="Camera"></div>
-              </div>
               <div class="lockscreen-clock">
                 <span id="lockscreen-clock-numbers"></span>
                 <span id="lockscreen-clock-meridiem"></span>

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -129,7 +129,6 @@ var LockScreen = {
 
     /* Gesture */
     this.area.addEventListener('mousedown', this);
-    this.altCameraButton.addEventListener('mousedown', this);
     this.areaCamera.addEventListener('mousedown', this);
     this.areaUnlock.addEventListener('mousedown', this);
     this.iconContainer.addEventListener('mousedown', this);
@@ -305,8 +304,7 @@ var LockScreen = {
 
       case 'mousedown':
         if (evt.target === this.areaUnlock ||
-           evt.target === this.areaCamera ||
-           evt.target === this.altCameraButton) {
+           evt.target === this.areaCamera) {
           evt.preventDefault();
           this.handleIconClick(evt.target);
           break;
@@ -461,7 +459,6 @@ var LockScreen = {
     var self = this;
     switch (target) {
       case this.areaCamera:
-      case this.altCameraButton:
         var panelOrFullApp = function panelOrFullApp() {
           // If the passcode is enabled and it has a timeout which has passed
           // switch to secure camera

--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -118,10 +118,6 @@
   visibility: inherit;
 }
 
-[data-panel="main"] #lockscreen-alt-camera {
-  visibility: hidden;
-}
-
 [data-panel="emergency-call"] #lockscreen-panel-main {
   transform: translateX(-100%);
 }
@@ -246,7 +242,6 @@
   pointer-events: none;
 }
 
-#lockscreen-alt-camera.lockscreen-icon:active,
 .lockscreen-icon-area:active > .lockscreen-icon {
   background-color: rgb(0, 138, 170);
 }
@@ -313,17 +308,11 @@ button::-moz-focus-inner {
   background-size: 3rem;
 }
 
-#lockscreen-alt-camera > div,
 #lockscreen-area-camera > div {
   background-image: url('./images/icon-camera.png');
   background-position: center;
   background-repeat: no-repeat;
   background-size: 2.4rem;
-}
-
-#lockscreen-alt-camera {
-  float: right;
-  pointer-events: auto;
 }
 
 [data-panel="emergency-call"] #lockscreen-panel-passcode {


### PR DESCRIPTION
Remove the alt-camera button that is not used anymore (but has `visibility: hidden` a.t.m.) but causes the time to wrap on the lock screen. Fix for [#875271](https://bugzilla.mozilla.org/show_bug.cgi?id=875271).
