### PR TITLE
Bug 829023 - [Settings] Don't use dividers to separate paragraphs in thesame text block | Follow up patch

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2599,11 +2599,13 @@
 
       <div>
         <ul>
-          <li class="description" data-l10n-id="crash-reports-description-1"></li>
-          <li class="description" data-l10n-id="crash-reports-description-2"></li>
-          <li>
-            <p class="description">
-              <span data-l10n-id="crash-reports-description-3-start"></span><a href="https://www.mozilla.org/privacy/" data-l10n-id="crash-reports-description-3-privacy" class="link-text"></a><span data-l10n-id="crash-reports-description-3-end"></span>
+          <li class="description">
+            <p data-l10n-id="crash-reports-description-1"></p>
+            <p data-l10n-id="crash-reports-description-2"></p>
+            <p>
+              <span data-l10n-id="crash-reports-description-3-start"></span>
+              <a href="https://www.mozilla.org/privacy/" data-l10n-id="crash-reports-description-3-privacy" class="link-text"></a>
+              <span data-l10n-id="crash-reports-description-3-end"></span>
             </p>
           </li>
         </ul>

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -96,16 +96,21 @@ section[role="region"] > div {
 .description {
   padding: 1rem 2rem 1rem 3rem;
   font-size: 1.7rem;
-  line-height: 23px;
+  line-height: 2.3rem;
   white-space: normal;
   -moz-hyphens: auto;
 }
 
 .description p {
   padding: 0 0 1rem;
-  font-size: 1.9rem;
+  font-size: 1.7rem;
+  line-height: 2.3rem;
   text-overflow: none;
   white-space: normal;
+}
+
+.description a {
+  font-size: 1.7rem;
 }
 
 .link-text, .tel-text a {
@@ -212,18 +217,18 @@ section li.password > p {
 
 #mediaStorage .space-stackedbar {
   background-color: #E7E7E7;
-  border: solid 1px #A6A6A6;
+  border: solid 0.1rem #A6A6A6;
   border-radius: 0.3rem;
   display: inline-block;
-  height: 30px;
+  height: 3rem;
   margin: 0.8rem 5%;
-  padding: 1px;
+  padding: 0.1rem;
   width: 90%;
 }
 
 #mediaStorage .space-stackedbar .stackedbar-item {
   display: inline-block;
-  height: 30px;
+  height: 3rem;
 }
 
 #mediaStorage .space-stackedbar .color-music,
@@ -247,7 +252,7 @@ section li.password > p {
 }
 
 #mediaStorage .color-free .stackedbar-color-label {
-  border: solid 1px #A6A6A6;
+  border: solid 0.1rem #A6A6A6;
 }
 
 #mediaStorage .color-music .stackedbar-color-label,
@@ -261,7 +266,7 @@ section li.password > p {
   display: inline-block;
   height: 2rem;
   left: 0.5rem;
-  padding: 0px;
+  padding: 0;
   position: absolute;
   top: 2.1rem;
   width: 2rem;


### PR DESCRIPTION
Bug [#829023](https://bugzilla.mozilla.org/show_bug.cgi?id=829023)
