### PR TITLE
[Bug_831248 - [Music] - Hide Untitled Album songs in Album tab and Untitled Artist songs in Artist tab.

### DIFF
--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -1110,6 +1110,14 @@ var ListView = {
 
     this.dataSource.push(result);
 
+    // Hide the untitled album songs under album tab option
+    // Hide the untitled artist songs under artist tab option
+    if ((option === 'album' && result.metadata.album === '') ||
+      (option === 'artist' && result.metadata.artist === '')) {
+       this.index++;
+     return;
+    }
+
     if (option !== 'playlist') {
       var firstLetter = result.metadata[option].charAt(0);
 


### PR DESCRIPTION
Proposed fix for Untitled Albums will be combined even though they have various artists that aren't the same.
