### PR TITLE
Bug 893579 - [Email] Trim whitespaces in contact name. r=asuth

### DIFF
--- a/apps/email/js/ext/mailapi/chewlayer.js
+++ b/apps/email/js/ext/mailapi/chewlayer.js
@@ -3542,7 +3542,7 @@ $mailchewStrings.events.on('strings', function(strings) {
 exports.generateReplyBody = function generateReplyMessage(reps, authorPair,
                                                           msgDate,
                                                           identity, refGuid) {
-  var useName = authorPair.name || authorPair.address;
+  var useName = authorPair.name ? authorPair.name.trim() : authorPair.address;
 
   var textMsg = '\n\n' +
                 l10n_wroteString.replace('{name}', useName) + ':\n',


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/235
