### PR TITLE
Bug 896322 - screen goes off after reset and before FTU starts while pow...

### DIFF
--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -382,8 +382,9 @@ var ScreenManager = {
   },
 
   _reconfigScreenTimeout: function scm_reconfigScreenTimeout() {
-    // Remove idle timer if screen wake lock is acquired.
-    if (this._screenWakeLocked) {
+    // Remove idle timer if screen wake lock is acquired or
+    // if no app has been displayed yet.
+    if (this._screenWakeLocked || !WindowManager.getDisplayedApp()) {
       this._setIdleTimeout(0);
     // The screen should be turn off with shorter timeout if
     // it was never unlocked.


### PR DESCRIPTION
...er-on video is playing

Bug 896322 - screen goes off after reset and before FTU starts while power-on video is playing
https://bugzilla.mozilla.org/show_bug.cgi?id=896322
