### PR TITLE
Bug 908949 - Move settings DOM into indivdual files r=kaze

### DIFF
--- a/apps/settings/elements/about.html
+++ b/apps/settings/elements/about.html
@@ -1,0 +1,96 @@
+<element name="about" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="deviceInfo"> Device Information </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <small id="deviceInfo-msisdn"></small>
+          <span data-l10n-id="deviceInfo-MSISDN"> Phone number </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.hardware"></small>
+          <span id="model-name" data-l10n-id="model-name"> Model </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.software"></small>
+          <span id="os-version" data-l10n-id="software"> Software </span>
+        </li>
+        <li>
+          <small id="last-update-date"></small>
+          <span data-l10n-id="last-updated"> Last Updated </span>
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#about-moreInfo"
+              data-l10n-id="more-info"> More Information </button>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="softwareUpdates"> Software Updates </h2>
+      </header>
+      <ul>
+        <li>
+          <p data-l10n-id="check-for-updates">Check for Updates</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select name="app.update.interval">
+              <option value="86400"   data-l10n-id="check-update-daily" selected>Daily</option>
+              <option value="604800"  data-l10n-id="check-update-weekly">Weekly</option>
+              <option value="2592000" data-l10n-id="check-update-monthly">Monthly</option>
+            </select>
+          </p>
+        </li>
+        <li>
+          <label>
+            <button id="check-update-now"
+              data-l10n-id="check-update-now"> Check Now </button>
+          </label>
+        </li>
+        <li id="update-status" class="description update-status">
+          <p class="description general-information"
+              data-l10n-id="checking-for-update">Checking for updates…</p>
+          <p class="description system-update-status"></p>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="aboutBrowserOS"> About Browser OS </h2>
+      </header>
+      <ul>
+        <li class="description" data-l10n-id="browser-os-desc">
+          Browser OS is the free and open source operating system from Mozilla.
+          Our mission is to promote openness, innovation and opportunity by
+          keeping the power of the Web in your hands.
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#about-yourRights"
+              data-l10n-id="your-rights"> Your Rights </button>
+          </label>
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#about-yourPrivacy"
+              data-l10n-id="your-privacy"> Your Privacy </button>
+          </label>
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#about-legal"
+              data-l10n-id="about-legal-info"> Legal Information </button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/about.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_legal.html
+++ b/apps/settings/elements/about_legal.html
@@ -1,0 +1,34 @@
+<element name="about-legal" extends="section">
+  <template>
+
+    <header>
+      <a href="#about">
+        <span class="icon icon-back">back</span>
+      </a>
+      <h1 data-l10n-id="about-legal-info"> Legal Information </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="about-mozilla"> Mozilla </h2>
+      </header>
+      <ul>
+        <li>
+          <a href="#about-licensing" data-l10n-id="open-source-notices">
+            Open Source Notices
+          </a>
+        </li>
+        <li>
+          <a href="#about-source-code" data-l10n-id="obtaining-source-code">
+            Obtaining Source Code
+          </a>
+        </li>
+      </ul>
+
+      <header hidden>
+        <h2 data-l10n-id="about-other"> Other </h2>
+      </header>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_licensing.html
+++ b/apps/settings/elements/about_licensing.html
@@ -1,0 +1,16 @@
+<element name="about-licensing" extends="section">
+  <template>
+
+    <header>
+      <a href="#about-legal">
+        <span class="icon icon-back">back</span>
+      </a>
+      <h1 data-l10n-id="open-source-notices">
+        Open Source Notices
+      </h1>
+    </header>
+
+    <iframe data-src="resources/open_source_license.html" id="os-license"></iframe>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_moreInfo.html
+++ b/apps/settings/elements/about_moreInfo.html
@@ -1,0 +1,82 @@
+<element name="about-moreInfo" extends="section">
+  <template>
+
+    <header>
+      <button type="reset">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <h1 data-l10n-id="more-info"> More Information </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <small data-name="deviceinfo.os"></small>
+          <span data-l10n-id="os-version"> OS Version </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.firmware_revision"></small>
+          <span data-l10n-id="firmware_revision"> Firmware Revision </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.hardware"></small>
+          <span data-l10n-id="hardware_revision"> Hardware Revision </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.mac"></small>
+          <span data-l10n-id="macAddress"> MAC address </span>
+        </li>
+        <li>
+          <small id="deviceInfo-imei"></small>
+          <span data-l10n-id="deviceInfo-IMEI"> IMEI </span>
+        </li>
+        <li>
+          <small id="deviceInfo-iccid"></small>
+          <span data-l10n-id="deviceInfo-ICCID"> ICCID </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.platform_version"></small>
+          <span data-l10n-id="platform_version"> Platform Version </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.platform_build_id"></small>
+          <span data-l10n-id="build-id"> Build Identifier </span>
+        </li>
+        <li>
+          <small data-name="deviceinfo.update_channel"></small>
+          <span data-l10n-id="update-channel"> Update Channel </span>
+        </li>
+        <li>
+          <label>
+            <button id="reset-phone" data-l10n-id="reset-phone">Reset Phone</button>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="gitInfo"> Git commit info </h2>
+      </header>
+      <ul>
+        <li>
+          <small id="gaia-commit-hash"></small>
+          <span id="gaia-commit-date"></span>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="devSettings"> Developer Settings </h2>
+      </header>
+      <ul>
+        <li>
+          <label>
+            <button data-href="#about-moreInfo-developer"
+              data-l10n-id="developer">Developer</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/factory_reset.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_moreInfo_developer.html
+++ b/apps/settings/elements/about_moreInfo_developer.html
@@ -1,0 +1,138 @@
+<element name="about-moreInfo-developer" extends="section">
+  <template>
+
+    <header>
+      <button type="reset">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <h1 data-l10n-id="developer"> Developer </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="debug">Debug</h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.grid.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="grid">Grid</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.fps.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="fps-monitor">Show frames per second</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.paint-flashing.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="paint-flashing">Flash repainted area</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="layers.draw-borders"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="layers-draw-borders">Flash repainted area</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.log-animations.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="log-animations">Log slow animations</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.ttl.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="ttl-monitor">Show time to load</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="devtools.debugger.remote-enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="remote-debugging">Remote Debugging</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="wifi.debugging.enabled" />
+            <span></span>
+          </label>
+          <a data-l10n-id="wifi-debugging">Wi-Fi output in adb</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="bluetooth.debugging.enabled" />
+            <span></span>
+          </label>
+          <a data-l10n-id="bluetooth-debugging">Bluetooth output in adb</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="dom.mozContacts.debugging.enabled" />
+            <span></span>
+          </label>
+          <a data-l10n-id="contacts-debugging">Contacts debugging output in adb</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.console.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="console-enabled">Console enabled</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="software-button.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="software-button-enabled">Software home button enabled</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.gaia.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="debug-gaia-enabled">Gaia debug traces</a>
+        </li>
+        <li>
+          <label>
+            <button id="ftuLauncher" data-l10n-id="launch-ftu">Launch FTU</button>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="keyboardLayouts">Keyboard Layouts</h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="keyboard.layouts.zhuyin"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="traditionalChinese-desc">Zhuyin</small>
+          <a data-l10n-id="traditionalChinese">Traditional Chinese</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="keyboard.layouts.pinyin"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="simplifiedChinese-desc">Pinyin</small>
+          <a data-l10n-id="simplifiedChinese">Simplified Chinese</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_source_code.html
+++ b/apps/settings/elements/about_source_code.html
@@ -1,0 +1,15 @@
+<element name="about-source-code" extends="section">
+  <template>
+
+    <header>
+      <a href="#about-legal">
+        <span class="icon icon-back">back</span>
+      </a>
+      <h1 data-l10n-id="obtaining-source-code">
+        Obtaining Source Code
+      </h1>
+    </header>
+    <iframe src="resources/obtaining_source_code.html" id="obtain-sc"></iframe>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_yourPrivacy.html
+++ b/apps/settings/elements/about_yourPrivacy.html
@@ -1,0 +1,34 @@
+<element name="about-yourPrivacy" extends="section">
+  <template>
+
+    <header>
+      <button type="reset">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <h1 data-l10n-id="your-privacy"> Your Privacy </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2> Mozilla </h2>
+      </header>
+      <ul>
+        <li>
+          <a class="privacy-menuitem privacy-browserOS" href="https://www.mozilla.org/privacy/firefox-os/" data-l10n-id="brandShortName">B2G OS</a>
+        </li>
+        <li>
+          <a class="privacy-menuitem privacy-marketPlace" href="https://marketplace.firefox.com/privacy-policy">Marketplace</a>
+        </li>
+      </ul>
+      <header>
+        <h2 data-l10n-id="about-other"> Other </h2>
+      </header>
+      <ul>
+        <li>
+          <a class="privacy-menuitem privacy-everythingME" href="http://corp.everything.me/privacy">everything.me</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/about_yourRights.html
+++ b/apps/settings/elements/about_yourRights.html
@@ -1,0 +1,42 @@
+<element name="about-yourRights" extends="section">
+  <template>
+
+    <header>
+      <button type="reset">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <h1 data-l10n-id="your-rights"> Your Rights </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li class="description" data-l10n-id="about-your-rights-0">
+          Browser OS is built on free and open source software by a community
+          of thousands from all over the world. There are a few things you
+          should know:
+        </li>
+        <li class="description" data-l10n-id="about-your-rights-1">
+          Browser OS is made available to you under the terms of several open
+          source licenses including the Mozilla Public License. A device
+          running Browser OS may also contain proprietary software from third
+          parties. Any code provided under open licenses give you the right
+          to modify the source code and distribute your modified versions as
+          long as you comply with their terms.
+        </li>
+        <li class="description" data-l10n-id="about-your-rights-2">
+          You are not granted any trademark rights or licenses to the
+          trademarks of the Mozilla Foundation or any party, including
+          without limitation the Browser name or logo.
+        </li>
+        <li class="description" data-l10n-id="about-your-rights-3">
+          Some features in Browser OS, such as the Crash Reporter, give you
+          the option to provide feedback to Mozilla. By choosing to submit
+          feedback, you give Mozilla permission to use the feedback to improve
+          its products, to publish the feedback on its websites, and to
+          distribute the feedback.
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/accessibility.html
+++ b/apps/settings/elements/accessibility.html
@@ -1,0 +1,29 @@
+<element name="accessibility" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="accessibility"> Accessibility </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="accessibility.invert"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="invertColors">Invert Colors</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="accessibility.screenreader"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="screenReader">Screen Reader</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/appPermissions.html
+++ b/apps/settings/elements/appPermissions.html
@@ -1,0 +1,42 @@
+<element name="appPermissions" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="appPermissions">
+        App permissions
+      </h1>
+    </header>
+
+    <div>
+      <ul></ul>
+
+      <ul>
+        <li>
+          <button id="clear-bookmarks-app" class="icon icon-dialog"
+                  style="visibility: hidden"
+                  data-l10n-id="clearBookmarkAppsData">
+            Clear bookmarks data
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <form role="dialog" data-type="confirm" hidden class="cb-alert">
+      <section>
+        <h1 data-l10n-id="confirmClearBookmarkAppsDataTitle">Clear private data from bookmarks</h1>
+        <p>
+          <strong data-l10n-id="confirmClearBookmarkAppsDataDesc">This clear private data from bookmarks that have been added to the home screen. This cannot be undone.</strong>
+        </p>
+      </section>
+      <menu>
+        <button class="cb-alert-cancel" data-l10n-id="cancel">Cancel</button>
+        <button class="cb-alert-clear recommend danger" data-l10n-id="clear">Clear</button>
+      </menu>
+    </form>
+
+    <script type="application/javascript" src="shared/js/manifest_helper.js"></script>
+    <script src="js/apps.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/appPermissions_details.html
+++ b/apps/settings/elements/appPermissions_details.html
@@ -1,0 +1,33 @@
+<element name="appPermissions-details" extends="section">
+  <template>
+
+    <header>
+      <a href="#appPermissions"><span class="icon icon-back">back</span></a>
+      <h1> </h1>
+    </header>
+
+    <div>
+      <header id="developer-header">
+        <h2 data-l10n-id="author">Author</h2>
+      </header>
+      <ul>
+        <li id="developer-infos">
+          <small><a target="_blank" href="http://github.com/mozilla-b2g/gaia/" data-href="http://github.com/mozilla-b2g/gaia/">http://github.com/mozilla-b2g/gaia/</a></small>
+          <a target="_blank" data-href="http://github.com/mozilla-b2g/gaia/"> The Gaia Team </a>
+        </li>
+      </ul>
+
+      <header id="permissionsListHeader">
+        <h2 data-l10n-id="permissions">Permissions</h2>
+      </header>
+      <ul>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="uninstallApp">Uninstall App</h2>
+      </header>
+      <button id="uninstall-app" data-l10n-id="uninstallApp" class="danger">Uninstall App</button>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/applicationStorage.html
+++ b/apps/settings/elements/applicationStorage.html
@@ -1,0 +1,39 @@
+<element name="applicationStorage" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="appStorage"> Application Storage </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <progress id="apps-space-bar" min="0" value="0" max="100"></progress>
+        </li>
+
+        <li>
+          <a data-l10n-id="apps-total-space"> Total Space
+            <span id="apps-total-space"></span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="apps-used-space"> Used
+            <span id="apps-used-space"></span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="apps-free-space"> Left
+            <span id="apps-free-space"></span>
+          </a>
+        </li>
+        <li class="description" data-l10n-id="media-storage-details">
+          Photos, videos, and music are stored in the SD Card.
+          See Media Storage for details.
+        </li>
+      </ul>
+    </div>
+    <script src="js/app_storage.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/battery.html
+++ b/apps/settings/elements/battery.html
@@ -1,0 +1,50 @@
+<element name="battery" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="battery"> Battery </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <a id="battery-level" data-l10n-id="batteryLevel">Current Battery Life
+            <span></span>
+          </a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="powerSaveMode">Power Save Mode</h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="powersave.enabled" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="powerSaveMode">Power Save Mode</a>
+        </li>
+        <li>
+          <p data-l10n-id="turnOnAuto">Turn on automatically</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select name="powersave.threshold">
+              <option value="0.05" data-l10n-id="powerSave-threshold" data-l10n-args='{"level":  "5"}'> 5% battery left</option>
+              <option value="0.15" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "15"}'>15% battery left</option>
+              <option value="0.25" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "25"}'>25% battery left</option>
+              <option value="-1" data-l10n-id="never">Never</option>
+            </select>
+          </p>
+        </li>
+        <li class="description" data-l10n-id="powerSave-explanation">
+          Turning on Power Save Mode turns off the phone’s Data, Bluetooth, and
+          Geolocation connections to extend battery life. You can still turn these
+          services back on manually.
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/bluetooth.html
+++ b/apps/settings/elements/bluetooth.html
@@ -1,0 +1,82 @@
+<element name="bluetooth" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="bluetooth"> Bluetooth </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li id="bluetooth-status" class="hint">
+          <label class="pack-switch">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <a data-l10n-id="bluetooth">Bluetooth</a>
+          <p data-l10n-id="bluetooth-enable-msg" id="bluetooth-enable-msg" class="explanation">
+            Turn Bluetooth on to view devices in the area.
+          </p>
+        </li>
+        <li hidden id="device-visible">
+          <label class="pack-switch">
+            <input type="checkbox" data-ignore />
+            <span></span>
+          </label>
+          <small id="bluetooth-device-name"></small>
+          <a data-l10n-id="bluetooth-visible-to-all">Visible to all</a>
+        </li>
+        <li hidden id="bluetooth-rename">
+          <label>
+            <button id="rename-device" data-l10n-id="rename-device" disabled>Rename My Device</button>
+          </label>
+        </li>
+      </ul>
+
+      <header id="bluetooth-paired-title">
+        <h2 data-l10n-id="bluetooth-paired-devices">Paired Devices</h2>
+      </header>
+      <ul id="bluetooth-paired-devices" class="devices">
+      </ul>
+
+      <header id="bluetooth-found-title">
+        <h2 data-l10n-id="bluetooth-devices-in-area">Devices found</h2>
+      </header>
+      <ul id="bluetooth-devices" class="devices">
+      </ul>
+      <div id="bluetooth-searching" data-l10n-id="search-for-device" class="explanation">
+        Searching for devices…
+      </div>
+      <ul hidden id="bluetooth-search">
+        <li>
+          <label>
+            <button id="search-device" data-l10n-id="search-device" disabled>Search for Devices</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <form role="dialog" data-type="action" id="paired-device-option" hidden>
+      <menu>
+        <button data-l10n-id="device-option-connect" id="connect-option">Connect</button>
+        <button data-l10n-id="device-option-disconnect" id="disconnect-option">Disconnect</button>
+        <button data-l10n-id="device-option-unpair" id="unpair-option">Unpair</button>
+        <button data-l10n-id="cancel">Cancel</button>
+      </menu>
+    </form>
+
+    <form role="dialog" data-type="confirm" id="unpair-device" hidden>
+      <section>
+        <h1>Confirmation</h1>
+        <p data-l10n-id="device-option-unpair-device">Unpair Device?</p>
+      </section>
+      <menu>
+        <button data-l10n-id="cancel">Cancel</button>
+        <button data-l10n-id="device-option-confirm" id="confirm-option" class="danger">Confirm</button>
+      </menu>
+    </form>
+
+    <script src="js/bluetooth.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/call.html
+++ b/apps/settings/elements/call.html
@@ -1,0 +1,117 @@
+<element name="call" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="callSettings"> Call Settings </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <small id="voiceMail-desc"></small>
+          <a data-href="#call-voiceMailSettings" data-l10n-id="voiceMail">Voicemail</a>
+        </li>
+        <li id="menuItem-voicePrivacyMode" hidden>
+          <label class="pack-switch checkbox-label">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <a data-l10n-id="voicePrivacyMode">Voice privacy mode</a>
+        </li>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="wap.push.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="wapPush">WAP Push</a>
+        </li>
+        <li id="menuItem-callWaiting" data-state="off">
+          <label class="pack-switch checkbox-label">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <label class="alert-label" hidden>
+            <span></span>
+          </label>
+          <a data-l10n-id="callWaiting">Call Waiting</a>
+        </li>
+        <li id="menuItem-cellBroadcast" class="disabled">
+          <label class="pack-switch checkbox-label">
+            <input type="checkbox" data-ignore disabled />
+            <span></span>
+          </label>
+          <a data-l10n-id="callBroadcastService">Cell broadcast service</a>
+        </li>
+        <li id="menuItem-callerId" class="disabled">
+          <a data-l10n-id="callerId">Caller ID</a>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="ril-callerId" data-setting="ril.callerId">
+              <option value="CLIR_DEFAULT" data-l10n-id="callerId-default">Network default</option>
+              <option value="CLIR_INVOCATION" data-l10n-id="callerId-hide">Hide number</option>
+              <option value="CLIR_SUPPRESSION" data-l10n-id="callerId-show">Show number</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="callForwarding"> Call Forwarding </h2>
+      </header>
+      <ul>
+        <li id="li-cfu-desc" class="disabled">
+          <small id="cfu-desc"></small>
+          <a id="menuItem-callForwardingUnconditional" data-href="#call-cf-unconditionalSettings" data-l10n-id="callForwardingUnconditional">Always forward</a>
+        </li>
+        <li id="li-cfmb-desc" class="disabled">
+          <small id="cfmb-desc"></small>
+          <a id="menuItem-callForwardingMobileBusy" data-href="#call-cf-mobileBusySettings" data-l10n-id="callForwardingMobileBusy">Forward when busy</a>
+        </li>
+        <li id="li-cfnrep-desc" class="disabled">
+          <small id="cfnrep-desc"></small>
+          <a id="menuItem-callForwardingNoReply" data-href="#call-cf-noReplySettings" data-l10n-id="callForwardingNoReply">Forward when unanswered</a>
+        </li>
+        <li id="li-cfnrea-desc" class="disabled">
+          <small id="cfnrea-desc"></small>
+          <a id="menuItem-callForwardingNotReachable" data-href="#call-cf-notReachableSettings" data-l10n-id="callForwardingNotReachable">Forward when unreachable</a>
+        </li>
+      </ul>
+    </div>
+
+    <form role="dialog" data-type="confirm" hidden class="cw-alert">
+      <section>
+        <h1 data-l10n-id="confirmCallWaitingTitle">Unable to confirm call waiting preferences</h1>
+        <p>
+          <strong data-l10n-id="confirmCallWaitingDesc">The device is currently unable to communicate with the carrier. Try setting the preference again.</strong>
+        </p>
+        <p class="cw-alert-sub-p">
+          <label class="pack-switch cw-alert-checkbox-label">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <span data-l10n-id="callWaiting">Call Waiting</span>
+        </p>
+      </section>
+      <menu>
+        <button class="cw-alert-cancel" data-l10n-id="cancel">Cancel</button>
+        <button class="cw-alert-set recommend" data-l10n-id="set">Set</button>
+      </menu>
+    </form>
+
+    <form role="dialog" data-type="confirm" hidden class="cf-alert">
+      <section>
+        <h1 data-l10n-id="callForwardingConfirmTitle">Call forwarding confirmation message</h1>
+        <p>
+          <strong id="cf-confirm-message"></strong>
+        </p>
+      </section>
+      <menu>
+        <button class="cf-alert-continue full" data-l10n-id="continue">Continue</button>
+      </menu>
+    </form>
+
+    <script src="js/call.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/call_cf_mobileBusySettings.html
+++ b/apps/settings/elements/call_cf_mobileBusySettings.html
@@ -1,0 +1,30 @@
+<element name="call-cf-mobileBusySettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
+    </header>
+
+    <div>
+      <ul id="cf-mobilebusy-advanced">
+        <li>
+          <p data-l10n-id="cf-numberWhenBusy">Number when busy</p>
+          <input type="tel" id="cf-mobilebusy-number" data-setting="ril.cf.mobilebusy.number" disabled/>
+        </li>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" data-setting="ril.cf.mobilebusy.enabled"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="callForwardingMobileBusyShort">When busy</small>
+          <a data-l10n-id="callForwardingForward">Forward</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/call_cf_noReplySettings.html
+++ b/apps/settings/elements/call_cf_noReplySettings.html
@@ -1,0 +1,30 @@
+<element name="call-cf-noReplySettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
+    </header>
+
+    <div>
+      <ul id="cf-noreply-advanced">
+        <li>
+          <p data-l10n-id="cf-numberWhenUnanswered">Number when unanswered</p>
+          <input type="tel" id="cf-noreply-number" data-setting="ril.cf.noreply.number" disabled/>
+        </li>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" data-setting="ril.cf.noreply.enabled"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="callForwardingNoReplyShort">When unanswered</small>
+          <a data-l10n-id="callForwardingForward">Forward</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/call_cf_notReachableSettings.html
+++ b/apps/settings/elements/call_cf_notReachableSettings.html
@@ -1,0 +1,30 @@
+<element name="call-cf-notReachableSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
+    </header>
+
+    <div>
+      <ul id="cf-notreachable-advanced">
+        <li>
+          <p data-l10n-id="cf-numberWhenUnreachable">Number when unreachable</p>
+          <input type="tel" id="cf-notreachable-number" data-setting="ril.cf.notreachable.number" disabled/>
+        </li>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" data-setting="ril.cf.notreachable.enabled"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="callForwardingNotReachableShort">When unreachable</small>
+          <a data-l10n-id="callForwardingForward">Forward</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/call_cf_unconditionalSettings.html
+++ b/apps/settings/elements/call_cf_unconditionalSettings.html
@@ -1,0 +1,30 @@
+<element name="call-cf-unconditionalSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
+    </header>
+
+    <div>
+      <ul id="cf-unconditional-advanced">
+        <li>
+          <p data-l10n-id="cf-alwaysUseThisNumber">Always use this number</p>
+          <input type="tel" id="cf-unconditional-number" data-setting="ril.cf.unconditional.number" disabled/>
+        </li>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" data-setting="ril.cf.unconditional.enabled"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="callForwardingUnconditionalShort">Always</small>
+          <a data-l10n-id="callForwardingForward">Forward</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/call_voiceMailSettings.html
+++ b/apps/settings/elements/call_voiceMailSettings.html
@@ -1,0 +1,22 @@
+<element name="call-voiceMailSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="voiceMail"> Voicemail </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <p data-l10n-id="voiceMail-number">Voicemail Number</p>
+          <input type="tel" id="vm-number" data-setting="ril.iccInfo.mbdn"/>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier.html
+++ b/apps/settings/elements/carrier.html
@@ -1,0 +1,74 @@
+<element name="carrier" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="cellularAndData"> Cellular &amp; Data </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <small id="dataNetwork-desc"></small>
+          <span data-l10n-id="dataNetwork">Carrier</span>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="dataConnectivity"> Data Connectivity </h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="ril.data.enabled" class="uninit"/>
+            <span></span>
+          </label>
+          <small id="dataConnection-desc"></small>
+          <a data-l10n-id="dataConnection">Data Connection</a>
+        </li>
+        <li id="dataConnection-expl" class="explanation" data-l10n-id="dataConnection-warning-message" hidden></li>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="ril.data.roaming_enabled" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="dataRoaming">Data Roaming</a>
+        </li>
+        <li id="dataRoaming-expl" class="explanation" data-l10n-id="dataRoaming-warning-message" hidden></li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
+      </header>
+      <ul>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#carrier-operatorSettings"
+              data-l10n-id="networkOperator"> Network Operator </button>
+          </label>
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#carrier-dataSettings"
+              data-l10n-id="dataSettings">Data Settings</button>
+          </label>
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#carrier-mmsSettings"
+              data-l10n-id="messageSettings">Message Settings</button>
+          </label>
+        </li>
+        <li>
+          <label>
+            <button class="icon icon-view" data-href="#carrier-suplSettings"
+              data-l10n-id="suplSettings">A-GPS Settings</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script defer src="js/carrier.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier_dataSettings.html
+++ b/apps/settings/elements/carrier_dataSettings.html
@@ -1,0 +1,64 @@
+<element name="carrier-dataSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="dataSettings"> Data Settings </h1>
+    </header>
+
+    <div>
+      <ul class="apnSettings-list">
+        <li class="apnSettings-custom">
+          <label class="pack-radio">
+            <input type="radio" data-setting="ril.data.carrier" name="dataApnSettingsCarrier" value="_custom_" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="custom">(custom settings)</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
+      </header>
+      <ul class="apnSettings-advanced">
+        <li>
+          <p data-l10n-id="apn">APN</p>
+          <input type="text" data-setting="ril.data.apn" />
+        </li>
+        <li>
+          <p data-l10n-id="identity">identity</p>
+          <input type="text" data-setting="ril.data.user" />
+        </li>
+        <li>
+          <p data-l10n-id="password">password</p>
+          <input type="text" data-setting="ril.data.passwd" />
+        </li>
+        <li>
+          <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
+          <input type="text" data-setting="ril.data.httpProxyHost" />
+        </li>
+        <li>
+          <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
+          <input type="text" data-setting="ril.data.httpProxyPort" />
+        </li>
+        <li>
+          <p data-l10n-id="apn-authType">Authentication</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="ril-data-authType" data-setting="ril.data.authtype">
+              <option value="notDefined" data-l10n-id="apn-authType-notDefined">Not defined</option>
+              <option value="none" data-l10n-id="apn-authType-none">None</option>
+              <option value="pap" data-l10n-id="apn-authType-pap">PAP</option>
+              <option value="chap" data-l10n-id="apn-authType-chap">CHAP</option>
+              <option value="papOrChap" data-l10n-id="apn-authType-papOrChap">PAP or CHAP</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier_dc_warning.html
+++ b/apps/settings/elements/carrier_dc_warning.html
@@ -1,0 +1,23 @@
+<element name="carrier-dc-warning" extends="section">
+  <template>
+
+    <form role="dialog" data-type="confirm">
+      <section>
+        <h1>
+          <span data-l10n-id="dataConnection-warning-head">Turn ON data connection?</span>
+        </h1>
+        <p>
+          <small data-l10n-id="dataConnection-warning-message">
+            Applications will automatically fetch data via data connection
+             when required. Additional data charges may apply.
+          </small>
+        </p>
+      </section>
+      <menu>
+        <button type="reset" data-l10n-id="notNow">Not now</button>
+        <button type="submit" class="recommend" data-l10n-id="turnOn">Turn ON</button>
+      </menu>
+    </form>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier_dr_warning.html
+++ b/apps/settings/elements/carrier_dr_warning.html
@@ -1,0 +1,23 @@
+<element name="carrier-dr-warning" extends="section">
+  <template>
+
+    <form role="dialog" data-type="confirm">
+      <section>
+        <h1>
+          <span data-l10n-id="dataRoaming-warning-head">Turn ON data roaming?</span>
+        </h1>
+        <p>
+          <small data-l10n-id="dataRoaming-warning-message">
+            Depending on your service agreement, significant roaming charges
+            may apply for data usage when you are in the roaming area.
+          </small>
+        </p>
+      </section>
+      <menu>
+        <button type="reset" data-l10n-id="notNow">Not now</button>
+        <button type="submit" class="recommend" data-l10n-id="turnOn">Turn ON</button>
+      </menu>
+    </form>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier_mmsSettings.html
+++ b/apps/settings/elements/carrier_mmsSettings.html
@@ -1,0 +1,108 @@
+<element name="carrier-mmsSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="messageSettings"> Message Settings </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="message-confirmation"> Message confirmation </h2>
+      </header>
+      <ul id="general-message-list">
+        <li id="delivery-reports" class="hint">
+          <label class="pack-switch">
+            <input type="checkbox" data-setting="ril.sms.requestStatusReport.enabled"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="message-delivery-reports"> Delivery reports </a>
+          <p class="explanation" data-l10n-id="message-delivery-reports-details">Request notification of delivery for each message sent</p>
+        </li>
+      </ul>
+      <header>
+        <h2 data-l10n-id="mmsTitle"> Multimedia messaging (MMS) </h2>
+      </header>
+      <ul class="mmsSettings-list">
+        <li class="hint">
+          <a data-l10n-id="auto-retrieve">Auto retrieve</a>
+          <p class="explanation" data-l10n-id="auto-retrieve-details">automatically retieve messages</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select data-setting="ril.mms.retrieval_mode">
+              <option value="manual" data-l10n-id="manual-retrieve">Off</option>
+              <option value="automatic" data-l10n-id="auto-roaming-retrieve">On with roaming</option>
+              <option value="automatic-home" data-l10n-id="auto-no-roaming-retrieve">On without roaming/option>
+            </select>
+          </p>
+        </li>
+      </ul>
+      <header>
+        <h2 data-l10n-id="apnSettings"> APN Settings </h2>
+      </header>
+      <ul class="apnSettings-list">
+        <li class="apnSettings-custom">
+          <label class="pack-radio">
+            <input type="radio" data-setting="ril.mms.carrier" name="mmsApnSettingsCarrier" value="_custom_" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="custom">(custom settings)</a>
+        </li>
+      </ul>
+      <header>
+        <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
+      </header>
+      <ul class="apnSettings-advanced">
+        <li>
+          <p data-l10n-id="apn">APN</p>
+          <input type="text" data-setting="ril.mms.apn" />
+        </li>
+        <li>
+          <p data-l10n-id="identity">identity</p>
+          <input type="text" data-setting="ril.mms.user" />
+        </li>
+        <li>
+          <p data-l10n-id="password">password</p>
+          <input type="text" data-setting="ril.mms.passwd" />
+        </li>
+        <li>
+          <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
+          <input type="text" x-inputmode="verbatim" data-setting="ril.mms.httpProxyHost" />
+        </li>
+        <li>
+          <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
+          <input type="number" x-inputmode="digits" data-setting="ril.mms.httpProxyPort" />
+        </li>
+        <li>
+          <p data-l10n-id="mmsproxy">MMS Proxy</p>
+          <input type="text" x-inputmode="verbatim" data-setting="ril.mms.mmsproxy" />
+        </li>
+        <li>
+          <p data-l10n-id="mmsport">MMS Port</p>
+          <input type="number" x-inputmode="digits" data-setting="ril.mms.mmsport" />
+        </li>
+        <li>
+          <p data-l10n-id="mmsc">MMSC</p>
+          <input type="text" x-inputmode="verbatim" data-setting="ril.mms.mmsc" />
+        </li>
+        <li>
+          <p data-l10n-id="apn-authType">Authentication</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="ril-mms-authType" data-setting="ril.mms.authtype">
+              <option value="notDefined" data-l10n-id="apn-authType-notDefined">Not defined</option>
+              <option value="none" data-l10n-id="apn-authType-none">None</option>
+              <option value="pap" data-l10n-id="apn-authType-pap">PAP</option>
+              <option value="chap" data-l10n-id="apn-authType-chap">CHAP</option>
+              <option value="papOrChap" data-l10n-id="apn-authType-papOrChap">PAP or CHAP</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier_operatorSettings.html
+++ b/apps/settings/elements/carrier_operatorSettings.html
@@ -1,0 +1,59 @@
+<element name="carrier-operatorSettings" extends="section">
+  <template>
+
+    <header>
+      <a href="#carrier"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="networkOperator"> Network Operator </h1>
+    </header>
+
+    <div id="carrier-operatorSettings-content">
+      <ul>
+        <li>
+          <p data-l10n-id="operator-networkType">Network Type</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select name="ril.radio.preferredNetworkType" id="preferredNetworkType">
+            </select>
+          </p>
+        </li>
+        <li id="operator-roaming-preference">
+          <p data-l10n-id="operator-roamingPreference">Roaming preference</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="operator-roaming-preference-selector">
+              <option data-l10n-id="operator-roamingPreference-home" value="home">Home</option>
+              <option data-l10n-id="operator-roamingPreference-any" value="any">Any</option>
+              <option data-l10n-id="operator-roamingPreference-affiliated" value="affiliated">Affiliated</option>
+            </select>
+          </p>
+        </li>
+        <li id="operator-autoSelect">
+          <label class="pack-switch">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <small></small>
+          <a data-l10n-id="operator-autoSelect">Automatic Selection</a>
+        </li>
+      </ul>
+
+      <header id="availableOperatorsHeader">
+        <h2 data-l10n-id="availableOperators"> Network Operators in the Area </h2>
+      </header>
+      <ul id="availableOperators" data-state="off">
+        <li class="explanation" data-state="off" data-l10n-id="operator-turnAutoSelectOff">
+          Turn Automatic Selection off to view available network operators.
+        </li>
+        <li class="explanation" data-state="on" data-l10n-id="scanning">
+          Searching…
+        </li>
+        <li data-state="ready">
+          <label>
+            <button data-l10n-id="scanNetworks">Search Again</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/carrier_suplSettings.html
+++ b/apps/settings/elements/carrier_suplSettings.html
@@ -1,0 +1,64 @@
+<element name="carrier-suplSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="suplSettings"> A-GPS Settings </h1>
+    </header>
+
+    <div>
+      <ul class="apnSettings-list">
+        <li class="apnSettings-custom">
+          <label class="pack-radio">
+            <input type="radio" data-setting="ril.supl.carrier" name="suplApnSettingsCarrier" value="_custom_" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="custom">(custom settings)</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
+      </header>
+      <ul class="apnSettings-advanced">
+        <li>
+          <p data-l10n-id="apn">APN</p>
+          <input type="text" data-setting="ril.supl.apn" />
+        </li>
+        <li>
+          <p data-l10n-id="identity">identity</p>
+          <input type="text" data-setting="ril.supl.user" />
+        </li>
+        <li>
+          <p data-l10n-id="password">password</p>
+          <input type="text" data-setting="ril.supl.passwd" />
+        </li>
+        <li>
+          <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
+          <input type="text" data-setting="ril.supl.httpProxyHost" />
+        </li>
+        <li>
+          <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
+          <input type="text" data-setting="ril.supl.httpProxyPort" />
+        </li>
+        <li>
+          <p data-l10n-id="apn-authType">Authentication</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="ril-supl-authType" data-setting="ril.supl.authtype">
+              <option value="notDefined" data-l10n-id="apn-authType-notDefined">Not defined</option>
+              <option value="none" data-l10n-id="apn-authType-none">None</option>
+              <option value="pap" data-l10n-id="apn-authType-pap">PAP</option>
+              <option value="chap" data-l10n-id="apn-authType-chap">CHAP</option>
+              <option value="papOrChap" data-l10n-id="apn-authType-papOrChap">PAP or CHAP</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/crashReports.html
+++ b/apps/settings/elements/crashReports.html
@@ -1,0 +1,24 @@
+<element name="crashReports" extends="section">
+  <template>
+
+    <header>
+      <a href="#improveBrowserOS"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="crashReports"> Crash Reports </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li class="description">
+          <p data-l10n-id="crash-reports-description-1"></p>
+          <p data-l10n-id="crash-reports-description-2"></p>
+          <p>
+            <span data-l10n-id="crash-reports-description-3-start"></span>
+            <a href="https://www.mozilla.org/privacy/" data-l10n-id="crash-reports-description-3-privacy" class="link-text"></a>
+            <span data-l10n-id="crash-reports-description-3-end"></span>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/dateTime.html
+++ b/apps/settings/elements/dateTime.html
@@ -1,0 +1,63 @@
+<element name="dateTime" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="dateAndTime"> Date &amp; Time </h1>
+    </header>
+
+    <div>
+      <ul id="time-auto" data-state="auto" hidden>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="time.nitz.automatic-update.enabled" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="setTimeAutomatically">Set Automatically</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="setTimeManually">Set Manually</h2>
+      </header>
+      <ul id="time-manual">
+        <li>
+          <label>
+            <input type="date" id="date-picker" min="1970-1-1" max="2037-12-31"/>
+          </label>
+          <a data-l10n-id="dateMessage">Date <span id="clock-date"></span> </a>
+        </li>
+        <li>
+          <label>
+            <input type="time" id="time-picker" />
+          </label>
+          <a data-l10n-id="timeMessage">Time <span id="clock-time"></span> </a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="timezoneMessage">Time zone</h2>
+      </header>
+      <ul id="timezone">
+        <li>
+          <p data-l10n-id="tz-region">Region</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="timezone-region"></select>
+          </p>
+        </li>
+        <li>
+          <p data-l10n-id="tz-city">City</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="timezone-city"></select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+    <script src="shared/js/tz_select.js"></script>
+    <script src="js/date_time.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/display.html
+++ b/apps/settings/elements/display.html
@@ -1,0 +1,63 @@
+<element name="display" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="display"> Display </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="screen.orientation.lock" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="lock-orientation">Lock screen orientation</a>
+        </li>
+      </ul>
+
+      <header id="wallpaper-header">
+        <h2 data-l10n-id="wallpaper">Wallpaper</h2>
+      </header>
+      <div id="wallpaper">
+        <img id="wallpaper-preview" alt="wallpaper preview"/>
+        <button id="wallpaper-button"></button>
+      </div>
+      <header>
+        <h2 data-l10n-id="brightness">Brightness</h2>
+      </header>
+      <ul>
+        <li id="brightness-auto">
+          <label class="pack-checkbox">
+            <input type="checkbox" name="screen.automatic-brightness" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="brightness-autoAdjust">Adjust Automatically</a>
+        </li>
+        <li id="brightness-manual">
+          <label>
+            <input type="range" name="screen.brightness" step="0.01" min="0.1" value="0.5" max="1" />
+            <span class="range-icons brightness"></span>
+          </label>
+        </li>
+        <li id="screen-timeout">
+          <p data-l10n-id="screen-timeout">Screen Timeout</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select name="screen.timeout" data-value-type="integer">
+              <option value="60"  data-l10n-id="one-minute" selected>1 minute</option>
+              <option value="120" data-l10n-id="two-minutes"> 2 minutes</option>
+              <option value="300" data-l10n-id="five-minutes">5 minutes</option>
+              <option value="600" data-l10n-id="ten-minutes">10 minutes</option>
+              <option value="0"   data-l10n-id="never">Never</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/wallpaper.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/doNotTrack.html
+++ b/apps/settings/elements/doNotTrack.html
@@ -1,0 +1,38 @@
+<element name="doNotTrack" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="doNotTrack"> Do Not Track </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="doNotTrack-dt">How does Do Not Track work?</h2>
+      </header>
+      <ul>
+        <li class="description">
+          <p data-l10n-id="doNotTrack-dd1">
+            When you turn on the Do Not Track feature, your device tells every
+            website and app (as well as advertisers and other content providers)
+            that you don’t want your behavior tracked.
+          </p>
+          <p data-l10n-id="doNotTrack-dd2">
+            Turning on Do Not Track won’t affect your ability to log into
+            websites, nor cause your device to forget your private information —
+            such as the contents of shopping carts, location information, or
+            log-in information.
+        </p>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="privacy.donottrackheader.enabled" />
+            <span></span>
+          </label>
+          <a data-l10n-id="doNotTrack">Do Not Track</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/help.html
+++ b/apps/settings/elements/help.html
@@ -1,0 +1,35 @@
+<element name="help" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="help"></h1>
+    </header>
+
+    <div>
+      <ul>
+        <li class="support-info">
+          <a data-l10n-id="online-support" id="online-support-link"> Online Support:
+            <span class="link-text" id="online-support-text"></span>
+          </a>
+        </li>
+        <li class="support-info">
+          <span data-l10n-id="call-support"> Call Support:
+            <span class="tel-text" id="call-support-numbers"></span>
+          </span>
+        </li>
+        <li>
+          <label>
+            <button data-l10n-id="user-guide"> User Guide </button>
+          </label>
+        </li>
+        <li class="no-support-info description" data-l10n-id="default-support">
+          Please contact your local provider for support.
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/support.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/homescreen.html
+++ b/apps/settings/elements/homescreen.html
@@ -1,0 +1,17 @@
+<element name="homescreen" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="homescreen"> Homescreen </h1>
+    </header>
+
+    <div>
+      <ul></ul>
+    </div>
+
+    <script type="application/javascript" src="shared/js/manifest_helper.js"></script>
+    <script src="js/homescreen.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/homescreen_details.html
+++ b/apps/settings/elements/homescreen_details.html
@@ -1,0 +1,20 @@
+<element name="homescreen-details" extends="section">
+  <template>
+
+    <header>
+      <a href="#homescreen"><span class="icon icon-back">back</span></a>
+      <h1> </h1>
+    </header>
+    <div>
+      <header>
+        <h2 class="description" data-l10n-id="description">Description</h2>
+      </header>
+      <p></p>
+      <header>
+        <h2 data-l10n-id="changeHomescreen">Change Homescreen</h2>
+      </header>
+      <button id="change-homescreen" data-l10n-id="changeHomescreenButton">Change</button>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/hotspot.html
+++ b/apps/settings/elements/hotspot.html
@@ -1,0 +1,67 @@
+<element name="hotspot" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="internetSharing"> Internet Sharing </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="internetSharing-wifi"> Wi-Fi </h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="tethering.wifi.enabled" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="wifi-hotspot">Wi-Fi Hotspot</a>
+        </li>
+        <li class="description" data-l10n-id="internetSharing-wifi-desc">
+          Allow other devices to share my phone’s Internet connection by connecting via Wi-Fi.
+        </li>
+        <li>
+          <a data-l10n-id="wifi-name">Name
+            <span data-name="tethering.wifi.ssid"></span>
+          </a>
+        </li>
+        <li class="password-item" hidden>
+          <a data-l10n-id="wifi-password">Password
+            <span data-name="tethering.wifi.security.password"></span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="wifi-security">Security
+            <span data-name="tethering.wifi.security.type"></span>
+          </a>
+        </li>
+        <li id="hotspot-settings-section">
+          <label>
+            <button class="icon icon-view"
+            data-l10n-id="hotspotSettings">Hotspot Settings</button>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="internetSharing-usb"> USB </h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="tethering.usb.enabled" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="usb-tethering">USB Tethering</a>
+        </li>
+        <li class="description" data-l10n-id="internetSharing-usb-desc">
+          Share my phone’s Internet connection with a USB-connected device.
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/hotspot.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/hotspot_wifiSettings.html
+++ b/apps/settings/elements/hotspot_wifiSettings.html
@@ -1,0 +1,42 @@
+<element name="hotspot-wifiSettings" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="hotspotSettings"> Hotspot Settings </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <p data-l10n-id="ssid-name">SSID Network Name</p>
+          <input type="text" data-setting="tethering.wifi.ssid" />
+        </li>
+        <li class="password">
+          <label class="pack-checkbox">
+            <input type="checkbox" data-ignore name="show_password" />
+            <span></span>
+          </label>
+          <span data-l10n-id="showPassword">Show password</span>
+          <p data-l10n-id="wifi-password">Password</p>
+          <input type="password" name="password" x-inputmode="verbatim" data-setting="tethering.wifi.security.password" />
+        </li>
+        <li>
+          <p data-l10n-id="wifi-security">Security</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">Security</button>
+            <select class="security-selector" data-setting="tethering.wifi.security.type">
+              <option value="open" data-l10n-id="hotspot-open">open</option>
+              <option value="wpa-psk" data-l10n-id="hotspot-wpa-psk">WPA (TKIP)</option>
+              <option value="wpa2-psk" data-l10n-id="hotspot-wpa2-psk">WPA2 (AES)</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/icc.html
+++ b/apps/settings/elements/icc.html
@@ -1,0 +1,27 @@
+<element name="icc" extends="section">
+  <template>
+
+    <header>
+      <button id="icc-stk-app-back" class="hidden">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <button id="icc-stk-help-exit" class="hidden">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <a href="#root" id="icc-stk-exit"><span data-l10n-id="back" class="icon icon-back">Back</span></a>
+      <h1 id="icc-stk-header"> SIM Toolkit </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 id="icc-stk-subheader"></h2>
+      </header>
+
+      <ul id="icc-stk-list">
+      </ul>
+    </div>
+
+    <script src="js/icc.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/improveBrowserOS.html
+++ b/apps/settings/elements/improveBrowserOS.html
@@ -1,0 +1,77 @@
+<element name="improveBrowserOS" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="improveBrowserOS">Improve Browser OS</h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label>
+            <button data-href="http://input.mozilla.org/feedback" data-l10n-id="sendMozillaFeedback"></button>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="performanceData">Performance Data</h2>
+      </header>
+      <ul>
+        <li>
+          <p class="description">
+            <span data-l10n-id="performanceDataInfo">
+              Help us improve Browser OS by sharing data about your phone.
+            </span>
+            <a href="http://mozilla.org/telemetry" data-l10n-id="learn-more" class="link-text">Learn More</a>
+          </p>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="debug.performance_data.shared" />
+            <span></span>
+          </label>
+          <a data-l10n-id="sharePerformanceData">Submit performance data</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="crashReports">Crash Reports</h2>
+      </header>
+      <ul>
+        <li>
+          <p class="description">
+            <span data-l10n-id="crashReportInfo">
+              Sending Mozilla a report when a crash occurs helps us fix the problem
+              for everyone. Reports are sent over Wi-Fi only.
+            </span>
+            <a href="#crashReports" data-l10n-id="learn-more" class="link-text">Learn More</a>
+          </p>
+        </li>
+        <li>
+          <label class="pack-radio">
+            <input type="radio" name="app.reportCrashes" value="always"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="alwaysSendReport">Always send a report</a>
+        </li>
+        <li>
+          <label class="pack-radio">
+            <input type="radio" name="app.reportCrashes" value="never" />
+            <span></span>
+          </label>
+          <a data-l10n-id="neverSendReport">Never send a report</a>
+        </li>
+        <li>
+          <label class="pack-radio">
+            <input type="radio" name="app.reportCrashes" value="ask" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="askToSendReport2">Ask each time</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/keyboard.html
+++ b/apps/settings/elements/keyboard.html
@@ -1,0 +1,77 @@
+<element name="keyboard" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="keyboard"> Keyboard </h1>
+    </header>
+
+    <div>
+      <ul hidden>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="keyboard.vibration"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="vibration">Vibration</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="keyboard.clicksound" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="clickSound">Click sound</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="keyboard.autocorrect"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="autoCorrect">Auto correction</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="keyboard.wordsuggestion"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="wordSuggestion">Word Suggestion</a>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <a href="#keyboard-selection" data-l10n-id="activeKeyboard">Active keyboard</a>
+        </li>
+      </ul>
+      <header>
+        <h2 data-l10n-id="installed">Installed</h2>
+      </header>
+      <ul id="allKeyboardList" hidden>
+      </ul>
+
+      <div id="textLayoutList" hidden>
+        <header>
+          <h2 data-l10n-id="keyboardlayouts">layouts</h2>
+        </header>
+        <ul></ul>
+      </div>
+
+      <div id="numberLayoutList" hidden>
+        <header>
+          <h2 data-l10n-id="numberKeyboardLayouts">Number Layouts</h2>
+        </header>
+        <ul></ul>
+      </div>
+
+      <div id="optionLayoutList" hidden>
+        <header>
+          <h2 data-l10n-id="optionKeyboardLayouts">Option Layouts</h2>
+        </header>
+        <ul></ul>
+      </div>
+
+    </div>
+    <script src="js/keyboard.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/keyboard_selection.html
+++ b/apps/settings/elements/keyboard_selection.html
@@ -1,0 +1,20 @@
+<element name="keyboard-selection" extends="section">
+  <template>
+
+    <header>
+      <a href="#keyboard"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="selectKeyboard"> Select keyboard </h1>
+    </header>
+
+    <div>
+      <ul id="enabledKeyboardList">
+      </ul>
+      <ul>
+        <li>
+          <button data-l10n-id="addMoreKeyboards" data-href="#keyboard-selection-addMore">Add more keyboards</button>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/keyboard_selection_addMore.html
+++ b/apps/settings/elements/keyboard_selection_addMore.html
@@ -1,0 +1,13 @@
+<element name="keyboard-selection-addMore" extends="section">
+  <template>
+
+    <header>
+      <a href="#keyboard-selection"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="addMoreKeyboards"> Add more keyboards </h1>
+    </header>
+
+    <div id="keyboardAppContainer">
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/languages.html
+++ b/apps/settings/elements/languages.html
@@ -1,0 +1,46 @@
+<element name="languages" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="language"> Language </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="sample-format">Sample Format</h2>
+      </header>
+      <ul>
+        <li class="description">
+          <p id="region-date">Friday, September 28 2012</p>
+          <p id="region-time">06:54 PM</p>
+        </li>
+        <li>
+          <p data-l10n-id="language">Language</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">Language</button>
+            <select name="language.current"></select>
+          </p>
+        </li>
+        <li hidden>
+          <p data-l10n-id="region">Region</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select name="region.current">
+              <option value="BR">Brasil</option>
+              <option value="CO">Columbia</option>
+              <option value="ES">España</option>
+              <option value="FR">France</option>
+              <option value="PT">Portugal</option>
+              <option value="TW">Taiwan</option>
+              <option value="UK">United Kingdom</option>
+              <option value="US">United States</option>
+              <option value="VZ">Venezuela</option>
+            </select>
+          </p>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/mediaStorage.html
+++ b/apps/settings/elements/mediaStorage.html
@@ -1,0 +1,51 @@
+<element name="mediaStorage" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="mediaStorage"> Media Storage </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input id="ums-switch" type="checkbox" data-ignore />
+            <span></span>
+          </label>
+          <small id="ums-desc">Disabled</small>
+          <a data-l10n-id="enableUSBStorage">Enable USB storage</a>
+        </li>
+      </ul>
+      <div id="volume-list">
+      </div>
+      <header>
+        <h2 data-l10n-id="advanced">Advanced</h2>
+      </header>
+      <ul>
+        <li>
+          <p data-l10n-id="default-media-location">Default media location</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select id="defaultMediaLocation" name="device.storage.writable.name">
+            </select>
+          </p>
+        </li>
+        <li data-l10n-id="default-media-location-msg" class="explanation">
+          Choose where photos, videos, music and downloads are stored by default.
+        </li>
+      </ul>
+    </div>
+    <form data-type="confirm" role="dialog" id="default-location-popup-container" hidden>
+      <section>
+        <p data-l10n-id="change-default-location-confirm">Changing the default media storage volume will effect where photos, videos, downloads and other media will be saved to by default. Existing data will remain in its current location.</p>
+      </section>
+      <menu>
+        <button id="default-location-cancel-btn" data-l10n-id="cancel">Cancel</button>
+        <button id="default-location-change-btn" data-l10n-id="change">Change</button>
+      </menu>
+    </form>
+    <script src="js/media_storage.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/notifications.html
+++ b/apps/settings/elements/notifications.html
@@ -1,0 +1,22 @@
+<element name="notifications" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="notifications"> Notifications </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="lockscreen.notifications-preview.enabled" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="lockscreen-notifications">Show on Lock Screen</a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/phoneLock.html
+++ b/apps/settings/elements/phoneLock.html
@@ -1,0 +1,56 @@
+<element name="phoneLock" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="phoneLock"> Phone Lock </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="lockscreen.enabled" id="lockscreen-enable" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="lockScreen">Lock Screen</a>
+        </li>
+        <li class="lockscreen-enabled">
+          <label class="pack-switch">
+            <input type="checkbox" name="lockscreen.passcode-lock.enabled" id="passcode-enable" class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="passcode-lock">Passcode Lock</a>
+        </li>
+        <li class="passcode-enabled" id="passcode-timeout-row">
+          <p data-l10n-id="require-passcode">Require passcode</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select name="lockscreen.passcode-lock.timeout">
+              <option value="0" data-l10n-id="immediately" selected>Immediately</option>
+              <option value="5" data-l10n-id="after-five-seconds">After 5 seconds</option>
+              <option value="15" data-l10n-id="after-fifteen-seconds">After 15 seconds</option>
+              <option value="30" data-l10n-id="after-thirty-seconds">After 30 seconds</option>
+              <option value="60" data-l10n-id="after-one-minute">After 1 minute</option>
+              <option value="120" data-l10n-id="after-two-minutes">After 2 minutes</option>
+              <option value="300" data-l10n-id="after-five-minutes">After 5 minutes</option>
+              <option value="600" data-l10n-id="after-ten-minutes">After 10 minutes</option>
+              <option value="900" data-l10n-id="after-fifteen-minutes">After 15 minutes</option>
+              <option value="1800" data-l10n-id="after-thirty-minutes">After 30 minutes</option>
+              <option value="3600" data-l10n-id="after-one-hour">After 1 hour</option>
+              <option value="14400" data-l10n-id="after-four-hours">After 4 hours</option>
+            </select>
+          </p>
+        </li>
+        <li class="passcode-enabled">
+          <label>
+            <button data-l10n-id="change-passcode" id="passcode-edit">Change Passcode</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/phone_lock.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/phoneLock_passcode.html
+++ b/apps/settings/elements/phoneLock_passcode.html
@@ -1,0 +1,41 @@
+<element name="phoneLock-passcode" extends="section">
+  <template>
+
+    <header>
+      <a href="#phoneLock"><span class="icon icon-back">back</span></a>
+      <menu type="toolbar" data-mode="new">
+        <button id="passcode-change" data-l10n-id="change">Change</button>
+      </menu>
+      <menu type="toolbar" data-mode="create">
+        <button id="passcode-create" data-l10n-id="create">Create</button>
+      </menu>
+      <h1 data-l10n-id="create-passcode"  data-mode="create">  Create a Passcode </h1>
+      <h1 data-l10n-id="current-passcode" data-mode="edit">    Current Passcode  </h1>
+      <h1 data-l10n-id="new-passcode"     data-mode="new">     New Passcode      </h1>
+      <h1 data-l10n-id="enter-passcode"   data-mode="confirm"> Enter Passcode    </h1>
+    </header>
+
+    <div class="passcode-overlay">
+      <input type="number" x-inputmode="digit" id="passcode-input" />
+      <div class="passcode-container" id="passcode-container">
+        <div class="passcode" id="passcode-pseudo-input">
+          <label data-l10n-id="passcode">Passcode</label>
+          <span class="passcode-digit"></span>
+          <span class="passcode-digit"></span>
+          <span class="passcode-digit"></span>
+          <span class="passcode-digit"></span>
+        </div>
+        <div class="passcode" data-mode="new,create" id="passcode-pseudo-confirm-input">
+          <label data-l10n-id="confirm-passcode" data-mode="new,create">Confirm Passcode</label>
+          <span class="passcode-digit"></span>
+          <span class="passcode-digit"></span>
+          <span class="passcode-digit"></span>
+          <span class="passcode-digit"></span>
+        </div>
+        <div class="passcode-error" data-l10n-id="incorrect-passcode" data-type="incorrect">Incorrect passcode!</div>
+        <div class="passcode-error" data-l10n-id="passcode-doesnt-match" data-type="mismatch">Passcode doesn't match. Try again!</div>
+      </div>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/simpin.html
+++ b/apps/settings/elements/simpin.html
@@ -1,0 +1,48 @@
+<element name="simpin" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="simSecurity"> SIM Security </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="whatIsSimPin">What is a SIM PIN?</h2>
+      </header>
+      <ul>
+        <li class="description">
+          <p data-l10n-id="simPinIntro1">
+          A SIM PIN prevents access to the SIM card cellular data networks. When
+          it’s on, any device containing the SIM card will request the PIN upon
+          restart.
+          </p>
+
+          <p data-l10n-id="simPinIntro2">
+            A SIM PIN is not the same as the Passcode used to unlock the device.
+          </p>
+        </li>
+      </ul>
+      <ul>
+        <li id="simpin-enabled">
+          <label class="pack-switch">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <a data-l10n-id="simPin">SIM PIN</a>
+        </li>
+      </ul>
+      <ul>
+        <li id="simpin-change">
+          <label>
+            <button data-l10n-id="changeSimPin" name="changeSimPin">Change PIN</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/simcard_lock.js"></script>
+    <script src="js/simcard_dialog.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/simpin_dialog.html
+++ b/apps/settings/elements/simpin_dialog.html
@@ -1,0 +1,62 @@
+<element name="simpin-dialog" extends="section">
+  <template>
+
+    <header>
+      <button type="reset">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <menu type="toolbar">
+      <button data-l10n-id="done" type="submit">Done</button>
+      </menu>
+      <h1></h1>
+    </header>
+
+    <div>
+      <div class="container">
+        <div id="errorMsg" class="error" hidden>
+          <div id="messageHeader">The PIN was incorrect.</div>
+          <span id="messageBody">3 tries left.</span>
+        </div>
+
+        <div id="triesLeft" data-l10-id="inputCodeRetriesLeft">
+          3 tries left
+        </div>
+
+        <div id="pinArea" class="sim-code-area">
+          <div data-l10n-id="simPin">SIM PIN</div>
+          <div class="input-wrapper">
+            <input type="password" x-inputmode="digit" name="simpin" size="8" maxlength="8" />
+          </div>
+        </div>
+
+        <div id="pukArea" class="sim-code-area">
+          <div data-l10n-id="pukCode">PUK Code</div>
+          <div class="input-wrapper">
+            <input type="password" x-inputmode="digit" name="simpuk" size="8" maxlength="8" />
+          </div>
+        </div>
+
+        <div id="newPinArea" class="sim-code-area">
+          <div data-l10n-id="newSimPinMsg">
+            Create PIN (must contain 4 to 8 digits)
+          </div>
+          <div class="input-wrapper">
+            <input type="password" x-inputmode="digit" name="newSimpin" size="8" maxlength="8" />
+          </div>
+        </div>
+
+        <div id="confirmPinArea" class="sim-code-area">
+          <div data-l10n-id="confirmNewSimPinMsg">
+            Confirm New PIN
+          </div>
+          <div class="input-wrapper">
+            <input type="password" x-inputmode="digit" name="confirmNewSimpin" size="8" maxlength="8" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="js/simcard_dialog.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/sound.html
+++ b/apps/settings/elements/sound.html
@@ -1,0 +1,97 @@
+<element name="sound" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="sound"> Sound </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <label class="pack-switch">
+            <input type="checkbox" name="vibration.enabled" checked class="uninit"/>
+            <span></span>
+          </label>
+          <a data-l10n-id="vibrate">Vibrate</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="volume">Volume</h2>
+      </header>
+      <ul>
+        <li class="sound-setting">
+          <p data-l10n-id="ringer-and-notification-sound">Ringer & Notifications</p>
+          <label>
+            <input type="range" name="audio.volume.notification" step="1" min="0" value="15" max="15">
+            <span class="range-icons volume"></span>
+          </label>
+        </li>
+        <li class="sound-setting">
+          <p data-l10n-id="alarm-sound">Alarm</p>
+          <label>
+            <input type="range" name="audio.volume.alarm" step="1" min="0" value="15" max="15">
+            <span class="range-icons volume"></span>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="tones">Tones</h2>
+      </header>
+      <ul>
+        <li>
+          <p data-l10n-id="ringer">Ringer</p>
+          <p class="fake-select">
+            <button id="call-tone-selection" class="icon icon-view" data-l10n-id="change"></button>
+          </p>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="other-sounds">Other Sounds</h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="phone.ring.keypad" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="keypad">Keypad</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="camera.shutter.enabled" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="camera-shutter">Camera Shutter</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="mail.sent-sound.enabled" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="sent-mail">Sent Mail</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="message.sent-sound.enabled" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="sent-message">Sent Message</a>
+        </li>
+        <li>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="lockscreen.unlock-sound.enabled" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="unlock-screen">Unlock Screen</a>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/sound.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/sound_selection.html
+++ b/apps/settings/elements/sound_selection.html
@@ -1,0 +1,31 @@
+<element name="sound-selection" extends="section">
+  <template>
+
+    <header>
+      <button type="reset">
+        <span data-l10n-id="back" class="icon icon-back">Back</span>
+      </button>
+      <menu type="toolbar">
+        <button data-l10n-id="done" type="submit">Done</button>
+      </menu>
+      <h1 data-l10n-id="select-tone"> Select a Tone </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="ring-tones">Ringtones</h2>
+      </header>
+      <ul id="ringtones-list">
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="alert-tones">Alert Tones</h2>
+      </header>
+      <ul id="notifications-list">
+      </ul>
+
+      <audio style="display: none;" src=""></audio>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/wifi.html
+++ b/apps/settings/elements/wifi.html
@@ -1,0 +1,64 @@
+<element name="wifi" extends="section">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="wifi"> Wi-Fi </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li id="wifi-enabled">
+          <label class="pack-switch">
+            <input type="checkbox" data-ignore/>
+            <span></span>
+          </label>
+          <a data-l10n-id="wifi">Wi-Fi</a>
+        </li>
+        <li hidden>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="wifi.notification"/>
+            <span></span>
+          </label>
+          <small data-l10n-id="networkNotification-expl">Notify me when an open network is available</small>
+          <a data-l10n-id="networkNotification">Network notification</a>
+        </li>
+        <li id="wps-column">
+          <small data-l10n-id="wpsDescription2">Automatic Wi-Fi setup</small>
+          <a data-l10n-id="wpsMessage">Connect with WPS</a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="availableNetworks"> Available Networks </h2>
+      </header>
+      <ul id="wifi-availableNetworks" data-state="off">
+        <li class="explanation" data-state="off" data-l10n-id="wifi-disabled">
+          Turn Wi-Fi on to view available networks.
+        </li>
+        <li data-state="on">
+          <progress></progress><span data-l10n-id="scanning">Searching…</span>
+        </li>
+        <li data-state="ready">
+          <label>
+            <button data-l10n-id="scanNetworks">Search Again</button>
+          </label>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
+      </header>
+      <ul>
+        <li>
+          <label>
+            <button id="manageNetworks" data-l10n-id="manageNetworks">Manage Networks</button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script src="js/wifi.js"></script>
+
+  </template>
+</element>

