### PR TITLE
Bug 888260 - Notify the user that we can't do anything

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -239,7 +239,8 @@ var Contacts = (function() {
   };
 
   var dataPickHandler = function dataPickHandler() {
-    var type, dataSet, noDataStr, selectDataStr;
+    var type, dataSet, noDataStr, noDataTitle, selectDataStr,
+        noDataCallback = ConfirmDialog.hide;
     var theContact = currentFbContact || currentContact;
     // Add the new pick type here:
     switch (ActivityHandler.activityDataType) {
@@ -255,6 +256,11 @@ var Contacts = (function() {
         noDataStr = _('no_email');
         selectDataStr = _('select_email');
         break;
+      default:
+        noDataTitle = _('filetypeUnsupportedTitle');
+        noDataStr = _('filetypeUnsupportedMessage');
+        noDataCallback = ActivityHandler.postCancel;
+        break;
     }
 
     var hasData = dataSet && dataSet.length;
@@ -268,9 +274,9 @@ var Contacts = (function() {
         // If no required type of data
         var dismiss = {
           title: _('ok'),
-          callback: ConfirmDialog.hide
+          callback: noDataCallback
         };
-        ConfirmDialog.show(null, noDataStr, dismiss);
+        ConfirmDialog.show(noDataTitle, noDataStr, dismiss);
         break;
       case 1:
         // if one required type of data

--- a/apps/communications/contacts/locales/contacts.en-US.properties
+++ b/apps/communications/contacts/locales/contacts.en-US.properties
@@ -174,3 +174,7 @@ notImported   = Not imported
 imported      = Imported
 today         = Today
 yesterday     = Yesterday
+
+# Nothing to pick
+filetypeUnsupportedTitle   = Invalid type of data
+filetypeUnsupportedMessage = This application cannot handle the type of data requested.


### PR DESCRIPTION
When being called by <input type="file">, for example, the 'pick'
activity is in such a state that we can be called, but we will just bail
the user out. Previously, this was done with just an empty confirm
dialog. It's better to notify the user that something was not possible
and notify the activity by canceling it.

Also look at bug 883341.
