### PR TITLE
Bug 917946 - Add Gaia-marionette tests for the settings app 

### DIFF
--- a/apps/settings/test/marionette/app/app.js
+++ b/apps/settings/test/marionette/app/app.js
@@ -1,0 +1,55 @@
+var Base = require('./base'),
+    BluetoothPanel = require('./regions/bluetooth'),
+    DoNotTrackPanel = require('./regions/do_not_track');
+
+/**
+ * Abstraction around settings app
+ * @constructor
+ * @param {Marionette.Client} client for operations.
+ */
+function Settings(client) {
+  this.client = client;
+  // Call the Base constructor to initiate base class.
+  Base.call(this, this.client, ORIGIN, Settings.Selectors);
+}
+
+module.exports = Settings;
+
+// origin of the settings app
+const ORIGIN = 'app://settings.gaiamobile.org';
+
+Settings.Selectors = {
+  'menuItemsSection': '#root',
+  'bluetoothMenuItem': '#menuItem-bluetooth',
+  'doNotTrackMenuItem': '#menuItem-doNotTrack'
+};
+
+Settings.prototype = {
+
+  __proto__: Base.prototype,
+
+  get bluetoothPanel() {
+    openPanel.call(this, 'bluetoothMenuItem');
+    return this._bluetoothPanel = this._bluetoothPanel ||
+      new BluetoothPanel(this.client);
+  },
+
+  get doNotTrackPanel() {
+    openPanel.call(this, 'doNotTrackMenuItem');
+    return this._doNotTrackPanel = this._doNotTrackPanel ||
+      new DoNotTrackPanel(this.client);
+  }
+
+};
+
+/**
+* @private
+*/
+function openPanel(selector) {
+  menuItem = this.waitForElement(selector);
+  parentSection = this.waitForElement('menuItemsSection');
+  menuItem.tap();
+  this.client.waitFor(function() {
+    return parentSection.location()['x'] + parentSection.size()['width'] == 0;
+  });
+}

--- a/apps/settings/test/marionette/app/base.js
+++ b/apps/settings/test/marionette/app/base.js
@@ -1,0 +1,41 @@
+/**
+ * Base app object to provide common methods to app objects
+ * @constructor
+ * @param {Marionette.Client} client for operations.
+ */
+function Base(client, origin, selectors) {
+  this.client = client;
+  this.origin = origin;
+  this.selectors = selectors;
+}
+
+module.exports = Base;
+
+Base.prototype = {
+
+  /**
+   * Launches settings app, switches to frame, and waits for it to be loaded.
+   */
+  launch: function() {
+    this.client.apps.launch(this.origin);
+    this.client.apps.switchToApp(this.origin);
+    this.client.helper.waitForElement('body');
+  },
+
+  /**
+   * @protected
+   * @param {String} name of selector [its a key in Settings.Selectors].
+   */
+  findElement: function(name) {
+    return this.client.findElement(this.selectors[name]);
+  },
+
+  /**
+   * @protected
+   * @param {String} name of selector [its a key in Settings.Selectors].
+   */
+  waitForElement: function(name) {
+    return this.client.helper.waitForElement(this.selectors[name]);
+  }
+
+};

--- a/apps/settings/test/marionette/app/regions/bluetooth.js
+++ b/apps/settings/test/marionette/app/regions/bluetooth.js
@@ -1,0 +1,45 @@
+var Base = require('../base');
+
+/**
+ * Abstraction around settings bluetooth panel
+ * @constructor
+ * @param {Marionette.Client} client for operations.
+ */
+function BluetoothPanel(client) {
+
+  // Call the Base constructor to initiate base class.
+  Base.call(this, client, null, BluetoothPanel.Selectors);
+
+}
+
+module.exports = BluetoothPanel;
+
+BluetoothPanel.Selectors = {
+  'bluetoothEnabledCheckbox': '#bluetooth-status input',
+  'bluetoothEnabledLabel': '#bluetooth-status span'
+};
+
+BluetoothPanel.prototype = {
+
+  __proto__: Base.prototype,
+
+  get isBluetoothEnabled() {
+    return this.findElement('bluetoothEnabledCheckbox')
+      .getAttribute('checked');
+  },
+
+  enableBluetooth: function() {
+    this.waitForElement('bluetoothEnabledLabel').tap();
+      this.client.waitFor(function() {
+        return this.isBluetoothEnabled;
+    }.bind(this));
+  },
+
+  disableBluetooth: function() {
+    this.waitForElement('bluetoothEnabledLabel').tap();
+      this.client.waitFor(function() {
+        return !this.isBluetoothEnabled;
+    }.bind(this));
+  }
+
+};

