### PR TITLE
Bug 894081 - (Try to) fix a leak in Gaia by registering its mozbrowserer...

### DIFF
--- a/apps/system/js/window.js
+++ b/apps/system/js/window.js
@@ -33,7 +33,7 @@
   window.AppError = function AppError(app) {
     var self = this;
     this.app = app;
-    this.app.frame.addEventListener('mozbrowsererror', function(evt) {
+    this.app.iframe.addEventListener('mozbrowsererror', function(evt) {
       if (evt.detail.type != 'other')
         return;
 

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -789,10 +789,16 @@ var WindowManager = (function() {
         type = 'appopen';
       }
 
-      app.frame.addEventListener(type, function apploaded(e) {
+      // Be careful about what you reference from within the closure below (or
+      // any other closures in this function), or you might leak
+      // homescreenFrame.  For example, referencing |document| causes this
+      // leak; that's why we pull the document off e.target.  See bug 894135,
+      // and if in doubt, ask one of the people referenced in that bug.
+      app.iframe.addEventListener(type, function apploaded(e) {
+        var doc = e.target.ownerDocument;
         e.target.removeEventListener(e.type, apploaded, true);
 
-        var evt = document.createEvent('CustomEvent');
+        var evt = doc.createEvent('CustomEvent');
         evt.initCustomEvent('apploadtime', true, false, {
           time: parseInt(Date.now() - iframe.dataset.start),
           type: (e.type == 'appopen') ? 'w' : 'c',


### PR DESCRIPTION
...ror listener on the mozbrowser iframe itself, rather than on one of the iframe's parent nodes.
