### PR TITLE
Bug 917837 - [Music] Use Full Line Highlights in Album View

### DIFF
--- a/apps/music/style/music.css
+++ b/apps/music/style/music.css
@@ -994,14 +994,14 @@ li.list-item a {
   text-overflow: ellipsis;
   width: 100%;
   height: 6rem;
-  background: transparent;
-  transition: background 200ms ease;
+  background-color: transparent;
+  transition: background-color 200ms ease;
 }
 
 li.list-item a:active {
   color: black;
   text-shadow: rgba(255, 255, 255, 0.5) 0.1rem 0.1rem;
-  background: rgb(0, 138, 170);
+  background-color: rgba(52,140,158, .6);
 }
 
 /* title width is 100% - 1rem(padding) - 6rem(albumArt) */


### PR DESCRIPTION
[Bug 917837](https://bugzilla.mozilla.org/show_bug.cgi?id=917837)