--- a/apps/settings/elements/wifi_auth.html
+++ b/apps/settings/elements/wifi_auth.html
@@ -1,0 +1,56 @@
+<element name="wifi-auth" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-ssid> Network Authentication </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <a data-l10n-id="security">security
+            <span data-security>WPA-PSK</span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="signalStrength">signal strength
+            <span data-signal>good</span>
+          </a>
+        </li>
+        <li class="eap">
+          <p data-l10n-id="eap">EAP method</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select>
+              <option value="SIM">EAP-SIM</option>
+              <option value="AKA">EAP-AKA</option>
+              <option value="AKA'">EAP-AKA'</option>
+            </select>
+          </p>
+        </li>
+        <li class="simpin">
+          <p data-l10n-id="simPin">SIM PIN</p>
+          <input type="text" data-ignore name="simPin" />
+        </li>
+        <li class="identity">
+          <p data-l10n-id="identity">identity</p>
+          <input type="text" data-ignore name="identity" />
+        </li>
+        <li class="password">
+          <label class="pack-checkbox">
+            <input type="checkbox" data-ignore name="show-pwd" id="pwd-auth" />
+            <span></span>
+          </label>
+          <span data-l10n-id="showPassword">show password</span>
+          <p data-l10n-id="password">password</p>
+          <input type="password" data-ignore name="password" maxlength="63" x-inputmode="verbatim" />
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/wifi_joinHidden.html
+++ b/apps/settings/elements/wifi_joinHidden.html
@@ -1,0 +1,62 @@
+<element name="wifi-joinHidden" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="authentication"> Authentication </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <p data-l10n-id="ssid-name">SSID Network Name</p>
+          <input type="text" data-ignore name="ssid" />
+        </li>
+        <li>
+          <p data-l10n-id="security">Security</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select>
+              <option data-l10n-id="securityNone">none</option>
+              <option>WEP</option>
+              <option selected>WPA-PSK</option>
+              <option>WPA-EAP</option>
+            </select>
+          </p>
+        </li>
+        <li class="eap">
+          <p data-l10n-id="eap">EAP method</p>
+          <p class="fake-select">
+            <button class="icon icon-dialog">empty</button>
+            <select>
+              <option value="SIM">EAP-SIM</option>
+              <option value="AKA">EAP-AKA</option>
+              <option value="AKA'">EAP-AKA'</option>
+            </select>
+          </p>
+        </li>
+        <li class="simpin">
+          <p data-l10n-id="simPin">SIM PIN</p>
+          <input type="text" data-ignore name="simPin" />
+        </li>
+        <li class="identity">
+          <p data-l10n-id="identity">identity</p>
+          <input type="text" data-ignore name="identity" />
+        </li>
+        <li class="password">
+          <label class="pack-checkbox">
+            <input type="checkbox" data-ignore name="show-pwd" id="pwd-joinHidden" />
+            <span></span>
+          </label>
+          <span data-l10n-id="showPassword">show password</span>
+          <p data-l10n-id="password">password</p>
+          <input type="password" data-ignore name="password" maxlength="63" />
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/wifi_manageNetworks.html
+++ b/apps/settings/elements/wifi_manageNetworks.html
@@ -1,0 +1,43 @@
+<element name="wifi-manageNetworks" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <h1 data-l10n-id="manageNetworks"> Manage Networks </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <small data-name="deviceinfo.mac"></small>
+          <a data-l10n-id="macAddress"> MAC address </a>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="knownNetworks"> Known Networks </h2>
+      </header>
+      <ul id="wifi-knownNetworks">
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="hiddenNetworks"> Hidden Networks </h2>
+      </header>
+      <ul>
+        <li>
+          <label>
+            <button id="joinHidden" data-l10n-id="joinHiddenNetwork">Join Hidden Networks</button>
+          </label>
+        </li>
+      </ul>
+    <div>
+
+    <form role="dialog" data-type="action" hidden>
+      <menu>
+        <button data-l10n-id="forgetNetwork">Forget network</button>
+        <button data-l10n-id="cancel" type="reset">Cancel</button>
+      </menu>
+    </form>
+
+  </template>
+</element>

