### PR TITLE
Bug 901079 - [Contacts] Contacts list should offer a select mode

### DIFF
--- a/apps/communications/contacts/import.html
+++ b/apps/communications/contacts/import.html
@@ -143,7 +143,7 @@
            </p>
         </form>
         <section id="groups-list-search">
-          <ol id="search-list" data-type="list">
+          <ol id="search-list" class="selecting" data-type="list">
           </ol>
         </section>
 

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -62,6 +62,7 @@
           <menu type="toolbar">
             <button role="menuitem" id="add-contact-button"><span class="icon icon-add" data-l10n-id="add">add</span></button>
             <button role="menuitem" id="settings-button"><span class="icon icon-settings" data-l10n-id="settings">settings</span></button>
+            <button  id="select-action" class="hide"></button>
           </menu>
           <h1 data-l10n-id="contacts">Contacts</h1>
         </header>
@@ -108,6 +109,16 @@
               </section>
             </div>
           </div>
+          <form id="selectable-form" role="dialog" data-type="confirm" class="hide no-overlay">
+            <menu id="select-all-wrapper">
+             <button id="deselect-all" class="edit-button" data-l10n-id="deselectAll" disabled>
+                Deselect all
+              </button>
+              <button id="select-all" class="edit-button" data-l10n-id="selectAll">
+                Select all
+              </button>
+            </menu>
+          </form>
         </article>
         <div id='fixed-container' class='fixed-title'></div>
       </section>

--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -225,7 +225,7 @@ var Contacts = (function() {
       addButton.classList.add('hide');
       settingsButton.classList.add('hide');
       appTitleElement.textContent = _('selectContact');
-    } else {
+    } else if (contactsList && !contactsList.isSelecting) {
       cancelButton.classList.add('hide');
       addButton.classList.remove('hide');
       settingsButton.classList.remove('hide');

--- a/apps/communications/contacts/js/search.js
+++ b/apps/communications/contacts/js/search.js
@@ -478,6 +478,14 @@ contacts.Search = (function() {
     searchList.removeChild(contact);
   };
 
+  var selectRow = function s_selectRow(id) {
+    var check = searchList.querySelector(
+      '#search-view input[value="' + id + '"]');
+    if (check) {
+      check.checked = !check.checked;
+    }
+  };
+
   function showProgress() {
     searchNoResult.classList.add('hide');
     searchProgress.classList.remove('hidden');
@@ -504,6 +512,7 @@ contacts.Search = (function() {
     'isInSearchMode': isInSearchMode,
     'enableSearch': enableSearch,
     // The purpose of this method is only for unit tests
-    'load': onLoad
+    'load': onLoad,
+    'selectRow': selectRow
   };
 })();

--- a/apps/communications/contacts/style/app.css
+++ b/apps/communications/contacts/style/app.css
@@ -661,3 +661,37 @@ nav[data-type="scrollbar"] p img {
   left: 25%;
   width: 4.8rem;
 }
+
+#groups-list.selecting label.pack-checkbox {
+  display: block !important;
+}
+
+#groups-container.selecting {
+  height: -moz-calc(100% - 7rem);
+}
+
+#groups-list label.pack-checkbox {
+  display: none !important;
+}
+
+.selecting li label {
+  left: -1rem !important;
+}
+
+.selecting li p {
+  padding-left: 2rem !important;
+}
+
+form[role="dialog"].no-overlay {
+  background: none;
+  pointer-events: none;
+  position: fixed;
+}
+
+form[role="dialog"].no-overlay button {
+  pointer-events: auto;
+}
+
+#selectable-form {
+  background: none;
+}

--- a/apps/communications/contacts/style/search.css
+++ b/apps/communications/contacts/style/search.css
@@ -131,3 +131,11 @@ form.search button[type="submit"] {
 .import #search-list > li[data-uuid] *:not(input) {
   pointer-events: none;
 }
+
+#search-list.selecting label.pack-checkbox {
+  display: block !important;
+}
+
+#search-list label.pack-checkbox {
+  display: none !important;
+}


### PR DESCRIPTION
Finally adding the `renderSelectCheck` in just 2 places to ensure we draw a check when we render a contact on demand.

As well needed to return a promise of contacts when we click on 'select all', since we will render on demand and won't have all the checkboxes there.

Maintaining  the two methods `enterSelectMode` and `exitSelectMode` since we are able to send a promise and the wait UX will happen in the consumer of this method, let's that consumer the chance to return the list back to it's normal state, also valid for cancelations.

Also tried to modify the test and leave them as much independent as possible.

Thank you again folks for reviewing
