### PR TITLE
Bug 885713 - propose a "make hint" that would use jshint instead of gjsl...

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,17 @@
+apps/homescreen/everything.me/**
+apps/pdfjs/content/**
+apps/pdfjs/test/**
+apps/email/build/**
+apps/email/built/**
+apps/email/js/ext/**
+apps/calendar/js/ext/**
+build/r.js
+apps/communications/contacts/oauth2/js/parameters.js
+apps/calendar/js/presets.js
+apps/email/js/alameda.js
+apps/email/js/tmpl_builder.js
+shared/js/opensearch.js
+apps/keyboard/js/imes/jspinyin/libpinyin.js
+shared/js/setImmediate.js
+apps/gallery/test/unit/setImmediate_test.js
+

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,43 @@
+{
+  "camelcase": false,
+  "curly": true,
+  "forin": false,
+  "immed": true,
+  "latedef": "nofunc",
+  "newcap": true,
+  "noarg": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": "vars",
+  "strict": true,
+  "trailing": true,
+  "maxlen": 80,
+
+  "eqnull": true,
+  "esnext": true,
+  "expr": true,
+  "globalstrict": true,
+
+  "maxerr": 1000,
+  "regexdash": true,
+  "laxcomma": true,
+  "proto": true,
+
+  "browser": true,
+  "devel": true,
+  "nonstandard": true,
+  "worker": true,
+  "predef": [
+    "suite",
+    "test",
+    "setup",
+    "teardown",
+    "suiteSetup",
+    "suiteTeardown",
+    "assert",
+    "require",
+    "requireApp",
+    "sinon"
+  ]
+}

--- a/build/lint-excluded-dirs.list
+++ b/build/lint-excluded-dirs.list
@@ -1,1 +1,0 @@
-homescreen/everything.me,pdfjs/content,pdfjs/test,email/build,email/built,email/js/ext,calendar/js/ext,tools/,b2g/

--- a/build/lint-excluded-files.list
+++ b/build/lint-excluded-files.list
@@ -1,1 +1,0 @@
-build/r.js,apps/communications/contacts/oauth2/js/parameters.js,apps/calendar/js/presets.js,apps/email/js/alameda.js,apps/email/js/tmpl_builder.js,shared/js/opensearch.js,apps/keyboard/js/imes/jspinyin/libpinyin.js,shared/js/setImmediate.js,apps/gallery/test/unit/setImmediate_test.js

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "debug": "*",
     "empty-port": "~0.0.1",
+    "jshint": "2.1.10",
     "mail-fakeservers": "~0.0.3",
     "marionette-apps": "0.3.0",
     "marionette-client": "0.15.5",

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -2,13 +2,13 @@
 
 LINTED_DIRECTORIES="apps shared"
 
-excluded_dirs_list="./build/lint-excluded-dirs.list"
-if [ ! -f $excluded_dirs_list ];
+excluded_list=".jshintignore"
+if [ ! -f $excluded_list ];
 then
   exit 0
 fi
 
-hash gjslint &> /dev/null
+hash gjslint > /dev/null 2>&1
 if [ $? -eq 1 ];
 then
   echo >&2 "You should install gjslint to lint your patch"
@@ -16,13 +16,11 @@ then
   exit 0
 fi
 
-excluded_dirs=`cat $excluded_dirs_list|tr "," " "`
-for dir in $excluded_dirs; do
-  grep_exclude="$grep_exclude -e $dir"
-done
+# LINTED_FILES needs to be space-separated
+diff_with_exclude=`git diff --staged --name-only --diff-filter=ACMRT -- $LINTED_DIRECTORIES | grep '\.js$' | tr '[:space:]' ' '`
+if [ -z "$diff_with_exclude" ] ; then
+  exit 0
+fi
 
-diff_with_exclude=`git diff --staged --name-only --diff-filter=ACMRT -- ${LINTED_DIRECTORIES} | grep -v $grep_exclude`
+LINTED_FILES="$diff_with_exclude" make -s lint
 
-# --disable 210,217,220,225 replaces --nojsdoc because it's broken in closure-linter 2.3.10
-# http://code.google.com/p/closure-linter/issues/detail?id=64
-gjslint --disable 210,217,220,225 -x "`cat ./build/lint-excluded-files.list`" $diff_with_exclude


### PR DESCRIPTION
...int

This adds
- a default .jshintrc configuration file
- a `make hint` launcher
- a way to launch the linters (including the old lint linter) for a specific app
  only.
- you can also use another jshint configuration file
