### PR TITLE
Bug 856074 - Controls on the call screen should be disabled until the call is reported connecting when dialing emergency number in airplane mode (r=etiennesegonzac)

### DIFF
--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -238,15 +238,6 @@ var OnCallHandler = (function onCallHandler() {
       telephony.muted = false;
     }
 
-    // Animating the screen in the viewport.
-    // We wait for the next tick because we may receive an exitCallScreen
-    // as soon as we're loaded.
-    setTimeout(function nextTick() {
-      if (!closing) {
-        toggleScreen();
-      }
-    });
-
     postToMainWindow('ready');
   }
 
@@ -294,6 +285,9 @@ var OnCallHandler = (function onCallHandler() {
       exitCallScreen(false);
     } else {
       CallScreen.calls.dataset.count = handledCalls.length;
+      if (!displayed && !closing) {
+        toggleScreen();
+      }
     }
   }
 


### PR DESCRIPTION
Once bug 823958 has been successfully solved, we move the toggleScreen() function to the oncallschanged handler since it is assured that it is called at least once (even with an empty call array).
