### PR TITLE
Bug 859035 - [l10n] Do not use the same "unknown" entity for Size & Author when installing a WebApp

### DIFF
--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -116,7 +116,7 @@ var AppInstallManager = {
     if (manifest.size) {
       this.size.textContent = this.humanizeSize(manifest.size);
     } else {
-      this.size.textContent = _('unknown');
+      this.size.textContent = _('unknown-size');
     }
 
     // Wrap manifest to get localized properties
@@ -125,10 +125,11 @@ var AppInstallManager = {
     this.msg.textContent = msg;
 
     if (manifest.developer) {
-      this.authorName.textContent = manifest.developer.name || _('unknown');
+      this.authorName.textContent = manifest.developer.name ||
+        _('unknown-author');
       this.authorUrl.textContent = manifest.developer.url || '';
     } else {
-      this.authorName.textContent = _('unknown');
+      this.authorName.textContent = _('unknown-author');
       this.authorUrl.textContent = '';
     }
 

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -63,6 +63,18 @@ install-app=Install {{name}}?
 size=Size
 author=Author
 unknown=Unknown
+
+# LOCALIZATION NOTE (unknown-size,unknown-author):
+# if you leave the original en-US value "{{unknown}}" in
+# the following two strings, the localization will be automatically picked
+# from the existing string with ID "unknown". If you need to adapt your
+# localization to different genders for author and size, you can localize
+# these strings. For example in French:
+# unknown-size=inconnue
+# unknown-author=inconnu
+unknown-size={{unknown}}
+unknown-author={{unknown}}
+
 install=Install
 bytes=bytes
 kB=kB

--- a/apps/system/locales/system.fr.properties
+++ b/apps/system/locales/system.fr.properties
@@ -63,6 +63,18 @@ install-app=Installer {{name}} ?
 size=Taille
 author=Auteur
 unknown=inconnu
+
+# LOCALIZATION NOTE (unknown-size,unknown-author):
+# if you leave the original en-US value "{{unknown}}" in
+# the following two strings, the localization will be automatically picked
+# from the existing string with ID "unknown". If you need to adapt your
+# localization to different genders for author and size, you can localize
+# these strings. For example in French:
+# unknown-size=inconnue
+# unknown-author=inconnu
+unknown-size=inconnue
+unknown-author=inconnu
+
 install=Installer
 bytes=octets
 kB=Ko

--- a/apps/system/test/unit/app_install_manager_test.js
+++ b/apps/system/test/unit/app_install_manager_test.js
@@ -287,7 +287,8 @@ suite('system/AppInstallManager >', function() {
           });
 
           AppInstallManager.handleAppInstallPrompt(evt.detail);
-          assert.equal('unknown', AppInstallManager.authorName.textContent);
+          assert.equal('unknown-author',
+            AppInstallManager.authorName.textContent);
           assert.equal('', AppInstallManager.authorUrl.textContent);
         });
 
@@ -305,7 +306,8 @@ suite('system/AppInstallManager >', function() {
           });
 
           AppInstallManager.handleAppInstallPrompt(evt.detail);
-          assert.equal('unknown', AppInstallManager.authorName.textContent);
+          assert.equal('unknown-author',
+            AppInstallManager.authorName.textContent);
           assert.equal('', AppInstallManager.authorUrl.textContent);
         });
 
@@ -325,7 +327,8 @@ suite('system/AppInstallManager >', function() {
           });
 
           AppInstallManager.handleAppInstallPrompt(evt.detail);
-          assert.equal('unknown', AppInstallManager.authorName.textContent);
+          assert.equal('unknown-author',
+            AppInstallManager.authorName.textContent);
           assert.equal('http://example.com',
             AppInstallManager.authorUrl.textContent);
         });
@@ -372,7 +375,7 @@ suite('system/AppInstallManager >', function() {
           });
 
           AppInstallManager.handleAppInstallPrompt(evt.detail);
-          assert.equal('unknown', AppInstallManager.size.textContent);
+          assert.equal('unknown-size', AppInstallManager.size.textContent);
         });
       });
 


### PR DESCRIPTION
PR for v1-train and v1.1.0hd only
