### PR TITLE
Bug 874769 - [Gaia] Use new WebAPI to access card state related attribute/event

### DIFF
--- a/apps/communications/contacts/js/contacts_settings.js
+++ b/apps/communications/contacts/js/contacts_settings.js
@@ -31,9 +31,9 @@ contacts.Settings = (function() {
   // Initialise the settings screen (components, listeners ...)
   var init = function initialize() {
     // To listen to card state changes is needed for enabling import from SIM
-    var mobileConn = navigator.mozMobileConnection;
-    if (mobileConn) {
-      mobileConn.oncardstatechange = Contacts.cardStateChanged;
+    var icc = navigator.mozIccManager;
+    if (icc) {
+      icc.oncardstatechange = Contacts.cardStateChanged;
     }
     fb.init(function onFbInit() {
       initContainers();
@@ -119,14 +119,14 @@ contacts.Settings = (function() {
   };
 
   var checkSIMCard = function checkSIMCard() {
-    var conn = window.navigator.mozMobileConnection;
+    var icc = window.navigator.mozIccManager;
 
-    if (!conn) {
+    if (!icc) {
       enableSIMImport(false);
       return;
     }
 
-    enableSIMImport(conn.cardState);
+    enableSIMImport(icc.cardState);
   };
 
   // Disables/Enables the actions over the sim import functionality

--- a/apps/communications/contacts/test/unit/contacts_settings_test.js
+++ b/apps/communications/contacts/test/unit/contacts_settings_test.js
@@ -23,7 +23,7 @@ var mocksHelperForContactSettings = new MocksHelper([
 mocksHelperForContactSettings.init();
 
 suite('Contacts settings', function() {
-  var checkForCard, real_, realNavigatorConn;
+  var checkForCard, real_, realNavigatorIcc;
   var mocksHelper = mocksHelperForContactSettings;
 
   function stub(additionalCode, ret) {
@@ -147,8 +147,8 @@ suite('Contacts settings', function() {
     setup(function() {
       document.body.innerHTML = dom;
 
-      realNavigatorConn = window.navigator.mozMobileConnection;
-      navigator.mozMobileConnection = { cardState: 'ready' };
+      realNavigatorIcc = window.navigator.mozIccManager;
+      navigator.mozIccManager = { cardState: 'ready' };
 
       contacts.Settings.init();
       checkForCard = utils.sdcard.checkStorageCard;
@@ -194,7 +194,7 @@ suite('Contacts settings', function() {
 
     teardown(function() {
       document.body.innerHTML = '';
-      window.navigator.mozMobileConnection = realNavigatorConn;
+      window.navigator.mozIccManager = realNavigatorIcc;
         utils.sdcard.checkStorageCard = checkForCard;
       mocksHelper.teardown();
       MockasyncStorage.clear();

--- a/apps/communications/dialer/js/telephony_helper.js
+++ b/apps/communications/dialer/js/telephony_helper.js
@@ -21,7 +21,8 @@ var TelephonyHelper = (function() {
     var telephony = navigator.mozTelephony;
     if (telephony) {
       var conn = window.navigator.mozMobileConnection;
-      var cardState = conn.cardState;
+      var icc = window.navigator.mozIccManager;
+      var cardState = icc.cardState;
       var emergencyOnly = conn.voice.emergencyCallsOnly;
       var call;
 

--- a/apps/communications/dialer/test/unit/mock_mozIccManager.js
+++ b/apps/communications/dialer/test/unit/mock_mozIccManager.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var MockMozIccManager = {
+  addEventListener: function mmim_addEventListener(event_name, listener) {
+  },
+
+  teardown: function mmim_teardown() {
+  }
+};

--- a/apps/communications/dialer/test/unit/telephony_helper_test.js
+++ b/apps/communications/dialer/test/unit/telephony_helper_test.js
@@ -3,6 +3,7 @@ requireApp('communications/dialer/test/unit/mock_moztelephony.js');
 requireApp('communications/dialer/test/unit/mock_confirm_dialog.js');
 requireApp('communications/dialer/test/unit/mock_l10n.js');
 requireApp('communications/dialer/test/unit/mock_mozMobileConnection.js');
+requireApp('communications/dialer/test/unit/mock_mozIccManager.js');
 
 
 if (!this.ConfirmDialog) {
@@ -24,6 +25,7 @@ suite('telephony helper', function() {
   var realLazyL10n;
   var realConfirmDialog;
   var realMozMobileConnection;
+  var realMozIccManager;
   var real_;
 
   suiteSetup(function() {
@@ -40,6 +42,9 @@ suite('telephony helper', function() {
 
     realMozMobileConnection = navigator.mozMobileConnection;
     navigator.mozMobileConnection = MockMozMobileConnection;
+
+    realMozIccManager = navigator.mock_mozIccManager;
+    navigator.mozIccManager = MockMozIccManager;
 
     realConfirmDialog = window.ConfirmDialog;
     window.ConfirmDialog = window.MockConfirmDialog;
@@ -65,6 +70,7 @@ suite('telephony helper', function() {
     window.LazyL10n = realLazyL10n;
     window.ConfirmDialog = realConfirmDialog;
     navigator.mozMobileConnection = realMozMobileConnection;
+    navigator.mozIccManager = realMozIccManager;
     _ = real_;
   });
 });

--- a/apps/communications/ftu/js/sim_manager.js
+++ b/apps/communications/ftu/js/sim_manager.js
@@ -16,7 +16,7 @@ var SimManager = {
 
     this.icc.addEventListener('icccardlockerror',
                                   this.handleUnlockError.bind(this));
-    this.mobConn.addEventListener('cardstatechange',
+    this.icc.addEventListener('cardstatechange',
                                   this.handleCardState.bind(this));
 
     this.alreadyImported = false;
@@ -78,9 +78,9 @@ var SimManager = {
   },
 
   available: function sm_available() {
-    if (!this.mobConn)
+    if (!this.icc)
       return false;
-    return (this.mobConn.cardState === 'ready');
+    return (this.icc.cardState === 'ready');
   },
 
  /**
@@ -98,7 +98,7 @@ var SimManager = {
   handleCardState: function sm_handleCardState(callback) {
     SimManager.checkSIMButton();
     this.accessCallback = (typeof callback === 'function') ? callback : null;
-    switch (this.mobConn.cardState) {
+    switch (this.icc.cardState) {
       case 'pinRequired':
         this.showPinScreen();
         break;
@@ -112,7 +112,7 @@ var SimManager = {
         break;
       default:
         if (this.accessCallback) {
-          this.accessCallback(this.mobConn.cardState === 'ready');
+          this.accessCallback(this.icc.cardState === 'ready');
         }
         break;
     }
@@ -190,7 +190,7 @@ var SimManager = {
     UIManager.pukcodeScreen.classList.remove('show');
     UIManager.xckcodeScreen.classList.add('show');
 
-    switch (this.mobConn.cardState) {
+    switch (this.icc.cardState) {
       case 'networkLocked':
         UIManager.unlockSimHeader.textContent = _('nckcode');
         UIManager.xckLabel.textContent = _('type_nck');
@@ -225,7 +225,7 @@ var SimManager = {
   unlock: function sm_unlock() {
     this._unlocked = false;
 
-    switch (this.mobConn.cardState) {
+    switch (this.icc.cardState) {
       case 'pinRequired':
         this.unlockPin();
         break;
@@ -313,7 +313,7 @@ var SimManager = {
   unlockXck: function sm_unlockXck() {
     var xck = UIManager.xckInput.value;
     var lockType;
-    switch (this.mobConn.cardState) {
+    switch (this.icc.cardState) {
       case 'networkLocked':
         lockType = 'nck';
         break;

--- a/apps/communications/ftu/test/unit/mock_navigator_moz_icc_manager.js
+++ b/apps/communications/ftu/test/unit/mock_navigator_moz_icc_manager.js
@@ -2,10 +2,18 @@
 
 (function() {
 
+  var props = ['cardState'];
   var listeners;
 
   function _init() {
+    props.forEach(function(prop) {
+      Mock[prop] = null;
+    });
     listeners = {};
+  }
+
+  function _setProperty(property, newState) {
+    Mock[property] = newState;
   }
 
   function _addEventListener(evtName, func) {
@@ -37,6 +45,7 @@
 
   var Mock = {
     mTeardown: _init,
+    setProperty: _setProperty,
     addEventListener: _addEventListener,
     removeEventListener: _removeEventListener,
     unlockCardLock: _unlockCardLock

--- a/apps/communications/ftu/test/unit/mock_navigator_moz_mobile_connection.js
+++ b/apps/communications/ftu/test/unit/mock_navigator_moz_mobile_connection.js
@@ -2,7 +2,7 @@
 
 (function() {
 
-  var props = ['voice', 'cardState', 'iccInfo', 'data', 'retryCount'];
+  var props = ['voice', 'iccInfo', 'data', 'retryCount'];
   var listeners;
 
   function _init() {

--- a/apps/communications/ftu/test/unit/sim_manager_test.js
+++ b/apps/communications/ftu/test/unit/sim_manager_test.js
@@ -19,7 +19,7 @@ suite('sim mgmt >', function() {
       realMozMobileConnection,
       realMozIccManager;
   var mocksHelper = mocksHelperForNavigation;
-  var conn, container;
+  var conn, icc, container;
 
   setup(function() {
     createDOM();
@@ -36,6 +36,7 @@ suite('sim mgmt >', function() {
     mocksHelper.setup();
     SimManager.init();
     conn = navigator.mozMobileConnection;
+    icc = navigator.mozIccManager;
   });
 
   teardown(function() {
@@ -86,7 +87,7 @@ suite('sim mgmt >', function() {
     });
 
     test('pinRequired shows PIN screen', function() {
-      conn.setProperty('cardState', 'pinRequired');
+      icc.setProperty('cardState', 'pinRequired');
       SimManager.handleCardState();
       assert.isTrue(UIManager.unlockSimScreen.classList.contains('show'));
       assert.isFalse(UIManager.pinRetriesLeft.classList.contains('hidden'));
@@ -95,7 +96,7 @@ suite('sim mgmt >', function() {
     });
 
     test('pukRequired shows PUK screen', function() {
-      conn.setProperty('cardState', 'pukRequired');
+      icc.setProperty('cardState', 'pukRequired');
       SimManager.handleCardState();
       assert.isTrue(UIManager.unlockSimScreen.classList.contains('show'));
       assert.isFalse(UIManager.pukRetriesLeft.classList.contains('hidden'));
@@ -104,7 +105,7 @@ suite('sim mgmt >', function() {
     });
 
     test('networkLocked shows XCK screen', function() {
-      conn.setProperty('cardState', 'networkLocked');
+      icc.setProperty('cardState', 'networkLocked');
       SimManager.handleCardState();
       assert.isTrue(UIManager.unlockSimScreen.classList.contains('show'));
       assert.isFalse(UIManager.xckRetriesLeft.classList.contains('hidden'));
@@ -123,10 +124,10 @@ suite('sim mgmt >', function() {
 
     suite('PIN unlock ', function() {
       suiteSetup(function() {
-        conn.setProperty('cardState', 'pinRequired');
+        icc.setProperty('cardState', 'pinRequired');
       });
       suiteTeardown(function() {
-        conn.setProperty('cardState', null);
+        icc.setProperty('cardState', null);
       });
 
       test('too short PIN', function() {
@@ -156,10 +157,10 @@ suite('sim mgmt >', function() {
 
     suite('PUK unlock ', function() {
       suiteSetup(function() {
-        conn.setProperty('cardState', 'pukRequired');
+        icc.setProperty('cardState', 'pukRequired');
       });
       suiteTeardown(function() {
-        conn.setProperty('cardState', null);
+        icc.setProperty('cardState', null);
       });
 
       test('wrong length PUK', function() {
@@ -218,10 +219,10 @@ suite('sim mgmt >', function() {
 
     suite('XCK unlock ', function() {
       suiteSetup(function() {
-        conn.setProperty('cardState', 'networkLocked');
+        icc.setProperty('cardState', 'networkLocked');
       });
       suiteTeardown(function() {
-        conn.setProperty('cardState', null);
+        icc.setProperty('cardState', null);
       });
 
       test('too short XCK', function() {

--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -42,13 +42,14 @@ var CostControlApp = (function() {
   var costcontrol, initialized = false;
   function onReady(callback) {
     var mobileConnection = window.navigator.mozMobileConnection;
+    var icc = window.navigator.mozIccManager;
     var cardState = checkCardState();
     var iccid = mobileConnection.iccInfo.iccid;
 
     // SIM not ready
     if (cardState !== 'ready') {
       debug('SIM not ready:', cardState);
-      mobileConnection.oncardstatechange = onReady;
+      icc.oncardstatechange = onReady;
 
     // SIM is ready, but ICC info is not ready yet
     } else if (!Common.isValidICCID(iccid)) {
@@ -58,7 +59,7 @@ var CostControlApp = (function() {
     // All ready
     } else {
       debug('SIM ready. ICCID:', iccid);
-      mobileConnection.oncardstatechange = undefined;
+      icc.oncardstatechange = undefined;
       mobileConnection.oniccinfochange = undefined;
       startApp(callback);
     }
@@ -67,9 +68,9 @@ var CostControlApp = (function() {
   // Check the card status. Return 'ready' if all OK or take actions for
   // special situations such as 'pin/puk locked' or 'absent'.
   function checkCardState() {
-    var mobileConnection = window.navigator.mozMobileConnection;
+    var icc = window.navigator.mozIccManager;
     var state, cardState;
-    state = cardState = mobileConnection.cardState;
+    state = cardState = icc.cardState;
 
     // SIM is absent
     if (cardState === 'absent') {

--- a/apps/costcontrol/js/fte.js
+++ b/apps/costcontrol/js/fte.js
@@ -14,16 +14,17 @@
   var defaultLowLimitThreshold = DEFAULT_LOW_LIMIT_THRESHOLD;
   window.addEventListener('DOMContentLoaded', function _onDOMReady() {
     var mobileConnection = window.navigator.mozMobileConnection;
+    var icc = window.navigator.mozIccManager;
     var stepsLeft = 2;
 
     // No SIM
-    if (!mobileConnection || mobileConnection.cardState === 'absent') {
+    if (!mobileConnection || !icc || icc.cardState === 'absent') {
       hasSim = false;
       trySetup();
 
     // SIM is not ready
-    } else if (mobileConnection.cardState !== 'ready') {
-      debug('SIM not ready:', mobileConnection.cardState);
+    } else if (icc.cardState !== 'ready') {
+      debug('SIM not ready:', icc.cardState);
       mobileConnection.oniccinfochange = _onDOMReady;
 
     // SIM is ready

--- a/apps/costcontrol/js/widget.js
+++ b/apps/costcontrol/js/widget.js
@@ -14,14 +14,15 @@ var Widget = (function() {
 
   var costcontrol;
   function onReady() {
+    var icc = window.navigator.mozIccManager;
     var mobileConnection = window.navigator.mozMobileConnection;
     var cardState = checkCardState();
     var iccid = mobileConnection.iccInfo.iccid;
 
     // SIM not ready
     if (cardState !== 'ready') {
-      debug('SIM not ready:', mobileConnection.cardState);
-      mobileConnection.oncardstatechange = onReady;
+      debug('SIM not ready:', icc.cardState);
+      icc.oncardstatechange = onReady;
 
     // SIM is ready, but ICC info is not ready yet
     } else if (!Common.isValidICCID(iccid)) {
@@ -31,7 +32,7 @@ var Widget = (function() {
     // All ready
     } else {
       debug('SIM ready. ICCID:', iccid);
-      mobileConnection.oncardstatechange = undefined;
+      icc.oncardstatechange = undefined;
       mobileConnection.oniccinfochange = undefined;
       startWidget();
     }
@@ -40,9 +41,9 @@ var Widget = (function() {
   // Check the card status. Return 'ready' if all OK or take actions for
   // special situations such as 'pin/puk locked' or 'absent'.
   function checkCardState() {
-    var mobileConnection = window.navigator.mozMobileConnection;
+    var icc = window.navigator.mozIccManager;
     var state, cardState;
-    state = cardState = mobileConnection.cardState;
+    state = cardState = icc.cardState;
 
     // SIM is absent
     if (cardState === 'absent') {

--- a/apps/costcontrol/test/unit/cost_control_test.js
+++ b/apps/costcontrol/test/unit/cost_control_test.js
@@ -2,6 +2,7 @@
 
 requireApp('costcontrol/test/unit/mock_debug.js');
 requireApp('costcontrol/test/unit/mock_moz_mobile_connection.js');
+requireApp('costcontrol/test/unit/mock_moz_icc_manager.js');
 requireApp('costcontrol/test/unit/mock_config_manager.js');
 requireApp('costcontrol/test/unit/mock_settings_listener.js');
 requireApp('costcontrol/js/utils/toolkit.js');
@@ -9,7 +10,8 @@ requireApp('costcontrol/js/costcontrol.js');
 
 var realSettingsListener,
     realConfigManager,
-    realMozMobileConnection;
+    realMozMobileConnection,
+    realMozIccManager;
 
 if (!this.SettingsListener) {
   this.SettingsListener = null;
@@ -23,6 +25,10 @@ if (!this.navigator.mozMobileConnection) {
   this.navigator.mozMobileConnection = null;
 }
 
+if (!this.navigator.mozIccManager) {
+  this.navigator.mozIccManager = null;
+}
+
 suite('Cost Control Service Hub Suite >', function() {
 
   suiteSetup(function() {
@@ -31,8 +37,11 @@ suite('Cost Control Service Hub Suite >', function() {
 
     realConfigManager = window.ConfigManager;
 
-    realMozMobileConnection = window.navigator.mozMozMobileConnection;
+    realMozMobileConnection = window.navigator.mozMobileConnection;
     window.navigator.mozMobileConnection = new MockMozMobileConnection();
+
+    realMozIccManager = window.navigator.mozIccManager;
+    window.navigator.mozIccManager = new MockMozIccManager();
   });
 
   suiteTeardown(function() {
@@ -40,6 +49,7 @@ suite('Cost Control Service Hub Suite >', function() {
     window.SettingsListener = realSettingsListener;
     window.ConfigManager = realConfigManager;
     window.navigator.mozMobileConnection = realMozMobileConnection;
+    window.navigator.mozIccManager = realMozIccManager;
   });
 
   function setupDelaySinceLastBalance(lastBalanceRequest, delay) {

--- a/apps/costcontrol/test/unit/mock_moz_icc_manager.js
+++ b/apps/costcontrol/test/unit/mock_moz_icc_manager.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var MockMozIccManager = function(state) {
+  state = state || {};
+
+  return state;
+};

--- a/apps/costcontrol/test/unit/startup_test.js
+++ b/apps/costcontrol/test/unit/startup_test.js
@@ -9,6 +9,7 @@ requireApp('costcontrol/test/unit/mock_debug.js');
 requireApp('costcontrol/test/unit/mock_common.js');
 requireApp('costcontrol/test/unit/mock_moz_l10n.js');
 requireApp('costcontrol/test/unit/mock_moz_mobile_connection.js');
+requireApp('costcontrol/test/unit/mock_moz_icc_manager.js');
 requireApp('costcontrol/shared/test/unit/mocks/' +
            'mock_navigator_moz_set_message_handler.js');
 requireApp('costcontrol/test/unit/mock_cost_control.js');
@@ -21,6 +22,7 @@ require('/shared/test/unit/load_body_html_helper.js');
 
 var realCommon,
     realMozMobileConnection,
+    realMozIccManager,
     realMozL10n,
     realCostControl,
     realConfigManager,
@@ -32,6 +34,10 @@ if (!this.Common) {
 
 if (!this.navigator.mozMobileConnection) {
   this.navigator.mozMobileConnection = null;
+}
+
+if (!this.navigator.mozIccManager) {
+  this.navigator.mozIccManager = null;
 }
 
 if (!this.navigator.mozL10n) {
@@ -57,6 +63,8 @@ suite('Application Startup Modes Test Suite >', function() {
 
     realMozMobileConnection = window.navigator.mozMobileConnection;
 
+    realMozIccManager = window.navigator.mozIccManager;
+
     realMozL10n = window.navigator.mozL10n;
     window.navigator.mozL10n = window.MockMozL10n;
 
@@ -78,6 +86,7 @@ suite('Application Startup Modes Test Suite >', function() {
   suiteTeardown(function() {
     window.Common = realCommon;
     window.navigator.mozMobileConnection = realMozMobileConnection;
+    window.navigator.mozIccManager = realMozIccManager;
     window.navigator.mozL10n = realMozL10n;
     window.CostControl = realCostControl;
     window.ConfigManager = realConfigManager;
@@ -166,7 +175,8 @@ suite('Application Startup Modes Test Suite >', function() {
   function setupCardState(cardState) {
     window.Common = new MockCommon({ isValidICCID: true });
     window.CostControl = new MockCostControl();
-    window.navigator.mozMobileConnection = new MockMozMobileConnection({
+    window.navigator.mozMobileConnection = new MockMozMobileConnection({});
+    window.navigator.mozIccManager = new MockMozIccManager({
       cardState: cardState
     });
   }
@@ -256,7 +266,8 @@ suite('Application Startup Modes Test Suite >', function() {
     loadBodyHTML('/index.html');
     window.Common = new MockCommon({ isValidICCID: true });
     window.CostControl = new MockCostControl();
-    window.navigator.mozMobileConnection = new MockMozMobileConnection({
+    window.navigator.mozMobileConnection = new MockMozMobileConnection({});
+    window.navigator.mozIccManager = new MockMozIccManager({
       cardState: 'ready'
     });
     window.ConfigManager = new MockConfigManager({

--- a/apps/settings/js/call.js
+++ b/apps/settings/js/call.js
@@ -28,6 +28,7 @@ var Calls = (function(window, document, undefined) {
     CALL_FORWARD_ACTION_ERASURE: 4
   };
 
+  var icc = getIccManager();
   var mobileConnection = getMobileConnection();
   var settings = window.navigator.mozSettings;
   var _voiceServiceClassMask = mobileConnection.ICC_SERVICE_CLASS_VOICE;
@@ -129,8 +130,8 @@ var Calls = (function(window, document, undefined) {
       'absent' : _('noSimCard'),
       'null' : _('simCardNotReady')
     };
-    var simCardState = kSimCardStates[mobileConnection.cardState ?
-                                      mobileConnection.cardState :
+    var simCardState = kSimCardStates[icc.cardState ?
+                                      icc.cardState :
                                       'null'];
     displayInfoForAll(simCardState);
   };
@@ -287,7 +288,7 @@ var Calls = (function(window, document, undefined) {
           return;
         }
         // Bails out in case of airplane mode.
-        if (mobileConnection.cardState !== 'ready') {
+        if (icc.cardState !== 'ready') {
           return;
         }
         var selector = 'input[data-setting="ril.cf.' + key + '.number"]';
@@ -403,19 +404,19 @@ var Calls = (function(window, document, undefined) {
 
   function initCallForwarding() {
     displayInfoForAll(_('callForwardingRequesting'));
-    if (!settings || !mobileConnection) {
+    if (!settings || !mobileConnection || !icc) {
       displayInfoForAll(_('callForwardingQueryError'));
       return;
     }
 
-    if (mobileConnection.cardState != 'ready') {
+    if (icc.cardState != 'ready') {
       displaySimCardStateInfo();
       return;
     }
 
     // Prevent sub panels from being selected while airplane mode.
-    mobileConnection.addEventListener('cardstatechange', function() {
-      enableTapOnCallForwardingItems(mobileConnection.cardState === 'ready');
+    icc.addEventListener('cardstatechange', function() {
+      enableTapOnCallForwardingItems(icc.cardState === 'ready');
     });
 
     // Initialize the call forwarding alert panel.
@@ -481,17 +482,17 @@ var Calls = (function(window, document, undefined) {
   }
 
   function initCallWaiting() {
-    if (!settings || !mobileConnection) {
+    if (!settings || !mobileConnection || !icc) {
       return;
     }
 
-    if (mobileConnection.cardState != 'ready') {
+    if (icc.cardState != 'ready') {
       return;
     }
 
     // Prevent the item from being changed while airplane mode.
-    mobileConnection.addEventListener('cardstatechange', function() {
-      enableTabOnCallWaitingItem(mobileConnection.cardState === 'ready');
+    icc.addEventListener('cardstatechange', function() {
+      enableTabOnCallWaitingItem(icc.cardState === 'ready');
     });
 
     var alertPanel = document.querySelector('#call .cw-alert');

--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -19,9 +19,10 @@ var Connectivity = (function(window, document, undefined) {
   var wifiManager = WifiHelper.getWifiManager();
   var bluetooth = getBluetooth();
   var mobileConnection = getMobileConnection();
+  var icc = getIccManager();
 
   mobileConnection.addEventListener('datachange', updateCarrier);
-  mobileConnection.addEventListener('cardstatechange', updateCallSettings);
+  icc.addEventListener('cardstatechange', updateCallSettings);
 
   // XXX if wifiManager implements addEventListener function
   // we can remove these listener lists.
@@ -192,11 +193,11 @@ var Connectivity = (function(window, document, undefined) {
       }
     };
 
-    if (!mobileConnection)
+    if (!mobileConnection || !icc)
       return setCarrierStatus({});
 
     // ensure the SIM card is present and unlocked
-    var cardState = mobileConnection.cardState || 'null';
+    var cardState = icc.cardState || 'null';
     var l10nId = kCardStateL10nId[cardState];
     if (l10nId) {
       return setCarrierStatus({ error: _(l10nId), l10nId: l10nId });
@@ -231,13 +232,13 @@ var Connectivity = (function(window, document, undefined) {
       return; // init will call updateCallSettings()
     }
 
-    var mobileConnection = getMobileConnection();
+    var icc = getIccManager();
 
-    if (!mobileConnection)
+    if (!icc)
       return;
 
     // update the current SIM card state
-    var cardState = mobileConnection.cardState || 'null';
+    var cardState = icc.cardState || 'null';
     localize(callDesc, kCardStateL10nId[cardState]);
   }
 

--- a/apps/settings/js/security_privacy.js
+++ b/apps/settings/js/security_privacy.js
@@ -26,10 +26,6 @@ var Security = {
       phonelockDesc.dataset.l10nId = enable ? 'enabled' : 'disabled';
     };
 
-    var mobileConnection = navigator.mozMobileConnection;
-    if (!mobileConnection)
-      return;
-
     var icc = navigator.mozIccManager;
     if (!icc)
       return;
@@ -37,7 +33,7 @@ var Security = {
     var simSecurityDesc = document.getElementById('simCardLock-desc');
     simSecurityDesc.style.fontStyle = 'italic';
 
-    switch (mobileConnection.cardState) {
+    switch (icc.cardState) {
       case null:
         simSecurityDesc.textContent = _('simCardNotReady');
         simSecurityDesc.dataset.l10nId = 'simCardNotReady';

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -862,16 +862,16 @@ window.addEventListener('load', function loadSettings() {
       }
     }
 
-    var mobileConnection = window.navigator.mozMobileConnection;
-    if (!mobileConnection) {
+    var iccManager = window.navigator.mozIccManager;
+    if (!iccManager) {
       disableSIMRelatedSubpanels(true);
     }
 
-    var cardState = mobileConnection.cardState;
+    var cardState = iccManager.cardState;
     disableSIMRelatedSubpanels(cardState !== 'ready');
 
-    mobileConnection.addEventListener('cardstatechange', function() {
-      var cardState = mobileConnection.cardState;
+    iccManager.addEventListener('cardstatechange', function() {
+      var cardState = iccManager.cardState;
       disableSIMRelatedSubpanels(cardState !== 'ready');
     });
   }

--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -52,7 +52,7 @@ var SimPinDialog = {
   handleCardState: function spl_handleCardState() {
     var _ = navigator.mozL10n.get;
 
-    var cardState = this.mobileConnection.cardState;
+    var cardState = this.icc.cardState;
     switch (cardState) {
       case 'pinRequired':
         this.lockType = 'pin';

--- a/apps/settings/js/simcard_lock.js
+++ b/apps/settings/js/simcard_lock.js
@@ -15,7 +15,7 @@ var SimPinLock = {
   updateSimCardStatus: function spl_updateSimStatus() {
     var _ = navigator.mozL10n.get;
 
-    var cardState = this.mobileConnection.cardState;
+    var cardState = this.icc.cardState;
     var cardStateMapping = {
       'null': 'simCardNotReady',
       'unknown': 'unknownSimCardState',
@@ -54,12 +54,12 @@ var SimPinLock = {
     if (!this.icc)
       return;
 
-    this.mobileConnection.addEventListener('cardstatechange',
+    this.icc.addEventListener('cardstatechange',
       this.updateSimCardStatus.bind(this));
 
     var self = this;
     this.simPinCheckBox.onchange = function spl_toggleSimPin() {
-      switch (self.mobileConnection.cardState) {
+      switch (self.icc.cardState) {
         case 'pukRequired':
           var enabled = this.checked;
           SimPinDialog.show('unlock',

--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -427,6 +427,30 @@ var getMobileConnection = function() {
   };
 };
 
+// create a fake mozIccManager if required (e.g. desktop browser)
+var getIccManager = function() {
+  var navigator = window.navigator;
+  if (('mozIccManager' in navigator) &&
+      navigator.mozIccManager) {
+    return navigator.mozIccManager;
+  }
+
+  function fakeEventListener(type, callback, bubble) {
+    if (initialized)
+      return;
+
+    // simulates a connection to a data network;
+    setTimeout(function fakeCallback() {
+      initialized = true;
+      callback();
+    }, 5000);
+  }
+
+  return {
+    addEventListener: fakeEventListener
+  };
+};
+
 var getBluetooth = function() {
   var navigator = window.navigator;
   if ('mozBluetooth' in navigator)

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -113,7 +113,7 @@ var AttentionScreen = {
 
       // This event is for SIM PIN lock module.
       // Because we don't need SIM PIN dialog during call
-      // but the mozMobileConnection cardstatechange event could
+      // but the mozIccManager cardstatechange event could
       // be invoked by airplane mode toggle before the call is established.
       this.dispatchEvent('callscreenwillopen');
     } else {
@@ -180,7 +180,7 @@ var AttentionScreen = {
     if (app && this._hasTelephonyPermission(app)) {
       // This event is for SIM PIN lock module.
       // Because we don't need SIM PIN dialog during call
-      // but the mozMobileConnection cardstatechange event could
+      // but the mozIccManager cardstatechange event could
       // be invoked by airplane mode toggle before the call is established.
       this.dispatchEvent('callscreenwillclose');
     }

--- a/apps/system/js/call_forwarding.js
+++ b/apps/system/js/call_forwarding.js
@@ -28,12 +28,16 @@
   if (!mobileConnection) {
     return;
   }
+  var icc = window.navigator.mozIccManager;
+  if (!icc) {
+    return;
+  }
 
   // Initialize the icon based on the card state and whether
   // it is in airplane mode
   var _cfIconStateInitialized = false;
   function initCallForwardingIconState() {
-    var cardState = mobileConnection.cardState;
+    var cardState = icc.cardState;
     if (_cfIconStateInitialized || cardState !== 'ready')
       return;
 
@@ -56,7 +60,7 @@
   settings.createLock().set({'ril.cf.enabled': false});
 
   initCallForwardingIconState();
-  mobileConnection.addEventListener('cardstatechange', function() {
+  icc.addEventListener('cardstatechange', function() {
     initCallForwardingIconState();
   });
   mobileConnection.addEventListener('iccinfochange', function() {

--- a/apps/system/js/internet_sharing.js
+++ b/apps/system/js/internet_sharing.js
@@ -18,6 +18,7 @@ var InternetSharing = (function() {
 
   var settings;
   var mobileConnection;
+  var iccManager;
   // null or unknown state will change to one of the following state
   var validCardState = ['absent',
                         'pinRequired',
@@ -44,7 +45,7 @@ var InternetSharing = (function() {
   }
 
   function checkCardAndInternetSharing() {
-    cardState = mobileConnection.cardState;
+    cardState = iccManager.cardState;
     if (validCardState.indexOf(cardState) > -1) {
       // if it is known cardState, we need to load internet sharing state from
       // settings
@@ -122,10 +123,14 @@ var InternetSharing = (function() {
     if (!mobileConnection) {
       return;
     }
+    iccManager = window.navigator.mozIccManager;
+    if (!iccManager) {
+      return;
+    }
     observerHooked = false;
     checkCardAndInternetSharing();
     // listen cardstatechange event for ready, pin, puk, or network unlocking.
-    mobileConnection.addEventListener('cardstatechange',
+    iccManager.addEventListener('cardstatechange',
                                       checkCardAndInternetSharing);
   }
   return {init: _init};

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -161,10 +161,15 @@ var LockScreen = {
     var conn = window.navigator.mozMobileConnection;
     if (conn && conn.voice) {
       conn.addEventListener('voicechange', this);
-      conn.addEventListener('cardstatechange', this);
       conn.addEventListener('iccinfochange', this);
       this.updateConnState();
       this.connstate.hidden = false;
+    }
+
+    /* icc state on lock screen */
+    var icc = window.navigator.mozIccManager;
+    if (icc) {
+      icc.addEventListener('cardstatechange', this);
     }
 
     var self = this;
@@ -797,6 +802,10 @@ var LockScreen = {
     if (!conn)
       return;
 
+    var icc = window.navigator.mozIccManager;
+    if (!icc)
+      return;
+
     navigator.mozL10n.ready(function() {
       var connstateLine1 = this.connstate.firstElementChild;
       var connstateLine2 = this.connstate.lastElementChild;
@@ -851,7 +860,7 @@ var LockScreen = {
       if (voice.emergencyCallsOnly) {
         updateConnstateLine1('emergencyCallsOnly');
 
-        switch (conn.cardState) {
+        switch (icc.cardState) {
           case 'unknown':
             updateConnstateLine2('emergencyCallsOnly-unknownSIMState');
             break;

--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -41,9 +41,13 @@
   if (!mobileConnection)
     return;
 
+  var icc = window.navigator.mozIccManager;
+  if (!icc)
+    return;
+
   // Check the mcc/mnc information on the SIM card.
   function checkICCInfo() {
-    if (!mobileConnection.iccInfo || mobileConnection.cardState !== 'ready')
+    if (!mobileConnection.iccInfo || icc.cardState !== 'ready')
       return;
 
     // ensure that the iccSettings have been retrieved

--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -7,9 +7,9 @@ var SimLock = {
   _duringCall: false,
 
   init: function sl_init() {
-    // Do not do anything if we can't have access to MobileConnection API
-    var conn = window.navigator.mozMobileConnection;
-    if (!conn)
+    // Do not do anything if we can't have access to IccMananger API
+    var icc = window.navigator.mozIccManager;
+    if (!icc)
       return;
 
     this.onClose = this.onClose.bind(this);
@@ -22,7 +22,7 @@ var SimLock = {
     window.addEventListener('unlock', this);
 
     // always monitor card state change
-    conn.addEventListener('cardstatechange', this.showIfLocked.bind(this));
+    icc.addEventListener('cardstatechange', this.showIfLocked.bind(this));
 
     // Listen to callscreenwillopen and callscreenwillclose event
     // to discard the cardstatechange event.
@@ -94,8 +94,8 @@ var SimLock = {
   },
 
   showIfLocked: function sl_showIfLocked() {
-    var conn = window.navigator.mozMobileConnection;
-    if (!conn)
+    var icc = window.navigator.mozIccManager;
+    if (!icc)
       return false;
 
     if (LockScreen.locked)
@@ -108,7 +108,7 @@ var SimLock = {
     if (this._duringCall)
       return false;
 
-    switch (conn.cardState) {
+    switch (icc.cardState) {
       // do nothing in either absent, unknown or null card states
       case null:
       case 'absent':

--- a/apps/system/js/simcard_dialog.js
+++ b/apps/system/js/simcard_dialog.js
@@ -69,7 +69,7 @@ var SimPinDialog = {
   handleCardState: function spl_handleCardState() {
     var _ = navigator.mozL10n.get;
 
-    var cardState = this.mobileConnection.cardState;
+    var cardState = this.icc.cardState;
     var lockType = this.lockTypeMap[cardState];
     var retryCount = this.mobileConnection.retryCount;
 

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -520,6 +520,10 @@ var StatusBar = {
       if (!conn || !conn.voice)
         return;
 
+      var icc = window.navigator.mozIccManager;
+      if (!icc)
+        return;
+
       var voice = conn.voice;
       var icon = this.icons.signal;
       var flightModeIcon = this.icons.flightMode;
@@ -535,7 +539,7 @@ var StatusBar = {
       flightModeIcon.hidden = true;
       icon.hidden = false;
 
-      if (conn.cardState === 'absent') {
+      if (icc.cardState === 'absent') {
         // no SIM
         delete icon.dataset.level;
         delete icon.dataset.emergency;

--- a/apps/system/test/unit/internet_sharing_test.js
+++ b/apps/system/test/unit/internet_sharing_test.js
@@ -3,6 +3,7 @@
 
 requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('system/test/unit/mock_navigator_moz_mobile_connection.js');
+requireApp('system/test/unit/mock_navigator_moz_icc_manager.js');
 requireApp('system/test/unit/mock_asyncStorage.js');
 requireApp('system/test/unit/mocks_helper.js');
 
@@ -20,6 +21,7 @@ suite('internet sharing > ', function() {
 
   var realSettings;
   var realMozMobileConnection;
+  var realMozIccManager;
 
   var mocksHelper = new MocksHelper(['asyncStorage']);
   mocksHelper.init();
@@ -31,12 +33,15 @@ suite('internet sharing > ', function() {
     navigator.mozSettings = MockNavigatorSettings;
     realMozMobileConnection = navigator.mozMobileConnection;
     navigator.mozMobileConnection = MockNavigatorMozMobileConnection;
+    realMozIccManager = navigator.mozIccManager;
+    navigator.mozIccManager = MockNavigatorMozIccManager;
     requireApp('system/js/internet_sharing.js', done);
   });
 
   suiteTeardown(function() {
     mocksHelper.suiteTeardown();
     navigator.MozMobileConnection = realMozMobileConnection;
+    navigator.mozIccManager = realMozIccManager;
     navigator.mozSettings = realSettings;
   });
   // helper function for batch assertion of asyncStorage
@@ -56,12 +61,12 @@ suite('internet sharing > ', function() {
   }
   // helper to change card state
   function changeCardState(state, iccid) {
-    MockNavigatorMozMobileConnection.cardState = state;
+    MockNavigatorMozIccManager.cardState = state;
     if (!MockNavigatorMozMobileConnection.iccInfo) {
       MockNavigatorMozMobileConnection.iccInfo = {};
     }
     MockNavigatorMozMobileConnection.iccInfo['iccid'] = iccid;
-    MockNavigatorMozMobileConnection.triggerEventListeners('cardstatechange',
+    MockNavigatorMozIccManager.triggerEventListeners('cardstatechange',
                                                            {});
   }
   // helper to change single key-value of mozSettings
@@ -89,7 +94,7 @@ suite('internet sharing > ', function() {
     // fresh startup
     test('null sim no settings', function() {
       // empty start
-      var mEventListeners = MockNavigatorMozMobileConnection.mEventListeners;
+      var mEventListeners = MockNavigatorMozIccManager.mEventListeners;
       var mObservers = MockNavigatorSettings.mObservers;
 
       assert.ok(
@@ -104,7 +109,7 @@ suite('internet sharing > ', function() {
     // card state from null to unknown(sim found, but not initialized)
     test('unknown sim no settings', function() {
       changeCardState('unknown', null);
-      var mEventListeners = MockNavigatorMozMobileConnection.mEventListeners;
+      var mEventListeners = MockNavigatorMozIccManager.mEventListeners;
       var mObservers = MockNavigatorSettings.mObservers;
       assert.ok(
         mEventListeners['cardstatechange'].length > 0);
@@ -119,7 +124,7 @@ suite('internet sharing > ', function() {
     test('sim1 pinRequired no settings', function() {
       changeCardState('pinRequired', null);
 
-      var mEventListeners = MockNavigatorMozMobileConnection.mEventListeners;
+      var mEventListeners = MockNavigatorMozIccManager.mEventListeners;
       var mObservers = MockNavigatorSettings.mObservers;
       assert.ok(
         mEventListeners['cardstatechange'].length > 0);
@@ -173,9 +178,9 @@ suite('internet sharing > ', function() {
     // user remove sim 1
     test('sim1 removed', function() {
       changeCardState('absent', null);
-      MockNavigatorMozMobileConnection.cardState = 'absent';
+      MockNavigatorMozIccManager.cardState = 'absent';
       MockNavigatorMozMobileConnection.iccInfo['iccid'] = null;
-      MockNavigatorMozMobileConnection.triggerEventListeners('cardstatechange',
+      MockNavigatorMozIccManager.triggerEventListeners('cardstatechange',
                                                              {});
       var testSet = [{'key': KEY_USB_TETHERING, 'result': false},
                      {'key': KEY_WIFI_HOTSPOT, 'result': false}];

--- a/apps/system/test/unit/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen_test.js
@@ -7,6 +7,7 @@ requireApp('system/js/lockscreen.js');
 
 requireApp('system/test/unit/mock_l10n.js');
 requireApp('system/test/unit/mock_mobile_connection.js');
+requireApp('system/test/unit/mock_icc_manager.js');
 requireApp('system/test/unit/mock_mobile_operator.js');
 requireApp('system/test/unit/mock_ftu_launcher.js');
 
@@ -25,6 +26,7 @@ suite('system/LockScreen >', function() {
   var realL10n;
   var realMobileOperator;
   var realMobileConnection;
+  var realIccManager;
   var realClock;
   var realFtuLauncher;
   var domConnstate;
@@ -49,6 +51,8 @@ suite('system/LockScreen >', function() {
 
     realMobileConnection = window.navigator.mozMobileConnection;
 
+    realIccManager = window.navigator.mozIccManager;
+
     domConnstate = document.createElement('div');
     domConnstate.id = 'lockscreen-connstate';
     domConnstateL1 = document.createElement('div');
@@ -69,6 +73,7 @@ suite('system/LockScreen >', function() {
         type: 'gsm'
       }
     };
+    window.navigator.mozIccManager = {};
     subject.cellbroadcastLabel = DUMMYTEXT1;
     subject.updateConnState();
     assert.equal(domConnstateL2.textContent, DUMMYTEXT1);
@@ -82,6 +87,7 @@ suite('system/LockScreen >', function() {
         type: 'wcdma'
       }
     };
+    window.navigator.mozIccManager = {};
     var carrier = 'TIM';
     var region = 'SP';
     var exceptedText = 'TIM SP';
@@ -96,6 +102,7 @@ suite('system/LockScreen >', function() {
     navigator.mozL10n = realL10n;
     window.MobileOperator = realMobileOperator;
     window.navigator.mozMobileConnection = realMobileConnection;
+    window.navigator.mozIccManager = realIccManager;
     window.Clock = window.realClock;
     window.FtuLauncher = realFtuLauncher;
 

--- a/apps/system/test/unit/mock_navigator_moz_icc_manager.js
+++ b/apps/system/test/unit/mock_navigator_moz_icc_manager.js
@@ -2,30 +2,30 @@
 
 (function() {
 
-  var props = ['voice', 'iccInfo', 'data'];
+  var props = ['cardState'];
   var eventListeners = null;
 
-  function mnmmc_init() {
+  function mnmim_init() {
     props.forEach(function(prop) {
       Mock[prop] = null;
     });
-    eventListeners = {'iccinfochange': []};
+    eventListeners = {'cardstatechange': []};
   }
 
-  function mnmmc_addEventListener(type, callback) {
+  function mnmim_addEventListener(type, callback) {
     if (eventListeners[type]) {
       eventListeners[type][eventListeners[type].length] = callback;
     }
   }
 
-  function mnmmc_removeEventListener(type, callback) {
+  function mnmim_removeEventListener(type, callback) {
     if (eventListeners[type]) {
       var idx = eventListeners[type].indexOf(callback);
       eventListeners[type].splice(idx, 1);
     }
   }
 
-  function mnmmc_triggerEventListeners(type, evt) {
+  function mnmim_triggerEventListeners(type, evt) {
     if (!eventListeners[type]) {
       return;
     }
@@ -44,16 +44,16 @@
   }
 
   var Mock = {
-    addEventListener: mnmmc_addEventListener,
-    removeEventListener: mnmmc_removeEventListener,
-    triggerEventListeners: mnmmc_triggerEventListeners,
-    mTeardown: mnmmc_init,
+    addEventListener: mnmim_addEventListener,
+    removeEventListener: mnmim_removeEventListener,
+    triggerEventListeners: mnmim_triggerEventListeners,
+    mTeardown: mnmim_init,
     get mEventListeners() {
       return eventListeners;
     }
   };
 
-  mnmmc_init();
+  mnmim_init();
 
-  window.MockNavigatorMozMobileConnection = Mock;
+  window.MockNavigatorMozIccManager = Mock;
 })();

--- a/apps/system/test/unit/quick_settings_test.js
+++ b/apps/system/test/unit/quick_settings_test.js
@@ -10,6 +10,7 @@ requireApp('system/test/unit/mock_settings_listener.js');
 requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('system/test/unit/mock_wifi_manager.js');
 requireApp('system/test/unit/mock_navigator_moz_mobile_connection.js');
+requireApp('system/test/unit/mock_navigator_moz_icc_manager.js');
 requireApp('system/test/unit/mock_activity.js');
 
 requireApp('system/js/quick_settings.js');

--- a/apps/system/test/unit/simcard_dialog_test.js
+++ b/apps/system/test/unit/simcard_dialog_test.js
@@ -14,9 +14,17 @@ suite('simcard dialog', function() {
   var mockUI;
 
   var MockMobileConnection = (function() {
+    return {
+      addEventListener: function(event, handler) {}
+    };
+  })();
+
+  var MockIccManager = (function() {
     var _cardState = null;
     return {
       addEventListener: function(event, handler) {},
+      setCardLock: function(options) {},
+      unlockCardLock: function(options) {},
       get cardState() {
         return _cardState;
       },
@@ -26,14 +34,6 @@ suite('simcard dialog', function() {
       mTeardown: function() {
         _cardState = null;
       }
-    };
-  })();
-
-  var MockIccManager = (function() {
-    return {
-      addEventListener: function(event, handler) {},
-      setCardLock: function(options) {},
-      unlockCardLock: function(options) {}
     };
   })();
 
@@ -126,16 +126,16 @@ suite('simcard dialog', function() {
   });
 
   teardown(function() {
-    MockMobileConnection.mTeardown();
+    MockIccManager.mTeardown();
   });
 
   suite('handle card state', function() {
     teardown(function() {
-      MockMobileConnection.mTeardown();
+      MockIccManager.mTeardown();
     });
 
     test('null', function() {
-      MockMobileConnection.mSetCardState(null);
+      MockIccManager.mSetCardState(null);
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -146,7 +146,7 @@ suite('simcard dialog', function() {
     });
 
     test('unknown', function() {
-      MockMobileConnection.mSetCardState('unknown');
+      MockIccManager.mSetCardState('unknown');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -157,7 +157,7 @@ suite('simcard dialog', function() {
     });
 
     test('absent', function() {
-      MockMobileConnection.mSetCardState('absent');
+      MockIccManager.mSetCardState('absent');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -168,7 +168,7 @@ suite('simcard dialog', function() {
     });
 
     test('ready', function() {
-      MockMobileConnection.mSetCardState('ready');
+      MockIccManager.mSetCardState('ready');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -179,7 +179,7 @@ suite('simcard dialog', function() {
     });
 
     test('pin required', function() {
-      MockMobileConnection.mSetCardState('pinRequired');
+      MockIccManager.mSetCardState('pinRequired');
       SimPinDialog.handleCardState();
 
       assert.isFalse(SimPinDialog.pinArea.hidden);
@@ -190,7 +190,7 @@ suite('simcard dialog', function() {
     });
 
     test('puk required', function() {
-      MockMobileConnection.mSetCardState('pukRequired');
+      MockIccManager.mSetCardState('pukRequired');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -201,7 +201,7 @@ suite('simcard dialog', function() {
     });
 
     test('network locked', function() {
-      MockMobileConnection.mSetCardState('networkLocked');
+      MockIccManager.mSetCardState('networkLocked');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -212,7 +212,7 @@ suite('simcard dialog', function() {
     });
 
     test('corporate locked', function() {
-      MockMobileConnection.mSetCardState('corporateLocked');
+      MockIccManager.mSetCardState('corporateLocked');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);
@@ -223,7 +223,7 @@ suite('simcard dialog', function() {
     });
 
     test('service provider locked', function() {
-      MockMobileConnection.mSetCardState('serviceProviderLocked');
+      MockIccManager.mSetCardState('serviceProviderLocked');
       SimPinDialog.handleCardState();
 
       assert.isTrue(SimPinDialog.pinArea.hidden);

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -4,6 +4,7 @@ requireApp('system/test/unit/mock_settings_listener.js');
 requireApp('system/test/unit/mock_l10n.js');
 requireApp('system/test/unit/mock_navigator_moz_mobile_connection.js');
 requireApp('system/test/unit/mock_navigator_moz_telephony.js');
+requireApp('system/test/unit/mock_navigator_moz_icc_manager.js');
 requireApp('system/test/unit/mock_mobile_operator.js');
 requireApp('system/test/unit/mocks_helper.js');
 
@@ -24,7 +25,7 @@ suite('system/Statusbar', function() {
   var mocksHelper;
 
   var realSettingsListener, realMozL10n, realMozMobileConnection,
-      realMozTelephony, realMobileOperator,
+      realMozTelephony, realMozIccManager, realMobileOperator,
       fakeIcons = [];
 
   suiteSetup(function() {
@@ -36,6 +37,8 @@ suite('system/Statusbar', function() {
     navigator.mozMobileConnection = MockNavigatorMozMobileConnection;
     realMozTelephony = navigator.mozTelephony;
     navigator.mozTelephony = MockNavigatorMozTelephony;
+    realMozIccManager = navigator.mozIccManager;
+    navigator.mozIccManager = MockNavigatorMozIccManager;
   });
 
   suiteTeardown(function() {
@@ -43,6 +46,7 @@ suite('system/Statusbar', function() {
     navigator.mozL10n = realMozL10n;
     navigator.mozMobileConnection = realMozMobileConnection;
     navigator.mozTelephony = realMozTelephony;
+    navigator.mozIccManager = realMozIccManager;
   });
 
   setup(function() {
@@ -73,6 +77,7 @@ suite('system/Statusbar', function() {
     fakeStatusBarNode.parentNode.removeChild(fakeStatusBarNode);
     MockNavigatorMozTelephony.mTeardown();
     MockNavigatorMozMobileConnection.mTeardown();
+    MockNavigatorMozIccManager.mTeardown();
   });
 
   suite('system-downloads', function() {
@@ -133,7 +138,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'absent';
+      MockNavigatorMozIccManager.cardState = 'absent';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -154,7 +159,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'absent';
+      MockNavigatorMozIccManager.cardState = 'absent';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -175,7 +180,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'pinRequired';
+      MockNavigatorMozIccManager.cardState = 'pinRequired';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -196,7 +201,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'ready';
+      MockNavigatorMozIccManager.cardState = 'ready';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -217,7 +222,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'absent';
+      MockNavigatorMozIccManager.cardState = 'absent';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -238,7 +243,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'pinRequired';
+      MockNavigatorMozIccManager.cardState = 'pinRequired';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -259,7 +264,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'pinRequired';
+      MockNavigatorMozIccManager.cardState = 'pinRequired';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       MockNavigatorMozTelephony.active = {
@@ -284,7 +289,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'pinRequired';
+      MockNavigatorMozIccManager.cardState = 'pinRequired';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       MockNavigatorMozTelephony.active = {
@@ -309,7 +314,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'pinRequired';
+      MockNavigatorMozIccManager.cardState = 'pinRequired';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -340,7 +345,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'ready';
+      MockNavigatorMozIccManager.cardState = 'ready';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -361,7 +366,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'ready';
+      MockNavigatorMozIccManager.cardState = 'ready';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);
@@ -382,7 +387,7 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'ready';
+      MockNavigatorMozIccManager.cardState = 'ready';
       MockNavigatorMozMobileConnection.iccInfo = {};
 
       StatusBar.update.signal.call(StatusBar);

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -15,6 +15,7 @@ requireApp('system/test/unit/mock_notification_screen.js');
 requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('system/shared/test/unit/mocks/mock_navigator_wake_lock.js');
 requireApp('system/test/unit/mock_navigator_moz_mobile_connection.js');
+requireApp('system/test/unit/mock_navigator_moz_icc_manager.js');
 requireApp('system/test/unit/mock_l10n.js');
 requireApp('system/test/unit/mock_asyncStorage.js');
 


### PR DESCRIPTION
Please see [bug 874769](https://bugzilla.mozilla.org/show_bug.cgi?id=874769).

In [bug 874744](https://bugzilla.mozilla.org/show_bug.cgi?id=874744), we move cardState related attribute/event from mozMobileConnection to mozIccManager. This pull request is to do corresponding changes in Gaia side. Because this changes affect many apps, so I split patch into 6 parts.

Thanks
