### PR TITLE
Bug 883760 - [Call log] Edit mode is open direclty as if there were entries selected to be deleted (r=fcampo).

### DIFF
--- a/apps/communications/dialer/js/call_log.js
+++ b/apps/communications/dialer/js/call_log.js
@@ -551,6 +551,7 @@ var CallLog = {
 
   showEditMode: function cl_showEditMode() {
     this.headerEditModeText.textContent = this._('edit');
+    this.deleteButton.classList.add('disabled');
     document.body.classList.add('recents-edit');
   },
 


### PR DESCRIPTION
Whenever the Edit mode is activated, the "Delete" button is set as disabled since that is its initial state.
