### PR TITLE
Bug 909017 - Fix test-coverage incompatible unit test

### DIFF
--- a/apps/homescreen/js/dragdrop.js
+++ b/apps/homescreen/js/dragdrop.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-const DragDropManager = (function() {
+var DragDropManager = (function() {
 
   /*
    * It defines the time (in ms) while checking limits is disabled

--- a/apps/homescreen/js/page.js
+++ b/apps/homescreen/js/page.js
@@ -1042,7 +1042,7 @@ dockProto.placeIcon = function pg_placeIcon(node, from, to, transition) {
     node.style.MozTransition = transition;
 };
 
-const TextOverflowDetective = (function() {
+var TextOverflowDetective = (function() {
 
   var iconFakeWrapperWidth;
   var iconFakeLabel;


### PR DESCRIPTION
Because blanket will execute script again in mocha unit testing that cause constant variable redefined twice and fail.
