### PR TITLE
Bug 913994 - [Messages] When sending SMS to a number included in a SMS, ...

### DIFF
--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -216,6 +216,7 @@ var MessageManager = {
 
     switch (window.location.hash) {
       case '#new':
+        ThreadUI.inThread = false;
         this.launchComposer(this.activity);
         break;
       case '#thread-list':

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -407,6 +407,7 @@ suite('message_manager.js >', function() {
     suite('> Switch to #new', function() {
       setup(function() {
         this.activity = MessageManager.activity = { test: true };
+        ThreadUI.inThread = true; // to test this is reset correctly
         window.location.hash = '#new';
         MessageManager.onHashChange();
       });
@@ -423,7 +424,6 @@ suite('message_manager.js >', function() {
           MessageManager.threadMessages.classList.add('new');
           MessageManager.slide.reset();
           ThreadUI.updateHeaderData.reset();
-          ThreadUI.inThread = false;
 
           this.threadId = MockThreads.currentId = 100;
           window.location.hash = '#thread=' + this.threadId;


### PR DESCRIPTION
...we should load the thread after clicking on send r=gnarf

The problem was simple: we were not resetting inThread when handling the #new
hash.
