### PR TITLE
Bug 914040 - BrowserDB gaia unit tests failing in TBPL

### DIFF
--- a/apps/browser/test/unit/browser_db_test.js
+++ b/apps/browser/test/unit/browser_db_test.js
@@ -109,11 +109,21 @@ suite('BrowserDB', function() {
       BrowserDB.db.getAllBookmarks(function(bookmarks) {
         assert.equal(bookmarks.length, 2);
 
-        assert.equal(bookmarks[0].uri, 'http://customize.test.mozilla.org/2');
-        assert.equal(bookmarks[0].title, 'customize test 2');
+        // We can't yet guarantee order of bookmarks (bug 895807)
+        if (bookmarks[0].uri == 'http://customize.test.mozilla.org/2') {
+          assert.equal(bookmarks[0].uri, 'http://customize.test.mozilla.org/2');
+          assert.equal(bookmarks[0].title, 'customize test 2');
 
-        assert.equal(bookmarks[1].uri, 'http://customize.test.mozilla.org/1');
-        assert.equal(bookmarks[1].title, 'customize test 1');
+          assert.equal(bookmarks[1].uri, 'http://customize.test.mozilla.org/1');
+          assert.equal(bookmarks[1].title, 'customize test 1');
+        } else {
+          assert.equal(bookmarks[1].uri, 'http://customize.test.mozilla.org/2');
+          assert.equal(bookmarks[1].title, 'customize test 2');
+
+          assert.equal(bookmarks[0].uri, 'http://customize.test.mozilla.org/1');
+          assert.equal(bookmarks[0].title, 'customize test 1');
+        }
+
 
         done();
       });


### PR DESCRIPTION
Should fix half or all of the unit test failures.
