### PR TITLE
Bug 864555 -  - [Dialer] [Regional] Display the voice mail label when calling to the VM service and the VM is not stored on the SIM

### DIFF
--- a/apps/communications/dialer/js/voicemail.js
+++ b/apps/communications/dialer/js/voicemail.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Voicemail = {
+  check: function vm_check(number, callback) {
+    // check the voicemail number if the number is in the sim card
+    var voicemail = navigator.mozVoicemail;
+    if (voicemail && voicemail.number) {
+      if (voicemail.number == number) {
+        callback(true);
+        return;
+      }
+    }
+
+    // check the voicemail number with  with the mozSetting value
+    // based on /shared/resources/apn.json
+    var settings = navigator.mozSettings;
+    var req = settings.createLock().get('ril.iccInfo.mbdn');
+
+    req.onsuccess = function getVoicemailNumber() {
+      var isVoicemailNumber = false;
+      var voicemailNumber = req.result['ril.iccInfo.mbdn'];
+
+      if (voicemailNumber === number) {
+        isVoicemailNumber = true;
+      }
+      callback(isVoicemailNumber);
+    };
+
+    req.onerror = function getVoicemailNumberError() {
+      callback(false);
+    };
+  }
+};

--- a/apps/communications/dialer/locales/shared.en-US.properties
+++ b/apps/communications/dialer/locales/shared.en-US.properties
@@ -1,6 +1,7 @@
 callAirplaneModeMessage=To make a call you need to disable airplane mode in settings.
 callAirplaneModeBtnOk=OK
 callAirplaneModeTitle=Airplane mode activated
+voiceMail=Voicemail
 emergencyNumber=Emergency number
 emergencyDialogBodyBadNumber=To make a call, the phone must be connected to a network.
 emergencyDialogBodyDeviceNotAccepted=Emergency calls are not allowed by the network.

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -29,6 +29,7 @@
     <script defer type="application/javascript" src="/dialer/js/keypad.js"></script>
     <script defer type="application/javascript" src="/dialer/js/utils.js"></script>
     <script defer type="application/javascript" src="/dialer/js/oncall.js"></script>
+    <script defer type="application/javascript" src="/dialer/js/voicemail.js"></script>
     <script defer type="application/javascript" src="/dialer/js/handled_call.js"></script>
 
     <!-- Lazy load these:

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -1,4 +1,5 @@
 requireApp('communications/dialer/js/handled_call.js');
+requireApp('communications/dialer/js/voicemail.js');
 
 requireApp('communications/dialer/test/unit/mock_keypad.js');
 requireApp('communications/dialer/test/unit/mock_call.js');
