### PR TITLE
Bug 921053 - Fix failing lockscreen/test_lockscreen_unlock_to_homescreen.py on master

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
@@ -13,7 +13,7 @@ class Homescreen(Base):
     _homescreen_iframe_locator = (By.CSS_SELECTOR, 'div.homescreen iframe')
     _homescreen_icon_locator = (By.CSS_SELECTOR, 'li.icon[aria-label="%s"]')
     _search_bar_icon_locator = (By.CSS_SELECTOR, '#evme-activation-icon input')
-    _landing_page_locator = (By.ID, 'landing-page')
+    _landing_page_locator = (By.ID, 'icongrid')
 
     def launch(self):
         Base.launch(self)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_homescreen_with_passcode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_homescreen_with_passcode.py
@@ -13,7 +13,7 @@ class TestLockScreen(GaiaTestCase):
 
     # Homescreen locators
     _homescreen_frame_locator = (By.CSS_SELECTOR, 'div.homescreen iframe')
-    _homescreen_landing_locator = (By.ID, 'landing-page')
+    _homescreen_landing_locator = (By.ID, 'icongrid')
 
     def setUp(self):
         GaiaTestCase.setUp(self)


### PR DESCRIPTION
These are failing on master: 

lockscreen/test_lockscreen_unlock_to_homescreen.py 
lockscreen/test_lockscreen_unlock_to_homescreen_with_passcode.py

because the homescreen landing locator has changed.
