### PR TITLE
Bug 906748 - [Messages] We don't see the cursor when we remove a "number" recipient

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -803,7 +803,7 @@
 
       case 'keyup':
 
-        // Last character is a semi-colorn treat as an
+        // Last character is a semi-colon, treat as an
         // "accept" of this recipient.
         if (typed && typed[length - 1] === ';') {
           isAcceptedRecipient = true;
@@ -826,6 +826,10 @@
           });
         }
 
+        if (!typed && keyCode === event.DOM_VK_BACK_SPACE) {
+          isPreventingDefault = true;
+          isDeletingRecipient = true;
+        }
 
 
         break;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=906748
- If nothing "typed" on keyup, assume isDeletingRecipient
- Updates unrelated test in thread_ui

Signed-off-by: Rick Waldron waldron.rick@gmail.com
