### PR TITLE
Bug 876754 - Use comma instead of | separator in contact auto suggestion

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1385,7 +1385,7 @@ var ThreadUI = global.ThreadUI = {
       var current = tels[i];
       var number = current.value;
       var title = details.title || number;
-      var type = current.type ? (current.type + ' |') : '';
+      var type = current.type ? (current.type + ',') : '';
 
       var contactLi = document.createElement('li');
       var data = {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=876754
