### PR TITLE
Bug 925296 - [Messages]overlap in the to field when adding a recipient

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -717,11 +717,7 @@ section[role="region"].new #messages-to-field {
 }
 
 #messages-recipients-list-container {
-  position: absolute;
-  top: 0;
   z-index: -1;
-
-  padding: 0 4rem;
   -moz-box-sizing: border-box;
   border-bottom: 0.1rem solid #4d4d4d;
   width: 100%;
@@ -732,7 +728,7 @@ section[role="region"].new #messages-to-field {
 }
 
 #messages-recipients-list {
-  padding-top: 1.4rem;
+  padding: 1.4rem 0 0 0.5rem;
 }
 /*
 Used by Recipients.View to display multi or single line.


### PR DESCRIPTION
- Replace the recipient absolute position / container padding and let the layout engine adjust recipient size automatically.
