### PR TITLE
Bug 916850: Fix 'metadata_block_picture' in OGG meta-data parser

### DIFF
--- a/apps/music/js/metadata.js
+++ b/apps/music/js/metadata.js
@@ -487,7 +487,15 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
       // we've seen in the file separately.
       var seen_fields = {};
       for (var i = 0; i < num_comments; i++) {
+        if (page.remaining() < 4) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment_length = page.readUnsignedInt(true);
+        if (comment_length > page.remaining()) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment = page.readUTF8Text(comment_length);
         var equal = comment.indexOf('=');
         if (equal !== -1) {

--- a/shared/js/blobview.js
+++ b/shared/js/blobview.js
@@ -8,7 +8,7 @@ var BlobView = (function() {
   // This constructor is for internal use only.
   // Use the BlobView.get() factory function or the getMore instance method
   // to obtain a BlobView object.
-  function BlobView(blob, sliceOffset, sliceLength, slice, 
+  function BlobView(blob, sliceOffset, sliceLength, slice,
                     viewOffset, viewLength, littleEndian)
   {
     this.blob = blob;                  // The parent blob that the data is from
@@ -167,6 +167,9 @@ var BlobView = (function() {
     // Methods to get and set the current position
     tell: function() {
       return this.index;
+    },
+    remaining: function() {
+      return this.byteLength - this.index;
     },
     seek: function(index) {
       if (index < 0)

--- a/test_apps/music2/js/metadata.js
+++ b/test_apps/music2/js/metadata.js
@@ -471,7 +471,15 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
 
       var num_comments = page.readUnsignedInt(true);
       for (var i = 0; i < num_comments; i++) {
+        if (page.remaining() < 4) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment_length = page.readUnsignedInt(true);
+        if (comment_length > page.remaining()) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment = page.readUTF8Text(comment_length);
         var equal = comment.indexOf('=');
         if (equal !== -1) {

--- a/test_apps/music2/js/metadata_scripts.js
+++ b/test_apps/music2/js/metadata_scripts.js
@@ -8,7 +8,7 @@ var BlobView = (function() {
   // This constructor is for internal use only.
   // Use the BlobView.get() factory function or the getMore instance method
   // to obtain a BlobView object.
-  function BlobView(blob, sliceOffset, sliceLength, slice, 
+  function BlobView(blob, sliceOffset, sliceLength, slice,
                     viewOffset, viewLength, littleEndian)
   {
     this.blob = blob;                  // The parent blob that the data is from
@@ -167,6 +167,9 @@ var BlobView = (function() {
     // Methods to get and set the current position
     tell: function() {
       return this.index;
+    },
+    remaining: function() {
+      return this.byteLength - this.index;
     },
     seek: function(index) {
       if (index < 0)
@@ -888,7 +891,15 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
 
       var num_comments = page.readUnsignedInt(true);
       for (var i = 0; i < num_comments; i++) {
+        if (page.remaining() < 4) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment_length = page.readUnsignedInt(true);
+        if (comment_length > page.remaining()) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment = page.readUTF8Text(comment_length);
         var equal = comment.indexOf('=');
         if (equal !== -1) {


### PR DESCRIPTION
When encountering incorrect meta data of type 'metadata_block_picture',
the OGG meta-data parser throws an exception and the Music app does
not list the audio file.

This patch changes the parser to only inspect the values of the meta-
data fields that it is interested in. All other values will be skipped.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
