### PR TITLE
Bug 903915 - [Flatfish][Homescreen] add support for large device

### DIFF
--- a/apps/homescreen/index.html
+++ b/apps/homescreen/index.html
@@ -13,6 +13,7 @@
     <!-- Shared code -->
     <script type="text/javascript" src="shared/js/l10n.js"></script>
     <script type="text/javascript" src="shared/js/l10n_date.js"></script>
+    <script type="text/javascript" defer src="shared/js/screen_layout.js"></script>
     <script type="text/javascript" defer src="shared/js/manifest_helper.js"></script>
     <script type="text/javascript" src="shared/js/settings_listener.js"></script>
     <script type="text/javascript" defer src="shared/js/async_storage.js"></script>

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -9,7 +9,6 @@ var GridManager = (function() {
   var PREFERRED_ICON_SIZE = 60 * (window.devicePixelRatio || 1);
 
   var SAVE_STATE_TIMEOUT = 100;
-  var BASE_WIDTH = 320;
   var BASE_HEIGHT = 460; // 480 - 20 (status bar height)
   var DEVICE_HEIGHT = window.innerHeight;
   var OPACITY_STEPS = 40; // opacity steps between [0,1]
@@ -46,6 +45,11 @@ var GridManager = (function() {
   if (DEVICE_HEIGHT - BASE_HEIGHT > BASE_HEIGHT / 5 ||
       DEVICE_HEIGHT / windowWidth >= 1.6) {
     MAX_ICONS_PER_PAGE = 4 * 5;
+  }
+
+  // tablet+ devices are stricted to 5 x 3 grid
+  if (ScreenLayout.getCurrentLayout() !== 'tiny') {
+    MAX_ICONS_PER_PAGE = 5 * 3;
   }
 
   var startEvent, isPanning = false, startX, currentX, deltaX, removePanHandler,

--- a/apps/homescreen/js/page.js
+++ b/apps/homescreen/js/page.js
@@ -18,9 +18,7 @@ function Icon(descriptor, app) {
 
 
 // Support rendering icons for different screens
-var BASE_WIDTH = 320;
 var SCALE_RATIO = window.devicePixelRatio;
-var MIN_ICON_SIZE = 52;
 var MAX_ICON_SIZE = 60;
 var ICON_PADDING_IN_CANVAS = 4;
 var ICONS_PER_ROW = 4;
@@ -30,8 +28,6 @@ var DRAGGING_TRANSITION = '-moz-transform .3s';
 Icon.prototype = {
 
   MAX_ICON_SIZE: MAX_ICON_SIZE,
-
-  MIN_ICON_SIZE: MIN_ICON_SIZE,
 
   // It defines the time (in ms) to ensure that the onDragStop method finishes
   FALLBACK_DRAG_STOP_DELAY: 1000,
@@ -381,6 +377,10 @@ Icon.prototype = {
   },
 
   updateAppStatus: function icon_updateAppStatus(app) {
+    // change default icon size for tablet+ device
+    if (ScreenLayout.getCurrentLayout() !== 'tiny') {
+      MAX_ICON_SIZE = 100;
+    }
     if (app) {
       this.downloading = app.downloading;
       this.cancelled = (app.installState === 'pending') && !app.downloading;

--- a/apps/homescreen/style/dock.css
+++ b/apps/homescreen/style/dock.css
@@ -56,3 +56,53 @@
 #footer li > div > *:not(img) {
   display: none;
 }
+
+/* For tablet+ Device */
+@media (min-width: 768px) and (orientation: landscape) {
+  #footer {
+    height: 16rem;
+  }
+
+  #footer .dockWrapper {
+    width: 160%;
+  }
+
+  #footer ol {
+    margin-top: 2.5rem;
+  }
+
+  #footer li {
+    width: calc(100% / 8);
+  }
+
+  #footer > div li,
+  #footer > div.scrollable li {
+    width: 22rem;
+  }
+
+  #footer > div li:first-child {
+    width: 10rem;
+    padding-left: 15rem;
+    padding-right: 6rem;
+  }
+
+  #footer li:first-child span.options {
+    left: 15rem;
+  }
+
+  #footer > div li:last-child:not(:first-child) {
+    width: 10rem;
+    padding-right: 15rem;
+    padding-left: 6rem;
+  }
+
+  #footer li:last-child:not(:first-child) span.options {
+    left: 6rem;
+  }
+
+  #footer li span.options {
+    width: calc(50% - .5rem);
+    height: 4.5rem;
+    background: url(../resources/images/delete.png) no-repeat left top / 4.5rem;
+  }
+}

