### PR TITLE
Bug 903137 - [SMS][MMS] Contextmenu prompt for email in message should display email address

### DIFF
--- a/apps/sms/js/link_action_handler.js
+++ b/apps/sms/js/link_action_handler.js
@@ -49,25 +49,16 @@
       }
 
       if (action === 'email-link') {
-        ThreadUI.activateContact({
+        ThreadUI.prompt({
           email: dataset.email,
           inMessage: true
         });
       }
 
       if (action === 'dial-link') {
-        number = dataset.dial;
-
-        Contacts.findByPhoneNumber(number, function(contacts) {
-          var isContact = contacts && contacts.length > 0;
-          var details = Utils.getContactDetails(number, contacts);
-
-          ThreadUI.activateContact({
-            name: details.title || details.name,
-            number: number,
-            isContact: isContact,
-            inMessage: true
-          });
+        ThreadUI.promptContact({
+          number: dataset.dial,
+          inMessage: true
         });
       }
 

--- a/apps/sms/test/unit/link_action_handler_test.js
+++ b/apps/sms/test/unit/link_action_handler_test.js
@@ -118,8 +118,8 @@ suite('LinkActionHandler', function() {
       mocksHelperLAH.teardown();
     });
 
-    test('dial-link: (known) delegates to activateContact ', function() {
-      this.sinon.stub(ThreadUI, 'activateContact');
+    test('dial-link: (known) delegates to promptContact ', function() {
+      this.sinon.stub(ThreadUI, 'promptContact');
       this.sinon.stub(Contacts, 'findByPhoneNumber')
         .callsArgWith(1, [{
           name: ['Huey'],
@@ -130,10 +130,8 @@ suite('LinkActionHandler', function() {
 
       LinkActionHandler.onContextMenu(events.phone);
 
-      assert.deepEqual(ThreadUI.activateContact.args[0][0], {
-        name: 'Huey',
+      assert.deepEqual(ThreadUI.promptContact.args[0][0], {
         number: '999',
-        isContact: true,
         inMessage: true
       });
 
@@ -141,17 +139,15 @@ suite('LinkActionHandler', function() {
       assert.ok(events.phone.stopPropagation.called);
     });
 
-    test('dial-link: (unknown) delegates to activateContact ', function() {
-      this.sinon.stub(ThreadUI, 'activateContact');
+    test('dial-link: (unknown) delegates to promptContact ', function() {
+      this.sinon.stub(ThreadUI, 'promptContact');
       this.sinon.stub(Contacts, 'findByPhoneNumber')
         .callsArgWith(1, []);
 
       LinkActionHandler.onContextMenu(events.phone);
 
-      assert.deepEqual(ThreadUI.activateContact.args[0][0], {
-        name: undefined,
+      assert.deepEqual(ThreadUI.promptContact.args[0][0], {
         number: '999',
-        isContact: false,
         inMessage: true
       });
 
@@ -159,13 +155,13 @@ suite('LinkActionHandler', function() {
       assert.ok(events.phone.stopPropagation.called);
     });
 
-    test('email-link: delegates to activateContact ', function() {
-      this.sinon.stub(ThreadUI, 'activateContact');
+    test('email-link: delegates to prompt ', function() {
+      this.sinon.stub(ThreadUI, 'prompt');
 
       LinkActionHandler.onContextMenu(events.email);
 
-      assert.ok(ThreadUI.activateContact.called);
-      assert.deepEqual(ThreadUI.activateContact.args[0][0], {
+      assert.ok(ThreadUI.prompt.called);
+      assert.deepEqual(ThreadUI.prompt.args[0][0], {
         email: 'a@b.com',
         inMessage: true
       });

--- a/apps/sms/test/unit/mock_thread_ui.js
+++ b/apps/sms/test/unit/mock_thread_ui.js
@@ -16,15 +16,13 @@ var MockThreadUI = {
   cleanFields: function() {},
   appendMessage: function() {},
   setMessageBody: function() {},
+  prompt: function() {},
+  promptContact: function() {},
 
   isShowSendMessageErrorCalledTimes: 0,
 
   showSendMessageError: function() {
     this.isShowSendMessageErrorCalledTimes += 1;
-  },
-
-  activateContact: function() {
-
   },
 
   mSetup: function() {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -2013,7 +2013,7 @@ suite('thread_ui.js >', function() {
 
     suite('OptionMenu', function() {
 
-      suite('activateContact', function() {
+      suite('prompt', function() {
         test('Single known', function() {
 
           Threads.set(1, {
@@ -2022,7 +2022,7 @@ suite('thread_ui.js >', function() {
 
           window.location.hash = '#thread=1';
 
-          ThreadUI.activateContact({
+          ThreadUI.prompt({
             number: '999',
             isContact: true
           });
@@ -2032,7 +2032,7 @@ suite('thread_ui.js >', function() {
           assert.equal(MockActivityPicker.dial.calledWith, '999');
         });
 
-        test('Single unknown', function() {
+        test('Single unknown (phone)', function() {
 
           Threads.set(1, {
             participants: ['999']
@@ -2040,14 +2040,20 @@ suite('thread_ui.js >', function() {
 
           window.location.hash = '#thread=1';
 
-          ThreadUI.activateContact({
+          ThreadUI.prompt({
             number: '999',
             isContact: false
           });
 
-          var items = MockOptionMenu.calls[0].items;
-
           assert.equal(MockOptionMenu.calls.length, 1);
+
+          var call = MockOptionMenu.calls[0];
+          var items = call.items;
+
+          // Ensures that the OptionMenu was given
+          // the phone number to diplay
+          assert.equal(call.section, '999');
+
           assert.equal(items.length, 4);
 
           // The first item is a "call" option
@@ -2063,6 +2069,42 @@ suite('thread_ui.js >', function() {
           assert.equal(items[3].name, 'cancel');
         });
 
+        test('Single unknown (email)', function() {
+
+          Threads.set(1, {
+            participants: ['999']
+          });
+
+          window.location.hash = '#thread=1';
+
+          ThreadUI.prompt({
+            email: 'a@b.com',
+            isContact: false
+          });
+
+          assert.equal(MockOptionMenu.calls.length, 1);
+
+          var call = MockOptionMenu.calls[0];
+          var items = call.items;
+
+          // Ensures that the OptionMenu was given
+          // the phone number to diplay
+          assert.equal(call.section, 'a@b.com');
+
+          assert.equal(items.length, 4);
+
+          // The first item is a "call" option
+          assert.equal(items[0].name, 'sendEmail');
+
+          // The second item is a "createNewContact" option
+          assert.equal(items[1].name, 'createNewContact');
+
+          // The third item is a "addToExistingContact" option
+          assert.equal(items[2].name, 'addToExistingContact');
+
+          // The fourth and last item is a "cancel" option
+          assert.equal(items[3].name, 'cancel');
+        });
         test('Multiple known', function() {
 
           Threads.set(1, {
@@ -2071,14 +2113,20 @@ suite('thread_ui.js >', function() {
 
           window.location.hash = '#thread=1';
 
-          ThreadUI.activateContact({
+          ThreadUI.prompt({
             number: '999',
             isContact: true
           });
 
-          var items = MockOptionMenu.calls[0].items;
-
           assert.equal(MockOptionMenu.calls.length, 1);
+
+          var call = MockOptionMenu.calls[0];
+          var items = call.items;
+
+          // Ensures that the OptionMenu was given
+          // the phone number to diplay
+          assert.equal(call.section, '999');
+
           assert.equal(items.length, 3);
 
           // The first item is a "call" option
@@ -2099,14 +2147,20 @@ suite('thread_ui.js >', function() {
 
           window.location.hash = '#thread=1';
 
-          ThreadUI.activateContact({
+          ThreadUI.prompt({
             number: '999',
             isContact: false
           });
 
-          var items = MockOptionMenu.calls[0].items;
-
           assert.equal(MockOptionMenu.calls.length, 1);
+
+          var call = MockOptionMenu.calls[0];
+          var items = call.items;
+
+          // Ensures that the OptionMenu was given
+          // the phone number to diplay
+          assert.equal(call.section, '999');
+
           assert.equal(items.length, 5);
 
           // The first item is a "call" option
@@ -2136,7 +2190,7 @@ suite('thread_ui.js >', function() {
           window.location.hash = '#thread=1';
 
 
-          ThreadUI.headerText.dataset.isContact = 'true';
+          ThreadUI.headerText.dataset.isContact = true;
           ThreadUI.headerText.dataset.number = '+12125559999';
 
           ThreadUI.onHeaderActivation();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=903137
- Make all prompts consistent
- Ensures that dataset.isContact strings are only used to derive a true isContact boolean
- Renames ThreadUI.activateContact to ThreadUI.prompt
  - The function no longer serves as only a "contact" prompt
  - May prompt any type of recipient (contact, unknown, email)
  - May prompt from header, group list or message content
- Renames ThreadUI.genPrompt to ThreadUI.prompContact
  - genPrompt is meaningless
  - The function is explicitly for creating a prompt with a known contact
  - Includes the contact info lookup
- Converts promptContact arguments to an object, instead of named parameters
- Update LinkActionHandler to delegate to promptContact, instead of doing it's own duplicated lookup
- Adds tests to ensure that a something is displayed when something is provided
  - Could be any of the following:
    - DOM UL
    - Email address
    - Phone Number
    - Name
- Updates LinkActionHandler tests to use the correct new function names

Signed-off-by: Rick Waldron waldron.rick@gmail.com
