### PR TITLE
Bug 890079 - Homescreen grid tests failing in TBPL with: document.create...

### DIFF
--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -141,15 +141,17 @@ suite('grid.js >', function() {
       });
 
       function sendTouchEvent(type, node, coords) {
-        var touch = document.createTouch(window, node, 1,
-          coords.x, coords.y, coords.x, coords.y);
-        var touchList = document.createTouchList(touch);
+        if (document.createTouch) {
+          var touch = document.createTouch(window, node, 1,
+            coords.x, coords.y, coords.x, coords.y);
+          var touchList = document.createTouchList(touch);
 
-        var evt = document.createEvent('TouchEvent');
-        evt.initTouchEvent(type, true, true, window,
-          0, false, false, false, false,
-          touchList, touchList, touchList);
-        node.dispatchEvent(evt);
+          var evt = document.createEvent('TouchEvent');
+          evt.initTouchEvent(type, true, true, window,
+            0, false, false, false, false,
+            touchList, touchList, touchList);
+          node.dispatchEvent(evt);
+        }
       }
 
       function sendMouseEvent(type, node, coords) {


### PR DESCRIPTION
...Touch is not a function r=crdlc

don't try to send touch events if document.createTouch is missing.
