### PR TITLE
Bug 890216 - [Clock] The button of creating alarm is not align with displaying date/day context

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -14,13 +14,13 @@ ul, ol {
   position: absolute;
   background: url(images/add_alarm.png) no-repeat center / 3.2rem;
   background-size: 100% auto;
-  padding: 2.2rem 1.5rem;
   height: 2.5rem;
   width: 3.2rem;
   border: none;
-  margin: 0;
-  right: 0.48rem;
-  top: 0.1rem;
+  top: 0;
+  right: 0;
+  margin-top: 2.1rem;
+  margin-right: 1.5rem;
   transition:  height 0.1s, width 0.1s, top 0.1s, right 0.1s;
 }
 

--- a/apps/clock/style/onring.css
+++ b/apps/clock/style/onring.css
@@ -175,7 +175,7 @@ html, body {
   #ring-clock-display {
     position: absolute;
     bottom: 0.6rem;
-    left: 4rem;
+    left: 4.2rem;
     border-bottom: none;
   }
 
@@ -192,7 +192,7 @@ html, body {
   #ring-alarm-label {
     position: absolute;
     top: 0.46rem;
-    left: 4rem;
+    left: 4.2rem;
     font-weight: bolder;
     font-size: 1.38rem;
     line-height: 1.44rem;


### PR DESCRIPTION
- Refine the layout to let them be align in baseline
- Increase margin left to avoid  alarm time/label overlaying with icon(attention screen in status bar mode)
