### PR TITLE
Bug 905237 - Remove UA override for several domains

### DIFF
--- a/build/ua-override-prefs.js
+++ b/build/ua-override-prefs.js
@@ -1,6 +1,5 @@
 // Send these sites a custom user-agent. Bugs to remove each override after
 // evangelism are included.
-pref("general.useragent.override.accounts.google.com", "\\(Mobile#(Android; Mobile"); // bug 805164
 pref("general.useragent.override.maps.google.com", "\\(Mobile#(Android; Mobile"); // bug 802981
 pref("general.useragent.override.uol.com.br", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826330
 pref("general.useragent.override.live.com", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826332
@@ -12,7 +11,6 @@ pref("general.useragent.override.abril.com.br", "\\(Mobile#(Android; Mobile"); /
 pref("general.useragent.override.msn.com", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826347
 pref("general.useragent.override.linkedin.com", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826348
 pref("general.useragent.override.itau.com.br", "\\(Mobile#(Android; Mobile"); // bug 826353
-pref("general.useragent.override.4shared.com", "\\(Mobile#(Android; Mobile"); // bug 826502
 pref("general.useragent.override.orkut.com.br", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 826504
 pref("general.useragent.override.r7.com", "\\(Mobile#(Android; Mobile"); // bug 826510
 pref("general.useragent.override.estadao.com.br", "\\(Mobile#(Android; Mobile"); // bug 826514
@@ -62,7 +60,6 @@ pref("general.useragent.override.orange.es", "\\(Mobile#(Android; Mobile"); // b
 pref("general.useragent.override.paginasamarillas.es", "\\(Mobile#(Android; Mobile"); // bug 828414
 pref("general.useragent.override.loteriasyapuestas.es", "\\(Mobile#(Android; Mobile"); // bug 828416
 pref("general.useragent.override.bbva.es", "\\(Mobile#(Android; Mobile"); // bug 828418
-pref("general.useragent.override.booking.com", "\\(Mobile#(Android; Mobile"); // bug 828420
 pref("general.useragent.override.publico.es", "\\(Mobile#(Android; Mobile"); // bug 828422
 pref("general.useragent.override.mercadolibre.com.ve", "\\(Mobile#(Android; Mobile"); // bug 828425
 pref("general.useragent.override.olx.com.ve", "\\(Mobile#(Android; Mobile"); // bug 828433
@@ -86,7 +83,6 @@ pref("general.useragent.override.deviantart.com", "\\(Mobile#(Android; Mobile");
 pref("general.useragent.override.nytimes.com", "\\(Mobile#(Android; Mobile"); // bug 843137
 pref("general.useragent.override.consumersearch.com", "\\(Mobile#(Android; Mobile"); // bug 843139
 pref("general.useragent.override.foodily.com", "\\(Mobile#(Android; Mobile"); // bug 843141
-pref("general.useragent.override.edmunds.com", "\\(Mobile#(Android; Mobile"); // bug 843146
 pref("general.useragent.override.icanhas.cheezburger.com", "\\(Mobile#(Android; Mobile"); // bug 843197
 pref("general.useragent.override.citibank.com", "\\(Mobile#(Android; Mobile"); // bug 843151
 pref("general.useragent.override.games.com", "\\(Mobile#(Android; Mobile"); // bug 843153
@@ -103,9 +99,7 @@ pref("general.useragent.override.slashgear.com", "\\(Mobile#(Android; Mobile"); 
 pref("general.useragent.override.chevrolet.com", "\\(Mobile#(Android; Mobile"); // bug 843186
 pref("general.useragent.override.deadline.com", "\\(Mobile#(Android; Mobile"); // bug 848854
 pref("general.useragent.override.3g.qq.com", "\\(Mobile#(Android; Mobile"); // bug 866577
-pref("general.useragent.override.aprod.hu", "\\(Mobile#(Android; Mobile"); // bug 878220
 pref("general.useragent.override.arukereso.hu", "\\(Mobile#(Android; Mobile"); // bug 878222
-pref("general.useragent.override.badoo.com", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 878224
 pref("general.useragent.override.blikk.hu", "\\(Mobile#(Android; Mobile"); // bug 878228
 pref("general.useragent.override.citromail.hu", "\\(Mobile#(Android; Mobile"); // bug 878230
 pref("general.useragent.override.hazipatika.com", "\\(Mobile#(Android; Mobile"); // bug 878232
@@ -117,7 +111,6 @@ pref("general.useragent.override.nemzetisport.hu", "\\(Mobile#(Android; Mobile")
 pref("general.useragent.override.nlcafe.hu", "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19"); // bug 878244
 pref("general.useragent.override.port.hu", "\\(Mobile#(Android; Mobile"); // bug 878246
 pref("general.useragent.override.portfolio.hu", "\\(Mobile#(Android; Mobile"); // bug 878249
-pref("general.useragent.override.profession.hu", "\\(Mobile#(Android; Mobile"); // bug 878251
 pref("general.useragent.override.vatera.hu", "\\(Mobile#(Android; Mobile"); // bug 878253
 pref("general.useragent.override.24sata.hr", "\\(Mobile#(Android; Mobile"); // bug 878255
 pref("general.useragent.override.bet365.com", "\\(Mobile#(Android; Mobile"); // bug 878256


### PR DESCRIPTION
badoo.com, booking.com, accounts.google.com, 4shared.com, edmunds.com, aprod.hu, profession.hu
