### PR TITLE
Bug 878662 - [System][Sound Manager] CEWarningDialog is displayed at CEW...

### DIFF
--- a/apps/system/js/sound_manager.js
+++ b/apps/system/js/sound_manager.js
@@ -134,7 +134,7 @@
   }
 
   function headsetVolumeup() {
-    if (currentVolume[getChannel()] >= CEWarningVol &&
+    if ((currentVolume[getChannel()] + 1) >= CEWarningVol &&
         getChannel() == 'content') {
       if (CEAccumulatorTime == 0) {
         var okfn = function() {
@@ -210,7 +210,7 @@
   function resetToCEMaxVolume(callback) {
     pendingRequestCount++;
     var req = SettingsListener.getSettingsLock().set({
-      'audio.volume.content': CEWarningVol
+      'audio.volume.content': CEWarningVol - 1
     });
 
     req.onsuccess = function onSuccess() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=878662
1. Title : [System][Sound Manager] CEWarningDialog is displayed at CEWarningVol + 1.
2. Precondition : Start playing video with earphone plugged in with low volume.
3. Tester's Action : Increase volume up to CEWarningVol.
4. Detailed Symptom (ENG.) : Notice the warning dialog is not displayed at CEWarningVol, but is displayed at CEWarningVol + 1.
5. Expected : The warning dialog should be displayed at CEWarningVol.
   6.Reproducibility: Y
          1)Frequency Rate : 100%
   7.
   Mozilla build ID: 20130526070207
   QCT Gaia Revision : 4d10e1297b859cacc174c0a54af61a7678d7c32d
   8.Personal email id:  hanj.kim25@gmail.com

This is because in headsetVolumeup function of sound_manager.js, the current volume is compared with CEWarningVol, when currentVolume + 1 should be compared.

  function headsetVolumeup() {
    if (currentVolume[getChannel()] >= CEWarningVol &&
        getChannel() == 'content') {

Similarly, in resetToCEMaxVolume function the Max Safe volume should be the one below the CEWarningVol.
Therefore, the code should be the following.

```
var req = SettingsListener.getSettingsLock().set({
  'audio.volume.content': CEWarningVol - 1
});
```
