### PR TITLE
Bug 889902 - [SMS] Attachments should use blobs instead of dataurl

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -294,7 +294,7 @@
     <div id="attachment-preview-tmpl" class="hide">
       <!--
       <div class="attachment">
-        <div class="thumbnail" style="background-image: url(${imgData})"></div>
+        <img src="${imgData}" class="thumbnail" />
         <div class="size-indicator">${size}</div>
       </div>
       <div class="file-name">${fileName}</div>

--- a/apps/sms/test/unit/attachment_test.js
+++ b/apps/sms/test/unit/attachment_test.js
@@ -24,16 +24,15 @@ suite('attachment_test.js', function() {
   function assertThumbnailPreview(el) {
     assert.ok(el.classList.contains('preview'));
     assert.isFalse(el.classList.contains('nopreview'));
-    assert.isNull(el.querySelector('div.placeholder'));
-    var thumbnail = el.querySelector('div.thumbnail');
+    assert.isNull(el.querySelector('div.thumbnail-placeholder'));
+    var thumbnail = el.querySelector('img.thumbnail');
     assert.ok(thumbnail);
-    assert.include(thumbnail.style.backgroundImage, 'data:image');
   };
 
   function assertThumbnailPlaceholder(el, type) {
     assert.ok(el.classList.contains('nopreview'));
     assert.isFalse(el.classList.contains('preview'));
-    assert.isNull(el.querySelector('div.thumbnail'));
+    assert.isNull(el.querySelector('img.thumbnail'));
     var placeholder = el.querySelector('div.thumbnail-placeholder');
     assert.ok(placeholder);
     assert.ok(placeholder.classList.contains(type + '-placeholder'));


### PR DESCRIPTION
Changed attachment tpl removing background image. Instead an Image node is inserted in the place of old div.
