### PR TITLE
Bug 796623 - Settings throw error in B2G desktop

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -871,7 +871,7 @@ window.addEventListener('load', function loadSettings() {
     }
 
     if (!IccHelper.enabled) {
-      disableSIMRelatedSubpanels(true);
+      return disableSIMRelatedSubpanels(true);
     }
 
     var cardState = IccHelper.cardState;


### PR DESCRIPTION
Fix for [#796623](https://bugzilla.mozilla.org/show_bug.cgi?id=796623). This causes a bunch of settings not to work under B2G desktop, f.e. App permissions.
