### PR TITLE
Bug 921928 - Add a role='application' attribute to apps iframes

### DIFF
--- a/apps/system/js/browser_frame.js
+++ b/apps/system/js/browser_frame.js
@@ -39,6 +39,11 @@ var BrowserFrame = (function invocation() {
     // platform.
     browser.setAttribute('mozbrowser', 'true');
 
+    // Mark the iframe as an application. This will be used by event fluffing
+    // heuristics, to avoid edge cases where the attention screen is prefered
+    // over user's applications, confere bug 921928.
+    browser.setAttribute('role', 'application');
+
     // Give a name to the frame for differentiating between main frame and
     // inline frame. With the name we can get frames of the same app using the
     // window.open method.


### PR DESCRIPTION
The event fluffing heuristic might, in some cases, activates the wrong
app. One documented case is bug 921928 where the attention screen might
get preferred over user's apps when tapping too close to it. Adding a
role application attribute enables us to tune the heuristic on Gecko
side and provider a smoother user experience.
