### PR TITLE
Bug 885544 - Stop setting Firefox compatibility when using DEBUG=1 mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DOGFOOD?=0
 TEST_AGENT_PORT?=8789
 
 # Enable compatibility to run in Firefox Desktop
-DESKTOP?=$(DEBUG)
+DESKTOP?=0
 # Disable first time experience screen
 NOFTU?=0
 # Automatically enable remote debugger


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=885544
