### PR TITLE
Bug 904345 - Handle the case of the 'ready' state r=kaze

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -78,7 +78,8 @@ var Connectivity = (function(window, document, undefined) {
       'corporateLocked' : 'simLockedPhone',
       'unknown' : 'unknownSimCardState',
       'absent' : 'noSimCard',
-      'null' : 'simCardNotReady'
+      'null' : 'simCardNotReady',
+      'ready': ''
     };
 
     updateCarrier();

--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -1117,7 +1117,14 @@
 
   // localize an element as soon as mozL10n is ready
   function localizeElement(element, id, args) {
-    if (!element || !id) {
+    if (!element) {
+      return;
+    }
+
+    if (!id) {
+      element.removeAttribute('data-l10n-id');
+      element.removeAttribute('data-l10n-args');
+      setTextContent(element, '');
       return;
     }
 


### PR DESCRIPTION
1. Add a case for the 'ready' state.
2. Clear the text content and l10n data if l10nId is empty.

https://bugzilla.mozilla.org/show_bug.cgi?id=904345
