### PR TITLE
 Bug 847032 - [email] IMAP only supports initially-SSL encrypted connections, STARTTLS upgrade not supported from unencrypted cleartext.

### DIFF
--- a/apps/email/js/cards/setup_manual_config.html
+++ b/apps/email/js/cards/setup_manual_config.html
@@ -76,18 +76,21 @@
                    data-maybe-required />
             <button type="reset"></button>
           </p>
+          <li class="sup-socket-select-container">
+            <span class="button icon icon-dialog">
+              <select class="mail-select sup-manual-imap-socket sup-socket-select">
+                <option value="SSL" data-l10n-id="setup-manual-socket-ssl">
+                  SsL</option>
+                <option value="STARTTLS" data-l10n-id="setup-manual-socket-starttls">
+                  StarttlS</option>
+              </select>
+            </span>
+          </li>
           <p>
             <input class="sup-manual-imap-port" type="text"
                    data-l10n-id="setup-manual-port" value="993"
                    data-maybe-required />
             <button type="reset"></button>
-          </p>
-          <p class="collapsed">
-            <span data-l10n-id="setup-manual-socket">SockeT TypE</span>
-            <select class="mail-select sup-manual-imap-socket">
-              <option value="SSL" data-l10n-id="setup-manual-socket-ssl">
-                SsL</option>
-            </select>
           </p>
         </div>
 
@@ -107,18 +110,21 @@
                    data-maybe-required />
             <button type="reset"></button>
           </p>
+          <li class="sup-socket-select-container">
+            <span class="button icon icon-dialog">
+              <select class="mail-select sup-manual-smtp-socket sup-socket-select">
+                <option value="SSL" data-l10n-id="setup-manual-socket-ssl">
+                  SsL</option>
+                <option value="STARTTLS" data-l10n-id="setup-manual-socket-starttls">
+                  StarttlS</option>
+              </select>
+            </span>
+          </li>
           <p>
             <input class="sup-manual-smtp-port" type="text"
                    data-l10n-id="setup-manual-port" value="465"
                    data-maybe-required />
             <button type="reset"></button>
-          </p>
-          <p class="collapsed">
-            <span data-l10n-id="setup-manual-socket">SockeT TypE</span>
-            <select class="mail-select sup-manual-smtp-socket">
-              <option value="SSL" data-l10n-id="setup-manual-socket-ssl">
-                SsL</option>
-            </select>
           </p>
         </div>
       </section>

