### PR TITLE
Bug 893724 - Adopt all build flags in Android.mk for all subsequent re-builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ manifest.appcache
 /build/custom-prefs.js
 /build/custom-settings.json
 /local.mk
+/.b2g.mk
 
 /tools/xpcwindow/vendor/
 

--- a/Android.mk
+++ b/Android.mk
@@ -14,7 +14,10 @@ LOCAL_SRC_FILES := profile.tar.gz
 LOCAL_MODULE_PATH := $(TARGET_OUT_DATA)/local
 include $(BUILD_PREBUILT)
 
-GAIA_MAKE_FLAGS := -C $(GAIA_PATH)
+# We will keep this flag in .b2g.mk so |./flash.sh gaia| follows
+# will correctly pick up the flags.
+GAIA_MAKE_FLAGS :=
+
 GAIA_PROFILE_INSTALL_PARENT := $(TARGET_OUT_DATA)/local
 GAIA_APP_INSTALL_PARENT := $(GAIA_PROFILE_INSTALL_PARENT)
 CLEAN_PROFILE := 0
@@ -66,7 +69,8 @@ $(LOCAL_PATH)/profile.tar.gz:
 ifeq ($(CLEAN_PROFILE), 1)
 	rm -rf $(GAIA_PATH)/profile $(GAIA_PATH)/profile.tar.gz
 endif
-	$(MAKE) -j1 $(GAIA_MAKE_FLAGS) profile
+	echo $(GAIA_MAKE_FLAGS) > $(GAIA_PATH)/.b2g.mk
+	$(MAKE) -j1 -C $(GAIA_PATH) $(GAIA_MAKE_FLAGS) profile
 	@if [ ! -d $(GAIA_PATH)/profile/indexedDB ]; then \
 	cd $(GAIA_PATH)/profile && tar cfz $(abspath $@) webapps; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@
 ###############################################################################
 -include local.mk
 
+# .b2g.mk recorded the make flags from Android.mk
+# This ensures |./flash.sh gaia| follows |./build.sh gaia| will pick up the same
+# flags.
+-include .b2g.mk
+
 # Headless bot does not need the full output of wget
 # and it can cause crashes in bot.io option is here so
 # -nv can be passed and turn off verbose output.


### PR DESCRIPTION
This patch is originally from @timdream.
