### PR TITLE
Bug 890896 - Prediction capitalization gives different scores when capitalize is true

### DIFF
--- a/apps/keyboard/js/imes/latin/predictions.js
+++ b/apps/keyboard/js/imes/latin/predictions.js
@@ -360,6 +360,10 @@ var Predictions = function() {
       ',' + maxCandidates +
       ',' + maxCorrections;
 
+    if (capitalize) {
+      input = input[0].toLowerCase() + input.substring(1);
+    }
+
     // Start searching for words soon...
     setTimeout(getWords);
 


### PR DESCRIPTION
Fix for [#890896](https://bugzilla.mozilla.org/show_bug.cgi?id=890896). We give different results back at the moment if the first character is a capital. I don't think we should do that, because in 99% of the case the capital is not selected by the user but rather the result of auto-capitalization. In this patch we'll always look for the lowercase version of the word so we get the same results in both cases.
