### PR TITLE
Bug 900399 - Make camera image size restriction customisable

### DIFF
--- a/build/settings.py
+++ b/build/settings.py
@@ -24,6 +24,7 @@ settings = {
  "audio.volume.cemaxvol": 11,
  "bluetooth.enabled": False,
  "camera.shutter.enabled": True,
+ "camera.image.preferredResolution": "",
  "camera.recording.preferredSizes": [],
  "clear.remote-windows.data": False,
  "debug.grid.enabled": False,


### PR DESCRIPTION
1. add `getPreferredResolution` function to query the value of `_preferredImageResolution` from settings. (key `camera.image.preferredResolution`)
2. update some function and variable names of the original `getPreferredSizes` function to make code consistent.
