### PR TITLE
Bug 910697 - Shows previous keyboard before displaying correct one

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -11,7 +11,7 @@
 // deepest interactive HTML element on the hierarchy or, if none, simply the
 // deepest element. This element must contain dataset-keycode and related
 // attributes.
-const IMERender = (function() {
+var IMERender = (function() {
 
   var ime, menu;
   var getUpperCaseValue, isSpecialKey;
@@ -199,7 +199,6 @@ const IMERender = (function() {
 
   var showIME = function hm_showIME() {
     delete this.ime.dataset.hidden;
-    this.ime.classList.remove('hide');
   };
 
   var hideIME = function km_hideIME() {

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -49,6 +49,10 @@ button::-moz-focus-inner {
   text-align: center;
 }
 
+#keyboard[data-hidden] {
+  visibility: hidden;
+}
+
 #keyboard.full-candidate-panel button.keyboard-key {
   visibility: hidden;
 }

--- a/apps/keyboard/test/unit/jspinyin_test.js
+++ b/apps/keyboard/test/unit/jspinyin_test.js
@@ -447,10 +447,10 @@ suite('jspinyin', function() {
     var tempLayoutPage = jspinyin._layoutPage;
 
     this.sinon.stub(glue, 'sendKey', function(keyCode) {
-      jspinyin.setLayoutPage(LAYOUT_PAGE_DEFAULT);
+      jspinyin.setLayoutPage('Default');
       done(function() {
         assert.equal(tempLayoutPage, 'test');
-        assert.equal(jspinyin._layoutPage, LAYOUT_PAGE_DEFAULT);
+        assert.equal(jspinyin._layoutPage, 'Default');
       });
     });
 

--- a/apps/keyboard/test/unit/keyboard_test.js
+++ b/apps/keyboard/test/unit/keyboard_test.js
@@ -1,0 +1,252 @@
+/*global requireApp suiteSetup suite teardown setup test sinon assert
+  suiteTeardown initKeyboard defaultKeyboardName Keyboards IMERender
+  isKeyboardRendered */
+requireApp('keyboard/js/keyboard.js');
+
+defaultKeyboardName = 'Default';
+Keyboards = {
+  Default: {
+    keys: []
+  },
+  telLayout: {
+    keys: []
+  },
+  en: {
+    keys: []
+  }
+};
+IMERender = {};
+
+suite('Keyboard', function() {
+  var imeRender;
+  var imm, _mozInputMethod, _mozSettings;
+
+  function setupIMERender() {
+    return {
+      init: sinon.stub(),
+      draw: sinon.stub(),
+      ime: document.createElement('div'),
+      hideIME: sinon.stub(),
+      showIME: sinon.stub(),
+      setInputMethodName: sinon.stub(),
+      setUpperCaseLock: sinon.stub(),
+      showCandidates: sinon.stub(),
+      getWidth: sinon.stub().returns(100)
+    };
+  }
+
+  suiteSetup(function() {
+    document.body.innerHTML += '<div id="confirm-dialog"></div>' +
+      '<div id="ftu-ok"></div>';
+
+    var confirmDialog = document.createElement('div');
+    confirmDialog.id = 'confirm-dialog';
+    document.body.appendChild(confirmDialog);
+
+    _mozInputMethod = navigator.mozInputMethod;
+    navigator.mozInputMethod = imm = {};
+
+    _mozSettings = navigator.mozSettings;
+    navigator.mozSettings = {
+      addObserver: sinon.stub()
+    };
+
+    window.IMERender = setupIMERender();
+    initKeyboard();
+  });
+
+  setup(function() {
+    window.IMERender = imeRender = setupIMERender();
+    window.location.hash = '#';
+
+    isKeyboardRendered = false;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozInputMethod = _mozInputMethod;
+    navigator.mozSettings = _mozSettings;
+  });
+
+  suite('Focus change', function() {
+    test('onInputContextChange w/o context, hide', function(next) {
+      isKeyboardRendered = true;
+
+      imm.inputcontext = null;
+      imm.oninputcontextchange();
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.hideIME, 1);
+        next();
+      }, 450);
+    });
+
+    test('onInputContextChange with text context', function(next) {
+      imm.inputcontext = {
+        type: 'text',
+        inputType: 'text',
+        inputMode: 'verbatim',
+        getText: createStubPromise(true, 'This is le text')
+      };
+      imm.oninputcontextchange();
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.draw, 1);
+        sinon.assert.calledWith(imeRender.draw, Keyboards.Default,
+          { inputType: 'text', showCandidatePanel: false, uppercase: false });
+        next();
+      }, 0);
+    });
+
+    test('onInputContextChange with tel context', function(next) {
+      imm.inputcontext = {
+        type: 'tel',
+        inputType: 'tel',
+        inputMode: '',
+        getText: createStubPromise(true, '01234567')
+      };
+      imm.oninputcontextchange();
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.draw, 1);
+        sinon.assert.calledWith(imeRender.draw, Keyboards.Default,
+          { inputType: 'tel', showCandidatePanel: false, uppercase: false });
+        next();
+      }, 0);
+    });
+
+    test('Hashchange should call draw for en-US', function(next) {
+      imm.inputcontext = {
+        type: 'text',
+        inputType: 'text',
+        inputMode: 'verbatim',
+        getText: createStubPromise(true, 'heeeeyo')
+      };
+
+      window.location.hash = '#en-US';
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.draw, 1);
+        sinon.assert.calledWith(imeRender.draw, Keyboards.en,
+          { inputType: 'text', showCandidatePanel: false, uppercase: false });
+        sinon.assert.callCount(imeRender.showIME, 1);
+        next();
+      }, 150);
+    });
+
+    test('Hashchange should call draw for tel', function(next) {
+      imm.inputcontext = {
+        type: 'tel',
+        inputType: 'tel',
+        inputMode: '',
+        getText: createStubPromise(true, 'heeeeyo')
+      };
+
+      window.location.hash = '#telLayout';
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.draw, 1);
+        sinon.assert.calledWith(imeRender.draw, Keyboards.telLayout,
+          { inputType: 'tel', showCandidatePanel: false, uppercase: false });
+        sinon.assert.callCount(imeRender.showIME, 1);
+        next();
+      }, 150);
+    });
+
+    test('Hashchange should call draw for tel', function(next) {
+      imm.inputcontext = {
+        type: 'tel',
+        inputType: 'tel',
+        inputMode: '',
+        getText: createStubPromise(true, 'heeeeyo')
+      };
+
+      window.location.hash = '#telLayout';
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.draw, 1);
+        sinon.assert.calledWith(imeRender.draw, Keyboards.telLayout,
+          { inputType: 'tel', showCandidatePanel: false, uppercase: false });
+        sinon.assert.callCount(imeRender.showIME, 1);
+        next();
+      }, 150);
+    });
+
+    test('Wait to show IME until hashevent occured', function(next) {
+      imm.inputcontext = {
+        type: 'text',
+        inputType: 'text',
+        inputMode: 'verbatim',
+        getText: createStubPromise(true, 'heeeeyo')
+      };
+      imm.oninputcontextchange();
+      // hashchange comes in a bit later...
+      setTimeout(function() {
+        window.location.hash = '#en-US';
+      }, 50);
+
+      setTimeout(function() {
+        sinon.assert.callCount(imeRender.draw, 1);
+        sinon.assert.calledWith(imeRender.draw, Keyboards.en);
+        sinon.assert.callCount(imeRender.showIME, 1);
+        next();
+      }, 150);
+    });
+  });
+
+  suite('Hiding', function() {
+    // Focus on an input field and callback when done the whole flow
+    function focus(next) {
+      imm.inputcontext = {
+        type: 'text',
+        inputType: 'text',
+        inputMode: 'verbatim',
+        getText: createStubPromise(true, 'heeeeyo')
+      };
+      imm.oninputcontextchange();
+      // hashchange comes in a bit later...
+      setTimeout(function() {
+        window.location.hash = '#en-US';
+        setTimeout(next, 0);
+      }, 50);
+    }
+
+    test('Hide when blur', function(next) {
+      focus(function() {
+        imm.inputcontext = null;
+        imm.oninputcontextchange();
+
+        setTimeout(function() {
+          sinon.assert.callCount(imeRender.hideIME, 1);
+          next();
+        }, 500);
+      });
+    });
+
+    test('Don\'t hide on quick blur/focus', function(next) {
+      focus(function() {
+        imm.inputcontext = null;
+        imm.oninputcontextchange();
+
+        // and directly get the next element
+        focus(function() {
+          setTimeout(function() {
+            sinon.assert.callCount(imeRender.hideIME, 0);
+            next();
+          }, 500);
+        });
+      });
+    });
+  });
+
+  function createStubPromise(success, returnValue, timeout) {
+    var ret = {
+      then: function(successCb, failureCb) {
+        setTimeout(
+          (success ? successCb : failureCb).bind(null, returnValue),
+          timeout || 0);
+      }
+    };
+    var o = sinon.stub().returns(ret);
+    return o;
+  }
+});

