### PR TITLE
Bug 877141 - Strip down non-break spaces from contenteditable

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -190,6 +190,13 @@ var Compose = (function() {
 
         var last = content.length - 1;
         var text = node.textContent;
+
+        // Bug 877141 - contenteditable wil insert non-break spaces when
+        // multiple consecutive spaces are entered, we don't want them.
+        if (text) {
+          text = text.replace(/\u00A0/g, ' ');
+        }
+
         if (node.nodeName == 'BR') {
           if (node === dom.message.lastChild) {
             continue;

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -159,6 +159,18 @@ suite('compose_test.js', function() {
         assert.equal(txt.length, 1, 'Single text content');
         assert.equal(txt[0], expected, 'correct content');
       });
+      test('Text with non-break spaces', function() {
+        Compose.append('start');
+        Compose.append('&nbsp;');
+        Compose.append('&nbsp;');
+        Compose.append('&nbsp;');
+        Compose.append(' ');
+        Compose.append('end');
+        var expected = 'start    end';
+        var txt = Compose.getContent();
+        assert.equal(txt.length, 1, 'Single text content');
+        assert.equal(txt[0], expected, 'correct content');
+      });
       test('Just attachment', function() {
         Compose.append(mockAttachment());
         var txt = Compose.getContent();


### PR DESCRIPTION
When several consecutives spaces are typed in a contenteditable element,
all but the last one are converted to non-break spaces. We don't want
this, here, so we simply replace them with normal spaces.
