### PR TITLE
Bug 891984: Properly render contacts in favorites.

### DIFF
--- a/apps/communications/contacts/js/contacts_list.js
+++ b/apps/communications/contacts/js/contacts_list.js
@@ -350,10 +350,10 @@ contacts.List = (function() {
   // visibile DOM elements will be rendered later via the visibility monitor.
   // This function ensures that necessary meta data is defined in the node
   // dataset.
-  var createPlaceholder = function createPlaceholder(contact) {
+  var createPlaceholder = function createPlaceholder(contact, group) {
     var ph = document.createElement('li');
     ph.dataset.uuid = contact.id;
-    var group = getFastGroupName(contact);
+    var group = group || getFastGroupName(contact);
     var order = null;
     if (!group) {
       order = getStringToBeOrdered(contact);
@@ -531,7 +531,7 @@ contacts.List = (function() {
 
   //Adds each contact to its group container
   function appendToList(contact, group, ph) {
-    ph = ph || createPlaceholder(contact);
+    ph = ph || createPlaceholder(contact, group);
     var list = headers[group];
 
     // If above the fold for list, render immediately
@@ -858,7 +858,9 @@ contacts.List = (function() {
     // If is favorite add as well to the favorite group
     if (isFavorite(contact)) {
       list = headers['favorites'];
-      addToGroup(renderedNode.cloneNode(), list);
+      var cloned = renderedNode.cloneNode();
+      cloned.dataset.group = 'favorites';
+      addToGroup(cloned, list);
     }
     toggleNoContactsScreen(false);
     FixedHeader.refresh();

--- a/apps/communications/contacts/test/unit/contacts_list_test.js
+++ b/apps/communications/contacts/test/unit/contacts_list_test.js
@@ -768,6 +768,39 @@ suite('Render contacts list', function() {
       done();
     });
 
+    // This test verifies that we properly render contact list elements
+    // for both its main group and favorites group.  This requires the
+    // visibility monitor to fire an onscreen event for each group element
+    // separately.  See bug 891984 for a previous error in this logic.
+    test('load and render many favorites', function(done) {
+      var names = ['AA', 'AB', 'AC', 'AD', 'AE', 'AF', 'AG', 'AH', 'AI'];
+      var list = [];
+      for (var i = 0; i < names.length; ++i) {
+        var name = names[i];
+        var c = new MockContactAllFields();
+        c.id = 'mock-' + i;
+        c.familyName = [name];
+        c.category = ['favorite'];
+        list.push(c);
+      }
+      doLoad(subject, list, function() {
+        var favList = assertGroup(groupFav, containerFav, names.length);
+        var lastFav = favList[favList.length - 1];
+        doOnscreen(subject, lastFav, function() {
+          assert.equal(lastFav.dataset.rendered, 'true',
+                       'contact should be rendered in "favorites" list');
+
+          var aList = assertGroup(groupA, containerA, names.length);
+          var lastA = aList[aList.length - 1];
+          doOnscreen(subject, lastA, function() {
+            assert.equal(lastA.dataset.rendered, 'true',
+                         'contact should be rendered in "A" list');
+            done();
+          });
+        });
+      });
+    });
+
     test('reseting the dom of the contacts list', function(done) {
       var newList = new MockContactsList();
       doLoad(subject, newList, function() {


### PR DESCRIPTION
Previously if a contact was a favorite, then we would only render it once
in either its main letter group or the favorites group.  This patch correctly
tracks the group so that we reference the contact properly in order to
render it for both groups.
