### PR TITLE
Bug 883058 - [SMS/MMS] One contact with very long name can be scrolled in recipient field

### DIFF
--- a/apps/sms/js/desktop_contacts_mock.js
+++ b/apps/sms/js/desktop_contacts_mock.js
@@ -389,6 +389,19 @@
     })
   );
 
+  ContactsDB.push(
+    new Contact({
+      familyName: 'Taumatawhakatangihangakoauauota',
+      givenName: 'Mateapokaiwhenuakitanatahu',
+      tel: [
+        {
+          value: '+18001114321',
+          type: ['Mobile']
+        }
+      ]
+    })
+  );
+
   // console.log( ContactsDB );
 
 

--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -653,19 +653,15 @@
       case 'pan':
         // Switch to multiline display when:
         //
-        //  1. There are 2 or more recipients in the list.
-        //  2. The recipients in the list have caused the
+        //  1. The recipients in the list have caused the
         //      container to grow enough to require the
         //      additional viewable area.
         //      (>1 visible lines or 1.5x the original size)
-        //  3. The user is "pulling down" the recipient list.
+        //  2. The user is "pulling down" the recipient list.
 
         // #1
-        if (owner.length > 1 &&
+        if (view.inner.scrollHeight > (view.dims.inner.height * 1.5)) {
           // #2
-          (view.inner.scrollHeight > (view.dims.inner.height * 1.5))) {
-
-          // #3
           if (event.detail.absolute.dy > 0) {
             this.visible('multiline');
           }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=883058
- Removes rule about a single contact prohibiting pull down
- Height of recipient-list itself is informative enough to determine "pullable" status
- http://en.wikipedia.org/wiki/Taumatawhakatangihangakoauauotamateapokaiwhenuakitanatahu

Signed-off-by: Rick Waldron waldron.rick@gmail.com