--- a/apps/settings/elements/wifi_status.html
+++ b/apps/settings/elements/wifi_status.html
@@ -1,0 +1,38 @@
+<element name="wifi-status" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="forget">Forget</span></button>
+      </menu>
+      <h1 data-ssid> Network Status </h1>
+    </header>
+
+    <div>
+      <ul>
+        <li>
+          <a data-l10n-id="security">security
+            <span data-security>WPA-PSK</span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="signalStrength">signal strength
+            <span data-signal>good</span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="ipAddress">IP Adddress
+            <span data-ip></span>
+          </a>
+        </li>
+        <li>
+          <a data-l10n-id="linkSpeed">link speed
+            <span data-speed></span>
+          </a>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/elements/wifi_wps.html
+++ b/apps/settings/elements/wifi_wps.html
@@ -1,0 +1,50 @@
+<element name="wifi-wps" extends="section">
+  <template>
+
+    <header>
+      <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
+      <menu type="toolbar">
+        <button type="submit"><span data-l10n-id="ok">OK</span></button>
+      </menu>
+      <h1 data-l10n-id="wpsMessage"> Connect with WPS </h1>
+    </header>
+
+    <div>
+      <header>
+        <h2 data-l10n-id="wpsMethodSelection">Select WPS method:</h2>
+      </header>
+      <ul>
+        <li>
+          <label class="pack-radio">
+            <input type="radio" data-setting="wifi.wps.method" name="wpsMethodSelection" value="pbc" checked />
+            <span></span>
+          </label>
+          <a data-l10n-id="wpsPbcLabel">Button connection</a>
+        </li>
+        <li>
+          <label class="pack-radio">
+            <input type="radio" data-setting="wifi.wps.method" name="wpsMethodSelection" value="myPin" />
+            <span></span>
+          </label>
+          <a data-l10n-id="wpsMyPinLabel">My PIN connection</a>
+        </li>
+        <li>
+          <label class="pack-radio">
+            <input type="radio" data-setting="wifi.wps.method" name="wpsMethodSelection" value="apPin" />
+            <span></span>
+          </label>
+          <a data-l10n-id="wpsApPinLabel">AP PIN connection</a>
+        </li>
+        <li id="wifi-wps-pin-area">
+          <p data-l10n-id="wpsPinDescription">PIN is 4 or 8 digits</p>
+          <input type="text" />
+        </li>
+        <li id="wifi-wps-pin-aps">
+          <p data-l10n-id="wpsPinAps">Select an opposite device</p>
+          <select></select>
+        </li>
+      </ul>
+    </div>
+
+  </template>
+</element>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8"/>
-    <meta http-equiv="pragma" content="no-cache"/>
+    <meta charset="utf-8">
+    <meta http-equiv="pragma" content="no-cache">
     <title>Settings</title>
 
     <!-- Debug/DUMP method support -->
