### PR TITLE
Bug 895726 - [Buri][Monitor][MMS] Unable to save attachement from Camera

### DIFF
--- a/apps/gallery/test/unit/mime_mapper_test.js
+++ b/apps/gallery/test/unit/mime_mapper_test.js
@@ -1,0 +1,110 @@
+'use strict';
+// We might need to modify the build script to run the shared lib
+// right under the shared folder in the future(bug 841422).
+require('/shared/js/mime_mapper.js');
+
+suite('Shared library mime_mapper api tests', function() {
+
+  suite('parse extension test', function() {
+    test('Filename with extension', function() {
+      var ext = MimeMapper._parseExtension('test.jpg');
+      assert.equal(ext, 'jpg');
+    });
+
+    test('Filename without extension', function() {
+      var ext = MimeMapper._parseExtension('test');
+      assert.equal(ext, '');
+    });
+
+    test('Filename is empty string', function() {
+      var ext = MimeMapper._parseExtension('');
+      assert.equal(ext, '');
+    });
+  });
+
+  suite('guess valid type from file properties test', function() {
+    test('Filename/mimetype is matched', function() {
+      var mimetype =
+        MimeMapper.guessTypeFromFileProperties('test.jpg', 'image/jpeg');
+      assert.equal(mimetype, 'image/jpeg');
+    });
+
+    test('Filename without extension but mimetype supported', function() {
+      var mimetype =
+        MimeMapper.guessTypeFromFileProperties('test', 'image/jpeg');
+      assert.equal(mimetype, 'image/jpeg');
+    });
+
+    test('Extension unsupported but mimetype supported', function() {
+      var mimetype =
+        MimeMapper.guessTypeFromFileProperties('test.txt', 'image/jpeg');
+      assert.equal(mimetype, 'image/jpeg');
+    });
+
+    test('Filename with valid extension but mimetype unsupported', function() {
+      var mimetype =
+        MimeMapper.guessTypeFromFileProperties('test.jpg',
+          'application/download');
+      assert.equal(mimetype, 'image/jpeg');
+    });
+
+    test('Filename and mimetype are both unsupported', function() {
+      var mimetype =
+        MimeMapper.guessTypeFromFileProperties('test',
+          'application/download');
+      assert.equal(mimetype, '');
+    });
+  });
+
+  suite('Check is filename matches type test', function() {
+    test('Extension/mimetype matches', function() {
+      var match = MimeMapper.isFilenameMatchesType('test.jpg', 'image/jpeg');
+      assert.isTrue(match);
+    });
+
+    test('Extension/mimetype does not match', function() {
+      var match = MimeMapper.isFilenameMatchesType('test.txt', 'image/jpeg');
+      assert.isFalse(match);
+    });
+
+    test('Filename without extension', function() {
+      var match = MimeMapper.isFilenameMatchesType('test', 'image/jpeg');
+      assert.isFalse(match);
+    });
+  });
+
+  suite('Ensure filename matches type test', function() {
+    test('Filename/mimetype is matched', function() {
+      var filename =
+        MimeMapper.ensureFilenameMatchesType('test.jpg', 'image/jpeg');
+      assert.equal(filename, 'test.jpg');
+    });
+
+    test('Filename without extension but mimetype supported', function() {
+      var filename =
+        MimeMapper.ensureFilenameMatchesType('test', 'image/jpeg');
+      assert.equal(filename, 'test.jpg');
+    });
+
+    test('Extension unsupported but mimetype supported', function() {
+      var filename =
+        MimeMapper.ensureFilenameMatchesType('test.txt', 'image/jpeg');
+      assert.equal(filename, 'test.txt.jpg');
+    });
+
+    test('Filename with valid extension but mimetype unsupported', function() {
+      var filename =
+        MimeMapper.ensureFilenameMatchesType('test.jpg',
+          'application/download');
+      assert.equal(filename, 'test.jpg');
+    });
+
+    test('Filename and mimetype are both unsupported', function() {
+      var filename =
+        MimeMapper.ensureFilenameMatchesType('test',
+          'application/download');
+      assert.equal(filename, 'test');
+    });
+  });
+});
+

--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -36,6 +36,7 @@
     <script defer src="shared/js/gesture_detector.js"></script>
     <script defer src="shared/js/settings_url.js"></script>
     <script defer src="shared/js/template.js"></script>
+    <script defer src="shared/js/mime_mapper.js"></script>
     -->
     <script defer src="shared/js/lazy_loader.js"></script>
     <script defer src="js/startup.js"></script>

