### PR TITLE
Bug 908657 - [Messages] the "unread" bit is not always removed when we r...

### DIFF
--- a/apps/sms/test/unit/messages_mockup.js
+++ b/apps/sms/test/unit/messages_mockup.js
@@ -10,6 +10,7 @@ function MockThreadMessages() {
       delivery: 'sending',
       error: true,
       id: 47,
+      threadId: 1,
       timestamp: getMockupedDate(0)
     },
     {
@@ -18,6 +19,7 @@ function MockThreadMessages() {
       body: 'Nothing :)',
       delivery: 'sent',
       id: 46,
+      threadId: 1,
       timestamp: getMockupedDate(0)
     },
     {
@@ -25,6 +27,7 @@ function MockThreadMessages() {
       body: 'Recibido!',
       delivery: 'received',
       id: 40,
+      threadId: 1,
       timestamp: getMockupedDate(2)
     },
     {
@@ -33,6 +36,7 @@ function MockThreadMessages() {
       body: 'Nothing :)',
       delivery: 'error',
       id: 460,
+      threadId: 1,
       timestamp: getMockupedDate(6)
     },
     {
@@ -41,6 +45,7 @@ function MockThreadMessages() {
       body: 'Nothing at all :)',
       delivery: 'error',
       id: 461,
+      threadId: 1,
       timestamp: getMockupedDate(6)
     }];
 

--- a/apps/sms/test/unit/mock_message_manager.js
+++ b/apps/sms/test/unit/mock_message_manager.js
@@ -14,7 +14,9 @@ var MockMessageManager = {
   },
   sendMMS: function() {
     return {};
-  }
+  },
+  markMessagesRead: function() {},
+  markThreadRead: function() {}
 };
 
 MockMessageManager.mSetup = function() {

--- a/apps/sms/test/unit/mock_moz_sms_filter.js
+++ b/apps/sms/test/unit/mock_moz_sms_filter.js
@@ -1,0 +1,1 @@
+var MockMozSmsFilter = function() {};

--- a/apps/sms/test/unit/mock_navigatormoz_sms.js
+++ b/apps/sms/test/unit/mock_navigatormoz_sms.js
@@ -4,6 +4,8 @@ var MockNavigatormozMobileMessage = {
   _mSmsRequest: null,
   _mMmsRequest: null,
   _mSegmentInfoRequests: [],
+  _mMarkReadRequest: null,
+  _mMessagesRequest: null,
 
   send: function(recipients, content) {
     this._mSmsRequest = [];
@@ -16,6 +18,49 @@ var MockNavigatormozMobileMessage = {
   sendMMS: function() {
     this._mMmsRequest = {};
     return this._mMmsRequest;
+  },
+
+  markMessageRead: function(messageId, value) {
+    this._mMarkReadRequest = {};
+    return this._mMarkReadRequest;
+  },
+
+  mTriggerMarkReadSuccess: function() {
+    var evt = { target: { result: null } };
+
+    if (this._mMarkReadRequest && this._mMarkReadRequest.onsuccess) {
+      var current = this._mMarkReadRequest;
+      this._mMarkReadRequest = null;
+      current.onsuccess.call(evt.target, evt);
+    }
+  },
+
+  getMessages: function(filter, invert) {
+    this._mMessagesRequest = {};
+    return this._mMessagesRequest;
+  },
+
+  mTriggerMessagesRequest: function(messages) {
+    var mock = this;
+    if (this._mMessagesRequest && this._mMessagesRequest.onsuccess) {
+      var cursor = {
+        done: false,
+        continue: function() {
+          var next = messages.shift();
+          if (next === undefined) {
+            this.result = null;
+            this.done = true;
+          } else {
+            this.result = next;
+          }
+
+          var evt = { target: cursor };
+          mock._mMessagesRequest.onsuccess.call(this, evt);
+        }
+      };
+
+      cursor.continue();
+    }
   },
 
   getSegmentInfoForText: function() {
@@ -122,5 +167,7 @@ var MockNavigatormozMobileMessage = {
     this._mSegmentInfoRequests = [];
     this._mSmsRequest = null;
     this._mMmsRequest = null;
+    this._mMarkReadRequest = null;
+    this._mMessagesRequest = null;
   }
 };

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -138,13 +138,15 @@ suite('SMS App Unit-Test', function() {
           filter = options.filter, // mozMessageFilter
           invert = options.invert, // invert selection
           end = options.end,   // CB when all messages retrieved
-          endArgs = options.endArgs; //Args for end
+          endArgs = options.endArgs, //Args for end
+          done = options.done;
 
         var messagesMockup = new MockThreadMessages();
         for (var i = 0, l = messagesMockup.length; i < l; i++) {
           each(messagesMockup[i]);
         }
-        end(endArgs);
+        end && end(endArgs);
+        done && done();
       });
 
     // We mockup the method for retrieving the info
@@ -378,7 +380,7 @@ suite('SMS App Unit-Test', function() {
     var _tci;
     // Setup for getting all messages rendered before every test
     setup(function(done) {
-      ThreadUI.renderMessages({}, done);
+      ThreadUI.renderMessages(1, done);
       _tci = ThreadUI.checkInputs;
     });
 
@@ -402,7 +404,7 @@ suite('SMS App Unit-Test', function() {
     suite('Thread-messages Edit mode (bubbles view)', function() {
       // Setup for getting all messages rendered before every test
       setup(function(done) {
-        ThreadUI.renderMessages({}, function() {
+        ThreadUI.renderMessages(1, function() {
           done();
         });
       });

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -20,6 +20,7 @@ requireApp('sms/test/unit/mock_attachment_menu.js');
 requireApp('sms/test/unit/mock_l10n.js');
 requireApp('sms/test/unit/mock_utils.js');
 requireApp('sms/test/unit/mock_navigatormoz_sms.js');
+requireApp('sms/test/unit/mock_moz_sms_filter.js');
 requireApp('sms/test/unit/mock_link_helper.js');
 requireApp('sms/test/unit/mock_moz_activity.js');
 requireApp('sms/shared/test/unit/mocks/mock_navigator_moz_settings.js');
@@ -44,6 +45,7 @@ var mocksHelperForThreadUI = new MocksHelper([
   'LinkActionHandler',
   'LinkHelper',
   'MozActivity',
+  'MozSmsFilter',
   'ActivityPicker',
   'OptionMenu',
   'Dialog',
@@ -1473,6 +1475,21 @@ suite('thread_ui.js >', function() {
       MockSMIL.parse.yields([{ text: payload }]);
       ThreadUI.buildMessageDOM(buildMMS(payload));
       assert.ok(Template.escape.calledWith(payload));
+    });
+  });
+
+  suite('renderMessages()', function() {
+    setup(function() {
+      // todo: use the MessageManager mock instead
+      this.sinon.stub(MessageManager, 'getMessages');
+      this.sinon.stub(MessageManager, 'markThreadRead');
+      ThreadUI.renderMessages(1);
+    });
+
+    test('we mark messages as read', function() {
+      MessageManager.getMessages.yieldTo('done');
+      this.sinon.clock.tick();
+      assert.ok(MessageManager.markThreadRead.calledWith(1));
     });
   });
 


### PR DESCRIPTION
...ead a thread r=borja
- added a markThreadRead in MessageManager, make the code easier to read and it
  will make it easier to use the new method from Bug 912943.
- added a "done" callback that is always called by getMessages
- we always mark the messages as read so removed unnecessary arguments to this
  method
- made renderMessages take a threadId instead of a filter, this was a leftover
  of our conversion to threadId instead of phone numbers
