### PR TITLE
Bug 832335 - [Clock] Display Alarm set notification inside Analog clock face

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -74,7 +74,9 @@
           <ul id="alarms"></ul>
         </div>
         <section id="banner-countdown" role="status">
-          <!-- this will be replaced dynamically -->
+          <!--
+            <p>${notice}</p>
+          -->
         </section>
       </div>
 

--- a/apps/clock/js/alarm_edit.js
+++ b/apps/clock/js/alarm_edit.js
@@ -359,7 +359,9 @@ var AlarmEdit = {
           return;
         }
         AlarmList.refreshItem(alarm);
-        AlarmManager.renderBannerBar(alarm.getNextAlarmFireTime());
+        LazyLoader.load(['js/banner.js'], function() {
+          new Banner(alarm.getNextAlarmFireTime());
+        });
         AlarmManager.updateAlarmStatusBar();
         callback && callback(null, alarm);
       });

--- a/apps/clock/js/alarm_manager.js
+++ b/apps/clock/js/alarm_manager.js
@@ -59,12 +59,6 @@ var AlarmManager = {
     alarm.setEnabled(enabled, callback);
   },
 
-  renderBannerBar: function am_renderBannerBar(date) {
-    LazyLoader.load(['js/banner.js'], function() {
-      BannerView.setStatus(date);
-    });
-  },
-
   updateAlarmStatusBar: function am_updateAlarmStatusBar() {
     var request = navigator.mozAlarms.getAll();
     request.onsuccess = function(e) {

--- a/apps/clock/js/banner.js
+++ b/apps/clock/js/banner.js
@@ -1,73 +1,97 @@
-var BannerView = {
+(function(exports) {
+  'use strict';
+  var bannerTimer;
+   /**
+   * Constructor function to create a new Banner notification instance
+   *
+   * @param {Number|Date} alarmTime Number or Date object indicating the time
+   *                                the next alarm will fire
+   * @return {String} displayTime Localized relative time to be passed to
+   *                              Banner.show()
+   */
+  function Banner(alarmTime) {
+    var _, timeLeft, displayTime, tl, countdownType, localTimes, unitObj;
+    // Alias localization here to allow for unit tests
+    _ = navigator.mozL10n.get;
 
-  _remainHours: 0,
-  _remainMinutes: 0,
+    // generate human readable numbers to pass to localization function
+    // Get hours and minutes from alarm
+    timeLeft = +alarmTime - Date.now();
+    tl = Utils.dateMath.fromMS(timeLeft, {
+      unitsPartial: ['days', 'hours', 'minutes']
+    });
 
-  get bannerCountdown() {
-    delete this.bannerCountdown;
-    return this.bannerCountdown = document.getElementById('banner-countdown');
-  },
-
-  init: function BV_init() {
-    this.bannerCountdown.addEventListener('click', this);
-  },
-
-  handleEvent: function al_handleEvent(evt) {
-    this.hideBannerStatus();
-  },
-
-  calRemainTime: function BV_calRemainTime(targetTime) {
-    var now = new Date();
-    var remainTime = targetTime.getTime() - now.getTime();
-    this._remainHours = Math.floor(remainTime / (60 * 60 * 1000)); // per hour
-    this._remainMinutes = Math.floor((remainTime / (60 * 1000)) -
-                          (this._remainHours * 60)); // per minute
-  },
-
-  setStatus: function BV_setStatus(nextAlarmFireTime) {
-    this.calRemainTime(nextAlarmFireTime);
-
-    var innerHTML = '';
-    if (this._remainHours === 0) {
-      innerHTML = _('countdown-lessThanAnHour', {
-        minutes: _('nMinutes', { n: this._remainMinutes })
-      });
-    } else if (this._remainHours < 24) {
-      innerHTML = _('countdown-moreThanAnHour', {
-        hours: _('nHours', { n: this._remainHours }),
-        minutes: _('nRemainMinutes', { n: this._remainMinutes })
-      });
+    // Match properties to localizations string types
+    // e.g. minutes maps to nMinutes if there are no hours but
+    // nRemainMinutes if hours > 0
+    if (tl.days) {
+      //countdown-moreThanADay is localized only for en-US while 913466 is open
+      countdownType = 'countdown-moreThanADay';
+      localTimes = [
+        ['days', 'nRemainDays', tl.days],
+        ['hours', 'nRemainHours', tl.hours]
+      ];
+    } else if (tl.hours > 0) {
+      countdownType = 'countdown-moreThanAnHour';
+      localTimes = [
+        ['hours', 'nHours', tl.hours],
+        ['minutes', 'nRemainMinutes', tl.minutes]
+      ];
     } else {
-      var remainDays = Math.floor(this._remainHours / 24);
-      var remainHours = this._remainHours - (remainDays * 24);
-      innerHTML = _('countdown-moreThanADay', {
-        days: _('nRemainDays', { n: remainDays }),
-        hours: _('nRemainHours', { n: remainHours })
-      });
+      countdownType = 'countdown-lessThanAnHour';
+      localTimes = [
+        ['minutes', 'nMinutes', tl.minutes]
+      ];
     }
-    this.bannerCountdown.innerHTML = '<p>' + innerHTML + '</p>';
 
-    this.showBannerStatus();
-    var self = this;
-    window.setTimeout(function cv_hideBannerTimeout() {
-      self.setBannerStatus(false);
-    }, 4000);
-  },
+    // Create an object to pass to mozL10n.get
+    // e.g. {minutes: _('nMinutes', {n: 3})}
+    unitObj = localTimes.reduce(function(lcl, time) {
+      lcl[time[0]] = _(time[1], {n: time[2]});
+      return lcl;
+    }, {});
 
-  setBannerStatus: function BV_setBannerStatus(visible) {
-    if (visible) {
-      this.bannerCountdown.classList.add('visible');
-    } else {
-      this.bannerCountdown.classList.remove('visible');
-    }
-  },
+    // mozL10n.get interpolates the units in unitObj inside the
+    // localization string for countdownType
+    displayTime = _(countdownType, unitObj);
 
-  showBannerStatus: function BV_showBannerStatus() {
-    this.setBannerStatus(true);
-  },
-
-  hideBannerStatus: function BV_hideBannerStatus() {
-    this.setBannerStatus(false);
+    // make banner, add visibility and kick off timer
+    this.notice = document.getElementById('banner-countdown');
+    // use this object rather than a function to retain context
+    this.notice.addEventListener('click', this);
+    this.show(displayTime);
   }
-};
-BannerView.init();
+  // with an object passed to the event handler it looks for
+  // a handleEvent method
+  Banner.prototype.handleEvent = function() {
+    this.hide();
+  };
+
+  Banner.prototype.show = function(time) {
+    var tmpl;
+    tmpl = new Template(this.notice);
+    // Clock localization files contain HTML used in shared notification styles
+    // which makes breaking out individual elements problematic
+    this.notice.innerHTML = tmpl.interpolate(
+      {notice: time},
+      // Localization strings contain strong tags
+      { safe: ['notice'] }
+    );
+    // 'visible' class controls the animation
+    this.notice.classList.add('visible');
+    // Debounce timer in case alarms are added more quickly than 4 seconds
+    if (bannerTimer) {
+      clearTimeout(bannerTimer);
+    }
+    // After 4 seconds, remove the banner
+    bannerTimer = setTimeout(this.hide.bind(this), 4000);
+    return this;
+  };
+
+  Banner.prototype.hide = function() {
+    this.notice.classList.remove('visible');
+    this.notice.removeEventListener('click', this);
+  };
+
+  exports.Banner = Banner;
+}(this));

--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -167,15 +167,14 @@ html, body {
 #banner-countdown {
   z-index: -1;
   opacity: 0;
-  bottom: -2rem;
   -moz-transition: all 600ms ease;
 }
 #banner-countdown.visible {
   z-index: 1;
   opacity: 1;
-  bottom: 0;
   -moz-transition: all 600ms ease;
 }
+
 #banner-countdown > p > strong {
   white-space: nowrap;
 }

--- a/apps/clock/test/unit/alarm_test.js
+++ b/apps/clock/test/unit/alarm_test.js
@@ -463,4 +463,3 @@ suite('Alarm Test', function() {
     });
   });
 });
