### PR TITLE
Bug 875497 - [MMS][SMS] Prevent multi-recipient pull down unless list of contacts is > 1 line

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -695,10 +695,21 @@
     switch (event.type) {
 
       case 'pan':
-        // If there are recipients in the list and the
-        // pan event is "pulling down", then switch the
-        // view to multiline display
-        if (owner.length > 1) {
+        // Switch to multiline display when:
+        //
+        //  1. There are 2 or more recipients in the list.
+        //  2. The recipients in the list have caused the
+        //      container to grow enough to require the
+        //      additional viewable area.
+        //      (>1 visible lines or 1.5x the original size)
+        //  3. The user is "pulling down" the recipient list.
+
+        // #1
+        if (owner.length > 1 &&
+          // #2
+          (view.inner.scrollHeight > (view.dims.inner.height * 1.5))) {
+
+          // #3
           if (event.detail.absolute.dy > 0) {
             this.visible('multiline');
           }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=875497

Signed-off-by: Rick Waldron waldron.rick@gmail.com
