### PR TITLE
Bug 923702: Do not run camera tests within system app.

### DIFF
--- a/apps/system/Makefile
+++ b/apps/system/Makefile
@@ -7,3 +7,4 @@ copy-camera-app:
 	@rm -rf ./camera
 	@cp -r ../camera ./camera
 	@rm ./camera/manifest.webapp
+	@rm -rf ./camera/test


### PR DESCRIPTION
See:  https://bugzilla.mozilla.org/show_bug.cgi?id=923702