@@ -29,6 +30,7 @@ if (!this.LazyL10n) {
 }
 
 suite('dialer/handled_call', function() {
+  const VOICEMAIL_NUMBER = '123';
   var subject;
   var mockCall;
   var fakeNode;
@@ -67,6 +69,14 @@ suite('dialer/handled_call', function() {
     window.Utils = MockUtils;
 
     phoneNumber = Math.floor(Math.random() * 10000);
+
+    sinon.stub(Voicemail, 'check', function(number, callback) {
+      var isVoicemailNumber = false;
+      if (number === VOICEMAIL_NUMBER) {
+        isVoicemailNumber = true;
+      }
+      callback(isVoicemailNumber);
+    });
   });
 
   suiteTeardown(function() {
@@ -76,6 +86,7 @@ suite('dialer/handled_call', function() {
     window.KeypadManager = realKeypadManager;
     window.LazyL10n = realLazyL10n;
     window.Utils = realUtils;
+    Voicemail.check.restore();
   });
 
   setup(function() {
@@ -525,6 +536,14 @@ suite('dialer/handled_call', function() {
 
     var numberNode = fakeNode.querySelector('.numberWrapper .number');
     assert.equal(numberNode.textContent, 'emergencyNumber');
+  });
+
+  test('should display voicemail label', function() {
+    mockCall = new MockCall('123', 'dialing');
+    subject = new HandledCall(mockCall, fakeNode);
+
+    var numberNode = fakeNode.querySelector('.numberWrapper .number');
+    assert.equal(numberNode.textContent, 'voiceMail');
   });
 
   suite('additional information', function() {

--- a/apps/communications/dialer/test/unit/mock_mozVoicemail.js
+++ b/apps/communications/dialer/test/unit/mock_mozVoicemail.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var MockMozVoicemail = {
+  number: null
+};

--- a/apps/communications/dialer/test/unit/voicemail_test.js
+++ b/apps/communications/dialer/test/unit/voicemail_test.js
@@ -1,0 +1,136 @@
+requireApp('communications/dialer/js/voicemail.js');
+
+requireApp('communications/dialer/test/unit/mock_mozVoicemail.js');
+requireApp('communications/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+
+suite('dialer/voicemail', function() {
+  var realMozVoicemail;
+  var realMozSettings;
+
+  suiteSetup(function() {
+    realMozVoicemail = navigator.mozVoicemail;
+    navigator.mozVoicemail = MockMozVoicemail;
+
+    realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozVoicemail = realMozVoicemail;
+    navigator.mozSettings = realMozSettings;
+  });
+
+  suite('SIM card and mozSettings have voicemail number', function() {
+    setup(function() {
+      MockMozVoicemail.number = '123';
+      MockNavigatorSettings.createLock().set(
+        { 'ril.iccInfo.mbdn': '123' }
+      );
+    });
+
+    teardown(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.mTeardown();
+    });
+
+    test('call the voicemail number', function(done) {
+      Voicemail.check('123', function(isVoicemailNumber) {
+        assert.ok(isVoicemailNumber);
+        done();
+      });
+    });
+
+    test('call a number is not the voicemail number', function(done) {
+      Voicemail.check('1234567890', function(isVoicemailNumber) {
+        assert.isFalse(isVoicemailNumber);
+        done();
+      });
+    });
+  });
+
+  suite('SIM card has voicemail number but ' +
+        'mozSettings does not have' , function() {
+    setup(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.createLock().set(
+        { 'ril.iccInfo.mbdn': '123' }
+      );
+    });
+
+    teardown(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.mTeardown();
+    });
+
+    test('call the voicemail number', function(done) {
+      Voicemail.check('123', function(isVoicemailNumber) {
+        assert.ok(isVoicemailNumber);
+        done();
+      });
+    });
+
+    test('call a number is not the voicemail number', function(done) {
+      Voicemail.check('1234567890', function(isVoicemailNumber) {
+        assert.isFalse(isVoicemailNumber);
+        done();
+      });
+    });
+  });
+
+
+  suite('SIM card has no voicemail number but mozSettings has' , function() {
+    setup(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.createLock().set(
+        { 'ril.iccInfo.mbdn': '123' }
+      );
+    });
+
+    teardown(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.mTeardown();
+    });
+
+    test('call the voicemail number', function(done) {
+      Voicemail.check('123', function(isVoicemailNumber) {
+        assert.ok(isVoicemailNumber);
+        done();
+      });
+    });
+
+    test('call a number is not the voicemail number', function(done) {
+      Voicemail.check('1234567890', function(isVoicemailNumber) {
+        assert.isFalse(isVoicemailNumber);
+        done();
+      });
+    });
+  });
+
+  suite('SIM card and mozSettings have no voicemail number' , function() {
+    setup(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.createLock().set(
+        { 'ril.iccInfo.mbdn': '' }
+      );
+    });
+
+    teardown(function() {
+      MockMozVoicemail.number = null;
+      MockNavigatorSettings.mTeardown();
+    });
+
+    test('call the voicemail number', function(done) {
+      Voicemail.check('123', function(isVoicemailNumber) {
+        assert.isFalse(isVoicemailNumber);
+        done();
+      });
+    });
+
+    test('call a number is not the voicemail number', function(done) {
+      Voicemail.check('1234567890', function(isVoicemailNumber) {
+        assert.isFalse(isVoicemailNumber);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Show the voicemail label.

If there is no voicemail number is the sim card,
we need to check the voicemail number with the /shared/resources/apn.json file.

http://bugzil.la/864555
