### PR TITLE
Bug 910707 - Bottom toolbar not visible on Nexus 4 

### DIFF
--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -145,25 +145,25 @@ body[data-online = 'offline'] li[data-offline-ready = 'false'] > div > span {
 }
 /* This is a dirty hack to hide the bottom toolbar while
  * the keyboard is active, than device-height - 40px
- * (for status bar/mini attention screen),
+ * (for status bar/mini attention screen/software home button),
  * then the keyboard is likely activated
  */
-/* For the Otoro, 320x480 */
-@media (device-height: 480px) and (max-height: 430px),
-       (device-height: 320px) and (max-height: 270px) {
-  footer { display: none !important; }
-  .apps > div { height: 100% !important; }
-}
-/* For the Galaxy SII, 640x480 */
-@media (device-height: 480px) and (max-height: 430px),
-       (device-height: 640px) and (max-height: 590px) {
-  footer { display: none !important; }
-  .apps > div { height: 100% !important; }
-}
 
-/* For the Twist , 960x540 */
-@media (device-height: 540px) and (max-height: 490px),
-       (device-height: 960px) and (max-height: 910px) {
+       /* For the Otoro, 320x480 */
+@media (device-height: 480px) and (max-height: 390px),
+       (device-height: 320px) and (max-height: 230px),
+       /* For the Nexus 4 640x384 (no hardware button) */
+       (device-height: 384px) and (max-height: 294px),
+       (device-height: 640px) and (max-height: 550px),
+       /* For the Galaxy SII, 640x480 */
+       (device-height: 480px) and (max-height: 390px),
+       /* For the Tablet, 800x1280 */
+       (device-height: 800px) and (max-height: 710px),
+       (device-height: 1280px) and (max-height: 1190px),
+       /* For the Twist , 960x540 */
+       (device-height: 540px) and (max-height: 450px),
+       (device-height: 960px) and (max-height: 870px) {
   footer { display: none !important; }
   .apps > div { height: 100% !important; }
+  #bg-overlay { height: 100%;}
 }

--- a/apps/settings/elements/about_more_info_developer.html
+++ b/apps/settings/elements/about_more_info_developer.html
@@ -90,14 +90,14 @@
           </label>
           <a data-l10n-id="console-enabled">Console enabled</a>
         </li>
-        <li>
+        <li id="software-home-button">
           <label class="pack-checkbox">
             <input type="checkbox" name="software-button.enabled"/>
             <span></span>
           </label>
           <a data-l10n-id="software-button-enabled">Software home button enabled</a>
         </li>
-        <li>
+        <li id="homegesture">
           <label class="pack-checkbox">
             <input type="checkbox" name="homegesture.enabled"/>
             <span></span>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -55,6 +55,9 @@
     <!-- Lazy loader -->
     <script defer="" src="/shared/js/lazy_loader.js"></script>
 
+    <!-- Screen layout watcher -->
+    <script defer="" src="/shared/js/screen_layout.js"></script>
+
     <!-- Specific code -->
     <script defer="" src="js/settings.js"></script>
 

--- a/apps/settings/js/about.js
+++ b/apps/settings/js/about.js
@@ -11,6 +11,13 @@ var About = {
     this.loadGaiaCommit();
     this.loadLastUpdated();
     this.networkStatus();
+    // hide software home button whenever the device has no hardware home button
+    if (!ScreenLayout.getCurrentLayout('hardwareHomeButton')) {
+      document.getElementById('software-home-button').style.display = 'none';
+      // always set homegesture enabled on tablet, so hide the setting
+      if (!ScreenLayout.getCurrentLayout('tiny'))
+        document.getElementById('homegesture').style.display = 'none';
+    }
   },
 
   networkStatus: function about_networkStatus() {
@@ -103,7 +110,7 @@ var About = {
     var deviceInfoMsisdn = document.getElementById('deviceInfo-msisdn');
     var deviceInfoImei = document.getElementById('deviceInfo-imei');
     var info = IccHelper.iccInfo;
-    if (!navigator.mozTelephony) {
+    if (!navigator.mozTelephony || !info) {
       deviceInfoIccid.parentNode.hidden = true;
       deviceInfoMsisdn.parentNode.hidden = true;
       deviceInfoImei.parentNode.hidden = true;

--- a/apps/settings/test/unit/about_test.js
+++ b/apps/settings/test/unit/about_test.js
@@ -5,6 +5,7 @@ requireApp('settings/test/unit/mock_navigator_settings.js');
 requireApp('settings/test/unit/mock_settings.js');
 requireApp('settings/test/unit/mocks_helper.js');
 requireApp('settings/js/about.js');
+requireApp('../../shared/js/screen_layout.js');
 
 var mocksForAbout = ['Settings'];
 

--- a/apps/system/js/home_gesture.js
+++ b/apps/system/js/home_gesture.js
@@ -21,17 +21,17 @@ var HomeGesture = {
     // This 'click' listener can prevent other element which
     // have click listener steal 'touchstart'.
     this.homeBar.addEventListener('click', this, true);
-    // enable gesture for tablet without hardware home button
-    // as default
-    if (!this.hasHardwareHomeButton && isTablet) {
-      SettingsListener.getSettingsLock().set({
-        'homegesture.enabled': true});
-    }
 
-    SettingsListener.observe('homegesture.enabled', false,
-      function onObserve(value) {
-        this.toggle(value);
-      }.bind(this));
+    if (!this.hasHardwareHomeButton && isTablet) {
+      // enable gesture for tablet without hardware home button
+      // as default
+      this.toggle(true);
+    } else {
+      SettingsListener.observe('homegesture.enabled', false,
+        function onObserve(value) {
+          this.toggle(value);
+        }.bind(this));
+    }
   },
 
   toggle: function hg_toggle(enable) {

--- a/apps/system/test/unit/home_gesture_test.js
+++ b/apps/system/test/unit/home_gesture_test.js
@@ -55,7 +55,7 @@ suite('enable/disable homegesture', function() {
     });
     HomeGesture.init();
     assert.equal(
-      MockNavigatorSettings.mSettings['homegesture.enabled'], undefined);
+      MockNavigatorSettings.mSettings['homegesture.enabled'], false);
   });
 
   test('initial gesture without hardware homebtn on tablet', function() {
@@ -64,7 +64,7 @@ suite('enable/disable homegesture', function() {
     });
     HomeGesture.init();
     assert.equal(
-      MockNavigatorSettings.mSettings['homegesture.enabled'], true);
+      HomeGesture.homeBar.style.display, 'block');
   });
 
   test('enable software button when homegesture is enabled', function() {

--- a/shared/test/unit/mocks/mock_navigator_moz_settings.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_settings.js
@@ -4,7 +4,8 @@
   var observers = {},
       // Set default message size with 300KB
       settings = {
-        'dom.mms.operatorSizeLimitation' : 300
+        'dom.mms.operatorSizeLimitation' : 300,
+        'homegesture.enabled': false
       },
       removedObservers = {};
 


### PR DESCRIPTION
1. add css mediaquery condition for dock footer display
2. make sure software home btn always display on Nexus 4