-    <script defer src="/shared/js/dump.js"></script>
-    <script defer src="/shared/js/settings_url.js"></script>
+    <script defer="" src="/shared/js/dump.js"></script>
+    <script defer="" src="/shared/js/settings_url.js"></script>
 
     <!-- Common style -->
-    <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>
-    <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>
+    <link rel="stylesheet" type="text/css" href="shared/style/headers.css">
+    <link rel="stylesheet" type="text/css" href="shared/style/switches.css">
 
     <!-- Specific style -->
-    <link rel="stylesheet" type="text/css" href="style/lists.css"/>
-    <link rel="stylesheet" type="text/css" href="style/icons.css"/>
-    <link rel="stylesheet" type="text/css" href="style/settings.css"/>
+    <link rel="stylesheet" type="text/css" href="style/lists.css">
+    <link rel="stylesheet" type="text/css" href="style/icons.css">
+    <link rel="stylesheet" type="text/css" href="style/settings.css">
 
     <!-- Panel Stylesheets
     <link rel="stylesheet" type="text/css" href="shared/style/action_menu.css"/>
@@ -42,25 +42,25 @@
     -->
 
     <!-- Localization -->
-    <link rel="resource" type="application/l10n" href="shared/locales/branding.ini"/>
-    <link rel="resource" type="application/l10n" href="shared/locales/date.ini"/>
-    <link rel="resource" type="application/l10n" href="shared/locales/permissions.ini"/>
-    <link rel="resource" type="application/l10n" href="shared/locales/tz.ini"/>
-    <link rel="resource" type="application/l10n" href="locales/locales.ini"/>
-    <script defer src="shared/js/l10n.js"></script>
-    <script defer src="shared/js/l10n_date.js"></script>
+    <link rel="resource" type="application/l10n" href="shared/locales/branding.ini">
+    <link rel="resource" type="application/l10n" href="shared/locales/date.ini">
+    <link rel="resource" type="application/l10n" href="shared/locales/permissions.ini">
+    <link rel="resource" type="application/l10n" href="shared/locales/tz.ini">
+    <link rel="resource" type="application/l10n" href="locales/locales.ini">
+    <script defer="" src="shared/js/l10n.js"></script>
+    <script defer="" src="shared/js/l10n_date.js"></script>
 
     <!-- For perf-measurement related utilities -->
-    <script defer src="/shared/js/performance_testing_helper.js"></script>
+    <script defer="" src="/shared/js/performance_testing_helper.js"></script>
 
     <!-- Lazy loader -->
-    <script defer src="/shared/js/lazy_loader.js"></script>
+    <script defer="" src="/shared/js/lazy_loader.js"></script>
 
     <!-- IccHelper -->
-    <script defer src="/shared/js/icc_helper.js"></script>
+    <script defer="" src="/shared/js/icc_helper.js"></script>
 
     <!-- Specific code -->
-    <script defer src="js/settings.js"></script>
+    <script defer="" src="js/settings.js"></script>
 
     <!-- shared helper library -->
     <!--<script defer src="shared/js/keyboard_helper.js"></script>-->
@@ -71,6 +71,62 @@
     <!--<script defer src="/shared/js/settings_listener.js"></script> -->
 
     <!-- all non-#root panels will lazy-load their own scripts -->
+    <link rel="import" href="/elements/wifi_status.html">
+    <link rel="import" href="/elements/wifi_auth.html">
+    <link rel="import" href="/elements/wifi_joinHidden.html">
+    <link rel="import" href="/elements/wifi_wps.html">
+    <link rel="import" href="/elements/wifi_manageNetworks.html">
+    <link rel="import" href="/elements/wifi.html">
+    <link rel="import" href="/elements/call_cf_notReachableSettings.html">
+    <link rel="import" href="/elements/call_cf_noReplySettings.html">
+    <link rel="import" href="/elements/call_cf_mobileBusySettings.html">
+    <link rel="import" href="/elements/call_cf_unconditionalSettings.html">
+    <link rel="import" href="/elements/call_voiceMailSettings.html">
+    <link rel="import" href="/elements/call.html">
+    <link rel="import" href="/elements/carrier_operatorSettings.html">
+    <link rel="import" href="/elements/carrier_dataSettings.html">
+    <link rel="import" href="/elements/carrier_mmsSettings.html">
+    <link rel="import" href="/elements/carrier_suplSettings.html">
+    <link rel="import" href="/elements/carrier_dc_warning.html">
+    <link rel="import" href="/elements/carrier_dr_warning.html">
+    <link rel="import" href="/elements/carrier.html">
+    <link rel="import" href="/elements/bluetooth.html">
+    <link rel="import" href="/elements/hotspot_wifiSettings.html">
+    <link rel="import" href="/elements/hotspot.html">
+    <link rel="import" href="/elements/sound_selection.html">
+    <link rel="import" href="/elements/sound.html">
+    <link rel="import" href="/elements/display.html">
+    <link rel="import" href="/elements/notifications.html">
+    <link rel="import" href="/elements/dateTime.html">
+    <link rel="import" href="/elements/languages.html">
+    <link rel="import" href="/elements/homescreen_details.html">
+    <link rel="import" href="/elements/homescreen.html">
+    <link rel="import" href="/elements/keyboard.html">
+    <link rel="import" href="/elements/keyboard_selection_addMore.html">
+    <link rel="import" href="/elements/keyboard_selection.html">
+    <link rel="import" href="/elements/phoneLock_passcode.html">
+    <link rel="import" href="/elements/phoneLock.html">
+    <link rel="import" href="/elements/simpin_dialog.html">
+    <link rel="import" href="/elements/simpin.html">
+    <link rel="import" href="/elements/appPermissions_details.html">
+    <link rel="import" href="/elements/appPermissions.html">
+    <link rel="import" href="/elements/doNotTrack.html">
+    <link rel="import" href="/elements/about_moreInfo_developer.html">
+    <link rel="import" href="/elements/about_moreInfo.html">
+    <link rel="import" href="/elements/about_yourRights.html">
+    <link rel="import" href="/elements/about_yourPrivacy.html">
+    <link rel="import" href="/elements/about_licensing.html">
+    <link rel="import" href="/elements/about_source_code.html">
+    <link rel="import" href="/elements/about_legal.html">
+    <link rel="import" href="/elements/about.html">
+    <link rel="import" href="/elements/battery.html">
+    <link rel="import" href="/elements/applicationStorage.html">
+    <link rel="import" href="/elements/mediaStorage.html">
+    <link rel="import" href="/elements/accessibility.html">
+    <link rel="import" href="/elements/crashReports.html">
+    <link rel="import" href="/elements/improveBrowserOS.html">
+    <link rel="import" href="/elements/help.html">
+    <link rel="import" href="/elements/icc.html">
   </head>
   <body class="skin-organic uninit">
 
