### PR TITLE
Bug 923876 - Remove pragma no-cache from gaia applications

### DIFF
--- a/apps/bluetooth/transfer.html
+++ b/apps/bluetooth/transfer.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Bluetooth</title>
     <!-- Localization -->
     <link rel="resource" type="application/l10n" href="locales/locales.ini" />

--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Browser</title>
     <!-- Shared CSS-->
     <!-- <link rel="stylesheet" href="shared/style/headers.css"> -->

--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -2,7 +2,6 @@
 <html class="ltr">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="pragma" content="no-cache">
   <title>Calendar</title>
   <link rel="stylesheet" type="text/css" href="/style/calendar.css">
   <link rel="stylesheet" type="text/css" href="/style/ui.css">

--- a/apps/camera/index.html
+++ b/apps/camera/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Camera</title>
     <link rel="resource" type="application/l10n" href="locales/locales.ini">
     <link rel="resource" type="application/l10n" href="/shared/locales/date.ini">

--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Clock</title>
     <link rel="stylesheet" type="text/css" href="style/clock.css">
     <link rel="stylesheet" type="text/css" href="style/alarm.css">

--- a/apps/clock/onring.html
+++ b/apps/clock/onring.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Clock</title>
     <link rel="stylesheet" type="text/css" href="style/clock.css">
     <link rel="stylesheet" type="text/css" href="style/alarm.css">

--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Dialer</title>
 
     <!-- Localization -->

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Dialer</title>
     <link rel="stylesheet" type="text/css" href="/dialer/style/oncall.css">
     <link rel="stylesheet" type="text/css" href="/dialer/style/oncall_status_bar.css">

--- a/apps/communications/ftu/index.html
+++ b/apps/communications/ftu/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="pragma" content="no-cache">
 
   <!-- Common style -->
   <link rel="stylesheet" type="text/css" href="/shared/style/headers.css">

--- a/apps/costcontrol/fte.html
+++ b/apps/costcontrol/fte.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="pragma" content="no-cache">
   <title data-l10n-id="fte">Usage First Time Experience</title>
 
   <!-- Building blocks Temporal -->

--- a/apps/costcontrol/index.html
+++ b/apps/costcontrol/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title data-l10n-id="usage">
       Usage
     </title>

--- a/apps/fl/download.html
+++ b/apps/fl/download.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Locked Content</title>
     <link rel="stylesheet" href="shared/style/confirm.css" type="text/css" />
     <link rel="stylesheet" href="shared/style_unstable/progress_activity.css" type="text/css" />

--- a/apps/fl/pick.html
+++ b/apps/fl/pick.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Locked Content</title>
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/switches.css">

--- a/apps/fm/index.html
+++ b/apps/fm/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>FM Radio</title>
     <link rel="stylesheet" href="style/fm.css" type="text/css" />
     <link rel="resource" type="application/l10n" href="locales/locales.ini" />

--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Gallery</title>
     <link rel="stylesheet" href="style/gallery.css" type="text/css" />
     <link rel="stylesheet" href="style/VideoPlayer.css" type="text/css" />

--- a/apps/gallery/open.html
+++ b/apps/gallery/open.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Gallery</title>
     <link rel="stylesheet" href="style/open.css" type="text/css" />
     <link rel="stylesheet" href="shared/style/headers.css" type="text/css" />

--- a/apps/music/index.html
+++ b/apps/music/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Music</title>
     <!-- Include shared building blocks -->
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>

--- a/apps/music/open.html
+++ b/apps/music/open.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Music</title>
     <link rel="stylesheet" href="style/music.css" type="text/css" />
     <!-- Include shared building blocks -->

--- a/apps/ringtones/pick.html
+++ b/apps/ringtones/pick.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>System Ringtones</title>
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Settings</title>
 
     <!-- Debug/DUMP method support -->

--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Messages</title>
     <!-- Stable Building blocks -->
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css">

--- a/apps/system/emergency-call/index.html
+++ b/apps/system/emergency-call/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Emergency Call Dialer</title>
     <link rel="stylesheet" type="text/css" href="style/dialer.css">
     <link rel="stylesheet" type="text/css" href="style/keypad.css">

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
 
     <!-- Shared code -->
     <script src="shared/js/l10n.js"></script>

--- a/apps/system/payment.html
+++ b/apps/system/payment.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
 
     <!-- Payment -->
     <script defer src="js/payment.js"></script>

--- a/apps/system/test/marionette/fakemusic/index.html
+++ b/apps/system/test/marionette/fakemusic/index.html
@@ -3,7 +3,6 @@
 
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Fake Music</title>
 
     <style>

--- a/apps/video/index.html
+++ b/apps/video/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Videos</title>
     <link rel="resource" type="application/l10n" href="locales/locales.ini" />
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css" />

