### PR TITLE
Bug 921360 - [LockScreen] Make the glitches on lockscreen invisible

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -522,7 +522,7 @@ var LockScreen = {
 
     // XXX: To solve the odd glitches amoung these 3 elements.
     // Make the center element scale more.
-    var glitchS = 0.3;
+    var glitchS = 1.8;
 
     var trackLength = this.rightIcon.offsetLeft -
                       this.leftIcon.offsetLeft +


### PR DESCRIPTION
Workaround patch which (almost) eliminates the problem.
