### PR TITLE
885278 updatetimeheaders with fixedheader

### DIFF
--- a/apps/sms/js/fixed_header.js
+++ b/apps/sms/js/fixed_header.js
@@ -32,6 +32,11 @@ var FixedHeader = (function FixedHeader() {
   };
 
   function immediateRefresh() {
+    if (!view) {
+      // init was not called yet
+      return;
+    }
+
     if (refreshTimeout) {
       clearTimeout(refreshTimeout);
     }
@@ -46,6 +51,7 @@ var FixedHeader = (function FixedHeader() {
       var offset = headingPosition - currentScroll;
       var currentHeight = currentHeader.offsetHeight;
       var differentHeaders = currentlyFixed != currentHeader;
+
       // Effect
       if (!notApplyEffect && Math.abs(offset) < currentHeight &&
           differentHeaders) {
@@ -56,23 +62,35 @@ var FixedHeader = (function FixedHeader() {
         fixedContainer.style.transform = transform;
       }
 
-      // Switching Header
+      // Found a header
       if (offset <= 0) {
         if (differentHeaders) {
-          if (!notApplyEffect)
+          if (!notApplyEffect) {
             fixedContainer.style.transform = 'translateY(0)';
-          currentlyFixed = currentHeader;
-          fixedContainer.textContent = currentHeader.textContent;
-          if (currentHeader.id == 'group-favorites') {
-            fixedContainer.innerHTML = currentHeader.innerHTML;
           }
+
+          currentlyFixed = currentHeader;
+          updateHeaderContent();
         }
+
         return;
       }
     }
+
+    // guess no header is above the top of the view
     currentlyFixed = null;
-    if (!notApplyEffect)
+    if (!notApplyEffect) {
       fixedContainer.style.transform = 'translateY(-100%)';
+    }
+  }
+
+  function updateHeaderContent() {
+    if (fixedContainer && currentlyFixed) {
+      var newContent = currentlyFixed.textContent;
+      if (fixedContainer.textContent !== newContent) {
+        fixedContainer.textContent = newContent;
+      }
+    }
   }
 
   var stop = function stop() {
@@ -80,8 +98,9 @@ var FixedHeader = (function FixedHeader() {
   };
 
   return {
-    'init': init,
-    'refresh': refresh,
-    'stop': stop
+    init: init,
+    refresh: refresh,
+    updateHeaderContent: updateHeaderContent,
+    stop: stop
   };
 })();

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -326,10 +326,10 @@ var ThreadListUI = {
       };
 
       appendThreads(threads, function at_callback() {
-        // Refresh fixed header logic
-        FixedHeader.refresh();
         // clear up abort method
         delete thlui_renderThreads.abort;
+        // set the fixed header
+        FixedHeader.refresh();
         // Boot update of headers
         Utils.updateTimeHeaders();
         // Once the rendering it's done, callback if needed
@@ -441,6 +441,7 @@ var ThreadListUI = {
       }
 
       this.appendThread(threadMockup);
+      FixedHeader.refresh();
       this.setEmpty(false);
     } else {
       this.renderThreads([threadMockup]);

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -57,6 +57,8 @@
           }
         }
       }
+
+      FixedHeader.updateHeaderContent();
     },
     startTimeHeaderScheduler: function ut_startTimeHeaderScheduler() {
       this.updateTimeHeaders();

--- a/apps/sms/test/unit/fixed_header_test.js
+++ b/apps/sms/test/unit/fixed_header_test.js
@@ -54,6 +54,15 @@ suite('FixedHeader >', function() {
       assert.equal(header.textContent, 'header 1');
     });
 
+    test('call updateHeaderContent, should have the new header', function() {
+      FixedHeader.refresh();
+      this.sinon.clock.tick();
+
+      view.querySelector('header').textContent = 'new header';
+      FixedHeader.updateHeaderContent();
+      assert.equal(header.textContent, 'new header');
+    });
+
     test('scroll then call refresh, should have a fixed header', function() {
       // we don't want to react to scroll events in that test
       view.removeEventListener('scroll', FixedHeader.refresh);

--- a/apps/sms/test/unit/mock_fixed_header.js
+++ b/apps/sms/test/unit/mock_fixed_header.js
@@ -1,5 +1,7 @@
 'use strict';
 var MockFixedHeader = {
   refresh: function() {},
+  updateHeaderContent: function() {},
+  stop: function() {},
   init: function() {}
 };

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -334,6 +334,7 @@ suite('thread_list_ui', function() {
       this.sinon.stub(ThreadListUI, 'renderThreads');
       this.sinon.stub(ThreadListUI, 'mark');
       this.sinon.stub(ThreadListUI, 'setEmpty');
+      this.sinon.spy(FixedHeader, 'refresh');
     });
 
     teardown(function() {
@@ -381,6 +382,10 @@ suite('thread_list_ui', function() {
       test('no thread is removed', function() {
         assert.isFalse(ThreadListUI.removeThread.called);
       });
+
+      test('refresh the fixed header', function() {
+        assert.ok(FixedHeader.refresh.called);
+      });
     });
 
     suite('same thread exist, older', function() {
@@ -410,6 +415,10 @@ suite('thread_list_ui', function() {
         assert.ok(ThreadListUI.removeThread.called);
         var threadId = ThreadListUI.removeThread.args[0][0];
         assert.equal(threadId, message.threadId);
+      });
+
+      test('refresh the fixed header', function() {
+        assert.ok(FixedHeader.refresh.called);
       });
     });
 


### PR DESCRIPTION
- always call refresh in updateTimeHeaders
- expose updateHeaderContent and use it in updateTimeHeaders so that the fixed
  header is changed in the same time than the other headers
