### PR TITLE
Bug 882994 - [email] UI: Replace sync progress bar (including candy bar) / messages spinner with single spinning refresh button.

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -193,8 +193,6 @@
             </ul>
           </header>
         </section>
-        <progress class="msg-list-progress hidden" value="0" total="1.0">
-        </progress>
         <!-- Scroll region -->
         <div class="msg-list-scrollouter">
           <!-- exists so we can force a minimum height -->
@@ -213,7 +211,6 @@
                  out of the way -->
             <div class="msg-messages-sync-container">
               <p class="msg-messages-syncing collapsed">
-                <progress class="small"></progress>
                 <span data-l10n-id="messages-syncing">Message loadinG</span>
               </p>
               <p class="msg-messages-sync-more collapsed">
@@ -230,7 +227,8 @@
         </div>
         <!-- Toolbar for non-multi-edit state -->
         <div class="msg-list-action-toolbar bottom-toolbar">
-          <button class="msg-refresh-btn bottom-btn msg-nonsearch-only"></button>
+          <button class="msg-refresh-btn bottom-btn msg-nonsearch-only"
+                  data-state="synchronized"></button>
           <button class="msg-search-btn bottom-btn msg-nonsearch-only"></button>
           <button class="msg-edit-btn bottom-btn"></button>
         </div>

--- a/apps/email/js/message-cards.js
+++ b/apps/email/js/message-cards.js
@@ -125,13 +125,6 @@ function MessageListCard(domNode, mode, args) {
     domNode.getElementsByClassName('msg-messages-sync-more')[0];
   this.syncMoreNode
     .addEventListener('click', this.onGetMoreMessages.bind(this), false);
-  this.progressNode =
-    domNode.getElementsByClassName('msg-list-progress')[0];
-  // The active timeout that will cause us to set the progressbar to
-  // indeterminate 'candybar' state when it fires.  Reset every time a new
-  // progress notification is received.
-  this.progressCandybarTimer = null;
-  this._bound_onCandybarTimeout = this.onCandybarTimeout.bind(this);
 
   // - header buttons: non-edit mode
   domNode.getElementsByClassName('msg-folder-list-btn')[0]
@@ -483,15 +476,7 @@ MessageListCard.prototype = {
         this.syncMoreNode.classList.add('collapsed');
         this.hideEmptyLayout();
 
-        this.progressNode.value = this.messagesSlice ?
-                                  this.messagesSlice.syncProgress : 0;
-        this.progressNode.classList.remove('pack-activity');
-        this.progressNode.classList.remove('hidden');
-        if (this.progressCandybarTimer)
-          window.clearTimeout(this.progressCandybarTimer);
-        this.progressCandybarTimer =
-          window.setTimeout(this._bound_onCandybarTimeout,
-                            this.PROGRESS_CANDYBAR_TIMEOUT_MS);
+        this.toolbar.refreshBtn.dataset.state = 'synchronizing';
         break;
       case 'syncfailed':
         // If there was a problem talking to the server, notify the user and
@@ -502,21 +487,9 @@ MessageListCard.prototype = {
 
         // Fall through...
       case 'synced':
+        this.toolbar.refreshBtn.dataset.state = 'synchronized';
         this.syncingNode.classList.add('collapsed');
-        this.progressNode.classList.remove('pack-activity');
-        this.progressNode.classList.add('hidden');
-        if (this.progressCandybarTimer) {
-          window.clearTimeout(this.progressCandybarTimer);
-          this.progressCandybarTimer = null;
-        }
         break;
-    }
-  },
-
-  onCandybarTimeout: function() {
-    if (this.progressCandybarTimer) {
-      this.progressNode.classList.add('pack-activity');
-      this.progressCandybarTimer = null;
     }
   },
 
@@ -1834,4 +1807,3 @@ Cards.defineCardWithDefaultMode(
     { tray: false },
     MessageReaderCard
 );
-

--- a/apps/email/style/message-cards.css
+++ b/apps/email/style/message-cards.css
@@ -414,6 +414,16 @@ input.msg-search-text-tease {
 .msg-refresh-btn {
   background-image: url("images/icons/refresh.png") !important;
 }
+.msg-refresh-btn[data-state="synchronizing"] {
+  animation: 0.9s msg-refresh-rotate infinite steps(30);
+}
+
+@keyframes msg-refresh-rotate {
+  from { transform: rotate(1deg); }
+  to   { transform: rotate(360deg); }
+}
+
+
 
 .msg-search-btn {
   background-image: url("images/icons/search.png") !important;
@@ -517,17 +527,7 @@ input.msg-search-text-tease {
   border-bottom: 0.1rem solid #bebebe;
   width: calc(100% - 3rem);
   margin: 0 auto;
-}
-
-.msg-messages-syncing > span {
-  display: inline-block;
-  vertical-align: middle;
-  line-height: normal;
-}
-
-.msg-messages-syncing > progress {
-  line-height: normal;
-  margin: 0 0.5rem 0 3rem !important;
+  text-align: center;
 }
 
 .msg-messages-sync-more {


### PR DESCRIPTION
This is both a performance win (animations chew CPU, especially the candybar)
and a UX win since it gets rid of the confusing determinate progress bar
status.
