### PR TITLE
Bug 876335 - Update additional information by HandledCall itself

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -23,6 +23,7 @@
 
     <!-- JS -->
     <script defer src="/shared/js/mouse_event_shim.js"></script>
+    <script defer src="/dialer/js/utils.js"></script>
     <script defer src="/dialer/js/tone_player.js"></script>
     <script defer src="/dialer/js/keypad.js"></script>
     <script defer src="/dialer/js/dialer.js"></script>

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -15,6 +15,8 @@ function HandledCall(aCall, aNode) {
   };
 
   this._initialState = this.call.state;
+  this._cachedInfo = '';
+  this._cachedAdditionalInfo = '';
 
   if (!aNode)
     return;
@@ -55,8 +57,6 @@ HandledCall.prototype.handleEvent = function hc_handle(evt) {
       break;
     case 'resuming':
       this.node.classList.remove('held');
-      break;
-    case 'resumed':
       if (this.photo) {
         CallScreen.setCallerContactImage(this.photo, true, false);
       }
@@ -136,15 +136,17 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
         };
         if (primaryInfo) {
           node.textContent = primaryInfo;
+          self._cachedInfo = primaryInfo;
         } else {
           LazyL10n.get(function gotL10n(_) {
-            node.textContent = _('withheld-number');
+            self._cachedInfo = _('withheld-number');
+            node.textContent = self._cachedInfo;
           });
         }
-        KeypadManager.formatPhoneNumber('end', true);
-        var additionalInfo =
+        self.formatPhoneNumber('end', true);
+        self._cachedAdditionalInfo =
           Utils.getPhoneNumberAdditionalInfo(matchingTel, contact, number);
-        KeypadManager.updateAdditionalContactInfo(additionalInfo);
+        self.replaceAdditionalContactInfo(self._cachedAdditionalInfo);
         if (contact.photo && contact.photo.length > 0) {
           self.photo = contact.photo[0];
           CallScreen.setCallerContactImage(self.photo, true, false);
@@ -163,10 +165,60 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
         return;
       }
 
-      node.textContent = number;
-      KeypadManager.formatPhoneNumber('end', true);
+      self._cachedInfo = number;
+      node.textContent = self._cachedInfo;
+      self.replaceAdditionalContactInfo(self._cachedAdditionalInfo);
+      self.formatPhoneNumber('end', true);
     }
   );
