### PR TITLE
Bug 843921 - [Homescreen] Remove deviceStorage permission r=crdlc

### DIFF
--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -12,7 +12,6 @@
     "webapps-manage":{},
     "systemXHR":{},
     "settings":{ "access": "readwrite" },
-    "device-storage:pictures":{ "access": "readonly" },
     "open-remote-window":{},
     "storage":{},
     "geolocation": {},


### PR DESCRIPTION
Obsoleting https://github.com/mozilla-b2g/gaia/pull/10191 in favor of a different commit message.
