### PR TITLE
Bug 908325 - Integration test script references paths incorrectly

### DIFF
--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -6,7 +6,7 @@ SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd "$( dirname "$SOURCE" )" && pwd )"
 
 # where all gaia specific customizations for mocha-marionette live.
-SHARED=$DIR/../shared/test/integration/
+SHARED=$DIR/../shared/test/integration
 
 # download b2g-desktop (if its not present)
 make -C $DIR/../ b2g


### PR DESCRIPTION
r=lightsofapollo
