### PR TITLE
Bug 865155 - Email divider lines are incorrect. They should have a 15 pixel gap at both ends to match system. | Follow up patch

### DIFF
--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -512,9 +512,11 @@ input.msg-search-text-tease {
   top: 40%;
 }
 
-.msg-messages-syncing,
-.msg-messages-sync-more {
+.msg-messages-sync-container > .msg-messages-syncing,
+.msg-messages-sync-container > .msg-messages-sync-more {
   border-bottom: 0.1rem solid #bebebe;
+  width: calc(100% - 3rem);
+  margin: 0 auto;
 }
 
 .msg-messages-syncing > span {


### PR DESCRIPTION
Bug [#865155](https://bugzilla.mozilla.org/show_bug.cgi?id=865155)
