### PR TITLE
Bug 911676 - check navigator.mozTelephony statements robustness

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -183,7 +183,6 @@
 
     <!-- Cost Control -->
     <link rel="stylesheet" type="text/css" href="style/cost_control/cost_control.css">
-    <script defer src="js/cost_control.js"></script>
 
     <!-- Quick Settings -->
     <link rel="stylesheet" type="text/css" href="style/quick_settings/quick_settings.css">

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -13,7 +13,7 @@ var QuickSettings = {
   init: function qs_init() {
     var settings = window.navigator.mozSettings;
     var conn = window.navigator.mozMobileConnection;
-    if (!settings || !conn)
+    if (!settings)
       return;
 
     this.getAllElements();
@@ -26,32 +26,36 @@ var QuickSettings = {
     /*
      * Monitor data network icon
      */
-    conn.addEventListener('datachange', function qs_onDataChange() {
-      var label = {
-        'lte': '4G', // 4G LTE
-        'ehrpd': '4G', // 4G CDMA
-        'hspa+': 'H+', // 3.5G HSPA+
-        'hsdpa': 'H', 'hsupa': 'H', 'hspa': 'H', // 3.5G HSDPA
-        'evdo0': '3G', 'evdoa': '3G', 'evdob': '3G', '1xrtt': '3G', // 3G CDMA
-        'umts': '3G', // 3G
-        'edge': 'E', // EDGE
-        'is95a': '2G', 'is95b': '2G', // 2G CDMA
-        'gprs': '2G'
-      };
-      self.data.dataset.network = label[conn.data.type];
-    });
+    if (conn) {
+      conn.addEventListener('datachange', function qs_onDataChange() {
+        var label = {
+          'lte': '4G', // 4G LTE
+          'ehrpd': '4G', // 4G CDMA
+          'hspa+': 'H+', // 3.5G HSPA+
+          'hsdpa': 'H', 'hsupa': 'H', 'hspa': 'H', // 3.5G HSDPA
+          'evdo0': '3G', 'evdoa': '3G', 'evdob': '3G', '1xrtt': '3G', // 3G CDMA
+          'umts': '3G', // 3G
+          'edge': 'E', // EDGE
+          'is95a': '2G', 'is95b': '2G', // 2G CDMA
+          'gprs': '2G'
+        };
+        self.data.dataset.network = label[conn.data.type];
+      });
 
-    /* monitor data setting
-     * TODO prevent quickly tapping on it
-     */
-    SettingsListener.observe('ril.data.enabled', true, function(value) {
-      if (value) {
-        self.data.dataset.enabled = 'true';
-      } else {
-        delete self.data.dataset.enabled;
-      }
-    });
-
+      /* monitor data setting
+       * TODO prevent quickly tapping on it
+       */
+      SettingsListener.observe('ril.data.enabled', true, function(value) {
+        if (value) {
+          self.data.dataset.enabled = 'true';
+        } else {
+          delete self.data.dataset.enabled;
+        }
+      });
+    } else {
+      // hide data icon without mozMobileConnection object
+      this.overlay.classList.add('non-mobile');
+    }
     /* monitor bluetooth setting and initialization/disable ready event
      * - when settings changed, update UI and lock toogle to prevent quickly
      *   tapping on it.

--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -37,6 +37,10 @@ var UtilityTray = {
     window.addEventListener('keyboardchangecanceled', this);
 
     this.overlay.addEventListener('transitionend', this);
+
+    if (window.navigator.mozMobileConnection) {
+      LazyLoader.load('js/cost_control.js');
+    }
   },
 
   startY: undefined,

--- a/apps/system/style/quick_settings/quick_settings.css
+++ b/apps/system/style/quick_settings/quick_settings.css
@@ -35,6 +35,10 @@ html, body {
   pointer-events: auto;
 }
 
+#quick-settings.non-mobile > a {
+  width: calc(25% - 0.2rem);
+}
+
 #quick-settings > .separator {
   border-right: 0.1rem black solid;
   border-left: 0.1rem gray solid;
@@ -53,6 +57,10 @@ html, body {
   border-right: 0;
 }
 
+#quick-settings.non-mobile > a:first-child,
+#quick-settings.non-mobile > a:last-child {
+  width: calc(25% - 0.1rem);
+}
 
 #quick-settings > a {
   background-position: center;
@@ -70,6 +78,10 @@ html, body {
 }
 #quick-settings-data {
   background-image: url(images/data-off.png);
+}
+.non-mobile #quick-settings-data,
+.non-mobile #quick-settings-data + .separator {
+  display: none;
 }
 #quick-settings-data[data-network="2G"]  {
   background-image: url(images/data-2g-off.png);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=911676
1. hide data icon from quicksettings when mozMobileConnection not exist.
2. use lazyloader for costcontrol.js.
