### PR TITLE
Bug 879187 - Re-render suggestion list after switching to new keyboard type

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -50,7 +50,11 @@
     displaysCandidates: displaysCandidates,
     click: click,
     select: select,
-    setLayoutParams: setLayoutParams
+    setLayoutParams: setLayoutParams,
+    rerenderCandidates: function() {
+      if (worker)
+        worker.postMessage({cmd: 'predict', args: [wordBeforeCursor()]});
+    }
   };
 
   // This is the object that is passed to init().
@@ -642,6 +646,7 @@
     // passing this data to the prediction engine if nothing has changed.
     var newmap = nearbyKeys(params);
     var serialized = JSON.stringify(newmap);
+
     if (serialized === serializedNearbyKeyMap)
       return;
 

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -750,10 +750,11 @@ function renderKeyboard(keyboardName) {
     IMERender.ime.classList.remove('full-candidate-panel');
 
     // And draw the layout
+    var showCandidatePanel = needsCandidatePanel();
     IMERender.draw(currentLayout, {
       uppercase: isUpperCase,
       inputType: currentInputType,
-      showCandidatePanel: needsCandidatePanel()
+      showCandidatePanel: showCandidatePanel
     });
 
     IMERender.setUpperCaseLock(isUpperCaseLocked ? 'locked' : isUpperCase);
@@ -764,6 +765,11 @@ function renderKeyboard(keyboardName) {
 
     // Tell the input method about the new keyboard layout
     updateLayoutParams();
+
+    if (showCandidatePanel && inputMethod.rerenderCandidates) {
+      // we switched keyboards, and need to re-render candidates
+      inputMethod.rerenderCandidates();
+    }
 
     isKeyboardRendered = true;
   }


### PR DESCRIPTION
Fix for [#879187](https://bugzilla.mozilla.org/show_bug.cgi?id=879187). At the moment the suggestion list disappears because the complete keyboard layout gets [re-rendered](https://github.com/mozilla-b2g/gaia/blob/master/apps/keyboard/js/render.js#L157). This patch instructs the worker to re-render the list of suggestions after keyboard has been switched.
