### PR TITLE
Bug 912388 - Show empty overlay when all videos are unplayable

### DIFF
--- a/apps/video/js/metadata.js
+++ b/apps/video/js/metadata.js
@@ -99,10 +99,12 @@ function processFirstQueuedItem() {
     return;
   }
 
-  // If there is no work queued, up return right away
+  // If there is no work queued, update dialog in case there are no playable
+  // videos; then return right away
   if (metadataQueue.length === 0) {
     processingQueue = false;
     hideThrobber();
+    updateDialog();
     return;
   }
 

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -366,10 +366,7 @@ function share(blobs) {
 function updateDialog() {
   if (videos.length !== 0 && (!storageState || playerShowing)) {
     showOverlay(null);
-    return;
-  }
-
-  if (storageState === MediaDB.UPGRADING) {
+  } else if (storageState === MediaDB.UPGRADING) {
     showOverlay('upgrade');
   } else if (storageState === MediaDB.NOCARD) {
     showOverlay('nocard');


### PR DESCRIPTION
- checks if dialog has to be updated, when `metadataQueue` has been fully processed
