### PR TITLE
Bug 924233: Add missing requires to video tests.

### DIFF
--- a/apps/video/test/unit/thumbnail_date_group_test.js
+++ b/apps/video/test/unit/thumbnail_date_group_test.js
@@ -10,6 +10,7 @@ require('/shared/js/media/media_utils.js');
 requireApp('/video/test/unit/mock_l10n.js');
 requireApp('/video/test/unit/mock_thumbnail_item.js');
 requireApp('/video/js/thumbnail_date_group.js');
+requireApp('/video/js/thumbnail_item.js');
 
 suite('Thumbnail Date Group Unit Tests', function() {
 

--- a/apps/video/test/unit/thumbnail_item_test.js
+++ b/apps/video/test/unit/thumbnail_item_test.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+require('/shared/js/l10n.js');
 require('/shared/js/template.js');
 require('/shared/js/media/media_utils.js');
 requireApp('/video/test/unit/mock_l10n.js');


### PR DESCRIPTION
See:  https://bugzilla.mozilla.org/show_bug.cgi?id=924233
