### PR TITLE
Follow up Bug 805133 - Calendar Month View Jumps Between 5 and 6 rows

### DIFF
--- a/apps/calendar/js/views/month_child.js
+++ b/apps/calendar/js/views/month_child.js
@@ -386,7 +386,7 @@
     activate: function() {
 
       this.element.classList.add(this.ACTIVE);
-      if (this.weeks === 6) {
+      if (this.weeks === 6 && this.element.parentNode.nextElementSibling) {
         this.element.parentNode.nextElementSibling.classList.add(this.LONG);
       }
 
@@ -415,7 +415,7 @@
      */
     deactivate: function() {
       this.element.classList.remove(this.ACTIVE);
-      if (this.weeks === 6) {
+      if (this.weeks === 6 && this.element.parentNode.nextElementSibling) {
         this.element.parentNode.nextElementSibling.classList.remove(this.LONG);
       }
     },


### PR DESCRIPTION
Follow up [#805133](https://bugzilla.mozilla.org/show_bug.cgi?id=805133)
