### PR TITLE
Bug 911670 - Change Wording of phonelock r=crh0716

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -394,7 +394,7 @@ mail=Mail
 privacyAndSecurity=Privacy & Security
 passcode-lock=Passcode lock
 passcode-lock-desc=Passcode: {{code}}
-phoneLock=Phone lock
+phoneLock=Screen lock
 simSecurity=SIM security
 
 # Security :: App permissions


### PR DESCRIPTION
Update wording of phonelock to "Screen lock".  Because in master branch, we have to support different devices and it doesn't make sense when using this wording in devices like tablet.

In this way, we change the wording to be more generic. 
