### PR TITLE
ug 896934 - [Settings] Listen new system message for Bluetooth pairing requests in connectivity.js

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -344,11 +344,8 @@ navigator.mozL10n.ready(function bluetoothSettings() {
     // when DefaultAdapter is ready.
     function initial() {
       // Bind message handler for incoming pairing requests
-      navigator.mozSetMessageHandler('bluetooth-pairing-request',
-        function bt_gotPairingRequestMessage(message) {
-          onRequestPairing(message);
-        }
-      );
+      window.removeEventListener('bluetooth-pairing-request', onRequestPairing);
+      window.addEventListener('bluetooth-pairing-request', onRequestPairing);
 
       navigator.mozSetMessageHandler('bluetooth-cancel',
         function bt_gotCancelMessage(message) {
@@ -686,6 +683,7 @@ navigator.mozL10n.ready(function bluetoothSettings() {
     }
 
     function onRequestPairing(evt) {
+      var evt = evt.detail;
       var showPairView = function bt_showPairView() {
         var device = {
           address: evt.address,

--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -294,29 +294,19 @@ var Connectivity = (function(window, document, undefined) {
 
   function initSystemMessageHandler() {
     // XXX this is not a good way to interact with bluetooth.js
-    var handlePairingRequest = function(message, method) {
+    var handlePairingRequest = function(message) {
       Settings.currentPanel = '#bluetooth';
       setTimeout(function() {
-        gDeviceList.onRequestPairing(message, method);
+        dispatchEvent(new CustomEvent('bluetooth-pairing-request', {
+          detail: message
+        }));
       }, 1500);
     };
 
     // Bind message handler for incoming pairing requests
-    navigator.mozSetMessageHandler('bluetooth-requestconfirmation',
-      function bt_gotConfirmationMessage(message) {
-        handlePairingRequest(message, 'confirmation');
-      }
-    );
-
-    navigator.mozSetMessageHandler('bluetooth-requestpincode',
-      function bt_gotPincodeMessage(message) {
-        handlePairingRequest(message, 'pincode');
-      }
-    );
-
-    navigator.mozSetMessageHandler('bluetooth-requestpasskey',
-      function bt_gotPasskeyMessage(message) {
-        handlePairingRequest(message, 'passkey');
+    navigator.mozSetMessageHandler('bluetooth-pairing-request',
+      function bt_gotPairingRequestMessage(message) {
+        handlePairingRequest(message);
       }
     );
   }


### PR DESCRIPTION
This patch replace requestconfirmation/requestpincode/requestpasskey with bluetooth.paring.request and also use eventlistener in bluetooth.js .
