### PR TITLE
Use keyboard's basicLayoutKey if it is defined. r=lchang

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -647,6 +647,10 @@ function modifyLayout(keyboardName) {
   var layout;
   if (altLayoutName) {
     layout = Keyboards[keyboardName][altLayoutName] || Keyboards[altLayoutName];
+    // Bug 914459 - Use keyboard's basicLayoutKey if it is defined.
+    if (Keyboards[keyboardName]['basicLayoutKey']) {
+      layout['basicLayoutKey'] = Keyboards[keyboardName]['basicLayoutKey'];
+    }
   }
   else {
     layout = Keyboards[keyboardName];


### PR DESCRIPTION
When keyboard defined basicLayoutKey, it should be used in alternateLayout and symbolLayout.
