### PR TITLE
Bug 877978 - [Gaia] Use new WebAPI to access iccInfo related attribute/event

### DIFF
--- a/apps/communications/ftu/js/data_mobile.js
+++ b/apps/communications/ftu/js/data_mobile.js
@@ -58,8 +58,8 @@ var DataMobile = {
     xhr.onreadystatechange = function() {
       if (xhr.readyState == 4 && (xhr.status == 200 || xhr.status === 0)) {
         // TODO: read mcc and mnc codes from 'operatorvariant.{mcc, mnc}'.
-        var mcc = navigator.mozMobileConnection.iccInfo.mcc;
-        var mnc = navigator.mozMobileConnection.iccInfo.mnc;
+        var mcc = IccHelper.iccInfo.mcc;
+        var mnc = IccHelper.iccInfo.mnc;
         var apnList = xhr.response;
         var apns = apnList[mcc] ? (apnList[mcc][mnc] || []) : [];
         // Looks for a valid APN configuration for data calls.

--- a/apps/communications/ftu/test/unit/data_mobile_test.js
+++ b/apps/communications/ftu/test/unit/data_mobile_test.js
@@ -1,24 +1,23 @@
 'use strict';
 
-requireApp(
-  'communications/ftu/test/unit/mock_navigator_moz_mobile_connection.js');
+requireApp('communications/ftu/test/unit/mock_icc_helper.js');
 requireApp('communications/ftu/test/unit/mock_settings.js');
 requireApp('system/test/unit/mock_settings_listener.js');
 requireApp('communications/ftu/js/data_mobile.js');
 
+var mocksHelperForNavigation = new MocksHelper(['IccHelper']);
+mocksHelperForNavigation.init();
 
 suite('mobile data >', function() {
   var realSettings,
-      realMozMobileConnection,
       settingKey = 'ril.data.enabled';
+  var mocksHelper = mocksHelperForNavigation;
 
   suiteSetup(function() {
     realSettings = navigator.mozSettings;
     navigator.mozSettings = MockNavigatorSettings;
 
-    realMozMobileConnection = navigator.mozMobileConnection;
-    navigator.mozMobileConnection = MockNavigatorMozMobileConnection;
-
+    mocksHelper.suiteSetup();
     DataMobile.init();
   });
 
@@ -26,8 +25,7 @@ suite('mobile data >', function() {
     navigator.mozSettings = realSettings;
     realSettings = null;
 
-    navigator.mozMobileConnection = realMozMobileConnection;
-    realMozMobileConnection = null;
+    mocksHelper.suiteTeardown();
   });
 
   test('load APN values from file', function(done) {
@@ -36,11 +34,8 @@ suite('mobile data >', function() {
                        'ril.data.passwd',
                        'ril.data.httpProxyHost',
                        'ril.data.httpProxyPort'];
-    MockNavigatorMozMobileConnection.iccInfo = {
-      mcc: '214',
-      mnc: '07'
-      // real values taken from /shared/resources/apn.json, careful if changed
-    };
+    // real values taken from /shared/resources/apn.json, careful if changed
+    IccHelper.setProperty('iccInfo', {mcc: '214', mnc: '07'});
     for (var settingName in settingList) {
       MockNavigatorSettings.mSettings[settingList[settingName]] = null;
     }
@@ -55,11 +50,8 @@ suite('mobile data >', function() {
   });
 
   test('toggle status of mobile data', function(done) {
-    MockNavigatorMozMobileConnection.iccInfo = {
-      mcc: '214',
-      mnc: '07'
-      // real values taken from /shared/resources/apn.json, careful if changed
-    };
+    // real values taken from /shared/resources/apn.json, careful if changed
+    IccHelper.setProperty('iccInfo', {mcc: '214', mnc: '07'});
     DataMobile.toggle(false, function() {
       assert.isFalse(MockNavigatorSettings.mSettings[settingKey]);
       done();

--- a/apps/communications/ftu/test/unit/mock_icc_helper.js
+++ b/apps/communications/ftu/test/unit/mock_icc_helper.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var MockIccHelper = {
-  mProps: {'cardState': null},
+  mProps: {'cardState': null, 'iccInfo': {}},
 
   setProperty: function _setProperty(property, newState) {
     this.mProps[property] = newState;
@@ -19,6 +19,10 @@ var MockIccHelper = {
 
   get cardState() {
     return this.mProps['cardState'];
+  },
+
+  get iccInfo() {
+    return this.mProps['iccInfo'];
   },
 
   unlockCardLock: function() {

--- a/apps/communications/ftu/test/unit/mock_navigator_moz_mobile_connection.js
+++ b/apps/communications/ftu/test/unit/mock_navigator_moz_mobile_connection.js
@@ -2,7 +2,7 @@
 
 (function() {
 
-  var props = ['voice', 'iccInfo', 'data', 'retryCount'];
+  var props = ['voice', 'data', 'retryCount'];
   var listeners;
 
   function _init() {

--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -41,9 +41,8 @@ var CostControlApp = (function() {
 
   var costcontrol, initialized = false;
   function onReady(callback) {
-    var mobileConnection = window.navigator.mozMobileConnection;
     var cardState = checkCardState();
-    var iccid = mobileConnection.iccInfo.iccid;
+    var iccid = IccHelper.iccInfo.iccid;
 
     // SIM not ready
     if (cardState !== 'ready') {
@@ -53,13 +52,13 @@ var CostControlApp = (function() {
     // SIM is ready, but ICC info is not ready yet
     } else if (!Common.isValidICCID(iccid)) {
       debug('ICC info not ready yet');
-      mobileConnection.oniccinfochange = onReady;
+      IccHelper.oniccinfochange = onReady;
 
     // All ready
     } else {
       debug('SIM ready. ICCID:', iccid);
       IccHelper.oncardstatechange = undefined;
-      mobileConnection.oniccinfochange = undefined;
+      IccHelper.oniccinfochange = undefined;
       startApp(callback);
     }
   }

--- a/apps/costcontrol/js/common.js
+++ b/apps/costcontrol/js/common.js
@@ -242,7 +242,7 @@ var Common = {
   // Checks for a SIM change
   checkSIMChange: function(callback, onerror) {
     asyncStorage.getItem('lastSIM', function _compareWithCurrent(lastSIM) {
-      var currentSIM = window.navigator.mozMobileConnection.iccInfo.iccid;
+      var currentSIM = IccHelper.iccInfo.iccid;
       if (currentSIM === null) {
         console.error('Impossible: or we don\'t have SIM (so this method ' +
                       'should not be called) or the RIL is returning null ' +

--- a/apps/costcontrol/js/config/config_manager.js
+++ b/apps/costcontrol/js/config/config_manager.js
@@ -4,7 +4,6 @@ var ConfigManager = (function() {
   'use strict';
 
   var today = new Date();
-  var connection = window.navigator.mozMobileConnection;
 
   var DEFAULT_SETTINGS = {
     'dataLimit': false,
@@ -97,8 +96,8 @@ var ConfigManager = (function() {
   }
 
   function getConfigFilePath() {
-    var mcc = connection.iccInfo.mcc;
-    var mnc = connection.iccInfo.mnc;
+    var mcc = IccHelper.iccInfo.mcc;
+    var mnc = IccHelper.iccInfo.mnc;
     var key = mcc + '_' + mnc;
     var configDir = configurationIndex[key];
     if (!configDir) {
@@ -149,8 +148,7 @@ var ConfigManager = (function() {
   var NO_ICCID = 'NOICCID';
   var settings;
   function requestSettings(callback) {
-    var currentICCID = window.navigator.mozMobileConnection.iccInfo.iccid ||
-                       NO_ICCID;
+    var currentICCID = IccHelper.iccInfo.iccid || NO_ICCID;
     asyncStorage.getItem(currentICCID, function _wrapGetItem(localSettings) {
       // No entry: set defaults
       try {
@@ -215,8 +213,7 @@ var ConfigManager = (function() {
     }
 
     // Set items and dispatch the events
-    var currentICCID = window.navigator.mozMobileConnection.iccInfo.iccid ||
-                       NO_ICCID;
+    var currentICCID = IccHelper.iccInfo.iccid || NO_ICCID;
     asyncStorage.setItem(currentICCID, JSON.stringify(settings),
       function _onSet() {
         requestSettings(function _onSettings(settings) {

--- a/apps/costcontrol/js/costcontrol.js
+++ b/apps/costcontrol/js/costcontrol.js
@@ -404,7 +404,7 @@ var CostControl = (function() {
           // Finally, store the result and continue
           mobileRequest.onsuccess = function _onMobileData() {
             var fakeTag = {
-              sim: connection.iccInfo.iccid,
+              sim: IccHelper.iccInfo.iccid,
               start: settings.lastDataReset,
               fixing: [[settings.lastDataReset, wifiFixing || 0]]
             };

--- a/apps/costcontrol/js/fte.js
+++ b/apps/costcontrol/js/fte.js
@@ -13,7 +13,6 @@
   var DEFAULT_LOW_LIMIT_THRESHOLD = 3;
   var defaultLowLimitThreshold = DEFAULT_LOW_LIMIT_THRESHOLD;
   window.addEventListener('DOMContentLoaded', function _onDOMReady() {
-    var mobileConnection = window.navigator.mozMobileConnection;
     var stepsLeft = 2;
 
     // No SIM
@@ -24,11 +23,11 @@
     // SIM is not ready
     } else if (IccHelper.cardState !== 'ready') {
       debug('SIM not ready:', IccHelper.cardState);
-      mobileConnection.oniccinfochange = _onDOMReady;
+      IccHelper.oniccinfochange = _onDOMReady;
 
     // SIM is ready
     } else {
-      mobileConnection.oniccinfochange = undefined;
+      IccHelper.oniccinfochange = undefined;
       trySetup();
     }
 

--- a/apps/costcontrol/js/widget.js
+++ b/apps/costcontrol/js/widget.js
@@ -14,9 +14,8 @@ var Widget = (function() {
 
   var costcontrol;
   function onReady() {
-    var mobileConnection = window.navigator.mozMobileConnection;
     var cardState = checkCardState();
-    var iccid = mobileConnection.iccInfo.iccid;
+    var iccid = IccHelper.iccInfo.iccid;
 
     // SIM not ready
     if (cardState !== 'ready') {
@@ -26,13 +25,13 @@ var Widget = (function() {
     // SIM is ready, but ICC info is not ready yet
     } else if (!Common.isValidICCID(iccid)) {
       debug('ICC info not ready yet');
-      mobileConnection.oniccinfochange = onReady;
+      IccHelper.oniccinfochange = onReady;
 
     // All ready
     } else {
       debug('SIM ready. ICCID:', iccid);
       IccHelper.oncardstatechange = undefined;
-      mobileConnection.oniccinfochange = undefined;
+      IccHelper.oniccinfochange = undefined;
       startWidget();
     }
   };

--- a/apps/costcontrol/test/unit/mock_icc_helper.js
+++ b/apps/costcontrol/test/unit/mock_icc_helper.js
@@ -10,6 +10,10 @@ var MockIccHelper = function(state) {
 
     get cardState() {
       return state;
+    },
+
+    get iccInfo() {
+      return {iccid: 'TEST_ICCID'};
     }
   };
 };

--- a/apps/costcontrol/test/unit/mock_moz_mobile_connection.js
+++ b/apps/costcontrol/test/unit/mock_moz_mobile_connection.js
@@ -3,12 +3,6 @@
 var MockMozMobileConnection = function(state) {
   state = state || {};
 
-  if (!state.iccInfo) {
-    state.iccInfo = {
-      iccid: 'TEST_ICCID'
-    };
-  }
-
   if (!state.voice) {
     state.voice = {
     };

--- a/apps/settings/js/about.js
+++ b/apps/settings/js/about.js
@@ -96,7 +96,10 @@ var About = {
     if (!mobileConnection)
       return;
 
-    var info = mobileConnection.iccInfo;
+    if (!IccHelper.enabled)
+      return;
+
+    var info = IccHelper.iccInfo;
     document.getElementById('deviceInfo-iccid').textContent = info.iccid;
     document.getElementById('deviceInfo-msisdn').textContent = info.msisdn ||
       navigator.mozL10n.get('unknown-phoneNumber');

--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -354,7 +354,6 @@ var getMobileConnection = function() {
     return navigator.mozMobileConnection;
 
   var initialized = false;
-  var fakeICCInfo = { shortName: 'Fake Free-Mobile', mcc: '208', mnc: '15' };
   var fakeNetwork = { shortName: 'Fake Orange F', mcc: '208', mnc: '1' };
   var fakeVoice = {
     state: 'notSearching',
@@ -376,7 +375,6 @@ var getMobileConnection = function() {
 
   return {
     addEventListener: fakeEventListener,
-    iccInfo: fakeICCInfo,
     get data() {
       return initialized ? { network: fakeNetwork } : null;
     },

--- a/apps/system/js/call_forwarding.js
+++ b/apps/system/js/call_forwarding.js
@@ -40,10 +40,10 @@
     if (_cfIconStateInitialized || cardState !== 'ready')
       return;
 
-    if (!mobileConnection.iccInfo)
+    if (!IccHelper.iccInfo)
       return;
 
-    var iccid = mobileConnection.iccInfo.iccid;
+    var iccid = IccHelper.iccInfo.iccid;
     if (!iccid)
       return;
 
@@ -62,7 +62,7 @@
   IccHelper.addEventListener('cardstatechange', function() {
     initCallForwardingIconState();
   });
-  mobileConnection.addEventListener('iccinfochange', function() {
+  IccHelper.addEventListener('iccinfochange', function() {
     initCallForwardingIconState();
   });
 
@@ -76,7 +76,7 @@
         enabled = true;
       }
       settings.createLock().set({'ril.cf.enabled': enabled});
-      asyncStorage.setItem('ril.cf.enabled.' + mobileConnection.iccInfo.iccid,
+      asyncStorage.setItem('ril.cf.enabled.' + IccHelper.iccInfo.iccid,
         enabled);
     }
   });
@@ -84,7 +84,7 @@
   settings.addObserver('ril.cf.carrier.enabled', function(event) {
     var showIcon = event.settingValue;
     settings.createLock().set({'ril.cf.enabled': showIcon});
-    asyncStorage.setItem('ril.cf.enabled.' + mobileConnection.iccInfo.iccid,
+    asyncStorage.setItem('ril.cf.enabled.' + IccHelper.iccInfo.iccid,
     showIcon);
   });
 })();

--- a/apps/system/js/icc_events.js
+++ b/apps/system/js/icc_events.js
@@ -14,8 +14,8 @@ var icc_events = {
       return;
     }
     var conn = window.navigator.mozMobileConnection;
-    DUMP(' STK Location changed to MCC=' + conn.iccInfo.mcc +
-      ' MNC=' + conn.iccInfo.mnc +
+    DUMP(' STK Location changed to MCC=' + IccHelper.iccInfo.mcc +
+      ' MNC=' + IccHelper.iccInfo.mnc +
       ' LAC=' + conn.voice.cell.gsmLocationAreaCode +
       ' CellId=' + conn.voice.cell.gsmCellId +
       ' Status/Connected=' + conn.voice.connected +
@@ -30,8 +30,8 @@ var icc_events = {
       eventType: icc._icc.STK_EVENT_TYPE_LOCATION_STATUS,
       locationStatus: status,
       locationInfo: {
-        mcc: conn.iccInfo.mcc,
-        mnc: conn.iccInfo.mnc,
+        mcc: IccHelper.iccInfo.mcc,
+        mnc: IccHelper.iccInfo.mnc,
         gsmLocationAreaCode: conn.voice.cell.gsmLocationAreaCode,
         gsmCellId: conn.voice.cell.gsmCellId
       }

--- a/apps/system/js/internet_sharing.js
+++ b/apps/system/js/internet_sharing.js
@@ -17,7 +17,6 @@
 var InternetSharing = (function() {
 
   var settings;
-  var mobileConnection;
   // null or unknown state will change to one of the following state
   var validCardState = ['absent',
                         'pinRequired',
@@ -75,19 +74,19 @@ var InternetSharing = (function() {
       // once cardState is ready, we need to read iccid
       // if iccInfo.iccid is not ready, we need to listen change of iccinfo
       // change, until iccid is ready
-      if (!mobileConnection.iccInfo || !mobileConnection.iccInfo.iccid) {
-        mobileConnection.oniccinfochange = function handler() {
+      if (!IccHelper.iccInfo || !IccHelper.iccInfo.iccid) {
+        IccHelper.oniccinfochange = function handler() {
           // wait for iccid is filled.
-          if (mobileConnection.iccInfo.iccid) {
-            mobileConnection.oniccinfochange = null;
-            doRestore('usb', mobileConnection.iccInfo.iccid);
-            doRestore('wifi', mobileConnection.iccInfo.iccid);
+          if (IccHelper.iccInfo.iccid) {
+            IccHelper.oniccinfochange = null;
+            doRestore('usb', IccHelper.iccInfo.iccid);
+            doRestore('wifi', IccHelper.iccInfo.iccid);
           }
         };
       } else {
         // iccInfo is ready, just use it.
-        doRestore('usb', mobileConnection.iccInfo.iccid);
-        doRestore('wifi', mobileConnection.iccInfo.iccid);
+        doRestore('usb', IccHelper.iccInfo.iccid);
+        doRestore('wifi', IccHelper.iccInfo.iccid);
       }
     } else {
       // card is not ready, just use absent to restore the value.
@@ -103,7 +102,7 @@ var InternetSharing = (function() {
     }
     // link the iccid with current internet state for future restoring.
     var type = (evt.settingName.indexOf('wifi') > -1) ? 'wifi' : 'usb';
-    var cardId = mobileConnection.iccInfo.iccid || 'absent';
+    var cardId = IccHelper.iccInfo.iccid || 'absent';
     // wifi hotspot cannot be enabled without sim
     if ('wifi' === type && 'absent' === cardId && true === evt.settingValue) {
       settings.createLock().set({'tethering.wifi.enabled': false});
@@ -116,10 +115,6 @@ var InternetSharing = (function() {
   function _init() {
     settings = window.navigator.mozSettings;
     if (!settings) {
-      return;
-    }
-    mobileConnection = window.navigator.mozMobileConnection;
-    if (!mobileConnection) {
       return;
     }
     if (!IccHelper.enabled) {

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -161,7 +161,6 @@ var LockScreen = {
     var conn = window.navigator.mozMobileConnection;
     if (conn && conn.voice) {
       conn.addEventListener('voicechange', this);
-      conn.addEventListener('iccinfochange', this);
       this.updateConnState();
       this.connstate.hidden = false;
     }
@@ -169,6 +168,7 @@ var LockScreen = {
     /* icc state on lock screen */
     if (IccHelper.enabled) {
       IccHelper.addEventListener('cardstatechange', this);
+      IccHelper.addEventListener('iccinfochange', this);
     }
 
     var self = this;

--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -37,16 +37,12 @@
    * and retrieve/apply APN settings if they differ.
    */
 
-  var mobileConnection = window.navigator.mozMobileConnection;
-  if (!mobileConnection)
-    return;
-
   if (!IccHelper.enabled)
     return;
 
   // Check the mcc/mnc information on the SIM card.
   function checkICCInfo() {
-    if (!mobileConnection.iccInfo || IccHelper.cardState !== 'ready')
+    if (!IccHelper.iccInfo || IccHelper.cardState !== 'ready')
       return;
 
     // ensure that the iccSettings have been retrieved
@@ -54,14 +50,14 @@
       return;
 
     // XXX sometimes we get 0/0 for mcc/mnc, even when cardState === 'ready'...
-    var mcc = mobileConnection.iccInfo.mcc || '0';
-    var mnc = mobileConnection.iccInfo.mnc || '0';
+    var mcc = IccHelper.iccInfo.mcc || '0';
+    var mnc = IccHelper.iccInfo.mnc || '0';
     if (mcc === '0')
       return;
 
     // avoid setting APN (and operator variant) settings if mcc/mnc codes
     // changes.
-    mobileConnection.removeEventListener('iccinfochange', checkICCInfo);
+    IccHelper.removeEventListener('iccinfochange', checkICCInfo);
 
     // same SIM card => do nothing
     if ((mcc == iccSettings.mcc) && (mnc == iccSettings.mnc)) {
@@ -236,6 +232,6 @@
    */
 
   getICCSettings(checkICCInfo);
-  mobileConnection.addEventListener('iccinfochange', checkICCInfo);
+  IccHelper.addEventListener('iccinfochange', checkICCInfo);
 })();
 

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -313,10 +313,13 @@ var StatusBar = {
       var conn = window.navigator.mozMobileConnection;
       if (conn) {
         conn.addEventListener('voicechange', this);
-        conn.addEventListener('iccinfochange', this);
         conn.addEventListener('datachange', this);
         this.update.signal.call(this);
         this.update.data.call(this);
+      }
+
+      if (IccHelper.enabled) {
+        IccHelper.addEventListener('iccinfochange', this);
       }
 
       window.addEventListener('wifi-statuschange',
@@ -347,8 +350,11 @@ var StatusBar = {
       var conn = window.navigator.mozMobileConnection;
       if (conn) {
         conn.removeEventListener('voicechange', this);
-        conn.removeEventListener('iccinfochange', this);
         conn.removeEventListener('datachange', this);
+      }
+
+      if (IccHelper.enabled) {
+        IccHelper.removeEventListener('iccinfochange', this);
       }
 
       window.removeEventListener('moznetworkupload', this);
@@ -365,7 +371,7 @@ var StatusBar = {
       var label = this.icons.label;
       var l10nArgs = JSON.parse(label.dataset.l10nArgs || '{}');
 
-      if (!conn || !conn.voice || !conn.voice.connected ||
+      if (!IccHelper.enabled || !conn || !conn.voice || !conn.voice.connected ||
           conn.voice.emergencyCallsOnly) {
         delete l10nArgs.operator;
         label.dataset.l10nArgs = JSON.stringify(l10nArgs);

--- a/apps/system/test/unit/internet_sharing_test.js
+++ b/apps/system/test/unit/internet_sharing_test.js
@@ -20,7 +20,6 @@ suite('internet sharing > ', function() {
   const TEST_ICCID2 = 'iccid-2';
 
   var realSettings;
-  var realMozMobileConnection;
 
   var mocksHelper = new MocksHelper(['asyncStorage', 'IccHelper']);
   mocksHelper.init();
@@ -30,14 +29,11 @@ suite('internet sharing > ', function() {
 
     realSettings = navigator.mozSettings;
     navigator.mozSettings = MockNavigatorSettings;
-    realMozMobileConnection = navigator.mozMobileConnection;
-    navigator.mozMobileConnection = MockNavigatorMozMobileConnection;
     requireApp('system/js/internet_sharing.js', done);
   });
 
   suiteTeardown(function() {
     mocksHelper.suiteTeardown();
-    navigator.MozMobileConnection = realMozMobileConnection;
     navigator.mozSettings = realSettings;
   });
   // helper function for batch assertion of asyncStorage
@@ -58,10 +54,7 @@ suite('internet sharing > ', function() {
   // helper to change card state
   function changeCardState(state, iccid) {
     MockIccHelper.mProps['cardState'] = state;
-    if (!MockNavigatorMozMobileConnection.iccInfo) {
-      MockNavigatorMozMobileConnection.iccInfo = {};
-    }
-    MockNavigatorMozMobileConnection.iccInfo['iccid'] = iccid;
+    MockIccHelper.mProps['iccInfo'] = {'iccid': iccid};
     MockIccHelper.mTriggerEventListeners('cardstatechange', {});
   }
   // helper to change single key-value of mozSettings
@@ -89,7 +82,7 @@ suite('internet sharing > ', function() {
     // fresh startup
     test('null sim no settings', function() {
       // empty start
-      var mEventListeners = IccHelper.mEventListeners;
+      var mEventListeners = MockIccHelper.mEventListeners;
       var mObservers = MockNavigatorSettings.mObservers;
 
       assert.ok(
@@ -104,7 +97,7 @@ suite('internet sharing > ', function() {
     // card state from null to unknown(sim found, but not initialized)
     test('unknown sim no settings', function() {
       changeCardState('unknown', null);
-      var mEventListeners = IccHelper.mEventListeners;
+      var mEventListeners = MockIccHelper.mEventListeners;
       var mObservers = MockNavigatorSettings.mObservers;
       assert.ok(
         mEventListeners['cardstatechange'].length > 0);
@@ -119,7 +112,7 @@ suite('internet sharing > ', function() {
     test('sim1 pinRequired no settings', function() {
       changeCardState('pinRequired', null);
 
-      var mEventListeners = IccHelper.mEventListeners;
+      var mEventListeners = MockIccHelper.mEventListeners;
       var mObservers = MockNavigatorSettings.mObservers;
       assert.ok(
         mEventListeners['cardstatechange'].length > 0);
@@ -138,22 +131,20 @@ suite('internet sharing > ', function() {
       changeCardState('ready', null);
 
       // ready state, wait for iccInfo ready.
-      var mEventListeners = MockNavigatorMozMobileConnection.mEventListeners;
-      assert.ok(MockNavigatorMozMobileConnection.oniccinfochange ||
+      var mEventListeners = MockIccHelper.mEventListeners;
+      assert.ok(MockIccHelper.oniccinfochange ||
                 mEventListeners['iccinfochange'].length == 1);
 
       // add iccInfo
-      MockNavigatorMozMobileConnection.iccInfo['dummy'] = 'dummyValue';
-      MockNavigatorMozMobileConnection.triggerEventListeners('iccinfochange',
-                                                             {});
-      assert.ok(MockNavigatorMozMobileConnection.oniccinfochange ||
+      MockIccHelper.mProps['iccInfo'] = {dummy: 'dummyValue'};
+      MockIccHelper.mTriggerEventListeners('iccinfochange', {});
+      assert.ok(MockIccHelper.oniccinfochange ||
                 mEventListeners['iccinfochange'].length == 1);
 
       // add iccid
-      MockNavigatorMozMobileConnection.iccInfo['iccid'] = TEST_ICCID1;
-      MockNavigatorMozMobileConnection.triggerEventListeners('iccinfochange',
-                                                             {});
-      assert.ok(!MockNavigatorMozMobileConnection.oniccinfochange ||
+      MockIccHelper.mProps['iccInfo'] = {iccid: TEST_ICCID1};
+      MockIccHelper.mTriggerEventListeners('iccinfochange', {});
+      assert.ok(!MockIccHelper.oniccinfochange ||
                 mEventListeners['iccinfochange'].length == 0);
 
       var testSet = [{'key': KEY_USB_TETHERING, 'result': false},
@@ -174,9 +165,8 @@ suite('internet sharing > ', function() {
     test('sim1 removed', function() {
       changeCardState('absent', null);
       IccHelper.mProps['cardState'] = 'absent';
-      MockNavigatorMozMobileConnection.iccInfo['iccid'] = null;
-      IccHelper.mTriggerEventListeners('cardstatechange',
-                                                             {});
+      IccHelper.mProps['iccInfo'] = null;
+      IccHelper.mTriggerEventListeners('cardstatechange', {});
       var testSet = [{'key': KEY_USB_TETHERING, 'result': false},
                      {'key': KEY_WIFI_HOTSPOT, 'result': false}];
       assertSettingsEquals(testSet);

--- a/apps/system/test/unit/mobile_operator_test.js
+++ b/apps/system/test/unit/mobile_operator_test.js
@@ -5,7 +5,7 @@
 requireApp('system/shared/js/mobile_operator.js');
 
 suite('shared/MobileOperator', function() {
-  var MockMobileConnection;
+  var MockMobileConnection, MockIccHelper;
   var BRAZIL_MCC = '724';
 
 
@@ -18,9 +18,14 @@ suite('shared/MobileOperator', function() {
           mnc: '6'
         },
         cell: { gsmLocationAreaCode: 71 }
-      },
+      }
+    };
+
+    MockIccHelper = {
       iccInfo: { spn: 'Fake SPN' }
     };
+
+    window.IccHelper = MockIccHelper;
   });
 
   suite('Worldwide connection', function() {
@@ -38,24 +43,24 @@ suite('shared/MobileOperator', function() {
       assert.isUndefined(infos.region);
     });
     test('Connection with SPN display', function() {
-      MockMobileConnection.iccInfo.isDisplaySpnRequired = true;
+      MockIccHelper.iccInfo.isDisplaySpnRequired = true;
       var infos = MobileOperator.userFacingInfo(MockMobileConnection);
       assert.equal(infos.operator, 'Fake SPN');
       assert.isUndefined(infos.carrier);
       assert.isUndefined(infos.region);
     });
     test('Connection with SPN display and network display', function() {
-      MockMobileConnection.iccInfo.isDisplaySpnRequired = true;
-      MockMobileConnection.iccInfo.isDisplayNetworkNameRequired = true;
+      MockIccHelper.iccInfo.isDisplaySpnRequired = true;
+      MockIccHelper.iccInfo.isDisplayNetworkNameRequired = true;
       var infos = MobileOperator.userFacingInfo(MockMobileConnection);
       assert.equal(infos.operator, 'Fake short Fake SPN');
       assert.isUndefined(infos.carrier);
       assert.isUndefined(infos.region);
     });
     test('Connection with same SPN and network name', function() {
-      MockMobileConnection.iccInfo.isDisplaySpnRequired = true;
-      MockMobileConnection.iccInfo.spn = 'Fake short';
-      MockMobileConnection.iccInfo.isDisplayNetworkNameRequired = true;
+      MockIccHelper.iccInfo.isDisplaySpnRequired = true;
+      MockIccHelper.iccInfo.spn = 'Fake short';
+      MockIccHelper.iccInfo.isDisplayNetworkNameRequired = true;
       var infos = MobileOperator.userFacingInfo(MockMobileConnection);
       assert.equal(infos.operator, 'Fake short');
       assert.isUndefined(infos.carrier);
@@ -70,7 +75,7 @@ suite('shared/MobileOperator', function() {
     });
     test('Connection with roaming and SPN display', function() {
       MockMobileConnection.voice.roaming = true;
-      MockMobileConnection.iccInfo.isDisplaySpnRequired = true;
+      MockIccHelper.iccInfo.isDisplaySpnRequired = true;
       var infos = MobileOperator.userFacingInfo(MockMobileConnection);
       assert.equal(infos.operator, 'Fake short');
       assert.isUndefined(infos.carrier);

--- a/apps/system/test/unit/mock_icc_helper.js
+++ b/apps/system/test/unit/mock_icc_helper.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var MockIccHelper = {
-  mProps: {'cardState': null},
+  mProps: {'cardState': null, 'iccInfo': {}},
 
-  mEventListeners: {'cardstatechange': []},
+  mEventListeners: {'cardstatechange': [], 'iccinfochange': []},
 
   mSuiteSetup: function icch_suite_setup() {
-    this.mProps = {'cardState': null};
-    this.mEventListeners = {'cardstatechange': []};
+    this.mProps = {'cardState': null, 'iccInfo': {}};
+    this.mEventListeners = {'cardstatechange': [], 'iccinfochange': []};
   },
 
   mTeardown: function icch_teardown() {},
@@ -36,6 +36,10 @@ var MockIccHelper = {
 
   get cardState() {
     return this.mProps['cardState'];
+  },
+
+  get iccInfo() {
+    return this.mProps['iccInfo'];
   },
 
   addEventListener: function icch_addEventListener(type, callback) {

--- a/apps/system/test/unit/mock_navigator_moz_mobile_connection.js
+++ b/apps/system/test/unit/mock_navigator_moz_mobile_connection.js
@@ -2,14 +2,14 @@
 
 (function() {
 
-  var props = ['voice', 'iccInfo', 'data'];
+  var props = ['voice', 'data'];
   var eventListeners = null;
 
   function mnmmc_init() {
     props.forEach(function(prop) {
       Mock[prop] = null;
     });
-    eventListeners = {'iccinfochange': []};
+    eventListeners = {};
   }
 
   function mnmmc_addEventListener(type, callback) {

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -135,7 +135,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'absent';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -156,7 +156,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'absent';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -177,7 +177,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'pinRequired';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -198,7 +198,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'ready';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -219,7 +219,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'absent';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -240,7 +240,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'pinRequired';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -261,7 +261,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'pinRequired';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       MockNavigatorMozTelephony.active = {
         state: 'connected'
@@ -286,7 +286,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'pinRequired';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       MockNavigatorMozTelephony.active = {
         state: 'dialing'
@@ -311,7 +311,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'pinRequired';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -342,7 +342,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'ready';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -363,7 +363,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'ready';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -384,7 +384,7 @@ suite('system/Statusbar', function() {
       };
 
       IccHelper.mProps['cardState'] = 'ready';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['iccInfo'] = {};
 
       StatusBar.update.signal.call(StatusBar);
 
@@ -404,8 +404,8 @@ suite('system/Statusbar', function() {
         network: {}
       };
 
-      MockNavigatorMozMobileConnection.cardState = 'pinRequired';
-      MockNavigatorMozMobileConnection.iccInfo = {};
+      IccHelper.mProps['cardState'] = 'pinRequired';
+      IccHelper.mProps['iccInfo'] = {};
 
       var mockTel = MockNavigatorMozTelephony;
 
@@ -437,7 +437,7 @@ suite('system/Statusbar', function() {
         }
       };
 
-      MockNavigatorMozMobileConnection.iccInfo = {
+      IccHelper.mProps['iccInfo'] = {
         isDisplaySpnRequired: false,
         spn: 'Fake SPN'
       };

--- a/shared/js/icc_helper.js
+++ b/shared/js/icc_helper.js
@@ -84,6 +84,21 @@ var IccHelper = (function() {
     get iccInfo() {
       var actor = actors['iccInfo'];
       return actor.iccInfo;
+    },
+
+    set oncardstatechange(callback) {
+      var actor = actors['cardState'];
+      actor.oncardstatechange = callback;
+    },
+
+    set oniccinfochange(callback) {
+      var actor = actors['iccInfo'];
+      actor.oniccinfochange = callback;
+    },
+
+    set onicccardlockerror(callback) {
+      var actor = actors['cardLock'];
+      actor.onicccardlockerror = callback;
     }
   };
 })();

--- a/shared/js/mobile_operator.js
+++ b/shared/js/mobile_operator.js
@@ -6,7 +6,7 @@ var MobileOperator = {
 
   userFacingInfo: function mo_userFacingInfo(mobileConnection) {
     var network = mobileConnection.voice.network;
-    var iccInfo = mobileConnection.iccInfo;
+    var iccInfo = IccHelper.iccInfo;
     var operator = network.shortName || network.longName;
 
     if (iccInfo.isDisplaySpnRequired && iccInfo.spn &&

--- a/shared/js/tz_select.js
+++ b/shared/js/tz_select.js
@@ -35,13 +35,13 @@ function tzSelect(regionSelector, citySelector, onchange, onload) {
     // default to the SIM codes if necessary.
     var mcc, mnc;
     var conn = navigator.mozMobileConnection;
-    if (conn) {
+    if (conn && IccHelper.enabled) {
       if (conn.voice && conn.voice.network) {
         mcc = conn.voice.network.mcc;
         mnc = conn.voice.network.mnc;
-      } else if (conn.iccInfo) {
-        mcc = conn.iccInfo.mcc;
-        mnc = conn.iccInfo.mnc;
+      } else if (IccHelper.iccInfo) {
+        mcc = IccHelper.iccInfo.mcc;
+        mnc = IccHelper.iccInfo.mnc;
       }
     }
     if (!mcc) {

--- a/tools/extensions/desktop-helper/content/data/lib/icc_manager.js
+++ b/tools/extensions/desktop-helper/content/data/lib/icc_manager.js
@@ -5,6 +5,9 @@
   }
 
   FFOS_RUNTIME.makeNavigatorShim('mozIccManager', {
+    iccInfo: {
+      iccid: true
+    },
     cardState: 'absent',
     setCardLock: function() {
       debug('setCardLock');

--- a/tools/extensions/desktop-helper/content/data/lib/mobile_connection.js
+++ b/tools/extensions/desktop-helper/content/data/lib/mobile_connection.js
@@ -5,9 +5,6 @@
   }
 
   FFOS_RUNTIME.makeNavigatorShim('mozMobileConnection', {
-    iccInfo: {
-      iccid: true
-    },
     voice: {
       connected: false
     },


### PR DESCRIPTION
Please see [bug 877978](https://bugzilla.mozilla.org/show_bug.cgi?id=877978).

In [bug 875721](https://bugzilla.mozilla.org/show_bug.cgi?id=875721), we move iccInfo related attribute/event from mozMobileConnection to mozIccManager. This pull request is to do corresponding changes in Gaia side.

Thanks
