### PR TITLE
Bug 870729 - Disable specific code errors instead of --nojsdoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,9 @@ endif
 
 # Lint apps
 lint:
-	gjslint --nojsdoc -r apps -r shared -e '$(shell cat ./build/lint-excluded-dirs.list)' -x '$(shell cat ./build/lint-excluded-files.list)'
+	# --disable 210,217,220,225 replaces --nojsdoc because it's broken in closure-linter 2.3.10
+	# http://code.google.com/p/closure-linter/issues/detail?id=64
+	gjslint --disable 210,217,220,225 -r apps -r shared -e '$(shell cat ./build/lint-excluded-dirs.list)' -x '$(shell cat ./build/lint-excluded-files.list)'
 
 # Erase all the indexedDB databases on the phone, so apps have to rebuild them.
 delete-databases:

--- a/tools/ci/unit/travis.sh
+++ b/tools/ci/unit/travis.sh
@@ -14,7 +14,7 @@ RED_COLOR=$(printf "\x1b[31;1m")
 GREEN_COLOR=$(printf "\x1b[32;1m")
 NORMAL_COLOR=$(printf "\x1b[0m")
 
-GJSLINT_PACKAGE_URL=http://closure-linter.googlecode.com/files/closure_linter-2.3.9.tar.gz
+GJSLINT_PACKAGE_URL=http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
 
 function waiting_port {
   for i in $(seq 1 $RETRY); do

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -21,4 +21,6 @@ done
 
 diff_with_exclude=`git diff --staged --name-only --diff-filter=ACMRT|grep -v $grep_exclude`
 
-gjslint --nojsdoc -x '`cat ./build/lint-excluded-files.list`' $diff_with_exclude
+# --disable 210,217,220,225 replaces --nojsdoc because it's broken in closure-linter 2.3.10
+# http://code.google.com/p/closure-linter/issues/detail?id=64
+gjslint --disable 210,217,220,225 -x '`cat ./build/lint-excluded-files.list`' $diff_with_exclude


### PR DESCRIPTION
This will let us use the latest closure-linter