--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -58,7 +58,7 @@ body[data-transitioning] .apps > div {
 }
 
 /* Adds 1 row of icons */
-@media all and (min-device-width: 320px) and (min-device-height: 640px) {
+@media (min-device-width: 320px) and (min-device-height: 640px) {
   .apps ol > li:nth-child(17) {
     display: inline-block;
   }
@@ -188,7 +188,7 @@ body[data-transitioning] .loading:after {
 
 /* For WVGA (800 x 480), adjust the padding to make app icons fit in 4 x 5 grid */
 /* The width here is described as CSS pixel, so it would be 320px while dppx = 1.5 */
-@media all and (min-device-width: 320px) and (max-device-width: 359px) and (max-aspect-ratio: 4 / 6) {
+@media (min-device-width: 320px) and (max-device-width: 359px) and (max-aspect-ratio: 4 / 6) {
   .apps ol > li > div {
     margin-top: 0;
   }
@@ -203,6 +203,43 @@ body[data-transitioning] .loading:after {
 
   /* Maximum 20 icons for page */
   .apps ol > li:nth-child(21) {
+    display: none;
+  }
+}
+
+/* For tablet+ Device */
+@media (min-width: 768px) and (orientation: landscape) {
+  .apps ol > li {
+    width: 20%; /* five a line */
+  }
+
+  /* Option to delete apps */
+  .apps ol > li span.options {
+    height: 4.5rem;
+    background: url(../resources/images/delete.png) no-repeat left top / 4.5rem;
+  }
+
+  .apps ol {
+    -moz-box-sizing: border-box;
+         box-sizing: border-box;
+    padding: 5.3rem 6rem 5.6rem 9.3rem;
+  }
+
+  .labelWrapper {
+    margin-top: 1.5rem;
+    font-size: 1.8rem;
+    line-height: 1.8rem;
+    height: 2.3rem;
+    font-weight: 400;
+  }
+
+  .apps ol > li > div > span > span {
+    font-size: 1.8rem;
+    text-shadow: 0 0 0.5rem;
+  }
+
+  /* Maximum 15 icons for page */
+  .apps ol > li:nth-child(16) {
     display: none;
   }
 }

--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -14,6 +14,7 @@ requireApp('homescreen/test/unit/mock_hidden_apps.js');
 requireApp('homescreen/test/unit/mock_manifest_helper.js');
 requireApp('homescreen/test/unit/mock_icon_retriever.js');
 
+require('/shared/js/screen_layout.js');
 requireApp('homescreen/js/grid.js');
 
 var mocksHelperForGrid = new MocksHelper([

--- a/apps/homescreen/test/unit/page_test.js
+++ b/apps/homescreen/test/unit/page_test.js
@@ -6,6 +6,7 @@ requireApp('homescreen/test/unit/mock_xmlhttprequest.js');
 requireApp('homescreen/test/unit/mock_icon_retriever.js');
 requireApp('homescreen/test/unit/mock_grid_manager.js');
 
+require('/shared/js/screen_layout.js');
 requireApp('homescreen/js/page.js');
 
 var mocksHelperForPage = new MocksHelper([


### PR DESCRIPTION
-   To test this patch on nightly:
  1.  `$ make DEBUG=1 GAIA_DEV_PIXELS_PER_PX=2` (*)
  2.  to set responsive design window to 1280 x 800 px, enter `about:config` and set `devtools.responsiveUI.presents` to `{“key”:”1280x800”, “width”:1280, “height”:800}`

(*) add `GAIA_DEV_PIXELS_PER_PX=2` option is a temp solution for large device, will followed by `adaptive image support` patch to allow show different size image in same density
