### PR TITLE
Bug 853933 - Don't inline all locales as JSON in the HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,14 +20,18 @@ manifest.appcache
 
 /apps/*/test/unit/_sandbox.html
 /apps/*/test/unit/_proxy.html
+/apps/*/locales-obj
 /apps/*/shared
 /apps/settings/resources/support.json
 /apps/settings/resources/sensors.json
 /apps/system/resources/icc.json
 /test_apps/*/test/unit/_sandbox.html
 /test_apps/*/test/unit/_proxy.html
+/test_apps/*/locales-obj
+/test_external_apps/*/locales-obj
 /showcase_apps/*/test/unit/_sandbox.html
 /showcase_apps/*/test/unit/_proxy.html
+/showcase_apps/*/locales-obj
 
 /profile/
 /profile-debug/

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ LOCALES_FILE?=shared/resources/languages.json
 GAIA_LOCALE_SRCDIRS=shared $(GAIA_APP_SRCDIRS)
 GAIA_DEFAULT_LOCALE?=en-US
 GAIA_INLINE_LOCALES?=1
+GAIA_CONCAT_LOCALES?=1
 
 ###############################################################################
 # The above rules generate the profile/ folder and all its content.           #
@@ -436,6 +437,7 @@ define run-js-command
 	const OFFICIAL = "$(MOZILLA_OFFICIAL)";                                     \
 	const GAIA_DEFAULT_LOCALE = "$(GAIA_DEFAULT_LOCALE)";                       \
 	const GAIA_INLINE_LOCALES = "$(GAIA_INLINE_LOCALES)";                       \
+	const GAIA_CONCAT_LOCALES = "$(GAIA_CONCAT_LOCALES)";                       \
 	const GAIA_ENGINE = "xpcshell";                                             \
 	const GAIA_DISTRIBUTION_DIR = "$(GAIA_DISTRIBUTION_DIR)";                   \
 	';                                                                          \

--- a/build/webapp-zip.js
+++ b/build/webapp-zip.js
@@ -206,10 +206,15 @@ Gaia.webapps.forEach(function(webapp) {
   debug('# Create zip for: ' + webapp.domain);
   let files = ls(webapp.sourceDirectoryFile);
   files.forEach(function(file) {
-      // Ignore l10n files if they have been inlined
-      if (GAIA_INLINE_LOCALES &&
+      // Ignore l10n files if they have been inlined or concatenated
+      if ((GAIA_INLINE_LOCALES === '1' || GAIA_CONCAT_LOCALES === '1') &&
           (file.leafName === 'locales' || file.leafName === 'locales.ini'))
         return;
+
+      // Ignore concatenated l10n files if GAIA_CONCAT_LOCALES is not set
+      if (file.leafName === 'locales-obj' && GAIA_CONCAT_LOCALES !== '1')
+        return;
+
       // Ignore files from /shared directory (these files were created by
       // Makefile code). Also ignore files in the /test directory.
       if (file.leafName !== 'shared' && file.leafName !== 'test')
@@ -261,7 +266,7 @@ Gaia.webapps.forEach(function(webapp) {
               used.js.push(path);
             break;
           case 'locales':
-            if (!GAIA_INLINE_LOCALES) {
+            if (GAIA_INLINE_LOCALES !== '1') {
               let localeName = path.substr(0, path.lastIndexOf('.'));
               if (used.locales.indexOf(localeName) == -1) {
                 used.locales.push(localeName);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=853933

Currently, in order to ensure that apps are translated before first paint, all l10n resources are included as one multi-locales JSON dictionary, which is serialized in an inline `<script>` element for each HTML document.  This works fine when shipping few locales, but it can increase the document size quite badly for 60+ locales, thus delaying the startup time very significantly.

This patch allows to support 60+ locales more easily by having:
- one minimal JSON dictionary per locale in each HTML file;
- one extensive JSON dictionary per locale in each webapp.

The inline JSON dictionary is split on a per-locale basis (= one `<script>` node per supported locale) and only contains the l10n strings that are required to translate the HTML document: the "startup cost" of each locale becomes neglectable, and it removes the risk of high RAM consumption when parsing a giant multi-locale JSON at startup.

All l10n resources that are not declared in the HTML document are concatenated in a single JSON dictionary per locale: this reduces the number of disk I/O to load l10n resources and does not increase the total disk size of each webapp.  To enable this, this patch implements a `{{locale}}` quasi-litteral in the HTML markup that is used to declare l10n resources:

``` html
<link rel="prefetch" type="application/l10n" href="/{{locale}}.json" />
```

where `{{locale}}` is replaced by the value of `navigator.language`.

Note that this latter optimization is only interesting for apps that wait for the `localized` event to start. With the inline JSON dictionary for the declarative content and the `mozL10n.localize()` method, most apps could probably stop waiting for this `localized` event now.
