### PR TITLE
Bug 897308 - [email/activesync] Username in URL query is "undefined"

### DIFF
--- a/apps/email/js/ext/mailapi/activesync/protocollayer.js
+++ b/apps/email/js/ext/mailapi/activesync/protocollayer.js
@@ -2876,7 +2876,7 @@
       // Build the URL parameters.
       var params = [
         ['Cmd', aCommand],
-        ['User', this._email],
+        ['User', this._username],
         ['DeviceId', this._deviceId],
         ['DeviceType', this._deviceType]
       ];


### PR DESCRIPTION
r=@asutherland over IRC.

https://bugzilla.mozilla.org/show_bug.cgi?id=897308
