### PR TITLE
Bug 874273 - [Lockscreen] Display cell broadcast information only on 2G mode

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -110,6 +110,11 @@ var LockScreen = {
   */
   HANDLE_MAX: 70,
 
+  /*
+  * Types of 2G Networks
+  */
+  NETWORKS_2G: ['gsm', 'gprs', 'edge'],
+
   /**
    * Object used for handling the clock UI element, wraps all related timers
    */
@@ -894,9 +899,14 @@ var LockScreen = {
       }
 
       var operatorInfos = MobileOperator.userFacingInfo(conn);
-      if (this.cellbroadcastLabel) {
+      var is2G = this.NETWORKS_2G.some(function checkConnectionType(elem) {
+        return (conn.voice.type == elem);
+      });
+      if (this.cellbroadcastLabel && is2G) {
+        self.connstate.classList.add('twolines');
         connstateLine2.textContent = this.cellbroadcastLabel;
       } else if (operatorInfos.carrier) {
+        self.connstate.classList.add('twolines');
         connstateLine2.textContent = operatorInfos.carrier + ' ' +
           operatorInfos.region;
       }

--- a/apps/system/test/unit/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen_test.js
@@ -1,0 +1,104 @@
+'use strict';
+requireApp('system/test/unit/mock_clock.js', function() {
+  window.realClock = window.Clock;
+  window.Clock = MockClock;
+requireApp('system/js/lockscreen.js');
+});
+
+requireApp('system/test/unit/mock_l10n.js');
+requireApp('system/test/unit/mock_mobile_connection.js');
+requireApp('system/test/unit/mock_mobile_operator.js');
+requireApp('system/test/unit/mock_ftu_launcher.js');
+
+
+if (!this.MobileOperator) {
+  this.MobileOperator = null;
+}
+
+if (!this.FtuLauncher) {
+  this.FtuLauncher = null;
+}
+
+
+suite('system/LockScreen >', function() {
+  var subject;
+  var realL10n;
+  var realMobileOperator;
+  var realMobileConnection;
+  var realClock;
+  var realFtuLauncher;
+  var domConnstate;
+  var domConnstateL1;
+  var domConnstateL2;
+  var DUMMYTEXT1 = 'foo';
+
+  setup(function() {
+    subject = window.LockScreen;
+
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = window.MockL10n;
+
+    realMobileOperator = window.MobileOperator;
+    window.MobileOperator = MockMobileOperator;
+
+    realClock = window.Clock;
+    window.Clock = MockClock;
+
+    realFtuLauncher = window.FtuLauncher;
+    window.FtuLauncher = MockFtuLauncher;
+
+    realMobileConnection = window.navigator.mozMobileConnection;
+
+    domConnstate = document.createElement('div');
+    domConnstate.id = 'lockscreen-connstate';
+    domConnstateL1 = document.createElement('div');
+    domConnstateL2 = document.createElement('div');
+    domConnstate.appendChild(domConnstateL1);
+    domConnstate.appendChild(domConnstateL2);
+    document.body.appendChild(domConnstate);
+
+    subject.connstate = domConnstate;
+
+  });
+
+  test('2G Mode: should update cell broadcast info on connstate Line 2',
+  function() {
+    window.navigator.mozMobileConnection = {
+      voice: {
+        connected: 'true',
+        type: 'gsm'
+      }
+    };
+    subject.cellbroadcastLabel = DUMMYTEXT1;
+    subject.updateConnState();
+    assert.equal(domConnstateL2.textContent, DUMMYTEXT1);
+  });
+
+  test('3G Mode: should update carrier and region info on connstate Line 2',
+  function() {
+    window.navigator.mozMobileConnection = {
+      voice: {
+        connected: 'true',
+        type: 'wcdma'
+      }
+    };
+    var carrier = 'TIM';
+    var region = 'SP';
+    var exceptedText = 'TIM SP';
+    MobileOperator.mCarrier = carrier;
+    MobileOperator.mRegion = region;
+    subject.cellbroadcastLabel = DUMMYTEXT1;
+    subject.updateConnState();
+    assert.equal(domConnstateL2.textContent, exceptedText);
+  });
+
+  teardown(function() {
+    navigator.mozL10n = realL10n;
+    window.MobileOperator = realMobileOperator;
+    window.navigator.mozMobileConnection = realMobileConnection;
+    window.Clock = window.realClock;
+    window.FtuLauncher = realFtuLauncher;
+
+    document.body.removeChild(domConnstate);
+  });
+});

--- a/apps/system/test/unit/mock_clock.js
+++ b/apps/system/test/unit/mock_clock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function MockClock() {
+  this.membervariable = 0;
+}

--- a/apps/system/test/unit/mock_ftu_launcher.js
+++ b/apps/system/test/unit/mock_ftu_launcher.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var MockFtuLauncher = {
+  isFtuRunning: function() {
+    return false;
+  }
+};


### PR DESCRIPTION
Notice:
Although the CellBroadcast event listener has already been done before, given no real cell broadcast signal, this patch is confirmed only by unit test.
