### PR TITLE
Bug 920546 - [Messages] Short-term fixes for the recipient panel

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -311,7 +311,7 @@
 
     <div id="messages-recipient-tmpl" class="hide">
       <!--
-      <span class="recipient" x-inputmode="verbatim"
+      <span class="${className}" x-inputmode="verbatim"
         contenteditable="${editable}"
         data-number="${number}" data-source="${source}" data-name="${name}"
         data-carrier="${carrier}" data-separator="${separator}" data-type="${type}">

--- a/apps/sms/js/contacts.js
+++ b/apps/sms/js/contacts.js
@@ -3,6 +3,18 @@
 (function(exports) {
   'use strict';
 
+  var filterFns = {
+    startsWith: function(a, b) {
+      a = a.toLowerCase();
+      b = b.toLowerCase();
+      return a.startsWith(b);
+    },
+    equality: function(a, b) {
+      a = a.toLowerCase();
+      b = b.toLowerCase();
+      return a === b;
+    }
+  };
   /**
    * isMatch
    *
@@ -13,8 +25,11 @@
    * @param {Object} criteria fields and terms to validate a contact.
    *        - fields (fields of a contact record).
    *        - terms (terms to validate against contact record field values).
+   * @param {Function} filterFn function accepts 2 arguments for
+   *                             comparison.
+   *
    */
-  function isMatch(contact, criteria) {
+  function isMatch(contact, criteria, filterFn) {
     /**
      * Validation Strategy
      *
@@ -22,9 +37,9 @@
      * 2. Let _contact_ be a contact record.
      * 3. For each _term_ [...input list], with the label _outer_
      *   - For each _field_ of [givenName, familyName]
-     *     - For each _value_ in _contact_[ _field_ ]
+     *     - For each _value_ of _contact_[ _field_ ]
      *       - Let _found_[ _term_ ] be the result of calling
-     *           _value_.startsWith( _term_ )
+     *         _filterFn_( _value_, _term_).
      *         - If _found_[ _term_ ] is **true**, continue to
      *           loop labelled _outer_
      * 4. If every value of _key_ in _found_ is **true** return **true**,
@@ -40,8 +55,9 @@
       for (var j = 0, jlen = criteria.fields.length; j < jlen; j++) {
         var field = criteria.fields[j];
         for (var k = 0, klen = contact[field].length; k < klen; k++) {
-          var value = contact[field][k];
-          if ((found[term] = value.toLowerCase().startsWith(term))) {
+          var value = contact[field][k].trim();
+
+          if ((found[term] = filterFn(value, term))) {
             continue outer;
           }
         }
@@ -91,7 +107,7 @@
              *    result a no-op.
              *
              */
-            typeof filter.filterValue === 'undefined' ? null : []
+            typeof filter.filterValue === 'undefined' ? null : [], {}
           );
         });
         return;
@@ -155,20 +171,24 @@
       request.onsuccess = function onsuccess() {
         var contacts = this.result.slice();
         var fields = ['givenName', 'familyName'];
+        var criteria = { fields: fields, terms: lower };
         var results = [];
         var contact;
 
         // Step 7
         if (terms.length > 1) {
           while ((contact = contacts.pop())) {
-            if (isMatch(contact, { fields: fields, terms: lower })) {
+            if (isMatch(contact, criteria, filterFns.startsWith)) {
               results.push(contact);
             }
           }
         } else {
           results = contacts;
         }
-        callback(results);
+
+        callback(results, {
+          terms: terms
+        });
       };
 
       request.onerror = function onerror() {
@@ -185,6 +205,27 @@
         filterOp: 'contains',
         filterValue: filterValue
       }, callback);
+    },
+
+    findExact: function contacts_findBy(filterValue, callback) {
+      return this.findBy({
+        filterBy: ['givenName', 'familyName'],
+        filterOp: 'contains',
+        filterValue: filterValue
+      }, function(results, meta) {
+        var contact = results && results.length ? results[0] : null;
+        var criteria = {
+          fields: ['name'],
+          terms: [filterValue]
+        };
+        var isExact = false;
+
+        if (contact) {
+          isExact = isMatch(contact, criteria, filterFns.equality);
+        }
+
+        callback(isExact ? [contact] : []);
+      });
     },
     findByPhoneNumber: function contacts_findByPhone(filterValue, callback) {
       return this.findBy({

--- a/apps/sms/js/desktop-only/contacts.js
+++ b/apps/sms/js/desktop-only/contacts.js
@@ -430,6 +430,20 @@
     })
   );
 
+  ContactsDB.push(
+    new Contact({
+      familyName: '',
+      givenName: 'Bob',
+      tel: [
+        {
+          value: '555-666-1234',
+          type: ['Mobile'],
+          carrier: 'ScamCo'
+        }
+      ]
+    })
+  );
+
   // console.log( ContactsDB );
 
 

--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -13,17 +13,55 @@
   var data = new WeakMap();
   var events = new WeakMap();
   var relation = new WeakMap();
