### PR TITLE
Bug 882899 - [SMS][MMS] Utils.getContactCarrier throws TypeError if tel not found (found is undefined)

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -249,7 +249,14 @@
       for (var i = 0; i < length; i++) {
         tel = tels[i];
 
-        if (tel.value === input) {
+        // Based on...
+        //  - ITU-T E.123 (http://www.itu.int/rec/T-REC-E.123-200102-I/)
+        //  - ITU-T E.164 (http://www.itu.int/rec/T-REC-E.164-201011-I/)
+        //
+        // ...It would appear that a maximally-minimal
+        // 7 digit comparison is safe.
+        //
+        if (tel.value && tel.value.slice(-7) === input.slice(-7)) {
           found = tel;
         }
 
@@ -263,6 +270,10 @@
 
         carrier = tel.carrier;
         type = tel.type[0];
+      }
+
+      if (!found) {
+        return '';
       }
 
       type = found.type[0];

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -458,6 +458,34 @@ suite('Utils', function() {
       assert.equal(a, 'Mobile | Nynex');
       assert.equal(b, 'Mobile | MCI');
     });
+
+    test('Multi different carrier, same type - intl number', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '1234567890', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '0987654321', type: ['Mobile'], carrier: 'MCI'}
+      ];
+
+      var a = Utils.getContactCarrier('+1234567890', tel);
+      var b = Utils.getContactCarrier('+0987654321', tel);
+
+      assert.equal(a, 'Mobile | Nynex');
+      assert.equal(b, 'Mobile | MCI');
+    });
+
+    test('Multi different carrier, same type - never match', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '1234567890', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '0987654321', type: ['Mobile'], carrier: 'MCI'}
+      ];
+
+      var a = Utils.getContactCarrier('+9999999999', tel);
+      var b = Utils.getContactCarrier('+9999999999', tel);
+
+      assert.equal(a, '');
+      assert.equal(b, '');
+    });
   });
 
   suite('Utils for MMS user story test', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=882899

Signed-off-by: Rick Waldron waldron.rick@gmail.com
