### PR TITLE
Bug 877751 - Handle Cell Broadcast System messages in the system app.

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -126,6 +126,9 @@
     <!-- Authentication Dialog-->
     <script defer src="js/authentication_dialog.js"></script>
 
+    <!-- Cell Broadcast System -->
+    <script defer src="js/cell_broadcast_system.js"></script>
+
     <!-- Value selector -->
     <link rel="stylesheet" type="text/css" href="style/value_selector/value_selector.css">
     <link rel="stylesheet" type="text/css" href="style/value_selector/time_picker.css">

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -41,6 +41,7 @@ var AttentionScreen = {
     window.addEventListener('home', this.hide.bind(this));
     window.addEventListener('holdhome', this.hide.bind(this));
     window.addEventListener('appwillopen', this.appOpenHandler.bind(this));
+    window.addEventListener('emergencyalert', this.hide.bind(this));
 
     window.addEventListener('will-unlock', this.screenUnlocked.bind(this));
   },

--- a/apps/system/js/cell_broadcast_system.js
+++ b/apps/system/js/cell_broadcast_system.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var CellBroadcastSystem = {
+
+  _sound: 'style/notifications/ringtones/notifier_exclamation.ogg',
+
+  init: function cbs_init() {
+    if (navigator && navigator.mozCellBroadcast) {
+      navigator.mozCellBroadcast.onreceived = this.show.bind(this);
+    }
+  },
+
+  show: function cbs_show(event) {
+    var conn = window.navigator.mozMobileConnection;
+    var msg = event.message;
+
+    if (conn &&
+        conn.voice.network.mcc === MobileOperator.BRAZIL_MCC &&
+        msg.messageId === MobileOperator.BRAZIL_CELLBROADCAST_CHANNEL) {
+      LockScreen.setCellbroadcastLabel(msg.body);
+      return;
+    }
+
+    var title = navigator.mozL10n.get('system-alert');
+    var showDialog = function() {
+      ModalDialog.showWithPseudoEvent({
+        title: title,
+        text: msg.body,
+        type: 'alert'
+      });
+    };
+
+    // If we are not inside the lockscreen, show the dialog
+    // immediately, dispatch an event to hide
+    if (!LockScreen.locked) {
+      this.dispatchEvent('emergencyalert');
+      this.playNotification();
+      showDialog();
+      return;
+    }
+
+    // If we are on the lock screen then create a notification
+    // that invokes the dialog
+    var notification = NotificationScreen.addNotification({
+      title: title,
+      text: msg.body
+    });
+    notification.addEventListener('tap', showDialog);
+  },
+
+  playNotification: function cbs_playNotification() {
+    var ringtonePlayer = new Audio();
+    ringtonePlayer.src = this._sound;
+    ringtonePlayer.mozAudioChannelType = 'notification';
+    ringtonePlayer.play();
+    window.setTimeout(function smsRingtoneEnder() {
+      ringtonePlayer.pause();
+      ringtonePlayer.src = '';
+    }, 2000);
+  },
+
+  dispatchEvent: function cbs_dispatchEvent(name, detail) {
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent(name, true, true, detail);
+    window.dispatchEvent(evt);
+  }
+};
+
+CellBroadcastSystem.init();

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -163,17 +163,6 @@ var LockScreen = {
     }
 
     var self = this;
-    if (navigator && navigator.mozCellBroadcast) {
-      navigator.mozCellBroadcast.onreceived = function onReceived(event) {
-        var msg = event.message;
-        if (conn &&
-            conn.voice.network.mcc === MobileOperator.BRAZIL_MCC &&
-            msg.messageId === MobileOperator.BRAZIL_CELLBROADCAST_CHANNEL) {
-          self.cellbroadcastLabel = msg.body;
-          self.updateConnState();
-        }
-      };
-    }
 
     SettingsListener.observe('lockscreen.enabled', true, function(value) {
       self.setEnabled(value);
@@ -1058,6 +1047,13 @@ var LockScreen = {
       container.removeEventListener(e.type, animationend);
       overlay.classList.remove('elastic');
     });
+  },
+
+  // Used by CellBroadcastSystem to notify the lockscreen of
+  // any incoming CB messages that need to be displayed.
+  setCellbroadcastLabel: function ls_setCellbroadcastLabel(label) {
+    this.cellbroadcastLabel = label;
+    this.updateConnState();
   }
 };
 

--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -26,6 +26,7 @@ var UtilityTray = {
     }, this);
 
     window.addEventListener('screenchange', this);
+    window.addEventListener('emergencyalert', this);
     window.addEventListener('home', this);
     window.addEventListener('attentionscreenshow', this);
 
@@ -36,6 +37,7 @@ var UtilityTray = {
     switch (evt.type) {
       case 'attentionscreenshow':
       case 'home':
+      case 'emergencyalert':
         if (this.shown) {
           this.hide();
         }

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -338,3 +338,6 @@ free-space[few]=Less than {{value}} {{unit}} remaining.
 free-space[many]=Less than {{value}} {{unit}} remaining.
 free-space[other]=Less than {{value}} {{unit}} remaining.
 unknown-free-space=Unknown remaining space.
+
+# Cell Broadcast System
+system-alert=System Alert


### PR DESCRIPTION
We do not distinguish between message classes as specified (and
previously implemented).

If a message is received while in the lockscreen then a notification
is sent which wakes the screen, sounds a notification and displays
it on the lock screen, clicking on the notification will then show
a dialog with a full message.

If we are currently using the device the dialog will be displayed
immediately.
