### PR TITLE
Bug 891927 - [test-agent] the sinon sandbox is not always restored when ...

### DIFF
--- a/test_apps/test-agent/common/test/sinon_helper.js
+++ b/test_apps/test-agent/common/test/sinon_helper.js
@@ -5,6 +5,7 @@ window.requireCommon('vendor/sinon/sinon.js', function() {
   });
 
   teardown(function() {
-    this.sinon = sinon.sandbox.restore();
+    this.sinon.restore();
+    this.sinon = null;
   });
 });


### PR DESCRIPTION
...it's used in the most outer suite's setup r=jlal
