### PR TITLE
Bug 905045 - Remove 'bluetooth-authorize' system message from the manifest r=evelyn

### DIFF
--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -38,7 +38,6 @@
     }
   },
   "messages": ["bluetooth-pairing-request",
-               "bluetooth-authorize",
                "bluetooth-cancel",
                "bluetooth-pairedstatuschanged"],
   "locales": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=905045
