### PR TITLE
[Audio][Video]-Bug-838898_Cannot upon unknown mediatype dialog r=dominickuo

### DIFF
--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -444,7 +444,8 @@ var BluetoothTransfer = {
         // Cannot identify MIMETYPE
         // So, show cannot open file dialog with unknow media type
         UtilityTray.hide();
-        self.showUnknownMediaPrompt(fileName);
+        if (a.error.name === 'NO_PROVIDER')
+          self.showUnknownMediaPrompt(fileName);
       };
       a.onsuccess = function(e) {
         var msg = 'open activity onsuccess';


### PR DESCRIPTION
Fix involves checking for ErrorType as NO_PROVIDER  before showing Cannot open received file, Unknown Media type confirm dialog box.

As of now in master, dialog box is shown in error cases such as 'ActivityCanceled' (user comes out of activity by pressing home icon )
