### PR TITLE
Bug 887564: Do not show phone # in name edit field

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -271,7 +271,6 @@ contacts.List = (function() {
   // for rendering the contacts list
   // Images, Facebook data and searcheable info will be lazy loaded
   var renderContact = function renderContact(contact, fbContacts) {
-    contact = refillContactData(contact);
     var contactContainer = document.createElement('li');
     contactContainer.dataset.uuid = contact.id;
     var fbUid = getFbUid(contact);
@@ -283,7 +282,8 @@ contacts.List = (function() {
     contactContainer.dataset.updated = timestampDate.getTime();
     // contactInner is a link with 3 p elements:
     // name, socaial marks and org
-    var nameElement = getHighlightedName(contact);
+    var displayName = getDisplayName(contact);
+    var nameElement = getHighlightedName(displayName);
     addOrderOptions(nameElement, contact);
     contactContainer.appendChild(nameElement);
     contactsCache[contact.id] = {
@@ -762,21 +762,22 @@ contacts.List = (function() {
   };
 
   // Fills the contact data to display if no givenName and familyName
-  var refillContactData = function refillContactData(contact) {
-    if (!hasName(contact)) {
-      contact.givenName = [];
-      if (contact.org && contact.org.length > 0) {
-        contact.givenName.push(contact.org[0]);
-      } else if (contact.tel && contact.tel.length > 0) {
-        contact.givenName.push(contact.tel[0].value);
-      } else if (contact.email && contact.email.length > 0) {
-        contact.givenName.push(contact.email[0].value);
-      } else {
-        contact.givenName.push(_('noName'));
-      }
+  var getDisplayName = function getDisplayName(contact) {
+    if (hasName(contact))
+      return { givenName: contact.givenName, familyName: contact.familyName };
+
+    var givenName = [];
+    if (contact.org && contact.org.length > 0) {
+      givenName.push(contact.org[0]);
+    } else if (contact.tel && contact.tel.length > 0) {
+      givenName.push(contact.tel[0].value);
+    } else if (contact.email && contact.email.length > 0) {
+      givenName.push(contact.email[0].value);
+    } else {
+      givenName.push(_('noName'));
     }
 
-    return contact;
+    return { givenName: givenName };
   };
 
   var addToGroup = function addToGroup(contact, list) {
@@ -883,30 +884,33 @@ contacts.List = (function() {
     return ret;
   };
 
-  // Perform contact refresh by id
-  var refresh = function refresh(id, callback, op) {
-    remove(id);
-    if (typeof(id) == 'string') {
-      getContactById(id, function(contact, fbData) {
-        var enrichedContact = null;
-        if (fb.isFbContact(contact)) {
-          var fbContact = new fb.Contact(contact);
-          enrichedContact = fbContact.merge(fbData);
-        }
-        addToList(contact, enrichedContact);
-        if (callback) {
-          callback(id);
-        }
-      });
-    } else {
-      var contact = id;
-      remove(contact.id);
-      // Add without looking for extras, just what we have as contact
-      addToList(contact);
-      if (callback) {
-        callback(contact.id);
-      }
+  // Perform contact refresh.  First arg may be either an ID or a contact
+  // object.  If an ID is passed then the contact is retrieved from the
+  // database.  Otherwise refresh the list based on the given contact
+  // object without looking up any information.
+  var refresh = function refresh(idOrContact, callback) {
+    // Passed a contact, not an ID
+    if (typeof(idOrContact) !== 'string') {
+      refreshContact(idOrContact, null, callback);
+      return;
     }
+
+    // Passed an ID, so look up contact
+    getContactById(idOrContact, function(contact, fbData) {
+      var enrichedContact = null;
+      if (fb.isFbContact(contact)) {
+        var fbContact = new fb.Contact(contact);
+        enrichedContact = fbContact.merge(fbData);
+      }
+      refreshContact(contact, enrichedContact, callback);
+    });
+  };
+
+  var refreshContact = function refreshContact(contact, enriched, callback) {
+    remove(contact.id);
+    addToList(contact, enriched);
+    if (callback)
+      callback(contact.id);
   };
 
   var callbacks = [];


### PR DESCRIPTION
Previously the contacts_list code would overwrite the givenName field in
the contact object.  This was done so that different values could be
shown in the list if a name was not present.  This causes problems, though,
when the contact object is shared between multiple parts of the app.  In
this case the contacts_form code was getting handed one of these modified
contact objects.

Modify the code to calculate the display name, but not modify the contact
object itself.  Also refactor how contacts_list refresh() works when given
a contact object instead of an ID.  The previous code was a bit confusing
and called remove() twice for objects.
