### PR TITLE
Bug 872914 - [Email] Active Sync Mailbox continuously loading email when click on refresh on first auto retrieval

### DIFF
--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -3697,6 +3697,8 @@ function MailDB(testOptions, successCb, errorCb, upgradeCb) {
   };
 
   var dbVersion = CUR_VERSION;
+  if (testOptions && testOptions.dbDelta)
+    dbVersion += testOptions.dbDelta;
   if (testOptions && testOptions.dbVersion)
     dbVersion = testOptions.dbVersion;
   var openRequest = IndexedDB.open('b2g-email', dbVersion), self = this;


### PR DESCRIPTION
This has r=@asutherland from https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/201 and has been fairly extensively smoketested. Proper unit tests forthcoming.

This fixes both bug 872914 and bug 868642.
