### PR TITLE
Bug 915081 - Hide the end-and-answer button during CDMA call waiting

### DIFF
--- a/apps/communications/dialer/js/call_screen.js
+++ b/apps/communications/dialer/js/call_screen.js
@@ -57,6 +57,21 @@ var CallScreen = {
     this.calls.classList.toggle('big-duration', enabled);
   },
 
+  /**
+   * When enabled hides the end-and-answer button in call waiting mode and
+   * displays only the hold-and-answer one.
+   *
+   * @param {Boolean} enabled Enables hold-and-answer-only operation.
+   */
+  set holdAndAnswerOnly(enabled) {
+    this.incomingContainer.classList.toggle('hold-and-answer-only', enabled);
+  },
+
+  /**
+   * When enabled displays the CDMA-specific call-waiting UI
+   *
+   * @param {Boolean} enabled Enables the CDMA call-waiting UI.
+   */
   set cdmaCallWaiting(enabled) {
     this.calls.classList.toggle('switch', enabled);
     this.callToolbar.classList.toggle('no-add-call', enabled);

--- a/apps/communications/dialer/js/calls_handler.js
+++ b/apps/communications/dialer/js/calls_handler.js
@@ -297,6 +297,10 @@ var CallsHandler = (function callsHandler() {
       });
     });
 
+    if (cdmaCallWaiting()) {
+      CallScreen.holdAndAnswerOnly = true;
+    }
+
     CallScreen.showIncoming();
     playWaitingTone(call);
   }

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -615,6 +615,19 @@
     font-size: 0.9em;
   }
 
+  #incoming-container.hold-and-answer-only #incoming-answer {
+    width: 100%;
+  }
+
+  #incoming-container.hold-and-answer-only #incoming-answer > span[role="button"] {
+    margin-left: 1.0rem;
+    margin-right: 1.0rem;
+  }
+
+  #incoming-container.hold-and-answer-only #incoming-end {
+    display: none;
+  }
+
   #incoming-answer > span[role="button"] {
     background: url('images/btn_resume.png') repeat-x center / auto 100%;
     line-height: 4rem;

--- a/apps/communications/dialer/style/oncall_status_bar.css
+++ b/apps/communications/dialer/style/oncall_status_bar.css
@@ -121,4 +121,8 @@
     display: none;
   }
 
+  #calls > section .switch-calls {
+    display: none;
+  }
+
 }

--- a/apps/communications/dialer/test/unit/call_screen_test.js
+++ b/apps/communications/dialer/test/unit/call_screen_test.js
@@ -38,6 +38,7 @@ suite('call screen', function() {
       lockedClockNumbers,
       lockedClockMeridiem,
       lockedDate;
+  var incomingContainer;
 
   mocksHelperForCallScreen.attachTestHelpers();
 
@@ -103,6 +104,10 @@ suite('call screen', function() {
     lockedHeader.appendChild(lockedDate);
     screen.appendChild(lockedHeader);
 
+    incomingContainer = document.createElement('article');
+    incomingContainer.id = 'incoming-container';
+    screen.appendChild(incomingContainer);
+
     // Replace the existing elements
     // Since we can't make the CallScreen look for them again
     if (CallScreen != null) {
@@ -116,6 +121,7 @@ suite('call screen', function() {
       CallScreen.lockedClockNumbers = lockedClockNumbers;
       CallScreen.lockedClockMeridiem = lockedClockMeridiem;
       CallScreen.lockedDate = lockedDate;
+      CallScreen.incomingContainer = incomingContainer;
     }
 
     requireApp('communications/dialer/js/call_screen.js', done);
@@ -154,6 +160,16 @@ suite('call screen', function() {
         assert.isFalse(calls.classList.contains('switch'));
         assert.isFalse(callToolbar.classList.contains('no-add-call'));
       });
+
+      test('holdAndAnswerOnly should add the hold-and-answer-only class',
+        function() {
+          assert.isFalse(
+            incomingContainer.classList.contains('hold-and-answer-only'));
+          CallScreen.holdAndAnswerOnly = true;
+          assert.isTrue(
+            incomingContainer.classList.contains('hold-and-answer-only'));
+        }
+      );
     });
 
     suite('insertCall', function() {

--- a/apps/communications/dialer/test/unit/calls_handler_test.js
+++ b/apps/communications/dialer/test/unit/calls_handler_test.js
@@ -247,6 +247,11 @@ suite('calls handler', function() {
         assert.isTrue(playSpy.calledOnce);
       });
 
+      test('should display the hold-and-answer button only', function() {
+        MockMozTelephony.mTriggerCallsChanged();
+        assert.isTrue(MockCallScreen.mHoldAndAnswerOnly);
+      });
+
       test('should do the same after answering another call', function() {
         MockMozTelephony.mTriggerCallsChanged();
         var showSpy = this.sinon.spy(MockCallScreen, 'showIncoming');

--- a/apps/communications/dialer/test/unit/mock_call_screen.js
+++ b/apps/communications/dialer/test/unit/mock_call_screen.js
@@ -54,6 +54,11 @@ var MockCallScreen = {
   },
   mSingleLine: null,
 
+  set holdAndAnswerOnly(enabled) {
+    this.mHoldAndAnswerOnly = enabled;
+  },
+  mHoldAndAnswerOnly: false,
+
   set cdmaCallWaiting(enabled) {
     this.mCdmaCallWaiting = enabled;
   },


### PR DESCRIPTION
- Removed the end-and-answer button when in CDMA call waiting mode as it
  does not support ending the first call and answering the other one,
  the hold-and-answer button is enlarged to fill up the entire container
  under these conditions
- Refactored the CDMA CSS code
- Added unit-tests covering the changes
