### PR TITLE
Bug 910446: Handle duration changes in Music app

### DIFF
--- a/apps/music/js/Player.js
+++ b/apps/music/js/Player.js
@@ -118,6 +118,7 @@ var PlayerView = {
 
     this.audio.addEventListener('play', this);
     this.audio.addEventListener('pause', this);
+    this.audio.addEventListener('durationchange', this);
     this.audio.addEventListener('timeupdate', this);
     this.audio.addEventListener('ended', this);
 
@@ -650,6 +651,7 @@ var PlayerView = {
         }
         this.isSeeking = false;
         break;
+      case 'durationchange':
       case 'timeupdate':
         if (!this.isSeeking)
           this.updateSeekBar();


### PR DESCRIPTION
With the landing of bug 831224, the duration of MP3 files is
computed while they are playing, and updated accordingly. If
this happens, we distribute a 'durationchange' event to the
related apps.

With this patch, we handle 'durationchange' in the Music app.
All we have to do is to update the displayed duration and ensure
that the end timeout triggers at the end of the track.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
