### PR TITLE
Change pages with wheel event.

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -380,6 +380,19 @@ var GridManager = (function() {
         }
 
         break;
+
+      case 'wheel':
+        if (evt.deltaMode === evt.DOM_DELTA_PAGE && evt.deltaX) {
+          // XXX: Scroll one page at a time
+          if (evt.deltaX > 0 && currentPage < pages.length - 1) {
+            GridManager.goToNextPage();
+          } else if (evt.deltaX < 0 && currentPage > 0) {
+            GridManager.goToPreviousPage();
+          }
+          evt.stopPropagation();
+          evt.preventDefault();
+        }
+        break;
     }
   }
 
@@ -867,6 +880,7 @@ var GridManager = (function() {
 
     container = document.querySelector(selector);
     container.addEventListener('contextmenu', handleEvent);
+    container.addEventListener('wheel', handleEvent);
     ensurePanning();
 
     limits.left = container.offsetWidth * 0.05;


### PR DESCRIPTION
This is used by our screen reader. A user scrolls a vew by one page length with two gingers. The screen reader does this by dispatching a wheel event. It makes sense in paginated content like a hom screen to capture these wheel events and use them for switching pages.
