### PR TITLE
Bug 919567. Stopwatch and Timer Panels do not update from underlying dat...

### DIFF
--- a/apps/clock/js/stopwatch.js
+++ b/apps/clock/js/stopwatch.js
@@ -7,7 +7,7 @@
   function Defaults() {
     this.startTime = 0;
     this.totalElapsed = 0;
-    this.isStarted = false;
+    this.state = Stopwatch.RESET;
     this.laps = [];
   }
 
@@ -29,24 +29,28 @@
 
     obj.startTime = opts.startTime || defaults.startTime;
     obj.totalElapsed = opts.totalElapsed || defaults.totalElapsed;
-    obj.isStarted = opts.isStarted || defaults.isStarted;
+    obj.state = opts.state || defaults.state;
     obj.laps = opts.laps ? opts.laps.slice() : defaults.laps;
 
     priv.set(this, obj);
   };
 
+  Stopwatch.RUNNING = 'RUNNING';
+  Stopwatch.PAUSED = 'PAUSED';
+  Stopwatch.RESET = 'RESET';
+
   Stopwatch.prototype = {
 
     constructor: Stopwatch,
 
-    /**
-    * isStarted Returns the isStarted state
-    *
-    * @return {boolean} return isStarted state
-    */
-    isStarted: function sw_isStarted() {
+    getState: function() {
       var sw = priv.get(this);
-      return sw.isStarted;
+      return sw.state;
+    },
+
+    setState: function(state) {
+      var sw = priv.get(this);
+      sw.state = state;
     },
 
     /**
@@ -54,11 +58,11 @@
     */
     start: function sw_start() {
       var sw = priv.get(this);
-      if (sw.isStarted) {
+      if (sw.state === Stopwatch.RUNNING) {
         return;
       }
       sw.startTime = Date.now();
-      sw.isStarted = true;
+      this.setState(Stopwatch.RUNNING);
     },
 
     /**
@@ -69,11 +73,10 @@
     getElapsedTime: function sw_getElapsedTime() {
       var sw = priv.get(this);
       var elapsed = 0;
-      if (sw.isStarted) {
+      if (sw.state === Stopwatch.RUNNING) {
         elapsed = Date.now() - sw.startTime;
       }
       elapsed += sw.totalElapsed;
-
       return new Date(elapsed);
     },
 
@@ -82,12 +85,12 @@
     */
     pause: function sw_pause() {
       var sw = priv.get(this);
-      if (!sw.isStarted) {
+      if (sw.state === Stopwatch.PAUSED) {
         return;
       }
-      sw.isStarted = false;
       var elapsed = Date.now() - sw.startTime;
       sw.totalElapsed += elapsed;
+      this.setState(Stopwatch.PAUSED);
     },
 
     /**
@@ -97,7 +100,7 @@
     */
     lap: function sw_lap() {
       var sw = priv.get(this);
-      if (!sw.isStarted) {
+      if (sw.state !== Stopwatch.RUNNING) {
         return new Date(0);
       }
 

--- a/apps/clock/js/stopwatch_panel.js
+++ b/apps/clock/js/stopwatch_panel.js
@@ -65,41 +65,28 @@
 
   Stopwatch.Panel.prototype.showButtons = function() {
     Array.prototype.forEach.call(arguments, function(a) {
-      this.nodes[a].classList.remove('hide');
+      this.nodes[a].classList.remove('hidden');
     }, this);
   };
 
   Stopwatch.Panel.prototype.hideButtons = function() {
     Array.prototype.forEach.call(arguments, function(a) {
-      this.nodes[a].classList.add('hide');
+      this.nodes[a].classList.add('hidden');
     }, this);
   };
 
   Stopwatch.Panel.prototype.setState = function(state) {
     switch (state) {
       case Stopwatch.RUNNING:
-        this.interval = setInterval(this.update.bind(this), 50);
-        this.showButtons('pause', 'lap');
-        this.hideButtons('start', 'resume', 'reset');
+        this.onstart();
         break;
 
       case Stopwatch.PAUSED:
-        clearInterval(this.interval);
-        this.nodes.reset.removeAttribute('disabled');
-        this.showButtons('resume', 'reset');
-        this.hideButtons('pause', 'start', 'lap');
+        this.onpause();
         break;
 
       case Stopwatch.RESET:
-        clearInterval(this.interval);
-        this.showButtons('start', 'reset');
-        this.hideButtons('pause', 'resume', 'lap');
-        this.nodes.reset.setAttribute('disabled', 'true');
-        // clear lap list
-        var node = this.nodes.laps;
-        while (node.hasChildNodes()) {
-          node.removeChild(node.lastChild);
-        }
+        this.onreset();
         break;
     }
     this.update();
@@ -113,8 +100,8 @@
     this.setState(stopwatch.getState());
 
     //Clear any existing lap indicators and make new ones
-    var lapsUl = this.nodes['laps'];
-    lapsUl.innerHTML = '';
+    var lapsUl = this.nodes.laps;
+    lapsUl.textContent = '';
     var laps = stopwatch.getLapDurations();
     for (var i = 0; i < laps.length; i++) {
       this.onlap(new Date(laps[i]));
@@ -152,20 +139,25 @@
   };
 
   Stopwatch.Panel.prototype.onstart = function() {
-    this.setState(Stopwatch.RUNNING);
+    this.interval = setInterval(this.update.bind(this), 50);
+    this.showButtons('pause', 'lap');
+    this.hideButtons('start', 'resume', 'reset');
   };
 
   Stopwatch.Panel.prototype.onpause = function() {
-    this.setState(Stopwatch.PAUSED);
+    clearInterval(this.interval);
+    this.nodes.reset.removeAttribute('disabled');
+    this.showButtons('resume', 'reset');
+    this.hideButtons('pause', 'start', 'lap');
   };
 
   Stopwatch.Panel.prototype.onresume = function() {
-    this.setState(Stopwatch.RUNNING);
+    this.onstart();
   };
 
   Stopwatch.Panel.prototype.onlap = function(val) {
-    var node = this.nodes['laps'];
-    var num = node.childNodes.length + 1 + '';
+    var node = this.nodes.laps;
+    var num = node.childNodes.length + 1;
     if (num > 99) {
       return;
     }
@@ -173,7 +165,7 @@
     var li = document.createElement('li');
     li.setAttribute('class', 'lap-cell');
     var html = this.lapTemplate.interpolate({
-      num: num,
+      num: String(num),
       time: time
     });
     li.innerHTML = html;
@@ -181,7 +173,13 @@
   };
 
   Stopwatch.Panel.prototype.onreset = function() {
-    this.setState(Stopwatch.RESET);
+    clearInterval(this.interval);
+    this.showButtons('start', 'reset');
+    this.hideButtons('pause', 'resume', 'lap');
+    this.nodes.reset.setAttribute('disabled', 'true');
+    // clear lap list
+    var node = this.nodes.laps;
+    this.nodes.laps.textContent = '';
   };
 
 }(Stopwatch, Panel));

--- a/apps/clock/js/stopwatch_panel.js
+++ b/apps/clock/js/stopwatch_panel.js
@@ -110,12 +110,10 @@
 
   Stopwatch.Panel.prototype.onvisibilitychange = function(isVisible) {
     var stopwatch = priv.get(this).stopwatch;
-
-    if (isVisible) {
-      //Stopwatch is being shown
+    if (isVisible) {      
       this.setState(stopwatch.getState());
     } else {
-      // Stopwatch is being hidden. Clear the interval
+      // Clear the interval that updates the time display
       clearInterval(this.interval);
     }
   };
@@ -178,8 +176,8 @@
     this.hideButtons('pause', 'resume', 'lap');
     this.nodes.reset.setAttribute('disabled', 'true');
     // clear lap list
-    var node = this.nodes.laps;
     this.nodes.laps.textContent = '';
+    this.update();
   };
 
 }(Stopwatch, Panel));

--- a/apps/clock/js/stopwatch_panel.js
+++ b/apps/clock/js/stopwatch_panel.js
@@ -110,7 +110,7 @@
 
   Stopwatch.Panel.prototype.onvisibilitychange = function(isVisible) {
     var stopwatch = priv.get(this).stopwatch;
-    if (isVisible) {      
+    if (isVisible) {
       this.setState(stopwatch.getState());
     } else {
       // Clear the interval that updates the time display

--- a/apps/clock/js/timer_panel.js
+++ b/apps/clock/js/timer_panel.js
@@ -90,6 +90,7 @@ Timer.Panel.prototype.onvisibilitychange = function(isVisible) {
   var nodes = this.nodes;
   var dialog = View.instance(this.nodes.dialog);
   var timer = this.timer;
+  var isPaused = false;
 
   if (isVisible) {
     // No active timer, or timer has expired...
@@ -102,7 +103,8 @@ Timer.Panel.prototype.onvisibilitychange = function(isVisible) {
         timer.cancel();
       }
       this.dialog();
-    } else {
+    }
+    else {
 
       if (timer.state !== Timer.STARTED) {
         // Active timer exists...
@@ -110,11 +112,35 @@ Timer.Panel.prototype.onvisibilitychange = function(isVisible) {
         timer.on('end', this.dialog.bind(this));
 
         if (timer.state === Timer.REACTIVATING) {
+          // Reviving to started state,
+          // show the pause button, hide the start button
           this.toggle(nodes.pause, nodes.start);
-          timer.start();
         } else {
+          // Reviving to paused state,
+          // show the start button, hide the pause button
           this.toggle(nodes.start, nodes.pause);
+
+          isPaused = true;
         }
+
+        if (timer.state === Timer.INITIALIZED) {
+          this.dialog();
+          this.update();
+        } else {
+          // Calling start will "revive" and update
+          // both a paused and not-paused timers.
+          //  - Updates the endAt and resets the pauseAt
+          //  - Sync the object.
+          timer.start();
+
+          if (isPaused) {
+            // Immediately re-pause the timer.
+            timer.pause();
+          }
+          this.dialog({ isVisible: false });
+        }
+
+
       }
     }
   }

--- a/apps/clock/js/timer_panel.js
+++ b/apps/clock/js/timer_panel.js
@@ -103,8 +103,7 @@ Timer.Panel.prototype.onvisibilitychange = function(isVisible) {
         timer.cancel();
       }
       this.dialog();
-    }
-    else {
+    } else {
 
       if (timer.state !== Timer.STARTED) {
         // Active timer exists...
@@ -190,8 +189,8 @@ Timer.Panel.prototype.update = function(remaining = 0) {
  * @return {Object} Timer.Panel.
  */
 Timer.Panel.prototype.toggle = function(show, hide) {
-  show.classList.remove('hide');
-  hide.classList.add('hide');
+  show.classList.remove('hidden');
+  hide.classList.add('hidden');
   return this;
 };
 

--- a/apps/clock/test/unit/stopwatch_panel_test.js
+++ b/apps/clock/test/unit/stopwatch_panel_test.js
@@ -142,7 +142,7 @@ suite('Stopwatch.Panel', function() {
   test('Add laps', function() {
 
     function getLapInfo() {
-      var laps = panel.nodes['laps'].querySelectorAll('li');
+      var laps = panel.nodes.laps.querySelectorAll('li');
       laps = Array.prototype.slice.call(laps);
       return laps.map(function(e) {
         return {
@@ -175,11 +175,35 @@ suite('Stopwatch.Panel', function() {
     laps = getLapInfo();
     assert.equal(laps.length, 2);
 
-    assert.equal(laps[0].lapName, 'Lap 2');
-    assert.equal(laps[0].lapTime, '00:09');
+    assert.deepEqual(laps, [
+      { lapName: 'Lap 2', lapTime: '00:09' },
+      { lapName: 'Lap 1', lapTime: '00:03' }
+    ]);
 
-    assert.equal(laps[1].lapName, 'Lap 1');
-    assert.equal(laps[1].lapTime, '00:03');
+  });
+
+  test('Reset stopwatch', function() {
+    var laps;
+
+    panel.setStopwatch(runningSw());
+    assert.equal(panel.nodes.time.textContent, '00:00');
+
+    //Advance and click the lap button (twice)
+    clock.tick(3000);
+    panel.nodes.lap.click();
+    clock.tick(9000);
+    panel.nodes.lap.click();
+
+    laps = panel.nodes['laps'].querySelectorAll('li');
+    assert.equal(laps.length, 2);
+
+    //Reset
+    panel.nodes.pause.click();
+    panel.nodes.reset.click();
+    laps = panel.nodes['laps'].querySelectorAll('li');
+    assert.equal(laps.length, 0);
+    assert.equal(panel.nodes.time.textContent, '00:00');
+    
 
   });
 

--- a/apps/clock/test/unit/stopwatch_panel_test.js
+++ b/apps/clock/test/unit/stopwatch_panel_test.js
@@ -64,15 +64,7 @@ suite('Stopwatch.Panel', function() {
   });
 
   setup(function() {
-    clock = sinon.useFakeTimers();
-  });
-
-  teardown(function() {
-    clock.restore();
-  });
-
-  suiteTeardown(function() {
-
+    clock = this.sinon.useFakeTimers();
   });
 
   test('Default', function() {

--- a/apps/clock/test/unit/stopwatch_panel_test.js
+++ b/apps/clock/test/unit/stopwatch_panel_test.js
@@ -203,7 +203,7 @@ suite('Stopwatch.Panel', function() {
     laps = panel.nodes['laps'].querySelectorAll('li');
     assert.equal(laps.length, 0);
     assert.equal(panel.nodes.time.textContent, '00:00');
-    
+
 
   });
 

--- a/apps/clock/test/unit/stopwatch_panel_test.js
+++ b/apps/clock/test/unit/stopwatch_panel_test.js
@@ -1,0 +1,197 @@
+requireApp('clock/js/emitter.js');
+requireApp('clock/js/view.js');
+requireApp('clock/js/panel.js');
+requireApp('clock/js/utils.js');
+
+requireApp('clock/js/stopwatch.js');
+requireApp('clock/js/stopwatch_panel.js');
+
+suite('Stopwatch.Panel', function() {
+
+  var defaultSw, sevenMinSw, fourSecPausedSw, withLapsSw, runningSw;
+  var isHidden, isVisible;
+  var panel;
+  var clock;
+
+  suiteSetup(function() {
+    var sevenMin = 7 * 60 * 1000;
+    var fourSec = 4 * 1000;
+    var thirtyMins = 30 * 60 * 1000;
+
+    runningSw = function() {
+      return new Stopwatch({
+        startTime: Date.now(),
+        totalElapsed: 0,
+        state: Stopwatch.RUNNING,
+        laps: []
+      });
+    };
+
+    sevenMinSw = function() {
+      return new Stopwatch({
+        startTime: Date.now(),
+        totalElapsed: sevenMin,
+        state: Stopwatch.RUNNING,
+        laps: []
+      });
+    };
+
+    fourSecPausedSw = function() {
+      return new Stopwatch({
+        startTime: Date.now(),
+        totalElapsed: fourSec,
+        state: Stopwatch.PAUSED,
+        laps: []
+      });
+    };
+
+    withLapsSw = function() {
+      return new Stopwatch({
+        startTime: Date.now(),
+        totalElapsed: sevenMin,
+        state: Stopwatch.RUNNING,
+        laps: [{time: Date.now(), duration: thirtyMins}]
+      });
+    };
+
+    isHidden = function(element) {
+      var klasses = element.className.split(/\s+/);
+      return klasses.some(function(e) { return e === 'hide'; });
+    };
+
+    isVisible = function(element) {
+      return !isHidden(element);
+    };
+
+    loadBodyHTML('/index.html');
+
+    panel = new Stopwatch.Panel(document.getElementById('stopwatch-panel'));
+  });
+
+  beforeEach(function() {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+  suiteTeardown(function() {
+
+  });
+
+  test('Default', function() {
+    assert.equal(panel.nodes.time.textContent, '00:00');
+    assert.isTrue(isVisible(panel.nodes.start));
+    assert.isTrue(isVisible(panel.nodes.reset));
+
+    assert.isTrue(isHidden(panel.nodes.pause));
+    assert.isTrue(isHidden(panel.nodes.lap));
+    assert.isTrue(isHidden(panel.nodes.resume));
+  });
+
+  test('Seven Minute Running', function() {
+    panel.setStopwatch(sevenMinSw());
+
+    assert.equal(panel.nodes.time.textContent, '07:00');
+    assert.isTrue(isVisible(panel.nodes.pause));
+    assert.isTrue(isVisible(panel.nodes.lap));
+
+    assert.isTrue(isHidden(panel.nodes.start));
+    assert.isTrue(isHidden(panel.nodes.reset));
+    assert.isTrue(isHidden(panel.nodes.resume));
+
+    clock.tick(3000);
+    assert.equal(panel.nodes.time.textContent, '07:03');
+  });
+
+  test('Pause a stopwatch', function() {
+    panel.setStopwatch(sevenMinSw());
+    panel.nodes.pause.click();
+
+    clock.tick(3000);
+    assert.equal(panel.nodes.time.textContent, '07:00');
+  });
+
+  test('Four Second Paused', function() {
+    panel.setStopwatch(fourSecPausedSw());
+
+    assert.equal(panel.nodes.time.textContent, '00:04');
+    assert.isTrue(isVisible(panel.nodes.resume));
+    assert.isTrue(isVisible(panel.nodes.reset));
+
+    assert.isTrue(isHidden(panel.nodes.pause));
+    assert.isTrue(isHidden(panel.nodes.start));
+    assert.isTrue(isHidden(panel.nodes.lap));
+
+    clock.tick(3000);
+    assert.equal(panel.nodes.time.textContent, '00:04');
+  });
+
+  test('Resume a stopwatch', function() {
+    panel.setStopwatch(fourSecPausedSw());
+    panel.nodes.resume.click();
+
+    clock.tick(3000);
+    assert.equal(panel.nodes.time.textContent, '00:07');
+  });
+
+  test('Pre-existing laps', function() {
+    panel.setStopwatch(withLapsSw());
+
+    var laps = panel.nodes['laps'].querySelectorAll('li');
+    assert.equal(laps.length, 1);
+
+    var lapName = laps[0].children[0].textContent.trim();
+    var lapTime = laps[0].children[1].textContent.trim();
+
+    assert.equal(lapName, 'Lap 1');
+    assert.equal(lapTime, '30:00');
+
+  });
+
+  test('Add laps', function() {
+
+    function getLapInfo() {
+      var laps = panel.nodes['laps'].querySelectorAll('li');
+      laps = Array.prototype.slice.call(laps);
+      return laps.map(function(e) {
+        return {
+          lapName: e.children[0].textContent.trim(),
+          lapTime: e.children[1].textContent.trim()
+        };
+      });
+    };
+
+    panel.setStopwatch(runningSw());
+    assert.equal(panel.nodes.time.textContent, '00:00');
+
+    //Advance and click the lap button
+    clock.tick(3000);
+    assert.equal(panel.nodes.time.textContent, '00:03');
+
+    panel.nodes.lap.click();
+    var laps = getLapInfo();
+    assert.equal(laps.length, 1);
+
+    assert.equal(laps[0].lapName, 'Lap 1');
+    assert.equal(laps[0].lapTime, '00:03');
+
+    //Advance and add another lap
+    clock.tick(9000);
+    assert.equal(panel.nodes.time.textContent, '00:12');
+
+    panel.nodes.lap.click();
+
+    laps = getLapInfo();
+    assert.equal(laps.length, 2);
+
+    assert.equal(laps[0].lapName, 'Lap 2');
+    assert.equal(laps[0].lapTime, '00:09');
+
+    assert.equal(laps[1].lapName, 'Lap 1');
+    assert.equal(laps[1].lapTime, '00:03');
+
+  });
+
+});

--- a/apps/clock/test/unit/stopwatch_panel_test.js
+++ b/apps/clock/test/unit/stopwatch_panel_test.js
@@ -9,7 +9,7 @@ requireApp('clock/js/stopwatch_panel.js');
 suite('Stopwatch.Panel', function() {
 
   var defaultSw, sevenMinSw, fourSecPausedSw, withLapsSw, runningSw;
-  var isHidden, isVisible;
+  var isHidden;
   var panel;
   var clock;
 
@@ -55,12 +55,7 @@ suite('Stopwatch.Panel', function() {
     };
 
     isHidden = function(element) {
-      var klasses = element.className.split(/\s+/);
-      return klasses.some(function(e) { return e === 'hide'; });
-    };
-
-    isVisible = function(element) {
-      return !isHidden(element);
+      return element.className.contains('hidden');
     };
 
     loadBodyHTML('/index.html');
@@ -68,11 +63,11 @@ suite('Stopwatch.Panel', function() {
     panel = new Stopwatch.Panel(document.getElementById('stopwatch-panel'));
   });
 
-  beforeEach(function() {
+  setup(function() {
     clock = sinon.useFakeTimers();
   });
 
-  afterEach(function() {
+  teardown(function() {
     clock.restore();
   });
 
@@ -82,8 +77,8 @@ suite('Stopwatch.Panel', function() {
 
   test('Default', function() {
     assert.equal(panel.nodes.time.textContent, '00:00');
-    assert.isTrue(isVisible(panel.nodes.start));
-    assert.isTrue(isVisible(panel.nodes.reset));
+    assert.isFalse(isHidden(panel.nodes.start));
+    assert.isFalse(isHidden(panel.nodes.reset));
 
     assert.isTrue(isHidden(panel.nodes.pause));
     assert.isTrue(isHidden(panel.nodes.lap));
@@ -94,8 +89,8 @@ suite('Stopwatch.Panel', function() {
     panel.setStopwatch(sevenMinSw());
 
     assert.equal(panel.nodes.time.textContent, '07:00');
-    assert.isTrue(isVisible(panel.nodes.pause));
-    assert.isTrue(isVisible(panel.nodes.lap));
+    assert.isFalse(isHidden(panel.nodes.pause));
+    assert.isFalse(isHidden(panel.nodes.lap));
 
     assert.isTrue(isHidden(panel.nodes.start));
     assert.isTrue(isHidden(panel.nodes.reset));
@@ -117,8 +112,8 @@ suite('Stopwatch.Panel', function() {
     panel.setStopwatch(fourSecPausedSw());
 
     assert.equal(panel.nodes.time.textContent, '00:04');
-    assert.isTrue(isVisible(panel.nodes.resume));
-    assert.isTrue(isVisible(panel.nodes.reset));
+    assert.isFalse(isHidden(panel.nodes.resume));
+    assert.isFalse(isHidden(panel.nodes.reset));
 
     assert.isTrue(isHidden(panel.nodes.pause));
     assert.isTrue(isHidden(panel.nodes.start));

--- a/apps/clock/test/unit/stopwatch_panel_test.js
+++ b/apps/clock/test/unit/stopwatch_panel_test.js
@@ -132,6 +132,8 @@ suite('Stopwatch.Panel', function() {
     var lapName = laps[0].children[0].textContent.trim();
     var lapTime = laps[0].children[1].textContent.trim();
 
+    // TODO: Localize this value
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=921115
     assert.equal(lapName, 'Lap 1');
     assert.equal(lapTime, '30:00');
 

--- a/apps/clock/test/unit/stopwatch_test.js
+++ b/apps/clock/test/unit/stopwatch_test.js
@@ -21,7 +21,7 @@ suite('Stopwatch', function() {
   suite('constructor', function() {
 
     test('defaults', function() {
-      assert.isFalse(this.sw.isStarted());
+      assert.isTrue(this.sw.getState() === Stopwatch.RESET);
       assert.equal(this.sw.getElapsedTime().getTime(), 0);
       assert.deepEqual(this.sw.getLapDurations(), []);
     });
@@ -30,7 +30,7 @@ suite('Stopwatch', function() {
       var input = {
         startTime: Date.now(),
         totalElapsed: oneHour,
-        isStarted: true,
+        state: Stopwatch.RUNNING,
         laps: [{time: Date.now(), duration: oneHour}]
       };
       this.sw = new Stopwatch(input);
@@ -52,23 +52,25 @@ suite('Stopwatch', function() {
 
   });
 
-  suite('isStarted', function() {
+  suite('isRunning', function() {
 
     test('before start', function() {
-      assert.isFalse(this.sw.isStarted());
+      assert.isFalse(this.sw.getState() === Stopwatch.RUNNING);
+      assert.isFalse(this.sw.getState() === Stopwatch.PAUSED);
+      assert.isTrue(this.sw.getState() === Stopwatch.RESET);
     });
 
     test('start and elapse 1hr', function() {
       this.sw.start();
       this.clock.tick(oneHour);
-      assert.isTrue(this.sw.isStarted());
+      assert.isTrue(this.sw.getState() === Stopwatch.RUNNING);
     });
 
     test('elapse 1hr and pause', function() {
       this.sw.start();
       this.clock.tick(oneHour);
       this.sw.pause();
-      assert.isFalse(this.sw.isStarted());
+      assert.isTrue(this.sw.getState() === Stopwatch.PAUSED);
     });
 
     test('pause and resume', function() {
@@ -77,7 +79,7 @@ suite('Stopwatch', function() {
       this.sw.pause();
       this.clock.tick(oneHour);
       this.sw.start();
-      assert.isTrue(this.sw.isStarted());
+      assert.isTrue(this.sw.getState() === Stopwatch.RUNNING);
     });
 
     test('pause and reset', function() {
@@ -86,7 +88,7 @@ suite('Stopwatch', function() {
       this.sw.pause();
       this.clock.tick(oneHour);
       this.sw.reset();
-      assert.isFalse(this.sw.isStarted());
+      assert.isTrue(this.sw.getState() === Stopwatch.RESET);
     });
 
   });
@@ -210,7 +212,7 @@ suite('Stopwatch', function() {
       var expected = {
         startTime: 0,
         totalElapsed: 0,
-        isStarted: false,
+        state: Stopwatch.RESET,
         laps: []
       };
       var actual = this.sw.toSerializable();
@@ -238,7 +240,7 @@ suite('Stopwatch', function() {
         var expected = {
           startTime: d,
           totalElapsed: 0,
-          isStarted: true,
+          state: Stopwatch.RUNNING,
           laps: []
         };
         var actual = this.sw.toSerializable();
@@ -250,7 +252,7 @@ suite('Stopwatch', function() {
         var expected = {
           startTime: d,
           totalElapsed: oneHour,
-          isStarted: false,
+          state: Stopwatch.PAUSED,
           laps: []
         };
         var actual = this.sw.toSerializable();
@@ -262,7 +264,7 @@ suite('Stopwatch', function() {
         var expected = {
           startTime: d,
           totalElapsed: 0,
-          isStarted: true,
+          state: Stopwatch.RUNNING,
           laps: [{time: Date.now(), duration: oneHour}]
         };
         var actual = this.sw.toSerializable();
@@ -276,7 +278,7 @@ suite('Stopwatch', function() {
         var expected = {
           startTime: 0,
           totalElapsed: 0,
-          isStarted: false,
+          state: Stopwatch.RESET,
           laps: []
         };
         var actual = this.sw.toSerializable();
@@ -290,7 +292,7 @@ suite('Stopwatch', function() {
         var expected = {
           startTime: Date.now(),
           totalElapsed: oneHour,
-          isStarted: true,
+          state: Stopwatch.RUNNING,
           laps: []
         };
         var actual = this.sw.toSerializable();

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -33,7 +33,7 @@ suite('Timer.Panel', function() {
 
   setup(function() {
     clock = this.sinon.useFakeTimers();
-  });  
+  });
 
   test('shape:prototype ', function() {
     assert.ok(Timer.Panel);
@@ -84,13 +84,13 @@ suite('Timer.Panel', function() {
 
     panel.toggle(start, pause);
 
-    assert.isFalse(start.classList.contains('hidden'));
-    assert.isTrue(pause.classList.contains('hidden'));
+    assert.isFalse(isHidden(start));
+    assert.isTrue(isHidden(pause));
 
     panel.toggle(pause, start);
 
-    assert.isTrue(start.classList.contains('hidden'));
-    assert.isFalse(pause.classList.contains('hidden'));
+    assert.isTrue(isHidden(start));
+    assert.isFalse(isHidden(pause));
   });
 
   test('Set timer state (paused)', function() {

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -22,14 +22,7 @@ suite('Timer.Panel', function() {
     Picker = MockPicker;
 
     isHidden = function(element) {
-      var klasses = element.className.split(/\s+/);
-      return klasses.some(function(e) {
-        return e === 'hide' || e === 'hidden';
-      });
-    };
-
-    isVisible = function(element) {
-      return !isHidden(element);
+      return element.className.contains('hidden');
     };
 
   });
@@ -38,11 +31,11 @@ suite('Timer.Panel', function() {
     Picker = p;
   });
 
-  beforeEach(function() {
+  setup(function() {
     clock = sinon.useFakeTimers();
   });
 
-  afterEach(function() {
+  teardown(function() {
     clock.restore();
   });
 
@@ -95,26 +88,26 @@ suite('Timer.Panel', function() {
 
     panel.toggle(start, pause);
 
-    assert.isFalse(start.classList.contains('hide'));
-    assert.isTrue(pause.classList.contains('hide'));
+    assert.isFalse(start.classList.contains('hidden'));
+    assert.isTrue(pause.classList.contains('hidden'));
 
     panel.toggle(pause, start);
 
-    assert.isTrue(start.classList.contains('hide'));
-    assert.isFalse(pause.classList.contains('hide'));
+    assert.isTrue(start.classList.contains('hidden'));
+    assert.isFalse(pause.classList.contains('hidden'));
   });
 
   test('Set timer state (paused)', function() {
     var now = Date.now();
     var oneHour = 60 * 60 * 1000;
     var timer = new Timer({
-      'startAt': now,
-      'endAt': now + oneHour,
-      'pauseAt': now,
-      'duration': oneHour,
-      'lapsed': 0,
-      'state': 2, //paused
-      'sound': '0'
+      startAt: now,
+      endAt: now + oneHour,
+      pauseAt: now,
+      duration: oneHour,
+      lapsed: 0,
+      state: 2, //paused
+      sound: '0'
     });
 
     var panel = new Timer.Panel(document.getElementById('timer-panel'));
@@ -124,9 +117,9 @@ suite('Timer.Panel', function() {
     assert.isTrue(isHidden(panel.nodes.dialog));
     assert.isTrue(isHidden(panel.nodes.pause));
 
-    assert.isTrue(isVisible(panel.nodes.time));
-    assert.isTrue(isVisible(panel.nodes.start));
-    assert.isTrue(isVisible(panel.nodes.cancel));
+    assert.isFalse(isHidden(panel.nodes.time));
+    assert.isFalse(isHidden(panel.nodes.start));
+    assert.isFalse(isHidden(panel.nodes.cancel));
 
     assert.equal(panel.nodes.time.textContent, '01:00:00');
     clock.tick(5000);
@@ -138,13 +131,13 @@ suite('Timer.Panel', function() {
     var now = Date.now();
     var oneHour = 60 * 60 * 1000;
     var timer = new Timer({
-      'startAt': now,
-      'endAt': now + oneHour,
-      'pauseAt': 0,
-      'duration': oneHour,
-      'lapsed': 0,
-      'state': 1, //started
-      'sound': '0'
+      startAt: now,
+      endAt: now + oneHour,
+      pauseAt: 0,
+      duration: oneHour,
+      lapsed: 0,
+      state: 1, //started
+      sound: '0'
     });
 
     var panel = new Timer.Panel(document.getElementById('timer-panel'));
@@ -154,9 +147,9 @@ suite('Timer.Panel', function() {
     assert.isTrue(isHidden(panel.nodes.dialog));
     assert.isTrue(isHidden(panel.nodes.start));
 
-    assert.isTrue(isVisible(panel.nodes.time));
-    assert.isTrue(isVisible(panel.nodes.pause));
-    assert.isTrue(isVisible(panel.nodes.cancel));
+    assert.isFalse(isHidden(panel.nodes.time));
+    assert.isFalse(isHidden(panel.nodes.pause));
+    assert.isFalse(isHidden(panel.nodes.cancel));
 
     assert.equal(panel.nodes.time.textContent, '01:00:00');
     clock.tick(5000);
@@ -169,7 +162,7 @@ suite('Timer.Panel', function() {
     panel.timer = timer;
     panel.onvisibilitychange(true);
 
-    assert.isTrue(isVisible(panel.nodes.dialog));
+    assert.isFalse(isHidden(panel.nodes.dialog));
 
     assert.equal(panel.nodes.time.textContent, '00:00:00');
     clock.tick(5000);

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -32,12 +32,8 @@ suite('Timer.Panel', function() {
   });
 
   setup(function() {
-    clock = sinon.useFakeTimers();
-  });
-
-  teardown(function() {
-    clock.restore();
-  });
+    clock = this.sinon.useFakeTimers();
+  });  
 
   test('shape:prototype ', function() {
     assert.ok(Timer.Panel);

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -102,7 +102,7 @@ suite('Timer.Panel', function() {
       pauseAt: now,
       duration: oneHour,
       lapsed: 0,
-      state: 2, //paused
+      state: Timer.PAUSED,
       sound: '0'
     });
 
@@ -132,7 +132,7 @@ suite('Timer.Panel', function() {
       pauseAt: 0,
       duration: oneHour,
       lapsed: 0,
-      state: 1, //started
+      state: Timer.STARTED,
       sound: '0'
     });
 

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -11,6 +11,8 @@ requireApp('clock/js/timer_panel.js');
 
 suite('Timer.Panel', function() {
   var p;
+  var clock;
+  var isHidden, isVisible;
 
   suiteSetup(function() {
     loadBodyHTML('/index.html');
@@ -19,10 +21,29 @@ suite('Timer.Panel', function() {
 
     Picker = MockPicker;
 
+    isHidden = function(element) {
+      var klasses = element.className.split(/\s+/);
+      return klasses.some(function(e) {
+        return e === 'hide' || e === 'hidden';
+      });
+    };
+
+    isVisible = function(element) {
+      return !isHidden(element);
+    };
+
   });
 
   suiteTeardown(function() {
     Picker = p;
+  });
+
+  beforeEach(function() {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    clock.restore();
   });
 
   test('shape:prototype ', function() {
@@ -81,6 +102,78 @@ suite('Timer.Panel', function() {
 
     assert.isTrue(start.classList.contains('hide'));
     assert.isFalse(pause.classList.contains('hide'));
+  });
+
+  test('Set timer state (paused)', function() {
+    var now = Date.now();
+    var oneHour = 60 * 60 * 1000;
+    var timer = new Timer({
+      'startAt': now,
+      'endAt': now + oneHour,
+      'pauseAt': now,
+      'duration': oneHour,
+      'lapsed': 0,
+      'state': 2, //paused
+      'sound': '0'
+    });
+
+    var panel = new Timer.Panel(document.getElementById('timer-panel'));
+    panel.timer = timer;
+    panel.onvisibilitychange(true);
+
+    assert.isTrue(isHidden(panel.nodes.dialog));
+    assert.isTrue(isHidden(panel.nodes.pause));
+
+    assert.isTrue(isVisible(panel.nodes.time));
+    assert.isTrue(isVisible(panel.nodes.start));
+    assert.isTrue(isVisible(panel.nodes.cancel));
+
+    assert.equal(panel.nodes.time.textContent, '01:00:00');
+    clock.tick(5000);
+    assert.equal(panel.nodes.time.textContent, '01:00:00');
+
+  });
+
+  test('Set timer state (started)', function() {
+    var now = Date.now();
+    var oneHour = 60 * 60 * 1000;
+    var timer = new Timer({
+      'startAt': now,
+      'endAt': now + oneHour,
+      'pauseAt': 0,
+      'duration': oneHour,
+      'lapsed': 0,
+      'state': 1, //started
+      'sound': '0'
+    });
+
+    var panel = new Timer.Panel(document.getElementById('timer-panel'));
+    panel.timer = timer;
+    panel.onvisibilitychange(true);
+
+    assert.isTrue(isHidden(panel.nodes.dialog));
+    assert.isTrue(isHidden(panel.nodes.start));
+
+    assert.isTrue(isVisible(panel.nodes.time));
+    assert.isTrue(isVisible(panel.nodes.pause));
+    assert.isTrue(isVisible(panel.nodes.cancel));
+
+    assert.equal(panel.nodes.time.textContent, '01:00:00');
+    clock.tick(5000);
+    assert.equal(panel.nodes.time.textContent, '00:59:55');
+  });
+
+  test('Set timer state (blank timer)', function() {
+    var timer = new Timer();
+    var panel = new Timer.Panel(document.getElementById('timer-panel'));
+    panel.timer = timer;
+    panel.onvisibilitychange(true);
+
+    assert.isTrue(isVisible(panel.nodes.dialog));
+
+    assert.equal(panel.nodes.time.textContent, '00:00:00');
+    clock.tick(5000);
+    assert.equal(panel.nodes.time.textContent, '00:00:00');
   });
 
   suite('Timer.Panel, Events', function() {


### PR DESCRIPTION
This commit is for https://bugzilla.mozilla.org/show_bug.cgi?id=919567. Given a stopWatch object the Stopwatch.Panel should set itself up accordingly, given a Timer object the Timer.panel should updated itself accordingly. While this is in support of https://bugzilla.mozilla.org/show_bug.cgi?id=910325 it does not add or modify any persistence related code (Stopwatch didn't have any, Timer did).

For Stopwatch/Stopwatch.Panel I've added this functionality and added some new tests in stopwatch_panel_test.js. I also had to change stopwatch_test.js a bit. Evelyn you may want to take a look. 

Note: I assume that the stopwatch rolling back to 0 after 59:59 is in spec. If not we should file a bug

For Timer/Timer.Panel, I've added some tests in timer_panel_test.js. Changes to timer.js mainly came from Rick but I had to modify it a bit.

With regards to the timer I had discussed refactoring this code with Rick, to centralize the Panels state changing code (pulling it out of onvisibilitychange and the onclick handlers). As well as eliminate the REACTIVATING states; and combine CANCELLED AND INITIALIZED (c.f. Stopwatch.Panel in this patch for what I am thinking of). This commit doesn't have that refactoring (and does fix the bug), but I still think it would be a good idea. I find the code in onvisibilitychange a little more complex that it likely needs with the nested state checks. 

You'll also notice that in the tests where I set timers directly, I'm not testing creating a cancelled timer, or a reactivating one. The cancelled state is one that is in between running and initialized, and the reactivating state also seems to be an intermediate one, these do not really have on screen representations of their own (i think of cancelled as the transition to initialized/reset/not running). So i'm not sure if these should be tested (though directly creating a cancelled timer would not show the timer creating dialog—but none of the code does this as we never persist cancelled timers).

Anyways, I think Rick felt that it was too big of a refactor to be worthwhile. But i think that as states get added (e.g. expired), it may be useful to un-nest some of that code. 

Let me know if you have any thoughts. Thanks
