### PR TITLE
Bug 906581 - [Messages] Keyboard should always close when send button is pressed . r = gnarf

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -370,19 +370,23 @@ var ThreadUI = global.ThreadUI = {
     }
   },
 
-  assimilateRecipients: function thui_assimilateRecipients() {
+  assimilateRecipients: function thui_assimilateRecipients(sending) {
     var isNew = window.location.hash === '#new';
     var node = this.recipientsList.lastChild;
     var typed;
+    var refocuselem = this.input;
 
     if (!isNew || node === null) {
       return;
     }
 
+    if (sending) {
+      refocuselem = this.sendButton;
+    }
     // Restore the recipients list input area to
     // single line view.
     this.recipients.visible('singleline', {
-      refocus: this.input,
+      refocus: refocuselem,
       noPreserve: true
     });
 
@@ -1470,7 +1474,7 @@ var ThreadUI = global.ThreadUI = {
     // User may return to recipients, type a new recipient
     // manually and then click the sendButton without "accepting"
     // the recipient.
-    this.assimilateRecipients();
+    this.assimilateRecipients(true);
 
     // not sure why this happens - replace me if you know
     this.container.classList.remove('hide');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=906581
  This is a regression issue.The problem is with the assimilateRecipients() in thread_ui.js
  Here we are always refocusing with the input, refocus: this.input.
  When we are sending a message,we should not keep the focus in the input as the refocus happens  asynchronously.

 Please review the patch
