### PR TITLE
Bug 877969 - [Buri][call log]The missed call log shows abnormally and cannot be delete (r=etiennesegonzac)

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -166,7 +166,10 @@ HandledCall.prototype.remove = function hc_remove() {
 };
 
 HandledCall.prototype.connected = function hc_connected() {
-  this.recentsEntry.type += '-connected';
+  if (this.recentsEntry &&
+    (this.recentsEntry.type.indexOf('-connected') == -1)) {
+    this.recentsEntry.type += '-connected';
+  }
 
   if (!this.node)
     return;

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -270,9 +270,9 @@ suite('dialer/handled_call', function() {
     });
   });
 
-
   suite('holding', function() {
     setup(function() {
+      mockCall._connect();
       mockCall._hold();
     });
 
@@ -284,6 +284,8 @@ suite('dialer/handled_call', function() {
   suite('resuming', function() {
     setup(function() {
       MockCallScreen.mSyncSpeakerCalled = false;
+      mockCall._connect();
+      mockCall._hold();
       mockCall._resume();
     });
 
@@ -293,6 +295,10 @@ suite('dialer/handled_call', function() {
 
     test('sync speaker', function() {
       assert.isTrue(MockCallScreen.mSyncSpeakerCalled);
+    });
+
+    test('multiple hold resume should not affect the recentEntry type', function() {
+      assert.equal(subject.recentsEntry.type, 'dialing-connected');
     });
   });
 

--- a/apps/communications/dialer/test/unit/mock_call.js
+++ b/apps/communications/dialer/test/unit/mock_call.js
@@ -54,7 +54,7 @@ function MockCall(aNumber, aState) {
     if (this._handler) {
       this.state = 'resuming';
       this._handler.handleEvent({call: this});
-      this.state = 'resumed';
+      this.state = 'connected';
       this._handler.handleEvent({call: this});
     }
   }).bind(this);


### PR DESCRIPTION
Avoiding several holding and resuming to add the '-connected' string to to the end of HandleCall's recentEntry's type ;-)

Each time a call is resumed a new 'connected' call state change is notified (not a 'resumed' one).

Unit test included.
