### PR TITLE
Bug 876598 - Remove dead space on side and bottom of keyboard

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -37,7 +37,7 @@ button::-moz-focus-inner {
   bottom: 0;
   z-index: 15;
   width: 100%;
-  padding: 0.8rem 0 0.2rem;
+  padding: 0.8rem 0 0;
   border-top: 0.2rem solid;
   -moz-border-top-colors: #0b0b0b #999d9d;
   background-color: #6d7273;
@@ -57,6 +57,10 @@ button::-moz-focus-inner {
   padding: 0 0.1rem;
   border: none;
   background: none;
+}
+
+.keyboard-last-row .keyboard-key {
+  padding-bottom: 0.2rem;
 }
 
 /* Visible keys */
@@ -645,3 +649,11 @@ bubble above the key when you tap and hold. */
   color: #555;
 }
 
+/* Increase tap area for first / last keys in a row that
+  doesn't fill full width */
+.keyboard-key.float-key-first {
+  text-align: right;
+}
+.keyboard-key.float-key-last {
+  text-align: left;
+}


### PR DESCRIPTION
Fix for [#876598](https://bugzilla.mozilla.org/show_bug.cgi?id=876598). This PR removes the padding-bottom of the keyboard area and makes the last keyboard row higher instead. It also enlarges the key container for the first and last key in a row when the full width is not being used, to fill up the row completely. This reduces mistapping in the keyboard as there is no more dead space.
