### PR TITLE
Bug 924955 - Enable tests for Hamachi device

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -19,5 +19,3 @@ lan = true
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
 online = true
-# Bug 922334 - crash in sysconf [B2G][Browser][Youtube] Playing youtube videos crash the browser tab
-xfail = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
@@ -2,8 +2,6 @@
 [test_call_contact.py]
 skip-if = device == "desktop"
 carrier = true
-xfail = true
-# Bug 914823 - crash in mozilla::gl::SharedSurface_Gralloc::~SharedSurface_Gralloc
 [test_edit_contact.py]
 [test_sms_contact.py]
 skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
@@ -7,8 +7,6 @@ skip-if = device == "desktop"
 [test_cost_control_data_alert_mobile.py]
 skip-if = device == "desktop"
 online = true
-# Bug 914809 - crash in mozilla::layers::GrallocBufferActor::ActorDestroy
-xfail = true
 [test_cost_control_reset_wifi.py]
 skip-if = device == "desktop"
 online = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
@@ -6,13 +6,9 @@ carrier = true
 skip-if = device == "desktop"
 [test_dialer.py]
 skip-if = device == "desktop"
-xfail = true
-# Bug 914823 - crash in mozilla::gl::SharedSurface_Gralloc::~SharedSurface_Gralloc
 [test_MMI.py]
 skip-if = device == "desktop"
 [test_dialer_add_contact.py]
 skip-if = device == "desktop"
 [test_call_log_all_calls.py]
 skip-if = device == "desktop"
-xfail = true
-# Bug 914823 - crash in mozilla::gl::SharedSurface_Gralloc::~SharedSurface_Gralloc

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
@@ -7,5 +7,3 @@ carrier = true
 [test_sms_with_attachments.py]
 skip-if = device == "desktop"
 carrier = true
-# Bug 906933 - Failing to connect/reconnect to cell data
-xfail = true


### PR DESCRIPTION
These may still fail for Unagi device but Hamachi is teh new priority!
