### PR TITLE
Bug 910579 - Proxy and port values for automatic APN are not set for Movistar Spain SIMs

### DIFF
--- a/apps/communications/ftu/js/data_mobile.js
+++ b/apps/communications/ftu/js/data_mobile.js
@@ -53,7 +53,15 @@ var DataMobile = {
         var mnc = navigator.mozMobileConnection.iccInfo.mnc;
         var apnList = xhr.response;
         var apns = apnList[mcc] ? (apnList[mcc][mnc] || []) : [];
-        var selectedAPN = apns[0];
+        var selectedAPN = {};
+        for (var i = 0; i < apns.length; i++) {
+          if (apns[i] &&
+              apns[i].type &&
+              (apns[i].type.indexOf('default') != -1)) {
+            selectedAPN = apns[i];
+            break;
+          }
+        }
         // Set data in 'Settings'
         var lock = self.settings.createLock();
         lock.set({ 'ril.data.apn': selectedAPN.apn || '' });


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=910579 please.

This bug will only land on v1-train and v1.1.0hd branches. See https://bugzilla.mozilla.org/show_bug.cgi?id=910579#c7 please.
