### PR TITLE
Bug 909017 - Fix test-coverage incompatible unit test

### DIFF
--- a/apps/calendar/js/calendar.js
+++ b/apps/calendar/js/calendar.js
@@ -6,7 +6,7 @@
 
   var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-  window.Calendar = {
+  window.Calendar || window.Calendar = {
 
     ERROR: 'error',
     DEBUG: false,


### PR DESCRIPTION
Because blanket will execute script again in mocha unit testing that cause global variable redefined twice and fail.
