### PR TITLE
[Bug 890437] E.me swipe keyboard hide [r=Evyatron]

### DIFF
--- a/apps/homescreen/everything.me/js/Core.js
+++ b/apps/homescreen/everything.me/js/Core.js
@@ -66,7 +66,7 @@ window.Evme = new function Evme_Core() {
             }
         }
 
-        Evme.Brain.Searchbar.blur();
+        Evme.Searchbar.blur();
         return false; // allow navigation to homescreen
     };
 


### PR DESCRIPTION
Swiping left while Everything.me searchbar is focused, keeps the keyboard up.
This is the bugfix.

https://bugzilla.mozilla.org/show_bug.cgi?id=890437
