### PR TITLE
Bug 923448 - In test_clock_turn_on_off_alarm.py remove the sleep and add a wait_for_checkbox_state_to_change

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/clock/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/clock/app.py
@@ -82,6 +82,7 @@ class Clock(Base):
         _tap_locator = (By.CSS_SELECTOR, '.alarm-item')
         _check_box_locator = (By.CSS_SELECTOR, '.alarmList .input-enable')
         _enable_button_locator = (By.CSS_SELECTOR, 'label.alarmList')
+        _alarm_checked_banner_locator = (By.CSS_SELECTOR, '#banner-countdown > p')
 
         @property
         def label(self):
@@ -97,6 +98,12 @@ class Clock(Base):
 
         def tap_checkbox(self):
             self.root_element.find_element(*self._enable_button_locator).tap()
+
+        def wait_for_alarm_to_uncheck(self):
+            self.wait_for_condition(lambda m: self.root_element.find_element(*self._check_box_locator).is_selected() == False)
+
+        def wait_for_banner_not_displayed(self):
+            self.wait_for_element_not_displayed(*self._alarm_checked_banner_locator)
 
         def tap(self):
             self.wait_for_element_displayed(*self._tap_locator)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/clock/test_clock_turn_on_off_alarm.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/clock/test_clock_turn_on_off_alarm.py
@@ -31,12 +31,11 @@ class TestClockTurnOnOffAlarm(GaiaTestCase):
         origin_alarm_checked = alarm.is_alarm_active
 
         alarm.tap_checkbox()
-        time.sleep(2)  # TODO: Remove the sleep and add a wait_for_checkbox_state_to_change (one day)
+        alarm.wait_for_alarm_to_uncheck()
         self.assertTrue(origin_alarm_checked != alarm.is_alarm_active, 'user should be able to turn on the alarm.')
 
         origin_alarm_checked = alarm.is_alarm_active
 
         alarm.tap_checkbox()
-        time.sleep(2)  # TODO: Remove the sleep and add a wait_for_checkbox_state_to_change (one day)
-
+        alarm.wait_for_banner_not_displayed()
         self.assertTrue(origin_alarm_checked != alarm.is_alarm_active, 'user should be able to turn off the alarm.')


### PR DESCRIPTION
I removed the sleep and instead of adding a wait_for_checkbox_state_to_change method, I added 2 methods, one for each changing state: wait_for_alarm_to_uncheck and wait_for_banner_not_displayed
