### PR TITLE
Bug 829023 - [Settings] Don't use dividers to separate paragraphs in the same text block

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1862,7 +1862,23 @@
       </header>
 
       <div>
+        <header>
+          <h2 data-l10n-id="doNotTrack-dt">How does Do Not Track work?</h2>
+        </header>
         <ul>
+          <li class="description">
+            <p data-l10n-id="doNotTrack-dd1">
+              When you turn on the Do Not Track feature, your device tells every
+              website and app (as well as advertisers and other content providers)
+              that you don’t want your behavior tracked.
+            </p>
+            <p data-l10n-id="doNotTrack-dd2">
+              Turning on Do Not Track won’t affect your ability to log into
+              websites, nor cause your device to forget your private information —
+              such as the contents of shopping carts, location information, or
+              log-in information.
+          </p>
+          </li>
           <li>
             <label>
               <input type="checkbox" name="privacy.donottrackheader.enabled" />
@@ -1871,23 +1887,6 @@
             <a data-l10n-id="doNotTrack">Do Not Track</a>
           </li>
         </ul>
-
-        <dl>
-          <dt data-l10n-id="doNotTrack-dt">
-            How does Do Not Track work?
-          </dt>
-          <dd data-l10n-id="doNotTrack-dd1">
-            When you turn on the Do Not Track feature, your device tells every
-            website and app (as well as advertisers and other content providers)
-            that you don’t want your behavior tracked.
-          </dd>
-          <dd data-l10n-id="doNotTrack-dd2">
-            Turning on Do Not Track won’t affect your ability to log into
-            websites, nor cause your device to forget your private information —
-            such as the contents of shopping carts, location information, or
-            log-in information.
-          </dd>
-        </dl>
       </div>
       -->
     </section>


### PR DESCRIPTION
Bug [#829023](https://bugzilla.mozilla.org/show_bug.cgi?id=829023)
