### PR TITLE
Bug 882680: Update discovered Bluetooth devices without names

### DIFF
--- a/apps/communications/dialer/js/mmi_ui.js
+++ b/apps/communications/dialer/js/mmi_ui.js
@@ -5,7 +5,7 @@ var MmiUI = {
   COMMS_APP_ORIGIN: document.location.protocol + '//' +
     document.location.host,
   _: null,
-  _conn: null,
+  _icc: null,
 
   get headerTitleNode() {
     delete this.headerTitleNode;
@@ -182,12 +182,12 @@ var MmiUI = {
   },
 
   handleError: function ph_handleError(data) {
-    if (!this._conn)
-      this._conn = window.navigator.mozMobileConnection;
+    if (!this._icc)
+      this._icc = window.navigator.mozIccManager;
     var error = data.error ? data.error : this._('mmi-error');
     switch (error) {
       case 'IncorrectPassword':
-        var retries = this._conn.retryCount;
+        var retries = this._icc.unlockRetryCount;
         error = this._('pinError');
         if (retries)
           error += this._('inputCodeRetriesLeft', {n: retries});

--- a/apps/communications/ftu/js/sim_manager.js
+++ b/apps/communications/ftu/js/sim_manager.js
@@ -9,6 +9,9 @@ var SimManager = {
     this.mobConn = window.navigator.mozMobileConnection;
     if (!this.mobConn)
       return;
+    this.iccManager = window.navigator.mozIccManager;
+    if (!this.iccManager)
+      return;
     _ = navigator.mozL10n.get;
 
     this.mobConn.addEventListener('icccardlockerror',
@@ -22,7 +25,7 @@ var SimManager = {
                           'retryCount', {
                             configurable: true,
                             get: function() {
-                              return this.mobConn.retryCount;
+                              return this.iccManager.unlockRetryCount;
                             }
                           });
   },

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -492,9 +492,18 @@ navigator.mozL10n.ready(function bluetoothSettings() {
     // callback function when an avaliable device found
     function onDeviceFound(evt) {
       var device = evt.device;
-      // ignore duplicate and paired device
-      if (openList.index[device.address] || pairList.index[device.address])
+      // ignore paired device
+      if (pairList.index[device.address])
         return;
+
+      var duplicateDevice = null;
+
+      // ignore or update duplicate device
+      if (openList.index[device.address]) {
+        duplicateDevice = openList.index[device.address][0];
+        if (duplicateDevice.name)
+          return;
+      }
 
       var aItem = newListItem(device, 'device-status-tap-connect');
 
@@ -513,7 +522,11 @@ navigator.mozL10n.ready(function bluetoothSettings() {
         };
 
       };
-      openList.list.appendChild(aItem);
+
+      if (duplicateDevice == null)
+        openList.list.appendChild(aItem);
+      else
+        openList.list.replaceChild(aItem, openList.index[duplicateDevice.address][1]);
       openList.index[device.address] = [device, aItem];
     }
 

--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -26,6 +26,7 @@ var SimPinDialog = {
   errorMsgBody: document.getElementById('messageBody'),
 
   mobileConnection: null,
+  iccManager: null,
 
   lockType: 'pin',
   action: 'unlock',
@@ -248,7 +249,7 @@ var SimPinDialog = {
         break;
     }
 
-    var retryCount = this.mobileConnection.retryCount;
+    var retryCount = this.iccManager.unlockRetryCount;
     if (!retryCount) {
       this.triesLeftMsg.hidden = true;
     } else {
@@ -289,6 +290,10 @@ var SimPinDialog = {
   init: function spl_init() {
     this.mobileConnection = window.navigator.mozMobileConnection;
     if (!this.mobileConnection)
+      return;
+
+    this.iccManager = window.navigator.mozIccManager;
+    if (!this.iccManager)
       return;
 
     this.mobileConnection.addEventListener('icccardlockerror',

--- a/apps/system/js/simcard_dialog.js
+++ b/apps/system/js/simcard_dialog.js
@@ -27,6 +27,7 @@ var SimPinDialog = {
   errorMsgBody: document.getElementById('messageBody'),
 
   mobileConnection: null,
+  iccManager: null,
 
   lockType: 'pin',
   action: 'unlock',
@@ -70,7 +71,7 @@ var SimPinDialog = {
 
     var cardState = this.mobileConnection.cardState;
     var lockType = this.lockTypeMap[cardState];
-    var retryCount = this.mobileConnection.retryCount;
+    var retryCount = this.iccManager.unlockRetryCount;
 
     if (!retryCount) {
       this.triesLeftMsg.hidden = true;
@@ -322,6 +323,10 @@ var SimPinDialog = {
 
     this.mobileConnection = window.navigator.mozMobileConnection;
     if (!this.mobileConnection)
+      return;
+
+    this.iccManager = window.navigator.mozIccManager;
+    if (!this.iccManager)
       return;
 
     this.mobileConnection.addEventListener('icccardlockerror',


### PR DESCRIPTION
Sometimes we don't receive the name for a discovered Bluetooth device,
and simply display 'Unknown device' in the Settings app. If the device
later announces itself again, we simply ignore the update.

With this patch, updates for 'unknown' devices are not ignored, but
the list entry in thre Settings app gets replaced. If the device now
supplied a name for itself, the list entry will show the device's
name.
