### PR TITLE
Bug 898294 - [Gallery] Statusbar show when switching from camera app to gallery

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -408,8 +408,6 @@ var WindowManager = (function() {
       };
     }
 
-    screenElement.classList.remove('fullscreen-app');
-
     // Inform keyboardmanager that we've finished the transition
     dispatchEvent(new CustomEvent('appclose'));
   }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=898294

remove dup screenElement.classList.remove('fullscreen-app') in windowClosed since it's already done in setDisplayedApp.
