### PR TITLE
Bug 883834 - Touch events position is wrong on desktop when a DOM element is scrollable; r=vingtetun, a=NPOTB

### DIFF
--- a/tools/extensions/desktop-helper/content/touch-events.js
+++ b/tools/extensions/desktop-helper/content/touch-events.js
@@ -141,7 +141,7 @@ var TouchEventHandler = (function touchEventHandler() {
       let content = evt.target.ownerDocument.defaultView;
       var utils = content.QueryInterface(Ci.nsIInterfaceRequestor)
                          .getInterface(Ci.nsIDOMWindowUtils);
-      utils.sendMouseEvent(type, evt.pageX, evt.pageY, 0, 1, 0, true);
+      utils.sendMouseEvent(type, evt.clientX, evt.clientY, 0, 1, 0, true);
     },
     sendContextMenu: function teh_sendContextMenu(target, x, y, delay) {
       let doc = target.ownerDocument;


### PR DESCRIPTION
(cherry picked from commit f2e1981e5ac09b72e1e8ffcbc0f5f6c42cb92037)
