### PR TITLE
Bug 893793 - callforwarding success message needs better wording.

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -124,7 +124,7 @@ cf-numberWhenUnanswered=Number when unanswered
 cf-numberWhenBusy=Number when busy
 
 callForwardingInvalidNumberError=This phone number is invalid.
-callForwardingSetSuccess=Operation successfully set.
+callForwardingSetSuccess=Operation succeeded.
 callForwardingSetForbidden=Your operator does not support that operation.
 callForwardingSetError=Call settings error.
 


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=893793 please.