-

--- a/apps/clock/test/unit/banner_test.js
+++ b/apps/clock/test/unit/banner_test.js
@@ -1,0 +1,56 @@
+requireApp('clock/js/banner.js');
+requireApp('clock/js/utils.js');
+
+requireApp('clock/test/unit/mocks/mock_navigator_mozl10n.js');
+requireApp('clock/test/unit/mocks/mock_mozAlarm.js');
+
+suite('Banner', function() {
+  var nml;
+  suiteSetup(function() {
+    // store timezone offset for fake timers
+    var offset = (new Date()).getTimezoneOffset() * 60 * 1000;
+    nml = navigator.mozL10n;
+
+    navigator.mozL10n = MockL10n;
+
+    loadBodyHTML('/index.html');
+    // The timestamp for "Tue Jul 16 2013 06:00:00" according to the local
+    // system's time zone
+    this.sixAm = 1373954400000 + offset;
+    this.clock = sinon.useFakeTimers(this.sixAm);
+
+    // The timestamp for "Tue Jul 16 2013 16:12:00" according to the local
+    // system's time zone
+    // add to this.sixAm to avoid failures on machines in unknown locales
+    this.fourish = this.sixAm + (10 * 60 * 60 * 1000) + (12 * 60 * 1000);
+
+  });
+
+  test('Banner should make notification visible', function(done) {
+    var note = document.getElementById('banner-countdown');
+    new Banner(this.fourish);
+    // banner adds the class name to the element
+    var visible = note.className.split(/\s+/).some(function(elem) {
+      return elem === 'visible';
+    });
+    assert.ok(visible);
+    done();
+  });
+  test('Banner should call localization function', function(done) {
+    var localized = this.sinon.spy(navigator.mozL10n, 'get');
+    new Banner(this.fourish);
+    assert.ok(localized.called);
+    done();
+  });
+  test('Banner should pass correct parameters', function(done) {
+    var note, passed;
+    note = document.getElementById('banner-countdown');
+    passed = this.sinon.spy(navigator.mozL10n, 'get');
+    // build banner
+    new Banner(this.fourish);
+    // Check passed in arguments
+    assert.deepEqual({n: 10}, passed.args[0][1]);
+    assert.deepEqual({n: 12}, passed.args[1][1]);
+    done();
+  });
+});


### PR DESCRIPTION
Refactors banner notification code to:
- move banner animation to above the bottom of the screen, giving the user a hint that the element can be dismissed and doesn't displace more persistent alarm indications.
- add unit tests for the creation and format of the banner notification
- move the call to `banner.js` out of `AlarmManager` and into the save callback of `AlarmEdit` to separate concerns between rendering and database interactions.
