### PR TITLE
Bug 924233: Add missing requires to homescreen tests.

### DIFF
--- a/apps/homescreen/test/unit/homescreen_test.js
+++ b/apps/homescreen/test/unit/homescreen_test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('/shared/js/lazy_loader.js');
 requireApp('homescreen/test/unit/mock_app.js');
 requireApp('homescreen/test/unit/mock_request.html.js');
 requireApp('homescreen/test/unit/mock_lazy_loader.js');
@@ -7,6 +8,7 @@ requireApp('homescreen/test/unit/mock_l10n.js');
 requireApp('homescreen/test/unit/mock_grid_manager.js');
 requireApp('homescreen/test/unit/mock_pagination_bar.js');
 requireApp('homescreen/test/unit/mock_manifest_helper.js');
+requireApp('homescreen/js/grid_components.js');
 requireApp('homescreen/js/message.js');
 requireApp('homescreen/js/request.js');
 

--- a/apps/homescreen/test/unit/request_test.js
+++ b/apps/homescreen/test/unit/request_test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+requireApp('homescreen/test/unit/mock_l10n.js');
 requireApp('homescreen/test/unit/mock_request.html.js');
 requireApp('homescreen/js/request.js');
 


### PR DESCRIPTION
See:  https://bugzilla.mozilla.org/show_bug.cgi?id=924233
