### PR TITLE
Bug 895726 - Ensure valid filename when triggering Gallery view activity

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -35,6 +35,7 @@
     <script defer src="shared/js/notification_helper.js"></script>
     <script defer src="shared/js/gesture_detector.js"></script>
     <script defer src="shared/js/settings_url.js"></script>
+    <script defer src="shared/js/mime_mapper.js"></script>
     -->
     <script defer src="shared/js/lazy_loader.js"></script>
     <script defer src="js/startup.js"></script>

--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -218,7 +218,8 @@
         name: 'open',
         data: {
           type: this.blob.type,
-          filename: this.name,
+          filename:
+            MimeMapper.ensureFilenameMatchesType(this.name, this.blob.type),
           blob: this.blob,
           allowSave: options && options.allowSave
         }

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -9,6 +9,7 @@ var lazyLoadFiles = [
   'shared/js/notification_helper.js',
   'shared/js/gesture_detector.js',
   'shared/js/settings_url.js',
+  'shared/js/mime_mapper.js',
   'js/dialog.js',
   'js/blacklist.js',
   'js/contacts.js',

--- a/shared/js/mime_mapper.js
+++ b/shared/js/mime_mapper.js
@@ -89,5 +89,20 @@ var MimeMapper = {
 
   guessTypeFromExtension: function(extension) {
     return this._extensionToTypeMap[extension];
+  },
+
+  isFilenameMatchesType: function(filename, mimetype) {
+    var array = filename.split('.');
+    var extension = array[array.length - 1];
+    var guessedType = this.guessTypeFromExtension(extension);
+    return (guessedType == mimetype);
+  },
+
+  ensureFilenameMatchesType: function(filename, mimetype) {
+    if (!this.isFilenameMatchesType(filename, mimetype)) {
+      var guessedExt = this.guessExtensionFromType(mimetype);
+      filename += '.' + guessedExt;
+    }
+    return filename;
   }
 };


### PR DESCRIPTION
Gallery will be in charge of maybe saving the file that we are passing.
If we pass it a file that has no extension, trying to save inside the
'pictures' DeviceStorage will fail because of the missing extension. So
we check if the filename has one and if it does not, we force one by
guessing from mime type.
