### PR TITLE
Bug 879779 - [MMS] [UX] Message thread. Adjust beggining of content when there's no phone/carrier banner in the layout

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -844,6 +844,7 @@ var ThreadUI = global.ThreadUI = {
     //
     Contacts.findByPhoneNumber(number, function gotContact(contacts) {
       var carrierTag = document.getElementById('contact-carrier');
+      var threadMessages = document.getElementById('thread-messages');
       // Bug 867948: contacts null is a legitimate case, and
       // getContactDetails is okay with that.
       var details = Utils.getContactDetails(number, contacts);
@@ -876,13 +877,13 @@ var ThreadUI = global.ThreadUI = {
 
         if (carrierText) {
           carrierTag.textContent = carrierText;
-          carrierTag.classList.remove('hide');
+          threadMessages.classList.add('has-carrier');
         } else {
-          carrierTag.classList.add('hide');
+          threadMessages.classList.remove('has-carrier');
         }
       } else {
         // Hide carrier tag in group message or unknown contact cases.
-        carrierTag.classList.add('hide');
+        threadMessages.classList.remove('has-carrier');
       }
 
       if (callback) {

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -98,7 +98,7 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
 }
 
 [data-type="list"] header:first-child {
-  padding-top: 1.5rem;
+  padding-top: 1.2rem;
 }
 
 #threads-container[data-type="list"] ul {
@@ -270,10 +270,6 @@ section[role="region"].new > header:first-child form {
   display: block;
 }
 
-.new .carrier-wrapper {
-  display: none;
-}
-
 .new #messages-edit-icon {
   display: none;
 }
@@ -298,15 +294,23 @@ section[role="region"].new > header:first-child form {
   Messages Style as 'bubbles'
 */
 
+#contact-carrier {
+  display: none;
+}
+
+section[class="panel has-carrier"] #contact-carrier {
+  display: block;
+}
+
+section.has-carrier .article-list header:first-child {
+  margin-top: 2rem;
+}
+
 .article-list {
   -moz-box-sizing: border-box;
   background: none repeat scroll 0 0 #E4E4E4;
   text-align: left;
   z-index: 5;
-}
-
-.article-list header:first-child {
-  margin-top: 2rem;
 }
 
 .article-list header {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1737,10 +1737,9 @@ suite('thread_ui.js >', function() {
 
             fn([new MockContact()]);
 
-            var carrierTag = document.getElementById('contact-carrier');
+            var threadMessages = document.getElementById('thread-messages');
 
-            assert.isFalse(carrierTag.classList.contains('hide'));
-
+            assert.isTrue(threadMessages.classList.contains('has-carrier'));
             done();
           });
 
@@ -1764,9 +1763,9 @@ suite('thread_ui.js >', function() {
 
             fn([new MockContact()]);
 
-            var carrierTag = document.getElementById('contact-carrier');
+            var threadMessages = document.getElementById('thread-messages');
 
-            assert.isTrue(carrierTag.classList.contains('hide'));
+            assert.isFalse(threadMessages.classList.contains('has-carrier'));
 
             done();
           });
@@ -1913,9 +1912,9 @@ suite('thread_ui.js >', function() {
           window.location.hash = '#thread=1';
           ThreadUI.updateHeaderData();
 
-          var carrierTag = document.getElementById('contact-carrier');
+          var threadMessages = document.getElementById('thread-messages');
 
-          assert.isTrue(carrierTag.classList.contains('hide'));
+          assert.isFalse(threadMessages.classList.contains('has-carrier'));
         });
 
       });


### PR DESCRIPTION
Set message content below the header with 1.5 rem.

http://bugzil.la/879779
