### PR TITLE
Bug 870320 - [Email]Attachment size and attachments are not aligned properly in email composer

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -359,6 +359,7 @@
                      data-l10n-id="compose-attachments[zero]">AttachmentS:</span>
               <div class="cmp-attachment-container cmp-addr-container">
                 <div class="cmp-attachments-size">
+		  <span class="cmp-attachments-size-text"></span>
                 </div>
                 <div class="cmp-attachment-add cmp-file-add"></div>
               </div>

--- a/apps/email/js/compose-cards.js
+++ b/apps/email/js/compose-cards.js
@@ -476,7 +476,7 @@ ComposeCard.prototype = {
     var attachmentLabel =
       this.domNode.getElementsByClassName('cmp-attachment-label')[0];
     var attachmentsSize =
-      this.domNode.getElementsByClassName('cmp-attachments-size')[0];
+      this.domNode.getElementsByClassName('cmp-attachments-size-text')[0];
 
     attachmentLabel.textContent =
       mozL10n.get('compose-attachments',

--- a/apps/email/style/compose-cards.css
+++ b/apps/email/style/compose-cards.css
@@ -25,6 +25,14 @@
   float: left;
 }
 
+.cmp-attachments-size-text{
+  height: 3rem;
+  margin-left: 0.5rem;
+  line-height: 3rem;
+  border: 0 !important;
+  background: none;
+}
+
 .cmp-peep-bubble {
   float: left;
   overflow: hidden;
@@ -122,6 +130,7 @@ input.cmp-subject-text {
 .cmp-attachment-item {
   list-style-type: none;
   height: 4rem;
+  margin: 1rem;
 }
 .cmp-attachment-icon {
   background: url("images/icons/message-list-attachment.png") no-repeat scroll center transparent;
@@ -141,7 +150,7 @@ input.cmp-subject-text {
 .cmp-attachment-filesize {
   color: gray;
   display: inline-block;
-  margin-top: -3.5rem;
+  margin-top: -3rem;
   max-width: 4.5rem;
   vertical-align: middle;
 }


### PR DESCRIPTION
1) Used Span element to provide fix ".cmp-attachments-size" white space and alignment with the ".cmp-attachment-label"

2) adjusted margin top ".cmp-attachment-filesize" to make alignment with ".cmp-attachment-filename"

3) Provide margin for .cmp-attachment-item , to make sure envelope line does not touch with the remove button.

Please review
