### PR TITLE
Bug 920357 - cancel edit mode by clicking non-icon area

### DIFF
--- a/apps/homescreen/js/homescreen.js
+++ b/apps/homescreen/js/homescreen.js
@@ -72,6 +72,9 @@ var Homescreen = (function() {
       var manager = target.parentNode === DockManager.page.olist ? DockManager :
                                                                    GridManager;
       manager.contextmenu(evt);
+      if (Homescreen.isInEditMode()) {
+        document.body.addEventListener('click', onClickHandler);
+      }
     } else if (!Homescreen.isInEditMode()) {
       // No long press over an icon neither edit mode
       LazyLoader.load('js/wallpaper.js', function callWallpaper() {
@@ -79,8 +82,16 @@ var Homescreen = (function() {
       });
     }
   }
+  // dismiss edit mode by tapping in an area of the view where there is no icon
+  function onClickHandler(evt) {
+    if (!('isIcon' in evt.target.dataset)) {
+      exitFromEditMode();
+    }
+  }
 
   function exitFromEditMode() {
+    document.body.removeEventListener('click', onClickHandler);
+
     Homescreen.setMode('normal');
     GridManager.exitFromEditMode();
     if (typeof ConfirmDialog !== 'undefined') {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=920357
Add the ability to dismiss app grid edit mode by tapping in an area of the view where there is no icon
