### PR TITLE
Bug 837251 - Compose textarea doesn't occupy available screen space or show bounding box (leading to users thinking messages are truncated).

### DIFF
--- a/apps/email/js/cards/compose.html
+++ b/apps/email/js/cards/compose.html
@@ -64,7 +64,7 @@
       <ul class="cmp-attachment-container">
       </ul>
     </div>
-    <textarea class="cmp-body-text" rows="1"></textarea>
+    <textarea class="cmp-body-text"></textarea>
     <div class="cmp-body-html">
     </div>
   </div>

--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -435,17 +435,7 @@ ComposeCard.prototype = {
    * Make our textarea grow as new lines are added...
    */
   onTextBodyDelta: function() {
-    var value = this.textBodyNode.value, newlines = 0, idx = -1;
-    while (true) {
-      idx = value.indexOf('\n', idx + 1);
-      if (idx === -1)
-        break;
-      newlines++;
-    }
-    // the last line won't have a newline
-    var neededRows = newlines + 1;
-    if (this.textBodyNode.rows !== neededRows)
-      this.textBodyNode.rows = neededRows;
+    this.textBodyNode.style.height = this.textBodyNode.scrollHeight + 'px';
   },
 
   insertAttachments: function() {

--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -97,9 +97,9 @@ input.cmp-subject-text {
   -moz-box-sizing: border-box;
   width: calc(100% - 4rem);
   min-height: 10rem;
+  max-height: none !important;
   margin: 1rem 1.5rem;
   display: block;
-  overflow: hidden;
   padding: 0rem;
   font-size: 1.7rem;
   line-height: 1.9rem;


### PR DESCRIPTION
This is just a rebased version of asuth's https://github.com/mozilla-b2g/gaia/pull/8051.
