### PR TITLE
Bug 920039 - Check if app has manifest in keyboard_helper

### DIFF
--- a/shared/js/keyboard_helper.js
+++ b/shared/js/keyboard_helper.js
@@ -148,7 +148,7 @@ var KeyboardHelper = {
       apps.forEach(function eachApp(app) {
         // keyboard apps will set role as 'keyboard'
         // https://wiki.mozilla.org/WebAPI/KeboardIME#Proposed_Manifest_of_a_3rd-Party_IME
-        if ('keyboard' !== app.manifest.role) {
+        if (!app.manifest || 'keyboard' !== app.manifest.role) {
           return;
         }
         //XXX remove this hard code check if one day system app no longer


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=920039.

Bluetooth doesn't have manifest in FF nightly, so put a safeguard here.
