### PR TITLE
Bug 885264 - [SMS/MMS] Ensure Carrier Unknown is displayed for manually entered recipients r=julienw

### DIFF
--- a/apps/sms/js/desktop_contacts_mock.js
+++ b/apps/sms/js/desktop_contacts_mock.js
@@ -272,7 +272,8 @@
       familyName: 'Shannon',
       givenName: 'Claude',
       tel: {
-        value: '103'
+        value: '103',
+        type: 'Mobile'
       }
     })
   );

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -822,15 +822,11 @@ var ThreadUI = global.ThreadUI = {
     //
     Contacts.findByPhoneNumber(number, function gotContact(contacts) {
       var carrierTag = document.getElementById('contact-carrier');
-      /** If we have more than one contact sharing the same phone number
-       *  we show the title of contact detail with validate name/company
-       *  and how many other contacts share that same number. We think it's
-       *  user's responsability to correct this mess with the agenda.
-       */
       // Bug 867948: contacts null is a legitimate case, and
       // getContactDetails is okay with that.
       var details = Utils.getContactDetails(number, contacts);
       var contactName = details.title || number;
+      var carrierText;
 
       this.headerText.dataset.isContact = !!details.isContact;
       this.headerText.textContent = navigator.mozL10n.get(
@@ -841,14 +837,29 @@ var ThreadUI = global.ThreadUI = {
 
       // The carrier banner is meaningless and confusing in
       // group message mode.
-      if (thread.participants.length === 1) {
-        if (contacts && contacts.length) {
-          carrierTag.textContent = Utils.getContactCarrier(
-            number, contacts[0].tel
-          );
+      if (thread.participants.length === 1 &&
+          (contacts && contacts.length)) {
+
+
+        carrierText = Utils.getCarrierTag(
+          number, contacts[0].tel, details
+        );
+
+        // Known Contact with at least:
+        //
+        //  1. a name
+        //  2. a carrier
+        //  3. a type
+        //
+
+        if (carrierText) {
+          carrierTag.textContent = carrierText;
           carrierTag.classList.remove('hide');
+        } else {
+          carrierTag.classList.add('hide');
         }
       } else {
+        // Hide carrier tag in group message or unknown contact cases.
         carrierTag.classList.add('hide');
       }
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -216,32 +216,37 @@
       return details;
     },
 
-    getContactCarrier: function(input, tels) {
+    getCarrierTag: function ut_getCarrierTag(input, tels, details) {
       /**
         1. If a phone number has carrier associated with it
             the output will be:
 
-          Firstname Lastname
           type | carrier
 
         2. If there is no carrier associated with the phone number
             the output will be:
 
-          Firstname Lastname
           type | phonenumber
 
         3. If for some reason a single contact has two phone numbers with
             the same type and the same carrier the output will be:
 
-          Firstname Lastname
           type | phonenumber
 
-      */
+        4. If for some reason a single contact has no name and no carrier,
+            the output will be:
 
+          type
+
+        5. If for some reason a single contact has no name, no type
+            and no carrier, the output will be nothing.
+      */
       var length = tels.length;
+      var hasDetails = typeof details !== 'undefined';
       var hasUniqueCarriers = true;
       var hasUniqueTypes = true;
-      var found, tel, type, carrier, value;
+      var name = hasDetails ? details.name : '';
+      var found, tel, type, carrier, value, ending;
 
       for (var i = 0; i < length; i++) {
         tel = tels[i];
@@ -259,18 +264,23 @@
         }
 
         carrier = tel.carrier;
-        type = tel.type[0];
+        type = (tel.type && tel.type[0]) || '';
       }
 
       if (!found) {
         return '';
       }
 
-      type = found.type[0];
-      carrier = hasUniqueCarriers || hasUniqueTypes ? found.carrier : '';
+      type = (found.type && found.type[0]) || '';
+      carrier = (hasUniqueCarriers || hasUniqueTypes) ? found.carrier : '';
       value = carrier || found.value;
+      ending = ' | ' + (carrier || value);
 
-      return type + ' | ' + (carrier || value);
+      if (hasDetails && !name && !carrier) {
+        ending = '';
+      }
+
+      return type + ending;
     },
 
     // Based on "non-dialables" in https://github.com/andreasgal/PhoneNumber.js

--- a/apps/sms/test/unit/mock_utils.js
+++ b/apps/sms/test/unit/mock_utils.js
@@ -20,6 +20,7 @@ var MockUtils = {
   params: Utils.params,
   getContactDetails: Utils.getContactDetails,
   getResizedImgBlob: Utils.getResizedImgBlob,
+  getCarrierTag: Utils.getCarrierTag,
   removeNonDialables: Utils.removeNonDialables,
   compareDialables: Utils.compareDialables
 };

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1657,7 +1657,7 @@ suite('thread_ui.js >', function() {
     });
   });
 
-  suite('Header Actions', function() {
+  suite('Header Actions/Display', function() {
     setup(function() {
       window.location.hash = '';
       MockActivityPicker.call.mSetup();
@@ -1670,156 +1670,257 @@ suite('thread_ui.js >', function() {
       MockActivityPicker.call.mTeardown();
       MockOptionMenu.mTeardown();
     });
+    // See: utils_test.js
+    // Utils.getCarrierTag
+    //
+    suite('Single participant', function() {
 
-    test('Single participant: Contact Options (known)', function() {
+      suite('Options', function() {
+        test('Contact Options (known)', function() {
 
-      Threads.set(1, {
-        participants: ['999']
+          Threads.set(1, {
+            participants: ['999']
+          });
+
+          window.location.hash = '#thread=1';
+
+          ThreadUI.headerText.dataset.isContact = true;
+          ThreadUI.headerText.dataset.number = '999';
+
+          ThreadUI.onHeaderActivation();
+
+          var calls = MockOptionMenu.calls;
+
+          assert.equal(calls.length, 1);
+          assert.equal(calls[0].section, '999');
+          assert.equal(calls[0].items.length, 3);
+          assert.equal(typeof calls[0].complete, 'function');
+        });
+
+        test('Contact Options (unknown)', function() {
+
+          Threads.set(1, {
+            participants: ['777']
+          });
+
+          window.location.hash = '#thread=1';
+
+          ThreadUI.headerText.dataset.isContact = false;
+          ThreadUI.headerText.dataset.number = '777';
+
+          ThreadUI.onHeaderActivation();
+
+          var calls = MockOptionMenu.calls;
+
+          assert.equal(calls.length, 1);
+          assert.equal(calls[0].header, '777');
+          assert.equal(calls[0].items.length, 5);
+          assert.equal(typeof calls[0].complete, 'function');
+        });
       });
 
-      window.location.hash = '#thread=1';
+      suite('Carrier Tag', function() {
+        test('Carrier Tag (non empty string)', function(done) {
 
-      ThreadUI.headerText.dataset.isContact = true;
-      ThreadUI.headerText.dataset.number = '999';
+          Threads.set(1, {
+            participants: ['+12125559999']
+          });
 
-      ThreadUI.onHeaderActivation();
+          window.location.hash = '#thread=1';
 
-      var calls = MockOptionMenu.calls;
+          this.sinon.stub(MockUtils, 'getCarrierTag', function() {
+            return 'non empty string';
+          });
 
-      assert.equal(calls.length, 1);
-      assert.equal(calls[0].section, '999');
-      assert.equal(calls[0].items.length, 3);
-      assert.equal(typeof calls[0].complete, 'function');
+          this.sinon.stub(
+            MockContacts, 'findByPhoneNumber', function(phone, fn) {
+
+            fn([new MockContact()]);
+
+            var carrierTag = document.getElementById('contact-carrier');
+
+            assert.isFalse(carrierTag.classList.contains('hide'));
+
+            done();
+          });
+
+          ThreadUI.updateHeaderData();
+        });
+
+        test('Carrier Tag (empty string)', function(done) {
+
+          Threads.set(1, {
+            participants: ['+12125559999']
+          });
+
+          window.location.hash = '#thread=1';
+
+          this.sinon.stub(MockUtils, 'getCarrierTag', function() {
+            return '';
+          });
+
+          this.sinon.stub(
+            MockContacts, 'findByPhoneNumber', function(phone, fn) {
+
+            fn([new MockContact()]);
+
+            var carrierTag = document.getElementById('contact-carrier');
+
+            assert.isTrue(carrierTag.classList.contains('hide'));
+
+            done();
+          });
+
+          ThreadUI.updateHeaderData();
+        });
+      });
     });
 
-    test('Single participant: Contact Options (unknown)', function() {
-
-      Threads.set(1, {
-        participants: ['777']
+    suite('Multi participant', function() {
+      setup(function() {
+        window.location.hash = '';
+        MockActivityPicker.call.mSetup();
+        MockOptionMenu.mSetup();
       });
 
-      window.location.hash = '#thread=1';
-
-      ThreadUI.headerText.dataset.isContact = false;
-      ThreadUI.headerText.dataset.number = '777';
-
-      ThreadUI.onHeaderActivation();
-
-      var calls = MockOptionMenu.calls;
-
-      assert.equal(calls.length, 1);
-      assert.equal(calls[0].header, '777');
-      assert.equal(calls[0].items.length, 5);
-      assert.equal(typeof calls[0].complete, 'function');
-    });
-
-    test('Multi participant: DOES NOT Invoke Activities', function() {
-
-      Threads.set(1, {
-        participants: ['999', '888']
+      teardown(function() {
+        Threads.delete(1);
+        window.location.hash = '';
+        MockActivityPicker.call.mTeardown();
+        MockOptionMenu.mTeardown();
       });
 
-      window.location.hash = '#thread=1';
+      suite('Options', function() {
 
-      ThreadUI.headerText.dataset.isContact = true;
-      ThreadUI.headerText.dataset.number = '999';
+        test('DOES NOT Invoke Activities', function() {
 
-      ThreadUI.onHeaderActivation();
+          Threads.set(1, {
+            participants: ['999', '888']
+          });
 
-      assert.equal(MockActivityPicker.call.called, false);
-      assert.equal(MockActivityPicker.call.calledWith, null);
-    });
+          window.location.hash = '#thread=1';
 
-    test('Multi participant: DOES NOT Invoke Options', function() {
+          ThreadUI.headerText.dataset.isContact = true;
+          ThreadUI.headerText.dataset.number = '999';
 
-      Threads.set(1, {
-        participants: ['999', '888']
+          ThreadUI.onHeaderActivation();
+
+          assert.equal(MockActivityPicker.call.called, false);
+          assert.equal(MockActivityPicker.call.calledWith, null);
+        });
+
+        test('DOES NOT Invoke Options', function() {
+
+          Threads.set(1, {
+            participants: ['999', '888']
+          });
+
+          window.location.hash = '#thread=1';
+
+          ThreadUI.headerText.dataset.isContact = true;
+          ThreadUI.headerText.dataset.number = '999';
+
+          ThreadUI.onHeaderActivation();
+
+          assert.equal(MockOptionMenu.calls.length, 0);
+        });
+
+        test('Moves to Group View', function(done) {
+          Threads.set(1, {
+            participants: ['999', '888']
+          });
+
+          // Change to #thread=n
+          window.onhashchange = function() {
+            // Change to #group-view (per ThreadUI.onHeaderActivation())
+            window.onhashchange = function() {
+              assert.equal(window.location.hash, '#group-view');
+              assert.equal(
+                ThreadUI.headerText.textContent, 'participant{"n":2}'
+              );
+              window.onhashchange = null;
+              done();
+            };
+
+            ThreadUI.onHeaderActivation();
+            ThreadUI.groupView();
+          };
+
+          window.location.hash = '#thread=1';
+        });
+
+        test('Correctly Displayed', function() {
+          var contacts = {
+            a: new MockContact(),
+            b: new MockContact()
+          };
+
+          // Truncate the tel record arrays; there should
+          // only be one when renderContact does its
+          // loop and comparison of dialiables
+          contacts.a.tel.length = 1;
+          contacts.b.tel.length = 1;
+
+          // Set to our "participants"
+          contacts.a.tel[0].value = '999';
+          contacts.b.tel[0].value = '888';
+
+          // "input" value represents the participant entry value
+          // that would be provided in ThreadUI.groupView()
+          ThreadUI.renderContact({
+            contact: contacts.a,
+            input: '999',
+            target: ThreadUI.participantsList,
+            isContact: true,
+            isSuggestion: false
+          });
+
+          ThreadUI.renderContact({
+            contact: contacts.b,
+            input: '888',
+            target: ThreadUI.participantsList,
+            isContact: true,
+            isSuggestion: false
+          });
+
+          assert.equal(
+            ThreadUI.participantsList.children.length, 2
+          );
+        });
+
+        test('Reset Group View', function() {
+          var list = ThreadUI.participants.firstElementChild;
+
+          assert.equal(list.children.length, 0);
+
+          list.innerHTML = '<li></li><li></li><li></li>';
+
+          assert.equal(list.children.length, 3);
+
+          ThreadUI.groupView.reset();
+
+          assert.equal(list.children.length, 0);
+        });
       });
 
-      window.location.hash = '#thread=1';
+      suite('Carrier Tag', function() {
+        test('Carrier Tag (empty string)', function() {
 
-      ThreadUI.headerText.dataset.isContact = true;
-      ThreadUI.headerText.dataset.number = '999';
+          Threads.set(1, {
+            participants: ['999', '888']
+          });
 
-      ThreadUI.onHeaderActivation();
+          window.location.hash = '#thread=1';
+          ThreadUI.updateHeaderData();
 
-      assert.equal(MockOptionMenu.calls.length, 0);
-    });
+          var carrierTag = document.getElementById('contact-carrier');
 
-    test('Multi participant: Moves to Group View', function(done) {
-      Threads.set(1, {
-        participants: ['999', '888']
+          assert.isTrue(carrierTag.classList.contains('hide'));
+        });
+
       });
-
-      // Change to #thread=n
-      window.onhashchange = function() {
-        // Change to #group-view (per ThreadUI.onHeaderActivation())
-        window.onhashchange = function() {
-          assert.equal(window.location.hash, '#group-view');
-          assert.equal(ThreadUI.headerText.textContent, 'participant{"n":2}');
-          window.onhashchange = null;
-          done();
-        };
-
-        ThreadUI.onHeaderActivation();
-        ThreadUI.groupView();
-      };
-
-      window.location.hash = '#thread=1';
     });
 
-    test('Multi participant: Correctly Displayed', function() {
-      var contacts = {
-        a: new MockContact(),
-        b: new MockContact()
-      };
-
-      // Truncate the tel record arrays; there should
-      // only be one when renderContact does its
-      // loop and comparison of dialiables
-      contacts.a.tel.length = 1;
-      contacts.b.tel.length = 1;
-
-      // Set to our "participants"
-      contacts.a.tel[0].value = '999';
-      contacts.b.tel[0].value = '888';
-
-      // "input" value represents the participant entry value
-      // that would be provided in ThreadUI.groupView()
-      ThreadUI.renderContact({
-        contact: contacts.a,
-        input: '999',
-        target: ThreadUI.participantsList,
-        isContact: true,
-        isSuggestion: false
-      });
-
-      ThreadUI.renderContact({
-        contact: contacts.b,
-        input: '888',
-        target: ThreadUI.participantsList,
-        isContact: true,
-        isSuggestion: false
-      });
-
-      assert.equal(
-        ThreadUI.participantsList.children.length, 2
-      );
-    });
-
-    test('Multi participant: Reset Group View', function() {
-      var list = ThreadUI.participants.firstElementChild;
-
-      assert.equal(list.children.length, 0);
-
-      list.innerHTML = '<li></li><li></li><li></li>';
-
-      assert.equal(list.children.length, 3);
-
-      ThreadUI.groupView.reset();
-
-      assert.equal(list.children.length, 0);
-    });
   });
 
   suite('Sending Behavior (onSendClick)', function() {

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -355,15 +355,38 @@ suite('Utils', function() {
     });
   });
 
-  suite('Utils.getContactCarrier', function() {
+  suite('Utils.getCarrierTag', function() {
+    /**
+      1. If a phone number has carrier associated with it
+          the output will be:
 
+        type | carrier
+
+      2. If there is no carrier associated with the phone number
+          the output will be:
+
+        type | phonenumber
+
+      3. If for some reason a single contact has two phone numbers with
+          the same type and the same carrier the output will be:
+
+        type | phonenumber
+
+      4. If for some reason a single contact has no name and no carrier,
+          the output will be:
+
+        type
+
+      5. If for some reason a single contact has no name, no type
+          and no carrier, the output will be nothing.
+    */
     test('Single with carrier', function() {
       // ie. contact.tel [ ... ]
       var tel = [
         {value: '101', type: ['Mobile'], carrier: 'Nynex'}
       ];
 
-      var a = Utils.getContactCarrier('101', tel);
+      var a = Utils.getCarrierTag('101', tel);
 
       assert.equal(a, 'Mobile | Nynex');
     });
@@ -374,9 +397,42 @@ suite('Utils', function() {
         {value: '201', type: ['Mobile'], carrier: null}
       ];
 
-      var a = Utils.getContactCarrier('201', tel);
+      var a = Utils.getCarrierTag('201', tel);
 
       assert.equal(a, 'Mobile | 201');
+    });
+
+    test('Single no name', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '201', type: ['Mobile'], carrier: 'Telco'}
+      ];
+
+      var a = Utils.getCarrierTag('201', tel, { name: '' });
+
+      assert.equal(a, 'Mobile | Telco');
+    });
+
+    test('Single no name, no carrier', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '201', type: ['Mobile'], carrier: null}
+      ];
+
+      var a = Utils.getCarrierTag('201', tel, { name: '' });
+
+      assert.equal(a, 'Mobile');
+    });
+
+    test('Single no name, no carrier, no type', function() {
+      // ie. contact.tel [ ... ]
+      var tel = [
+        {value: '201', type: [], carrier: null}
+      ];
+
+      var a = Utils.getCarrierTag('201', tel, { name: '' });
+
+      assert.equal(a, '');
     });
 
     test('Multi different carrier & type, match both', function() {
@@ -386,8 +442,8 @@ suite('Utils', function() {
         {value: '302', type: ['Home'], carrier: 'MCI'}
       ];
 
-      var a = Utils.getContactCarrier('301', tel);
-      var b = Utils.getContactCarrier('302', tel);
+      var a = Utils.getCarrierTag('301', tel);
+      var b = Utils.getCarrierTag('302', tel);
 
       assert.equal(a, 'Mobile | Nynex');
       assert.equal(b, 'Home | MCI');
@@ -400,7 +456,7 @@ suite('Utils', function() {
         {value: '402', type: ['Home'], carrier: 'MCI'}
       ];
 
-      var a = Utils.getContactCarrier('401', tel);
+      var a = Utils.getCarrierTag('401', tel);
 
       assert.equal(a, 'Mobile | Nynex');
     });
@@ -412,7 +468,7 @@ suite('Utils', function() {
         {value: '502', type: ['Home'], carrier: 'MCI'}
       ];
 
-      var a = Utils.getContactCarrier('502', tel);
+      var a = Utils.getCarrierTag('502', tel);
 
       assert.equal(a, 'Home | MCI');
     });
@@ -424,8 +480,8 @@ suite('Utils', function() {
         {value: '602', type: ['Mobile'], carrier: 'Nynex'}
       ];
 
-      var a = Utils.getContactCarrier('601', tel);
-      var b = Utils.getContactCarrier('602', tel);
+      var a = Utils.getCarrierTag('601', tel);
+      var b = Utils.getCarrierTag('602', tel);
 
       assert.equal(a, 'Mobile | 601');
       assert.equal(b, 'Mobile | 602');
@@ -438,8 +494,8 @@ suite('Utils', function() {
         {value: '702', type: ['Home'], carrier: 'Nynex'}
       ];
 
-      var a = Utils.getContactCarrier('701', tel);
-      var b = Utils.getContactCarrier('702', tel);
+      var a = Utils.getCarrierTag('701', tel);
+      var b = Utils.getCarrierTag('702', tel);
 
       assert.equal(a, 'Mobile | Nynex');
       assert.equal(b, 'Home | Nynex');
@@ -452,8 +508,8 @@ suite('Utils', function() {
         {value: '802', type: ['Mobile'], carrier: 'MCI'}
       ];
 
-      var a = Utils.getContactCarrier('801', tel);
-      var b = Utils.getContactCarrier('802', tel);
+      var a = Utils.getCarrierTag('801', tel);
+      var b = Utils.getCarrierTag('802', tel);
 
       assert.equal(a, 'Mobile | Nynex');
       assert.equal(b, 'Mobile | MCI');
@@ -466,8 +522,8 @@ suite('Utils', function() {
         {value: '0987654321', type: ['Mobile'], carrier: 'MCI'}
       ];
 
-      var a = Utils.getContactCarrier('+1234567890', tel);
-      var b = Utils.getContactCarrier('+0987654321', tel);
+      var a = Utils.getCarrierTag('+1234567890', tel);
+      var b = Utils.getCarrierTag('+0987654321', tel);
 
       assert.equal(a, 'Mobile | Nynex');
       assert.equal(b, 'Mobile | MCI');
@@ -480,8 +536,8 @@ suite('Utils', function() {
         {value: '0987654321', type: ['Mobile'], carrier: 'MCI'}
       ];
 
-      var a = Utils.getContactCarrier('+9999999999', tel);
-      var b = Utils.getContactCarrier('+9999999999', tel);
+      var a = Utils.getCarrierTag('+9999999999', tel);
+      var b = Utils.getCarrierTag('+9999999999', tel);
 
       assert.equal(a, '');
       assert.equal(b, '');


### PR DESCRIPTION
1. If a phone number has carrier associated with it
   the output will be:
   
   type | carrier
2. If there is no carrier associated with the phone number
   the output will be:
   
   type | phonenumber
3. If for some reason a single contact has two phone numbers with
   the same type and the same carrier the output will be:
   
   type | phonenumber
4. If for some reason a single contact has no name and no carrier,
   the output will be:
   
   type
5. If for some reason a single contact has no name, no type
   and no carrier, the output will be nothing.

https://bugzilla.mozilla.org/show_bug.cgi?id=885264
