### PR TITLE
removed the wait_for_favorite_list_not_displayed method

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/fmradio/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/fmradio/app.py
@@ -48,9 +48,6 @@ class FmRadio(Base):
         self.marionette.find_element(*self._favorite_button_locator).tap()
         self.wait_for_condition(lambda m: current_favorite_channel_count + 1 == len(self.favorite_channels))
 
-    def wait_for_favorite_list_not_displayed(self):
-        self.wait_for_element_not_displayed(*self._favorite_list_locator)
-
     @property
     def is_power_button_on(self):
         return self.marionette.find_element(*self._power_button_locator).get_attribute('data-enabled') == 'true'
@@ -73,3 +70,4 @@ class FmRadio(Base):
 
         def remove(self):
             self.root_element.find_element(*self._remove_locator).tap()
+            self.wait_for_element_not_present(*self._frequency_locator)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/fmradio/test_fmradio_remove_from_favorite.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/fmradio/test_fmradio_remove_from_favorite.py
@@ -35,8 +35,6 @@ class TestFMRadioRemoveFromFavorite(GaiaTestCase):
 
         # remove the station from favorite list
         self.fm_radio.favorite_channels[0].remove()
-        # TODO: The remove method should wait for the favourite to be removed. bug 864296
-        self.fm_radio.wait_for_favorite_list_not_displayed()
 
         # verify the change of favorite after remove
         self.assertEqual(0, len(self.fm_radio.favorite_channels))


### PR DESCRIPTION
This is for Bug 923402 (Bug 923402 - In test_fmradio_remove_from_favorite.py the remove method should wait for the favourite to be removed )
https://bugzilla.mozilla.org/show_bug.cgi?id=923402
