### PR TITLE
Bug 926524: Remove bound click handler in MessageListTopbar.

### DIFF
--- a/apps/email/js/message_list_topbar.js
+++ b/apps/email/js/message_list_topbar.js
@@ -58,7 +58,10 @@ MessageListTopbar.prototype = {
    * @param {Element} el The div we'll decorate.
    */
   decorate: function(el) {
-    el.addEventListener('click', this._onclick.bind(this));
+    // bind() creates a unique function object, so save a handle to
+    // it in order to remove the listener later.
+    this._clickHandler = this._onclick.bind(this);
+    el.addEventListener('click', this._clickHandler);
     this._el = el;
     this.updateNewEmailCount();
     return this._el;
@@ -83,7 +86,8 @@ MessageListTopbar.prototype = {
    */
   destroy: function() {
     if (this._el) {
-      this._el.removeEventListener('click', this._onclick.bind(this));
+      this._el.removeEventListener('click', this._clickHandler);
+      this._clickHandler = null;
       this._el.classList.add('collapsed');
       this._el.textContent = '';
       this._el = null;

--- a/apps/email/test/unit/message_list_topbar_test.js
+++ b/apps/email/test/unit/message_list_topbar_test.js
@@ -103,8 +103,13 @@ suite('MessageListTopbar', function() {
 
   suite('#destroy', function() {
     setup(function() {
+      sinon.stub(subject, '_onclick');
       subject.decorate(el);
       subject.render();
+    });
+
+    teardown(function() {
+      subject._onclick.restore();
     });
 
     test('should hide _el', function() {
@@ -126,7 +131,6 @@ suite('MessageListTopbar', function() {
     });
 
     test('should remove the click listener on _el', function() {
-      sinon.stub(subject, '_onclick');
       subject.destroy();
       el.click();
       sinon.assert.notCalled(subject._onclick);


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=926524
