### PR TITLE
We can shutdown at 0% since the Gecko BatteryManager will reserve 2% at all times.

### DIFF
--- a/apps/system/js/battery_manager.js
+++ b/apps/system/js/battery_manager.js
@@ -8,7 +8,7 @@ var BatteryManager = {
   TRANSITION_SPEED: 1.8,
   TRANSITION_FRACTION: 0.30,
 
-  AUTO_SHUTDOWN_LEVEL: 0.02,
+  AUTO_SHUTDOWN_LEVEL: 0.0,
   EMPTY_BATTERY_LEVEL: 0.1,
 
   _battery: window.navigator.battery,


### PR DESCRIPTION
After landing Gecko patch on bug 852361 we can merge this pull request safely.
