### PR TITLE
Bug 914414 - Refactor l10n.js

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -15,3 +15,5 @@ apps/keyboard/js/imes/jspinyin/libpinyin.js
 shared/js/setImmediate.js
 apps/gallery/test/unit/setImmediate_test.js
 apps/wappush/js/ext/**
+shared/js/l10n.js
+build/l10n.js

--- a/apps/email/test/unit/mock_l10n.js
+++ b/apps/email/test/unit/mock_l10n.js
@@ -17,6 +17,7 @@
       }
       return key;
     },
+    translate: function translate(element) {},
     DateTimeFormat: DateTimeFormat
   };
 

--- a/apps/email/test/unit/setup_manual_config_protocol_dropdown_test.js
+++ b/apps/email/test/unit/setup_manual_config_protocol_dropdown_test.js
@@ -3,21 +3,30 @@
 
 requireApp('email/js/alameda.js');
 requireApp('email/test/config.js');
+requireApp('email/test/unit/mock_l10n.js');
+
 suite('IMAP protocol dropdown', function() {
   var el;
   var smc;
   var SetupManualConfig;
+  var mozL10n;
 
   suiteSetup(function(done) {
     testConfig({
         suiteTeardown: suiteTeardown,
         done: done,
-        defines: {}
+        defines: {
+          'l10n!': function() {
+            return MockL10n;
+          }
+        }
       },
-      ['cards/setup_manual_config', 'tmpl!cards/setup_manual_config.html'],
-               function(smc, tmpl) {
+      ['cards/setup_manual_config', 'tmpl!cards/setup_manual_config.html',
+       'l10n!'],
+      function(smc, tmpl, l) {
         SetupManualConfig = smc;
         el = tmpl;
+        mozL10n = l;
       }
     );
   });

--- a/apps/gallery/test/unit/l10n_test.js
+++ b/apps/gallery/test/unit/l10n_test.js
@@ -154,7 +154,7 @@ suite('L10n', function() {
     test('ARIA labels', function() {
       elem.dataset.l10nId = 'a11y-label';
       _translate(elem);
-      assert.equal(elem.getAttribute('aria-label'), 'label via ARIA');
+      assert.equal(elem['aria-label'], 'label via ARIA');
     });
   });
 

--- a/apps/gallery/test/unit/setup.js
+++ b/apps/gallery/test/unit/setup.js
@@ -10,8 +10,29 @@
     document.head.appendChild(resource);
   }
 
+  function l10nScript(ast, langs) {
+    for (var i = 0, lang; lang = langs[i]; i++) {
+      var inline = document.createElement('script');
+      inline.setAttribute('type', 'application/l10n');
+      inline.setAttribute('lang', lang);
+      inline.textContent = JSON.stringify(ast);
+      document.head.appendChild(inline);
+    }
+  }
+
   l10nLink('/locales/locales.ini');
   l10nLink('/shared/locales/date.ini');
+
+  l10nScript({
+    type: 'WebL10n',
+    body: {
+      'inline-translation-test': {
+        value: {
+          content: 'static content provided by inlined JSON'
+        }
+      }
+    }
+  }, ['fr']);
 
   // setup localization....
   require('/shared/js/l10n.js', function() {

--- a/apps/sms/test/unit/activity_handler_test.js
+++ b/apps/sms/test/unit/activity_handler_test.js
@@ -475,18 +475,22 @@ suite('ActivityHandler', function() {
     var message;
     var text;
     var realMozMobileMessage;
+    var realMozL10n;
 
     setup(function() {
       text = 'test';
       Compose.append(text);
       message = MockMessages.sms();
       realMozMobileMessage = navigator.mozMobileMessage;
+      realMozL10n = navigator.mozL10n;
       navigator.mozMobileMessage = MockNavigatormozMobileMessage;
+      navigator.mozL10n = MockL10n;
       this.sinon.stub(window, 'confirm');
     });
 
     teardown(function() {
       navigator.mozMobileMessage = realMozMobileMessage;
+      navigator.mozL10n = realMozL10n;
     });
 
     suite('confirm false', function() {

--- a/apps/video/test/unit/video_test.js
+++ b/apps/video/test/unit/video_test.js
@@ -20,6 +20,15 @@ suite('Video App Unit Tests', function() {
   });
 
   suite('#Video Info Populate Data', function() {
+
+    suiteSetup(function() {
+      MediaUtils._ = MockL10n.get;
+    });
+
+    suiteTeardown(function() {
+      MediaUtils._ = navigator.mozL10n.get;
+    });
+
     before(function() {
       currentVideo = {
         metadata: {

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -589,7 +589,7 @@ function execute(options) {
   config = options;
 
   Services.scriptloader.loadSubScript('file:///' + config.GAIA_DIR +
-      '/shared/js/l10n.js?reload=' + new Date().getTime(), win);
+      '/build/l10n.js?reload=' + new Date().getTime(), win);
   Services.scriptloader.loadSubScript('file:///' + config.GAIA_DIR +
       '/build/jsmin.js?reload=' + new Date().getTime(), scope);
   JSMin = scope.JSMin;

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -26,7 +26,10 @@ var l10nLocales;
 function newDictionary() {
   let dictionary = {};
   l10nLocales.forEach(function(lang) {
-    dictionary[lang] = {};
+    dictionary[lang] = {
+      type: 'WebL10n',
+      body: {}
+    };
   });
   return dictionary;
 }
@@ -420,8 +423,8 @@ function optimize_concatL10nResources(doc, webapp, dictionary) {
 
   // merge the l10n dictionary into webapp.dictionary
   for (let lang in dictionary) {
-    for (let id in dictionary[lang]) {
-      webapp.dictionary[lang][id] = dictionary[lang][id];
+    for (let id in dictionary[lang].body) {
+      webapp.dictionary[lang].body[id] = dictionary[lang].body[id];
     }
   }
 }

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -394,7 +394,11 @@ function optimize_concatL10nResources(doc, webapp, dictionary) {
 
   var resources = doc.querySelectorAll('link[type="application/l10n"]');
   if (resources.length) {
+    let meta = doc.createElement('meta');
+    meta.name = 'locales';
+    meta.content = l10nLocales.join(',');
     let parentNode = resources[0].parentNode;
+    parentNode.insertBefore(meta, resources[0]);
     let fetch = false;
     for (let i = 0; i < resources.length; i++) {
       let link = resources[i];

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -1,128 +1,402 @@
 /* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-'use strict';
+(function (window, undefined) {
 
-/**
- * This library exposes a `navigator.mozL10n' object to handle client-side
- * application localization. See: https://github.com/fabi1cazenave/webL10n
- */
+function define(name, payload) {
+  define.modules[name] = payload;
+}
 
