### PR TITLE
WIP patch Bug 816912 - 3rd party keyboard apps management

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -62,6 +62,7 @@
     <script defer src="js/settings.js"></script>
 
     <!-- shared helper library -->
+    <!--<script defer src="shared/js/keyboard_helper.js"></script>-->
     <!--<script defer src="shared/js/mouse_event_shim.js"></script>-->
     <!--<script defer src="shared/js/mobile_operator.js"></script>-->
     <!--<script defer src="shared/js/async_storage.js"></script>-->
@@ -1564,135 +1565,29 @@
           </li>
         </ul>
 
-        <header>
-          <h2 data-l10n-id="keyboardLayouts">Layouts</h2>
-        </header>
-        <ul id="keyboard-layouts">
-          <li id="language-keyboard">
-            <small></small>
-            <a></a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.english" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="english">English</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.dvorak"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="dvorak">English (Dvorak)</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.spanish"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="spanish">Spanish</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.portuguese"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="portuguese">Portuguese (Brazilian)</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.polish"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="polish">Polish</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.catalan"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="catalan">Catalan</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.czech"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="czech">Czech</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.french"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="french">French</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.german"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="german">German</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.norwegian"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="norwegian">Norwegian</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.russian"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="russian">Russian</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.serbian"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="serbian">Serbian</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.slovak"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="slovak">Slovak</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.turkish"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="turkish">Turkish</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.arabic"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="arabic">Arabic</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.hebrew"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="hebrew">Hebrew</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.greek"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="greek">Greek</a>
-          </li>
-        </ul>
+        <div id="textLayoutList" hidden>
+          <header>
+            <h2 data-l10n-id="keyboardlayouts">layouts</h2>
+          </header>
+          <ul></ul>
+        </div>
+
+        <div id="numberLayoutList" hidden>
+          <header>
+            <h2 data-l10n-id="numberKeyboardLayouts">Number Layouts</h2>
+          </header>
+          <ul></ul>
+        </div>
+
+        <div id="optionLayoutList" hidden>
+          <header>
+            <h2 data-l10n-id="optionKeyboardLayouts">Option Layouts</h2>
+          </header>
+          <ul></ul>
+        </div>
+  
       </div>
+      <script src="js/keyboard.js"></script>
       -->
     </section>
 

