### PR TITLE
Bug 835243 -  [OPEN_][Bluetooth]Bluetooth device name can be unrestricted input and does not have limit.

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -206,6 +206,7 @@ bluetooth-enable-msg = Turn Bluetooth on to view devices in the area.
 bluetooth-paired-devices   = Paired devices
 bluetooth-devices-in-area  = Devices in the area
 bluetooth-visible-to-all = Visible to all
+bluetooth-name-maxlength-alert = Your device name exceeds {{length}} characters. Please retry again.
 bt-status-nopaired = No devices paired
 bt-status-turnoff  = Turned off
 bt-status-paired = {[ plural(n) ]}


### PR DESCRIPTION
- refactor code (take the check part before getting deviceInfo) 
- add a confirm window to ask users rename again or not
- limit device name with MAX 20 characters
