### PR TITLE
[Video]-Bug830022-Parse Video title correctly for ogg video formats r=davidflanagan

### DIFF
--- a/apps/video/js/metadata.js
+++ b/apps/video/js/metadata.js
@@ -257,7 +257,7 @@ function getMetadata(videofile, callback) {
   // Derive the video title from its filename.
   function fileNameToVideoName(filename) {
     filename = filename.split('/').pop()
-      .replace(/\.(webm|ogv|mp4|3gp)$/, '')
+      .replace(/\.(webm|ogv|ogg|mp4|3gp)$/, '')
       .replace(/[_\.]/g, ' ');
     return filename.charAt(0).toUpperCase() + filename.slice(1);
   }


### PR DESCRIPTION
Strip ogg extension when showing video title for ogg video formats
