### PR TITLE
Bug 887896 - Regression: Focussing address bar does not show & select URL

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -936,9 +936,6 @@ var Browser = {
 
   urlFocus: function browser_urlFocus(e) {
     if (this.currentScreen === this.PAGE_SCREEN) {
-      // Hide modal dialog
-      ModalDialog.hide();
-      AuthenticationDialog.hide();
       this.urlInput.value = this.currentTab.url;
       this.sslIndicator.value = '';
       this.setUrlBar(this.currentTab.url);


### PR DESCRIPTION
This is the code that causes the error and it isn't actually needed because you can never focus the URL bar when a full screen dialog is being displayed.
