### PR TITLE
Bug 884725 - [Facebook] When clicking on facebook sync error notification, Dialer App. disappears after opening (r=jmcanterafonseca)

### DIFF
--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -7,6 +7,7 @@ var CallHandler = (function callHandler() {
   var callScreenWindowReady = false;
   var btCommandsToForward = [];
   var currentActivity = null;
+  var FB_SYNC_ERROR_PARAM = 'isSyncError';
 
   /* === Settings === */
   var screenState = null;
@@ -64,10 +65,16 @@ var CallHandler = (function callHandler() {
       return;
     }
 
-    navigator.mozApps.getSelf().onsuccess = function gotSelf(evt) {
-      var app = evt.target.result;
+    navigator.mozApps.getSelf().onsuccess = function gotSelf(selfEvt) {
+      var app = selfEvt.target.result;
       app.launch('dialer');
-      window.location.hash = '#recents-view';
+      var location = document.createElement('a');
+      location.href = evt.imageURL;
+      if (location.search.indexOf(FB_SYNC_ERROR_PARAM) !== -1) {
+        window.location.hash = '#contacts-view';
+      } else {
+        window.location.hash = '#call-log-view';
+      }
     };
   }
 

--- a/apps/communications/facebook/js/fb_sync_init.js
+++ b/apps/communications/facebook/js/fb_sync_init.js
@@ -18,6 +18,7 @@ fb.sync = Sync;
   // Delay in closing the window
   var CLOSE_DELAY = 5000;
   var FB_TRAY_ICON = '/contacts/style/images/f_logo.png';
+  var FB_SYNC_ERROR_PARAM = 'isSyncError';
 
   Alarm.init = function() {
     fb.init(function fb_alarm_init() {
@@ -72,7 +73,7 @@ fb.sync = Sync;
         showNotification({
           title: _('facebook'),
           body: _('notificationLogin'),
-          iconURL: FB_TRAY_ICON,
+          iconURL: FB_TRAY_ICON + '?' + FB_SYNC_ERROR_PARAM + '=1',
           callback: handleInvalidToken
         });
       break;
@@ -88,7 +89,7 @@ fb.sync = Sync;
         showNotification({
           title: _('facebook'),
           body: _('syncError'),
-          iconURL: FB_TRAY_ICON,
+          iconURL: FB_TRAY_ICON + '?' + FB_SYNC_ERROR_PARAM + '=1',
           callback: function() {
             scheduleAt(fb.syncPeriod, closeApp);
           }


### PR DESCRIPTION
An outdated hash (#recents-view) was being used in dialer.js instead of the right one (#call-log-view).
