### PR TITLE
Bug 890989 - [sms] we should not split the phone numbers on spaces

### DIFF
--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -190,7 +190,7 @@
       return this.findBy({
         filterBy: ['tel'],
         filterOp: 'match',
-        filterValue: filterValue
+        filterValue: filterValue.replace(/\s+/g, '')
       }, callback);
     }
   };

--- a/apps/sms/test/unit/contacts_test.js
+++ b/apps/sms/test/unit/contacts_test.js
@@ -384,6 +384,20 @@ suite('Contacts', function(done) {
     });
   });
 
+  suite('Contacts.findByPhoneNumber', function() {
+
+    test('removes spaces', function(done) {
+      var mozContacts = navigator.mozContacts;
+
+      Contacts.findByPhoneNumber('+33 1 23 45 67 89', function(contacts) {
+        assert.equal(
+          mozContacts.mHistory[0].filter.filterValue, '+33123456789'
+        );
+        done();
+      });
+    });
+  });
+
   suite('Contacts.findBy (success)', function() {
 
     test('(object, ...), Match', function(done) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=890989
Signed-off-by: Rick Waldron waldron.rick@gmail.com
