### PR TITLE
Bug 902352 - Make Gaia keyboard treats the placeholder

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -104,7 +104,10 @@
   const SEMICOLON = 59;
 
   const WS = /^\s+$/;                    // all whitespace characters
-  const WORDSEP = /^[\s.,?!;:]+$/;       // word separator characters
+
+  // word separator characters
+  // U+FFFC is the placeholder character for non-text object
+  const WORDSEP = /^[\s.,?!;:\ufffc]+$/;
 
   const DOUBLE_SPACE_TIME = 700; // ms between spaces to convert to ". "
 


### PR DESCRIPTION
character U+FFFC as word separator.
