### PR TITLE
Bug #884329 - Add missing Nun Sofit to the Hebrew keyboard layout

### DIFF
--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -500,7 +500,7 @@ const Keyboards = {
     keys: [
       [
         { value: 'ק' }, { value: 'ר' }, { value: 'א' }, { value: 'ט' },
-        { value: 'ו' }, { value: 'ו' }, { value: 'ם' }, { value: 'פ' },
+        { value: 'ו' }, { value: 'ן' }, { value: 'ם' }, { value: 'פ' },
         { value: '⌫', ratio: 2, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
       ], [
         { value: 'ש' }, { value: 'ד' }, { value: 'ג' }, { value: 'כ' },


### PR DESCRIPTION
For some reason we had Vav twice and no Nun Sofit.
More information: https://en.wikipedia.org/wiki/%D7%9F#Hebrew_Nun

This fixes bug #884329
