### PR TITLE
Bug 912033 - Pop down animation keyboard

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -385,8 +385,7 @@ var KeyboardManager = {
     };
 
     // If the keyboard is hidden, or when transitioning is not finished
-    if (this.keyboardFrameContainer.classList.contains('hide') ||
-        this.keyboardFrameContainer.dataset.transitionIn === 'true') {
+    if (this.keyboardFrameContainer.dataset.transitionIn === 'true') {
       this.showKeyboard(updateHeight);
     } else {
       updateHeight();
@@ -400,7 +399,7 @@ var KeyboardManager = {
         break;
       case 'activitywillclose':
       case 'appwillclose':
-        this.hideKeyboard();
+        this.hideKeyboardImmediately();
         break;
       //XXX the following case hasn't been tested.
       case 'mozbrowsererror': // OOM
@@ -462,8 +461,11 @@ var KeyboardManager = {
       return;
     }
 
-    this.keyboardFrameContainer.classList.remove('hide');
-    this.keyboardFrameContainer.dataset.transitionIn = 'true';
+    if (this.keyboardFrameContainer.classList.contains('hide')) {
+      delete this.keyboardFrameContainer.dataset.transitionOut;
+      this.keyboardFrameContainer.classList.remove('hide');
+      this.keyboardFrameContainer.dataset.transitionIn = 'true';
+    }
 
     // XXX Keyboard transition may be affected by window.open event,
     // and thus the keyboard looks like jump into screen.
@@ -479,8 +481,12 @@ var KeyboardManager = {
           onTransitionEnd);
 
       delete self.keyboardFrameContainer.dataset.transitionIn;
-      self._debug('keyboard display transitionend');
+      self._debug('showKeyboard display transitionend');
 
+      // keyboard is now hidden?
+      if (self.keyboardFrameContainer.classList.contains('hide')) {
+        return;
+      }
       if (callback) {
         callback();
       }
@@ -534,10 +540,45 @@ var KeyboardManager = {
   },
 
   hideKeyboard: function km_hideKeyboard() {
-    this.resetShowingKeyboard();
+    var self = this;
+    var onTransitionEnd = function(evt) {
+      if (evt.propertyName !== 'transform') {
+        return;
+      }
+      self.keyboardFrameContainer.removeEventListener('transitionend',
+        onTransitionEnd);
+
+      self._debug('hideKeyboard display transitionend');
+
+      // prevent destroying the keyboard when we're not hidden anymore
+      if (!self.keyboardFrameContainer.classList.contains('hide')) {
+        return;
+      }
+
+      self.resetShowingKeyboard();
+    };
+    this.keyboardFrameContainer.addEventListener('transitionend',
+      onTransitionEnd);
+
     this.keyboardHeight = 0;
     window.dispatchEvent(new CustomEvent('keyboardhide'));
     this.keyboardFrameContainer.classList.add('hide');
+  },
+
+  hideKeyboardImmediately: function km_hideImmediately() {
+    this.keyboardHeight = 0;
+    window.dispatchEvent(new CustomEvent('keyboardhide'));
+
+    var keyboard = this.keyboardFrameContainer;
+    keyboard.classList.add('notransition');
+    keyboard.classList.add('hide');
+    // Trigger reflow, because the class changes will be grouped
+    // and the notransition has no effect
+    keyboard.offsetHeight;
+
+    // after reflow it's safe to remove the class again
+    keyboard.classList.remove('notransition');
+    this.resetShowingKeyboard();
   },
 
   switchToNext: function km_switchToNext() {

--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -537,6 +537,13 @@ var WindowManager = (function() {
 
     var onSwitchWindow = isSwitchWindow();
 
+    // Send a synthentic 'appwillclose' event.
+    // The keyboard uses this and the appclose event to know when to close
+    // See https://github.com/andreasgal/gaia/issues/832
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent('appwillclose', true, false, { origin: origin });
+    closeFrame.dispatchEvent(evt);
+
     if (!onSwitchWindow) {
       // invoke openWindow to show homescreen here
       // XXX: This doesn't really do the opening. Clean it.
@@ -550,13 +557,6 @@ var WindowManager = (function() {
         app.resize();
       }
     }
-
-    // Send a synthentic 'appwillclose' event.
-    // The keyboard uses this and the appclose event to know when to close
-    // See https://github.com/andreasgal/gaia/issues/832
-    var evt = document.createEvent('CustomEvent');
-    evt.initCustomEvent('appwillclose', true, false, { origin: origin });
-    closeFrame.dispatchEvent(evt);
 
     transitionCloseCallback = function startClosingTransition() {
       // Remove the wrapper and reset the homescreen to a normal state

--- a/apps/system/style/system/keyboard.css
+++ b/apps/system/style/system/keyboard.css
@@ -25,6 +25,8 @@
 #keyboards.hide {
   opacity: 0;
   transform: translateY(100%);
+  /* ease-in for disappearing */
+  transition: opacity 0.4s ease-in, transform 0.4s ease-in;
 }
 
 #keyboards iframe {
@@ -79,4 +81,8 @@
   content: '';
 
   background: url(../icons/Keyboard.png) top left no-repeat;
+}
+
+.notransition {
+  transition: none !important;
 }


### PR DESCRIPTION
Fix for [#912033](https://bugzilla.mozilla.org/show_bug.cgi?id=912033). It's dependent on #912028 because of the more sane flow introduced there, plus the tests.

What it does:
1. Don't hide the iframe where the 3rd party keyboard lives until pop down anim is played
2. Change animation to ease-in for pop down because you want slow->fast instead of other way around when disappearing

I tested this on GP Keon with mc and it looks nice and smooth.
