### PR TITLE
Bug 916010 - [Contacts] Follow up for visual polish of bug 902399

### DIFF
--- a/apps/communications/contacts/matching_contacts.html
+++ b/apps/communications/contacts/matching_contacts.html
@@ -81,14 +81,18 @@
         </ul>
     -->
     <form id="matching-details" class="hide" role="dialog" data-type="confirm">
-      <img src="">
-      <h1></h1>
       <section class="matched-info">
+        <h1></h1>
+        <p class="no-border">
+          <img src="">
+          <strong> &nbsp; </strong>
+          <small> &nbsp; </small>
+        </p>
         <ul id="matching-list">
         </ul>
       </section>
       <menu>
-        <button type="button" class="full" data-l10n-id="ok">Ok</button>
+        <button class="full" data-l10n-id="ok">Ok</button>
       </menu>
     </form>
   </body>

--- a/apps/communications/contacts/style/matching_contacts.css
+++ b/apps/communications/contacts/style/matching_contacts.css
@@ -77,59 +77,35 @@ li[aria-disabled="true"] p.match-main-reason {
 }
 
 /*
-  Confirmation message with detailed information
-  This is a mixed customization between confirm.css and value_selector.css from shared
+  Confirmation message with detailed information.
  */
-#matching-details {
-  padding-top: 0;
-}
-
-#matching-details:before { /* Removes vertical-alignment */
-  display: none;
-}
-
-#matching-details h1 { /* Same header as shared/style_unstable/value_selectors.css */
-  font-weight: 400;
-  font-size: 1.9rem;
-  line-height: 4.8rem;
-  color: #fff;
-  border-bottom: 0.1rem solid #616262;
-  background: rgba(0 ,0, 0, .2);
-  margin: 0 -1.5rem;
-  padding: 0 3rem 1rem 4.5rem;
-  height: 4.8rem;
-  -moz-box-sizing: border-box;
+#matching-details .matched-info {
+  overflow-y: auto;
+  max-height: calc(100% - 7.8rem)
 }
 
 #matching-details img {
-  float: right;
   background: transparent no-repeat center / cover;
-  width: 4.8rem;
-  height: 4.8rem;
-  font-size: 0;
+  width: 5.5rem;
+  height: 5.5rem;
 }
 
-#matching-details .matched-info {
-  padding: 3rem 3rem 0;
-  -moz-box-sizing: border-box;
-  overflow-y: auto;
-  max-height: calc(100% - 4.8rem);
+#matching-details p.no-border {
+  border: 0;
 }
 
-#matching-details .matched-info li {
-  font-size: 1.4rem;
-  line-height: 1.8rem;
-  color: #fff;
-  margin-bottom: 1.8rem;
-}
-
-#matching-details .matched-info li[aria-selected] {
+#matching-details [aria-selected] {
   color: #0EB0D0;
 }
 
-#matching-details .matched-info p {
-  border: none;
-  margin: 0;
-  padding: 0;
-  line-height: inherit;
+#matching-list {
+  word-wrap: break-word;
+  padding: 1rem 1.5rem;
+  border-top: 0.1rem solid #686868;
+  line-height: 3rem;
+  font-size: 1.7rem;
+}
+
+#matching-list span {
+  display: block;
 }


### PR DESCRIPTION
Update to include the new design and guidelines provided by UX regarding the duplicate contact details information screen.

We have kindly asked @rnowm to update the confirm with content BB (http://buildingfirefoxos.com/building-blocks/confirm.html) to properly manage the absence of <img> and/or <small> elements in this BB. In case no <small> element is included, the <strong> element should vertically align with the image or the space reserved for it.
