### PR TITLE
Bug 877956 - [Dialer] Save wrong contact name in Call log

### DIFF
--- a/apps/communications/dialer/js/contacts.js
+++ b/apps/communications/dialer/js/contacts.js
@@ -136,7 +136,7 @@ var Contacts = {
       });
 
       // Finding the best match
-      var matchResult = SimplePhoneMatcher.bestMatch(variants, matches);
+      var matchResult = SimplePhoneMatcher.bestMatch(number, variants, matches);
 
       var contact = request.result[matchResult.bestMatchIndex];
       var contactsWithSameNumber;

--- a/apps/communications/dialer/js/suggestion_bar.js
+++ b/apps/communications/dialer/js/suggestion_bar.js
@@ -113,7 +113,8 @@ var SuggestionBar = {
     var matches = contact.tel.map(function getNumber(tel) {
         return tel.value;
       });
-    var matchResult = SimplePhoneMatcher.bestMatch(variants, [matches]);
+    var matchResult = SimplePhoneMatcher.
+                      bestMatch(this._phoneNumber, variants, [matches]);
     // use first phone number if bestMatch can't give us localIndex
     var matchedTel = (matchResult.localIndex != null) ?
                  tel[matchResult.localIndex] : tel[0];

--- a/apps/communications/dialer/test/unit/simple_phone_matcher_test.js
+++ b/apps/communications/dialer/test/unit/simple_phone_matcher_test.js
@@ -200,7 +200,9 @@ suite('lib/simple_phone_matcher', function() {
         bestMatchIndex: bestMatchIndex,
         localIndex: localIndex
       };
-      assert.deepEqual(result, SimplePhoneMatcher.bestMatch(variants, matches));
+      var inputNumber = '0971118876';
+      assert.deepEqual(result,
+      SimplePhoneMatcher.bestMatch(inputNumber, variants, matches));
     }
 
     setup(function() {
@@ -231,6 +233,30 @@ suite('lib/simple_phone_matcher', function() {
       var variants = [];
       var matches = [['112233', '118876'], ['000']];
       testBestMatch(0, 0, variants, matches);
+    });
+
+    test('match the number without national code', function() {
+      var inputNumber = '0971118876';
+      var matches = [['0971118876'], ['+55971118876']];
+      var result = {
+        bestMatchIndex: 0,
+        localIndex: 0
+      };
+
+      assert.deepEqual(result,
+      SimplePhoneMatcher.bestMatch(inputNumber, variants, matches));
+    });
+
+    test('match the number with national code', function() {
+      var inputNumber = '+55971118876';
+      var matches = [['0971118876'], ['+55971118876']];
+      var result = {
+        bestMatchIndex: 1,
+        localIndex: 0
+      };
+
+      assert.deepEqual(result,
+      SimplePhoneMatcher.bestMatch(inputNumber, variants, matches));
     });
   });
 });

--- a/shared/js/simple_phone_matcher.js
+++ b/shared/js/simple_phone_matcher.js
@@ -50,14 +50,26 @@ var SimplePhoneMatcher = {
   //    }
   // ie. bestMatchIndex will be the index in the contact arrays, localIndex
   // the index in the phone numbers array of this contact
-  bestMatch: function spm_bestMatchIndex(variants, matches) {
+  bestMatch: function spm_bestMatchIndex(inputNumber, variants, matches) {
     var bestMatchIndex = 0;
     var bestLocalIndex = 0;
     var bestMatchLength = 0;
 
-    matches.forEach(function(match, matchIndex) {
-      match.forEach(function(number, localIndex) {
+    for (var matchIndex = 0; matchIndex < matches.length; matchIndex++) {
+      var match = matches[matchIndex];
+      for (var localIndex = 0; localIndex < match.length; localIndex++) {
+        var number = match[localIndex];
         var sanitizedNumber = this.sanitizedNumber(number);
+
+        if (sanitizedNumber === inputNumber) {
+          bestMatchIndex = matchIndex;
+          bestLocalIndex = localIndex;
+
+          return {
+            bestMatchIndex: bestMatchIndex,
+            localIndex: bestLocalIndex
+          };
+        }
 
         variants.forEach(function match(variant) {
           if (variant.indexOf(sanitizedNumber) !== -1 ||
@@ -71,8 +83,8 @@ var SimplePhoneMatcher = {
             }
           }
         });
-      }, this);
-    }, this);
+      }
+    }
 
     return {
       bestMatchIndex: bestMatchIndex,


### PR DESCRIPTION
Return the contact when its number is equal the number input from user.

http://bugzil.la/877956
