### PR TITLE
bug 913701

### DIFF
--- a/apps/browser/test/unit/browser_db_test.js
+++ b/apps/browser/test/unit/browser_db_test.js
@@ -79,16 +79,16 @@ suite('BrowserDB', function() {
   var realMozSettings = null;
   this.timeout(5000);
 
+  suiteSetup(function() {
+    realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozSettings = realMozSettings;
+  });
+
   suite('BrowserDB.operatorVariantCustomization', function() {
-
-    suiteSetup(function() {
-      realMozSettings = navigator.mozSettings;
-      navigator.mozSettings = MockNavigatorSettings;
-    });
-
-    suiteTeardown(function() {
-      navigator.mozSettings = realMozSettings;
-    });
 
     setup(function(done) {
       BrowserDB.init(function() {


### PR DESCRIPTION
MozSettings must be present at all times because it's required by simple_operator_variant_helper.js. If it's not present on window.navigator it will cause test failures because SimpleOperatorVariantHelper cannot function as expected.
