### PR TITLE
Bug 924233: Fix l10n test by removing sinon cleanup handler after initia...

### DIFF
--- a/apps/gallery/test/unit/l10n_test.js
+++ b/apps/gallery/test/unit/l10n_test.js
@@ -70,7 +70,10 @@ suite('L10n', function() {
     document.head.appendChild(inline);
 
     navigator.mozL10n.language.code = lang;
-    navigator.mozL10n.ready(function() {
+    navigator.mozL10n.ready(function suiteSetup_ready() {
+      // Make sure to remove this event listener in case we re-translate
+      // below.  The xhr mock won't exist any more.
+      window.removeEventListener('localized', suiteSetup_ready);
       xhr.restore();
       done();
     });


### PR DESCRIPTION
...l translation.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=924233
