### PR TITLE
[Clock] Bug 913468 Simplify clock banner notification and add unit test

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -41,6 +41,7 @@
     <script defer src="js/alarm.js"></script>
     <script defer src="js/active_alarm.js"></script>
     <script defer src="js/alarmsdb.js"></script>
+    <script defer src="js/banner.js"></script>
     <script defer src="js/clock_view.js"></script>
     <script defer src="js/alarm_list.js"></script>
     <script defer src="js/alarm_manager.js"></script>
@@ -183,6 +184,11 @@
         <span class="label">${label}</span>
         <span class="repeat">${repeat}</span>
       </a>
+      -->
+    </div>
+    <div id="banner-tmpl" class="hide">
+      <!--
+        <p>${notice}</p>
       -->
     </div>
 

--- a/apps/clock/js/alarm_edit.js
+++ b/apps/clock/js/alarm_edit.js
@@ -355,7 +355,7 @@ var AlarmEdit = {
           return;
         }
         AlarmList.refreshItem(alarm);
-        AlarmManager.renderBannerBar(alarm.getNextAlarmFireTime());
+        AlarmList.banner.show(alarm.getNextAlarmFireTime());
         AlarmManager.updateAlarmStatusBar();
         callback && callback(null, alarm);
       });

--- a/apps/clock/js/alarm_list.js
+++ b/apps/clock/js/alarm_list.js
@@ -61,6 +61,7 @@ var AlarmList = {
     this.template = new Template('alarm-list-item-tmpl');
     this.newAlarmButton.addEventListener('click', this);
     this.alarms.addEventListener('click', this);
+    this.banner = new Banner('banner-countdown', 'banner-tmpl');
     this.refresh();
     AlarmManager.regUpdateAlarmEnableState(this.refreshItem.bind(this));
   },
