### PR TITLE
Bug 919962 - [MMS] Converting to text layout when sending a MMS r=gnarf

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1499,11 +1499,14 @@ var ThreadUI = global.ThreadUI = {
 
   cleanFields: function thui_cleanFields(forceClean) {
     var clean = (function clean() {
-      Compose.clear();
+      // Compose.clear might cause a conversion from mms -> sms
+      // Therefore we're reseting the message type here because
+      // in messageComposerTypeHandler we're using this value to know
+      // if the message type changed, and to display the convertNotice
+      // accordingly
+      this.composeForm.dataset.messageType = 'sms';
 
-      // Compose.clear might cause a conversion from mms -> sms, we need
-      // to ensure the message is hidden after we clear fields.
-      this.convertNotice.classList.add('hide');
+      Compose.clear();
 
       // reset the counter
       this.sendButton.dataset.counter = '';

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -968,6 +968,26 @@ suite('thread_ui.js >', function() {
         'conversion banner is hidden at 3 seconds');
 
     });
+
+    test('we dont display the banner when cleaning fields', function() {
+
+      // let's move to MMS type
+      Compose.type = 'mms';
+
+      // and ignore this banner which should be there
+      this.sinon.clock.tick(ThreadUI.CONVERTED_MESSAGE_DURATION);
+
+      this.sinon.spy(Compose, 'clear');
+
+      ThreadUI.cleanFields();
+      MockNavigatormozMobileMessage.mTriggerSegmentInfoSuccess({
+        segments: 0,
+        charsAvailableInLastSegment: 0
+      });
+
+      assert.isTrue(Compose.clear.called);
+      assert.isTrue(convertBanner.classList.contains('hide'));
+    });
   });
 
   suite('Recipient Assimiliation', function() {


### PR DESCRIPTION
We now display the banner in an asynchronous way therefore the previous way to
hide the banner synchronously didn't work.

This patch changes the logic then: instead of hiding the banner after displaying
it, it now prevents the banner from being displayed at all.
