### PR TITLE
add double quotes to nodejs and npm paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,8 +517,8 @@ tests: webapp-manifests offline
 
 .PHONY: common-install
 common-install:
-	@test -x $(NODEJS) || (echo "Please Install NodeJS -- (use aptitude on linux or homebrew on osx)" && exit 1 )
-	@test -x $(NPM) || (echo "Please install NPM (node package manager) -- http://npmjs.org/" && exit 1 )
+	@test -x "$(NODEJS)" || (echo "Please Install NodeJS -- (use aptitude on linux or homebrew on osx)" && exit 1 )
+	@test -x "$(NPM)" || (echo "Please install NPM (node package manager) -- http://npmjs.org/" && exit 1 )
 
 	cd $(TEST_AGENT_DIR) && npm install .
 


### PR DESCRIPTION
fix the problem when path contains whitespaces
