### PR TITLE
Bug 876358 - [Call log] 'retryCount' should be 1 for new group calls. r=...

### DIFF
--- a/apps/communications/dialer/js/call_log_db.js
+++ b/apps/communications/dialer/js/call_log_db.js
@@ -251,7 +251,7 @@ var CallLogDBManager = {
         groups[key] = {
           id: id,
           lastEntryDate: this._getDayDate(record.date),
-          retryCount: record.retryCount
+          retryCount: 1
         };
       }
 


### PR DESCRIPTION
...etienne
