### PR TITLE
[Bug-897942] [SMS] contact type(Home,Work,Mobile) always displayed in English for other languages also . r=Steve Chung

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -436,7 +436,8 @@
     getDisplayObject: function(theTitle, tel) {
       var number = tel.value;
       var title = theTitle || number;
-      var type = tel.type && tel.type.length ? tel.type[0] : '';
+      var type = tel.type &&
+        tel.type.length ? navigator.mozL10n.get(tel.type[0]) : '';
       var carrier = tel.carrier ? (tel.carrier + ', ') : '';
       var separator = type || carrier ? ' | ' : '';
       var data = {

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -103,6 +103,7 @@ faxHome   = Fax home
 faxOffice = Fax office
 faxOther  = Fax other
 another   = Another
+Other     = Other
 
 # Date and time
 today         = today


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=897942

STR:
1. Message -> New Message
2. In the recipient, type the first letter of the contact 
3. Check the Label name in the retrieved search list.
Actual:The Label type is always shown in English
Expected: The Label types should be shown in respective languages
