### PR TITLE
Bug 889899: use <div> instead of <iframe> for MMS attachment containers, r=julienw

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" type="text/css" href="style/root.css">
     <link rel="stylesheet" type="text/css" href="style/common.css">
     <link rel="stylesheet" type="text/css" href="style/sms.css">
+    <link rel="stylesheet" type="text/css" href="style/attachment.css">
     <!-- Localization -->
     <link rel="resource" type="application/l10n" href="locales/locales.ini">
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini">
@@ -36,7 +37,6 @@
     -->
     <script defer src="shared/js/lazy_loader.js"></script>
     <script defer src="js/startup.js"></script>
-
   </head>
 
   <body role="application">
@@ -63,7 +63,6 @@
             <p data-l10n-id="noMessages-text">Start communicating now</p>
           </div>
         </div>
-
 
         <form id="threads-edit-form" role="dialog" data-type="edit">
           <section>
@@ -171,6 +170,7 @@
         </form>
       </section>
     </article>
+
     <article id="loading">
       <form role="dialog" data-type="confirm" class="loading-container">
         <section>
@@ -181,6 +181,7 @@
         </section>
       </form>
     </article>
+
     <menu id="attachment-options-menu" class="hide" tabindex="-1">
       <div>
         <form id="attachment-options" role="dialog" data-type="action">
@@ -194,7 +195,11 @@
         </form>
       </div>
     </menu>
-    </div>
+
+    <!--
+      -  Templates
+      -->
+
     <div id="messages-contact-tmpl" class="hide">
       <!--
       <a class="suggestion"
@@ -274,18 +279,40 @@
       -->
     </div>
 
-    <div id="attachment-tmpl" class="hide">
+    <div id="attachment-nopreview-tmpl" class="hide">
+      <!--
+      <div class="attachment">
+        <div class="thumbnail-placeholder ${type}-placeholder">
+          <div class="${errorClass}"></div>
+        </div>
+        <div class="size-indicator">${size}</div>
+      </div>
+      <div class="file-name">${fileName}</div>
+      -->
+    </div>
+
+    <div id="attachment-preview-tmpl" class="hide">
+      <!--
+      <div class="attachment">
+        <div class="thumbnail" style="background-image: url(${imgData})"></div>
+        <div class="size-indicator">${size}</div>
+      </div>
+      <div class="file-name">${fileName}</div>
+      -->
+    </div>
+
+    <div id="attachment-draft-tmpl" class="hide">
       <!--
       <head>
         <meta charset="utf-8">
         <base href="${baseURL}">
+        <style type="text/css">
+          html, body { font-size: 10px; }
+        </style>
         <link rel="stylesheet" type="text/css" href="style/attachment.css">
       </head>
-      <body class="attachment ${draftClass}">
-        <div style="${inlineStyle}" class="placeholder ${type}-placeholder">
-          <div class="${errorClass}"></div>
-        </div>
-        <div class="size-indicator">${size}</div>
+      <body class="attachment-draft ${previewClass}">
+        ${attachmentHTML}
       </body>
       -->
     </div>

