### PR TITLE
Bug 895480 - Bluetooth app tries to handle Share URL activity and fails

### DIFF
--- a/apps/bluetooth/manifest.webapp
+++ b/apps/bluetooth/manifest.webapp
@@ -21,6 +21,10 @@
   "orientation": "portrait-primary",
   "activities": {
     "share": {
+      "filters": {
+        "type": ["image/*", "audio/*", "video/*", "text/vcard"],
+        "blobs": { "required":true }
+       },
       "disposition": "inline",
       "returnValue": true,
       "href": "/transfer.html"


### PR DESCRIPTION
Add correct filter type and blobs for share activity of Bluetooth File Transfer app.
