### PR TITLE
Bug 870416 - [MMS] Recipients container multiline view takes all available space r=gnarf

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -292,5 +292,14 @@
       </body>
       -->
     </div>
+
+    <div id="height-rule-tmpl" class="hide">
+      <!--
+      #messages-recipients-list.multiline {
+        overflow-y: scroll;
+        height: ${height}px;
+      }
+      -->
+    </div>
   </body>
 </html>

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -180,13 +180,19 @@ var ThreadUI = global.ThreadUI = {
     //  Currently, there are 3 Assimilations.
     //
 
+    var assimilate = this.assimilateRecipients.bind(this);
+
     // Assimilation 1
     this.input.addEventListener(
-      'focus', this.assimilateRecipients.bind(this)
+      'focus', assimilate
+    );
+    // Assimilation 1
+    this.input.addEventListener(
+      'click', assimilate
     );
     // Assimilation 2
     this.attachButton.addEventListener(
-      'click', this.assimilateRecipients.bind(this)
+      'click', assimilate
     );
 
     this.container.addEventListener(
@@ -239,6 +245,8 @@ var ThreadUI = global.ThreadUI = {
       subheaderMutationHandler);
 
     ThreadUI.setInputMaxHeight();
+
+    generateHeightRule();
   },
 
   // Initialize Recipients list and Recipients.View (DOM)
@@ -364,6 +372,18 @@ var ThreadUI = global.ThreadUI = {
       if (node.isPlaceholder) {
         typed = node.textContent.trim();
 
+        // Clicking on the compose input will trigger
+        // an assimilation. If the recipient input
+        // is a lone semi-colon:
+        //
+        //  1. Clear the contents of the editable placeholder
+        //  2. Do not assimilate the value.
+        //
+        if (typed === ';') {
+          node.textContent = '';
+          break;
+        }
+
         // If the user actually typed something,
         // assume it's a manually entered recipient.
         // Push a recipient into the recipients
@@ -415,6 +435,9 @@ var ThreadUI = global.ThreadUI = {
   resizeHandler: function thui_resizeHandler() {
     this.setInputMaxHeight();
     this.updateInputHeight();
+
+    generateHeightRule();
+
     // Scroll to bottom
     this.scrollViewToBottom();
     // Make sure the caret in the "Compose" area is visible
@@ -1887,5 +1910,66 @@ ThreadUI.groupView.reset = function groupViewReset() {
 };
 
 window.confirm = window.confirm; // allow override in unit tests
+
+/**
+ * generateHeightRule
+ *
+ * Generates a new style element, appends to head
+ * and inserts a generated rule for applying a class
+ * to the recipients list to set its height for
+ * multiline mode.
+ *
+ * @return {Boolean} true if rule was created, false if not.
+ */
+function generateHeightRule() {
+  var available, css, computed, occupied, index,
+      sheet, sheets, style, tmpl;
+
+  occupied = generateHeightRule.occupied;
+
+  if (occupied == null) {
+    computed = window.getComputedStyle(ThreadUI.recipientsList, null);
+
+    occupied = generateHeightRule.occupied = [
+      ThreadUI.INPUT_MARGIN,
+      ThreadUI.subheader.scrollHeight,
+      ThreadUI.sendButton.scrollHeight,
+      parseInt(computed.getPropertyValue('margin-bottom'), 10)
+    ].reduce(function(a, b) { return a + b; });
+  }
+
+  available = ThreadUI.container.clientHeight - occupied;
+
+  if (available === generateHeightRule.available) {
+    return false;
+  }
+
+  if (!generateHeightRule.sheet) {
+    style = document.createElement('style');
+    document.head.appendChild(style);
+    sheets = document.styleSheets;
+  }
+
+  sheet = generateHeightRule.sheet || sheets[sheets.length - 1];
+  index = generateHeightRule.index || sheet.cssRules.length;
+  tmpl = generateHeightRule.tmpl || Utils.Template('height-rule-tmpl');
+
+  css = tmpl.interpolate({
+    height: String(available)
+  }, { safe: ['height'] });
+
+  if (generateHeightRule.index) {
+    sheet.deleteRule(index);
+  }
+
+  sheet.insertRule(css, index);
+
+  generateHeightRule.available = available;
+  generateHeightRule.index = index;
+  generateHeightRule.sheet = sheet;
+  generateHeightRule.tmpl = tmpl;
+
+  return true;
+}
 
 }(this));

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -3,7 +3,7 @@
 (function(exports) {
   'use strict';
   var rdashes = /-(.)/g;
-  var rmatcher = /\$\{([^{]+)\}/g;
+  var rmatcher = /\$\{([^}]+)\}/g;
   var rescape = /[.?*+^$[\]\\(){}|-]/g;
   var rentity = /[&<>"']/g;
   var rentities = {

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -748,11 +748,13 @@ section[role="region"].new #messages-to-field {
 /*
 Used by Recipients.View to display multi or single line.
 Do not remove.
-*/
+
+generateHeightRule() (in ThreadUI/thread_ui.js) will create:
 #messages-recipients-list.multiline {
   overflow-y: scroll;
-  height: 8.8rem;
+  height: {max available height}px;
 }
+*/
 #messages-recipients-list.singleline {
   overflow-y: hidden;
   height: 2.4rem;

--- a/apps/sms/test/unit/thread_ui_integration_test.js
+++ b/apps/sms/test/unit/thread_ui_integration_test.js
@@ -446,6 +446,12 @@ suite('ThreadUI Integration', function() {
       assert.equal(recipients.length, 0);
       // And one displayed child...
       assert.equal(children.length, 1);
+
+      // The the ";" has been removed from the
+      // recipients list
+      assert.equal(
+        ThreadUI.recipientsList.children[0].textContent, ''
+      );
     });
 
 

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -721,16 +721,27 @@ suite('Utils.Template', function() {
   });
 
   suite('interpolate', function() {
-    var node = document.createElement('div');
-    node.appendChild(document.createComment('<span>${str}</span>'));
+    var html = document.createElement('div');
+    var css = document.createElement('div');
+    html.appendChild(document.createComment('<span>${str}</span>'));
+    css.appendChild(document.createComment('#foo { height: ${height}px; }'));
 
-    test('interpolate(data)', function() {
-      var tmpl = Utils.Template(node);
+    test('interpolate(data) => html', function() {
+      var tmpl = Utils.Template(html);
       var interpolated = tmpl.interpolate({
         str: 'test'
       });
       assert.equal(typeof interpolated, 'string');
       assert.equal(interpolated, '<span>test</span>');
+    });
+
+    test('interpolate(data) => css', function() {
+      var tmpl = Utils.Template(css);
+      var interpolated = tmpl.interpolate({
+        height: '100'
+      });
+      assert.equal(typeof interpolated, 'string');
+      assert.equal(interpolated, '#foo { height: 100px; }');
     });
   });
 


### PR DESCRIPTION
Gallery of states https://www.dropbox.com/sh/op52z1e2278rbhd/Ub0S-76SH9#/
- When the screen resizes, generate a CSS rule that calculates the max available height
- Renames an existing element to match the naming convention
- Adds non-html interpolation support to the tempalte matcher regex

https://bugzilla.mozilla.org/show_bug.cgi?id=870416
Signed-off-by: Rick Waldron waldron.rick@gmail.com
