### PR TITLE
Bug 910997 - Trigger the close event after remove it from layout

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -368,13 +368,6 @@ var NotificationScreen = {
   },
 
   removeNotification: function ns_removeNotification(notificationId) {
-    var event = document.createEvent('CustomEvent');
-    event.initCustomEvent('mozContentEvent', true, true, {
-      type: 'desktop-notification-close',
-      id: notificationId
-    });
-    window.dispatchEvent(event);
-
     var notifSelector = '[data-notification-id="' + notificationId + '"]';
     var notificationNode = this.container.querySelector(notifSelector);
     var lockScreenNotificationNode =
@@ -387,6 +380,13 @@ var NotificationScreen = {
       lockScreenNotificationNode.parentNode
         .removeChild(lockScreenNotificationNode);
     this.updateStatusBarIcon();
+
+    var event = document.createEvent('CustomEvent');
+    event.initCustomEvent('mozContentEvent', true, true, {
+      type: 'desktop-notification-close',
+      id: notificationId
+    });
+    window.dispatchEvent(event);
   },
 
   clearAll: function ns_clearAll() {


### PR DESCRIPTION
This logic hurts the idea of "onclose" event since it should be trigged when the Notification is being closed. But I don't understand why after the first event is trigged, the others don't execute the lines below   |window.dispatchEvent(event);|

Could anyone explain it?
