### PR TITLE
Bug 891855 - [sms][mms] Gaia should handle the error codes properly to pop up reasonable prompt

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1482,14 +1482,6 @@ var ThreadUI = global.ThreadUI = {
     var buttonLabel = '';
 
     switch (errorName) {
-      case 'NoSignalError':
-      case 'NotFoundError':
-      case 'UnknownError':
-      case 'InternalError':
-        messageTitle = 'sendGeneralErrorTitle';
-        messageBody = 'sendGeneralErrorBody';
-        buttonLabel = 'sendGeneralErrorBtnOk';
-        break;
       case 'NoSimCardError':
         messageTitle = 'sendNoSimCardTitle';
         messageBody = 'sendNoSimCardBody';
@@ -1499,6 +1491,16 @@ var ThreadUI = global.ThreadUI = {
         messageTitle = 'sendAirplaneModeTitle';
         messageBody = 'sendAirplaneModeBody';
         buttonLabel = 'sendAirplaneModeBtnOk';
+        break;
+      case 'NoSignalError':
+      case 'NotFoundError':
+      case 'UnknownError':
+      case 'InternalError':
+      case 'InvalidAddressError'
+      default:
+        messageTitle = 'sendGeneralErrorTitle';
+        messageBody = 'sendGeneralErrorBody';
+        buttonLabel = 'sendGeneralErrorBtnOk';
         break;
     }
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -844,6 +844,15 @@ suite('thread_ui.js >', function() {
                       'sendGeneralErrorBody');
         });
 
+        test('show general error for invalid address error', function() {
+          ThreadUI.showSendMessageError('InvalidAddressError');
+          assert.isTrue(MockDialog.instances[0].show.called);
+          assert.equal(MockDialog.calls[0].title.value,
+                      'sendGeneralErrorTitle');
+          assert.equal(MockDialog.calls[0].body.value,
+                      'sendGeneralErrorBody');
+        });
+
         test('show no SIM card', function() {
           ThreadUI.showSendMessageError('NoSimCardError');
           assert.isTrue(MockDialog.instances[0].show.called);


### PR DESCRIPTION
Just adding new error cases, without changing the existing strings (that's for a followup)
