### PR TITLE
Bug 874058 - [Cost control] In FTE VIVO SIM case the text and the buttons are not formated properly

### DIFF
--- a/apps/costcontrol/fte.html
+++ b/apps/costcontrol/fte.html
@@ -124,23 +124,25 @@
       <header>
         <h1 data-l10n-id="fte-prepaid2-title">Low balance alert</h1>
       </header>
-      <ul class="content settings">
-        <li>
-          <label class="end">
-            <input id="low-limit" class="settings-option" data-option="lowLimit" type="checkbox" checked="checked" data-type="switch">
-            <span></span>
-          </label>
-          <p data-l10n-id="low-balance-alert">Low Balance alert</p>
-        </li>
-        <li>
-          <label class="end" for="low-limit-input">
-            <span id="currency"></span>
-            <input id="low-limit-input" class="settings-option" data-option="lowLimitThreshold" data-disable-on="lowLimit=false" type="number">
-          </label>
-          <p data-l10n-id="low-balance-explanation2">When balance is below</p>
-        </li>
-      </ul>
-      <p class="step-hint" data-l10n-id="fte-prepaid2-hint">Set an alert to avoid running out of credit.</p>
+      <section class="content">
+        <ul class="settings">
+          <li>
+            <label class="end">
+              <input id="low-limit" class="settings-option" data-option="lowLimit" type="checkbox" checked="checked" data-type="switch">
+              <span></span>
+            </label>
+            <p data-l10n-id="low-balance-alert">Low Balance alert</p>
+          </li>
+          <li>
+            <label class="end" for="low-limit-input">
+              <span id="currency"></span>
+              <input id="low-limit-input" class="settings-option" data-option="lowLimitThreshold" data-disable-on="lowLimit=false" type="number">
+            </label>
+            <p data-l10n-id="low-balance-explanation2">When balance is below</p>
+          </li>
+        </ul>
+        <p class="step-hint" data-l10n-id="fte-prepaid2-hint">Set an alert to avoid running out of credit.</p>
+      </section>
       <menu data-items="2">
         <button data-navigation="back">
           <span></span>
@@ -158,92 +160,94 @@
       <header>
         <h1 data-l10n-id="fte-prepaid3-title">Data Report and Alert</h1>
       </header>
