### PR TITLE
Bug 916055 - [FDN] the PIN2 dialog box always says “Disable FDN”, never “Enable FDN”

### DIFF
--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -330,6 +330,7 @@ function SimPinDialog(dialog) {
         lockType = 'pin2';
         setInputMode('pin');
         _localize(dialogTitle, 'fdnEnable');
+        break;
       case 'disable_fdn':
         lockType = 'pin2';
         setInputMode('pin');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=916055
