### PR TITLE
Bug 855117 - Move the description to a separate li r=evelyn

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -977,7 +977,6 @@
             </label>
             <small id="dataConnection-desc"></small>
             <a data-l10n-id="dataConnection">Data Connection</a>
-            <p id="dataConnection-expl" class="explanation" data-l10n-id="dataConnection-warning-message" hidden></p>
           </li>
           <li id="dataConnection-expl" class="explanation" data-l10n-id="dataConnection-warning-message" hidden></li>
           <li class="hint">
@@ -986,8 +985,8 @@
               <span></span>
             </label>
             <a data-l10n-id="dataRoaming">Data Roaming</a>
-            <p id="dataRoaming-expl" class="explanation" data-l10n-id="dataRoaming-warning-message" hidden></p>
           </li>
+          <li id="dataRoaming-expl" class="explanation" data-l10n-id="dataRoaming-warning-message" hidden></li>
         </ul>
 
         <header>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=855117
