### PR TITLE
Bug 883737 - [Bluetooth][File-Transfer] screen layout size is exceeded in Bluetooth Transfer pop-up screen

### DIFF
--- a/apps/system/style/modal_dialog/prompt.css
+++ b/apps/system/style/modal_dialog/prompt.css
@@ -42,3 +42,9 @@
   color: #cbcbcb;
   display: block;
 }
+
+/* Since considering 20px height of status bar,
+   overwrite padding top which is defined in shared/style/confirm.css*/
+form[role="dialog"][data-type="confirm"] {
+  padding: 2rem 0 7rem;
+}


### PR DESCRIPTION
Revise "padding top" to fix overlaying title while content is more over inner panel.
