### PR TITLE
Bug 914317 -  [B2G] [Bluetooth] "Unable to Pair" message has placeholder text. 

### DIFF
--- a/apps/system/js/modal_dialog.js
+++ b/apps/system/js/modal_dialog.js
@@ -202,6 +202,12 @@ var ModalDialog = {
       message = escapeHTML(message);
     }
 
+    // XXX: Bug 916658 - Remove unused l10n resources from b2g gecko
+    // If we have removed translations from Gecko, then we can remove this.
+    if (target.dataset.frameType === 'window') {
+      title = '';
+    }
+
     switch (type) {
       case 'alert':
         elements.alertMessage.innerHTML = message;


### PR DESCRIPTION
- check frameType before assigning title to modal-dialog
