### PR TITLE
Bug 918995 - [1.2][email] Multiple email notification should have senders listed in reverse chronological order of email timestamp

### DIFF
--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -13539,6 +13539,7 @@ CronSync.prototype = {
       var notifyHeaders = [];
       newHeaders.some(function(header, i) {
         notifyHeaders.push({
+          date: header.date,
           from: header.author.name || header.author.address,
           subject: header.subject,
           accountId: account.id,

--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -142,7 +142,11 @@ define(function(require) {
                       n: result.count,
                       accountName: result.address
                     }),
-                    makeNotificationDesc(result.latestMessageInfos),
+                    makeNotificationDesc(result.latestMessageInfos.sort(
+                                           function(a, b) {
+                                             return b.date - a.date;
+                                           }
+                                        )),
                     iconUrl + '#' + dataString
                   );
                 } else {


### PR DESCRIPTION
Hi James,

Currently, we could not write the integration tests for the bug.
Because we could not use different two email accounts to send email to one specified email account in tests.

For example, there are two email accounts testy1 and testy2 in https://github.com/mozilla-b2g/gaia/blob/master/apps/email/test/marionette/notification_click_test.js#L18, testy2 could not send a email to testy1.

So we could not create a notification like:
2 new emails - testy1@localhost
testy2, testy1

And it might be a issue about "mail-fakeservers" in https://github.com/mozilla-b2g/gaia/blob/master/apps/email/test/marionette/lib/servers/fakeimap.js#L1.

Maybe we could review and land the patch first. After we fix the mail-fakeservers issues, then we could add the integration tests for this bug. Or we have another way to write the tests?

How to you think?
Thanks.

http://bugzil.la/918995