--- a/apps/keyboard/test/unit/latin_test.js
+++ b/apps/keyboard/test/unit/latin_test.js
@@ -290,19 +290,19 @@ suite('latin input method capitalization and punctuation', function() {
 
       // test the output
       assert.equal(output, expected,
-                   'expected "' + expected + '" for input "' + input + '"');
+                  'expected "' + expected + '" for input "' + input + '"');
     });
   }
 });
 
 /*
- * This code is an attempt to test whether word suggestions are offered when
- * they are expected. It doesn't work because when we load latin.js from
- * this test file instead of the app, the path is wrong for loading the
- * worker thread, and the suggestion engine doesn't actually start up
- *
- * So for now, we can only test capitalization and punctuation
- *
+* This code is an attempt to test whether word suggestions are offered when
+* they are expected. It doesn't work because when we load latin.js from
+* this test file instead of the app, the path is wrong for loading the
+* worker thread, and the suggestion engine doesn't actually start up
+*
+* So for now, we can only test capitalization and punctuation
+*
 var finishTest; // we store the done function here
 var suggestionsExpected;
 var suggestionsTimer;

--- a/apps/keyboard/test/unit/render_test.js
+++ b/apps/keyboard/test/unit/render_test.js
@@ -1,5 +1,4 @@
 /*global requireApp suite test assert setup teardown IMERender */
-requireApp('keyboard/js/render.js');
 
 suite('Renderer', function() {
   function makeDescriptor(val) {
@@ -10,6 +9,10 @@ suite('Renderer', function() {
       writable: true
     };
   }
+
+  suiteSetup(function(next) {
+    requireApp('keyboard/js/render.js', next);
+  });
 
   suite('resizeUI', function() {
     function createKeyboardRow(chars, layoutWidth) {


### PR DESCRIPTION
Fix for [#910697](https://bugzilla.mozilla.org/show_bug.cgi?id=910697). Basically:
1. Fix showIME and hideIME as they don't do anything at the moment. Uses visibility rather than display to ensure that we don't need another full reflow of all keys.
2. Don't call showIME before creating the new keyboard is complete
3. Don't call hideIME if a focus event comes directly after blur
4. Test cases around all this
