### PR TITLE
Bug 904105 - part 1: using argument instead of module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,38 +289,37 @@ TEST_DIRS ?= $(CURDIR)/tests
 
 
 define BUILD_CONFIG
-exports.config = {
-	"GAIA_DIR" : "$(CURDIR)",
-	"PROFILE_DIR" : "$(CURDIR)$(SEP)$(PROFILE_FOLDER)",
-	"PROFILE_FOLDER" : "$(PROFILE_FOLDER)",
-	"GAIA_SCHEME" : "$(SCHEME)",
-	"GAIA_DOMAIN" : "$(GAIA_DOMAIN)",
-	"DEBUG" : $(DEBUG),
-	"LOCAL_DOMAINS" : $(LOCAL_DOMAINS),
-	"DESKTOP" : $(DESKTOP),
-	"DEVICE_DEBUG" : $(DEVICE_DEBUG),
-	"HOMESCREEN" : "$(HOMESCREEN)",
-	"GAIA_PORT" : "$(GAIA_PORT)",
-	"GAIA_LOCALES_PATH" : "$(GAIA_LOCALES_PATH)",
-	"LOCALES_FILE" : "$(subst \,\\,$(LOCALES_FILE))",
-	"BUILD_APP_NAME" : "$(BUILD_APP_NAME)",
-	"PRODUCTION" : "$(PRODUCTION)",
-	"GAIA_OPTIMIZE" : "$(GAIA_OPTIMIZE)",
-	"GAIA_DEV_PIXELS_PER_PX" : "$(GAIA_DEV_PIXELS_PER_PX)",
-	"DOGFOOD" : "$(DOGFOOD)",
-	"OFFICIAL" : "$(MOZILLA_OFFICIAL)",
-	"GAIA_DEFAULT_LOCALE" : "$(GAIA_DEFAULT_LOCALE)",
-	"GAIA_INLINE_LOCALES" : "$(GAIA_INLINE_LOCALES)",
-	"GAIA_CONCAT_LOCALES" : "$(GAIA_CONCAT_LOCALES)",
-	"GAIA_ENGINE" : "xpcshell",
-	"GAIA_DISTRIBUTION_DIR" : "$(GAIA_DISTRIBUTION_DIR)",
-	"GAIA_APPDIRS" : "$(GAIA_APPDIRS)",
-	"NOFTU" : "$(NOFTU)",
-	"REMOTE_DEBUGGER" : "$(REMOTE_DEBUGGER)",
-	"TARGET_BUILD_VARIANT" : "$(TARGET_BUILD_VARIANT)",
-	"SETTINGS_PATH" : "$(SETTINGS_PATH)"
+{ \
+	"GAIA_DIR" : "$(CURDIR)", \
+	"PROFILE_DIR" : "$(CURDIR)$(SEP)$(PROFILE_FOLDER)", \
+	"PROFILE_FOLDER" : "$(PROFILE_FOLDER)", \
+	"GAIA_SCHEME" : "$(SCHEME)", \
+	"GAIA_DOMAIN" : "$(GAIA_DOMAIN)", \
+	"DEBUG" : $(DEBUG), \
+	"LOCAL_DOMAINS" : $(LOCAL_DOMAINS), \
+	"DESKTOP" : $(DESKTOP), \
+	"DEVICE_DEBUG" : $(DEVICE_DEBUG), \
+	"HOMESCREEN" : "$(HOMESCREEN)", \
+	"GAIA_PORT" : "$(GAIA_PORT)", \
+	"GAIA_LOCALES_PATH" : "$(GAIA_LOCALES_PATH)", \
+	"LOCALES_FILE" : "$(subst \,\\,$(LOCALES_FILE))", \
+	"BUILD_APP_NAME" : "$(BUILD_APP_NAME)", \
+	"PRODUCTION" : "$(PRODUCTION)", \
+	"GAIA_OPTIMIZE" : "$(GAIA_OPTIMIZE)", \
+	"GAIA_DEV_PIXELS_PER_PX" : "$(GAIA_DEV_PIXELS_PER_PX)", \
+	"DOGFOOD" : "$(DOGFOOD)", \
+	"OFFICIAL" : "$(MOZILLA_OFFICIAL)", \
+	"GAIA_DEFAULT_LOCALE" : "$(GAIA_DEFAULT_LOCALE)", \
+	"GAIA_INLINE_LOCALES" : "$(GAIA_INLINE_LOCALES)", \
+	"GAIA_CONCAT_LOCALES" : "$(GAIA_CONCAT_LOCALES)", \
+	"GAIA_ENGINE" : "xpcshell", \
+	"GAIA_DISTRIBUTION_DIR" : "$(GAIA_DISTRIBUTION_DIR)", \
+	"GAIA_APPDIRS" : "$(GAIA_APPDIRS)", \
+	"NOFTU" : "$(NOFTU)", \
+	"REMOTE_DEBUGGER" : "$(REMOTE_DEBUGGER)", \
+	"TARGET_BUILD_VARIANT" : "$(TARGET_BUILD_VARIANT)", \
+	"SETTINGS_PATH" : "$(SETTINGS_PATH)" \
 }
-
 endef
 export BUILD_CONFIG
 
@@ -496,12 +495,8 @@ XULRUNNERSDK=./xulrunner-sdk/bin/run-mozilla.sh
 XPCSHELLSDK=./xulrunner-sdk/bin/xpcshell
 endif
 
-.PHONY: build-config-js
-build-config-js:
-	echo "$$BUILD_CONFIG" > $(CURDIR)$(SEP)build$(SEP)config.js
-
 .PHONY: install-xulrunner-sdk
-install-xulrunner-sdk: build-config-js
+install-xulrunner-sdk:
 ifndef USE_LOCAL_XULRUNNER_SDK
 ifneq ($(XULRUNNER_SDK_DOWNLOAD),$(shell cat .xulrunner-url 2> /dev/null))
 	rm -rf xulrunner-sdk
@@ -520,7 +515,7 @@ define run-js-command
 	$(XULRUNNERSDK) $(XPCSHELLSDK) \
 		-e "const GAIA_BUILD_DIR='$(BUILDDIR)'" \
 		-f build/xpcshell-commonjs.js \
-		-e "try{ require('$(strip $1)').execute(); } \
+		-e "try{ require('$(strip $1)').execute($$BUILD_CONFIG); } \
 				catch(e) {dump('Exception: ' + e + '\n' + e.stack + '\n');}"
 endef
 

--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var utils = require('./utils');
-var config = require('./config').config;
+var config;
 
 const PREFERRED_ICON_SIZE = 60;
 const GAIA_CORE_APP_SRCDIR = 'apps';
@@ -49,14 +49,17 @@ function bestMatchingIcon(preferred_size, manifest, origin) {
 }
 
 function iconDescriptor(directory, app_name, entry_point) {
-  let origin = utils.gaiaOriginURL(app_name);
-  let manifestURL = utils.gaiaManifestURL(app_name);
+  let gaia = utils.getGaia(config);
+  let origin = utils.gaiaOriginURL(app_name, config.GAIA_SCHEME,
+    config.GAIA_DOMAIN, config.GAIA_PORT);
+  let manifestURL = utils.gaiaManifestURL(app_name,
+    config.GAIA_SCHEME,  config.GAIA_DOMAIN, config.GAIA_PORT);
 
   // Locate the directory of a given app.
   // If the directory (Gaia.distributionDir)/(directory)/(app_name) exists,
   // favor it over (GAIA_DIR)/(directory)/(app_name).
-  let targetDir = utils.Gaia.distributionDir ?
-    utils.Gaia.distributionDir : config.GAIA_DIR;
+  let targetDir = gaia.distributionDir ?
+    gaia.distributionDir : config.GAIA_DIR;
   let dir = utils.getFile(targetDir, directory, app_name);
 
   if (!dir.exists()) {
@@ -109,7 +112,9 @@ function iconDescriptor(directory, app_name, entry_point) {
   };
 }
 
-function execute() {
+function execute(options) {
+  config = options;
+  var distDir = config.GAIA_DISTRIBUTION_DIR;
   // zeroth grid page is the dock
   let customize = {'homescreens': [
     [
@@ -142,7 +147,7 @@ function execute() {
   }
 
   customize = JSON.parse(utils.getDistributionFileContent('homescreens',
-    customize));
+    customize, distDir));
   // keep e.me on by default
   let search_page_enabled = (customize.search_page) ?
                             customize.search_page.enabled : true;
@@ -210,7 +215,7 @@ function execute() {
   content = ['4850', '7000'];
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('sms-blacklist', content));
+    utils.getDistributionFileContent('sms-blacklist', content, distDir));
 
   // Active Sensors
   init = utils.getFile(config.GAIA_DIR,
@@ -218,7 +223,7 @@ function execute() {
   content = { ambientLight: true };
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('sensors', content));
+    utils.getDistributionFileContent('sensors', content, distDir));
 
   // Support
   init = utils.getFile(config.GAIA_DIR,
@@ -226,7 +231,7 @@ function execute() {
   content = null;
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('support', content));
+    utils.getDistributionFileContent('support', content, distDir));
 
   // Browser
   init = utils.getFile(config.GAIA_DIR, 'apps', 'browser', 'js', 'init.json');
@@ -286,7 +291,7 @@ function execute() {
   };
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('browser', content));
+    utils.getDistributionFileContent('browser', content, distDir));
 
   // Active Sensors
   init = utils.getFile(config.GAIA_DIR,
@@ -294,7 +299,7 @@ function execute() {
   content = { ambientLight: true };
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('sensors', content));
+    utils.getDistributionFileContent('sensors', content, distDir));
 
   // Support
   init = utils.getFile(config.GAIA_DIR,
@@ -302,7 +307,7 @@ function execute() {
   content = null;
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('support', content));
+    utils.getDistributionFileContent('support', content, distDir));
 
   // Network Types
   init = utils.getFile(config.GAIA_DIR,
@@ -313,7 +318,7 @@ function execute() {
   };
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('network', content));
+    utils.getDistributionFileContent('network', content, distDir));
 
   // ICC / STK
   init = utils.getFile(config.GAIA_DIR,
@@ -322,7 +327,8 @@ function execute() {
     'defaultURL': 'http://www.mozilla.org/en-US/firefoxos/'
   };
 
-  utils.writeContent(init, utils.getDistributionFileContent('icc', content));
+  utils.writeContent(init,
+    utils.getDistributionFileContent('icc', content, distDir));
 
   // WAP UA profile url
   init = utils.getFile(config.GAIA_DIR,
@@ -330,7 +336,7 @@ function execute() {
   content = {};
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('wapuaprof.json', content));
+    utils.getDistributionFileContent('wapuaprof.json', content, distDir));
 
   // WAP Push
   init = utils.getFile(config.GAIA_DIR, 'apps', 'wappush', 'js', 'whitelist.json');
@@ -400,7 +406,8 @@ function execute() {
   };
 
   utils.writeContent(init, 'Calendar.Presets = ' +
-               utils.getDistributionFileContent('calendar', content) + ';');
+               utils.getDistributionFileContent('calendar', content, distDir) +
+               ';');
 
   // Communications config
   init = utils.getFile(config.GAIA_DIR,
@@ -414,7 +421,7 @@ function execute() {
     'testToken': ''
   };
   utils.writeContent(init,
-    utils.getDistributionFileContent('communications', content));
+    utils.getDistributionFileContent('communications', content, distDir));
 
   // Communications External Services
   init = utils.getFile(config.GAIA_DIR,
@@ -431,7 +438,8 @@ function execute() {
 
   utils.writeContent(init,
     'var oauthflow = this.oauthflow || {}; oauthflow.params = ' +
-    utils.getDistributionFileContent('communications_services', content) + ';');
+    utils.getDistributionFileContent('communications_services', content,
+    distDir) + ';');
 }
 
 exports.execute = execute;

--- a/build/optimize-clean.js
+++ b/build/optimize-clean.js
@@ -1,14 +1,16 @@
 var utils = require('./utils');
-var config = require('./config').config;
+var config;
 
 function debug(str) {
   //dump(' -*- l10n-clean.js: ' + str + '\n');
 }
 
-function execute() {
+function execute(options) {
+  var gaia = utils.getGaia(options);
+  config = options;
   debug('Begin');
 
-  utils.Gaia.webapps.forEach(function(webapp) {
+  gaia.webapps.forEach(function(webapp) {
     // if BUILD_APP_NAME isn't `*`, we only accept one webapp
     if (config.BUILD_APP_NAME != '*' &&
       webapp.sourceDirectoryName != config.BUILD_APP_NAME) {
@@ -22,7 +24,7 @@ function execute() {
     files.forEach(function(file) {
       if (
         re.test(file.leafName) ||
-        file.leafName.indexOf(utils.Gaia.aggregatePrefix) === 0
+        file.leafName.indexOf(gaia.aggregatePrefix) === 0
       ) {
         file.remove(false);
       }

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -1,14 +1,16 @@
 
 'use strict';
 
-var config = require('./config').config;
+var config;
 var utils = require('./utils');
 
 function debug(msg) {
   //dump('-*- preferences.js ' + msg + '\n');
 }
 
-function execute() {
+function execute(options) {
+  config = options
+  var gaia = utils.getGaia(config);
   const prefs = [];
 
   let homescreen = config.HOMESCREEN +
@@ -22,7 +24,7 @@ function execute() {
   let domains = [];
   domains.push(config.GAIA_DOMAIN);
 
-  utils.Gaia.webapps.forEach(function(webapp) {
+  gaia.webapps.forEach(function(webapp) {
     domains.push(webapp.domain);
   });
 
@@ -139,7 +141,7 @@ function execute() {
     prefs.push(['extensions.gaia.device_pixel_suffix', suffix]);
 
     let appPathList = [];
-    utils.Gaia.webapps.forEach(function(webapp) {
+    gaia.webapps.forEach(function(webapp) {
       appPathList.push(webapp.sourceAppDirectoryName + '/' +
                        webapp.sourceDirectoryName);
     });
@@ -186,9 +188,9 @@ function execute() {
     });
   }
 
-  if (utils.Gaia.engine === 'xpcshell') {
+  if (gaia.engine === 'xpcshell') {
     writePrefs();
-  } else if (utils.Gaia.engine === 'b2g') {
+  } else if (gaia.engine === 'b2g') {
     setPrefs();
   }
 }

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -1,6 +1,7 @@
 var utils = require('./utils');
-var config = require('./config').config;
+var config;
 const { Cc, Ci, Cr, Cu } = require('chrome');
+Cu.import('resource://gre/modules/Services.jsm');
 
 const INSTALL_TIME = 132333986000;
 // Match this to value in applications-data.js
@@ -14,15 +15,6 @@ let io = Cc['@mozilla.org/network/io-service;1']
 
 let webappsTargetDir = Cc['@mozilla.org/file/local;1']
                .createInstance(Ci.nsILocalFile);
-webappsTargetDir.initWithPath(config.PROFILE_DIR);
-// Create profile folder if doesn't exists
-if (!webappsTargetDir.exists())
-  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt('0755', 8));
-// Create webapps folder if doesn't exists
-webappsTargetDir.append('webapps');
-if (!webappsTargetDir.exists())
-  webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt('0755', 8));
-
 let manifests = {};
 
 let id = 1;
@@ -273,8 +265,19 @@ function fillExternalAppManifest(webapp) {
   };
 }
 
-function execute() {
-  utils.Gaia.webapps.forEach(function(webapp) {
+function execute(options) {
+  config = options;
+
+  webappsTargetDir.initWithPath(config.PROFILE_DIR);
+  // Create profile folder if doesn't exists
+  if (!webappsTargetDir.exists())
+    webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt('0755', 8));
+  // Create webapps folder if doesn't exists
+  webappsTargetDir.append('webapps');
+  if (!webappsTargetDir.exists())
+    webappsTargetDir.create(Ci.nsIFile.DIRECTORY_TYPE, parseInt('0755', 8));
+
+  utils.getGaia(config).webapps.forEach(function(webapp) {
     // If BUILD_APP_NAME isn't `*`, we only accept one webapp
     if (config.BUILD_APP_NAME != '*' &&
       webapp.sourceDirectoryName != config.BUILD_APP_NAME) {


### PR DESCRIPTION
previously we wrote config module by makefile and require it on
each module in GAIA_DIR/build. it would be great if using argument for
build config because we can dynamicly change build config when we use
those modules.

e.g., if using those module in firefox exntesion, user can change build
config in a web form if we use argument, but it's difficult by module.
