### PR TITLE
Bug 887190 - Upon introducing wrong PIN code, focus and keyboard go away and the user can't try it again

### DIFF
--- a/apps/communications/ftu/js/sim_manager.js
+++ b/apps/communications/ftu/js/sim_manager.js
@@ -247,6 +247,7 @@ var SimManager = {
       UIManager.pinError.textContent = _('pinValidation');
       UIManager.pinInput.classList.add('onerror');
       UIManager.pinError.classList.remove('hidden');
+      UIManager.pinInput.focus();
       return;
     } else {
       UIManager.pinInput.classList.remove('onerror');
@@ -329,6 +330,7 @@ var SimManager = {
       UIManager.xckInput.classList.add('onerror');
       UIManager.xckError.classList.remove('hidden');
       UIManager.xckError.textContent = _(lockType + 'Validation');
+      UIManager.xckInput.focus();
       return;
     } else {
       UIManager.pinInput.classList.remove('onerror');


### PR DESCRIPTION
On First Time Use, if the user introduces a wrong PIN when requested, the UI will point out that it is a wrong code, but also take away focus and thus the keyboard from the input field. The user can't focus on the field again by tapping the field, being forced to skip the PIN code setup and having to do it later on when the system is ready.

This fix re-focus on the PIN input field when the user introduces a wrong code.
