### PR TITLE
Bug 903271 - Show statusbar when attention screen appears on fullscreen app

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -442,7 +442,8 @@ var WindowManager = (function() {
       // The "real" fix for this defect is tracked in bug 842102.
       setTimeout(function _setVisible() { iframe.setVisible(false); }, 50);
     }
-
+    // XXX: This removal will wrongly remove 'fullscreen-app' class when
+    // switching two full-screen apps. We should reconsider when to remove it.
     screenElement.classList.remove('fullscreen-app');
 
     // Inform keyboardmanager that we've finished the transition


### PR DESCRIPTION
This is a v1-train only patch since
1. Not reproducible on master.
2. v1-train contains bug 834765 patch, which is backed out on master.
