### PR TITLE
Bug 910170 - [CONTACTS] The export button isn't disabled when no contact is selected (r=jmcanterafonseca).

### DIFF
--- a/apps/communications/contacts/js/views/list.js
+++ b/apps/communications/contacts/js/views/list.js
@@ -1494,6 +1494,7 @@ contacts.List = (function() {
   var exitSelectMode = function exitSelectMode(canceling) {
     inSelectMode = false;
     selectAllChecked = false;
+    currentlySelected = 0;
     selectNavigationController.back();
 
     // Hide and show buttons
@@ -1507,6 +1508,7 @@ contacts.List = (function() {
       button.classList.remove('hide');
     });
 
+    selectActionButton.disabled = true;
     selectActionButton.classList.add('hide');
 
     // Clean the checks


### PR DESCRIPTION
Reseting values when exiting the selection mode.
