### PR TITLE
Bug 896825: Call the closeCallback even if the close transition has been cancelled.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -593,8 +593,11 @@ var WindowManager = (function() {
       }
 
       // We have been canceled by another transition.
-      if (!closeFrame || transitionCloseCallback != startClosingTransition)
+      if (!closeFrame || transitionCloseCallback != startClosingTransition) {
+        setTimeout(closeCallback);
+        closeCallback = null;
         return;
+      }
 
       // Make sure we're not called twice.
       transitionCloseCallback = null;


### PR DESCRIPTION
Dropping the callback on the floor can leave <iframe mozbrowser> in the DOM and leak lots of memory.
