### PR TITLE
Merge pull request #10352 from davidflanagan/bug882197

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -391,12 +391,11 @@
   // field. Also update our internal state to match the new textfield
   // content and cursor position.
   function replaceBeforeCursor(oldWord, newWord) {
+    var oldWordLen = oldWord.length;
     if (keyboard.replaceSurroundingText) {
-      keyboard.replaceSurroundingText(newWord, oldWord.length, 0);
+      keyboard.replaceSurroundingText(newWord, oldWordLen, 0);
     }
     else {
-      var oldWordLen = oldWord.length;
-
       // Find the first character in currentWord and newWord that differs
       // so we know how many backspaces we need to send.
       for (var firstdiff = 0; firstdiff < oldWordLen; firstdiff++) {


### PR DESCRIPTION
Bug 882197: remember cursor position after calling replaceSurroundingText r=dhylands(cherry picked from commit d86821224617d03f566fa7668e5fe68df764893e)