--- a/apps/video/view.html
+++ b/apps/video/view.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Videos</title>
     <link rel="resource" type="application/l10n" href="locales/locales.ini" />
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css">

--- a/apps/wallpaper/pick.html
+++ b/apps/wallpaper/pick.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Wallpaper</title>
     <link rel="stylesheet" href="style/wallpaper.css" type="text/css" />
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css"/>

--- a/apps/wallpaper/share.html
+++ b/apps/wallpaper/share.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Wallpaper</title>
     <link rel="stylesheet" type="text/css" href="style/wallpaper.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/buttons.css"/>

--- a/apps/wappush/index.html
+++ b/apps/wappush/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>WAP Push</title>
 
     <!-- Localization -->

--- a/apps/wappush/message.html
+++ b/apps/wappush/message.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>WAP Push message</title>
 
     <!-- Localization -->

--- a/showcase_apps/crystalskull/index.html
+++ b/showcase_apps/crystalskull/index.html
@@ -1,8 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="utf-8"> 
-    <meta http-equiv="pragma" content="no-cache">
+    <meta charset="utf-8">
     <title>Glass / Refraction, reflection, fresnel, chromatic dispersion | J3D</title> 
 
     <link type="text/css" rel="stylesheet" href="style/common.css">

--- a/showcase_apps/twittershare/index.html
+++ b/showcase_apps/twittershare/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Image Uploader</title>
 
     <link rel="stylesheet" type="text/css" href="style/twittershare.css"/>

--- a/test_apps/ds-test/index.html
+++ b/test_apps/ds-test/index.html
@@ -1,7 +1,6 @@
   <!DOCTYPE HTML>
   <head>
       <meta charset="utf-8" />
-      <meta http-equiv="pragma" content="no-cache" />
 <html>
     <meta name="viewport" content="width=device-width" />
     <title>Device Storage Test</title>

--- a/test_apps/geoloc/index.html
+++ b/test_apps/geoloc/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Geolocation Debug</title>
     <link rel="stylesheet" type="text/css" href="shared/style/buttons.css" />
     <link rel="stylesheet" type="text/css" href="shared/style/headers.css" />

--- a/test_apps/image-uploader/index.html
+++ b/test_apps/image-uploader/index.html
@@ -3,7 +3,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="pragma" content="no-cache" />
     <title>Image Uploader</title>
     <script type="application/javascript" src="js/ext/sha1.js"></script>
     <script type="application/javascript" src="js/ext/oauth.js"></script>

--- a/test_apps/membuster/index.html
+++ b/test_apps/membuster/index.html
@@ -3,7 +3,6 @@
 
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Template</title>
 
     <style>

--- a/test_apps/share-receiver/index.html
+++ b/test_apps/share-receiver/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Share Receiver</title>
     <script src="js/share-receiver.js"></script>
   </head>

--- a/test_apps/template/index.html
+++ b/test_apps/template/index.html
@@ -3,7 +3,6 @@
 
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Template</title>
 
     <style>

--- a/test_apps/test-receiver-1/index.html
+++ b/test_apps/test-receiver-1/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Test Receiver</title>
   </head>
   <body>

--- a/test_apps/test-receiver-2/index.html
+++ b/test_apps/test-receiver-2/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Test Receiver</title>
   </head>
   <body>

--- a/test_apps/test-receiver-inline/index.html
+++ b/test_apps/test-receiver-inline/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Test Receiver</title>
     <script src="js/inline-receiver.js" defer></script>
     <style>

--- a/test_apps/uitest/tests/identity-get.html
+++ b/test_apps/uitest/tests/identity-get.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Identity Demo: get() API</title>
 
     <link rel="stylesheet" type="text/css" href="style/style.css">

--- a/test_apps/uitest/tests/identity.html
+++ b/test_apps/uitest/tests/identity.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Identity Demo</title>
 
     <link rel="stylesheet" type="text/css" href="style/style.css">

--- a/test_apps/uitest/tests/inputmode.html
+++ b/test_apps/uitest/tests/inputmode.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Inputmode tests</title>
     <style>
       input { width: 150px; }

--- a/test_external_apps/packstubtest/index.html
+++ b/test_external_apps/packstubtest/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="pragma" content="no-cache">
     <title>Packaged Stub Test</title>
     <link rel="stylesheet" type="text/css" href="style/app.css">
     <link rel="resource" type="application/l10n" href="locales/locales.ini">


### PR DESCRIPTION
Rationale for removal:
- These meta tags aren't really doing anything for us today being packaged applications.
- They cause a bit of confusion when you see them in HTML files as there is no reason for them being there.
- It's trivial to add these again should they provide some benefit in the future.
