### PR TITLE
Bug 920037 - [Messages] In participant option menu, overlay display should only dislay unknown number/email once

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -2045,21 +2045,24 @@ var ThreadUI = global.ThreadUI = {
     var number = opts.number || '';
 
     Contacts.findByPhoneNumber(number, function(results) {
-      var ul = document.createElement('ul');
       var isContact = results && results.length;
       var contact = isContact ? results[0] : {
         tel: [{ value: number }]
       };
+      var ul;
 
-      ul.classList.add('contact-prompt');
+      if (isContact) {
+        ul = document.createElement('ul');
+        ul.classList.add('contact-prompt');
 
-      this.renderContact({
-        contact: contact,
-        input: number,
-        target: ul,
-        isContact: isContact,
-        isSuggestion: false
-      });
+        this.renderContact({
+          contact: contact,
+          input: number,
+          target: ul,
+          isContact: isContact,
+          isSuggestion: false
+        });
+      }
 
       this.prompt({
         name: name,
@@ -2124,6 +2127,8 @@ var ThreadUI = global.ThreadUI = {
     var name = opt.name || number || email;
     var isContact = opt.isContact || false;
     var inMessage = opt.inMessage || false;
+    var header = '';
+    var section = typeof opt.body !== 'undefined' ? opt.body : '';
     var items = [];
     var params, props;
 
@@ -2137,8 +2142,26 @@ var ThreadUI = global.ThreadUI = {
       return;
     }
 
+    // Create a params object.
+    //  - complete: callback to be invoked when a
+    //      button in the menu is pressed
+    //  - section: node to display above
+    //      the options in the option menu.
+    //  - header: string or node to display in the
+    //      in the header of the option menu
+    //  - items: array of options to display in menu
+    //
+    params = {
+      complete: complete,
+      section: section,
+      header: '',
+      items: null
+    };
+
     // All non-email activations will see a "Call" option
     if (email) {
+      header = email;
+
       items.push({
         l10nId: 'sendEmail',
         method: function oCall(param) {
@@ -2147,6 +2170,8 @@ var ThreadUI = global.ThreadUI = {
         params: [email]
       });
     } else {
+      header = number;
+
       items.push({
         l10nId: 'call',
         method: function oCall(param) {
@@ -2169,17 +2194,9 @@ var ThreadUI = global.ThreadUI = {
       }
     }
 
-
-    // Combine the items and complete callback into
-    // a single params object.
-    params = {
-      items: items,
-      complete: complete
-    };
-
-    // If this is a known contact, display an option menu
-    // with buttons for "Call" and "Cancel"
-    params.section = typeof opt.body !== 'undefined' ? opt.body : name;
+    // Define the initial header, items and section properties
+    params.header = header;
+    params.items = items;
 
     if (!isContact) {
 
@@ -2187,7 +2204,10 @@ var ThreadUI = global.ThreadUI = {
         number ? {tel: number} : {email: email}
       ];
 
-      params.header = number;
+      // Unknown participants will have options to
+      //  - Create A New Contact
+      //  - Add To An Existing Contact
+      //
       params.items.push({
           l10nId: 'createNewContact',
           method: function oCreate(param) {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -2635,7 +2635,10 @@ suite('thread_ui.js >', function() {
 
           // Ensures that the OptionMenu was given
           // the phone number to diplay
-          assert.equal(call.section, '999');
+          assert.equal(call.header, '999');
+
+          // Only known Contact details should appear in the "section"
+          assert.equal(call.section, '');
 
           assert.equal(items.length, 4);
 
@@ -2671,8 +2674,11 @@ suite('thread_ui.js >', function() {
           var items = call.items;
 
           // Ensures that the OptionMenu was given
-          // the phone number to diplay
-          assert.equal(call.section, 'a@b.com');
+          // the email address to diplay
+          assert.equal(call.header, 'a@b.com');
+
+          // Only known Contact details should appear in the "section"
+          assert.equal(call.section, '');
 
           assert.equal(items.length, 4);
 
@@ -2708,7 +2714,7 @@ suite('thread_ui.js >', function() {
 
           // Ensures that the OptionMenu was given
           // the phone number to diplay
-          assert.equal(call.section, '999');
+          assert.equal(call.header, '999');
 
           assert.equal(items.length, 3);
 
@@ -2742,7 +2748,7 @@ suite('thread_ui.js >', function() {
 
           // Ensures that the OptionMenu was given
           // the phone number to diplay
-          assert.equal(call.section, '999');
+          assert.equal(call.header, '999');
 
           assert.equal(items.length, 5);
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=920037
- Re-organize the assignment of OptionMenu params
- Only set params.section if the participant is an known contact participant
- Limit calls to renderContact for those participants that are known contacts
- Update tests
  - assert content of params.header value
  - assert that params.section is an empty string for unknown participants

Signed-off-by: Rick Waldron waldron.rick@gmail.com
