### PR TITLE
Bug 884703 - Remove inline styles on visual keys if present

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -478,8 +478,16 @@ const IMERender = (function() {
 
     // Width calc
     if (layout) {
+      var keyboard = document.getElementById('keyboard');
+
+      // Remove inline styles on rotation
+      [].forEach.call(keyboard.querySelectorAll('.visual-wrapper[style]'),
+        function(item) {
+          item.style.width = '';
+        });
+
       layoutWidth = layout.width || 10;
-      var totalWidth = document.getElementById('keyboard').clientWidth;
+      var totalWidth = keyboard.clientWidth;
       var placeHolderWidth = totalWidth / layoutWidth;
 
       var ratio, keys, rows = document.querySelectorAll('.keyboard-row');


### PR DESCRIPTION
Fix for [#884703](https://bugzilla.mozilla.org/show_bug.cgi?id=884703). When rotating we only apply `resizeUI` and don't re-render the whole UI. Therefore the style.width property on a visual key is still set and we get the value derived from that back in `visualKey.offsetWidth`. This patch removes the width before resizing the keys. The reason I don't do it inline is because it triggers a reflow for every key we apply this to, so rather do that at the beginning.

Tests for this change are in #10532.
