### PR TITLE
Bug 896172 - [Spanish][Notification] Overlapping of message and time in ...

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -155,13 +155,11 @@ html, body {
   position: absolute;
   right: 0;
   top: -.2rem;
-  left: -moz-calc(55px + 19.5rem);
+  left: 25rem;
   color: #52B6CC;
   margin: 13px 15px 0 0;
   padding: 0;
   display: inline;
-  font-size: 1rem;
-  font-weight: bold;
   line-height: 16px;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Bug 896172 - [Spanish][Notification] Overlapping of message and time in notification screen
https://bugzilla.mozilla.org/show_bug.cgi?id=896172

Please note that this issue was discovered in Spanish language and in v1-train.
