### PR TITLE
Bug 885700 - Remove obsolete strings from the Dialer locale

### DIFF
--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -58,15 +58,6 @@ call=Call
 hangup-a11y-button.aria-label=Hang Up
 pickup-a11y-button.aria-label=Pick up
 
-## LOCALIZATION NOTE: contactNameWithOthers is displayed for missed calls when the number is associated with more than one contact.
-## LOCALIZATION NOTE: case `zero` is never used, no need to translate it.
-contactNameWithOthersSuffix={[ plural(n) ]}
-contactNameWithOthersSuffix[one]=or {{ n }} other
-contactNameWithOthersSuffix[two]=or {{ n }} other
-contactNameWithOthersSuffix[few]=or {{ n }} other
-contactNameWithOthersSuffix[many]=or {{ n }} other
-contactNameWithOthersSuffix[other]=or {{ n }} other
-
 settings=Settings
 
 #Call duration units


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=885700
