### PR TITLE
Bug 903260 - [SMS][MMS] SettingsURL value is never used in sms/js/notification.js: Ringtones BROKEN

### DIFF
--- a/apps/sms/js/notification.js
+++ b/apps/sms/js/notification.js
@@ -1,27 +1,21 @@
 (function(exports) {
   'use strict';
 
-  var settings = {};
-  var mozSettings = navigator.mozSettings;
+  function entry(key, value) {
+    settings[key] = urls[key] ? urls[key].set(value) : value;
+  }
 
+  var mozSettings = navigator.mozSettings;
+  var settings = {};
   var urls = {
     'notification.ringtone': new SettingsURL()
   };
 
-  function entry(key, value) {
-    if (urls[key]) {
-      urls[key].set(value);
-      settings[key] = true;
-    } else {
-      settings[key] = value;
-    }
-  }
-
-  ([
+  [
     'audio.volume.notification',
     'notification.ringtone',
     'vibration.enabled'
-  ]).forEach(function(key) {
+  ].forEach(function(key) {
     if (mozSettings) {
       var request = mozSettings.createLock().get(key);
       request.onsuccess = function() {

--- a/apps/sms/test/unit/mock_audio.js
+++ b/apps/sms/test/unit/mock_audio.js
@@ -1,6 +1,16 @@
 'use strict';
 
-function MockAudio() {}
+function MockAudio() {
+  MockAudio.instances.push(this);
+}
+
+MockAudio.mSetup = function() {
+  MockAudio.instances = [];
+};
+
+MockAudio.mTeardown = function() {
+  MockAudio.instances = [];
+};
 
 MockAudio.prototype.play = function() {};
 MockAudio.prototype.pause = function() {};

--- a/apps/sms/test/unit/notification_test.js
+++ b/apps/sms/test/unit/notification_test.js
@@ -5,13 +5,14 @@ requireApp('sms/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('sms/test/unit/mock_audio.js');
 requireApp('sms/test/unit/mock_navigator_vibrate.js');
 
+var mocksHelperNotifications = new MocksHelper(['SettingsURL']).init();
+
 suite('check the ringtone and vibrate function', function() {
   var realAudio;
   var realMozSettings;
   var realVibrate;
 
-  var mocksHelper = new MocksHelper(['SettingsURL']).init();
-  mocksHelper.attachTestHelpers();
+  mocksHelperNotifications.attachTestHelpers();
 
   suiteSetup(function(done) {
 
@@ -33,7 +34,8 @@ suite('check the ringtone and vibrate function', function() {
     Audio = realAudio;
     navigator.mozSettings = realMozSettings;
     navigator.vibrate = realVibrate;
-    mocksHelper.suiteTeardown;
+
+    mocksHelperNotifications.suiteTeardown();
   });
 
   setup(function() {
@@ -41,12 +43,20 @@ suite('check the ringtone and vibrate function', function() {
     this.sinon.spy(Audio.prototype, 'play');
     this.sinon.spy(navigator, 'vibrate');
     this.sinon.spy(window, 'Audio');
+
+    this.sinon.stub(SettingsURL.prototype, 'get', function() {
+      return 'ringtone';
+    });
+
+    this.sinon.stub(SettingsURL.prototype, 'set', function(value) {
+      return value;
+    });
+
+    MockAudio.mSetup();
   });
 
   teardown(function() {
-    Audio.prototype.play.restore();
-    navigator.vibrate.restore();
-    window.Audio.restore();
+    MockAudio.mTeardown();
   });
 
   function triggerObservers(settings) {
@@ -76,6 +86,9 @@ suite('check the ringtone and vibrate function', function() {
 
       assert.ok(Audio.called);
       assert.deepEqual(navigator.vibrate.args[0][0], [200, 200, 200, 200]);
+      assert.deepEqual(MockAudio.instances[0], {
+        src: 'ringtone', mozAudioChannelType: 'notification'
+      });
     });
   });
 
@@ -97,6 +110,9 @@ suite('check the ringtone and vibrate function', function() {
 
       assert.ok(Audio.called);
       assert.equal(navigator.vibrate.args.length, 0);
+      assert.deepEqual(MockAudio.instances[0], {
+        src: 'ringtone', mozAudioChannelType: 'notification'
+      });
     });
   });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=903260
- Make the mock's set method behave enough like the real thing to write a correct test
- Assign the result of the call to set(…) to the actual local setting
- Tests
  - Ensure that the src property is as expected

Signed-off-by: Rick Waldron waldron.rick@gmail.com
