### PR TITLE
Bug 886081 - Pepephone battery saving APN

### DIFF
--- a/shared/resources/apn/service_providers.xml
+++ b/shared/resources/apn/service_providers.xml
@@ -3140,7 +3140,7 @@ conceived.
 		<name>Pepephone</name>
 		<gsm>
 			<network-id mcc="214" mnc="06"/>
-			<apn value="gprs.pepephone.com" >
+			<apn value="gprsmov.pepephone.com" >
 				<plan type="postpaid"/>
 				<usage type="internet"/>
 			</apn>


### PR DESCRIPTION
The APN for Pepephone is not the suggested one for mobile devices.
