### PR TITLE
Bug 891395 - Fix regexp that matches HiDPI. This avoid overriding apn.json

### DIFF
--- a/build/webapp-zip.js
+++ b/build/webapp-zip.js
@@ -344,7 +344,7 @@ Gaia.webapps.forEach(function(webapp) {
 
     // Add not only file itself but all its hidpi-suffixed versions.
     let fileNameRegexp = new RegExp(
-        '^' + file.leafName.replace(/(\.[a-z]+$)/, '@?.*x?\\$1') + '$');
+        '^' + file.leafName.replace(/(\.[a-z]+$)/, '(@.*x)?\\$1') + '$');
     ls(file.parent, false).forEach(function(listFile) {
       if (fileNameRegexp.test(listFile.leafName)) {
         addToZip(zip, '/shared/resources/' + path, listFile);


### PR DESCRIPTION
This should unbreak the cell connectivity.
