### PR TITLE
Bug 907757 - Give better error message for missing phone and email

### DIFF
--- a/apps/communications/contacts/js/activities.js
+++ b/apps/communications/contacts/js/activities.js
@@ -96,17 +96,17 @@ var ActivityHandler = {
       case 'webcontacts/tel':
         type = 'contact';
         dataSet = theContact.tel;
-        noDataStr = _('no_phones');
+        noDataStr = _('no_contact_phones');
         break;
       case 'webcontacts/contact':
         type = 'number';
         dataSet = theContact.tel;
-        noDataStr = _('no_phones');
+        noDataStr = _('no_contact_phones');
         break;
       case 'webcontacts/email':
         type = 'email';
         dataSet = theContact.email;
-        noDataStr = _('no_email');
+        noDataStr = _('no_contact_email');
         break;
     }
     var hasData = dataSet && dataSet.length;

--- a/apps/communications/contacts/locales/contacts.en-US.properties
+++ b/apps/communications/contacts/locales/contacts.en-US.properties
@@ -19,8 +19,8 @@ editContact        = Edit contact
 deleteConfirmMsg   = Delete contact?
 remove             = Remove
 comments           = Comments
-no_phones          = No phones
-no_email           = No email
+no_contact_phones  = This contact does not have a phone number
+no_contact_email   = This contact does not have an email address
 removePhotoConfirm = Remove contact picture?
 loadingContacts    = Loading contacts…
 # LOCALIZATION NOTE(noContactsActivity): Shown when using the context menu to add

--- a/apps/communications/contacts/test/unit/contacts_activities_test.js
+++ b/apps/communications/contacts/test/unit/contacts_activities_test.js
@@ -176,7 +176,7 @@ suite('Test Activities', function() {
       ActivityHandler.dataPickHandler(contact);
       assert.isTrue(ConfirmDialog.showing);
       assert.isNull(ConfirmDialog.title);
-      assert.equal(ConfirmDialog.text, _('no_phones'));
+      assert.equal(ConfirmDialog.text, _('no_contact_phones'));
     });
 
      test('webcontacts/tel, 1 result', function() {
@@ -216,7 +216,7 @@ suite('Test Activities', function() {
       ActivityHandler.dataPickHandler(contact);
       assert.isTrue(ConfirmDialog.showing);
       assert.isNull(ConfirmDialog.title);
-      assert.equal(ConfirmDialog.text, _('no_phones'));
+      assert.equal(ConfirmDialog.text, _('no_contact_phones'));
     });
 
     test('webcontacts/contact, 1 result', function() {
@@ -243,7 +243,7 @@ suite('Test Activities', function() {
       ActivityHandler.dataPickHandler(contact);
       assert.isTrue(ConfirmDialog.showing);
       assert.isNull(ConfirmDialog.title);
-      assert.equal(ConfirmDialog.text, _('no_email'));
+      assert.equal(ConfirmDialog.text, _('no_contact_email'));
     });
 
     test('webcontacts/email, 1 result', function() {


### PR DESCRIPTION
When we pick a contact, we cannot filter whether they have an email or a
phone number, depending on the pick request. This might make the user
pick contacts that are invalid in this case. So we notify this with an
alert. This commit ensure that we bring better error messages in this
case.
