### PR TITLE
Bug 873931 - Statusbar does not show when fullscreen is canceled.

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -340,6 +340,8 @@ var StatusBar = {
         if (this.screen.classList.contains('fullscreen-app') ||
             document.mozFullScreen) {
           this.hide();
+        } else {
+          this.show();
         }
 
         this.clock.start(this.update.time.bind(this));


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=873931
1. Title : [System][Statusbar] Statusbar does not show when fullscreen is canceled.
2. Precondition : Run an app that has an option to turn fullscreen mode on/off.
3. Tester's Action : Turn fullscreen mode on and off.
4. Detailed Symptom (ENG.) : Observe the statusbar is not displayed. Instead, you can see through the homescrean background.
5. Expected : The statusbar should be displayed.
   6.Reproducibility: Y
          1)Frequency Rate : 100%
   7.Gaia Revision: a503d9a1d0a588f3689243c1ddc0f016ede51b9d
   8.Personal email id:  hanj.kim25@gmail.com

This is a regression from Bug 834765.
