### PR TITLE
Bug 861081 -  [Gaia][Settings] Use new WebAPI to access SIM lock functionality

### DIFF
--- a/apps/communications/ftu/js/sim_manager.js
+++ b/apps/communications/ftu/js/sim_manager.js
@@ -6,12 +6,15 @@ var SimManager = {
   _unlocked: false,
 
   init: function sm_init() {
+    this.icc = window.navigator.mozIccManager;
+    if (!this.icc)
+      return;
     this.mobConn = window.navigator.mozMobileConnection;
     if (!this.mobConn)
       return;
     _ = navigator.mozL10n.get;
 
-    this.mobConn.addEventListener('icccardlockerror',
+    this.icc.addEventListener('icccardlockerror',
                                   this.handleUnlockError.bind(this));
     this.mobConn.addEventListener('cardstatechange',
                                   this.handleCardState.bind(this));
@@ -251,7 +254,7 @@ var SimManager = {
 
     // Unlock SIM
     var options = {lockType: 'pin', pin: pin };
-    var req = this.mobConn.unlockCardLock(options);
+    var req = this.icc.unlockCardLock(options);
     req.onsuccess = (function sm_unlockSuccess() {
       this._unlocked = true;
       this.hideScreen();
@@ -300,7 +303,7 @@ var SimManager = {
 
     // Unlock SIM with PUK and new PIN
     var options = {lockType: 'puk', puk: pukCode, newPin: newpinCode };
-    var req = this.mobConn.unlockCardLock(options);
+    var req = this.icc.unlockCardLock(options);
     req.onsuccess = (function sm_unlockSuccess() {
       this._unlocked = true;
       this.hideScreen();
@@ -333,7 +336,7 @@ var SimManager = {
 
     // Unlock SIM
     var options = {lockType: lockType, pin: xck };
-    var req = this.mobConn.unlockCardLock(options);
+    var req = this.icc.unlockCardLock(options);
     req.onsuccess = (function sm_unlockSuccess() {
       this._unlocked = true;
       this.hideScreen();

--- a/apps/communications/ftu/test/unit/mock_navigator_moz_icc_manager.js
+++ b/apps/communications/ftu/test/unit/mock_navigator_moz_icc_manager.js
@@ -2,18 +2,10 @@
 
 (function() {
 
-  var props = ['voice', 'cardState', 'iccInfo', 'data', 'retryCount'];
   var listeners;
 
   function _init() {
-    props.forEach(function(prop) {
-      Mock[prop] = null;
-    });
     listeners = {};
-  }
-
-  function _setProperty(property, newState) {
-    Mock[property] = newState;
   }
 
   function _addEventListener(evtName, func) {
@@ -31,14 +23,26 @@
     }
   }
 
+  function _unlockCardLock(options) {
+    var settingsRequest = {
+      result: {},
+      set onsuccess(callback) {
+        callback.call(this);
+      },
+      set onerror(callback) {}
+    };
+
+    return settingsRequest;
+  }
+
   var Mock = {
     mTeardown: _init,
-    setProperty: _setProperty,
     addEventListener: _addEventListener,
-    removeEventListener: _removeEventListener
+    removeEventListener: _removeEventListener,
+    unlockCardLock: _unlockCardLock
   };
 
   _init();
 
-  window.MockNavigatorMozMobileConnection = Mock;
+  window.MockNavigatorMozIccManager = Mock;
 })();

--- a/apps/communications/ftu/test/unit/sim_manager_test.js
+++ b/apps/communications/ftu/test/unit/sim_manager_test.js
@@ -2,6 +2,8 @@
 
 requireApp(
   'communications/ftu/test/unit/mock_navigator_moz_mobile_connection.js');
+requireApp(
+  'communications/ftu/test/unit/mock_navigator_moz_icc_manager.js');
 requireApp('communications/ftu/test/unit/mock_ui_manager.js');
 
 requireApp('communications/ftu/js/sim_manager.js');
@@ -14,7 +16,8 @@ mocksHelperForNavigation.init();
 
 suite('sim mgmt >', function() {
   var realL10n,
-      realMozMobileConnection;
+      realMozMobileConnection,
+      realMozIccManager;
   var mocksHelper = mocksHelperForNavigation;
   var conn, container;
 
@@ -23,6 +26,9 @@ suite('sim mgmt >', function() {
 
     realMozMobileConnection = navigator.mozMobileConnection;
     navigator.mozMobileConnection = MockNavigatorMozMobileConnection;
+
+    realMozIccManager = navigator.mozIccManager;
+    navigator.mozIccManager = MockNavigatorMozIccManager;
 
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
@@ -35,6 +41,9 @@ suite('sim mgmt >', function() {
   teardown(function() {
     navigator.mozMobileConnection = realMozMobileConnection;
     realMozMobileConnection = null;
+
+    navigator.mozIccManager = realMozIccManager;
+    realMozIccManager = null;
 
     navigator.mozL10n = realL10n;
     realL10n = null;

--- a/apps/settings/js/security_privacy.js
+++ b/apps/settings/js/security_privacy.js
@@ -30,6 +30,10 @@ var Security = {
     if (!mobileConnection)
       return;
 
+    var icc = navigator.mozIccManager;
+    if (!icc)
+      return;
+
     var simSecurityDesc = document.getElementById('simCardLock-desc');
     simSecurityDesc.style.fontStyle = 'italic';
 
@@ -50,7 +54,7 @@ var Security = {
 
     simSecurityDesc.style.fontStyle = 'normal';
     // with SIM card, query its status
-    var req = mobileConnection.getCardLock('pin');
+    var req = icc.getCardLock('pin');
     req.onsuccess = function spl_checkSuccess() {
       var enabled = req.result.enabled;
       simSecurityDesc.textContent = (enabled) ?

--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -26,6 +26,7 @@ var SimPinDialog = {
   errorMsgBody: document.getElementById('messageBody'),
 
   mobileConnection: null,
+  icc: null,
 
   lockType: 'pin',
   action: 'unlock',
@@ -136,7 +137,7 @@ var SimPinDialog = {
 
   unlockCardLock: function spl_unlockCardLock(options) {
     var self = this;
-    var req = this.mobileConnection.unlockCardLock(options);
+    var req = this.icc.unlockCardLock(options);
     req.onsuccess = function sp_unlockSuccess() {
       self.close();
       if (self.onsuccess)
@@ -179,7 +180,7 @@ var SimPinDialog = {
 
   setCardLock: function spl_setCardLock(options) {
     var self = this;
-    var req = this.mobileConnection.setCardLock(options);
+    var req = this.icc.setCardLock(options);
     req.onsuccess = function spl_enableSuccess() {
       self.close();
       if (self.onsuccess)
@@ -291,7 +292,11 @@ var SimPinDialog = {
     if (!this.mobileConnection)
       return;
 
-    this.mobileConnection.addEventListener('icccardlockerror',
+    this.icc = window.navigator.mozIccManager;
+    if (!this.icc)
+      return;
+
+    this.icc.addEventListener('icccardlockerror',
       this.handleError.bind(this));
 
     this.dialogDone.onclick = this.verify.bind(this);

--- a/apps/settings/js/simcard_lock.js
+++ b/apps/settings/js/simcard_lock.js
@@ -10,6 +10,7 @@ var SimPinLock = {
   changeSimPinButton: document.querySelector('#simpin-change button'),
 
   mobileConnection: null,
+  icc: null,
 
   updateSimCardStatus: function spl_updateSimStatus() {
     var _ = navigator.mozL10n.get;
@@ -31,7 +32,7 @@ var SimPinLock = {
 
     // with SIM card, query its status
     var self = this;
-    var req = this.mobileConnection.getCardLock('pin');
+    var req = this.icc.getCardLock('pin');
     req.onsuccess = function spl_checkSuccess() {
       var enabled = req.result.enabled;
       self.simSecurityDesc.textContent = (enabled) ?
@@ -47,6 +48,10 @@ var SimPinLock = {
   init: function spl_init() {
     this.mobileConnection = window.navigator.mozMobileConnection;
     if (!this.mobileConnection)
+      return;
+
+    this.icc = window.navigator.mozIccManager;
+    if (!this.icc)
       return;
 
     this.mobileConnection.addEventListener('cardstatechange',

--- a/apps/system/js/simcard_dialog.js
+++ b/apps/system/js/simcard_dialog.js
@@ -27,6 +27,7 @@ var SimPinDialog = {
   errorMsgBody: document.getElementById('messageBody'),
 
   mobileConnection: null,
+  icc: null,
 
   lockType: 'pin',
   action: 'unlock',
@@ -184,7 +185,7 @@ var SimPinDialog = {
   },
 
   unlockCardLock: function spl_unlockCardLock(options) {
-    var req = this.mobileConnection.unlockCardLock(options);
+    var req = this.icc.unlockCardLock(options);
     req.onsuccess = this.close.bind(this, 'success');
   },
 
@@ -220,7 +221,7 @@ var SimPinDialog = {
   },
 
   setCardLock: function spl_setCardLock(options) {
-    var req = this.mobileConnection.setCardLock(options);
+    var req = this.icc.setCardLock(options);
     req.onsuccess = this.close.bind(this, 'success');
   },
   inputFieldControl: function spl_inputField(isPin, isPuk, isXck, isNewPin) {
@@ -324,7 +325,11 @@ var SimPinDialog = {
     if (!this.mobileConnection)
       return;
 
-    this.mobileConnection.addEventListener('icccardlockerror',
+    this.icc = window.navigator.mozIccManager;
+    if (!this.icc)
+      return;
+
+    this.icc.addEventListener('icccardlockerror',
       this.handleError.bind(this));
 
     this.dialogDone.onclick = this.verify.bind(this);

--- a/apps/system/test/unit/simcard_dialog_test.js
+++ b/apps/system/test/unit/simcard_dialog_test.js
@@ -9,15 +9,14 @@ if (!window['SimPinDialog'])
 
 suite('simcard dialog', function() {
   var realL10n = window.navigator.mozL10n;
-  var realMobileConnection = window.navigator.mobileConnection;
+  var realMobileConnection = window.navigator.mozMobileConnection;
+  var realIccManager = window.navigator.mozIccManager;
   var mockUI;
 
   var MockMobileConnection = (function() {
     var _cardState = null;
     return {
       addEventListener: function(event, handler) {},
-      setCardLock: function(options) {},
-      unlockCardLock: function(options) {},
       get cardState() {
         return _cardState;
       },
@@ -27,6 +26,14 @@ suite('simcard dialog', function() {
       mTeardown: function() {
         _cardState = null;
       }
+    };
+  })();
+
+  var MockIccManager = (function() {
+    return {
+      addEventListener: function(event, handler) {},
+      setCardLock: function(options) {},
+      unlockCardLock: function(options) {}
     };
   })();
 
@@ -40,6 +47,7 @@ suite('simcard dialog', function() {
   suiteSetup(function() {
     window.navigator.mozL10n = MockL10n;
     window.navigator.mozMobileConnection = MockMobileConnection;
+    window.navigator.mozIccManager = MockIccManager;
     window['SystemDialog'] = MockSystemDialog;
 
     var mockUIMarkup = [
@@ -106,6 +114,7 @@ suite('simcard dialog', function() {
   suiteTeardown(function() {
     window.navigator.mozL10n = realL10n;
     window.navigator.mozMobileConnection = realMobileConnection;
+    window.navigator.mozIccManager = realIccManager;
     window['SystemDialog'] = null;
 
     mockUI.innerHTML = '';


### PR DESCRIPTION
Please see [bug 861081](https://bugzilla.mozilla.org/show_bug.cgi?id=861081).

In [bug 860585](https://bugzilla.mozilla.org/show_bug.cgi?id=860585), we move cardLock related API from mozMobileConnection to mozIccManager. This pull request is to do corresponding changes in Gaia side.

Thanks
