### PR TITLE
Bug 912541 - Make the performance test work again

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -733,7 +733,8 @@ var WindowManager = (function() {
     var evt = doc.createEvent('CustomEvent');
     evt.initCustomEvent('apploadtime', true, false, {
       time: parseInt(Date.now() - iframe.dataset.start),
-      type: (e.type == 'appopen') ? 'w' : 'c'
+      type: (e.type == 'appopen') ? 'w' : 'c',
+      src: iframe.src // this is used in the performance framework
     });
     iframe.dispatchEvent(evt);
   }

--- a/tests/js/vendor/marionette.js
+++ b/tests/js/vendor/marionette.js
@@ -693,7 +693,7 @@
       this.socket.write(this.stringify(data), 'utf8');
     } else {
       //moztcp socket
-      this.socket.send(this.stringify(data));
+      this.socket.rawSocket.send(this.stringify(data));
     }
   };
 
@@ -2032,6 +2032,7 @@
     });
 
     var socket = Object.create(rawSocket);
+    socket.rawSocket = rawSocket;
 
     eventMethods.forEach(function(method) {
       socket[method] = events[method].bind(events);

--- a/tools/xpcwindow/lib/loader.js
+++ b/tools/xpcwindow/lib/loader.js
@@ -1,11 +1,15 @@
 const Cc = Components.classes;
 const Ci = Components.interfaces;
+const Cu = Components.utils;
 
 const mozIJSSubScriptLoader = Cc[
   '@mozilla.org/moz/jssubscript-loader;1'
 ].getService(
   Components.interfaces.mozIJSSubScriptLoader
 );
+
+Cu.import('resource://gre/modules/Services.jsm');
+Services.prefs.setBoolPref('dom.mozTCPSocket.enabled', true);
 
 var args = _ARGV.split(' ');
 


### PR DESCRIPTION
- set the bool pref to be able to use TCPSocket
- dirty hack to be able to call send on the TCPSocket even when Object.create
  was used
