### PR TITLE
Bug 881195 - [Buri][Setting] WIFI status not correctly displayed at startup, r=kaze

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2783,7 +2783,7 @@
             <a id="menuItem-gps" class="menu-item" data-l10n-id="geolocation">Geolocation</a>
           </li>
           <li>
-            <small id="wifi-desc" class="menu-item-desc" data-l10n-id="fullStatus-disconnected">offline</small>
+            <small id="wifi-desc" class="menu-item-desc"></small>
             <a id="menuItem-wifi" class="menu-item" href="#wifi" data-l10n-id="wifi">Wi-Fi</a>
           </li>
           <li id="call-settings">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=881195
