### PR TITLE
Bug 898721 - [B2G][Helix][MMS]when view picture in mms,the font of title is too big

### DIFF
--- a/apps/gallery/style/open.css
+++ b/apps/gallery/style/open.css
@@ -6,7 +6,7 @@ html {
   padding: 0;
   margin: 0;
   overflow: hidden;
-  font-size: 1rem;
+  font-size: 10px;
 }
 
 body {


### PR DESCRIPTION
- HD branch regression: We should set root html font-size(rem) to 10px here.
