### PR TITLE
Bug 876774 - Use 'match' operation to find the number

### DIFF
--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -189,7 +189,7 @@
     findByPhoneNumber: function contacts_findByPhone(filterValue, callback) {
       return this.findBy({
         filterBy: ['tel'],
-        filterOp: 'equals',
+        filterOp: 'match',
         filterValue: filterValue
       }, callback);
     }


### PR DESCRIPTION
The 'match' operation is provided for 'tel' field in order to be able to
find the phone number whatever its form (national or international).
