### PR TITLE
Bug 877077 - Pass the call node to keypad manager when updating

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -55,8 +55,6 @@ HandledCall.prototype.handleEvent = function hc_handle(evt) {
       break;
     case 'resuming':
       this.node.classList.remove('held');
-      break;
-    case 'resumed':
       if (this.photo) {
         CallScreen.setCallerContactImage(this.photo, true, false);
       }
@@ -144,7 +142,7 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
         KeypadManager.formatPhoneNumber('end', true);
         var additionalInfo =
           Utils.getPhoneNumberAdditionalInfo(matchingTel, contact, number);
-        KeypadManager.updateAdditionalContactInfo(additionalInfo);
+        KeypadManager.updateAdditionalContactInfo(additionalInfo, self.node);
         if (contact.photo && contact.photo.length > 0) {
           self.photo = contact.photo[0];
           CallScreen.setCallerContactImage(self.photo, true, false);

--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -424,7 +424,7 @@ var KeypadManager = {
           this._isKeypadClicked = true;
           this._phoneNumber = key;
           this._additionalContactInfo = '';
-          this._updateAdditionalContactInfoView();
+          this._updateAdditionalContactInfoView(CallScreen.activeCall);
         } else {
           this._phoneNumber += key;
         }
@@ -519,15 +519,15 @@ var KeypadManager = {
   },
 
   updateAdditionalContactInfo:
-    function kh_updateAdditionalContactInfo(additionalContactInfo) {
+    function kh_updateAdditionalContactInfo(additionalContactInfo, callNode) {
     this._additionalContactInfo = additionalContactInfo;
-    this._updateAdditionalContactInfoView();
+    this._updateAdditionalContactInfoView(callNode);
   },
 
   _updateAdditionalContactInfoView:
-    function kh__updateAdditionalContactInfoView() {
-    var phoneNumberView = CallScreen.activeCall.querySelector('.number');
-    var additionalview = CallScreen.activeCall.querySelector(
+    function kh__updateAdditionalContactInfoView(callNode) {
+    var phoneNumberView = callNode.querySelector('.number');
+    var additionalview = callNode.querySelector(
       '.additionalContactInfo');
     if (!this._additionalContactInfo ||
       this._additionalContactInfo.trim() === '') {
@@ -541,8 +541,10 @@ var KeypadManager = {
     }
   },
 
-  restoreAdditionalContactInfo: function kh_restoreAdditionalContactInfo() {
-    this.updateAdditionalContactInfo(this._originalAdditionalContactInfo);
+  restoreAdditionalContactInfo:
+    function kh_restoreAdditionalContactInfo(callNode) {
+    this.updateAdditionalContactInfo(this._originalAdditionalContactInfo,
+      callNode);
   },
 
   _callVoicemail: function kh_callVoicemail() {

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -13,7 +13,7 @@ var CallScreen = {
 
   get activeCall() {
     delete this.activeCall;
-    return this.activeCall = this.calls.querySelector(':not(.held)');
+    return this.activeCall = this.calls.querySelector('.call:not(.held)');
   },
 
   mainContainer: document.getElementById('main-container'),
@@ -131,7 +131,7 @@ var CallScreen = {
 
   hideKeypad: function cs_hideKeypad() {
     KeypadManager.restorePhoneNumber('end', true);
-    KeypadManager.restoreAdditionalContactInfo();
+    KeypadManager.restoreAdditionalContactInfo(this.activeCall);
     this.body.classList.remove('showKeypad');
   },
 

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -44,7 +44,7 @@
     <article id="call-screen" data-layout>
       <div id="locked-contact-photo"></div>
       <article id="calls" data-count="0">
-        <section data-occupied="false">
+        <section class="call" data-occupied="false">
           <div class="numberWrapper">
             <div class="number font-light noAdditionalContactInfo"></div>
           </div>
@@ -60,7 +60,7 @@
             </div>
           </div>
         </section>
-        <section data-occupied="false" hidden>
+        <section class="call" data-occupied="false" hidden>
           <div class="numberWrapper">
             <div class="number font-light noAdditionalContactInfo">
             </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=877077

When initializing the handled call of the second incoming call, CallScreen.activeCall is still the node the first call. Which results to that the additional information of the node representing the first call is altered with the information of the second call.

In this patch we pass the call node to the update function explicitly. In addition to it, remove the 'resumed' case (which is not existing) and fix the CallScreen.activeCall function.
