### PR TITLE
Bug 896907 - [Camera] No preview shown for successful video pick activity

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -464,17 +464,29 @@ var Camera = {
     }
   },
 
-  showConfirmation: function camera_showConfirmation(show) {
+  showConfirmation: function camera_showConfirmation(show, isVideo) {
     var controls = document.getElementById('controls');
     var confirmation = document.getElementById('confirmation');
+    var previewControls = document.getElementById('preview-controls');
 
     if (show) {
       controls.classList.add('hidden');
       confirmation.classList.remove('hidden');
+      // video player control for video pick confirmation only
+      previewControls.classList.add('hidden');
+      this.toggleFlashBtn.classList.add('hidden');
+      this.toggleButton.classList.add('hidden');
+
+      if(isVideo)
+        preview.classList.remove('offscreen');
     }
     else {
       controls.classList.remove('hidden');
       confirmation.classList.add('hidden');
+      previewControls.classList.remove('hidden');
+      preview.classList.add('offscreen');
+      this.toggleFlashBtn.classList.remove('hidden');
+      this.toggleButton.classList.remove('hidden');
     }
   },
 
@@ -671,7 +683,10 @@ var Camera = {
             Filmstrip.addVideo(videofile);
             self._savedMedia = videofile;
             self.stopPreview();
-            self.showConfirmation(true);
+            setTimeout(function() {
+              Filmstrip.previewItem(0);
+              self.showConfirmation(true, true);
+            },500);
           } else {
             Filmstrip.addVideo(videofile);
             Filmstrip.show(Camera.FILMSTRIP_DURATION);
@@ -743,6 +758,9 @@ var Camera = {
       rule.style.MozTransform = 'rotate(' + -(orientation + 1) + 'deg)';
       this._phoneOrientation = orientation;
 
+      // disable rotation of filmstrip preview during pick activity
+      if (this._pendingPick)
+        return;
       Filmstrip.setOrientation(orientation);
     }
   },
@@ -978,7 +996,7 @@ var Camera = {
     this.hideFocusRing();
 
     if (this._pendingPick) {
-      this.showConfirmation(true);
+      this.showConfirmation(true, false);
 
       // Just save the blob temporarily until the user presses "Retake" or
       // "Select".
@@ -996,7 +1014,7 @@ var Camera = {
 
   retakePressed: function camera_retakePressed() {
     this._savedMedia = null;
-    this.showConfirmation(false);
+    this.showConfirmation(false,false);
     this.cancelPickButton.removeAttribute('disabled');
     if (this._captureMode === this.CAMERA) {
       this.resumePreview();
@@ -1009,7 +1027,7 @@ var Camera = {
     var self = this;
     var media = this._savedMedia;
     this._savedMedia = null;
-    this.showConfirmation(false);
+    this.showConfirmation(false, false);
     if (this._captureMode === this.CAMERA) {
       this._addPictureToStorage(media, function(name, absolutePath) {
         this._resizeBlobIfNeeded(media, function(resized_blob) {

--- a/apps/camera/js/filmstrip.js
+++ b/apps/camera/js/filmstrip.js
@@ -114,6 +114,20 @@ var Filmstrip = (function() {
       frame.displayVideo(item.blob, item.poster,
                          item.width, item.height,
                          item.rotation);
+
+        // fix for MMS Video issue-changing the values of videoPoster
+		// and videoPlayer elements for the video pick activity confirmation
+        if (Camera._pendingPick) {
+          var videoPoster = document.getElementsByClassName('videoPoster')[0];
+          videoPoster.style.top = '28%';
+          videoPoster.style.left = '23%';
+          var videoPlayer = document.getElementsByClassName('videoPlayer')[0];
+          videoPlayer.style.top = '28%';
+          videoPlayer.style.left = '23%';
+          var videoPlayerControls =
+                document.getElementsByClassName('videoPlayerControls')[0];
+          videoPlayerControls.style.bottom = '15px';
+        }
     }
 
     preview.classList.remove('offscreen');
@@ -663,6 +677,7 @@ var Filmstrip = (function() {
     addVideo: addVideo,
     deleteItem: deleteItem,
     clear: clear,
-    setOrientation: setOrientation
+    setOrientation: setOrientation,
+    previewItem: previewItem
   };
 }());

--- a/apps/camera/style/camera.css
+++ b/apps/camera/style/camera.css
@@ -33,7 +33,7 @@ html, body {
   right: 0;
   left: 0;
   padding: 1.5rem;
-  z-index: 50;
+  z-index: 110;
   background-color: rgba(0, 0, 0, 0.8);
   overflow: hidden;
   white-space: nowrap;
@@ -293,6 +293,14 @@ form[role="dialog"][data-type="confirm"] menu.hidden {
 
 #toggle-flash {
   left: 2rem;
+}
+
+#toggle-camera.hidden {
+  display:none;
+}
+
+#toggle-camera.hidden {
+  display:none;
 }
 
 #toggle-camera[data-mode=back]:after {


### PR DESCRIPTION
Hi David,

In this patch we are using filmstrip methods to preview an video.
1. calling preview item with a delay (delay is used because the addVideo function takes time to create thumbnail, other stuff)
2. creating dynamic values for videoPoster and videoPlayer css values. This was done to maintain separate values for video pick activity
3. Bringing confirmation to the front by making z-index value to 110 (highest)
4. Hiding toggle flash and toggle camera button for image and video preview of pick activity.

Please review the patch.
