### PR TITLE
Bug 910210 - Overlay.update() should accept an optional parameter to override internal counter [r=arcturus]

### DIFF
--- a/apps/communications/contacts/js/utilities/overlay.js
+++ b/apps/communications/contacts/js/utilities/overlay.js
@@ -29,10 +29,20 @@ var utils = this.utils || {};
       });
     }
 
-    this.update = function() {
-      progressElement.setAttribute('value', (++counter * 100) / total);
-      showMessage();
-    };
+    /**
+     * Updates progress bar and message. It takes an optional `value` parameter
+     * to overwrite the internal counter with this value.
+     * @param {Number} value Overrides internal counter.
+     */
+    this.update = function(value) {
+      if (value && value <= total && value >= counter) {
+        counter = value;
+        progressElement.setAttribute('value', (counter * 100) / total);
+      } else {
+        progressElement.setAttribute('value', (++counter * 100) / total);
+      }
+       showMessage();
+     };
 
     this.setTotal = function(ptotal) {
       total = ptotal;


### PR DESCRIPTION
When testing streaming import for massive vcard files, it is convenient to update the progress var in a set interval, to avoid updating it (and touching DOM) hundreds of times per second. It would be good to have an optional parameter to `update` in order to set the progress value, instead of calling the method every time the `counter` value is incremented by one.
