### PR TITLE
Bug 925370 - Update e.me app on aurora

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
@@ -6,20 +6,22 @@ online = true
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
-# Bug 915644 - Searching skyfall on ev.me returns API error
-xfail = true
+expected = fail
+
 [test_everythingme_app_install.py]
 # Bug 877604 - long_press action failing on B2G desktop client when installing an Everything.me app
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
+expected = fail
+
 [test_everythingme_search.py]
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
-# Bug 915644 - Searching skyfall on ev.me returns API error
-xfail = true
+
 [test_everythingme_search_accented.py]
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
+
 [test_everythingme_launch_packaged_app.py]


### PR DESCRIPTION
The e.me app was updated on aurora and the app needs to be updated too.

The tests that need typing into the search bar will fail because of a known issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=925342

In order to test the pull, add a time.sleep(2) here before running the tests: 
https://github.com/mozilla-b2g/gaia/blob/master/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py#L175
