### PR TITLE
Bug 904085 - Fixed bug from previous related commit r=gregor

### DIFF
--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -1212,6 +1212,7 @@ Evme.Brain = new function Evme_Brain() {
             app = apps[i];
             if (app) {
               icons[app.id] = app.icon;
+              shortcutsToUpdate[key].push(app.id);
             }
           }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=904085

The previous commit in master (4cc6143c) did not take into consideration a small code difference between master and v1-train in the updateShortcutIcons() function. This is the fix.

Now that the code is fixed, take a look at the "games" icon -  it's made of 3 icons. Click "games", wait for results to show up, click back - now the "games" icon has been updated those the first 3 results.