+  var rdigit = /^\d/;
 
   function Recipient(opts) {
+    var number;
+
     opts = opts || {};
     this.name = opts.name || opts.number || '';
-    this.number = opts.number || '';
+    this.number = (opts.number || '') + '';
     this.email = opts.email || '';
     this.editable = opts.editable || 'true';
     this.source = opts.source || 'manual';
     this.type = opts.type || '';
     this.separator = opts.separator || '';
     this.carrier = opts.carrier || '';
+    this.className = 'recipient';
+
+    // isLookupable
+    //  the recipient was accepted by pressing <enter>
+    //
+    this.isLookupable = opts.isLookupable || false;
+
+    // isInvalid
+    //  the typed value is non-digit and we've determined
+    //  that there are no matches in the user's contacts
+    //
+    this.isInvalid = opts.isInvalid || false;
+
+    // isQuestionable
+    //  the typed value is non-digit and may have a match
+    //  in the user's contacts
+    //
+    this.isQuestionable = opts.isQuestionable || false;
+
+    // If the recipient was entered manually and
+    // the trimmed, typed text starts with a non-number
+    // (ignoring the presense of a '+'), the input value
+    // is questionable and may be invalid.
+    number = this.number[0] === '+' ? this.number.slice(1) : this.number;
+
+    if (this.source === 'manual' && !rdigit.test(number)) {
+      this.isQuestionable = true;
+    }
+
+    // If the recipient is either questionable or invalid,
+    // mark it visually for the user.
+    //
+    if (this.isQuestionable || this.isInvalid) {
+      this.className += ' attention';
+    }
   }
 
   /**
@@ -47,7 +85,25 @@
     return this;
   };
 
-  Recipient.FIELDS = ['name', 'number', 'email', 'editable', 'source'];
+  /**
+   * clone
+   *
+   * Create a clone Recipient record. This
+   * is used for exposing a Recipient record
+   * to external code, specifically in events.
+   *
+   * @return {Recipient}
+   *
+   */
+  Recipient.prototype.clone = function() {
+    return new Recipient(this);
+  };
+
+  Recipient.FIELDS = [
+    'name', 'number', 'email', 'editable', 'source',
+    'type', 'separator', 'carrier',
+    'isQuestionable', 'isInvalid', 'isLookupable'
+  ];
 
   /**
    * Recipients
@@ -99,17 +155,13 @@
       },
       numbers: {
         get: function() {
-          var unique = [];
-          var numbers = list.map(function(recipient) {
-            return recipient.number || recipient.email;
-          });
-
-          for (var number of numbers) {
-            if (unique.indexOf(number) === -1) {
-              unique.push(number);
+          return list.reduce(function(unique, recipient) {
+            var value = recipient.number || recipient.email;
+            if (!recipient.isInvalid && unique.indexOf(value) === -1) {
+              unique.push(value);
             }
-          }
-          return unique;
+            return unique;
+          }, []);
         }
       },
       inputValue: {
@@ -209,6 +261,7 @@
    */
   Recipients.prototype.add = function(entry) {
     var list = data.get(this);
+    var added;
     /*
     Entry {
       name, number [, editable, source ]
@@ -233,11 +286,15 @@
     // Don't bother rejecting duplicates, always add every
     // entry to the recipients list. For reference, see:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=880628
-    list.push(new Recipient(entry));
+    list.push(added = new Recipient(entry));
 
-    // XXX:Workaround for cleaning search result while duplicate
-    //     Dispatch add event no matter duplicate or not
-    this.emit('add', list.length);
+    // XXX: Workaround for cleaning search result while duplicate
+    //      Dispatch add event no matter duplicate or not.
+    //
+    //      Send a "clone" of the added recipient, this protects
+    //      the actual Recipient object from being written to
+    //      directly.
+    this.emit('add', list.length, added.clone());
 
     // Render the view
     this.render();
@@ -258,9 +315,11 @@
     var index = typeof recipOrIndex === 'number' ?
       recipOrIndex : list.indexOf(recipOrIndex);
 
-    // Use the normalization of new Recipient() to
-    // correct any missing, but required fields.
-    list[index].set(new Recipient(entry));
+    if (index > -1) {
+      // Use the normalization of new Recipient() to
+      // correct any missing, but required fields.
+      list[index].set(new Recipient(entry));
+    }
 
     return this.render();
   };
@@ -372,6 +431,8 @@
     // Set focus on the last "placeholder" element
     this.reset().focus();
   };
+
+  Recipients.View.isObscured = false;
 
   Recipients.View.prototype.reset = function() {
     // Clear any displayed text (not likely to exist)
@@ -529,7 +590,10 @@
 
     if (node && node.isPlaceholder) {
       node.contentEditable = true;
-      node.focus();
+
+      if (!Recipients.View.isObscured) {
+        node.focus();
+      }
     }
 
     range.selectNodeContents(node);
@@ -645,6 +709,7 @@
     var isAcceptedRecipient = false;
     var isEdittingRecipient = false;
     var isDeletingRecipient = false;
+    var isLookupable = false;
     var target = event.target;
     var keyCode = event.keyCode;
     var editable = 'false';
@@ -758,6 +823,7 @@
                   );
                   this.reset();
                 }
+                Recipients.View.isObscured = false;
 
                 // #1 & #2
                 this.focus();
@@ -900,6 +966,7 @@
               if (keyCode !== event.DOM_VK_TAB) {
 
                 isAcceptedRecipient = true;
+                isLookupable = true;
 
                 // Display the actual typed text that we're
                 // going to accept as a recipient (trimmed)
@@ -918,7 +985,8 @@
           name: typed,
           number: typed,
           editable: editable,
-          source: 'manual'
+          source: 'manual',
+          isLookupable: isLookupable
         });
 
         // Clear the displayed list
@@ -1013,6 +1081,8 @@
           }
         });
       dialog.show();
+
+      Recipients.View.isObscured = true;
     }
   };
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -400,43 +400,50 @@
     */
     getContactDisplayInfo: function(resolver, phoneNumber, callback) {
       resolver(phoneNumber, function onContacts(contacts) {
-        var contact;
-        if (Array.isArray(contacts)) {
-          if (contacts.length > 0) {
-            contact = contacts[0];
-          }
-        } else if (contacts !== null) {
-          contact = contacts;
-        }
-
-        // Only exit when no contact and no phone number case.
-        if (!contact && !phoneNumber) {
-          callback(null);
-          return;
-        }
-
-        var telLength = (contact && contact.tel) ? contact.tel.length : 0;
-        var tel;
-        // Look for the right tel. A contact can contains more than
-        // one contact, so we need to identify which one is the right one.
-        for (var i = 0; i < telLength; i++) {
-          if (contact.tel[i].value === phoneNumber) {
-            tel = contact.tel[i];
-            break;
-          }
-        }
-        // If after looking there is no tel. matching, we apply
-        // directly the phoneNumber
-        if (!tel) {
-          tel = {type: [''], value: phoneNumber, carrier: ''};
-        }
-        // Get the title in the standard way
-        var details = Utils.getContactDetails(tel, contact);
-        var info = Utils.getDisplayObject(details.title || null, tel);
-
-        callback(info);
+        callback(Utils.basicContact(phoneNumber, contacts));
       });
     },
+
+    basicContact: function(number, records, callback) {
+      var record;
+      if (Array.isArray(records)) {
+        if (records.length > 0) {
+          record = records[0];
+        }
+      } else if (records !== null) {
+        record = records;
+      }
+
+      // Only exit when no record and no phone number case.
+      if (!record && !number) {
+        if (typeof callback === 'function') {
+          callback(null);
+        }
+        return;
+      }
+
+      var telLength = (record && record.tel) ? record.tel.length : 0;
+      var tel;
+      // Look for the right tel. A record can contains more than
+      // one record, so we need to identify which one is the right one.
+      for (var i = 0; i < telLength; i++) {
+        if (record.tel[i].value === number) {
+          tel = record.tel[i];
+          break;
+        }
+      }
+      // If after looking there is no tel. matching, we apply
+      // directly the number
+      if (!tel) {
+        tel = {type: [''], value: number, carrier: ''};
+      }
+      // Get the title in the standard way
+      var details = Utils.getContactDetails(tel, record);
+      var info = Utils.getDisplayObject(details.title || null, tel);
+
+      return info;
+    },
+
     /*
       Given a title for a contact, a the current information for
       an specific phone, of that contact, creates an object with

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -9,7 +9,7 @@ html, body {
 }
 
 
-/* 
+/*
   Override BB. Some CSS tweaks for having a better confirm readability
 */
 form[role="dialog"][data-type="confirm"] p {
@@ -229,7 +229,7 @@ form[data-type="action"] img[src=""] {
 #new-message-notice-content {
   margin: 1rem 2rem;
   padding: 0;
-  
+
   overflow: hidden;
 
   white-space: nowrap;
@@ -830,6 +830,28 @@ generateHeightRule() (in ThreadUI/thread_ui.js) will create:
   margin-right: 0.5rem;
   padding: 0 0.8rem;
   border-width: 0.1rem;
+}
+
+.recipient[contenteditable=false].attention {
+  padding-left: 1.2rem;
+
+  border: 0.1rem solid #b90000;
+
+  background: transparent;
+}
+
+.recipient[contenteditable=false].attention::before {
+  position: absolute;
+
+  border-bottom-left-radius: 0.3rem;
+  border-top-left-radius: 0.3rem;
+  padding: 0.2rem 0.2rem 0 0.2rem;
+  margin-left: -1.2rem;
+  margin-top: -0.1rem;
+
+  background-color: #b90000;
+  color: #fff;
+  content: "!";
 }
 
 .article-list[data-type="list"] ul.contact-list {

--- a/apps/sms/test/unit/contacts_test.js
+++ b/apps/sms/test/unit/contacts_test.js
@@ -94,6 +94,12 @@ suite('Contacts', function(done) {
                     ]);
                   }
 
+                  if (filter.filterValue === 'doozer') {
+                    return MockContact.list([
+                      { givenName: ['Jane'], familyName: ['Doozer'] }
+                    ]);
+                  }
+
                   // All other cases
                   return MockContact.list();
                 }());
