### PR TITLE
Bug 883737 - [Bluetooth][File-Transfer] screen layout size is exceeded in Bluetooth Transfer pop-up screen(v1-train)

### DIFF
--- a/apps/system/style/themes/default/core.css
+++ b/apps/system/style/themes/default/core.css
@@ -9,7 +9,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  padding: 1.5rem 0 7rem;
+  padding: 2rem 0 7rem;
   color: #fff;
   font-size: 0;
   font-family: "MozTT", Sans-serif;
@@ -35,6 +35,8 @@
   padding: 0 1.5rem;
   vertical-align: middle;
   white-space: normal;  
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 [role="dialog"] h3 {


### PR DESCRIPTION
Since the building block reference is different from gaia:master, I file another pull request for fixing v1-train only.
- Revise "padding top" to fix overlaying title while content is more over inner panel.
- Add overflow-y: auto for inner panel of confirm dialog.
