### PR TITLE
Bug 871852 - [Email] Email sending fails silently when sending large (fo...

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -1021,6 +1021,15 @@
           <button id="msg-browse-ok" class="recommend" data-l10n-id="dialog-button-ok">OK</button>
         </menu>
       </form>
+      <form role="dialog" class="msg-attach-confirm" data-type="confirm">
+        <section>
+          <h1></h1>
+          <p></p>
+        </section>
+        <menu>
+          <button id="msg-attach-ok" class="full" data-l10n-id="dialog-button-ok">OK</button>
+        </menu>
+      </form>
     </div>
     <!-- Widget nodes for the compose cards; styles use the cmp prefix -->
     <div id="templ-cmp">

--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -5,6 +5,11 @@
  **/
 
 /**
+ * Max composer attachment size is defined as 5120000 bytes.
+ */
+var  MAX_ATTACHMENT_SIZE = 5120000;
+
+/**
  * To make it easier to focus input boxes, we have clicks on their owning
  * container cause a focus event to occur on the input.  This method helps us
  * also position the cursor based on the location of the click so the cursor
@@ -412,8 +417,38 @@ ComposeCard.prototype = {
             attTemplate.getElementsByClassName('cmp-attachment-filename')[0],
           filesizeTemplate =
             attTemplate.getElementsByClassName('cmp-attachment-filesize')[0];
+      var totalSize = 0;
       for (var i = 0; i < this.composer.attachments.length; i++) {
         var attachment = this.composer.attachments[i];
+        //check for attachment max size
+        if ( (totalSize + attachment.blob.size) > MAX_ATTACHMENT_SIZE) {
+
+          /*Remove all the remaining attachments from composer*/
+          while (this.composer.attachments.length > i) {
+            this.composer.removeAttachment(this.composer.attachments[i]);
+          }
+          var dialog = msgNodes['attach-confirm'].cloneNode(true);
+          var title = dialog.getElementsByTagName('h1')[0];
+          var content = dialog.getElementsByTagName('p')[0];
+
+          if (this.composer.attachments.length > 0) {
+            title.textContent = mozL10n.get('composer-attachments-large');
+            content.textContent = mozL10n.get('compose-attchments-size-exceeded');
+          } else {
+            title.textContent = mozL10n.get('composer-attachment-large');
+            content.textContent = mozL10n.get('compose-attchment-size-exceeded');
+          }
+          ConfirmDialog.show(dialog,
+          {
+          // ok
+          id: 'msg-attach-ok',
+          handler: function(){
+            this.updateAttachmentsSize();
+          }.bind(this)
+          });
+          return;
+        }
+        totalSize = totalSize + attachment.blob.size;
         filenameTemplate.textContent = attachment.name;
         filesizeTemplate.textContent = prettyFileSize(attachment.blob.size);
         var attachmentNode = attTemplate.cloneNode(true);

--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -7,7 +7,7 @@
 /**
  * Max composer attachment size is defined as 5120000 bytes.
  */
-var  MAX_ATTACHMENT_SIZE = 5120000;
+var MAX_ATTACHMENT_SIZE = 5120000;
 
 /**
  * To make it easier to focus input boxes, we have clicks on their owning
@@ -421,7 +421,7 @@ ComposeCard.prototype = {
       for (var i = 0; i < this.composer.attachments.length; i++) {
         var attachment = this.composer.attachments[i];
         //check for attachment max size
-        if ( (totalSize + attachment.blob.size) > MAX_ATTACHMENT_SIZE) {
+        if ((totalSize + attachment.blob.size) > MAX_ATTACHMENT_SIZE) {
 
           /*Remove all the remaining attachments from composer*/
           while (this.composer.attachments.length > i) {
@@ -433,19 +433,22 @@ ComposeCard.prototype = {
 
           if (this.composer.attachments.length > 0) {
             title.textContent = mozL10n.get('composer-attachments-large');
-            content.textContent = mozL10n.get('compose-attchments-size-exceeded');
+            content.textContent =
+	      mozL10n.get('compose-attchments-size-exceeded');
           } else {
             title.textContent = mozL10n.get('composer-attachment-large');
-            content.textContent = mozL10n.get('compose-attchment-size-exceeded');
+            content.textContent =
+	      mozL10n.get('compose-attchment-size-exceeded');
           }
           ConfirmDialog.show(dialog,
-          {
-          // ok
-          id: 'msg-attach-ok',
-          handler: function(){
-            this.updateAttachmentsSize();
-          }.bind(this)
-          });
+           {
+            // ok
+            id: 'msg-attach-ok',
+            handler: function() {
+              this.updateAttachmentsSize();
+            }.bind(this)
+           }
+          );
           return;
         }
         totalSize = totalSize + attachment.blob.size;

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -190,7 +190,7 @@ compose-send-message-failed=Sending email failed
 composer-attachment-large=Attachment too large
 composer-attachments-large=Attachments too large
 compose-attchment-size-exceeded=The selected attachment is too large to send with this message.
-compose-attchments-size-exceeded=The total size of the selected attachments is too large to send with this message. Try selecting fewer files.
+compose-attchments-size-exceeded=The selected attachments are too large to send with this message. Try selecting fewer files.
 dialog-button-ok=OK
 
 attachment-size-kib={{kilobytes}}K

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -187,7 +187,10 @@ compose-discard-message=Discard email?
 compose-discard-confirm=Discard
 compose-sending-message=Sending email
 compose-send-message-failed=Sending email failed
-
+composer-attachment-large=Attachment too large
+composer-attachments-large=Attachments too large
+compose-attchment-size-exceeded=The selected attachment is too large to send with this message.
+compose-attchments-size-exceeded=The total size of the selected attachments is too large to send with this message. Try selecting fewer files.
 dialog-button-ok=OK
 
 attachment-size-kib={{kilobytes}}K


### PR DESCRIPTION
...r an email) files (ex: 25 MB), No limit on max attachments size

Implementation is done as below.
1) Limited max attachment size to 5120000bytes (5MB)
2) When attaching from composer we can attach only one image at a time, so we check whether that total attachment size including the image does not exceed 5MB.
3) From gallery we can attach multiple files, the current implementation inserts the number of attachments that can be allowed in the composer and shows the alert to user.

Notes:
AFAIK gallery supports displaying of images max size 2.5 MB , so we would not get a scenario of single attachments exceeding the max limit. However as per suggested string locales are taken care for such case as well.

Please review
