### PR TITLE
Bug 909017 - Fix test-coverage incompatible unit test

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -11,7 +11,7 @@
 // deepest interactive HTML element on the hierarchy or, if none, simply the
 // deepest element. This element must contain dataset-keycode and related
 // attributes.
-const IMERender = (function() {
+var IMERender = (function() {
 
   var ime, menu;
   var getUpperCaseValue, isSpecialKey;


### PR DESCRIPTION
Because blanket will execute script again in mocha unit testing that cause constant variable redefined twice and fail.
