### PR TITLE
Bug 887216 - [MMS] The header in a group message is active, it works as the go back key

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1763,8 +1763,8 @@ var ThreadUI = global.ThreadUI = {
       return;
     }
 
+    // Do nothing while in participants list view.
     if (!Threads.active && Threads.lastId) {
-      window.location.hash = '#thread=' + Threads.lastId;
       return;
     }
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1838,6 +1838,10 @@ suite('thread_ui.js >', function() {
               assert.equal(
                 ThreadUI.headerText.textContent, 'participant{"n":2}'
               );
+              // View should not go back to thread view when header is
+              // activated in group-view
+              ThreadUI.onHeaderActivation();
+              assert.equal(window.location.hash, '#group-view');
               window.onhashchange = null;
               done();
             };


### PR DESCRIPTION
- Fix issue in https://bugzilla.mozilla.org/show_bug.cgi?id=887216