--- a/apps/settings/test/marionette/app/regions/do_not_track.js
+++ b/apps/settings/test/marionette/app/regions/do_not_track.js
@@ -1,0 +1,45 @@
+var Base = require('../base');
+
+/**
+ * Abstraction around settings do not track panel
+ * @constructor
+ * @param {Marionette.Client} client for operations.
+ */
+function DoNotTrackPanel(client) {
+
+  // Call the Base constructor to initiate base class.
+  Base.call(this, client, null, DoNotTrackPanel.Selectors);
+
+}
+
+module.exports = DoNotTrackPanel;
+
+DoNotTrackPanel.Selectors = {
+  'doNotTrackEnabledCheckbox': '#doNotTrack input',
+  'doNotTrackEnabledLabel': '#doNotTrack label'
+};
+
+DoNotTrackPanel.prototype = {
+
+  __proto__: Base.prototype,
+
+  get isDoNotTrackEnabled() {
+    return this.findElement('doNotTrackEnabledCheckbox')
+      .getAttribute('checked');
+  },
+
+  enableDoNotTrack: function() {
+    this.waitForElement('doNotTrackEnabledLabel').tap();
+      this.client.waitFor(function() {
+        return this.isDoNotTrackEnabled;
+    }.bind(this));
+  },
+
+  disableDoNotTrack: function() {
+    this.waitForElement('doNotTrackEnabledLabel').tap();
+      this.client.waitFor(function() {
+        return !this.isDoNotTrackEnabled;
+    }.bind(this));
+  }
+
+};

--- a/apps/settings/test/marionette/tests/bluetooth_settings_test.js
+++ b/apps/settings/test/marionette/tests/bluetooth_settings_test.js
@@ -1,0 +1,30 @@
+var Settings = require('../app/app'),
+    assert = require('assert');
+
+marionette('manipulate bluetooth settings', function() {
+  var client = marionette.client();
+  var settingsApp;
+
+  setup(function() {
+    settingsApp = new Settings(client);
+    settingsApp.launch();
+    // Navigate to the Bluetooth menu
+    bluetoothPanel = settingsApp.bluetoothPanel;
+  });
+
+  test('check bluetooth initial state', function() {
+    assert.ok(
+      !bluetoothPanel.isBluetoothEnabled,
+      'bluetooth is disabled by default'
+    );
+  });
+
+  test('enable bluetooth', function() {
+    bluetoothPanel.enableBluetooth();
+    assert.ok(
+      bluetoothPanel.isBluetoothEnabled,
+      'bluetooth has been enabled'
+    );
+  });
+
+});

--- a/apps/settings/test/marionette/tests/do_not_track_settings_test.js
+++ b/apps/settings/test/marionette/tests/do_not_track_settings_test.js
@@ -1,0 +1,30 @@
+var Settings = require('../app/app'),
+    assert = require('assert');
+
+marionette('manipulate do not track settings', function() {
+  var client = marionette.client();
+  var settingsApp;
+
+  setup(function() {
+    settingsApp = new Settings(client);
+    settingsApp.launch();
+    // Navigate to the Do Not Track menu
+    doNotTrackPanel = settingsApp.doNotTrackPanel;
+  });
+
+  test('check do not track initial state', function() {
+    assert.ok(
+      !doNotTrackPanel.isDoNotTrackEnabled,
+      'do not track is disabled by default'
+    );
+  });
+
+  test('enable do not track', function() {
+    doNotTrackPanel.enableDoNotTrack();
+    assert.ok(
+      doNotTrackPanel.isDoNotTrackEnabled,
+      'do not track has been enabled'
+    );
+  });
+
+});


### PR DESCRIPTION
This is a proof-of-concept / request for feedback regarding this approach to writing js integration tests.

It includes a `Base` app object which other app objects can extend in order to inherit common functionality.
It includes a starting point for a `Settings` app object, as well as a `BluetoothPanel` region object.

Not having a lot of experience writing object oriented Javascript I may have done some things that are not ideal, so I am eager to hear feedback/suggestions. I will add specific comments to the pull request in areas where I am unsure about what I did.

Pinging @lightsofapollo and @gaye for comments, but any and all feedback is welcome.
