### PR TITLE
Bug 899487 - Play a notification when changing sound level

### DIFF
--- a/apps/settings/js/sound.js
+++ b/apps/settings/js/sound.js
@@ -144,10 +144,11 @@
 
           list.element.onclick = function onListClick(evt) {
             if (evt.target.tagName == 'LABEL') {
-              if (evt.target.querySelector('input').value == 'none')
+              var file = evt.target.querySelector('input').value;
+              if (file == 'none')
                 stopAudioPreview();
               else
-                audioPreview(evt.target, key);
+                audioPreview(file, key, 'notification');
             }
           };
         });
@@ -205,9 +206,32 @@
     }
   }
 
+  var previewSoundLevel = function sound_PreviewSoundLevel(event, channel) {
+    var value = event.settingValue;
+    stopAudioPreview();
+
+    var sound = 'notifications';
+    var element = lists[sound].element;
+    var key = lists[sound].settingName + '.name';
+    var request = navigator.mozSettings.createLock().get(key);
+    request.onsuccess = function successGetCurrentSound() {
+      var filename = request.result[key];
+      debug('success get current sound: ' + key + ' = ' + filename);
+      audioPreview(filename, sound, channel);
+    };
+  };
+
+  function prepareSoundPreview() {
+    navigator.mozSettings.addObserver('audio.volume.notification',
+      previewSoundLevel.bind(this, {}, 'notification'));
+    navigator.mozSettings.addObserver('audio.volume.alarm',
+      previewSoundLevel.bind(this, {}, 'alarm'));
+  }
+
   // main
   generateSoundsLists();
   assignButtonsActions();
+  prepareSoundPreview();
 
   var button = document.getElementById('call-tone-selection');
   button.onclick = function() {

--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -71,21 +71,22 @@ function openDialog(dialogID, onSubmit, onReset) {
  * First click = play, second click = pause.
  */
 
-function audioPreview(element, type) {
+function audioPreview(filename, type, channel) {
   var audio = document.querySelector('#sound-selection audio');
   var source = audio.src;
   var playing = !audio.paused;
 
-  // Both ringer and notification are using notification channel
-  audio.mozAudioChannelType = 'notification';
+  // Both ringer and notification are using the specified channel
+  audio.mozAudioChannelType = channel;
 
-  var url = '/shared/resources/media/' + type + '/' +
-            element.querySelector('input').value;
+  var url = '/shared/resources/media/' + type + '/' + filename;
   audio.src = url;
   if (source === audio.src && playing) {
+    console.warn('sound pausing');
     audio.pause();
     audio.src = '';
   } else {
+    console.warn('sound playing');
     audio.play();
   }
 }

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -27,7 +27,8 @@
     "power":{},
     "idle":{},
     "telephony":{},
-    "audio-channel-notification":{}
+    "audio-channel-notification":{},
+    "audio-channel-alarm":{}
   },
   "activities": {
     "configure": {


### PR DESCRIPTION
When the user changes the sound level, he might want to be able to have
a preview of what it will actually be like in real life. So let's play
the notification sound he has choosen from settings, as a preview.
