### PR TITLE
Makefile: do not assume bash lives in /bin/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ GAIA_PORT?=
 endif
 
 # Force bash for all shell commands since we depend on bash-specific syntax
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # what OS are we on?
 SYS=$(shell uname -s)


### PR DESCRIPTION
bash does not necessarily live in /bin/.  Replace the explicit
`/bin/bash' value with`/usr/bin/env bash' so that GNU make can
find bash if it does not live in /usr/bin/env.
