### PR TITLE
Bug 836275 - [Calendar UX VD] Event detail: Light grey backgrund should be #f4f4f4

### DIFF
--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -209,7 +209,7 @@ ol.link-list li:only-child a {
   overflow: hidden;
   visibility: hidden;
   /* completely override other views */
-  background: #E6E6E0;
+  background-color: #f4f4f4;
   position: absolute;
   top: 0;
   width: 100%;


### PR DESCRIPTION
Bug [#836275](https://bugzilla.mozilla.org/show_bug.cgi?id=836275)
