### PR TITLE
Bug 877615 - [MMS] New message composer: Recipients field stays expanded after discarding a previous multi recipient message

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -218,6 +218,7 @@ var ThreadUI = global.ThreadUI = {
 
     if (this.recipients) {
       this.recipients.length = 0;
+      this.recipients.visible('singleline');
       this.recipients.focus();
     } else {
       this.recipients = new Recipients({

--- a/apps/sms/test/unit/mock_recipients.js
+++ b/apps/sms/test/unit/mock_recipients.js
@@ -27,6 +27,10 @@ MockRecipients.prototype.focus = function() {
   return this;
 };
 
+MockRecipients.prototype.visible = function() {
+  return this;
+};
+
 MockRecipients.prototype.on = function(event, callback) {
   this.events[event].push(callback);
   return this;


### PR DESCRIPTION
Set the visible style to "singleline" when go into New message view.
Note: Since we reset the length of recipient to zero, we should set the visible style to "singleline".
