### PR TITLE
Bug 877595 - Make mozContacts works again with the browser-helper extension

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -57,7 +57,6 @@ if (BROWSER) {
 
   // Enable apis use on the device
   prefs.push(["dom.sms.enabled", true]);
-  prefs.push(["dom.mozContacts.enabled", true]);
   prefs.push(["dom.mozTCPSocket.enabled", true]);
   prefs.push(["notification.feature.enabled", true]);
   prefs.push(["dom.sysmsg.enabled", true]);
@@ -70,6 +69,11 @@ if (BROWSER) {
   prefs.push(["dom.mozSettings.enabled", true]);
   prefs.push(["dom.navigator-property.disable.mozSettings", false]);
   prefs.push(["dom.mozPermissionSettings.enabled", true]);
+
+  // Contacts
+  prefs.push(["dom.mozContacts.enabled", true]);
+  prefs.push(["dom.navigator-property.disable.mozContacts", false]);
+  prefs.push(["dom.global-constructor.disable.mozContact", false]);
 }
 
 if (DEBUG) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=877595
