### PR TITLE
Refactor rendering methods for Analog clock

### DIFF
--- a/apps/clock/js/clock_view.js
+++ b/apps/clock/js/clock_view.js
@@ -146,7 +146,7 @@ var ClockView = {
     var d = new Date();
     var time = Utils.getLocaleTime(d);
     this.time.textContent = time.t;
-    this.hourState.textContent = time.p || '  '; // 2 non-break spaces
+    this.hourState.textContent = time.p || '  '; // 2 non-break spaces
 
     this.timeouts.digital = setTimeout(
       this.updateDigitalClock.bind(this), (60 - d.getSeconds()) * 1000
@@ -159,52 +159,45 @@ var ClockView = {
     if (opts.needsResize) {
       this.resizeAnalogClock();
     }
+    // retreive cached elements if cache does not exist
+    if ( !this.hands ) {
+      this.hands = {};
+      ['secondhand', 'minutehand', 'hourhand'].forEach(function(hand) {
+        this.hands[hand] = document.getElementById(hand);
+      }, this);
+    }
 
-    // Update the SVG clock graphic to show current time
-    var now = new Date(); // Current time
-    var sec = now.getSeconds(); // Seconds
-    var min = now.getMinutes(); // Minutes
-    var hour = (now.getHours() % 12) + min / 60; // Fractional hours
-    var lastHour = (now.getHours() - 1 % 12) + min / 60;
-    // 6 degrees per second
-    this.setTransform('secondhand', sec * 6, (sec - 1) * 6);
-    // Inverse angle 180 degrees for rect hands
-    // 6 degrees per minute
-    this.setTransform('minutehand', min * 6 - 180, (min - 1) * 6 - 180);
-    // 30 degrees per hour
-    this.setTransform('hourhand', hour * 30 - 180, (lastHour) * 30 - 180);
-
+    var now = new Date();
+    var sec, min, hour;
+    sec = now.getSeconds();
+    min = now.getMinutes();
+    // hours progress gradually
+    hour = (now.getHours() % 12) + min / 60;
+    this.setTransform('secondhand', sec);
+    this.setTransform('minutehand', min);
+    this.setTransform('hourhand', hour);
+    // update again in one second
     this.timeouts.analog = setTimeout(
       this.updateAnalogClock.bind(this), 1000 - now.getMilliseconds()
     );
   },
 
-  setTransform: function cv_setTransform(id, angle, from) {
-    !this.rotation && (this.rotation = {});
-    // Get SVG elements for the hands of the clock
-    var hand = document.getElementById(id);
-    // Set an SVG attribute on them to move them around the clock face
-    if (!this.rotation[id]) {
-      this.rotation[id] =
-        document.createElementNS('http://www.w3.org/2000/svg',
-                                 'animateTransform');
+  setTransform: function cv_setTransform(id, angle) {
+    var hand = this.hands[id];
+    // return correct angle for different hands
+    function conv(timeFrag) {
+      var mult, offset;
+      // generate a conformable number to rotate about
+      // 30 degrees per hour 6 per second and minute
+      mult = id === 'hourhand' ? 30 : 6;
+      // note the minute and hour hands are reversed relative to the secondhand
+      offset = id === 'secondhand' ? 0 : 180;
+      // we generate the angle from the fractional sec/min/hour
+      return (timeFrag * mult) - offset;
     }
-    if (!hand) { return; }
-
-    // In order to repaint once see, i use this trick. See Bug 817993
-    var rotate = this.rotation[id];
-    // don't repaint unless hand has changed
-    if (rotate.getAttribute('to') == angle + ',135,135')
-      return;
-
-    rotate.setAttribute('attributeName', 'transform');
-    rotate.setAttribute('attributeType', 'xml');
-    rotate.setAttribute('type', 'rotate');
-    rotate.setAttribute('from', from + ',135,135');
-    rotate.setAttribute('to', angle + ',135,135');
-    rotate.setAttribute('dur', '0.001s');
-    rotate.setAttribute('fill', 'freeze');
-    hand.appendChild(rotate);
+    // Use transform rotate on the rect itself vs on a child element
+    // avoids unexpected behavior if either dur and fill are set to defaults
+    hand.setAttribute('transform', 'rotate(' + conv(angle) + ',135,135)');
   },
 
   handleEvent: function cv_handleEvent(event) {

--- a/apps/clock/test/unit/clock_view_test.js
+++ b/apps/clock/test/unit/clock_view_test.js
@@ -81,7 +81,7 @@ suite('ClockView', function() {
       function() {
       ClockView.updateDigitalClock();
       assert.equal(Date.parse(ClockView.time.innerHTML), this.sixAm + 1000);
-      assert.equal(ClockView.hourState.innerHTML, '&nbsp;&nbsp;');
+      assert.equal(ClockView.hourState.innerHTML, '  ');
     });
 
     test('time and hourState elements are not updated twice in the same ' +
@@ -89,7 +89,7 @@ suite('ClockView', function() {
       ClockView.updateDigitalClock();
       this.clock.tick(59 * 1000 - 1);
       assert.equal(Date.parse(ClockView.time.innerHTML), this.sixAm + 1000);
-      assert.equal(ClockView.hourState.innerHTML, '&nbsp;&nbsp;');
+      assert.equal(ClockView.hourState.innerHTML, '  ');
     });
 
     test('time and hourState elements are updated each minute', function() {
@@ -97,7 +97,7 @@ suite('ClockView', function() {
       this.clock.tick(59 * 1000);
       assert.equal(Date.parse(ClockView.time.innerHTML),
         this.sixAm + 60 * 1000);
-      assert.equal(ClockView.hourState.innerHTML, '&nbsp;&nbsp;');
+      assert.equal(ClockView.hourState.innerHTML, '  ');
     });
 
   });
@@ -114,88 +114,62 @@ suite('ClockView', function() {
       this.clock = sinon.useFakeTimers(this.sixAm + 1200);
     });
 
-    teardown(function() {
-      // The method under test caches the SVG `animateTransform` elements it
-      // creates, meaning that simply clearing the contents of the "-hand"
-      // elements will not prevent state leakage.
-      ['secondHand', 'minuteHand', 'hourHand'].forEach(function(hand) {
-        var node = this[hand].childNodes[0];
 
-        [].forEach.call(node.attributes, function(attr) {
-          // Guard against environments
-          if (typeof attr !== 'undefined') {
-            node.removeAttribute(attr.nodeName);
-          }
-        });
-      }, this);
-    });
 
     test('second-, minute-, and hour- hands are updated immediately',
       function() {
       var rotate;
-
       ClockView.updateAnalogClock();
 
-      rotate = this.secondHand.childNodes[0];
+      rotate = this.secondHand;
       assert.ok(rotate, 'Second hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '0,135,135');
-      assert.equal(rotate.getAttribute('to'), '6,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(6,135,135)');
 
-      rotate = this.minuteHand.childNodes[0];
+      rotate = this.minuteHand;
       assert.ok(rotate, 'Minute hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '-186,135,135');
-      assert.equal(rotate.getAttribute('to'), '-180,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(-180,135,135)');
 
-      rotate = this.hourHand.childNodes[0];
+      rotate = this.hourHand;
       assert.ok(rotate, 'Hour hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '-30,135,135');
-      assert.equal(rotate.getAttribute('to'), '0,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(0,135,135)');
     });
 
     test('second-, minute-, and hour- hands are not updated twice in the ' +
       'same second', function() {
       var rotate;
-
       ClockView.updateAnalogClock();
       this.clock.tick(799);
 
-      rotate = this.secondHand.childNodes[0];
+      rotate = this.secondHand;
       assert.ok(rotate, 'Second hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '0,135,135');
-      assert.equal(rotate.getAttribute('to'), '6,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(6,135,135)');
 
-      rotate = this.minuteHand.childNodes[0];
+      rotate = this.minuteHand;
       assert.ok(rotate, 'Minute hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '-186,135,135');
-      assert.equal(rotate.getAttribute('to'), '-180,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(-180,135,135)');
 
-      rotate = this.hourHand.childNodes[0];
+      rotate = this.hourHand;
       assert.ok(rotate, 'Hour hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '-30,135,135');
-      assert.equal(rotate.getAttribute('to'), '0,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(0,135,135)');
     });
 
     test('second-, minute-, and hour- hands are updated each second',
       function() {
       var rotate;
-
       ClockView.updateAnalogClock();
       this.clock.tick(800);
 
-      rotate = this.secondHand.childNodes[0];
+      rotate = this.secondHand;
       assert.ok(rotate, 'Second hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '6,135,135');
-      assert.equal(rotate.getAttribute('to'), '12,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(12,135,135)');
 
-      rotate = this.minuteHand.childNodes[0];
+      rotate = this.minuteHand;
       assert.ok(rotate, 'Minute hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '-186,135,135');
-      assert.equal(rotate.getAttribute('to'), '-180,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(-180,135,135)');
 
-      rotate = this.hourHand.childNodes[0];
+      rotate = this.hourHand;
       assert.ok(rotate, 'Hour hand rotation element exists');
-      assert.equal(rotate.getAttribute('from'), '-30,135,135');
-      assert.equal(rotate.getAttribute('to'), '0,135,135');
+      assert.equal(rotate.getAttribute('transform'), 'rotate(0,135,135)');
     });
 
   });


### PR DESCRIPTION
1. Simplifies computation of angles for `setTransform`. Fractional seconds, minutes, hours are passed to `setTransform` which computes the resultant angle.
2. Removes extraneous SVG attributes, including `dur=0.001s`, which does not materially impact the animation (as no interpolation will occur in a time range shorter than the page repaint.
3. Removes checks against repainting clocks, which didn't seem to be live code. May close [Bug 817993](https://bugzilla.mozilla.org/show_bug.cgi?id=817993).
4. Caches element selection and moves animated element creation out of the update code.
