### PR TITLE
Bug 900539 - [SMS][MMS] Context Menu options for email address in message body

### DIFF
--- a/apps/sms/js/activity_picker.js
+++ b/apps/sms/js/activity_picker.js
@@ -1,86 +1,100 @@
+(function(exports) {
 'use strict';
 
-/*
-The Activity Picker exposes common activity
-calls used by SMS App
-*/
+function tryActivity(opts, onsuccess, onerror) {
+  var activity;
+
+  if (typeof onerror !== 'function') {
+    onerror = function(error) {
+      console.warn('Unhandled error spawning activity; ' + error.message);
+    };
+  }
+
+  try {
+    activity = new MozActivity(opts);
+
+    if (typeof onsuccess === 'function') {
+      activity.onsuccess = onsuccess;
+    }
+
+    activity.onerror = onerror;
+
+  } catch (e) {
+    onerror.call(activity, e);
+  }
+}
 
 var ActivityPicker = {
-  call:
-   function ap_call(phone) {
-    try {
-      var activity = new MozActivity({
-        name: 'dial',
-        data: {
-          type: 'webtelephony/number',
-          number: phone
-        }
-      });
-    } catch (e) {
-      console.log('WebActivities unavailable? : ' + e);
-    }
+  dial: function ap_call(number, onsuccess, onerror) {
+    var params = {
+      name: 'dial',
+      data: {
+        type: 'webtelephony/number',
+        number: number
+      }
+    };
+
+    tryActivity(params, onsuccess, onerror);
+  },
+  email: function ap_email(email, onsuccess, onerror) {
+    var params = {
+      name: 'new',
+      data: {
+        type: 'mail',
+        URI: 'mailto:' + email
+      }
+    };
+
+    tryActivity(params, onsuccess, onerror);
+  },
+  url: function ap_browse(url, onsuccess, onerror) {
+    var params = {
+      name: 'view',
+      data: {
+        type: 'url',
+        url: url
+      }
+    };
+
+    tryActivity(params, onsuccess, onerror);
   },
   createNewContact:
-   function ap_createNewContact(param,
-     onSuccess, onFailure) {
-     try {
-      var activity = new MozActivity({
-        name: 'new',
-        data: {
-          type: 'webcontacts/contact',
-          params: param
-        }
-      });
-      activity.onsuccess = function ap_contactCreateSuccess() {
-        if (onSuccess && typeof onSuccess === 'function') {
-          onSuccess();
-        }
-      };
-      activity.onerror = function ap_contactCreateFailure() {
-        if (onFailure && typeof onFailure === 'function') {
-          onFailure();
-        }
-      };
-    } catch (e) {
-      console.log('WebActivities unavailable? : ' + e);
-    }
+   function ap_createNewContact(contactProps, onsuccess, onerror) {
+    var params = {
+      name: 'new',
+      data: {
+        type: 'webcontacts/contact',
+        params: contactProps
+      }
+    };
+
+    tryActivity(params, onsuccess, onerror);
   },
   addToExistingContact:
-   function ap_addToExistingContact(param, 
-    onSuccess, onFailure) {
-    try {
-      var activity = new MozActivity({
-        name: 'update',
-        data: {
-          type: 'webcontacts/contact',
-          params: param
-        }
-      });
-      activity.onsuccess = function ap_contactUpdateSuccess() {
-        if (onSuccess && typeof onSuccess === 'function') {
-          onSuccess();
-        }
-      };
-      activity.onerror = function ap_contactUpdateFailure() {
-        if (onFailure && typeof onFailure === 'function') {
-          onFailure();
-        }
-      };
-    } catch (e) {
-        console.log('WebActivities unavailable? : ' + e);
-    }
+   function ap_addToExistingContact(contactProps, onsuccess, onerror) {
+    var params = {
+      name: 'update',
+      data: {
+        type: 'webcontacts/contact',
+        params: contactProps
+      }
+    };
+
+    tryActivity(params, onsuccess, onerror);
   },
-  sendMessage: function ap_sendMessage(phone) {
-    try {
-      var activity = new MozActivity({
-        name: 'new',
-        data: {
-          type: 'websms/sms',
-          number: phone
-        }
-      });
-    } catch (e) {
-      console.log('WebActivities unavailable? : ' + e);
-    }
+  sendMessage: function ap_sendMessage(phone, onsuccess, onerror) {
+    var params = {
+      name: 'new',
+      data: {
+        type: 'websms/sms',
+        number: phone
+      }
+    };
+
+    tryActivity(params, onsuccess, onerror);
   }
 };
+
+exports.ActivityPicker = ActivityPicker;
+
+}(this));

--- a/apps/sms/js/link_helper.js
+++ b/apps/sms/js/link_helper.js
@@ -58,8 +58,8 @@ var LINK_TYPES = {
       return link;
     },
     transform: function phoneTransform(phone, link) {
-      return '<a data-phonenumber="' + phone +
-        '" data-action="phone-link">' + phone + '</a>';
+      return '<a data-dial="' + phone +
+        '" data-action="dial-link">' + phone + '</a>';
     }
   },
 

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1951,11 +1951,12 @@ var ThreadUI = global.ThreadUI = {
     var _ = navigator.mozL10n.get;
     var thread = Threads.get(Threads.lastId || Threads.currentId);
     var number = opt.number;
-    var name = opt.name || number;
+    var email = opt.email;
+    var name = opt.name || number || email;
     var isContact = opt.isContact || false;
     var inMessage = opt.inMessage || false;
     var items = [];
-    var params;
+    var params, props;
 
     // Multi-participant activation for for a single, known
     // recipient contact, that is not triggered from a message,
@@ -1963,30 +1964,42 @@ var ThreadUI = global.ThreadUI = {
     if ((thread && thread.participants.length === 1) &&
         isContact && !inMessage) {
 
-      ActivityPicker.call(number);
+      ActivityPicker.dial(number);
       return;
     }
 
-    // All activations will see a "Call" option
-    items.push({
-      name: _('call'),
-      method: function oCall(param) {
-        ActivityPicker.call(param);
-      },
-      params: [number]
-    });
-
-    // Multi-participant activations or in-message numbers
-    // will include a "Send Message" option in the menu
-    if ((thread && thread.participants.length > 1) || inMessage) {
+    // All non-email activations will see a "Call" option
+    if (email) {
       items.push({
-        name: _('sendMessage'),
+        name: _('sendEmail'),
         method: function oCall(param) {
-          ActivityPicker.sendMessage(param);
+          ActivityPicker.dial(param);
+        },
+        params: [email]
+      });
+    } else {
+      items.push({
+        name: _('call'),
+        method: function oCall(param) {
+          ActivityPicker.dial(param);
         },
         params: [number]
       });
+
+
+      // Multi-participant activations or in-message numbers
+      // will include a "Send Message" option in the menu
+      if ((thread && thread.participants.length > 1) || inMessage) {
+        items.push({
+          name: _('sendMessage'),
+          method: function oCall(param) {
+            ActivityPicker.sendMessage(param);
+          },
+          params: [number]
+        });
+      }
     }
+
 
     // Combine the items and complete callback into
     // a single params object.
@@ -2003,6 +2016,10 @@ var ThreadUI = global.ThreadUI = {
 
     } else {
 
+      props = [
+        number ? {tel: number} : {email: email}
+      ];
+
       params.header = number;
       params.items.push({
           name: _('createNewContact'),
@@ -2011,7 +2028,7 @@ var ThreadUI = global.ThreadUI = {
               param, ThreadUI.onCreateContact
             );
           },
-          params: [{'tel': number}]
+          params: props
         },
         {
           name: _('addToExistingContact'),
@@ -2020,7 +2037,7 @@ var ThreadUI = global.ThreadUI = {
               param, ThreadUI.onCreateContact
             );
           },
-          params: [{'tel': number}]
+          params: props
         }
       );
     }

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -114,6 +114,7 @@ incorrectDate = (incorrect date)
 addToExistingContact    = Add to an existing contact
 createNewContact        = Create new contact
 call                    = Call
+sendEmail               = Send email
 
 # MMS message
 mms-message          = MMS message
@@ -126,4 +127,3 @@ unnamed-attachment   = untitled
 file-too-large       = The file you have selected is too large
 resize-image         = Resizing the attached image
 no-attachment-text   = There is a problem with the attached file and it cannot be downloaded.
-

--- a/apps/sms/test/unit/activity_picker_test.js
+++ b/apps/sms/test/unit/activity_picker_test.js
@@ -1,0 +1,338 @@
+'use strict';
+
+requireApp('sms/js/activity_picker.js');
+requireApp('sms/js/utils.js');
+
+requireApp('sms/test/unit/mock_l10n.js');
+requireApp('sms/test/unit/mock_moz_activity.js');
+requireApp('sms/test/unit/mock_utils.js');
+
+var mocksHelperAP = new MocksHelper([
+  'MozActivity',
+  'Utils'
+]).init();
+
+suite('ActivityPicker', function() {
+  var realMozL10n, events, onsuccess, onerror;
+
+  suiteSetup(function() {
+    realMozL10n = navigator.mozL10n;
+    navigator.mozL10n = MockL10n;
+    mocksHelperAP.suiteSetup();
+
+    onsuccess = function() {};
+    onerror = function() {};
+  });
+
+  suiteTeardown(function() {
+    navigator.mozL10n = realMozL10n;
+    mocksHelperAP.suiteTeardown();
+  });
+
+  setup(function() {
+    mocksHelperAP.setup();
+  });
+
+  teardown(function() {
+    mocksHelperAP.teardown();
+  });
+
+  suite('dial', function() {
+
+    test('dial(number) ', function() {
+      ActivityPicker.dial('999');
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'dial',
+        data: { type: 'webtelephony/number', number: '999' }
+      });
+    });
+
+    test('dial(number, success) ', function() {
+      ActivityPicker.dial('999', onsuccess);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'dial',
+        data: { type: 'webtelephony/number', number: '999' }
+      });
+    });
+
+    test('dial(number, success, error) ', function() {
+      ActivityPicker.dial('999', onsuccess, onerror);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.equal(
+        MozActivity.instances[0].onerror, onerror
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'dial',
+        data: { type: 'webtelephony/number', number: '999' }
+      });
+    });
+  });
+
+  suite('email', function() {
+
+    test('email(email) ', function() {
+      ActivityPicker.email('a@b.com');
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'mail',
+          URI: 'mailto:a@b.com'
+        }
+      });
+    });
+
+    test('email(email, success) ', function() {
+      ActivityPicker.email('a@b.com', onsuccess);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'mail',
+          URI: 'mailto:a@b.com'
+        }
+      });
+    });
+
+    test('email(email, success, error) ', function() {
+      ActivityPicker.email('a@b.com', onsuccess, onerror);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.equal(
+        MozActivity.instances[0].onerror, onerror
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'mail',
+          URI: 'mailto:a@b.com'
+        }
+      });
+    });
+  });
+
+  suite('url', function() {
+
+    test('url(url) ', function() {
+      ActivityPicker.url('http://mozilla.com');
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'view',
+        data: {
+          type: 'url',
+          url: 'http://mozilla.com'
+        }
+      });
+    });
+
+    test('url(url, success) ', function() {
+      ActivityPicker.url('http://mozilla.com', onsuccess);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'view',
+        data: {
+          type: 'url',
+          url: 'http://mozilla.com'
+        }
+      });
+    });
+
+    test('url(url, success, error) ', function() {
+      ActivityPicker.url('http://mozilla.com', onsuccess, onerror);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.equal(
+        MozActivity.instances[0].onerror, onerror
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'view',
+        data: {
+          type: 'url',
+          url: 'http://mozilla.com'
+        }
+      });
+    });
+  });
+
+  suite('createNewContact', function() {
+
+    test('createNewContact(props) ', function() {
+      ActivityPicker.createNewContact({foo: ['bar']});
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'webcontacts/contact',
+          params: {foo: ['bar']}
+        }
+      });
+    });
+
+    test('createNewContact(props, success) ', function() {
+      ActivityPicker.createNewContact({foo: ['bar']}, onsuccess);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'webcontacts/contact',
+          params: {foo: ['bar']}
+        }
+      });
+    });
+
+    test('createNewContact(props, success, error) ', function() {
+      ActivityPicker.createNewContact({foo: ['bar']}, onsuccess, onerror);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.equal(
+        MozActivity.instances[0].onerror, onerror
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'webcontacts/contact',
+          params: {foo: ['bar']}
+        }
+      });
+    });
+  });
+
+  suite('addToExistingContact', function() {
+
+    test('addToExistingContact(props) ', function() {
+      ActivityPicker.addToExistingContact({foo: ['bar']});
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'update',
+        data: {
+          type: 'webcontacts/contact',
+          params: {foo: ['bar']}
+        }
+      });
+    });
+
+    test('addToExistingContact(props, success) ', function() {
+      ActivityPicker.addToExistingContact({foo: ['bar']}, onsuccess);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'update',
+        data: {
+          type: 'webcontacts/contact',
+          params: {foo: ['bar']}
+        }
+      });
+    });
+
+    test('addToExistingContact(props, success, error) ', function() {
+      ActivityPicker.addToExistingContact({foo: ['bar']}, onsuccess, onerror);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.equal(
+        MozActivity.instances[0].onerror, onerror
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'update',
+        data: {
+          type: 'webcontacts/contact',
+          params: {foo: ['bar']}
+        }
+      });
+    });
+  });
+
+  suite('sendMessage', function() {
+
+    test('sendMessage(phone) ', function() {
+      ActivityPicker.sendMessage('999');
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'websms/sms',
+          number: '999'
+        }
+      });
+    });
+
+    test('sendMessage(phone, success) ', function() {
+      ActivityPicker.sendMessage('999', onsuccess);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'websms/sms',
+          number: '999'
+        }
+      });
+    });
+
+    test('sendMessage(phone, success, error) ', function() {
+      ActivityPicker.sendMessage('999', onsuccess, onerror);
+
+      assert.equal(
+        MozActivity.instances[0].onsuccess, onsuccess
+      );
+
+      assert.equal(
+        MozActivity.instances[0].onerror, onerror
+      );
+
+      assert.deepEqual(MozActivity.calls[0], {
+        name: 'new',
+        data: {
+          type: 'websms/sms',
+          number: '999'
+        }
+      });
+    });
+  });
+
+
+});

