### PR TITLE
Bug 922687 - Enable test_everythingme_launch_packaged_app against Travis-TBPL desktop builds, r=zac

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -35,6 +35,7 @@ disabled = Bug 877611
 [functional/contacts/test_delete_contact.py]
 [functional/contacts/test_add_contact_to_favorites.py]
 disabled = Bug 891430
+[functional/everythingme/test_everythingme_launch_packaged_app.py]
 [functional/homescreen/test_homescreen_edit_mode.py]
 [functional/homescreen/test_homescreen_launch_here_maps.py]
 disabled = Bug 865323


### PR DESCRIPTION
An outstanding pull request [1] enables this to run on Travis. This PR adds this test to the TBPL manifest file.

[1] https://github.com/mozilla-b2g/gaia/pull/12477
