### PR TITLE
Bug 883732 - Fix SMS tests

### DIFF
--- a/apps/sms/test/unit/thread_ui_integration_test.js
+++ b/apps/sms/test/unit/thread_ui_integration_test.js
@@ -200,31 +200,32 @@ suite('ThreadUI Integration', function() {
       toField.click();
 
       // Simulate list growth
-      recipientsList.style.height = '50px';
+      recipientsList.style.height = '100px';
 
       // Listen for the pan event, simulated immediately following.
       toField.addEventListener('pan', function panTest() {
-        assert.isTrue(toField.classList.contains('multiline'));
+        done(function() {
+          assert.isTrue(toField.classList.contains('multiline'));
 
-        toField.removeEventListener('pan', panTest, false);
+          toField.removeEventListener('pan', panTest, false);
 
-        // Once the pan event has occured, the following steps
-        // will simulate the user actions necessary for testing
-        // the return to single line mode
+          // Once the pan event has occured, the following steps
+          // will simulate the user actions necessary for testing
+          // the return to single line mode
 
-        // 1. Enter text into the editable "placeholder"
-        children[2].textContent = '0';
+          // 1. Enter text into the editable "placeholder"
+          children[2].textContent = '0';
 
-        // 2. Trigger a "keyup" event
-        children[2].dispatchEvent(
-          new CustomEvent('keyup', {
-            bubbles: true
-          })
-        );
+          // 2. Trigger a "keyup" event
+          children[2].dispatchEvent(
+            new CustomEvent('keyup', {
+              bubbles: true
+            })
+          );
 
-        // toField should now be "singleline" again
-        assert.isTrue(toField.classList.contains('singleline'));
-        done();
+          // toField should now be "singleline" again
+          assert.isTrue(toField.classList.contains('singleline'));
+        });
       });
 
       // Simulate pan event
@@ -257,15 +258,16 @@ suite('ThreadUI Integration', function() {
       });
 
       // Simulate list growth
-      recipientsList.style.height = '50px';
+      recipientsList.style.height = '100px';
 
       // Listen for the pan event, simulated immediately following.
       toField.addEventListener('click', function clickTest() {
-        toField.removeEventListener('click', clickTest, false);
+        done(function() {
+          toField.removeEventListener('click', clickTest, false);
 
-        // toField should now be "singleline" again
-        assert.isTrue(toField.classList.contains('singleline'));
-        done();
+          // toField should now be "singleline" again
+          assert.isTrue(toField.classList.contains('singleline'));
+        });
       });
 
       // Artificially set the list to multiline view

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1334,7 +1334,7 @@ suite('thread_ui.js >', function() {
         name: 'imageTest.jpg',
         blob: testImageBlob
       }];
-      var viewSpy = sinon.spy(Attachment.prototype, 'view');
+      var viewSpy = this.sinon.spy(Attachment.prototype, 'view');
 
       // quick dirty creation of a thread with image:
       var output = ThreadUI.createMmsContent(inputArray);
@@ -1350,8 +1350,6 @@ suite('thread_ui.js >', function() {
 
       assert.equal(viewSpy.callCount, 1);
       assert.ok(viewSpy.calledWith, { allowSave: true });
-
-      viewSpy.reset();
     });
   });
 


### PR DESCRIPTION
- Wrap the code inside the `done` callback
- use an height of 60px instead of 50px to trigger multiline mode
- use this.sinon instead of sinon to ensure correct restore
- fix long-standing linter problem
