### PR TITLE
Bug 900413: [Messages] Should detect and link 5 digit short codes in mes...

### DIFF
--- a/apps/sms/js/link_helper.js
+++ b/apps/sms/js/link_helper.js
@@ -26,7 +26,7 @@ function checkDomain(domain) {
 // defines things that can match right before to be a "safe" link
 var safeStart = /[\s,:;\(>]/;
 
-const MINIMUM_DIGITS_IN_PHONE_NUMBER = 6;
+const MINIMUM_DIGITS_IN_PHONE_NUMBER = 5;
 
 /**
  * For each category of links:
@@ -53,6 +53,10 @@ var LINK_TYPES = {
       var onlyDigits = Utils.removeNonDialables(phone);
 
       if (onlyDigits.length < MINIMUM_DIGITS_IN_PHONE_NUMBER) {
+        return false;
+      }
+      if (onlyDigits.length === MINIMUM_DIGITS_IN_PHONE_NUMBER &&
+        phone.length !== onlyDigits.length) {
         return false;
       }
       return link;

--- a/apps/sms/test/unit/link_helper_test.js
+++ b/apps/sms/test/unit/link_helper_test.js
@@ -253,13 +253,34 @@ suite('link_helper_test.js', function() {
       test('word after preceding number', function() {
         testPhoneMatch('600123123 1Test', '600123123');
       });
+      [
+        // Bug 900413 - detect 5 digit short codes
+        '24242',
+        '10086',
+        '+1234'
+      ].forEach(function(phone) {
+        test(phone, testPhoneOK.bind(null, phone));
+      });
     });
 
     suite('Failures', function() {
-      ['0.34', '1200', '5000', '0.122', '0921'].forEach(function(phone) {
-        test(phone, function() {
-          testPhoneNOK(phone);
-        });
+      [
+        '0.34',
+        '1200',
+        '5000',
+        '0.122',
+        '0921',
+        // Bug 900413 - 5 digit codes with separators not allowed
+        '1-10-13',
+        '12-3-13',
+        '1-800-A',
+        '1(234)5',
+        '1234..5',
+        '1 2 3 45',
+        '1\t23\t45',
+        '12+34'
+      ].forEach(function(phone) {
+         test(phone, testPhoneNOK.bind(null, phone));
       });
     });
 


### PR DESCRIPTION
Bug 900413: [Messages] Should detect and link 5 digit short codes in message text. - r=gnarf
- Updated minimum digits to be detected as a phone number to 5
- Ensured that when 5 digits, the number is only 5 characters without removing separators
