### PR TITLE
Bug 896594 - [B2G][Leo][Settings]Display: The brightness adjustment slider is unresponsive. r=arthurcc

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -409,6 +409,7 @@ ul li > label .range-icons {
   margin: 0 auto;
   width: calc(100% - 5.4rem);
   height: 3rem;
+  pointer-events: none;
 }
 
 ul li > label .range-icons.brightness {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=896594

Add pointer-events: none to fix this bug.
