### PR TITLE
Bug 885283 - [sms] receiving a SMS from an existing thread but on a new ...

### DIFF
--- a/apps/sms/js/fixed_header.js
+++ b/apps/sms/js/fixed_header.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var FixedHeader = (function FixedHeader() {
-  var headings;
   var selector;
   var view;
   var fixedContainer;
   var currentlyFixed;
   var notApplyEffect;
+  var refreshTimeout;
 
   /**
    * Start listening scroll event, and applying the fixed header effect
@@ -20,18 +20,25 @@ var FixedHeader = (function FixedHeader() {
     view = document.querySelector(scrollView);
     fixedContainer = document.querySelector(container);
     refresh();
-    view.addEventListener('scroll', scrolling);
+    view.addEventListener('scroll', refresh);
     notApplyEffect = typeof noEffect === 'undefined' ? false : noEffect;
+    refreshTimeout = null;
   };
 
   var refresh = function refresh() {
-    headings = view.querySelectorAll(selector);
-    // after setting up a new headings selection, check the scroll again
-    // in case we removed the header we have currently fixed.
-    scrolling();
+    if (refreshTimeout === null) {
+      refreshTimeout = setTimeout(immediateRefresh);
+    }
   };
 
-  var scrolling = function scrolling() {
+  function immediateRefresh() {
+    if (refreshTimeout) {
+      clearTimeout(refreshTimeout);
+    }
+    refreshTimeout = null;
+
+    var headings = view.querySelectorAll(selector);
+
     var currentScroll = view.scrollTop;
     for (var i = headings.length - 1; i >= 0; i--) {
       var currentHeader = headings[i];
@@ -66,23 +73,15 @@ var FixedHeader = (function FixedHeader() {
     currentlyFixed = null;
     if (!notApplyEffect)
       fixedContainer.style.transform = 'translateY(-100%)';
-  };
+  }
 
   var stop = function stop() {
-    view.removeEventListener('scroll', scrolling);
-  };
-
-  var start = function start() {
-    var header = headings[0];
-    if (header) {
-      fixedContainer.textContent = header.textContent;
-    }
+    view.removeEventListener('scroll', refresh);
   };
 
   return {
     'init': init,
     'refresh': refresh,
-    'start': start,
     'stop': stop
   };
 })();

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -68,21 +68,6 @@ var MessageManager = {
   onMessageSent: function mm_onMessageSent(e) {
     ThreadUI.onMessageSent(e.message);
   },
-  // This method fills the gap while we wait for next 'getThreads' request,
-  // letting us rendering the new thread with a better performance.
-  createThreadMockup: function mm_createThreadMockup(message) {
-    // Given a message we create a thread as a mockup. This let us render the
-    // thread without requesting Gecko, so we increase the performance and we
-    // reduce Gecko requests.
-    return {
-        id: message.threadId,
-        participants: [message.sender],
-        body: message.body,
-        timestamp: message.timestamp,
-        unreadCount: 1,
-        lastMessageType: message.type || 'sms'
-      };
-  },
 
   onMessageReceived: function mm_onMessageReceived(e) {
     var message = e.message;
@@ -103,7 +88,7 @@ var MessageManager = {
     threadId = message.threadId;
 
     if (Threads.has(threadId)) {
-      Threads.get(message.threadId).messages.push(message);
+      Threads.get(threadId).messages.push(message);
     }
 
     if (threadId === Threads.currentId) {
@@ -115,43 +100,7 @@ var MessageManager = {
       ThreadUI.scrollViewToBottom();
       Utils.updateTimeHeaders();
     } else {
-      var threadMockup = this.createThreadMockup(message);
-
-      if (!Threads.get(message.threadId)) {
-        Threads.set(message.threadId, threadMockup);
-        Threads.get(message.threadId).messages.push(message);
-      }
-
-      if (ThreadListUI.container.getElementsByTagName('ul').length === 0) {
-        ThreadListUI.renderThreads([threadMockup]);
-      } else {
-        var timestamp = threadMockup.timestamp.getTime();
-        var previousThread = document.getElementById('thread-' + threadId);
-        if (previousThread && previousThread.dataset.time > timestamp) {
-          // If the received SMS it's older that the latest one
-          // We need only to update the 'unread status'
-          ThreadListUI.mark(threadId, 'unread');
-          return;
-        }
-        // We remove the previous one in order to place the new one properly
-        if (previousThread) {
-          var threadsInContainer = previousThread.parentNode.children.length;
-          if (threadsInContainer === 1) {
-            // If it's the last one we should remove the container
-            var oldThreadContainer = previousThread.parentNode;
-            var oldHeaderContainer = oldThreadContainer.previousSibling;
-            ThreadListUI.container.removeChild(oldThreadContainer);
-            ThreadListUI.container.removeChild(oldHeaderContainer);
-          } else {
-            var threadsContainerID = 'threadsContainer_' +
-                              Utils.getDayDate(threadMockup.timestamp);
-            var threadsContainer =
-              document.getElementById(threadsContainerID);
-            threadsContainer.removeChild(previousThread);
-          }
-        }
-        ThreadListUI.appendThread(threadMockup);
-      }
+      ThreadListUI.onMessageReceived(message);
     }
   },
 

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -399,6 +399,54 @@ var ThreadListUI = {
       ThreadListUI.container.appendChild(fragment);
     }
   },
+
+  // This method fills the gap while we wait for next 'getThreads' request,
+  // letting us rendering the new thread with a better performance.
+  createThreadMockup: function mm_createThreadMockup(message) {
+    // Given a message we create a thread as a mockup. This let us render the
+    // thread without requesting Gecko, so we increase the performance and we
+    // reduce Gecko requests.
+    return {
+      id: message.threadId,
+      participants: [message.sender],
+      body: message.body,
+      timestamp: message.timestamp,
+      unreadCount: 1,
+      lastMessageType: message.type || 'sms'
+    };
+  },
+
+  onMessageReceived: function thlui_onMessageReceived(message) {
+    var threadMockup = this.createThreadMockup(message);
+    var threadId = message.threadId;
+
+    if (!Threads.get(threadId)) {
+      Threads.set(threadId, threadMockup);
+      Threads.get(threadId).messages.push(message);
+    }
+
+    if (this.container.querySelector('ul')) {
+      var timestamp = threadMockup.timestamp.getTime();
+      var previousThread = document.getElementById('thread-' + threadId);
+      if (previousThread && previousThread.dataset.time > timestamp) {
+        // If the received SMS it's older that the latest one
+        // We need only to update the 'unread status'
+        this.mark(threadId, 'unread');
+        return;
+      }
+
+      // We remove the previous one in order to place the new one properly
+      if (previousThread) {
+        this.removeThread(threadId);
+      }
+
+      this.appendThread(threadMockup);
+      this.setEmpty(false);
+    } else {
+      this.renderThreads([threadMockup]);
+    }
+  },
+
   appendThread: function thlui_appendThread(thread) {
     var timestamp = thread.timestamp.getTime();
     // We create the DOM element of the thread

--- a/apps/sms/test/unit/fixed_header_test.js
+++ b/apps/sms/test/unit/fixed_header_test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+requireApp('sms/js/fixed_header.js');
+
+suite('FixedHeader >', function() {
+  var header;
+  var view;
+
+
+  setup(function() {
+    loadBodyHTML('/index.html');
+    this.sinon.useFakeTimers();
+
+    var viewSelector = '#threads-container';
+    var headerSelector = '#threads-header-container';
+
+    FixedHeader.init(viewSelector,
+                     headerSelector,
+                     'header');
+
+    header = document.querySelector(headerSelector);
+    view = document.querySelector(viewSelector);
+
+    // we don't have CSS so we must force the scroll here
+    view.style.overflow = 'scroll';
+    view.style.height = '50px';
+
+    this.sinon.clock.tick();
+  });
+
+  test('at init, empty list, we don\'t have a fixed header', function() {
+    assert.equal(header.textContent, '');
+  });
+
+  suite('longer list', function() {
+    setup(function() {
+      var mockThreadListMarkup = '';
+      for (var i = 1; i < 50; i++) {
+        mockThreadListMarkup +=
+          '<header>header ' + i + '</header>' +
+          '<ul>' +
+            '<li>this is a thread</li>' +
+            '<li>this is another thread</li>' +
+          '</ul>';
+      }
+
+      view.innerHTML = mockThreadListMarkup;
+    });
+
+    test('call refresh, should have the first header', function() {
+      FixedHeader.refresh();
+      this.sinon.clock.tick();
+
+      assert.equal(header.textContent, 'header 1');
+    });
+
+    test('scroll then call refresh, should have a fixed header', function() {
+      // we don't want to react to scroll events in that test
+      view.removeEventListener('scroll', FixedHeader.refresh);
+      view.scrollTop = 200;
+      FixedHeader.refresh();
+      this.sinon.clock.tick();
+
+      assert.ok(header.textContent);
+    });
+
+    test('scroll without calling refresh, should have a fixed header',
+    function(done) {
+      var clock = this.sinon.clock;
+
+      view.addEventListener('scroll', function onscroll() {
+        view.removeEventListener('scroll', onscroll);
+        clock.tick();
+        assert.ok(header.textContent);
+        done();
+      });
+
+      view.scrollTop = 200;
+    });
+  });
+});

--- a/apps/sms/test/unit/mock_messages.js
+++ b/apps/sms/test/unit/mock_messages.js
@@ -12,7 +12,7 @@ var MockMessages = {
       delivery: 'received',
       type: 'sms',
       messageClass: 'normal',
-      timestamp: Date.now(),
+      timestamp: new Date(),
       read: true
     };
 
@@ -26,6 +26,10 @@ var MockMessages = {
   },
 
   mms: function(opts = {}) {
+    var now = new Date();
+    var tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
     // default mms message
     var message = {
       id: 1,
@@ -34,12 +38,12 @@ var MockMessages = {
       receivers: ['receiver'],
       delivery: 'received',
       type: 'mms',
-      timestamp: Date.now(),
+      timestamp: now,
       read: true,
       subject: '',
       smil: null,
       attachments: [new Blob(['body'], {type: 'text/plain'})],
-      expiryDate: Date.now()
+      expiryDate: tomorrow
     };
 
     for (var key in message) {

--- a/apps/sms/test/unit/mock_utils.js
+++ b/apps/sms/test/unit/mock_utils.js
@@ -11,6 +11,7 @@ var MockUtils = {
     return 12;
   },
   getDayDate: Utils.getDayDate,
+  getHeaderDate: Utils.getHeaderDate,
   getFormattedHour: Utils.getFormattedHour,
   updateTimeHeaders: function() {},
   // real code needed here to map types

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -12,6 +12,7 @@ requireApp('sms/js/thread_list_ui.js');
 requireApp('sms/test/unit/mock_fixed_header.js');
 requireApp('sms/test/unit/mock_l10n.js');
 requireApp('sms/test/unit/mock_message_manager.js');
+requireApp('sms/test/unit/mock_messages.js');
 requireApp('sms/test/unit/mock_utils.js');
 requireApp('sms/test/unit/mock_waiting_screen.js');
 
@@ -35,6 +36,18 @@ suite('thread_list_ui', function() {
   suiteTeardown(function() {
     navigator.mozL10n = nativeMozL10n;
   });
+
+  function insertMockMarkup(someDate) {
+    someDate = +someDate;
+    var markup =
+      '<header></header>' +
+      '<ul id="threadsContainer_' + someDate + '">' +
+        '<li id="thread-1" data-time="' + someDate + '"></li>' +
+        '<li id="thread-2" data-time="' + someDate + '""></li>' +
+      '</ul>';
+
+    ThreadListUI.container.innerHTML = markup;
+  }
 
   suite('delayed rendering loops', function() {
 
@@ -311,6 +324,185 @@ suite('thread_list_ui', function() {
       var payload = 'hello <a href="world">world</a>';
       ThreadListUI.createThread(buildMMSThread(payload));
       assert.ok(MockUtils.escapeHTML.calledWith(payload));
+    });
+  });
+
+  suite('onMessageReceived', function() {
+    setup(function() {
+      this.sinon.stub(ThreadListUI, 'removeThread');
+      this.sinon.stub(ThreadListUI, 'appendThread');
+      this.sinon.stub(ThreadListUI, 'renderThreads');
+      this.sinon.stub(ThreadListUI, 'mark');
+      this.sinon.stub(ThreadListUI, 'setEmpty');
+    });
+
+    teardown(function() {
+      Threads.clear();
+    });
+
+    suite('in empty welcome screen,', function() {
+      var message;
+      setup(function() {
+        message = MockMessages.sms();
+        ThreadListUI.onMessageReceived(message);
+      });
+
+      test('render the whole list', function() {
+        assert.ok(ThreadListUI.renderThreads.called);
+        // first call, first argument, first item
+        var thread = ThreadListUI.renderThreads.args[0][0][0];
+        assert.equal(thread.id, message.threadId);
+        assert.equal(thread.body, message.body);
+      });
+    });
+
+    suite('other threads exist', function() {
+      var message;
+      setup(function() {
+        var someDate = new Date(2013, 1, 1);
+        insertMockMarkup(someDate);
+
+        var nextDate = new Date(2013, 1, 2);
+        message = MockMessages.sms({
+          threadId: 3,
+          timestamp: nextDate
+        });
+        ThreadListUI.onMessageReceived(message);
+      });
+
+      test('new thread is appended', function() {
+        assert.ok(ThreadListUI.appendThread.called);
+        // first call, first argument
+        var thread = ThreadListUI.appendThread.args[0][0];
+        assert.equal(thread.id, message.threadId);
+        assert.equal(thread.body, message.body);
+      });
+
+      test('no thread is removed', function() {
+        assert.isFalse(ThreadListUI.removeThread.called);
+      });
+    });
+
+    suite('same thread exist, older', function() {
+      var message;
+
+      setup(function() {
+        var someDate = new Date(2013, 1, 1);
+        insertMockMarkup(someDate);
+
+        var nextDate = new Date(2013, 1, 2);
+        message = MockMessages.sms({
+          threadId: 2,
+          timestamp: nextDate
+        });
+        ThreadListUI.onMessageReceived(message);
+      });
+
+      test('new thread is appended', function() {
+        assert.ok(ThreadListUI.appendThread.called);
+        // first call, first argument
+        var thread = ThreadListUI.appendThread.args[0][0];
+        assert.equal(thread.id, message.threadId);
+        assert.equal(thread.body, message.body);
+      });
+
+      test('old thread is removed', function() {
+        assert.ok(ThreadListUI.removeThread.called);
+        var threadId = ThreadListUI.removeThread.args[0][0];
+        assert.equal(threadId, message.threadId);
+      });
+    });
+
+    suite('same thread exist, newer', function() {
+      var message;
+
+      setup(function() {
+        var someDate = new Date(2013, 1, 1);
+        insertMockMarkup(someDate);
+
+        var prevDate = new Date(2013, 1, 0);
+        message = MockMessages.sms({
+          threadId: 2,
+          timestamp: prevDate
+        });
+        ThreadListUI.onMessageReceived(message);
+      });
+
+      test('no new thread is appended', function() {
+        assert.isFalse(ThreadListUI.appendThread.called);
+      });
+
+      test('no old thread is removed', function() {
+        assert.isFalse(ThreadListUI.removeThread.called);
+      });
+
+      test('old thread is marked unread', function() {
+        assert.ok(ThreadListUI.mark.called);
+        var args = ThreadListUI.mark.args[0];
+        assert.equal(args[0], message.threadId);
+        assert.equal(args[1], 'unread');
+      });
+    });
+  });
+
+  suite('appendThread', function() {
+    setup(function() {
+      this.sinon.stub(ThreadListUI, 'setContact');
+      this.sinon.stub(ThreadListUI, 'checkInputs');
+    });
+
+    suite('new thread and new message in a day', function() {
+      var thread;
+
+      setup(function() {
+        var someDate = new Date(2013, 1, 1).getTime();
+        insertMockMarkup(someDate);
+
+        var nextDate = new Date(2013, 1, 2);
+        var message = MockMessages.sms({
+          threadId: 3,
+          timestamp: nextDate
+        });
+
+        thread = ThreadListUI.createThreadMockup(message);
+        ThreadListUI.appendThread(thread);
+      });
+
+      test('show up in a new container', function() {
+        var newContainerId = 'threadsContainer_' + thread.timestamp.getTime();
+        var newContainer = document.getElementById(newContainerId);
+        assert.ok(newContainer);
+        assert.ok(newContainer.querySelector('li'));
+        var expectedThreadId = 'thread-' + thread.id;
+        assert.equal(newContainer.querySelector('li').id, expectedThreadId);
+      });
+    });
+
+    suite('existing thread and new message in a day', function() {
+      var thread;
+
+      setup(function() {
+        var someDate = new Date(2013, 1, 1).getTime();
+        insertMockMarkup(someDate);
+
+        var nextDate = new Date(2013, 1, 2);
+        var message = MockMessages.sms({
+          threadId: 2,
+          timestamp: nextDate
+        });
+
+        thread = ThreadListUI.createThreadMockup(message);
+        ThreadListUI.appendThread(thread);
+      });
+
+      test('show up in a new container', function() {
+        var newContainerId = 'threadsContainer_' + thread.timestamp.getTime();
+        var newContainer = document.getElementById(newContainerId);
+        assert.ok(newContainer);
+        assert.ok(newContainer.querySelector('li'));
+        var expectedThreadId = 'thread-' + thread.id;
+        assert.equal(newContainer.querySelector('li').id, expectedThreadId);
+      });
     });
   });
 });


### PR DESCRIPTION
...thread container is broken r=gnarf
- Refactored how threads are added when a new message is received
- This incidentally resolves the bug
- FixedHeader can't refresh the title too much, I was afraid when I saw it's
  being called when a thread is removed
- adds tests
