### PR TITLE
Bug 882916 - [Email] Forward/Reply/Reply All functionality breaks on structured clone failure when e-mail sender already exists and has been cached. r=lightsofapollo

### DIFF
--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -677,10 +677,14 @@ var ContactCache = exports.ContactCache = {
     }
     // known contact; unpack contact info
     else if (entry !== undefined) {
-      peep = new MailPeep(entry.name || addressPair.name || '', emailAddress,
-                          entry.id,
-                          (entry.photo && entry.photo.length) ?
-                            entry.photo[0] : null);
+      var name = addressPair.name || '';
+      if (entry.name && entry.name.length)
+        name = entry.name[0];
+      peep = new MailPeep(
+        name,
+        emailAddress,
+        entry.id,
+        (entry.photo && entry.photo.length) ? entry.photo[0] : null);
     }
     // not yet looked-up; assume it's a miss and we'll fix-up if it's a hit
     else {


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/221
