### PR TITLE
Bug 922936 - Xfail test_play_youtube_video due to bug 922334

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -19,3 +19,5 @@ lan = true
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
 online = true
+# Bug 922334 - crash in sysconf [B2G][Browser][Youtube] Playing youtube videos crash the browser tab
+xfail = true


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=922334 - crash in sysconf [B2G][Browser][Youtube] Playing youtube videos crash the browser tab

Fails only on master.
