### PR TITLE
Bug 867948 - Ensure findByPhoneNumber callback checks their values

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -47,7 +47,8 @@ var ActivityHandler = {
       Contacts.findByPhoneNumber(number, function findContact(results) {
         var record, details, name, contact;
 
-        if (results.length) {
+        // Bug 867948: results null is a legitimate case
+        if (results && results.length) {
           record = results[0];
           details = Utils.getContactDetails(number, record);
           name = record.name.length && record.name[0];
@@ -309,11 +310,11 @@ var ActivityHandler = {
 
         Contacts.findByPhoneNumber(message.sender, function gotContact(
                                                                 contact) {
-          var sender;
-          if (contact.length && contact[0].name) {
+          var sender = message.sender;
+          if (!contact) {
+            console.error('We got a null contact for sender:', sender);
+          } else if (contact.length && contact[0].name) {
             sender = Utils.escapeHTML(contact[0].name[0]);
-          } else {
-            sender = message.sender;
           }
 
           if (message.type === 'sms') {

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -698,6 +698,8 @@ var ThreadUI = global.ThreadUI = {
        *  and how many other contacts share that same number. We think it's
        *  user's responsability to correct this mess with the agenda.
        */
+      // Bug 867948: contacts null is a legitimate case, and
+      // getContactDetails is okay with that.
       var details = Utils.getContactDetails(number, contacts);
       var contactName = details.title || number;
 


### PR DESCRIPTION
This is legitimate (and it seems meaningfull) for findByPhoneNumber to
return either null or empty array, depending on the case. However, we
must ensure to properly check for those returns values, otherwise we
might blow up in the air.
