### PR TITLE
bug 823385 - Show developer provided description of a permission inside ...

### DIFF
--- a/apps/system/js/permission_manager.js
+++ b/apps/system/js/permission_manager.js
@@ -3,6 +3,8 @@
 
 'use strict';
 
+const Ci = Components.interfaces;
+
 var PermissionManager = (function() {
   var _ = navigator.mozL10n.get;
 
@@ -49,8 +51,17 @@ var PermissionManager = (function() {
     var str = '';
 
     var permissionID = 'perm-' + detail.permission.replace(':', '-');
-    if (detail.isApp) { // App
-      str = _(permissionID + '-appRequest', { 'app': detail.appName });
+    // The app is certified o priviledged
+    if ((detail.appType == Ci.nsIPrincipal.APP_STATUS_PRIVILEGED) ||
+       (detail.appType ==  Ci.nsIPrincipal.APP_STATUS_CERTIFIED)) { 
+      str = _(permissionID + '-appRequest', { 'app': detail.appName })
+            + detail.description;//Added to show permissions description
+    // The app is webapp
+    } else if (detail.appType == Ci.nsIPrincipal.APP_STATUS_INSTALLED) {
+      //Added to show permissions description with a warning about its origin
+      //Comment next two lines if don't want to show description for webapps
+      str = _(permissionID + '-appRequest', { 'app': detail.appName })
+            + "Provided by developer: " + detail.description;
     } else { // Web content
       str = _(permissionID + '-webRequest', { 'site': detail.origin });
     }

--- a/apps/system/js/permission_manager.js
+++ b/apps/system/js/permission_manager.js
@@ -53,15 +53,15 @@ var PermissionManager = (function() {
     var permissionID = 'perm-' + detail.permission.replace(':', '-');
     // The app is certified o priviledged
     if ((detail.appType == Ci.nsIPrincipal.APP_STATUS_PRIVILEGED) ||
-       (detail.appType ==  Ci.nsIPrincipal.APP_STATUS_CERTIFIED)) { 
-      str = _(permissionID + '-appRequest', { 'app': detail.appName })
-            + detail.description;//Added to show permissions description
+       (detail.appType == Ci.nsIPrincipal.APP_STATUS_CERTIFIED)) {
+      str = _(permissionID + '-appRequest', { 'app': detail.appName }) +
+            detail.description;//Added to show permissions description
     // The app is webapp
     } else if (detail.appType == Ci.nsIPrincipal.APP_STATUS_INSTALLED) {
       //Added to show permissions description with a warning about its origin
       //Comment next two lines if don't want to show description for webapps
-      str = _(permissionID + '-appRequest', { 'app': detail.appName })
-            + "Provided by developer: " + detail.description;
+      str = _(permissionID + '-appRequest', { 'app': detail.appName }) +
+            'Provided by developer: ' + detail.description;
     } else { // Web content
       str = _(permissionID + '-webRequest', { 'site': detail.origin });
     }

--- a/test_apps/geoloc/manifest.webapp
+++ b/test_apps/geoloc/manifest.webapp
@@ -8,8 +8,13 @@
     "url": "https://github.com/lissyx/gaia-geoloc"
   },
   "permissions": {
-    "geolocation":{},
-    "device-storage:sdcard":{ "access": "readonly" }
+    "geolocation":{ 
+      "description": "Needed to navigate you"
+    },
+    "device-storage:sdcard":{
+      "description": "Needed to read the maps",
+      "access": "readonly"
+    }
   },
   "locales": {
     "en-US": {


### PR DESCRIPTION
...the permission prompt. r=vingtetun.

Also have modified geoloc's manifest.webapp to test it.
Don't forget to add permission description to all app's manifest.webapp you want to test with, because although its presence it's mandatory in all manifest, it's still not present
