### PR TITLE
Bug 881648 - [MMS] There is not maximum limit warning

### DIFF
--- a/apps/sms/js/settings.js
+++ b/apps/sms/js/settings.js
@@ -21,7 +21,7 @@ var Settings = {
     req.onsuccess = function mm_getSizeSuccess() {
       var size = req.result[key];
       if (size && !isNaN(size)) {
-        Settings.mmsSizeLimitation = size * 1024;
+        Settings.mmsSizeLimitation = size;
       }
     };
   }

--- a/apps/sms/test/unit/settings_test.js
+++ b/apps/sms/test/unit/settings_test.js
@@ -52,7 +52,7 @@ suite('Message App settings Unit-Test', function() {
 
         var req = lock.get.returnValues[0];
         req.result = {
-          'dom.mms.operatorSizeLimitation': 500
+          'dom.mms.operatorSizeLimitation': 512000
         };
         req.onsuccess();
 

--- a/build/settings.py
+++ b/build/settings.py
@@ -126,7 +126,7 @@ settings = {
  "ril.mms.user": "",
  "ril.mms.retrieval_mode": "automatic-home",
  "ril.mms.authtype": "notDefined",
- "dom.mms.operatorSizeLimitation": 0,
+ "dom.mms.operatorSizeLimitation": 307200,
  "ril.radio.preferredNetworkType": "",
  "ril.radio.disabled": False,
  "ril.supl.apn": "",


### PR DESCRIPTION
- Define a default size limitation with 307200 bytes(300kilobytes) in settings key.
- The patch and Bug 873758(https://github.com/mozilla-b2g/gaia/pull/9854/files#L3R24) should be reviewed together. We should allow units unified in bytes.
