### PR TITLE
Bug 918755 - Enable 3 camera tests gaia-ui-tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/camera/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/camera/manifest.ini
@@ -5,13 +5,7 @@ sdcard = true
 
 [test_camera_capture_photo.py]
 skip-if = device == "desktop"
-# Bug 913418 - Opening image from film strip results in black screen
-xfail = true
 [test_camera_capture_video.py]
 skip-if = device == "desktop"
-# Bug 912957 - Film strip not visible after taking a video
-xfail = true
 [test_camera_multiple_shots.py]
 skip-if = device == "desktop"
-# Bug 913418 - Opening image from film strip results in black screen
-xfail = true


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=918755
