### PR TITLE
Bug 914557 - Turn on the screen (brightness, not unlock) when the connect prompt appears. r=alive

### DIFF
--- a/apps/system/js/remote_debugger.js
+++ b/apps/system/js/remote_debugger.js
@@ -15,6 +15,11 @@ var RemoteDebugger = (function() {
         return;
       }
 
+      // We want the user attention, so we need to turn the screen on
+      // if it's off.
+      if (!ScreenManager.screenEnabled)
+        ScreenManager.turnScreenOn();
+
       // Reusing the ModalDialog infrastructure.
       ModalDialog.showWithPseudoEvent({
         text: navigator.mozL10n.get('remoteDebuggerMessage'),


### PR DESCRIPTION
got a r+ from https://bugzilla.mozilla.org/show_bug.cgi?id=914557
