### PR TITLE
Bug 898917 - [Statusbar][Camera][Geo] Reduce Indicator Timeout to displa...

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -67,7 +67,7 @@ var StatusBar = {
     'call-forwarding'],
 
   /* Timeout for 'recently active' indicators */
-  kActiveIndicatorTimeout: 60 * 1000,
+  kActiveIndicatorTimeout: 5 * 1000,
 
   /* Whether or not status bar is actively updating or not */
   active: true,


### PR DESCRIPTION
...y recording/geo-sensor icon after finish

Bug 898917 - [Statusbar][Camera][Geo] Reduce Indicator Timeout to display recording/geo-sensor icon after finish
https://bugzilla.mozilla.org/show_bug.cgi?id=898917

Currently the indicator timeout to display recording/geo-sensor icon on statusbar after finish is set to 1 minute.
And this seems way too long so that a user could misinterprete it. 

As per our operator's request, we'd like to change it to 5 seconds.
