### PR TITLE
Bug 917465 - [Email] launching a mail notification will cause Email app to spin and load forever

### DIFF
--- a/apps/email/js/app_messages.js
+++ b/apps/email/js/app_messages.js
@@ -17,8 +17,6 @@ define(function(require) {
     pending[type] = true;
   });
 
-  var lastNotifyId = 0;
-
   var appMessages = evt.mix({
     /**
      * Whether or not we have pending messages.
@@ -66,16 +64,15 @@ define(function(require) {
     },
 
     onNotification: function(msg) {
+      // Skip notification events that are not from a notification
+      // "click". The system app will also notify this method of
+      // any close events for notificaitons, which are not at all
+      // interesting, at least for the purposes here.
+      if (!msg.clicked)
+        return;
+
       // icon url parsing is a cray cray way to pass day day
       var data = queryString.toObject((msg.imageURL || '').split('#')[1]);
-
-      // Do not handle duplicate notifications. May be a bug in the
-      // notifications system.
-      if (data.notifyId && data.notifyId === lastNotifyId) {
-        return;
-      }
-
-      lastNotifyId = data.notifyId;
 
       if (document.hidden) {
         appSelf.latest('self', function(app) {

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -1267,6 +1267,14 @@ MessageListCard.prototype = {
   },
 
   _folderChanged: function(folder) {
+    // It is possible that the notification of latest folder is fired
+    // but in the meantime the foldersSlice could be cleared due to
+    // a change in the current account, before this listener is called.
+    // So skip this work if no foldersSlice, this method will be called
+    // again soon.
+    if (!model.foldersSlice)
+      return;
+
     // Folder could have changed because account changed. Make sure
     // the cacheableFolderId is still set correctly.
     var inboxFolder = model.foldersSlice.getFirstFolderWithType('inbox');

--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -7,9 +7,7 @@ define(function(require) {
       model = require('model'),
       mozL10n = require('l10n!'),
       notificationHelper = require('shared/js/notification_helper'),
-      fromObject = require('query_string').fromObject,
-      notifyIdBase = Date.now(),
-      notifyCounter = 0;
+      fromObject = require('query_string').fromObject;
 
   model.latestOnce('api', function(api) {
     var hasBeenVisible = !document.hidden,
@@ -65,6 +63,7 @@ define(function(require) {
         // and synthesize an "event" ourselves.
         notification.onclick = function() {
           evt.emit('notification', {
+            clicked: true,
             imageURL: iconUrl,
             tag: notificationId
           });
@@ -128,22 +127,13 @@ define(function(require) {
               if (!model.getAccount(result.id).notifyOnNew)
                 return;
 
-              var dataString,
-                  // Construct an ID for the notification. Ideally this
-                  // should not be needed, but looks like there is
-                  // a bug in the system notification code that could
-                  // send a double fire to a mozSetMessageHandler.
-                  // Using datetime plus a counter, since using date
-                  // alone inside the forEach loop across accounts could
-                  // result in the same notifyId.
-                  notifyId = notifyIdBase + '-' + (notifyCounter += 1);
+              var dataString;
 
               if (navigator.mozNotification) {
                 if (result.count > 1) {
                   dataString = fromObject({
                     type: 'message_list',
-                    accountId: result.id,
-                    notifyId: notifyId
+                    accountId: result.id
                   });
 
                   sendNotification(
@@ -160,8 +150,7 @@ define(function(require) {
                       dataString = fromObject({
                         type: 'message_reader',
                         accountId: info.accountId,
-                        messageSuid: info.messageSuid,
-                        notifyId: notifyId
+                        messageSuid: info.messageSuid
                       });
 
                     sendNotification(

--- a/apps/email/test/marionette/lib/email_evt.js
+++ b/apps/email/test/marionette/lib/email_evt.js
@@ -17,6 +17,7 @@ EmailEvt.prototype = {
       var evt = window.wrappedJSObject.require('evt');
 
       evt.emit('notification', {
+        clicked: true,
         imageURL: url
       });
 

--- a/apps/email/test/marionette/lib/email_sync.js
+++ b/apps/email/test/marionette/lib/email_sync.js
@@ -9,15 +9,12 @@ EmailSync.prototype = {
   /**
    * Call this in the setup() for the test.
    */
-/*
+
   setup: function() {
-    //WHAT? this does not work here. Must do it in
-    //the actual test. Bananas, since a readFileSync
-    //of the path for the mock works.
-    //this.client.contentScript.inject(__dirname +
-    //  '/mocks/mock_navigator_mozalarms.js');
+    this.client.contentScript.inject(__dirname +
+      '/mocks/mock_navigator_moz_set_message_handler.js');
   },
-*/
+
   /**
    * Does the work to trigger a sync using helpers in
    * mock_navigator_mozalarms.js. Assumes the mock

--- a/apps/email/test/marionette/notification_click_test.js
+++ b/apps/email/test/marionette/notification_click_test.js
@@ -60,9 +60,7 @@ marionette('email notifications, click', function() {
     evt = new EmailEvt(client);
     notification = new Notification(client);
     sync = new EmailSync(client);
-
-    client.contentScript.inject(__dirname +
-      '/lib/mocks/mock_navigator_moz_set_message_handler.js');
+    sync.setup();
 
     app.launch();
   });

--- a/apps/email/test/marionette/notification_disable_test.js
+++ b/apps/email/test/marionette/notification_disable_test.js
@@ -50,9 +50,7 @@ marionette('email notifications, disable', function() {
   setup(function() {
     app = new Email(client);
     sync = new EmailSync(client);
-
-    client.contentScript.inject(__dirname +
-      '/lib/mocks/mock_navigator_moz_set_message_handler.js');
+    sync.setup();
 
     app.launch();
   });

--- a/apps/email/test/marionette/notification_foreground_test.js
+++ b/apps/email/test/marionette/notification_foreground_test.js
@@ -59,9 +59,7 @@ marionette('email notifications, foreground', function() {
     app = new Email(client);
     notification = new Notification(client);
     sync = new EmailSync(client);
-
-    client.contentScript.inject(__dirname +
-      '/lib/mocks/mock_navigator_moz_set_message_handler.js');
+    sync.setup();
 
     app.launch();
   });


### PR DESCRIPTION
The issue was my poor understanding of notification API: it triggers mozSetMessageHandler listeners for every notification closed. So what was happening:
- email is sent to two email addresses, both configured to be syncing messages.
- this results in two notifications, one for each account.
- one notification is clicked.
- due to an implementation detail in the system notification code, it also then closes all notifications for associated with the app that gets the notification click.
- This results in the system firing three events to the 'notification' message handler in the email app: one for the click and two close notifications.

I should have been checking message.clicked to know if the message handler notification was from a click or a close, and not do the goofy notifyId checking I was doing before. The notifyId checking was added because I saw to message handler events when testing with one account configured. Turns out the second was the "onclose" message. The notifyId setup was not sufficient with these three events because the third event is for a close of an unrelated notification. This caused the bug.

So the fix is: check for message.clicked, and only do work in those cases. I then removed the hacky notifyId stuff, and then updated the integration test to pass .clicked to operate correctly. I also fixed a bad assumption in email_sync test code, and updated the tests to use email_sync's setup() to do the message handler mock injection.
