### PR TITLE
Bug 902959 - Do not return apps if there's entry points

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -847,11 +847,18 @@ var GridManager = (function() {
   function getApps(suppressHiddenRoles) {
     var apps = [];
     for (var origin in appsByOrigin) {
+      var app = appsByOrigin[origin];
+
+      // app.manifest is null until the downloadsuccess/downloadapplied event
+      var manifest = app.manifest || app.updateManifest;
+
       if (suppressHiddenRoles &&
-        HIDDEN_ROLES.indexOf(appsByOrigin[origin].manifest.role) !== -1) {
+         (HIDDEN_ROLES.indexOf(manifest.role) !== -1 ||
+          manifest.entry_points
+        )) {
         continue;
       }
-      apps.push(appsByOrigin[origin]);
+      apps.push(app);
     }
     return apps;
   }

--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -316,4 +316,50 @@ suite('grid.js >', function() {
     });
   });
 
+  suite('apps >', function() {
+      var manifests = [
+        {
+          role: 'app'
+        },
+        {
+          role: 'keyboard'
+        },
+        {
+          role: 'app',
+          entry_points: [
+            {}, {}
+          ]
+        }
+      ];
+
+      // Install a few fake applications
+      setup(function(done) {
+        manifests.forEach(function(manifest, idx) {
+          GridManager.install(new MockApp({
+            origin: 'fake' + idx,
+            manifest: manifest
+          }));
+        });
+
+        // Install something with updateManifest, but not manifest
+        GridManager.install(new MockApp({
+          origin: 'updateManifestOnly',
+          manifest: undefined,
+          updateManifest: {
+            role: 'keyboard'
+          }
+        }));
+
+        setTimeout(done.bind(null, undefined), SAVE_STATE_WAIT_TIMEOUT);
+      });
+
+      test('#getApps', function() {
+        var allApps = GridManager.getApps();
+        assert.equal(allApps.length, 4, 'all apps returned');
+
+        var visibleApps = GridManager.getApps(true);
+        assert.equal(visibleApps.length, 1, 'non-visible apps not returned');
+      });
+  });
+
 });


### PR DESCRIPTION
This hides applications from showing up if the manifest declares entry_points.
