### PR TITLE
Bug 904625 - Display correct Airplane Mode error message

### DIFF
--- a/apps/communications/dialer/js/telephony_helper.js
+++ b/apps/communications/dialer/js/telephony_helper.js
@@ -9,7 +9,7 @@ var TelephonyHelper = (function() {
       return;
     }
     var conn = window.navigator.mozMobileConnection;
-    if (!conn || !conn.voice || !conn.voice.network) {
+    if (!conn || !conn.voice) {
       // No voice connection, the call won't make it
       displayMessage('NoNetwork');
       return;


### PR DESCRIPTION
When the user makes a phone call to a non emergency number and the
device is in airplane mode, we should display a message stating we are
in airplane mode and not that we have no network.
