### PR TITLE
[Bug 903400] Search space trim [r=21]

### DIFF
--- a/apps/homescreen/everything.me/modules/Searchbar/Searchbar.js
+++ b/apps/homescreen/everything.me/modules/Searchbar/Searchbar.js
@@ -51,7 +51,7 @@ Evme.Searchbar = new function Evme_Searchbar() {
     };
     
     this.getValue = function getValue() {
-        return value;
+        return trim(value) === '' ? '' : value;
     };
     
     this.isFocused = function getIsFocused() {
@@ -169,7 +169,7 @@ Evme.Searchbar = new function Evme_Searchbar() {
         if (currentValue !== value) {
             value = currentValue;
 
-            if (value === "") {
+            if (self.getValue() === '') {
                 timeoutSearchOnBackspace && window.clearTimeout(timeoutSearchOnBackspace);
                 cbEmpty();
             } else {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=903400

Searching for " " retrieves installed and cloud apps.
May mess up the history in the helper as well.

This is a bug fix.
