### PR TITLE
Bug 840147 & Bug 877903 : fix orientation problem on open/close app animation.

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -220,6 +220,7 @@
     <!-- Any module that wants to intercept the Home button and prevent the -->
     <!-- homescreen from being displayed must come before this script. -->
     <link rel="stylesheet" type="text/css" href="style/window.css">
+    <script defer src="js/orientation_observer.js"></script>
     <script defer src="js/window.js"></script>
     <script defer src="js/window_manager.js"></script>
 

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -32,6 +32,7 @@ var KeyboardManager = (function() {
   var previousHash = '';
 
   var urlparser = document.createElement('a');
+  var appClosing = false;
   keyboard.addEventListener('mozbrowserlocationchange', function(e) {
     urlparser.href = e.detail;
     if (previousHash == urlparser.hash)
@@ -41,6 +42,12 @@ var KeyboardManager = (function() {
     var type = urlparser.hash.split('=');
     switch (type[0]) {
       case '#show':
+        // If an app is closing, we should ignore any #show triggered by
+        // resize events which come from orientation change events.
+        if (appClosing) {
+          return;
+        }
+
         var updateHeight = function updateHeight() {
           container.removeEventListener('transitionend', updateHeight);
           if (container.classList.contains('hide')) {
@@ -87,7 +94,13 @@ var KeyboardManager = (function() {
     window.addEventListener(eventType, function closeKeyboard() {
       dispatchEvent(new CustomEvent('keyboardhide'));
       container.classList.add('hide');
+      if (eventType == 'appwillclose') {
+        appClosing = true;
+      }
     });
+
+  window.addEventListener('appclose', function appClose() {
+    appClosing = false;
   });
 })();
 

--- a/apps/system/js/orientation_observer.js
+++ b/apps/system/js/orientation_observer.js
@@ -1,0 +1,50 @@
+/* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+var OrientationObserver = {
+  deviceOrientation: 'portrait-primary',
+  init: function oo_init() {
+    window.addEventListener('screenchange', this);
+  },
+
+  handleEvent: function oo_handleEvent(evt) {
+    switch (evt.type) {
+      case 'screenchange':
+        // We only observe device orientation when screen is on.
+        if (evt.detail.screenEnabled) {
+          window.addEventListener('deviceorientation', this);
+        } else {
+          window.removeEventListener('deviceorientation', this);
+        }
+        break;
+
+      case 'deviceorientation':
+        // Orientation is 0 starting at 'natural portrait' increasing
+        // going clockwise
+        this.deviceOrientation =
+          (evt.beta < -45 && evt.beta > -135) ? 'portrait-primary' :
+          (evt.beta > 45 && evt.beta < 135) ? 'portrait-secondary' :
+          (evt.gamma < -45 && evt.gamma > -135) ? 'landscape-secondary' :
+          (evt.gamma > 45 && evt.gamma < 135) ? 'landscape-primary' :
+          this.deviceOrientation;
+        break;
+    }
+  },
+
+  // If an app doesn't designate orientation, or designates only "landscape"
+  // or "portrait", select one for it by looking at current orientation.
+  determine: function oo_determine(appOrientation) {
+    var result;
+    result = appOrientation || this.deviceOrientation;
+    if (result == 'landscape' || result == 'portrait') {
+      result = this.deviceOrientation.startsWith(result) ?
+               this.deviceOrientation :
+               result + '-primary';
+    }
+    return result;
+  }
+};
+
+OrientationObserver.init();

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -112,20 +112,6 @@ var WindowManager = (function() {
     return displayedApp || null;
   }
 
-  function requireFullscreen(origin) {
-    var app = runningApps[origin];
-    if (!app)
-      return false;
-
-    var manifest = app.manifest;
-    if ('entry_points' in manifest && manifest.entry_points &&
-        manifest.type == 'certified') {
-       manifest = manifest.entry_points[origin.split('/')[3]];
-    }
-
-    return 'fullscreen' in manifest ? manifest.fullscreen : false;
-  }
-
   // Make the specified app the displayed app.
   // Public function.  Pass null to make the homescreen visible
   function launch(origin) {
@@ -160,39 +146,14 @@ var WindowManager = (function() {
       return null;
   }
 
-  // Set the size of the app's iframe to match the size of the screen.
-  // We have to call this on resize events (which happen when the
-  // phone orientation is changed). And also when an app is launched
-  // and each time an app is brought to the front, since the
-  // orientation could have changed since it was last displayed
-  function setAppSize(origin, changeActivityFrame) {
-    var app = runningApps[origin];
-    if (!app)
-      return;
-
-    var frame = app.frame;
-    var manifest = app.manifest;
-
-    var cssWidth = window.innerWidth + 'px';
-    var cssHeight = window.innerHeight - StatusBar.height;
-    if ('wrapper' in frame.dataset) {
-      cssHeight -= 10;
-    }
-    cssHeight += 'px';
-
-    if (!screenElement.classList.contains('attention') &&
-        requireFullscreen(origin)) {
-      cssHeight = window.innerHeight + 'px';
-    }
-
-    frame.style.width = cssWidth;
-    frame.style.height = cssHeight;
-
-    // We will call setInlineActivityFrameSize()
-    // if changeActivityFrame is not explicitly set to false.
-    if (changeActivityFrame !== false)
+  // XXX: appWindow.resize needs to call setInlineActivityFramseSize().
+  // We should maintain a link in appWindow to activity frame
+  // so that appWindow can resize activity by itself.
+  window.addEventListener('appresize', function appResized(evt) {
+    if (evt.detail.changeActivityFrame) {
       setInlineActivityFrameSize();
-  }
+    }
+  });
 
   // App's height is relevant to keyboard height
   function setAppHeight(keyboardHeight) {
@@ -319,6 +280,7 @@ var WindowManager = (function() {
 
   windows.addEventListener('transitionend', function frameTransitionend(evt) {
     var prop = evt.propertyName;
+
     var frame = evt.target;
     if (prop !== 'transform')
       return;
@@ -427,8 +389,12 @@ var WindowManager = (function() {
     // Set displayedApp to the new value
     displayedApp = iframe.dataset.frameOrigin;
 
+    var app = runningApps[displayedApp];
+
+    app.addClearRotateTransition();
     // Set orientation for the new app
     setOrientationForApp(displayedApp);
+
   }
 
   // Execute when the application is actually loaded
@@ -471,6 +437,7 @@ var WindowManager = (function() {
   // Executes when app closing transition finishes.
   function windowClosed(frame) {
     var iframe = frame.firstChild;
+    var origin = iframe.dataset.frameOrigin;
 
     // If the FTU is closing, make sure we save this state
     if (iframe.src == ftuURL) {
@@ -486,6 +453,8 @@ var WindowManager = (function() {
 
     frame.classList.remove('active');
     windows.classList.remove('active');
+
+    runningApps[origin].addClearRotateTransition();
 
     // set the closed frame visibility to false
 
@@ -516,6 +485,9 @@ var WindowManager = (function() {
     }
 
     screenElement.classList.remove('fullscreen-app');
+
+    // Inform keyboardmanager that we've finished the transition
+    dispatchEvent(new CustomEvent('appclose'));
   }
 
   // Save the screenshot
@@ -752,7 +724,7 @@ var WindowManager = (function() {
     openCallback = callback || function() {};
 
     // set the size of the opening app
-    setAppSize(origin);
+    app.resize();
 
     if (origin === homescreen) {
       // We cannot apply background screenshot to home screen app since
@@ -779,8 +751,10 @@ var WindowManager = (function() {
       return;
     }
 
-    if (requireFullscreen(origin))
+    if (app.isFullScreen())
       screenElement.classList.add('fullscreen-app');
+
+    app.setRotateTransition(app.manifest.orientation);
 
     transitionOpenCallback = function startOpeningTransition() {
       // We have been canceled by another transition.
@@ -862,10 +836,6 @@ var WindowManager = (function() {
     setCloseFrame(app.frame);
     closeCallback = callback || function() {};
 
-    // Animate the window close.  Ensure the homescreen is in the
-    // foreground since it will be shown during the animation.
-    var homescreenFrame = ensureHomescreen();
-
     // invoke openWindow to show homescreen here
     openWindow(homescreen, null);
 
@@ -877,8 +847,12 @@ var WindowManager = (function() {
 
     // Set the size of both homescreen app and the closing app
     // since the orientation had changed.
-    setAppSize(homescreen);
-    setAppSize(origin);
+    runningApps[homescreen].resize();
+    app.setRotateTransition();
+
+    // Animate the window close.  Ensure the homescreen is in the
+    // foreground since it will be shown during the animation.
+    var homescreenFrame = ensureHomescreen();
 
     // Send a synthentic 'appwillclose' event.
     // The keyboard uses this and the appclose event to know when to close
@@ -937,13 +911,13 @@ var WindowManager = (function() {
                   app.manifest.name, app.manifest, app.manifestURL,
                   /* expectingSystemMessage */ false);
       runningApps[homescreen].iframe.dataset.start = Date.now();
-      setAppSize(homescreen);
+      runningApps[homescreen].resize();
       if (displayedApp != homescreen &&
         'setVsibile' in runningApps[homescreen].iframe)
         runningApps[homescreen].iframe.setVisible(false);
     } else if (reset) {
       runningApps[homescreen].iframe.src = homescreenURL;
-      setAppSize(homescreen);
+      runningApps[homescreen].resize();
     }
 
     return runningApps[homescreen].frame;
@@ -1207,6 +1181,12 @@ var WindowManager = (function() {
       if (rv === false) {
         console.warn('screen.mozLockOrientation() returned false for',
                      origin, 'orientation', manifest.orientation);
+        // Prevent breaking app size on desktop since we've resized landscape
+        // apps for transition.
+        if (app.frame.dataset.orientation == 'landscape-primary' ||
+            app.frame.dataset.orientation == 'landscape-secondary') {
+          app.resize();
+        }
       }
     } else {  // If no orientation was requested, then let it rotate
       screen.mozUnlockOrientation();
@@ -1324,7 +1304,7 @@ var WindowManager = (function() {
     });
     runningApps[origin] = app;
 
-    if (requireFullscreen(origin)) {
+    if (app.isFullScreen()) {
       frame.classList.add('fullscreen-app');
     }
     if (origin === ftuURL) {
@@ -1594,7 +1574,7 @@ var WindowManager = (function() {
           // set the size of the iframe
           // so Cards View will get a correct screenshot of the frame
           if (!e.detail.isActivity) {
-            setAppSize(origin, false);
+            app.resize(false);
             if ('setVisible' in app.iframe)
               app.iframe.setVisible(false);
           }
@@ -2149,7 +2129,7 @@ var WindowManager = (function() {
 
         setAppHeight(evt.detail.height);
       } else if (displayedApp) {
-        setAppSize(displayedApp);
+        runningApps[displayedApp].resize();
       }
     });
   });

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -39,18 +39,32 @@
   margin: 0;
   margin-top: 2rem;
   position: absolute;
-  background-size: contain;
-  background-position: center center;
-  background-repeat: no-repeat;
   opacity: 0;
   pointer-events: none;
   transform: scale(0.8);
 }
 
-#cards-view .card.landscape, #cards-view .card.landscape-primary,
-#cards-view .card.landscape-secondary {
-  height: 43%;
-  margin-top: calc(43% + 2rem);
+#cards-view .screenshotView {
+  background-size: cover;
+  background-position: left top;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+#cards-view .screenshotView.landscape,
+#cards-view .screenshotView.landscape-primary {
+  transform: rotate(90deg);
+}
+
+#cards-view .screenshotView.landscape-secondary {
+  transform: rotate(270deg);
+}
+
+#cards-view .screenshotView.portrait-secondary {
+  transform: rotate(180deg);
+  transform-origin: 50% 50%;
 }
 
 #cards-view .card h1 {

--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -276,13 +276,83 @@ body {
   visibility: hidden;
 }
 
-#screen.cards-view > #windows > .appWindow.closing {
+#windows > .appWindow.portrait-secondary {
+  transform: rotate(180deg);
+  margin-top: -2rem;
+  overflow: visible;
+}
+
+#windows > .appWindow.landscape-primary {
+  transform: rotate(90deg);
+  overflow: visible;
+}
+
+#windows > .appWindow.landscape-secondary {
+  transform: rotate(270deg);
+  margin-left: 2rem;
+  overflow: visible;
+}
+
+/* placeholder for status bar of previous orientation */
+#windows > .appWindow.landscape-primary:not(.fullscreen-app):after,
+#windows > .appWindow.landscape-secondary:not(.fullscreen-app):after,
+#windows > .appWindow.portrait-secondary:not(.fullscreen-app):after {
+  display: block;
+  height: 2rem;
+  width: 100%;
+  left: 0;
+  top: -2rem;
+  position: absolute;
+  content: ' ';
+  font-size: 1.8rem;
+  background: #000000;
+}
+
+#windows > .appWindow.fullscreen-app.portrait-secondary,
+#windows > .appWindow.fullscreen-app.landscape-primary,
+#windows > .appWindow.fullscreen-app.landscape-secondary {
+  margin: 0;
+}
+#windows > .appWindow.closing {
+  /* The animation takes .3 seconds so users cannot touch the app while the
+   * closing animation is performing */
+  pointer-events: none;
+}
+
+#screen.cards-view > #windows > .appWindow.closing.portrait-primary {
   transform: scale(0.8);
