### PR TITLE
Bug 872976 - Delay the timing of restoring connection to decrease the failure rate

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -369,7 +369,16 @@ navigator.mozL10n.ready(function bluetoothSettings() {
           if (connected) {
             showDeviceConnected(device.address, true);
           } else {
-            setDeviceConnect(device);
+            // If we restore connection right after Bleutooth is enabled, the
+            // failure rate would be higher than delaying for several seconds.
+            // That's because most Bluetooth headsets are smart enough and
+            // would try to reconnect with us once they found the connection
+            // is dropped, and that may fail since two connections happen at
+            // the same time.
+            stopDiscovery();
+            setTimeout(function() {
+              setDeviceConnect(device);
+            }, 5000);
           }
         });
       });


### PR DESCRIPTION
To make restore connection feature more stable, I made two changes:
1. Stop discovering before connect. I've done the same thing before, see bug 873352 for more information.
2. Delay 5 seconds for restoring connection.
