### PR TITLE
Bug 905314 - Long tapping on a bookmark in the bookmarks tab no longer brings up the Bookmarks dialog

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -785,7 +785,7 @@ var Browser = {
       Toolbar.refreshBookmarkButton.bind(Toolbar));
     this.hideBookmarkMenu();
     // refresh bookmark tab
-    this.showBookmarksTab();
+    this.showBookmarksTab(true);
   },
 
   // responsible to show the specific action menu
@@ -829,6 +829,13 @@ var Browser = {
       }).bind(this));
   },
 
+  bindBookmarkTabContextMenu:
+    function browser_bindBookmarkTabContextMenu(link) {
+    var that = this;
+    link.addEventListener('contextmenu', function() {
+      that.showBookmarkTabContextMenu(link.href);
+    });
+  },
   // Adaptor to show menu while press bookmark star
   showBookmarkMenu: function browser_showBookmarkMenu() {
     this.showActionMenu(this.currentTab.url);
@@ -1034,11 +1041,12 @@ var Browser = {
    * @return {Node}
    * @private
    */
-  _appendAwesomeScreenItems: function(parent, itemList) {
+  _appendAwesomeScreenItems: function(parent, itemList, current_tab) {
     var newList = this._awesomeListTemplate.cloneNode();
     itemList.forEach(function(data) {
       if (!data) return;
-      newList.appendChild(this.drawAwesomescreenListItem(data));
+      newList.appendChild(
+        this.drawAwesomescreenListItem(data, null, current_tab));
     }, this);
 
     var oldList = parent.firstElementChild;
@@ -1184,6 +1192,9 @@ var Browser = {
     var cache = this._itemListCache;
     if (cache[data.uri]) {
       entry = cache[data.uri].cloneNode(true);
+      if (current_tab === 'bookmark') {
+        this.bindBookmarkTabContextMenu(entry.firstChild);
+      }
       this._clearItemCache();
       return entry;
     }
@@ -1210,10 +1221,7 @@ var Browser = {
 
     // Enable longpress manipulation in bookmark tab
     if (current_tab === 'bookmark') {
-      var that = this;
-      link.addEventListener('contextmenu', function() {
-        that.showBookmarkTabContextMenu(link.href);
-      });
+      this.bindBookmarkTabContextMenu(link);
     }
 
     var underlay = ',url(./style/images/favicon-underlay.png)';
@@ -1269,13 +1277,14 @@ var Browser = {
     parent.appendChild(ul);
   },
 
-  showBookmarksTab: function browser_showBookmarksTab() {
+  showBookmarksTab: function browser_showBookmarksTab(needRefresh) {
+
     // Do nothing if we are already in the bookmarks tab
     if (this.bookmarksTab.classList.contains('selected') &&
-      this.bookmarks.classList.contains('selected')) {
+      this.bookmarks.classList.contains('selected') &&
+      !needRefresh) {
       return;
     }
-
     this.deselectAwesomescreenTabs();
     this.bookmarksTab.classList.add('selected');
     this.bookmarks.classList.add('selected');
@@ -1283,7 +1292,7 @@ var Browser = {
   },
 
   showBookmarks: function browser_showBookmarks(bookmarks) {
-    this._appendAwesomeScreenItems(this.bookmarks, bookmarks);
+    this._appendAwesomeScreenItems(this.bookmarks, bookmarks, 'bookmark');
   },
 
   openInNewTab: function browser_openInNewTab(url) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=905314
1. add bindBookmarkTabContextMenu method
2. execute bindBookmarkTabContextMenu if link of bookmark list is in cache 
3. add needRefresh flag to force showBookmarksTab update bookmark list
