### PR TITLE
Bug 853313 - [Email] Properly parse 'mailto' links that don't...

### DIFF
--- a/apps/email/js/query_uri.js
+++ b/apps/email/js/query_uri.js
@@ -2,7 +2,7 @@ define(function() {
   function queryURI(uri) {
     function addressesToArray(addresses) {
       if (!addresses)
-        return [''];
+        return [];
       addresses = addresses.split(/[,;]/);
       var addressesArray = addresses.filter(function notEmpty(addr) {
         return addr.trim() !== '';
@@ -18,7 +18,8 @@ define(function() {
       bodyReg = /(?:^|&)body=([^\&]*)/i,
       ccReg = /(?:^|&)cc=([^\&]*)/i,
       bccReg = /(?:^|&)bcc=([^\&]*)/i;
-      var to = addressesToArray(decodeURIComponent(parts[0])),
+      // Check if the 'to' field is set and properly decode it
+      var to = parts[0] ? addressesToArray(decodeURIComponent(parts[0])) : [],
       subject,
       body,
       cc,

--- a/apps/email/test/unit/mail_app_test.js
+++ b/apps/email/test/unit/mail_app_test.js
@@ -31,6 +31,10 @@ suite('email/mail_app', function() {
     undefined, undefined, undefined, undefined],
     'to multi-addresses test fail (separator ",")');
 
+    assert.deepEqual(queryURI('mailto:'),
+    [[], undefined, undefined, undefined, undefined],
+    'no to address test fail');
+
 
   });
 
@@ -38,12 +42,12 @@ suite('email/mail_app', function() {
   test('#cc', function() {
 
     assert.deepEqual(queryURI('mailto:?cc=EmailCc.address@mailto.com'),
-    [[''], undefined, undefined, ['EmailCc.address@mailto.com'], undefined],
+    [[], undefined, undefined, ['EmailCc.address@mailto.com'], undefined],
     'cc single address test fail');
 
     assert.deepEqual(queryURI('mailto:?cc=EmailCc.address1@mailto.com;' +
     'EmailCc.address2@mailto.com;EmailCc.address3@mailto.com'),
-    [[''], undefined, undefined, ['EmailCc.address1@mailto.com',
+    [[], undefined, undefined, ['EmailCc.address1@mailto.com',
     'EmailCc.address2@mailto.com',
     'EmailCc.address3@mailto.com'], undefined],
     'cc multi-addresses test fail');
@@ -55,12 +59,12 @@ suite('email/mail_app', function() {
  test('#bcc', function() {
 
     assert.deepEqual(queryURI('mailto:?bcc=EmailBcc.address@mailto.com'),
-    [[''], undefined, undefined, undefined, ['EmailBcc.address@mailto.com']],
+    [[], undefined, undefined, undefined, ['EmailBcc.address@mailto.com']],
     'bcc single address test');
 
     assert.deepEqual(queryURI('mailto:?bcc=EmailBcc.address1@mailto.com;' +
     'EmailBcc.address2@mailto.com;EmailBcc.address3@mailto.com'),
-    [[''], undefined, undefined, undefined, ['EmailBcc.address1@mailto.com',
+    [[], undefined, undefined, undefined, ['EmailBcc.address1@mailto.com',
     'EmailBcc.address2@mailto.com',
     'EmailBcc.address3@mailto.com']], 'bcc multi-addresses test fail');
 
@@ -71,7 +75,7 @@ suite('email/mail_app', function() {
  test('#subject', function() {
 
     assert.deepEqual(queryURI('mailto:?subject=This is the subject line'),
-    [[''], 'This is the subject line', undefined, undefined, undefined],
+    [[], 'This is the subject line', undefined, undefined, undefined],
     'subject test fail');
 
 
@@ -81,7 +85,7 @@ suite('email/mail_app', function() {
  test('#body', function() {
 
     assert.deepEqual(queryURI('mailto:?body=This is the body'),
-    [[''], undefined, 'This is the body', undefined, undefined],
+    [[], undefined, 'This is the body', undefined, undefined],
     'body test fail');
 
 


### PR DESCRIPTION
... have a 'to' address
