### PR TITLE
Bug 916772 - Importing objects from project folder while running gaiatests results in a import error

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/runtests.py
+++ b/tests/python/gaia-ui-tests/gaiatest/runtests.py
@@ -174,6 +174,11 @@ class GaiaTestRunner(MarionetteTestRunner):
         self.test_handlers.extend([GaiaTestCase])
 
     def run_tests(self, tests):
+        # add tests source dir and previous dir to python path
+        tests_dir = os.path.abspath(tests[0])
+        sys.path.append(tests_dir)
+        sys.path.append(os.path.split(tests_dir)[0])
+
         MarionetteTestRunner.run_tests(self, tests)
 
         if self.html_output:


### PR DESCRIPTION
add the current (tests) dir and the previous one (test project root) to sys.path
