### PR TITLE
Bug 883756 - [Call log] Tapping on an entry from a contact does not take to that contact's detail view screen but to a different one (r=arcturus)

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -56,7 +56,6 @@
     <script defer src="/dialer/js/contacts.js"></script>
     <script defer src="/dialer/js/contact_data_manager.js"></script>
     <script defer src="/dialer/js/suggestion_bar.js"></script>
-    <script defer src="/dialer/js/recents.js"></script>
     <script defer src="/dialer/js/telephony_helper.js"></script>
     <script defer src="/dialer/js/mmi.js"></script>
     <script defer src="/dialer/js/mmi_ui.js"></script>

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -132,6 +132,7 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
     if (contact) {
       var primaryInfo = Utils.getPhoneNumberPrimaryInfo(matchingTel, contact);
       var contactCopy = {
+        id: contact.id,
         name: contact.name,
         org: contact.org,
         tel: contact.tel


### PR DESCRIPTION
We were not passing the contact's id from handled_call.js to call_log.js and this id is needed for the proper rendering of the Call Log and navigation.
