### PR TITLE
[Bug 923445] Align grid icons on first page [r=crdlc]

### DIFF
--- a/apps/homescreen/everything.me/css/everything.me.css
+++ b/apps/homescreen/everything.me/css/everything.me.css
@@ -106,7 +106,7 @@
 }
 .apps > div.evmePage {
     -moz-box-sizing: border-box;
-    padding-top: calc(25% + 1.3rem);
+    padding-top: 9.6rem;
 }
 
 .evme-displayed .apps > div.evmePage {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=923445
