### PR TITLE
Bug 906581 - [Messages] Keyboard should always close when pressing Send

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -578,23 +578,21 @@
     view.outer.addEventListener('transitionend', function te() {
       var last;
 
-      if (state.visible === 'singleline' && opts.refocus) {
+      if (location.hash === '#new' && state.visible === 'singleline') {
         last = view.inner.lastElementChild;
 
         if (opts.refocus) {
           opts.refocus.focus();
-        } else {
-          last.focus();
         }
 
-        if (opts.refocus && opts.noPreserve) {
-          while (last.isPlaceholder) {
-            last.parentNode.removeChild(last);
-            last = view.inner.lastElementChild;
-          }
+        while (last !== null && last.isPlaceholder) {
+          last.parentNode.removeChild(last);
+          last = view.inner.lastElementChild;
         }
 
-        last.scrollIntoView(true);
+        if (last !== null) {
+          last.scrollIntoView(true);
+        }
       }
 
       state.isTransitioning = false;

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -381,10 +381,7 @@ var ThreadUI = global.ThreadUI = {
 
     // Restore the recipients list input area to
     // single line view.
-    this.recipients.visible('singleline', {
-      refocus: this.input,
-      noPreserve: true
-    });
+    this.recipients.visible('singleline');
 
     do {
       if (node.isPlaceholder) {

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -39,6 +39,9 @@ suite('Recipients', function() {
 
     mocksHelper.setup();
 
+    this.sinon.spy(Recipients.View.prototype, 'visible');
+    this.sinon.spy(Element.prototype, 'scrollIntoView');
+
     recipients = new Recipients({
       outer: 'messages-to-field',
       inner: 'messages-recipients-list',
@@ -608,6 +611,89 @@ suite('Recipients', function() {
           });
 
           MockDialog.triggers.confirm();
+        });
+      });
+    });
+
+    suite('Visibility Modes', function() {
+      var outer, inner, target, visible;
+
+      setup(function() {
+        location.hash = '#new';
+
+        outer = document.getElementById('messages-to-field');
+        inner = document.getElementById('messages-recipients-list');
+        target = document.createElement('input');
+        visible = Recipients.View.prototype.visible;
+
+        this.sinon.spy(target, 'focus');
+      });
+
+      teardown(function() {
+        location.hash = '';
+      });
+
+      suite('to singleline ', function() {
+        setup(function() {
+          recipients.visible('multiline');
+        });
+        test('singleline ', function() {
+          // Assert the last state is multiline
+          assert.equal(visible.args[0][0], 'multiline');
+
+          // Next, set back to singleline
+          recipients.visible('singleline');
+
+          assert.ok(visible.called);
+          assert.equal(visible.args[1][0], 'singleline');
+        });
+
+        test('singleline + refocus ', function() {
+          // Assert the last state is multiline
+          assert.equal(visible.args[0][0], 'multiline');
+
+          outer.addEventListener('transitionend', function handler() {
+            var last = inner.lastElementChild;
+
+            assert.ok(target.focus.called);
+            assert.ok(visible.called);
+            assert.equal(visible.args[0][0], 'singleline');
+            assert.deepEqual(visible.args[0][1], {
+              refocus: target
+            });
+
+            assert.ok(target.focus.called);
+            assert.ok(last.scrollIntoView.called);
+
+            done();
+
+            outer.removeEventListener('transitionend', handler);
+          });
+
+          recipients.visible('singleline', {
+            refocus: target
+          });
+
+          outer.dispatchEvent(
+            new CustomEvent('transitionend')
+          );
+        });
+      });
+
+      suite('to multiline ', function() {
+        setup(function() {
+          recipients.visible('singleline');
+        });
+
+        test('multiline ', function() {
+          // Assert the last state is singleline
+          assert.equal(visible.args[0][0], 'singleline');
+
+          // Next, set back to multiline
+          recipients.visible('multiline');
+
+          assert.ok(visible.called);
+          assert.equal(visible.args[1][0], 'multiline');
         });
       });
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=906581
- Don't execute transitionend handler for recipient list visibility unless app is in "new" view
- Don't manually refocus

Signed-off-by: Rick Waldron waldron.rick@gmail.com