@@ -94,2765 +150,177 @@
       -->
 
     <!-- Connectivity :: Wi-Fi :: Network Status -->
-    <section role="region" id="wifi-status">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="forget">Forget</span></button>
-        </menu>
-        <h1 data-ssid> Network Status </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <a data-l10n-id="security">security
-              <span data-security>WPA-PSK</span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="signalStrength">signal strength
-              <span data-signal>good</span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="ipAddress">IP Adddress
-              <span data-ip></span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="linkSpeed">link speed
-              <span data-speed></span>
-            </a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="wifi-status" role="region" id="wifi-status"></section>
 
     <!-- Connectivity :: Wi-Fi :: Network Authentication -->
-    <section role="region" id="wifi-auth">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-ssid> Network Authentication </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <a data-l10n-id="security">security
-              <span data-security>WPA-PSK</span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="signalStrength">signal strength
-              <span data-signal>good</span>
-            </a>
-          </li>
-          <li class="eap">
-            <p data-l10n-id="eap">EAP method</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select>
-                <option value="SIM">EAP-SIM</option>
-                <option value="AKA">EAP-AKA</option>
-                <option value="AKA'">EAP-AKA'</option>
-              </select>
-            </p>
-          </li>
-          <li class="simpin">
-            <p data-l10n-id="simPin">SIM PIN</p>
-            <input type="text" data-ignore name="simPin" />
-          </li>
-          <li class="identity">
-            <p data-l10n-id="identity">identity</p>
-            <input type="text" data-ignore name="identity" />
-          </li>
-          <li class="password">
-            <label class="pack-checkbox">
-              <input type="checkbox" data-ignore name="show-pwd" id="pwd-auth" />
-              <span></span>
-            </label>
-            <span data-l10n-id="showPassword">show password</span>
-            <p data-l10n-id="password">password</p>
-            <input type="password" data-ignore name="password" maxlength="63" x-inputmode="verbatim" />
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="wifi-auth" role="region" id="wifi-auth"></section>
 
     <!-- Connectivity :: Wi-Fi :: Join Hidden Network -->
-    <section role="region" id="wifi-joinHidden">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="authentication"> Authentication </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <p data-l10n-id="ssid-name">SSID Network Name</p>
-            <input type="text" data-ignore name="ssid" />
-          </li>
-          <li>
-            <p data-l10n-id="security">Security</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select>
-                <option data-l10n-id="securityNone">none</option>
-                <option>WEP</option>
-                <option selected>WPA-PSK</option>
-                <option>WPA-EAP</option>
-              </select>
-            </p>
-          </li>
-          <li class="eap">
-            <p data-l10n-id="eap">EAP method</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select>
-                <option value="SIM">EAP-SIM</option>
-                <option value="AKA">EAP-AKA</option>
-                <option value="AKA'">EAP-AKA'</option>
-              </select>
-            </p>
-          </li>
-          <li class="simpin">
-            <p data-l10n-id="simPin">SIM PIN</p>
-            <input type="text" data-ignore name="simPin" />
-          </li>
-          <li class="identity">
-            <p data-l10n-id="identity">identity</p>
-            <input type="text" data-ignore name="identity" />
-          </li>
-          <li class="password">
-            <label class="pack-checkbox">
-              <input type="checkbox" data-ignore name="show-pwd" id="pwd-joinHidden" />
-              <span></span>
-            </label>
-            <span data-l10n-id="showPassword">show password</span>
-            <p data-l10n-id="password">password</p>
-            <input type="password" data-ignore name="password" maxlength="63" />
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="wifi-joinHidden" role="region" id="wifi-joinHidden"></section>
 
     <!-- Connectivity :: Wi-Fi :: WPS -->
-    <section role="region" id="wifi-wps">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="wpsMessage"> Connect with WPS </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="wpsMethodSelection">Select WPS method:</h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-radio">
-              <input type="radio" data-setting="wifi.wps.method" name="wpsMethodSelection" value="pbc" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="wpsPbcLabel">Button connection</a>
-          </li>
-          <li>
-            <label class="pack-radio">
-              <input type="radio" data-setting="wifi.wps.method" name="wpsMethodSelection" value="myPin" />
-              <span></span>
-            </label>
-            <a data-l10n-id="wpsMyPinLabel">My PIN connection</a>
-          </li>
-          <li>
-            <label class="pack-radio">
-              <input type="radio" data-setting="wifi.wps.method" name="wpsMethodSelection" value="apPin" />
-              <span></span>
-            </label>
-            <a data-l10n-id="wpsApPinLabel">AP PIN connection</a>
-          </li>
-          <li id="wifi-wps-pin-area">
-            <p data-l10n-id="wpsPinDescription">PIN is 4 or 8 digits</p>
-            <input type="text" />
-          </li>
-          <li id="wifi-wps-pin-aps">
-            <p data-l10n-id="wpsPinAps">Select an opposite device</p>
-            <select></select>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="wifi-wps" role="region" id="wifi-wps"></section>
 
     <!-- Connectivity :: Wi-Fi :: Saved Networks -->
-    <section role="region" id="wifi-manageNetworks">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <h1 data-l10n-id="manageNetworks"> Manage Networks </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <small data-name="deviceinfo.mac"></small>
-            <a data-l10n-id="macAddress"> MAC address </a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="knownNetworks"> Known Networks </h2>
-        </header>
-        <ul id="wifi-knownNetworks">
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="hiddenNetworks"> Hidden Networks </h2>
-        </header>
-        <ul>
-          <li>
-            <label>
-              <button id="joinHidden" data-l10n-id="joinHiddenNetwork">Join Hidden Networks</button>
-            </label>
-          </li>
-        </ul>
-      <div>
-
-      <form role="dialog" data-type="action" hidden>
-        <menu>
-          <button data-l10n-id="forgetNetwork">Forget network</button>
-          <button data-l10n-id="cancel" type="reset">Cancel</button>
-        </menu>
-      </form>
-      -->
-    </section>
+    <section is="wifi-manageNetworks" role="region" id="wifi-manageNetworks"></section>
 
     <!-- Connectivity :: Wi-Fi -->
-    <section role="region" id="wifi">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="wifi"> Wi-Fi </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li id="wifi-enabled">
-            <label class="pack-switch">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <a data-l10n-id="wifi">Wi-Fi</a>
-          </li>
-          <li hidden>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="wifi.notification"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="networkNotification-expl">Notify me when an open network is available</small>
-            <a data-l10n-id="networkNotification">Network notification</a>
-          </li>
-          <li id="wps-column">
-            <small data-l10n-id="wpsDescription2">Automatic Wi-Fi setup</small>
-            <a data-l10n-id="wpsMessage">Connect with WPS</a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="availableNetworks"> Available Networks </h2>
-        </header>
-        <ul id="wifi-availableNetworks" data-state="off">
-          <li class="explanation" data-state="off" data-l10n-id="wifi-disabled">
-            Turn Wi-Fi on to view available networks.
-          </li>
-          <li data-state="on">
-            <progress></progress><span data-l10n-id="scanning">Searching…</span>
-          </li>
-          <li data-state="ready">
-            <label>
-              <button data-l10n-id="scanNetworks">Search Again</button>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
-        </header>
-        <ul>
-          <li>
-            <label>
-              <button id="manageNetworks" data-l10n-id="manageNetworks">Manage Networks</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/wifi.js"></script>
-      -->
-    </section>
+    <section is="wifi" role="region" id="wifi"></section>
 
     <!-- Connectivity :: Call :: Call Forwarding Not Reachable -->
-    <section role="region" id="call-cf-notReachableSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
-      </header>
-
-      <div>
-        <ul id="cf-notreachable-advanced">
-          <li>
-            <p data-l10n-id="cf-numberWhenUnreachable">Number when unreachable</p>
-            <input type="tel" id="cf-notreachable-number" data-setting="ril.cf.notreachable.number" disabled/>
-          </li>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" data-setting="ril.cf.notreachable.enabled"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="callForwardingNotReachableShort">When unreachable</small>
-            <a data-l10n-id="callForwardingForward">Forward</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="call-cf-notReachableSettings" role="region" id="call-cf-notReachableSettings"></section>
 
     <!-- Connectivity :: Call :: Call Forwarding No Reply -->
-    <section role="region" id="call-cf-noReplySettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
-      </header>
-
-      <div>
-        <ul id="cf-noreply-advanced">
-          <li>
-            <p data-l10n-id="cf-numberWhenUnanswered">Number when unanswered</p>
-            <input type="tel" id="cf-noreply-number" data-setting="ril.cf.noreply.number" disabled/>
-          </li>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" data-setting="ril.cf.noreply.enabled"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="callForwardingNoReplyShort">When unanswered</small>
-            <a data-l10n-id="callForwardingForward">Forward</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="call-cf-noReplySettings" role="region" id="call-cf-noReplySettings"></section>
 
     <!-- Connectivity :: Call :: Call Forwarding Mobile Busy -->
-    <section role="region" id="call-cf-mobileBusySettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
-      </header>
-
-      <div>
-        <ul id="cf-mobilebusy-advanced">
-          <li>
-            <p data-l10n-id="cf-numberWhenBusy">Number when busy</p>
-            <input type="tel" id="cf-mobilebusy-number" data-setting="ril.cf.mobilebusy.number" disabled/>
-          </li>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" data-setting="ril.cf.mobilebusy.enabled"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="callForwardingMobileBusyShort">When busy</small>
-            <a data-l10n-id="callForwardingForward">Forward</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="call-cf-mobileBusySettings" role="region" id="call-cf-mobileBusySettings"></section>
 
     <!-- Connectivity :: Call :: Call Forwarding Unconditional -->
-    <section role="region" id="call-cf-unconditionalSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="callForwarding"> Call forwarding </h1>
-      </header>
-
-      <div>
-        <ul id="cf-unconditional-advanced">
-          <li>
-            <p data-l10n-id="cf-alwaysUseThisNumber">Always use this number</p>
-            <input type="tel" id="cf-unconditional-number" data-setting="ril.cf.unconditional.number" disabled/>
-          </li>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" data-setting="ril.cf.unconditional.enabled"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="callForwardingUnconditionalShort">Always</small>
-            <a data-l10n-id="callForwardingForward">Forward</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="call-cf-unconditionalSettings" role="region" id="call-cf-unconditionalSettings"></section>
 
     <!-- Connectivity :: Call :: Voice Mail -->
-    <section role="region" id="call-voiceMailSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="voiceMail"> Voicemail </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <p data-l10n-id="voiceMail-number">Voicemail Number</p>
-            <input type="tel" id="vm-number" data-setting="ril.iccInfo.mbdn"/>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="call-voiceMailSettings" role="region" id="call-voiceMailSettings"></section>
 
     <!-- Connectivity :: Call -->
-    <section role="region" id="call">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="callSettings"> Call Settings </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <small id="voiceMail-desc"></small>
-            <a data-href="#call-voiceMailSettings" data-l10n-id="voiceMail">Voicemail</a>
-          </li>
-          <li id="menuItem-voicePrivacyMode" hidden>
-            <label class="pack-switch checkbox-label">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <a data-l10n-id="voicePrivacyMode">Voice privacy mode</a>
-          </li>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="wap.push.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="wapPush">WAP Push</a>
-          </li>
-          <li id="menuItem-callWaiting" data-state="off">
-            <label class="pack-switch checkbox-label">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <label class="alert-label" hidden>
-              <span></span>
-            </label>
-            <a data-l10n-id="callWaiting">Call Waiting</a>
-          </li>
-          <li id="menuItem-cellBroadcast" class="disabled">
-            <label class="pack-switch checkbox-label">
-              <input type="checkbox" data-ignore disabled />
-              <span></span>
-            </label>
-            <a data-l10n-id="callBroadcastService">Cell broadcast service</a>
-          </li>
-          <li id="menuItem-callerId" class="disabled">
-            <a data-l10n-id="callerId">Caller ID</a>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="ril-callerId" data-setting="ril.callerId">
-                <option value="CLIR_DEFAULT" data-l10n-id="callerId-default">Network default</option>
-                <option value="CLIR_INVOCATION" data-l10n-id="callerId-hide">Hide number</option>
-                <option value="CLIR_SUPPRESSION" data-l10n-id="callerId-show">Show number</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="callForwarding"> Call Forwarding </h2>
-        </header>
-        <ul>
-          <li id="li-cfu-desc" class="disabled">
-            <small id="cfu-desc"></small>
-            <a id="menuItem-callForwardingUnconditional" data-href="#call-cf-unconditionalSettings" data-l10n-id="callForwardingUnconditional">Always forward</a>
-          </li>
-          <li id="li-cfmb-desc" class="disabled">
-            <small id="cfmb-desc"></small>
-            <a id="menuItem-callForwardingMobileBusy" data-href="#call-cf-mobileBusySettings" data-l10n-id="callForwardingMobileBusy">Forward when busy</a>
-          </li>
-          <li id="li-cfnrep-desc" class="disabled">
-            <small id="cfnrep-desc"></small>
-            <a id="menuItem-callForwardingNoReply" data-href="#call-cf-noReplySettings" data-l10n-id="callForwardingNoReply">Forward when unanswered</a>
-          </li>
-          <li id="li-cfnrea-desc" class="disabled">
-            <small id="cfnrea-desc"></small>
-            <a id="menuItem-callForwardingNotReachable" data-href="#call-cf-notReachableSettings" data-l10n-id="callForwardingNotReachable">Forward when unreachable</a>
-          </li>
-        </ul>
-      </div>
-
-      <form role="dialog" data-type="confirm" hidden class="cw-alert">
-        <section>
-          <h1 data-l10n-id="confirmCallWaitingTitle">Unable to confirm call waiting preferences</h1>
-          <p>
-            <strong data-l10n-id="confirmCallWaitingDesc">The device is currently unable to communicate with the carrier. Try setting the preference again.</strong>
-          </p>
-          <p class="cw-alert-sub-p">
-            <label class="pack-switch cw-alert-checkbox-label">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <span data-l10n-id="callWaiting">Call Waiting</span>
-          </p>
-        </section>
-        <menu>
-          <button class="cw-alert-cancel" data-l10n-id="cancel">Cancel</button>
-          <button class="cw-alert-set recommend" data-l10n-id="set">Set</button>
-        </menu>
-      </form>
-
-      <form role="dialog" data-type="confirm" hidden class="cf-alert">
-        <section>
-          <h1 data-l10n-id="callForwardingConfirmTitle">Call forwarding confirmation message</h1>
-          <p>
-            <strong id="cf-confirm-message"></strong>
-          </p>
-        </section>
-        <menu>
-          <button class="cf-alert-continue full" data-l10n-id="continue">Continue</button>
-        </menu>
-      </form>
-
-      <script src="js/call.js"></script>
-      -->
-    </section>
+    <section is="call" role="region" id="call"></section>
 
     <!-- Connectivity :: Cellular & Data :: Network Operator -->
-    <section role="region" id="carrier-operatorSettings">
-      <!--
-      <header>
-        <a href="#carrier"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="networkOperator"> Network Operator </h1>
-      </header>
-
-      <div id="carrier-operatorSettings-content">
-        <ul>
-          <li>
-            <p data-l10n-id="operator-networkType">Network Type</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select name="ril.radio.preferredNetworkType" id="preferredNetworkType">
-              </select>
-            </p>
-          </li>
-          <li id="operator-roaming-preference">
-            <p data-l10n-id="operator-roamingPreference">Roaming preference</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="operator-roaming-preference-selector">
-                <option data-l10n-id="operator-roamingPreference-home" value="home">Home</option>
-                <option data-l10n-id="operator-roamingPreference-any" value="any">Any</option>
-                <option data-l10n-id="operator-roamingPreference-affiliated" value="affiliated">Affiliated</option>
-              </select>
-            </p>
-          </li>
-          <li id="operator-autoSelect">
-            <label class="pack-switch">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <small></small>
-            <a data-l10n-id="operator-autoSelect">Automatic Selection</a>
-          </li>
-        </ul>
-
-        <header id="availableOperatorsHeader">
-          <h2 data-l10n-id="availableOperators"> Network Operators in the Area </h2>
-        </header>
-        <ul id="availableOperators" data-state="off">
-          <li class="explanation" data-state="off" data-l10n-id="operator-turnAutoSelectOff">
-            Turn Automatic Selection off to view available network operators.
-          </li>
-          <li class="explanation" data-state="on" data-l10n-id="scanning">
-            Searching…
-          </li>
-          <li data-state="ready">
-            <label>
-              <button data-l10n-id="scanNetworks">Search Again</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="carrier-operatorSettings" role="region" id="carrier-operatorSettings"></section>
 
     <!-- Connectivity :: Cellular & Data :: Data Settings -->
-    <section role="region" id="carrier-dataSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="dataSettings"> Data Settings </h1>
-      </header>
-
-      <div>
-        <ul class="apnSettings-list">
-          <li class="apnSettings-custom">
-            <label class="pack-radio">
-              <input type="radio" data-setting="ril.data.carrier" name="dataApnSettingsCarrier" value="_custom_" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="custom">(custom settings)</a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
-        </header>
-        <ul class="apnSettings-advanced">
-          <li>
-            <p data-l10n-id="apn">APN</p>
-            <input type="text" data-setting="ril.data.apn" />
-          </li>
-          <li>
-            <p data-l10n-id="identity">identity</p>
-            <input type="text" data-setting="ril.data.user" />
-          </li>
-          <li>
-            <p data-l10n-id="password">password</p>
-            <input type="text" data-setting="ril.data.passwd" />
-          </li>
-          <li>
-            <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
-            <input type="text" data-setting="ril.data.httpProxyHost" />
-          </li>
-          <li>
-            <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
-            <input type="text" data-setting="ril.data.httpProxyPort" />
-          </li>
-          <li>
-            <p data-l10n-id="apn-authType">Authentication</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="ril-data-authType" data-setting="ril.data.authtype">
-                <option value="notDefined" data-l10n-id="apn-authType-notDefined">Not defined</option>
-                <option value="none" data-l10n-id="apn-authType-none">None</option>
-                <option value="pap" data-l10n-id="apn-authType-pap">PAP</option>
-                <option value="chap" data-l10n-id="apn-authType-chap">CHAP</option>
-                <option value="papOrChap" data-l10n-id="apn-authType-papOrChap">PAP or CHAP</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="carrier-dataSettings" role="region" id="carrier-dataSettings"></section>
 
     <!-- Connectivity :: Cellular & Data :: Message Settings -->
