### PR TITLE
Bug 905944 - [Bluetooth] Connection would hang after sent a file to a FXOS phone without sd card

### DIFF
--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -1,5 +1,8 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* API Summary:
+   stopSendingFile(in DOMString aDeviceAddress);
+   confirmReceivingFile(in DOMString aDeviceAddress, in bool aConfirmation); */
 'use strict';
 
 var BluetoothTransfer = {
@@ -130,6 +133,10 @@ var BluetoothTransfer = {
                                     });
           });
         } else {
+          var adapter = Bluetooth.getAdapter();
+          if (adapter != null)
+            adapter.confirmReceivingFile(address, false);
+
           self.showStorageUnavaliablePrompt(errorMessage);
         }
     });
@@ -305,6 +312,14 @@ var BluetoothTransfer = {
     var address = evt.address;
     var id = 'div[data-id="' + address + '"]';
     var finishedTask = this.transferStatusList.querySelector(id);
+    // If we decline receiving file, Bluetooth won't callback
+    // 'bluetooth-opp-transfer-start', 'bluetooth-opp-update-progress' event.
+    // So that there is no progress element which was created on notification.
+    // There is only 'bluetooth-opp-transfer-complete' event to notify Gaia the
+    // transferring request in failed case.
+    if (finishedTask == null)
+      return;
+
     finishedTask.removeEventListener('click',
                                      this.onCancelTransferTask.bind(this));
     this.transferStatusList.removeChild(finishedTask);


### PR DESCRIPTION
- Tell gecko Bluetooth to decline the receiving file request.
- Do an early return if there is no transferring progress on notification.
