### PR TITLE
Bug 906316 - Don't download the xulrunner SDK each time we change a bran...

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,17 @@
+apps/homescreen/everything.me/**
+apps/pdfjs/content/**
+apps/pdfjs/test/**
+apps/email/build/**
+apps/email/built/**
+apps/email/js/ext/**
+apps/calendar/js/ext/**
+build/r.js
+apps/communications/contacts/oauth2/js/parameters.js
+apps/calendar/js/presets.js
+apps/email/js/alameda.js
+apps/email/js/tmpl_builder.js
+shared/js/opensearch.js
+apps/keyboard/js/imes/jspinyin/libpinyin.js
+shared/js/setImmediate.js
+apps/gallery/test/unit/setImmediate_test.js
+

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,43 @@
+{
+  "camelcase": false,
+  "curly": true,
+  "forin": false,
+  "immed": true,
+  "latedef": "nofunc",
+  "newcap": true,
+  "noarg": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": "vars",
+  "strict": true,
+  "trailing": true,
+  "maxlen": 80,
+
+  "eqnull": true,
+  "esnext": true,
+  "expr": true,
+  "globalstrict": true,
+
+  "maxerr": 1000,
+  "regexdash": true,
+  "laxcomma": true,
+  "proto": true,
+
+  "browser": true,
+  "devel": true,
+  "nonstandard": true,
+  "worker": true,
+  "predef": [
+    "suite",
+    "test",
+    "setup",
+    "teardown",
+    "suiteSetup",
+    "suiteTeardown",
+    "assert",
+    "require",
+    "requireApp",
+    "sinon"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,24 @@
 # JSHINTRC=<path> will use this config file when running jshint               #
 #                                                                             #
 ###############################################################################
+#                                                                             #
+# XULrunner download and location configuration                               #
+#                                                                             #
+# USE_LOCAL_XULRUNNER_SDK  : if you have a local XULrunner installation and   #
+#                            wants to use it                                  #
+#                                                                             #
+# XULRUNNER_DIRECTORY      : if you use USE_LOCAL_XULRUNNER_SDK, this is      #
+#                            where your local XULrunner installation is       #
+#                                                                             #
+# XULRUNNER_BASE_DIRECTORY : if you don't use USE_LOCAL_XULRUNNER_SDK, this   #
+#                            is where you want the automatic XULrunner        #
+#                            download to uncompress.                          #
+#                                                                             #
+# Submakes will get XULRUNNER_DIRECTORY, XULRUNNERSDK and XPCSHELLSDK as      #
+# absolute paths.                                                             #
+#                                                                             #
+###############################################################################
+
 -include local.mk
 
 # .b2g.mk recorded the make flags from Android.mk
@@ -75,6 +93,9 @@ PROFILE_FOLDER?=profile-debug
 endif
 
 PROFILE_FOLDER?=profile
+
+STAGE_FOLDER?=build_stage
+export STAGE_FOLDER
 
 LOCAL_DOMAINS?=1
 
@@ -382,13 +403,14 @@ ifneq ($(DEBUG),1)
 endif
 endif
 
+.PHONY: app-makefiles
 app-makefiles:
 	@for d in ${GAIA_APPDIRS}; \
 	do \
 		if [[ ("$$d" =~ "${BUILD_APP_NAME}") || (${BUILD_APP_NAME} == "*") ]]; then \
 			for mfile in `find $$d -mindepth 1 -maxdepth 1 -name "Makefile"` ;\
 			do \
-				make -C `dirname $$mfile`; \
+				make -C `dirname $$mfile` || exit 1 ;\
 			done; \
 		fi; \
 	done;
@@ -477,7 +499,12 @@ reference-workload-x-heavy:
 
 # The install-xulrunner target arranges to get xulrunner downloaded and sets up
 # some commands for invoking it. But it is platform dependent
+# IMPORTANT: you should generally change the directory name when you change the
+# URL unless you know what you're doing
 XULRUNNER_SDK_URL=http://ftp.mozilla.org/pub/mozilla.org/xulrunner/nightly/2013/08/2013-08-07-03-02-16-mozilla-central/xulrunner-26.0a1.en-US.
+XULRUNNER_BASE_DIRECTORY?=xulrunner-sdk-26
+XULRUNNER_DIRECTORY?=$(XULRUNNER_BASE_DIRECTORY)/xulrunner-sdk
+XULRUNNER_URL_FILE=$(XULRUNNER_BASE_DIRECTORY)/.url
 
 ifeq ($(SYS),Darwin)
 # For mac we have the xulrunner-sdk so check for this directory
@@ -490,14 +517,14 @@ else
 # 64-bit
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_MAC_SDK_URL)x86_64.sdk.tar.bz2
 endif
-XULRUNNERSDK=./xulrunner-sdk/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=./xulrunner-sdk/bin/XUL.framework/Versions/Current/xpcshell
+XULRUNNERSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/run-mozilla.sh)
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/xpcshell)
 
 else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
 # For windows we only have one binary
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_SDK_URL)win32.sdk.zip
 XULRUNNERSDK=
-XPCSHELLSDK=./xulrunner-sdk/bin/xpcshell
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/xpcshell)
 
 else
 # Otherwise, assume linux
@@ -509,23 +536,37 @@ XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_LINUX_SDK_URL)x86_64.sdk.tar.bz2
 else
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_LINUX_SDK_URL)i686.sdk.tar.bz2
 endif
-XULRUNNERSDK=./xulrunner-sdk/bin/run-mozilla.sh
-XPCSHELLSDK=./xulrunner-sdk/bin/xpcshell
+XULRUNNERSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/run-mozilla.sh)
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/xpcshell)
 endif
+
+# It's difficult to figure out XULRUNNERSDK in subprocesses; it's complex and
+# some builders may want to override our find logic (ex: TBPL).
+# So let's export these variables to external processes.
+export XULRUNNER_DIRECTORY XULRUNNERSDK XPCSHELLSDK
 
 .PHONY: install-xulrunner-sdk
 install-xulrunner-sdk:
+	@echo "XULrunner directory: $(XULRUNNER_DIRECTORY)"
 ifndef USE_LOCAL_XULRUNNER_SDK
-ifneq ($(XULRUNNER_SDK_DOWNLOAD),$(shell cat .xulrunner-url 2> /dev/null))
-	rm -rf xulrunner-sdk
+ifneq ($(XULRUNNER_SDK_DOWNLOAD),$(shell test -d $(XULRUNNER_DIRECTORY) && cat $(XULRUNNER_URL_FILE) 2> /dev/null))
+# must download the xulrunner sdk
+	rm -rf $(XULRUNNER_BASE_DIRECTORY)
+	@echo "Downloading XULRunner..."
 	$(DOWNLOAD_CMD) $(XULRUNNER_SDK_DOWNLOAD)
 ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
-	unzip xulrunner*.zip && rm xulrunner*.zip
+	mkdir "$(XULRUNNER_BASE_DIRECTORY)"
+	@echo "Unzipping XULRunner..."
+	unzip -q xulrunner*.zip -d "$(XULRUNNER_BASE_DIRECTORY)" && rm -f xulrunner*.zip
 else
-	tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2
-endif
-	@echo $(XULRUNNER_SDK_DOWNLOAD) > .xulrunner-url
-endif
+	mkdir $(XULRUNNER_BASE_DIRECTORY)
+	tar xjf xulrunner*.tar.bz2 -C $(XULRUNNER_BASE_DIRECTORY) && rm -f xulrunner*.tar.bz2 || \
+		( echo; \
+		echo "We failed extracting the XULRunner SDK archive which may be corrupted."; \
+		echo "You should run 'make really-clean' and try again." ; false )
+endif # MINGW32
+	@echo $(XULRUNNER_SDK_DOWNLOAD) > $(XULRUNNER_URL_FILE)
+endif # XULRUNNER_SDK_DOWNLOAD
 endif # USE_LOCAL_XULRUNNER_SDK
 
 define run-js-command
@@ -948,11 +989,11 @@ endif
 
 # clean out build products
 clean:
-	rm -rf profile profile-debug profile-test $(PROFILE_FOLDER)
+	rm -rf profile profile-debug profile-test $(PROFILE_FOLDER) $(STAGE_FOLDER)
 
 # clean out build products and tools
 really-clean: clean
-	rm -rf xulrunner-sdk .xulrunner-url node_modules
+	rm -rf xulrunner-* .xulrunner-* node_modules
 
 .git/hooks/pre-commit: tools/pre-commit
 	test -d .git && cp tools/pre-commit .git/hooks/pre-commit || true

--- a/apps/email/Makefile
+++ b/apps/email/Makefile
@@ -1,16 +1,9 @@
-SYS=$(shell uname -s)
-
-ifeq ($(SYS),Darwin)
-XULRUNNERSDK=../../xulrunner-sdk/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk/bin/XUL.framework/Versions/Current/xpcshell
-else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
-# For windows we only have one binary
-XULRUNNERSDK=
-XPCSHELLSDK=../../xulrunner-sdk/bin/xpcshell
-else
-# Otherwise, assume linux
-XULRUNNERSDK=../../xulrunner-sdk/bin/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk/bin/xpcshell
+# We can't figure out XULRUNNERSDK on our own; it's complex and some builders
+# # may want to override our find logic (ex: TBPL), so let's just leave it up to
+# # the root Makefile.  If you know what you're doing, you can manually define
+# # XULRUNNERSDK and XPCSHELLSDK on the command line.
+ifndef XPCSHELLSDK
+$(error This Makefile needs to be run by the root gaia makefile. Use `make APP=email` from the root gaia directory.)
 endif
 
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))

--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -22,10 +22,18 @@ if [ ! -d $DIR/../profile-test ]; then
   PROFILE_FOLDER=profile-test make -C $DIR/../
 fi
 
-# find the xulrunner
-XULRUNNER=`cd $DIR/../xulrunner-sdk* && pwd`
+if [ -z "$XULRUNNER_DIRECTORY" ] ; then
+  # the xulrunner directory isn't in the environment
+  XULRUNNER_DIRECTORY=`ls -d "$DIR/../xulrunner-sdk"* | sort -nr | head -n1 2> /dev/null`
+fi
+
+if [ -z "$XULRUNNER_DIRECTORY" ] ; then
+  echo "Couldn't find XULrunner. Please execute this file from 'make' or install XULrunner yourself."
+  exit 1
+fi
+
 # find xpcshell and put it in the path
-XPCSHELL_DIR=$(dirname $(find $XULRUNNER/bin -type f -name "xpcshell" | head -n 1));
+XPCSHELL_DIR=$(dirname $(find "$XULRUNNER_DIRECTORY" -type f -name "xpcshell" | head -n 1));
 
 # wrap marionette-mocha with gaia's defaults. We also need to alter the paths to
 # xpcshell in available for email fake servers.

--- a/build/lint-excluded-dirs.list
+++ b/build/lint-excluded-dirs.list
@@ -1,1 +1,0 @@
-homescreen/everything.me,pdfjs/content,pdfjs/test,email/build,email/built,email/js/ext,calendar/js/ext,tools/,b2g/

--- a/build/lint-excluded-files.list
+++ b/build/lint-excluded-files.list
@@ -1,1 +1,0 @@
-build/r.js,apps/communications/contacts/oauth2/js/parameters.js,apps/calendar/js/presets.js,apps/email/js/alameda.js,apps/email/js/tmpl_builder.js,shared/js/opensearch.js,apps/keyboard/js/imes/jspinyin/libpinyin.js,shared/js/setImmediate.js,apps/gallery/test/unit/setImmediate_test.js

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "debug": "*",
     "empty-port": "~0.0.1",
+    "jshint": "2.1.10",
     "mail-fakeservers": "~0.0.3",
     "marionette-apps": "0.3.0",
     "marionette-client": "0.15.5",

--- a/tests/js/bin/runner
+++ b/tests/js/bin/runner
@@ -8,10 +8,11 @@ XPCSHELL=`which xpcshell`
 
 if [ ! -x "$XPCSHELL" ]
 then
-  PATH=$GAIA_DIR/xulrunner-sdk/bin/:$PATH;
+  PATH=$XULRUNNER_DIRECTORY/bin/:$PATH;
   if [ -n "${VERBOSE}" ]
   then
-    echo "xpcshell is not found adding xulrunner-sdk using $GAIA_DIR/xulrunner-sdk/bin/xpcshell."
+    echo "xpcshell is not found in the PATH"
+    echo "Using $XULRUNNER_DIRECTORY/bin/xpcshell."
   fi
 fi
 

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -2,13 +2,13 @@
 
 LINTED_DIRECTORIES="apps shared"
 
-excluded_dirs_list="./build/lint-excluded-dirs.list"
-if [ ! -f $excluded_dirs_list ];
+excluded_list=".jshintignore"
+if [ ! -f $excluded_list ];
 then
   exit 0
 fi
 
-hash gjslint &> /dev/null
+hash gjslint > /dev/null 2>&1
 if [ $? -eq 1 ];
 then
   echo >&2 "You should install gjslint to lint your patch"
@@ -16,13 +16,11 @@ then
   exit 0
 fi
 
-excluded_dirs=`cat $excluded_dirs_list|tr "," " "`
-for dir in $excluded_dirs; do
-  grep_exclude="$grep_exclude -e $dir"
-done
+# LINTED_FILES needs to be space-separated
+diff_with_exclude=`git diff --staged --name-only --diff-filter=ACMRT -- $LINTED_DIRECTORIES | grep '\.js$' | tr '[:space:]' ' '`
+if [ -z "$diff_with_exclude" ] ; then
+  exit 0
+fi
 
-diff_with_exclude=`git diff --staged --name-only --diff-filter=ACMRT -- ${LINTED_DIRECTORIES} | grep -v $grep_exclude`
+LINTED_FILES="$diff_with_exclude" make -s lint
 
-# --disable 210,217,220,225 replaces --nojsdoc because it's broken in closure-linter 2.3.10
-# http://code.google.com/p/closure-linter/issues/detail?id=64
-gjslint --disable 210,217,220,225 -x "`cat ./build/lint-excluded-files.list`" $diff_with_exclude


### PR DESCRIPTION
...ch if their configuration are different r=yurenju,asuth

This also shows a message when the archive file seems to be corrupted, advising
to run "make really-clean". Also changed "make really-clean" to remove all
xulrunner related files.

We now uncompress the archive directly in a specific directory that should
change when we change the URL.

We use a dot file inside the xulrunner SDK directory to keep the URL used to
download that SDK.

Now we can also define XULRUNNER_DIRECTORY from the command-line. If not
defined, it will use the default xulrunner-sdk-26.

We export the new XULRUNNER_DIRECTORY variable along with the
existing various xulrunner program paths. These paths have been made absolute
using make's `abspath` operation.

The patch also removes the ./ prefixes to those paths as they're likely useless
and prevent from using an absolute path when defining XULRUNNER_DIRECTORY from
the command line.

This patch also remove the email's build_stage directory when running "make
clean".

This _will_ make all devs redownload XULRunner, sorry.
