### PR TITLE
Bug 915970 - [Clock] Prepare Stopwatch for persistence

### DIFF
--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -133,7 +133,14 @@
       var obj = {};
       for (var i in sw) {
         if (sw.hasOwnProperty(i)) {
-          obj[i] = sw[i];
+          if(Object.prototype.toString.call(sw[i]).slice(8, -1) === 'Array') {
+            var copy = sw[i].map(function(item) {
+              return item;
+            });
+            obj[i] = copy;
+          } else {
+            obj[i] = sw[i];
+          }
         }
       }
       return obj;

--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -133,7 +133,7 @@
       var obj = {};
       for (var i in sw) {
         if (sw.hasOwnProperty(i)) {
-          if(Object.prototype.toString.call(sw[i]).slice(8, -1) === 'Array') {
+          if (Object.prototype.toString.call(sw[i]).slice(8, -1) === 'Array') {
             var copy = sw[i].map(function(item) {
               return item;
             });

--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -18,7 +18,7 @@
     obj.startTime = opts.startTime || defaults.startTime;
     obj.totalElapsed = opts.totalElapsed || defaults.totalElapsed;
     obj.isStarted = opts.isStarted || defaults.isStarted;
-    obj.laps = opts.laps || defaults.laps;
+    obj.laps = opts.laps ? opts.laps.slice() : defaults.laps.slice();
 
     priv.set(this, obj);
   };
@@ -133,11 +133,8 @@
       var obj = {};
       for (var i in sw) {
         if (sw.hasOwnProperty(i)) {
-          if (Object.prototype.toString.call(sw[i]).slice(8, -1) === 'Array') {
-            var copy = sw[i].map(function(item) {
-              return item;
-            });
-            obj[i] = copy;
+          if (Array.isArray(sw[i])) {
+            obj[i] = sw[i].slice();
           } else {
             obj[i] = sw[i];
           }

--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -18,7 +18,7 @@
     obj.startTime = opts.startTime || defaults.startTime;
     obj.totalElapsed = opts.totalElapsed || defaults.totalElapsed;
     obj.isStarted = opts.isStarted || defaults.isStarted;
-    obj.laps = opts.laps ? opts.laps.slice() : defaults.laps.slice();
+    obj.laps = opts.laps ? opts.laps.slice() : defaults.laps;
 
     priv.set(this, obj);
   };

--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -2,7 +2,7 @@
 
   'use strict';
 
-  var wm = new WeakMap();
+  var priv = new WeakMap();
 
   function Defaults() {
     this.startTime = 0;
@@ -11,8 +11,16 @@
     this.laps = [];
   }
 
-  function Stopwatch() {
-    this.reset();
+  function Stopwatch(opts = {}) {
+    var defaults = new Defaults();
+    var obj = {};
+
+    obj.startTime = opts.startTime || defaults.startTime;
+    obj.totalElapsed = opts.totalElapsed || defaults.totalElapsed;
+    obj.isStarted = opts.isStarted || defaults.isStarted;
+    obj.laps = opts.laps || defaults.laps;
+
+    priv.set(this, obj);
   };
 
   Stopwatch.prototype = {
@@ -25,7 +33,7 @@
     * @return {boolean} return isStarted state
     */
     isStarted: function sw_isStarted() {
-      var sw = wm.get(this);
+      var sw = priv.get(this);
       return sw.isStarted;
     },
 
@@ -33,7 +41,7 @@
     * start Starts the stopwatch, either from a reset or paused state
     */
     start: function sw_start() {
-      var sw = wm.get(this);
+      var sw = priv.get(this);
       if (sw.isStarted) {
         return;
       }
@@ -47,7 +55,7 @@
     * @return {Date} return total elapsed duration
     */
     getElapsedTime: function sw_getElapsedTime() {
-      var sw = wm.get(this);
+      var sw = priv.get(this);
       var elapsed = 0;
       if (sw.isStarted) {
         elapsed = Date.now() - sw.startTime;
@@ -61,7 +69,7 @@
     * pause Pauses the stopwatch
     */
     pause: function sw_pause() {
-      var sw = wm.get(this);
+      var sw = priv.get(this);
       if (!sw.isStarted) {
         return;
       }
@@ -76,7 +84,7 @@
     * @return {Date} return the lap duration
     */
     lap: function sw_lap() {
-      var sw = wm.get(this);
+      var sw = priv.get(this);
       if (!sw.isStarted) {
         return new Date(0);
       }
@@ -103,7 +111,7 @@
     * @return {Array} return an array of lap durations
     */
     getLapDurations: function sw_getLapDurations() {
-      var sw = wm.get(this);
+      var sw = priv.get(this);
       return sw.laps.map(function(lap) {
         return lap.duration;
       });
@@ -113,7 +121,22 @@
     * reset Resets the stopwatch back to 0, clears laps
     */
     reset: function sw_reset() {
-      wm.set(this, new Defaults());
+      priv.set(this, new Defaults());
+    },
+
+    /**
+    * toSerializable Returns a serializable object for persisting Stopwatch data
+    * @return {Object} A serializable object
+    */
+    toSerializable: function sw_toSerializable() {
+      var sw = priv.get(this);
+      var obj = {};
+      for (var i in sw) {
+        if (sw.hasOwnProperty(i)) {
+          obj[i] = sw[i];
+        }
+      }
+      return obj;
     }
 
   };

--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -133,11 +133,7 @@
       var obj = {};
       for (var i in sw) {
         if (sw.hasOwnProperty(i)) {
-          if (Array.isArray(sw[i])) {
-            obj[i] = sw[i].slice();
-          } else {
-            obj[i] = sw[i];
-          }
+          obj[i] = Array.isArray(sw[i]) ? sw[i].slice() : sw[i];
         }
       }
       return obj;

--- a/apps/clock/test/unit/stopwatch_test.js
+++ b/apps/clock/test/unit/stopwatch_test.js
@@ -27,14 +27,27 @@ suite('Stopwatch', function() {
     });
 
     test('from object', function() {
-      var obj = {
+      var input = {
         startTime: Date.now(),
         totalElapsed: oneHour,
         isStarted: true,
         laps: [{time: Date.now(), duration: oneHour}]
       };
-      this.sw = new Stopwatch(obj);
-      assert.deepEqual(obj, this.sw.toSerializable());
+      this.sw = new Stopwatch(input);
+      assert.deepEqual(input, this.sw.toSerializable());
+    });
+
+    test('deep copy', function() {
+      var input = {
+        startTime: Date.now(),
+        totalElapsed: oneHour,
+        isStarted: true,
+        laps: [{time: Date.now(), duration: oneHour}]
+      };
+      this.sw = new Stopwatch(input);
+      var serialized = this.sw.toSerializable();
+      serialized.laps.push({ time: 0, duration: oneHour });
+      assert.notEqual(serialized.laps, input.laps, 'laps should not be equal');
     });
 
   });

--- a/apps/clock/test/unit/stopwatch_test.js
+++ b/apps/clock/test/unit/stopwatch_test.js
@@ -4,7 +4,6 @@ requireApp('clock/js/utils.js');
 suite('Stopwatch', function() {
 
   var oneHour = 1 * 60 * 60 * 1000;
-  var d;
 
   suiteSetup(function() {
     this.sw = new Stopwatch();
@@ -195,17 +194,19 @@ suite('Stopwatch', function() {
   suite('toSerializable', function() {
 
     test('default', function() {
-      var obj1 = {
+      var expected = {
         startTime: 0,
         totalElapsed: 0,
         isStarted: false,
         laps: []
       };
-      var obj2 = this.sw.toSerializable();
-      assert.deepEqual(obj1, obj2);
+      var actual = this.sw.toSerializable();
+      assert.deepEqual(expected, actual);
     });
 
     suite('started', function() {
+
+      var d;
 
       setup(function() {
         d = Date.now();
@@ -213,67 +214,74 @@ suite('Stopwatch', function() {
         this.clock.tick(oneHour);
       });
 
+      test('deep copy', function() {
+        this.sw.pause();
+        var serialized = this.sw.toSerializable();
+        serialized.laps.push({ duration: 23, time: 0 });
+        assert.deepEqual(this.sw.getLapDurations(), []);
+      });
+
       test('elapse 1hr', function() {
-        var obj1 = {
+        var expected = {
           startTime: d,
           totalElapsed: 0,
           isStarted: true,
           laps: []
         };
-        var obj2 = this.sw.toSerializable();
-        assert.deepEqual(obj1, obj2);
+        var actual = this.sw.toSerializable();
+        assert.deepEqual(expected, actual);
       });
 
       test('elapse 1hr and pause', function() {
         this.sw.pause();
-        var obj1 = {
+        var expected = {
           startTime: d,
           totalElapsed: oneHour,
           isStarted: false,
           laps: []
         };
-        var obj2 = this.sw.toSerializable();
-        assert.deepEqual(obj1, obj2);
+        var actual = this.sw.toSerializable();
+        assert.deepEqual(expected, actual);
       });
 
       test('elapse 1hr and lap', function() {
         this.sw.lap();
-        var obj1 = {
+        var expected = {
           startTime: d,
           totalElapsed: 0,
           isStarted: true,
           laps: [{time: Date.now(), duration: oneHour}]
         };
-        var obj2 = this.sw.toSerializable();
-        assert.deepEqual(obj1, obj2);
+        var actual = this.sw.toSerializable();
+        assert.deepEqual(expected, actual);
       });
 
       test('pause and reset', function() {
         this.sw.pause();
         this.clock.tick(oneHour);
         this.sw.reset();
-        var obj1 = {
+        var expected = {
           startTime: 0,
           totalElapsed: 0,
           isStarted: false,
           laps: []
         };
-        var obj2 = this.sw.toSerializable();
-        assert.deepEqual(obj1, obj2);
+        var actual = this.sw.toSerializable();
+        assert.deepEqual(expected, actual);
       });
 
       test('pause and resume', function() {
         this.sw.pause();
         this.clock.tick(oneHour);
         this.sw.start();
-        var obj1 = {
+        var expected = {
           startTime: Date.now(),
           totalElapsed: oneHour,
           isStarted: true,
           laps: []
         };
-        var obj2 = this.sw.toSerializable();
-        assert.deepEqual(obj1, obj2);
+        var actual = this.sw.toSerializable();
+        assert.deepEqual(expected, actual);
       });
 
     });

--- a/apps/clock/test/unit/stopwatch_test.js
+++ b/apps/clock/test/unit/stopwatch_test.js
@@ -4,6 +4,7 @@ requireApp('clock/js/utils.js');
 suite('Stopwatch', function() {
 
   var oneHour = 1 * 60 * 60 * 1000;
+  var d;
 
   suiteSetup(function() {
     this.sw = new Stopwatch();
@@ -16,6 +17,27 @@ suite('Stopwatch', function() {
   teardown(function() {
     this.clock.restore();
     this.sw.reset();
+  });
+
+  suite('constructor', function() {
+
+    test('defaults', function() {
+      assert.isFalse(this.sw.isStarted());
+      assert.equal(this.sw.getElapsedTime().getTime(), 0);
+      assert.deepEqual(this.sw.getLapDurations(), []);
+    });
+
+    test('from object', function() {
+      var obj = {
+        startTime: Date.now(),
+        totalElapsed: oneHour,
+        isStarted: true,
+        laps: [{time: Date.now(), duration: oneHour}]
+      };
+      this.sw = new Stopwatch(obj);
+      assert.deepEqual(obj, this.sw.toSerializable());
+    });
+
   });
 
   suite('isStarted', function() {
@@ -166,6 +188,94 @@ suite('Stopwatch', function() {
     test('elapse 1hr & reset', function() {
       this.sw.reset();
       assert.equal(this.sw.getElapsedTime().getTime(), 0);
+    });
+
+  });
+
+  suite('toSerializable', function() {
+
+    test('default', function() {
+      var obj1 = {
+        startTime: 0,
+        totalElapsed: 0,
+        isStarted: false,
+        laps: []
+      };
+      var obj2 = this.sw.toSerializable();
+      assert.deepEqual(obj1, obj2);
+    });
+
+    suite('started', function() {
+
+      setup(function() {
+        d = Date.now();
+        this.sw.start();
+        this.clock.tick(oneHour);
+      });
+
+      test('elapse 1hr', function() {
+        var obj1 = {
+          startTime: d,
+          totalElapsed: 0,
+          isStarted: true,
+          laps: []
+        };
+        var obj2 = this.sw.toSerializable();
+        assert.deepEqual(obj1, obj2);
+      });
+
+      test('elapse 1hr and pause', function() {
+        this.sw.pause();
+        var obj1 = {
+          startTime: d,
+          totalElapsed: oneHour,
+          isStarted: false,
+          laps: []
+        };
+        var obj2 = this.sw.toSerializable();
+        assert.deepEqual(obj1, obj2);
+      });
+
+      test('elapse 1hr and lap', function() {
+        this.sw.lap();
+        var obj1 = {
+          startTime: d,
+          totalElapsed: 0,
+          isStarted: true,
+          laps: [{time: Date.now(), duration: oneHour}]
+        };
+        var obj2 = this.sw.toSerializable();
+        assert.deepEqual(obj1, obj2);
+      });
+
+      test('pause and reset', function() {
+        this.sw.pause();
+        this.clock.tick(oneHour);
+        this.sw.reset();
+        var obj1 = {
+          startTime: 0,
+          totalElapsed: 0,
+          isStarted: false,
+          laps: []
+        };
+        var obj2 = this.sw.toSerializable();
+        assert.deepEqual(obj1, obj2);
+      });
+
+      test('pause and resume', function() {
+        this.sw.pause();
+        this.clock.tick(oneHour);
+        this.sw.start();
+        var obj1 = {
+          startTime: Date.now(),
+          totalElapsed: oneHour,
+          isStarted: true,
+          laps: []
+        };
+        var obj2 = this.sw.toSerializable();
+        assert.deepEqual(obj1, obj2);
+      });
+
     });
 
   });


### PR DESCRIPTION
- Stopwatch
  - constructor takes options object now to override any default fields
  - toSerializable serializes the four internal fields into an object
- Tests
  - constructor works with defaults or from options
  - toSerializable returns the proper object based on different stopwatch states
