### PR TITLE
Homescreen: Scroll applist immediately on touchmove

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var VELOCITY_SCROLL = 0.019; //Range 0.01 pixel/msec to 0.10 pixel/msec
+var DISTANCE_SCROLL = 1;    //Range 1 pixel to 10 pixels
+var PAGE_DELAY = 150;       //Range 0 msec to 600 msecs
+
 var GridManager = (function() {
   var MAX_ICONS_PER_PAGE = 4 * 4;
   var PREFERRED_ICON_SIZE = 60;
@@ -42,6 +46,10 @@ var GridManager = (function() {
 
   var startEvent, isPanning = false, startX, currentX, deltaX, removePanHandler,
       noop = function() {};
+
+  var velocity_fastswipe = 0;
+  var fastswipe_distance = 0;
+  var time_period_fastswipe = 0;
 
   var isTouch = 'ontouchstart' in window;
   var touchstart = isTouch ? 'touchstart' : 'mousedown';
@@ -202,6 +210,10 @@ var GridManager = (function() {
         currentX = getX(evt);
         deltaX = panningResolver.getDeltaX(evt);
 
+        fastswipe_distance = Math.abs(currentX - startX);
+        time_period_fastswipe = Math.abs(evt.timeStamp - touchStartTimestamp);
+        velocity_fastswipe = fastswipe_distance / time_period_fastswipe;
+
         if (deltaX === 0)
           return;
 
@@ -218,6 +230,23 @@ var GridManager = (function() {
 
         // Since we're panning, the icon we're over shouldn't be active
         removeActive();
+        var velocity = panningResolver.getVelocity();
+        var distanceToTravel = 0.5 * Math.abs(velocity) * velocity /
+                               swipeFriction;
+        if ((fastswipe_distance > DISTANCE_SCROLL &&
+            velocity_fastswipe > VELOCITY_SCROLL) ||
+            (Math.abs(deltaX + distanceToTravel) > swipeThreshold)) {
+            // Scroll detected early in 1st touchmove event
+            // Starting full page transition immediately
+            touchEndTimestamp = evt ? (evt.timeStamp) : Number.MAX_VALUE;
+            window.mozRequestAnimationFrame(function panTouchEnd() {
+              onTouchEnd(deltaX, evt, velocity_fastswipe, fastswipe_distance);
+            });
+        }
+        else {
+        // Pan detected in 1st touchmove event
+        // This will start partial page transition
+        // Full page transition will happen on touchend event
 
         var refresh;
 
@@ -339,11 +368,15 @@ var GridManager = (function() {
           container.removeEventListener(touchmove, pan, true);
 
           window.mozRequestAnimationFrame(function panTouchEnd() {
-            onTouchEnd(deltaX, e);
+            onTouchEnd(deltaX, e, Number.MIN_VALUE, Number.MIN_VALUE);
           });
         };
 
+        velocity_fastswipe = 0;
+        fastswipe_distance = 0;
+        time_period_fastswipe = 0;
         window.addEventListener(touchend, removePanHandler, true);
+        }
         window.removeEventListener(touchend, handleEvent);
 
         break;
@@ -380,14 +413,16 @@ var GridManager = (function() {
     overlayStyle.opacity = index === landingPage ? 0 : opacityOnAppGridPageMax;
   }
 
-  function onTouchEnd(deltaX, evt) {
+  function onTouchEnd(deltaX, evt, velocity_fastswipe, fastswipe_distance) {
     var page = currentPage;
 
     var velocity = panningResolver.getVelocity();
     var distanceToTravel = 0.5 * Math.abs(velocity) * velocity / swipeFriction;
     // If the actual distance plus the coast distance is more than 40% the
     // screen, transition to the next page
-    if (Math.abs(deltaX + distanceToTravel) > swipeThreshold) {
+    if ((Math.abs(deltaX + distanceToTravel) > swipeThreshold) ||
+        (fastswipe_distance > DISTANCE_SCROLL &&
+         velocity_fastswipe > VELOCITY_SCROLL)) {
       var forward = dirCtrl.goesForward(deltaX);
       if (forward && currentPage < pages.length - 1) {
         page = page + 1;
@@ -401,7 +436,7 @@ var GridManager = (function() {
       pageHelper.getCurrent().tap(evt.target);
     }
 
-    goToPage(page);
+    goToPage(page, false, true);
   }
 
   function attachEvents() {
@@ -493,9 +528,8 @@ var GridManager = (function() {
 
   var touchStartTimestamp = 0;
   var touchEndTimestamp = 0;
-  var lastGoingPageTimestamp = 0;
 
-  function goToPage(index, callback) {
+  function goToPage(index, callback, delayedflag) {
     if (index < 0 || index >= pages.length)
       return;
 
@@ -507,11 +541,7 @@ var GridManager = (function() {
       document.location.hash = '';
     }
 
-    var delay = touchEndTimestamp - lastGoingPageTimestamp ||
-                kPageTransitionDuration;
-    lastGoingPageTimestamp += delay;
-    var duration = delay < kPageTransitionDuration ?
-                   delay : kPageTransitionDuration;
+    var duration = kPageTransitionDuration;
 
     var previousPage = pages[currentPage];
     var newPage = pages[index];
@@ -543,10 +573,23 @@ var GridManager = (function() {
           pages[index + 1].moveByWithEffect(windowWidth, duration);
         }
 
-        container.addEventListener('transitionend', function transitionEnd(e) {
-          container.removeEventListener('transitionend', transitionEnd);
-          goToPageCallback(index, previousPage, newPage, false, callback);
-        });
+        if (delayedflag) {
+          // Delays additional paints at the end of scroll
+          // This avoids stutter on the last paint before the final page is
+          // drawn
+          container.addEventListener('transitionend', function transitionEnd(e)
+          {
+            container.removeEventListener('transitionend', transitionEnd);
+            setTimeout(goToPageCallback, PAGE_DELAY, index, previousPage,
+                       newPage, true, callback);
+          });
+        } else {
+          container.addEventListener('transitionend', function transitionEnd(e)
+          {
+            container.removeEventListener('transitionend', transitionEnd);
+            goToPageCallback(index, previousPage, newPage, false, callback);
+          });
+        }
       } else {
         // Swipe from rigth to left on the last page on the grid
         goToPageCallback(index, previousPage, newPage, false, callback);
@@ -562,10 +605,20 @@ var GridManager = (function() {
     previousPage.moveByWithEffect(-forward * windowWidth, duration);
     newPage.moveByWithEffect(0, duration);
 
-    container.addEventListener('transitionend', function transitionEnd(e) {
-      container.removeEventListener('transitionend', transitionEnd);
-      goToPageCallback(index, previousPage, newPage, true, callback);
-    });
+    if (delayedflag) {
+      // Delays additional paints at the end of scroll
+      // This avoids stutter on the last paint before the final page is drawn
+      container.addEventListener('transitionend', function transitionEnd(e) {
+        container.removeEventListener('transitionend', transitionEnd);
+        setTimeout(goToPageCallback, PAGE_DELAY, index, previousPage, newPage,
+                   true, callback);
+      });
+    } else {
+      container.addEventListener('transitionend', function transitionEnd(e) {
+        container.removeEventListener('transitionend', transitionEnd);
+        goToPageCallback(index, previousPage, newPage, true, callback);
+      });
+    }
   }
 
   function goToNextPage(callback) {


### PR DESCRIPTION
touchmove and touchend causes two paints. This avoids delay
between these two paints and starts scroll immediately on touchmove.
This also delays additional paints at the end of scroll.

Change-Id: I56e56c438483fc6fb111f2e8c4c8c26314c8e041
