### PR TITLE
Bug 906377 - [Messages] Guard against null placeholder errors when pressing Send

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -588,13 +588,15 @@
         }
 
         if (opts.refocus && opts.noPreserve) {
-          while (last.isPlaceholder) {
+          while (last !== null && last.isPlaceholder) {
             last.parentNode.removeChild(last);
             last = view.inner.lastElementChild;
           }
         }
 
-        last.scrollIntoView(true);
+        if (last !== null) {
+          last.scrollIntoView(true);
+        }
       }
 
       state.isTransitioning = false;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=906377
- Adds conditional guards to avoid TypeErrors when placeholders are null

Signed-off-by: Rick Waldron waldron.rick@gmail.com
