### PR TITLE
Bug 914100 - [Messages] Prevent keyboard from disappearing when recipients are rendered after user input

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -831,7 +831,6 @@
           isDeletingRecipient = true;
         }
 
-
         break;
 
       case 'keypress':
@@ -924,20 +923,28 @@
 
         // Clear the displayed list
         // Render the recipients as a fresh list
-        // Set focus on the very placeholder item.
-        this.render().focus();
+        this.render();
+
+        // Defer setting focus to the next execution turn to allow
+        // recipients list rendering (innerHTML) to complete.
+        setTimeout(this.focus.bind(this), 0);
       }
     }
 
     if (isDeletingRecipient) {
-      this.render().focus();
+      this.render();
+
+      // Defer setting focus
+      setTimeout(this.focus.bind(this), 0);
     }
 
     if (isEdittingRecipient) {
       // Make the last added entry "editable"
       target.contentEditable = true;
       target.isPlaceholder = true;
-      this.focus(target);
+
+      // Defer setting focus
+      setTimeout(this.focus.bind(this, target), 0);
     }
 
     if (isPreventingDefault) {


### PR DESCRIPTION
- Recipients.View
  - Had a race condition between `render()` and `focus()` because of calls to `innerHTML` within `render()` (and `target.isPlaceholder`?) which were asynchronous
  - Used `setTimeout` in 3 places to defer setting focus to the next execution turn to allow recipients list rendering to complete
- Tests:
  - Integration test needed?
- Questions:
  - This now fixes three cases of the keyboard hiding:
    - when adding recipients by typing ';'
    - when deleting manually entered contacts
    - when deleting contacts entered from the contacts app.
  - However, the keyboard _still_ hides when you are adding recipients from the contacts app, because that gets handled by `Recipients.prototype.add`, which calls `render()` at the end, but not `focus()`. This may be desired behavior when you are generally adding from contacts app, or maybe not.  I suggest adding a `focus()` here as well.  Waiting for review to decide.