-    <section role="region" id="carrier-mmsSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="messageSettings"> Message Settings </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="message-confirmation"> Message confirmation </h2>
-        </header>
-        <ul id="general-message-list">
-          <li id="delivery-reports" class="hint">
-            <label class="pack-switch">
-              <input type="checkbox" data-setting="ril.sms.requestStatusReport.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="message-delivery-reports"> Delivery reports </a>
-            <p class="explanation" data-l10n-id="message-delivery-reports-details">Request notification of delivery for each message sent</p>
-          </li>
-        </ul>
-        <header>
-          <h2 data-l10n-id="mmsTitle"> Multimedia messaging (MMS) </h2>
-        </header>
-        <ul class="mmsSettings-list">
-          <li class="hint">
-            <a data-l10n-id="auto-retrieve">Auto retrieve</a>
-            <p class="explanation" data-l10n-id="auto-retrieve-details">automatically retieve messages</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select data-setting="ril.mms.retrieval_mode">
-                <option value="manual" data-l10n-id="manual-retrieve">Off</option>
-                <option value="automatic" data-l10n-id="auto-roaming-retrieve">On with roaming</option>
-                <option value="automatic-home" data-l10n-id="auto-no-roaming-retrieve">On without roaming/option>
-              </select>
-            </p>
-          </li>
-        </ul>
-        <header>
-          <h2 data-l10n-id="apnSettings"> APN Settings </h2>
-        </header>
-        <ul class="apnSettings-list">
-          <li class="apnSettings-custom">
-            <label class="pack-radio">
-              <input type="radio" data-setting="ril.mms.carrier" name="mmsApnSettingsCarrier" value="_custom_" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="custom">(custom settings)</a>
-          </li>
-        </ul>
-        <header>
-          <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
-        </header>
-        <ul class="apnSettings-advanced">
-          <li>
-            <p data-l10n-id="apn">APN</p>
-            <input type="text" data-setting="ril.mms.apn" />
-          </li>
-          <li>
-            <p data-l10n-id="identity">identity</p>
-            <input type="text" data-setting="ril.mms.user" />
-          </li>
-          <li>
-            <p data-l10n-id="password">password</p>
-            <input type="text" data-setting="ril.mms.passwd" />
-          </li>
-          <li>
-            <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
-            <input type="text" x-inputmode="verbatim" data-setting="ril.mms.httpProxyHost" />
-          </li>
-          <li>
-            <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
-            <input type="number" x-inputmode="digits" data-setting="ril.mms.httpProxyPort" />
-          </li>
-          <li>
-            <p data-l10n-id="mmsproxy">MMS Proxy</p>
-            <input type="text" x-inputmode="verbatim" data-setting="ril.mms.mmsproxy" />
-          </li>
-          <li>
-            <p data-l10n-id="mmsport">MMS Port</p>
-            <input type="number" x-inputmode="digits" data-setting="ril.mms.mmsport" />
-          </li>
-          <li>
-            <p data-l10n-id="mmsc">MMSC</p>
-            <input type="text" x-inputmode="verbatim" data-setting="ril.mms.mmsc" />
-          </li>
-          <li>
-            <p data-l10n-id="apn-authType">Authentication</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="ril-mms-authType" data-setting="ril.mms.authtype">
-                <option value="notDefined" data-l10n-id="apn-authType-notDefined">Not defined</option>
-                <option value="none" data-l10n-id="apn-authType-none">None</option>
-                <option value="pap" data-l10n-id="apn-authType-pap">PAP</option>
-                <option value="chap" data-l10n-id="apn-authType-chap">CHAP</option>
-                <option value="papOrChap" data-l10n-id="apn-authType-papOrChap">PAP or CHAP</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="carrier-mmsSettings" role="region" id="carrier-mmsSettings"></section>
 
     <!-- Connectivity :: Cellular & Data :: A-GPS Settings -->
-    <section role="region" id="carrier-suplSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="suplSettings"> A-GPS Settings </h1>
-      </header>
-
-      <div>
-        <ul class="apnSettings-list">
-          <li class="apnSettings-custom">
-            <label class="pack-radio">
-              <input type="radio" data-setting="ril.supl.carrier" name="suplApnSettingsCarrier" value="_custom_" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="custom">(custom settings)</a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
-        </header>
-        <ul class="apnSettings-advanced">
-          <li>
-            <p data-l10n-id="apn">APN</p>
-            <input type="text" data-setting="ril.supl.apn" />
-          </li>
-          <li>
-            <p data-l10n-id="identity">identity</p>
-            <input type="text" data-setting="ril.supl.user" />
-          </li>
-          <li>
-            <p data-l10n-id="password">password</p>
-            <input type="text" data-setting="ril.supl.passwd" />
-          </li>
-          <li>
-            <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>
-            <input type="text" data-setting="ril.supl.httpProxyHost" />
-          </li>
-          <li>
-            <p data-l10n-id="httpProxyPort">HTTP Proxy Port</p>
-            <input type="text" data-setting="ril.supl.httpProxyPort" />
-          </li>
-          <li>
-            <p data-l10n-id="apn-authType">Authentication</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="ril-supl-authType" data-setting="ril.supl.authtype">
-                <option value="notDefined" data-l10n-id="apn-authType-notDefined">Not defined</option>
-                <option value="none" data-l10n-id="apn-authType-none">None</option>
-                <option value="pap" data-l10n-id="apn-authType-pap">PAP</option>
-                <option value="chap" data-l10n-id="apn-authType-chap">CHAP</option>
-                <option value="papOrChap" data-l10n-id="apn-authType-papOrChap">PAP or CHAP</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="carrier-suplSettings" role="region" id="carrier-suplSettings"></section>
 
     <!-- Connectivity :: Cellular & Data :: Data Connection Warnings -->
-    <section role="region" id="carrier-dc-warning">
-      <!--
-      <form role="dialog" data-type="confirm">
-        <section>
-          <h1>
-            <span data-l10n-id="dataConnection-warning-head">Turn ON data connection?</span>
-          </h1>
-          <p>
-            <small data-l10n-id="dataConnection-warning-message">
-              Applications will automatically fetch data via data connection
-               when required. Additional data charges may apply.
-            </small>
-          </p>
-        </section>
-        <menu>
-          <button type="reset" data-l10n-id="notNow">Not now</button>
-          <button type="submit" class="recommend" data-l10n-id="turnOn">Turn ON</button>
-        </menu>
-      </form>
-      -->
-    </section>
+    <section is="carrier-dc-warning" role="region" id="carrier-dc-warning"></section>
 
     <!-- Connectivity :: Cellular & Data :: Data Roaming Warnings -->
-    <section role="region" id="carrier-dr-warning">
-      <!--
-      <form role="dialog" data-type="confirm">
-        <section>
-          <h1>
-            <span data-l10n-id="dataRoaming-warning-head">Turn ON data roaming?</span>
-          </h1>
-          <p>
-            <small data-l10n-id="dataRoaming-warning-message">
-              Depending on your service agreement, significant roaming charges
-              may apply for data usage when you are in the roaming area.
-            </small>
-          </p>
-        </section>
-        <menu>
-          <button type="reset" data-l10n-id="notNow">Not now</button>
-          <button type="submit" class="recommend" data-l10n-id="turnOn">Turn ON</button>
-        </menu>
-      </form>
-      -->
-    </section>
+    <section is="carrier-dr-warning" role="region" id="carrier-dr-warning"></section>
 
     <!-- Connectivity :: Cellular & Data -->
-    <section role="region" id="carrier">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="cellularAndData"> Cellular &amp; Data </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <small id="dataNetwork-desc"></small>
-            <span data-l10n-id="dataNetwork">Carrier</span>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="dataConnectivity"> Data Connectivity </h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="ril.data.enabled" class="uninit"/>
-              <span></span>
-            </label>
-            <small id="dataConnection-desc"></small>
-            <a data-l10n-id="dataConnection">Data Connection</a>
-          </li>
-          <li id="dataConnection-expl" class="explanation" data-l10n-id="dataConnection-warning-message" hidden></li>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="ril.data.roaming_enabled" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="dataRoaming">Data Roaming</a>
-          </li>
-          <li id="dataRoaming-expl" class="explanation" data-l10n-id="dataRoaming-warning-message" hidden></li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="advancedSettings"> Advanced Settings </h2>
-        </header>
-        <ul>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#carrier-operatorSettings"
-                data-l10n-id="networkOperator"> Network Operator </button>
-            </label>
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#carrier-dataSettings"
-                data-l10n-id="dataSettings">Data Settings</button>
-            </label>
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#carrier-mmsSettings"
-                data-l10n-id="messageSettings">Message Settings</button>
-            </label>
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#carrier-suplSettings"
-                data-l10n-id="suplSettings">A-GPS Settings</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <script defer src="js/carrier.js"></script>
-      -->
-    </section>
+    <section is="carrier" role="region" id="carrier"></section>
 
     <!-- Connectivity :: Bluetooth -->
-    <section role="region" id="bluetooth">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="bluetooth"> Bluetooth </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li id="bluetooth-status" class="hint">
-            <label class="pack-switch">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <a data-l10n-id="bluetooth">Bluetooth</a>
-            <p data-l10n-id="bluetooth-enable-msg" id="bluetooth-enable-msg" class="explanation">
-              Turn Bluetooth on to view devices in the area.
-            </p>
-          </li>
-          <li hidden id="device-visible">
-            <label class="pack-switch">
-              <input type="checkbox" data-ignore />
-              <span></span>
-            </label>
-            <small id="bluetooth-device-name"></small>
-            <a data-l10n-id="bluetooth-visible-to-all">Visible to all</a>
-          </li>
-          <li hidden id="bluetooth-rename">
-            <label>
-              <button id="rename-device" data-l10n-id="rename-device" disabled>Rename My Device</button>
-            </label>
-          </li>
-        </ul>
-
-        <header id="bluetooth-paired-title">
-          <h2 data-l10n-id="bluetooth-paired-devices">Paired Devices</h2>
-        </header>
-        <ul id="bluetooth-paired-devices" class="devices">
-        </ul>
-
-        <header id="bluetooth-found-title">
-          <h2 data-l10n-id="bluetooth-devices-in-area">Devices found</h2>
-        </header>
-        <ul id="bluetooth-devices" class="devices">
-        </ul>
-        <div id="bluetooth-searching" data-l10n-id="search-for-device" class="explanation">
-          Searching for devices…
-        </div>
-        <ul hidden id="bluetooth-search">
-          <li>
-            <label>
-              <button id="search-device" data-l10n-id="search-device" disabled>Search for Devices</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <form role="dialog" data-type="action" id="paired-device-option" hidden>
-        <menu>
-          <button data-l10n-id="device-option-connect" id="connect-option">Connect</button>
-          <button data-l10n-id="device-option-disconnect" id="disconnect-option">Disconnect</button>
-          <button data-l10n-id="device-option-unpair" id="unpair-option">Unpair</button>
-          <button data-l10n-id="cancel">Cancel</button>
-        </menu>
-      </form>
-
-      <form role="dialog" data-type="confirm" id="unpair-device" hidden>
-        <section>
-          <h1>Confirmation</h1>
-          <p data-l10n-id="device-option-unpair-device">Unpair Device?</p>
-        </section>
-        <menu>
-          <button data-l10n-id="cancel">Cancel</button>
-          <button data-l10n-id="device-option-confirm" id="confirm-option" class="danger">Confirm</button>
-        </menu>
-      </form>
-
-      <script src="js/bluetooth.js"></script>
-      -->
-    </section>
+    <section is="bluetooth" role="region" id="bluetooth"></section>
 
     <!-- Connectivity :: Internet Sharing :: Portable Wi-Fi Hotspot -->
-    <section role="region" id="hotspot-wifiSettings">
-      <!--
-      <header>
-        <button type="reset"><span data-l10n-id="back" class="icon icon-back">Back</span></button>
-        <menu type="toolbar">
-          <button type="submit"><span data-l10n-id="ok">OK</span></button>
-        </menu>
-        <h1 data-l10n-id="hotspotSettings"> Hotspot Settings </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <p data-l10n-id="ssid-name">SSID Network Name</p>
-            <input type="text" data-setting="tethering.wifi.ssid" />
-          </li>
-          <li class="password">
-            <label class="pack-checkbox">
-              <input type="checkbox" data-ignore name="show_password" />
-              <span></span>
-            </label>
-            <span data-l10n-id="showPassword">Show password</span>
-            <p data-l10n-id="wifi-password">Password</p>
-            <input type="password" name="password" x-inputmode="verbatim" data-setting="tethering.wifi.security.password" />
-          </li>
-          <li>
-            <p data-l10n-id="wifi-security">Security</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">Security</button>
-              <select class="security-selector" data-setting="tethering.wifi.security.type">
-                <option value="open" data-l10n-id="hotspot-open">open</option>
-                <option value="wpa-psk" data-l10n-id="hotspot-wpa-psk">WPA (TKIP)</option>
-                <option value="wpa2-psk" data-l10n-id="hotspot-wpa2-psk">WPA2 (AES)</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="hotspot-wifiSettings" role="region" id="hotspot-wifiSettings"></section>
 
     <!-- Connectivity :: Internet Sharing -->
-    <section role="region" id="hotspot">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="internetSharing"> Internet Sharing </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="internetSharing-wifi"> Wi-Fi </h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="tethering.wifi.enabled" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="wifi-hotspot">Wi-Fi Hotspot</a>
-          </li>
-          <li class="description" data-l10n-id="internetSharing-wifi-desc">
-            Allow other devices to share my phone’s Internet connection by connecting via Wi-Fi.
-          </li>
-          <li>
-            <a data-l10n-id="wifi-name">Name
-              <span data-name="tethering.wifi.ssid"></span>
-            </a>
-          </li>
-          <li class="password-item" hidden>
-            <a data-l10n-id="wifi-password">Password
-              <span data-name="tethering.wifi.security.password"></span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="wifi-security">Security
-              <span data-name="tethering.wifi.security.type"></span>
-            </a>
-          </li>
-          <li id="hotspot-settings-section">
-            <label>
-              <button class="icon icon-view"
-              data-l10n-id="hotspotSettings">Hotspot Settings</button>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="internetSharing-usb"> USB </h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="tethering.usb.enabled" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="usb-tethering">USB Tethering</a>
-          </li>
-          <li class="description" data-l10n-id="internetSharing-usb-desc">
-            Share my phone’s Internet connection with a USB-connected device.
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/hotspot.js"></script>
-      -->
-    </section>
+    <section is="hotspot" role="region" id="hotspot"></section>
 
     <!-- Personalization :: Sound :: Sound Selection -->
-    <section role="region" id="sound-selection">
-      <!--
-      <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <menu type="toolbar">
-          <button data-l10n-id="done" type="submit">Done</button>
-        </menu>
-        <h1 data-l10n-id="select-tone"> Select a Tone </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="ring-tones">Ringtones</h2>
-        </header>
-        <ul id="ringtones-list">
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="alert-tones">Alert Tones</h2>
-        </header>
-        <ul id="notifications-list">
-        </ul>
-
-        <audio style="display: none;" src=""></audio>
-      </div>
-      -->
-    </section>
+    <section is="sound-selection" role="region" id="sound-selection"></section>
 
     <!-- Personalization :: Sound -->
-    <section role="region" id="sound">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="sound"> Sound </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="vibration.enabled" checked class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="vibrate">Vibrate</a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="volume">Volume</h2>
-        </header>
-        <ul>
-          <li class="sound-setting">
-            <p data-l10n-id="ringer-and-notification-sound">Ringer & Notifications</p>
-            <label>
-              <input type="range" name="audio.volume.notification" step="1" min="0" value="15" max="15">
-              <span class="range-icons volume"></span>
-            </label>
-          </li>
-          <li class="sound-setting">
-            <p data-l10n-id="alarm-sound">Alarm</p>
-            <label>
-              <input type="range" name="audio.volume.alarm" step="1" min="0" value="15" max="15">
-              <span class="range-icons volume"></span>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="tones">Tones</h2>
-        </header>
-        <ul>
-          <li>
-            <p data-l10n-id="ringer">Ringer</p>
-            <p class="fake-select">
-              <button id="call-tone-selection" class="icon icon-view" data-l10n-id="change"></button>
-            </p>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="other-sounds">Other Sounds</h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="phone.ring.keypad" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="keypad">Keypad</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="camera.shutter.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="camera-shutter">Camera Shutter</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="mail.sent-sound.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="sent-mail">Sent Mail</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="message.sent-sound.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="sent-message">Sent Message</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="lockscreen.unlock-sound.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="unlock-screen">Unlock Screen</a>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/sound.js"></script>
-      -->
-    </section>
+    <section is="sound" role="region" id="sound"></section>
 
     <!-- Personalization :: Display -->
-    <section role="region" id="display">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="display"> Display </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="screen.orientation.lock" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="lock-orientation">Lock screen orientation</a>
-          </li>
-        </ul>
-
-        <header id="wallpaper-header">
-          <h2 data-l10n-id="wallpaper">Wallpaper</h2>
-        </header>
-        <div id="wallpaper">
-          <img id="wallpaper-preview" alt="wallpaper preview"/>
-          <button id="wallpaper-button"></button>
-        </div>
-        <header>
-          <h2 data-l10n-id="brightness">Brightness</h2>
-        </header>
-        <ul>
-          <li id="brightness-auto">
-            <label class="pack-checkbox">
-              <input type="checkbox" name="screen.automatic-brightness" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="brightness-autoAdjust">Adjust Automatically</a>
-          </li>
-          <li id="brightness-manual">
-            <label>
-              <input type="range" name="screen.brightness" step="0.01" min="0.1" value="0.5" max="1" />
-              <span class="range-icons brightness"></span>
-            </label>
-          </li>
-          <li id="screen-timeout">
-            <p data-l10n-id="screen-timeout">Screen Timeout</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select name="screen.timeout" data-value-type="integer">
-                <option value="60"  data-l10n-id="one-minute" selected>1 minute</option>
-                <option value="120" data-l10n-id="two-minutes"> 2 minutes</option>
-                <option value="300" data-l10n-id="five-minutes">5 minutes</option>
-                <option value="600" data-l10n-id="ten-minutes">10 minutes</option>
-                <option value="0"   data-l10n-id="never">Never</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/wallpaper.js"></script>
-      -->
-    </section>
+    <section is="display" role="region" id="display"></section>
 
     <!-- Personalization :: Notifications -->
-    <section role="region" id="notifications">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="notifications"> Notifications </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="lockscreen.notifications-preview.enabled" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="lockscreen-notifications">Show on Lock Screen</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="notifications" role="region" id="notifications"></section>
 
     <!-- Personalization :: Date & Time -->
-    <section role="region" id="dateTime">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="dateAndTime"> Date &amp; Time </h1>
-      </header>
-
-      <div>
-        <ul id="time-auto" data-state="auto" hidden>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="time.nitz.automatic-update.enabled" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="setTimeAutomatically">Set Automatically</a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="setTimeManually">Set Manually</h2>
-        </header>
-        <ul id="time-manual">
-          <li>
-            <label>
-              <input type="date" id="date-picker" min="1970-1-1" max="2037-12-31"/>
-            </label>
-            <a data-l10n-id="dateMessage">Date <span id="clock-date"></span> </a>
-          </li>
-          <li>
-            <label>
-              <input type="time" id="time-picker" />
-            </label>
-            <a data-l10n-id="timeMessage">Time <span id="clock-time"></span> </a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="timezoneMessage">Time zone</h2>
-        </header>
-        <ul id="timezone">
-          <li>
-            <p data-l10n-id="tz-region">Region</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="timezone-region"></select>
-            </p>
-          </li>
-          <li>
-            <p data-l10n-id="tz-city">City</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="timezone-city"></select>
-            </p>
-          </li>
-        </ul>
-      </div>
-
-      <script src="shared/js/tz_select.js"></script>
-      <script src="js/date_time.js"></script>
-      -->
-    </section>
+    <section is="dateTime" role="region" id="dateTime"></section>
 
     <!-- Personalization :: Language & Region -->
     <!-- We should remove 'hidden' on the region selector and set
       -  data-l10n-id to languageAndRegion after being implemented in v2. -->
