### PR TITLE
Merge pull request #9218 from mcirlanaru/bug_834542

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -755,7 +755,7 @@ var LockScreen = {
     this.loadPanel(panel, function panelLoaded() {
       self.unloadPanel(overlay.dataset.panel, panel,
         function panelUnloaded() {
-          self.dispatchEvent('lockpanelchange');
+          self.dispatchEvent('lockpanelchange', { 'panel': panel });
 
           overlay.dataset.panel = panel;
           self._switchingPanel = false;

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -90,10 +90,6 @@ body, html {
   font-size: 1rem;
 }
 
-#screen.locked #statusbar-time {
-  display: none;
-}
-
 .sb-icon {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
Bug 834542 - Display time in the status bar for the emergency call screen, r=@timdream(cherry picked from commit 564b1b13d0b1d19753450d5355c9124dd07b2e02)

Conflicts:

```
apps/system/js/lockscreen.js
apps/system/js/statusbar.js
```
