### PR TITLE
Bug 890443 - [SMS] the "fixed header" style and transitions should be ad...

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -55,7 +55,7 @@
         </header>
         <article id="threads-container" class="view-body" data-type="list">
         </article>
-        <div id="threads-header-container" class="fixed-title"></div>
+        <div id="threads-header-container" class="fixed-title no-fixed-header"></div>
 
         <div id="threads-no-messages" class="hide">
           <div id="no-result-message">

--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -6,6 +6,9 @@
 var ActivityHandler = {
   isLocked: false,
   init: function() {
+    if (!window.navigator.mozSetMessageHandler) {
+      return;
+    }
     window.navigator.mozSetMessageHandler('activity', this.global.bind(this));
 
     // We want to register the handler only when we're on the launch path

--- a/apps/sms/js/desktop_sms_mock.js
+++ b/apps/sms/js/desktop_sms_mock.js
@@ -429,7 +429,7 @@
         participants: ['1977'],
         lastMessageType: 'sms',
         body: 'Alo, how are you today, my friend? :)',
-        timestamp: new Date(now - (60000 * 12)),
+        timestamp: new Date(now - 172800000),
         unreadCount: 0
       },
       {
@@ -444,7 +444,7 @@
         id: 4,
         participants: ['197746797'],
         body: 'short (delivery: received)',
-        timestamp: new Date(Date.now() - 100000),
+        timestamp: new Date(Date.now() - 172800000),
         lastMessageType: 'sms',
         unreadCount: 0
       },
@@ -453,14 +453,14 @@
         participants: ['14886783487'],
         lastMessageType: 'sms',
         body: 'Hello world!',
-        timestamp: new Date(Date.now() - 60000000),
+        timestamp: new Date(Date.now() - 600000000),
         unreadCount: 2
       },
       {
         id: 6,
         participants: ['052780'],
         lastMessageType: 'mms',
-        timestamp: new Date(now - (60000 * 10)),
+        timestamp: new Date(now - (60000000 * 10)),
         unreadCount: 0
       },
       {
@@ -474,21 +474,21 @@
         id: 8,
         participants: ['123456'],
         lastMessageType: 'mms',
-        timestamp: new Date(Date.now() - 150000),
+        timestamp: new Date(Date.now() - 150000000),
         unreadCount: 0
       },
       {
         id: 9,
         participants: participants,
         lastMessageType: 'mms',
-        timestamp: new Date(now),
+        timestamp: new Date(new Date(now) - 150000000),
         unreadCount: 0
       },
       {
         id: 10,
         participants: ['+12125551234', '+15551237890'],
         lastMessageType: 'mms',
-        timestamp: new Date(now),
+        timestamp: new Date(new Date(now) - 874554444444),
         unreadCount: 0
       }
     ]