+};
+
+HandledCall.prototype.replaceAdditionalContactInfo =
+  function hc_replaceAdditionalContactInfo(additionalContactInfo) {
+  if (!additionalContactInfo ||
+    additionalContactInfo.trim() === '') {
+    this.additionalInfoNode.textContent = '';
+    this.additionalInfoNode.classList.add('noAdditionalContactInfo');
+    this.numberNode.classList.add('noAdditionalContactInfo');
+  } else {
+    this.numberNode.classList.remove('noAdditionalContactInfo');
+    this.additionalInfoNode.classList.remove('noAdditionalContactInfo');
+    this.additionalInfoNode.textContent = additionalContactInfo;
+  }
+};
+
+HandledCall.prototype.restoreAdditionalContactInfo =
+  function hc_restoreAdditionalContactInfo(additionalContactInfo) {
+    this.replaceAdditionalContactInfo(this._cachedAdditionalInfo);
+};
+
+HandledCall.prototype.formatPhoneNumber =
+  function hc_formatPhoneNumber(ellipsisSide, maxFontSize) {
+    var fakeView = this.node.querySelector('.fake-number');
+    var view = this.numberNode;
+
+    var newFontSize;
+    if (maxFontSize) {
+      newFontSize = KeypadManager.maxFontSize;
+    } else {
+      newFontSize =
+        Utils.getNextFontSize(view, fakeView, KeypadManager.maxFontSize,
+          KeypadManager.minFontSize, kFontStep);
+    }
+    view.style.fontSize = newFontSize + 'px';
+    Utils.addEllipsis(view, fakeView, ellipsisSide);
+};
+
+HandledCall.prototype.replacePhoneNumber =
+  function hc_replacePhoneNumber(phoneNumber, ellipsisSide, maxFontSize) {
+    this.numberNode.textContent = phoneNumber;
+    this.formatPhoneNumber(ellipsisSide, maxFontSize);
+};
+
+HandledCall.prototype.restorePhoneNumber =
+  function hc_restorePhoneNumber() {
+    this.numberNode.textContent = this._cachedInfo;
+    this.formatPhoneNumber('end', true);
 };
 
 HandledCall.prototype.updateDirection = function hc_updateDirection() {

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -12,8 +12,7 @@ var CallScreen = {
   calls: document.getElementById('calls'),
 
   get activeCall() {
-    delete this.activeCall;
-    return this.activeCall = this.calls.querySelector(':not(.held)');
+    return OnCallHandler.activeCall();
   },
 
   mainContainer: document.getElementById('main-container'),
@@ -76,7 +75,7 @@ var CallScreen = {
     if (window.innerHeight <= 40) {
       if (this.body.classList.contains('showKeypad')) {
         this._typedNumber = KeypadManager._phoneNumber;
-        KeypadManager.restorePhoneNumber('end', true);
+        KeypadManager.restorePhoneNumber();
       }
     } else if (this.body.classList.contains('showKeypad')) {
       KeypadManager.updatePhoneNumber(this._typedNumber, 'begin', true);
@@ -130,7 +129,7 @@ var CallScreen = {
   },
 
   hideKeypad: function cs_hideKeypad() {
-    KeypadManager.restorePhoneNumber('end', true);
+    KeypadManager.restorePhoneNumber();
     KeypadManager.restoreAdditionalContactInfo();
     this.body.classList.remove('showKeypad');
   },
@@ -313,16 +312,8 @@ var OnCallHandler = (function onCallHandler() {
       CallScreen.turnSpeakerOff();
     }
 
-    var node = null;
     // Find an available node for displaying the call
-    var children = CallScreen.calls.children;
-    for (var i = 0; i < children.length; i++) {
-      var n = children[i];
-      if (n.dataset.occupied === 'false') {
-        node = n;
-        break;
-      }
-    }
+    var node = CallScreen.calls.querySelector('.call[data-occupied="false"]');
     var hc = new HandledCall(call, node);
     handledCalls.push(hc);
 
@@ -756,6 +747,19 @@ var OnCallHandler = (function onCallHandler() {
     }, 3000);
   }
 
+  function activeCall() {
+    var telephonyActiveCall = telephony.active;
+    var activeCall = null;
+    for (var i = 0; i < handledCalls.length; i++) {
+      var handledCall = handledCalls[i];
+      if (telephonyActiveCall === handledCall.call) {
+        activeCall = handledCall;
+        break;
+      }
+    }
+    return activeCall;
+  }
+
   return {
     setup: setup,
 
@@ -774,7 +778,8 @@ var OnCallHandler = (function onCallHandler() {
 
     addRecentEntry: addRecentEntry,
 
-    notifyBusyLine: notifyBusyLine
+    notifyBusyLine: notifyBusyLine,
+    activeCall: activeCall
   };
 })();
 

--- a/apps/communications/dialer/js/utils.js
+++ b/apps/communications/dialer/js/utils.js
@@ -46,11 +46,13 @@ var Utils = {
     }
     return null;
   },
+
   toCamelCase: function ut_toCamelCase(str) {
     return str.replace(/\-(.)/g, function replacer(str, p1) {
       return p1.toUpperCase();
     });
   },
+
   // XXX: this is way too complex for the task accomplished
   getPhoneNumberAdditionalInfo: function ut_getPhoneNumberAdditionalInfo(
     matchingTel, associatedContact, inputNumber) {
@@ -91,6 +93,82 @@ var Utils = {
       }
     }
     return additionalInfo;
+  },
+
+  addEllipsis: function ut_addEllipsis(view, fakeView, ellipsisSide) {
+    var side = ellipsisSide || 'begin';
+    LazyL10n.get(function localized(_) {
+      var localizedSide;
+      if (navigator.mozL10n.language.direction === 'rtl') {
+        localizedSide = (side === 'begin' ? 'right' : 'left');
+      } else {
+        localizedSide = (side === 'begin' ? 'left' : 'right');
+      }
+      var computedStyle = window.getComputedStyle(view, null);
+      var currentFontSize = parseInt(
+        computedStyle.getPropertyValue('font-size')
+      );
+      var viewWidth = view.getBoundingClientRect().width;
+      fakeView.style.fontSize = currentFontSize + 'px';
+      fakeView.innerHTML = view.value ? view.value : view.innerHTML;
+
+      var value = fakeView.innerHTML;
+
+      // Guess the possible position of the ellipsis in order to minimize
+      // the following while loop iterations:
+      var counter = value.length -
+        (viewWidth *
+         (fakeView.textContent.length /
+           fakeView.getBoundingClientRect().width));
+
+      var newPhoneNumber;
+      while (fakeView.getBoundingClientRect().width > viewWidth) {
+
+        if (localizedSide == 'left') {
+          newPhoneNumber = '\u2026' + value.substr(-value.length + counter);
+        } else if (localizedSide == 'right') {
+          newPhoneNumber = value.substr(0, value.length - counter) + '\u2026';
+        }
+
+        fakeView.innerHTML = newPhoneNumber;
+        counter++;
+      }
+
+      if (newPhoneNumber) {
+        if (view.value) {
+          view.value = newPhoneNumber;
+        } else {
+          view.innerHTML = newPhoneNumber;
+        }
+      }
+    });
+  },
+
+  getNextFontSize:
+    function ut_getNextFontSize(view, fakeView, maxFontSize,
+      minFontSize, fontStep) {
+        var computedStyle = window.getComputedStyle(view, null);
+        var fontSize = parseInt(computedStyle.getPropertyValue('font-size'));
+        var viewWidth = view.getBoundingClientRect().width;
+        var viewHeight = view.getBoundingClientRect().height;
+        fakeView.style.fontSize = fontSize + 'px';
+        fakeView.innerHTML = (view.value ? view.value : view.innerHTML);
+
+        var rect = fakeView.getBoundingClientRect();
+
+        while ((rect.width < viewWidth) && (fontSize < maxFontSize)) {
+          fontSize = Math.min(fontSize + fontStep, maxFontSize);
+          fakeView.style.fontSize = fontSize + 'px';
+          rect = fakeView.getBoundingClientRect();
+        }
+
+        while ((rect.width > viewWidth) && (fontSize > minFontSize)) {
+          fontSize = Math.max(fontSize - fontStep, minFontSize);
+          fakeView.style.fontSize = fontSize + 'px';
+          rect = fakeView.getBoundingClientRect();
+        }
+
+        return fontSize;
   }
 };
 

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -44,7 +44,7 @@
     <article id="call-screen" data-layout>
       <div id="locked-contact-photo"></div>
       <article id="calls" data-count="0">
-        <section data-occupied="false">
+        <section class="call" data-occupied="false">
           <div class="numberWrapper">
             <div class="number font-light noAdditionalContactInfo"></div>
           </div>
@@ -60,7 +60,7 @@
             </div>
           </div>
         </section>
-        <section data-occupied="false" hidden>
+        <section class="call" data-occupied="false" hidden>
           <div class="numberWrapper">
             <div class="number font-light noAdditionalContactInfo">
             </div>

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -502,6 +502,14 @@ suite('dialer/handled_call', function() {
     });
   });
 
