### PR TITLE
 Bug 912906 - Extend the unit test timeout to 5 seconds for

### DIFF
--- a/apps/browser/test/unit/browser_db_test.js
+++ b/apps/browser/test/unit/browser_db_test.js
@@ -77,6 +77,7 @@ var clearBrowserStores = function(done) {
 
 suite('BrowserDB', function() {
   var realMozSettings = null;
+  this.timeout(5000);
 
   suite('BrowserDB.operatorVariantCustomization', function() {
 


### PR DESCRIPTION
 browser_db_test.