--- a/apps/sms/js/fixed_header.js
+++ b/apps/sms/js/fixed_header.js
@@ -4,9 +4,18 @@ var FixedHeader = (function FixedHeader() {
   var selector;
   var view;
   var fixedContainer;
+  var fixedContainerHeight;
   var currentlyFixed;
-  var notApplyEffect;
   var refreshTimeout;
+
+  var hideClass = 'no-fixed-header';
+
+  // matches(element, selector)
+  var matches = document.documentElement.matches ||
+    document.documentElement.mozMatchesSelector ||
+    document.documentElement.webkitMatchesSelector ||
+    document.documentElement.msMatchesSelector;
+  matches = matches.call.bind(matches);
 
   /**
    * Start listening scroll event, and applying the fixed header effect
@@ -15,13 +24,13 @@ var FixedHeader = (function FixedHeader() {
    *                             going to contain the top header.
    * @param  {String} select     Selector of the headers to be checked.
    */
-  var init = function init(scrollView, container, select, noEffect) {
+  var init = function init(scrollView, container, select) {
     selector = select;
     view = document.querySelector(scrollView);
     fixedContainer = document.querySelector(container);
+    fixedContainerHeight = fixedContainer.offsetHeight;
     refresh();
     view.addEventListener('scroll', refresh);
-    notApplyEffect = typeof noEffect === 'undefined' ? false : noEffect;
     refreshTimeout = null;
   };
 
@@ -30,6 +39,15 @@ var FixedHeader = (function FixedHeader() {
       refreshTimeout = setTimeout(immediateRefresh);
     }
   };
+
+  function findNextHeader(header) {
+    var nextHeader = header;
+    do {
+      nextHeader = nextHeader.nextElementSibling;
+    } while (nextHeader && !matches(nextHeader, selector));
+
+    return nextHeader;
+  }
 
   function immediateRefresh() {
     if (!view) {
@@ -42,54 +60,87 @@ var FixedHeader = (function FixedHeader() {
     }
     refreshTimeout = null;
 
-    var headings = view.querySelectorAll(selector);
+    findFixedHeader();
+    updatePosition();
+  }
 
-    var currentScroll = view.scrollTop;
-    for (var i = headings.length - 1; i >= 0; i--) {
-      var currentHeader = headings[i];
-      var headingPosition = currentHeader.offsetTop - view.offsetTop;
-      var offset = headingPosition - currentScroll;
-      var currentHeight = currentHeader.offsetHeight;
-      var differentHeaders = currentlyFixed != currentHeader;
-
-      // Effect
-      if (!notApplyEffect && Math.abs(offset) < currentHeight &&
-          differentHeaders) {
-        var toMove = Math.abs(offset) - currentHeight;
-        var inEffect = toMove <= 0;
-        var translateTop = 'translateY(' + toMove + 'px)';
-        var transform = inEffect ? translateTop : null;
-        fixedContainer.style.transform = transform;
-      }
-
-      // Found a header
-      if (offset <= 0) {
-        if (differentHeaders) {
-          if (!notApplyEffect) {
-            fixedContainer.style.transform = 'translateY(0)';
-          }
-
-          currentlyFixed = currentHeader;
-          updateHeaderContent();
-        }
-
-        return;
-      }
+  function findFixedHeader() {
+    var currentHeader = view.querySelector(selector);
+    if (!currentHeader) {
+      // empty list
+      setCurrentlyFixed(null);
+      return;
     }
 
-    // guess no header is above the top of the view
-    currentlyFixed = null;
-    if (!notApplyEffect) {
-      fixedContainer.style.transform = 'translateY(-100%)';
+    var prevHeader, newFixed;
+    var viewPadding = currentHeader.offsetTop - view.offsetTop;
+
+    do {
+      var currentScroll = view.scrollTop;
+      var headingPosition = currentHeader.offsetTop - view.offsetTop;
+      var offset = headingPosition - currentScroll - viewPadding;
+
+      // Found a header that's below the top
+      // the fixed header should be the previous one
+      // unless it's the first one
+      if (offset > 0) {
+        newFixed = prevHeader || currentHeader;
+        break;
+      }
+
+      prevHeader = currentHeader;
+    } while ((currentHeader = findNextHeader(currentHeader)));
+
+    // if we found no header below the top, this means the last one should be
+    // fixed
+    setCurrentlyFixed(newFixed || prevHeader);
+  }
+
+  function updatePosition() {
+    if (!currentlyFixed) {
+      fixedContainer.classList.add(hideClass);
+      return;
+    }
+
+    var nextHeader = findNextHeader(currentlyFixed);
+    if (!nextHeader) {
+      fixedContainer.style.transform = null;
+      return;
+    }
+
+    var viewPadding = view.querySelector(selector).offsetTop - view.offsetTop;
+    var currentScroll = view.scrollTop;
+    var headingPosition = nextHeader.offsetTop - view.offsetTop;
+    var offset = headingPosition - currentScroll - viewPadding;
+
+    if (offset < fixedContainerHeight) {
+      var toMove = offset - fixedContainerHeight;
+      fixedContainer.style.transform = 'translateY(' + toMove + 'px)';
+    } else {
+      fixedContainer.style.transform = null;
+    }
+  }
+
+  function setCurrentlyFixed(newFixed) {
+    if (newFixed !== currentlyFixed) {
+      currentlyFixed = newFixed;
+      updateHeaderContent();
     }
   }
 
   function updateHeaderContent() {
-    if (fixedContainer && currentlyFixed) {
+    if (!fixedContainer) {
+      return;
+    }
+
+    if (currentlyFixed) {
       var newContent = currentlyFixed.textContent;
       if (fixedContainer.textContent !== newContent) {
         fixedContainer.textContent = newContent;
       }
+      fixedContainer.classList.remove(hideClass);
+    } else {
+      fixedContainer.classList.add(hideClass);
     }
   }
 

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -72,7 +72,7 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
 
 /* Override Building Block [Lists] styles */
 [data-type="list"] {
-  padding: 0;
+  padding: 0.7rem 0 0 0;
   text-align: left;
 }
 
@@ -94,11 +94,6 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
 
 [data-type="list"] header {
   margin: 0 1.5rem;
-  padding: 0.5rem 1.5rem;
-}
-
-[data-type="list"] header:first-child {
-  padding-top: 1.2rem;
 }
 
 #threads-container[data-type="list"] ul {
@@ -317,6 +312,7 @@ section.has-carrier .article-list header:first-child {
   border-bottom-color: transparent;
   border-bottom-style: solid;
   -moz-box-sizing: border-box;
+  padding: 0;
 
   background: none repeat scroll 0 0 #E4E4E4;
   text-align: left;
@@ -667,22 +663,28 @@ form.bottom[role="search"].messages-compose-form {
 */
 .fixed-title {
   position: absolute;
+  z-index: 4;
   top: 5rem;
-  width: calc(100% - 6rem);
-  padding: 1.5rem 1.5rem 0.5rem;
+
+  width: calc(100% - 5rem);
+  height: 1.8rem;
+  padding: 1.2rem 1rem 0.5rem;
   margin: 0 1.5rem;
   border-bottom: solid 0.1rem #ff4e00;
+
   background-repeat: no-repeat;
   background-color: #FFFFFF;
-  transform: translateY(-3rem);
+  color: #FF4E00;
   pointer-events: none;
   text-align: left;
   text-transform: uppercase;
   font-size: 1.6rem;
   font-weight: normal;
   line-height: 1.8rem;
-  color: #FF4E00;
-  z-index: 4;
+}
+
+.fixed-title.no-fixed-header {
+  transform: translateY(-100%);
 }
 
 /*

--- a/apps/sms/test/unit/fixed_header_test.js
+++ b/apps/sms/test/unit/fixed_header_test.js
@@ -3,20 +3,15 @@
 requireApp('sms/js/fixed_header.js');
 
 suite('FixedHeader >', function() {
+  var viewSelector = '#threads-container';
+  var headerSelector = '#threads-header-container';
+
   var header;
   var view;
-
 
   setup(function() {
     loadBodyHTML('/index.html');
     this.sinon.useFakeTimers();
-
-    var viewSelector = '#threads-container';
-    var headerSelector = '#threads-header-container';
-
-    FixedHeader.init(viewSelector,
-                     headerSelector,
-                     'header');
 
     header = document.querySelector(headerSelector);
     view = document.querySelector(viewSelector);
@@ -24,67 +19,138 @@ suite('FixedHeader >', function() {
     // we don't have CSS so we must force the scroll here
     view.style.overflow = 'scroll';
     view.style.height = '50px';
-
-    this.sinon.clock.tick();
   });
 
-  test('at init, empty list, we don\'t have a fixed header', function() {
+  test('before init, empty list, call updateHeaderContent', function() {
+    FixedHeader.updateHeaderContent();
     assert.equal(header.textContent, '');
+    assert.ok(header.classList.contains('no-fixed-header'));
   });
 
-  suite('longer list', function() {
+  suite('init >', function() {
     setup(function() {
-      var mockThreadListMarkup = '';
-      for (var i = 1; i < 50; i++) {
-        mockThreadListMarkup +=
-          '<header>header ' + i + '</header>' +
-          '<ul>' +
-            '<li>this is a thread</li>' +
-            '<li>this is another thread</li>' +
-          '</ul>';
-      }
+      FixedHeader.init(viewSelector,
+                       headerSelector,
+                       'header');
 
-      view.innerHTML = mockThreadListMarkup;
-    });
-
-    test('call refresh, should have the first header', function() {
-      FixedHeader.refresh();
       this.sinon.clock.tick();
-
-      assert.equal(header.textContent, 'header 1');
     });
 
-    test('call updateHeaderContent, should have the new header', function() {
-      FixedHeader.refresh();
-      this.sinon.clock.tick();
-
-      view.querySelector('header').textContent = 'new header';
-      FixedHeader.updateHeaderContent();
-      assert.equal(header.textContent, 'new header');
+    test('empty list, we don\'t have a fixed header', function() {
+      assert.equal(header.textContent, '');
+      assert.ok(header.classList.contains('no-fixed-header'));
     });
 
-    test('scroll then call refresh, should have a fixed header', function() {
-      // we don't want to react to scroll events in that test
-      view.removeEventListener('scroll', FixedHeader.refresh);
-      view.scrollTop = 200;
-      FixedHeader.refresh();
-      this.sinon.clock.tick();
+    suite('longer list', function() {
+      setup(function() {
+        var mockThreadListMarkup = '';
+        for (var i = 1; i < 50; i++) {
+          mockThreadListMarkup +=
+            '<header>header ' + i + '</header>' +
+            '<ul>' +
+              '<li>this is a thread</li>' +
+              '<li>this is another thread</li>' +
+            '</ul>';
+        }
 
-      assert.ok(header.textContent);
-    });
-
-    test('scroll without calling refresh, should have a fixed header',
-    function(done) {
-      var clock = this.sinon.clock;
-
-      view.addEventListener('scroll', function onscroll() {
-        view.removeEventListener('scroll', onscroll);
-        clock.tick();
-        assert.ok(header.textContent);
-        done();
+        view.innerHTML = mockThreadListMarkup;
+        header.classList.add('no-fixed-header');
       });
 
-      view.scrollTop = 200;
+      test('call refresh, should have the first header', function() {
+        FixedHeader.refresh();
+        this.sinon.clock.tick();
+
+        assert.equal(header.textContent, 'header 1');
+        assert.isFalse(header.classList.contains('no-fixed-header'));
+      });
+
+      test('call updateHeaderContent, should have the new header', function() {
+        FixedHeader.refresh();
+        this.sinon.clock.tick();
+
+        view.querySelector('header').textContent = 'new header';
+        FixedHeader.updateHeaderContent();
+        assert.equal(header.textContent, 'new header');
+        assert.isFalse(header.classList.contains('no-fixed-header'));
+      });
+
+      test('hide the header then call updateHeaderContent',
+      function() {
+        FixedHeader.refresh();
+        this.sinon.clock.tick();
+
+        header.classList.add('no-fixed-header');
+        FixedHeader.updateHeaderContent();
+        assert.equal(header.textContent, 'header 1');
+        assert.isFalse(header.classList.contains('no-fixed-header'),
+          'should show the header');
+      });
+
+      test('scroll then call refresh, should have a fixed header', function() {
+        // we don't want to react to scroll events in that test
+        view.removeEventListener('scroll', FixedHeader.refresh);
+        view.scrollTop = 200;
+        FixedHeader.refresh();
+        this.sinon.clock.tick();
+
+        assert.ok(header.textContent);
+        assert.isFalse(header.classList.contains('no-fixed-header'));
+      });
+
+      test('scroll without calling refresh, should have a fixed header',
+      function(done) {
+        var clock = this.sinon.clock;
+
+        view.addEventListener('scroll', function onscroll() {
+          view.removeEventListener('scroll', onscroll);
+          clock.tick();
+          assert.ok(header.textContent);
+          assert.isFalse(header.classList.contains('no-fixed-header'));
+          done();
+        });
+
+        view.scrollTop = 200;
+      });
     });
+
+    suite('longer list with only one header', function() {
+      setup(function() {
+        var mockThreadListMarkup = '<header>header</header><ul>';
+
+        for (var i = 1; i < 50; i++) {
+          mockThreadListMarkup += '<li>this is a thread</li>';
+        }
+
+        mockThreadListMarkup += '</ul>';
+
+        view.innerHTML = mockThreadListMarkup;
+        header.classList.add('no-fixed-header');
+      });
+
+      test('call refresh, should have the first header', function() {
+        FixedHeader.refresh();
+        this.sinon.clock.tick();
+
+        assert.equal(header.textContent, 'header');
+        assert.isFalse(header.classList.contains('no-fixed-header'));
+      });
+
+      test('scroll without calling refresh, should have a fixed header',
+      function(done) {
+        var clock = this.sinon.clock;
+
+        view.addEventListener('scroll', function onscroll() {
+          view.removeEventListener('scroll', onscroll);
+          clock.tick();
+          assert.equal(header.textContent, 'header');
+          assert.isFalse(header.classList.contains('no-fixed-header'));
+          done();
+        });
+
+        view.scrollTop = 200;
+      });
+    });
+
   });
 });


### PR DESCRIPTION
...justed so that it's not jumping when changing header r=schung

Important changes
- changes how the fixed header is found. Now we're iterating starting with the
  top instead of the bottom. In the SMS app, the most common cases is when the
  list is not scrolled so much, and therefore starting at the top will likely be
  way faster once the list is long.
- we don't position the header in the same loop, now we position the header
  depending on the next header, if it exists.
- we use a specific hiding class instead of specifying the 100% transform
  translation in the js code. Also, using a 100% transform translation is used
  instead of display none, so that we can get some necessary measurements in the
  init method. Most notably, we need to take into account the view's padding
  top.

Less important changes:
- changed the desktop mock so that we have more headers when loading in Firefox
- check that we have mozSetMessageHandler before using it so that we can launch
  the app in main Firefox
- moved the first header's margin top to the view's padding top. BTW this
  removes a building blocks override.
