### PR TITLE
Bug 892519 - [email] Notifications - Email App Not Foreground

### DIFF
--- a/apps/email/build/email.build.js
+++ b/apps/email/build/email.build.js
@@ -3,6 +3,9 @@
   baseUrl: 'js',
   dir: '../../../build_stage/email',
   mainConfigFile: '../js/mail_app.js',
+  paths: {
+    prim: 'empty:'
+  },
 /*
   wrap: {
     start: 'plog("@@@ START OF BUILD LAYER");',

--- a/apps/email/js/app_self.js
+++ b/apps/email/js/app_self.js
@@ -1,0 +1,50 @@
+/*jshint browser: true */
+/*globals define */
+
+/**
+ * Provides a wrapper over the mozApps.getSelf() API. Structured as an
+ * evt emitter, with "latest" support, and "latest" is overridden so
+ * that the call to getSelf() is delayed until the very first need
+ * for it.
+ *
+ * This allows code to have a handle on this module, instead of making
+ * the getSelf() call, and then only trigger the fetch via a call to
+ * latest, delaying the work until it is actually needed. Once getSelf()
+ * is fetched once, the result is reused.
+ */
+define(function(require, exports, module) {
+  var evt = require('evt');
+
+  var appSelf = evt.mix({}),
+      mozApps = navigator.mozApps,
+      oldLatest = appSelf.latest,
+      loaded = false;
+
+  if (!mozApps) {
+    appSelf.self = {};
+    loaded = true;
+  }
+
+  function loadSelf() {
+    mozApps.getSelf().onsuccess = function(event) {
+      loaded = true;
+      var app = event.target.result;
+      appSelf.self = app;
+      appSelf.emit('self', appSelf.self);
+    };
+  }
+
+  // Override latest to only do the work when something actually wants to
+  // listen.
+  appSelf.latest = function(id) {
+    if (!loaded)
+      loadSelf();
+
+    if (id !== 'self')
+      throw new Error(module.id + ' only supports "self" property');
+
+    return oldLatest.apply(this, arguments);
+  };
+
+  return appSelf;
+});

--- a/apps/email/js/cards/account_prefs_mixins.js
+++ b/apps/email/js/cards/account_prefs_mixins.js
@@ -1,0 +1,96 @@
+/*jshint browser: true */
+/*global define, console, _secretDebug */
+
+define(function(require) {
+  var evt = require('evt'),
+      mozL10n = require('l10n!');
+
+  /**
+   * mixin properties for cards that share similar actions around the account
+   * preferences.
+   * ASSUMES the following properties have been initialized on the object
+   * - this.domNode
+   * - this.account
+   */
+
+  return {
+    // Call this in target object's constructor to wire up the common prefs.
+    _bindPrefs: function(checkIntervalClassName, //sync interval select box
+                         notifyEmailClassName) { //notify email checkbox
+
+      if (checkIntervalClassName) {
+        // Wire up the sync interval select box.
+        var checkIntervalNode = this.nodeFromClass(checkIntervalClassName),
+            currentInterval = this.account.syncInterval,
+            syncIntervalString = String(currentInterval),
+            extraOptions = [];
+
+        // Allow for fast sync options set via the settings_debug
+        // secret debugging screen.
+        if (typeof _secretDebug !== 'undefined' && _secretDebug.fastSync) {
+          extraOptions = extraOptions.concat(_secretDebug.fastSync);
+        }
+
+        // If existing sync option is not in the set shown in the UI,
+        // allow for dynamically inserting it.
+        var hasOption = Array.slice(checkIntervalNode.options, 0)
+                        .some(function(option) {
+                          return syncIntervalString === option.value;
+                        });
+        if (!hasOption && extraOptions.indexOf(currentInterval) === -1)
+          extraOptions.push(currentInterval);
+
+        // Add any extra sync interval options.
+        extraOptions.forEach(function(interval) {
+          var node = document.createElement('option'),
+              seconds = interval / 1000;
+
+          node.value = String(interval);
+          mozL10n.localize(node, 'settings-check-dynamic', { n: seconds });
+          checkIntervalNode.appendChild(node);
+        });
+
+        checkIntervalNode.value = syncIntervalString;
+        checkIntervalNode.addEventListener('change',
+                                           this.onChangeSyncInterval.bind(this),
+                                           false);
+      }
+
+      if (notifyEmailClassName) {
+        var notifyMailNode = this.nodeFromClass(notifyEmailClassName);
+        notifyMailNode.addEventListener('click',
+                                        this.onNotifyEmailClick.bind(this),
+                                        false);
+        notifyMailNode.checked = this.account.notifyOnNew;
+      }
+    },
+
+    nodeFromClass: function(className) {
+      return this.domNode.getElementsByClassName(className)[0];
+    },
+
+    onChangeSyncInterval: function(event) {
+      var value = parseInt(event.target.value, 10);
+      console.log('sync interval changed to', value);
+      var data = {syncInterval: value};
+
+      // On account creation, may not have a full account object yet.
+      if (this.account.modifyAccount)
+        this.account.modifyAccount(data);
+      else
+        evt.emitWhenListener('accountModified', this.account.id, data);
+    },
+
+    onNotifyEmailClick: function(event) {
+      var checked = event.target.checked;
+      console.log('notifyOnNew changed to: ' + checked);
+      var data = {notifyOnNew: checked};
+
+      // On account creation, may not have a full account object yet.
+      if (this.account.modifyAccount)
+        this.account.modifyAccount(data);
+      else
+        evt.emitWhenListener('accountModified', this.account.id, data);
+    }
+  };
+});

--- a/apps/email/js/cards/fld/account_item.html
+++ b/apps/email/js/cards/fld/account_item.html
@@ -1,5 +1,8 @@
 <a class="fld-account-item">
   <span class="fld-account-name"></span>
   <span class="fld-account-problem icon collapsed">!</span>
-  <span class="fld-account-unread"></span>
+  <div class="fld-account-lastsync">
+    <span data-l10n-id="fld-account-picker-last-sync"></span>
+    <span class="fld-account-lastsync-value"></span>
+  </div>
 </a>

--- a/apps/email/js/cards/settings_account.html
+++ b/apps/email/js/cards/settings_account.html
@@ -1,5 +1,6 @@
 <!-- Per-account settings menu; largely read-only for now -->
-<section class="card-settings-account card skin-organic" role="region">
+<section class="card-settings-account card-settings-account-common card skin-organic"
+         role="region">
   <header class="tng-account-header">
     <a href="#" class="tng-back-btn back-btn header-left-btn">
       <span class="icon icon-back"></span>
@@ -7,9 +8,32 @@
     <h1 class="tng-account-header-label header-label">AccounT NamE</h1>
   </header>
   <section class="scrollregion-below-header skin-organic" role="region">
+    <header class="collapsed"></header>
+    <header class="tng-main-accounts-label">
+      <h2 data-l10n-id="settings-sub-header-account">
+        AccounT
+      </h2>
+    </header>
+    <li class="list-text-with-sub">
+      <span data-l10n-id="settings-account-name" class="list-text">
+        YouR NamE</span>
+      <span class="tng-account-name list-sub-text">YouR NamE</span>
+    </li>
+    <li class="list-text-with-sub">
+      <span data-l10n-id="settings-account-display-notifications"
+            class="list-text aside start">
+        DisplaY NotificationS FoR NeW MessageS</span>
+      <em class="aside end">
+        <label class="pack-switch">
+          <input class="tng-notify-mail" type="checkbox">
+          <span></span>
+        </label>
+      </em>
+    </li>
     <li>
-      <span data-l10n-id="settings-default-account" class="list-text">
-        DefaulT AccounT</span>
+      <span data-l10n-id="settings-default-account"
+            class="list-text aside start">
+        SeT AS DefaulT EmaiL</span>
       <em class="aside end">
         <label class="pack-checkbox tng-default-label">
           <input class="tng-default-input" type="checkbox">
@@ -17,15 +41,35 @@
         </label>
       </em>
     </li>
-    <li>
-      <span data-l10n-id="settings-account-type" class="list-text">
-        AccounT TypE</span>
-      <div class="aside end">
-        <span class="tng-account-type list-value">AccounT TypE</span>
-      </div>
+
+    <header class="tng-main-accounts-label">
+      <h2 data-l10n-id="settings-sub-header-data">
+        DatA
+      </h2>
+    </header>
+    <li class="syncinterval-setting select-item">
+      <label data-l10n-id="settings-account-check-mail" class="list-text">
+        ChecK FoR NeW MessageS</label>
+      <span class="button icon icon-dialog">
+        <select class="tng-account-check-interval mail-select">
+          <option value="0" data-l10n-id="settings-check-every-manual">
+            ManuallY</option>
+          <option value="300000" data-l10n-id="settings-check-every-5min">
+            5 MinuteS</option>
+          <option value="600000" data-l10n-id="settings-check-every-10min">
+            10 MinuteS</option>
+          <option value="900000" data-l10n-id="settings-check-every-15min">
+            15 MinuteS</option>
+          <option value="1800000" data-l10n-id="settings-check-every-30min">
+            30 MinuteS</option>
+          <option value="3600000" data-l10n-id="settings-check-every-60min">
+            60 MinuteS</option>
+        </select>
+      </span>
     </li>
-    <li class="synchronize-setting">
-      <label data-l10n-id="settings-account-synchronize" class="list-text">SynchronizE</label>
+    <li class="synchronize-setting select-item">
+      <label data-l10n-id="settings-account-synchronize-window"
+             class="list-text">DayS TO SynC</label>
       <span class="button icon icon-dialog">
         <select class="mail-select tng-account-synchronize">
           <option value="auto" data-l10n-id="settings-synchronize-auto">
@@ -45,10 +89,22 @@
         </select>
       </span>
     </li>
+
+    <header class="tng-main-accounts-label">
+      <h2 data-l10n-id="settings-sub-header-server">
+        ServeR SettingS
+      </h2>
+    </header>
     <li>
-      <a href="#" data-l10n-id="settings-account-credentials"
-        class="tng-account-credentials list-text">CredentialS</a>
-      <em class="aside end"></em>
+      <a href="#" data-l10n-id="settings-account-userpass"
+        class="tng-account-credentials list-text">UsernamE AnD PassworD</a>
+    </li>
+    <li>
+      <span data-l10n-id="settings-account-type" class="list-text aside start">
+        AccounT TypE</span>
+      <div class="aside end">
+        <span class="tng-account-type list-value">AccounT TypE</span>
+      </div>
     </li>
     <div class="tng-account-server-container"></div>
     <li class="align-center">

