### PR TITLE
Only turn off wifi in cleanup when restarting device

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -495,16 +495,17 @@ class GaiaTestCase(MarionetteTestCase):
         # disable sound completely
         self.data_layer.set_volume(0)
 
-        # disable carrier data connection
-        if self.device.has_mobile_connection:
-            self.data_layer.disable_cell_data()
+        if self.restart:
+            # disable carrier data connection
+            if self.device.has_mobile_connection:
+                self.data_layer.disable_cell_data()
 
-        self.data_layer.disable_cell_roaming()
+            self.data_layer.disable_cell_roaming()
 
-        if self.device.has_wifi:
-            self.data_layer.enable_wifi()
-            self.data_layer.forget_all_networks()
-            self.data_layer.disable_wifi()
+            if self.device.has_wifi:
+                self.data_layer.enable_wifi()
+                self.data_layer.forget_all_networks()
+                self.data_layer.disable_wifi()
 
         # remove data
         self.data_layer.remove_all_contacts(self._script_timeout)


### PR DESCRIPTION
Only turn cel data and wifi off when the --restart option is set.  This reduces gaiatest failure and test dev time by avoiding wifi connection issues.
