### PR TITLE
Bug 895307 - [SMS] should detect phone numbers when then word before it ends with a number

### DIFF
--- a/apps/sms/js/link_helper.js
+++ b/apps/sms/js/link_helper.js
@@ -24,7 +24,7 @@ function checkDomain(domain) {
 }
 
 // defines things that can match right before to be a "safe" link
-var safeStart = '\n\t\r\f .,:;(>'.split('');
+var safeStart = /[\s,:;\(>]/;
 
 const MINIMUM_DIGITS_IN_PHONE_NUMBER = 6;
 
@@ -133,9 +133,18 @@ function searchForLinks(type, string) {
 
   // while we match stuff...
   while (match = regexp.exec(string)) {
+
     // if the match isn't at the begining of the string, check for a safe
-    // character set before the match before we call it a linkSpec
-    if (match.index && safeStart.indexOf(string[match.index - 1]) === -1) {
+    // character before the match
+
+    var rest = string.slice(match.index - 1);
+    if (match.index && !safeStart.test(rest.charAt(0))) {
+
+      // we should only advance the regexp to the next safeStart
+      var nextSafe = safeStart.exec(rest);
+      if (nextSafe) {
+        regexp.lastIndex = match.index + nextSafe.index;
+      }
       continue;
     }
 

--- a/apps/sms/test/unit/link_helper_test.js
+++ b/apps/sms/test/unit/link_helper_test.js
@@ -212,6 +212,12 @@ suite('link_helper_test.js', function() {
 
   suite('LinkHelper Phone replacements', function() {
 
+    function testPhoneMatch(text, match) {
+      var expected = text.replace(match, phone2msg(match));
+      var result = LinkHelper.searchAndLinkClickableData(text);
+      assert.equal(result, expected);
+    }
+
     function phone2msg(phone) {
       return '<a data-phonenumber="' + phone + '"' +
              ' data-action="phone-link">' + phone + '</a>';
@@ -239,6 +245,10 @@ suite('link_helper_test.js', function() {
 
       test('Phone from #887737', function() {
         testPhoneOK('+5511 98907-6047');
+      });
+
+      test('Phone proceding trailing number', function() {
+        testPhoneMatch('Test1 600123123', '600123123');
       });
     });
 


### PR DESCRIPTION
- Removes '.' as a safe character - this means blah.http://blah.com/ will no longer match (okay?)
- Only advances the regexp matcher to the next "safe character" when encountering a non-safe start
