### PR TITLE
Bug 911709 - [MMS] missing l10n entity

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -198,7 +198,7 @@
         <form id="attachment-options" role="dialog" data-type="action">
           <header></header>
           <menu>
-            <button id="attachment-options-view" data-l10n-id="view-attachment"></button>
+            <button id="attachment-options-view"></button>
             <button id="attachment-options-remove"></button>
             <button id="attachment-options-replace"></button>
             <button id="attachment-options-cancel" data-l10n-id="cancel"></button>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=911709

This button label is filled dynamically according to the attachment type. Setting a `data-l10n-id` attribute makes no sense and generates an l10n warning at build time.
