### PR TITLE
Bug 904220 - [Clock] Unit tests should not create actual alarm records

### DIFF
--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -202,4 +202,3 @@ html, body {
 body.hidden *[data-l10n-id] {
   visibility: hidden;
 }
-

--- a/apps/clock/test/unit/alarm_test.js
+++ b/apps/clock/test/unit/alarm_test.js
@@ -1,101 +1,138 @@
-requireApp('clock/js/utils.js');
 requireApp('clock/js/alarmsdb.js');
 requireApp('clock/js/alarm_edit.js');
-requireApp('clock/js/alarm_manager.js');
 requireApp('clock/js/alarm_list.js');
+requireApp('clock/js/alarm_manager.js');
+requireApp('clock/js/utils.js');
+
+requireApp('clock/test/unit/mocks/mock_alarm_list.js');
+requireApp('clock/test/unit/mocks/mock_alarm_manager.js');
+requireApp('clock/test/unit/mocks/mock_asyncstorage.js');
+requireApp('clock/test/unit/mocks/mock_navigator_mozl10n.js');
+
 
 suite('AlarmEditView', function() {
-  var subject;
+  var al, am, nml;
+  var id = 1;
 
-  before(function() {
-    subject = AlarmEdit;
+  suiteSetup(function() {
+    al = AlarmList;
+    am = AlarmManager;
+    nml = navigator.mozL10n;
 
+    AlarmList = MockAlarmList;
+    AlarmManager = MockAlarmManager;
+    navigator.mozL10n = MockmozL10n;
+
+    loadBodyHTML('/index.html');
+  });
+
+  suiteTeardown(function() {
+    AlarmList = al;
+    AlarmManager = am;
+    navigator.mozL10n = nml;
+  });
+
+
+  setup(function() {
     // shim the edit alarm view
-    delete subject.element;
-    subject.element = document.createElement('div');
-    subject.element.dataset.id = '';
-    delete subject.labelInput;
-    subject.labelInput = document.createElement('input');
-    delete subject.timeSelect;
-    subject.timeSelect = document.createElement('input');
-    subject.initTimeSelect();
+    delete AlarmEdit.labelInput;
+    AlarmEdit.labelInput = document.createElement('input');
+    delete AlarmEdit.timeSelect;
+    AlarmEdit.timeSelect = document.createElement('input');
+    AlarmEdit.initTimeSelect();
 
-    sinon.stub(subject, 'getSoundSelect');
-    sinon.stub(subject, 'getVibrateSelect');
-    sinon.stub(subject, 'getSnoozeSelect');
-    sinon.stub(subject, 'getRepeatSelect');
-  });
 
-  beforeEach(function() {
-    subject.alarm = subject.getDefaultAlarm();
-    subject.getSoundSelect.returns(subject.alarm.sound);
-    subject.getVibrateSelect.returns(subject.alarm.vibrate);
-    subject.getSnoozeSelect.returns(subject.alarm.snooze);
-    subject.getRepeatSelect.returns(subject.alarm.repeat);
-  });
+    this.sinon.stub(AlarmEdit, 'getSoundSelect');
+    this.sinon.stub(AlarmEdit, 'getVibrateSelect');
+    this.sinon.stub(AlarmEdit, 'getSnoozeSelect');
+    this.sinon.stub(AlarmEdit, 'getRepeatSelect');
 
-  after(function() {
-    subject.getSoundSelect.restore();
-    subject.getVibrateSelect.restore();
-    subject.getSnoozeSelect.restore();
-    subject.getRepeatSelect.restore();
+    this.sinon.stub(AlarmManager, 'toggleAlarm');
+
+    this.sinon.stub(AlarmManager, 'putAlarm', function(alarm, callback) {
+      alarm.id = id++;
+      callback(alarm);
+    });
+
+    this.sinon.stub(AlarmManager, 'delete', function(alarm, callback) {
+      callback(alarm);
+    });
+
+    AlarmEdit.alarm = AlarmEdit.getDefaultAlarm();
+
+    // Define the stubs to return the same values set in the
+    // default alarm object.
+    AlarmEdit.getSoundSelect.returns(AlarmEdit.alarm.sound);
+    AlarmEdit.getVibrateSelect.returns(AlarmEdit.alarm.vibrate);
+    AlarmEdit.getSnoozeSelect.returns(AlarmEdit.alarm.snooze);
+    AlarmEdit.getRepeatSelect.returns(AlarmEdit.alarm.repeat);
   });
 
   test('should save and delete an alarm', function(done) {
-    var spyRefresh = sinon.stub(AlarmList, 'refresh');
-    subject.save(function(alarm) {
+    this.sinon.stub(AlarmList, 'refresh');
+
+    AlarmEdit.save(function(alarm) {
       assert.ok(alarm.id);
-      sinon.assert.calledOnce(spyRefresh);
-      subject.alarm = alarm;
-      subject.element.dataset.id = alarm.id;
-      subject.delete(function() {
-        sinon.assert.calledTwice(spyRefresh);
-        AlarmList.refresh.restore();
+      assert.ok(AlarmList.refresh.calledOnce);
+      assert.ok(AlarmManager.putAlarm.calledOnce);
+      assert.ok(AlarmManager.toggleAlarm.calledOnce);
+
+      AlarmEdit.alarm = alarm;
+      AlarmEdit.element.dataset.id = alarm.id;
+
+      AlarmEdit.delete(function() {
+        assert.ok(AlarmList.refresh.calledTwice);
         done();
       });
     });
   });
 
   test('should add an alarm with sound, no vibrate', function(done) {
-    var spyRefresh = sinon.stub(AlarmList, 'refresh');
+    this.sinon.stub(AlarmList, 'refresh');
 
     // mock the view to turn off vibrate
-    subject.getVibrateSelect.returns('0');
-    subject.save(function(alarm) {
+    AlarmEdit.getVibrateSelect.returns(0);
+    AlarmEdit.save(function(alarm) {
       assert.ok(alarm.id);
-      sinon.assert.calledOnce(spyRefresh);
-      AlarmList.refresh.restore();
-      AlarmManager.getAlarmById(alarm.id, function(alarm) {
-        assert.equal(alarm.vibrate, 0);
-        assert.notEqual(alarm.sound, 0);
-        done();
-      });
+      assert.ok(AlarmList.refresh.calledOnce);
+      assert.ok(AlarmManager.putAlarm.calledOnce);
+      assert.ok(AlarmManager.toggleAlarm.calledOnce);
+
+
+      assert.equal(alarm.vibrate, 0);
+      assert.notEqual(alarm.sound, 0);
+
+      done();
     });
   });
 
   test('should update existing alarm with no sound, vibrate', function(done) {
-    var spyRefresh = sinon.stub(AlarmList, 'refresh');
+    this.sinon.stub(AlarmList, 'refresh');
 
     // mock the view to turn sound on and vibrate off
-    subject.getVibrateSelect.returns('0');
-    subject.save(function(alarm) {
+    AlarmEdit.getVibrateSelect.returns(0);
+    AlarmEdit.save(function(alarm) {
       assert.ok(alarm.id);
-      sinon.assert.calledOnce(spyRefresh);
-      subject.getVibrateSelect.returns('1');
-      subject.getSoundSelect.returns('0');
-      subject.alarm = alarm;
-      subject.element.dataset.id = alarm.id;
-      subject.save(function(alarm) {
+      assert.ok(AlarmList.refresh.calledOnce);
+      assert.ok(AlarmManager.putAlarm.calledOnce);
+      assert.ok(AlarmManager.toggleAlarm.calledOnce);
+
+      AlarmEdit.getVibrateSelect.returns(1);
+      AlarmEdit.getSoundSelect.returns(0);
+
+      AlarmEdit.alarm = alarm;
+      AlarmEdit.element.dataset.id = alarm.id;
+
+      AlarmEdit.save(function(alarm) {
         assert.ok(alarm.id);
-        sinon.assert.calledTwice(spyRefresh);
-        AlarmList.refresh.restore();
-        AlarmManager.getAlarmById(alarm.id, function(alarm) {
-          assert.equal(alarm.vibrate, 1);
-          assert.equal(alarm.sound, 0);
-          done();
-        });
+        assert.ok(AlarmList.refresh.calledTwice);
+        assert.ok(AlarmManager.putAlarm.calledTwice);
+        assert.ok(AlarmManager.toggleAlarm.calledTwice);
+
+        assert.equal(alarm.vibrate, 1);
+        assert.equal(alarm.sound, 0);
+        done();
       });
     });
   });
-
 });

--- a/apps/clock/test/unit/clock_view_test.js
+++ b/apps/clock/test/unit/clock_view_test.js
@@ -7,14 +7,13 @@ suite('ClockView', function() {
     // The timestamp for "Tue Jul 16 2013 06:00:00" according to the local
     // system's time zone
     this.sixAm = 1373954400000 + (new Date()).getTimezoneOffset() * 60 * 1000;
+    loadBodyHTML('/index.html');
   });
 
   suite('updateDaydate', function() {
 
     suiteSetup(function() {
-      this.dayDateElem = document.createElement('div');
-      this.dayDateElem.id = 'clock-day-date';
-      document.body.appendChild(this.dayDateElem);
+      this.dayDateElem = document.getElementById('clock-day-date');
     });
 
     setup(function() {
@@ -53,12 +52,8 @@ suite('ClockView', function() {
   suite('updateDigitalClock', function() {
 
     suiteSetup(function() {
-      this.timeElem = document.createElement('div');
-      this.timeElem.id = 'clock-time';
-      document.body.appendChild(this.timeElem);
-      this.hourStateElem = document.createElement('div');
-      this.hourStateElem.id = 'clock-hour24-state';
-      document.body.appendChild(this.hourStateElem);
+      this.timeElem = document.getElementById('clock-time');
+      this.hourStateElem = document.getElementById('clock-hour24-state');
     });
 
     setup(function() {
@@ -104,15 +99,9 @@ suite('ClockView', function() {
   suite('updateAnalogClock', function() {
 
     suiteSetup(function() {
-      this.secondHand = document.createElement('rect');
-      this.secondHand.id = 'secondhand';
-      document.body.appendChild(this.secondHand);
-      this.minuteHand = document.createElement('rect');
-      this.minuteHand.id = 'minutehand';
-      document.body.appendChild(this.minuteHand);
-      this.hourHand = document.createElement('rect');
-      this.hourHand.id = 'hourhand';
-      document.body.appendChild(this.hourHand);
+      this.secondHand = document.getElementById('secondhand');
+      this.minuteHand = document.getElementById('minutehand');
+      this.hourHand = document.getElementById('hourhand');
     });
 
     setup(function() {

--- a/apps/clock/test/unit/mocks/mock_alarm_list.js
+++ b/apps/clock/test/unit/mocks/mock_alarm_list.js
@@ -1,0 +1,18 @@
+MockAlarmList = {
+  alarmList: [],
+  refreshingAlarms: [],
+  _previousAlarmCount: 0,
+  handleEvent: function() {},
+  alarmEditView: function() {},
+  init: function() {},
+  refresh: function() {},
+  buildAlarmContent: function() {},
+  refreshItem: function() {},
+  fillList: function() {},
+  getAlarmFromList: function() {},
+  getAlarmCount: function() {
+    return 1;
+  },
+  toggleAlarmEnableState: function() {},
+  deleteCurrent: function() {}
+};

--- a/apps/clock/test/unit/mocks/mock_alarm_manager.js
+++ b/apps/clock/test/unit/mocks/mock_alarm_manager.js
@@ -1,0 +1,11 @@
+MockAlarmManager = {
+  toggleAlarm: function() {},
+  set: function() {},
+  unset: function() {},
+  delete: function() {},
+  getAlarmList: function() {},
+  getAlarmById: function() {},
+  putAlarm: function() {},
+  updateAlarmStatusBar: function() {},
+  regUpdateAlarmEnableState: function() {}
+};

--- a/apps/clock/test/unit/mocks/mock_navigator_mozl10n.js
+++ b/apps/clock/test/unit/mocks/mock_navigator_mozl10n.js
@@ -1,0 +1,6 @@
+MockmozL10n = {
+  translate: function() {
+  },
+  get: function() {
+  }
+};

--- a/apps/clock/test/unit/setup.js
+++ b/apps/clock/test/unit/setup.js
@@ -6,3 +6,11 @@ requireApp('email/test/unit/mock_l10n.js', function() {
   navigator.mozL10n = MockL10n;
 
 });
+
+if (typeof asyncStorage === 'undefined') {
+  require('/shared/js/async_storage.js');
+}
+
+if (typeof loadBodyHTML === 'undefined') {
+  require('/shared/test/unit/load_body_html_helper.js');
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=904220

commit af2a65e
Author: Mike Pennisi mike@mikepennisi.com
Date:   Tue Aug 13 15:32:54 2013 -0400

```
Fix bug in unit tests

Loading the application HTML into the unit test environment breaks some
assumptions made by the tests. Notably: elements appended to the DOM
which have identical DOM IDs will no longer be returned by
`document.getElementById`.

A slightly cleaner approach might involve re-loading the `body` HTML
before *every* test and referencing elements from the global `ClockView`
object directly. This has two drawbacks:

1. It will tend to slow down the test suite (especially as more tests
   are written)
2. It will require further re-factoring of the application logic (which
   caches references to its DOM nodes when they are first referenced).

For these reasons, we might prefer the simplistic fix outlined by this
patch.

Part of this fix requires consistently loading the `loadBodyHTML`
utility function in `setup.js` (so that it is loaded when the test-agent
runs the entire test suite *and* when it runs individual test files).
```

commit 0ca745a
Author: Rick Waldron waldron.rick@gmail.com
Date:   Mon Aug 12 18:46:31 2013 -0400

```
Bug 904220 - [Clock] Unit tests should not create actual alarm records

https://bugzilla.mozilla.org/show_bug.cgi?id=904220

- Reorders require files alphabetically
- Adds Mocks:
    - mock_alarm_list.js
    - mock_alarm_manager.js
    - mock_navigator_mozl10n.js
- Update tests to use actual markup as fixture
- Update tests to use the same mocha API as other tests
- Use mocks instead of creating real alarm records
- Use sinon sandbox features

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>
```
