### PR TITLE
Bug 914459 - Use keyboard's basicLayoutKey if it is defined.

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -685,9 +685,11 @@ function modifyLayout(keyboardName) {
 
     // This gives the author the ability to change the basic layout
     // key contents
+    // 'layout' holds alternatelayout which doesn't include basicLayoutKey.
+    // Check and use 'basicLayoutKey' defined by each keyboard.
     var basicLayoutKey = 'ABC';
-    if (layout['basicLayoutKey']) {
-      basicLayoutKey = layout['basicLayoutKey'];
+    if (Keyboards[keyboardName]['basicLayoutKey']) {
+      basicLayoutKey = Keyboards[keyboardName]['basicLayoutKey'];
     }
 
     if (!layout['disableAlternateLayout']) {


### PR DESCRIPTION
When a keyboard defines basicLayoutKey but no alternateLayout, it will use the base alternateLayout + basicLayoutKey. Need to clean the basicLayoutKey after it is assigned, otherwise the basicLayoutKey will be used by other keyboard which do not define an alternateLayout.
