### PR TITLE
Bug 924233: Add missing requires to comms unit tests.

### DIFF
--- a/apps/communications/contacts/test/unit/link_test.js
+++ b/apps/communications/contacts/test/unit/link_test.js
@@ -1,3 +1,4 @@
+require('/shared/js/text_normalizer.js');
 requireApp('communications/contacts/test/unit/mock_link.html.js');
 requireApp('communications/contacts/test/unit/mock_l10n.js');
 requireApp('communications/facebook/test/unit/mock_curtain.js');

--- a/apps/communications/contacts/test/unit/navigation_test.js
+++ b/apps/communications/contacts/test/unit/navigation_test.js
@@ -1,3 +1,4 @@
+require('/shared/js/lazy_loader.js');
 requireApp('communications/contacts/test/unit/mock_contacts_index.html.js');
 requireApp('communications/contacts/js/navigation.js');
 

--- a/apps/communications/ftu/test/unit/support_contacts_customizer_test.js
+++ b/apps/communications/ftu/test/unit/support_contacts_customizer_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 requireApp('communications/ftu/js/customizers/customizer.js');
+requireApp('communications/ftu/js/customizers/wallpaper_customizer.js');
 requireApp('communications/ftu/js/customizers/support_contacts_customizer.js');
 requireApp('communications/ftu/test/unit/mock_navigator_moz_settings.js');
 


### PR DESCRIPTION
See:  https://bugzilla.mozilla.org/show_bug.cgi?id=924233
