### PR TITLE
Bug 874796 - Add setting to disable / enable cell broadcast alerts.

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -505,6 +505,13 @@
             </label>
             <a data-l10n-id="callWaiting">Call Waiting</a>
           </li>
+          <li id="menuItem-cellBroadcast">
+            <label class="checkbox-label">
+              <input type="checkbox" data-type="switch" name="ril.cellbroadcast.disabled" />
+              <span></span>
+            </label>
+            <a data-l10n-id="cellBroadcast">Cell broadcast service</a>
+          </li>
         </ul>
 
         <header>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -108,6 +108,7 @@ callForwardingQueryError=Error in query
 callForwardingForwardingVoiceTo=Voice calls to
 callForwardingNotForwarding=Disabled
 callForwardingConfirmTitle=Call forwarding confirmation message
+callBroadcastService=Cell broadcast service
 
 confirmCallWaitingTitle=Unable to confirm call waiting preferences
 confirmCallWaitingDesc=The device is currently unable to communicate with the carrier. Try setting the preference again.

--- a/apps/system/js/cell_broadcast_system.js
+++ b/apps/system/js/cell_broadcast_system.js
@@ -2,12 +2,28 @@
 
 var CellBroadcastSystem = {
 
+  _settingsDisabled: null,
+  _settingsKey: 'ril.cellbroadcast.disabled',
   _sound: 'style/notifications/ringtones/notifier_exclamation.ogg',
 
   init: function cbs_init() {
+    var self = this;
     if (navigator && navigator.mozCellBroadcast) {
       navigator.mozCellBroadcast.onreceived = this.show.bind(this);
     }
+
+    var settings = window.navigator.mozSettings;
+    var req = settings.createLock().get(this._settingsKey);
+    req.onsuccess = function() {
+      self._settingsDisabled = req.result[self._settingsKey];
+    };
+
+    settings.addObserver(this._settingsKey,
+                         this.settingsChangedHandler.bind(this));
+  },
+
+  settingsChangedHandler: function cbs_settingsChangedHandler(event) {
+    this._settingsDisabled = event.settingValue;
   },
 
   show: function cbs_show(event) {
@@ -18,6 +34,10 @@ var CellBroadcastSystem = {
         conn.voice.network.mcc === MobileOperator.BRAZIL_MCC &&
         msg.messageId === MobileOperator.BRAZIL_CELLBROADCAST_CHANNEL) {
       LockScreen.setCellbroadcastLabel(msg.body);
+      return;
+    }
+
+    if (this._settingsDisabled) {
       return;
     }
 

--- a/build/settings.py
+++ b/build/settings.py
@@ -119,6 +119,7 @@ settings = {
  "ril.supl.passwd": "",
  "ril.supl.user": "",
  "ril.sms.strict7BitEncoding.enabled": False,
+ "ril.cellbroadcast.disabled": False,
  "screen.automatic-brightness": True,
  "screen.brightness": 1,
  "screen.timeout": 60,


### PR DESCRIPTION
The setting does not currently effect channel 50 cell broadcast
messages, which will be displayed regardless of this setting.