@@ -381,6 +387,23 @@ suite('Contacts', function(done) {
 
         // navigator.mozContacts.find was called?
         assert.equal(mHistory.length, 1);
+        done();
+      });
+    });
+  });
+
+
+  suite('Contacts.findExact', function() {
+    test('yields a match ', function(done) {
+      Contacts.findExact('jane doozer', function(contacts) {
+        assert.equal(contacts.length, 1);
+        done();
+      });
+    });
+
+    test('yields no matches ', function(done) {
+      Contacts.findExact('j doozer', function(contacts) {
+        assert.equal(contacts.length, 0);
         done();
       });
     });

--- a/apps/sms/test/unit/mock_contacts.js
+++ b/apps/sms/test/unit/mock_contacts.js
@@ -32,6 +32,11 @@ var MockContacts = {
     this.mCallCallback(callback, result);
   },
 
+  findExact: function mc_findByString(value, callback) {
+    var result = MockContact.list();
+    this.mCallCallback(callback, result);
+  },
+
   mTeardown: function mc_mTeardown() {
     this.mAsync = false;
   }

--- a/apps/sms/test/unit/mock_recipients.js
+++ b/apps/sms/test/unit/mock_recipients.js
@@ -18,7 +18,7 @@ MockRecipients.prototype.add = function(contact) {
   this.recipientsList.appendChild(span);
   this.length++;
   this.numbers.push(contact.number);
-  this.emit('add', this.length);
+  this.emit('add', this.length, contact);
   return this;
 };
 
@@ -37,6 +37,10 @@ MockRecipients.prototype.render = function() {
 };
 
 MockRecipients.prototype.focus = function() {
+  return this;
+};
+
+MockRecipients.prototype.update = function() {
   return this;
 };
 

--- a/apps/sms/test/unit/mock_utils.js
+++ b/apps/sms/test/unit/mock_utils.js
@@ -24,5 +24,6 @@ var MockUtils = {
   getCarrierTag: Utils.getCarrierTag,
   removeNonDialables: Utils.removeNonDialables,
   probablyMatches: Utils.probablyMatches,
-  getDisplayObject: Utils.getDisplayObject
+  getDisplayObject: Utils.getDisplayObject,
+  basicContact: Utils.basicContact
 };

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -69,7 +69,11 @@ suite('Recipients', function() {
       // Disambiguation 'display' attributes
       type: 'Type',
       separator: ' | ',
-      carrier: 'Carrier'
+      carrier: 'Carrier',
+      className: 'recipient',
+      isLookupable: false,
+      isQuestionable: false,
+      isInvalid: false
     };
   });
 
@@ -91,7 +95,6 @@ suite('Recipients', function() {
       assert.ok(Recipients.prototype.off);
       assert.ok(Recipients.prototype.emit);
     });
-
 
     test('recipients.add() 1 ', function() {
       var recipient;
@@ -134,6 +137,15 @@ suite('Recipients', function() {
       } catch (e) {
         assert.equal(e.message, 'recipient entry missing number');
       }
+    });
+
+    test('recipients.add() turns `number` to string >', function(done) {
+      recipients.on('add', function(_, record) {
+        assert.equal(typeof record.number, 'string');
+        recipients.off('add');
+        done();
+      });
+      recipients.add({ number: 999 });
     });
 
 
@@ -229,6 +241,18 @@ suite('Recipients', function() {
       assert.equal(recipients.numbers[0], '999');
     });
 
+    test('recipients.numbers contains no invalid entries ', function() {
+      recipients.add({
+        number: '999'
+      });
+      recipients.add({
+        number: 'foo',
+        isInvalid: true
+      });
+
+      assert.equal(recipients.numbers.length, 1);
+    });
+
     test('recipients.on(add, ...)', function(done) {
       recipients.on('add', function(count) {
         assert.ok(true);
@@ -254,6 +278,33 @@ suite('Recipients', function() {
       recipients.remove(recipients.list[0]);
     });
 
+    suite('Detecting Questionable Entries', function() {
+      test('Correctly detects a questionable entry ', function(done) {
+        recipients.on('add', function(count, added) {
+          assert.isTrue(added.isQuestionable);
+          recipients.off('add');
+          done();
+        });
+
+        recipients.add({
+          number: 'abc',
+          source: 'manual'
+        });
+      });
+
+      test('Ignore entries that are not questionable ', function(done) {
+        recipients.on('add', function(count, added) {
+          assert.isFalse(added.isQuestionable);
+          recipients.off('add');
+          done();
+        });
+
+        recipients.add({
+          number: '999',
+          source: 'manual'
+        });
+      });
+    });
   });
 
   suite('Recipients.View', function() {
@@ -482,6 +533,10 @@ suite('Recipients', function() {
 
       suite('Clicks on accepted recipients', function() {
 
+        setup(function() {
+          Recipients.View.isObscured = false;
+        });
+
         test('while manually entering a recipient ', function() {
           var view = document.getElementById('messages-recipients-list');
 
@@ -513,6 +568,21 @@ suite('Recipients', function() {
           //    - A placeholder for the cursor
           //
           assert.equal(view.children.length, 3);
+        });
+
+        test('obscures the recipients view to prevent focus ', function() {
+          var view = document.getElementById('messages-recipients-list');
+
+          fixture.source = 'contacts';
+
+          recipients.add(fixture).focus();
+
+          // A recipient is accepted
+          assert.equal(recipients.length, 1);
+
+          view.firstElementChild.click();
+
+          assert.isTrue(Recipients.View.isObscured);
         });
 
         test('with only accepted recipients ', function() {

--- a/apps/sms/test/unit/thread_ui_integration_test.js
+++ b/apps/sms/test/unit/thread_ui_integration_test.js
@@ -90,21 +90,9 @@ suite('ThreadUI Integration', function() {
   });
 
   suite('Search Contact Events', function() {
-    var realSearchContact;
 
     setup(function() {
-      realSearchContact = ThreadUI.searchContact;
-
-      ThreadUI.searchContact = function(filterValue) {
-        ThreadUI.searchContact.called++;
-        ThreadUI.searchContact.calledWith = filterValue;
-      };
-      ThreadUI.searchContact.called = 0;
-      ThreadUI.searchContact.calledWith = '';
-    });
-
-    teardown(function() {
-      realSearchContact = ThreadUI.searchContact;
+      this.sinon.spy(ThreadUI, 'searchContact');
     });
 
     test('toFieldInput handler, successful', function() {
@@ -117,8 +105,8 @@ suite('ThreadUI Integration', function() {
 
       ThreadUI.toFieldInput.call(ThreadUI, fakeEvent);
 
-      assert.equal(ThreadUI.searchContact.called, 1);
-      assert.equal(ThreadUI.searchContact.calledWith, 'abc');
+      sinon.assert.calledOnce(ThreadUI.searchContact);
+      sinon.assert.calledWith(ThreadUI.searchContact, 'abc');
     });
 
     test('toFieldInput handler, unsuccessful', function() {
@@ -131,16 +119,15 @@ suite('ThreadUI Integration', function() {
 
       ThreadUI.toFieldInput.call(ThreadUI, fakeEvent);
 
-      assert.equal(ThreadUI.searchContact.called, 1);
-      assert.equal(ThreadUI.searchContact.calledWith, '');
+      sinon.assert.called(ThreadUI.searchContact);
+      sinon.assert.calledWith(ThreadUI.searchContact, '');
 
       fakeEvent.target.textContent = 'abd';
       fakeEvent.target.isPlaceholder = false;
 
       ThreadUI.toFieldInput.call(ThreadUI, fakeEvent);
 
-      assert.equal(ThreadUI.searchContact.called, 1);
-      assert.equal(ThreadUI.searchContact.calledWith, '');
+      assert.isFalse(ThreadUI.searchContact.calledTwice);
     });
   });
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1,8 +1,9 @@
 /*global mocha, MocksHelper, MockAttachment, MockL10n, loadBodyHTML, ThreadUI,
-         MockNavigatormozMobileMessage, Compose, MockDialog, Template, MockSMIL,
-         Utils, MessageManager, LinkActionHandler, LinkHelper, Attachment,
-         MockContact, MockOptionMenu, MockActivityPicker, Threads, Settings,
-         MockMessages, MockUtils, MockContacts, ActivityHandler */
+         MockNavigatormozMobileMessage, Contacts, Compose, MockDialog,
+         Template, MockSMIL, Utils, MessageManager, LinkActionHandler,
+         LinkHelper, Attachment, MockContact, MockOptionMenu,
+         MockActivityPicker, Threads, Settings, MockMessages, MockUtils,
+         MockContacts, ActivityHandler */
 
 'use strict';
 
@@ -226,7 +227,7 @@ suite('thread_ui.js >', function() {
       window.location.hash = '';
     });
 
-    suite('Thread View', function() {
+    suite('In #thread view, button should be...', function() {
       setup(function() {
         window.location.hash = '#thread-1';
       });
@@ -235,18 +236,18 @@ suite('thread_ui.js >', function() {
         window.location.hash = '';
       });
 
-      test('button should be disabled at the beginning', function() {
+      test('disabled at the beginning', function() {
         Compose.clear();
         assert.isTrue(sendButton.disabled);
       });
 
-      test('button should be enabled when there is some text', function() {
+      test('enabled when there is message input', function() {
         Compose.append('Hola');
         assert.isFalse(sendButton.disabled);
       });
 
-      test('button should not be disabled if there is some text ' +
-        'but too many segments', function() {
+      test('enabled when there is message input, but too many segments',
+        function() {
 
         Compose.append('Hola');
         this.sinon.clock.tick(ThreadUI.UPDATE_DELAY);
@@ -263,7 +264,7 @@ suite('thread_ui.js >', function() {
     });
 
 
-    suite('#new mode >', function() {
+    suite('In #new view, button should be...', function() {
       setup(function() {
         window.location.hash = '#new';
         Compose.clear();
@@ -278,79 +279,130 @@ suite('thread_ui.js >', function() {
         ThreadUI.recipients.inputValue = '';
       });
 
-      test('button should be disabled when there is neither contact or input',
-        function() {
-        assert.isTrue(sendButton.disabled);
-      });
+      suite('enabled', function() {
 
-      test('button should be disabled when there is no contact', function() {
-        Compose.append('Hola');
-        assert.isTrue(sendButton.disabled);
-      });
+        suite('when there is message input...', function() {
 
-      test('button should be enabled with recipient input', function() {
-        Compose.append('Hola');
-        ThreadUI.recipients.inputValue = '999';
+          test('and recipient field value is valid ', function() {
+            Compose.append('Hola');
+            ThreadUI.recipients.inputValue = '999';
 
-        // Call directly since no input event will be triggered
-        ThreadUI.enableSend();
-        assert.isFalse(sendButton.disabled);
-      });
+            // Call directly since no input event will be triggered
+            ThreadUI.enableSend();
+            assert.isFalse(sendButton.disabled);
+          });
 
-      test('button should be enabled after adding a recipient when text exists',
-        function() {
-        Compose.append('Hola');
+          test('after adding a valid recipient ',
+            function() {
+            Compose.append('Hola');
 
-        ThreadUI.recipients.add({
-          number: '999'
+            ThreadUI.recipients.add({
+              number: '999'
+            });
+
+            assert.isFalse(sendButton.disabled);
+          });
+
+          test('after adding valid & questionable recipients ', function() {
+            Compose.append('Hola');
+
+            ThreadUI.recipients.add({
+              number: 'foo',
+              isQuestionable: true
+            });
+
+            ThreadUI.recipients.add({
+              number: '999'
+            });
+
+            assert.isFalse(sendButton.disabled);
+          });
         });
 
-        assert.isFalse(sendButton.disabled);
-      });
+        suite('when a valid recipient exists...', function() {
+          test('after adding message input ', function() {
 
-      test('button should be enabled after adding text when recipient exists',
-        function() {
+            ThreadUI.recipients.add({
+              number: '999'
+            });
+            Compose.append('Hola');
 
-        ThreadUI.recipients.add({
-          number: '999'
-        });
-        Compose.append('Hola');
-
-        assert.isFalse(sendButton.disabled);
-      });
-
-      // TODO: Fix this test to be about being over the MMS limit inside #840035
-
-      test('button should be disabled when there is both contact and ' +
-          'input, but too much data to send as mms',
-        function() {
-
-        ThreadUI.recipients.add({
-          number: '999'
+            assert.isFalse(sendButton.disabled);
+          });
         });
 
-        Compose.append(mockAttachment(300 * 1024));
 
-        assert.isFalse(sendButton.disabled);
-        Compose.append('Hola');
+        test('after appending image within size limits ', function() {
+          ThreadUI.recipients.add({
+            number: '999'
+          });
 
-        assert.isTrue(sendButton.disabled);
+          Compose.append(mockImgAttachment());
+          assert.isFalse(sendButton.disabled);
+        });
       });
 
-      test('When adding an image that is under the limitation, button ' +
-           'should be enabled right after appended',
-        function() {
+      suite('disabled', function() {
 
-        ThreadUI.recipients.add({
-          number: '999'
+        test('when there is no message input or recipient ', function() {
+          assert.isTrue(sendButton.disabled);
         });
 
-        Compose.append(mockImgAttachment());
-        assert.isFalse(sendButton.disabled);
+        test('when message is over data limit ', function() {
+          ThreadUI.recipients.add({
+            number: '999'
+          });
+
+          Compose.append(mockAttachment(300 * 1024));
+
+          assert.isFalse(sendButton.disabled);
+          Compose.append('Hola');
+
+          assert.isTrue(sendButton.disabled);
+        });
+
+
+        suite('when there is message input...', function() {
+          test('there is no recipient ', function() {
+            Compose.append('Hola');
+            assert.isTrue(sendButton.disabled);
+          });
+
+          test('recipient field value is questionable ', function() {
+            Compose.append('Hola');
+            ThreadUI.recipients.inputValue = 'a';
+
+            // Call directly since no input event will be triggered
+            ThreadUI.enableSend();
+            assert.isTrue(sendButton.disabled);
+          });
+
+          test('after adding a questionable recipient ', function() {
+            Compose.append('Hola');
+
+            ThreadUI.recipients.add({
+              number: 'foo',
+              isQuestionable: true
+            });
+
+            assert.isFalse(sendButton.disabled);
+          });
+        });
+
+        suite('when a valid recipient exists...', function() {
+          test('there is no message input ', function() {
+
+            ThreadUI.recipients.add({
+              number: 'foo'
+            });
+
+            assert.isTrue(sendButton.disabled);
+          });
+        });
       });
 
-      test('When adding an oversized image, button should be disabled while ' +
-           'resizing and enabled when resize complete',
+      test('disabled while resizing oversized image and ' +
+        'enabled when resize complete ',
         function(done) {
 
         ThreadUI.recipients.add({
@@ -1001,10 +1053,13 @@ suite('thread_ui.js >', function() {
   });
 
   suite('Recipient Assimiliation', function() {
-
     setup(function() {
-      this.sinon.spy(ThreadUI.recipients, 'visible');
+      this.sinon.spy(ThreadUI, 'validateContact');
       this.sinon.spy(ThreadUI.recipients, 'add');
+      this.sinon.spy(ThreadUI.recipients, 'remove');
+      this.sinon.spy(ThreadUI.recipients, 'update');
+      this.sinon.spy(ThreadUI.recipients, 'visible');
+      this.sinon.spy(Utils, 'basicContact');
 
       Threads.set(1, {
         participants: ['999']
@@ -1014,6 +1069,20 @@ suite('thread_ui.js >', function() {
     teardown(function() {
       Threads.delete(1);
       window.location.hash = '';
+    });
+
+    suite('Existing Conversation', function() {
+
+      setup(function() {
+        window.location.hash = '#thread=1';
+      });
+
+      test('Will not assimilate recipients ', function() {
+        ThreadUI.assimilateRecipients();
+
+        sinon.assert.notCalled(ThreadUI.recipients.visible);
+        sinon.assert.notCalled(ThreadUI.recipients.add);
+      });
     });
 
     suite('New Conversation', function() {
@@ -1030,45 +1099,381 @@ suite('thread_ui.js >', function() {
       });
 
       teardown(function() {
-        ThreadUI.recipientsList.removeChild(node);
+        if (ThreadUI.recipientsList.children.length) {
+          ThreadUI.recipientsList.removeChild(node);
+        }
       });
 
-      test('Will assimilate recipients', function() {
-        var visible, add;
+      suite('Typed number', function() {
+        test('Triggers assimilation ', function() {
+          var visible;
 
-        ThreadUI.assimilateRecipients();
+          ThreadUI.assimilateRecipients();
 
-        visible = ThreadUI.recipients.visible;
-        add = ThreadUI.recipients.add;
+          visible = ThreadUI.recipients.visible;
 
-        assert.ok(visible.called);
-        assert.equal(visible.args[0][0], 'singleline');
+          assert.isTrue(visible.called);
+          assert.isTrue(visible.firstCall.calledWith('singleline'));
+          assert.isTrue(ThreadUI.recipients.add.called);
+          assert.isTrue(
+            ThreadUI.recipients.add.calledWithMatch({
+              name: '999',
+              number: '999',
+              source: 'manual'
+            })
+          );
+        });
+      });
 
-        assert.ok(add.called);
-        assert.deepEqual(add.args[0][0], {
-          name: '999',
-          number: '999',
-          source: 'manual'
+      suite('Typed non-number', function() {
+        var realContacts;
+
+        suiteSetup(function() {
+          realContacts = window.Contacts;
+          window.Contacts = MockContacts;
+        });
+
+        suiteTeardown(function() {
+          window.Contacts = realContacts;
+        });
+
+        setup(function() {
+          this.sinon.spy(ThreadUI, 'searchContact');
+          this.sinon.spy(ThreadUI, 'exactContact');
+        });
+
+        test('Triggers assimilation & silent search ', function() {
+          node.textContent = 'foo';
+          ThreadUI.assimilateRecipients();
+
+          assert.isTrue(ThreadUI.recipients.add.called);
+          assert.isTrue(
+            ThreadUI.recipients.add.calledWithMatch({
+              name: 'foo',
+              number: 'foo',
+              source: 'manual'
+            })
+          );
+        });
+
+        test('Matches contact ', function() {
+          var record = {
+            isQuestionable: true,
+            name: 'Jane Doozer',
+            number: 'Jane Doozer',
+            source: 'manual'
+          };
+
+          this.sinon.stub(Contacts, 'findByString').yields(
+            MockContact.list([
+              { givenName: ['Jane'], familyName: ['Doozer'] }
+            ])
+          );
+
+          ThreadUI.searchContact(
+            record.number, ThreadUI.validateContact.bind(ThreadUI, record)
+          );
+
+          assert.isTrue(ThreadUI.recipients.remove.called);
+          assert.isTrue(ThreadUI.recipients.add.called);
+          assert.isTrue(
+            ThreadUI.recipients.add.calledWithMatch({
+              name: 'Jane Doozer',
+              number: '+346578888888',
+              type: 'Mobile',
+              carrier: 'TEF, ',
+              separator: ' | ',
+              source: 'contacts',
+              nameHTML: '',
+              numberHTML: ''
+            })
+          );
+        });
+
+        test('Does not match contact ', function() {
+          // Clear out the existing recipient field fixtures
+          ThreadUI.recipients.length = 0;
+          ThreadUI.recipientsList.textContent = '';
+
+          var record = {
+            isQuestionable: true,
+            name: 'Jane Doozer',
+            number: 'Jane Doozer',
+            source: 'manual'
+          };
+
+          this.sinon.stub(Contacts, 'findByString', function(term, callback) {
+            callback([]);
+          });
+
+          ThreadUI.searchContact(
+            record.number, ThreadUI.validateContact.bind(ThreadUI, record)
+          );
+
+          sinon.assert.called(ThreadUI.recipients.update);
+
+          record.isInvalid = true;
+
+          sinon.assert.calledWithMatch(ThreadUI.recipients.update, 0, record);
+        });
+
+        test('Exact contact ', function() {
+          var record = {
+            isQuestionable: true,
+            name: 'Jane Doozer',
+            number: 'Jane Doozer',
+            source: 'manual'
+          };
+
+          this.sinon.stub(Contacts, 'findExact').yields(
+            MockContact.list([
+              { givenName: ['Jane'], familyName: ['Doozer'] }
+            ])
+          );
+
+          ThreadUI.exactContact(
+            record.number, ThreadUI.validateContact.bind(ThreadUI, record)
+          );
+
+          assert.isTrue(ThreadUI.recipients.remove.called);
+          assert.isTrue(ThreadUI.recipients.add.called);
+          assert.isTrue(
+            ThreadUI.recipients.add.calledWithMatch({
+              name: 'Jane Doozer',
+              number: '+346578888888',
+              type: 'Mobile',
+              carrier: 'TEF, ',
+              separator: ' | ',
+              source: 'contacts',
+              nameHTML: '',
+              numberHTML: ''
+            })
+          );
+        });
+
+        test('No exact contact ', function() {
+          // Clear out the existing recipient field fixtures
+          ThreadUI.recipients.length = 0;
+          ThreadUI.recipientsList.textContent = '';
+
+          var record = {
+            isQuestionable: true,
+            name: 'Jane Doozer',
+            number: 'Jane Doozer',
+            source: 'manual'
+          };
+
+          this.sinon.stub(Contacts, 'findExact').yields([], {});
+
+          ThreadUI.exactContact(
+            record.number, ThreadUI.validateContact.bind(ThreadUI, record)
+          );
+
+          sinon.assert.called(ThreadUI.recipients.update);
+
+          record.isInvalid = true;
+
+          sinon.assert.calledWithMatch(ThreadUI.recipients.update, 0, record);
+        });
+
+        test('No exact contact, editting recipient ', function() {
+          var record = {
+            isQuestionable: true,
+            name: 'Jane Doozer',
+            number: 'Jane Doozer',
+            source: 'manual'
+          };
+
+          this.sinon.stub(Contacts, 'findExact', function(term, callback) {
+            callback([], {});
+          });
+
+          ThreadUI.exactContact(
+            record.number, ThreadUI.validateContact.bind(ThreadUI, record)
+          );
+
+          assert.isFalse(ThreadUI.recipients.update.called);
+        });
+
+        test('Determines correct strategy ', function() {
+          var record = {
+            isQuestionable: true,
+            isLookupable: true,
+            name: 'Jane Doozer',
+            number: 'Jane Doozer',
+            source: 'manual'
+          };
+
+          ThreadUI.recipients.add(record);
+
+          record.isLookupable = false;
+
+          ThreadUI.recipients.add(record);
+
+          sinon.assert.calledOnce(ThreadUI.searchContact);
+          sinon.assert.calledOnce(ThreadUI.exactContact);
         });
       });
     });
 
-    suite('Existing Conversation', function() {
+    suite('validateContact', function() {
+      var fixture, contacts;
 
       setup(function() {
-        window.location.hash = '#thread=1';
+        fixture = {
+          name: 'Janet Jones',
+          number: '+346578888888',
+          source: 'manual',
+          isInvalid: false
+        };
+
+        contacts = MockContact.list([
+          { givenName: ['Janet'], familyName: ['Jones'] }
+        ]);
       });
 
-      test('Will not assimilate recipients ', function() {
-        var visible, add;
+      suite('No Recipients', function() {
+        test('input value has matching record ', function() {
 
-        ThreadUI.assimilateRecipients();
+          ThreadUI.validateContact(fixture, '', contacts);
 
-        visible = ThreadUI.recipients.visible;
-        add = ThreadUI.recipients.add;
+          sinon.assert.calledOnce(ThreadUI.recipients.remove);
+          sinon.assert.calledWith(ThreadUI.recipients.remove, 0);
 
-        assert.isFalse(visible.called);
-        assert.isFalse(add.called);
+          assert.equal(
+            ThreadUI.recipients.add.firstCall.args[0].source, 'contacts'
+          );
+          assert.equal(
+            ThreadUI.recipients.add.firstCall.args[0].number, '+346578888888'
+          );
+        });
+
+        test('input value is invalid ', function() {
+          // An actual accepted recipient from contacts
+          fixture.number = 'foo';
+          fixture.isQuestionable = true;
+
+          ThreadUI.recipients.add(fixture);
+          assert.isFalse(fixture.isInvalid);
+
+          ThreadUI.recipientsList.lastElementChild.textContent = '';
+
+          ThreadUI.validateContact(fixture, '', []);
+
+          sinon.assert.calledOnce(ThreadUI.recipients.update);
+          sinon.assert.calledWithMatch(ThreadUI.recipients.update, 1, fixture);
+
+          assert.isTrue(fixture.isInvalid);
+        });
+      });
+
+      suite('Has Recipients', function() {
+
+
+        test('input value has matching duplicate record w/ ' +
+              'multiple, different tel records (accept) ', function() {
+
+          // An actual accepted recipient from contacts
+          ThreadUI.recipients.add(fixture);
+
+          // The last accepted recipient, manually entered.
+          ThreadUI.recipients.add({
+            name: 'Janet Jones',
+            number: 'Janet Jones',
+            source: 'manual'
+          });
+
+          ThreadUI.validateContact(fixture, '', contacts);
+
+          sinon.assert.calledOnce(ThreadUI.recipients.remove);
+          sinon.assert.calledWith(ThreadUI.recipients.remove, 1);
+
+          assert.equal(
+            ThreadUI.recipients.add.lastCall.args[0].source, 'contacts'
+          );
+          assert.equal(
+            ThreadUI.recipients.add.lastCall.args[0].number, '+12125559999'
+          );
+          assert.equal(
+            Utils.basicContact.returnValues[0].number, '+12125559999'
+          );
+        });
+
+        test('input value has multiple matching records, the ' +
+              'first is a duplicate, use next (accept) ', function() {
+
+          contacts = MockContact.list([
+            { givenName: ['Janet'], familyName: ['Jones'] },
+            { givenName: ['Jane'], familyName: ['Johnson'] }
+          ]);
+
+          contacts[0].tel = [{value: '777'}];
+          contacts[1].tel = [{value: '888'}];
+
+          // An actual accepted recipient from contacts
+          ThreadUI.recipients.add({
+            name: 'Janet Jones',
+            number: '777',
+            source: 'contacts'
+          });
+
+          // The last accepted recipient, manually entered.a
+          ThreadUI.recipients.add({
+            name: 'Jane',
+            number: 'Jane',
+            source: 'manual'
+          });
+
+          ThreadUI.validateContact(fixture, '', contacts);
+
+          // Called from here, then called again for the
+          // second contact record.
+          sinon.assert.calledTwice(ThreadUI.validateContact);
+
+          sinon.assert.called(ThreadUI.recipients.remove);
+          sinon.assert.called(ThreadUI.recipients.add);
+
+          assert.equal(
+            ThreadUI.recipients.add.lastCall.args[0].source, 'contacts'
+          );
+          assert.equal(
+            ThreadUI.recipients.add.lastCall.args[0].number, '888'
+          );
+          assert.equal(
+            Utils.basicContact.returnValues[0].number, '888'
+          );
+        });
+
+        test('input value has matching duplicate record w/ ' +
+              'single, same tel record (invalid) ', function() {
+
+          // Get rid of the second tel record to create a "duplicate"
+          contacts[0].tel.length = 1;
+
+          // An actual accepted recipient from contacts
+          fixture.source = 'contacts';
+          ThreadUI.recipients.add(fixture);
+
+          fixture.source = 'manual';
+          // The last accepted recipient, manually entered.
+          ThreadUI.recipients.add(fixture);
+
+          assert.isFalse(fixture.isInvalid);
+
+          ThreadUI.recipientsList.lastElementChild.textContent = '';
+          ThreadUI.validateContact(fixture, '', contacts);
+
+          // ThreadUI.recipients.update is called with the updated
+          // source recipient object. This object's isValid property
+          // has been set to true.
+          sinon.assert.calledOnce(
+            ThreadUI.recipients.update
+          );
+          sinon.assert.calledWithMatch(
+            ThreadUI.recipients.update, 1, fixture
+          );
+          assert.isTrue(fixture.isInvalid);
+        });
       });
     });
   });

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -934,7 +934,6 @@ suite('getContactDisplayInfo', function() {
         assert.deepEqual(Utils.getContactDetails.args[0][0], tel);
         assert.ok(Utils.getDisplayObject.called);
         assert.deepEqual(Utils.getDisplayObject.args[0][1], tel);
-        MockContact.list.restore();
         done();
       }
     );
@@ -957,7 +956,6 @@ suite('getContactDisplayInfo', function() {
         assert.deepEqual(Utils.getContactDetails.args[0][0], tel);
         assert.ok(Utils.getDisplayObject.called);
         assert.deepEqual(Utils.getDisplayObject.args[0][1], tel);
-        MockContact.list.restore();
         done();
       }
     );
@@ -974,7 +972,6 @@ suite('getContactDisplayInfo', function() {
         assert.isFalse(Utils.getContactDetails.called);
         assert.isFalse(Utils.getDisplayObject.called);
         assert.equal(data, null);
-        MockContact.list.restore();
         done();
       }
     );


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=920546
- Apply new "invalid recipient" indicator style
- Decouple searchContact from list display
- Create ThreadUI.listContact(...)
- Create ThreadUI.validateContact(...)
- Adds two level validation:
  - Is the entry questionable?
    - This kicks off a silent search for matching contacts
    - If there are one or more matches, use the first to create a Recipient
  - Is the entry invalid?
    - This state is reached if no contacts could be found
      for the typed value.
    - Prevents enableSend
    - Prevents "export" of recipient entry at Send
      (when mixed with multiple valid recipients)
- Refactor Utils.getContactDisplayInfo logic
- Adds tests for enableSend
- Adds tests for questionable Recipient detection.

Changes, post review:

> Bug 1:
> - enter a bogus recipient, press enter to "accept" it
> - press backspace => the cursor is correctly inside the contenteditable element, but it's still "red" and the keyboard is hiding

Fixed by adding CSS rules:
  [contenteditable=false].attention
  [contenteditable=true].attention

---

> Bug 2:
> - with the recipient light workload, that has a "Adam L. Card" contact
> - typing exactly "Adam L. Card" => no match
> - typing "Adam Card" => match

Yep, this has always been true. See also: https://bugzilla.mozilla.org/show_bug.cgi?id=860804

---

> Bug 3:
> - add text in the composer
> - add a bogus contact => the send button is enabled, should be disabled

Fixed by being more explicit in enableSend:

Set hasRecipients to true based on the following conditions:
1. There is a valid recipients object
2. One of the following is true:
   - The recipients object contains at least 1 valid recipient
     - OR -
   - There is >1 character typed and the value will not
     evaluate to a NaN

Signed-off-by: Rick Waldron waldron.rick@gmail.com