+  test('should display contact name', function() {
+    mockCall = new MockCall('888', 'incoming');
+    subject = new HandledCall(mockCall, fakeNode);
+
+    var numberNode = fakeNode.querySelector('.numberWrapper .number');
+    assert.equal(numberNode.textContent, 'test name');
+  });
+
   test('should display withheld-number l10n key', function() {
     mockCall = new MockCall('', 'incoming');
     subject = new HandledCall(mockCall, fakeNode);
@@ -520,19 +528,62 @@ suite('dialer/handled_call', function() {
   });
 
   suite('additional information', function() {
+    var additionalInfoNode;
+
+    setup(function() {
+      additionalInfoNode = fakeNode.querySelector('.additionalContactInfo');
+    });
+
     test('check additional info updated', function() {
       mockCall = new MockCall('888', 'incoming');
       subject = new HandledCall(mockCall, fakeNode);
-
-      assert.isTrue(MockKeypadManager.mUpdateAdditionalContactInfo);
+      assert.equal(additionalInfoNode.textContent, '888');
     });
 
     test('check without additional info', function() {
       mockCall = new MockCall('999', 'incoming');
       subject = new HandledCall(mockCall, fakeNode);
-
-      var additionalInfoNode = fakeNode.querySelector('.additionalContactInfo');
       assert.equal('', additionalInfoNode.textContent);
+    });
+
+    test('check replace additional info', function() {
+      mockCall = new MockCall('888', 'incoming');
+      subject = new HandledCall(mockCall, fakeNode);
+      subject.replaceAdditionalContactInfo('test additional info');
+      assert.equal(additionalInfoNode.textContent, 'test additional info');
+    });
+
+    test('check restore additional info', function() {
+      mockCall = new MockCall('888', 'incoming');
+      subject = new HandledCall(mockCall, fakeNode);
+      subject.replaceAdditionalContactInfo('test additional info');
+      subject.restoreAdditionalContactInfo();
+      assert.equal(additionalInfoNode.textContent, '888');
+    });
+  });
+
+  suite('phone number', function() {
+    var numberNode;
+
+    setup(function() {
+      numberNode = fakeNode.querySelector('.numberWrapper .number');
+    });
+
+    test('check replace number', function() {
+      mockCall = new MockCall('888', 'incoming');
+      subject = new HandledCall(mockCall, fakeNode);
+
+      subject.replacePhoneNumber('12345678');
+      assert.equal(numberNode.textContent, '12345678');
+    });
+
+    test('check restore number', function() {
+      mockCall = new MockCall('888', 'incoming');
+      subject = new HandledCall(mockCall, fakeNode);
+
+      subject.replacePhoneNumber('12345678');
+      subject.restorePhoneNumber();
+      assert.equal(numberNode.textContent, 'test name');
     });
   });
 

--- a/apps/communications/dialer/test/unit/mock_keypad.js
+++ b/apps/communications/dialer/test/unit/mock_keypad.js
@@ -1,3 +1,5 @@
+kFontStep = 4;
+
 var MockKeypadManager = {
   formatPhoneNumber:
     function khm_formatPhoneNumber(ellipsisSide) {

--- a/apps/communications/dialer/test/unit/mock_utils.js
+++ b/apps/communications/dialer/test/unit/mock_utils.js
@@ -29,6 +29,13 @@ var MockUtils = {
     return matchingTel.value % 2 == 0 ? matchingTel.value : undefined;
   },
 
+  addEllipsis: function ut_addEllipsis() {},
+
+  getNextFontSize: function ut_getNextFontSize(view, fakeView, maxFontSize,
+    minFontSize, fontStep) {
+    return maxFontSize;
+  },
+
   mTearDown: function tearDown() {
     this.mCalledPrettyDate = false;
     this.mCalledHeaderDate = false;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=876335

When initializing the handled call of the second incoming call, CallScreen.activeCall is still the node the first call. Which results to that the additional information of the node representing the first call is altered with the information of the second call.

In this patch we let HandleCall update the additional information by itself. In addition to it, remove the 'resumed' case (which is not existing) and fix the CallScreen.activeCall function.
