### PR TITLE
Bug 893838 - [Messages] Deleting threads and messages takes forever

### DIFF
--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -21,6 +21,7 @@ delete            = Delete
 deleting-messages = Deleting…
 select-all        = Select all
 deselect-all      = Deselect all
+selected-all      = Selected All
 selected          = {[ plural(n) ]}
 selected[zero]    = none selected
 selected[one]     = {{n}} selected

--- a/apps/sms/test/unit/mock_message_manager.js
+++ b/apps/sms/test/unit/mock_message_manager.js
@@ -7,6 +7,9 @@ var MockMessageManager = {
       callback();
     }
   },
+  deleteMessages: function(messageIds, callback) {
+    this.deleteMessage(messageIds, callback);
+  },
   onHashChange: function() {},
   launchComposer: function() {},
   sendSMS: function() {

--- a/apps/sms/test/unit/mock_navigatormoz_sms.js
+++ b/apps/sms/test/unit/mock_navigatormoz_sms.js
@@ -21,6 +21,17 @@ var MockNavigatormozMobileMessage = {
     return this.mNextSegmentInfo || this.mDefaultSegmentInfo;
   },
 
+  getMessages: function() {
+    var cursor = {
+      result: null
+    };
+    setTimeout(function() {
+      cursor.onsuccess();
+    });
+    return cursor;
+
+  },
+
   getThreads: function() {
     var cursor = {
       result: null

--- a/apps/sms/test/unit/mock_threads.js
+++ b/apps/sms/test/unit/mock_threads.js
@@ -9,5 +9,14 @@ var MockThreads = {
 
   has: function() {
     return false;
+  },
+  get: function() {
+  },
+  set: function(id, record) {
+    return {
+      selectAll: false,
+      deleteAll: false,
+      messages: []
+    };
   }
 };

--- a/apps/sms/test/unit/threads_test.js
+++ b/apps/sms/test/unit/threads_test.js
@@ -7,6 +7,12 @@ suite('Threads', function() {
     window.location.hash = '';
   });
 
+  var defaults = {
+    deleteAll: false,
+    selectAll: false,
+    messages: []
+  };
+
   teardown(function() {
     Threads.clear();
   });
@@ -26,7 +32,26 @@ suite('Threads', function() {
 
     test('Threads.set(key, val)', function() {
       Threads.set(1, {});
-      assert.deepEqual(Threads.get(1), { messages: [] });
+      assert.deepEqual(Threads.get(1), defaults);
+      assert.equal(Threads.size, 1);
+    });
+
+    test('Threads.set(key, val) returns thread', function() {
+      assert.deepEqual(Threads.set(1, {}), defaults);
+      assert.equal(Threads.size, 1);
+    });
+
+    test('Threads.set(key, val) updates existing thread', function() {
+      var thread = Threads.set(1, {});
+
+      assert.deepEqual(Threads.set(1, { foo: 'bar' }), thread);
+      assert.equal(Threads.size, 1);
+    });
+
+    test('Threads.set(key) no value, creates default', function() {
+      var thread = Threads.set(1, {});
+
+      assert.deepEqual(Threads.set(1, { foo: 'bar' }), thread);
       assert.equal(Threads.size, 1);
     });
 
@@ -53,6 +78,21 @@ suite('Threads', function() {
     });
   });
 
+  suite('Threads.List', function() {
+    test('selectAll', function() {
+      assert.isFalse(Threads.List.selectAll);
+    });
+    test('deleteAll', function() {
+      assert.isFalse(Threads.List.deleteAll);
+    });
+    test('deleting', function() {
+      assert.deepEqual(Threads.List.deleting, []);
+    });
+    test('tracking', function() {
+      assert.deepEqual(Threads.List.tracking, {});
+    });
+  });
+
   suite('Operational', function() {
     setup(function() {
       window.location.hash = '';
@@ -76,11 +116,57 @@ suite('Threads', function() {
       window.location.hash = '#thread=5';
       assert.deepEqual(Threads.active, {
         a: 'alpha',
+        selectAll: false,
+        deleteAll: false,
         messages: []
       });
 
       window.location.hash = '';
       assert.equal(Threads.active, null);
+    });
+
+    test('Threads.get(#).messages', function() {
+      var thread;
+
+      Threads.set(6, { b: 'beta' });
+
+      thread = Threads.get(6);
+
+      assert.deepEqual(thread, {
+        b: 'beta',
+        selectAll: false,
+        deleteAll: false,
+        messages: []
+      });
+
+      Threads.get(6).messages.push({id: 1});
+
+      assert.deepEqual(thread, {
+        b: 'beta',
+        selectAll: false,
+        deleteAll: false,
+        messages: [{id: 1}]
+      });
+
+      // Attempt to add a duplicate
+      Threads.get(6).messages.push({id: 1});
+
+      assert.deepEqual(thread, {
+        b: 'beta',
+        selectAll: false,
+        deleteAll: false,
+        messages: [{id: 1}]
+      });
+
+      // Attempt to add a new
+      Threads.get(6).messages.push({id: 2});
+
+      assert.deepEqual(thread, {
+        b: 'beta',
+        selectAll: false,
+        deleteAll: false,
+        messages: [{id: 1}, {id: 2}]
+      });
     });
   });
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=893838
- Updates desktop mock:
  - Create an expensive thread of MMS messages
  - Mock delete support for array of message ids
  - Adds Z for Zombie, a console API for generating threads and messages 
    - Z.threads(num, interval)
    - Z.messages(num, interval)
- Creates message caching
- Optimized, one step removal for all messages
  - Safe incoming messages in selectAll mode
- Optimized, one step removal for all threads
- Updates UI as priority, deletes actual messages asynchronously

Signed-off-by: Rick Waldron waldron.rick@gmail.com
