### PR TITLE
Bug 890572 [email] set background transparent for smoother cold start

### DIFF
--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -19,7 +19,7 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-  background-color: white;
+  background-color: transparent;
 }
 
 #cardContainer,


### PR DESCRIPTION
Results in smoother cold startup transition by avoiding a brief white flash.
