### PR TITLE
Bug 890151 - [CB] CH50 CB message should not be displayed…

### DIFF
--- a/apps/system/js/cell_broadcast_system.js
+++ b/apps/system/js/cell_broadcast_system.js
@@ -24,20 +24,24 @@ var CellBroadcastSystem = {
 
   settingsChangedHandler: function cbs_settingsChangedHandler(event) {
     this._settingsDisabled = event.settingValue;
+
+    if (this._settingsDisabled) {
+      LockScreen.setCellbroadcastLabel();
+    }
   },
 
   show: function cbs_show(event) {
     var conn = window.navigator.mozMobileConnection;
     var msg = event.message;
 
+    if (this._settingsDisabled) {
+      return;
+    }
+
     if (conn &&
         conn.voice.network.mcc === MobileOperator.BRAZIL_MCC &&
         msg.messageId === MobileOperator.BRAZIL_CELLBROADCAST_CHANNEL) {
       LockScreen.setCellbroadcastLabel(msg.body);
-      return;
-    }
-
-    if (this._settingsDisabled) {
       return;
     }
 


### PR DESCRIPTION
…  when the Cell Broadcast service is off, see [bug 890151](https://bugzilla.mozilla.org/show_bug.cgi?id=890151).

This is a rebased version of Hyuna’s patch, see https://github.com/mozilla-b2g/gaia/pull/10926
