### PR TITLE
Bug 895480 - Bluetooth app tries to handle Share URL activity and fails

### DIFF
--- a/apps/bluetooth/manifest.webapp
+++ b/apps/bluetooth/manifest.webapp
@@ -21,6 +21,10 @@
   "orientation": "portrait-primary",
   "activities": {
     "share": {
+      "filters": {
+        "type": ["image/*", "audio/*", "video/*", "text/vcard"],
+        "blobs": { "required":true }
+       },
       "disposition": "inline",
       "returnValue": true,
       "href": "/transfer.html"

--- a/apps/browser/test/marionette/share_url_test.js
+++ b/apps/browser/test/marionette/share_url_test.js
@@ -45,7 +45,11 @@ marionette('share url from browser', function() {
     browser.searchBar.sendKeys(url);
     browser.searchButton.click();
     browser.shareButton.click();
-    browser.clickShareEmail();
+    // Since share url via email is supported only,
+    // email share url activity will handle the request directly.
+    // Once there are other share url activity ready,
+    // we have to roll back for clicking "E-Mail" activity.
+    // browser.clickShareEmail();
   }
 
   suite('without an existing email account', function() {


### PR DESCRIPTION
- add correct filter "type" and "blobs" required for supported "share activity" of Bluetooth app.
- disabled `clickShareEmail()` from share url activity from integration test
