### PR TITLE
Bug 906841 - Add entrypoints to search r=crldc, ran

### DIFF
--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -837,7 +837,8 @@ Evme.Brain = new function Evme_Brain() {
                 "query": Searcher.getDisplayedQuery(),
                 "source": Searcher.getDisplayedSource(),
                 "icon": data.data.icon,
-                "installed": data.data.installed || false
+                "installed": data.data.installed || false,
+                "entryPoint": data.data.entryPoint
             };
 
             var elApp = data.el,
@@ -928,7 +929,11 @@ Evme.Brain = new function Evme_Brain() {
         this.appRedirectExecute = function appRedirectExecute(data){
             var appIcon = Evme.Utils.formatImageData(data.icon);
             if (data.installed) {
-                GridManager.getAppByOrigin(data.appUrl).launch();
+                if (data.entryPoint) {
+                    GridManager.getAppByOrigin(data.appUrl).launch(data.entryPoint);
+                } else {
+                    GridManager.getAppByOrigin(data.appUrl).launch();
+                }
             } else {
                 Evme.Utils.getRoundIcon(appIcon, function onIconReady(roundedAppIcon) {
                     Evme.Utils.sendToOS(Evme.Utils.OSMessages.APP_CLICK, {
@@ -1737,19 +1742,21 @@ Evme.Brain = new function Evme_Brain() {
             }
 
             for (var i=0; i<_apps.length; i++) {
-                var app = _apps[i],
-                    name = Evme.Utils.sendToOS(Evme.Utils.OSMessages.GET_APP_NAME, app);
+                var icon = _apps[i],
+                    app = icon.app,
+                    name = icon.descriptor.name;
 
                 if (regex.test(name) || typeApps && typeApps.indexOf(app.manifest.name) !== -1) {
                     apps.push({
                        'id': app._id,
                        'name': name,
+                       'entryPoint': icon.descriptor.entry_point,
                        'installed': true,
                        'appUrl': app.origin,
                        'favUrl': app.origin,
                        'appType': app.isBookmark ? 'bookmark' : 'installed',
                        'preferences': '',
-                       'icon': Evme.Utils.sendToOS(Evme.Utils.OSMessages.GET_APP_ICON, app),
+                       'icon': Evme.Utils.sendToOS(Evme.Utils.OSMessages.GET_APP_ICON, icon.descriptor),
                        'requiresLocation': false,
                        'appNativeUrl': '',
                        'numShares': 0,

--- a/apps/homescreen/everything.me/js/etmmanager.js
+++ b/apps/homescreen/everything.me/js/etmmanager.js
@@ -52,7 +52,7 @@ var EvmeManager = (function EvmeManager() {
     }
 
     function getApps() {
-        return GridManager.getApps(true);
+        return GridManager.getApps(true /* Flatten */, true /* Hide hidden */);
     }
 
     function getAppIcon(app) {
@@ -62,22 +62,6 @@ var EvmeManager = (function EvmeManager() {
                 'renderedIcon' in iconObject.descriptor) {
             return iconObject.descriptor.renderedIcon;
         }
-    }
-
-    function getAppName(app) {
-        var manifest = app.manifest;
-        if (!manifest) {
-            return null;
-        }
-
-        if ('locales' in manifest) {
-            var locale = manifest.locales[document.documentElement.lang];
-            if (locale && locale.name) {
-                return locale.name;
-            }
-        }
-
-        return manifest.name;
     }
 
     function getIconSize() {
@@ -99,7 +83,6 @@ var EvmeManager = (function EvmeManager() {
         },
         getApps: getApps,
         getAppIcon: getAppIcon,
-        getAppName: getAppName,
 
         openUrl: openUrl,
 

--- a/apps/homescreen/everything.me/js/helpers/Utils.js
+++ b/apps/homescreen/everything.me/js/helpers/Utils.js
@@ -20,7 +20,6 @@ Evme.Utils = new function Evme_Utils() {
             "MENU_HEIGHT": "menu-height",
             "GET_ALL_APPS": "get-all-apps",
             "GET_APP_ICON": "get-app-icon",
-            "GET_APP_NAME": "get-app-name",
             "EVME_OPEN": "evme-open"
         };
     
@@ -125,8 +124,6 @@ Evme.Utils = new function Evme_Utils() {
                 return EvmeManager.getApps();
             case OSMessages.GET_APP_ICON:
                 return EvmeManager.getAppIcon(data);
-            case OSMessages.GET_APP_NAME:
-                return EvmeManager.getAppName(data);
             case OSMessages.GET_ICON_SIZE:
                 return EvmeManager.getIconSize();
             case OSMessages.EVME_OPEN:

--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -842,9 +842,11 @@ var GridManager = (function() {
    * Ways to enumerate installed apps & bookmarks and find out whether
    * a certain "origin" is available as an existing installed app or
    * bookmark. Only used by Everything.me at this point.
+   * @param {Boolean} expands manifests with multiple entry points.
    * @param {Boolean} disallows hidden apps.
+   * @return {Array} icon objects.
    */
-  function getApps(suppressHiddenRoles) {
+  function getApps(expandApps, suppressHiddenRoles) {
     var apps = [];
     for (var origin in appsByOrigin) {
       var app = appsByOrigin[origin];
@@ -852,13 +854,18 @@ var GridManager = (function() {
       // app.manifest is null until the downloadsuccess/downloadapplied event
       var manifest = app.manifest || app.updateManifest;
 
-      if (suppressHiddenRoles &&
-         (HIDDEN_ROLES.indexOf(manifest.role) !== -1 ||
-          manifest.entry_points
-        )) {
+      if (suppressHiddenRoles && HIDDEN_ROLES.indexOf(manifest.role) !== -1) {
         continue;
       }
-      apps.push(app);
+
+      if (expandApps && manifest.entry_points) {
+        for (var i in manifest.entry_points) {
+          apps.push(new Icon(buildDescriptor(app, i), app));
+        }
+        continue;
+      }
+
+      apps.push(new Icon(buildDescriptor(app), app));
     }
     return apps;
   }
@@ -1014,22 +1021,14 @@ var GridManager = (function() {
   }
 
   /*
-   * Create or update a single icon for an Application (or Bookmark) object.
+   * Builds a descriptor for an icon object
    */
-  function createOrUpdateIconForApp(app, entryPoint) {
-    // Make sure we update the icon/label when the app is updated.
-    if (!app.isBookmark) {
-      app.ondownloadapplied = function ondownloadapplied(event) {
-        createOrUpdateIconForApp(event.application, entryPoint);
-        app.ondownloadapplied = null;
-        app.ondownloaderror = null;
-      };
-      app.ondownloaderror = function ondownloaderror(event) {
-        createOrUpdateIconForApp(app, entryPoint);
-      };
-    }
-
+  function buildDescriptor(app, entryPoint) {
     var manifest = app.manifest ? app.manifest : app.updateManifest;
+
+    if (!manifest)
+      return;
+
     var iconsAndNameHolder = manifest;
     if (entryPoint)
       iconsAndNameHolder = manifest.entry_points[entryPoint];
@@ -1052,6 +1051,27 @@ var GridManager = (function() {
     if (haveLocale && !app.isBookmark) {
       descriptor.localizedName = iconsAndNameHolder.name;
     }
+
+    return descriptor;
+  }
+
+  /*
+   * Create or update a single icon for an Application (or Bookmark) object.
+   */
+  function createOrUpdateIconForApp(app, entryPoint) {
+    // Make sure we update the icon/label when the app is updated.
+    if (!app.isBookmark) {
+      app.ondownloadapplied = function ondownloadapplied(event) {
+        createOrUpdateIconForApp(event.application, entryPoint);
+        app.ondownloadapplied = null;
+        app.ondownloaderror = null;
+      };
+      app.ondownloaderror = function ondownloaderror(event) {
+        createOrUpdateIconForApp(app, entryPoint);
+      };
+    }
+
+    var descriptor = buildDescriptor(app, entryPoint);
 
     // If there's an existing icon for this bookmark/app/entry point already,
     // let it update itself.

--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -316,7 +316,7 @@ suite('grid.js >', function() {
     });
   });
 
-  suite('apps >', function() {
+  suite('#getApps >', function() {
       var manifests = [
         {
           role: 'app'
@@ -353,12 +353,24 @@ suite('grid.js >', function() {
         setTimeout(done.bind(null, undefined), SAVE_STATE_WAIT_TIMEOUT);
       });
 
-      test('#getApps', function() {
+      test('returns all apps', function() {
         var allApps = GridManager.getApps();
-        assert.equal(allApps.length, 4, 'all apps returned');
+        assert.equal(allApps.length, 4);
+      });
 
-        var visibleApps = GridManager.getApps(true);
-        assert.equal(visibleApps.length, 1, 'non-visible apps not returned');
+      test('filters apps', function() {
+        var visibleApps = GridManager.getApps(false, true);
+        assert.equal(visibleApps.length, 2);
+      });
+
+      test('flattens entry points', function() {
+        var allApps = GridManager.getApps(true);
+        assert.equal(allApps.length, 5);
+      });
+
+      test('filters and flattens entry points', function() {
+        var visibleApps = GridManager.getApps(true, true);
+        assert.equal(visibleApps.length, 3);
       });
   });
 


### PR DESCRIPTION
This makes GridManager::getApps return an array of icon objects. The reason being is that the icon objects hold the information necessary to render apps from entry points, while the app object does not.

The diff is a little hard to read due to the abstraction of the buildDescriptor logic.
