### PR TITLE
Bug 902124 - Makefile should configure gaia-marionette

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ BUILD_APP_NAME=$(APP)
 endif
 
 REPORTER?=Spec
+MOCHA_REPORTER?=dot
+NPM_REGISTRY?=http://registry.npmjs.org
 
 GAIA_INSTALL_PARENT?=/data/local
 ADB_REMOUNT?=0
@@ -594,7 +596,7 @@ ifndef APPS
 endif
 
 node_modules:
-	npm install
+	npm install --registry $(NPM_REGISTRY)
 
 b2g: node_modules
 	./node_modules/.bin/mozilla-download --verbose --product b2g $@
@@ -603,7 +605,8 @@ b2g: node_modules
 test-integration:
 	# override existing profile-test folder.
 	PROFILE_FOLDER=profile-test make
-	./bin/gaia-marionette $(shell find . -path "*test/marionette/*_test.js")
+	NPM_REGISTRY=$(NPM_REGISTRY) ./bin/gaia-marionette $(shell find . -path "*test/marionette/*_test.js") \
+		--reporter $(MOCHA_REPORTER)
 
 .PHONY: test-perf
 test-perf:

--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -12,7 +12,10 @@ SHARED=$DIR/../shared/test/integration
 make -C $DIR/../ b2g
 
 # make sure node_modules are 100% up to date
-`cd $DIR && npm install`
+if [ ! -z "$NPM_REGISTRY" ]; then
+  NPM_REGISTRY="http://registry.npmjs.org"
+fi
+`cd $DIR && npm install --registry $NPM_REGISTRY`
 
 # tests can timeout without the profile-test folder so build it here.
 if [ ! -d $DIR/../profile-test ]; then

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "marionette-profile-builder": "0.0.2",
     "marionette-js-runner": "0.3.0",
     "mocha": "1.12.0",
+    "mocha-tbpl-reporter": "~0.0.4",
     "mozilla-download": "~0.2.1",
     "node-static": "0.6.9",
     "travis-project-jobs": "0.0.1"


### PR DESCRIPTION
Allow |make test-integration| to send down configuration for mocha reporter and npm registry.

r=lightsofapollo a=test-only
