### PR TITLE
Bug 919006 -  Email fails to start properly (xhr needs responseType text)

### DIFF
--- a/apps/email/js/text.js
+++ b/apps/email/js/text.js
@@ -18,6 +18,7 @@ define({
         }
       }
     };
+    xhr.responseType = 'text';
     xhr.send(null);
   }
 });


### PR DESCRIPTION
Apparently latest mozcentral gecko is more strict about responseType. This change should have been done in the email app a while ago anyway.
