### PR TITLE
Bug 904640 - [Messages] Keyboard should always close when pressing Send r=julienw

### DIFF
--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -202,6 +202,10 @@ var MessageManager = {
   },
 
   onHashChange: function mm_onHashChange(e) {
+    // Ensure that no specific element is left focused
+    // when changing UI panels
+    document.activeElement.blur();
+
     // Group Participants should never persist any hash changes
     ThreadUI.groupView.reset();
 

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -274,4 +274,32 @@ suite('message_manager.js >', function() {
       assert.ok(ThreadUI.setMessageBody.calledWith('Youtube url'));
     });
   });
+
+  suite('onHashChange', function() {
+    test('Remove any focus left on specific elements ', function() {
+      this.sinon.spy(document.activeElement, 'blur');
+
+      MessageManager.onHashChange();
+
+      assert.ok(document.activeElement.blur.called);
+    });
+
+    test('Exit edit mode (Thread or Message) ', function() {
+      this.sinon.spy(ThreadUI, 'cancelEdit');
+      this.sinon.spy(ThreadListUI, 'cancelEdit');
+
+      MessageManager.onHashChange();
+
+      assert.ok(ThreadUI.cancelEdit.called);
+      assert.ok(ThreadListUI.cancelEdit.called);
+    });
+
+    test('Reset Group Participants View ', function() {
+      this.sinon.spy(ThreadUI.groupView, 'reset');
+
+      MessageManager.onHashChange();
+
+      assert.ok(ThreadUI.groupView.reset.called);
+    });
+  });
 });

--- a/apps/sms/test/unit/mock_thread_list_ui.js
+++ b/apps/sms/test/unit/mock_thread_list_ui.js
@@ -1,6 +1,28 @@
 'use strict';
 
 var MockThreadListUI = {
-  renderThreads: function() {
-  }
+  count: 0,
+  inEditMode: false,
+  init: function() {},
+  getAllInputs: function() {},
+  getSelectedInputs: function() {},
+  setContact: function() {},
+  handleEvent: function() {},
+  checkInputs: function() {},
+  cleanForm: function() {},
+  toggleCheckedAll: function() {},
+  removeThread: function() {},
+  delete: function() {},
+  setEmpty: function() {},
+  startEdit: function() {},
+  cancelEdit: function() {},
+  renderThreads: function() {},
+  createThread: function() {},
+  insertThreadContainer: function() {},
+  createThreadMockup: function() {},
+  onMessageReceived: function() {},
+  appendThread: function() {},
+  createThreadContainer: function() {},
+  updateContactsInfo: function() {},
+  mark: function() {}
 };

--- a/apps/sms/test/unit/mock_thread_ui.js
+++ b/apps/sms/test/unit/mock_thread_ui.js
@@ -1,9 +1,15 @@
 'use strict';
 
 var MockThreadUI = {
+  LAST_MESSSAGES_BUFFERING_TIME: 600000,
+  CHUNK_SIZE: 10,
+  CONVERTED_MESSAGE_DURATION: 3000,
+  IMAGE_RESIZE_DURATION: 3000,
   recipients: null,
   recipientsList: document.createElement('div'),
-
+  inEditMode: false,
+  inThread: false,
+  init: function() {},
   initRecipients: function() {
     this.recipients = new Recipients({
       outer: 'messages-to-field',
@@ -11,20 +17,71 @@ var MockThreadUI = {
       template: new Utils.Template('messages-recipient-tmpl')
     });
   },
-
-  // simple stubs
-  cleanFields: function() {},
-  appendMessage: function() {},
+  initSentAudio: function() {},
+  getAllInputs: function() {},
+  getSelectedInputs: function() {},
   setMessageBody: function() {},
-  prompt: function() {},
+  messageComposerInputHandler: function() {},
+  assimilateRecipients: function() {},
+  messageComposerTypeHandler: function() {},
+  subheaderMutationHandler: function() {},
+  resizeHandler: function() {},
+  requestContact: function() {},
+  updateComposerHeader: function() {},
+  isScrolledManually: false,
+  manageScroll: function() {},
+  scrollViewToBottom: function() {},
+  setInputMaxHeight: function() {},
+  back: function() {},
+  isKeyboardDisplayed: function() {},
+  enableSend: function() {},
+  updateSmsSegmentLimit: function() {},
+  updateCounter: function() {},
+  updateCounterForMms: function() {},
+  updateInputHeight: function() {},
+  getMessageContainer: function() {},
+  updateHeaderData: function() {},
+  initializeRendering: function() {},
+  stopRendering: function() {},
+  showFirstChunk: function() {},
+  createMmsContent: function() {},
+  renderMessages: function() {},
+  _createNotDownloadedHTML: function() {},
+  buildMessageDOM: function() {},
+  appendMessage: function() {},
+  showChunkOfMessages: function() {},
+  cleanForm: function() {},
+  clear: function() {},
+  toggleCheckedAll: function() {},
+  startEdit: function() {},
+  delete: function() {},
+  cancelEdit: function() {},
+  chooseMessage: function() {},
+  checkInputs: function() {},
+  handleMessageClick: function() {},
+  handleEvent: function() {},
+  cleanFields: function() {},
+  onSendClick: function() {},
+  onMessageSent: function() {},
+  onMessageFailed: function() {},
+  onDeliverySuccess: function() {},
+  removeMessageDOM: function() {},
+  retrieveMMS: function() {},
+  resendMessage: function() {},
+  renderContact: function() {},
+  toFieldKeypress: function() {},
+  toFieldInput: function() {},
+  searchContact: function() {},
+  onHeaderActivation: function() {},
+  onParticipantClick: function() {},
   promptContact: function() {},
-
+  groupView: function() {},
+  prompt: function() {},
+  onCreateContact: function() {},
   isShowSendMessageErrorCalledTimes: 0,
-
   showSendMessageError: function() {
     this.isShowSendMessageErrorCalledTimes += 1;
   },
-
   mSetup: function() {
     this.isShowSendMessageErrorCalledTimes = 0;
   },
@@ -33,3 +90,5 @@ var MockThreadUI = {
     this.isShowSendMessageErrorCalledTimes = 0;
   }
 };
+
+MockThreadUI.groupView.reset = function() {};

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -2728,7 +2728,6 @@ suite('thread_ui.js >', function() {
       MessageManager.sendSMS.mTeardown();
     });
 
-
     test('SMS, 1 Recipient, stays in view', function() {
       ThreadUI.recipients.add({
         number: '999'


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=904640
- Remove focus from all elements before panel change by calling document.activeElement.blur() in MessageManager.onHashChange
- Updates Mocks: 
  - MockThreadListUI to contain all properties (data and method)
  - MockThreadUI to contain all properties (data and method)
- Tests MessageManager.onHashChange:
  - Remove any focus left on specific elements
    - Assert on spy intel for document.activeElement.blur
  - Exit edit mode (Thread or Message) 
    - Assert on spy intel for:
      - ThreadUI.cancelEdit
      - ThreadListUI.cancelEdit
  - Reset Group Participants View 
    - Assert on spy intel for ThreadUI.groupView.reset

Signed-off-by: Rick Waldron waldron.rick@gmail.com
