### PR TITLE
Bug 910132 - [Flatfish][Homescreen] add support for large device for por...

### DIFF
--- a/apps/homescreen/style/dock.css
+++ b/apps/homescreen/style/dock.css
@@ -58,17 +58,24 @@
 }
 
 /* For tablet+ Device */
-@media (min-width: 768px) and (orientation: landscape) {
+@media (min-width: 768px) {
   #footer {
     height: 16rem;
   }
 
-  #footer .dockWrapper {
-    width: 160%;
-  }
-
   #footer ol {
     margin-top: 2.5rem;
+  }
+
+  #footer > div li,
+  #footer > div.scrollable li {
+    width: 15rem;
+  }
+}
+
+@media (min-width: 768px) and (orientation: landscape) {
+  #footer .dockWrapper {
+    width: 160%;
   }
 
   #footer li {

--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -208,12 +208,7 @@ body[data-transitioning] .loading:after {
 }
 
 /* For tablet+ Device */
-@media (min-width: 768px) and (orientation: landscape) {
-  .apps ol > li {
-    width: 20%; /* five a line */
-  }
-
-  /* Option to delete apps */
+@media (min-width: 768px) {
   .apps ol > li span.options {
     height: 4.5rem;
     background: url(../resources/images/delete.png) no-repeat left top / 4.5rem;
@@ -241,5 +236,11 @@ body[data-transitioning] .loading:after {
   /* Maximum 15 icons for page */
   .apps ol > li:nth-child(16) {
     display: none;
+  }
+}
+
+@media (min-width: 768px) and (orientation: landscape) {
+  .apps ol > li {
+    width: 20%; /* five a line */
   }
 }


### PR DESCRIPTION
-   To test this patch on nightly:
  1.  `$ make DEBUG=1 GAIA_DEV_PIXELS_PER_PX=2` (*)
  2.  to set responsive design window to 1280 x 800 px, enter `about:config` and set `devtools.responsiveUI.presents` to `{“key”:”1280x800”, “width”:1280, “height”:800}`

(*) add `GAIA_DEV_PIXELS_PER_PX=2` option is a temp solution for large device, will followed by `adaptive image support` patch to allow show different size image in same density
