### PR TITLE
Bug 876145: l10n, fix localizability of title in authentication dialog (browser)

### DIFF
--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -176,7 +176,7 @@
         <menu type="toolbar">
           <button id="http-authentication-ok" data-l10n-id="login">Login</button>
         </menu>
-        <h1 l10n-id="login-to-a-website">Login to a website</h1>
+        <h1 data-l10n-id="login-to-a-website">Login to a website</h1>
       </header>
       <span id="http-authentication-message"></span>
       <label data-l10n-id="username">Username


### PR DESCRIPTION
Replace l10n-id with data-l10n-id in browser. As it is, the
authentication dialog's title is always displayed in English.
