### PR TITLE
Bug 831446 - remove delete button from secure lockscreen camera, r=djf

### DIFF
--- a/apps/camera/js/filmstrip.js
+++ b/apps/camera/js/filmstrip.js
@@ -51,8 +51,12 @@ var Filmstrip = (function() {
   setOrientation(Camera._phoneOrientation);
 
   // In secure mode, we never want the user to see the share button.
-  if (Camera._secureMode)
+  // We also remove the delete button because we currently can't
+  // display confirmation dialogs in the system app.
+  if (Camera._secureMode) {
     shareButton.parentNode.removeChild(shareButton);
+    deleteButton.parentNode.removeChild(deleteButton);
+  }
 
   function isShown() {
     return !filmstrip.classList.contains('hidden');
@@ -138,6 +142,11 @@ var Filmstrip = (function() {
    }
 
   function deleteCurrentItem() {
+    // The button should be gone, but hard exit from this function
+    // just in case.
+    if (Camera._secureMode)
+      return;
+
     var item = items[currentItemIndex];
     var msg, storage, filename;
 
@@ -152,10 +161,7 @@ var Filmstrip = (function() {
       filename = item.filename;
     }
 
-    // The system app is not allowed to use confirm, I think
-    // so if we're running in secure mode, just delete the file without
-    // confirmation
-    if (Camera._secureMode || confirm(msg)) {
+    if (confirm(msg)) {
       // Remove the item from the array of items
       items.splice(currentItemIndex, 1);
 


### PR DESCRIPTION
Carrying r+ from preview PR https://github.com/mozilla-b2g/gaia/pull/11787
