### PR TITLE
Bug 883822: [SMS] focus the Compose area when started as a "new" activity

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -398,6 +398,11 @@ var Compose = (function() {
       return this;
     },
 
+    focus: function() {
+      dom.message.focus();
+      return this;
+    },
+
     onAttachClick: function thui_onAttachClick(event) {
       var request = this.requestAttachment();
       request.onsuccess = this.append.bind(this);

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -159,10 +159,13 @@ var MessageManager = {
         return;
       }
 
-      // Choose the appropiate contact resolver, if we
-      // have a contact object, and no number,just use a dummy source,
-      // and return the contact, if not, if we have a number, use
-      // one of the functions to get a contact based on a number
+      /**
+       * Choose the appropriate contact resolver:
+       *  - if we have a phone number and no contact, rely on findByPhoneNumber
+       *    to get a contact matching the number;
+       *  - if we have a contact object and no phone number, just use a dummy
+       *    source that returns the contact.
+       */
       var findByPhoneNumber = Contacts.findByPhoneNumber.bind(Contacts);
       var number = activity.number;
       if (activity.contact && !number) {
@@ -172,28 +175,25 @@ var MessageManager = {
         number = activity.contact.number || activity.contact.tel[0].value;
       }
 
+      // Add recipients and fill+focus the Compose area.
       if (activity.contact && number) {
         Utils.getContactDisplayInfo(
           findByPhoneNumber, number, function onData(data) {
             data.source = 'contacts';
             ThreadUI.recipients.add(data);
+            ThreadUI.setMessageBody(activity.body);
           }
         );
       } else {
-        // If the activity delivered the number of an
-        // unknown recipient, create a recipient directly.
+        // If the activity delivered the number of an unknown recipient,
+        // create a recipient directly.
         ThreadUI.recipients.add({
           number: activity.number,
           source: 'manual'
         });
+        ThreadUI.setMessageBody(activity.body);
       }
 
-      // If the message has a body, use it to populate the input field.
-      if (activity.body) {
-        ThreadUI.setMessageBody(
-          activity.body
-        );
-      }
       // Clean activity object
       this.activity = null;
     }.bind(this));

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -328,7 +328,10 @@ var ThreadUI = global.ThreadUI = {
   // Method for setting the body of a SMS/MMS from activity
   setMessageBody: function thui_setMessageBody(value) {
     Compose.clear();
-    Compose.append(value);
+    if (value) {
+      Compose.append(value);
+    }
+    Compose.focus();
   },
 
   messageComposerInputHandler: function thui_messageInputHandler(event) {

--- a/apps/sms/test/unit/activity_handler_test.js
+++ b/apps/sms/test/unit/activity_handler_test.js
@@ -313,6 +313,7 @@ suite('ActivityHandler', function() {
 
   suite('"new" activity', function() {
     var realMozL10n;
+
     // Mockup activity
     var newActivity = {
       source: {
@@ -323,14 +324,26 @@ suite('ActivityHandler', function() {
         }
       }
     };
+
+    var newActivity_empty = {
+      source: {
+        name: 'new',
+        data: {
+          number: '123'
+        }
+      }
+    };
+
     suiteSetup(function() {
       window.location.hash = '#new';
       realMozL10n = navigator.mozL10n;
       navigator.mozL10n = MockL10n;
     });
+
     suiteTeardown(function() {
       navigator.mozL10n = realMozL10n;
     });
+
     test('Activity lock should be released properly', function() {
       // Review the status after handling the activity
       this.sinon.stub(MessageManager, 'launchComposer', function(activity) {
@@ -352,6 +365,36 @@ suite('ActivityHandler', function() {
 
       // Call the activity. As we are in 'new' there is no hashchange.
       MockNavigatormozSetMessageHandler.mTrigger('activity', newActivity);
+    });
+
+    test('new message activity clears, fills and focuses the Compose area',
+      function() {
+      this.sinon.stub(Compose, 'clear', function() {
+        assert.ok(true, 'the Compose area is cleared');
+      });
+      this.sinon.stub(Compose, 'append', function() {
+        assert.ok(true, 'message body has been appended to the Compose area');
+      });
+      this.sinon.stub(Compose, 'focus', function() {
+        assert.ok(true, 'the Compose area is focused');
+      });
+
+      MockNavigatormozSetMessageHandler.mTrigger('activity', newActivity);
+    });
+
+    test('do not fill the Compose area if the activity body is empty',
+      function() {
+      this.sinon.stub(Compose, 'clear', function() {
+        assert.ok(true, 'the Compose area is cleared');
+      });
+      this.sinon.stub(Compose, 'append', function() {
+        assert.ok(false, 'nothing has been appended to the Compose area');
+      });
+      this.sinon.stub(Compose, 'focus', function() {
+        assert.ok(true, 'the Compose area is focused');
+      });
+
+      MockNavigatormozSetMessageHandler.mTrigger('activity', newActivity_empty);
     });
 
     test('new message with user input msg, discard it', function() {

--- a/apps/sms/test/unit/mock_compose.js
+++ b/apps/sms/test/unit/mock_compose.js
@@ -2,6 +2,7 @@
 
 var MockCompose = {
   clear: function() {},
+  focus: function() {},
   append: function() {},
   isEmpty: function() {
     return this.mEmpty;

--- a/apps/sms/test/unit/mock_thread_ui.js
+++ b/apps/sms/test/unit/mock_thread_ui.js
@@ -12,13 +12,12 @@ var MockThreadUI = {
     });
   },
 
-  cleanFields: function() {
-  },
+  // simple stubs
+  cleanFields: function() {},
+  appendMessage: function() {},
+  setMessageBody: function() {},
 
   isShowSendMessageErrorCalledTimes: 0,
-
-  appendMessage: function() {
-  },
 
   showSendMessageError: function() {
     this.isShowSendMessageErrorCalledTimes += 1;
@@ -32,3 +31,4 @@ var MockThreadUI = {
     this.isShowSendMessageErrorCalledTimes = 0;
   }
 };
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=883822

When the Compose screen is triggered by an activity (e.g. when clicking on a message icon from the call log), recipients are inserted and the onscreen keyboard is triggered. The problem is, the focus is set **within** a recipient block, not in the input itself: thus, the onscreen keyboard doesn’t disappear when the back button is hit.

A possible fix would have been to focus the recipient input rather than the recipient block, but it’s simpler to focus the Compose area instead (and that’s one less tap for the user). That’s what this simple patch does.
