### PR TITLE
Bug 887761 - Prevent multilocale build rules from messing up with gaia revisions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ endif
 multilocale-clean:
 	@echo "Cleaning l10n bits..."
 ifeq ($(wildcard .hg),.hg)
-	@hg update --clean
+  @hg revert -a --no-backup
 	@hg status -n $(GAIA_LOCALE_SRCDIRS) | grep '\.properties' | xargs rm -rf
 else
 	@git ls-files --other --exclude-standard $(GAIA_LOCALE_SRCDIRS) | grep '\.properties' | xargs rm -f


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=887761#c28
