### PR TITLE
Bug 909686 - Allow desktop helper extensions to send chromeEvents

### DIFF
--- a/tools/extensions/browser-helper@gaiamobile.org/bootstrap.js
+++ b/tools/extensions/browser-helper@gaiamobile.org/bootstrap.js
@@ -62,6 +62,10 @@ function startup(data, reason) {
       ResponsiveUIManager.once('on', function(event, tab, responsive) {
         let document = tab.ownerDocument;
 
+        browserWindow.shell = {
+          sendChromeEvent: sendChromeEvent
+        };
+
         // Ensure tweaking only the first responsive mode opened
         responsive.stack.classList.add('os-mode');
 


### PR DESCRIPTION
Fix for [#909686](https://bugzilla.mozilla.org/show_bug.cgi?id=909686).
