### PR TITLE
Bug 895817 - [SMS/MMS] Selecting a contact from facebook is not working

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -387,26 +387,32 @@
 
       Used mainly in activities since they need to pick a contact from just
       the number.
+
+      In order to workaround facebook contact issue(bug 895817), it should be
+      able to hanle the case about phone number without matched contact.
     */
     getContactDisplayInfo: function(resolver, phoneNumber, callback) {
       resolver(phoneNumber, function onContacts(contacts) {
         var contact;
         if (Array.isArray(contacts)) {
-          if (contacts.length == 0) {
-            callback(null);
-            return;
+          if (contacts.length > 0) {
+            contact = contacts[0];
           }
-          contact = contacts[0];
-        } else {
-          if (contacts === null) {
-            callback(null);
-            return;
-          }
+        } else if (contacts !== null) {
           contact = contacts;
         }
 
-        var tel = null;
-        for (var i = 0; i < contact.tel.length && tel == null; i++) {
+        // Only exit when no contact and no phone number case.
+        if (!contact && !phoneNumber) {
+          callback(null);
+          return;
+        }
+
+        var telLength = (contact && contact.tel) ? contact.tel.length : 0;
+        var tel = (telLength > 0) ? null :
+          {type: [''], value: phoneNumber, carrier: ''};
+
+        for (var i = 0; i < telLength && tel == null; i++) {
           if (contact.tel[i].value === phoneNumber) {
             tel = contact.tel[i];
           }

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -2,6 +2,7 @@
 
 requireApp('sms/test/unit/mock_fixed_header.js');
 requireApp('sms/test/unit/mock_contact.js');
+requireApp('sms/test/unit/mock_contacts.js');
 requireApp('sms/test/unit/mock_l10n.js');
 requireApp('sms/js/utils.js');
 
@@ -1029,5 +1030,95 @@ suite('getDisplayObject', function() {
     assert.equal(data.type, type);
     assert.equal(data.carrier, carrier + ', ');
     assert.equal(data.number, value);
+  });
+});
+
+suite('getContactDisplayInfo', function() {
+  setup(function() {
+    this.sinon.spy(Utils, 'getContactDetails');
+    this.sinon.spy(Utils, 'getDisplayObject');
+  });
+
+  teardown(function() {
+    Utils.getContactDetails.reset();
+    Utils.getDisplayObject.reset();
+  });
+
+  test('Valid contact with phonenumber', function(done) {
+    Utils.getContactDisplayInfo(
+      MockContacts.findByPhoneNumber.bind(MockContacts),
+      '+346578888888',
+      function onData(data) {
+        var tel = MockContact.list()[0].tel[0];
+        assert.ok(Utils.getContactDetails.called);
+        assert.deepEqual(Utils.getContactDetails.args[0][0], tel);
+        assert.ok(Utils.getDisplayObject.called);
+        assert.deepEqual(Utils.getDisplayObject.args[0][1], tel);
+        done();
+      }
+    );
+  });
+
+  test('Empty contact with phonenumber', function(done) {
+    this.sinon.stub(MockContact, 'list', function() {
+      return [];
+    });
+    Utils.getContactDisplayInfo(
+      MockContacts.findByPhoneNumber.bind(MockContacts),
+      '+348888888888',
+      function onData(data) {
+        var tel = {
+          'value': '+348888888888',
+          'type': [''],
+          'carrier': ''
+        };
+        assert.ok(Utils.getContactDetails.called);
+        assert.deepEqual(Utils.getContactDetails.args[0][0], tel);
+        assert.ok(Utils.getDisplayObject.called);
+        assert.deepEqual(Utils.getDisplayObject.args[0][1], tel);
+        MockContact.list.restore();
+        done();
+      }
+    );
+  });
+
+  test('Null contact with phonenumber', function(done) {
+    this.sinon.stub(MockContact, 'list', function() {
+      return null;
+    });
+    Utils.getContactDisplayInfo(
+      MockContacts.findByPhoneNumber.bind(MockContacts),
+      '+348888888888',
+      function onData(data) {
+        var tel = {
+          'value': '+348888888888',
+          'type': [''],
+          'carrier': ''
+        };
+        assert.ok(Utils.getContactDetails.called);
+        assert.deepEqual(Utils.getContactDetails.args[0][0], tel);
+        assert.ok(Utils.getDisplayObject.called);
+        assert.deepEqual(Utils.getDisplayObject.args[0][1], tel);
+        MockContact.list.restore();
+        done();
+      }
+    );
+  });
+
+  test('No contact and no phonenumber', function(done) {
+    this.sinon.stub(MockContact, 'list', function() {
+      return [];
+    });
+    Utils.getContactDisplayInfo(
+      MockContacts.findByPhoneNumber.bind(MockContacts),
+      '',
+      function onData(data) {
+        assert.isFalse(Utils.getContactDetails.called);
+        assert.isFalse(Utils.getDisplayObject.called);
+        assert.equal(data, null);
+        MockContact.list.restore();
+        done();
+      }
+    );
   });
 });


### PR DESCRIPTION
- Although contact data from facebook does not integrated with mozContact, we still need to handle contact picker in other proper way instead of returning nothing.