--- a/apps/email/js/cards/setup_manual_config.js
+++ b/apps/email/js/cards/setup_manual_config.js
@@ -80,6 +80,11 @@ function SetupManualConfig(domNode, mode, args) {
   this.requireFields('smtp', true);
   this.requireFields('activeSync', false);
 
+  this.formItems.imap.socket.addEventListener(
+    'change', this.onChangeImapSocket.bind(this));
+  this.formItems.smtp.socket.addEventListener(
+    'change', this.onChangeSmtpSocket.bind(this));
+
   new FormNavigation({
     formElem: this.formNode,
     onLast: this.onNext.bind(this)
@@ -153,6 +158,31 @@ SetupManualConfig.prototype = {
     this.requireFields('imap', isImapSmtp);
     this.requireFields('smtp', isImapSmtp);
     this.requireFields('activeSync', !isImapSmtp);
+  },
+
+  // If the user selects a different socket type, autofill the most likely port.
+  onChangeImapSocket: function(event) {
+    const SSL_VALUE = '993';
+    const STARTTLS_VALUE = '143';
+    var socketType = event.target.value;
+    var portField = this.formItems.imap.port;
+    if (socketType === 'SSL' && portField.value === STARTTLS_VALUE) {
+      portField.value = SSL_VALUE;
+    } else if (socketType == 'STARTTLS' && portField.value == SSL_VALUE) {
+      portField.value = STARTTLS_VALUE;
+    }
+  },
+
+  onChangeSmtpSocket: function(event) {
+    const SSL_VALUE = '465';
+    const STARTTLS_VALUE = '587';
+    var socketType = event.target.value;
+    var portField = this.formItems.smtp.port;
+    if (socketType === 'SSL' && portField.value === STARTTLS_VALUE) {
+      portField.value = SSL_VALUE;
+    } else if (socketType == 'STARTTLS' && portField.value == SSL_VALUE) {
+      portField.value = STARTTLS_VALUE;
+    }
   },
 
   requireFields: function(type, required) {

--- a/apps/email/js/ext/mailapi/composite/configurator.js
+++ b/apps/email/js/ext/mailapi/composite/configurator.js
@@ -4004,7 +4004,8 @@ SmtpAccount.prototype = {
       conn = $simplesmtp(
         this.connInfo.port, this.connInfo.hostname,
         {
-          secureConnection: this.connInfo.crypto === true,
+          secureConnection: (this.connInfo.crypto == 'ssl' ||
+                             this.connInfo.crypto === true),
           ignoreTLS: this.connInfo.crypto === false,
           auth: {
             user: this.credentials.username,
@@ -4393,14 +4394,17 @@ exports.configurator = {
       imapConnInfo = {
         hostname: domainInfo.incoming.hostname,
         port: domainInfo.incoming.port,
-        crypto: domainInfo.incoming.socketType === 'SSL',
-
+        crypto: (typeof domainInfo.incoming.socketType === 'string' ?
+                 domainInfo.incoming.socketType.toLowerCase() :
+                 domainInfo.incoming.socketType),
         blacklistedCapabilities: null,
       };
       smtpConnInfo = {
         hostname: domainInfo.outgoing.hostname,
         port: domainInfo.outgoing.port,
-        crypto: domainInfo.outgoing.socketType === 'SSL',
+        crypto: (typeof domainInfo.incoming.socketType === 'string' ?
+                 domainInfo.incoming.socketType.toLowerCase() :
+                 domainInfo.incoming.socketType),
       };
     }
 

--- a/apps/email/js/ext/mailapi/imap/probe.js
+++ b/apps/email/js/ext/mailapi/imap/probe.js
@@ -67,6 +67,9 @@ NetSocket.prototype.setKeepAlive = function(shouldKeepAlive) {
 NetSocket.prototype.write = function(buffer) {
   this._sendMessage('write', [buffer.buffer, buffer.byteOffset, buffer.length]);
 };
+NetSocket.prototype.upgradeToSecure = function() {
+  this._sendMessage('upgradeToSecure', []);
+};
 NetSocket.prototype.end = function() {
   if (this.destroyed)
     return;
@@ -440,7 +443,8 @@ ImapConnection.prototype.connect = function(loginCb) {
 
   if (this._LOG) this._LOG.connect(this._options.host, this._options.port);
 
-  this._state.conn = (this._options.crypto ? tls : net).connect(
+  this._state.conn = ((this._options.crypto === 'ssl' ||
+                       this._options.crypto === true) ? tls : net).connect(
                        this._options.port, this._options.host);
   this._state.tmrConn = setTimeoutFunc(this._fnTmrConn.bind(this, loginCb),
                                        this._options.connTimeout);
@@ -452,21 +456,19 @@ ImapConnection.prototype.connect = function(loginCb) {
       self._state.tmrConn = null;
     }
     self._state.status = STATES.NOAUTH;
-    /*
-    We will need to add support for node-like starttls emulation on top of TCPSocket
-    once TCPSocket supports starttls (see also bug 784816).
 
     if (self._options.crypto === 'starttls') {
-      self._send('STARTTLS', function() {
-        starttls(self, function() {
-	  if (!self.authorized)
-	    throw new Error("starttls failed");
-	  fnInit();
-        });
+      self._send('STARTTLS', null, function(err) {
+        if (err) {
+          loginCb(err);
+        } else {
+          self._state.conn.upgradeToSecure();
+	        fnInit();
+        }
       });
       return;
     }
-    */
+
     fnInit();
   });
 

--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -3290,9 +3290,11 @@ define('mailapi/worker-support/configparser-main',[],function() {
           config.outgoing[child.tagName] = child.textContent;
         }
 
+        const ALLOWED_SOCKET_TYPES = ['SSL', 'STARTTLS'];
+
         // We do not support unencrypted connections outside of unit tests.
-        if (config.incoming.socketType !== 'SSL' ||
-            config.outgoing.socketType !== 'SSL') {
+        if (ALLOWED_SOCKET_TYPES.indexOf(config.incoming.socketType) === -1 ||
+            ALLOWED_SOCKET_TYPES.indexOf(config.outgoing.socketType) === -1) {
           config = null;
           status = 'unsafe';
         }
@@ -4130,6 +4132,10 @@ define('mailapi/worker-support/net-main',[],function() {
     delete socks[uid];
   }
 
+  function upgradeToSecure(uid) {
+    socks[uid].upgradeToSecure();
+  }
+
   function write(uid, data, offset, length) {
     // XXX why are we doing this? ask Vivien or try to remove...
     socks[uid].send(data, offset, length);
@@ -4149,6 +4155,9 @@ define('mailapi/worker-support/net-main',[],function() {
           break;
         case 'write':
           write(uid, args[0], args[1], args[2]);
+          break;
+        case 'upgradeToSecure':
+          upgradeToSecure(uid);
           break;
       }
     }

--- a/apps/email/js/input_areas.js
+++ b/apps/email/js/input_areas.js
@@ -6,18 +6,20 @@
  * Bug 830127 should fix input_areas.css and move this JS functionality
  * to a shared JS file, so this file won't be in the email app for long.
  */
-function hookupInputAreaResetButtons(e) {
-  // This selector is from shared/style/input_areas.css
-  var selector = 'form p input + button[type="reset"],' +
-    'form p textarea + button[type="reset"]';
-  var resetButtons = e.querySelectorAll(selector);
-  for (var i = 0, n = resetButtons.length; i < n; i++) {
-    resetButtons[i].addEventListener('mousedown', function(e) {
-      e.preventDefault();   // Don't take focus from the input field
-    });
-    resetButtons[i].addEventListener('click', function(e) {
-      e.target.previousElementSibling.value = ''; // Clear input field
-      e.preventDefault();   // Don't reset the rest of the form.
-    });
-  }
-}
+define(function(require, exports) {
+  return function hookupInputAreaResetButtons(e) {
+    // This selector is from shared/style/input_areas.css
+    var selector = 'form p input + button[type="reset"],' +
+          'form p textarea + button[type="reset"]';
+    var resetButtons = e.querySelectorAll(selector);
+    for (var i = 0, n = resetButtons.length; i < n; i++) {
+      resetButtons[i].addEventListener('mousedown', function(e) {
+        e.preventDefault();   // Don't take focus from the input field
+      });
+      resetButtons[i].addEventListener('click', function(e) {
+        e.target.previousElementSibling.value = ''; // Clear input field
+        e.preventDefault();   // Don't reset the rest of the form.
+      });
+    }
+  };
+});

--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -10,8 +10,7 @@ var Cards, Toaster,
     toasterNode = require('tmpl!./cards/toaster.html'),
     ValueSelector = require('value_selector');
 
-// Does not return a module value, just need it to make globals
-require('input_areas');
+var hookupInputAreaResetButtons = require('input_areas');
 
 function addClass(domNode, name) {
   if (domNode) {

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -93,7 +93,10 @@ setup-manual-activesync-header=ActiveSync settings
 setup-manual-next=Next
 
 setup-manual-socket=Socket Type
+# Technical term, should not be translated
 setup-manual-socket-ssl=SSL
+# Technical term, should not be translated
+setup-manual-socket-starttls=STARTTLS
 
 setup-manual-hostname.placeholder=Hostname
 setup-manual-port.placeholder=Port Number

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -285,8 +285,8 @@ section.card-settings-account li span.button select {
   font-weight: bold;
 }
 
-
-.sup-manual-account-type {
+.sup-manual-account-type,
+.sup-socket-select {
   font-size: 1.7rem;
   font-weight: bold;
   background: none;
@@ -295,10 +295,15 @@ section.card-settings-account li span.button select {
   padding: 0.7rem 0 0.7rem 1.5rem;
 }
 
-li.sup-manual-account-type-container {
+li.sup-manual-account-type-container,
+li.sup-socket-select-container {
   overflow: hidden;
   min-height: 100%;
   border-bottom: none;
+}
+
+li.sup-socket-select-container {
+  margin-top: 1rem;
 }
 
 li.sup-manual-account-type-container .button {

--- a/apps/email/test/unit/setup_manual_config_protocol_dropdown_test.js
+++ b/apps/email/test/unit/setup_manual_config_protocol_dropdown_test.js
@@ -1,0 +1,55 @@
+/*global requireApp, suite, setup, testConfig, test, assert,
+  document, sinon, teardown, suiteSetup, suiteTeardown */
+
+requireApp('email/js/alameda.js');
+requireApp('email/test/config.js');
+suite('IMAP protocol dropdown', function() {
+  var el;
+  var smc;
+  var SetupManualConfig;
+
+  suiteSetup(function(done) {
+    testConfig({
+        suiteTeardown: suiteTeardown,
+        done: done,
+        defines: {}
+      },
+      ['cards/setup_manual_config', 'tmpl!cards/setup_manual_config.html'],
+               function(smc, tmpl) {
+        SetupManualConfig = smc;
+        el = tmpl;
+      }
+    );
+  });
+
+  setup(function() {
+    smc = new SetupManualConfig(el, null, {});
+  });
+
+  suite('IMAP port selection', function() {
+    test('should change upon selecting STARTTLS', function() {
+      var dropdown = el.getElementsByClassName('sup-manual-imap-socket')[0];
+      var port = el.getElementsByClassName('sup-manual-imap-port')[0];
+      assert.equal(port.value, '993');
+      assert.equal(dropdown.value, 'SSL');
+
+      dropdown.value = 'STARTTLS';
+      dropdown.dispatchEvent(new Event('change'));
+      assert.equal(port.value, '143');
+    });
+  });
+
+  suite('SMTP port selection', function() {
+    test('should change upon selecting STARTTLS', function() {
+      var dropdown = el.getElementsByClassName('sup-manual-smtp-socket')[0];
+      var port = el.getElementsByClassName('sup-manual-smtp-port')[0];
+      assert.equal(port.value, '465');
+      assert.equal(dropdown.value, 'SSL');
+
+      dropdown.value = 'STARTTLS';
+      dropdown.dispatchEvent(new Event('change'));
+      assert.equal(port.value, '587');
+    });
+  });
+
+});


### PR DESCRIPTION
Adds support for STARTTLS in both IMAP and SMTP using mozTCPSocket.upgradeToSecure().
