### PR TITLE
Bug 916956 - Sinon sandbox not available in suiteSetup

### DIFF
--- a/test_apps/test-agent/common/test/sinon_helper.js
+++ b/test_apps/test-agent/common/test/sinon_helper.js
@@ -1,5 +1,10 @@
 // load sinon.js
 window.requireCommon('vendor/sinon/sinon.js', function() {
+  var suiteSandbox;
+  suiteSetup(function() {
+    this.sinon = suiteSandbox = sinon.sandbox.create();
+  });
+
   setup(function() {
     this.sinon = sinon.sandbox.create();
   });
@@ -7,5 +12,9 @@ window.requireCommon('vendor/sinon/sinon.js', function() {
   teardown(function() {
     this.sinon.restore();
     this.sinon = null;
+  });
+
+  suiteTeardown(function() {
+    suiteSandbox.restore();
   });
 });


### PR DESCRIPTION
I've named the suite's sandbox `suiteSandbox`. It might make sense to _also_ define it as `this.sinon` because (although not as accurate) it will make usage of the sandbox identical from within `suiteSetup`s, `setup`s, and `test`s. I'm not sure if that could cause confusion, though: code that assumes `this.sinon` refers to the same object in `suiteSetup` and `setup` functions will not work. Will this detail actually matter?