-(function(window) {
-  var gL10nData = {};
-  var gLanguage = '';
-  var gMacros = {};
-  var gReadyState = 'loading';
+// un-instantiated modules
+define.modules = {};
+// instantiated modules
+define.exports = {};
 
-  // DOM element properties that may be localized with a key:value pair.
-  var gNestedProps = ['style', 'dataset'];
-
-
-  /**
-   * Localization resources are declared in the HTML document with <link> nodes:
-   *   <link rel="prefetch" type="application/l10n" href="locales.ini" />
-   * Such *.ini files are multi-locale dictionaries where all supported locales
-   * are listed / defined / imported, and where a fallback locale can easily be
-   * defined.
-   *
-   * These *.ini files can also be compiled to locale-specific JSON dictionaries
-   * with the `getDictionary()' method.  Such JSON dictionaries can be used:
-   *  - either with a <link> node:
-   *   <link rel="prefetch" type="application/l10n" href="{{locale}}.json" />
-   *   (in which case, {{locale}} will be replaced by `navigator.language')
-   *  - or with an inline <script> node:
-   *   <script type="application/l10n" lang="fr"> ... </script>
-   *   (in which case, the script matching `navigator.language' will be parsed)
-   *
-   * This is where `gDefaultLocale' comes in: if a JSON dictionary for the
-   * current `navigator.language' value can't be found, use the one matching the
-   * default locale.  Note that if the <html> element has a `lang' attribute,
-   * its value becomes the default locale.
-   */
-
-  var gDefaultLocale = 'en-US';
-
-
-  /**
-   * Synchronously loading l10n resources significantly minimizes flickering
-   * from displaying the app with non-localized strings and then updating the
-   * strings. Although this will block all script execution on this page, we
-   * expect that the l10n resources are available locally on flash-storage.
-   *
-   * As synchronous XHR is generally considered as a bad idea, we're still
-   * loading l10n resources asynchronously -- but we keep this in a setting,
-   * just in case... and applications using this library should hide their
-   * content until the `localized' event happens.
-   */
-
-  var gAsyncResourceLoading = true; // read-only
-
-
-  /**
-   * Debug helpers
-   *
-   *   gDEBUG == 0: don't display any console message
-   *   gDEBUG == 1: display only warnings, not logs
-   *   gDEBUG == 2: display all console messages
-   */
-
-  var gDEBUG = 1;
-
-  function consoleLog(message) {
-    if (gDEBUG >= 2) {
-      console.log('[l10n] ' + message);
+function normalize(path) {
+  var parts = path.split('/');
+  var normalized = [];
+  for (var i = 0; i < parts.length; i++) {
+    if (parts[i] == '.') {
+      // don't add it to `normalized`
+      continue;
+    } else if (parts[i] == '..') {
+      normalized.pop();
+    } else {
+      normalized.push(parts[i]);
     }
-  };
+  }
+  return normalized.join('/');
+}
 
-  function consoleWarn(message) {
-    if (gDEBUG) {
-      console.warn('[l10n] ' + message);
+function join(a, b) {
+  return a ? a.trim().replace(/\/{0,}$/, '/') + b.trim() : b.trim();
+}
+
+function dirname(path) {
+  return path ? path.split('/').slice(0, -1).join('/') : null;
+}
+
+function req(leaf, name) {
+  name = normalize(join(dirname(leaf), name));
+  if (name in define.exports) {
+    return define.exports[name];
+  }
+  if (!(name in define.modules)) {
+    throw new Error('Module not defined: ' + name);
+  }
+
+  var module = define.modules[name];
+  if (typeof module == 'function') {
+    var exports = {};
+    var reply = module(req.bind(null, name), exports, { id: name, uri: '' });
+    module = (reply !== undefined) ? reply : exports;
+  }
+  return define.exports[name] = module;
+}
+
+// for the top-level required modules, leaf is null
+var require = req.bind(null, null);
+define('l20n/webl10n', function(require, exports, module) {
+  'use strict';
+
+
+  var L20n = require('../l20n');
+
+  var ctx;
+  var isBootstrapped = false;
+  var isPretranslated = false;
+
+
+  if (typeof(document) === 'undefined') {
+    // during build time, we don't bootstrap until mozL10n.language.code is set
+    Object.defineProperty(navigator, 'mozL10n', {
+      get: function() {
+        isBootstrapped = false;
+        ctx = L20n.getContext();
+        ctx.addEventListener('error', addBuildMessage.bind(null, 'error'));
+        ctx.addEventListener('warning', addBuildMessage.bind(null, 'warn'));
+        return createPublicAPI(ctx);
+      },
+      enumerable: true
+    });
+  } else {
+    ctx = L20n.getContext();
+    navigator.mozL10n = createPublicAPI(ctx);
+    ctx.addEventListener('error', logMessage.bind(null, 'error'));
+    ctx.addEventListener('warning', logMessage.bind(null, 'warn'));
+
+    isPretranslated = document.documentElement.lang === navigator.language;
+
+    if (isPretranslated) {
+      // if the DOM has been pretranslated, defer bootstrap as long as possible
+      waitFor('complete', function() {
+        window.setTimeout(bootstrap);
+      });
+    } else {
+      // otherwise, if the DOM is loaded, bootstrap now to fire 'localized'
+      if (document.readyState === 'complete') {
+        window.setTimeout(bootstrap);
+      } else {
+        // or wait for the DOM to be interactive to try to pretranslate it 
+        // using the inline resources
+        waitFor('interactive', pretranslate);
+      }
     }
-  };
+  }
 
-  function consoleWarn_missingKeys(untranslatedElements, lang) {
-    var len = untranslatedElements.length;
-    if (!len || !gDEBUG) {
+  function waitFor(state, callback) {
+    if (document.readyState === state) {
+      callback();
+      return;
+    }
+    document.addEventListener('readystatechange', function l10n_onrsc() {
+      if (document.readyState === state) {
+        callback();
+      }
+    });
+  }
+
+  function pretranslate() {
+    if (inlineLocalization()) {
+      // if inlineLocalization succeeded, defer bootstrap
+      waitFor('complete', function() {
+        window.setTimeout(bootstrap);
+      });
+    } else {
+      bootstrap();
+    }
+  }
+
+  function inlineLocalization() {
+    var body = document.body;
+    var scripts = body.querySelectorAll('script[type="application/l10n"]');
+    if (scripts.length === 0) {
+      return false;
+    }
+    var inline = L20n.getContext();
+    inline.addEventListener('error', logMessage.bind(null, 'error'));
+    inline.addEventListener('warning', logMessage.bind(null, 'warn'));
+
+    var langs = [];
+    for (var i = 0; i < scripts.length; i++) {
+      var lang = scripts[i].getAttribute('lang');
+      langs.push(lang);
+      // pass the node to save memory
+      inline.addDictionary(scripts[i], lang);
+    }
+    inline.once(function() {
+      translateFragment(inline);
+      isPretranslated = true;
+    });
+    inline.registerLocales('en-US', langs);
+    inline.requestLocales(navigator.language);
+    // XXX check if we actually negotiatied navigator.language (i.e. the 
+    // corresponding <script> was present)?
+    return true;
+  }
+
+
+  function bootstrap(forcedLocale) {
+    isBootstrapped = true;
+
+    var availableLocales = [];
+
+    var head = document.head;
+    var iniLinks = head.querySelectorAll('link[type="application/l10n"]' + 
+                                         '[href$=".ini"]');
+    var jsonLinks = head.querySelectorAll('link[type="application/l10n"]' + 
+                                          '[href$=".json"]');
+
+    for (var i = 0; i < jsonLinks.length; i++) {
+      var uri = jsonLinks[i].getAttribute('href');
+      ctx.linkResource(uri.replace.bind(uri, /\{\{\s*locale\s*\}\}/));
+    }
+
+    ctx.ready(function() {
+      // XXX instead of using a flag, we could store the list of 
+      // yet-to-localize nodes that we get from the inline context, and 
+      // localize them here.
+      if (!isPretranslated) {
+        translateFragment(ctx);
+      }
+      isPretranslated = false;
+      fireLocalizedEvent(ctx);
+    });
+
+    // listen to language change events
+    if ('mozSettings' in navigator && navigator.mozSettings) {
+      navigator.mozSettings.addObserver('language.current', function(event) {
+        ctx.requestLocales(event.settingValue);
+      });
+    }
+
+    var iniToLoad = iniLinks.length;
+    if (iniToLoad === 0) {
+      ctx.registerLocales('en-US', getAvailable());
+      ctx.requestLocales(forcedLocale || navigator.language);
       return;
     }
 
-    var missingIDs = [];
-    for (var i = 0; i < len; i++) {
-      var l10nId = untranslatedElements[i].getAttribute('data-l10n-id');
-      if (missingIDs.indexOf(l10nId) < 0) {
-        missingIDs.push(l10nId);
+    var io = require('./platform/io');
+    for (i = 0; i < iniLinks.length; i++) {
+      var url = iniLinks[i].getAttribute('href');
+      io.load(url, iniLoaded.bind(null, url));
+    }
+
+    function iniLoaded(url, err, text) {
+      if (err) {
+        throw err;
+      }
+
+      var ini = parseINI(text, url);
+      availableLocales.push.apply(availableLocales, ini.locales);
+      for (var i = 0; i < ini.resources.length; i++) {
+        var uri = ini.resources[i].replace('en-US', '{{locale}}');
+        ctx.linkResource(uri.replace.bind(uri, '{{locale}}'));
+      }
+      iniToLoad--;
+      if (iniToLoad === 0) {
+        ctx.registerLocales('en-US', availableLocales);
+        ctx.requestLocales(forcedLocale || navigator.language);
       }
     }
-    console.warn('[l10n] ' +
-        missingIDs.length + ' missing key(s) for [' + lang + ']: ' +
-        missingIDs.join(', '));
+
   }
 
-
-  /**
-   * DOM helpers for the so-called "HTML API".
-   *
-   * These functions are written for modern browsers. For old versions of IE,
-   * they're overridden in the 'startup' section at the end of this file.
-   */
-
-  function getL10nResourceLinks() {
-    return document.querySelectorAll('link[type="application/l10n"]');
+  function getAvailable() {
+    var metaLocs = document.head.querySelector('meta[name="locales"]');
+    if (metaLocs) {
+      return metaLocs.getAttribute('content').split(',').map(String.trim);
+    } else {
+      return [];
+    }
   }
 
-  function getL10nDictionary(lang) {
-    var getInlineDict = function(locale) {
-      var sel = 'script[type="application/l10n"][lang="' + locale + '"]';
-      return document.querySelector(sel);
+  var patterns = {
+    section: /^\s*\[(.*)\]\s*$/,
+    import: /^\s*@import\s+url\((.*)\)\s*$/i,
+    entry: /[\r\n]+/
+  };
+
+  function parseINI(source, iniPath) {
+    var entries = source.split(patterns['entry']);
+    var locales = ['en-US'];
+    var genericSection = true;
+    var uris = [];
+
+    for (var i = 0; i < entries.length; i++) {
+      var line = entries[i];
+      // we only care about en-US resources
+      if (genericSection && patterns['import'].test(line)) {
+        var match = patterns['import'].exec(line);
+        var uri = relativePath(iniPath, match[1]);
+        uris.push(uri);
+        continue;
+      }
+
+      // but we need the list of all locales in the ini, too
+      if (patterns['section'].test(line)) {
+        genericSection = false;
+        var match = patterns['section'].exec(line);
+        locales.push(match[1]);
+      }
+    }
+    return {
+      locales: locales,
+      resources: uris
     };
-    // TODO: support multiple internal JSON dictionaries
-    var script = getInlineDict(lang) || getInlineDict(gDefaultLocale);
-    return script ? JSON.parse(script.innerHTML) : null;
+  }
+
+  function relativePath(baseUrl, url) {
+    if (url[0] == '/') {
+      return url;
+    }
+
+    var dirs = baseUrl.split('/')
+      .slice(0, -1)
+      .concat(url.split('/'))
+      .filter(function(path) {
+        return path !== '.';
+      });
+
+    return dirs.join('/');
+  }
+
+  function createPublicAPI(ctx) {
+    var rtlLocales = ['ar', 'fa', 'he', 'ps', 'ur'];
+    return {
+      get: function l10n_get(id, data) {
+        var entity = ctx.getEntity(id, data);
+        // entity.locale is null if the entity could not be displayed in any of
+        // the locales in the current fallback chain
+        if (!entity.locale) {
+          return '';
+        }
+        return entity.value;
+      },
+      localize: localizeNode.bind(null, ctx),
+      translate: translateFragment.bind(null, ctx),
+      language: {
+        get code() {
+          return ctx.supportedLocales[0];
+        },
+        set code(lang) {
+          if (!isBootstrapped) {
+            // build-time optimization uses this
+            bootstrap(lang);
+          } else {
+            ctx.requestLocales(lang);
+          }
+        },
+        get direction() {
+          if (rtlLocales.indexOf(ctx.supportedLocales[0]) >= 0) {
+            return 'rtl';
+          } else {
+            return 'ltr';
+          }
+        }
+      },
+      ready: ctx.ready.bind(ctx),
+      getDictionary: getSubDictionary,
+      get readyState() {
+        return ctx.isReady ? 'complete' : 'loading';
+      }
+    };
+  }
+
+  var DEBUG = false;
+  function logMessage(type, e) {
+    if (DEBUG) {
+      console[type](e);
+    }
+  }
+
+  var buildMessages = {};
+  function addBuildMessage(type, e) {
+    if (!(type in buildMessages)) {
+      buildMessages[type] = [];
+    }
+    if (e instanceof L20n.Context.TranslationError &&
+        e.locale === ctx.supportedLocales[0] &&
+        buildMessages[type].indexOf(e.entity) === -1) {
+      buildMessages[type].push(e.entity);
+    }
+  }
+
+  function flushBuildMessages(variant) {
+    for (var type in buildMessages) {
+      if (buildMessages[type].length) {
+        console.log('[l10n] [' + ctx.supportedLocales[0] + ']: ' +
+            buildMessages[type].length + ' missing ' + variant + ': ' +
+            buildMessages[type].join(', '));
+        buildMessages[type] = [];
+      }
+    }
+  }
+
+  // return a sub-dictionary sufficient to translate a given fragment
+  function getSubDictionary(fragment) {
+    var ast = {
+      type: 'WebL10n',
+      body: {}
+    };
+
+    if (!fragment) {
+      ast.body = ctx.getSources();
+      flushBuildMessages('compared to en-US');
+      return ast;
+    }
+
+    var elements = getTranslatableChildren(fragment);
+
+    for (var i = 0, l = elements.length; i < l; i++) {
+      var attrs = getL10nAttributes(elements[i]);
+      var source = ctx.getSource(attrs.id);
+      if (!source) {
+        continue;
+      }
+      ast.body[attrs.id] = source;
+
+      // check for any dependencies
+      var entity = ctx.getEntity(attrs.id, attrs.args);
+      for (var id in entity.identifiers) {
+        if (!entity.identifiers.hasOwnProperty(id)) {
+          continue;
+        }
+        var depSource = ctx.getSource(id);
+        if (depSource) {
+          ast.body[id] = depSource;
+        }
+      }
+    }
+    flushBuildMessages('in the visible DOM');
+    return ast;
   }
 
   function getTranslatableChildren(element) {
     return element ? element.querySelectorAll('*[data-l10n-id]') : [];
   }
+
 
   function getL10nAttributes(element) {
     if (!element) {
@@ -136,7 +410,7 @@
       try {
         args = JSON.parse(l10nArgs);
       } catch (e) {
-        consoleWarn('could not parse arguments for #' + l10nId);
+        console.warn('could not parse arguments for ' + l10nId);
       }
     }
     return { id: l10nId, args: args };
@@ -170,333 +444,1480 @@
     }
   }
 
-  function fireL10nReadyEvent() {
-    var evtObject = document.createEvent('Event');
-    evtObject.initEvent('localized', false, false);
-    evtObject.language = gLanguage;
-    window.dispatchEvent(evtObject);
+  function translateNode(ctx, node) {
+    var attrs = getL10nAttributes(node);
+    if (!attrs.id) {
+      return true;
+    }
+
+    var entity = ctx.getEntity(attrs.id, attrs.args);
+    if (!entity.locale) {
+      return false;
+    }
+
+    if (entity.value) {
+      setTextContent(node, entity.value);
+    }
+
+    for (var key in entity.attributes) {
+      if (entity.attributes.hasOwnProperty(key)) {
+        var attr = entity.attributes[key];
+        var pos = key.indexOf('.');
+        if (pos !== -1) {
+          node[key.substr(0, pos)][key.substr(pos + 1)] = attr;
+        } else {
+          node[key] = attr;
+        }
+      }
+    }
+    return true;
+  }
+  
+  // localize an node as soon as ctx is ready
+  function localizeNode(ctx, element, id, args) {
+    if (!element) {
+      return;
+    }
+
+    if (!id) {
+      element.removeAttribute('data-l10n-id');
+      element.removeAttribute('data-l10n-args');
+      setTextContent(element, '');
+      return;
+    }
+
+    // set the data-l10n-[id|args] attributes
+    element.setAttribute('data-l10n-id', id);
+    if (args && typeof args === 'object') {
+      element.setAttribute('data-l10n-args', JSON.stringify(args));
+    } else {
+      element.removeAttribute('data-l10n-args');
+    }
+
+    // if ctx is ready, translate now;
+    // if not, the element will be translated along with the document anyway.
+    if (ctx.isReady) {
+      translateNode(ctx, element);
+    }
+  }
+  
+  // translate an array of HTML nodes
+  // -- returns an array of nodes that could not be translated
+  function translateNodes(ctx, elements) {
+    var untranslated = [];
+    for (var i = 0, l = elements.length; i < l; i++) {
+      if (!translateNode(ctx, elements[i])) {
+        untranslated.push(elements[i]);
+      }
+    }
+    return untranslated;
   }
 
-
-  /**
-   * l10n resource parser:
-   *  - reads (async XHR) the l10n resource matching `lang';
-   *  - imports linked resources (synchronously) when specified;
-   *  - parses the text data (fills `gL10nData');
-   *  - triggers success/failure callbacks when done.
-   *
-   * @param {string} href
-   *    URL of the l10n resource to parse.
-   *
-   * @param {string} lang
-   *    locale (language) to parse.
-   *
-   * @param {Function} successCallback
-   *    triggered when the l10n resource has been successully parsed.
-   *
-   * @param {Function} failureCallback
-   *    triggered when the an error has occured.
-   *
-   * @return {void}
-   *    fills gL10nData.
-   */
-
-  function parseResource(href, lang, successCallback, failureCallback) {
-    var baseURL = href.replace(/\/[^\/]*$/, '/');
-
-    // handle escaped characters (backslashes) in a string
-    function evalString(text) {
-      if (text.lastIndexOf('\\') < 0) {
-        return text;
-      }
-      return text.replace(/\\\\/g, '\\')
-                 .replace(/\\n/g, '\n')
-                 .replace(/\\r/g, '\r')
-                 .replace(/\\t/g, '\t')
-                 .replace(/\\b/g, '\b')
-                 .replace(/\\f/g, '\f')
-                 .replace(/\\{/g, '{')
-                 .replace(/\\}/g, '}')
-                 .replace(/\\"/g, '"')
-                 .replace(/\\'/g, "'");
+  // translate an HTML subtree
+  // -- returns an array of elements that could not be translated
+  function translateFragment(ctx, element) {
+    element = element || document.documentElement;
+    var untranslated = translateNodes(ctx, getTranslatableChildren(element));
+    if (!translateNode(ctx, element)) {
+      untranslated.push(element);
     }
+    return untranslated;
+  }
 
-    // parse *.properties text data into an l10n dictionary
-    function parseProperties(text) {
-      var dictionary = [];
+  function fireLocalizedEvent(ctx) {
+    var event = document.createEvent('Event');
+    event.initEvent('localized', false, false);
+    event.language = ctx.supportedLocales[0];
+    window.dispatchEvent(event);
+  }
 
-      // token expressions
-      var reBlank = /^\s*|\s*$/;
-      var reComment = /^\s*#|^\s*$/;
-      var reSection = /^\s*\[(.*)\]\s*$/;
-      var reImport = /^\s*@import\s+url\((.*)\)\s*$/i;
-      var reSplit = /^([^=\s]*)\s*=\s*(.+)$/;
-      var reUnicode = /\\u([0-9a-fA-F]{1,4})/g;
-      var reMultiline = /[^\\]\\$/;
+  return L20n;
+});
+define('l20n', function(require, exports, module) {
+  'use strict';
 
-      // parse the *.properties file into an associative array
-      function parseRawLines(rawText, extendedSyntax) {
-        var entries = rawText.replace(reBlank, '').split(/[\r\n]+/);
-        var currentLang = '*';
-        var genericLang = lang.replace(/-[a-z]+$/i, '');
-        var skipLang = false;
-        var match = '';
+  var Context = require('./l20n/context').Context;
 
-        for (var i = 0; i < entries.length; i++) {
-          var line = entries[i];
-
-          // comment or blank line?
-          if (reComment.test(line)) {
-            continue;
-          }
-
-          // multi-line?
-          while (reMultiline.test(line) && i < entries.length) {
-            line = line.slice(0, line.length - 1) +
-              entries[++i].replace(reBlank, '');
-          }
-
-          // the extended syntax supports [lang] sections and @import rules
-          if (extendedSyntax) {
-            if (reSection.test(line)) { // section start?
-              match = reSection.exec(line);
-              currentLang = match[1];
-              skipLang = (currentLang !== '*') &&
-                  (currentLang !== lang) && (currentLang !== genericLang);
-              continue;
-            } else if (skipLang) {
-              continue;
-            }
-            if (reImport.test(line)) { // @import rule?
-              match = reImport.exec(line);
-              loadImport(baseURL + match[1]); // load the resource synchronously
-            }
-          }
-
-          // key-value pair
-          var tmp = line.match(reSplit);
-          if (tmp && tmp.length == 3) {
-            // unescape unicode char codes if needed (e.g. '\u00a0')
-            var val = tmp[2].replace(reUnicode, function(match, token) {
-              return unescape('%u' + '0000'.slice(token.length) + token);
-            });
-            dictionary[tmp[1]] = evalString(val);
-          }
-        }
-      }
-
-      // import another *.properties file
-      function loadImport(url) {
-        loadResource(url, function(content) {
-          parseRawLines(content, false); // don't allow recursive imports
-        }, null, false); // load synchronously
-      }
-
-      // fill the dictionary
-      parseRawLines(text, true);
-      return dictionary;
-    }
-
-    // load the specified resource file
-    function loadResource(url, onSuccess, onFailure, asynchronous) {
-      onSuccess = onSuccess || function _onSuccess(data) {};
-      onFailure = onFailure || function _onFailure() {
-        consoleWarn(url + ' not found.');
-      };
-
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', url, asynchronous);
-      if (xhr.overrideMimeType) {
-        xhr.overrideMimeType('text/plain; charset=utf-8');
-      }
-      xhr.onreadystatechange = function() {
-        if (xhr.readyState == 4) {
-          if (xhr.status == 200 || xhr.status === 0) {
-            onSuccess(xhr.responseText);
-          } else {
-            onFailure();
-          }
-        }
-      };
-      xhr.onerror = onFailure;
-      xhr.ontimeout = onFailure;
-
-      // in Firefox OS with the app:// protocol, trying to XHR a non-existing
-      // URL will raise an exception here -- hence this ugly try...catch.
-      try {
-        xhr.send(null);
-      } catch (e) {
-        onFailure();
-      }
-    }
-
-    // load and parse l10n data (warning: global variables are used here)
-    loadResource(href, function(response) {
-      if (/\.json$/.test(href)) {
-        gL10nData = JSON.parse(response); // TODO: support multiple JSON files
-      } else { // *.ini or *.properties file
-        var data = parseProperties(response);
-        for (var key in data) {
-          var id, prop, nestedProp, index = key.lastIndexOf('.');
-          if (index > 0) { // a property name has been specified
-            id = key.slice(0, index);
-            prop = key.slice(index + 1);
-            index = id.lastIndexOf('.');
-            if (index > 0) { // a nested property may have been specified
-              nestedProp = id.substr(index + 1);
-              if (gNestedProps.indexOf(nestedProp) > -1) {
-                id = id.substr(0, index);
-                prop = nestedProp + '.' + prop;
-              }
-            }
-          } else { // no property name: assuming text content by default
-            index = key.lastIndexOf('[');
-            if (index > 0) { // we have a macro index
-              id = key.slice(0, index);
-              prop = '_' + key.slice(index);
-            } else {
-              id = key;
-              prop = '_';
-            }
-          }
-          if (!gL10nData[id]) {
-            gL10nData[id] = {};
-          }
-          gL10nData[id][prop] = data[key];
-        }
-      }
-
-      // trigger callback
-      if (successCallback) {
-        successCallback();
-      }
-    }, failureCallback, gAsyncResourceLoading);
+  exports.Context = Context;
+  exports.getContext = function L20n_getContext(id) {
+      return new Context(id);
   };
 
-  // load and parse all resources for the specified locale
-  function loadLocale(lang, translationRequired) {
-    clear();
-    gReadyState = 'loading';
-    gLanguage = lang;
+});
+define('l20n/context', function(require, exports, module) {
+  'use strict';
 
-    var untranslatedElements = [];
+  var EventEmitter = require('./events').EventEmitter;
+  var Parser = require('./parser').Parser;
+  var Compiler = require('./compiler').Compiler;
+  var io = require('./platform/io');
+  var getPluralRule = require('./plurals').getPluralRule;
 
-    // if there is an inline / pre-compiled dictionary,
-    // the current HTML document can be translated right now
-    var inlineDict = getL10nDictionary(lang);
-    if (inlineDict) {
-      gL10nData = inlineDict;
-      if (translationRequired) {
-        untranslatedElements = translateFragment();
+  function Resource(id, parser) {
+    var self = this;
+
+    this.id = id;
+    this.resources = [];
+    this.source = null;
+    this.ast = null;
+
+    this.build = build;
+
+    function build(callback, sync) {
+      if (self.source) {
+        parse();
+      } else if (self.ast) {
+        callback();
+      } else {
+        io.load(self.id, parse, sync);
+      }
+
+      function parse(err, text) {
+        if (err) {
+          self.ast = {
+            type: 'WebL10n',
+            body: {}
+          };
+          return callback(err);
+        } else if (text === undefined) {
+          self.ast = parser.parse(self.source);
+        } else {
+          if (/\.json/.test(self.id)) {
+            // JSON is guaranteed to be an AST
+            self.ast = JSON.parse(text);
+          } else {
+            self.source = text;
+            self.ast = parser.parse(self.source);
+          }
+        }
+        callback();
       }
     }
+  }
 
-    // translate the document if required and fire a `localized' event
-    function finish() {
-      if (translationRequired) {
-        if (!inlineDict) {
-          // no inline dictionary has been used: translate the whole document
-          untranslatedElements = translateFragment();
-        } else if (untranslatedElements.length) {
-          // the document should have been already translated but the inline
-          // dictionary didn't include all necessary l10n keys:
-          // try to translate all remaining elements now
-          untranslatedElements = translateElements(untranslatedElements);
+  function Locale(id, parser, compiler, emitter) {
+    this.id = id;
+    this.resources = [];
+    this.entries = null;
+    this.ast = {
+      type: 'WebL10n',
+      body: {}
+    };
+    this.isReady = false;
+
+    this.build = build;
+    this.getEntry = getEntry;
+    this.hasResource = hasResource;
+
+    var self = this;
+
+    function build(callback) {
+      if (!callback) {
+        var sync = true;
+      }
+
+      var resourcesToBuild = self.resources.length;
+      if (resourcesToBuild === 0) {
+        throw new ContextError('Locale has no resources');
+      }
+
+      var resourcesWithErrors = 0;
+      self.resources.forEach(function(res) {
+        res.build(resourceBuilt, sync);
+      });
+
+      function resourceBuilt(err) {
+        if (err) {
+          resourcesWithErrors++;
+          emitter.emit(err instanceof ContextError ? 'error' : 'warning', err);
+        }
+        resourcesToBuild--;
+        if (resourcesToBuild == 0) {
+          if (resourcesWithErrors == self.resources.length) {
+            // XXX Bug 908780 - Decide what to do when all resources in
+            // a locale are missing or broken
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=908780
+            emitter.emit('error',
+                         new ContextError('Locale has no valid resources'));
+          }
+          flatten();
         }
       }
-      // tell the rest of the world we're done
-      // -- note that `gReadyState' must be set before the `localized' event is
-      //    fired for `localizeElement()' to work as expected
-      gReadyState = 'complete';
-      fireL10nReadyEvent(lang);
-      consoleWarn_missingKeys(untranslatedElements, lang);
+
+      function flatten() {
+        self.ast.body = self.resources.reduce(function(prev, curr) {
+          if (!curr.ast) {
+            return prev;
+          }
+          for (var key in curr.ast.body) {
+            if (curr.ast.body.hasOwnProperty(key)) {
+              prev[key] = curr.ast.body[key];
+            }
+          }
+          return prev;
+        }, self.ast.body);
+        compile();
+      }
+
+      function compile() {
+        self.entries = compiler.compile(self.ast);
+        self.isReady = true;
+        if (callback) {
+          callback();
+        }
+      }
     }
 
-    // l10n resource loader
-    function l10nResourceLink(link) {
-      /**
-       * l10n resource links can use the following syntax for href:
-       * <link type="application/l10n" href="resources/{{locale}}.json" />
-       * -- in which case, {{locale}} will be replaced by `navigator.language'.
-       */
-      var re = /\{\{\s*locale\s*\}\}/;
+    function getEntry(id) {
+      if (this.entries.hasOwnProperty(id)) {
+        return this.entries[id];
+      }
+      return undefined;
+    }
 
-      var parse = function(locale, onload, onerror) {
-        var href = unescape(link.href).replace(re, locale);
-        parseResource(href, locale, onload, function notFound() {
-          consoleWarn(href + ' not found.');
-          onerror();
-        });
+    function hasResource(uri) {
+      return this.resources.some(function(res) {
+        return res.id === uri;
+      });
+    }
+  }
+
+  function Context(id) {
+
+    this.id = id;
+
+    this.registerLocales = registerLocales;
+    this.requestLocales = requestLocales;
+    this.addDictionary = addDictionary;
+    this.addResource = addResource;
+    this.linkResource = linkResource;
+
+    this.get = get;
+    this.getEntity = getEntity;
+    this.getSource = getSource;
+    this.getSources = getSources;
+    this.ready = ready;
+    this.once = once;
+
+    this.addEventListener = addEventListener;
+    this.removeEventListener = removeEventListener;
+
+    Object.defineProperty(this, 'supportedLocales', {
+      get: function() { return _fallbackChain.slice(); },
+      enumerable: true
+    });
+
+    // registered and available languages
+    var _default = 'i-default';
+    var _registered = [_default];
+    var _requested = [];
+    var _fallbackChain = [];
+    // Locale objects corresponding to the registered languages
+    var _locales = {};
+
+    // URLs or text of resources (with information about the type) added via
+    // linkResource
+    var _reslinks = [];
+
+    var _isReady = false;
+    var _isFrozen = false;
+
+    Object.defineProperty(this, 'isReady', {
+      get: function() { return _isReady; },
+      enumerable: true
+    });
+
+    var _emitter = new EventEmitter();
+    var _parser = new Parser();
+    var _compiler = new Compiler();
+
+    _parser.addEventListener('error', error);
+    _compiler.addEventListener('error', warn);
+
+    var self = this;
+
+    function get(id, data) {
+      if (!_isReady) {
+        throw new ContextError('Context not ready');
+      }
+      return getFromLocale.call(self, 0, id, data).value;
+    }
+
+    function getEntity(id, data) {
+      if (!_isReady) {
+        throw new ContextError('Context not ready');
+      }
+      return getFromLocale.call(self, 0, id, data);
+    }
+
+    function getSource(id) {
+      if (!_isReady) {
+        throw new ContextError('Context not ready');
+      }
+
+      var current = 0;
+      var locale = getLocale(_fallbackChain[current]);
+      // if the requested id doesn't exist in the first locale, fall back
+      while (!locale.getEntry(id)) {
+        warn(new TranslationError('Not found', id, _fallbackChain, locale));
+        var nextLocale = _fallbackChain[++current];
+        if (!nextLocale) {
+          return null;
+        }
+
+        locale = getLocale(nextLocale);
+        if (!locale.isReady) {
+          locale.build();
+        }
+      }
+      return locale.ast.body[id];
+    }
+
+    function getSources() {
+      if (!_isReady) {
+        throw new ContextError('Context not ready');
+      }
+      var defLoc = getLocale(_default);
+      if (!defLoc.isReady) {
+        defLoc.build();
+      }
+      var body = {};
+      for (var id in defLoc.entries) {
+        if (!defLoc.entries.hasOwnProperty(id)) {
+          continue;
+        }
+        // if it's an Entity, add it
+        if (defLoc.entries[id].get) {
+          var source = getSource(id);
+          if (source) {
+            body[id] = source;
+          }
+        }
+      }
+      return body;
+    }
+
+    function ready(callback) {
+      if (_isReady) {
+        setTimeout(callback);
+      }
+      addEventListener('ready', callback);
+    }
+
+    function once(callback) {
+      if (_isReady) {
+        setTimeout(callback);
+      }
+      var callAndRemove = function callAndRemove() {
+        removeEventListener('ready', callAndRemove);
+        callback();
       };
+      addEventListener('ready', callAndRemove);
+    }
 
-      this.load = function(locale, onload, onerror) {
-        onerror = onerror || function() {};
-        parse(locale, onload, function parseFallbackLocale() {
-          /**
-           * For links like <link href="resources/{{locale}}.json" />,
-           * there's no way to know if the resource file matching the current
-           * language has been found... before trying to fetch it with XHR
-           * => if something went wrong, try the default locale as fallback.
-           */
-          if (re.test(unescape(link.href)) && gDefaultLocale != locale) {
-            consoleLog('Trying the fallback locale: ' + gDefaultLocale);
-            parse(gDefaultLocale, onload, onerror);
-          } else {
-            onerror();
+    function getFromLocale(cur, id, data, prevSource) {
+      var loc = _fallbackChain[cur];
+      if (!loc) {
+        error(new RuntimeError('Unable to get translation', id,
+                               _fallbackChain));
+        // imitate the return value of Compiler.Entity.get
+        return {
+          value: prevSource ? prevSource.source : id,
+          attributes: {},
+          globals: {},
+          locale: prevSource ? prevSource.loc : null
+        };
+      }
+
+      var locale = getLocale(loc);
+      if (!locale.isReady) {
+        // build without a callback, synchronously
+        locale.build(null);
+      }
+
+      var entry = locale.getEntry(id);
+
+      // if the entry is missing, just go to the next locale immediately
+      if (entry === undefined) {
+        warn(new TranslationError('Not found', id, _fallbackChain, locale));
+        return getFromLocale.call(this, cur + 1, id, data, prevSource);
+      }
+
+      // otherwise, try to get the value of the entry
+      try {
+        var value = entry.get(data);
+      } catch (e) {
+        if (e instanceof Compiler.RuntimeError) {
+          error(new TranslationError(e.message, id, _fallbackChain, locale));
+          if (e instanceof Compiler.ValueError) {
+            // salvage the source string which the compiler wasn't able to
+            // evaluate completely;  this is still better than returning the
+            // identifer;  prefer a source string from locales earlier in the
+            // fallback chain, if available
+            var source = prevSource || { source: e.source, loc: locale.id };
+            return getFromLocale.call(this, cur + 1, id, data, source);
+          }
+          return getFromLocale.call(this, cur + 1, id, data, prevSource);
+        } else {
+          throw error(e);
+        }
+      }
+      value.locale = locale.id;
+      return value;
+    }
+
+    function add(text, locale) {
+      var res = new Resource(null, _parser);
+      res.source = text;
+      locale.resources.push(res);
+    }
+
+    function addResource(text) {
+      if (_isFrozen) {
+        throw new ContextError('Context is frozen');
+      }
+      _reslinks.push(['text', text]);
+    }
+
+    function addDictionary(scriptNode, loc) {
+      if (_isFrozen) {
+        throw new ContextError('Context is frozen');
+      }
+      _reslinks.push(['dict', scriptNode, loc]);
+    }
+
+    function addJSON(scriptNode, locale) {
+      var res = new Resource(null);
+      res.ast = JSON.parse(scriptNode.innerHTML);
+      locale.resources.push(res);
+    }
+
+    function linkResource(uri) {
+      if (_isFrozen) {
+        throw new ContextError('Context is frozen');
+      }
+      _reslinks.push([typeof uri === 'function' ? 'template' : 'uri', uri]);
+    }
+
+    function link(uri, locale) {
+      if (!locale.hasResource(uri)) {
+        var res = new Resource(uri, _parser);
+        locale.resources.push(res);
+      }
+    }
+
+    function registerLocales(defaultLocale, availableLocales) {
+      if (_isFrozen) {
+        throw new ContextError('Context is frozen');
+      }
+
+      if (defaultLocale === undefined) {
+        return;
+      }
+
+      _default = defaultLocale;
+      _registered = [];
+
+      if (!availableLocales) {
+        availableLocales = [];
+      }
+      availableLocales.push(defaultLocale);
+
+      // uniquify `available` into `_registered`
+      availableLocales.forEach(function l10n_ctx_addlocale(locale) {
+        if (typeof locale !== 'string') {
+          throw new ContextError('Language codes must be strings');
+        }
+        if (_registered.indexOf(locale) === -1) {
+          _registered.push(locale);
+        }
+      });
+    }
+
+    function negotiate(available, requested, defaultLocale) {
+      if (available.indexOf(requested[0]) === -1 ||
+          requested[0] === defaultLocale) {
+        return [defaultLocale];
+      } else {
+        return [requested[0], defaultLocale];
+      }
+    }
+
+    function getLocale(code) {
+      if (_locales[code]) {
+        return _locales[code];
+      }
+
+      var locale = new Locale(code, _parser, _compiler, _emitter);
+      _locales[code] = locale;
+      // populate the locale with resources
+      for (var j = 0; j < _reslinks.length; j++) {
+        var res = _reslinks[j];
+        if (res[0] === 'text') {
+          // a resource added via addResource(String)
+          add(res[1], locale);
+        } else if (res[0] === 'dict') {
+          // a JSON resource added via addDictionary(HTMLScriptElement)
+          // only add if no locale was specified or if the locale specified
+          // matches the locale being created here
+          if (res[2] === undefined || res[2] === locale.id) {
+            addJSON(res[1], locale);
+          }
+        } else if (res[0] === 'uri') {
+          // a resource added via linkResource(String)
+          link(res[1], locale);
+        } else {
+          // a resource added via linkResource(Function);  the function
+          // passed is a URL template and it takes the current locale's code
+          // as an argument
+          link(res[1](locale.id), locale);
+        }
+      }
+      locale.ast.body['plural'] = {
+        type: 'Macro',
+        args: [{
+          type: 'Identifier',
+          name: 'n'
+        }],
+        expression: getPluralRule(code)
+      };
+      return locale;
+    }
+
+    function requestLocales() {
+      if (_isFrozen && !_isReady) {
+        throw new ContextError('Context not ready');
+      }
+
+      if (_reslinks.length == 0) {
+        warn(new ContextError('Context has no resources; not freezing'));
+        return;
+      }
+
+      _isFrozen = true;
+      _requested = Array.prototype.slice.call(arguments);
+
+      if (_requested.length) {
+        _requested.forEach(function l10n_throwError(locale) {
+          if (typeof locale !== 'string') {
+            throw new ContextError('Language codes must be strings');
           }
         });
-      };
-    }
+      }
 
-    // check all <link type="application/l10n" href="..." /> nodes
-    // and load the resource files
-    var resourceLinks = getL10nResourceLinks();
-    var resourceCount = resourceLinks.length;
-    if (!resourceCount) {
-      consoleLog('no resource to load, early way out');
-      translationRequired = false;
-      finish();
-    } else {
-      var onResourceCallback = function() {
-        if (--resourceCount <= 0) { // <=> all resources have been XHR'ed
-          finish();
-        }
-      };
-      for (var i = 0, l = resourceCount; i < l; i++) {
-        var resource = new l10nResourceLink(resourceLinks[i]);
-        resource.load(lang, onResourceCallback, onResourceCallback);
+      var fallbackChain = negotiate(_registered, _requested, _default);
+      // if the negotiator returned something, freeze synchronously
+      if (fallbackChain) {
+        freeze(fallbackChain);
       }
     }
+
+    function freeze(fallbackChain) {
+      _fallbackChain = fallbackChain;
+      var locale = getLocale(_fallbackChain[0]);
+      if (locale.isReady) {
+        setReady();
+      } else {
+        locale.build(setReady);
+      }
+    }
+
+    function setReady() {
+      _isReady = true;
+      _emitter.emit('ready');
+    }
+
+    function addEventListener(type, listener) {
+      _emitter.addEventListener(type, listener);
+    }
+
+    function removeEventListener(type, listener) {
+      _emitter.removeEventListener(type, listener);
+    }
+
+    function warn(e) {
+      _emitter.emit('warning', e);
+      return e;
+    }
+
+    function error(e) {
+      _emitter.emit('error', e);
+      return e;
+    }
   }
 
-  // clear all l10n data
-  function clear() {
-    gL10nData = {};
-    gLanguage = '';
-    // TODO: clear all non predefined macros.
-    // There's no such macro /yet/ but we're planning to have some...
+  Context.Error = ContextError;
+  Context.RuntimeError = RuntimeError;
+  Context.TranslationError = TranslationError;
+
+  function ContextError(message) {
+    this.name = 'ContextError';
+    this.message = message;
+  }
+  ContextError.prototype = Object.create(Error.prototype);
+  ContextError.prototype.constructor = ContextError;
+
+  function RuntimeError(message, id, supported) {
+    ContextError.call(this, message);
+    this.name = 'RuntimeError';
+    this.entity = id;
+    this.supportedLocales = supported.slice();
+    this.message = id + ': ' + message + '; tried ' + supported.join(', ');
+  }
+  RuntimeError.prototype = Object.create(ContextError.prototype);
+  RuntimeError.prototype.constructor = RuntimeError;
+
+  function TranslationError(message, id, supported, locale) {
+    RuntimeError.call(this, message, id, supported);
+    this.name = 'TranslationError';
+    this.locale = locale.id;
+    this.message = '[' + this.locale + '] ' + id + ': ' + message;
+  }
+  TranslationError.prototype = Object.create(RuntimeError.prototype);
+  TranslationError.prototype.constructor = TranslationError;
+
+  exports.Context = Context;
+  exports.Locale = Locale;
+  exports.Resource = Resource;
+
+});
+define('l20n/events', function(require, exports, module) {
+  'use strict';
+
+  function EventEmitter() {
+    this._listeners = {};
   }
 
+  EventEmitter.prototype.emit = function ee_emit() {
+    var args = Array.prototype.slice.call(arguments);
+    var type = args.shift();
+    if (!this._listeners[type]) {
+      return false;
+    }
 
-  /**
-   * Get rules for plural forms (shared with JetPack), see:
-   * http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
-   * https://github.com/mozilla/addon-sdk/blob/master/python-lib/plural-rules-generator.p
-   *
-   * @param {string} lang
-   *    locale (language) used.
-   *
-   * @return {Function}
-   *    returns a function that gives the plural form name for a given integer:
-   *       var fun = getPluralRules('en');
-   *       fun(1)    -> 'one'
-   *       fun(0)    -> 'other'
-   *       fun(1000) -> 'other'.
-   */
+    var typeListeners = this._listeners[type].slice();
+    for (var i = 0; i < typeListeners.length; i++) {
+      typeListeners[i].apply(this, args);
+    }
+    return true;
+  };
+
+  EventEmitter.prototype.addEventListener = function ee_add(type, listener) {
+    if (!(type in this._listeners)) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(listener);
+  };
+
+  EventEmitter.prototype.removeEventListener = function ee_rm(type, listener) {
+    var typeListeners = this._listeners[type];
+    var pos = typeListeners.indexOf(listener);
+    if (pos === -1) {
+      return;
+    }
+
+    typeListeners.splice(pos, 1);
+  };
+
+  exports.EventEmitter = EventEmitter;
+
+});
+define('l20n/parser', function(require, exports, module) {
+  'use strict';
+
+  var EventEmitter = require('./events').EventEmitter;
+
+  var nestedProps = ['style', 'dataset'];
+
+  function Parser() {
+
+    /* Public */
+
+    this.parse = parse;
+    this.addEventListener = addEventListener;
+    this.removeEventListener = removeEventListener;
+
+
+    var MAX_PLACEABLES = 100;
+
+    var _emitter = new EventEmitter();
+
+    var patterns = {
+      comment: /^\s*#|^\s*$/,
+      entity: /^([^=\s]+)\s*=\s*(.+)$/,
+      multiline: /[^\\]\\$/,
+      plural: /\{\[\s*plural\(([^\)]+)\)\s*\]\}/,
+      unicode: /\\u([0-9a-fA-F]{1,4})/g,
+      entries: /[\r\n]+/
+    };
+
+    function parse(source) {
+      var ast = {};
+
+      var entries = source.split(patterns['entries']);
+      for (var i = 0; i < entries.length; i++) {
+        var line = entries[i];
+
+        if (patterns['comment'].test(line)) {
+          continue;
+        }
+
+        while (patterns['multiline'].test(line) && i < entries.length) {
+          line = line.slice(0, line.length - 1) + entries[++i].trim();
+        }
+
+        var entityMatch = line.match(patterns['entity']);
+        if (entityMatch && entityMatch.length == 3) {
+          try {
+            parseEntity(entityMatch, ast);
+          } catch (e) {
+            if (e instanceof ParserError) {
+              _emitter.emit('error', e);
+              continue;
+            }
+          }
+        }
+      }
+      return {
+        type: 'WebL10n',
+        body: ast
+      };
+    }
+
+    function setEntityValue(id, attr, key, value, ast) {
+      var entry = ast[id];
+      var item;
+
+      if (!entry) {
+        entry = {};
+        ast[id] = entry;
+      }
+
+      if (attr) {
+        if (!('attrs' in entry)) {
+          entry.attrs = {};
+        }
+        if (!(attr in entry.attrs)) {
+          entry.attrs[attr] = {};
+        }
+        item = entry.attrs[attr];
+      } else {
+        item = entry;
+      }
+
+      if (!key) {
+        item.value = value;
+      } else {
+        if (item.value.type !== 'Hash') {
+          var match = item.value.content.match(patterns['plural']);
+          if (!match) {
+            throw new ParserError('Expected macro call');
+          }
+          item.index = [
+          {
+            type: 'CallExpression',
+              callee: {
+                type: 'Identifier',
+                name: 'plural'
+              },
+              arguments: [{
+                type: 'Identifier',
+                name: match[1].trim()
+              }]
+          }
+          ];
+          item.value = {
+            type: 'Hash',
+            content: []
+          };
+        }
+        item.value.content.push({
+          type: 'HashItem',
+          key: key,
+          value: value
+        });
+        if (key === 'other') {
+          item.value.content[item.value.content.length - 1].default = true;
+        }
+      }
+    }
+
+    function parseEntity(match, ast) {
+      var name, key, attr, pos;
+      var value = parseValue(match[2]);
+
+      pos = match[1].indexOf('[');
+      if (pos !== -1) {
+        name = match[1].substr(0, pos);
+        key = match[1].substring(pos + 1, match[1].length - 1);
+      } else {
+        name = match[1];
+        key = null;
+      }
+
+      var nameElements = name.split('.');
+
+      if (nameElements.length > 1) {
+        var attrElements = [];
+        attrElements.push(nameElements.pop());
+        if (nameElements.length > 1) {
+          // special quirk to comply with webl10n's behavior
+          if (nestedProps.indexOf(
+                nameElements[nameElements.length - 1]) !== -1) {
+            attrElements.push(nameElements.pop());
+          }
+        } else if (attrElements[0] === 'ariaLabel') {
+          // special quirk to comply with webl10n's behavior
+          attrElements[0] = 'aria-label';
+        }
+        name = nameElements.join('.');
+        attr = attrElements.reverse().join('.');
+      } else {
+        attr = null;
+      }
+
+      setEntityValue(name, attr, key, value, ast);
+    }
+
+    function unescapeControlCharacters(str) {
+      return str.replace(/\\\\/g, '\\')
+                .replace(/\\n/g, '\n')
+                .replace(/\\r/g, '\r')
+                .replace(/\\t/g, '\t')
+                .replace(/\\b/g, '\b')
+                .replace(/\\f/g, '\f')
+                .replace(/\\{/g, '{')
+                .replace(/\\}/g, '}')
+                .replace(/\\"/g, '"')
+                .replace(/\\'/g, "'");
+    }
+
+    function unescapeUnicode(str) {
+      return str.replace(patterns.unicode, function(match, token) {
+        return unescape('%u' + '0000'.slice(token.length) + token);
+      });
+    }
+
+    function unescapeString(str) {
+      if (str.lastIndexOf('\\') !== -1) {
+        str = unescapeControlCharacters(str);
+      }
+      return unescapeUnicode(str);
+    }
+
+    function parseValue(str) {
+
+      var placeables = 0;
+
+      if (str.indexOf('{{') === -1) {
+        return {
+          content: unescapeString(str)
+        };
+      }
+      var chunks = str.split('{{');
+      var body = [];
+
+      chunks.forEach(function (chunk, num) {
+        if (num === 0) {
+          if (chunk.length > 0) {
+            body.push({
+              content: unescapeString(chunk)
+            });
+          }
+          return;
+        }
+        var parts = chunk.split('}}');
+        if (parts.length < 2) {
+          throw new ParserError('Expected "}}"');
+        }
+        body.push({
+          type: 'Identifier',
+          name: parts[0].trim()
+        });
+        placeables++;
+        if (placeables > MAX_PLACEABLES) {
+          throw new ParserError('Too many placeables, maximum allowed is ' +
+            MAX_PLACEABLES);
+        }
+        if (parts[1].length > 0) {
+          body.push({
+            content: unescapeString(parts[1])
+          });
+        }
+      });
+      return {
+        type: 'ComplexString',
+        content: body,
+        source: str
+      };
+    }
+
+    function addEventListener(type, listener) {
+      return _emitter.addEventListener(type, listener);
+    }
+
+    function removeEventListener(type, listener) {
+      return _emitter.removeEventListener(type, listener);
+    }
+  }
+
+  /* ParserError class */
+
+  Parser.Error = ParserError;
+
+  function ParserError(message) {
+    this.name = 'ParserError';
+    this.message = message;
+  }
+  ParserError.prototype = Object.create(Error.prototype);
+  ParserError.prototype.constructor = ParserError;
+
+  exports.Parser = Parser;
+
+});
+define('l20n/compiler', function(require, exports, module) {
+  'use strict';
+
+  var EventEmitter = require('./events').EventEmitter;
+
+  function Compiler() {
+
+    // Public
+
+    this.compile = compile;
+    this.addEventListener = addEventListener;
+    this.removeEventListener = removeEventListener;
+
+    // Private
+
+    var MAX_PLACEABLE_LENGTH = 2500;
+
+    var _emitter = new EventEmitter();
+    var _references = {
+      identifiers: {}
+    };
+
+    var _entryTypes = {
+      Entity: Entity,
+      Macro: Macro
+    };
+
+    // Public API functions
+
+    function compile(ast, env) {
+      if (!env) {
+        env = {};
+      }
+
+      for (var id in ast.body) {
+        if (!ast.body.hasOwnProperty(id)) {
+          continue;
+        }
+        var entry = ast.body[id];
+        var constructor = _entryTypes[entry.type || 'Entity'];
+        try {
+          env[id] = new constructor(id, entry, env);
+        } catch (e) {
+          requireCompilerError(e);
+        }
+      }
+      return env;
+    }
+
+    function addEventListener(type, listener) {
+      return _emitter.addEventListener(type, listener);
+    }
+
+    function removeEventListener(type, listener) {
+      return _emitter.removeEventListener(type, listener);
+    }
+
+    // utils
+
+    function emitError(ctor, message, entry, source) {
+      var e = new ctor(message, entry, source);
+      _emitter.emit('error', e);
+      return e;
+    }
+
+    // The Entity object.
+    function Entity(id, node, env) {
+      this.id = id;
+      this.env = env;
+      this.index = [];
+      this.attributes = {};
+      if (node.index) {
+        for (var i = 0; i < node.index.length; i++) {
+          this.index.push(IndexExpression(node.index[i], this));
+        }
+      }
+      if (node.attrs) {
+        for (var key in node.attrs) {
+          if (node.attrs.hasOwnProperty(key)) {
+            this.attributes[key] = new Attribute(key, node.attrs[key], this);
+          }
+        }
+      }
+      // Bug 817610 - Optimize a fast path for String entities in the Compiler
+      if (node.value && !node.value.type) {
+        this.value = node.value.content;
+      } else {
+        this.value = LazyExpression(node.value, this, this.index);
+      }
+    }
+
+    Entity.prototype.getString = function E_getString(ctxdata) {
+      try {
+        var locals = {
+          __this__: this,
+          __env__: this.env
+        };
+        return _resolve(this.value, locals, ctxdata);
+      } catch (e) {
+        requireCompilerError(e);
+        // `ValueErrors` are not emitted in `StringLiteral` where they are 
+        // created, because if the string in question is being evaluated in an 
+        // index, we'll emit an `IndexError` instead.  To avoid duplication, 
+        // `ValueErrors` are only be emitted if they actually make it to 
+        // here.  See `IndexExpression` for an example of why they wouldn't.
+        if (e instanceof ValueError) {
+          _emitter.emit('error', e);
+        }
+        throw e;
+      }
+    };
+
+    Entity.prototype.get = function E_get(ctxdata) {
+      // reset `_references` to an empty state
+      _references.identifiers = {};
+      var entity = {
+        value: this.getString(ctxdata),
+        attributes: {}
+      };
+      for (var key in this.attributes) {
+        if (this.attributes.hasOwnProperty(key)) {
+          entity.attributes[key] = this.attributes[key].getString(ctxdata);
+        }
+      }
+      entity.identifiers = _references.identifiers;
+      return entity;
+    };
+
+
+    function Attribute(key, node, entity) {
+      this.key = key;
+      this.entity = entity;
+      this.index = [];
+      if (node.index) {
+        for (var i = 0; i < node.index.length; i++) {
+          this.index.push(IndexExpression(node.index[i], this));
+        }
+      }
+      // Bug 817610 - Optimize a fast path for String entities in the Compiler
+      if (node.value && !node.value.type) {
+        this.value = node.value.content;
+      } else {
+        this.value = LazyExpression(node.value, entity, this.index);
+      }
+    }
+
+    Attribute.prototype.getString = function A_getString(ctxdata) {
+      try {
+        var locals = {
+          __this__: this.entity,
+          __env__: this.entity.env
+        };
+        return _resolve(this.value, locals, ctxdata);
+      } catch (e) {
+        requireCompilerError(e);
+        if (e instanceof ValueError) {
+          _emitter.emit('error', e);
+        }
+        throw e;
+      }
+    };
+
+    function Macro(id, node, env) {
+      this.id = id;
+      this.env = env;
+      this.local = node.local || false;
+      this.expression = node.expression;
+      this.args = node.args;
+    }
+    Macro.prototype._call = function M_call(arg) {
+      return [null, this.expression.call(null, arg)];
+    };
+
+
+    var EXPRESSION_TYPES = {
+      'Identifier': Identifier,
+      'String': StringLiteral,
+      'Hash': HashLiteral,
+      'HashItem': Expression,
+      'ComplexString': ComplexString,
+      'CallExpression': CallExpression
+    };
+
+    function Expression(node, entry, index) {
+      // An entity can have no value.  It will be resolved to `null`.
+      if (!node) {
+        return null;
+      }
+      // assume String type by default
+      var type = node.type || 'String';
+      if (!EXPRESSION_TYPES[type]) {
+        throw emitError('CompilationError', 'Unknown expression type' + type);
+      }
+      if (index) {
+        index = index.slice();
+      }
+      return EXPRESSION_TYPES[type](node, entry, index);
+    }
+
+    function LazyExpression(node, entry, index) {
+      // An entity can have no value.  It will be resolved to `null`.
+      if (!node) {
+        return null;
+      }
+      var expr;
+      return function(locals, ctxdata, prop) {
+        if (expr) {
+          return expr(locals, ctxdata, prop);
+        }
+        expr = Expression(node, entry, index);
+        return expr(locals, ctxdata, prop);
+      };
+    }
+
+    function _resolve(expr, locals, ctxdata) {
+      // Bail out early if it's a primitive value or `null`.  This is exactly 
+      // what we want.
+      if (typeof expr === 'string' || 
+          typeof expr === 'boolean' || 
+          typeof expr === 'number' ||
+          !expr) {
+        return expr;
+      }
+
+      // Check if `expr` is an Entity or an Attribute
+      if (expr.value !== undefined) {
+        return _resolve(expr.value, locals, ctxdata);
+      }
+
+      // Check if `expr` is an expression
+      if (typeof expr === 'function') {
+        var current = expr(locals, ctxdata);
+        locals = current[0], current = current[1];
+        return _resolve(current, locals, ctxdata);
+      }
+
+      // Throw if `expr` is a macro
+      if (expr.expression) {
+        throw new RuntimeError('Uncalled macro: ' + expr.id);
+      }
+
+      // Throw if `expr` is a non-primitive from ctxdata
+      throw new RuntimeError('Cannot resolve ctxdata of type ' + typeof expr);
+
+    }
+
+    function Identifier(node, entry) {
+      var name = node.name;
+      return function identifier(locals, ctxdata) {
+        if (ctxdata && ctxdata.hasOwnProperty(name)) {
+          return  [locals, ctxdata[name]];
+        }
+        if (!locals.__env__.hasOwnProperty(name)) {
+          throw new RuntimeError('Reference to an unknown entry: ' + name);
+        }
+        _references.identifiers[name] = true;
+        locals = {
+          __this__: locals.__env__[name],
+          __env__: locals.__env__
+        };
+        return [locals, locals.__this__];
+      };
+    }
+
+    function StringLiteral(node) {
+      return function stringLiteral(locals, ctxdata) {
+        return [locals, node.content];
+      };
+    }
+
+    function ComplexString(node, entry) {
+      var content = [];
+      for (var i = 0; i < node.content.length; i++) {
+        content.push(Expression(node.content[i], entry));
+      }
+
+      // Every complexString needs to have its own `dirty` flag whose state 
+      // persists across multiple calls to the given complexString.  On the 
+      // other hand, `dirty` must not be shared by all complexStrings.  Hence 
+      // the need to define `dirty` as a variable available in the closure.  
+      // Note that the anonymous function is a self-invoked one and it returns 
+      // the closure immediately.
+      return function() {
+        var dirty = false;
+        return function complexString(locals, ctxdata) {
+          if (dirty) {
+            throw new RuntimeError('Cyclic reference detected');
+          }
+          dirty = true;
+          var parts = [];
+          try {
+            for (var i = 0; i < content.length; i++) {
+              var part = _resolve(content[i], locals, ctxdata);
+              if (typeof part !== 'string' && typeof part !== 'number') {
+                throw new RuntimeError('Placeables must be strings or ' +
+                                       'numbers');
+              }
+              if (part.length > MAX_PLACEABLE_LENGTH) {
+                throw new RuntimeError('Placeable has too many characters, ' +
+                                       'maximum allowed is ' +
+                                       MAX_PLACEABLE_LENGTH);
+              }
+              parts.push(part);
+            }
+          } catch (e) {
+            requireCompilerError(e);
+            // only throw, don't emit yet.  If the `ValueError` makes it to 
+            // `getString()` it will be emitted there.  It might, however, be 
+            // cought by `IndexExpression` and changed into a `IndexError`.  
+            // See `IndexExpression` for more explanation.
+            throw new ValueError(e.message, entry, node.source);
+          } finally {
+            dirty = false;
+          }
+          return [locals, parts.join('')];
+        }
+      }();
+    }
+
+    function IndexExpression(node, entry) {
+      var expression = Expression(node, entry);
+
+      // This is analogous to `ComplexString` in that an individual index can 
+      // only be visited once during the resolution of an Entity.  `dirty` is 
+      // set in a closure context of the returned function.
+      return function() {
+        var dirty = false;
+        return function indexExpression(locals, ctxdata) {
+          if (dirty) {
+            throw new RuntimeError('Cyclic reference detected');
+          }
+          dirty = true;
+          try {
+            // We need to resolve `expression` here so that we catch errors 
+            // thrown deep within.  Without `_resolve` we might end up with an 
+            // unresolved Entity object, and no "Cyclic reference detected" 
+            // error would be thown.
+            var retval = _resolve(expression, locals, ctxdata);
+          } catch (e) {
+            // If it's an `IndexError` thrown deeper within `expression`, it 
+            // has already been emitted by its `indexExpression`.  We can 
+            // safely re-throw it here.
+            if (e instanceof IndexError) {
+              throw e;
+            }
+
+            // Otherwise, make sure it's a `RuntimeError` or a `ValueError` and 
+            // throw and emit an `IndexError`.
+            requireCompilerError(e);
+            throw emitError(IndexError, e.message, entry);
+          } finally {
+            dirty = false;
+          }
+          return [locals, retval];
+        }
+      }();
+    }
+
+    function HashLiteral(node, entry, index) {
+      var content = {};
+      var defaultKey;
+      var defaultIndex = index.shift();
+      for (var i = 0; i < node.content.length; i++) {
+        var elem = node.content[i];
+        // use `elem.value` to skip `HashItem` and create the value right away
+        content[elem.key] = Expression(elem.value, entry, index);
+        if (elem.default) {
+          defaultKey = elem.key;
+        }
+      }
+      return function hashLiteral(locals, ctxdata) {
+        var keysToTry = [defaultIndex, defaultKey];
+        var keysTried = [];
+        locals.__overrides__ = {
+          zero: 'zero' in content,
+          one: 'one' in content,
+          two: 'two' in content
+        };
+        for (var i = 0; i < keysToTry.length; i++) {
+          var key = _resolve(keysToTry[i], locals, ctxdata);
+          if (key === undefined) {
+            continue;
+          }
+          keysTried.push(key);
+          if (content.hasOwnProperty(key)) {
+            return [locals, content[key]];
+          }
+        }
+        var message = 'Hash key lookup failed ' +
+                      '(tried "' + keysTried.join('", "') + '").';
+        throw emitError(IndexError, message, entry);
+      };
+    }
+
+    function CallExpression(node, entry) {
+      var callee = Expression(node.callee, entry);
+      // support only one argument per callExpr for now
+      var arg = Expression(node.arguments[0], entry);
+      return function callExpression(locals, ctxdata) {
+        // when arg is called, it returns a [locals, value] tuple; store the 
+        // value in evaluated_args
+        var argValue = arg(locals, ctxdata)[1];
+
+        argValue = parseFloat(argValue);
+        if (isNaN(argValue)) {
+          throw new RuntimeError('Macro arguments must be numbers');
+        }
+
+        // special cases for zero, one, two if they are defined on the hash
+        if (argValue === 0 && locals.__overrides__.zero) {
+          return [null, 'zero'];
+        }
+        if (argValue === 1 && locals.__overrides__.one) {
+          return [null, 'one'];
+        }
+        if (argValue === 2 && locals.__overrides__.two) {
+          return [null, 'two'];
+        }
+
+        // callee is an expression pointing to a macro, e.g. an identifier
+        var macro = callee(locals, ctxdata);
+        locals = macro[0], macro = macro[1];
+        if (!macro.expression) {
+          throw new RuntimeError('Expected a macro, got a non-callable.');
+        }
+        // Rely entirely on the platform implementation to detect recursion.
+        return macro._call(argValue);
+      };
+    }
+
+  }
+
+  Compiler.Error = CompilerError;
+  Compiler.CompilationError = CompilationError;
+  Compiler.RuntimeError = RuntimeError;
+  Compiler.ValueError = ValueError;
+  Compiler.IndexError = IndexError;
+
+
+  // `CompilerError` is a general class of errors emitted by the Compiler.
+  function CompilerError(message) {
+    this.name = 'CompilerError';
+    this.message = message;
+  }
+  CompilerError.prototype = Object.create(Error.prototype);
+  CompilerError.prototype.constructor = CompilerError;
+
+  // `CompilationError` extends `CompilerError`.  It's a class of errors 
+  // which happen during compilation of the AST.
+  function CompilationError(message, entry) {
+    CompilerError.call(this, message);
+    this.name = 'CompilationError';
+    this.entry = entry.id;
+  }
+  CompilationError.prototype = Object.create(CompilerError.prototype);
+  CompilationError.prototype.constructor = CompilationError;
+
+  // `RuntimeError` extends `CompilerError`.  It's a class of errors which 
+  // happen during the evaluation of entries, i.e. when you call 
+  // `entity.toString()`.
+  function RuntimeError(message) {
+    CompilerError.call(this, message);
+    this.name = 'RuntimeError';
+  };
+  RuntimeError.prototype = Object.create(CompilerError.prototype);
+  RuntimeError.prototype.constructor = RuntimeError;
+
+  // `ValueError` extends `RuntimeError`.  It's a class of errors which 
+  // happen during the composition of a ComplexString value.  It's easier to 
+  // recover from than an `IndexError` because at least we know that we're 
+  // showing the correct member of the hash.
+  function ValueError(message, entry, source) {
+    RuntimeError.call(this, message);
+    this.name = 'ValueError';
+    this.entry = entry.id;
+    this.source = source;
+  }
+  ValueError.prototype = Object.create(RuntimeError.prototype);
+  ValueError.prototype.constructor = ValueError;
+
+  // `IndexError` extends `RuntimeError`.  It's a class of errors which 
+  // happen during the lookup of a hash member.  It's harder to recover 
+  // from than `ValueError` because we en dup not knowing which variant of the 
+  // entity value to show and in case the meanings are divergent, the 
+  // consequences for the user can be serious.
+  function IndexError(message, entry) {
+    RuntimeError.call(this, message);
+    this.name = 'IndexError';
+    this.entry = entry.id;
+  };
+  IndexError.prototype = Object.create(RuntimeError.prototype);
+  IndexError.prototype.constructor = IndexError;
+
+  function requireCompilerError(e) {
+    if (!(e instanceof CompilerError)) {
+      throw e;
+    }
+  }
+
+  exports.Compiler = Compiler;
+
+});
+define('l20n/platform/io', function(require, exports, module) {
+  'use strict';
+
+  exports.load = function load(url, callback, sync) {
+    var xhr = new XMLHttpRequest();
+
+    if (xhr.overrideMimeType) {
+      xhr.overrideMimeType('text/plain');
+    }
+
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState == 4) {
+        if (xhr.status == 200 || xhr.status == 0) {
+          callback(null, xhr.responseText);
+        } else {
+          var ex = new IOError('Not found: ' + url);
+          callback(ex);
+        }
+      }
+    };
+
+    xhr.open('GET', url, !sync);
+    xhr.send('');
+  };
+
+  function IOError(message) {
+    this.name = 'IOError';
+    this.message = message;
+  }
+  IOError.prototype = Object.create(Error.prototype);
+  IOError.prototype.constructor = IOError;
+
+  exports.Error = IOError;
+
+});
+define('l20n/plurals', function(require, exports, module) {
+  'use strict';
 
   var kPluralForms = ['zero', 'one', 'two', 'few', 'many', 'other'];
 
-  function getPluralRules(lang) {
+  function getPluralRule(lang) {
     var locales2rules = {
       'af': 3,
       'ak': 4,
@@ -885,357 +2306,15 @@
     // return a function that gives the plural form name for a given integer
     var index = locales2rules[lang.replace(/-.*$/, '')];
     if (!(index in pluralRules)) {
-      consoleWarn('plural form unknown for [' + lang + ']');
       return function() { return 'other'; };
     }
     return pluralRules[index];
   }
 
-  // pre-defined 'plural' macro
-  gMacros.plural = function(str, param, key, prop) {
-    var n = parseFloat(param);
-    if (isNaN(n)) {
-      return str;
-    }
+  exports.getPluralRule = getPluralRule;
 
-    var data = gL10nData[key];
-    if (!data) {
-      return str;
-    }
+});
+// hook up the HTML bindings
+require('l20n/webl10n');
 
-    // initialize _pluralRules
-    if (!gMacros._pluralRules) {
-      gMacros._pluralRules = getPluralRules(gLanguage);
-    }
-    var index = '[' + gMacros._pluralRules(n) + ']';
-
-    // try to find a [zero|one|two] form if it's defined
-    if (n === 0 && (prop + '[zero]') in data) {
-      str = data[prop + '[zero]'];
-    } else if (n == 1 && (prop + '[one]') in data) {
-      str = data[prop + '[one]'];
-    } else if (n == 2 && (prop + '[two]') in data) {
-      str = data[prop + '[two]'];
-    } else if ((prop + index) in data) {
-      str = data[prop + index];
-    } else if ((prop + '[other]') in data) {
-      str = data[prop + '[other]'];
-    }
-
-    return str;
-  };
-
-
-  /**
-   * l10n dictionary functions
-   */
-
-  var reArgs = /\{\{\s*(.+?)\s*\}\}/;                       // arguments
-  var reIndex = /\{\[\s*([a-zA-Z]+)\(([a-zA-Z]+)\)\s*\]\}/; // index macros
-
-  // fetch an l10n object, warn if not found, apply `args' if possible
-  function getL10nData(key, args) {
-    var data = gL10nData[key];
-    if (!data) {
-      return null;
-    }
-
-    /**
-     * This is where l10n expressions should be processed.
-     * The plan is to support C-style expressions from the l20n project;
-     * until then, only two kinds of simple expressions are supported:
-     *   {[ index ]} and {{ arguments }}.
-     */
-    var rv = {};
-    for (var prop in data) {
-      var str = data[prop];
-      str = substIndexes(str, args, key, prop);
-      str = substArguments(str, args, key);
-      rv[prop] = str;
-    }
-    return rv;
-  }
-
-  // return an array of all {{arguments}} found in a string
-  function getL10nArgs(str) {
-    var args = [];
-    var match = reArgs.exec(str);
-    while (match && match.length >= 2) {
-      args.push({
-        name: match[1], // name of the argument
-        subst: match[0] // substring to replace (including braces and spaces)
-      });
-      str = str.substr(match.index + match[0].length);
-      match = reArgs.exec(str);
-    }
-    return args;
-  }
-
-  // return a sub-dictionary sufficient to translate a given fragment
-  function getSubDictionary(fragment) {
-    if (!fragment) { // by default, return a clone of the whole dictionary
-      return JSON.parse(JSON.stringify(gL10nData));
-    }
-
-    var dict = {};
-    var elements = getTranslatableChildren(fragment);
-
-    function checkGlobalArguments(str) {
-      var match = getL10nArgs(str);
-      for (var i = 0; i < match.length; i++) {
-        var arg = match[i].name;
-        if (arg in gL10nData) {
-          dict[arg] = gL10nData[arg];
-        }
-      }
-    }
-
-    for (var i = 0, l = elements.length; i < l; i++) {
-      var id = getL10nAttributes(elements[i]).id;
-      var data = gL10nData[id];
-      if (!id || !data) {
-        continue;
-      }
-
-      dict[id] = data;
-      for (var prop in data) {
-        var str = data[prop];
-        checkGlobalArguments(str);
-
-        if (reIndex.test(str)) { // macro index
-          for (var j = 0; j < kPluralForms.length; j++) {
-            var key = id + '[' + kPluralForms[j] + ']';
-            if (key in gL10nData) {
-              dict[key] = gL10nData[key];
-              checkGlobalArguments(gL10nData[key]);
-            }
-          }
-        }
-      }
-    }
-
-    return dict;
-  }
-
-  // replace {[macros]} with their values
-  function substIndexes(str, args, key, prop) {
-    var reMatch = reIndex.exec(str);
-    if (!reMatch || !reMatch.length) {
-      return str;
-    }
-
-    // an index/macro has been found
-    // Note: at the moment, only one parameter is supported
-    var macroName = reMatch[1];
-    var paramName = reMatch[2];
-    var param;
-    if (args && paramName in args) {
-      param = args[paramName];
-    } else if (paramName in gL10nData) {
-      param = gL10nData[paramName];
-    }
-
-    // there's no macro parser yet: it has to be defined in gMacros
-    if (macroName in gMacros) {
-      var macro = gMacros[macroName];
-      str = macro(str, param, key, prop);
-    }
-    return str;
-  }
-
-  // replace {{arguments}} with their values
-  function substArguments(str, args, key) {
-    var match = getL10nArgs(str);
-    for (var i = 0; i < match.length; i++) {
-      var sub, arg = match[i].name;
-      if (args && arg in args) {
-        sub = args[arg];
-      } else if (arg in gL10nData) {
-        sub = gL10nData[arg]['_'];
-      } else {
-        consoleLog('argument {{' + arg + '}} for #' + key + ' is undefined.');
-        return str;
-      }
-      str = str.replace(match[i].subst, sub);
-    }
-    return str;
-  }
-
-  // translate an HTML element
-  // -- returns true if the element could be translated, false otherwise
-  function translateElement(element) {
-    var l10n = getL10nAttributes(element);
-    if (!l10n.id) {
-      return true;
-    }
-
-    // get the related l10n object
-    var data = getL10nData(l10n.id, l10n.args);
-    if (!data) {
-      return false;
-    }
-
-    // translate element (TODO: security checks?)
-    for (var k in data) {
-      if (k === '_') {
-        setTextContent(element, data._);
-      } else {
-        var idx = k.lastIndexOf('.');
-        var nestedProp = k.substr(0, idx);
-        if (gNestedProps.indexOf(nestedProp) > -1) {
-          element[nestedProp][k.substr(idx + 1)] = data[k];
-        } else if (k === 'ariaLabel') {
-          element.setAttribute('aria-label', data[k]);
-        } else {
-          element[k] = data[k];
-        }
-      }
-    }
-    return true;
-  }
-
-  // translate an array of HTML elements
-  // -- returns an array of elements that could not be translated
-  function translateElements(elements) {
-    var untranslated = [];
-    for (var i = 0, l = elements.length; i < l; i++) {
-      if (!translateElement(elements[i])) {
-        untranslated.push(elements[i]);
-      }
-    }
-    return untranslated;
-  }
-
-  // translate an HTML subtree
-  // -- returns an array of elements that could not be translated
-  function translateFragment(element) {
-    element = element || document.documentElement;
-    var untranslated = translateElements(getTranslatableChildren(element));
-    if (!translateElement(element)) {
-      untranslated.push(element);
-    }
-    return untranslated;
-  }
-
-  // localize an element as soon as mozL10n is ready
-  function localizeElement(element, id, args) {
-    if (!element) {
-      return;
-    }
-
-    if (!id) {
-      element.removeAttribute('data-l10n-id');
-      element.removeAttribute('data-l10n-args');
-      setTextContent(element, '');
-      return;
-    }
-
-    // set the data-l10n-[id|args] attributes
-    element.setAttribute('data-l10n-id', id);
-    if (args && typeof args === 'object') {
-      element.setAttribute('data-l10n-args', JSON.stringify(args));
-    } else {
-      element.removeAttribute('data-l10n-args');
-    }
-
-    // if l10n resources are ready, translate now;
-    // if not, the element will be translated along with the document anyway.
-    if (gReadyState === 'complete') {
-      translateElement(element);
-    }
-  }
-
-
-  /**
-   * Startup & Public API
-   *
-   * This section is quite specific to the B2G project: old browsers are not
-   * supported and the API is slightly different from the standard webl10n one.
-   */
-
-  // load the default locale on startup
-  function l10nStartup() {
-    gDefaultLocale = document.documentElement.lang || gDefaultLocale;
-    gReadyState = 'interactive';
-    consoleLog('loading [' + navigator.language + '] resources, ' +
-        (gAsyncResourceLoading ? 'asynchronously.' : 'synchronously.'));
-
-    // load the default locale and translate the document if required
-    var translationRequired =
-      (document.documentElement.lang !== navigator.language);
-    loadLocale(navigator.language, translationRequired);
-  }
-
-  // the B2G build system doesn't expose any `document'...
-  if (typeof(document) !== 'undefined') {
-    if (document.readyState === 'complete' ||
-      document.readyState === 'interactive') {
-      window.setTimeout(l10nStartup);
-    } else {
-      document.addEventListener('DOMContentLoaded', l10nStartup);
-    }
-  }
-
-  // load the appropriate locale if the language setting has changed
-  if ('mozSettings' in navigator && navigator.mozSettings) {
-    navigator.mozSettings.addObserver('language.current', function(event) {
-      loadLocale(event.settingValue, true);
-    });
-  }
-
-  // public API
-  navigator.mozL10n = {
-    // get a localized string
-    get: function l10n_get(key, args) {
-      var data = getL10nData(key, args);
-      if (!data) {
-        consoleWarn('#' + key + ' is undefined.');
-        return '';
-      } else {
-        return data._;
-      }
-    },
-
-    // get|set the document language and direction
-    get language() {
-      return {
-        // get|set the document language (ISO-639-1)
-        get code() { return gLanguage; },
-        set code(lang) { loadLocale(lang, true); },
-
-        // get the direction (ltr|rtl) of the current language
-        get direction() {
-          // http://www.w3.org/International/questions/qa-scripts
-          // Arabic, Hebrew, Farsi, Pashto, Urdu
-          var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
-          return (rtlList.indexOf(gLanguage) >= 0) ? 'rtl' : 'ltr';
-        }
-      };
-    },
-
-    // translate an element or document fragment
-    translate: translateFragment,
-
-    // localize an element (= set its data-l10n-* attributes and translate it)
-    localize: localizeElement,
-
-    // get (a part of) the dictionary for the current locale
-    getDictionary: getSubDictionary,
-
-    // this can be used to prevent race conditions
-    get readyState() { return gReadyState; },
-    ready: function l10n_ready(callback) {
-      if (!callback) {
-        return;
-      }
-      if (gReadyState == 'complete') {
-        window.setTimeout(callback);
-      } else {
-        window.addEventListener('localized', callback);
-      }
-    }
-  };
-
-  consoleLog('library loaded.');
 })(this);
-


### PR DESCRIPTION
The first step of switching Gaia over to L20n (bug 913712) should minimize the impact of the change;  we therefore simply aim to replace the shared/js/l10n.js file.  No changes to the API nor the file format are being made at this point.

We created a branch of the main L20n codebase which supports the .properties files and is fully compatible with the navigator.mozL10n API.  This means that no changes are need to the l10n infrastructure, the build infrastructure and the developer process.  Everything should just work as it did before.

The code is developed in https://github.com/l20n/l20n.js/tree/gaia and bugs can be filed against the L20n Product in Bugzilla (Component: Gaia Bindings).  Test results are at https://travis-ci.org/l20n/l20n.js

Switching to this special version of L20n already brings a number of improvements:
- modular code which encapsulates main concepts of localization with a clean OOP approach,
- clean start-up which prevents race conditions on app launch and on language change,
- robust language negotiation via the Intl object,
- smart language fallback using the negotiatied fallback chain,
- much better error reporting, especially on build time,
- increased security thanks to the compilation step.

Other features of L20n can be implemented over time as progressive improvements.

Some minimal changes were needed to the build scripts (because of the change in how the inlined JSON looks like and where we take the information about the available locales). The pull request also updates a few tests which made too many assumptions about how l10n.sj was loaded.

The last commit lands the actual L20n code in shared/js/l10n.js.  It deserves perhaps a little bit more explanation:

The structure of L20n in https://github.com/l20n/l20n.js/tree/gaia (names of modules are derived from folder and file names):
- ./lib/l20n/ - the core library
- ./lib/client/l20n - clientside overrides (for I/O)
- ./bindings/l20n - platform bindings

We recommend to review the components in the following order, starting from most isolated classes, to more algorithmic code:

1) event.js - simple EventEmitter

2) io.js - simple XHR based I/O

3) intl.js 
- subset of ECMA 402 implementation extended to support prioritizeLocales giving us full language negotiation
- once we standardize prioritizeLocales in second edition of ECMA 402 we will be able to remove this
- read more https://mail.mozilla.org/pipermail/es-discuss/2013-July/031771.html

4) plurals.js - pretty close copy of the l10n.js:getPluralRule

5) parser.js 
- .properties parser.
- one thing to notice is that we initially parse every string as "simple" and only mark it for lazy complexString resolution

6) compiler.js - the compiler class creates JavaScript objects and functions out of the AST that is the result of the parsing.  This provides a runtime environment for localization and helps safe-guard the evaluation of entities and macro expressions.  The full version of L20n supports custom macros and the compilation step ensures no malicious code is being interpreted. Since shared/js/l10n.js doesn't support custom macros, we turned them off as well in this version, but by keeping the compiler we're ready to re-add them in the future with little effort.

7) context.js - context has three classes:
- Resource - single resource object,
- Locale - single locale object with multiple resources for a given locale id,
- Context - core class of L20n which manages loading resources, resolving them and locale fallback.

8) webl10n.js
- platform bindings. HTML node translation, pretranslation, INI parsing, public events
