### PR TITLE
Bug 883834 - Touch events position is wrong on desktop when a DOM element is scrollable

### DIFF
--- a/tools/extensions/desktop-helper/content/touch-events.js
+++ b/tools/extensions/desktop-helper/content/touch-events.js
@@ -141,7 +141,7 @@ var TouchEventHandler = (function touchEventHandler() {
       let content = evt.target.ownerDocument.defaultView;
       var utils = content.QueryInterface(Ci.nsIInterfaceRequestor)
                          .getInterface(Ci.nsIDOMWindowUtils);
-      utils.sendMouseEvent(type, evt.pageX, evt.pageY, 0, 1, 0, true);
+      utils.sendMouseEvent(type, evt.clientX, evt.clientY, 0, 1, 0, true);
     },
     sendContextMenu: function teh_sendContextMenu(target, x, y, delay) {
       let doc = target.ownerDocument;


### PR DESCRIPTION
I'm not an expert of Touch events, but this seems to fix this issue.
It's not very clear why we should pass `clientY` here, as the createTouch documentation mention a `PageY` argument:
https://developer.mozilla.org/en-US/docs/Web/API/DocumentTouch.createTouch
And `PageY` is described as:
`"The Y coordinate of the touch point relative to the viewport, including any scroll offset."`

I do not exactly understand what "including any scroll offset" means...
But the first part of the sentence seems to describe more `ClientY` than `PageY`!

Then I'm wondering if we have similar bugs for faked mouse and contextmenu events.
