### PR TITLE
Bug 896945 Customize the open-app treatment based on the showApp and showOnly flags r=alive r=fabrice

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1344,41 +1344,46 @@ var WindowManager = (function() {
           return;
         }
 
-        if (isRunning(origin)) {
-          // If the app is in foreground, it's too risky to change it's
-          // URL. We'll ignore this request.
-          if (displayedApp !== origin) {
-            var iframe = getAppFrame(origin).firstChild;
+        // If the message specifies we only have to show the app,
+        // then we don't have to do anything here
+        if (!e.detail.onlyShowApp) {
+          if (isRunning(origin)) {
+            // If the app is in foreground, it's too risky to change it's
+            // URL. We'll ignore this request.
+            if (displayedApp !== origin) {
+              var iframe = getAppFrame(origin).firstChild;
 
-            // If the app is opened and it is loaded to the correct page,
-            // then there is nothing to do.
-            if (iframe.src !== e.detail.url) {
-              // Rewrite the URL of the app frame to the requested URL.
-              // XXX: We could ended opening URls not for the app frame
-              // in the app frame. But we don't care.
-              iframe.src = e.detail.url;
+              // If the app is opened and it is loaded to the correct page,
+              // then there is nothing to do.
+              if (iframe.src !== e.detail.url) {
+                // Rewrite the URL of the app frame to the requested URL.
+                // XXX: We could ended opening URls not for the app frame
+                // in the app frame. But we don't care.
+                iframe.src = e.detail.url;
+              }
             }
-          }
-        } else if (origin !== homescreen) {
-          // XXX: We could ended opening URls not for the app frame
-          // in the app frame. But we don't care.
-          var app = appendFrame(null, origin, e.detail.url,
-                      name, manifest, app.manifestURL,
-                      /* expectingSystemMessage */ true);
+          } else if (origin !== homescreen) {
+            // XXX: We could ended opening URls not for the app frame
+            // in the app frame. But we don't care.
+            var app = appendFrame(null, origin, e.detail.url,
+                                  name, manifest, app.manifestURL,
+                                  /* expectingSystemMessage */ true);
 
-          // set the size of the iframe
-          // so Cards View will get a correct screenshot of the frame
-          if (!e.detail.isActivity) {
-            app.resize(false);
-            if ('setVisible' in app.iframe)
-              app.iframe.setVisible(false);
+            // set the size of the iframe
+            // so Cards View will get a correct screenshot of the frame
+            if (!e.detail.isActivity) {
+              app.resize(false);
+              if ('setVisible' in app.iframe)
+                app.iframe.setVisible(false);
+            }
+          } else {
+            ensureHomescreen();
           }
-        } else {
-          ensureHomescreen();
         }
 
-        // We will only bring web activity handling apps to the foreground
-        if (!e.detail.isActivity)
+        // We will only bring apps to the foreground when the message
+        // specifically requests it.
+        if (!e.detail.showApp)
           return;
 
         // XXX: the correct way would be for UtilityTray to close itself


### PR DESCRIPTION
The Gecko patch on Bug 896945 _must_ be checked in before checking in this one. For the most part applying Gecko patch without applying this one should be safe (not everything will work correctly, but most things will actually do) but the reverse isn't true.
