### PR TITLE
Bug 852369 - [Email] Support multiple email addresses in mailto links.

### DIFF
--- a/apps/email/js/query_uri.js
+++ b/apps/email/js/query_uri.js
@@ -3,7 +3,7 @@ define(function() {
     function addressesToArray(addresses) {
       if (!addresses)
         return [''];
-      addresses = addresses.split(';');
+      addresses = addresses.split(/[,;]/);
       var addressesArray = addresses.filter(function notEmpty(addr) {
         return addr.trim() !== '';
       });

--- a/apps/email/test/unit/mail_app_test.js
+++ b/apps/email/test/unit/mail_app_test.js
@@ -23,7 +23,13 @@ suite('email/mail_app', function() {
     'mailto:Email.address1@mailto.com;Email.address2@mailto.com'),
     [['Email.address1@mailto.com', 'Email.address2@mailto.com'],
     undefined, undefined, undefined, undefined],
-    'to multi-addresses test fail');
+    'to multi-addresses test fail (separator ";")');
+
+    assert.deepEqual(queryURI(
+    'mailto:Email.address1@mailto.com,Email.address2@mailto.com'),
+    [['Email.address1@mailto.com', 'Email.address2@mailto.com'],
+    undefined, undefined, undefined, undefined],
+    'to multi-addresses test fail (separator ",")');
 
 
   });


### PR DESCRIPTION
Note: Appears this was the only lost commit due to the bad history rewrite earlier. Going to take the easy path and just cherry-pick what's needed.
