### PR TITLE
Bug 920598 - Fix failing /camera/test_camera_capture_video.py on master

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/camera/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/camera/app.py
@@ -57,7 +57,7 @@ class Camera(Base):
         self.wait_for_element_not_displayed(*self._video_timer_locator)
 
     def tap_capture(self):
-        self.wait_for_element_displayed(*self._capture_button_locator)
+        self.wait_for_camera_ready()
         self.marionette.find_element(*self._capture_button_locator).tap()
 
     def tap_select_button(self):


### PR DESCRIPTION
camera/test_camera_capture_video.py is failing on master.

The capture video button is disabled a few seconds and it needs a wait for it to be enabled.
