### PR TITLE
Bug 877169 - [SMS][Regression] Resend touch area is not working. It should be limited *only* to the icon.

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1147,6 +1147,8 @@ var ThreadUI = global.ThreadUI = {
         elems.bubble = currentNode;
       } else if (currentNode.classList.contains('message')) {
         elems.message = currentNode;
+      } else if (currentNode.classList.contains('pack-end')) {
+        elems.packEnd = currentNode;
       }
       currentNode = currentNode.parentNode;
     }
@@ -1169,9 +1171,9 @@ var ThreadUI = global.ThreadUI = {
       return;
     }
 
-    // Click events originating from within a "bubble" of an error message
+    // Click events originating from a "pack-end" aside of an error message
     // should trigger a prompt for retransmission.
-    if (elems.message.classList.contains('error')) {
+    if (elems.message.classList.contains('error') && elems.packEnd) {
       if (window.confirm(_('resend-confirmation'))) {
         this.resendMessage(elems.message.dataset.messageId);
       }

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1224,25 +1224,27 @@ suite('thread_ui.js >', function() {
       window.confirm.restore();
       ThreadUI.resendMessage.restore();
     });
-    test('clicking on an error message bubble triggers a confirmation dialog',
+    test('clicking on "pack-end" aside in an error message' +
+      'triggers a confirmation dialog',
       function() {
-      this.elems.errorMsg.querySelector('.bubble').click();
+      this.elems.errorMsg.querySelector('.pack-end').click();
       assert.equal(window.confirm.callCount, 1);
     });
-    test('clicking within an error message bubble triggers a confirmation ' +
-      'dialog', function() {
-      this.elems.errorMsg.querySelector('.bubble *').click();
-      assert.equal(window.confirm.callCount, 1);
+    test('clicking on p element in an error message' +
+      'does not triggers a confirmation  dialog',
+      function() {
+      this.elems.errorMsg.querySelector('.bubble p').click();
+      assert.equal(window.confirm.callCount, 0);
     });
     test('clicking on an error message does not trigger a confirmation dialog',
       function() {
       this.elems.errorMsg.click();
       assert.equal(window.confirm.callCount, 0);
     });
-    test('clicking on an error message bubble and accepting the ' +
+    test('clicking on "pack-end" aside in an error message and accepting the ' +
       'confirmation dialog triggers a message re-send operation', function() {
       window.confirm.returns(true);
-      this.elems.errorMsg.querySelector('.bubble').click();
+      this.elems.errorMsg.querySelector('.pack-end').click();
       assert.equal(ThreadUI.resendMessage.callCount, 1);
     });
     test('clicking on an error message bubble and rejecting the ' +


### PR DESCRIPTION
Only click the error icon in a message to trigger the resend dialogue.

Please refer to below pages:
http://bugzil.la/877169#c8
http://bugzil.la/877169#c9
