### PR TITLE
Bug 907692 - [Contacts] transforming to vcard should provide a blob

### DIFF
--- a/apps/communications/contacts/test/unit/contact2vcard_test.js
+++ b/apps/communications/contacts/test/unit/contact2vcard_test.js
@@ -93,5 +93,26 @@ suite('mozContact to vCard', function() {
         done();
       });
     });
+
+    test('Convert contact to vcard blob', function(done) {
+      var contact = new MockContactAllFields();
+      ContactToVcardBlob([contact], function(blob) {
+        assert.isNotNull(blob);
+        assert.equal('text/vcard', blob.type);
+        // Fetch the same content as a normal vcard
+        ContactToVcard([contact], function(vcard) {
+          // Size of blob in bytes should be the length of the string
+          assert.equal(vcard.length, blob.size);
+          // Read the content and verify that is what we generate
+          var reader = new FileReader();
+          reader.addEventListener('loadend', function() {
+            var blobContent = reader.result;
+            assert.equal(blobContent, vcard);
+            done();
+          });
+          reader.readAsText(blob);
+        });
+      });
+    });
   });
 });

--- a/shared/js/contact2vcard.js
+++ b/shared/js/contact2vcard.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var ContactToVcard;
+var ContactToVcardBlob;
 
 function ISODateString(d) {
   function pad(n) {
@@ -61,6 +62,17 @@ function ISODateString(d) {
   function joinFields(fields) {
     return fields.filter(function(f) { return !!f; }).join('\n');
   }
+
+  function toBlob(vcard) {
+    return new Blob([vcard], {'type': 'text/vcard'});
+  }
+
+  ContactToVcardBlob = function(contacts, callback) {
+    ContactToVcard(contacts, function onVcard(vcard) {
+      vcard = vcard ? toBlob(vcard) : null;
+      callback(toBlob(vcard));
+    });
+  };
 
   ContactToVcard = function(ctArray, callback) {
     var numContacts = ctArray.length;


### PR DESCRIPTION
During the transformation to vcard, we can choose to receive a blob instead of the string with the vcard content.
