### PR TITLE
Bug 913324 - Select biggest icon that fits on the screen

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -1144,7 +1144,16 @@ var WindowManager = (function() {
 
     sizes.sort(function(x, y) { return y - x; });
 
-    return icons[sizes[0]];
+    var index = 0;
+    var width = document.documentElement.clientWidth;
+    for (var i = 0; i < sizes.length; i++) {
+      if (sizes[i] < width) {
+        index = i;
+        break;
+      }
+    }
+
+    return icons[sizes[index]];
   }
 
   // TODO: Move into app window.


### PR DESCRIPTION
When launching an app, we display one of the icon defined in its
manifest. If the application defines several ones, then we need to
select the biggest one that fits into the screen.
