### PR TITLE
Bug 903960 - [SMS] Switching to message view when selecting left side of the message

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -118,7 +118,16 @@ form[role="dialog"][data-type="edit"] header menu[type="toolbar"] button {
   overflow: hidden;
 
   opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+[data-type="list"] li > .pack-checkbox input ~ span:after {
+  opacity: 0;
   transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+[data-type="list"] li > a > p {
+  transition: transform 0.3s ease;
 }
 
 [data-type="list"] aside.icon-unread {
@@ -148,7 +157,13 @@ form[data-type="action"] img[src=""] {
 .edit [data-type="list"] li > label {
   opacity: 1;
   pointer-events: auto;
-  transform: translateX(5rem);
+  left: -1.4rem;
+}
+
+.edit [data-type="list"] li > .pack-checkbox input ~ span:after {
+  opacity: 1;
+  transform: translateX(4.5rem);
+  left: -2.2rem;
 }
 
 .edit [data-type="list"] li > a > aside.icon-unread {
@@ -157,7 +172,6 @@ form[data-type="action"] img[src=""] {
 
 .edit [data-type="list"] li > a > p {
   transform: translateX(3.5rem);
-  transition: all 0.3s ease;
 }
 
 .edit #threads-container[data-type="list"] aside.pack-end {


### PR DESCRIPTION
- Fix
  - Changed the left position of the label to take up the whole space
  - Removed the translation and translation transition from the `<label>`
  - Added translation and transition to the `<span>` with the checkbox itself
  - Separated the translation transition for the `<p>` so it moves back gracefully
- Tests
  - TBD in another bug