--- a/apps/sms/test/unit/link_helper_test.js
+++ b/apps/sms/test/unit/link_helper_test.js
@@ -219,8 +219,8 @@ suite('link_helper_test.js', function() {
     }
 
     function phone2msg(phone) {
-      return '<a data-phonenumber="' + phone + '"' +
-             ' data-action="phone-link">' + phone + '</a>';
+      return '<a data-dial="' + phone + '"' +
+             ' data-action="dial-link">' + phone + '</a>';
     }
 
     function testPhoneOK(phone) {
@@ -300,7 +300,7 @@ suite('link_helper_test.js', function() {
         '<a data-url="http://stackoverflow.com/q/12882966/" ' +
         'data-action="url-link" >http://stackoverflow.com/q/12882966/</a>' +
         ' and call me at ' +
-        '<a data-phonenumber="+18155551212" data-action="phone-link">' +
+        '<a data-dial="+18155551212" data-action="dial-link">' +
         '+18155551212</a> or (e-mail <a data-email="user@hostname.tld"' +
         ' data-action="email-link">user@hostname.tld</a>)';
       assert.equal(LinkHelper.searchAndLinkClickableData(test), expected);

--- a/apps/sms/test/unit/mock_activity_picker.js
+++ b/apps/sms/test/unit/mock_activity_picker.js
@@ -4,7 +4,11 @@
 var MockActivityPicker = {};
 
 
-['call', 'createNewContact', 'addToExistingContact'].forEach(function(fn) {
+[
+ 'email', 'dial', 'url',
+ 'createNewContact', 'addToExistingContact',
+ 'sendMessage'
+].forEach(function(fn) {
   MockActivityPicker[fn] = function() {
     MockActivityPicker[fn].called = true;
     MockActivityPicker[fn].calledWith = [].slice.call(arguments);

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -692,14 +692,14 @@ suite('SMS App Unit-Test', function() {
       Message.id = id;
       Message.body = messageBody;
       var messageDOM = ThreadUI.buildMessageDOM(Message, false);
-      var anchors = messageDOM.querySelectorAll('[data-phonenumber]');
+      var anchors = messageDOM.querySelectorAll('[data-dial]');
       assert.equal(anchors.length, 3,
         '3 Contact handlers are attached for 3 phone numbers in DOM');
-      assert.equal(anchors[0].dataset.phonenumber,
+      assert.equal(anchors[0].dataset.dial,
         '408-746-9721', 'First number link is 408-746-9721');
-      assert.equal(anchors[1].dataset.phonenumber,
+      assert.equal(anchors[1].dataset.dial,
         '4087469721', 'Second number is 4087469721');
-      assert.equal(anchors[2].dataset.phonenumber,
+      assert.equal(anchors[2].dataset.dial,
         '7469721', 'Third number is 7469721');
     });
 
@@ -713,23 +713,23 @@ suite('SMS App Unit-Test', function() {
       Message.id = id;
       Message.body = messageBody;
       var messageDOM = ThreadUI.buildMessageDOM(Message, false);
-      var anchors = messageDOM.querySelectorAll('[data-phonenumber]');
+      var anchors = messageDOM.querySelectorAll('[data-dial]');
 
       assert.equal(anchors.length, 7,
         '7 Contact handlers are attached for 7 phone numbers in DOM');
-      assert.equal(anchors[0].dataset.phonenumber,
+      assert.equal(anchors[0].dataset.dial,
         '995-382-7369', 'First number is 995-382-7369');
-      assert.equal(anchors[1].dataset.phonenumber,
+      assert.equal(anchors[1].dataset.dial,
         '4458901', 'Second number is 4458901');
-      assert.equal(anchors[2].dataset.phonenumber,
+      assert.equal(anchors[2].dataset.dial,
         '789-7890', 'Third number is 789-7890');
-      assert.equal(anchors[3].dataset.phonenumber,
+      assert.equal(anchors[3].dataset.dial,
         '+1-556-667-7789', 'Fourth number is +1-556-667-7789');
-      assert.equal(anchors[4].dataset.phonenumber,
+      assert.equal(anchors[4].dataset.dial,
         '9953827369', 'Fifth number is 9953827369');
-      assert.equal(anchors[5].dataset.phonenumber,
+      assert.equal(anchors[5].dataset.dial,
         '+12343454567', 'Sixth number is +12343454567');
-      assert.equal(anchors[6].dataset.phonenumber,
+      assert.equal(anchors[6].dataset.dial,
         '+919810137553', 'Seventh number is +919810137553');
       // The phone links generated shouldn have 'href'
       var anchorsLength = anchors.length;

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1486,8 +1486,8 @@ suite('thread_ui.js >', function() {
       this.sinon.spy(LinkActionHandler, 'onContextMenu');
 
       this.sinon.stub(LinkHelper, 'searchAndLinkClickableData', function() {
-        return '<a data-phonenumber="' + phone +
-        '" data-action="phone-link">' + phone + '</a>';
+        return '<a data-dial="' + phone +
+        '" data-action="dial-link">' + phone + '</a>';
       });
 
       ThreadUI.appendMessage({
@@ -1959,15 +1959,16 @@ suite('thread_ui.js >', function() {
 
   suite('Header Actions/Display', function() {
     setup(function() {
+      Threads.delete(1);
       window.location.hash = '';
-      MockActivityPicker.call.mSetup();
+      MockActivityPicker.dial.mSetup();
       MockOptionMenu.mSetup();
     });
 
     teardown(function() {
       Threads.delete(1);
       window.location.hash = '';
-      MockActivityPicker.call.mTeardown();
+      MockActivityPicker.dial.mTeardown();
       MockOptionMenu.mTeardown();
     });
 
@@ -1988,8 +1989,8 @@ suite('thread_ui.js >', function() {
           });
 
           assert.equal(MockOptionMenu.calls.length, 0);
-          assert.ok(MockActivityPicker.call.called);
-          assert.equal(MockActivityPicker.call.calledWith, '999');
+          assert.ok(MockActivityPicker.dial.called);
+          assert.equal(MockActivityPicker.dial.calledWith, '999');
         });
 
         test('Single unknown', function() {
@@ -2105,7 +2106,7 @@ suite('thread_ui.js >', function() {
           assert.equal(MockOptionMenu.calls.length, 0);
 
           // Does initiate a "call" activity
-          assert.equal(MockActivityPicker.call.called, 1);
+          assert.equal(MockActivityPicker.dial.called, 1);
         });
 
         test('Single unknown', function() {
@@ -2195,14 +2196,14 @@ suite('thread_ui.js >', function() {
     suite('Multi participant', function() {
       setup(function() {
         window.location.hash = '';
-        MockActivityPicker.call.mSetup();
+        MockActivityPicker.dial.mSetup();
         MockOptionMenu.mSetup();
       });
 
       teardown(function() {
         Threads.delete(1);
         window.location.hash = '';
-        MockActivityPicker.call.mTeardown();
+        MockActivityPicker.dial.mTeardown();
         MockOptionMenu.mTeardown();
       });
 
@@ -2221,8 +2222,8 @@ suite('thread_ui.js >', function() {
 
           ThreadUI.onHeaderActivation();
 
-          assert.equal(MockActivityPicker.call.called, false);
-          assert.equal(MockActivityPicker.call.calledWith, null);
+          assert.equal(MockActivityPicker.dial.called, false);
+          assert.equal(MockActivityPicker.dial.calledWith, null);
         });
 
         test('DOES NOT Invoke Options', function() {


### PR DESCRIPTION
- Changes "phone-link" to "dial-link" to match ActivityPicker.dial (allows directly mapping action to ActivityPicker function)
- Changes "data-phonenumber" to "data-dial" to match ActivityPicker.dial
- Consolidates duplicated MozActivity calls for email, phone and url links
  - Simplifies LinkActionHandler APIs to delegate to ActivityPicker wherever possible
- Removes duplicated try/catch boilerplate by providing an private abstract function for safely invoking MozActivity.
- Adds new locale string for "Send email" in email context menu
- Updates ThreadUI.activateContact to provide a "Send email" option, instead of a "Call" option when handling activations originating from an email address.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
