### PR TITLE
Bug 884890 - [sms] we're scrolling the recipients too low

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -769,7 +769,7 @@ Do not remove.
   border: .1rem solid #4d4d4d;
   color: #2c2c2c;
   height: 2.2rem;
-  margin: .8rem .5rem -0.8rem 0;
+  margin: 0 .5rem 0 0;
   border-radius: .3rem;
   font-size: 1.7rem;
 }


### PR DESCRIPTION
- Removes unnecessary margin
- Scrolling to top of list will match bottom edge of last visible recipient
- Scrolling to bottom of list will match bottom edge of last recipient in list
- Scrolling to bottom of list will reveal bottom edge of an "out of view" recipient (as shown in visual design specs)

https://bugzilla.mozilla.org/show_bug.cgi?id=884890
Signed-off-by: Rick Waldron waldron.rick@gmail.com
