### PR TITLE
Bug 880390: Only add 'callschanged' listener once.

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -168,6 +168,8 @@ var StatusBar = {
 
   headphonesActive: false,
 
+  listeningCallschanged: false,
+
   /**
    * this keeps how many current installs/updates we do
    * it triggers the icon "systemDownloads"
@@ -201,6 +203,8 @@ var StatusBar = {
 
   init: function sb_init() {
     this.getAllElements();
+
+    this.listeningCallschanged = false;
 
     // Refresh the time to reflect locale changes
     this.update.time.call(this, new Date());
@@ -750,7 +754,8 @@ var StatusBar = {
 
   addCallListener: function sb_addCallListener() {
     var telephony = navigator.mozTelephony;
-    if (telephony) {
+    if (telephony && !this.listeningCallschanged) {
+      this.listeningCallschanged = true;
       telephony.addEventListener('callschanged', this);
     }
   },
@@ -758,6 +763,7 @@ var StatusBar = {
   removeCallListener: function sb_addCallListener() {
     var telephony = navigator.mozTelephony;
     if (telephony) {
+      this.listeningCallschanged = false;
       telephony.removeEventListener('callschanged', this);
     }
   },

--- a/apps/system/test/unit/mock_navigator_moz_telephony.js
+++ b/apps/system/test/unit/mock_navigator_moz_telephony.js
@@ -29,6 +29,23 @@
     }
   }
 
+  function mnmt_countEventListener(evtName, func) {
+    var count = 0;
+    var list = listeners[evtName];
+
+    if (!list) {
+      return count;
+    }
+
+    for (var i = 0; i < list.length; ++i) {
+      if (list[i] === func) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
   function mnmt_mTriggerEvent(evt) {
     var evtName = evt.type;
     if (listeners[evtName]) {
@@ -45,6 +62,7 @@
   var Mock = {
     addEventListener: mnmt_addEventListener,
     removeEventListener: mnmt_removeEventListener,
+    mCountEventListener: mnmt_countEventListener,
     mTeardown: mnmt_init,
     mTriggerEvent: mnmt_mTriggerEvent
   };


### PR DESCRIPTION
On b2g18 after bug 823958, adding an event listener can trigger another
event.  Since the callschanged listener is added from an event, this
can cause an infinite loop.

The simplest solution, recommended by :bent, is to avoid adding the listener
if its already registered.
