### PR TITLE
Bug 899816 - [helix][Gallery] The images are displayed in 2 columns instead of 3 columns, leaving an empty black space

### DIFF
--- a/apps/gallery/style/gallery.css
+++ b/apps/gallery/style/gallery.css
@@ -181,9 +181,13 @@ section {
    * Padding-bottom is used here in order to set div height with respect
    * to device width.
    */
-  width: calc((100% - 0.2rem) / 3 );
+  width: calc(100% / 3 - 0.1rem);
   height: 0;
-  padding-bottom: calc((100% - 0.3rem) / 3 );
+  padding-bottom: calc(100% / 3 - 0.1rem);
+}
+
+.thumbnail:nth-child(3n) {
+  margin-right: 0;
 }
 
 .thumbnail.selected {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=899816

a regression of bug 898701. Change the width calc back.
