### PR TITLE
Bug 892518 - email: [User Story] Ability to Change Sync Interval

### DIFF
--- a/apps/email/test/marionette/lib/debug.js
+++ b/apps/email/test/marionette/lib/debug.js
@@ -3,7 +3,7 @@
 // Run a test with DEBUG=true in front to get console listing of
 // helper method calls:
 // DEBUG=true ./bin/gaia-marionette whatever_test.js
-var debug = true; //process.env.DEBUG;
+var debug = process.env.DEBUG;
 
 module.exports = function(logPrefix, obj) {
 

--- a/apps/email/test/marionette/lib/debug.js
+++ b/apps/email/test/marionette/lib/debug.js
@@ -1,0 +1,30 @@
+/*global module, console, process */
+
+// Run a test with DEBUG=true in front to get console listing of
+// helper method calls:
+// DEBUG=true ./bin/gaia-marionette whatever_test.js
+var debug = true; //process.env.DEBUG;
+
+module.exports = function(logPrefix, obj) {
+
+  if (!debug)
+    return;
+
+  // Optionally log all calls done to prototype methods. Uncomment this
+  // section to get traces when trying to debug where flow gets stuck.
+  Object.keys(obj).forEach(function(key) {
+    var desc = Object.getOwnPropertyDescriptor(obj, key);
+    if (!desc.get && !desc.set && typeof obj[key] === 'function') {
+      var oldMethod = obj[key];
+      obj[key] = function() {
+
+        var args = Array.prototype.slice.call(arguments, 0).map(function(arg) {
+          return String(arg);
+        }).join(', ');
+
+        console.log(logPrefix + '.' + key + '(' + args + ')');
+        return oldMethod.apply(this, arguments);
+      };
+    }
+  });
+};

--- a/apps/email/test/marionette/lib/email.js
+++ b/apps/email/test/marionette/lib/email.js
@@ -325,7 +325,7 @@ Email.prototype = {
   },
 
   _tapSelector: function(selector) {
-    //this.client.helper.waitForElement(selector);
+    this.client.helper.waitForElement(selector);
     this.client.findElement(selector).tap();
   },
 

--- a/apps/email/test/marionette/lib/email.js
+++ b/apps/email/test/marionette/lib/email.js
@@ -325,7 +325,7 @@ Email.prototype = {
   },
 
   _tapSelector: function(selector) {
-    this.client.helper.waitForElement(selector);
+    //this.client.helper.waitForElement(selector);
     this.client.findElement(selector).tap();
   },
 

--- a/apps/email/test/marionette/lib/email_data.js
+++ b/apps/email/test/marionette/lib/email_data.js
@@ -1,0 +1,67 @@
+/*jshint node: true, browser: true */
+/*global marionetteScriptFinished */
+
+/**
+ * Manipulates email's data APIs in the app.
+ */
+function EmailData(client) {
+  this.client = client;
+}
+module.exports = EmailData;
+
+EmailData.prototype = {
+  /**
+   * Gets the current account for the given account ID. Just returns the
+   * _wireRep as that will survive the serialization hops.
+   * @param  {String} accountId
+   * @return {Object} the account._wireRep object, or undefined if not found.
+   */
+  getCurrentAccount: function() {
+    var client = this.client;
+    return client.executeAsyncScript(function() {
+      var model = window.wrappedJSObject.require('model');
+      model.latest('account', function(account) {
+        marionetteScriptFinished(account._wireRep);
+      });
+    });
+  },
+
+  /**
+   * Gets the current account for the given account ID. Just returns the
+   * _wireRep as that will survive the serialization hops.
+   * @param  {String} accountId
+   * @return {Object} the account._wireRep object, or undefined if not found.
+   */
+  waitForCurrentAccountUpdate: function(key, value) {
+    var client = this.client;
+    return client.executeAsyncScript(function(key, value) {
+
+      var account,
+          model = window.wrappedJSObject.require('model'),
+          acctsSlice = model.api.viewAccounts(false);
+
+      function checkDone() {
+        if (account[key] === value) {
+          acctsSlice.die();
+          marionetteScriptFinished(true);
+        }
+      }
+
+      acctsSlice.oncomplete = function() {
+        account = acctsSlice.defaultAccount;
+        checkDone();
+      };
+
+      acctsSlice.onchange = function(item) {
+        if (account) {
+          if (account.id === item.id) {
+            checkDone();
+          }
+        }
+      };
+
+    }, [key, value]);
+  }
+};
+
+require('./debug')('email/data', EmailData.prototype);

--- a/apps/email/test/marionette/lib/mocks/mock_navigator_mozalarms.js
+++ b/apps/email/test/marionette/lib/mocks/mock_navigator_mozalarms.js
@@ -1,0 +1,66 @@
+Components.utils.import('resource://gre/modules/Services.jsm');
+
+Services.obs.addObserver(function(document) {
+  if (!document || !document.location)
+    return;
+
+  var window = document.defaultView.wrappedJSObject;
+  var fakeAlarms = [];
+
+  function makeSafeObject(obj) {
+    var exposedProps = {};
+    Object.keys(obj).forEach(function(key) {
+      exposedProps[key] = 'wr';
+    });
+    obj.__exposedProps__ = exposedProps;
+    return obj;
+  }
+
+  function makeFakeRequest(result) {
+    var request = makeSafeObject({
+      onsuccess: null,
+      onerror: null
+    });
+
+    window.setTimeout(function() {
+      if (request.onsuccess) {
+        request.onsuccess(result);
+      }
+    });
+
+    return request;
+  }
+
+  window.navigator.__defineGetter__('mozAlarms', function() {
+    return {
+      __exposedProps__: {
+        remove: 'r',
+        add: 'r',
+        getAll: 'r'
+      },
+
+      remove: function() {
+        // just ignore
+      },
+
+      add: function(date, respectTimezone, data) {
+        fakeAlarms.push(makeSafeObject(data));
+        return makeFakeRequest({});
+      },
+
+      getAll: function() {
+        return makeFakeRequest(makeSafeObject({
+          target: makeSafeObject({
+            result: []
+          })
+        }));
+      }
+    };
+  });
+
+
+  window.navigator.__defineGetter__('__mozFakeAlarms', function() {
+    return fakeAlarms;
+  });
+
+}, 'document-element-inserted', false);

--- a/apps/email/test/marionette/notification_foreground_test.js
+++ b/apps/email/test/marionette/notification_foreground_test.js
@@ -1,7 +1,7 @@
 /*jshint node: true */
 /*global marionette, window, setup, test */
 
-var Email = require('./email');
+var Email = require('./lib/email');
 var assert = require('assert');
 var serverHelper = require('./lib/server_helper');
 

--- a/apps/email/test/marionette/notification_set_interval_test.js
+++ b/apps/email/test/marionette/notification_set_interval_test.js
@@ -1,0 +1,74 @@
+/*jshint node: true */
+/*global marionette, setup, test */
+
+var Email = require('./lib/email');
+var EmailData = require('./lib/email_data');
+var assert = require('assert');
+var serverHelper = require('./lib/server_helper');
+
+marionette('email notifications, foreground', function() {
+  var app,
+      client = marionette.client({
+        settings: {
+          // disable keyboard ftu because it blocks our display
+          'keyboard.ftu.enabled': false
+        }
+      }),
+      server1 = serverHelper.use({
+                  credentials: {
+                    username: 'testy1',
+                    password: 'testy1'
+                  }
+                }, this);
+
+  function getAlarms(client) {
+    var alarms;
+    client.waitFor(function() {
+      alarms = client.executeScript(function() {
+        var alarms = window.wrappedJSObject.navigator.__mozFakeAlarms;
+        if (alarms && alarms.length) {
+            return alarms;
+        }
+       });
+      return alarms;
+    });
+    return alarms;
+  }
+
+  setup(function() {
+    app = new Email(client);
+
+    client.contentScript.inject(__dirname +
+      '/lib/mocks/mock_navigator_mozalarms.js');
+    app.launch();
+  });
+
+  test('should change sync interval from manual to 1 hour',
+  function() {
+    app.manualSetupImapEmail(server1);
+
+    // Open settings and change the sync interval value.
+    app.tapFolderListButton();
+    app.tapSettingsButton();
+    app.tapSettingsAccountIndex(0);
+    app.setSyncIntervalSelectValue(3600000);
+
+    // Wait for the account to report that it has the syncInterval
+    // change.
+    var emailData = new EmailData(client);
+    emailData.waitForCurrentAccountUpdate('syncInterval', 3600000);
+
+    // Make sure an alarm was set.
+    var alarms = getAlarms(client);
+    assert(alarms.length === 1, 'have one alarm');
+    var alarm = alarms[0];
+    assert(alarm.interval === 3600000, 'has correct interval value');
+
+    // Close the app, relaunch and make sure syncInterval was
+    // persisted correctly
+    app.close();
+    app.launch();
+    var account = emailData.getCurrentAccount();
+    assert(account.syncInterval === 3600000, 'sync interval is correct');
+  });
+});

--- a/apps/email/test/marionette/reply_imap_email_test.js
+++ b/apps/email/test/marionette/reply_imap_email_test.js
@@ -1,4 +1,4 @@
-var Email = require('./email');
+var Email = require('./lib/email');
 var assert = require('assert');
 var format = require('util').format;
 var serverHelper = require('./lib/server_helper');

--- a/apps/email/test/marionette/send_imap_email_test.js
+++ b/apps/email/test/marionette/send_imap_email_test.js
@@ -1,4 +1,4 @@
-var Email = require('./email');
+var Email = require('./lib/email');
 var assert = require('assert');
 var serverHelper = require('./lib/server_helper');
 


### PR DESCRIPTION
main-frame-setup change will be reviewed in the gelam pull request, and is minor fix:
https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/249

The code that provides this basic feature was already delivered in bug [892519](https://bugzilla.mozilla.org/show_bug.cgi?id=892519). This changeset is mainly about the integration test addition.

This changeset also introduces some new plumbing for email integration tests. In the email/test/marionette directory:
- email.js was moved to lib/email.js. @lightsofapollo suggested moving all the helper scripts into libs and leave tests in the marionette directory.
- lib/email_data.js: provides wrappers over data operations sent to the email app's content space.
- lib/debug.js formalizes the helper function instrumentation that existed earlier for just lib/email.js
- lib/mocks/mock_navigator_mozalarms.js: a mock for mozAlarms to test correct setting of mozAlarms from the app code.
- lib/email.js: in _tapSelector, a waitForElement was added to make sure the tap target is visible and available for clicking. This seems to fix the intermittent waitForTransitionEnd failure currently seen in the tests. At least I think so. I ran all email unit tests 7 times in a row. That resulted in 8 tests running, for a total of 56 attempts at an intermittent failure. Previously, the failure would have happened before reaching 56 runs.
