### PR TITLE
Bug 907680 - [HD][Settings] System Update "Install Now" button should beblue not red

### DIFF
--- a/apps/system/js/updatable.js
+++ b/apps/system/js/updatable.js
@@ -227,7 +227,8 @@ SystemUpdatable.prototype.showApplyPrompt = function() {
 
   var confirm = {
     title: _('installNow'),
-    callback: this.acceptInstall.bind(this)
+    callback: this.acceptInstall.bind(this),
+    recommend: true
   };
 
   UtilityTray.hide();


### PR DESCRIPTION
[Bug 907680](https://bugzilla.mozilla.org/show_bug.cgi?id=907680)
