### PR TITLE
Bug 877033 - [System] mozfullscreenchange event should be listened to ha...

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1873,7 +1873,7 @@ var WindowManager = (function() {
   // When the status bar is active it doubles in height so we need a resize
   var appResizeEvents = ['resize', 'status-active', 'status-inactive',
                          'keyboardchange', 'keyboardhide',
-                         'attentionscreenhide', 'fullscreenchange'];
+                         'attentionscreenhide', 'mozfullscreenchange'];
   appResizeEvents.forEach(function eventIterator(event) {
     window.addEventListener(event, function on(evt) {
       var keyboardHeight = KeyboardManager.getHeight();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=877033
1. Title: [System] mozfullscreenchange event should be listened to handle fullscreen on/off by a video content within browser app.
2. Precondition : 
3. Tester's Action : 
               1) Go to a web page that has a link to a video file.
               2) Click on the link, which normally is used to download it
               3) Watch the streamed video, switch to full screen, rotate to horizontal mode, turn off full screen, next turn on full screen again and rotate to vertical, next torn off full screen
4. Detailed Symptom (ENG.) : When leaving full screen in horizontal and vertical mode there is UI error in bottom Web Browser bar 
5. Expected : No UI problems
   6.Reproducibility: Y
   1)Frequency Rate : 100%
   7.Personal email id:  hanj.kim25@gmail.com

Currently, 'fullscreenchange' was added by Bug 871407 for this purpose. However it needs to be replaced by 'mozfullscreenchange'.
https://github.com/mozilla-b2g/gaia/commit/2bfe0807ffa800ee46b77456b530e4a2c747ad70

  var appResizeEvents = ['resize', 'status-active', 'status-inactive',
                         'keyboardchange', 'keyboardhide',
                         'attentionscreenhide', 'fullscreenchange'];
  appResizeEvents.forEach(function eventIterator(event) {
    window.addEventListener(event, function on(evt) {
      ...
    });
  });
