### PR TITLE
Bug 880215 - Ensure configuration is suitable before using it

### DIFF
--- a/apps/costcontrol/js/message_handler.js
+++ b/apps/costcontrol/js/message_handler.js
@@ -324,8 +324,11 @@
         clearTimeout(closing);
         ConfigManager.requestAll(function _onInfo(configuration, settings) {
           // Non expected SMS
-          if (configuration.balance.senders.indexOf(sms.sender) === -1 &&
-              configuration.topup.senders.indexOf(sms.sender) === -1) {
+          // configuration.balance or configuration.topup might not be set
+          // if the provider is not known, which is the case in default setup
+          if (!configuration.balance || !configuration.topup ||
+              (configuration.balance.senders.indexOf(sms.sender) === -1 &&
+               configuration.topup.senders.indexOf(sms.sender) === -1)) {
             closeIfProceeds();
             return;
           }


### PR DESCRIPTION
If the user's SIM card is not recognized by the CostControl config, then
there is no configuration.balance nor configuration.topup, hence the
application will not behave correctly. Ensuring the configuration is
usable mitigates this issue.
