### PR TITLE
Bug 895287 - Set wifi.suspended to false when manually turning off wifi

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -43,9 +43,10 @@ navigator.mozL10n.ready(function wifiSettings() {
 
   // toggle wifi on/off
   gWifiCheckBox.onchange = function toggleWifi() {
+    // 'wifi.suspended is always false if users toggle wifi manually'
     settings.createLock().set({
       'wifi.enabled': this.checked,
-      'wifi.suspended': !this.checked
+      'wifi.suspended': false
     }).onerror = function() {
       // Fail to write mozSettings, return toggle control to the user.
       gWifiCheckBox.disabled = false;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=895287