+}
+
+#screen.cards-view > #windows > .appWindow.closing.portrait-secondary {
+  transform: scale(0.8) rotate(180deg);
+}
+
+#screen.cards-view > #windows > .appWindow.closing.landscape-primary {
+  transform: scale(0.8) rotate(90deg);
+}
+
+#screen.cards-view > #windows > .appWindow.closing.landscape-secondary {
+  transform: scale(0.8) rotate(270deg);
 }
 
 #windows > .appWindow:not(.homescreen):not(.active):not(.inlineActivity):not(.opening) {
   opacity: 0;
   transform: scale(0.6);
+}
+
+#windows > .appWindow:not(.homescreen):not(.active):not(.inlineActivity):not(.opening).portrait-secondary {
+  opacity: 0;
+  transform: scale(0.6) rotate(180deg);
+}
+
+#windows > .appWindow:not(.homescreen):not(.active):not(.inlineActivity):not(.opening).landscape-primary {
+  opacity: 0;
+  transform: scale(0.6) rotate(90deg);
+}
+
+#windows > .appWindow:not(.homescreen):not(.active):not(.inlineActivity):not(.opening).landscape-secondary {
+  opacity: 0;
+  transform: scale(0.6) rotate(270deg);
 }
 
 #windows > .appWindow.opening {

