### PR TITLE
Bug 905563 - long press a item with nodeName |a| should also be able to open new link; fix regression of bug 907056 if long press on nothing, contextMenuHasCalled should be set false

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1020,9 +1020,11 @@ var Browser = {
   // default actions attached
   generateSystemMenuItem: function browser_generateSystemMenuItem(item) {
     var self = this;
-    switch (item.nodeName) {
+    var nodeName = item.nodeName ? item.nodeName.toUpperCase() : '';
+    switch (nodeName) {
       case 'A':
         return {
+          id: 'open-in-new-tab',
           label: _('open-in-new-tab'),
           callback: function() {
             self.openInNewTab(item.data.uri);
@@ -1037,7 +1039,7 @@ var Browser = {
           'AUDIO': 'audio'
         };
         var type = typeMap[item.nodeName];
-        if (item.nodeName === 'VIDEO' && !item.data.hasVideo) {
+        if (nodeName === 'VIDEO' && !item.data.hasVideo) {
           type = 'audio';
         }
 
@@ -1093,11 +1095,13 @@ var Browser = {
     }
 
     if (Object.keys(menuItems).length === 0) {
+      self.contextMenuHasCalled = false;
       return;
     }
 
     menuItems.forEach(function(menuitem) {
       var li = document.createElement('li');
+      li.id = menuitem.id;
       var button = this.createButton(menuitem.label, menuitem.icon);
 
       button.addEventListener('click', function() {

--- a/apps/browser/test/marionette/contextmenu_test.js
+++ b/apps/browser/test/marionette/contextmenu_test.js
@@ -1,0 +1,57 @@
+var Browser = require('./lib/browser'),
+    Server = require('./lib/server'),
+    assert = require('assert');
+    Actions = require('marionette-client').Actions;
+
+marionette('search', function() {
+  var client = marionette.client();
+  var subject;
+  var server;
+  var actions = new Actions(client);
+
+
+  // this could be abstracted further
+  suiteSetup(function(done) {
+    Server.create(function(err, _server) {
+      server = _server;
+      done();
+    });
+  });
+
+  suiteTeardown(function() {
+    server.stop();
+  });
+
+  setup(function() {
+    subject = new Browser(client);
+    subject.launch();
+
+    client.helper.waitForElement('body.loaded');
+  });
+
+  suite('navigate to coolpage.html', function() {
+    var frame;
+    setup(function() {
+      url = server.url('coolpage.html');
+      subject.searchBar.sendKeys(url);
+      subject.searchButton.click();
+      frame = subject.currentTabFrame();
+      client.switchToFrame(frame);
+    });
+
+    test('long press link and open context menu', function() {
+      client.helper.waitForElement('#link');
+      var link = client.findElement('#link');
+
+      actions.longPress(link, 1.5).perform();
+
+      subject.backToApp();
+
+      var openItem = client.findElement('#open-in-new-tab');
+      openItem.click();
+
+      var tabsBadge = client.findElement('#tabs-badge');
+      assert.equal(tabsBadge.text(), '2›');
+    });
+  });
+});

--- a/apps/browser/test/marionette/fixtures/coolpage.html
+++ b/apps/browser/test/marionette/fixtures/coolpage.html
@@ -5,5 +5,8 @@
   <title>cool page</title>
 </head>
 <body>
+	<a href="google.com">
+		<span id="link">test link</span>
+	</a>
 </body>
 </html>

--- a/apps/browser/test/marionette/lib/browser.js
+++ b/apps/browser/test/marionette/lib/browser.js
@@ -50,6 +50,14 @@ Browser.prototype = {
   launch: function() {
     this.client.apps.launch(Browser.URL);
     this.client.apps.switchToApp(Browser.URL);
+  },
+
+  /**
+   * Back to Browser app frame
+   */
+  backToApp: function() {
+    this.client.switchToFrame();
+    this.client.apps.switchToApp(Browser.URL);
   }
 };
 


### PR DESCRIPTION
1. long press a item with nodeName |a| should also be able to open new link
2. fix regression of bug 907056 if long press on nothing, contextMenuHasCalled should be set false
