### PR TITLE
Bug 857901: Increase keyboard character-delete speed

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -177,7 +177,7 @@ const CANDIDATE_PANEL_SWITCH_TIMEOUT = 100;
 const ACCENT_CHAR_MENU_TIMEOUT = 700;
 
 // Backspace repeat delay and repeat rate
-const REPEAT_RATE = 100;
+const REPEAT_RATE = 75;
 const REPEAT_TIMEOUT = 700;
 
 // How long to wait for more focuschange events before processing


### PR DESCRIPTION
UX informs me that 75ms seems to be a good interval, and that the
initial delay is fine where it is.
