### PR TITLE
Bug 906627 - [Camera][Helix] The flash light is still open after user pressed the home button

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -541,6 +541,24 @@ var Camera = {
     }
   },
 
+  turnOffFlash: function camera_turnOffFlash() {
+    var flash = this._flashState[this._captureMode];
+    flash.currentMode = 0;
+    this.setFlashMode();
+  },
+
+  // isAuto: true if caller want to set it as auto; false for always light.
+  // Auto mode only works when camera is currently at camera mode (not video).
+  turnOnFlash: function camera_turnOnFlash(isAuto) {
+    var flash = this._flashState[this._captureMode];
+    if (this._captureMode === this.CAMERA) {
+      flash.currentMode = isAuto ? 1 : 2;
+    } else {
+      flash.currentMode = 1;
+    }
+    this.setFlashMode();
+  },
+
   toggleFlash: function camera_toggleFlash() {
     var flash = this._flashState[this._captureMode];
     flash.currentMode = (flash.currentMode + 1) % flash.modes.length;
@@ -1508,6 +1526,7 @@ Camera.init();
 
 document.addEventListener('visibilitychange', function() {
   if (document.hidden) {
+    Camera.turnOffFlash();
     Camera.stopPreview();
     Camera.cancelPick();
     Camera.cancelPositionUpdate();


### PR DESCRIPTION
Add two functions which allow caller directly turn on/off the flash. Because we can't fix this bug if we can only toggle the flash from all exposed methods.