-    <section role="region" id="languages">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="language"> Language </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="sample-format">Sample Format</h2>
-        </header>
-        <ul>
-          <li class="description">
-            <p id="region-date">Friday, September 28 2012</p>
-            <p id="region-time">06:54 PM</p>
-          </li>
-          <li>
-            <p data-l10n-id="language">Language</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">Language</button>
-              <select name="language.current"></select>
-            </p>
-          </li>
-          <li hidden>
-            <p data-l10n-id="region">Region</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select name="region.current">
-                <option value="BR">Brasil</option>
-                <option value="CO">Columbia</option>
-                <option value="ES">España</option>
-                <option value="FR">France</option>
-                <option value="PT">Portugal</option>
-                <option value="TW">Taiwan</option>
-                <option value="UK">United Kingdom</option>
-                <option value="US">United States</option>
-                <option value="VZ">Venezuela</option>
-              </select>
-            </p>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="languages" role="region" id="languages"></section>
 
     <!-- Personalization :: Homescreen :: details -->
-    <section role="region" id="homescreen-details">
-      <!--
-      <header>
-        <a href="#homescreen"><span class="icon icon-back">back</span></a>
-        <h1> </h1>
-      </header>
-      <div>
-        <header>
-          <h2 class="description" data-l10n-id="description">Description</h2>
-        </header>
-        <p></p>
-        <header>
-          <h2 data-l10n-id="changeHomescreen">Change Homescreen</h2>
-        </header>
-        <button id="change-homescreen" data-l10n-id="changeHomescreenButton">Change</button>
-      </div>
-      -->
-    </section>
+    <section is="homescreen-details" role="region" id="homescreen-details"></section>
 
     <!-- Personalization :: Homescreen -->
-    <section role="region" id="homescreen">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="homescreen"> Homescreen </h1>
-      </header>
-
-      <div>
-        <ul></ul>
-      </div>
-
-      <script type="application/javascript" src="shared/js/manifest_helper.js"></script>
-      <script src="js/homescreen.js"></script>
-      -->
-    </section>
+    <section is="homescreen" role="region" id="homescreen"></section>
 
     <!-- Personalization :: Keyboard :: Select Keyboard :: Add More Keyboards -->
-    <section role="region" id="keyboard-selection-addMore">
-      <!--
-      <header>
-        <a href="#keyboard-selection"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="addMoreKeyboards"> Add more keyboards </h1>
-      </header>
-
-      <div id="keyboardAppContainer">
-      </div>
-      -->
-    </section>
+    <section is="keyboard-selection-addMore" role="region" id="keyboard-selection-addMore"></section>
 
     <!-- Personalization :: Keyboard :: Select Keyboard -->
-    <section role="region" id="keyboard-selection">
-      <!--
-      <header>
-        <a href="#keyboard"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="selectKeyboard"> Select keyboard </h1>
-      </header>
-
-      <div>
-        <ul id="enabledKeyboardList">
-        </ul>
-        <ul>
-          <li>
-            <button data-l10n-id="addMoreKeyboards" data-href="#keyboard-selection-addMore">Add more keyboards</button>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="keyboard-selection" role="region" id="keyboard-selection"></section>
 
     <!-- Personalization :: Keyboard -->
-    <section role="region" id="keyboard">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="keyboard"> Keyboard </h1>
-      </header>
-
-      <div>
-        <ul hidden>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.vibration"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="vibration">Vibration</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.clicksound" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="clickSound">Click sound</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.autocorrect"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="autoCorrect">Auto correction</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.wordsuggestion"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="wordSuggestion">Word Suggestion</a>
-          </li>
-        </ul>
-
-        <ul>
-          <li>
-            <a href="#keyboard-selection" data-l10n-id="activeKeyboard">Active keyboard</a>
-          </li>
-        </ul>
-        <header>
-          <h2 data-l10n-id="installed">Installed</h2>
-        </header>
-        <ul id="allKeyboardList" hidden>
-        </ul>
-
-        <div id="textLayoutList" hidden>
-          <header>
-            <h2 data-l10n-id="keyboardlayouts">layouts</h2>
-          </header>
-          <ul></ul>
-        </div>
-
-        <div id="numberLayoutList" hidden>
-          <header>
-            <h2 data-l10n-id="numberKeyboardLayouts">Number Layouts</h2>
-          </header>
-          <ul></ul>
-        </div>
-
-        <div id="optionLayoutList" hidden>
-          <header>
-            <h2 data-l10n-id="optionKeyboardLayouts">Option Layouts</h2>
-          </header>
-          <ul></ul>
-        </div>
-  
-      </div>
-      <script src="js/keyboard.js"></script>
-      -->
-    </section>
+    <section is="keyboard" role="region" id="keyboard"></section>
 
     <!-- Security :: Phone Lock :: PIN Input -->
-    <section role="region" id="phoneLock-passcode">
-      <!--
-      <header>
-        <a href="#phoneLock"><span class="icon icon-back">back</span></a>
-        <menu type="toolbar" data-mode="new">
-          <button id="passcode-change" data-l10n-id="change">Change</button>
-        </menu>
-        <menu type="toolbar" data-mode="create">
-          <button id="passcode-create" data-l10n-id="create">Create</button>
-        </menu>
-        <h1 data-l10n-id="create-passcode"  data-mode="create">  Create a Passcode </h1>
-        <h1 data-l10n-id="current-passcode" data-mode="edit">    Current Passcode  </h1>
-        <h1 data-l10n-id="new-passcode"     data-mode="new">     New Passcode      </h1>
-        <h1 data-l10n-id="enter-passcode"   data-mode="confirm"> Enter Passcode    </h1>
-      </header>
-
-      <div class="passcode-overlay">
-        <input type="number" x-inputmode="digit" id="passcode-input" />
-        <div class="passcode-container" id="passcode-container">
-          <div class="passcode" id="passcode-pseudo-input">
-            <label data-l10n-id="passcode">Passcode</label>
-            <span class="passcode-digit"></span>
-            <span class="passcode-digit"></span>
-            <span class="passcode-digit"></span>
-            <span class="passcode-digit"></span>
-          </div>
-          <div class="passcode" data-mode="new,create" id="passcode-pseudo-confirm-input">
-            <label data-l10n-id="confirm-passcode" data-mode="new,create">Confirm Passcode</label>
-            <span class="passcode-digit"></span>
-            <span class="passcode-digit"></span>
-            <span class="passcode-digit"></span>
-            <span class="passcode-digit"></span>
-          </div>
-          <div class="passcode-error" data-l10n-id="incorrect-passcode" data-type="incorrect">Incorrect passcode!</div>
-          <div class="passcode-error" data-l10n-id="passcode-doesnt-match" data-type="mismatch">Passcode doesn't match. Try again!</div>
-        </div>
-      </div>
-      -->
-    </section>
+    <section is="phoneLock-passcode" role="region" id="phoneLock-passcode"></section>
 
     <!-- Security :: Phone Lock -->
-    <section role="region" id="phoneLock" data-passcode-enabled="false" data-lockscreen-enabled="false">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="phoneLock"> Phone Lock </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="lockscreen.enabled" id="lockscreen-enable" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="lockScreen">Lock Screen</a>
-          </li>
-          <li class="lockscreen-enabled">
-            <label class="pack-switch">
-              <input type="checkbox" name="lockscreen.passcode-lock.enabled" id="passcode-enable" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="passcode-lock">Passcode Lock</a>
-          </li>
-          <li class="passcode-enabled" id="passcode-timeout-row">
-            <p data-l10n-id="require-passcode">Require passcode</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select name="lockscreen.passcode-lock.timeout">
-                <option value="0" data-l10n-id="immediately" selected>Immediately</option>
-                <option value="5" data-l10n-id="after-five-seconds">After 5 seconds</option>
-                <option value="15" data-l10n-id="after-fifteen-seconds">After 15 seconds</option>
-                <option value="30" data-l10n-id="after-thirty-seconds">After 30 seconds</option>
-                <option value="60" data-l10n-id="after-one-minute">After 1 minute</option>
-                <option value="120" data-l10n-id="after-two-minutes">After 2 minutes</option>
-                <option value="300" data-l10n-id="after-five-minutes">After 5 minutes</option>
-                <option value="600" data-l10n-id="after-ten-minutes">After 10 minutes</option>
-                <option value="900" data-l10n-id="after-fifteen-minutes">After 15 minutes</option>
-                <option value="1800" data-l10n-id="after-thirty-minutes">After 30 minutes</option>
-                <option value="3600" data-l10n-id="after-one-hour">After 1 hour</option>
-                <option value="14400" data-l10n-id="after-four-hours">After 4 hours</option>
-              </select>
-            </p>
-          </li>
-          <li class="passcode-enabled">
-            <label>
-              <button data-l10n-id="change-passcode" id="passcode-edit">Change Passcode</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/phone_lock.js"></script>
-      -->
-    </section>
+    <section is="phoneLock" role="region" id="phoneLock" data-passcode-enabled="false" data-lockscreen-enabled="false"></section>
 
     <!-- Security :: SIM Security :: SIM PIN Input -->
-    <section role="region" id="simpin-dialog">
-      <!--
-      <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <menu type="toolbar">
-        <button data-l10n-id="done" type="submit">Done</button>
-        </menu>
-        <h1></h1>
-      </header>
-
-      <div>
-        <div class="container">
-          <div id="errorMsg" class="error" hidden>
-            <div id="messageHeader">The PIN was incorrect.</div>
-            <span id="messageBody">3 tries left.</span>
-          </div>
-
-          <div id="triesLeft" data-l10-id="inputCodeRetriesLeft">
-            3 tries left
-          </div>
-
-          <div id="pinArea" class="sim-code-area">
-            <div data-l10n-id="simPin">SIM PIN</div>
-            <div class="input-wrapper">
-              <input type="password" x-inputmode="digit" name="simpin" size="8" maxlength="8" />
-            </div>
-          </div>
-
-          <div id="pukArea" class="sim-code-area">
-            <div data-l10n-id="pukCode">PUK Code</div>
-            <div class="input-wrapper">
-              <input type="password" x-inputmode="digit" name="simpuk" size="8" maxlength="8" />
-            </div>
-          </div>
-
-          <div id="newPinArea" class="sim-code-area">
-            <div data-l10n-id="newSimPinMsg">
-              Create PIN (must contain 4 to 8 digits)
-            </div>
-            <div class="input-wrapper">
-              <input type="password" x-inputmode="digit" name="newSimpin" size="8" maxlength="8" />
-            </div>
-          </div>
-
-          <div id="confirmPinArea" class="sim-code-area">
-            <div data-l10n-id="confirmNewSimPinMsg">
-              Confirm New PIN
-            </div>
-            <div class="input-wrapper">
-              <input type="password" x-inputmode="digit" name="confirmNewSimpin" size="8" maxlength="8" />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <script src="js/simcard_dialog.js"></script>
-      -->
-    </section>
+    <section is="simpin-dialog" role="region" id="simpin-dialog"></section>
 
     <!-- Security :: SIM Security -->
-    <section role="region" id="simpin">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="simSecurity"> SIM Security </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="whatIsSimPin">What is a SIM PIN?</h2>
-        </header>
-        <ul>
-          <li class="description">
-            <p data-l10n-id="simPinIntro1">
-            A SIM PIN prevents access to the SIM card cellular data networks. When
-            it’s on, any device containing the SIM card will request the PIN upon
-            restart.
-            </p>
-
-            <p data-l10n-id="simPinIntro2">
-              A SIM PIN is not the same as the Passcode used to unlock the device.
-            </p>
-          </li>
-        </ul>
-        <ul>
-          <li id="simpin-enabled">
-            <label class="pack-switch">
-              <input type="checkbox" data-ignore/>
-              <span></span>
-            </label>
-            <a data-l10n-id="simPin">SIM PIN</a>
-          </li>
-        </ul>
-        <ul>
-          <li id="simpin-change">
-            <label>
-              <button data-l10n-id="changeSimPin" name="changeSimPin">Change PIN</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/simcard_lock.js"></script>
-      <script src="js/simcard_dialog.js"></script>
-      -->
-    </section>
+    <section is="simpin" role="region" id="simpin"></section>
 
     <!-- Security :: Application Permissions :: Details -->
-    <section role="region" id="appPermissions-details">
-      <!--
-      <header>
-        <a href="#appPermissions"><span class="icon icon-back">back</span></a>
-        <h1> </h1>
-      </header>
-
-      <div>
-        <header id="developer-header">
-          <h2 data-l10n-id="author">Author</h2>
-        </header>
-        <ul>
-          <li id="developer-infos">
-            <small><a target="_blank" href="http://github.com/mozilla-b2g/gaia/" data-href="http://github.com/mozilla-b2g/gaia/">http://github.com/mozilla-b2g/gaia/</a></small>
-            <a target="_blank" data-href="http://github.com/mozilla-b2g/gaia/"> The Gaia Team </a>
-          </li>
-        </ul>
-
-        <header id="permissionsListHeader">
-          <h2 data-l10n-id="permissions">Permissions</h2>
-        </header>
-        <ul>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="uninstallApp">Uninstall App</h2>
-        </header>
-        <button id="uninstall-app" data-l10n-id="uninstallApp" class="danger">Uninstall App</button>
-      </div>
-      -->
-    </section>
+    <section is="appPermissions-details" role="region" id="appPermissions-details"></section>
 
     <!-- Security :: Application Permissions -->
-    <section role="region" id="appPermissions">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="appPermissions">
-          App permissions
-        </h1>
-      </header>
-
-      <div>
-        <ul></ul>
-
-        <ul>
-          <li>
-            <button id="clear-bookmarks-app" class="icon icon-dialog"
-                    style="visibility: hidden"
-                    data-l10n-id="clearBookmarkAppsData">
-              Clear bookmarks data
-            </button>
-          </li>
-        </ul>
-      </div>
-
-      <form role="dialog" data-type="confirm" hidden class="cb-alert">
-        <section>
-          <h1 data-l10n-id="confirmClearBookmarkAppsDataTitle">Clear private data from bookmarks</h1>
-          <p>
-            <strong data-l10n-id="confirmClearBookmarkAppsDataDesc">This clear private data from bookmarks that have been added to the home screen. This cannot be undone.</strong>
-          </p>
-        </section>
-        <menu>
-          <button class="cb-alert-cancel" data-l10n-id="cancel">Cancel</button>
-          <button class="cb-alert-clear recommend danger" data-l10n-id="clear">Clear</button>
-        </menu>
-      </form>
-
-      <script type="application/javascript" src="shared/js/manifest_helper.js"></script>
-      <script src="js/apps.js"></script>
-      -->
-    </section>
+    <section is="appPermissions" role="region" id="appPermissions"></section>
 
     <!-- Security :: Do Not Track -->
-    <section role="region" id="doNotTrack">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="doNotTrack"> Do Not Track </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="doNotTrack-dt">How does Do Not Track work?</h2>
-        </header>
-        <ul>
-          <li class="description">
-            <p data-l10n-id="doNotTrack-dd1">
-              When you turn on the Do Not Track feature, your device tells every
-              website and app (as well as advertisers and other content providers)
-              that you don’t want your behavior tracked.
-            </p>
-            <p data-l10n-id="doNotTrack-dd2">
-              Turning on Do Not Track won’t affect your ability to log into
-              websites, nor cause your device to forget your private information —
-              such as the contents of shopping carts, location information, or
-              log-in information.
-          </p>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="privacy.donottrackheader.enabled" />
-              <span></span>
-            </label>
-            <a data-l10n-id="doNotTrack">Do Not Track</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="doNotTrack" role="region" id="doNotTrack"></section>
 
     <!-- Device :: Information :: More Information :: Developer -->
-    <section role="region" id="about-moreInfo-developer">
-      <!--
-      <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <h1 data-l10n-id="developer"> Developer </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="debug">Debug</h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.grid.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="grid">Grid</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.fps.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="fps-monitor">Show frames per second</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.paint-flashing.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="paint-flashing">Flash repainted area</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="layers.draw-borders"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="layers-draw-borders">Flash repainted area</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.log-animations.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="log-animations">Log slow animations</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.ttl.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="ttl-monitor">Show time to load</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="devtools.debugger.remote-enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="remote-debugging">Remote Debugging</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="wifi.debugging.enabled" />
-              <span></span>
-            </label>
-            <a data-l10n-id="wifi-debugging">Wi-Fi output in adb</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="bluetooth.debugging.enabled" />
-              <span></span>
-            </label>
-            <a data-l10n-id="bluetooth-debugging">Bluetooth output in adb</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="dom.mozContacts.debugging.enabled" />
-              <span></span>
-            </label>
-            <a data-l10n-id="contacts-debugging">Contacts debugging output in adb</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.console.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="console-enabled">Console enabled</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="software-button.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="software-button-enabled">Software home button enabled</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.gaia.enabled"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="debug-gaia-enabled">Gaia debug traces</a>
-          </li>
-          <li>
-            <label>
-              <button id="ftuLauncher" data-l10n-id="launch-ftu">Launch FTU</button>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="keyboardLayouts">Keyboard Layouts</h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.zhuyin"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="traditionalChinese-desc">Zhuyin</small>
-            <a data-l10n-id="traditionalChinese">Traditional Chinese</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="keyboard.layouts.pinyin"/>
-              <span></span>
-            </label>
-            <small data-l10n-id="simplifiedChinese-desc">Pinyin</small>
-            <a data-l10n-id="simplifiedChinese">Simplified Chinese</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="about-moreInfo-developer" role="region" id="about-moreInfo-developer"></section>
 
     <!-- Device :: Information :: More Information -->
-    <section role="region" id="about-moreInfo">
-      <!--
-      <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <h1 data-l10n-id="more-info"> More Information </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <small data-name="deviceinfo.os"></small>
-            <span data-l10n-id="os-version"> OS Version </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.firmware_revision"></small>
-            <span data-l10n-id="firmware_revision"> Firmware Revision </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.hardware"></small>
-            <span data-l10n-id="hardware_revision"> Hardware Revision </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.mac"></small>
-            <span data-l10n-id="macAddress"> MAC address </span>
-          </li>
-          <li>
-            <small id="deviceInfo-imei"></small>
-            <span data-l10n-id="deviceInfo-IMEI"> IMEI </span>
-          </li>
-          <li>
-            <small id="deviceInfo-iccid"></small>
-            <span data-l10n-id="deviceInfo-ICCID"> ICCID </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.platform_version"></small>
-            <span data-l10n-id="platform_version"> Platform Version </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.platform_build_id"></small>
-            <span data-l10n-id="build-id"> Build Identifier </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.update_channel"></small>
-            <span data-l10n-id="update-channel"> Update Channel </span>
-          </li>
-          <li>
-            <label>
-              <button id="reset-phone" data-l10n-id="reset-phone">Reset Phone</button>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="gitInfo"> Git commit info </h2>
-        </header>
-        <ul>
-          <li>
-            <small id="gaia-commit-hash"></small>
-            <span id="gaia-commit-date"></span>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="devSettings"> Developer Settings </h2>
-        </header>
-        <ul>
-          <li>
-            <label>
-              <button data-href="#about-moreInfo-developer"
-                data-l10n-id="developer">Developer</button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/factory_reset.js"></script>
-      -->
-    </section>
+    <section is="about-moreInfo" role="region" id="about-moreInfo"></section>
 
     <!-- Device :: Information :: Your Rights -->
