### PR TITLE
bug 898130 - label desktop-helper as fx-compatible and set recommended maxVersion; r=vingtetun, a=NPOTB

### DIFF
--- a/tools/extensions/activities/install.rdf
+++ b/tools/extensions/activities/install.rdf
@@ -10,9 +10,9 @@
 	  <em:iconURL>chrome://activities.js/skin/logo.png</em:iconURL>
     <em:targetApplication>
       <Description>
-       <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+       <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
        <em:minVersion>6.0</em:minVersion>
-       <em:maxVersion>24.0.*</em:maxVersion>
+       <em:maxVersion>25.*</em:maxVersion>
      </Description>
     </em:targetApplication>
     <em:unpack>true</em:unpack>

--- a/tools/extensions/desktop-helper/install.rdf
+++ b/tools/extensions/desktop-helper/install.rdf
@@ -14,6 +14,13 @@
        <em:maxVersion>32.0.*</em:maxVersion>
      </Description>
     </em:targetApplication>
+    <em:targetApplication>
+      <Description>
+       <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
+       <em:minVersion>6.0</em:minVersion>
+       <em:maxVersion>25.*</em:maxVersion>
+     </Description>
+    </em:targetApplication>
     <em:unpack>true</em:unpack>
     <em:bootstrap>true</em:bootstrap>
     <em:creator>Kevin Grandon</em:creator>


### PR DESCRIPTION
[bug 898130](https://bugzilla.mozilla.org/show_bug.cgi?id=898130)