--- a/apps/system/test/unit/cards_view_test.js
+++ b/apps/system/test/unit/cards_view_test.js
@@ -66,22 +66,54 @@ suite('cards view >', function() {
 
     MockWindowManager.mRunningApps = {
       'http://sms.gaiamobile.org': {
-        launchTime: 2,
+        launchTime: 5,
         name: 'SMS',
         frame: document.createElement('div'),
         iframe: document.createElement('iframe'),
         manifest: {
           orientation: 'portrait-primary'
-        }
+        },
+        currentOrientation: 'portrait-primary'
       },
       'http://game.gaiamobile.org': {
-        launchTime: 1,
+        launchTime: 4,
         name: 'GAME',
         frame: document.createElement('div'),
         iframe: document.createElement('iframe'),
         manifest: {
           orientation: 'landscape-primary'
-        }
+        },
+        currentOrientation: 'landscape-primary'
+      },
+      'http://game2.gaiamobile.org': {
+        launchTime: 3,
+        name: 'GAME2',
+        frame: document.createElement('div'),
+        iframe: document.createElement('iframe'),
+        manifest: {
+          orientation: 'landscape-secondary'
+        },
+        currentOrientation: 'landscape-secondary'
+      },
+      'http://game3.gaiamobile.org': {
+        launchTime: 2,
+        name: 'GAME3',
+        frame: document.createElement('div'),
+        iframe: document.createElement('iframe'),
+        manifest: {
+          orientation: 'landscape'
+        },
+        currentOrientation: 'landscape-primary'
+      },
+      'http://game4.gaiamobile.org': {
+        launchTime: 1,
+        name: 'GAME4',
+        frame: document.createElement('div'),
+        iframe: document.createElement('iframe'),
+        manifest: {
+          orientation: 'portrait-secondary'
+        },
+        currentOrientation: 'portrait-secondary'
       }
     };
     MockWindowManager.mDisplayedApp = 'http://sms.gaiamobile.org';
