### PR TITLE
Bug 898804 - [Calendar] There is a big space area shown in calendar settings page

### DIFF
--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -141,11 +141,6 @@ ol.link-list a {
   padding-left: 1.5rem;
 }
 
-#advanced-settings-view .account-list {
-  height: calc(50% - 2.5rem);
-  overflow-y: scroll;
-}
-
 #advanced-settings-view .settings-list label,
 #advanced-settings-view .account-list a {
   text-transform: none;


### PR DESCRIPTION
Remove the whitespace in settings page.
http://bugzil.la/898804