-      <ul class="content settings">
-        <li>
-          <div class="end buttons-list">
-            <span class="button icon icon-dialog fake-select">
-              <select class="settings-option" data-option="trackingPeriod">
-                <option value="monthly" data-l10n-id="monthly">Monthly</option>
-                <option value="weekly" data-l10n-id="weekly">Weekly</option>
-                <option value="never" data-l10n-id="never">Never</option>
-              </select>
-            </span>
-          </div>
-          <p data-l10n-id="reset-report">Reset report</p>
-        </li>
-        <li>
-          <div class="end buttons-list">
-            <span class="button icon icon-dialog fake-select">
-              <select id="pre3-select-weekday" class="settings-option" data-option="resetTime" data-hide-on="trackingPeriod!=weekly" data-disable-on="trackingPeriod!=weekly">
-                <option class="monday" value="1" data-l10n-id="monday">Monday</option>
-                <option value="2" data-l10n-id="tuesday">Tuesday</option>
-                <option value="3" data-l10n-id="wednesday">Wednesday</option>
-                <option value="4" data-l10n-id="thursday">Thursday</option>
-                <option value="5" data-l10n-id="friday">Friday</option>
-                <option value="6" data-l10n-id="saturday">Saturday</option>
-                <option class="sunday" value="0" data-l10n-id="sunday">Sunday</option>
-              </select>
-            </span>
-          </div>
-          <p data-l10n-id="starting-on">Starting on</p>
-        </li>
-        <li>
-          <div class="end buttons-list">
-            <span class="button icon icon-dialog fake-select">
-              <select class="settings-option icon icon-dialog" data-option="resetTime" data-hide-on="trackingPeriod!=monthly" data-disable-on="trackingPeriod!=monthly">
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
-                <option value="6">6</option>
-                <option value="7">7</option>
-                <option value="8">8</option>
-                <option value="9">9</option>
-                <option value="10">10</option>
-                <option value="11">11</option>
-                <option value="12">12</option>
-                <option value="13">13</option>
-                <option value="14">14</option>
-                <option value="15">15</option>
-                <option value="16">16</option>
-                <option value="17">17</option>
-                <option value="18">18</option>
-                <option value="19">19</option>
-                <option value="20">20</option>
-                <option value="21">21</option>
-                <option value="22">22</option>
-                <option value="23">23</option>
-                <option value="24">24</option>
-                <option value="25">25</option>
-                <option value="26">26</option>
-                <option value="27">27</option>
-                <option value="28">28</option>
-                <option value="29">29</option>
-                <option value="30">30</option>
-                <option value="31">31</option>
-              </select>
-            </span>
-          </div>
-          <p data-l10n-id="starting-on">Starting on</p>
-        </li>
-        <li>
-          <label class="end">
-            <input class="settings-option" data-option="dataLimit" type="checkbox" data-type="switch">
-            <span></span>
-          </label>
-          <p data-l10n-id="data-limit-alert">Data use alert</p>
-        </li>
-        <li>
-          <div class="end buttons-list">
-            <button class="settings-option icon icon-dialog" data-widget-type="data-limit"  data-disable-on="dataLimit=false" data-hide-on="dataLimit=false">
-              <span class="tag"></span>
-            </button>
-          </div>
-          <p data-l10n-id="data-limit-value2">When use is above</p>
-        </li>
-      </ul>
-      <p class="step-hint" data-l10n-id="fte-prepaid3-hint">Receive reports about your Internet usage and set an alert to avoid using too much.</p>
+      <section class="content">
+        <ul class="settings">
+          <li>
+            <div class="end buttons-list">
+              <span class="button icon icon-dialog fake-select">
+                <select class="settings-option" data-option="trackingPeriod">
+                  <option value="monthly" data-l10n-id="monthly">Monthly</option>
+                  <option value="weekly" data-l10n-id="weekly">Weekly</option>
+                  <option value="never" data-l10n-id="never">Never</option>
+                </select>
+              </span>
+            </div>
+            <p data-l10n-id="reset-report">Reset report</p>
+          </li>
+          <li>
+            <div class="end buttons-list">
+              <span class="button icon icon-dialog fake-select">
+                <select id="pre3-select-weekday" class="settings-option" data-option="resetTime" data-hide-on="trackingPeriod!=weekly" data-disable-on="trackingPeriod!=weekly">
+                  <option class="monday" value="1" data-l10n-id="monday">Monday</option>
+                  <option value="2" data-l10n-id="tuesday">Tuesday</option>
+                  <option value="3" data-l10n-id="wednesday">Wednesday</option>
+                  <option value="4" data-l10n-id="thursday">Thursday</option>
+                  <option value="5" data-l10n-id="friday">Friday</option>
+                  <option value="6" data-l10n-id="saturday">Saturday</option>
+                  <option class="sunday" value="0" data-l10n-id="sunday">Sunday</option>
+                </select>
+              </span>
+            </div>
+            <p data-l10n-id="starting-on">Starting on</p>
+          </li>
+          <li>
+            <div class="end buttons-list">
+              <span class="button icon icon-dialog fake-select">
+                <select class="settings-option icon icon-dialog" data-option="resetTime" data-hide-on="trackingPeriod!=monthly" data-disable-on="trackingPeriod!=monthly">
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                  <option value="7">7</option>
+                  <option value="8">8</option>
+                  <option value="9">9</option>
+                  <option value="10">10</option>
+                  <option value="11">11</option>
+                  <option value="12">12</option>
+                  <option value="13">13</option>
+                  <option value="14">14</option>
+                  <option value="15">15</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                  <option value="21">21</option>
+                  <option value="22">22</option>
+                  <option value="23">23</option>
+                  <option value="24">24</option>
+                  <option value="25">25</option>
+                  <option value="26">26</option>
+                  <option value="27">27</option>
+                  <option value="28">28</option>
+                  <option value="29">29</option>
+                  <option value="30">30</option>
+                  <option value="31">31</option>
+                </select>
+              </span>
+            </div>
+            <p data-l10n-id="starting-on">Starting on</p>
+          </li>
+          <li>
+            <label class="end">
+              <input class="settings-option" data-option="dataLimit" type="checkbox" data-type="switch">
+              <span></span>
+            </label>
+            <p data-l10n-id="data-limit-alert">Data use alert</p>
+          </li>
+          <li>
+            <div class="end buttons-list">
+              <button class="settings-option icon icon-dialog" data-widget-type="data-limit"  data-disable-on="dataLimit=false" data-hide-on="dataLimit=false">
+                <span class="tag"></span>
+              </button>
+            </div>
+            <p data-l10n-id="data-limit-value2">When use is above</p>
+          </li>
+        </ul>
+        <p class="step-hint" data-l10n-id="fte-prepaid3-hint">Receive reports about your Internet usage and set an alert to avoid using too much.</p>
+      </section>
       <menu data-items="2">
         <button data-navigation="back">
           <span></span>
