### PR TITLE
Merge pull request #10729 from mcirlanaru/bug_846494

### DIFF
--- a/apps/system/style/sleep_menu/sleep_menu.css
+++ b/apps/system/style/sleep_menu/sleep_menu.css
@@ -26,6 +26,7 @@
   padding: 0 2.5rem 0 2rem;
   vertical-align: middle;
   white-space: normal;
+  word-wrap: break-word;
   width: 100%;
 }
 
@@ -59,11 +60,10 @@
   font-family: 'MozTT',Sans-serif;
   font-size: 2.2rem;
   font-weight: lighter;
-  height: 5.9rem;
-  line-height: 5.9rem;
+  line-height: 3.3rem;
   list-style: none outside none;
   margin: 0;
-  padding-bottom: 1px;
+  padding: 1.3rem 0;
   position: relative;
   display: block;
   text-decoration: none;


### PR DESCRIPTION
Bug 846494 - Display sleep menu labels on multiple lines if ... r=@alivedise(cherry picked from commit c9beb369584e11e34d562164376036e55eec54f7)

Conflicts:

```
apps/system/style/sleep_menu/sleep_menu.css
```
