### PR TITLE
Bug 880390: Only add 'callschanged' listener once.

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -168,6 +168,8 @@ var StatusBar = {
 
   headphonesActive: false,
 
+  listeningCallschanged: false,
+
   /**
    * this keeps how many current installs/updates we do
    * it triggers the icon "systemDownloads"
@@ -201,6 +203,8 @@ var StatusBar = {
 
   init: function sb_init() {
     this.getAllElements();
+
+    this.listeningCallschanged = false;
 
     // Refresh the time to reflect locale changes
     this.update.time.call(this, new Date());
@@ -750,7 +754,8 @@ var StatusBar = {
 
   addCallListener: function sb_addCallListener() {
     var telephony = navigator.mozTelephony;
-    if (telephony) {
+    if (telephony && !this.listeningCallschanged) {
+      this.listeningCallschanged = true;
       telephony.addEventListener('callschanged', this);
     }
   },
@@ -758,6 +763,7 @@ var StatusBar = {
   removeCallListener: function sb_addCallListener() {
     var telephony = navigator.mozTelephony;
     if (telephony) {
+      this.listeningCallschanged = false;
       telephony.removeEventListener('callschanged', this);
     }
   },

--- a/apps/system/test/unit/mock_navigator_moz_telephony.js
+++ b/apps/system/test/unit/mock_navigator_moz_telephony.js
@@ -29,6 +29,23 @@
     }
   }
 
+  function mnmt_countEventListener(evtName, func) {
+    var count = 0;
+    var list = listeners[evtName];
+
+    if (!list) {
+      return count;
+    }
+
+    for (var i = 0; i < list.length; ++i) {
+      if (list[i] === func) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
   function mnmt_mTriggerEvent(evt) {
     var evtName = evt.type;
     if (listeners[evtName]) {
@@ -45,6 +62,7 @@
   var Mock = {
     addEventListener: mnmt_addEventListener,
     removeEventListener: mnmt_removeEventListener,
+    mCountEventListener: mnmt_countEventListener,
     mTeardown: mnmt_init,
     mTriggerEvent: mnmt_mTriggerEvent
   };

--- a/build/utils.js
+++ b/build/utils.js
@@ -216,25 +216,25 @@ function makeWebappsObject(dirs) {
   };
 }
 
-let externalAppsDirs = ['external-apps'];
+let additionalSrcDirNames = ['external-apps'];
 
 if (DOGFOOD === '0' && PRODUCTION === '0') {
-  externalAppsDirs.push('test_external_apps');
+  additionalSrcDirNames.push('test_external_apps');
 }
 
 if (GAIA_DISTRIBUTION_DIR) {
   let externalAppsDir = new FileUtils.File(GAIA_DISTRIBUTION_DIR);
   externalAppsDir.append('external-apps');
   if (externalAppsDir.exists()) {
-      externalAppsDirs.push(externalAppsDir.path);
+      additionalSrcDirNames.push(externalAppsDir.path);
   }
 }
 
 const Gaia = {
   engine: GAIA_ENGINE,
   sharedFolder: getFile(GAIA_DIR, 'shared'),
-  webapps: makeWebappsObject(GAIA_APP_SRCDIRS),
-  externalWebapps: makeWebappsObject(externalAppsDirs.join(' ')),
+  webapps: makeWebappsObject(GAIA_APP_SRCDIRS + ' ' +
+                             additionalSrcDirNames.join(' ')),
   aggregatePrefix: 'gaia_build_',
   distributionDir: GAIA_DISTRIBUTION_DIR
 };

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -67,11 +67,7 @@ function checkOrigin(origin) {
   }
 }
 
-Gaia.webapps.forEach(function (webapp) {
-  // If BUILD_APP_NAME isn't `*`, we only accept one webapp
-  if (BUILD_APP_NAME != '*' && webapp.sourceDirectoryName != BUILD_APP_NAME)
-    return;
-
+function fillAppManifest(webapp) {
   // Compute webapp folder name in profile
   let webappTargetDirName = webapp.domain;
 
@@ -105,21 +101,12 @@ Gaia.webapps.forEach(function (webapp) {
     appStatus:     getAppStatus(webapp.manifest.type),
     localId:       localId
   };
+}
 
-});
 
 let errors = [];
 
-// Process external webapps from /gaia/external-app/ folder
-Gaia.externalWebapps.forEach(function (webapp) {
-  // If BUILD_APP_NAME isn't `*`, we only accept one webapp
-  if (BUILD_APP_NAME != '*' && webapp.sourceDirectoryName != BUILD_APP_NAME)
-    return;
-
-  if (!webapp.metaData) {
-    return;
-  }
-
+function fillExternalAppManifest(webapp) {
   // Compute webapp folder name in profile
   let webappTargetDirName = webapp.sourceDirectoryName;
 
@@ -231,7 +218,19 @@ Gaia.externalWebapps.forEach(function (webapp) {
     packageEtag:   packageEtag,
     appStatus:     getAppStatus(webapp.metaData.type || "web"),
   };
+}
 
+Gaia.webapps.forEach(function (webapp) {
+  // If BUILD_APP_NAME isn't `*`, we only accept one webapp
+  if (BUILD_APP_NAME != '*' && webapp.sourceDirectoryName != BUILD_APP_NAME) {
+    return;
+  }
+
+  if (webapp.metaData) {
+    fillExternalAppManifest(webapp);
+  } else {
+    fillAppManifest(webapp);
+  }
 });
 
 if (errors.length) {
@@ -248,4 +247,3 @@ manifestFile.append('webapps.json');
 
 // stringify json with 2 spaces indentation
 writeContent(manifestFile, JSON.stringify(manifests, null, 2) + '\n');
-


### PR DESCRIPTION
On b2g18 after bug 823958, adding an event listener can trigger another
event.  Since the callschanged listener is added from an event, this
can cause an infinite loop.

The simplest solution, recommended by :bent, is to avoid adding the listener
if its already registered.
