### PR TITLE
Bug 914599 - Improve Call Settings when FDN is enabled

### DIFF
--- a/apps/settings/elements/call.html
+++ b/apps/settings/elements/call.html
@@ -55,6 +55,7 @@
           </p>
         </li>
         <li>
+          <small id="fdnSettings-desc"></small>
           <a data-href="#call-fdnSettings" data-l10n-id="fdn">Fixed dialing numbers</a>
         </li>
       </ul>
@@ -63,6 +64,13 @@
         <h2 data-l10n-id="callForwarding"> Call Forwarding </h2>
       </header>
       <ul>
+        <li id="fdnSettingsBlocked" class="description" hidden>
+          <p>
+            <span data-l10n-id="fdn-enabled-warning">
+              Call forwarding is disabled by FDN.
+            </span>
+          </p>
+        </li>
         <li id="li-cfu-desc" class="disabled">
           <small id="cfu-desc"></small>
           <a id="menuItem-callForwardingUnconditional" data-href="#call-cf-unconditionalSettings" data-l10n-id="callForwardingUnconditional">Always forward</a>

--- a/apps/settings/js/call.js
+++ b/apps/settings/js/call.js
@@ -451,32 +451,38 @@ var Calls = (function(window, document, undefined) {
     enableTapOnCallForwardingItems(false);
 
     var req = mobileConnection.getCallingLineIdRestriction();
-    req.onsuccess = req.onerror = function() {
+    req.onsuccess = req.onerror = function(event) {
       var input = document.getElementById('ril-callerId');
 
       var value = 'CLIR_DEFAULT';
-      switch (req.result['m']) {
-        case 1: // Permanently provisioned
-        case 3: // Temporary presentation disallowed
-        case 4: // Temporary presentation allowed
-          switch (req.result['n']) {
-            case 1: // CLIR invoked
-              value = 'CLIR_INVOCATION';
-              break;
-            case 2: // CLIR suppressed
-              value = 'CLIR_SUPPRESSION';
-              break;
-            case 0: // Network default
-            default:
-              value = 'CLIR_DEFAULT';
-              break;
-          }
-          break;
-        case 0: // Not Provisioned
-        case 2: // Unknown (network error, etc)
-        default:
-          value = 'CLIR_DEFAULT';
-          break;
+
+      // In some legitimates error cases (FdnCheckFailure), the req.result is
+      // undefined. This is fine, we want this, and in this case we will just
+      // display an error message for all the matching requests.
+      if (req.result) {
+        switch (req.result['m']) {
+          case 1: // Permanently provisioned
+          case 3: // Temporary presentation disallowed
+          case 4: // Temporary presentation allowed
+            switch (req.result['n']) {
+              case 1: // CLIR invoked
+                value = 'CLIR_INVOCATION';
+                break;
+              case 2: // CLIR suppressed
+                value = 'CLIR_SUPPRESSION';
+                break;
+              case 0: // Network default
+              default:
+                value = 'CLIR_DEFAULT';
+                break;
+            }
+            break;
+          case 0: // Not Provisioned
+          case 2: // Unknown (network error, etc)
+          default:
+            value = 'CLIR_DEFAULT';
+            break;
+        }
       }
 
       input.value = value;
@@ -762,6 +768,29 @@ var Calls = (function(window, document, undefined) {
     });
   }
 
+  function updateFdnStatus() {
+    if (!IccHelper.enabled) {
+      return;
+    }
+
+    var req = IccHelper.getCardLock('fdn');
+    req.onsuccess = function spl_checkSuccess() {
+      var enabled = req.result.enabled;
+
+      var simFdnDesc = document.querySelector('#fdnSettings-desc');
+      localize(simFdnDesc, enabled ? 'enabled' : 'disabled');
+
+      var fdnSettingsBlocked = document.querySelector('#fdnSettingsBlocked');
+      fdnSettingsBlocked.hidden = !enabled;
+
+      var callForwardingOptions = document.querySelectorAll(
+        '#li-cfu-desc, #li-cfmb-desc, #li-cfnrep-desc, #li-cfnrea-desc');
+      for (var i = 0, l = callForwardingOptions.length; i < l; i++) {
+        callForwardingOptions[i].hidden = enabled;
+      }
+    };
+  }
+
   // Call subpanel navigation control.
   window.addEventListener('panelready', function(e) {
     // If navigation is from #root to #call panels then update UI always.
@@ -773,6 +802,7 @@ var Calls = (function(window, document, undefined) {
 
     if (!updatingInProgress) {
       updateVoiceMailItemState();
+      updateFdnStatus();
       updateCallerIdItemState(
         function panelready_updateCallerIdItemState() {
           updateCallWaitingItemState(

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -146,6 +146,7 @@ fdnAttemptMsg3[many]=You have {{n}} tries left to enter the correct code before 
 fdnAttemptMsg3[other]=You have {{n}} tries left to enter the correct code before locking the SIM card.
 fdnLastChanceMsg=This is your last chance to enter the correct PIN2. Otherwise, you must enter the PUK2 code to use this SIM card.
 fdnErrorMsg=The PIN2 code is incorrect.
+fdn-enabled-warning=Call forwarding is disabled by FDN.
 
 
 # Connectivity :: Cellular & Data


### PR DESCRIPTION
When the Fixed Dialing Numbers options is enabled, many features are
disabled, and USSD/MMI codes fall into this set. This will thus make the
many call settings parameters getting into error state. The present
commit aims at: avoiding undefined state of the call settings, and
improving the feedback we send to user by clearly stating that call
forwaring options are unavaiable due to FDN enabled.