@@ -210,7 +211,7 @@ var AlarmList = {
       // setEnabled saves to database
       alarm.setEnabled(!alarm.enabled, function al_putAlarm(err, alarm) {
         if (alarm.enabled) {
-          AlarmManager.renderBannerBar(alarm.getNextAlarmFireTime());
+          this.banner.show(alarm.getNextAlarmFireTime());
         }
         this.refreshItem(alarm);
         AlarmManager.updateAlarmStatusBar();

--- a/apps/clock/js/alarm_manager.js
+++ b/apps/clock/js/alarm_manager.js
@@ -59,12 +59,6 @@ var AlarmManager = {
     alarm.setEnabled(enabled, callback);
   },
 
-  renderBannerBar: function am_renderBannerBar(date) {
-    LazyLoader.load(['js/banner.js'], function() {
-      BannerView.setStatus(date);
-    });
-  },
-
   updateAlarmStatusBar: function am_updateAlarmStatusBar() {
     var request = navigator.mozAlarms.getAll();
     request.onsuccess = function(e) {

--- a/apps/clock/js/startup.js
+++ b/apps/clock/js/startup.js
@@ -34,6 +34,7 @@ var loadQueue = [
     'js/panel.js',
     'js/clock_view.js',
     'js/alarm_list.js',
+    'js/banner.js',
     'js/alarm_manager.js'
   ],
   [

--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -154,16 +154,15 @@ html, body {
 #banner-countdown {
   z-index: -1;
   opacity: 0;
-  bottom: -2rem;
   -moz-transition: all 600ms ease;
 }
 #banner-countdown.visible {
   z-index: 1;
   opacity: 1;
-  bottom: 0;
   -moz-transition: all 600ms ease;
 }
-#banner-countdown > p > strong {
+
+#banner-countdown strong {
   white-space: nowrap;
 }
 

--- a/apps/clock/test/unit/alarm_edit_test.js
+++ b/apps/clock/test/unit/alarm_edit_test.js
@@ -40,6 +40,7 @@ suite('AlarmEditView', function() {
     AlarmList = al;
     AlarmManager = am;
     AlarmsDB = _AlarmsDB;
+    navigator.mozL10n = nml;
     ActiveAlarm.handler.restore();
   });
 
@@ -76,7 +77,6 @@ suite('AlarmEditView', function() {
       this.sinon.stub(AlarmEdit, 'getRepeatSelect');
 
       this.sinon.stub(AlarmManager, 'toggleAlarm');
-      this.sinon.stub(AlarmManager, 'renderBannerBar');
       this.sinon.stub(AlarmManager, 'updateAlarmStatusBar');
 
       // Define the stubs to return the same values set in the
@@ -95,6 +95,7 @@ suite('AlarmEditView', function() {
 
     test('should save an alarm, no id', function(done) {
       this.sinon.stub(AlarmList, 'refreshItem');
+      this.sinon.stub(AlarmList.banner, 'show');
       AlarmEdit.alarm = new Alarm({
         hour: 5,
         minute: 17,
@@ -103,7 +104,6 @@ suite('AlarmEditView', function() {
         }
       });
       AlarmEdit.element.dataset.id = null;
-
       AlarmEdit.save(function(err, alarm) {
         assert.ok(!err);
         assert.ok(alarm.id);
@@ -113,7 +113,7 @@ suite('AlarmEditView', function() {
         assert.ok(AlarmList.refreshItem.calledWithExactly(alarm));
 
         // Rendered BannerBar
-        assert.ok(AlarmManager.renderBannerBar.calledOnce);
+        assert.ok(AlarmList.banner.show.calledOnce);
         assert.ok(AlarmManager.updateAlarmStatusBar.calledOnce);
         done();
       });
@@ -122,6 +122,7 @@ suite('AlarmEditView', function() {
 
     test('should save an alarm, existing id', function(done) {
       this.sinon.stub(AlarmList, 'refreshItem');
+      this.sinon.stub(AlarmList.banner, 'show');
       var curid = AlarmsDB.idCount++;
       AlarmEdit.alarm = new Alarm({
         id: curid,
@@ -142,7 +143,7 @@ suite('AlarmEditView', function() {
         assert.ok(AlarmList.refreshItem.calledWithExactly(alarm));
 
         // Rendered BannerBar
-        assert.ok(AlarmManager.renderBannerBar.calledOnce);
+        assert.ok(AlarmList.banner.show.calledOnce);
         assert.ok(AlarmManager.updateAlarmStatusBar.calledOnce);
         done();
       });

--- a/apps/clock/test/unit/alarm_list_test.js
+++ b/apps/clock/test/unit/alarm_list_test.js
@@ -6,22 +6,27 @@ requireApp('clock/js/alarm_manager.js');
 requireApp('clock/js/alarm_edit.js');
 requireApp('clock/js/alarm_list.js');
 requireApp('clock/js/active_alarm.js');
+requireApp('clock/js/banner.js');
+requireApp('clock/js/clock_view.js');
 
 requireApp('clock/test/unit/mocks/mock_alarmsDB.js');
 requireApp('clock/test/unit/mocks/mock_alarm_manager.js');
 requireApp('clock/test/unit/mocks/mock_asyncstorage.js');
+requireApp('clock/test/unit/mocks/mock_banner.js');
 requireApp('clock/test/unit/mocks/mock_navigator_mozl10n.js');
 requireApp('clock/test/unit/mocks/mock_mozAlarm.js');
 
 suite('AlarmList', function() {
-  var am, nml, nma, fixture, dom;
+  var am, bn, nml, nma, fixture, dom;
 
   suiteSetup(function() {
     am = AlarmManager;
+    bn = Banner;
     nml = navigator.mozL10n;
     nma = navigator.mozAlarms;
 
     AlarmManager = MockAlarmManager;
+    Banner = MockBanner;
     navigator.mozL10n = MockL10n;
     navigator.mozAlarms = MockMozAlarms;
 
@@ -32,6 +37,7 @@ suite('AlarmList', function() {
 
   suiteTeardown(function() {
     AlarmManager = am;
+    Banner = bn;
     navigator.mozL10n = nml;
     navigator.mozAlarms = nma;
   });

--- a/apps/clock/test/unit/alarm_test.js
+++ b/apps/clock/test/unit/alarm_test.js
@@ -463,4 +463,3 @@ suite('Alarm Test', function() {
     });
   });
 });
-

--- a/apps/clock/test/unit/banner_test.js
+++ b/apps/clock/test/unit/banner_test.js
@@ -1,0 +1,61 @@
+requireApp('clock/js/banner.js');
+requireApp('clock/js/utils.js');
+
+requireApp('clock/test/unit/mocks/mock_navigator_mozl10n.js');
+
+suite('Banner', function() {
+  var nml;
+  suiteSetup(function() {
+    // store timezone offset for fake timers
+    var offset = (new Date()).getTimezoneOffset() * 60 * 1000;
+    nml = navigator.mozL10n;
+
+    navigator.mozL10n = MockL10n;
+
+    // The timestamp for "Tue Jul 16 2013 06:00:00" according to the local
+    // system's time zone
+    this.sixAm = 1373954400000 + offset;
+    this.clock = sinon.useFakeTimers(this.sixAm);
+
+    // The timestamp for "Tue Jul 16 2013 16:12:00" according to the local
+    // system's time zone
+    // add to this.sixAm to avoid failures on machines in unknown locales
+    this.fourish = this.sixAm + (10 * 60 * 60 * 1000) + (12 * 60 * 1000);
+
+    // Instantiate the Banner once with an element
+    this.noteElem = document.createElement('div');
+    this.banner = new Banner(this.noteElem);
+  });
+
+  suiteTeardown(function() {
+    navigator.mozL10n = nml;
+    this.clock.restore();
+  });
+
+  suite('#show', function() {
+    test('should make notification visible ', function(done) {
+      var visible;
+
+      this.banner.show(this.fourish);
+      visible = this.noteElem.className.split(/\s+/).some(function(elem) {
+        return elem === 'visible';
+      });
+      assert.ok(visible);
+      done();
+    });
+  });
+
+  suite('#render', function() {
+    test('should pass correct parameters to mozL10n.get ', function(done) {
+      var passed;
+      passed = this.sinon.spy(navigator.mozL10n, 'get');
+      // build banner
+      this.banner.render(this.fourish);
+      // Check passed in arguments
+      assert.deepEqual({n: 10}, passed.args[0][1]);
+      assert.deepEqual({n: 12}, passed.args[1][1]);
+      done();
+    });
+  });
+
+});

--- a/apps/clock/test/unit/mocks/mock_alarm_list.js
+++ b/apps/clock/test/unit/mocks/mock_alarm_list.js
@@ -2,6 +2,9 @@ MockAlarmList = {
   alarmList: [],
   refreshingAlarms: [],
   count: 0,
+  banner: {
+    show: function() {}
+  },
   handleEvent: function() {},
   alarmEditView: function() {},
   init: function() {},

--- a/apps/clock/test/unit/mocks/mock_alarm_manager.js
+++ b/apps/clock/test/unit/mocks/mock_alarm_manager.js
@@ -1,6 +1,5 @@
 MockAlarmManager = {
   toggleAlarm: function() {},
-  renderBannerBar: function() {},
   updateAlarmStatusBar: function() {},
   regUpdateAlarmEnableState: function() {}
 };

--- a/apps/clock/test/unit/mocks/mock_banner.js
+++ b/apps/clock/test/unit/mocks/mock_banner.js
@@ -1,0 +1,11 @@
+(function(exports) {
+  function MockBanner() {
+  }
+
+  MockBanner.prototype = {
+    show: function() {}
+  };
+
+  exports.MockBanner = MockBanner;
+
+}(this));


### PR DESCRIPTION
Refactor banner notice:
- Use shared template.js to remove HTML from `banner.js`
- Convert Banner to a constructor function and instantiate a new banner for each alarm notice
- Add unit tests
