### PR TITLE
Bug 914375 - fix multiple cosmetic l10n errors in system/index.html

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -568,9 +568,9 @@
           <div id="frame-container">
             <div id="popup-error-dialog" role="dialog" class="generic-dialog">
               <div class="inner">
-                <h3 data-l10n-id="error-title" id="popup-error-title">Hmm, the app is having problems.</h3>
+                <h3 id="popup-error-title">Hmm, the app is having problems.</h3>
                 <p>
-                <span data-l10n-id="error-message" id="popup-error-message">The app has encountered an error and is not loading properly.</span>
+                <span id="popup-error-message">The app has encountered an error and is not loading properly.</span>
                 </p>
               </div>
               <menu data-items="2">
@@ -852,7 +852,7 @@
         </section>
         <menu data-items="2">
           <button type="reset" id="emergency-callback-stay-button" data-l10n-id="cancel">Cancel</button>
-          <button class="recommend" type="button" id="emergency-callback-exit-button" data-l10n-id="Ok">ok</button>
+          <button class="recommend" type="button" id="emergency-callback-exit-button" data-l10n-id="ok">ok</button>
         </menu>
       </form>
 

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -136,6 +136,7 @@ screenshotSDCardInUse = Memory card is in use
 screenshotSDCardLow   = Not enough space on memory card
 
 # lock screen
+confirmation=Confirmation
 emergency-call-button=Emergency Call
 emergency-call=Emergency Call
 unlock-a11y-button.ariaLabel=Unlock


### PR DESCRIPTION
Intentionally I leave message content with English strings (although it should be replaced with l10n strings from JS) in case JS goes wrong.
