### PR TITLE
Bug 921459 - Enable test_settings_change_keyboard_language for desktopb2g builds, r=zac

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -27,7 +27,6 @@ sdcard = true
 [test_settings_wallpaper.py]
 [test_settings_passcode.py]
 [test_settings_change_keyboard_language.py]
-skip-if = device == "desktop"
 [test_settings_device_info.py]
 # Many values are not populated on Desktop
 skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -43,7 +43,6 @@ disabled = Bug 865323
 [functional/lockscreen/test_lockscreen_unlock_to_homescreen.py]
 disabled = Bug 831852
 [functional/settings/test_settings_change_keyboard_language.py]
-disabled = Bug 920853 - English keyboard is not selectable in Settings::Keyboards
 [functional/settings/test_settings_change_language.py]
 [functional/settings/test_settings_do_not_track.py]
 [functional/settings/test_settings_gps.py]


### PR DESCRIPTION
I tested this locally on the desktop build and it passes. Let's see how Travis likes it, and then enable it on Travis and TBPL.
