### PR TITLE
[Bug 908513] fix shortcuts translations issue [r=crdlc]

### DIFF
--- a/apps/homescreen/everything.me/modules/Shortcuts/Shortcuts.js
+++ b/apps/homescreen/everything.me/modules/Shortcuts/Shortcuts.js
@@ -14,9 +14,7 @@ Evme.Shortcuts = new function Evme_Shortcuts() {
         
         scroll = new Scroll(Evme.$("#shortcuts-list", el));
         
-        if (navigator.mozSettings) {
-          navigator.mozSettings.addObserver('language.current', onLanguageChange);
-        }
+        window.addEventListener('localized', onLanguageChange);
         
         Evme.EventHandler.trigger(NAME, "init");
     };

--- a/apps/homescreen/everything.me/modules/Tasker/Tasker.js
+++ b/apps/homescreen/everything.me/modules/Tasker/Tasker.js
@@ -20,7 +20,10 @@ Evme.Tasker = new function Evme_Tasker() {
 
     // trigger when language changes. pass "true" to force the trigger
     navigator.mozSettings.addObserver('language.current', function onLanguageChange(e) {
-      self.trigger(true);
+      window.addEventListener('localized', function localized() {
+        window.removeEventListener('localized', localized);
+        self.trigger(true);
+      });
     });
 
     // set the alarm


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=908513
- Make sure to always use the most valid translation OR default to the original one if there's nothing more suitable.
- When sending to the API to update icons, they sometimes come back in a different order, so they're now reordered according to the user's original order.
- Changed "language changed" event to "localized", since sometimes the methods ran before the new translations were ready - which caused the code to use the old translation.
