### PR TITLE
Bug 905831 - Use correct default configuration

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -282,7 +282,7 @@ var Browser = {
       } else if (data[mccCode + DEFAULT_MNC]) {
         callback(data[mccCode + DEFAULT_MNC]);
       } else if (data[DEFAULT_MCC + DEFAULT_MNC]) {
-        callback(DEFAULT_MCC + DEFAULT_MNC);
+        callback(data[DEFAULT_MCC + DEFAULT_MNC]);
       } else {
         callback(null);
         console.error('No configuration data found.');


### PR DESCRIPTION
When the user has an unsupported carrier, we use a default search
engine, so we need to pass the callback this configuration. This commits
fixes the issue by passing the callback the search engine configuration
at [DEFAULT_MCC + DEFAULT_MNC] in the 'data' structure, instead of
pasing (DEFAULT_MCC + DEFAULT_MNC) to callback.
