### PR TITLE
Bug 868270 - [Email] Email Body search filter is broken, always shows empty. r=asuth

### DIFF
--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -9393,9 +9393,9 @@ BodyFilter.prototype = {
         matchQuotes = this.matchQuotes,
         idx;
 
-    for (var iBodyRep = 0; iBodyRep < body.bodyReps.length; iBodyRep += 2) {
-      var bodyType = body.bodyReps[iBodyRep],
-          bodyRep = body.bodyReps[iBodyRep + 1];
+    for (var iBodyRep = 0; iBodyRep < body.bodyReps.length; iBodyRep++) {
+      var bodyType = body.bodyReps[iBodyRep].type,
+          bodyRep = body.bodyReps[iBodyRep].content;
 
       if (bodyType === 'plain') {
         for (var iRep = 0; iRep < bodyRep.length && matches.length < stopAfter;


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/210