--- a/apps/settings/js/keyboard.js
+++ b/apps/settings/js/keyboard.js
@@ -1,0 +1,100 @@
+/* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+/* We will get this const definition from shared/js/keyboard_helper.js
+const TYPE_GROUP = {
+  'text': true,
+  'number': true,
+  'option': true
+}
+
+const SETTINGS_KEY = 'keyboard.enabled-layouts';
+*/
+
+var KeyboardLayout = {
+  keyboardLayouts: {},
+
+  init: function kl_init() {
+    this.getAllElements();
+    KeyboardHelper.getAllLayouts(this.makeLayoutList.bind(this));
+    Settings.mozSettings.addObserver('keyboard.enabled-layouts',
+        this.updateList.bind(this));
+  },
+
+  getAllElements: function kl_getAllElements() {
+    for (var type in TYPE_GROUP) {
+      var key = type + 'LayoutList';
+      this[key] = document.getElementById(key);
+    }
+  },
+
+  makeLayoutList: function kl_makeLayoutList(allLayouts) {
+    this.keyboardLayouts = allLayouts;
+    // make lists
+    for (var type in TYPE_GROUP) {
+      var listElement = this[type + 'LayoutList'].querySelector('ul');
+      var layouts = this.keyboardLayouts[type];
+
+      this.clearLayoutList(listElement);
+      for (var i in layouts) {
+        var aItem = this.newLayoutItem(type, i, layouts[i]);
+        listElement.appendChild(aItem);
+      }
+      // all lists are default hidden, we will show the list only when
+      // there are more than one layouts for the user configure.
+      this[type + 'LayoutList'].hidden = (layouts.length <= 1);
+    }
+  },
+
+  updateList: function kl_updateList(evt) {
+    this.makeLayoutList(JSON.parse(evt.settingValue));
+  },
+
+  newLayoutItem: function kl_appendLayout(type, index, layout) {
+    var layoutName = document.createElement('a');
+    //XXX we should display an unique name here, not just layout name.
+    layoutName.textContent = layout.name;
+
+    var label = document.createElement('label');
+    var checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.dataset.type = type;
+    checkbox.dataset.index = index;
+    checkbox.checked = layout.enabled;
+    checkbox.addEventListener('change', this);
+    var span = document.createElement('span');
+
+    label.appendChild(checkbox);
+    label.appendChild(span);
+
+    var li = document.createElement('li');
+    li.appendChild(label);
+    li.appendChild(layoutName);
+    return li;
+  },
+
+  clearLayoutList: function kl_clearLayoutList(list) {
+    while (list.hasChildNodes()) {
+      list.removeChild(list.lastChild);
+    }
+  },
+
+  handleEvent: function kl_handleEvent(evt) {
+    if (evt.target.type !== 'checkbox')
+      return;
+    // TODO should check if this is the last one
+    // if yes, prevent it to be disabled.
+    var checkbox = evt.target;
+    var layoutType = checkbox.dataset.type;
+    var layoutIndex = checkbox.dataset.index;
+    this.keyboardLayouts[layoutType][layoutIndex].enabled = checkbox.checked;
+
+    var obj = {};
+    obj[SETTINGS_KEY] = JSON.stringify(this.keyboardLayouts);
+    Settings.mozSettings.createLock().set(obj);
+  }
+};
+
+navigator.mozL10n.ready(KeyboardLayout.init.bind(KeyboardLayout));

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -304,7 +304,7 @@ var Settings = {
         setTimeout(this.updateLanguagePanel);
         break;
       case 'keyboard':
-        Settings.updateKeyboardPanel();
+        //Settings.updateKeyboardPanel();
         break;
       case 'battery':             // full battery status
         Battery.update();
@@ -775,50 +775,50 @@ var Settings = {
   },
 
   updateKeyboardPanel: function settings_updateKeyboardPanel() {
-    var panel = document.getElementById('keyboard');
+    // var panel = document.getElementById('keyboard');
     // Update the keyboard layouts list from the Keyboard panel
-    if (panel) {
-      this.getSupportedKbLayouts(function updateKbList(keyboards) {
-        var kbLayoutsList = document.getElementById('keyboard-layouts');
-        // Get pointers to the top list entry and its labels which are used to
-        // pin the language associated keyboard at the top of the keyboards list
-        var pinnedKb = document.getElementById('language-keyboard');
-        var pinnedKbLabel = pinnedKb.querySelector('a');
-        var pinnedKbSubLabel = pinnedKb.querySelector('small');
-        pinnedKbSubLabel.textContent = '';
+    // if (panel) {
+    //   this.getSupportedKbLayouts(function updateKbList(keyboards) {
+    //     var kbLayoutsList = document.getElementById('keyboard-layouts');
+    //   // Get pointers to the top list entry and its labels which are used to
+    // // pin the language associated keyboard at the top of the keyboards list
+    //     var pinnedKb = document.getElementById('language-keyboard');
+    //     var pinnedKbLabel = pinnedKb.querySelector('a');
+    //     var pinnedKbSubLabel = pinnedKb.querySelector('small');
+    //     pinnedKbSubLabel.textContent = '';
 
-        // Get the current language and its associate keyboard layout
-        var currentLang = document.documentElement.lang;
-        var langKeyboard = keyboards.layout[currentLang];
+    //     // Get the current language and its associate keyboard layout
+    //     var currentLang = document.documentElement.lang;
+    //     var langKeyboard = keyboards.layout[currentLang];
 
-        var kbSelector = 'input[name="keyboard.layouts.' + langKeyboard + '"]';
-        var kbListQuery = kbLayoutsList.querySelector(kbSelector);
+    //  var kbSelector = 'input[name="keyboard.layouts.' + langKeyboard + '"]';
+    //     var kbListQuery = kbLayoutsList.querySelector(kbSelector);
 
-        if (kbListQuery) {
-          // Remove the entry from the list since it will be pinned on top
-          // of the Keyboard Layouts list
-          var kbListEntry = kbListQuery.parentNode.parentNode;
-          kbListEntry.hidden = true;
+    //     if (kbListQuery) {
+    //       // Remove the entry from the list since it will be pinned on top
+    //       // of the Keyboard Layouts list
+    //       var kbListEntry = kbListQuery.parentNode.parentNode;
+    //       kbListEntry.hidden = true;
 
-          var label = kbListEntry.querySelector('a');
-          var sub = kbListEntry.querySelector('small');
-          pinnedKbLabel.dataset.l10nId = label.dataset.l10nId;
-          pinnedKbLabel.textContent = label.textContent;
-          if (sub) {
-            pinnedKbSubLabel.dataset.l10nId = sub.dataset.l10nId;
-            pinnedKbSubLabel.textContent = sub.textContent;
-          }
-        } else {
-          // If the current language does not have an associated keyboard,
-          // fallback to the default keyboard: 'en'
-          // XXX update this if the list order in index.html changes
-          var englishEntry = kbLayoutsList.children[1];
-          englishEntry.hidden = true;
-          pinnedKbLabel.dataset.l10nId = 'english';
-          pinnedKbSubLabel.textContent = '';
-        }
-      });
-    }
+    //       var label = kbListEntry.querySelector('a');
+    //       var sub = kbListEntry.querySelector('small');
+    //       pinnedKbLabel.dataset.l10nId = label.dataset.l10nId;
+    //       pinnedKbLabel.textContent = label.textContent;
+    //       if (sub) {
+    //         pinnedKbSubLabel.dataset.l10nId = sub.dataset.l10nId;
+    //         pinnedKbSubLabel.textContent = sub.textContent;
+    //       }
+    //     } else {
+    //       // If the current language does not have an associated keyboard,
+    //       // fallback to the default keyboard: 'en'
+    //       // XXX update this if the list order in index.html changes
+    //       var englishEntry = kbLayoutsList.children[1];
+    //       englishEntry.hidden = true;
+    //       pinnedKbLabel.dataset.l10nId = 'english';
+    //       pinnedKbSubLabel.textContent = '';
+    //     }
+    //   });
+    // }
   }
 };
 
