### PR TITLE
Fix Bug 908343 and Bug 908350

### DIFF
--- a/apps/keyboard/js/layout.js
+++ b/apps/keyboard/js/layout.js
@@ -632,7 +632,8 @@ const Keyboards = {
     menuLabel: 'Pусский',
     imEngine: 'latin',
     alt: {
-      // incomplete
+      е: 'ё',
+      ь: 'ъ'
     },
     width: 11,
     keys: [


### PR DESCRIPTION
Fix for [Bug 908343] The letter yer is missed in Russian keyboard and [Bug 908350] Not possible to enter letter Yo on Russian keyboard
