### PR TITLE
Bug 898978 - [MMS][HD] Message attachment layout is broken only on hd branch

### DIFF
--- a/apps/sms/style/attachment.css
+++ b/apps/sms/style/attachment.css
@@ -146,6 +146,7 @@
   background-repeat: no-repeat;
   background-position: left top;
   background-size: 160px;
+}
 
 .attachment-container .thumbnail,
 .attachment-container .thumbnail-placeholder {


### PR DESCRIPTION
- Fix small css bug after v1-train merge in hd branch
