### PR TITLE
Bug 918762 - Un xfail test dialer airplane mode

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
@@ -4,8 +4,6 @@ carrier = true
 
 [test_dialer_airplane_mode.py]
 skip-if = device == "desktop"
-# Bug 904625 - Wrong error message displayed when making a call in airplane mode
-xfail = true
 [test_dialer.py]
 skip-if = device == "desktop"
 xfail = true


### PR DESCRIPTION
unxfail Bug 904625 - Wrong error message displayed when making a call in airplane mode
