### PR TITLE
Bug 888799: Display message if callee is busy

### DIFF
--- a/apps/communications/dialer/js/calls_handler.js
+++ b/apps/communications/dialer/js/calls_handler.js
@@ -16,7 +16,6 @@ var CallsHandler = (function callsHandler() {
   var closing = false;
   var animating = false;
   var ringing = false;
-  var busyNotificationLock = false;
 
   /* === Settings === */
   var activePhoneSound = null;
@@ -119,7 +118,6 @@ var CallsHandler = (function callsHandler() {
   }
 
   function addCall(call) {
-    busyNotificationLock = false;
     // Once we already have 1 call, we need to care about incoming
     // calls and insert new dialing calls.
     if (handledCalls.length &&
@@ -318,7 +316,7 @@ var CallsHandler = (function callsHandler() {
   }
 
   function exitCallScreen(animate) {
-    if (closing || busyNotificationLock) {
+    if (closing) {
       return;
     }
 
@@ -544,7 +542,6 @@ var CallsHandler = (function callsHandler() {
   }
 
   function end() {
-    busyNotificationLock = false;
     // If there is an active call we end this one
     if (telephony.active) {
       telephony.active.hangUp();
@@ -603,24 +600,6 @@ var CallsHandler = (function callsHandler() {
     postToMainWindow(message);
   }
 
-  function notifyBusyLine() {
-    busyNotificationLock = true;
-    // ANSI call waiting tone for a 3 seconds window.
-    var sequence = [[480, 620, 500],
-                    [0, 0, 500],
-                    [480, 620, 500],
-                    [0, 0, 500],
-                    [480, 620, 500],
-                    [0, 0, 500]];
-    TonePlayer.playSequence(sequence);
-    setTimeout(function busyLineStopped() {
-      if (handledCalls.length === 0) {
-        busyNotificationLock = false;
-        exitCallScreen(true);
-      }
-    }, 3000);
-  }
-
   function activeCall() {
     var telephonyActiveCall = telephony.active;
     var activeCall = null;
@@ -652,7 +631,6 @@ var CallsHandler = (function callsHandler() {
 
     addRecentEntry: addRecentEntry,
 
-    notifyBusyLine: notifyBusyLine,
     activeCall: activeCall
   };
 })();

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -70,9 +70,6 @@ HandledCall.prototype.handleEvent = function hc_handle(evt) {
       CallsHandler.updateKeypadEnabled();
       this.node.classList.add('held');
       break;
-    case 'busy':
-      this.busy();
-      break;
   }
 };
 
@@ -269,10 +266,6 @@ HandledCall.prototype.connected = function hc_connected() {
   this.updateDirection();
   CallScreen.enableKeypad();
   CallScreen.syncSpeakerEnabled();
-};
-
-HandledCall.prototype.busy = function hc_busy() {
-  CallsHandler.notifyBusyLine();
 };
 
 HandledCall.prototype.disconnected = function hc_disconnected() {

--- a/apps/communications/dialer/js/telephony_helper.js
+++ b/apps/communications/dialer/js/telephony_helper.js
@@ -57,6 +57,8 @@ var TelephonyHelper = (function() {
             displayMessage('DeviceNotAccepted');
           } else if (errorName === 'RadioNotAvailable') {
             displayMessage('FlightMode');
+          } else if (errorName === 'BusyError') {
+            displayMessage('NumberIsBusy');
           } else {
             // If the call failed for some other reason we should still
             // display something to the user. See bug 846403.
@@ -97,6 +99,10 @@ var TelephonyHelper = (function() {
       case 'UnableToCall':
         dialogTitle = 'unableToCallTitle';
         dialogBody = 'unableToCallMessage';
+        break;
+      case 'NumberIsBusy':
+        dialogTitle = 'numberIsBusyTitle';
+        dialogBody = 'numberIsBusyMessage';
         break;
       default:
         console.error('Invalid message argument'); // Should never happen

--- a/apps/communications/dialer/locales/shared.en-US.properties
+++ b/apps/communications/dialer/locales/shared.en-US.properties
@@ -1,6 +1,8 @@
 callAirplaneModeMessage=To make a call you need to disable airplane mode in settings.
 callAirplaneModeBtnOk=OK
 callAirplaneModeTitle=Airplane mode activated
+numberIsBusyTitle=Number is busy
+numberIsBusyMessage=The number is currently busy. Please try again later.
 voiceMail=Voicemail
 emergencyNumber=Emergency number
 emergencyDialogBodyBadNumber=To make a call, the phone must be connected to a network.

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -216,17 +216,6 @@ suite('dialer/handled_call', function() {
     });
   });
 
-  suite('busy', function() {
-    setup(function() {
-      mockCall._busy();
-    });
-
-    test('playing busy tone', function() {
-      assert.isTrue(MockCallsHandler.mNotifyBusyLineCalled);
-    });
-  });
-
-
   suite('holding', function() {
     setup(function() {
       mockCall._hold();

--- a/apps/communications/dialer/test/unit/mock_call.js
+++ b/apps/communications/dialer/test/unit/mock_call.js
@@ -44,15 +44,6 @@ function MockCall(aNumber, aState) {
     }
   }).bind(this);
 
-  this._busy = (function() {
-    if (this._handler) {
-      this.state = 'busy';
-      if ('handleEvent' in this._handler) {
-        this._handler.handleEvent({call: this});
-      }
-    }
-  }).bind(this);
-
   this._disconnect = (function() {
     if (this._handler) {
       this.state = 'disconnected';

--- a/apps/communications/dialer/test/unit/mock_calls_handler.js
+++ b/apps/communications/dialer/test/unit/mock_calls_handler.js
@@ -1,6 +1,5 @@
 var MockCallsHandler = {
   mLastEntryAdded: null,
-  mNotifyBusyLineCalled: false,
   mUpdateKeypadEnabledCalled: true,
 
   updateKeypadEnabled: function() {
@@ -12,13 +11,8 @@ var MockCallsHandler = {
     this.mLastEntryAdded = entry;
   },
 
-  notifyBusyLine: function notifyBusyLine() {
-    this.mNotifyBusyLineCalled = true;
-  },
-
   mTeardown: function() {
     this.mLastEntryAdded = null;
-    this.mNotifyBusyLineCalled = false;
     this.mUpdateKeypadEnabledCalled = true;
   }
 };

--- a/apps/communications/dialer/test/unit/telephony_helper_test.js
+++ b/apps/communications/dialer/test/unit/telephony_helper_test.js
@@ -158,6 +158,13 @@ suite('telephony helper', function() {
       });
     });
 
+    test('should handle BusyError', function() {
+      subject.call('123');
+      mockCall.onerror(createCallError('BusyError'));
+      spyConfirmShow.calledWith('numberIsBusyTitle',
+                                'numberIsBusyMessage');
+    });
+
     test('should handle DeviceNotAcceptedError', function() {
       subject.call('123');
       mockCall.onerror(createCallError('DeviceNotAcceptedError'));


### PR DESCRIPTION
Busy calls are now signaled by error, instead of call state. This
patch adds a related message to the TelephonyHelper for informing
the user.

The old code used to play a tone for 3 seconds and close the Call
dialog afterwards. We cannot do this any longer because TonePlayer
expects the Call dialog to be around, which has already been closed
when the error gets handled.

This patch also replaces the related test of the Dialer app by a new
one. The new test verifies that the Dialer app displays the correct
error message when the number is busy.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
