### PR TITLE
Bug 925702 - Reenable tests/functional/dialer tests on aurora

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py
@@ -12,8 +12,7 @@ class CallScreen(Phone):
     _call_screen_locator = (By.CSS_SELECTOR, "iframe[name='call_screen0']")
     _calling_contact_locator = (By.CSS_SELECTOR, 'div.number')
     _calling_contact_information_locator = (By.CSS_SELECTOR, 'div.additionalContactInfo')
-    # Quick fix locator until Bug 912490 is merged in.
-    _outgoing_call_locator = (By.XPATH, '//section[div/div[@class="direction outgoing"]]')
+    _outgoing_call_locator = (By.CSS_SELECTOR, '.handled-call.outgoing')
     _hangup_bar_locator = (By.ID, 'callbar-hang-up-action')
 
     def __init__(self, marionette):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
@@ -4,19 +4,11 @@ carrier = true
 
 [test_dialer_airplane_mode.py]
 skip-if = device == "desktop"
-# Bug 904625 - Wrong error message displayed when making a call in airplane mode
-xfail = true
 [test_dialer.py]
 skip-if = device == "desktop"
-xfail = true
-# Bug 914823 - crash in mozilla::gl::SharedSurface_Gralloc::~SharedSurface_Gralloc
 [test_MMI.py]
 skip-if = device == "desktop"
-xfail = true
-# Bug 915038 - [Dialer] IMEI code not working in dialer app
 [test_dialer_add_contact.py]
 skip-if = device == "desktop"
 [test_call_log_all_calls.py]
 skip-if = device == "desktop"
-xfail = true
-# Bug 914823 - crash in mozilla::gl::SharedSurface_Gralloc::~SharedSurface_Gralloc


### PR DESCRIPTION
Remove xfails for all tests in tests/functional/dialer on aurora since bug 904625, bug 914823 and bug 915038 have been fixed.

In order to re-enable all the tests, this locator needs to be updated:
https://github.com/mozilla-b2g/gaia/blob/v1.2/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py#L16
