### PR TITLE
Bug 925348: Spread out contact scroll rendering work.

### DIFF
--- a/apps/communications/contacts/js/views/list.js
+++ b/apps/communications/contacts/js/views/list.js
@@ -90,8 +90,9 @@ contacts.List = (function() {
     toRender.push(el);
 
     // Avoid rescheduling the timer if it has not run yet.
-    if (renderTimer)
+    if (renderTimer) {
       return;
+    }
 
     renderTimer = setTimeout(doRenderTimer);
   };
@@ -111,13 +112,15 @@ contacts.List = (function() {
   };
 
   var renderLoadedContact = function(el, id) {
-    if (el.dataset.rendered)
+    if (el.dataset.rendered) {
       return;
+    }
     id = id || el.dataset.uuid;
     var group = el.dataset.group;
     var contact = loadedContacts[id] ? loadedContacts[id][group] : null;
-    if (!contact)
+    if (!contact) {
       return;
+    }
     renderContact(contact, el);
     clearLoadedContact(el, id, group);
   };
@@ -654,7 +657,9 @@ contacts.List = (function() {
     var vm_file = '/shared/js/tag_visibility_monitor.js';
     LazyLoader.load([vm_file], function() {
       var scrollMargin = ~~(viewHeight * 1.5);
-      var scrollDelta = ~~(scrollMargin / 2);
+      // NOTE: Making scrollDelta too large will cause janky scrolling
+      //       due to bursts of onscreen() calls from the monitor.
+      var scrollDelta = ~~(scrollMargin / 10);
       monitor = monitorTagVisibility(scrollable, 'li', scrollMargin,
                                      scrollDelta, onscreen, offscreen);
     });


### PR DESCRIPTION
This commit avoids spikes of DOM modifications during scrolling by tweaking
the tag_visibility_monitor parameters.  The new parameters result in more
frequent updates from the monitor which spreads the resulting work out
over time during scrolling.

See:  https://bugzilla.mozilla.org/show_bug.cgi?id=925348
