### PR TITLE
Bug 907629 - Notify STK application when Settings is about to get killed

### DIFF
--- a/apps/settings/js/icc.js
+++ b/apps/settings/js/icc.js
@@ -50,7 +50,7 @@
     document.getElementById('icc-stk-app-back').onclick = stkResGoBack;
     document.getElementById('icc-stk-help-exit').onclick = updateMenu;
 
-    window.onunload = function() {
+    window.onbeforeunload = function() {
       responseSTKCommand({
         resultCode: icc.STK_RESULT_NO_RESPONSE_FROM_USER
       }, true);


### PR DESCRIPTION
It seems like doing it in the onunload callback is already too late, and
it makes the STK behaving wrongly.
