### PR TITLE
Bug 877192 - Dont trigger the utility tray when tapping home button on GP Keon

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -54,6 +54,14 @@ var UtilityTray = {
             evt.target !== this.statusbar)
           return;
 
+        // needed for bug 877192 - GeeksPhone Keon emits touchstart on 0,0
+        // when pressing home button
+        if (evt.touches.length &&
+              evt.touches[0].screenX === 0 && evt.touches[0].screenY === 0 &&
+              evt.touches[0].clientX === 0 && evt.touches[0].clientY === 0) {
+          return;
+        }
+
         this.active = true;
         // XXX: required for Mouse2Touch fake events to function
         evt.target.setCapture(true);


### PR DESCRIPTION
Fix for [#877192](https://bugzilla.mozilla.org/show_bug.cgi?id=877192). I've verified this on two different versions of the GeeksPhone Keon. The ZTE, Alcatel and GP Peak don't have this behavior.

When you press the home button on the orange GeeksPhone a touch event is thrown at position 0,0. This gets handled by the OS as a normal touch at that position and gets translated to the element that sits at that position. In our case the utility tray. We now show the little animation that shows the utility tray when you tap it. It's easily reproducible on master branch, didn't check older versions. I couldn't find anything to distinguish this touch from any user originated ones, except that it happens at 0,0. This is probably an odd place for a human to tap the screen anyway, so I'd guess this patch is sufficient.
