### PR TITLE
Bug 877145 - [SMS] [regression] Carrier display in contact search / thread headers

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -171,9 +171,13 @@
         // Carrier logic
         if (name) {
           // Check if other phones with same type and carrier
+          // Convert the tel-type to string before tel-type comparison.
+          // TODO : We might need to handle multiple tel type in the future.
           for (i = 0; i < length; i++) {
+            var telType = contact.tel[i].type.toString();
+            var phoneType = phone.type.toString();
             if (contact.tel[i].value !== phone.value &&
-                contact.tel[i].type === phone.type &&
+                telType === phoneType &&
                 contact.tel[i].carrier === phone.carrier) {
               carrier = phone.value;
             }

--- a/apps/sms/test/unit/mock_contact.js
+++ b/apps/sms/test/unit/mock_contact.js
@@ -20,12 +20,12 @@ function MockContact(name) {
   this.tel = [
     {
       'value': '+346578888888',
-      'type': 'Mobile',
+      'type': ['Mobile'],
       'carrier': 'TEF'
     },
     {
       'value': '+12125559999',
-      'type': 'Batphone',
+      'type': 'Batphone', // Make sure we cover both strings and arrays
       'carrier': 'XXX'
     }
   ];

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -216,6 +216,26 @@ suite('Utils', function() {
 
     });
 
+    test('(number, contact (has another number with same type and carrier))',
+         function() {
+      var contact = new MockContact();
+      contact.tel[2] = {
+        'value': '+346578889999',
+        'type': ['Mobile'],
+        'carrier': 'TEF'
+      };
+
+      var details = Utils.getContactDetails('+346578888888', contact);
+      assert.deepEqual(details, {
+        isContact: true,
+        title: 'Pepito Grillo',
+        name: 'Pepito Grillo',
+        org: '',
+        carrier: 'Mobile | +346578888888'
+      });
+
+    });
+
     test('(number, contact, { photoURL: true })', function() {
       var contact = new MockContact();
       contact.photo = [


### PR DESCRIPTION
A workaround for contact type issue. Convert the type to string every time before type comparison.
