### PR TITLE
Bug 925357 - Have a way to disable / enable the soft keyboard

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -80,6 +80,7 @@ var KeyboardManager = {
       console.log('[Keyboard Manager] ' + msg);
   },
   keyboardHeight: 0,
+  enabled: true,
 
   init: function km_init() {
     var self = this;
@@ -123,6 +124,9 @@ var KeyboardManager = {
         case 'inputmethod-contextchange':
           self.inputFocusChange(evt);
           break;
+        case 'inputmethod-toggle-softkeyboard':
+          self.toggleSoftKeyboard(evt.detail.enabled);
+          break;
       }
     });
 
@@ -138,6 +142,13 @@ var KeyboardManager = {
       res[k].push(curr);
       return res;
     }, {});
+  },
+
+  toggleSoftKeyboard: function kn_toggleSoftKeyboard(enabled) {
+    this.enabled = enabled;
+    if (!enabled) {
+      this.hideKeyboard();
+    }
   },
 
   getHeight: function kn_getHeight() {
@@ -222,6 +233,9 @@ var KeyboardManager = {
     // Skip the <select> element and inputs with type of date/time,
     // handled in system app for now
     if (!type || type in IGNORED_INPUT_TYPES)
+      return;
+
+    if (!this.enabled)
       return;
 
     var self = this;


### PR DESCRIPTION
Fix for [#925357](https://bugzilla.mozilla.org/show_bug.cgi?id=925357). Toggle soft keyboards.

Also updated Keyboard.jsm that still lives in both Gecko/Gaia (a follow up for that already exists for when we completely remove mozKeyboard). So please look only at keyboard_manager.js.
