### PR TITLE
Bug 908984 - follow-up to bug 906316: submake launches need to know the ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ app-makefiles:
 	do \
 		for mfile in `find $$d -mindepth 1 -maxdepth 1 -name "Makefile"` ;\
 		do \
-			make -C `dirname $$mfile`; \
+			$(MAKE) -C `dirname $$mfile`; \
 		done; \
 	done;
 
@@ -418,14 +418,14 @@ else
 # 64-bit
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_MAC_SDK_URL)x86_64.sdk.tar.bz2
 endif
-XULRUNNERSDK=./$(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=./$(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/xpcshell
+XULRUNNERSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/run-mozilla.sh)
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/xpcshell)
 
 else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
 # For windows we only have one binary
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_SDK_URL)win32.sdk.zip
 XULRUNNERSDK=
-XPCSHELLSDK=./$(XULRUNNER_DIRECTORY)/bin/xpcshell
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/xpcshell)
 
 else
 # Otherwise, assume linux
@@ -437,9 +437,11 @@ XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_LINUX_SDK_URL)x86_64.sdk.tar.bz2
 else
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_LINUX_SDK_URL)i686.sdk.tar.bz2
 endif
-XULRUNNERSDK=./$(XULRUNNER_DIRECTORY)/bin/run-mozilla.sh
-XPCSHELLSDK=./$(XULRUNNER_DIRECTORY)/bin/xpcshell
+XULRUNNERSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/run-mozilla.sh)
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/xpcshell)
 endif
+# we need these variables in external processes
+export XULRUNNER_DIRECTORY XULRUNNERSDK XPCSHELLSDK
 
 .PHONY: install-xulrunner-sdk
 install-xulrunner-sdk:

--- a/apps/email/Makefile
+++ b/apps/email/Makefile
@@ -1,16 +1,9 @@
-SYS=$(shell uname -s)
-
-ifeq ($(SYS),Darwin)
-XULRUNNERSDK=../../xulrunner-sdk-26/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk-26/bin/XUL.framework/Versions/Current/xpcshell
-else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
-# For windows we only have one binary
-XULRUNNERSDK=
-XPCSHELLSDK=../../xulrunner-sdk-26/bin/xpcshell
-else
-# Otherwise, assume linux
-XULRUNNERSDK=../../xulrunner-sdk-26/bin/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk-26/bin/xpcshell
+# We can't figure out XULRUNNERSDK on our own; it's complex and some builders
+# # may want to override our find logic (ex: TBPL), so let's just leave it up to
+# # the root Makefile.  If you know what you're doing, you can manually define
+# # XULRUNNERSDK and XPCSHELLSDK on the command line.
+ifndef XULRUNNERSDK
+$(error This Makefile needs to be run by the root gaia makefile. Use APP=email)
 endif
 
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))


### PR DESCRIPTION
...new directory too

In this patch, we export the new XULRUNNER_DIRECTORY variable along with the
existing various xulrunner program paths. These paths have been made absolute
using make's `abspath` operation.

The patch also removes the ./ prefixes to those paths as they're likely useless
and prevent from using an absolute path when defining XULRUNNER_DIRECTORY from
the command line.