@@ -152,17 +184,34 @@ suite('cards view >', function() {
       CardsView.hideCardSwitcher();
     });
 
-    test('cardsview defines a landscape app', function() {
-      assert.isTrue(cardsView.
-        querySelector('li[data-origin="http://game.gaiamobile.org"]').classList.
-        contains('landscape'));
+    var testCardOrientation = function(origin, orientation) {
+      var card = cardsView.querySelector('li[data-origin="' + origin + '"]');
+      card.dispatchEvent(new CustomEvent('onviewport'));
+      return card.querySelector('.screenshotView')
+          .classList.contains(orientation);
+    };
+
+    test('cardsview defines a landscape-primary app', function() {
+      assert.isTrue(testCardOrientation('http://game.gaiamobile.org',
+                                        'landscape-primary'));
+    });
+    test('cardsview defines a landscape-secondary app', function() {
+      assert.isTrue(testCardOrientation('http://game2.gaiamobile.org',
+                                        'landscape-secondary'));
+    });
+    test('cardsview defines a landscape app in landscape-primary', function() {
+      assert.isTrue(testCardOrientation('http://game3.gaiamobile.org',
+                                        'landscape-primary'));
+    });
+    test('cardsview defines a portrait app in portrait-primary', function() {
+      assert.isTrue(testCardOrientation('http://sms.gaiamobile.org',
+                                        'portrait-primary'));
+    });
+    test('cardsview defines a portrait-secondary app', function() {
+      assert.isTrue(testCardOrientation('http://game4.gaiamobile.org',
+                                        'portrait-secondary'));
     });
 
-    test('cardsview defines a portrait app', function() {
-      assert.isFalse(cardsView.
-        querySelector('li[data-origin="http://sms.gaiamobile.org"]').classList.
-        contains('landscape'));
-    });
   });
 });
 

