### PR TITLE
[Gallery]- Bug 901410 - Fix of setting img src as null triggers error r=davidflanagan

### DIFF
--- a/shared/js/media/media_frame.js
+++ b/shared/js/media/media_frame.js
@@ -229,7 +229,7 @@ MediaFrame.prototype.clear = function clear() {
 
   // Hide the image
   this.image.style.display = 'none';
-  this.image.src = null;  // XXX: use about:blank or '' here?
+  this.image.src = '';  // Use '' instead of null. See Bug 901410
 
   // Hide the video player
   if (this.video) {


### PR DESCRIPTION
Pull request to fix invalid message dialog over the picture frame, when a file received via Bluetooth or email is opened using gallery app.
