### PR TITLE
	Bug 900361 - Enable customization per target device of resolution for FB images

### DIFF
--- a/apps/communications/contacts/js/import_utils.js
+++ b/apps/communications/contacts/js/import_utils.js
@@ -6,12 +6,6 @@
   // Scale ratio for different devices
   var SCALE_RATIO = window.innerWidth / 320;
 
-  // Minimum size in px for profile detail image
-  var IMG_DETAIL_WIDTH = 200;
-
-  // Minimum size in px for profile thumbnail image
-  var IMG_THUMB_SIZE = 120;
-
   var LAST_IMPORT_TIMESTAMP_SUFFIX = '_last_import_timestamp';
 
   function scale(size) {
@@ -19,8 +13,9 @@
   }
 
   importUtils.getPreferredPictureBox = function() {
+    var imgThumbSize = oauthflow.params['facebook'].imgThumbSize;
     var out = {
-      width: scale(IMG_THUMB_SIZE)
+      width: scale(imgThumbSize)
     };
 
     out.height = out.width;
@@ -29,7 +24,8 @@
   };
 
   importUtils.getPreferredPictureDetail = function() {
-    return scale(IMG_DETAIL_WIDTH);
+    var imgDetailWidth = oauthflow.params['facebook'].imgDetailWidth;
+    return scale(imgDetailWidth);
   };
 
   importUtils.setTimestamp = function(type, callback) {

--- a/apps/communications/contacts/test/unit/link_test.js
+++ b/apps/communications/contacts/test/unit/link_test.js
@@ -9,11 +9,13 @@ requireApp('communications/contacts/js/utilities/binary_search.js');
 requireApp('communications/contacts/js/utilities/templates.js');
 requireApp('communications/contacts/test/unit/mock_linked_contacts.js');
 requireApp('communications/contacts/test/unit/mock_fb.js');
+requireApp('communications/contacts/test/unit/mock_oauthflow.js');
 requireApp('communications/contacts/js/fb/fb_link.js');
 
 var realImageLoader,
     realAsyncStorage,
     realFb,
+    realOauthflow,
     linkProposal,
     linkProposalChild;
 
@@ -30,6 +32,9 @@ if (!this.fb) {
   this.fb = null;
 }
 
+if (!this.oauthflow) {
+  this.oauthflow = null;
+}
 
 suite('Link Friends Test Suite', function() {
 
@@ -43,6 +48,9 @@ suite('Link Friends Test Suite', function() {
     realFb = window.fb;
     window.fb = Mockfb;
     window.fb.link = realFb.link;
+
+    realOauthflow = window.oauthflow;
+    window.oauthflow = MockOauthflow;
 
     document.body.innerHTML = MockLinkHtml;
 
@@ -192,6 +200,7 @@ suite('Link Friends Test Suite', function() {
     window.asyncStorage = realAsyncStorage;
     window.navigator.mozL10n = realL10n;
     window.fb = realFb;
+    window.oauthflow = realOauthflow;
   });
 
 });

--- a/apps/communications/contacts/test/unit/mock_oauthflow.js
+++ b/apps/communications/contacts/test/unit/mock_oauthflow.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var MockOauthflow = {
+  params: {
+    'facebook': {
+      'appOrigin': 'app://communications.gaiamobile.org',
+      'redirectURI': 'https://www.facebook.com/connect/login_success.html',
+      'loginPage': 'https://m.facebook.com/dialog/oauth/?',
+      'applicationId': '123456',
+      'scope': [
+        'friends_about_me',
+        'friends_birthday',
+        'friends_hometown',
+        'friends_location',
+        'friends_work_history',
+        'read_stream'
+      ],
+      'redirectMsg':
+'http://intense-tundra-4122.herokuapp.com/fbowd/oauth2_new/dialogs_end.html',
+      'redirectLogout':
+'http://intense-tundra-4122.herokuapp.com/fbowd/oauth2_new/logout.json',
+      'imgDetailWidth': 200,
+      'imgThumbSize': 120
+    },
+    'live': {
+      'appOrigin': 'app://communications.gaiamobile.org',
+      'redirectURI': 'https://www.mozilla.org/',
+      'loginPage': 'https://login.live.com/oauth20_authorize.srf?',
+      'applicationId': '123456',
+      'scope': [
+        'wl.basic',
+        'wl.contacts_emails',
+        'wl.contacts_phone_numbers',
+        'wl.contacts_birthday',
+        'wl.contacts_postal_addresses'
+      ],
+      'logoutUrl': 'https://login.live.com/logout.srf'
+    },
+    'gmail': {
+      'appOrigin': 'app://communications.gaiamobile.org',
+      'redirectURI':
+'https://serene-cove-3587.herokuapp.com/liveowd/oauth2_new/flow_live.html',
+      'loginPage': 'https://accounts.google.com/o/oauth2/auth?',
+      'applicationId': '664741361278.apps.googleusercontent.com',
+      'scope': [
+        'https://www.google.com/m8/feeds/'
+      ],
+      'logoutUrl': 'https://accounts.google.com/Logout'
+    }
+  }
+};

--- a/apps/communications/facebook/test/unit/facebook_connector_test.js
+++ b/apps/communications/facebook/test/unit/facebook_connector_test.js
@@ -6,8 +6,10 @@ requireApp('communications/facebook/js/facebook_connector.js');
 requireApp('communications/facebook/test/unit/mock_fb_graph_data.js');
 requireApp('communications/facebook/test/unit/mock_fb_query.js');
 requireApp('communications/contacts/js/import_utils.js');
+requireApp('communications/contacts/test/unit/mock_oauthflow.js');
 
 var realFbUtils,
+    realOauthflow,
     subject;
 
 if (!this.FacebookConnector) {
@@ -18,11 +20,19 @@ if (!this.fb) {
   this.fb = null;
 }
 
+if (!this.oauthflow) {
+  this.oauthflow = null;
+}
+
 suite('Facebook Connector Tests', function() {
   suiteSetup(function() {
     realFbUtils = window.fb.utils;
     window.fb.utils = MockFbQuery;
+
     subject = window.FacebookConnector;
+
+    realOauthflow = window.oauthflow;
+    window.oauthflow = MockOauthflow;
   });
 
 
@@ -80,5 +90,6 @@ suite('Facebook Connector Tests', function() {
 
   suiteTeardown(function() {
     window.fb.utils = realFbUtils;
+    window.oauthflow = realOauthflow;
   });
 });

--- a/apps/communications/import/test/unit/import_test.js
+++ b/apps/communications/import/test/unit/import_test.js
@@ -3,6 +3,7 @@ requireApp('communications/import/test/unit/mock_import.html.js');
 requireApp('communications/contacts/test/unit/mock_l10n.js');
 requireApp('communications/contacts/test/unit/mock_asyncstorage.js');
 requireApp('communications/contacts/test/unit/mock_search.js');
+requireApp('communications/contacts/test/unit/mock_oauthflow.js');
 requireApp('communications/contacts/js/import_utils.js');
 requireApp('communications/contacts/js/utilities/dom.js');
 requireApp('communications/contacts/js/fb/friends_list.js');
@@ -21,6 +22,7 @@ var realSearch,
     realImageLoader,
     realAlphaScroll,
     realAsyncStorage,
+    realOauthflow,
     groupsListChild, groupsList;
 
 if (!this.FixedHeader) {
@@ -41,6 +43,10 @@ if (!this.contacts) {
 
 if (!this.onrendered) {
   this.onrendered = true;
+}
+
+if (!this.oauthflow) {
+  this.oauthflow = null;
 }
 
 setup(function() {
@@ -65,6 +71,9 @@ suite('Import Friends Test Suite', function() {
 
     realAsyncStorage = window.asyncStorage;
     window.asyncStorage = MockasyncStorage;
+
+    realOauthflow = window.oauthflow;
+    window.oauthflow = MockOauthflow;
 
     document.body.innerHTML = MockImportHtml;
 
@@ -187,6 +196,7 @@ suite('Import Friends Test Suite', function() {
     window.ImageLoader = realImageLoader;
     window.contacts.Search = realSearch;
     window.asyncStorage = realAsyncStorage;
+    window.oauthflow = realOauthflow;
   });
 
 });

--- a/build/communications_services.json
+++ b/build/communications_services.json
@@ -14,7 +14,11 @@
     "redirectMsg":
       "http://intense-tundra-4122.herokuapp.com/fbowd/oauth2_new/dialogs_end.html",
     "redirectLogout":
-      "http://intense-tundra-4122.herokuapp.com/fbowd/oauth2_new/logout.json"
+      "http://intense-tundra-4122.herokuapp.com/fbowd/oauth2_new/logout.json",
+    "imgDetailWidth":
+      200,
+    "imgThumbSize":
+      120
   },
 
   "live": {


### PR DESCRIPTION
Simple patch to load the image size values from a json instead of using hardcoded ones.

Tested on unagi and peak devices
