### PR TITLE
Bug 903438 - [Settings][HD] Text spacing incorrect in "Call Settings" and "Celluar & Data"

### DIFF
--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -95,6 +95,7 @@ ul li > label.pack-switch + small {
 ul li > small:not(:empty) + a,
 ul li > small:not(:empty) + span {
   line-height: 4.4rem;
+  padding-bottom: 0.1rem; /* Bug 903438 */ 
 }
 
 


### PR DESCRIPTION
[Bug 903438](https://bugzilla.mozilla.org/show_bug.cgi?id=903438)
