### PR TITLE
Bug 894263 - Power saving mode should be disabled after switching...

### DIFF
--- a/apps/system/js/battery_manager.js
+++ b/apps/system/js/battery_manager.js
@@ -287,7 +287,7 @@ var PowerSaveHandler = (function PowerSaveHandler() {
           return;
         }
 
-        if (value != -1 && battery.level > value && _powerSaveEnabled) {
+        if (battery.level > value && _powerSaveEnabled) {
           setMozSettings({'powersave.enabled' : false});
           return;
         }


### PR DESCRIPTION
... to 'never'

If the power saving mode was previously enabled and the user switches the _turn on automatically_ threshold to `never`, the mode should be disabled, thus ensuring that the functions previously disabled (i.e. Wi-Fi, Data, Geolocation, Bluetooth) are enabled again.
