### PR TITLE
Bug 863466 - [system] focus the alert/confirm/etc dialogs so that the ke...

### DIFF
--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -188,7 +188,8 @@
     -->
     </section>
 
-    <form role="dialog" id="modal-dialog-confirm" data-type="confirm" hidden>
+    <form role="dialog" id="modal-dialog-confirm" data-type="confirm"
+      tabindex="-1" hidden>
       <!-- <section>
              <p><span id="modal-dialog-confirm-message"></span></p>
            </section>
@@ -198,7 +199,8 @@
            </menu> -->
     </form>
 
-    <form role="dialog" id="modal-dialog-alert" data-type="confirm" hidden>
+    <form role="dialog" id="modal-dialog-alert" data-type="confirm"
+      tabindex="-1" hidden>
     <!--
       <section>
         <p><span id="modal-dialog-alert-message"></span></p>
@@ -209,7 +211,8 @@
     -->
     </form>
 
-    <form role="dialog" id="modal-dialog-prompt" data-type="confirm" hidden>
+    <form role="dialog" id="modal-dialog-prompt" data-type="confirm"
+      tabindex="-1" hidden>
     <!--
       <section>
         <p>
@@ -226,7 +229,8 @@
     -->
     </form>
 
-    <form role="dialog" id="modal-dialog-custom-prompt" data-type="confirm" hidden>
+    <form role="dialog" id="modal-dialog-custom-prompt" data-type="confirm"
+      tabindex="-1" hidden>
     <!--
       <section>
         <p><span id="modal-dialog-custom-prompt-message"></span></p>

--- a/apps/browser/js/modal_dialog.js
+++ b/apps/browser/js/modal_dialog.js
@@ -107,13 +107,14 @@ var ModalDialog = {
       case 'alert':
         elements.alertMessage.innerHTML = message;
         elements.alert.hidden = false;
+        elements.alert.focus();
         break;
 
       case 'prompt':
         elements.prompt.hidden = false;
         elements.promptInput.value = evt.detail.initialValue;
         elements.promptMessage.innerHTML = message;
-        elements.promptInput.focus();
+        elements.prompt.focus();
         break;
 
       case 'custom-prompt':
@@ -153,11 +154,14 @@ var ModalDialog = {
           // We assume that checkbox custom message is already translated
           checkbox.nextElementSibling.textContent = prompt.checkboxMessage;
         }
+
+        elements.customPrompt.focus();
         break;
 
       case 'confirm':
         elements.confirm.hidden = false;
         elements.confirmMessage.innerHTML = message;
+        elements.confirm.focus();
         break;
     }
   },

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -577,7 +577,7 @@
         </div>
 
         <div id="modal-dialog">
-          <div id="modal-dialog-alert" role="dialog">
+          <div id="modal-dialog-alert" role="dialog" tabindex="-1">
             <div class="modal-dialog-message-container inner">
               <h3 id="modal-dialog-alert-title"></h3>
               <p>
@@ -589,7 +589,7 @@
             </menu>
           </div>
 
-          <div id="modal-dialog-confirm" role="dialog">
+          <div id="modal-dialog-confirm" role="dialog" tabindex="-1">
             <div class="modal-dialog-message-container inner">
               <h3 id="modal-dialog-confirm-title"></h3>
               <p>
@@ -602,7 +602,7 @@
             </menu>
           </div>
 
-          <div id="modal-dialog-prompt" role="dialog">
+          <div id="modal-dialog-prompt" role="dialog" tabindex="-1">
             <div class="modal-dialog-message-container inner">
               <h3 id="modal-dialog-prompt-title"></h3>
               <p>
@@ -616,7 +616,7 @@
             </menu>
           </div>
 
-          <div id="modal-dialog-select-one" role="dialog">
+          <div id="modal-dialog-select-one" role="dialog" tabindex="-1">
             <div class="modal-dialog-message-container inner">
               <h3 id="modal-dialog-select-one-title"></h3>
               <ul id="modal-dialog-select-one-menu"></ul>

--- a/apps/system/js/modal_dialog.js
+++ b/apps/system/js/modal_dialog.js
@@ -207,6 +207,7 @@ var ModalDialog = {
         elements.alert.classList.add('visible');
         this.setTitle('alert', '');
         elements.alertOk.textContent = evt.yesText ? evt.yesText : _('ok');
+        elements.alert.focus();
         break;
 
       case 'prompt':
@@ -217,6 +218,7 @@ var ModalDialog = {
         elements.promptOk.textContent = evt.yesText ? evt.yesText : _('ok');
         elements.promptCancel.textContent = evt.noText ?
           evt.noText : _('cancel');
+        elements.prompt.focus();
         break;
 
       case 'confirm':
@@ -226,11 +228,13 @@ var ModalDialog = {
         elements.confirmOk.textContent = evt.yesText ? evt.yesText : _('ok');
         elements.confirmCancel.textContent = evt.noText ?
           evt.noText : _('cancel');
+        elements.confirm.focus();
         break;
 
       case 'selectone':
         this.buildSelectOneDialog(message);
         elements.selectOne.classList.add('visible');
+        elements.selectOne.focus();
         break;
     }
 


### PR DESCRIPTION
...yboard is dismissed r=alive,benfrancis

This changes the dialogs in both the browser and the system, for the apps
content and the web content.

In this patch we focus the whole dialog, so that no default action is selected
by default. This effectively fixes the initial bug, and probably makes
accessibility better, even if we'll need more work for this.
