### PR TITLE
Bug 896393 - [Dialer] Keyboard doesnt show in apps when moved from Dialer Contact to other apps.

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -202,9 +202,8 @@ var WindowManager = (function() {
   // to the current closeFrame (before overwriting the reference)
   function setCloseFrame(frame) {
     if (closeFrame) {
+      windowClosed(closeFrame);
       removeFrameClasses(closeFrame);
-      // closeFrame should not be set to active
-      closeFrame.classList.remove('active');
     }
 
     closeFrame = frame;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=896393

listen to appwillopen event to enable keyboard showing.
