### PR TITLE
Bug 889735 [MMS] when attaching so many images,size of the attached MMS ...

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -415,6 +415,7 @@ var Compose = (function() {
         case 'attachment-options-remove':
           attachments.delete(this.currentAttachmentDOM);
           dom.message.removeChild(this.currentAttachmentDOM);
+          state.size = null;
           composeCheck({type: 'input'});
           AttachmentMenu.close();
           break;
@@ -425,6 +426,7 @@ var Compose = (function() {
             attachments.set(el, newAttachment);
             dom.message.insertBefore(el, this.currentAttachmentDOM);
             dom.message.removeChild(this.currentAttachmentDOM);
+            state.size = null;
             composeCheck({type: 'input'});
             AttachmentMenu.close();
           }).bind(this);


### PR DESCRIPTION
...content is not refreshed even after removing some images

Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=889735