--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -214,11 +214,18 @@
     },
 
     view: function(options) {
+      // Make sure media is openable and savable even if:
+      //   - Blob mimetype is unsupported but file extension is valid.
+      //   - File extenion is missing or invalid but mimetype is supported.
+
+      var mimetype =
+        MimeMapper.guessTypeFromFileProperties(this.name, this.blob.type);
+      var filename = MimeMapper.ensureFilenameMatchesType(this.name, mimetype);
       var activity = new MozActivity({
         name: 'open',
         data: {
-          type: this.blob.type,
-          filename: this.name,
+          type: mimetype,
+          filename: filename,
           blob: this.blob,
           allowSave: options && options.allowSave
         }

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -10,6 +10,7 @@ var lazyLoadFiles = [
   'shared/js/gesture_detector.js',
   'shared/js/settings_url.js',
   'shared/js/template.js',
+  'shared/js/mime_mapper.js',
   'js/dialog.js',
   'js/blacklist.js',
   'js/contacts.js',

--- a/apps/sms/test/unit/attachment_test.js
+++ b/apps/sms/test/unit/attachment_test.js
@@ -6,10 +6,14 @@ requireApp('sms/js/utils.js');
 requireApp('sms/test/unit/mock_attachment_menu.js');
 requireApp('sms/test/unit/mock_l10n.js');
 requireApp('sms/test/unit/mock_utils.js');
+requireApp('sms/test/unit/mock_moz_activity.js');
+requireApp('sms/test/unit/mock_mime_mapper.js');
 
 var MocksHelperForAttachment = new MocksHelper([
   'AttachmentMenu',
-  'Utils'
+  'Utils',
+  'MozActivity',
+  'MimeMapper'
 ]).init();
 
 suite('attachment_test.js', function() {
@@ -177,6 +181,37 @@ suite('attachment_test.js', function() {
       assertThumbnailPlaceholder(el, 'video');
       assert.isNull(el.querySelector('div.corrupted'));
       done();
+    });
+  });
+
+  suite('view attachment with open activity', function() {
+    setup(function() {
+      this.sinon.spy(MimeMapper, 'guessTypeFromFileProperties');
+      this.sinon.spy(MimeMapper, 'ensureFilenameMatchesType');
+    });
+
+    test('Open normal image attachment', function() {
+      var attachment = new Attachment(testImageBlob, {
+        name: 'IMG_0554.jpg'
+      });
+      var typeSpy = MimeMapper.guessTypeFromFileProperties;
+      var matchSpy = MimeMapper.ensureFilenameMatchesType;
+      attachment.view();
+      assert.ok(typeSpy.calledWith('IMG_0554.jpg', 'image/jpeg'));
+      assert.ok(matchSpy.calledWith('IMG_0554.jpg', typeSpy.returnValues[0]));
+      assert.equal(MockMozActivity.calls.length, 1);
+    });
+
+    test('Filename has no extension', function() {
+      var attachment = new Attachment(testImageBlob, {
+        name: 'IMG_0554'
+      });
+      var typeSpy = MimeMapper.guessTypeFromFileProperties;
+      var matchSpy = MimeMapper.ensureFilenameMatchesType;
+      attachment.view();
+      assert.ok(typeSpy.calledWith('IMG_0554', 'image/jpeg'));
+      assert.ok(matchSpy.calledWith('IMG_0554', typeSpy.returnValues[0]));
+      assert.equal(MockMozActivity.calls.length, 1);
     });
   });
 });

--- a/apps/sms/test/unit/mock_mime_mapper.js
+++ b/apps/sms/test/unit/mock_mime_mapper.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var MockMimeMapper = {
+  guessTypeFromFileProperties: function(filename, mimetype) {
+    return mimetype;
+  },
+
+  ensureFilenameMatchesType: function(filename, mimetype) {
+    return filename;
+  }
+};

--- a/shared/js/mime_mapper.js
+++ b/shared/js/mime_mapper.js
@@ -80,6 +80,10 @@ var MimeMapper = {
     // Text
     'vcf': 'text/vcard'
   },
+  _parseExtension: function(filename) {
+    var array = filename.split('.');
+    return array.length > 1 ? array.pop() : '';
+  },
 
   isSupportedType: function(mimetype) {
     return (mimetype in this._typeToExtensionMap);
@@ -89,11 +93,40 @@ var MimeMapper = {
     return (extension in this._extensionToTypeMap);
   },
 
+  isFilenameMatchesType: function(filename, mimetype) {
+    var extension = this._parseExtension(filename);
+    var guessedType = this.guessTypeFromExtension(extension);
+    return (guessedType == mimetype);
+  },
+
   guessExtensionFromType: function(mimetype) {
     return this._typeToExtensionMap[mimetype];
   },
 
   guessTypeFromExtension: function(extension) {
     return this._extensionToTypeMap[extension];
+  },
+
+  // If mimetype is not in the supported list, we will try to
+  // predict the possible valid mimetype based on extension.
+  guessTypeFromFileProperties: function(filename, mimetype) {
+    var extension = this._parseExtension(filename);
+    var type = this.isSupportedType(mimetype) ?
+      mimetype : this.guessTypeFromExtension(extension);
+    return type || '';
+  },
+
+  // if mimetype is not supported, preserve the original extension
+  // and add the predict result as new extension.
+  // If both filename and mimetype are not supported, return the original
+  // filename.
+  ensureFilenameMatchesType: function(filename, mimetype) {
+    if (!this.isFilenameMatchesType(filename, mimetype)) {
+      var guessedExt = this.guessExtensionFromType(mimetype);
+      if (guessedExt) {
+        filename += '.' + guessedExt;
+      }
+    }
+    return filename;
   }
 };


### PR DESCRIPTION
Continue the work from https://github.com/mozilla-b2g/gaia/pull/11747. This patch is focused on refine the behavior about viewing attachment with open activity:
- Make sure attachment is open-able even blob mimetype is unsupported but file extension is valid.
- Make sure attachment is savable even file extenion is missing or invalid but mimetype is supported.
