### PR TITLE
Bug 912028 - Background is visible on keyboard pop in

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -40,7 +40,7 @@ const TYPE_GROUP_MAPPING = {
 const FOCUS_CHANGE_DELAY = 20;
 
 var KeyboardManager = {
-  keyboardFrameContainer: document.getElementById('keyboards'),
+  keyboardFrameContainer: null,
 
   // The set of installed keyboard layouts grouped by type_group.
   // This is a map from type_group to an object arrays.
@@ -82,6 +82,8 @@ var KeyboardManager = {
 
   init: function km_init() {
     var self = this;
+
+    this.keyboardFrameContainer = document.getElementById('keyboards');
 
     this.notifIMEContainer =
             document.getElementById('keyboard-show-ime-list');
@@ -314,8 +316,7 @@ var KeyboardManager = {
 
     var self = this;
     var updateHeight = function km_updateHeight() {
-      self.keyboardFrameContainer.removeEventListener(
-        'transitionend', updateHeight);
+      self._debug('updateHeight: ' + self.keyboardHeight);
       if (self.keyboardFrameContainer.classList.contains('hide')) {
         // The keyboard has been closed already, let's not resize the
         // application and ends up with half apps.
@@ -330,10 +331,10 @@ var KeyboardManager = {
       window.dispatchEvent(new CustomEvent('keyboardchange', detail));
     };
 
-    if (this.keyboardFrameContainer.classList.contains('hide')) {
-      this.showKeyboard();
-      this.keyboardFrameContainer.addEventListener(
-        'transitionend', updateHeight);
+    // If the keyboard is hidden, or when transitioning is not finished
+    if (this.keyboardFrameContainer.classList.contains('hide') ||
+        this.keyboardFrameContainer.dataset.transitionIn === 'true') {
+      this.showKeyboard(updateHeight);
     } else {
       updateHeight();
     }
@@ -434,18 +435,29 @@ var KeyboardManager = {
          'mozbrowserresize', this, true);
   },
 
-  showKeyboard: function km_showKeyboard() {
+  showKeyboard: function km_showKeyboard(callback) {
     this.keyboardFrameContainer.classList.remove('hide');
+    this.keyboardFrameContainer.dataset.transitionIn = 'true';
 
     // XXX Keyboard transition may be affected by window.open event,
     // and thus the keyboard looks like jump into screen.
     // It may because window.open blocks main thread?
     // Monitor transitionend time here.
     var self = this;
-    var onTransitionEnd = function km_onTransitionEnd() {
+    var onTransitionEnd = function(evt) {
+      if (evt.propertyName !== 'transform') {
+        return;
+      }
+
       self.keyboardFrameContainer.removeEventListener('transitionend',
           onTransitionEnd);
+
+      delete self.keyboardFrameContainer.dataset.transitionIn;
       self._debug('keyboard display transitionend');
+
+      if (callback) {
+        callback();
+      }
     };
     this.keyboardFrameContainer.addEventListener('transitionend',
         onTransitionEnd);

--- a/apps/system/style/system/keyboard.css
+++ b/apps/system/style/system/keyboard.css
@@ -9,7 +9,7 @@
   height: 100%;
 
   transform: translateY(0);
-  transition: visibility 0.2s ease, transform 0.4s ease;
+  transition: opacity 0.2s ease, transform 0.4s ease;
 }
 
 @media not all and (-moz-physical-home-button) {
@@ -23,8 +23,7 @@
 }
 
 #keyboards.hide {
-  visibility: hidden;
-
+  opacity: 0;
   transform: translateY(100%);
 }
 

--- a/apps/system/test/unit/keyboard_manager_test.js
+++ b/apps/system/test/unit/keyboard_manager_test.js
@@ -1,0 +1,137 @@
+/*global requireApp suite test assert setup teardown suiteSetup
+  KeyboardManager Applications sinon */
+requireApp('system/js/keyboard_manager.js');
+
+// Prevent auto-init
+Applications = {
+  ready: false
+};
+
+suite('KeyboardManager', function() {
+  function setupHTML() {
+    var rc = document.querySelector('#run-container');
+    rc.innerHTML = '';
+
+    rc.innerHTML += '<div id="keyboard-show-ime-list">' +
+      '<div class="fake-notification"><div class="message tip"></div></div>' +
+      '</div>';
+    rc.innerHTML += '<div id="keyboards" class="hide">hoi</div>';
+  }
+
+  function injectCss(transition) {
+    transition = transition || 'transform 0.05s ease';
+
+    var el = document.getElementById('km-style');
+    if (!el) {
+      el = document.createElement('style');
+      el.id = 'km-style';
+      document.head.appendChild(el);
+    }
+    el.innerHTML =
+      '#keyboards {\n' +
+        'transform: translateY(0);\n' +
+        'transition: ' + transition + ';\n' +
+      '}\n' +
+      '#keyboards.hide {\n' +
+        'opacity: 0;\n' +
+        'transform: translateY(100%);\n' +
+      '}';
+  }
+
+  suiteSetup(function() {
+    injectCss();
+
+    document.body.innerHTML += '<div id="run-container"></div>';
+  });
+
+  setup(function(next) {
+    setupHTML();
+    KeyboardManager.init();
+
+    // Give some time to stabilize
+    setTimeout(next, 500);
+  });
+
+  test('showKeyboard triggers transition', function(next) {
+    var triggered = false;
+    KeyboardManager.keyboardFrameContainer.addEventListener('transitionend',
+      function() {
+        triggered = true;
+      });
+
+    KeyboardManager.showKeyboard();
+
+    setTimeout(function() {
+      assert.equal(triggered, true);
+      next();
+    }, 100);
+  });
+
+  test('UpdateHeight waits until transition finished', function(next) {
+    var called = false;
+    window.addEventListener('keyboardchange', function() {
+      called = true;
+    });
+
+    KeyboardManager.showKeyboard();
+    KeyboardManager.resizeKeyboard({
+      detail: { height: 200 },
+      stopPropagation: sinon.stub()
+    });
+
+    // animation takes 50 ms. so 20 ms. is safe
+    setTimeout(function() {
+      assert.equal(called, false, 'KeyboardChange triggered 20 ms');
+    }, 20);
+
+    setTimeout(function() {
+      assert.equal(called, true, 'KeyboardChange triggered 100 ms');
+      next();
+    }, 100);
+  });
+
+  test('ShowKeyboard waits for transform transition', function(next) {
+    injectCss('opacity 0.05s ease, transform 0.3s ease');
+
+    KeyboardManager.showKeyboard();
+
+    setTimeout(function() {
+      assert.equal(
+        'transitionIn' in KeyboardManager.keyboardFrameContainer.dataset,
+        true,
+        'TransitionIn canceled due to opacity');
+    }, 100);
+
+    setTimeout(function() {
+      assert.equal(
+        'transitionIn' in KeyboardManager.keyboardFrameContainer.dataset,
+        false,
+        'TransitionIn not canceled due to transform');
+      next();
+    }, 350);
+  });
+
+  test('UpdateHeight waits for transform transition', function(next) {
+    var called = false;
+    window.addEventListener('keyboardchange', function() {
+      called = true;
+    });
+
+    injectCss('opacity 0.05s ease, transform 0.3s ease');
+
+    KeyboardManager.showKeyboard();
+    KeyboardManager.resizeKeyboard({
+      detail: { height: 200 },
+      stopPropagation: sinon.stub()
+    });
+
+    setTimeout(function() {
+      assert.equal(called, false, 'KeyboardChange triggered by opacity');
+    }, 100);
+
+    setTimeout(function() {
+      assert.equal(called, true, 'KeyboardChange triggered by transform');
+      next();
+    }, 350);
+  });
+});


### PR DESCRIPTION
This fixes [#912028](https://bugzilla.mozilla.org/show_bug.cgi?id=912028). The current code tried to address this issue already but made two wrong assumptions:
1. If `hide` was not in classList of keyboard the height would be updated directly. It didn't take into account that the open transition might be happening at that time and the height would be incorrect.
2. Listens to first transform event that comes in, and that is the visibility transition; not the transform (which we should be waiting for).
3. (CSS) We ease on visibility but that doesn't have an ease. Should do it on opacity.

So those are the issues addressed. I've written tests around it because it felt quite fragile when touching it; and it helps with quickly testing my assumptions as well :-)
