### PR TITLE
Bug 900630 - Update gaia-ui-tests.json to pull in latest Marionette, a=t...

### DIFF
--- a/tests/python/gaia-ui-tests.json
+++ b/tests/python/gaia-ui-tests.json
@@ -1,4 +1,4 @@
 {
     "repo": "https://hg.mozilla.org/integration/gaia-ui-tests",
-    "revision": "2c03885ec2c1"
+    "revision": "db5033b9467e"
 }


### PR DESCRIPTION
...est-only
