### PR TITLE
Bug 911075 - [Contacts] Nothing happens if the user try export contacts as vcard while the sd card is in use

### DIFF
--- a/apps/communications/contacts/locales/contacts.en-US.properties
+++ b/apps/communications/contacts/locales/contacts.en-US.properties
@@ -99,6 +99,7 @@ exportContactsTitle     = Export Contacts
 simExport-title       = Export to SIM
 sdExport-title        = Export to SD Card
 btExport-title        = Export to Bluetooth
+sdUMSEnabled          = Cannot use SD Card because USB storage is enabled
 
 # SIM import
 simContacts-import    = Import SIM contacts

--- a/apps/communications/contacts/test/unit/views/settings_test.js
+++ b/apps/communications/contacts/test/unit/views/settings_test.js
@@ -1,5 +1,6 @@
 require('/shared/js/lazy_loader.js');
 requireElements('communications/contacts/elements/settings.html');
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('communications/contacts/test/unit/mock_contacts.js');
 requireApp('communications/contacts/test/unit/mock_asyncstorage.js');
 requireApp('communications/contacts/test/unit/mock_fb.js');
@@ -197,6 +198,87 @@ suite('Contacts settings', function() {
 
     teardown(function() {
       MockasyncStorage.clear();
+    });
+  });
+
+  suite('SD Export when UMS enabled', function() {
+    var realSettings = navigator.mozSettings;
+    var importSDButton = exportSDButton = null;
+    var checkForCard;
+
+    suiteSetup(function() {
+      checkForCard = utils.sdcard.checkStorageCard;
+      utils.sdcard.checkStorageCard = function() { return true; };
+      navigator.mozSettings = MockNavigatorSettings;
+    });
+
+    suiteTeardown(function() {
+      navigator.mozSettings.mTeardown();
+      navigator.mozSettings = realSettings;
+      utils.sdcard.checkStorageCard = checkForCard;
+    });
+
+    setup(function() {
+      navigator.mozSettings.mTeardown();
+
+      importSDButton = document.getElementById('import-sd-option').
+        firstElementChild;
+      exportSDButton = document.getElementById('export-sd-option').
+        firstElementChild;
+    });
+
+    function setUMS(value) {
+      navigator.mozSettings.createLock().set({
+        'ums.enabled': value
+      });
+    }
+
+    function triggerUMSChange(value) {
+      navigator.mozSettings.mTriggerObservers('ums.enabled', {
+        'settingValue': value
+      });
+    }
+
+    test('Without the UMS enabled', function() {
+      setUMS(false);
+
+      contacts.Settings.init();
+      assert.ok(!importSDButton.hasAttribute('disabled'));
+      assert.ok(!exportSDButton.hasAttribute('disabled'));
+    });
+
+    test('Without UMS enabled at start and enabling it', function(done) {
+      setUMS(false);
+
+      contacts.Settings.init();
+
+      // Trigger the ums change
+      triggerUMSChange(true);
+
+      setTimeout(function checkStorageButtons() {
+        assert.ok(importSDButton.hasAttribute('disabled'));
+        assert.ok(exportSDButton.hasAttribute('disabled'));
+        done();
+      }, 200);
+    });
+
+    test('With UMS enabled at start and disabling it', function(done) {
+      setUMS(true);
+
+      contacts.Settings.init();
+      contacts.Settings.refresh(function onRefreshFinished() {
+        assert.ok(importSDButton.hasAttribute('disabled'));
+        assert.ok(exportSDButton.hasAttribute('disabled'));
+
+        triggerUMSChange(false);
+
+        setTimeout(function checkStorageButtons() {
+          assert.ok(!importSDButton.hasAttribute('disabled'));
+          assert.ok(!exportSDButton.hasAttribute('disabled'));
+          done();
+        }, 200);
+      });
+
     });
   });
 });


### PR DESCRIPTION
If we have UMS (usb massive storage) enabled we are not able to access the sdcard so both the importer and the exporter to this medium, need to check for the setting and as well listen to any changes on this.
