### PR TITLE
Bug 910713 - Global key isnt hidden if there is only one layout

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -709,7 +709,8 @@ function modifyLayout(keyboardName) {
     }
 
     // switch languages button
-    if (!layout['hidesSwitchKey']) {
+    var supportsSwitching = navigator.mozInputMethod.mgmt.supportsSwitching();
+    if (!layout['hidesSwitchKey'] && supportsSwitching) {
       space.ratio -= 1.5;
       row.splice(c, 0, {
         value: '&#x1f310;',


### PR DESCRIPTION
Fix for [#910713](https://bugzilla.mozilla.org/show_bug.cgi?id=910713)
