### PR TITLE
Bug 916100 - [Contacts] Taapping on the disabled merge button when there are not contacts selected to be merged make it to change its colour (r=jmcanterafonseca)

### DIFF
--- a/apps/communications/contacts/style/matching_contacts.css
+++ b/apps/communications/contacts/style/matching_contacts.css
@@ -72,6 +72,10 @@ li[aria-disabled="true"] p.match-main-reason {
   background: #e8e8e8;
 }
 
+#footer button:not([disabled]) {
+  pointer-events: auto;
+}
+
 /*
   Confirmation message with detailed information
   This is a mixed customization between confirm.css and value_selector.css from shared


### PR DESCRIPTION
The UI of the matching contacts screen is kind of weird regarding the use of the pointer-events property since not setting to none at a #footer level makes the whole screen disabled regarding tapping events.

The solution provided is based on what we initially had but solving the flicking effect reported in this bug.