@@ -349,24 +353,26 @@
       <header>
         <h1 data-l10n-id="fte-postpaid3-title">Data Alert</h1>
       </header>
-      <ul class="content settings">
-        <li>
-          <label class="end">
-            <input class="settings-option" data-option="dataLimit" type="checkbox" data-type="switch">
-            <span></span>
-          </label>
-          <p data-l10n-id="data-limit-alert">Data use alert</p>
-        </li>
-        <li>
-          <div class="end buttons-list">
-            <button class="settings-option icon icon-dialog" data-widget-type="data-limit" data-disable-on="dataLimit=false" data-hide-on="dataLimit=false">
-              <span class="tag"></span>
-            </button>
-          </div>
-          <p data-l10n-id="data-limit-value2">When use is above</p>
-        </li>
-      </ul>
-      <p class="step-hint" data-l10n-id="fte-postpaid3-hint">Set an alert to avoid using too much data.</p>
+      <section class="content">
+        <ul class="settings">
+          <li>
+            <label class="end">
+              <input class="settings-option" data-option="dataLimit" type="checkbox" data-type="switch">
+              <span></span>
+            </label>
+            <p data-l10n-id="data-limit-alert">Data use alert</p>
+          </li>
+          <li>
+            <div class="end buttons-list">
+              <button class="settings-option icon icon-dialog" data-widget-type="data-limit" data-disable-on="dataLimit=false" data-hide-on="dataLimit=false">
+                <span class="tag"></span>
+              </button>
+            </div>
+            <p data-l10n-id="data-limit-value2">When use is above</p>
+          </li>
+        </ul>
+        <p class="step-hint" data-l10n-id="fte-postpaid3-hint">Set an alert to avoid using too much data.</p>
+      </section>
       <menu data-items="2">
         <button data-navigation="back">
           <span></span>

--- a/apps/costcontrol/style/app.css
+++ b/apps/costcontrol/style/app.css
@@ -81,7 +81,7 @@ input.error {
   overflow-y: auto;
   position: absolute;
   bottom: 0;
-  top: 0rem;
+  top: 0;
   left: 0;
   right: 0;
 }

--- a/apps/costcontrol/style/views/firsttime.css
+++ b/apps/costcontrol/style/views/firsttime.css
@@ -62,9 +62,16 @@ body[role="application"] [role="dialog"] {
 
 /* Content */
 #firsttime-view .content {
-  padding: 3.5rem 1.5rem 0;
+  padding: 0 1.5rem 0;
+  margin-top: 3.5rem;
   list-style: none;
-  margin: 0;
+}
+
+/* Wrapper with scroll */
+#firsttime-view section.content {
+  -moz-box-sizing: border-box;
+  max-height: calc(100% - 5rem - 3.5rem - 6.8rem); /* window height - header height - steps progress - menu height  */
+  overflow-x: auto;
 }
 
 #firsttime-view .content h2 {
@@ -160,14 +167,6 @@ body[role="application"] [role="dialog"] {
 #firsttime-view .settings li {
   padding-left: 0;
   padding-right: 0;
-}
-
-#firsttime-view .settings li label.end {
-  margin-right: 0.5rem;
-}
-
-#firsttime-view .settings li > .end {
-  right: 0;
 }
 
 .step-hint {

--- a/apps/costcontrol/style/views/settings.css
+++ b/apps/costcontrol/style/views/settings.css
@@ -43,8 +43,13 @@
   min-height: 3.6rem;
 }
 
+.settings li p {
+  overflow: hidden;
+}
+
 .settings li p:only-of-type {
-  line-height: 3.6rem;
+  padding-top: 0.8rem;
+  line-height: 2rem;
 }
 
 .settings li[aria-disabled="true"]:after {
@@ -71,15 +76,14 @@
 
 /* End elements */
 .settings li > .end {
-  position: absolute;
-  right: 0;
-  top: 50%;
+  position: relative;
   height: 4.6rem;
-  margin-top: -2.3rem;
+  float: right;
+  margin: -0.5rem 0.4rem -0.5rem;
 }
 
-.settings li > .end.switch {
-  right: 0.5rem;
+.settings li > label.end {
+  margin-right: 0.5rem;
 }
 
 .settings li > .end:before {


### PR DESCRIPTION
I've created a new modifier for `.content` in `firsttime.css`. When it is used by a `<section>` applies vertical scroll overflow keeping a safe area equal to our persitant UI elements (header, progress steps and menu actions)
