### PR TITLE
Bug 901421 - Set shuffle mode when playing a song list

### DIFF
--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -1197,6 +1197,7 @@ var ListView = {
                 PlayerView.setSourceType(TYPE_MIX);
 
                 PlayerView.dataSource = this.dataSource;
+                PlayerView.setShuffle(true);
                 PlayerView.play(targetIndex);
             }.bind(this));
           } else if (option) {


### PR DESCRIPTION
When switching to playing by song title, the dataSource value of the
PlayerView object will be updated, but its shuffledList is not in sync
anymore. This means that we will try to next/previous on a list of
indexes (shuffledList) that does not match anymore the dataSource list,
hence exposing the "nothing happens" behavior.
