### PR TITLE
Bug 886238: Retrieve number of unlock retries from IccManager

### DIFF
--- a/apps/communications/dialer/js/mmi_ui.js
+++ b/apps/communications/dialer/js/mmi_ui.js
@@ -5,7 +5,6 @@ var MmiUI = {
   COMMS_APP_ORIGIN: document.location.protocol + '//' +
     document.location.host,
   _: null,
-  _conn: null,
 
   get headerTitleNode() {
     delete this.headerTitleNode;
@@ -182,15 +181,12 @@ var MmiUI = {
   },
 
   handleError: function ph_handleError(data) {
-    if (!this._conn)
-      this._conn = window.navigator.mozMobileConnection;
     var error = data.error ? data.error : this._('mmi-error');
     switch (error) {
       case 'IncorrectPassword':
-        var retries = this._conn.retryCount;
         error = this._('pinError');
-        if (retries)
-          error += this._('inputCodeRetriesLeft', {n: retries});
+        if (data.retryCount)
+          error += this._('inputCodeRetriesLeft', {n: data.retryCount});
         break;
       case 'NEW_PIN_MISMATCH':
         error = this._('newpinConfirmation');

--- a/apps/communications/ftu/js/sim_manager.js
+++ b/apps/communications/ftu/js/sim_manager.js
@@ -20,14 +20,6 @@ var SimManager = {
                                   this.handleCardState.bind(this));
 
     this.alreadyImported = false;
-
-    Object.defineProperty(this,
-                          'retryCount', {
-                            configurable: true,
-                            get: function() {
-                              return this.mobConn.retryCount;
-                            }
-                          });
   },
 
   handleUnlockError: function sm_handleUnlockError(data) {
@@ -136,14 +128,18 @@ var SimManager = {
     if (this._unlocked)
       return;
 
-    if (!this.retryCount || this.retryCount === 'undefined') {
-      UIManager.pinRetriesLeft.classList.add('hidden');
-    } else {
-      var l10nArgs = {n: this.retryCount};
-      UIManager.pinRetriesLeft.textContent = _('inputCodeRetriesLeft',
-                                               l10nArgs);
-      UIManager.pinRetriesLeft.classList.remove('hidden');
-    }
+    var req = this.icc.getCardLockRetryCount('pin');
+    req.onsuccess = (function sm_getCardLockRetryCountSuccess() {
+      if (!req.result.retryCount || req.result.retryCount === 'undefined') {
+        UIManager.pinRetriesLeft.classList.add('hidden');
+      } else {
+        var l10nArgs = {n: req.result.retryCount};
+        UIManager.pinRetriesLeft.textContent = _('inputCodeRetriesLeft',
+                                                 l10nArgs);
+        UIManager.pinRetriesLeft.classList.remove('hidden');
+      }
+    }).bind(this);
+
     UIManager.activationScreen.classList.remove('show');
     UIManager.unlockSimScreen.classList.add('show');
     UIManager.pincodeScreen.classList.add('show');
@@ -155,14 +151,18 @@ var SimManager = {
     if (this._unlocked)
       return;
 
-    if (!this.retryCount) {
-      UIManager.pukRetriesLeft.classList.add('hidden');
-    } else {
-      var l10nArgs = {n: this.retryCount};
-      UIManager.pukRetriesLeft.textContent = _('inputCodeRetriesLeft',
-                                               l10nArgs);
-      UIManager.pukRetriesLeft.classList.remove('hidden');
-    }
+    var req = this.icc.getCardLockRetryCount('puk');
+    req.onsuccess = (function sm_getCardLockRetryCountSuccess() {
+      if (!req.result.retryCount) {
+        UIManager.pukRetriesLeft.classList.add('hidden');
+      } else {
+        var l10nArgs = {n: req.result.retryCount};
+        UIManager.pukRetriesLeft.textContent = _('inputCodeRetriesLeft',
+                                                 l10nArgs);
+        UIManager.pukRetriesLeft.classList.remove('hidden');
+      }
+    }).bind(this);
+
     UIManager.unlockSimScreen.classList.add('show');
     UIManager.activationScreen.classList.remove('show');
     UIManager.pincodeScreen.classList.remove('show');
@@ -176,10 +176,12 @@ var SimManager = {
     if (this._unlocked)
       return;
 
-    if (!this.retryCount) {
+    var retryCount = 0; // Don't know how to retrieve retry counter.
+
+    if (!retryCount) {
       UIManager.xckRetriesLeft.classList.add('hidden');
     } else {
-      var l10nArgs = {n: this.retryCount};
+      var l10nArgs = {n: retryCount};
       UIManager.xckRetriesLeft.textContent = _('inputCodeRetriesLeft',
                                                l10nArgs);
       UIManager.xckRetriesLeft.classList.remove('hidden');

--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -249,14 +249,16 @@ var SimPinDialog = {
         break;
     }
 
-    var retryCount = this.mobileConnection.retryCount;
-    if (!retryCount) {
-      this.triesLeftMsg.hidden = true;
-    } else {
-      var l10nArgs = { n: retryCount };
-      this.triesLeftMsg.textContent = _('inputCodeRetriesLeft', l10nArgs);
-      this.triesLeftMsg.hidden = false;
-    }
+    var req = this.icc.getCardLockRetryCount(this.lockType);
+    req.onsuccess = (function spl_getCardLockRetryCountSuccess() {
+      if (!req.result.retryCount) {
+        this.triesLeftMsg.hidden = true;
+      } else {
+        var l10nArgs = { n: req.result.retryCount };
+        this.triesLeftMsg.textContent = _('inputCodeRetriesLeft', l10nArgs);
+        this.triesLeftMsg.hidden = false;
+      }
+    }).bind(this);
 
     if (onsuccess && typeof onsuccess === 'function')
       this.onsuccess = onsuccess;

--- a/apps/system/js/simcard_dialog.js
+++ b/apps/system/js/simcard_dialog.js
@@ -71,15 +71,16 @@ var SimPinDialog = {
 
     var cardState = this.mobileConnection.cardState;
     var lockType = this.lockTypeMap[cardState];
-    var retryCount = this.mobileConnection.retryCount;
-
-    if (!retryCount) {
-      this.triesLeftMsg.hidden = true;
-    } else {
-      var l10nArgs = { n: retryCount };
-      this.triesLeftMsg.textContent = _('inputCodeRetriesLeft', l10nArgs);
-      this.triesLeftMsg.hidden = false;
-    }
+    var req = this.icc.getCardLockRetryCount(lockType);
+    req.onsuccess = (function spl_getCardLockRetryCountOnSuccess() {
+      if (!req.result.retryCount) {
+        this.triesLeftMsg.hidden = true;
+      } else {
+        var l10nArgs = { n: req.result.retryCount };
+        this.triesLeftMsg.textContent = _('inputCodeRetriesLeft', l10nArgs);
+        this.triesLeftMsg.hidden = false;
+      }
+    }).bind(this);
 
     switch (lockType) {
       case 'pin':


### PR DESCRIPTION
Gaia apps that allow for the unlocking of the SIM card now retrieve
the number of remaining tries from the IccManager. The interface in
MobileConnection is deprecated and has been removed.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
