### PR TITLE
Bug 890847 - [SMS/MMS] The options shown in the dialog when tapping on a contact into ‘To’ field are the wrong way round

### DIFF
--- a/apps/sms/js/dialog.js
+++ b/apps/sms/js/dialog.js
@@ -91,7 +91,6 @@ var Dialog = function(params) {
     cancelButton.dataset.l10nId = cancelOption.text.value;
   }
   handlers.set(cancelButton, cancelOption);
-  menu.appendChild(cancelButton);
 
   if (params.options.confirm) {
     var confirmOption = params.options.confirm;
@@ -99,7 +98,7 @@ var Dialog = function(params) {
     var confirm = !confirmOption.text.l10n ?
         confirmOption.text.value : _(confirmOption.text.value);
     confirmButton.textContent = confirm;
-    confirmButton.className = 'recommend';
+    cancelButton.className = 'recommend';
     if (confirmOption.text.l10n) {
       confirmButton.dataset.l10nId = confirmOption.text.value;
     }
@@ -109,7 +108,7 @@ var Dialog = function(params) {
     // If there is only one item, we take the 100% of the space available
     cancelButton.style.width = '100%';
   }
-
+  menu.appendChild(cancelButton);
   this.form.addEventListener('submit', function(event) {
     event.preventDefault();
   });

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -658,6 +658,10 @@ form.bottom[role="search"].messages-compose-form {
   height: 4rem;
 }
 
+#loading p {
+  border-bottom: none;
+}
+
 /*
   No result container
 */

--- a/apps/sms/test/unit/dialog_test.js
+++ b/apps/sms/test/unit/dialog_test.js
@@ -138,8 +138,8 @@ suite('Dialog', function() {
     var formOptions = dialogForm.getElementsByTagName('button');
     assert.equal(formOptions.length, 2);
     // We check localization
-    assert.equal(formOptions[0].dataset.l10nId, l10nCancel);
-    assert.equal(formOptions[1].dataset.l10nId, l10nConfirm);
+    assert.equal(formOptions[0].dataset.l10nId, l10nConfirm);
+    assert.equal(formOptions[1].dataset.l10nId, l10nCancel);
   });
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=890847
