### PR TITLE
Bug 901449 - [STK] missing l10n entities, r=timdream

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -1,5 +1,6 @@
 ok=OK
 back=Back
+help=Help
 cancel=Cancel
 close=Close
 
@@ -343,8 +344,11 @@ unknown-free-space=Unknown remaining space.
 system-alert=System Alert
 cb-channel=Channel {{channel}}
 
-# ICC / STK
+# ICC / STK (= SIM Toolkit)
 icc-message=Operator message
 icc-confirmCall-defaultmessage=Call {{number}}?
 icc-alertMessage-defaultmessage=Sending message
 icc-confirmMessage-defaultmessage=Send message?
+# LOCALIZATION NOTE: (icc-inputtitle) = title of SIM Toolkit input dialog panels
+icc-inputtitle=STK Query
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=901449

follow-up of #10607
