### PR TITLE
Bug 926875 - Move the iframe.focus call out of the hot path to avoid an ...

### DIFF
--- a/apps/system/js/window_manager.js
+++ b/apps/system/js/window_manager.js
@@ -357,11 +357,14 @@ var WindowManager = (function() {
         HomescreenLauncher.getHomescreen().setVisible(false);
       }
 
-      // Give the focus to the frame
-      iframe.focus();
-
       waitForNextPaint(frame, function makeWindowActive() {
         frame.classList.add('render');
+
+        // Giving focus to the frame can create an expensive reflow, so let's
+        // delay it until the frame has rendered.
+        if (frame.classList.contains('active')) {
+          iframe.focus();
+        }
       });
     }
 


### PR DESCRIPTION
...expensive reflow. r=alive
