### PR TITLE
Bug 903947 - [Messages] The last recipient is copied everytime when selecting recipeint for removing r=julienw

### DIFF
--- a/apps/sms/js/dialog.js
+++ b/apps/sms/js/dialog.js
@@ -49,6 +49,7 @@ var Dialog = function(params) {
   this.form = document.createElement('form');
   this.form.dataset.type = 'confirm';
   this.form.setAttribute('role', 'dialog');
+  this.form.tabIndex = -1;
 
   // We fill the main info
 
@@ -137,6 +138,7 @@ var Dialog = function(params) {
 // We prototype functions to show/hide the UI of action-menu
 Dialog.prototype.show = function() {
   document.body.appendChild(this.form);
+  this.form.focus();
 };
 
 Dialog.prototype.hide = function() {

--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -635,6 +635,7 @@
     var target = event.target;
     var keyCode = event.keyCode;
     var editable = 'false';
+    var lastElement = view.inner.lastElementChild;
     var typed, recipient, length, last, list, previous;
 
     // All keyboard events will need some information
@@ -695,7 +696,8 @@
           // If Recipient is clicked while another is actively
           // being editted, save the in-edit recipient before
           // transforming the target into an editable recipient.
-          typed = view.inner.lastElementChild.textContent.trim();
+          typed = lastElement && lastElement.isPlaceholder ?
+            lastElement.textContent.trim() : '';
 
           if (typed) {
             owner.add({

--- a/apps/sms/test/unit/dialog_test.js
+++ b/apps/sms/test/unit/dialog_test.js
@@ -12,8 +12,7 @@ suite('Dialog', function() {
   suiteSetup(function() {
     loadBodyHTML('/index.html');
     navigator.mozL10n = MockL10n;
-    params =
-    {
+    params = {
       title: {
         value: 'Foo Title',
         l10n: false
@@ -30,7 +29,6 @@ suite('Dialog', function() {
           }
         }
       }
-
     };
   });
 
@@ -68,6 +66,17 @@ suite('Dialog', function() {
     // We check the type
     var dialogForm = currentlyDefinedForms[currentlyDefinedFormsLength - 1];
     assert.equal(dialogForm.dataset.type, 'confirm');
+  });
+
+
+  test('Focus', function() {
+    var dialog = new Dialog(params);
+
+    this.sinon.spy(dialog.form, 'focus');
+
+    dialog.show();
+
+    assert.ok(dialog.form.focus.called);
   });
 
   test('Checking the structure. Default.', function() {

--- a/apps/sms/test/unit/mock_dialog.js
+++ b/apps/sms/test/unit/mock_dialog.js
@@ -9,8 +9,12 @@ function MockDialog(params) {
       MockDialog.triggers[option].called = true;
       params.options[option].method();
     };
-  });
 
+    // Setup the initial |false| value, this
+    // prevents assert.isFalse from failing
+    // on |undefined| trigger properties
+    MockDialog.triggers[option].called = false;
+  });
 }
 
 MockDialog.triggers = {};

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -464,58 +464,151 @@ suite('Recipients', function() {
 
       assert.equal(view.firstElementChild, view.lastElementChild);
     });
-  });
 
-  suite('Recipients.View.prompts', function() {
+    suite('Interaction', function() {
 
-    test('Recipients.View.prompts ', function() {
-      assert.ok(Recipients.View.prompts);
+      suite('Clicks on accepted recipients', function() {
+
+        test('while manually entering a recipient ', function() {
+          var view = document.getElementById('messages-recipients-list');
+
+          fixture.source = 'contacts';
+
+          recipients.add(fixture).focus();
+
+          // A recipient is accepted
+          assert.equal(recipients.length, 1);
+
+          // The recipient list contains:
+          //
+          //    - A rendered recipient
+          //    - A placeholder for the cursor
+          //
+          assert.equal(view.children.length, 2);
+
+          // Simulated manual entry of an unknown recipient
+          // (ie. not a stored contact)
+          view.lastElementChild.textContent = '999';
+          view.firstElementChild.click();
+
+          // A recipient is accepted
+          assert.equal(recipients.length, 2);
+
+          // The recipient list contains:
+          //
+          //    - Two rendered recipients
+          //    - A placeholder for the cursor
+          //
+          assert.equal(view.children.length, 3);
+        });
+
+        test('with only accepted recipients ', function() {
+          var view = document.getElementById('messages-recipients-list');
+
+          fixture.source = 'contacts';
+
+          recipients.add(fixture).focus();
+
+          // A recipient is accepted
+          assert.equal(recipients.length, 1);
+
+          // The recipient list contains:
+          //
+          //    - A rendered recipient
+          //    - A placeholder for the cursor
+          //
+          assert.equal(view.children.length, 2);
+
+          view.firstElementChild.click();
+
+          // No changes
+          assert.equal(recipients.length, 1);
+          assert.equal(view.children.length, 2);
+        });
+
+        test('with no placeholder at end of list ', function() {
+          var view = document.getElementById('messages-recipients-list');
+
+          fixture.source = 'contacts';
+
+          recipients.add(fixture).focus();
+
+          // A recipient is accepted
+          assert.equal(recipients.length, 1);
+
+          // The recipient list contains:
+          //
+          //    - A rendered recipient
+          //    - A placeholder for the cursor
+          //
+          assert.equal(view.children.length, 2);
+
+          // Remove the placeholder
+          view.removeChild(view.lastElementChild);
+
+          // Confirm the placeholder has been removed.
+          assert.equal(view.children.length, 1);
+
+          view.firstElementChild.click();
+
+          // No changes
+          assert.equal(recipients.length, 1);
+          assert.equal(view.children.length, 1);
+        });
+      });
     });
 
-    suite('Recipients.View.prompts.remove ', function() {
-      var recipient;
+    suite('Prompts', function() {
 
-      setup(function() {
-        // This simulates a recipient object
-        // as it would exist in the recipient data array.
-        //
-        // The values MUST be strings.
-        recipient = {
-          display: 'Mobile | Telco, 101',
-          editable: 'false',
-          email: '',
-          name: 'Alan Turing',
-          number: '101',
-          source: 'contacts'
-        };
+      test('Recipients.View.prompts ', function() {
+        assert.ok(Recipients.View.prompts);
       });
 
-      test('Recipients.View.prompts.remove ', function() {
-        assert.ok(Recipients.View.prompts.remove);
-      });
+      suite('Recipients.View.prompts.remove ', function() {
+        var recipient;
 
-      test('cancel ', function(done) {
-
-        Recipients.View.prompts.remove(recipient, function(response) {
-          assert.ok(MockDialog.triggers.cancel.called);
-          assert.ok(!MockDialog.triggers.confirm.called);
-          assert.ok(!response.isConfirmed);
-          done();
+        setup(function() {
+          // This simulates a recipient object
+          // as it would exist in the recipient data array.
+          //
+          // The values MUST be strings.
+          recipient = {
+            display: 'Mobile | Telco, 101',
+            editable: 'false',
+            email: '',
+            name: 'Alan Turing',
+            number: '101',
+            source: 'contacts'
+          };
         });
 
-        MockDialog.triggers.cancel();
-      });
-
-      test('remove ', function(done) {
-
-        Recipients.View.prompts.remove(recipient, function(response) {
-          assert.ok(MockDialog.triggers.confirm.called);
-          assert.ok(!MockDialog.triggers.cancel.called);
-          assert.ok(response.isConfirmed);
-          done();
+        test('Recipients.View.prompts.remove ', function() {
+          assert.ok(Recipients.View.prompts.remove);
         });
 
-        MockDialog.triggers.confirm();
+        test('cancel ', function(done) {
+
+          Recipients.View.prompts.remove(recipient, function(response) {
+            assert.ok(MockDialog.triggers.cancel.called);
+            assert.isFalse(MockDialog.triggers.confirm.called);
+            assert.isFalse(response.isConfirmed);
+            done();
+          });
+
+          MockDialog.triggers.cancel();
+        });
+
+        test('remove ', function(done) {
+
+          Recipients.View.prompts.remove(recipient, function(response) {
+            assert.ok(MockDialog.triggers.confirm.called);
+            assert.isFalse(MockDialog.triggers.cancel.called);
+            assert.ok(response.isConfirmed);
+            done();
+          });
+
+          MockDialog.triggers.confirm();
+        });
       });
     });
   });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=903947
- Clicks on accepted recipients...
  - Should close the keyboard, if it's a known contact recipient
  - while manually entering a recipient:
    - Two rendered recipients
    - A placeholder for the cursor
  -  with only accepted recipients:
    - no changes, no assimilated recipients
  - with no placeholder at end of list:
    - no changes, no assimilated recipients

This patch also fixes https://bugzilla.mozilla.org/show_bug.cgi?id=903943

Signed-off-by: Rick Waldron waldron.rick@gmail.com
