### PR TITLE
Bug 835887 - [Calendar UX VD] "Remove account" overlay button should be red

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -535,7 +535,7 @@
     </section>
     <menu>
       <button class="delete-cancel" data-l10n-id="cancel">Cancel</button>
-      <button class="recommend delete-confirm" data-l10n-id="confirm">Confirm</button>
+      <button class="danger delete-confirm" data-l10n-id="confirm">Confirm</button>
     </menu>
   </form>
 

--- a/apps/calendar/style/modify_account_view.css
+++ b/apps/calendar/style/modify_account_view.css
@@ -69,6 +69,10 @@
   display: none;
 }
 
+#remove-account-dialog p {
+  font-size: 2.2rem;
+}
+
 #modify-account-view.auth-oauth2.create .user,
 #modify-account-view .sync-errors,
 #modify-account-view .oauth2-sign-in {


### PR DESCRIPTION
Bug [#835887](https://bugzilla.mozilla.org/show_bug.cgi?id=835887)
