### PR TITLE
Bug 891788 - The Sms compose tests are slow r=gnarf

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -211,6 +211,7 @@ var Compose = (function() {
         this.onAttachClick.bind(this));
 
       this.clear();
+      this.clearListeners();
 
       return this;
     },
@@ -230,6 +231,12 @@ var Compose = (function() {
         }
       }
       return this;
+    },
+
+    clearListeners: function() {
+      for (var type in handlers) {
+        handlers[type] = [];
+      }
     },
 
     getContent: function() {

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -425,7 +425,7 @@ suite('compose_test.js', function() {
               done();
             }
           }
-        };
+        }
         Compose.on('input', onInput);
         Compose.append(mockImgAttachment());
       });
@@ -434,22 +434,25 @@ suite('compose_test.js', function() {
     suite('Message Type Events', function() {
       var form;
       var expectType = 'sms';
+
       function typeChange(event) {
         assert.equal(Compose.type, expectType);
         typeChange.called++;
       }
-      suiteSetup(function() {
-        Compose.on('type', typeChange);
-      });
-      suiteTeardown(function() {
-        Compose.off('type', typeChange);
-      });
+
       setup(function() {
         expectType = 'sms';
         Compose.clear();
         typeChange.called = 0;
         form = document.getElementById('messages-compose-form');
+
+        Compose.on('type', typeChange);
       });
+
+      teardown(function() {
+        Compose.off('type', typeChange);
+      });
+
       test('Message switches type when adding/removing attachment',
         function() {
         // form must have the data-message-type set


### PR DESCRIPTION
clear the input listeners at init
