### PR TITLE
Bug 892397 - Specify hidden apps in their respective manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ manifest.appcache
 /apps/calendar/js/presets.js
 /apps/email/built/
 /apps/homescreen/js/init.json
-/apps/homescreen/js/hiddenapps.js
-/apps/settings/js/hiddenapps.js
 /apps/costcontrol/js/config.json
 /apps/sms/js/blacklist.json
 /test_apps/test-agent/test/config.json

--- a/apps/bluetooth/manifest.webapp
+++ b/apps/bluetooth/manifest.webapp
@@ -1,6 +1,7 @@
 {
   "name": "Send To Bluetooth Device",
   "type": "certified",
+  "role": "system",
   "description": "Gaia Bluetooth Transfer",
   "launch_path": "/transfer.html",
   "developer": {
@@ -23,7 +24,7 @@
       "disposition": "inline",
       "returnValue": true,
       "href": "/transfer.html"
-    }   
+    }
   },
   "permissions": {
     "bluetooth":{},

--- a/apps/homescreen/index.html
+++ b/apps/homescreen/index.html
@@ -41,7 +41,6 @@
     <script type="text/javascript" defer src="js/homescreen.js"></script>
     <script type="text/javascript" defer src="js/configurator.js"></script>
     <script type="text/javascript" defer src="js/wallpaper.js"></script>
-    <script type="text/javascript" defer src="js/hiddenapps.js"></script>
 
     <link rel="resource" type="application/l10n" href="locales/locales.ini">
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini">

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -8,6 +8,7 @@ var GridManager = (function() {
   var BASE_HEIGHT = 460; // 480 - 20 (status bar height)
   var DEVICE_HEIGHT = window.innerHeight;
   var OPACITY_STEPS = 40; // opacity steps between [0,1]
+  var HIDDEN_ROLES = ['system', 'keyboard', 'homescreen'];
 
   var container;
 
@@ -960,18 +961,14 @@ var GridManager = (function() {
    * points, each one is represented as an icon.)
    */
   function processApp(app, callback) {
-    // Ignore system apps.
-    if (HIDDEN_APPS.indexOf(app.manifestURL) != -1)
-      return;
-
     appsByOrigin[app.origin] = app;
 
     var manifest = app.manifest ? app.manifest : app.updateManifest;
-    if (!manifest)
+    if (!manifest || HIDDEN_ROLES.indexOf(manifest.role) !== -1)
       return;
 
     var entryPoints = manifest.entry_points;
-    if (!entryPoints || manifest.type != 'certified') {
+    if (!entryPoints || manifest.type !== 'certified') {
       createOrUpdateIconForApp(app);
       return;
     }

--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -3,6 +3,7 @@
   "description": "Gaia Homescreen",
   "launch_path": "/index.html#root",
   "type": "certified",
+  "role": "homescreen",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/andreasgal/gaia"

--- a/apps/keyboard/manifest.webapp
+++ b/apps/keyboard/manifest.webapp
@@ -2,6 +2,7 @@
   "name": "Keyboard",
   "description": "Gaia Keyboard",
   "type": "certified",
+  "role": "keyboard",
   "developer": {
     "name": "The Gaia Team",
     "url": "https://github.com/mozilla-b2g/gaia"

--- a/apps/pdfjs/manifest.webapp
+++ b/apps/pdfjs/manifest.webapp
@@ -2,6 +2,7 @@
   "name": "PDF Viewer",
   "description": "Portable Document Format(PDF) Viewer",
   "type": "certified",
+  "role": "system",
   "developer": {
     "name": "The pdf.js Team",
     "url": "https://github.com/mozilla/pdf.js"

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1974,7 +1974,6 @@
       </form>
 
       <script type="application/javascript" src="shared/js/manifest_helper.js"></script>
-      <script src="js/hiddenapps.js"></script>
       <script src="js/apps.js"></script>
       -->
     </section>

--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -120,9 +120,6 @@ var ApplicationsList = {
       var apps = evt.target.result;
 
       apps.forEach(function(app) {
-        if (HIDDEN_APPS.indexOf(app.manifestURL) != -1)
-          return;
-
         var manifest = app.manifest ? app.manifest : app.updateManifest;
         if (manifest.type != 'certified') {
           self._apps.push(app);

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -1,6 +1,7 @@
 {
   "name": "System",
   "type": "certified",
+  "role": "system",
   "description": "Main System",
   "launch_path": "/index.html",
   "developer": {

--- a/apps/wallpaper/manifest.webapp
+++ b/apps/wallpaper/manifest.webapp
@@ -2,6 +2,7 @@
   "name": "Wallpaper",
   "description": "Gaia Wallpaper Picker",
   "type": "certified",
+  "role": "system",
   "orientation": "portrait-primary",
   "developer": {
     "name": "The Gaia Team",

--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -198,30 +198,6 @@ let init = getFile(GAIA_DIR, GAIA_CORE_APP_SRCDIR,
                   'homescreen', 'js', 'init.json');
 writeContent(init, JSON.stringify(content));
 
-// Apps that should never appear in settings > app permissions
-// bug 830659: We want homescreen to appear in order to remove e.me geolocation
-// permission
-let hidden_apps = [
-  gaiaManifestURL('keyboard'),
-  gaiaManifestURL('wallpaper'),
-  gaiaManifestURL('bluetooth'),
-  gaiaManifestURL('pdfjs')
-];
-
-init = getFile(GAIA_DIR, GAIA_CORE_APP_SRCDIR, 'settings', 'js',
-               'hiddenapps.js');
-writeContent(init, 'var HIDDEN_APPS = ' + JSON.stringify(hidden_apps));
-
-// Apps that should never appear as icons in the homescreen grid or dock
-hidden_apps = hidden_apps.concat([
-  gaiaManifestURL('homescreen'),
-  gaiaManifestURL('system')
-]);
-
-init = getFile(GAIA_DIR, GAIA_CORE_APP_SRCDIR, 'homescreen', 'js',
-               'hiddenapps.js');
-writeContent(init, 'var HIDDEN_APPS = ' + JSON.stringify(hidden_apps));
-
 // SMS
 init = getFile(GAIA_DIR, 'apps', 'sms', 'js', 'blacklist.json');
 content = ['4850', '7000'];

--- a/build/lint-excluded-files.list
+++ b/build/lint-excluded-files.list
@@ -1,1 +1,1 @@
-build/r.js,apps/communications/contacts/oauth2/js/parameters.js,apps/calendar/js/presets.js,apps/email/js/alameda.js,apps/email/js/text_builder.js,apps/homescreen/js/hiddenapps.js,apps/settings/js/hiddenapps.js
+build/r.js,apps/communications/contacts/oauth2/js/parameters.js,apps/calendar/js/presets.js,apps/email/js/alameda.js,apps/email/js/text_builder.js


### PR DESCRIPTION
Fix for [#892397](https://bugzilla.mozilla.org/show_bug.cgi?id=892397). This moves the responsibility of hiding apps to the manifest files of the apps themselves.

We're adding a field to the manifest so that might be an undesired change. The code in settings/ that is removed is no longer necessary. If an application is not certified, it'll always show up in the settings, if it's certified, only when it has permissions that can be set.
