### PR TITLE
Bug 893630 - [alarm] when the alarm is triggered when the device is in sleep mode, the system's clock is not updated

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -167,7 +167,9 @@ var StatusBar = {
         self.settingValues[settingKey] = false;
       })(settingKey);
     }
-
+    // Listen to 'attentionscreenshow/hide' from attention_screen.js
+    window.addEventListener('attentionscreenshow', this);
+    window.addEventListener('attentionscreenhide', this);
     // Listen to 'screenchange' from screen_manager.js
     window.addEventListener('screenchange', this);
 
@@ -196,13 +198,13 @@ var StatusBar = {
       case 'screenchange':
         this.setActive(evt.detail.screenEnabled);
         break;
-
+      case 'attentionscreenhide':
       case 'lock':
         // Hide the clock in the statusbar when screen is locked
         this.icons.time.hidden = true;
         this.clock.stop();
         break;
-
+      case 'attentionscreenshow':
       case 'unlock':
         // Display the clock in the statusbar when screen is unlocked
         this.icons.time.hidden = false;


### PR DESCRIPTION
1. watch attentionscreenshow/hide event in statusbar.js to enable/disable clock
2. add test case for timebar display 
