### PR TITLE
Bug 910068 - manual config of email uses autocorrect in hostname input box

### DIFF
--- a/apps/email/js/cards/setup_manual_config.html
+++ b/apps/email/js/cards/setup_manual_config.html
@@ -71,8 +71,10 @@
             <button type="reset"></button>
           </p>
           <p>
-            <input class="sup-manual-imap-hostname" type="url"
+            <input class="sup-manual-imap-hostname" type="text"
                    data-l10n-id="setup-manual-hostname"
+                   x-inputmode="verbatim"
+                   inputmode="verbatim"
                    data-maybe-required />
             <button type="reset"></button>
           </p>
@@ -102,8 +104,10 @@
             <button type="reset"></button>
           </p>
           <p>
-            <input class="sup-manual-smtp-hostname" type="url"
+            <input class="sup-manual-smtp-hostname" type="text"
                    data-l10n-id="setup-manual-hostname"
+                   x-inputmode="verbatim"
+                   inputmode="verbatim"
                    data-maybe-required />
             <button type="reset"></button>
           </p>
@@ -131,8 +135,10 @@
         </header>
         <div class="sup-form">
           <p>
-            <input class="sup-manual-activesync-hostname" type="url"
+            <input class="sup-manual-activesync-hostname" type="text"
                    data-l10n-id="setup-manual-hostname"
+                   x-inputmode="verbatim"
+                   inputmode="verbatim"
                    data-maybe-required />
             <button type="reset"></button>
           </p>

--- a/apps/email/js/cards/setup_manual_config.html
+++ b/apps/email/js/cards/setup_manual_config.html
@@ -71,7 +71,7 @@
             <button type="reset"></button>
           </p>
           <p>
-            <input class="sup-manual-imap-hostname" type="text"
+            <input class="sup-manual-imap-hostname" type="url"
                    data-l10n-id="setup-manual-hostname"
                    data-maybe-required />
             <button type="reset"></button>
@@ -102,7 +102,7 @@
             <button type="reset"></button>
           </p>
           <p>
-            <input class="sup-manual-smtp-hostname" type="text"
+            <input class="sup-manual-smtp-hostname" type="url"
                    data-l10n-id="setup-manual-hostname"
                    data-maybe-required />
             <button type="reset"></button>
@@ -131,7 +131,7 @@
         </header>
         <div class="sup-form">
           <p>
-            <input class="sup-manual-activesync-hostname" type="text"
+            <input class="sup-manual-activesync-hostname" type="url"
                    data-l10n-id="setup-manual-hostname"
                    data-maybe-required />
             <button type="reset"></button>


### PR DESCRIPTION
This changes the hostname input boxes to the correct type so that autocorrect is not used when entering in hostnames.
