### PR TITLE
[Bug 912386] fix long-tap on app won't prevent normal click [r=crdlc]

### DIFF
--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -29,6 +29,7 @@ Evme.Brain = new function Evme_Brain() {
         CLASS_WHEN_HAS_QUERY = 'evme-has-query',
         CLASS_WHEN_COLLECTION_VISIBLE = 'evme-collection-visible',
         CLASS_WHEN_LOADING_SHORTCUTS_SUGGESTIONS = 'evme-suggest-collections-loading',
+        CLASS_WHEN_SAVING_TO_HOMESCREEN = 'save-to-homescreen',
 
         L10N_SYSTEM_ALERT = 'alert',
 
@@ -668,12 +669,15 @@ Evme.Brain = new function Evme_Brain() {
         }
 
         function saveToHomescreen(data, showConfirm) {
-            var isAppInstalled = EvmeManager.isAppInstalled(data.app.getFavLink());
+            var isAppInstalled = EvmeManager.isAppInstalled(data.app.getFavLink()),
+                classList = data.el.classList;
 
             if (isAppInstalled) {
+                classList.add(CLASS_WHEN_SAVING_TO_HOMESCREEN);
                 window.alert(Evme.Utils.l10n(L10N_SYSTEM_ALERT, 'app-install-exists', {
                     'name': data.data.name
                 }));
+                classList.remove(CLASS_WHEN_SAVING_TO_HOMESCREEN);
                 return;
             }
 
@@ -681,7 +685,12 @@ Evme.Brain = new function Evme_Brain() {
                 var msg = Evme.Utils.l10n(L10N_SYSTEM_ALERT, 'app-install-confirm', {
                     'name': data.data.name
                 });
-                if (!window.confirm(msg)) {
+
+                classList.add(CLASS_WHEN_SAVING_TO_HOMESCREEN);
+                var saved = window.confirm(msg);
+                classList.remove(CLASS_WHEN_SAVING_TO_HOMESCREEN);
+
+                if (!saved) {
                     return;
                 }
             }

--- a/apps/homescreen/everything.me/modules/Results/Results.css
+++ b/apps/homescreen/everything.me/modules/Results/Results.css
@@ -52,8 +52,12 @@
     position: relative; /* for span.remove positioning */
 }
 
-.evmeScope .evme-apps ul.marketapps li{
+.evmeScope .evme-apps ul.marketapps li {
     height: 9.3rem;
+}
+
+.evmeScope .evme-apps ul li.save-to-homescreen {
+  pointer-events: none;
 }
 
 .evmeScope .evme-apps:not(.has-installed) .has-installed-visible {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=912386

Workaround for probable Gecko bug:
1. Search for any query
2. Long press a cloud app
Expected: A confirmation prompt opens
Actual: A confirmation prompt opens, AND app opens in the bg.
