### PR TITLE
Bug 912951 - Send content event from gaia -> chrome with layout info for supportsSwitching

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -136,6 +136,19 @@ var KeyboardManager = {
       var initType = self.showingLayout.type;
       var initIndex = self.showingLayout.index;
       self.launchLayoutFrame(self.keyboardLayouts[initType][initIndex]);
+
+      // Let chrome know about how many keyboards we have
+      var layouts = {};
+      Object.keys(self.keyboardLayouts).forEach(function(k) {
+        layouts[k] = self.keyboardLayouts[k].length;
+      });
+
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent('mozContentEvent', true, true, {
+        type: 'inputmethod-update-layouts',
+        layouts: layouts
+      });
+      window.dispatchEvent(event);
     }
     KeyboardHelper.getInstalledKeyboards(resetLayoutList);
   },

--- a/tools/extensions/browser-helper@gaiamobile.org/bootstrap.js
+++ b/tools/extensions/browser-helper@gaiamobile.org/bootstrap.js
@@ -191,6 +191,8 @@ function startup(data, reason) {
         mm.addMessageListener('Forms:SendKey:Result:OK', Keyboard);
         mm.addMessageListener('Forms:SequenceError', Keyboard);
         mm.addMessageListener('Forms:GetContext:Result:OK', Keyboard);
+        mm.addMessageListener('Forms:SetComposition:Result:OK', Keyboard);
+        mm.addMessageListener('Forms:EndComposition:Result:OK', Keyboard);
         mm.loadFrameScript('chrome://keyboard.js/content/forms.js', true);
       } catch(e) {
         debug('Can\'t load Keyboard.jsm. Likely because the keyboard addon is not here.');

--- a/tools/extensions/browser-helper@gaiamobile.org/content/shell.js
+++ b/tools/extensions/browser-helper@gaiamobile.org/content/shell.js
@@ -12,6 +12,7 @@ let Cu = Components.utils;
 let Cr = Components.results;
 
 Cu.import('resource://gre/modules/Services.jsm');
+Cu.import('resource://gre/modules/Keyboard.jsm');
 
 // Various helpers coming from /b2g/chrome/content/shell.js
 function getContentWindow() {
@@ -164,3 +165,24 @@ SettingsListener.observe('language.current', 'en-US', function(value) {
     });
   }
 });
+
+/**
+ * This code comes from b2g/chrome/content/shell.js
+ * For now just the keyboard stuff, should copy everything over at some point
+ */
+getContentWindow().addEventListener('mozContentEvent', function(evt) {
+  let detail = evt.detail;
+  dump('XXX FIXME : Got a mozContentEvent: ' + detail.type + "\n");
+
+  switch(detail.type) {
+    case 'inputmethod-update-layouts':
+      KeyboardHelper.handleEvent(detail);
+      break;
+  }
+});
+
+let KeyboardHelper = {
+  handleEvent: function keyboard_handleEvent(aMessage) {
+    Keyboard.setLayouts(aMessage.layouts);
+  }
+};

