### PR TITLE
Bug 886758 - [Settings] Users are not able to disable the sim lock from ...

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -852,9 +852,14 @@ window.addEventListener('load', function loadSettings() {
 
   function handleRadioAndCardState() {
     function disableSIMRelatedSubpanels(disable) {
-      const itemIds = ['call-settings',
-                       'data-connectivity',
-                       'simSecurity-settings'];
+      var itemIds = ['call-settings',
+                     'data-connectivity'];
+
+      // Disable SIM security item only in case of SIM absent.
+      var cardState = IccHelper.cardState;
+      if (cardState && cardState === 'absent') {
+        itemIds.push('simSecurity-settings');
+      }
 
       for (var id = 0; id < itemIds.length; id++) {
         var item = document.getElementById(itemIds[id]);


### PR DESCRIPTION
...settings app when the sim card is not ready

See bug https://bugzilla.mozilla.org/show_bug.cgi?id=886758 please.
