### PR TITLE
Bug 871930 - Do not use SimplePhoneMatcher's variants when doing a mozContact "match" request.

### DIFF
--- a/apps/communications/dialer/js/contacts.js
+++ b/apps/communications/dialer/js/contacts.js
@@ -90,13 +90,14 @@ var Contacts = {
         filterValue: number
       };
     } else {
-      // get the phone number variants
+      // get the phone number variants (for the Facebook lookup)
       variants = SimplePhoneMatcher.generateVariants(number);
+      var sanitizedNumber = SimplePhoneMatcher.sanitizedNumber(number);
 
       options = {
         filterBy: ['tel'],
         filterOp: 'match',
-        filterValue: variants[0] // matching the shortest variant
+        filterValue: sanitizedNumber
       };
     }
 


### PR DESCRIPTION
r=gal
