### PR TITLE
bug 885647: wifi.suspended is not inverse of wifi.enabled, r=kaze

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -44,8 +44,7 @@ navigator.mozL10n.ready(function wifiSettings() {
   // toggle wifi on/off
   gWifiCheckBox.onchange = function toggleWifi() {
     settings.createLock().set({
-      'wifi.enabled': this.checked,
-      'wifi.suspended': !this.checked
+      'wifi.enabled': this.checked
     }).onerror = function() {
       // Fail to write mozSettings, return toggle control to the user.
       gWifiCheckBox.disabled = false;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=885647
