### PR TITLE
Bug 913895 - [Flatfish][homescreen] better tablet swipe threadshold

### DIFF
--- a/distribution_tablet/homescreens.json
+++ b/distribution_tablet/homescreens.json
@@ -6,5 +6,10 @@
     ["apps", "gallery"],
     ["apps", "music"]
   ]
-]
+],
+ "swipe": {
+    "threshold": 0.25,
+    "friction": 0.1,
+    "transition_duration": 300
+ }
 }


### PR DESCRIPTION
please test it with `GAIA_DISTRIBUTION_DIR=distribution_tablet GAIA_DEV_PIXELS_PER_PX=1.5 make DEBUG=1` build script