--- a/apps/system/test/unit/orientation_observer_test.js
+++ b/apps/system/test/unit/orientation_observer_test.js
@@ -1,0 +1,97 @@
+'use strict';
+requireApp('system/js/orientation_observer.js');
+
+suite('orientation observer >', function() {
+  var subject;
+  var portraitPrimary = {
+    beta: -90,
+    alpha: 0,
+    gamma: 0
+  };
+  var portraitSecondary = {
+    beta: 90,
+    alpha: 0,
+    gamma: 0
+  };
+  var landscapePrimary = {
+    beta: 0,
+    alpha: 0,
+    gamma: 90
+  };
+  var landscapeSecondary = {
+    beta: 0,
+    alpha: 0,
+    gamma: -90
+  };
+
+  var coordinate = {
+    'portrait-primary': portraitPrimary,
+    'portrait-secondary': portraitSecondary,
+    'landscape-primary': landscapePrimary,
+    'landscape-secondary': landscapeSecondary
+  };
+
+  var appOrientationTestData = [
+    {app: null, device: 'portrait-primary', result: 'portrait-primary'},
+    {app: null, device: 'portrait-secondary', result: 'portrait-secondary'},
+    {app: null, device: 'landscape-primary', result: 'landscape-primary'},
+    {app: null, device: 'landscape-secondary', result: 'landscape-secondary'},
+
+    {app: 'portrait', device: 'portrait-primary',
+                      result: 'portrait-primary'},
+    {app: 'portrait', device: 'portrait-secondary',
+                      result: 'portrait-secondary'},
+    {app: 'portrait', device: 'landscape-primary',
+                      result: 'portrait-primary'},
+    {app: 'portrait', device: 'landscape-secondary',
+                      result: 'portrait-primary'},
+
+    {app: 'landscape', device: 'portrait-primary',
+                       result: 'landscape-primary'},
+    {app: 'landscape', device: 'portrait-secondary',
+                       result: 'landscape-primary'},
+    {app: 'landscape', device: 'landscape-primary',
+                       result: 'landscape-primary'},
+    {app: 'landscape', device: 'landscape-secondary',
+                       result: 'landscape-secondary'},
+
+    {app: 'portrait-primary', device: 'landscape-secondary',
+                                 result: 'portrait-primary'},
+    {app: 'portrait-secondary', device: 'landscape-primary',
+                                 result: 'portrait-secondary'},
+    {app: 'landscape-primary', device: 'portrait-primary',
+                                 result: 'landscape-primary'},
+    {app: 'landscape-secondary', device: 'landscape-primary',
+                                 result: 'landscape-secondary'}
+  ];
+
+  setup(function() {
+    subject = OrientationObserver;
+    subject.handleEvent({type: 'screenchange', detail: {screenEnabled: true}});
+  });
+
+  var makeOrientationEvent = function(coordinate) {
+    return {
+      type: 'deviceorientation',
+      alpha: coordinate.alpha,
+      beta: coordinate.beta,
+      gamma: coordinate.gamma
+    };
+  };
+
+  test('orientation event handler', function() {
+    for (var key in coordinate) {
+      subject.handleEvent(makeOrientationEvent(coordinate[key]));
+      assert.equal(subject.deviceOrientation, key);
+    }
+  });
+
+  test('app orientation determinator', function() {
+    appOrientationTestData.forEach(function(elem) {
+      subject.handleEvent(makeOrientationEvent(coordinate[elem.device]));
+      assert.equal(subject.determine(elem.app), elem.result);
+    });
+  });
+
+  teardown(function() {});
+});


### PR DESCRIPTION
This is for v1-train only patch.
Mostly the same logic as @98e70417ca684d26052768511e6a347a319c0991, with the following need to be noticed:
- CSS rules differs significantly to adapt the legacy open/close app animation on v1-train.
- App-to-app transition doesn't need any fix in master with respect to orientation, but seems it's not so good in v1-train. I'm not sure if we have any plan uplifting new app-to-app transition. 
- Apps setting their orientation as "landscape" rather than "landscape-primary" or "landscape-secondary" will be opened in landscape-primary by default now.
