### PR TITLE
Bug 888153 - [contacts] Import from vCard 4.0 has email missing in Contacts app

### DIFF
--- a/apps/communications/contacts/js/utilities/vcard_parser.js
+++ b/apps/communications/contacts/js/utilities/vcard_parser.js
@@ -189,8 +189,10 @@ VCFReader.processComm = function(vcardObj, contactObj) {
       var cur = {};
 
       if (v.meta) {
-        if (v.value)
+        if (v.value) {
           cur.value = VCFReader.decodeQP(v.meta, v.value[0]);
+          cur.value = cur.value.replace(/^tel:/i, '');
+        }
 
         metaValues = Object.keys(v.meta).map(function(key) {
           return v.meta[key];
@@ -231,9 +233,7 @@ VCFReader.processFields = function(vcardObj, contactObj) {
   return contactObj;
 };
 
-VCFReader.Re1 = /^\s*(version|fn|title|org)\s*:(.+)$/i;
-VCFReader.Re2 = /^([^:;]+);?([^:]+)?:(.+)$/i;
-VCFReader.ReKey = /item\d{1,2}\./;
+VCFReader.ReBasic = /^([^:]+):(.+)$/i;
 VCFReader.ReTuple = /([a-z]+)=(.*)/i;
 
 VCFReader._parseTuple = function(p, i) {
@@ -250,26 +250,58 @@ VCFReader._parseTuple = function(p, i) {
  * @private
  */
 VCFReader.parseLine_ = function(line) {
-  if (!VCFReader.Re2.test(line)) return null;
-  var results = line.match(VCFReader.Re2);
-  var key = results[1].replace(VCFReader.ReKey, '').toLowerCase().trim();
+  if (!VCFReader.ReBasic.test(line)) return null;
 
+  var parsed = VCFReader.ReBasic.exec(line);
+  var tuples = parsed[1].split(/[;,]/);
+  var key = tuples.shift();
   var meta = {};
-  if (results[2]) {
-    results[2].split(/[;,]/).forEach(function(l, i) {
-      var p = VCFReader._parseTuple(l, i);
-      if (p)
-        meta[p[0]] = p[1];
-    });
-  }
+
+  tuples.forEach(function(l, i) {
+    var tuple = VCFReader._parseTuple(l, i);
+    meta[tuple[0]] = tuple[1];
+  });
 
   return {
-    key: key,
+    key: key.toLowerCase(),
     data: {
       meta: meta,
-      value: results[3].split(';')
+      value: parsed[2].split(';')
     }
   };
+};
+
+VCFReader.splitLines = function(vcf) {
+  var lines = [];
+  var currentStr = '';
+  var inLabel = false;
+  for (var i = 0, l = vcf.length; i < l; i++) {
+    if (vcf[i] === '"') {
+      inLabel = !inLabel;
+      currentStr += vcf[i];
+      continue;
+    }
+
+    if (inLabel || vcf[i] !== '\n') {
+      currentStr += vcf[i];
+      continue;
+    }
+
+    var sub = vcf.substring(i + 1, vcf.length - 1);
+    if (currentStr.toLowerCase().indexOf('label;') !== -1 &&
+      sub.search(/^[^\n]+:/) === -1) {
+      currentStr += vcf[i];
+      continue;
+    }
+
+    if (sub.search(/^[^\S\n\r]+/) !== -1) {
+      continue;
+    }
+
+    lines.push([currentStr]);
+    currentStr = '';
+  }
+  return lines;
 };
 
 /**
@@ -282,11 +314,7 @@ VCFReader.parseSingleEntry = function(input) {
   if (!input) return null;
 
   var fields = {};
-  // When a line starts with a whitespace it means it is a continuation of the
-  // previous line. We join them here.
-  input = input.replace(/(\r\n|\r|\n)[^\S\n\r]+/g, '');
-
-  var lines = input.split(/\r\n|\r|\n/);
+  var lines = VCFReader.splitLines(input);
   lines.forEach(function(line) {
     var parsedLine = VCFReader.parseLine_(line);
     if (parsedLine) {
@@ -318,7 +346,6 @@ VCFReader.vcardToContact = function(vcard) {
   VCFReader.processAddr(vcard, obj);
   VCFReader.processComm(vcard, obj);
   VCFReader.processFields(vcard, obj);
-
   var contact = new mozContact();
   contact.init(obj);
 

--- a/apps/communications/contacts/test/unit/vcard_parsing_test.js
+++ b/apps/communications/contacts/test/unit/vcard_parsing_test.js
@@ -53,10 +53,10 @@ var vcf3 = 'BEGIN:VCARD\n' +
   'TEL;TYPE=home,voice;VALUE=uri:tel:+1-404-555-1212\n' +
   'ADR;TYPE=work;LABEL="100 Waters Edge\nBaytown, ' +
   'LA 30314\nUnited States of America"\n' +
-  ':;;100 Waters Edge;Baytown;LA;30314;United States of America\n' +
+  '  :;;100 Waters Edge;Baytown;LA;30314;United States of America\n' +
   'ADR;TYPE=home;LABEL="42 Plantation St.\nBaytown, ' +
   'LA 30314\nUnited States of America"\n' +
-  ':;;42 Plantation St.;Baytown;LA;30314;United States of America\n' +
+  '  :;;42 Plantation St.;Baytown;LA;30314;United States of America\n' +
   'EMAIL:forrestgump@example.com\n' +
   'REV:20080424T195243Z\n' +
   'END:VCARD';
@@ -232,8 +232,6 @@ suite('vCard parsing settings', function() {
         assert.strictEqual('Fórrest', contact.givenName[0]);
         assert.strictEqual('Bóbba Gump Shrimp Co.', contact.org[0]);
         assert.strictEqual('Shrómp Man', contact.jobTitle[0]);
-//        assert.strictEqual('http://www.example.com/dir_photos/my_photo.gif',
-//          contact.photo[0]);
 
         assert.strictEqual('WORK', contact.tel[0].type[0]);
         assert.strictEqual('(111) 555-1212', contact.tel[0].value);
@@ -283,9 +281,6 @@ suite('vCard parsing settings', function() {
         assert.strictEqual('Forrest', contact.givenName[0]);
         assert.strictEqual('Bubba Gump Shrimp Co.', contact.org[0]);
         assert.strictEqual('Shrimp Man', contact.jobTitle[0]);
-//        assert.strictEqual('http://www.example.com/dir_photos/my_photo.gif',
-//          contact.photo[0]);
-
 
         assert.strictEqual('WORK', contact.tel[0].type[0]);
         assert.strictEqual('(111) 555-1212', contact.tel[0].value);
@@ -315,6 +310,53 @@ suite('vCard parsing settings', function() {
       });
     });
 
+    test('- should return a correct JSON object from VCF 4.0', function(done) {
+      var reader = new VCFReader(vcf3);
+
+      reader.onread = stub();
+      reader.onimported = stub();
+      reader.onerror = stub();
+
+      reader.process(function import_finish(contacts) {
+        assert.strictEqual(1, contacts.length);
+
+        assert.strictEqual(1, reader.onread.callCount);
+        assert.strictEqual(1, reader.onimported.callCount);
+        assert.strictEqual(0, reader.onerror.callCount);
+
+        var contact = contacts[0];
+
+        assert.strictEqual('Forrest Gump', contact.name[0]);
+        assert.strictEqual('Forrest', contact.givenName[0]);
+        assert.strictEqual('Bubba Gump Shrimp Co.', contact.org[0]);
+        assert.strictEqual('Shrimp Man', contact.jobTitle[0]);
+
+        assert.strictEqual('work', contact.tel[0].type[0]);
+        assert.strictEqual('+1-111-555-1212', contact.tel[0].value);
+        assert.strictEqual('home', contact.tel[1].type[0]);
+        assert.strictEqual('+1-404-555-1212', contact.tel[1].value);
+
+        assert.strictEqual('work', contact.adr[0].type[0]);
+
+        assert.strictEqual('100 Waters Edge', contact.adr[0].streetAddress);
+        assert.strictEqual('Baytown', contact.adr[0].locality);
+        assert.strictEqual('LA', contact.adr[0].region);
+        assert.strictEqual('30314', contact.adr[0].postalCode);
+        assert.strictEqual('United States of America',
+          contact.adr[0].countryName);
+        assert.strictEqual('home', contact.adr[1].type[0]);
+        assert.strictEqual('42 Plantation St.', contact.adr[1].streetAddress);
+        assert.strictEqual('Baytown', contact.adr[1].locality);
+        assert.strictEqual('LA', contact.adr[1].region);
+        assert.strictEqual('30314', contact.adr[1].postalCode);
+        assert.strictEqual('United States of America',
+          contact.adr[1].countryName);
+
+        assert.strictEqual('forrestgump@example.com', contact.email[0].value);
+        done();
+
+      });
+    });
 
     test('- should return a single entry', function(done) {
       var reader = new VCFReader(vcfwrong1);


### PR DESCRIPTION
Fixed vCard 4.0 parsing.
- Fixed `tel:` prefix issues.
- Improved parser, it is not based on regex anymore.
- Parses several meta fields now, not only one.
- Added Unit tests.
