### PR TITLE
Bug 905134 - [HD][Settings] Call waiting warning icon in the wrong location

### DIFF
--- a/apps/settings/style/icons.css
+++ b/apps/settings/style/icons.css
@@ -197,6 +197,7 @@ aside.connecting {
 
  #menuItem-callWaiting .alert-label > span {
   position: absolute;
+  right: 1.5rem;
   width: 3rem;
   height: 3rem;
   background-image: url(images/call_waiting_disabled.png);


### PR DESCRIPTION
[Bug 905134](https://bugzilla.mozilla.org/show_bug.cgi?id=905134)