--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -10,6 +10,7 @@
  */
 var Compose = (function() {
   var placeholderClass = 'placeholder';
+  var attachmentClass = 'attachment-container';
 
   var slice = Array.prototype.slice;
   var attachments = new WeakMap();
@@ -406,7 +407,7 @@ var Compose = (function() {
     },
 
     onAttachmentClick: function thui_onAttachmentClick(event) {
-      if (event.target.className === 'attachment' && !state.resizing) {
+      if (event.target.classList.contains(attachmentClass) && !state.resizing) {
         this.currentAttachmentDOM = event.target;
         this.currentAttachment = attachments.get(event.target);
         AttachmentMenu.open(this.currentAttachment);

--- a/apps/sms/style/attachment.css
+++ b/apps/sms/style/attachment.css
@@ -1,11 +1,89 @@
-html, body {
-  font-size: 10px;
+/**
+ * Attachment containers are either:
+ *  - <div> elements, in the message thread;
+ *  - <iframe> elements, in the Compose area (draft attachments).
+ * Both containers have an `attachment-container' class, but only <iframe>
+ * containers have an `attachment-draft' class.
+ */
+.attachment-container {
+  position: relative;
+
+  display: block;
+  border: none;
+  height: 82px; /* default size = 80 px + border */
+  width: 82px;
 }
 
-body {
-  font-family: 'Feura Sans', sans-serif;
+.attachment-draft {
   margin: 0;
   padding: 0;
+
+  font-family: sans-serif;
+}
+
+/* make sure all pointer events are sent to the main container */
+.attachment-draft *,
+.attachment-container * {
+  pointer-events: none;
+}
+
+.attachment-container.nopreview { /* 80x80 px placeholder + filename below */
+  height: calc(82px + 2.7rem); /* font-size = 1.7rem + 1rem margin */
+  width: 122px;
+}
+
+.attachment-container.preview { /* 80x80 px thumbnail, no filename shown */
+  /* thumbnail size is defined dynamically, extensible to 80x120 or 120x80 */
+}
+
+.article-list[data-type="list"] .message .attachment-container {
+  margin: 1rem 0;
+}
+
+.article-list[data-type="list"] .message.outgoing .attachment-container {
+  margin-left: auto;
+  margin-right: 0;
+}
+
+/**
+ * Attachments that occur at the bounds of an MMS message do not need
+ * additional spacing.
+ */
+#messages-container[data-type="list"] .message .attachment-container:first-child {
+  margin-top: 0;
+}
+#messages-container[data-type="list"] .message .attachment-container:last-child {
+  margin-bottom: 0;
+}
+
+.attachment {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 80px;
+  height: 80px;
+  border: 1px solid #018eac;
+  border-radius: 2px;
+}
+
+.outgoing .attachment {
+  left: auto;
+  right: 0;
+}
+
+.preview .attachment {
+  -moz-box-sizing: border-box;
+       box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+
+  background-color: rgba(0, 170, 205, 0.45);
+}
+
+.preview .attachment:active,
+.preview .attachment:hover {
+  background-color: rgba(0, 140, 170, 1);
 }
 
 .size-indicator {
@@ -22,11 +100,45 @@ body {
   font-size: 1.5rem;
 }
 
-.draft .size-indicator {
+.attachment-draft .size-indicator {
   display: block;
 }
 
-.placeholder {
+.file-name {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0;
+  left: 0;
+
+  height: 1.7rem;
+  display: none;
+
+  line-height: 1.7rem;
+  font-size: 1.7rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #474747;
+}
+
+.outgoing .file-name {
+  text-align: right;
+}
+
+.nopreview .file-name {
+  display: block;
+}
+
+.thumbnail {
+  width: 100%;
+  height: 100%;
+
+  background-image: none;
+  background-repeat: no-repeat;
+  background-position: center center
+}
+
+.thumbnail-placeholder {
   width: 100%;
   height: 100%;
 
@@ -36,36 +148,50 @@ body {
   background-size: 160px;
 }
 
-.placeholder:active,
-.placeholder:hover {
+.attachment-container .thumbnail,
+.attachment-container .thumbnail-placeholder {
+  position: absolute;
+  top: 0
+}
+
+.attachment-draft:hover .thumbnail-placeholder,
+.attachment-draft:active .thumbnail-placeholder,
+.attachment-container:hover .thumbnail-placeholder,
+.attachment-container:active .thumbnail-placeholder {
   background-position: right top;
 }
 
 .img-placeholder {
-  background-position: left -82px;
+  background-position: left -80px;
 }
 
-.img-placeholder:active,
-.img-placeholder:hover {
-  background-position: right -82px;
+.attachment-draft:hover .img-placeholder,
+.attachment-draft:active .img-placeholder,
+.attachment-container:hover .img-placeholder,
+.attachment-container:active .img-placeholder {
+  background-position: right -80px;
 }
 
 .audio-placeholder {
-  background-position: left -164px;
+  background-position: left -160px;
 }
 
-.audio-placeholder:active,
-.audio-placeholder:hover {
-  background-position: right -164px;
+.attachment-draft:hover .audio-placeholder,
+.attachment-draft:active .audio-placeholder,
+.attachment-container:hover .audio-placeholder,
+.attachment-container:active .audio-placeholder {
+  background-position: right -160px;
 }
 
 .video-placeholder {
-  background-position: left -242px;
+  background-position: left -240px;
 }
 
-.video-placeholder:active,
-.video-placeholder:hover {
-  background-position: right -242px;
+.attachment-draft:hover .video-placeholder,
+.attachment-draft:active .video-placeholder,
+.attachment-container:hover .video-placeholder,
+.attachment-container:active .video-placeholder  {
+  background-position: right -240px;
 }
 
 .corrupted {
@@ -77,3 +203,4 @@ body {
   background-position: center center;
   background-size: 82px;
 }
+

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -378,27 +378,9 @@ section.has-carrier .article-list header:first-child {
   background: #fff;
 }
 
-.article-list[data-type="list"] .message .attachment {
-  display: block;
-  margin: 1rem 0;
-}
-/* Attachments that occur at the bounds of an MMS message do not need
- * additional spacing. */
-#messages-container[data-type="list"] .message .attachment:first-child {
-  margin-top: 0;
-}
-#messages-container[data-type="list"] .message .attachment:last-child {
-  margin-bottom: 0;
-}
-
 #messages-container[data-type="list"] .message.mms .bubble img {
   height: auto;
   width: auto;
-}
-
-.article-list[data-type="list"] .message.outgoing .attachment {
-  margin-left: auto;
-  margin-right: 0;
 }
 
 .article-list[data-type="list"] .message.outgoing .bubble {
@@ -617,18 +599,6 @@ form.bottom[role="search"].messages-compose-form {
   top: 0.8rem;
   content: attr(data-placeholder);
   pointer-events: none;
-}
-
-.attachment {
-  display: block;
-  width: 80px;
-  height: 80px;
-  max-width: 120px;
-  max-height: 120px;
-  border: 1px solid #018eac;
-  border-radius: 2px;
-
-  background-color: rgba(0, 170, 205, 0.45);
 }
 
 #send-message-container {

--- a/apps/sms/test/unit/attachment_test.js
+++ b/apps/sms/test/unit/attachment_test.js
@@ -21,6 +21,24 @@ suite('attachment_test.js', function() {
   var testAudioBlob;
   var testVideoBlob;
 
+  function assertThumbnailPreview(el) {
+    assert.ok(el.classList.contains('preview'));
+    assert.isFalse(el.classList.contains('nopreview'));
+    assert.isNull(el.querySelector('div.placeholder'));
+    var thumbnail = el.querySelector('div.thumbnail');
+    assert.ok(thumbnail);
+    assert.include(thumbnail.style.backgroundImage, 'data:image');
+  };
+
+  function assertThumbnailPlaceholder(el, type) {
+    assert.ok(el.classList.contains('nopreview'));
+    assert.isFalse(el.classList.contains('preview'));
+    assert.isNull(el.querySelector('div.thumbnail'));
+    var placeholder = el.querySelector('div.thumbnail-placeholder');
+    assert.ok(placeholder);
+    assert.ok(placeholder.classList.contains(type + '-placeholder'));
+  };
+
   suiteSetup(function(done) {
     // this sometimes takes longer because we fetch 4 assets via XHR
     this.timeout(5000);
@@ -80,11 +98,11 @@ suite('attachment_test.js', function() {
       name: 'Image attachment'
     });
     var el = attachment.render(function() {
-      assert.ok(el.src, 'src set');
-      assert.ok(el.classList.contains('attachment'));
+      assert.ok(el.classList.contains('attachment-container'));
       assert.equal(el.dataset.attachmentType, 'img');
-      // broken image => there should be a `corrupted' class
-      assert.include(el.src, 'corrupted');
+      // broken image => no thumbnail and `corrupted' class
+      assertThumbnailPlaceholder(el, 'img');
+      assert.ok(el.querySelector('div.corrupted'));
       done();
     });
   });
@@ -94,13 +112,11 @@ suite('attachment_test.js', function() {
       name: 'Image attachment'
     });
     var el = attachment.render(function() {
-      assert.ok(el.src, 'src set');
-      assert.ok(el.classList.contains('attachment'));
+      assert.ok(el.classList.contains('attachment-container'));
       assert.equal(el.dataset.attachmentType, 'img');
-      // image < message limit => there should be a dataURL thumbnail
-      assert.include(el.src, 'background');
-      assert.include(el.src, 'data:image');
-      assert.ok(el.src.indexOf('corrupted') < 0);
+      // image < message limit => dataURL thumbnail
+      assertThumbnailPreview(el);
+      assert.isNull(el.querySelector('div.corrupted'));
       done();
     });
   });
@@ -113,13 +129,11 @@ suite('attachment_test.js', function() {
       name: 'Image attachment'
     });
     var el = attachment.render(function() {
-      assert.ok(el.src, 'src set');
-      assert.ok(el.classList.contains('attachment'));
+      assert.ok(el.classList.contains('attachment-container'));
       assert.equal(el.dataset.attachmentType, 'img');
-      // ensure it's not using a thumbnail
-      assert.ok(el.src.indexOf('data:image') < 0);
-      // and it isn't "corrupted"
-      assert.ok(el.src.indexOf('corrupted') < 0);
+      // image > message limit => no thumbnail preview
+      assertThumbnailPlaceholder(el, 'img');
+      assert.isNull(el.querySelector('div.corrupted'));
       done();
     });
   });
@@ -129,13 +143,11 @@ suite('attachment_test.js', function() {
       name: 'Image attachment'
     });
     var el = attachment.render(function() {
-      assert.ok(el.src, 'src set');
-      assert.ok(el.classList.contains('attachment'));
+      assert.ok(el.classList.contains('attachment-container'));
       assert.equal(el.dataset.attachmentType, 'img');
-      // image < message limit => there should be a dataURL thumbnail
-      assert.include(el.src, 'background');
-      assert.include(el.src, 'data:image');
-      assert.ok(el.src.indexOf('corrupted') < 0);
+      // image < message limit => dataURL thumbnail
+      assertThumbnailPreview(el);
+      assert.isNull(el.querySelector('div.corrupted'));
       done();
     });
   });
@@ -145,10 +157,11 @@ suite('attachment_test.js', function() {
       name: 'Audio attachment'
     });
     var el = attachment.render(function() {
-      assert.ok(el.src, 'src set');
-      assert.ok(el.classList.contains('attachment'));
+      assert.ok(el.classList.contains('attachment-container'));
       assert.equal(el.dataset.attachmentType, 'audio');
-      assert.ok(el.src.indexOf('corrupted') < 0);
+      // not an image => no thumbnail preview
+      assertThumbnailPlaceholder(el, 'audio');
+      assert.isNull(el.querySelector('div.corrupted'));
       done();
     });
   });
@@ -158,12 +171,13 @@ suite('attachment_test.js', function() {
       name: 'Video attachment'
     });
     var el = attachment.render(function() {
-      assert.ok(el.src, 'src set');
-      assert.ok(el.classList.contains('attachment'));
+      assert.ok(el.classList.contains('attachment-container'));
       assert.equal(el.dataset.attachmentType, 'video');
-      assert.ok(el.src.indexOf('corrupted') < 0);
+      // not an image => no thumbnail preview
+      assertThumbnailPlaceholder(el, 'video');
+      assert.isNull(el.querySelector('div.corrupted'));
       done();
     });
   });
-
 });
+

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -73,12 +73,12 @@ suite('compose_test.js', function() {
       smallImageBlob = blob;
     });
   });
+
   suiteTeardown(function() {
     navigator.mozL10n = realMozL10n;
   });
 
   suite('Message Composition', function() {
-
     var message;
 
     setup(function() {
@@ -88,6 +88,7 @@ suite('compose_test.js', function() {
       // Compose.init('messages-compose-form');
       message = document.querySelector('[contenteditable]');
     });
+
     suite('Placeholder', function() {
       setup(function(done) {
         Compose.clear();
@@ -338,7 +339,7 @@ suite('compose_test.js', function() {
         Compose.clear();
       });
 
-      test('Attaching creates iframe.attachment', function() {
+      test('Attaching creates iframe.attachment-container', function() {
         var attachment = mockAttachment();
         Compose.append(attachment);
         var iframes = message.querySelectorAll('iframe');
@@ -347,7 +348,8 @@ suite('compose_test.js', function() {
         // get alarmed at window[0] pointing to the iframe
         Compose.clear();
         assert.equal(iframes.length, 1, 'One iframe');
-        assert.ok(iframes[0].classList.contains('attachment'), '.attachment');
+        assert.ok(iframes[0].classList.contains('attachment-container'),
+          '.attachment-container');
         assert.ok(txt[0] === attachment, 'iframe WeakMap\'d to attachment');
       });
     });
@@ -499,6 +501,7 @@ suite('compose_test.js', function() {
       });
     });
   });
+
   suite('Attachment pre-send menu', function() {
     setup(function() {
       this.blob = new Blob(['test'], {type: 'image/png'});
@@ -511,7 +514,6 @@ suite('compose_test.js', function() {
 
       // trigger a click on attachment
       this.attachment.mNextRender.click();
-
     });
     test('click opens menu', function() {
       assert.isTrue(AttachmentMenu.open.called);
@@ -591,6 +593,7 @@ suite('compose_test.js', function() {
       });
     });
   });
+
   suite('Image attachment pre-send menu', function() {
     setup(function() {
       this.sinon.stub(AttachmentMenu, 'open');
@@ -615,3 +618,4 @@ suite('compose_test.js', function() {
     });
   });
 });
+

--- a/apps/sms/test/unit/mock_attachment.js
+++ b/apps/sms/test/unit/mock_attachment.js
@@ -5,7 +5,7 @@ function MockAttachment(blob, options) {
   options = options || {};
   this.name = options.name;
   this.mNextRender = document.createElement('iframe');
-  this.mNextRender.className = 'attachment';
+  this.mNextRender.className = 'attachment-container';
 }
 
 MockAttachment.prototype = {
@@ -17,7 +17,7 @@ MockAttachment.prototype = {
   },
   render: function() {
     this.mNextRender = document.createElement('iframe');
-    this.mNextRender.className = 'attachment';
+    this.mNextRender.className = 'attachment-container';
     return this.mNextRender;
   },
   view: function() {}


### PR DESCRIPTION
Attachment containers use `<iframe>` in the SMS app because they are handy in the Compose area (work well in a contenteditable element): this ensures that attachment blocks are deletable but not editable.  However, `<iframes>` are a pain to use in the message thread, and can become a performance killer on threads with lots of attachments.

This patch keeps `<iframe>` containers for draft attachments in the Compose area but relies on `<div>` containers for the message thread.  To achieve this we use three templates:
- one `attachment-preview` template:
  - display it in a 80x80 px placeholder (can be extended to 120x80 or 80x120);
  - display the attachment size if in the Compose window;
  - do not display the file name for images
    (another patch will enable to display the file name on video with previews)
- one `attachment-nopreview` template: (audio, video, large images)
  - display the attachment type as a 80x80 px icon (audio, video, image, other);
  - display the attachment size if in the Compose window;
  - display the file name, both in the Compose window and in the message thread.
- one `attachment-draft` template to embed one of the two previous templates in an `<iframe>` container for the Compose area.

Non-draft attachments are displayed in a `<div>` container. In both cases (div or iframe), the container carries an `attachment-container` class and a `preview` or `nopreview` one.

Side notes:
- this fixes bug 882094 (display attachment file names in MMS);
- the `bubbleEvents` method has been slightly re-rewritten to be more self-explanatory;
- some basic cleanup has been done on the HTML & CSS front.
