### PR TITLE
Bug 917689 - LockScreen won't slide on B2G desktop and Firefox nightly

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -507,6 +507,7 @@ var LockScreen = {
   handleSlideBegin: function() {
     this.lightIcons();
     this.restoreSlider();
+    this._sliderPulling = true;
   },
 
   handleSlide: function() {
@@ -522,6 +523,7 @@ var LockScreen = {
     // Drag from left to right or counter-direction.
     if ('' !== this._slidingToward && dir !== this._slidingToward) {
       this.restoreSlider();
+      this._sliderPulling = true;
     }
     this._slidingToward = dir;
 
@@ -589,6 +591,8 @@ var LockScreen = {
       this.sliderCenter.classList.add('touched');
       this.sliderRight.classList.add('touched');
     }
+    this.darkIcon();
+    this._slideCount = 0;
   },
 
   // Restore all slider elements.
@@ -628,7 +632,7 @@ var LockScreen = {
         h.style.transform = '';
     });
 
-    this._sliderPulling = true;
+    this._sliderPulling = false;
     this._sliderReachEnd = false;
   },
 


### PR DESCRIPTION
The flag will be set at wrong time.
