### PR TITLE
Bug 854785 - Ensure to round seconds when updating call duration

### DIFF
--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -83,7 +83,9 @@ HandledCall.prototype.startTimer = function hc_startTimer() {
   this.durationNode.classList.add('isTimer');
   LazyL10n.get((function localized(_) {
     this._ticker = setInterval(function hc_updateTimer(self, startTime) {
-      var elapsed = new Date(Date.now() - startTime);
+      // Bug 834334: Ensure that 28.999 -> 29.000
+      var delta = Math.round((Date.now() - startTime) / 1000) * 1000;
+      var elapsed = new Date(delta);
       var duration = {
         h: padNumber(elapsed.getUTCHours()),
         m: padNumber(elapsed.getUTCMinutes()),


### PR DESCRIPTION
When computing the duration, glitches can interfere thus that the
duration computed might be a bit under the interval of 1000ms. In the
event of this case, one would see a first tick with, for example, a
call duration of 28.001 secs, and a next tick with a duration of 28.999.
