### PR TITLE
Bug 876658 - Dont perform autocorrect if old & new word are the same

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -413,7 +413,8 @@
   // character. It performs auto correction or auto punctuation or just
   // inserts the character.
   function handleCorrections(keycode) {
-    if (correcting && autoCorrection && !correctionDisabled && atWordEnd()) {
+    if (correcting && autoCorrection && !correctionDisabled && atWordEnd() &&
+        wordBeforeCursor() !== autoCorrection) {
       autoCorrect(keycode);
     }
     else if (punctuating && cursor >= 2 &&
@@ -637,15 +638,20 @@
   function select(word) {
     var oldWord = wordBeforeCursor();
 
-    // Send backspaces
-    for (var i = 0, n = oldWord.length; i < n; i++)
-      keyboard.sendKey(BACKSPACE);
+    if (oldWord === word) {
+      keyboard.sendKey(SPACE);
+    }
+    else {
+      // Send backspaces
+      for (var i = 0, n = oldWord.length; i < n; i++)
+        keyboard.sendKey(BACKSPACE);
 
-    // Send the word
-    keyboard.sendString(word);
+      // Send the word
+      keyboard.sendString(word);
 
-    // Send a space
-    keyboard.sendKey(SPACE);
+      // Send a space
+      keyboard.sendKey(SPACE);
+    }
 
     // Update internal state
     inputText =


### PR DESCRIPTION
Fix for [#876658](https://bugzilla.mozilla.org/show_bug.cgi?id=876658). Currently the word is replaced by the new word even if the 2 words are the same. Because this is blocking you'll see a flicker, which is pretty annoying.