-    <section role="region" id="about-yourRights">
-      <!--
-      <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <h1 data-l10n-id="your-rights"> Your Rights </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li class="description" data-l10n-id="about-your-rights-0">
-            Browser OS is built on free and open source software by a community
-            of thousands from all over the world. There are a few things you
-            should know:
-          </li>
-          <li class="description" data-l10n-id="about-your-rights-1">
-            Browser OS is made available to you under the terms of several open
-            source licenses including the Mozilla Public License. A device
-            running Browser OS may also contain proprietary software from third
-            parties. Any code provided under open licenses give you the right
-            to modify the source code and distribute your modified versions as
-            long as you comply with their terms.
-          </li>
-          <li class="description" data-l10n-id="about-your-rights-2">
-            You are not granted any trademark rights or licenses to the
-            trademarks of the Mozilla Foundation or any party, including
-            without limitation the Browser name or logo.
-          </li>
-          <li class="description" data-l10n-id="about-your-rights-3">
-            Some features in Browser OS, such as the Crash Reporter, give you
-            the option to provide feedback to Mozilla. By choosing to submit
-            feedback, you give Mozilla permission to use the feedback to improve
-            its products, to publish the feedback on its websites, and to
-            distribute the feedback.
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="about-yourRights" role="region" id="about-yourRights"></section>
 
     <!-- Device :: Information :: Your Privacy -->
-    <section role="region" id="about-yourPrivacy">
-      <!--
-      <header>
-        <button type="reset">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <h1 data-l10n-id="your-privacy"> Your Privacy </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2> Mozilla </h2>
-        </header>
-        <ul>
-          <li>
-            <a class="privacy-menuitem privacy-browserOS" href="https://www.mozilla.org/privacy/firefox-os/" data-l10n-id="brandShortName">B2G OS</a>
-          </li>
-          <li>
-            <a class="privacy-menuitem privacy-marketPlace" href="https://marketplace.firefox.com/privacy-policy">Marketplace</a>
-          </li>
-        </ul>
-        <header>
-          <h2 data-l10n-id="about-other"> Other </h2>
-        </header>
-        <ul>
-          <li>
-            <a class="privacy-menuitem privacy-everythingME" href="http://corp.everything.me/privacy">everything.me</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="about-yourPrivacy" role="region" id="about-yourPrivacy"></section>
 
     <!-- Device :: Information :: Legal :: Open Source Notices -->
-    <section role="region" id="about-licensing">
-      <!--
-      <header>
-        <a href="#about-legal">
-          <span class="icon icon-back">back</span>
-        </a>
-        <h1 data-l10n-id="open-source-notices">
-          Open Source Notices
-        </h1>
-      </header>
-
-      <iframe data-src="resources/open_source_license.html" id="os-license"></iframe>
-      -->
-    </section>
+    <section is="about-licensing" role="region" id="about-licensing"></section>
 
     <!-- Device :: Information :: Legal :: Obtaining Source Code -->
-    <section role="region" id="about-source-code">
-      <!--
-      <header>
-        <a href="#about-legal">
-          <span class="icon icon-back">back</span>
-        </a>
-        <h1 data-l10n-id="obtaining-source-code">
-          Obtaining Source Code
-        </h1>
-      </header>
-      <iframe src="resources/obtaining_source_code.html" id="obtain-sc"></iframe>
-      -->
-    </section>
+    <section is="about-source-code" role="region" id="about-source-code"></section>
 
     <!-- Device :: Information :: Legal -->
-    <section role="region" id="about-legal">
-      <!--
-      <header>
-        <a href="#about">
-          <span class="icon icon-back">back</span>
-        </a>
-        <h1 data-l10n-id="about-legal-info"> Legal Information </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 data-l10n-id="about-mozilla"> Mozilla </h2>
-        </header>
-        <ul>
-          <li>
-            <a href="#about-licensing" data-l10n-id="open-source-notices">
-              Open Source Notices
-            </a>
-          </li>
-          <li>
-            <a href="#about-source-code" data-l10n-id="obtaining-source-code">
-              Obtaining Source Code
-            </a>
-          </li>
-        </ul>
-
-        <header hidden>
-          <h2 data-l10n-id="about-other"> Other </h2>
-        </header>
-      </div>
-      -->
-    </section>
+    <section is="about-legal" role="region" id="about-legal"></section>
 
     <!-- Device :: Information -->
-    <section role="region" id="about">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="deviceInfo"> Device Information </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <small id="deviceInfo-msisdn"></small>
-            <span data-l10n-id="deviceInfo-MSISDN"> Phone number </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.hardware"></small>
-            <span id="model-name" data-l10n-id="model-name"> Model </span>
-          </li>
-          <li>
-            <small data-name="deviceinfo.software"></small>
-            <span id="os-version" data-l10n-id="software"> Software </span>
-          </li>
-          <li>
-            <small id="last-update-date"></small>
-            <span data-l10n-id="last-updated"> Last Updated </span>
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#about-moreInfo"
-                data-l10n-id="more-info"> More Information </button>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="softwareUpdates"> Software Updates </h2>
-        </header>
-        <ul>
-          <li>
-            <p data-l10n-id="check-for-updates">Check for Updates</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select name="app.update.interval">
-                <option value="86400"   data-l10n-id="check-update-daily" selected>Daily</option>
-                <option value="604800"  data-l10n-id="check-update-weekly">Weekly</option>
-                <option value="2592000" data-l10n-id="check-update-monthly">Monthly</option>
-              </select>
-            </p>
-          </li>
-          <li>
-            <label>
-              <button id="check-update-now"
-                data-l10n-id="check-update-now"> Check Now </button>
-            </label>
-          </li>
-          <li id="update-status" class="description update-status">
-            <p class="description general-information"
-                data-l10n-id="checking-for-update">Checking for updates…</p>
-            <p class="description system-update-status"></p>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="aboutBrowserOS"> About Browser OS </h2>
-        </header>
-        <ul>
-          <li class="description" data-l10n-id="browser-os-desc">
-            Browser OS is the free and open source operating system from Mozilla.
-            Our mission is to promote openness, innovation and opportunity by
-            keeping the power of the Web in your hands.
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#about-yourRights"
-                data-l10n-id="your-rights"> Your Rights </button>
-            </label>
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#about-yourPrivacy"
-                data-l10n-id="your-privacy"> Your Privacy </button>
-            </label>
-          </li>
-          <li>
-            <label>
-              <button class="icon icon-view" data-href="#about-legal"
-                data-l10n-id="about-legal-info"> Legal Information </button>
-            </label>
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/about.js"></script>
-      -->
-    </section>
+    <section is="about" role="region" id="about"></section>
 
     <!-- Device :: Battery -->
-    <section role="region" id="battery">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="battery"> Battery </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <a id="battery-level" data-l10n-id="batteryLevel">Current Battery Life
-              <span></span>
-            </a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="powerSaveMode">Power Save Mode</h2>
-        </header>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input type="checkbox" name="powersave.enabled" class="uninit"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="powerSaveMode">Power Save Mode</a>
-          </li>
-          <li>
-            <p data-l10n-id="turnOnAuto">Turn on automatically</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select name="powersave.threshold">
-                <option value="0.05" data-l10n-id="powerSave-threshold" data-l10n-args='{"level":  "5"}'> 5% battery left</option>
-                <option value="0.15" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "15"}'>15% battery left</option>
-                <option value="0.25" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "25"}'>25% battery left</option>
-                <option value="-1" data-l10n-id="never">Never</option>
-              </select>
-            </p>
-          </li>
-          <li class="description" data-l10n-id="powerSave-explanation">
-            Turning on Power Save Mode turns off the phone’s Data, Bluetooth, and
-            Geolocation connections to extend battery life. You can still turn these
-            services back on manually.
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="battery" role="region" id="battery"></section>
 
     <!-- Device :: Device Storage -->
-    <section role="region" id="applicationStorage">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="appStorage"> Application Storage </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <progress id="apps-space-bar" min="0" value="0" max="100"></progress>
-          </li>
-
-          <li>
-            <a data-l10n-id="apps-total-space"> Total Space
-              <span id="apps-total-space"></span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="apps-used-space"> Used
-              <span id="apps-used-space"></span>
-            </a>
-          </li>
-          <li>
-            <a data-l10n-id="apps-free-space"> Left
-              <span id="apps-free-space"></span>
-            </a>
-          </li>
-          <li class="description" data-l10n-id="media-storage-details">
-            Photos, videos, and music are stored in the SD Card.
-            See Media Storage for details.
-          </li>
-        </ul>
-      </div>
-      <script src="js/app_storage.js"></script>
-      -->
-    </section>
+    <section is="applicationStorage" role="region" id="applicationStorage"></section>
 
     <!-- Device :: Media Storage -->
-    <section role="region" id="mediaStorage">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="mediaStorage"> Media Storage </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label class="pack-switch">
-              <input id="ums-switch" type="checkbox" data-ignore />
-              <span></span>
-            </label>
-            <small id="ums-desc">Disabled</small>
-            <a data-l10n-id="enableUSBStorage">Enable USB storage</a>
-          </li>
-        </ul>
-        <div id="volume-list">
-        </div>
-        <header>
-          <h2 data-l10n-id="advanced">Advanced</h2>
-        </header>
-        <ul>
-          <li>
-            <p data-l10n-id="default-media-location">Default media location</p>
-            <p class="fake-select">
-              <button class="icon icon-dialog">empty</button>
-              <select id="defaultMediaLocation" name="device.storage.writable.name">
-              </select>
-            </p>
-          </li>
-          <li data-l10n-id="default-media-location-msg" class="explanation">
-            Choose where photos, videos, music and downloads are stored by default.
-          </li>
-        </ul>
-      </div>
-      <form data-type="confirm" role="dialog" id="default-location-popup-container" hidden>
-        <section>
-          <p data-l10n-id="change-default-location-confirm">Changing the default media storage volume will effect where photos, videos, downloads and other media will be saved to by default. Existing data will remain in its current location.</p>
-        </section>
-        <menu>
-          <button id="default-location-cancel-btn" data-l10n-id="cancel">Cancel</button>
-          <button id="default-location-change-btn" data-l10n-id="change">Change</button>
-        </menu>
-      </form>
-      <script src="js/media_storage.js"></script>
-      -->
-    </section>
+    <section is="mediaStorage" role="region" id="mediaStorage"></section>
 
     <!-- Device :: Accessibility -->
-    <section role="region" id="accessibility">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="accessibility"> Accessibility </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="accessibility.invert"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="invertColors">Invert Colors</a>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="accessibility.screenreader"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="screenReader">Screen Reader</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="accessibility" role="region" id="accessibility"></section>
 
     <!-- Device :: Improve Browser OS :: Crash Reports-->
-    <section role="region" id="crashReports">
-      <!--
-      <header>
-        <a href="#improveBrowserOS"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="crashReports"> Crash Reports </h1>
-      </header>
-
-      <div>
-        <ul>
-          <li class="description">
-            <p data-l10n-id="crash-reports-description-1"></p>
-            <p data-l10n-id="crash-reports-description-2"></p>
-            <p>
-              <span data-l10n-id="crash-reports-description-3-start"></span>
-              <a href="https://www.mozilla.org/privacy/" data-l10n-id="crash-reports-description-3-privacy" class="link-text"></a>
-              <span data-l10n-id="crash-reports-description-3-end"></span>
-            </p>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="crashReports" role="region" id="crashReports"></section>
 
     <!-- Device :: Improve Browser OS -->
-    <section role="region" id="improveBrowserOS">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="improveBrowserOS">Improve Browser OS</h1>
-      </header>
-
-      <div>
-        <ul>
-          <li>
-            <label>
-              <button data-href="http://input.mozilla.org/feedback" data-l10n-id="sendMozillaFeedback"></button>
-            </label>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="performanceData">Performance Data</h2>
-        </header>
-        <ul>
-          <li>
-            <p class="description">
-              <span data-l10n-id="performanceDataInfo">
-                Help us improve Browser OS by sharing data about your phone.
-              </span>
-              <a href="http://mozilla.org/telemetry" data-l10n-id="learn-more" class="link-text">Learn More</a>
-            </p>
-          </li>
-          <li>
-            <label class="pack-checkbox">
-              <input type="checkbox" name="debug.performance_data.shared" />
-              <span></span>
-            </label>
-            <a data-l10n-id="sharePerformanceData">Submit performance data</a>
-          </li>
-        </ul>
-
-        <header>
-          <h2 data-l10n-id="crashReports">Crash Reports</h2>
-        </header>
-        <ul>
-          <li>
-            <p class="description">
-              <span data-l10n-id="crashReportInfo">
-                Sending Mozilla a report when a crash occurs helps us fix the problem
-                for everyone. Reports are sent over Wi-Fi only.
-              </span>
-              <a href="#crashReports" data-l10n-id="learn-more" class="link-text">Learn More</a>
-            </p>
-          </li>
-          <li>
-            <label class="pack-radio">
-              <input type="radio" name="app.reportCrashes" value="always"/>
-              <span></span>
-            </label>
-            <a data-l10n-id="alwaysSendReport">Always send a report</a>
-          </li>
-          <li>
-            <label class="pack-radio">
-              <input type="radio" name="app.reportCrashes" value="never" />
-              <span></span>
-            </label>
-            <a data-l10n-id="neverSendReport">Never send a report</a>
-          </li>
-          <li>
-            <label class="pack-radio">
-              <input type="radio" name="app.reportCrashes" value="ask" checked />
-              <span></span>
-            </label>
-            <a data-l10n-id="askToSendReport2">Ask each time</a>
-          </li>
-        </ul>
-      </div>
-      -->
-    </section>
+    <section is="improveBrowserOS" role="region" id="improveBrowserOS"></section>
 
     <!-- Device :: Help -->
-    <section role="region" id="help">
-      <!--
-      <header>
-        <a href="#root"><span class="icon icon-back">back</span></a>
-        <h1 data-l10n-id="help"></h1>
-      </header>
-
-      <div>
-        <ul>
-          <li class="support-info">
-            <a data-l10n-id="online-support" id="online-support-link"> Online Support:
-              <span class="link-text" id="online-support-text"></span>
-            </a>
-          </li>
-          <li class="support-info">
-            <span data-l10n-id="call-support"> Call Support:
-              <span class="tel-text" id="call-support-numbers"></span>
-            </span>
-          </li>
-          <li>
-            <label>
-              <button data-l10n-id="user-guide"> User Guide </button>
-            </label>
-          </li>
-          <li class="no-support-info description" data-l10n-id="default-support">
-            Please contact your local provider for support.
-          </li>
-        </ul>
-      </div>
-
-      <script src="js/support.js"></script>
-      -->
-    </section>
+    <section is="help" role="region" id="help"></section>
 
     <!-- SIM Toolkit -->
-    <section role="region" id="icc">
-      <!--
-      <header>
-        <button id="icc-stk-app-back" class="hidden">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <button id="icc-stk-help-exit" class="hidden">
-          <span data-l10n-id="back" class="icon icon-back">Back</span>
-        </button>
-        <a href="#root" id="icc-stk-exit"><span data-l10n-id="back" class="icon icon-back">Back</span></a>
-        <h1 id="icc-stk-header"> SIM Toolkit </h1>
-      </header>
-
-      <div>
-        <header>
-          <h2 id="icc-stk-subheader"></h2>
-        </header>
-
-        <ul id="icc-stk-list">
-        </ul>
-      </div>
-
-      <script src="js/icc.js"></script>
-      -->
-    </section>
+    <section is="icc" role="region" id="icc"></section>
 
     <!-- Main List -->
-    <section role="region" id="root" class="current">
+    <section role="region" id="root" class="current" data-rendered="true">
       <header>
         <h1 data-l10n-id="settings"> Settings </h1>
       </header>
@@ -2865,14 +333,14 @@
         <ul>
           <li>
             <label class="pack-switch">
-              <input type="checkbox" name="ril.radio.disabled" class="uninit"/>
+              <input name="ril.radio.disabled" class="uninit" type="checkbox">
               <span></span>
             </label>
             <a id="menuItem-airplaneMode" class="menu-item" data-l10n-id="airplaneMode">Airplane Mode</a>
           </li>
           <li>
             <label class="pack-switch">
-              <input type="checkbox" name="geolocation.enabled" class="uninit"/>
+              <input name="geolocation.enabled" class="uninit" type="checkbox">
               <span></span>
             </label>
             <a id="menuItem-gps" class="menu-item" data-l10n-id="geolocation">Geolocation</a>
@@ -2883,8 +351,7 @@
           </li>
           <li id="call-settings">
             <small id="call-desc" class="menu-item-desc"></small>
-            <a id="menuItem-callSettings" class="menu-item" href="#call"
-              data-l10n-id="callSettings">Call Settings</a>
+            <a id="menuItem-callSettings" class="menu-item" href="#call" data-l10n-id="callSettings">Call Settings</a>
           </li>
           <li id="data-connectivity">
             <small id="data-desc" class="menu-item-desc"></small>
@@ -2934,10 +401,10 @@
         </ul>
 
         <!-- Main :: Accounts -->
-        <header hidden>
+        <header hidden="">
           <h2 data-l10n-id="accounts">Accounts</h2>
         </header>
-        <ul hidden>
+        <ul hidden="">
           <li>
             <a id="menuItem-persona" class="menu-item" href="#persona" data-l10n-id="persona">Persona</a>
           </li>
@@ -2974,7 +441,7 @@
         <ul>
           <li>
             <label class="pack-switch">
-              <input type="checkbox" id="ums-switch-root" data-ignore />
+              <input id="ums-switch-root" data-ignore="" type="checkbox">
               <span></span>
             </label>
             <small id="ums-desc-root" class="menu-item-desc">Disabled</small>
@@ -3002,7 +469,7 @@
             <small id="battery-desc" class="menu-item-desc"></small>
             <a id="menuItem-battery" class="menu-item" href="#battery" data-l10n-id="battery">Battery</a>
           </li>
-          <li hidden>
+          <li hidden="">
             <a id="menuItem-accessibility" class="menu-item" href="#accessibility" data-l10n-id="accessibility">Accessibility</a>
           </li>
           <li>
@@ -3026,4 +493,5 @@
       </div>
     </section>
   </body>
+
 </html>


### PR DESCRIPTION
Moves the DOM from a comment node into a separate file. This should generally be exactly the same performance wise as what we have today. You can compare the generated HTML in: profile/webapps/settings.gaiamobile.org/application.zip to the index.html in master.

One modification was made to add support for asynchronously loaded panels as this is needed for DEBUG mode. As everything is present on the device, and the callback is fired on the same tick, there should be no performance impact.
