### PR TITLE
Bug 861093 - "Ok" should be spelled "OK" in Facebook Contacts

### DIFF
--- a/apps/communications/contacts/locales/fb/facebook.en-US.properties
+++ b/apps/communications/contacts/locales/fb/facebook.en-US.properties
@@ -65,7 +65,7 @@ curtainRetry     = Retry
 
 connectionLost       = No Internet connection
 connectionLostMsg    = Friends’ photos will not be added to your contacts. Continue anyway?
-yesOption            = Ok
+yesOption            = OK
 noOption             = Cancel
 
 # Status


### PR DESCRIPTION
Bug 861093 - "Ok" should be spelled "OK" in Facebook Contacts
