### PR TITLE
Bug 909991 - [Helix] Labels in browser settings are so small it's hard to read

### DIFF
--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -9,7 +9,7 @@
     <!-- <link rel="stylesheet" href="shared/style/input_areas.css"> -->
     <!-- <link rel="stylesheet" href="shared/style/status.css"> -->
     <!-- <link rel="stylesheet" href="shared/style/confirm.css"> -->
-
+    <!-- <link rel="stylesheet" href="shared/style/buttons.css"> -->
     <!-- <link rel="stylesheet" href="style/modal_dialog/modal_dialog.css"> -->
     <!-- <link rel="stylesheet" href="style/modal_dialog/prompt.css"> -->
     <!-- <link rel="stylesheet" href="style/themes/default/core.css"> -->


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=909991

add <!-- <link rel="stylesheet" href="shared/style/buttons.css"> --> in index.html
