### PR TITLE
Bug 886245 - Ignore calls to openCallScreen when it is already executing r=etienne, a=leo+

### DIFF
--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -299,16 +299,19 @@ var CallHandler = (function callHandler() {
   // where we want to open a new call screen while the previous one is
   // animating out of the screen.
   var callScreenId = 0;
+  var openingWindow = false;
   function openCallScreen(openCallback) {
-    if (callScreenWindow)
+    if (callScreenWindow || openingWindow)
       return;
 
+    openingWindow = true;
     var host = document.location.host;
     var protocol = document.location.protocol;
     var urlBase = protocol + '//' + host + '/dialer/oncall.html';
 
     var highPriorityWakeLock = navigator.requestWakeLock('high-priority');
     var openWindow = function dialer_openCallScreen(state) {
+      openingWindow = false;
       callScreenWindow = window.open(urlBase + '#' + state,
                   ('call_screen' + callScreenId++), 'attention');
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=886245
