### PR TITLE
Bug 886602 - Disable homescreen dragdrop test in TBPL for orange, r=mdas...

### DIFF
--- a/tests/python/gaia-unit-tests/gaia_unit_test/disabled.json
+++ b/tests/python/gaia-unit-tests/gaia_unit_test/disabled.json
@@ -1,4 +1,5 @@
 [
   "calendar/test/unit/views/modify_event_test.js",
-  "gallery/test/unit/GestureDetector_test.js"
+  "gallery/test/unit/GestureDetector_test.js",
+  "homescreen/test/unit/dragdrop_test.js"
 ]


### PR DESCRIPTION
..., a=test-only
