### PR TITLE
[MMS][896958]Handling the ActivityCanceled event from Gecko in SMS application when Home button is pressed to avaoid application error. r=borjasalguero

### DIFF
--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -227,6 +227,9 @@
       activity.onerror = function() {
         var _ = navigator.mozL10n.get;
         console.error('error with open activity', this.error.name);
+        if (this.error.name === 'ActivityCanceled') {
+          return;
+        }
         alert(_('attachmentOpenError'));
       };
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=896958
