### PR TITLE
Bug 924078 - Remove xfail for camera tests on aurora

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/camera/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/camera/manifest.ini
@@ -5,13 +5,7 @@ sdcard = true
 
 [test_camera_capture_photo.py]
 skip-if = device == "desktop"
-# Bug 913418 - Opening image from film strip results in black screen
-xfail = true
 [test_camera_capture_video.py]
 skip-if = device == "desktop"
-# Bug 912957 - Film strip not visible after taking a video
-xfail = true
 [test_camera_multiple_shots.py]
 skip-if = device == "desktop"
-# Bug 913418 - Opening image from film strip results in black screen
-xfail = true


### PR DESCRIPTION
Since bug 913418 has been fixed, tests in tests/functional/camera/manifest.ini can be un-xfailed.

test_camera_capture_video.py will fail, but the fix is in the pull for bug 924079 - Fix failing /camera/test_camera_capture_video.py on aurora