--- a/tools/extensions/keyboard/content/Keyboard.jsm
+++ b/tools/extensions/keyboard/content/Keyboard.jsm
@@ -23,7 +23,8 @@ let Keyboard = {
     'SetValue', 'RemoveFocus', 'SetSelectedOption', 'SetSelectedOptions',
     'SetSelectionRange', 'ReplaceSurroundingText', 'ShowInputMethodPicker',
     'SwitchToNextInputMethod', 'HideInputMethod',
-    'GetText', 'SendKey', 'GetContext'
+    'GetText', 'SendKey', 'GetContext',
+    'SetComposition', 'EndComposition'
   ],
 
   get messageManager() {
@@ -35,6 +36,12 @@ let Keyboard = {
 
   set messageManager(mm) {
     this._messageManager = mm;
+  },
+
+  sendAsyncMessage: function(name, data) {
+    try {
+      this.messageManager.sendAsyncMessage(name, data);
+    } catch(e) { }
   },
 
   init: function keyboardInit() {
@@ -66,6 +73,8 @@ let Keyboard = {
       mm.addMessageListener('Forms:SendKey:Result:OK', this);
       mm.addMessageListener('Forms:SequenceError', this);
       mm.addMessageListener('Forms:GetContext:Result:OK', this);
+      mm.addMessageListener('Forms:SetComposition:Result:OK', this);
+      mm.addMessageListener('Forms:EndComposition:Result:OK', this);
 
       // When not running apps OOP, we need to load forms.js here since this
       // won't happen from dom/ipc/preload.js
@@ -116,6 +125,8 @@ let Keyboard = {
       case 'Forms:SendKey:Result:OK':
       case 'Forms:SequenceError':
       case 'Forms:GetContext:Result:OK':
+      case 'Forms:SetComposition:Result:OK':
+      case 'Forms:EndComposition:Result:OK':
         let name = msg.name.replace(/^Forms/, 'Keyboard');
         this.forwardEvent(name, msg);
         break;
@@ -153,6 +164,12 @@ let Keyboard = {
       case 'Keyboard:GetContext':
         this.getContext(msg);
         break;
+      case 'Keyboard:SetComposition':
+        this.setComposition(msg);
+        break;
+      case 'Keyboard:EndComposition':
+        this.endComposition(msg);
+        break;
     }
   },
 
@@ -175,28 +192,27 @@ let Keyboard = {
   },
 
   setSelectedOption: function keyboardSetSelectedOption(msg) {
-    this.messageManager.sendAsyncMessage('Forms:Select:Choice', msg.data);
+    this.sendAsyncMessage('Forms:Select:Choice', msg.data);
   },
 
   setSelectedOptions: function keyboardSetSelectedOptions(msg) {
-    this.messageManager.sendAsyncMessage('Forms:Select:Choice', msg.data);
+    this.sendAsyncMessage('Forms:Select:Choice', msg.data);
   },
 
   setSelectionRange: function keyboardSetSelectionRange(msg) {
-    this.messageManager.sendAsyncMessage('Forms:SetSelectionRange', msg.data);
+    this.sendAsyncMessage('Forms:SetSelectionRange', msg.data);
   },
 
   setValue: function keyboardSetValue(msg) {
-    this.messageManager.sendAsyncMessage('Forms:Input:Value', msg.data);
+    this.sendAsyncMessage('Forms:Input:Value', msg.data);
   },
 
   removeFocus: function keyboardRemoveFocus() {
-    this.messageManager.sendAsyncMessage('Forms:Select:Blur', {});
+    this.sendAsyncMessage('Forms:Select:Blur', {});
   },
 
   replaceSurroundingText: function keyboardReplaceSurroundingText(msg) {
-    this.messageManager.sendAsyncMessage('Forms:ReplaceSurroundingText',
-                                         msg.data);
+    this.sendAsyncMessage('Forms:ReplaceSurroundingText', msg.data);
   },
 
   showInputMethodPicker: function keyboardShowInputMethodPicker() {
@@ -214,15 +230,40 @@ let Keyboard = {
   },
 
   getText: function keyboardGetText(msg) {
-    this.messageManager.sendAsyncMessage('Forms:GetText', msg.data);
+    this.sendAsyncMessage('Forms:GetText', msg.data);
   },
 
   sendKey: function keyboardSendKey(msg) {
-    this.messageManager.sendAsyncMessage('Forms:Input:SendKey', msg.data);
+    this.sendAsyncMessage('Forms:Input:SendKey', msg.data);
   },
 
   getContext: function keyboardGetContext(msg) {
-    this.messageManager.sendAsyncMessage('Forms:GetContext', msg.data);
+    if (this._layouts) {
+      ppmm.broadcastAsyncMessage('Keyboard:LayoutsChange', this._layouts);
+    }
+
+    this.sendAsyncMessage('Forms:GetContext', msg.data);
+  },
+
+  setComposition: function keyboardSetComposition(msg) {
+    this.sendAsyncMessage('Forms:SetComposition', msg.data);
+  },
+
+  endComposition: function keyboardEndComposition(msg) {
+    this.sendAsyncMessage('Forms:EndComposition', msg.data);
+  },
+
+  /**
+   * Get the number of keyboard layouts active from keyboard_manager
+   */
+  _layouts: null,
+  setLayouts: function keyboardSetLayoutCount(layouts) {
+    // The input method plugins may not have loaded yet,
+    // cache the layouts so on init we can respond immediately instead
+    // of going back and forth between keyboard_manager
+    this._layouts = layouts;
+
+    ppmm.broadcastAsyncMessage('Keyboard:LayoutsChange', layouts);
   }
 };
 


### PR DESCRIPTION
The gaia part, I added some stuff to the desktop helper to forward contentEvents as we don't do that today.
