### PR TITLE
Bug 826325 - preventDefault all mozbrowserwindowopen events so that Gecko won't attempt to open them

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -613,6 +613,9 @@ var Browser = {
   },
 
   handleWindowOpen: function browser_handleWindowOpen(evt) {
+    // Prevent Gecko from opening this
+    evt.preventDefault();
+
     var url = evt.detail.url;
     var frame = evt.detail.frameElement;
     var tab = this.createTab(url, frame);

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -81,6 +81,9 @@ var AttentionScreen = {
 
   // show the attention screen overlay with newly created frame
   open: function as_open(evt) {
+    // Prevent Gecko from opening this
+    evt.preventDefault();
+
     if (evt.detail.features != 'attention')
       return;
 

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -275,6 +275,9 @@ var KeyboardManager = {
   },
 
   handleKeyboardRequest: function km_handleKeyboardRequest(evt) {
+    // Prevent Gecko from opening this
+    evt.preventDefault();
+
     var url = evt.detail.url;
     this._debug('handleKeyboardRequest: ' + url);
     // everything is hack here! will be removed after having real platform API

--- a/apps/system/js/popup_manager.js
+++ b/apps/system/js/popup_manager.js
@@ -163,6 +163,9 @@ var PopupManager = {
         break;
 
       case 'mozbrowseropenwindow':
+        // Prevent Gecko from opening this
+        evt.preventDefault();
+
         var detail = evt.detail;
         var openerType = evt.target.dataset.frameType;
         var openerOrigin = evt.target.dataset.frameOrigin;

--- a/apps/system/js/wrapper_factory.js
+++ b/apps/system/js/wrapper_factory.js
@@ -13,6 +13,9 @@
     },
 
     handleEvent: function wf_handleEvent(evt) {
+      // Prevent Gecko from opening this
+      evt.preventDefault();
+
       var detail = evt.detail;
 
       // If it's a normal window.open request, ignore.


### PR DESCRIPTION
With the patch in Bug 826325, Gecko is altered so that if you don't call preventDefault on these events, they'll fall through and be sent to Gecko's normal window.open code code paths:

http://mxr.mozilla.org/mozilla-central/source/xpfe/appshell/src/nsContentTreeOwner.cpp#845

To maintain its old behavior, Gaia should just always call preventDefault()
