### PR TITLE
Bug 900870 - Register to onpairedstatuschanged and remove bluetooth-pairedstatuschanged system message r=evelyn

### DIFF
--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -353,12 +353,10 @@ navigator.mozL10n.ready(function bluetoothSettings() {
         }
       );
 
-      navigator.mozSetMessageHandler('bluetooth-pairedstatuschanged',
-        function bt_getPairedMessage(message) {
-          dispatchEvent(new CustomEvent('bluetooth-pairedstatuschanged'));
-          showDevicePaired(message.paired, 'Authentication Failed');
-        }
-      );
+      defaultAdapter.onpairedstatuschanged = function bt_getPairedMessage(evt) {
+        dispatchEvent(new CustomEvent('bluetooth-pairedstatuschanged'));
+        showDevicePaired(evt.status, 'Authentication Failed');
+      };
 
       defaultAdapter.onhfpstatuschanged = function bt_getConnectedMessage(evt) {
         showDeviceConnected(evt.address, evt.status);

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -38,8 +38,7 @@
     }
   },
   "messages": ["bluetooth-pairing-request",
-               "bluetooth-cancel",
-               "bluetooth-pairedstatuschanged"],
+               "bluetooth-cancel"],
   "locales": {
     "ar": {
       "name": "الضبط",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=900870
