### PR TITLE
Bug 919507 - Disable test_browser_search

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -12,6 +12,8 @@ lan = false
 lan = true
 [test_browser_tabs.py]
 [test_browser_search.py]
+# Bug 919515 - [Browser] Searching for words in the URL bar is not giving a search results
+xfail = true
 [test_browser_navigation.py]
 [test_browser_bookmark.py]
 [test_browser_play_youtube_video.py]


### PR DESCRIPTION
Bug 919515 - [Browser] Searching for words in the URL bar is not giving a search results
