### PR TITLE
Bug 883341 - Ensure that the 'pick' activity is valid for Contacts

### DIFF
--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -91,7 +91,10 @@
   "activities": {
     "pick": {
       "filters": {
-        "type": ["webcontacts/contact","webcontacts/email"]
+        "type": {
+          "required": true,
+          "value": ["webcontacts/contact","webcontacts/email"]
+        }
        },
       "disposition": "inline",
       "href": "/contacts/index.html?pick",


### PR DESCRIPTION
When the user tap on an <input type="file"> field, this triggers a
'pick' activity with no data, hence any app implementing the 'pick'
activity handler will be proposed. However, the Contacts app does not
know how to properly handle this case (in fact it does not make sense),
so we force the filtering to be done with the proper mime type: Contacts
app will not be proposed anymore for 'pick' activity triggered from
<input type="file"> user interaction. Thanks to Andrea Marchesini
(:baku) for suggesting this!
