### PR TITLE
Bug 889055 - Render UI tests fail in TBPL

### DIFF
--- a/apps/keyboard/test/unit/render_test.js
+++ b/apps/keyboard/test/unit/render_test.js
@@ -40,6 +40,15 @@ suite('Renderer', function() {
 
       _iw = Object.getOwnPropertyDescriptor(Window.prototype, 'innerWidth');
       _ih = Object.getOwnPropertyDescriptor(Window.prototype, 'innerHeight');
+
+      // we're testing layout stuff, so make sure to also have width/height
+      // in a headless browser
+      Object.defineProperty(Window.prototype, 'innerWidth',
+        makeDescriptor(300));
+      Object.defineProperty(ime, 'clientWidth',
+        makeDescriptor(300));
+      Object.defineProperty(Window.prototype, 'innerHeight',
+        makeDescriptor(400));
     });
 
     teardown(function() {
@@ -88,6 +97,7 @@ suite('Renderer', function() {
         function(el) {
           return el.clientWidth;
         });
+
       assert.notEqual(all[0], 0);
       assert.equal(all.every(function(el) {
         return el === all[0];


### PR DESCRIPTION
Fix for [#889055](https://bugzilla.mozilla.org/show_bug.cgi?id=889055). I think this is because we're running in a headless browser or a browser with width/height of 0, but I have no easy way to verify this.
