### PR TITLE
Bug 906598 - Move Keyboard settings into app itself

### DIFF
--- a/apps/keyboard/js/settings/settings.js
+++ b/apps/keyboard/js/settings/settings.js
@@ -1,0 +1,49 @@
+(function() {
+  // Get the settings, and then show the panel afterwards
+  var panel = document.querySelector('#general-settings');
+  getSettings(panel, function() {
+    panel.style.display = 'block';
+  });
+
+  /**
+   * Gets the settings based on information from the dom
+   */
+  function getSettings(section, callback) {
+    if (!navigator.mozSettings) {
+      return callback();
+    }
+
+    var li = section.querySelectorAll('li[data-setting]');
+    var lock = navigator.mozSettings.createLock();
+    var toCompletion = li.length;
+
+    [].forEach.call(li, function(item) {
+      var key = item.dataset.setting;
+      var cb = item.querySelector('input[type=checkbox]');
+
+      var getReq = lock.get(key);
+      getReq.onsuccess = function() {
+        if (getReq.result[key] !== undefined) {
+          cb.checked = getReq.result[key];
+        }
+        if (--toCompletion === 0) {
+          callback();
+        }
+      };
+      getReq.onerror = function() {
+        // onerror the checked value is the default value
+        if (--toCompletion === 0) {
+          callback();
+        }
+      };
+
+      // Toggling checkbox updates the setting
+      cb.addEventListener('change', function(e) {
+        var setLock = navigator.mozSettings.createLock();
+        var obj = {};
+        obj[key] = cb.checked;
+        setLock.set(obj);
+      });
+    });
+  }
+})();

--- a/apps/keyboard/locales/keyboard.en-US.properties
+++ b/apps/keyboard/locales/keyboard.en-US.properties
@@ -1,1 +1,7 @@
 ok=OK
+keyboardSettings=Keyboard settings
+
+vibration=Vibration
+clickSound=Click sound
+autoCorrect=Auto correction
+wordSuggestion=Word suggestion

--- a/apps/keyboard/settings.html
+++ b/apps/keyboard/settings.html
@@ -3,8 +3,65 @@
 <head>
   <meta charset="utf-8">
   <title>Keyboard Settings</title>
+  <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>
+  <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>
+  <link rel="stylesheet" type="text/css" href="shared/style_unstable/lists.css"/>
+  <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>
+  <link rel="stylesheet" type="text/css" href="style/settings.css"/>
+  <link rel="resource" type="application/l10n" href="locales/locales.ini"/>
+  <script defer src="shared/js/l10n.js"></script>
+  <script defer src="js/settings/settings.js"></script>
 </head>
-<body>
-    <h1>Built-in Keyboard Settings</h1>
+<body class="skin-organic">
+  <section role="region">
+    <header>
+      <h1 data-l10n-id="keyboardSettings">Keyboard settings</h1>
+    </header>
+    <div>
+      <section data-type="list" id="general-settings">
+        <ul>
+          <li data-setting="keyboard.vibration">
+            <aside class="pack-end">
+              <label class="pack-checkbox">
+                <input type="checkbox" id="cb-vibration">
+                <span></span>
+              </label>
+            </aside>
+            <p><label data-l10n-id="vibration" for="cb-vibration">Vibration</label></p>
+          </li>
+
+          <li data-setting="keyboard.clicksound">
+            <aside class="pack-end">
+              <label class="pack-checkbox">
+                <input type="checkbox" id="cb-clickSound">
+                <span></span>
+              </label>
+            </aside>
+            <p><label data-l10n-id="clickSound" for="cb-clickSound">Click sound</label></p>
+          </li>
+
+          <li data-setting="keyboard.autocorrect">
+            <aside class="pack-end">
+              <label class="pack-checkbox">
+                <input type="checkbox" checked id="cb-autoCorrect">
+                <span></span>
+              </label>
+            </aside>
+            <p><label data-l10n-id="autoCorrect" for="cb-autoCorrect">Auto correction</label></p>
+          </li>
+
+          <li data-setting="keyboard.wordsuggestion">
+            <aside class="pack-end">
+              <label class="pack-checkbox">
+                <input type="checkbox" checked id="cb-wordSuggestion">
+                <span></span>
+              </label>
+            </aside>
+            <p><label data-l10n-id="wordSuggestion" for="cb-wordSuggestion">Word suggestion</label></p>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </section>
 </body>
 </html>

--- a/apps/keyboard/style/settings.css
+++ b/apps/keyboard/style/settings.css
@@ -1,0 +1,36 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  font-size: 10px;
+  overflow: hidden;
+  background: white;
+}
+
+/**
+ * Headers should not scroll with the rest of the page, except for #root.
+ */
+section[role="region"] > header {
+  position: absolute;
+}
+
+section[role="region"] > div {
+  position: absolute;
+  top: 5rem;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: calc(100% - 5rem);
+  overflow-y: scroll;
+}
+
+aside.pack-end > label {
+  margin-top: 0.5rem;
+}
+
+section[data-type="list"] p>label {
+  width: 100%;
+  display: inline-block;
+}

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -345,38 +345,8 @@ numberKeyboardLayouts=Number layouts
 optionKeyboardLayouts=Option layouts
 activeKeyboard=Active keyboard
 keypad=Keypad
-vibration=Vibration
-clickSound=Click sound
-autoCorrect=Auto correction
-wordSuggestion=Word suggestion
 selectKeyboard=Select keyboard
 addMoreKeyboards=Add more keyboards
-english=English
-dvorak=English (Dvorak)
-spanish=Spanish
-portuguese=Portuguese Brazilian
-catalan=Catalan
-czech=Czech
-french=French
-german=German
-hungarian=Hungarian
-norwegian=Norwegian
-slovak=Slovak
-turkish=Turkish
-romanian=Romanian
-russian=Russian
-arabic=Arabic
-greek=Greek
-hebrew=Hebrew
-jp-kanji=Japanese
-jp-kanji-desc=Kanji
-traditionalChinese=Traditional Chinese
-traditionalChinese-desc=Zhuyin
-simplifiedChinese=Simplified Chinese
-simplifiedChinese-desc=Pinyin
-polish=Polish
-serbian=Serbian
-
 
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
 # Accounts (N/A)


### PR DESCRIPTION
This brings back the settings screen, but now as a child of the keyboard application itself. I think we should not rely on global settings for this in the future but rather go to asyncStorage but that'll breaking customization scripts, FTU, language settings, at the moment.

I've moved the en-US localization strings out of settings and into this app. Guess that's enough?

This PR includes RudyLu/3rdParty_keyboard_support_commit2, and two patches of mine to allow it to work in FF (yay, easier development). 
1. Land RudyLu/3rdParty_keyboard_support_commit2
2. Land this