@@ -837,6 +837,7 @@ window.addEventListener('load', function loadSettings() {
 
   LazyLoader.load(['js/utils.js'], startupLocale);
   LazyLoader.load([
+      'shared/js/keyboard_helper.js',
       'js/airplane_mode.js',
       'js/battery.js',
       'shared/js/async_storage.js',
@@ -980,13 +981,13 @@ function initLocale() {
 
   // update the keyboard layouts list by resetting the top pinned element,
   // since it displays the previous language setting
-  var kbLayoutsList = document.getElementById('keyboard-layouts');
-  if (kbLayoutsList) {
-    var prevKbLayout = kbLayoutsList.querySelector('li[hidden]');
-    prevKbLayout.hidden = false;
+  // var kbLayoutsList = document.getElementById('keyboard-layouts');
+  // if (kbLayoutsList) {
+  //   var prevKbLayout = kbLayoutsList.querySelector('li[hidden]');
+  //   prevKbLayout.hidden = false;
 
-    Settings.updateKeyboardPanel();
-  }
+  //   Settings.updateKeyboardPanel();
+  // }
 }
 
 // Do initialization work that doesn't depend on the DOM, as early as

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -317,6 +317,8 @@ longDateFormat=%A, %B %d, %Y
 # Personalization :: Keyboard
 keyboard=Keyboard
 keyboardLayouts=Keyboard layouts
+numberKeyboardLayouts=Number layouts
+optionKeyboardLayouts=Option layouts
 keypad=Keypad
 vibration=Vibration
 clickSound=Click sound

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -18,6 +18,7 @@
     <script defer src="shared/js/manifest_helper.js"></script>
     <script defer src="shared/js/icc_helper.js"></script>
     <script defer src="shared/js/mime_mapper.js"></script>
+    <script defer src="shared/js/keyboard_helper.js"></script>
 
     <!-- Wrapper -->
     <link rel="stylesheet" type="text/css" href="style/wrapper/wrapper.css">

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -1,18 +1,220 @@
 'use strict';
 
-var KeyboardManager = (function() {
-  var keyboardHeight = 0;
+// If we get a focuschange event from mozKeyboard for an element with
+// one of these types, we'll just ignore it.
+// XXX we won't skip these types in the future when we move value selector
+// to an app.
+const IGNORED_INPUT_TYPES = {
+  'select-one': true,
+  'select-multiple': true,
+  'date': true,
+  'time': true,
+  'datetime': true,
+  'datetime-local': true
+};
 
-  function getKeyboardURL() {
-    // TODO: Retrieve it from Settings, allowing 3rd party keyboards
-    var host = document.location.host;
-    var domain = host.replace(/(^[\w\d]+\.)?([\w\d]+\.[a-z]+)/, '$2');
-    var protocol = document.location.protocol;
+const TYPE_GROUP_MAPPING = {
+  // text
+  'text': 'text',
+  'textarea': 'text',
+  'url': 'text',
+  'email': 'text',
+  'password': 'text',
+  'search': 'text',
+  // number
+  'number': 'number',
+  'tel': 'number',
+  // option
+  'select-one': 'option',
+  'select-multiple': 'option',
+  'time': 'option',
+  'week': 'option',
+  'month': 'option',
+  'date': 'option',
+  'datetime': 'option',
+  'datetime-local': 'option',
+  'color': 'option'
+};
 
-    return protocol + '//keyboard.' + domain + '/';
-  }
+// How long to wait for more focuschange events before processing
+const FOCUS_CHANGE_DELAY = 20;
 
-  function generateKeyboard(container, keyboardURL, manifestURL) {
+var KeyboardManager = {
+  keyboardFrameContainer: document.getElementById('keyboard-frame'),
+
+  // The set of installed keyboard apps grouped by type_group.
+  // This is a map from type_group to an object arrays.
+  // Each element in the object arrays represents a keyboard layout:
+  // {
+  //    name: the keyboard layout's name
+  //    appName: the keyboard app name
+  //    origin: the keyboard's origin
+  //    path: the keyboard's launch path
+  // }
+  keyboardLayouts: {},
+
+  // The set of running keyboards.
+  // This is a map from keyboard origin to an object like this:
+  // 'keyboard.gaiamobile.org' : {
+  //   'English': aIframe
+  // }
+  runningLayouts: {},
+  showingLayout: {
+    frame: null,
+    type: 'text',
+    index: 0,
+    reset: function() {
+      this.frame = null;
+      this.type = 'text';
+      this.index = 0;
+    }
+  },
+
+  focusChangeTimeout: 0,
+  switchChangeTimeout: 0,
+  _onDebug: false,
+  _debug: function km_debug(msg) {
+    if (this._onDebug)
+      console.log('[Keyboard Manager] ' + msg);
+  },
+  keyboardHeight: 0,
+
+  init: function km_init() {
+    var self = this;
+    this.keyboardFrameContainer.classList.add('hide');
+
+    // get enabled keyboard from mozSettings, parse their manifest
+    this.updateLayouts();
+
+    //register settings change
+    var settings = window.navigator.mozSettings;
+    settings.addObserver(SETTINGS_KEY, this.updateLayouts.bind(this));
+
+    // For Bug 812115: hide the keyboard when the app is closed here,
+    // since it would take a longer round-trip to receive focuschange
+    // Also in Bug 856692 we realise that we need to close the keyboard
+    // when an inline activity goes away.
+    window.addEventListener('appwillclose', this);
+    window.addEventListener('activitywillclose', this);
+
+    window.navigator.mozKeyboard.onfocuschange =
+      this.inputFocusChange.bind(this);
+  },
+
+  getHeight: function kn_getHeight() {
+    return this.keyboardHeight;
+  },
+
+  updateLayouts: function km_updateLayouts(evt) {
+    var self = this;
+    function resetLayoutList(allLayouts) {
+      self.keyboardLayouts = {};
+      // filter out disabled layouts
+      for (var type in allLayouts) {
+        self.keyboardLayouts[type] = [];
+        for (var i in allLayouts[type]) {
+          if (allLayouts[type][i].enabled)
+            self.keyboardLayouts[type].push(allLayouts[type][i]);
+        }
+      }
+      self.showingLayout.reset();
+      var initType = self.showingLayout.type;
+      var initIndex = self.showingLayout.index;
+      self.launchLayoutFrame(self.keyboardLayouts[initType][initIndex]);
+    }
+    if (evt) {
+      // update because of observing settings change
+      var allLayouts = JSON.parse(evt.settingValue);
+      resetLayoutList(allLayouts);
+    } else {
+      // update because of initializing
+      KeyboardHelper.getAllLayouts(resetLayoutList);
+    }
+  },
+
+  inputFocusChange: function km_inputFocusChange(evt) {
+    // let value selector notice the event
+    window.dispatchEvent(new CustomEvent('inputfocuschange', evt));
+
+    var state = evt.detail;
+    var type = state.type;
+
+    // Skip the <select> element and inputs with type of date/time,
+    // handled in system app for now
+    if (!type || type in IGNORED_INPUT_TYPES)
+      return;
+
+    var self = this;
+    // We can get multiple focuschange events in rapid succession
+    // so wait a bit before responding to see if we get another.
+    clearTimeout(this.focusChangeTimeout);
+    this.focusChangeTimeout = setTimeout(function keyboardFocusChanged() {
+      var group = TYPE_GROUP_MAPPING[type];
+      var index = self.showingLayout.index;
+
+      if (type === 'blur') {
+        self._debug('get blur event');
+        self.hideKeyboard();
+      } else {
+        self._debug('get focus event');
+        // by the order in Settings app, we should display
+        // the first (default) one.
+        self.setKeyboardToShow(group, 0);
+        self.showKeyboard();
+      }
+    }, FOCUS_CHANGE_DELAY);
+  },
+
+  launchLayoutFrame: function km_launchLayoutFrame(layout) {
+    if (this.isRunningLayout(layout)) {
+      this._debug('this layout is running');
+      return this.runningLayouts[layout.origin][layout.name];
+    }
+    var layoutFrame = null;
+    if (this.isRunningKeyboard(layout)) {
+      var runningKeybaord = this.runningLayouts[layout.origin];
+      for (var name in runningKeybaord) {
+        var oldPath = runningKeybaord[name].dataset.framePath;
+        var newPath = layout.path;
+        if (oldPath.substring(0, oldPath.indexOf('#')) ===
+            newPath.substring(0, newPath.indexOf('#'))) {
+          layoutFrame = runningKeybaord[name];
+          layoutFrame.src = layout.origin + newPath;
+          this._debug(name + ' is overwritten: ' + layoutFrame.src);
+          delete runningKeybaord[name];
+          break;
+        }
+      }
+    }
+    if (!layoutFrame)
+      layoutFrame = this.loadKeyboardLayout(layout);
+    // TODO make sure setVisible function is ready
+    layoutFrame.setVisible(false);
+    layoutFrame.hidden = true;
+    layoutFrame.dataset.frameName = layout.name;
+    layoutFrame.dataset.frameOrigin = layout.origin;
+    layoutFrame.dataset.framePath = layout.path;
+    if (!(layout.origin in this.runningLayouts))
+      this.runningLayouts[layout.origin] = {};
+
+    this.runningLayouts[layout.origin][layout.name] = layoutFrame;
+    return layoutFrame;
+  },
+
+  isRunningKeyboard: function km_isRunningKeyboard(layout) {
+    return this.runningLayouts.hasOwnProperty(layout.origin);
+  },
+
+  isRunningLayout: function km_isRunningLayout(layout) {
+    if (!this.isRunningKeyboard(layout))
+      return false;
+    return this.runningLayouts[layout.origin].hasOwnProperty(layout.name);
+  },
+
+  loadKeyboardLayout: function km_loadKeyboardLayout(layout) {
+    // Generate a <iframe mozbrowser> containing the keyboard.
+    var keyboardURL = layout.origin + layout.path;
+    var manifestURL = layout.origin + '/manifest.webapp';
     var keyboard = document.createElement('iframe');
     keyboard.src = keyboardURL;
     keyboard.setAttribute('mozbrowser', 'true');
@@ -20,110 +222,186 @@ var KeyboardManager = (function() {
     keyboard.setAttribute('mozapp', manifestURL);
     //keyboard.setAttribute('remote', 'true');
 
-    container.appendChild(keyboard);
+    this.keyboardFrameContainer.appendChild(keyboard);
     return keyboard;
-  }
+  },
 
-  // Generate a <iframe mozbrowser> containing the keyboard.
-  var container = document.getElementById('keyboard-frame');
-  var keyboardURL = getKeyboardURL() + 'index.html';
-  var manifestURL = getKeyboardURL() + 'manifest.webapp';
-  var keyboard = generateKeyboard(container, keyboardURL, manifestURL);
-
-  // Listen for mozbrowserlocationchange of keyboard iframe.
-  var previousHash = '';
-
-  var urlparser = document.createElement('a');
-  var appClosing = false;
-  keyboard.addEventListener('mozbrowserlocationchange', function(e) {
-    urlparser.href = e.detail;
-    if (previousHash == urlparser.hash)
+  handleKeyboardRequest: function km_handleKeyboardRequest(evt) {
+    var url = evt.detail.url;
+    this._debug('handleKeyboardRequest: ' + url);
+    // everything is hack here! will be removed after having real platform API
+    if (url.lastIndexOf('keyboard-test') < 0)
       return;
-    previousHash = urlparser.hash;
+    evt.stopPropagation();
 
-    var type = urlparser.hash.split('=');
-    switch (type[0]) {
-      case '#show':
+    var showed = this.showingLayout;
+    if (!showed.frame || !url.contains(showed.frame.dataset.frameOrigin))
+      return;
 
-        // If an app is closing, we should ignore any #show triggered by
-        // resize events which come from orientation change events.
-        if (appClosing) {
-          return;
-        }
+    var urlparser = document.createElement('a');
+    urlparser.href = url;
+    var keyword = urlparser.hash.split('=')[1];
 
-        //XXX: The url will contain the info for keyboard height
-        keyboardHeight = parseInt(type[1]);
+    var self = this;
+    switch (keyword) {
+      case 'switchlayout':
+        clearTimeout(this.switchChangeTimeout);
+        this.switchChangeTimeout = setTimeout(function keyboardSwitchLayout() {
+          var length = self.keyboardLayouts[showed.type].length;
+          var index = (showed.index + 1) % length;
 
-        var updateHeight = function updateHeight() {
-          container.removeEventListener('transitionend', updateHeight);
-          if (container.classList.contains('hide')) {
+          self.resetShowingKeyboard();
+          self.setKeyboardToShow(showed.type, index);
+        }, FOCUS_CHANGE_DELAY);
+        break;
+      case 'showlayoutlist':
+        clearTimeout(this.switchChangeTimeout);
+        this.switchChangeTimeout = setTimeout(function keyboardLayoutList() {
+          var items = [];
+          self.keyboardLayouts[showed.type].forEach(function(layout, index) {
+            var label = layout.appName + ' ' + layout.name;
+            items.push({
+              label: label,
+              value: index
+            });
+          });
+          self.hideKeyboard();
+          //XXX the menu is not scrollable now, and it will take focus away
+          // https://bugzilla.mozilla.org/show_bug.cgi?id=859708
+          // https://bugzilla.mozilla.org/show_bug.cgi?id=859713
+          ListMenu.request(items, 'Layout selection', function(selectedIndex) {
+            self.setKeyboardToShow(showed.type, selectedIndex);
+            self.showKeyboard();
+          }, null);
+        }, FOCUS_CHANGE_DELAY);
+        break;
+      // if there is only one number, it should be update height
+      default:
+        var updateHeight = function km_updateHeight() {
+          self.keyboardFrameContainer.removeEventListener(
+              'transitionend', updateHeight);
+          if (self.keyboardFrameContainer.classList.contains('hide')) {
             // The keyboard has been closed already, let's not resize the
             // application and ends up with half apps.
             return;
           }
-
+          // to do
           var detail = {
             'detail': {
               'height': keyboardHeight
             }
           };
-
-          dispatchEvent(new CustomEvent('keyboardchange', detail));
+          window.dispatchEvent(new CustomEvent('keyboardchange', detail));
         };
 
-        if (container.classList.contains('hide')) {
-          container.classList.remove('hide');
-          container.addEventListener('transitionend', updateHeight);
-          return;
+        if (this.keyboardFrameContainer.classList.contains('hide')) {
+          this.showKeyboard();
+          this.keyboardFrameContainer.addEventListener(
+              'transitionend', updateHeight);
+        } else {
+          updateHeight();
         }
-
-        updateHeight();
-        break;
-
-      case '#hide':
-        // inform window manager to resize app first or
-        // it may show the underlying homescreen
-        keyboardHeight = 0;
-        dispatchEvent(new CustomEvent('keyboardhide'));
-        container.classList.add('hide');
         break;
     }
-  });
+  },
 
-  function getHeight() {
-    return keyboardHeight;
-  }
+  handleEvent: function km_handleEvent(evt) {
+    switch (evt.type) {
+      case 'mozbrowseropenwindow':
+        this.handleKeyboardRequest(evt);
+        break;
+      case 'activitywillclose':
+      case 'appwillclose':
+        window.dispatchEvent(new CustomEvent('keyboardhide'));
+        this.keyboardFrameContainer.classList.add('hide');
+        break;
+      //XXX the following three cases haven't been tested.
+      case 'mozbrowsererror': // OOM
+        var origin = evt.target.dataset.frameOrigin;
+        this.removeKeyboard(origin);
+        break;
+      case 'applicationinstall': //app installed
+        this.updateLayoutSettings();
+        break;
+      case 'applicationuninstall': //app uninstalled
+        var origin = evt.detail.application.origin;
+        this.removeKeyboard(origin);
+        this.updateLayoutSettings();
+        break;
+    }
+  },
 
-  // For Bug 812115: hide the keyboard when the app is closed here,
-  // since it would take a longer round-trip to receive focuschange
-  // Also in Bug 856692 we realise that we need to close the keyboard
-  // when an inline activity goes away.
-  var closeKeyboardEvents = [
-    'appwillclose',
-    'activitywillclose',
-    'activitymenuwillopen',
-    // Hide the keyboard when the cards view is shown (i.e. by long
-    // pressing the home button -- 'holdhome')
-    'holdhome'
-  ];
-  closeKeyboardEvents.forEach(function onEvent(eventType) {
-    window.addEventListener(eventType, function closeKeyboard() {
-      keyboardHeight = 0;
-      dispatchEvent(new CustomEvent('keyboardhide'));
-      container.classList.add('hide');
-      if (eventType == 'appwillclose') {
-        appClosing = true;
-      }
+  removeKeyboard: function km_removeKeyboard(origin) {
+    if (!this.runningLayouts.hasOwnProperty(origin))
+      return;
+
+    if (this.showingLayout.frame.dataset.frameOrigin === origin) {
+      this.hideKeyboard();
+    }
+
+    for (var name in this.runningLayouts[origin]) {
+      var frame = this.runningLayouts[origin][name];
+      windows.removeChild(frame);
+      delete this.runningLayouts[origin][name];
+    }
+
+    delete this.runningLayouts[origin];
+  },
+
+  updateLayoutSettings: function km_updateLayoutSettings() {
+    KeyboardHelper.getInstalledLayouts(function(allLayouts) {
+      var obj = {};
+      obj[SETTINGS_KEY] = JSON.stringify(allLayouts);
+      var settings = window.navigator.mozSettings;
+      settings.createLock().set(obj);
     });
-  });
+  },
 
-  window.addEventListener('appclose', function appClose() {
-    appClosing = false;
-  });
+  setKeyboardToShow: function km_setKeyboardToShow(group, index) {
+    this._debug('set layout to display: type=' + group + ' index=' + index);
+    this.showingLayout.type = group;
+    this.showingLayout.index = index;
+    var layout = this.keyboardLayouts[group][index];
+    this.showingLayout.frame = this.launchLayoutFrame(layout);
+    this.showingLayout.frame.hidden = false;
+    this.showingLayout.frame.setVisible(true);
+    this.showingLayout.frame.addEventListener(
+        'mozbrowseropenwindow', this, true);
+  },
 
-  return {
-    getHeight: getHeight
-  };
+  showKeyboard: function km_showKeyboard() {
+    this.keyboardFrameContainer.classList.remove('hide');
 
-})();
+    // XXX Keyboard transition may be affected by window.open event,
+    // and thus the keyboard looks like jump into screen.
+    // It may because window.open blocks main thread?
+    // Monitor transitionend time here.
+    var self = this;
+    var onTransitionEnd = function km_onTransitionEnd() {
+      self.keyboardFrameContainer.removeEventListener('transitionend',
+          onTransitionEnd);
+      self._debug('keyboard display transitionend');
+    };
+    this.keyboardFrameContainer.addEventListener('transitionend',
+        onTransitionEnd);
+  },
 
+  resetShowingKeyboard: function km_resetShowingKeyboard() {
+    if (!this.showingLayout.frame) {
+      return;
+    }
+    this.showingLayout.frame.hidden = true;
+    this.showingLayout.frame.setVisible(false);
+    this.showingLayout.frame.removeEventListener(
+        'mozbrowseropenwindow', this, true);
+    this.showingLayout.reset();
+  },
+
+  hideKeyboard: function km_hideKeyboard() {
+    this.resetShowingKeyboard();
+    window.dispatchEvent(new CustomEvent('keyboardhide'));
+    this.keyboardFrameContainer.classList.add('hide');
+  }
+};
+
+KeyboardManager.init();

--- a/apps/system/js/list_menu.js
+++ b/apps/system/js/list_menu.js
@@ -163,7 +163,7 @@ var ListMenu = {
         if (!value) {
           return;
         }
-
+        value = parseInt(value);
         this.hide(this.onreturn.bind(this, value));
         break;
 

--- a/apps/system/js/value_selector/value_selector.js
+++ b/apps/system/js/value_selector/value_selector.js
@@ -23,7 +23,7 @@ var ValueSelector = {
   init: function vs_init() {
     var self = this;
 
-    window.navigator.mozKeyboard.onfocuschange = function onfocuschange(evt) {
+    window.addEventListener('inputfocuschange', function onfocuschange(evt) {
       var typeToHandle = ['select-one', 'select-multiple', 'date',
         'time', 'datetime', 'datetime-local', 'blur'];
 
@@ -73,7 +73,7 @@ var ValueSelector = {
           self.hide();
           break;
       }
-    };
+    });
 
     this._element = document.getElementById('value-selector');
     this._element.addEventListener('mousedown', this);

--- a/apps/system/style/system/keyboard.css
+++ b/apps/system/style/system/keyboard.css
@@ -9,7 +9,7 @@
   height: 100%;
 
   transform: translateY(0);
-  -moz-transition: visibility 0.2s ease, -moz-transform 0.2s ease;
+  transition: visibility 0.2s ease, transform 0.4s ease;
 }
 
 @media not all and (-moz-physical-home-button) {

--- a/shared/js/keyboard_helper.js
+++ b/shared/js/keyboard_helper.js
@@ -1,0 +1,102 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+/**
+ * Helper object to find all installed keyboard apps and layouts.
+ * (Need mozApps.mgmt permission)
+ */
+
+const TYPE_GROUP = {
+  'text': true,
+  'number': true,
+  'option': true
+};
+
+const SETTINGS_KEY = 'keyboard.enabled-layouts';
+
+var KeyboardHelper = {
+  getAllLayouts: function kh_getAllLayouts(callback) {
+    var self = this;
+    var settings = window.navigator.mozSettings;
+    var request = settings.createLock().get(SETTINGS_KEY);
+    request.onsuccess = function(e) {
+      var value = request.result[SETTINGS_KEY];
+      if (!value) {
+        self.getInstalledLayouts(function(allLayouts) {
+          //XXX write settings back, this shouldn't happen.
+          var obj = {};
+          obj[SETTINGS_KEY] = JSON.stringify(allLayouts);
+          settings.createLock().set(obj);
+          callback(allLayouts);
+        });
+      } else {
+        var allLayouts = JSON.parse(value);
+        callback(allLayouts);
+      }
+    };
+  },
+
+  getInstalledKeyboards: function kh_getInstalledKeyboards(callback) {
+    if (!navigator.mozApps || !navigator.mozApps.mgmt)
+      return;
+
+    navigator.mozApps.mgmt.getAll().onsuccess = function onsuccess(event) {
+      var apps = event.target.result;
+      var keyboardApps = [];
+      apps.forEach(function eachApp(app) {
+        // keyboard apps will request keyboard API permission
+        if (!(app.manifest.permissions && 'keyboard' === app.manifest.role))
+          return;
+        //XXX remove this hard code check if one day system app no longer
+        //    use mozKeyboard API
+        if (app.origin === 'app://system.gaiamobile.org')
+          return;
+        // all keyboard apps should define its layout(s) in entry_points section
+        if (!app.manifest.entry_points)
+          return;
+        keyboardApps.push(app);
+      });
+
+      if (keyboardApps.length > 0 && callback)
+        callback(keyboardApps);
+    };
+  },
+
+  getInstalledLayouts: function kh_getInstalledLayouts(callback) {
+    this.getInstalledKeyboards(function parseLayouts(apps) {
+      var keyboardLayouts = {};
+      apps.forEach(function(app) {
+        var entryPoints = app.manifest.entry_points;
+        for (var name in entryPoints) {
+          var launchPath = entryPoints[name].launch_path;
+          if (!entryPoints[name].type) {
+            console.warn('the keyboard app did not declare type.');
+            continue;
+          }
+          var supportTypes = entryPoints[name].type;
+          supportTypes.forEach(function(type) {
+            if (!type || !(type in TYPE_GROUP))
+              return;
+
+            if (!keyboardLayouts[type])
+              keyboardLayouts[type] = [];
+
+            keyboardLayouts[type].push({
+              'name': name,
+              'appName': app.manifest.name,
+              'origin': app.origin,
+              'path': launchPath,
+              'index': keyboardLayouts[type].length,
+              'enabled': true
+            });
+          });
+        }
+      });
+      if (callback)
+        callback(keyboardLayouts);
+    });
+  }
+};
+


### PR DESCRIPTION
1. manage running keyboard layouts in System app
2. list installed keyboard layouts in Settings app
3. use proposed manifest in 3rd party keyboard app "role": "keyboard", "launch_path": "/index.html#settings", "entry_points": { "english": { "launch_path": "/index.html", "description": "English layout", "type": ["text", "url", "number"] } },
