### PR TITLE
bug-909373-[Music] open activity saving feature robustness

### DIFF
--- a/apps/music/js/open.js
+++ b/apps/music/js/open.js
@@ -39,8 +39,9 @@ function handleOpenActivity(request) {
 
   // If the app that initiated this activity wants us to allow the
   // user to save this blob as a file, and if device storage is available
-  // and if there is enough free space, then display a save button.
-  if (data.allowSave && data.filename) {
+  // and if there is enough free space, and if provided file extention
+  // is appropriate for the file type, then display a save button.
+  if (data.allowSave && data.filename && checkFilename()) {
     getStorageIfAvailable('music', blob.size, function(ds) {
       storage = ds;
       saveButton.hidden = false;
@@ -94,6 +95,24 @@ function handleOpenActivity(request) {
         console.error('Error saving', filename, e);
       };
     });
+  }
+
+  function checkFilename() {
+    var dotIdx = data.filename.lastIndexOf('.'), ext, type;
+
+    if (dotIdx > -1) {
+      ext = data.filename.substr(dotIdx + 1);
+
+      // workaround for bug909373 and bug852864, since for audio/ogg files we
+      // get video/ogg for blob.type, we let any file with ogg extention pass
+      if (ext === 'ogg') {
+        return true;
+      } else {
+        return MimeMapper.guessTypeFromExtension(ext) === blob.type;
+      }
+    } else {
+      return false;
+    }
   }
 
   function showBanner(msg) {

--- a/apps/music/open.html
+++ b/apps/music/open.html
@@ -15,6 +15,7 @@
     <script type="text/javascript" src="shared/js/device_storage/get_storage_if_available.js"></script>
     <script type="text/javascript" src="shared/js/device_storage/get_unused_filename.js"></script>
     <script type="text/javascript" defer src="shared/js/blobview.js"></script>
+    <script type="text/javascript" defer src="shared/js/mime_mapper.js"></script>
     <script type="text/javascript" defer src="shared/js/async_storage.js"></script>
     <!-- Specific code -->
     <script type="text/javascript" defer src="js/metadata.js"></script>


### PR DESCRIPTION
in some cases for example `ogg` files, `guessTypeFromExtension(ext)` could return video instead of audio. To overcome this problem, but still check file extension is valid, I get the file type from extension and then check that it is audio or video. I am assuming any file that music player will be able to open must be one of these two.
- Note: this does not handle the edge case where open activity is called with a music file, but provides another music file type. For example `mp3` file claiming to be `ogg`.

I submit this PR so we can discuss if this is sufficient check or if we need to add more validation to cover the above case
