### PR TITLE
Bug 894338 - [Common] mismatch city name of Sao Paulo between tz.json an...

### DIFF
--- a/shared/resources/apn_tz.json
+++ b/shared/resources/apn_tz.json
@@ -157,7 +157,7 @@
   "714": "America/Panama", 
   "716": "America/Lima", 
   "722": "America/Argentina/Buenos_Aires", 
-  "724": "America/Sau_Paulo", 
+  "724": "America/Sao_Paulo", 
   "730": "America/Santiago", 
   "732": "America/Bogota", 
   "734": "America/Caracas", 


### PR DESCRIPTION
...d apn_tz.json
