### PR TITLE
Remove UA override for different domains 

### DIFF
--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -81,7 +81,6 @@ pref("general.useragent.override.bbva.es", "\\(Mobile#(Android; Mobile"); // bug
 pref("general.useragent.override.booking.com", "\\(Mobile#(Android; Mobile"); // bug 828420
 pref("general.useragent.override.publico.es", "\\(Mobile#(Android; Mobile"); // bug 828422
 pref("general.useragent.override.mercadolibre.com.ve", "\\(Mobile#(Android; Mobile"); // bug 828425
-pref("general.useragent.override.espn.go.com", "\\(Mobile#(Android; Mobile"); // bug 828431
 pref("general.useragent.override.olx.com.ve", "\\(Mobile#(Android; Mobile"); // bug 828433
 pref("general.useragent.override.rincondelvago.com", "\\(Mobile#(Android; Mobile"); // bug 828435
 pref("general.useragent.override.movistar.com.ve", "\\(Mobile#(Android; Mobile"); // bug 828439

--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -26,7 +26,6 @@ pref("general.useragent.override.noticias.uol.com.br", "\\(Mobile#(Android; Mobi
 pref("general.useragent.override.olx.com.br", "\\(Mobile#(Android; Mobile"); // bug 826720
 pref("general.useragent.override.bancobrasil.com.br", "\\(Mobile#(Android; Mobile"); // bug 826736
 pref("general.useragent.override.techtudo.com.br", "\\(Mobile#(Android; Mobile"); // bug 826845
-pref("general.useragent.override.clickjogos.uol.com.br", "\\(Mobile#(Android; Mobile"); // bug 826949
 pref("general.useragent.override.ebay.com", "\\(Mobile#(Android; Mobile");// bug 826958
 pref("general.useragent.override.bing.com", "\\(Mobile#(Android; Mobile"); // bug 827622
 pref("general.useragent.override.tam.com.br", "\\(Mobile#(Android; Mobile"); // bug 827623

--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -116,7 +116,6 @@ pref("general.useragent.override.virginatlantic.com", "\\(Mobile#(Android; Mobil
 pref("general.useragent.override.cheaptickets.com", "\\(Mobile#(Android; Mobile"); // bug 843168
 pref("general.useragent.override.etsy.com", "\\(Mobile#(Android; Mobile"); // bug 843170
 pref("general.useragent.override.zimbio.com", "\\(Mobile#(Android; Mobile"); // bug 843172
-pref("general.useragent.override.thinkgeek.com", "\\(Mobile#(Android; Mobile"); // bug 843174
 pref("general.useragent.override.tylted.com", "\\(Mobile#(Android; Mobile"); // bug 843176
 pref("general.useragent.override.txt2nite.com", "\\(Mobile#(Android; Mobile"); // bug 843178
 pref("general.useragent.override.slashgear.com", "\\(Mobile#(Android; Mobile"); // bug 843181

--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -51,7 +51,6 @@ pref("general.useragent.override.marca.com", "\\(Mobile#(Android; Mobile"); // b
 pref("general.useragent.override.wp.pl", "\\(Mobile#(Android; Mobile"); // bug 828351
 pref("general.useragent.override.gazeta.pl", "\\(Mobile#(Android; Mobile"); // bug 828354
 pref("general.useragent.override.o2.pl", "\\(Mobile#(Android; Mobile"); // bug 828356
-pref("general.useragent.override.ceneo.pl", "\\(Mobile#(Android; Mobile"); // bug 828358
 pref("general.useragent.override.sport.pl", "\\(Mobile#(Android; Mobile"); // bug 828360
 pref("general.useragent.override.tvn24.pl", "\\(Mobile#(Android; Mobile"); // bug 828362
 pref("general.useragent.override.nk.pl", "\\(Mobile#(Android; Mobile"); // bug 828364

--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -28,7 +28,6 @@ pref("general.useragent.override.bancobrasil.com.br", "\\(Mobile#(Android; Mobil
 pref("general.useragent.override.techtudo.com.br", "\\(Mobile#(Android; Mobile"); // bug 826845
 pref("general.useragent.override.ebay.com", "\\(Mobile#(Android; Mobile");// bug 826958
 pref("general.useragent.override.bing.com", "\\(Mobile#(Android; Mobile"); // bug 827622
-pref("general.useragent.override.tam.com.br", "\\(Mobile#(Android; Mobile"); // bug 827623
 pref("general.useragent.override.pontofrio.com.br", "\\(Mobile#(Android; Mobile"); // bug 827624
 pref("general.useragent.override.pagseguro.uol.com.br", "\\(Mobile#(Android; Mobile"); // bug 827625
 pref("general.useragent.override.magazineluiza.com.br", "\\(Mobile#(Android; Mobile"); // bug 827626


### PR DESCRIPTION
 890288 - Remove UA override for espn.go.com    189c3da
891994 - Remove UA override for clickjogos.uol.com.br   2f4cfcb
891997 - Remove UA override for tam.com.br  4522208
891998 - Remove UA override for ceneo.pl    f5fd7a4
892001 - Remove UA override for thinkgeek.com 
