### PR TITLE
bug-909372 [gallery] Improve view activity saving robustness r=johnhu

### DIFF
--- a/apps/gallery/js/open.js
+++ b/apps/gallery/js/open.js
@@ -87,7 +87,7 @@ window.addEventListener('localized', function() {
     // If the app that initiated this activity wants us to do allow the
     // user to save this blob as a file, and if device storage is available
     // and if there is enough free space, then display a save button.
-    if (activityData.allowSave && activityData.filename) {
+    if (activityData.allowSave && activityData.filename && checkFilename()) {
       getStorageIfAvailable('pictures', blob.size, function(ds) {
         storage = ds;
         $('menu').hidden = false;
@@ -156,6 +156,16 @@ window.addEventListener('localized', function() {
       else {
         displayError('imagetoobig');
       }
+    }
+  }
+
+  function checkFilename() {
+    var dotIdx = activityData.filename.lastIndexOf('.');
+    if (dotIdx > -1) {
+      var ext = activityData.filename.substr(dotIdx + 1);
+      return MimeMapper.guessTypeFromExtension(ext) === blob.type;
+    } else {
+      return false;
     }
   }
 

--- a/apps/gallery/open.html
+++ b/apps/gallery/open.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" defer src="shared/js/gesture_detector.js"></script>
     <script type="text/javascript" defer src="shared/js/media/media_frame.js"></script>
     <script type="text/javascript" defer src="shared/js/blobview.js"></script>
+    <script type="text/javascript" defer src="shared/js/mime_mapper.js"></script>
     <script type="text/javascript" defer src="shared/js/media/jpeg_metadata_parser.js"></script>
     <script type="text/javascript" defer src="shared/js/device_storage/get_storage_if_available.js"></script>
     <script type="text/javascript" defer src="shared/js/device_storage/get_unused_filename.js"></script>


### PR DESCRIPTION
if the file extension provided to view activity does not match the file type, do not enable save. As a result save button is not shown, when file name has wrong extension.
