### PR TITLE
Bug 880628 - [MMS/SMS] Multi-recipient. Allow manual entry of duplicate recipients r=gnarf

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -96,9 +96,17 @@
       },
       numbers: {
         get: function() {
-          return list.map(function(recipient) {
+          var unique = [];
+          var numbers = list.map(function(recipient) {
             return recipient.number || recipient.email;
           });
+
+          for (var number of numbers) {
+            if (unique.indexOf(number) === -1) {
+              unique.push(number);
+            }
+          }
+          return unique;
         }
       },
       inputValue: {
@@ -198,7 +206,6 @@
    */
   Recipients.prototype.add = function(entry) {
     var list = data.get(this);
-    var isSamePhoneNumber;
     /*
     Entry {
       name, number [, editable, source ]
@@ -220,15 +227,11 @@
       }
     });
 
-    isSamePhoneNumber = function(recipient) {
-      return recipient.number !== entry.number;
-    };
+    // Don't bother rejecting duplicates, always add every
+    // entry to the recipients list. For reference, see:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=880628
+    list.push(new Recipient(entry));
 
-    // Check that this is not a duplicate, if not,
-    // push into the recipients list
-    if (list.every(isSamePhoneNumber)) {
-      list.push(new Recipient(entry));
-    }
     // XXX:Workaround for cleaning search result while duplicate
     //     Dispatch add event no matter duplicate or not
     this.emit('add', list.length);

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -811,9 +811,13 @@ var ThreadUI = global.ThreadUI = {
 
       // The carrier banner is meaningless and confusing in
       // group message mode.
-      if (thread.participants.length === 1 && details.carrier) {
-        carrierTag.textContent = details.carrier;
-        carrierTag.classList.remove('hide');
+      if (thread.participants.length === 1) {
+        if (contacts && contacts.length) {
+          carrierTag.textContent = Utils.getContactCarrier(
+            number, contacts[0].tel
+          );
+          carrierTag.classList.remove('hide');
+        }
       } else {
         carrierTag.classList.add('hide');
       }
@@ -1515,6 +1519,13 @@ var ThreadUI = global.ThreadUI = {
       var number = current.value;
       var title = details.title || number;
       var type = current.type ? (current.type + ' |') : '';
+
+      // Search results are highlighted; Don't display numbers in the
+      // search results list if they have already been added to the
+      // list of recipients.
+      if (isHighlighted && this.recipients.numbers.indexOf(number) > -1) {
+        continue;
+      }
 
       var li = document.createElement('li');
       var data = {

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -94,7 +94,7 @@ suite('Recipients', function() {
       assert.ok(isValid(recipients.list[1], '777'));
     });
 
-    test('recipients.add() rejects dups ', function() {
+    test('recipients.add() allows dups ', function() {
       recipients.add({
         number: '999'
       });
@@ -102,8 +102,9 @@ suite('Recipients', function() {
         number: '999'
       });
 
-      assert.equal(recipients.length, 1);
+      assert.equal(recipients.length, 2);
       assert.ok(isValid(recipients.list[0], '999'));
+      assert.ok(isValid(recipients.list[1], '999'));
     });
 
     test('recipients.add() [invalid] >', function() {
@@ -189,6 +190,15 @@ suite('Recipients', function() {
       assert.equal(recipients.numbers[0], '999');
 
       recipients.numbers[0] = '***';
+      assert.equal(recipients.numbers[0], '999');
+    });
+
+    test('recipients.numbers is a unique list ', function() {
+      recipients.add(fixture);
+      recipients.add(fixture);
+      recipients.add(fixture);
+
+      assert.equal(recipients.numbers.length, 1);
       assert.equal(recipients.numbers[0], '999');
     });
 
@@ -304,7 +314,7 @@ suite('Recipients', function() {
       );
     });
 
-    test('recipients.add() rejects dups, displays correctly ', function() {
+    test('recipients.add() allows dups, displays correctly ', function() {
       var view = document.getElementById('messages-recipients-list');
 
       recipients.add({
@@ -318,17 +328,20 @@ suite('Recipients', function() {
       // 1 duplicate
       // -------------
       // 1 recipient
-      assert.equal(recipients.length, 1);
+      assert.equal(recipients.length, 2);
 
       // 1 recipients
       // 1 placeholder
       // -------------
       // 2 children
-      assert.equal(view.children.length, 2);
+      assert.equal(view.children.length, 3);
 
 
       assert.ok(
         is.corresponding(recipients.list[0], view.children[0], '999')
+      );
+      assert.ok(
+        is.corresponding(recipients.list[1], view.children[1], '999')
       );
       assert.ok(
         is.placeholder(view.lastElementChild)

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1414,6 +1414,68 @@ suite('thread_ui.js >', function() {
         html.contains('Mobile | +<span class="highlight">346578888888</span>')
       );
     });
+
+    test('Rendered Contact "type | carrier, number"', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      ThreadUI.renderContact({
+        contact: contact,
+        input: 'foo',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+      html = ul.firstElementChild.innerHTML;
+
+      assert.ok(html.contains('Mobile | TEF, +346578888888'));
+    });
+
+    test('Rendered Contact highlighted "type | carrier, number"', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      ThreadUI.renderContact({
+        contact: contact,
+        input: '346578888888',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+      html = ul.firstElementChild.innerHTML;
+
+      assert.ok(
+        html.contains(
+          'Mobile | TEF, +<span class="highlight">346578888888</span>'
+        )
+      );
+    });
+
+    test('Rendered Contact omits numbers in recipient list', function() {
+      var ul = document.createElement('ul');
+      var contact = new MockContact();
+      var html;
+
+      ThreadUI.recipients.add({
+        number: '+346578888888'
+      });
+
+      // This contact has two tel entries.
+      ThreadUI.renderContact({
+        contact: contact,
+        input: '+346578888888',
+        target: ul,
+        isContact: true,
+        isHighlighted: true
+      });
+
+      html = ul.innerHTML;
+
+      assert.ok(!html.contains('346578888888'));
+      assert.equal(ul.children.length, 1);
+    });
   });
 
   suite('Header Actions', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=880628
Signed-off-by: Rick Waldron waldron.rick@gmail.com
(cherry picked from commit 4ff9f94fdc607209bf57b4843a8102229db147e7)

Conflicts:

```
apps/sms/js/thread_ui.js
apps/sms/test/unit/thread_ui_test.js
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
