### PR TITLE
Bug 884050 - [SMS][MMS] Regression. New renderContact rules missed untested cases

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1518,10 +1518,19 @@ var ThreadUI = global.ThreadUI = {
     for (var i = 0; i < telsLength; i++) {
       var current = tels[i];
       // Only render a contact's tel value entry for the _specified_
-      // input value when not rendering a suggestion.
+      // input value when not rendering a suggestion. If the tel
+      // record value _doesn't_ match, then continue.
       //
+      if (!isSuggestion && !Utils.compareDialables(current.value, input)) {
+        continue;
+      }
 
-      if (!isSuggestion && Utils.compareDialables(current.value, input)) {
+      // If rendering for contact search result suggestions, don't
+      // render contact tel records for values that are already
+      // selected as recipients. This comparison should be safe,
+      // as the value in this.recipients.numbers comes from the same
+      // source that current.value comes from.
+      if (isSuggestion && this.recipients.numbers.indexOf(current.value) > -1) {
         continue;
       }
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1551,7 +1551,7 @@ suite('thread_ui.js >', function() {
       assert.equal(target.children.length, 2);
     });
 
-    test('Rendered Contact omits numbers in recipient list', function() {
+    test('Rendered Contact omit numbers already in recipient list', function() {
       var ul = document.createElement('ul');
       var contact = new MockContact();
       var html;
@@ -1566,7 +1566,7 @@ suite('thread_ui.js >', function() {
         input: '+346578888888',
         target: ul,
         isContact: true,
-        isHighlighted: true
+        isSuggestion: true
       });
 
       html = ul.innerHTML;
@@ -1685,6 +1685,45 @@ suite('thread_ui.js >', function() {
       };
 
       window.location.hash = '#thread=1';
+    });
+
+    test('Multi participant: Correctly Displayed', function() {
+      var contacts = {
+        a: new MockContact(),
+        b: new MockContact()
+      };
+
+      // Truncate the tel record arrays; there should
+      // only be one when renderContact does its
+      // loop and comparison of dialiables
+      contacts.a.tel.length = 1;
+      contacts.b.tel.length = 1;
+
+      // Set to our "participants"
+      contacts.a.tel[0].value = '999';
+      contacts.b.tel[0].value = '888';
+
+      // "input" value represents the participant entry value
+      // that would be provided in ThreadUI.groupView()
+      ThreadUI.renderContact({
+        contact: contacts.a,
+        input: '999',
+        target: ThreadUI.participantsList,
+        isContact: true,
+        isSuggestion: false
+      });
+
+      ThreadUI.renderContact({
+        contact: contacts.b,
+        input: '888',
+        target: ThreadUI.participantsList,
+        isContact: true,
+        isSuggestion: false
+      });
+
+      assert.equal(
+        ThreadUI.participantsList.children.length, 2
+      );
     });
 
     test('Multi participant: Reset Group View', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=884050
- Only render a contact's tel value entry for the _specified_ input value when not rendering a suggestion. If the tel record value _doesn't_ match, then continue.
- If rendering for contact search result suggestions, don't render contact tel records for values that are already selected as recipients. This comparison should be safe, as the value in this.recipients.numbers comes from the same source that current.value comes from.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
