### PR TITLE
Bug 873702 - [Email] HTML tags containing attributes without separating/delimiting whitespace will be emitted as text by the HTML sanitizer (bleach.js). r=daleharvey

### DIFF
--- a/apps/email/js/ext/mailapi/chewlayer.js
+++ b/apps/email/js/ext/mailapi/chewlayer.js
@@ -2193,37 +2193,33 @@ var HTMLParser = (function(){
   //
   // The spec defines attributes by what they must not include, which is:
   // [\0\s"'>/=] plus also no control characters, or non-unicode characters.
-  // But we currently use the same regexp as we use for tags because that's what
-  // the code was using already.
+  //
+  // The (inherited) code used to have the regular expression effectively
+  // validate the attribute syntax by including their grammer in the regexp.
+  // The problem with this is that it can make the regexp fail to match tags
+  // that are clearly tags.  When we encountered (quoted) attributes without
+  // whitespace between them, we would escape the entire tag.  Attempted
+  // trivial fixes resulted in regex back-tracking, which begged the issue of
+  // why the regex would do this in the first place.  So we stopped doing that.
   //
   // CDATA *is not a thing* in the HTML namespace.  <![CDATA[ just gets treated
   // as a "bogus comment".  See:
   // http://www.whatwg.org/specs/web-apps/current-work/multipage/tokenization.html#markup-declaration-open-state
 
-  // NOTE: tag and attr regexps changed to ignore name spaces prefixes!  via
+  // NOTE: tag and attr regexps changed to ignore name spaces prefixes!
+  //
+  // CHANGE: "we" previously required there to be white-space between attributes.
+  // Unfortunately, the world does not agree with this, so we now require
+  // whitespace only after the tag name prior to the first attribute and make
+  // the whole attribute clause optional.
+  //
   // - Regular Expressions for parsing tags and attributes
   // ^<                     anchored tag open character
   // (?:[-A-Za-z0-9_]+:)?   eat the namespace
   // ([-A-Za-z0-9_]+)       the tag name
-  // (                      repeated attributes:
-  //  (?:
-  //   \s+                  Mandatory whitespace between attribute names
-  //   (?:[-A-Za-z0-9_]+:)? optional attribute prefix
-  //   [-A-Za-z0-9_]+       attribute name
-  //   (?:                  The attribute doesn't need a value
-  //    \s*=\s*             whitespace, = to indicate value, whitespace
-  //    (?:                 attribute values:
-  //     (?:"[^"]*")|       double-quoted
-  //     (?:'[^']*')|       single-quoted
-  //     [^>\s]+            unquoted
-  //    )
-  //   )?                   (the attribute does't need a value)
-  //  )*                    (there can be multiple attributes)
-  // )                      (capture the list of attributes)
-  // \s*                    optional whitespace before the tag closer
-  // (\/?)                  optional self-closing character
+  // ([^>]*)                capture attributes and/or closing '/' if present
   // >                      tag close character
-  var startTag = /^<(?:[-A-Za-z0-9_]+:)?([-A-Za-z0-9_]+)((?:\s+(?:[-A-Za-z0-9_]+:)?[-A-Za-z0-9_]+(?:\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^>\s]+))?)*)\s*(\/?)>/,
+  var startTag = /^<(?:[-A-Za-z0-9_]+:)?([-A-Za-z0-9_]+)([^>]*)>/,
   // ^<\/                   close tag lead-in
   // (?:[-A-Za-z0-9_]+:)?   optional tag prefix
   // ([-A-Za-z0-9_]+)       tag name
@@ -2379,7 +2375,7 @@ var HTMLParser = (function(){
     // Clean up any remaining tags
     parseEndTag();
 
-    function parseStartTag( tag, tagName, rest, unary ) {
+    function parseStartTag( tag, tagName, rest ) {
       tagName = tagName.toLowerCase();
       if ( block[ tagName ] ) {
         while ( stack.last() && inline[ stack.last() ] ) {
@@ -2391,7 +2387,13 @@ var HTMLParser = (function(){
         parseEndTag( "", tagName );
       }
 
-      unary = empty[ tagName ] || !!unary;
+      var unary = empty[ tagName ];
+      // to simplify the regexp, the 'rest capture group now absorbs the /, so
+      // we need to strip it off if it's there.
+      if (rest.length && rest[rest.length - 1] === '/') {
+        unary = true;
+        rest = rest.slice(0, -1);
+      }
 
       if ( !unary )
         stack.push( tagName );


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/214
