### PR TITLE
Bug 878010 - Lock screen orientation for whole phone with item in quick settings

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1366,6 +1366,16 @@
       </header>
 
       <div>
+        <ul>
+          <li>
+            <label class="pack-switch">
+              <input type="checkbox" name="screen.orientation.lock" class="uninit"/>
+              <span></span>
+            </label>
+            <a data-l10n-id="lock-orientation">Lock screen orientation</a>
+          </li>
+        </ul>
+
         <header id="wallpaper-header">
           <h2 data-l10n-id="wallpaper">Wallpaper</h2>
         </header>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -303,6 +303,7 @@ two-minutes  =  2 minutes
 five-minutes =  5 minutes
 ten-minutes  = 10 minutes
 never=never
+lock-orientation=Lock orientation
 
 # Personalization :: Notifications
 notifications=Notifications


### PR DESCRIPTION
Proposed fix for [#878010](https://bugzilla.mozilla.org/show_bug.cgi?id=878010). This adds a setting `screen.lock` which allows you to set a global screen orientation lock for all apps that don't specify an orientation lock themselves. Plus an item in quick settings to control it.

For now I've chosen the airplane icon for this mode because don't want to spend too much time on a proposal. So to lock orientation choose the second airplane :) .
