### PR TITLE
Bug 916100 - [Contacts] Taapping on the disabled merge button when there are not contacts selected to be merged make it to change its colour (r=jmcanterafonseca)

### DIFF
--- a/apps/communications/contacts/style/matching_contacts.css
+++ b/apps/communications/contacts/style/matching_contacts.css
@@ -72,10 +72,6 @@ li[aria-disabled="true"] p.match-main-reason {
   background: #e8e8e8;
 }
 
-#footer button {
-  pointer-events: auto;
-}
-
 /*
   Confirmation message with detailed information
   This is a mixed customization between confirm.css and value_selector.css from shared


### PR DESCRIPTION
Hard to catch but straight-forward to solve. The matching_contacts.css was imposing the |pointer-events: auto| on the footer merge button.
