### PR TITLE
Bug 916917 - [B2G][Buri][Settings] Keyboard menu name in Settings app ap... r=crh0716

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -365,7 +365,7 @@
           </li>
           <li>
             <small id="keyboard-desc" class="menu-item-desc"></small>
-            <a id="menuItem-keyboard" class="menu-item" href="#keyboard" data-l10n-id="keyboard">Keyboard</a>
+            <a id="menuItem-keyboard" class="menu-item" href="#keyboard" data-l10n-id="keyboards">Keyboards</a>
           </li>
         </ul>
 


### PR DESCRIPTION
...pears to be displayed in Chinese when the device language is set to English
