### PR TITLE
Bug 885546 - VCF importer saves type="UTF-8" in contact fields [r=arcturus]

### DIFF
--- a/apps/communications/contacts/js/utilities/vcard_parser.js
+++ b/apps/communications/contacts/js/utilities/vcard_parser.js
@@ -13,32 +13,31 @@ var VCFReader = function(contents) {
 
 VCFReader.prototype.process = function(cb) {
   try {
-    this.rawContacts = this.contents
-      .split('END:VCARD')
-      .map(VCFReader.parseSingleEntry)
-      .filter(function(v) { return !!v; });
-    this.onread && this.onread(this.rawContacts.length);
+    var rawContacts = [];
+    this.contents = this.contents.split('END:VCARD');
+    this.contents.forEach(function(c) {
+      var parsed = VCFReader.parseSingleEntry(c);
+      if (parsed)
+        rawContacts.push(parsed);
+    });
+    this.contents = null;
+    this.onread && this.onread(rawContacts.length);
   } catch (e) {
     this.onerror && this.onerror(e);
     return;
   }
 
-  var allDone = false;
   var self = this;
-
-  var finalContacts = [];
-  this.validContacts = this.rawContacts.length;
-  this.rawContacts.forEach(function(ct) {
-    VCFReader.save(ct, onParsed);
-  });
+  var allDone = false;
+  this.totalContacts = rawContacts.length;
+  rawContacts.forEach(function(ct) { VCFReader.save(ct, onParsed); });
 
   function onParsed(err, ct) {
     self.onimported && self.onimported();
 
     self.processedContacts += 1;
-    finalContacts.push(ct);
     if (self.checkIfCompleted() && allDone === false) {
-      cb(finalContacts);
+      cb(rawContacts);
       allDone = true;
     }
   }
@@ -50,7 +49,7 @@ VCFReader.prototype.process = function(cb) {
  * @return {Boolean} return true if processed, false otherwise.
  */
 VCFReader.prototype.checkIfCompleted = function() {
-  return this.processedContacts === this.validContacts;
+  return this.processedContacts === this.totalContacts;
 };
 
 /**
@@ -121,8 +120,8 @@ VCFReader.processName = function(vcardObj, contactObj) {
   var parts = VCFReader.nameParts;
 
   // Set First Name right away as the 'name' property
-  if (vcardObj.fn)
-    contactObj.name = vcardObj.fn;
+  if (vcardObj.fn && vcardObj.fn.length)
+    contactObj.name = vcardObj.fn[0].value;
 
   if (vcardObj.n && vcardObj.n.length) {
     var values = vcardObj.n[0].value;
@@ -136,7 +135,7 @@ VCFReader.processName = function(vcardObj, contactObj) {
     // If we don't have a contact name at this point, make `name` be the
     // unification of all the name parts.
     if (!contactObj.name)
-      contactObj.name = [VCFReader.decodeQP(meta, values.join(' '))];
+      contactObj.name = [VCFReader.decodeQP(meta, values.join(' ').trim())];
   }
   contactObj.givenName = contactObj.givenName || contactObj.name;
   return contactObj;
@@ -198,9 +197,10 @@ VCFReader.processComm = function(vcardObj, contactObj) {
         });
 
         if (metaValues.indexOf('pref') > -1 || metaValues.indexOf('PREF') > -1)
-          cur.type = ['PREF'];
-        else
-          cur.type = [metaValues[0]]; // Take only the first meta type
+          cur.pref = true;
+
+        if (v.meta.type)
+          cur.type = [v.meta.type];
       }
 
       if (!contactObj[field])
@@ -232,26 +232,9 @@ VCFReader.processFields = function(vcardObj, contactObj) {
 };
 
 VCFReader.Re1 = /^\s*(version|fn|title|org)\s*:(.+)$/i;
-VCFReader.Re2 = /^([^:;]+);([^:]+):(.+)$/i;
+VCFReader.Re2 = /^([^:;]+);?([^:]+)?:(.+)$/i;
 VCFReader.ReKey = /item\d{1,2}\./;
 VCFReader.ReTuple = /([a-z]+)=(.*)/i;
-
-/**
- * Checks if a line is a 'simple' one, meaning that it has single
- * value. If it is, returns a record with a key:value structure like this:
- *
- * { key: 'fn', value: ['Johnny'] }
- *
- * @param {string} line Line in the VCF to be parsed.
- * @return {{key: string, value: Array}}
- * @private
- */
-VCFReader.parseSimpleLine_ = function(line) {
-  if (!VCFReader.Re1.test(line)) return null;
-  var results = line.match(VCFReader.Re1);
-  var key = results[1].toLowerCase().trim();
-  return {key: key, data: [results[2]]};
-};
 
 VCFReader._parseTuple = function(p, i) {
   var match = p.match(VCFReader.ReTuple);
@@ -266,16 +249,19 @@ VCFReader._parseTuple = function(p, i) {
  * @return {{key: string, data: {meta, value}}}
  * @private
  */
-VCFReader.parseComplexLine_ = function(line) {
+VCFReader.parseLine_ = function(line) {
   if (!VCFReader.Re2.test(line)) return null;
   var results = line.match(VCFReader.Re2);
   var key = results[1].replace(VCFReader.ReKey, '').toLowerCase().trim();
 
   var meta = {};
-  results[2].split(/(;|,)/).forEach(function(l, i) {
-    var p = VCFReader._parseTuple(l, i);
-    meta[p[0]] = p[1];
-  });
+  if (results[2]) {
+    results[2].split(/[;,]/).forEach(function(l, i) {
+      var p = VCFReader._parseTuple(l, i);
+      if (p)
+        meta[p[0]] = p[1];
+    });
+  }
 
   return {
     key: key,
@@ -302,13 +288,10 @@ VCFReader.parseSingleEntry = function(input) {
 
   var lines = input.split(/\r\n|\r|\n/);
   lines.forEach(function(line) {
-    var parsedLine = VCFReader.parseSimpleLine_(line);
-    if (parsedLine)
-      return fields[parsedLine.key] = parsedLine.data;
-
-    parsedLine = VCFReader.parseComplexLine_(line);
+    var parsedLine = VCFReader.parseLine_(line);
     if (parsedLine) {
-      if (!fields[parsedLine.key]) fields[parsedLine.key] = [];
+      if (!fields[parsedLine.key])
+        fields[parsedLine.key] = [];
 
       fields[parsedLine.key].push(parsedLine.data);
     }
@@ -336,7 +319,7 @@ VCFReader.vcardToContact = function(vcard) {
   VCFReader.processComm(vcard, obj);
   VCFReader.processFields(vcard, obj);
 
-  var contact = new navigator.mozContact();
+  var contact = new mozContact();
   contact.init(obj);
 
   return contact;

--- a/apps/communications/contacts/test/unit/vcard_parsing_test.js
+++ b/apps/communications/contacts/test/unit/vcard_parsing_test.js
@@ -5,7 +5,6 @@ requireApp('system/shared/test/unit/mocks/mock_navigator_moz_contact.js');
 var vcf1 = 'BEGIN:VCARD\n' +
   'VERSION:2.1\n' +
   'N;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:Gump;F=C3=B3rrest\n' +
-//  'FN:Forrest Gump\n' +
   'ORG;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:B=C3=B3bba Gump Shrimp Co.\n' +
   'TITLE;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:Shr=C3=B3mp Man\n' +
   'PHOTO;GIF:http://www.example.com/dir_photos/my_photo.gif\n' +
@@ -62,6 +61,17 @@ var vcf3 = 'BEGIN:VCARD\n' +
   'REV:20080424T195243Z\n' +
   'END:VCARD';
 
+var vcf4 = 'BEGIN:VCARD\n' +
+  'VERSION:3.0\n' +
+  'FN;CHARSET=UTF-8:Foo Bar\n' +
+  'N;CHARSET=UTF-8:Bar;Foo;;;\n' +
+  'BDAY;CHARSET=UTF-8:1975-05-20\n' +
+  'TEL;CHARSET=UTF-8;TYPE=CELL;PREF:(123) 456-7890\n' +
+  'TEL;CHARSET=UTF-8;TYPE=WORK:(123) 666-7890\n' +
+  'EMAIL;CHARSET=UTF-8;TYPE=HOME:example@example.org\n' +
+  'ORG;CHARSET=UTF-8:;\n' +
+  'END:VCARD\n';
+
 var vcfwrong1 = 'BEGIN:VCARD\n' +
   'VERSION:4.0\n' +
   'N:Gump;Forrest;;;\n' +
@@ -85,8 +95,8 @@ var vcfwrong1 = 'BEGIN:VCARD\n' +
   'akajslkfj\n' +
   'END:VCARD';
 
-if (!navigator.mozContact) {
-  navigator.mozContact = null;
+if (!mozContact) {
+  mozContact = null;
 }
 
 suite('vCard parsing settings', function() {
@@ -106,19 +116,20 @@ suite('vCard parsing settings', function() {
     nfn.callCount = 0;
     return nfn;
   }
+
   var realMozContact, realMozContacts;
   suite('SD Card import', function() {
     setup(function() {
       realMozContacts = navigator.mozContacts;
       navigator.mozContacts = MockMozContacts;
 
-      realMozContact = navigator.mozContact;
-      navigator.mozContact = MockMozContact;
+      realMozContact = window.mozContact;
+      window.mozContact = MockMozContact;
     });
 
     teardown(function() {
       navigator.mozContacts = realMozContacts;
-      navigator.mozContact = realMozContact;
+      window.mozContact = realMozContact;
     });
 
     test('- should properly decode Quoted Printable texts ', function(done) {
@@ -134,7 +145,9 @@ suite('vCard parsing settings', function() {
     test('- test for processing name 1 ', function(done) {
       var contact = new mozContact();
       var data = {
-        fn: ['Johnny'],
+        fn: [
+          { meta: {}, value: ['Johnny'] }
+        ],
         n: [
           {
             value: [
@@ -270,11 +283,12 @@ suite('vCard parsing settings', function() {
         var contact = contacts[0];
 
         assert.strictEqual('Forrest Gump', contact.name[0]);
-        assert.strictEqual('Forrest Gump', contact.givenName[0]);
+        assert.strictEqual('Forrest', contact.givenName[0]);
         assert.strictEqual('Bubba Gump Shrimp Co.', contact.org[0]);
         assert.strictEqual('Shrimp Man', contact.jobTitle[0]);
 //        assert.strictEqual('http://www.example.com/dir_photos/my_photo.gif',
 //          contact.photo[0]);
+
 
         assert.strictEqual('WORK', contact.tel[0].type[0]);
         assert.strictEqual('(111) 555-1212', contact.tel[0].value);
@@ -300,8 +314,11 @@ suite('vCard parsing settings', function() {
         assert.strictEqual('forrestgump@example.com', contact.email[0].value);
         assert.strictEqual('PREF', contact.email[0].type[0]);
         done();
+
       });
     });
+
+
     test('- should return a single entry', function(done) {
       var reader = new VCFReader(vcfwrong1);
       reader.onread = stub();
@@ -312,6 +329,39 @@ suite('vCard parsing settings', function() {
         assert.strictEqual(1, contacts.length);
         done();
       });
+    });
+    test('- Test for UTF8 charset', function(done) {
+      var reader = new VCFReader(vcf4);
+      reader.onread = stub();
+      reader.onimported = stub();
+      reader.onerror = stub();
+
+      reader.process(function import_finish(contacts) {
+        var contact = contacts[0];
+        assert.strictEqual('Foo Bar', contact.name[0]);
+        assert.strictEqual('Foo', contact.givenName[0]);
+        assert.strictEqual('CELL', contact.tel[0].type[0]);
+        assert.strictEqual('WORK', contact.tel[1].type[0]);
+        assert.strictEqual(true, contact.tel[0].pref);
+        assert.strictEqual('(123) 456-7890', contact.tel[0].value);
+        assert.strictEqual('(123) 666-7890', contact.tel[1].value);
+        assert.strictEqual('', contact.org[0]);
+        assert.strictEqual('HOME', contact.email[0].type[0]);
+        assert.strictEqual('example@example.org', contact.email[0].value);
+        done();
+      });
+    });
+    test('- Test for vcardToContact', function(done) {
+      VCFReader.processName = stub();
+      VCFReader.processAddr = stub();
+      VCFReader.processComm = stub();
+      VCFReader.processFields = function(vc, obj) {
+        obj.name = vc.name;
+      };
+
+      var ct = VCFReader.vcardToContact({ name: ['Sergi'] });
+      assert.strictEqual('Sergi', ct.name[0]);
+      done();
     });
   });
 });

--- a/apps/communications/contacts/test/unit/vcard_parsing_test.js
+++ b/apps/communications/contacts/test/unit/vcard_parsing_test.js
@@ -5,7 +5,6 @@ requireApp('system/shared/test/unit/mocks/mock_navigator_moz_contact.js');
 var vcf1 = 'BEGIN:VCARD\n' +
   'VERSION:2.1\n' +
   'N;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:Gump;F=C3=B3rrest\n' +
-//  'FN:Forrest Gump\n' +
   'ORG;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:B=C3=B3bba Gump Shrimp Co.\n' +
   'TITLE;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:Shr=C3=B3mp Man\n' +
   'PHOTO;GIF:http://www.example.com/dir_photos/my_photo.gif\n' +
@@ -62,6 +61,17 @@ var vcf3 = 'BEGIN:VCARD\n' +
   'REV:20080424T195243Z\n' +
   'END:VCARD';
 
+var vcf4 = 'BEGIN:VCARD\n' +
+  'VERSION:3.0\n' +
+  'FN;CHARSET=UTF-8:Foo Bar\n' +
+  'N;CHARSET=UTF-8:Bar;Foo;;;\n' +
+  'BDAY;CHARSET=UTF-8:1975-05-20\n' +
+  'TEL;CHARSET=UTF-8;TYPE=CELL;PREF:(123) 456-7890\n' +
+  'TEL;CHARSET=UTF-8;TYPE=WORK:(123) 666-7890\n' +
+  'EMAIL;CHARSET=UTF-8;TYPE=HOME:example@example.org\n' +
+  'ORG;CHARSET=UTF-8:;\n' +
+  'END:VCARD\n';
+
 var vcfwrong1 = 'BEGIN:VCARD\n' +
   'VERSION:4.0\n' +
   'N:Gump;Forrest;;;\n' +
@@ -85,10 +95,6 @@ var vcfwrong1 = 'BEGIN:VCARD\n' +
   'akajslkfj\n' +
   'END:VCARD';
 
-if (!navigator.mozContact) {
-  navigator.mozContact = null;
-}
-
 suite('vCard parsing settings', function() {
   function stub(additionalCode, ret) {
     if (additionalCode && typeof additionalCode !== 'function')
@@ -106,19 +112,22 @@ suite('vCard parsing settings', function() {
     nfn.callCount = 0;
     return nfn;
   }
+
   var realMozContact, realMozContacts;
   suite('SD Card import', function() {
     setup(function() {
       realMozContacts = navigator.mozContacts;
       navigator.mozContacts = MockMozContacts;
 
-      realMozContact = navigator.mozContact;
-      navigator.mozContact = MockMozContact;
+      if (window.mozContact)
+        realMozContact = window.mozContact;
+
+      window.mozContact = MockMozContact;
     });
 
     teardown(function() {
       navigator.mozContacts = realMozContacts;
-      navigator.mozContact = realMozContact;
+      window.mozContact = realMozContact || null;
     });
 
     test('- should properly decode Quoted Printable texts ', function(done) {
@@ -134,7 +143,9 @@ suite('vCard parsing settings', function() {
     test('- test for processing name 1 ', function(done) {
       var contact = new mozContact();
       var data = {
-        fn: ['Johnny'],
+        fn: [
+          { meta: {}, value: ['Johnny'] }
+        ],
         n: [
           {
             value: [
@@ -270,11 +281,12 @@ suite('vCard parsing settings', function() {
         var contact = contacts[0];
 
         assert.strictEqual('Forrest Gump', contact.name[0]);
-        assert.strictEqual('Forrest Gump', contact.givenName[0]);
+        assert.strictEqual('Forrest', contact.givenName[0]);
         assert.strictEqual('Bubba Gump Shrimp Co.', contact.org[0]);
         assert.strictEqual('Shrimp Man', contact.jobTitle[0]);
 //        assert.strictEqual('http://www.example.com/dir_photos/my_photo.gif',
 //          contact.photo[0]);
+
 
         assert.strictEqual('WORK', contact.tel[0].type[0]);
         assert.strictEqual('(111) 555-1212', contact.tel[0].value);
@@ -300,8 +312,11 @@ suite('vCard parsing settings', function() {
         assert.strictEqual('forrestgump@example.com', contact.email[0].value);
         assert.strictEqual('PREF', contact.email[0].type[0]);
         done();
+
       });
     });
+
+
     test('- should return a single entry', function(done) {
       var reader = new VCFReader(vcfwrong1);
       reader.onread = stub();
@@ -312,6 +327,39 @@ suite('vCard parsing settings', function() {
         assert.strictEqual(1, contacts.length);
         done();
       });
+    });
+    test('- Test for UTF8 charset', function(done) {
+      var reader = new VCFReader(vcf4);
+      reader.onread = stub();
+      reader.onimported = stub();
+      reader.onerror = stub();
+
+      reader.process(function import_finish(contacts) {
+        var contact = contacts[0];
+        assert.strictEqual('Foo Bar', contact.name[0]);
+        assert.strictEqual('Foo', contact.givenName[0]);
+        assert.strictEqual('CELL', contact.tel[0].type[0]);
+        assert.strictEqual('WORK', contact.tel[1].type[0]);
+        assert.strictEqual(true, contact.tel[0].pref);
+        assert.strictEqual('(123) 456-7890', contact.tel[0].value);
+        assert.strictEqual('(123) 666-7890', contact.tel[1].value);
+        assert.strictEqual('', contact.org[0]);
+        assert.strictEqual('HOME', contact.email[0].type[0]);
+        assert.strictEqual('example@example.org', contact.email[0].value);
+        done();
+      });
+    });
+    test('- Test for vcardToContact', function(done) {
+      VCFReader.processName = stub();
+      VCFReader.processAddr = stub();
+      VCFReader.processComm = stub();
+      VCFReader.processFields = function(vc, obj) {
+        obj.name = vc.name;
+      };
+
+      var ct = VCFReader.vcardToContact({ name: ['Sergi'] });
+      assert.strictEqual('Sergi', ct.name[0]);
+      done();
     });
   });
 });


### PR DESCRIPTION
This Pull Request does the following things:
- Assign proper type to multi-property fields (thus solving the UTF-8) bug
- Assign proper "PREF" property to `mozContact` if present
- Simplify and optimize parts of the code
- Fix regression introduced by referring to `navigator.mozContact` instead of just `mozContact`.

Thanks again, @arcturus!
