### PR TITLE
Bug 883565 - [Settings] Settings interface for SIM PIN unusable due to UI misplacement 

### DIFF
--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -266,10 +266,14 @@ var SimPinDialog = {
     this.origin = origin;
     Settings.currentPanel = '#simpin-dialog';
 
-    if (action === 'unlock' && this.lockType === 'puk')
-      this.pukInput.focus();
-    else
-      this.pinInput.focus();
+    var self = this;
+    window.addEventListener('panelready', function inputFocus() {
+      window.removeEventListener('panelready', inputFocus);
+      if (action === 'unlock' && self.lockType === 'puk')
+        self.pukInput.focus();
+      else
+        self.pinInput.focus();
+    });
 
   },
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=883565

focus input only after panelready
