### PR TITLE
Bug 906753 - [Messages] we should see the recipients count in the header when composing a multi-recipient messag

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -252,18 +252,14 @@ var ThreadUI = global.ThreadUI = {
 
   // Initialize Recipients list and Recipients.View (DOM)
   initRecipients: function thui_initRecipients() {
-    function recipientsChanged(count) {
-      var message = count ?
-        (count > 1 ? 'recipient[many]' : 'recipient[one]') :
-        'newMessage';
-
-      navigator.mozL10n.localize(this.headerText, message, {n: count});
-
+    var recipientsChanged = (function recipientsChanged() {
+      // update composer header whenever recipients change
+      this.updateComposerHeader();
       // check for enable send whenever recipients change
       this.enableSend();
       // Clean search result after recipient count change.
       this.container.textContent = '';
-    }
+    }).bind(this);
 
     if (this.recipients) {
       this.recipients.length = 0;
@@ -276,8 +272,8 @@ var ThreadUI = global.ThreadUI = {
         template: this.tmpl.recipient
       });
 
-      this.recipients.on('add', recipientsChanged.bind(this));
-      this.recipients.on('remove', recipientsChanged.bind(this));
+      this.recipients.on('add', recipientsChanged);
+      this.recipients.on('remove', recipientsChanged);
     }
     this.container.textContent = '';
   },

--- a/apps/sms/test/unit/mock_recipients.js
+++ b/apps/sms/test/unit/mock_recipients.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function MockRecipients(setup) {
   this.setup = setup;
   this.recipientsList = document.getElementById(setup.inner);
@@ -17,6 +19,16 @@ MockRecipients.prototype.add = function(contact) {
   this.length++;
   this.numbers.push(contact.number);
   this.emit('add', this.length);
+  return this;
+};
+
+MockRecipients.prototype.remove = function(phone) {
+  var index = this.numbers.indexOf(phone);
+  if (index != -1) {
+    this.numbers.splice(this.numbers.indexOf(phone), 1);
+    this.length--;
+    this.emit('remove', this.length);
+  }
   return this;
 };
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3000,6 +3000,47 @@ suite('thread_ui.js >', function() {
     });
   });
 
+  suite('recipient handling yields correct header', function() {
+    var localize;
+    setup(function() {
+      location.hash = '#new';
+      localize = this.sinon.spy(navigator.mozL10n, 'localize');
+    });
+
+    teardown(function() {
+      location.hash = '';
+    });
+
+    test('no recipients', function() {
+      ThreadUI.updateComposerHeader();
+      assert.deepEqual(localize.args[0], [
+        ThreadUI.headerText, 'newMessage'
+      ]);
+    });
+
+    test('add one recipient', function() {
+      ThreadUI.recipients.add({
+        number: '999'
+      });
+      assert.deepEqual(localize.args[0], [
+        ThreadUI.headerText, 'recipient', {n: 1}
+      ]);
+    });
+
+    test('add two recipients', function() {
+      ThreadUI.recipients.add({
+        number: '999'
+      });
+      ThreadUI.recipients.add({
+        number: '888'
+      });
+      assert.ok(localize.calledTwice);
+      assert.deepEqual(localize.args[1], [
+        ThreadUI.headerText, 'recipient', {n: 2}
+      ]);
+    });
+  });
+
   suite('initSentAudio', function() {
     test('calling function does not throw uncaught exception ', function() {
       assert.doesNotThrow(ThreadUI.initSentAudio);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=906753
- remove call to l10n.get
- replaced to use updateComposerHeader (per Julien W's recommendation)
- tests
  - add recipients updates composer header
  - localize is called with correct arguments
- updated mock recipients to have basic recipient remove logic
