### PR TITLE
Bug 875426 - mms settings input fields do not use correct keyboard

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -738,23 +738,23 @@
           </li>
           <li>
             <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
-            <input type="text" data-setting="ril.mms.httpProxyHost" />
+            <input type="text" x-inputmode="verbatim" data-setting="ril.mms.httpProxyHost" />
           </li>
           <li>
             <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
-            <input type="text" data-setting="ril.mms.httpProxyPort" />
+            <input type="number" x-inputmode="digits" data-setting="ril.mms.httpProxyPort" />
           </li>
           <li>
             <p data-l10n-id="mmsproxy">MMS Proxy</p>
-            <input type="text" data-setting="ril.mms.mmsproxy" />
+            <input type="text" x-inputmode="verbatim" data-setting="ril.mms.mmsproxy" />
           </li>
           <li>
             <p data-l10n-id="mmsport">MMS Port</p>
-            <input type="text" data-setting="ril.mms.mmsport" />
+            <input type="number" x-inputmode="digits" data-setting="ril.mms.mmsport" />
           </li>
           <li>
             <p data-l10n-id="mmsc">MMSC</p>
-            <input type="text" data-setting="ril.mms.mmsc" />
+            <input type="text" x-inputmode="verbatim" data-setting="ril.mms.mmsc" />
           </li>
         </ul>
       </div>

--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -159,6 +159,7 @@ ul li p + label:not([for]) {
 }
 
 ul li p + input[type="text"],
+ul li p + input[type="number"],
 ul li p + input[type="tel"],
 ul li p + input[type="password"] {
   width: calc(100% - 6rem);


### PR DESCRIPTION
Fix the keyboard input type and disable the auto-complete with MMSC and other related input fields.
