### PR TITLE
Bug 897090 - [Clock] L10n mocking is fragmented across test files

### DIFF
--- a/apps/clock/test/unit/alarm_test.js
+++ b/apps/clock/test/unit/alarm_test.js
@@ -1,5 +1,3 @@
-require('/shared/js/l10n.js');
-
 requireApp('clock/js/utils.js');
 requireApp('clock/js/alarmsdb.js');
 requireApp('clock/js/alarm_edit.js');

--- a/apps/clock/test/unit/setup.js
+++ b/apps/clock/test/unit/setup.js
@@ -1,0 +1,8 @@
+requireApp('email/test/unit/mock_l10n.js', function() {
+
+  var nativeMozL10n;
+
+  nativeMozL10n = navigator.mozL10n;
+  navigator.mozL10n = MockL10n;
+
+});

--- a/apps/clock/test/unit/utils_test.js
+++ b/apps/clock/test/unit/utils_test.js
@@ -1,20 +1,12 @@
-requireApp('email/test/unit/mock_l10n.js');
 requireApp('clock/js/utils.js');
 
 suite('Time functions', function() {
 
   suite('#summarizeDaysOfWeek', function() {
-    var nativeMozL10n, _, summarizeDaysOfWeek;
+    var summarizeDaysOfWeek;
 
     before(function() {
-      nativeMozL10n = navigator.mozL10n;
-      navigator.mozL10n = MockL10n;
-      _ = navigator.mozL10n.get;
       summarizeDaysOfWeek = Utils.summarizeDaysOfWeek;
-    });
-
-    after(function() {
-      navigator.mozL10n = nativeMozL10n;
     });
 
     test('should summarize everyday', function() {


### PR DESCRIPTION
Please note that this work depends on [Bug 897089 - [Clock] Utility methods pollute global scope](https://bugzilla.mozilla.org/show_bug.cgi?id=897089), which has been submitted as GitHub pull request #11127
