### PR TITLE
Bug 920860 - [Buri][Settings]The phone can create wrong number as passco...

### DIFF
--- a/apps/settings/js/phone_lock.js
+++ b/apps/settings/js/phone_lock.js
@@ -221,7 +221,7 @@ var PhoneLock = {
       case this.createPasscodeButton:
       case this.changePasscodeButton:
         evt.stopPropagation();
-        if (this.passcodePanel.dataset.passcodeStatus !== 'success') {
+        if (!this.checkPasscode()) {
           this.showErrorMessage();
           this.passcodeInput.focus();
           return;


### PR DESCRIPTION
The phone can create wrong number as passcode in phone lock

forcibly recheck the consistency between original code and confirm code
