### PR TITLE
Bug 924367 - Xfailed videoplayer tests with bug 874897 aurora

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/videoplayer/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/videoplayer/app.py
@@ -13,7 +13,7 @@ class VideoPlayer(Base):
     _progress_bar_locator = (By.ID, 'progress')
 
     # Video list/summary view
-    _video_items_locator = (By.CSS_SELECTOR, 'ul#thumbnails li[data-name]')
+    _video_items_locator = (By.CSS_SELECTOR, 'ul#thumbnails li.thumbnail')
     _video_name_locator = (By.CSS_SELECTOR, 'div.details')
 
     _empty_video_title_locator = (By.ID, 'overlay-title')


### PR DESCRIPTION
All videoplayer tests fail now because of bug 874897:
https://bugzilla.mozilla.org/show_bug.cgi?id=874897#c31
