### PR TITLE
Bug 907288 - [Messages] Recipients.prototype.remove should guard against calls to splice(-1, 1)

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -271,10 +271,14 @@
     var index = typeof recipOrIndex === 'number' ?
       recipOrIndex : list.indexOf(recipOrIndex);
 
+    if (index === -1) {
+      return this;
+    }
+
     list.splice(index, 1);
     this.emit('remove', list.length);
 
-    return this.render();
+    return this.render(index);
   };
 
   Recipients.prototype.render = function() {

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -39,6 +39,9 @@ suite('Recipients', function() {
 
     mocksHelper.setup();
 
+    this.sinon.spy(Recipients.prototype, 'render');
+    this.sinon.spy(Recipients.View.prototype, 'render');
+
     recipients = new Recipients({
       outer: 'messages-to-field',
       inner: 'messages-recipients-list',
@@ -133,9 +136,20 @@ suite('Recipients', function() {
       assert.deepEqual(recipient, fixture);
       assert.ok(isValid(recipient, '999'));
 
-
       recipients.remove(recipient);
       assert.equal(recipients.length, 0);
+
+      assert.ok(recipients.render.calledTwice);
+    });
+
+    test('recipients.remove(nonexistant) ', function() {
+      var recipient;
+
+      recipients.add(fixture);
+      recipients.remove(null);
+      assert.equal(recipients.length, 1);
+
+      assert.ok(recipients.render.calledOnce);
     });
 
     test('recipients.remove(index) ', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=907288
- If index === -1, return
- Tests:
  - Assert recipients.length correctness
  - Assert call to render

Signed-off-by: Rick Waldron waldron.rick@gmail.com
