### PR TITLE
Bug 875424 - mms settings has incorrect default

### DIFF
--- a/build/settings.py
+++ b/build/settings.py
@@ -103,7 +103,7 @@ settings = {
  "ril.mms.mmsproxy": "",
  "ril.mms.passwd": "",
  "ril.mms.user": "",
- "ril.mms.retrieval_mode": "automatic",
+ "ril.mms.retrieval_mode": "automatic-home",
  "dom.mms.operatorSizeLimitation": 0,
  "ril.radio.preferredNetworkType": "",
  "ril.radio.disabled": False,


### PR DESCRIPTION
Change the default mms message retrieval mode to automatic download without roaming status. 
