### PR TITLE
Bug 881716 - [SMS/MMS] Search result for contacts from Messaging app is not showing the carrier r=arcturus

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -198,7 +198,7 @@
         data-number="${number}" data-source="contacts" data-name="${name}">
         <p class="name">${nameHTML}</p>
         <p>
-          ${type} ${numberHTML}
+          ${type}${separator}${carrier}${numberHTML}
         </p>
       </a>
       -->

--- a/apps/sms/js/desktop_contacts_mock.js
+++ b/apps/sms/js/desktop_contacts_mock.js
@@ -348,6 +348,30 @@
     })
   );
 
+  ContactsDB.push(
+    new Contact({
+      familyName: 'Bird',
+      givenName: 'Big',
+      tel: {
+        value: '123456',
+        type: 'Mobile',
+        carrier: 'Nynex'
+      }
+    })
+  );
+
+  ContactsDB.push(
+    new Contact({
+      familyName: 'Carrier',
+      givenName: 'Igotno',
+      tel: {
+        value: '436797',
+        type: 'Mobile',
+        carrier: null
+      }
+    })
+  );
+
   // console.log( ContactsDB );
 
 

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -811,9 +811,11 @@ var ThreadUI = global.ThreadUI = {
 
       // The carrier banner is meaningless and confusing in
       // group message mode.
-      if (thread.participants.length === 1 && details.carrier) {
-        carrierTag.textContent = details.carrier;
-        carrierTag.classList.remove('hide');
+      if (thread.participants.length === 1) {
+        if (contacts && contacts.length) {
+          carrierTag.textContent = Utils.getContactCarrier(number, contacts[0].tel);
+          carrierTag.classList.remove('hide');
+        }
       } else {
         carrierTag.classList.add('hide');
       }
@@ -1514,14 +1516,21 @@ var ThreadUI = global.ThreadUI = {
       var current = tels[i];
       var number = current.value;
       var title = details.title || number;
+<<<<<<< HEAD
       var type = current.type ? (current.type + ' |') : '';
+=======
+      var type = current.type && current.type.length ? current.type[0] : '';
+      var carrier = current.carrier ? (current.carrier + ', ') : '';
+      var separator = type || carrier ? ' | ' : '';
+>>>>>>> 3c65d31... Bug 881716 - [SMS/MMS] Search result for contacts from Messaging app is not showing the carrier r=arcturus
 
       var li = document.createElement('li');
       var data = {
         name: Utils.escapeHTML(title),
         number: Utils.escapeHTML(number),
         type: type,
-        carrier: current.carrier || '',
+        carrier: carrier,
+        separator: separator,
         nameHTML: '',
         numberHTML: ''
       };

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -170,8 +170,8 @@
           // Convert the tel-type to string before tel-type comparison.
           // TODO : We might need to handle multiple tel type in the future.
           for (i = 0; i < length; i++) {
-            var telType = contact.tel[i].type.toString();
-            var phoneType = phone.type.toString();
+            var telType = contact.tel[i].type && contact.tel[i].type.toString();
+            var phoneType = phone.type && phone.type.toString();
             if (contact.tel[i].value !== phone.value &&
                 telType === phoneType &&
                 contact.tel[i].carrier === phone.carrier) {
@@ -213,6 +213,59 @@
       }
 
       return details;
+    },
+
+    getContactCarrier: function(input, tels) {
+      /**
+        1. If a phone number has carrier associated with it
+            the output will be:
+
+          Firstname Lastname
+          type | carrier
+
+        2. If there is no carrier associated with the phone number
+            the output will be:
+
+          Firstname Lastname
+          type | phonenumber
+
+        3. If for some reason a single contact has two phone numbers with
+            the same type and the same carrier the output will be:
+
+          Firstname Lastname
+          type | phonenumber
+
+      */
+
+      var length = tels.length;
+      var hasUniqueCarriers = true;
+      var hasUniqueTypes = true;
+      var found, tel, type, carrier, value;
+
+      for (var i = 0; i < length; i++) {
+        tel = tels[i];
+
+        if (tel.value === input) {
+          found = tel;
+        }
+
+        if (carrier && carrier === tel.carrier) {
+          hasUniqueCarriers = false;
+        }
+
+        if (type && type === tel.type[0]) {
+          hasUniqueTypes = false;
+        }
+
+        carrier = tel.carrier;
+        type = tel.type[0];
+      }
+
+      type = found.type[0];
+      carrier = hasUniqueCarriers || hasUniqueTypes ? found.carrier : '';
+      value = carrier || found.value;
+
+      return type + ' | ' + (carrier || value);
     },
 
     getResizedImgBlob: function ut_getResizedImgBlob(blob, limit, callback) {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1383,7 +1383,95 @@ suite('thread_ui.js >', function() {
       );
     });
 
+<<<<<<< HEAD
     test('Rendered Contact "type | number"', function() {
+=======
+    test('Rendered Contact "number"', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      contact.tel[0].carrier = null;
+      contact.tel[0].type = null;
+
+      ThreadUI.renderContact({
+        contact: contact,
+        input: 'foo',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+      html = ul.firstElementChild.innerHTML;
+
+      assert.ok(html.contains('+346578888888'));
+    });
+
+    test('Rendered Contact highlighted "number"', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      contact.tel[0].carrier = null;
+      contact.tel[0].type = null;
+
+      ThreadUI.renderContact({
+        contact: contact,
+        input: '346578888888',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+      html = ul.firstElementChild.innerHTML;
+
+      assert.ok(
+        html.contains('+<span class="highlight">346578888888</span>')
+      );
+    });
+
+    test('Rendered Contact "type | number"', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      contact.tel[0].carrier = null;
+
+      ThreadUI.renderContact({
+        contact: contact,
+        input: 'foo',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+      html = ul.firstElementChild.innerHTML;
+
+      assert.ok(html.contains('Mobile | +346578888888'));
+    });
+
+    test('Rendered Contact highlighted "type | number"', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      contact.tel[0].carrier = null;
+
+      ThreadUI.renderContact({
+        contact: contact,
+        input: '346578888888',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+      html = ul.firstElementChild.innerHTML;
+
+      assert.ok(
+        html.contains('Mobile | +<span class="highlight">346578888888</span>')
+      );
+    });
+
+
+
+    test('Rendered Contact "type | carrier, number"', function() {
+>>>>>>> 3c65d31... Bug 881716 - [SMS/MMS] Search result for contacts from Messaging app is not showing the carrier r=arcturus
       var ul = document.createElement('ul');
       var contact = new MockContact();
       var html;
@@ -1396,10 +1484,18 @@ suite('thread_ui.js >', function() {
         isHighlighted: true
       });
       html = ul.firstElementChild.innerHTML;
+<<<<<<< HEAD
       assert.ok(html.contains('Mobile | +346578888888'));
     });
 
     test('Rendered Contact highlighted "type | number"', function() {
+=======
+
+      assert.ok(html.contains('Mobile | TEF, +346578888888'));
+    });
+
+    test('Rendered Contact highlighted "type | carrier, number"', function() {
+>>>>>>> 3c65d31... Bug 881716 - [SMS/MMS] Search result for contacts from Messaging app is not showing the carrier r=arcturus
       var ul = document.createElement('ul');
       var contact = new MockContact();
       var html;
@@ -1412,8 +1508,15 @@ suite('thread_ui.js >', function() {
         isHighlighted: true
       });
       html = ul.firstElementChild.innerHTML;
+
       assert.ok(
+<<<<<<< HEAD
         html.contains('Mobile | +<span class="highlight">346578888888</span>')
+=======
+        html.contains(
+          'Mobile | TEF, +<span class="highlight">346578888888</span>'
+        )
+>>>>>>> 3c65d31... Bug 881716 - [SMS/MMS] Search result for contacts from Messaging app is not showing the carrier r=arcturus
       );
     });
   });

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -355,6 +355,111 @@ suite('Utils', function() {
     });
   });
 
+  suite('Utils.getContactCarrier', function() {
+
+    test('Single with carrier', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '101', type: ['Mobile'], carrier: 'Nynex'}
+      ];
+
+      var a = Utils.getContactCarrier('101', tel);
+
+      assert.equal(a, 'Mobile | Nynex');
+    });
+
+    test('Single no carrier', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '201', type: ['Mobile'], carrier: null}
+      ];
+
+      var a = Utils.getContactCarrier('201', tel);
+
+      assert.equal(a, 'Mobile | 201');
+    });
+
+    test('Multi different carrier & type, match both', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '301', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '302', type: ['Home'], carrier: 'MCI'}
+      ];
+
+      var a = Utils.getContactCarrier('301', tel);
+      var b = Utils.getContactCarrier('302', tel);
+
+      assert.equal(a, 'Mobile | Nynex');
+      assert.equal(b, 'Home | MCI');
+    });
+
+    test('Multi different carrier, match first', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '401', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '402', type: ['Home'], carrier: 'MCI'}
+      ];
+
+      var a = Utils.getContactCarrier('401', tel);
+
+      assert.equal(a, 'Mobile | Nynex');
+    });
+
+    test('Multi different carrier, match second', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '501', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '502', type: ['Home'], carrier: 'MCI'}
+      ];
+
+      var a = Utils.getContactCarrier('502', tel);
+
+      assert.equal(a, 'Home | MCI');
+    });
+
+    test('Multi same carrier & type', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '601', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '602', type: ['Mobile'], carrier: 'Nynex'}
+      ];
+
+      var a = Utils.getContactCarrier('601', tel);
+      var b = Utils.getContactCarrier('602', tel);
+
+      assert.equal(a, 'Mobile | 601');
+      assert.equal(b, 'Mobile | 602');
+    });
+
+    test('Multi same carrier, different type', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '701', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '702', type: ['Home'], carrier: 'Nynex'}
+      ];
+
+      var a = Utils.getContactCarrier('701', tel);
+      var b = Utils.getContactCarrier('702', tel);
+
+      assert.equal(a, 'Mobile | Nynex');
+      assert.equal(b, 'Home | Nynex');
+    });
+
+    test('Multi different carrier, same type', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '801', type: ['Mobile'], carrier: 'Nynex'},
+        {value: '802', type: ['Mobile'], carrier: 'MCI'}
+      ];
+
+      var a = Utils.getContactCarrier('801', tel);
+      var b = Utils.getContactCarrier('802', tel);
+
+      assert.equal(a, 'Mobile | Nynex');
+      assert.equal(b, 'Mobile | MCI');
+    });
+  });
+
   suite('Utils for MMS user story test', function() {
     test('Image rescaling to 300kB', function(done) {
       // Open test image for testing image resize ability


### PR DESCRIPTION
- Ensure that either "Type | Carrier" or "Type | PhoneNumber" displays in thread subheader
- Ensure that "Type | Carrier, Phone" displays in contact search results
- Ensure that "Phone" displays in contact search results when no type or carrier exists

https://bugzilla.mozilla.org/show_bug.cgi?id=881716
Signed-off-by: Rick Waldron waldron.rick@gmail.com
(cherry picked from commit 3c65d31e4e72fd2ee368ff3671f0c65e4f7eb956)
