### PR TITLE
Bug 880617 - Properly set and display the MAC address

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -13,6 +13,7 @@
 // display connectivity status on the main panel
 var Connectivity = (function(window, document, undefined) {
   var _initialized = false;
+  var _macAddress = '';
   var _ = navigator.mozL10n.get;
 
   // in util.js, we fake these device interfaces if they are not exist.
@@ -112,8 +113,20 @@ var Connectivity = (function(window, document, undefined) {
 
     // record the MAC address here because the "Device Information" panel
     // has to display it as well
-    if (settings) {
-      settings.createLock().set({ 'deviceinfo.mac': wifiManager.macAddress });
+    if (!_macAddress && settings) {
+      var req = settings.createLock().get('deviceinfo.mac');
+      req.onsuccess = function macAddr_onsuccess() {
+        _macAddress = req.result['deviceinfo.mac'];
+      };
+      req.onerror = function macAddr_onerror() {
+        // Check if the MAC address is set by the wifiManager and is valid
+        // XXX the wifiManager sets macAddress to the string 'undefined' when
+        //     it is not available
+        if (wifiManager.macAddress && wifiManager.macAddress != 'undefined') {
+          _macAddress = wifiManager.macAddress;
+          settings.createLock().set({ 'deviceinfo.mac': _macAddress });
+        }
+      };
     }
   }
 

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -473,7 +473,7 @@ var Settings = {
       for (i = 0; i < spanFields.length; i++) {
         var key = spanFields[i].dataset.name;
 
-        if (key && result[key] != undefined) {
+        if (key && result[key] && result[key] != 'undefined') {
           // check whether this setting comes from a select option
           // (it may be in a different panel, so query the whole document)
           rule = '[data-setting="' + key + '"] ' +
@@ -500,6 +500,11 @@ var Settings = {
             //  hide this field if it's undefined/empty.
             case 'deviceinfo.firmware_revision':
               spanFields[i].parentNode.hidden = true;
+              break;
+
+            case 'deviceinfo.mac':
+              var _ = navigator.mozL10n.get;
+              spanFields[i].textContent = _('macUnavailable');
               break;
           }
         }

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -69,6 +69,7 @@ showPassword=Show password
 networkNotification=Network notification
 networkNotification-expl=Notify me when an open network is available
 macAddress=MAC address
+macUnavailable=Not available
 noNetworksFound=No networks found
 noKnownNetworks=No known networks
 


### PR DESCRIPTION
Note: displaying the special case when the MAC address is not available is not really required if during the first time use of the phone the Wi-Fi is guaranteed to be enabled. In such a case the `deviceinfo.mac` setting will be set and will always be checked first when displaying the MAC address.