--- a/apps/email/js/cards/settings_debug.html
+++ b/apps/email/js/cards/settings_debug.html
@@ -20,6 +20,9 @@
       <li>
         <button class="tng-dbg-dump-storage">Dump log to storage</button>
       </li>
+      <li>
+        <button class="tng-dbg-fastsync">Enable faster sync options</button>
+      </li>
     </ul>
   </div>
 </section>

--- a/apps/email/js/cards/settings_debug.js
+++ b/apps/email/js/cards/settings_debug.js
@@ -1,4 +1,5 @@
 /*global define*/
+var _secretDebug;
 define(function(require) {
 
 var templateNode = require('tmpl!./settings_debug.html'),
@@ -6,6 +7,8 @@ var templateNode = require('tmpl!./settings_debug.html'),
     MailAPI = require('api'),
     Cards = common.Cards;
 
+if (!_secretDebug)
+  _secretDebug = {};
 
 /**
  * Quasi-secret card for troubleshooting/debugging support.  Not part of the
@@ -35,6 +38,9 @@ function SettingsDebugCard(domNode, mode, args) {
   this.dangerousLoggingButton.addEventListener(
     'click', this.cycleLogging.bind(this, true, 'dangerous'), false);
   this.cycleLogging(false);
+
+  domNode.querySelector('.tng-dbg-fastsync')
+         .addEventListener('click', this.fastSync.bind(this), true);
 
   // - hookup
 }
@@ -77,6 +83,10 @@ SettingsDebugCard.prototype = {
     }
     this.loggingButton.textContent = label;
     this.dangerousLoggingButton.textContent = dangerLabel;
+  },
+
+  fastSync: function() {
+    _secretDebug.fastSync = [20000, 60000];
   },
 
   die: function() {

--- a/apps/email/js/cards/settings_main.html
+++ b/apps/email/js/cards/settings_main.html
@@ -23,28 +23,6 @@
       <h2 data-l10n-id="settings-general-section">GeneraL SettingS</h2>
     </header>
       <li class="collapsed">
-        <span data-l10n-id="settings-check-mail" class="list-text">
-          ChecK MaiL</span>
-        <em class="aside end">
-          <select class="tng-main-check-interval mail-select">
-            <option value="manual" data-l10n-id="settings-check-manual">
-              Manually</option>
-            <option value="3min" data-l10n-id="settings-check-3min">
-              3 Minutes</option>
-            <option value="5min" data-l10n-id="settings-check-5min">
-              5 Minutes</option>
-            <option value="10min" data-l10n-id="settings-check-10min">
-              10 Minutes</option>
-            <option value="15min" data-l10n-id="settings-check-15min">
-              15 Minutes</option>
-            <option value="30min" data-l10n-id="settings-check-30min">
-              30 Minutes</option>
-            <option value="60min" data-l10n-id="settings-check-60min">
-              60 Minutes</option>
-          </select>
-        </em>
-      </li>
-      <li class="collapsed">
         <span data-l10n-id="settings-show-images" class="list-text">
           AlwayS ShoW ImageS</span>
         <em class="aside end">
@@ -57,16 +35,6 @@
       <li class="collapsed">
         <span data-l10n-id="settings-download-attachments"
           class="list-text">DownloaD AttachmentS</span>
-        <em class="aside end">
-          <label class="pack-switch">
-            <input type="checkbox" checked="checked">
-            <span></span>
-          </label>
-        </em>
-      </li>
-      <li class="collapsed">
-        <span data-l10n-id="settings-notify-mail" class="list-text">
-          NotifY ME OF NeW MaiL</span>
         <em class="aside end">
           <label class="pack-switch">
             <input type="checkbox" checked="checked">

--- a/apps/email/js/cards/settings_main.js
+++ b/apps/email/js/cards/settings_main.js
@@ -19,13 +19,6 @@ function SettingsMainCard(domNode, mode, args) {
   domNode.getElementsByClassName('tng-close-btn')[0]
     .addEventListener('click', this.onClose.bind(this), false);
 
-  var checkIntervalNode =
-    domNode.getElementsByClassName('tng-main-check-interval')[0];
-console.log('  CONFIG CURRENTLY:', JSON.stringify(MailAPI.config));//HACK
-  checkIntervalNode.value = MailAPI.config.syncCheckIntervalEnum;
-  checkIntervalNode.addEventListener(
-    'change', this.onChangeSyncInterval.bind(this), false);
-
   this.accountsContainer =
     domNode.getElementsByClassName('tng-accounts-container')[0];
 
@@ -80,12 +73,6 @@ SettingsMainCard.prototype = {
       accountLabel.addEventListener('click',
         this.onClickEnterAccount.bind(this, account), false);
     }
-  },
-
-  onChangeSyncInterval: function(event) {
-    console.log('sync interval changed to', event.target.value);
-    MailAPI.modifyConfig({
-      syncCheckIntervalEnum: event.target.value });
   },
 
   onClickAddAccount: function() {

--- a/apps/email/js/cards/setup_account_info.js
+++ b/apps/email/js/cards/setup_account_info.js
@@ -3,9 +3,10 @@ define(function(require) {
 
 var templateNode = require('tmpl!./setup_account_info.html'),
     common = require('mail_common'),
-    model = require('model'),
     SETUP_ERROR_L10N_ID_MAP = require('./setup_l10n_map'),
+    evt = require('evt'),
     mozL10n = require('l10n!'),
+    model = require('model'),
     Cards = common.Cards,
     FormNavigation = common.FormNavigation;
 
@@ -51,16 +52,13 @@ function SetupAccountInfoCard(domNode, mode, args) {
 
 SetupAccountInfoCard.prototype = {
   onBack: function(event) {
-    // If we are the only card, we need to remove ourselves and tell the app
-    // to do initial card pushing.  This would happen if the app was started
-    // without any accounts.
-    if (Cards._cardStack.length === 1) {
-      Cards.removeAllCards();
-      model.init();
-    }
-    // Otherwise we were triggered from the settings UI and we can just pop
-    // our way back to that UI.
-    else {
+    if (!model.foldersSlice) {
+      // No account has been formally initialized, but one
+      // likely exists given that this back button should
+      // only be available for cases that have accounts.
+      // Likely just need the app to reset to load model.
+      evt.emit('resetApp');
+    } else {
       Cards.removeCardAndSuccessors(this.domNode, 'animate', 1);
     }
   },

--- a/apps/email/js/cards/setup_account_prefs.html
+++ b/apps/email/js/cards/setup_account_prefs.html
@@ -1,0 +1,45 @@
+<section class="card-setup-account-prefs card-settings-account-common card skin-organic"
+         role="region">
+  <header class="sup-account-header">
+    <menu type="toolbar">
+      <button class="sup-info-next-btn">
+        <span data-l10n-id="setup-info-next">NexT</span>
+      </button>
+    </menu>
+    <h1 class="sup-account-header-label"
+        data-l10n-id="setup-account-header3">NeW AccounT</h1>
+  </header>
+  <section class="scrollregion-below-header skin-organic" role="region">
+    <li class="syncinterval-setting select-item">
+      <label data-l10n-id="settings-account-check-mail" class="list-text">
+        ChecK FoR NeW MessageS</label>
+      <span class="button icon icon-dialog">
+        <select class="tng-account-check-interval mail-select">
+          <option value="0" data-l10n-id="settings-check-every-manual">
+            ManuallY</option>
+          <option value="300000" data-l10n-id="settings-check-every-5min">
+            5 MinuteS</option>
+          <option value="600000" data-l10n-id="settings-check-every-10min">
+            10 MinuteS</option>
+          <option value="900000" data-l10n-id="settings-check-every-15min">
+            15 MinuteS</option>
+          <option value="1800000" data-l10n-id="settings-check-every-30min">
+            30 MinuteS</option>
+          <option value="3600000" data-l10n-id="settings-check-every-60min">
+            60 MinuteS</option>
+        </select>
+      </span>
+    </li>
+    <li class="list-text-with-sub">
+      <span data-l10n-id="settings-account-display-notifications"
+            class="list-text aside start">
+        DisplaY NotificationS FoR NeW MessageS</span>
+      <em class="aside end">
+        <label class="pack-switch">
+          <input class="tng-notify-mail" type="checkbox">
+          <span></span>
+        </label>
+      </em>
+    </li>
+  </section>
+</section>

--- a/apps/email/js/cards/setup_account_prefs.js
+++ b/apps/email/js/cards/setup_account_prefs.js
@@ -1,0 +1,46 @@
+/*global define*/
+define(function(require) {
+
+var templateNode = require('tmpl!./setup_account_prefs.html'),
+    prefsMixin = require('./account_prefs_mixins'),
+    mix = require('mix'),
+    common = require('mail_common'),
+    Cards = common.Cards;
+
+/**
+ * Setup is done; add another account?
+ */
+function SetupAccountPrefsCard(domNode, mode, args) {
+  this.domNode = domNode;
+  this.account = args.account;
+
+  this.nextButton = this.nodeFromClass('sup-info-next-btn');
+  this.nextButton.addEventListener('click', this.onNext.bind(this), false);
+
+  this._bindPrefs('tng-account-check-interval', 'tng-notify-mail');
+}
+
+SetupAccountPrefsCard.prototype = {
+  onNext: function(event) {
+    Cards.pushCard(
+      'setup_done', 'default', 'animate',
+      {});
+  },
+
+  die: function() {
+  }
+};
+
+// Wire up some common pref handlers.
+mix(SetupAccountPrefsCard.prototype, prefsMixin);
+
+Cards.defineCardWithDefaultMode(
+    'setup_account_prefs',
+    { tray: false },
+    SetupAccountPrefsCard,
+    templateNode
+);
+
+return SetupAccountPrefsCard;
+
+});

--- a/apps/email/js/cards/setup_done.js
+++ b/apps/email/js/cards/setup_done.js
@@ -4,6 +4,7 @@ define(function(require) {
 var templateNode = require('tmpl!./setup_done.html'),
     common = require('mail_common'),
     model = require('model'),
+    evt = require('evt'),
     Cards = common.Cards;
 
 
@@ -18,20 +19,11 @@ function SetupDoneCard(domNode, mode, args) {
 }
 SetupDoneCard.prototype = {
   onAddAnother: function() {
-    // Nuke all cards
-    Cards.removeAllCards();
-    // Show the first setup card again.
-    Cards.pushCard(
-      'setup_account_info', 'default', 'immediate',
-      {
-        allowBack: true
-      });
+    evt.emit('addAccount');
   },
   onShowMail: function() {
     // Nuke this card
-    Cards.removeAllCards();
-    // Trigger the startup logic again; this should show the inbox this time.
-    model.init(true);
+    evt.emit('showLatestAccount');
   },
 
   die: function() {

--- a/apps/email/js/cards/setup_progress.js
+++ b/apps/email/js/cards/setup_progress.js
@@ -3,6 +3,7 @@ define(function(require) {
 
 var templateNode = require('tmpl!./setup_progress.html'),
     common = require('mail_common'),
+    model = require('model'),
     MailAPI = require('api'),
     Cards = common.Cards;
 
@@ -27,12 +28,12 @@ function SetupProgressCard(domNode, mode, args) {
       password: args.password
     },
     args.domainInfo || null,
-    function(err, errDetails) {
+    function(err, errDetails, account) {
       self.creationInProcess = false;
       if (err)
         self.onCreationError(err, errDetails);
       else
-        self.onCreationSuccess();
+        self.onCreationSuccess(account);
     });
 }
 SetupProgressCard.prototype = {
@@ -52,12 +53,11 @@ SetupProgressCard.prototype = {
     Cards.removeCardAndSuccessors(this.domNode, 'animate', 1);
   },
 
-  onCreationSuccess: function() {
-    // nuke the current card stack, replace them with the done card.
-    Cards.removeAllCards();
-    Cards.pushCard(
-      'setup_done', 'default', 'immediate',
-      {});
+  onCreationSuccess: function(account) {
+    Cards.pushCard('setup_account_prefs', 'default', 'animate',
+    {
+      account: account
+    });
   },
 
   die: function() {

--- a/apps/email/js/date.js
+++ b/apps/email/js/date.js
@@ -1,0 +1,27 @@
+/*global define */
+define(function(require) {
+  // TODO: move common date functions from mail_common into here over time,
+  // and then remove this dependency.
+  var common = require('mail_common');
+
+  var date = {
+    /**
+     * Given a node, show a pretty date for its contents.
+     * @param {Node} node  the DOM node.
+     * @param {Number} timestamp a timestamp like the one retuned
+     * from Date.getTime().
+     */
+    setPrettyNodeDate: function(node, timestamp) {
+      if (timestamp) {
+        node.dataset.time = timestamp.valueOf();
+        node.dataset.compactFormat = true;
+        node.textContent = common.prettyDate(timestamp, true);
+      } else {
+        node.textContent = '';
+        node.removeAttribute('data-time');
+      }
+    }
+  };
+
+  return date;
+});

--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -54,6 +54,8 @@ function MailAccount(api, wireRep, acctsSlice) {
   this.type = wireRep.type;
   this.name = wireRep.name;
   this.syncRange = wireRep.syncRange;
+  this.syncInterval = wireRep.syncInterval;
+  this.notifyOnNew = wireRep.notifyOnNew;
 
   /**
    * Is the account currently enabled, as in will we talk to the server?
@@ -111,6 +113,8 @@ MailAccount.prototype = {
   __update: function(wireRep) {
     this.enabled = wireRep.enabled;
     this.problems = wireRep.problems;
+    this.syncInterval = wireRep.syncInterval;
+    this.notifyOnNew = wireRep.notifyOnNew;
     this._wireRep.defaultPriority = wireRep.defaultPriority;
   },
 
@@ -178,7 +182,7 @@ function MailSenderIdentity(api, wireRep) {
   this._api = api;
   this.id = wireRep.id;
 
-  this.name = wireRep.displayName;
+  this.name = wireRep.name;
   this.address = wireRep.address;
   this.replyTo = wireRep.replyTo;
   this.signature = wireRep.signature;
@@ -1784,8 +1788,7 @@ MessageComposition.prototype = {
 
 };
 
-
-var LEGAL_CONFIG_KEYS = ['syncCheckIntervalEnum'];
+var LEGAL_CONFIG_KEYS = [];
 
 /**
  * Error reporting helper; we will probably eventually want different behaviours
@@ -3066,6 +3069,35 @@ MailAPI.prototype = {
   },
 
   //////////////////////////////////////////////////////////////////////////////
+  // mode setting for back end universe. Set interactive
+  // if the user has been exposed to the UI and it is a
+  // longer lived application, not just a cron sync.
+  setInteractive: function() {
+    this.__bridgeSend({
+      type: 'setInteractive'
+    });
+  },
+
+  //////////////////////////////////////////////////////////////////////////////
+  // cron syncing
+
+  /**
+   * Receive events about the start and stop of periodic syncing
+   */
+  _recv_cronSyncStart: function ma__recv_cronSyncStart(msg) {
+    if (this.oncronsyncstart)
+      this.oncronsyncstart(msg.accountIds);
+    return true;
+  },
+
+  _recv_cronSyncStop: function ma__recv_cronSyncStop(msg) {
+    if (this.oncronsyncstop)
+      this.oncronsyncstop(msg.accountsResults);
+    return true;
+  },
+
+
+  //////////////////////////////////////////////////////////////////////////////
   // Localization
 
   /**
@@ -3117,6 +3149,7 @@ MailAPI.prototype = {
     }
     return name;
   },
+
 
   //////////////////////////////////////////////////////////////////////////////
   // Configuration
@@ -3192,12 +3225,24 @@ define('mailapi/worker-support/main-router',[],function() {
   var worker = null;
 
   function register(module) {
-    var name = module.name;
+    var action,
+        name = module.name;
+
     modules.push(module);
 
-    listeners[name] = function(msg) {
-      module.process(msg.uid, msg.cmd, msg.args);
-    };
+    if (module.process) {
+      action = function(msg) {
+        module.process(msg.uid, msg.cmd, msg.args);
+      };
+    } else if (module.dispatch) {
+      action = function(msg) {
+        if (module.dispatch[msg.cmd]) {
+          module.dispatch[msg.cmd].apply(module.dispatch, msg.args);
+        }
+      };
+    }
+
+    listeners[name] = action;
 
     module.sendMessage = function(uid, cmd, args, transferArgs) {
     //dump('\x1b[34mM => w: send: ' + name + ' ' + uid + ' ' + cmd + '\x1b[0m\n');
@@ -3414,103 +3459,267 @@ define('mailapi/worker-support/configparser-main',[],function() {
   return self;
 });
 
-define('mailapi/worker-support/cronsync-main',[],function() {
+/*jshint browser: true */
+/*global define, console */
+define('mailapi/worker-support/cronsync-main',['require','evt'],function(require) {
   'use strict';
 
+  var evt = require('evt');
+
   function debug(str) {
-    //dump('CronSync: ' + str + '\n');
+    console.log('cronsync-main: ' + str);
   }
 
-  function clearAlarms() {
-    if (navigator.mozAlarms) {
-      var req = navigator.mozAlarms.getAll();
-      req.onsuccess = function(event) {
+  function makeData(accountIds, interval, date) {
+    return {
+      type: 'sync',
+      accountIds: accountIds,
+      interval: interval,
+      timestamp: date.getTime()
+    };
+  }
+
+  // Creates a string key from an array of string IDs. Uses a space
+  // separator since that cannot show up in an ID.
+  function makeAccountKey(accountIds) {
+    return 'id' + accountIds.join(' ');
+  }
+
+  // Converts 'interval' + intervalInMillis to just a intervalInMillis
+  // Number.
+  var prefixLength = 'interval'.length;
+  function toInterval(intervalKey) {
+    return parseInt(intervalKey.substring(prefixLength), 10);
+  }
+
+  // Makes sure two arrays have the same values, account IDs.
+  function hasSameValues(ary1, ary2) {
+    if (ary1.length !== ary2.length)
+      return false;
+
+    var hasMismatch = ary1.some(function(item, i) {
+      return item !== ary2[i];
+    });
+
+    return !hasMismatch;
+  }
+
+  if (navigator.mozSetMessageHandler) {
+    navigator.mozSetMessageHandler('alarm', function onAlarm(alarm) {
+      // Do not bother with alarms that are not sync alarms.
+      var data = alarm.data;
+      if (!data || data.type !== 'sync')
+        return;
+
+      // Need to acquire the wake locks during this alarm notification
+      // turn of the event loop -- later turns are not guaranteed to
+      // be up and running. However, knowing when to release the locks
+      // is only known to the front end, so publish event about it.
+      // Need a CPU lock since otherwise the app can be paused
+      // mid-function, which could lead to unexpected behavior, and the
+      // sync should be completed as quick as possible to then close
+      // down the app.
+      // TODO: removed wifi wake lock due to network complications, to
+      // be addressed in a separate changset.
+      if (navigator.requestWakeLock) {
+        var locks = [
+          navigator.requestWakeLock('cpu')
+        ];
+
+        debug('wake locks acquired: ' + locks +
+              ' for account IDs: ' + data.accountIds);
+
+        evt.emitWhenListener('cronSyncWakeLocks',
+                             makeAccountKey(data.accountIds), locks);
+      }
+
+      dispatcher._sendMessage('alarm', [data.accountIds, data.interval]);
+    });
+  }
+
+  var dispatcher = {
+    _routeReady: false,
+    _routeQueue: [],
+    _sendMessage: function(type, args) {
+      if (this._routeReady) {
+        // sendMessage is added to routeRegistration by the main-router module.
+        routeRegistration.sendMessage(null, type, args);
+      } else {
+        this._routeQueue.push([type, args]);
+      }
+    },
+
+    /**
+     * Called by worker side to indicate it can now receive messages.
+     */
+    hello: function() {
+      this._routeReady = true;
+      if (this._routeQueue.length) {
+        var queue = this._routeQueue;
+        this._routeQueue = [];
+        queue.forEach(function(args) {
+          this._sendMessage(args[0], args[1]);
+        }.bind(this));
+      }
+    },
+
+    /**
+     * Clears all sync-based alarms. Normally not called, except perhaps for
+     * tests or debugging.
+     */
+    clearAll: function() {
+      var mozAlarms = navigator.mozAlarms;
+      if (!mozAlarms)
+        return;
+
+      var r = mozAlarms.getAll();
+
+      r.onsuccess = function(event) {
         var alarms = event.target.result;
-        for (var i = 0; i < alarms.length; i++) {
-          navigator.mozAlarms.remove(alarms[i].id);
+        if (!alarms)
+          return;
+
+        alarms.forEach(function(alarm) {
+          if (alarm.data && alarm.data.type === 'sync')
+            mozAlarms.remove(alarm.id);
+        });
+      }.bind(this);
+      r.onerror = function(err) {
+        console.error('cronsync-main clearAll mozAlarms.getAll: error: ' +
+                      err);
+      }.bind(this);
+    },
+
+    /**
+     * Makes sure there is an alarm set for every account in
+     * the list.
+     * @param  {Object} syncData. An object with keys that are
+     * 'interval' + intervalInMilliseconds, and values are arrays
+     * of account IDs that should be synced at that interval.
+     */
+    ensureSync: function (syncData) {
+      var mozAlarms = navigator.mozAlarms;
+      if (!mozAlarms)
+        return;
+
+      debug('ensureSync called');
+
+      var request = mozAlarms.getAll();
+
+      request.onsuccess = function(event) {
+        var alarms = event.target.result;
+        if (!alarms)
+          return;
+
+        // Find all IDs being tracked by alarms
+        var expiredAlarmIds = [],
+            okAlarmIntervals = {},
+            uniqueAlarms = {};
+
+        alarms.forEach(function(alarm) {
+          // Only care about sync alarms.
+          if (!alarm.data || !alarm.data.type || alarm.data.type !== 'sync')
+            return;
+
+          var intervalKey = 'interval' + alarm.data.interval,
+              wantedAccountIds = syncData[intervalKey];
+
+          if (!wantedAccountIds || !hasSameValues(wantedAccountIds,
+                                                  alarm.data.accountIds)) {
+            debug('account array mismatch, canceling existing alarm');
+            expiredAlarmIds.push(alarm.id);
+          } else {
+            // Confirm the existing alarm is still good.
+            var interval = toInterval(intervalKey),
+                now = Date.now(),
+                alarmTime = alarm.data.timestamp,
+                accountKey = makeAccountKey(wantedAccountIds);
+
+            // If the interval is nonzero, and there is no other alarm found
+            // for that account combo, and if it is not in the past and if it
+            // is not too far in the future, it is OK to keep.
+            if (interval && !uniqueAlarms.hasOwnProperty(accountKey) &&
+                alarmTime > now && alarmTime < now + interval) {
+              debug('existing alarm is OK');
+              uniqueAlarms[accountKey] = true;
+              okAlarmIntervals[intervalKey] = true;
+            } else {
+              debug('existing alarm is out of interval range, canceling');
+              expiredAlarmIds.push(alarm.id);
+            }
+          }
+        });
+
+        expiredAlarmIds.forEach(function(alarmId) {
+          mozAlarms.remove(alarmId);
+        });
+
+        var alarmMax = 0,
+            alarmCount = 0,
+            self = this;
+
+        // Called when alarms are confirmed to be set.
+        function done() {
+          alarmCount += 1;
+          if (alarmCount < alarmMax)
+            return;
+
+          // Indicate ensureSync has completed because the
+          // back end is waiting to hear alarm was set before
+          // triggering sync complete.
+          self._sendMessage('syncEnsured');
         }
 
-        debug("clearAlarms: done.");
-      };
+        Object.keys(syncData).forEach(function(intervalKey) {
+          // Skip if the existing alarm is already good.
+          if (okAlarmIntervals.hasOwnProperty(intervalKey))
+            return;
 
-      req.onerror = function(event) {
-        debug("clearAlarms: failure.");
+          var interval = toInterval(intervalKey),
+              accountIds = syncData[intervalKey],
+              date = new Date(Date.now() + interval);
+
+          // Do not set an timer for a 0 interval, bad things happen.
+          if (!interval)
+            return;
+
+          alarmMax += 1;
+
+          var alarmRequest = mozAlarms.add(date, 'ignoreTimezone',
+                                       makeData(accountIds, interval, date));
+
+          alarmRequest.onsuccess = function() {
+            debug('success: mozAlarms.add for ' + 'IDs: ' + accountIds +
+                  ' at ' + interval + 'ms');
+            done();
+          };
+
+          alarmRequest.onerror = function(err) {
+            console.error('cronsync-main mozAlarms.add for IDs: ' +
+                          accountIds +
+                          ' failed: ' + err);
+          };
+        });
+
+        // If no alarms were added, indicate ensureSync is done.
+        if (!alarmMax)
+          done();
+      }.bind(this);
+
+      request.onerror = function(err) {
+        console.error('cronsync-main ensureSync mozAlarms.getAll: error: ' +
+                      err);
       };
     }
-  }
-
-  function addAlarm(time) {
-    if (navigator.mozAlarms) {
-      var req = navigator.mozAlarms.add(time, 'ignoreTimezone', {});
-
-      req.onsuccess = function() {
-        debug('addAlarm: done.');
-      };
-
-      req.onerror = function(event) {
-        debug('addAlarm: failure.');
-
-        var target = event.target;
-        console.warn('err:', target && target.error && target.error.name);
-      };
-    }
-  }
-
-  var gApp, gIconUrl;
-  navigator.mozApps.getSelf().onsuccess = function(event) {
-    gApp = event.target.result;
-    if (gApp)
-      gIconUrl = gApp.installOrigin + '/style/icons/Email.png';
   };
 
-  /**
-   * Try and bring up the given header in the front-end.
-   *
-   * XXX currently, we just cause the app to display, but we don't do anything
-   * to cause the actual message to be displayed.  Right now, since the back-end
-   * and the front-end are in the same app, we can easily tell ourselves to do
-   * things, but in the separated future, we might want to use a webactivity,
-   * and as such we should consider using that initially too.
-   */
-  function showApp(header) {
-    gApp.launch();
-  }
-
-  function showNotification(uid, title, body) {
-    var success = function() {
-      self.sendMessage(uid, 'showNotification', true);
-    };
-
-    var close = function() {
-      self.sendMessage(uid, 'showNotification', false);
-    };
-
-    NotificationHelper.send(title, body, gIconUrl, success, close);
-  }
-
-  var self = {
-    name: 'cronsyncer',
+  var routeRegistration = {
+    name: 'cronsync',
     sendMessage: null,
-    process: function(uid, cmd, args) {
-      debug('process ' + cmd);
-      switch (cmd) {
-        case 'clearAlarms':
-          clearAlarms.apply(this, args);
-          break;
-        case 'addAlarm':
-          addAlarm.apply(this, args);
-          break;
-        case 'showNotification':
-          args.unshift(uid);
-          showNotification.apply(this, args);
-          break;
-        case 'showApp':
-          showApp.apply(this, args);
-          break;
-      }
-    }
+    dispatch: dispatcher
   };
-  return self;
+
+  return routeRegistration;
 });
 
 define('mailapi/worker-support/devicestorage-main',[],function() {
@@ -3615,6 +3824,9 @@ if (("indexedDB" in window) && window.indexedDB) {
  *
  * Explanation of most recent bump:
  *
+ * Bumping to 22 because of account changes around cronsyncing, an "undefined"
+ * error with summaries and some constant changes.
+ *
  * Bumping to 21 because of massive error in partial fetching merges.
  *
  * Bumping to 20 because of block sizing changes.
@@ -3629,7 +3841,7 @@ if (("indexedDB" in window) && window.indexedDB) {
  * Bumping to 17 because we changed the folder representation to store
  * hierarchy.
  */
-var CUR_VERSION = 21;
+var CUR_VERSION = 22;
 
 /**
  * What is the lowest database version that we are capable of performing a
@@ -4204,9 +4416,7 @@ define('mailapi/main-frame-setup',
     sendMessage: null,
     process: function(uid, cmd, args) {
       var online = navigator.onLine;
-      var hasPendingAlarm = navigator.mozHasPendingMessage &&
-                            navigator.mozHasPendingMessage('alarm');
-      control.sendMessage(uid, 'hello', [online, hasPendingAlarm]);
+      control.sendMessage(uid, 'hello', [online]);
 
       window.addEventListener('online', function(evt) {
         control.sendMessage(uid, evt.type, [true]);
@@ -4214,11 +4424,6 @@ define('mailapi/main-frame-setup',
       window.addEventListener('offline', function(evt) {
         control.sendMessage(uid, evt.type, [false]);
       });
-      if (navigator.mozSetMessageHandler) {
-        navigator.mozSetMessageHandler('alarm', function(msg) {
-          control.sendMessage(uid, 'alarm', [msg]);
-        });
-      }
 
       $router.unregister(control);
     },

--- a/apps/email/js/html_cache_restore.js
+++ b/apps/email/js/html_cache_restore.js
@@ -1,15 +1,16 @@
-/*
+/*jshint browser: true */
+/*global performance, console */
 var _xstart = performance.timing.fetchStart -
               performance.timing.navigationStart;
 function plog(msg) {
   console.log(msg + ' ' + (performance.now() - _xstart));
 }
-*/
+
 
 // Use a global to work around issue with
 // navigator.mozHasPendingMessage only returning
 // true to the first call made to it.
-window.htmlCacheRestoreDetectedActivity = false;
+window.htmlCacheRestorePendingMessage = [];
 
 (function() {
   /**
@@ -77,11 +78,18 @@ window.htmlCacheRestoreDetectedActivity = false;
     document.head.appendChild(scriptNode);
   }
 
-  if (navigator.mozHasPendingMessage &&
-      navigator.mozHasPendingMessage('activity')) {
-    // TODO: mozHasPendingMessage can only be called once?
-    // Need to set up variable to delay normal code logic later
-    window.htmlCacheRestoreDetectedActivity = true;
+  // TODO: mozHasPendingMessage can only be called once?
+  // Need to set up variable to delay normal code logic later
+  if (navigator.mozHasPendingMessage) {
+    if (navigator.mozHasPendingMessage('activity'))
+      window.htmlCacheRestorePendingMessage.push('activity');
+    if (navigator.mozHasPendingMessage('alarm'))
+      window.htmlCacheRestorePendingMessage.push('alarm');
+    if (navigator.mozHasPendingMessage('notification'))
+      window.htmlCacheRestorePendingMessage.push('notification');
+  }
+
+  if (window.htmlCacheRestorePendingMessage.length) {
     startApp();
   } else {
     cardsNode.innerHTML = retrieve();

--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -531,6 +531,11 @@ Cards = {
     return this._findCard(query, true) > -1;
   },
 
+  isVisible: function(cardImpl) {
+    return !!(cardImpl.domNode &&
+              cardImpl.domNode.classList.contains('center'));
+  },
+
   findCardObject: function(query) {
     return this._cardStack[this._findCard(query)];
   },
@@ -843,6 +848,9 @@ Cards = {
 
       removeClass(beginNode, 'no-anim');
       removeClass(endNode, 'no-anim');
+
+      if (cardInst && cardInst.onCardVisible)
+        cardInst.onCardVisible();
     }
 
     // Hide toaster while active card index changed:
@@ -895,12 +903,15 @@ Cards = {
         Toaster.pendingStack.pop();
       }
 
-      // If any action to to at the end of transition trigger now.
+      // If any action to do at the end of transition trigger now.
       if (this._afterTransitionAction) {
         var afterTransitionAction = this._afterTransitionAction;
         this._afterTransitionAction = null;
         afterTransitionAction();
       }
+
+      if (activeCard.cardImpl.onCardVisible)
+        activeCard.cardImpl.onCardVisible();
 
       // If the card has next cards that can be preloaded, load them now.
       // Use of nextCards should be balanced with startup performance.

--- a/apps/email/js/mix.js
+++ b/apps/email/js/mix.js
@@ -1,0 +1,19 @@
+/*global define*/
+define(function() {
+  /**
+   * Mixes properties from source into target.
+   * @param  {Object} target   target of the mix.
+   * @param  {Object} source   source object providing properties to mix in.
+   * @param  {Boolean} override if target already has a the property,
+   * override it with the one from source.
+   * @return {Object}          the target object, now with the new properties
+   * mixed in.
+   */
+  return function mix(target, source, override) {
+    Object.keys(source).forEach(function(key) {
+      if (!target.hasOwnProperty(key) || override)
+        target[key] = source[key];
+    });
+    return target;
+  };
+});

--- a/apps/email/js/model.js
+++ b/apps/email/js/model.js
@@ -8,44 +8,114 @@ define(function(require) {
     throw new Error(msg);
   }
 
+/**
+ * Provides a front end to the API and slice objects returned from the API.
+ * Since the UI right now is driven by a shared set of slices, this module
+ * tracks those slices and creates events when they are changed. This means
+ * the card modules do not need a direct reference to each other to change
+ * the backing data for a card, and that card modules and app logic do not
+ * need a hard, static dependency on the MailAPI object. This allows some
+ * more flexible and decoupled loading scenarios. In particular, cards can
+ * be created an inserted into the DOM without needing the back end to
+ * complete its startup and initialization.
+ *
+ * It mixes in 'evt' capabilities, so it will be common to see model
+ * used with 'latest' and 'latestOnce' to get the latest model data
+ * whenever it loads.
+ *
+ * Down the road, it may make sense to have more than one model object
+ * in play. At that point, it may make sense to morph this into a
+ * constructor function and then have the card objects receive a model
+ * instance property for their model reference.
+ *
+ * @type {Object}
+ */
   var model = {
     firstRun: null,
 
+    /**
+    * acctsSlice event is fired when the property changes.
+    * event: acctsSlice
+    * @param {Object} the acctsSlice object.
+    **/
     acctsSlice: null,
+
+    /**
+    * account event is fired when the property changes.
+    * event: account
+    * @param {Object} the account object.
+    **/
     account: null,
 
+    /**
+    * foldersSlice event is fired when the property changes.
+    * event: foldersSlice
+    * @param {Object} the foldersSlice object.
+    **/
     foldersSlice: null,
+
+    /**
+    * folder event is fired when the property changes.
+    * event: folder
+    * @param {Object} the folder object.
+    **/
     folder: null,
 
     _callEmit: function(id) {
       this.emitWhenListener(id, this[id]);
     },
 
-    // Indicates if the model has been inited.
     inited: false,
 
-    // Returns true if there is an account. Should only be
-    // called after inited is true.
+    /**
+     * Returns true if there is an account. Should only be
+     * called after inited is true.
+     */
     hasAccount: function() {
       return !!(model.acctsSlice &&
                 model.acctsSlice.items &&
                 model.acctsSlice.items.length);
     },
 
-    init: function(showLatest) {
+    /**
+     * Given an account ID, get the account object. Only works once the
+     * acctsSlice property is available. Use model.latestOnce to get a
+     * handle on an acctsSlice property, then call this method.
+     * @param  {String} id account ID.
+     * @return {Object}    account object.
+     */
+    getAccount: function(id) {
+      if (!model.acctsSlice || !model.acctsSlice.items)
+        throw new Error('No acctsSlice available');
+
+      var targetAccount;
+      model.acctsSlice.items.some(function(account) {
+        if (account.id === id)
+          return !!(targetAccount = account);
+      });
+
+      return targetAccount;
+    },
+
+    /**
+     * Call this to initialize the model. It can be called more than once
+     * per the lifetime of an app. The usual use case for multiple calls
+     * is when a new account has been added.
+     * @param  {boolean} showLatest Choose the latest account in the
+     * acctsSlice. Otherwise it choose the account marked as the default
+     * account.
+     */
+    init: function(showLatest, callback) {
       // Set inited to false to indicate initialization is in progress.
       this.inited = false;
-
       require(['api'], function(MailAPI) {
-        this.api = MailAPI;
-
-        if (this.firstRun) {
-          this.firstRun(MailAPI);
-          this.firstRun = null;
+        if (!this.api) {
+          this.api = MailAPI;
+          this._callEmit('api', this.api);
         }
 
-        if (this.acctsSlice)
-          this.acctsSlice.die();
+        // If already initialized before, clear out previous state.
+        this.die();
 
         var acctsSlice = this.acctsSlice = MailAPI.viewAccounts(false);
         acctsSlice.oncomplete = (function() {
@@ -57,30 +127,115 @@ define(function(require) {
             var account = showLatest ? acctsSlice.items.slice(-1)[0] :
                                        acctsSlice.defaultAccount;
 
-            this.account = account;
-            this._callEmit('account');
-
-            var foldersSlice = MailAPI.viewFolders('account', account);
-            foldersSlice.oncomplete = (function() {
-              // Do not bother if accounts do not have an inbox.
-              var inboxFolder = foldersSlice.getFirstFolderWithType('inbox');
-              if (!inboxFolder)
-                dieOnFatalError('We have an account without an inbox!',
-                                foldersSlice.items);
-
-              this.foldersSlice = foldersSlice;
-              this.folder = inboxFolder;
-
-              this._callEmit('folder');
-              this._callEmit('foldersSlice');
-            }).bind(this);
-          } else {
-            this.die();
+            this.changeAccount(account, callback);
           }
+
           this.inited = true;
           this._callEmit('acctsSlice');
         }).bind(this);
       }.bind(this));
+    },
+
+    /**
+     * Changes the current account tracked by the model. This results
+     * in changes to the 'account', 'foldersSlice' and 'folder' properties.
+     * @param  {Object}   account  the account object.
+     * @param  {Function} callback function to call once the account and
+     * related folder data has changed.
+     */
+    changeAccount: function(account, callback) {
+      // Do not bother if account is the same.
+      if (this.account && this.account.id === account.id) {
+        if (callback)
+          callback();
+        return;
+      }
+
+      this._dieFolders();
+
+      this.account = account;
+      this._callEmit('account');
+
+      var foldersSlice = this.api.viewFolders('account', account);
+      foldersSlice.oncomplete = (function() {
+        this.foldersSlice = foldersSlice;
+        this.selectInbox(callback);
+        this._callEmit('foldersSlice');
+      }).bind(this);
+    },
+
+    /**
+     * Given an account ID, change the current account to that account.
+     * @param  {String} accountId
+     * @return {Function} callback
+     */
+    changeAccountFromId: function(accountId, callback) {
+      if (!this.acctsSlice || !this.acctsSlice.items.length)
+        throw new Error('No accounts available');
+
+      this.acctsSlice.items.some(function(account) {
+        if (account.id === accountId) {
+          this.changeAccount(account, callback);
+          return true;
+        }
+      }.bind(this));
+    },
+
+    /**
+     * Just changes the folder property tracked by the model.
+     * Assumes the folder still belongs to the currently tracked
+     * account.
+     * @param  {Object} folder the folder object to use.
+     */
+    changeFolder: function(folder) {
+      this.folder = folder;
+      this._callEmit('folder');
+    },
+
+    /**
+     * For the already loaded account and associated foldersSlice,
+     * set the inbox as the tracked 'folder'.
+     * @param  {Function} callback function called once the inbox
+     * has been selected.
+     */
+    selectInbox: function(callback) {
+      if (!this.foldersSlice)
+        throw new Error('No foldersSlice available');
+
+      var inboxFolder = this.foldersSlice.getFirstFolderWithType('inbox');
+      if (!inboxFolder)
+        dieOnFatalError('We have an account without an inbox!',
+                        this.foldersSlice.items);
+
+      if (this.folder && this.folder.id === inboxFolder.id) {
+        if (callback)
+          callback();
+      } else {
+        if (callback)
+          this.once('folder', callback);
+
+        this.changeFolder(inboxFolder);
+      }
+    },
+
+    /**
+     * Called by other code when it knows the current account
+     * has received new inbox messages. Just triggers an
+     * event with the count for now.
+     * @param  {Object} accountUpdate update object from
+     * sync.js accountResults object structure.
+     */
+    notifyInboxMessages: function(accountUpdate) {
+      if (accountUpdate.id === this.account.id)
+        model.emit('newInboxMessages', accountUpdate.count);
+    },
+
+    _dieFolders: function() {
+      if (this.foldersSlice)
+        this.foldersSlice.die();
+      this.foldersSlice = null;
+
+      this.folder = null;
     },
 
     die: function() {
@@ -89,11 +244,7 @@ define(function(require) {
       this.acctsSlice = null;
       this.account = null;
 
-      if (this.foldersSlice)
-        this.foldersSlice.die();
-      this.foldersSlice = null;
-
-      this.folder = null;
+      this._dieFolders();
     }
   };
 

--- a/apps/email/js/query_string.js
+++ b/apps/email/js/query_string.js
@@ -1,0 +1,34 @@
+/*global define */
+define(function() {
+  var queryString = {
+    /**
+     * Takes a querystring value, name1=value1&name2=value2... and converts
+     * to an object with named properties.
+     * @param  {String} value query string value.
+     * @return {Object}
+     */
+    toObject: function toObject(value) {
+      if (!value)
+        return null;
+
+      var result = {};
+
+      value.split('&').forEach(function(keyValue) {
+        var pair = keyValue.split('=');
+        result[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+      });
+      return result;
+    },
+
+    fromObject: function fromObject(object) {
+      var result = '';
+      Object.keys(object).forEach(function(key) {
+        result += (result ? '&' : '') + encodeURIComponent(key) +
+                 '=' + encodeURIComponent(object[key]);
+      });
+      return result;
+    }
+  };
+
+  return queryString;
+});

--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -1,0 +1,185 @@
+/*jshint browser: true */
+/*global define, console, plog, Notification */
+define(function(require) {
+
+  var appSelf = require('app_self'),
+      evt = require('evt'),
+      model = require('model'),
+      mozL10n = require('l10n!'),
+      notificationHelper = require('shared/js/notification_helper'),
+      fromObject = require('query_string').fromObject;
+
+  model.latestOnce('api', function(api) {
+    var hasBeenVisible = !document.hidden,
+        waitingOnCron = {};
+
+    // Let the back end know the app is interactive, not just
+    // a quick sync and shutdown case, so that it knows it can
+    // do extra work.
+    if (hasBeenVisible) {
+      api.setInteractive();
+    }
+
+    // If the page is ever not hidden, then do not close it later.
+    document.addEventListener('visibilitychange',
+      function onVisibilityChange() {
+        if (!document.hidden) {
+          hasBeenVisible = true;
+          api.setInteractive();
+        }
+    }, false);
+
+    // Creates a string key from an array of string IDs. Uses a space
+    // separator since that cannot show up in an ID.
+    function makeAccountKey(accountIds) {
+      return 'id' + accountIds.join(' ');
+    }
+
+    var sendNotification;
+    if (typeof Notification === 'undefined') {
+      console.log('email: notifications not available');
+      sendNotification = function() {};
+    } else {
+      sendNotification = function(notificationId, title, body, iconUrl) {
+        console.log('Notification sent for ' + notificationId);
+        notificationHelper.send(title, body, iconUrl);
+
+        /*
+        // TODO: explore this pathway for notification revocation, by using
+        // the "tag" on the notification options. Does not work right now --
+        // notification is triggered, but clicking on it generates an error
+        // in system app.
+        if (Notification.permission !== 'granted') {
+          console.log('email: notification skipped, permission: ' +
+                      Notification.permission);
+          return;
+        }
+
+        //TODO: consider setting dir and lang
+        //https://developer.mozilla.org/en-US/docs/Web/API/notification
+        var notification = new Notification(title, {
+          body: body,
+          icon: iconUrl,
+          tag: notificationId
+        });
+        */
+      };
+    }
+
+    api.oncronsyncstart = function(accountIds) {
+      console.log('email oncronsyncstart: ' + accountIds);
+      var accountKey = makeAccountKey(accountIds);
+      waitingOnCron[accountKey] = true;
+    };
+
+    function makeNotificationDesc(infos) {
+      // For now, just list who the mails are from, as there is no formatting
+      // possibilities in the existing notifications for the description
+      // section. Even new lines do not seem to work.
+      var froms = [];
+
+      infos.forEach(function(info) {
+        if (froms.indexOf(info.from) === -1)
+          froms.push(info.from);
+      });
+      return froms.join(', ');
+    }
+
+    /*
+    accountsResults is an object with the following structure:
+      accountIds: array of string account IDs.
+      updates: array of objects includes properties:
+        id: accountId,
+        name: account name,
+        count: number of new messages total
+        latestMessageInfos: array of latest message info objects,
+        with properties:
+          - from
+          - subject
+          - accountId
+          - messageSuid
+     */
+    api.oncronsyncstop = function(accountsResults) {
+      console.log('email oncronsyncstop: ' + accountsResults.accountIds);
+
+      appSelf.latest('self', function(app) {
+
+        model.latestOnce('account', function(currentAccount) {
+          var iconUrl = notificationHelper.getIconURI(app);
+          if (accountsResults.updates) {
+            accountsResults.updates.forEach(function(result) {
+              // If the current account is being shown, then just send
+              // an update to the model to indicate new messages, as
+              // the notification will happen within the app for that
+              // case.
+              if (currentAccount.id === result.id && !document.hidden) {
+                model.notifyInboxMessages(result);
+                return;
+              }
+
+              // If this account does not want notifications of new messages
+              // stop doing work.
+              if (!model.getAccount(result.id).notifyOnNew)
+                return;
+
+              var dataString;
+              if (navigator.mozNotification) {
+                if (result.count > 1) {
+                  dataString = fromObject({
+                    type: 'message_list',
+                    accountId: result.id
+                  });
+
+                  sendNotification(
+                    result.id,
+                    mozL10n.get('new-emails-notify', {
+                      n: result.count,
+                      accountName: result.address
+                    }),
+                    makeNotificationDesc(result.latestMessageInfos),
+                    iconUrl + '#' + dataString
+                  );
+                } else {
+                  result.latestMessageInfos.forEach(function(info) {
+                      dataString = fromObject({
+                        type: 'message_reader',
+                        accountId: info.accountId,
+                        messageSuid: info.messageSuid
+                      });
+
+                    sendNotification(
+                      result.id,
+                      info.subject,
+                      info.from,
+                      iconUrl + '#' + dataString
+                    );
+                  });
+                }
+              }
+            });
+          }
+        });
+
+        evt.emit('cronSyncStop', accountsResults.accountIds);
+
+        // Mark this accountId set as no longer waiting.
+        var accountKey = makeAccountKey(accountsResults.accountIds);
+        waitingOnCron[accountKey] = false;
+        var stillWaiting = Object.keys(waitingOnCron).some(function(key) {
+          return !!waitingOnCron[key];
+        });
+
+        if (!hasBeenVisible && !stillWaiting) {
+          var msg = 'mail sync complete, closing mail app';
+          if (typeof plog === 'function')
+            plog(msg);
+          else
+            console.log(msg);
+
+          window.close();
+        }
+      });
+    };
+
+  });
+});

--- a/apps/email/js/wake_locks.js
+++ b/apps/email/js/wake_locks.js
@@ -1,0 +1,65 @@
+/*jshint browser: true */
+/*globals define, console */
+
+define(function(require) {
+  var lockTimeouts = {},
+      evt = require('evt'),
+      allLocks = {},
+
+      // Only allow keeping the locks for a maximum of 45 seconds.
+      // This is to prevent a long, problematic sync from consuming
+      // all of the battery power in the phone. A more sophisticated
+      // method may be to adjust the size of the timeout based on
+      // past performance, but that would mean keeping a persistent
+      // log of attempts. This naive approach just tries to catch the
+      // most likely set of failures: just a temporary really bad
+      // cell network situation that once the next sync happens, the
+      // issue is resolved.
+      maxLockInterval = 45000;
+
+  function clearLocks(accountKey) {
+    console.log('email: clearing wake locks for "' + accountKey + '"');
+
+    // Clear timer
+    var lockTimeoutId = lockTimeouts[accountKey];
+    if (lockTimeoutId)
+      clearTimeout(lockTimeoutId);
+    lockTimeouts[accountKey] = 0;
+
+    // Clear the locks
+    var locks = allLocks[accountKey];
+    allLocks[accountKey] = null;
+    if (locks) {
+      locks.forEach(function(lock) {
+        lock.unlock();
+      });
+    }
+  }
+
+  // Creates a string key from an array of string IDs. Uses a space
+  // separator since that cannot show up in an ID.
+  function makeAccountKey(accountIds) {
+    return 'id' + accountIds.join(' ');
+  }
+
+  function onCronStop(accountIds) {
+    clearLocks(makeAccountKey(accountIds));
+  }
+
+  evt.on('cronSyncWakeLocks', function(accountKey, locks) {
+    if (lockTimeouts[accountKey]) {
+      // Only support one set of locks. Better to err on the side of
+      // saving the battery and not continue syncing vs supporting a
+      // pathologic error that leads to a compound set of locks but
+      // end up with more syncs completing.
+      clearLocks(accountKey);
+    }
+
+    allLocks[accountKey] = locks;
+
+    lockTimeouts[accountKey] = setTimeout(clearLocks.bind(null, accountKey),
+                                          maxLockInterval);
+  });
+
+  evt.on('cronSyncStop', onCronStop);
+});

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -111,6 +111,46 @@ setup-gmail-imap-message=You must enable IMAP on your Gmail account
 setup-gmail-imap-retry=Retry
 
 settings-main-header=Mail Settings
+
+# For account settings screen, there are sections of settings, and each
+#section has a header. One is Account, which shows general information
+# about the account, like the name.
+settings-sub-header-account=Account
+
+# Label in the "Account" sub-section of acccount settings that shows the
+# human name, not the email address, for the account.
+settings-account-name=Your name
+
+# Label in the "Account" sub-section of acccount settings for the checkbox
+# that enables getting phone notifications when new inbox email is found
+# via periodic sync with the mail server.
+settings-account-display-notifications=Display notifications for new messages
+
+# For account settings screen, there are sections of settings, and each
+# section has a header. One is Data, which deals with sync intervals and
+# time windows for the data that is fetched.
+settings-sub-header-data=Data
+
+# Label in the "Data" sub-section of acccount settings for the select box
+# that allows choosing how often to check the server for new messages in
+# the inbox. The possible select box options are listed in the
+# settings-check-every-* properties.
+settings-account-check-mail=Check for new messages
+
+# For account settings screen, there are sections of settings, and each
+# section has a header. One is "Server settings", which deals with the
+# name/password and server addresses.
+settings-sub-header-server=Server settings
+
+# Label in the "Server settings" sub-section of acccount settings for going
+# to a settings card that shows user name and password used to connect to
+# the mail server.
+settings-account-userpass=Username and password
+
+# In the account picker card, where the user can select which account to view
+# in the app, it shows when each account was last synchronized.
+fld-account-picker-last-sync=Last sync:
+
 settings-done=Done
 settings-account-section=Accounts
 settings-account-add=Add Account
@@ -126,18 +166,32 @@ settings-show-images=Always show images
 settings-download-attachments=Download attachments
 settings-notify-mail=Notify of new mail
 
-settings-check-3min=3 minutes
-settings-check-5min=5 minutes
-settings-check-10min=10 minutes
-settings-check-15min=15 minutes
-settings-check-30min=30 minutes
-settings-check-60min=60 minutes
-settings-check-manual=Manually
+# How often to check the mail server for new mail messages for the inbox.
+# "Manually" means, do not automatically connect on a periodic sync interval.
+# User will manually click the refresh button to check for new messages.
+settings-check-every-3min=Every 3 minutes
+settings-check-every-5min=Every 5 minutes
+settings-check-every-10min=Every 10 minutes
+settings-check-every-15min=Every 15 minutes
+settings-check-every-30min=Every 30 minutes
+settings-check-every-60min=Every hour
+settings-check-every-manual=Manually
 
-settings-default-account=Default account
+# Dynamically added sync interval checks. These are only added via special
+# debug/development tools, and are always in seconds. Otherwise, just
+# the settings-check-every-* options are visible.
+settings-check-dynamic={[ plural(n) ]}
+settings-check-dynamic[zero]  = seconds
+settings-check-dynamic[one]   = {{ n }} seconds
+settings-check-dynamic[two]   = {{ n }} seconds
+settings-check-dynamic[few]   = {{ n }} seconds
+settings-check-dynamic[many]  = {{ n }} seconds
+settings-check-dynamic[other] = {{ n }} seconds
+
+settings-default-account=Set as default email
 settings-account-type=Account type
 settings-account-credentials=Credentials
-settings-account-synchronize=Synchronize
+
 settings-activesync-label=ActiveSync settings
 settings-imap-label=IMAP settings
 settings-smtp-label=SMTP settings
@@ -148,6 +202,10 @@ settings-password=Password
 settings-save=Save
 settings-password-empty=Password field should not be empty
 
+# How much email to sync, in smallest unit of days, from the server. Only
+# valid for ActiveSync mail servers, not shown for other mail server types
+# like IMAP.
+settings-account-synchronize-window=Days to sync
 settings-synchronize-auto=Automatic
 settings-synchronize-one-day=1 day
 settings-synchronize-three-days=3 days
@@ -360,3 +418,14 @@ new-emails[two]={{ n }} New Emails
 new-emails[few]={{ n }} New Emails
 new-emails[many]={{ n }} New Emails
 new-emails[other]={{ n }} New Emails
+
+# new-emails-notify is used when a system notification is generatef during
+# a periodic background sync with the server. Since this goes to the system's
+# notification area and the user could have more than one account configured
+# with the email app, this notification includes the email address.
+new-emails-notify={[ plural(n) ]}
+new-emails-notify[one]=1 New Email - {{ accountName }}
+new-emails-notify[two]={{ n }} New Emails - {{ accountName }}
+new-emails-notify[few]={{ n }} New Emails - {{ accountName }}
+new-emails-notify[many]={{ n }} New Emails - {{ accountName }}
+new-emails-notify[other]={{ n }} New Emails - {{ accountName }}

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -8,7 +8,8 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "messages": [
-     { "alarm": "/index.html" }
+    { "alarm": "/index.html" },
+    { "notification": "/index.html" }
   ],
   "permissions": {
     "alarms":{},

--- a/apps/email/style/folder_cards.css
+++ b/apps/email/style/folder_cards.css
@@ -30,8 +30,12 @@
   font-weight: bold;
   padding-left: 2rem;
 }
-.fld-account-unread {
-  display: none;
+
+.fld-account-lastsync {
+  color: #c7c7c7;
+  font-size: 150%;
+  font-weight: normal;
+  padding: 0 1rem;
 }
 
 .card-folder-picker,

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -165,6 +165,18 @@ li a:active {
   background-color: #008AAA;
 }
 
+.list-text-with-sub {
+  padding: 2rem 0 1rem 0;
+}
+
+.list-text-with-sub .list-text {
+  line-height: 2.2rem;
+}
+
+li.select-item {
+  padding: 1rem 0 1rem 0;
+}
+
 .list-text {
   display: block;
   text-decoration: none;
@@ -187,14 +199,30 @@ li a:active {
   white-space: nowrap;
   color: #52B6CC;
   font-size: 1.8rem;
+  line-height: 5.5rem;
+}
+
+.list-sub-text {
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #5b5b5b;
+  font-size: 1.6rem;
+  padding-left: 3rem;
+}
+
+li .aside.start {
+  float: left;
+  width: calc(100% - 12rem);
 }
 
 li .aside.end {
-  position: absolute;
   float: right;
-  right: 0.5rem;
-  top: 0;
-  line-height: 5.5rem;
+}
+
+.aside.end .pack-switch {
+  padding-right: 3rem;
 }
 
 li.align-center {
@@ -252,25 +280,26 @@ li.settings-input-list {
   opacity: 0;
 }
 
-section.card-settings-account li {
+section.card-settings-account-common li {
   margin: 0 auto;
   overflow: hidden;
   width: 100%;
 }
 
-section.card-settings-account li.synchronize-setting label {
+section.card-settings-account-common li.syncinterval-setting label,
+section.card-settings-account-common li.synchronize-setting label {
   height: 3.5rem;
   line-height: 3.5rem;
   width: auto;
 }
 
-section.card-settings-account li span.button {
+section.card-settings-account-common li span.button {
   display: block;
   margin: 0 auto 1rem auto;
   width: calc(100% - 3rem);
 }
 
-section.card-settings-account li span.button select {
+section.card-settings-account-common li span.button select {
   padding-left: 0;
   text-align: left;
   text-indent: -0.22rem;
@@ -278,6 +307,11 @@ section.card-settings-account li span.button select {
   width: calc(100% + 10rem) !important;
 }
 
+section.card-settings-account-common li .pack-checkbox {
+  margin-top: 0.2rem;
+}
+
+.tng-account-check-interval,
 .tng-account-synchronize {
   background: none;
   border: transparent;

--- a/apps/email/test/config.js
+++ b/apps/email/test/config.js
@@ -20,8 +20,17 @@
       }
     },
     shim: {
-      l10ndate: ['l10nbase']
-    }
+      l10ndate: ['l10nbase'],
+
+      'shared/js/mime_mapper': {
+        exports: 'MimeMapper'
+      },
+
+      'shared/js/notification_helper': {
+        exports: 'NotificationHelper'
+      }
+    },
+    definePrim: 'prim'
   };
 
   global.testConfig = function(obj, ids, callback) {

--- a/apps/email/test/marionette/lib/mocks/mock_navigator_moz_set_message_handler.js
+++ b/apps/email/test/marionette/lib/mocks/mock_navigator_moz_set_message_handler.js
@@ -1,0 +1,27 @@
+Components.utils.import('resource://gre/modules/Services.jsm');
+
+Services.obs.addObserver(function(document) {
+  if (!document || !document.location)
+    return;
+
+  var window = document.defaultView.wrappedJSObject;
+  var messageHandler;
+
+  window.navigator.__defineGetter__('mozSetMessageHandler', function() {
+    return function(type, callback) {
+      if (type === 'alarm') {
+        messageHandler = callback;
+      }
+    };
+  });
+
+  window.__defineGetter__('fireMessageHandler', function() {
+    return function(data) {
+      if (messageHandler && typeof(messageHandler) === 'function') {
+        messageHandler(data);
+        return true;
+      }
+      return false;
+    };
+  });
+}, 'document-element-inserted', false);

--- a/apps/email/test/marionette/lib/servers/fakeimap.js
+++ b/apps/email/test/marionette/lib/servers/fakeimap.js
@@ -13,14 +13,19 @@ var DEFAULT_OPTIONS = Object.freeze({
  *
  * @param {Object} state target.
  * @param {Object} stack to pull updates from.
+ * @param {Object} options for setup.
  */
-function updateState(state, stack) {
+function updateState(state, stack, options) {
+  if (!options) {
+    options = DEFAULT_OPTIONS;
+  }
+
   state.imap = { port: stack.imapPort };
   state.smtp = { port: stack.smtpPort };
 
   [state.imap, state.smtp].forEach(function(serverState) {
-    serverState.username = DEFAULT_OPTIONS.credentials.username;
-    serverState.password = DEFAULT_OPTIONS.credentials.password;
+    serverState.username = options.credentials.username;
+    serverState.password = options.credentials.password;
     serverState.hostname = 'localhost';
   });
 }
@@ -46,6 +51,10 @@ function use(options, mochaContext) {
   // current imap/smtp servers
   var imapStack;
 
+  if (options === null) {
+    options = DEFAULT_OPTIONS;
+  }
+
   suiteSetup(function(done) {
     this.timeout('20s');
     server.create(function(err, control) {
@@ -56,9 +65,9 @@ function use(options, mochaContext) {
 
   // we need a new stack each test
   setup(function(done) {
-    controlServer.createImapStack(DEFAULT_OPTIONS, function(err, imap) {
+    controlServer.createImapStack(options, function(err, imap) {
       // update the state information
-      updateState(state, imap);
+      updateState(state, imap, options);
 
       imapStack = imap;
       done(err);

--- a/apps/email/test/marionette/notification_foreground_test.js
+++ b/apps/email/test/marionette/notification_foreground_test.js
@@ -1,0 +1,139 @@
+/*jshint node: true */
+/*global marionette, window, setup, test */
+
+var Email = require('./email');
+var assert = require('assert');
+var serverHelper = require('./lib/server_helper');
+
+marionette('email notifications, foreground', function() {
+  var app,
+      notificationContainer,
+      client = marionette.client({
+        settings: {
+          // disable keyboard ftu because it blocks our display
+          'keyboard.ftu.enabled': false
+        }
+      }),
+      server1 = serverHelper.use({
+                  credentials: {
+                    username: 'testy1',
+                    password: 'testy1'
+                  }
+                }, this),
+      server2 = serverHelper.use({
+                  credentials: {
+                    username: 'testy2',
+                    password: 'testy2'
+                  }
+                }, this);
+
+  function sendEmail(server) {
+    var email = server.imap.username + '@' + server.imap.hostname;
+    app.tapCompose();
+    app.typeTo(email);
+    app.typeSubject('test email');
+    app.typeBody('I still have a dream.');
+    app.tapSend();
+  }
+
+  function configureAndSend(messageCount) {
+
+    // Set up testy1, send email to testy1, since smtp fakserver
+    // is paired with the imap fakserver for that account. So,
+    // no cross sending of email across fakeserver instances.
+    app.manualSetupImapEmail(server1);
+
+    for (var i = 0; i < messageCount; i++)
+      sendEmail(server1);
+
+    // Now set up second account, to confirm system notifications
+    // are only triggered in certain situations.
+    app.tapFolderListButton();
+    app.tapSettingsButton();
+    app.tapAddAccountButton();
+    app.manualSetupImapEmail(server2);
+  }
+
+  function triggerSync() {
+    client.setScriptTimeout(200000);
+    // trigger sync in Email App
+    client.executeScript(function() {
+      var interval = 1000;
+      var date = new Date(Date.now() + interval).getTime();
+      var alarm = {
+        data: {
+          type: 'sync',
+          accountIds: ['0', '1'],
+          interval: interval,
+          timestamp: date
+        }
+      };
+      return window.wrappedJSObject.fireMessageHandler(alarm);
+    });
+
+    client.helper.wait(2000);
+  }
+
+  setup(function() {
+    app = new Email(client);
+
+    client.contentScript.inject(__dirname +
+      '/lib/mocks/mock_navigator_moz_set_message_handler.js');
+    app.launch();
+  });
+
+  test('should have 1 message notification in the different account',
+  function() {
+    configureAndSend(1);
+
+    triggerSync();
+
+    // Go back to system app
+    client.switchToFrame();
+
+    // Make sure notification container is visible
+    notificationContainer =
+      client.findElement('#desktop-notifications-container');
+
+    var img = notificationContainer.findElement('img');
+    assert(img.getAttribute('src').indexOf('type=message_reader') !== -1);
+    console.log('------ THIS A HACK WE NEED TO USE SYSTEM APPS HELPER ---');
+  });
+
+  test('should have bulk message notification in the different account',
+  function() {
+    configureAndSend(2);
+
+    triggerSync();
+
+    // Go back to system app
+    client.switchToFrame();
+
+    // Make sure notification container is visible
+    notificationContainer =
+      client.findElement('#desktop-notifications-container');
+
+    var img = notificationContainer.findElement('img');
+    assert(img.getAttribute('src').indexOf('type=message_list') !== -1);
+    console.log('------ THIS A HACK WE NEED TO USE SYSTEM APPS HELPER ---');
+  });
+
+  test('should not get a notification for same account', function() {
+    configureAndSend(1);
+
+    // Switch back to testy1 account in the UI
+    app.tapFolderListButton();
+    app.tapAccountListButton();
+    // switch to the testy1 account
+    app.switchAccount(1);
+    // hide the folder list page
+    app.tapFolderListCloseButton();
+
+    // Now sync
+    triggerSync();
+
+    client.findElement('#desktop-notifications-container', function(error) {
+      assert.ok(!!error);
+    });
+  });
+});

--- a/apps/email/test/unit/evt_test.js
+++ b/apps/email/test/unit/evt_test.js
@@ -219,6 +219,23 @@ suite('evt', function() {
       evt.mix(data);
     });
 
+
+    test('double latestOnce listeners', function() {
+      var count = 0;
+
+      function onLatest(token) {
+        count += 1;
+
+        assert.equal(token, 'one');
+      }
+
+      data.latestOnce('token', onLatest);
+      data.latestOnce('token', onLatest);
+
+      data.setToken('one');
+      assert.equal(count, 2);
+    });
+
     test('delayed value', function() {
       var count = 0;
 

--- a/apps/email/test/unit/mix_test.js
+++ b/apps/email/test/unit/mix_test.js
@@ -1,0 +1,62 @@
+/*jshint browser: true */
+/*global requireApp, suite, testConfig, test, assert,
+  suiteSetup, suiteTeardown */
+
+requireApp('email/js/alameda.js');
+requireApp('email/test/config.js');
+
+suite('mix', function() {
+  var mix;
+
+  suiteSetup(function(done) {
+    testConfig(
+      {
+        suiteTeardown: suiteTeardown,
+        done: done
+      },
+      ['mix'],
+      function(m) {
+        mix = m;
+      }
+    );
+  });
+
+  suite('#mix', function() {
+
+    test('basic use', function() {
+      var target = {
+            'a': 'target',
+            'b': 'target'
+          },
+          source = {
+            'b': 'source',
+            'c': 'source'
+          };
+
+      mix(target, source);
+
+      assert.equal('target', target.a);
+      assert.equal('target', target.b);
+      assert.equal('source', target.c);
+    });
+
+    test('override', function() {
+      var target = {
+            'a': 'target',
+            'b': 'target'
+          },
+          source = {
+            'b': 'source',
+            'c': 'source'
+          };
+
+      mix(target, source, true);
+
+      assert.equal('target', target.a);
+      assert.equal('source', target.b);
+      assert.equal('source', target.c);
+    });
+
+  });
+
+});

--- a/apps/email/test/unit/query_string_test.js
+++ b/apps/email/test/unit/query_string_test.js
@@ -1,0 +1,74 @@
+/*jshint browser: true */
+/*global requireApp, suite, testConfig, test, assert,
+  suiteSetup, suiteTeardown */
+
+requireApp('email/js/alameda.js');
+requireApp('email/test/config.js');
+
+suite('query_string', function() {
+  var queryString,
+      string1 = 'type=message_list&accountId=A',
+      object1 = {
+        type: 'message_list',
+        accountId: 'A'
+      },
+      string2 = 'type=message_reader&accountId=B&messageSuid=B%2F1',
+      object2 = {
+        type: 'message_reader',
+        accountId: 'B',
+        messageSuid: 'B/1'
+      };
+
+  suiteSetup(function(done) {
+    testConfig(
+      {
+        suiteTeardown: suiteTeardown,
+        done: done
+      },
+      ['query_string'],
+      function(q) {
+        queryString = q;
+      }
+    );
+  });
+
+  suite('#toObject', function() {
+
+    test('basic use', function() {
+      var result1 = queryString.toObject(string1),
+          result2 = queryString.toObject(string2);
+
+      assert.equal('message_list', result1.type);
+      assert.equal('A', result1.accountId);
+
+      assert.equal('message_reader', result2.type);
+      assert.equal('B', result2.accountId);
+      assert.equal('B/1', result2.messageSuid);
+    });
+
+  });
+
+  suite('#fromObject', function() {
+
+    test('basic use', function() {
+      var result1 = queryString.fromObject(object1),
+          result2 = queryString.fromObject(object2);
+
+      assert.equal(string1, result1);
+      assert.equal(string2, result2);
+    });
+
+  });
+
+  suite('encodeURIComponent use', function() {
+
+    test('basic use', function() {
+      var result1 = queryString
+                    .toObject('url%26type=http%3A%2F%2Fmozilla.com%2F');
+
+      assert.equal('http://mozilla.com/', result1['url&type']);
+    });
+
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "marionette-apps": "0.3.0",
     "marionette-client": "~0.15.0",
     "marionette-helper": "0.0.6",
+    "marionette-content-script": "0.0.0",
     "marionette-js-runner": "~0.1.0",
     "mocha": "1.12.0",
     "mozilla-download": "~0.2.1",

--- a/shared/test/integration/setup.js
+++ b/shared/test/integration/setup.js
@@ -1,3 +1,4 @@
 // all tests need app support
 marionette.plugin('apps', require('marionette-apps'));
 marionette.plugin('helper', require('marionette-helper'));
+marionette.plugin('contentScript', require('marionette-content-script'));


### PR DESCRIPTION
Preliminary Gaia pull request. While this code works and has had some end-to-end testing on a phone, there is a high likelihood it will need some changes before it is merge-worthy. Most importantly, it is lacking tests. Doing a pull request now though to work through any higher level design issues first.

Terms:
- BE: back end: usually means GELAM itself, including the main-frame-setup.js and code under that, the worker code.
- FE: front end: the code in gaia for showing the email UI and front end logic.
### General notes

Existing accounts are treated to be "manual" sync (syncInterval of 0) and not notified of new mail. Any new account created with this branch of the code will be set to "notify of new mail", but sync is set to "manual" by default.

There are some UI controls in the settings for an account to turn on syncing. However, this UI is **just temporary**, with the real UI coming in [Bug 892518](https://bugzilla.mozilla.org/show_bug.cgi?id=892518). The temporary hacky UI also has to "DEV" settings at the bottom, for 20 secs and 60 secs to make testing some things easier. **Be sure to set it back to manual** if you use one of those settings, to save the forests and perhaps bad consequences from your email provider from hammering them with too many syncs.

Right now notifications are only text based, and do not allow any formatting. If the sync results in 1 or 2 emails, then a notification for each email is generated showing the subject and the author. If more than two, then there is just one notification that tells the number of new messages, and then a comma separated list of unique authors.

That layout seemed to work well: there was not much room for much else.

There is no revoking or removing of notifications as that is not available in the platform at the moment.

Clicking on the notifications should go somewhere useful: if multi-email notification, to the message list for that email account. If a single email notification, then jumping to that message.

If the email app is visible when the new message comes in:
- If in the account for the message, no notification.
- If for an account that is not the current one being shown in the app, a system notification is sent.

All alarm and notification work goes through the index.html file. This is partly because right now alarms can only be fired [for the same page that sets them](https://bugzilla.mozilla.org/show_bug.cgi?id=800431). Once that alarm bug is fixed and SharedWorkers are available, a more efficient approach may be possible.

Still to do:
- Add tests.
- There are new l10n string work to wire up.
- See if sync time can be reduced. It takes about 10 seconds right now from start to finish on a wifi network for an account that is already synced.

Related GELAM changeset pull request:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/232

Notes on the implementation:
### app_messages

It now listens for 'notification' messages, and converts the data passed via the iconURL into a data structure that is then passed to app code.
### app_self

module for wrapping the mozApps.getSelf() call, as it is needed to get an iconURL for the notification. It uses the evt so that other code can use the "latest" callback structure to get the mozApps value.
### account_picker, folder_picker

They no longer look for related cards and prod them to update to new account/folder values, but instead, the other cards now just listen to the `model` module for changes.
### message_list

Listens to model now for changes instead of waiting for a direct call from folder_picker.
### settings_account.js/.html

Has the hacky UI for the syncInterval and notifyOnNew setting. That UI was stolen from the hidden portions that were in settings_main.html.
### cards/setup_progress.js

Sets some defaults for the new account values.
### evt.js

Had a bug around "once" notifications. New unit test confirms the fix.
### html_cache_restore.js

Checks for alarm and notification pending messages as it did before for activities, but now sets an object specifying what was detected. This is done since calling mozHasPendingMessage only seems to work once per type.
### mail_app.js

Loads the new modules that handle the sync events and wake locks, then registers for 'notification' messages to know how to start up the UI.
### model.js

Refactored a bit to allow setting account and folder more granularly. Used mostly for the notification listening in mail_app.js to switch to the correct account/folder to use for the UI.
### query_string.js

Handle converting an object to a querystring value to add to iconURL, and then to hydrate that querystring back into an object.
### sync.js

Handles the "cron start" and "cron stop" messages from the back end. Determines how to notify the user, and then emits a "cronSyncStop" that is used by the wake_locks module to know when to release the wake locks. sync.js also will shut down the app if it has not been made visible during the time it was started.
### wake_locks.js

Handles the 'conrSyncWakeLocks' event that is broadacast from the BE, and then listens for 'cronSyncStop' from sync.js to know when to release the locks. Also sets up a timer for 45 seconds as a max time for the locks, to prevent a bug from keeping the wake locks operational forever. This means syncs neeed to finish within 45 seconds or risk going into sleep state.
