### PR TITLE
Bug 908124 - An error message is shown after successfully open a received photo and click 'home' key.

### DIFF
--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -442,11 +442,18 @@ var BluetoothTransfer = {
       a.onerror = function(e) {
         var msg = 'open activity error:' + a.error.name;
         self.debug(msg);
-        // Cannot identify MIMETYPE
-        // So, show cannot open file dialog with unknow media type
-        UtilityTray.hide();
-        if (a.error.name === 'NO_PROVIDER')
+        switch (a.error.name) {
+        case 'NO_PROVIDER':
+          UtilityTray.hide();
+          // Cannot identify MIMETYPE
+          // So, show cannot open file dialog with unknow media type
           self.showUnknownMediaPrompt(fileName);
+          return;
+        case 'ActivityCanceled':
+        case 'USER_ABORT':
+        default:
+          return;
+        }
       };
       a.onsuccess = function(e) {
         var msg = 'open activity onsuccess';


### PR DESCRIPTION
- Handle "NO_PROVIDER" and "ActivityCanceled" event correctly.
