### PR TITLE
Bug 926971 - Use wait_for_everything_me_loaded in e.me tests, r=zac

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
@@ -28,10 +28,6 @@ class SearchPanel(Base):
         self.wait_for_condition(lambda m: self.marionette.find_element(*self._search_title_query_locator).text.lower() ==
                                 search_term.lower())
 
-    def wait_for_keyboard_visible(self):
-        self.wait_for_condition(
-            lambda m: 'evme-keyboard-visible' in self.marionette.find_element(*self._body).get_attribute('class'))
-
     def wait_for_everything_me_loaded(self):
         self.wait_for_condition(
             lambda m: 'evme-loading' not in self.marionette.find_element(*self._body).get_attribute('class'))

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
@@ -16,6 +16,8 @@ skip-if = device == "desktop"
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
 # TODO switch to fail-if when bug 884528 is fixed
 skip-if = device == "desktop"
+# Bug 927023 - [e.me] The type reported for "Skyfall" has changed from "Movies" to "BrandInfo"
+xfail = true
 
 [test_everythingme_search_accented.py]
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_launch_app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_launch_app.py
@@ -21,7 +21,7 @@ class TestEverythingMeLaunchApp(GaiaTestCase):
         homescreen.switch_to_homescreen_frame()
 
         search_panel = homescreen.tap_search_bar()
-        search_panel.wait_for_keyboard_visible()
+        search_panel.wait_for_everything_me_loaded()
         search_panel.type_into_search_box(app_name)
 
         search_panel.wait_for_everything_me_results_to_load()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_search.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_search.py
@@ -23,7 +23,7 @@ class TestEverythingMeSearch(GaiaTestCase):
         homescreen.switch_to_homescreen_frame()
 
         search_panel = homescreen.tap_search_bar()
-        search_panel.wait_for_keyboard_visible()
+        search_panel.wait_for_everything_me_loaded()
         search_panel.type_into_search_box(test_string)
 
         search_panel.wait_for_type('Movies')

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_search_accented.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_search_accented.py
@@ -23,7 +23,7 @@ class TestEverythingMeSearchAccented(GaiaTestCase):
         homescreen.switch_to_homescreen_frame()
 
         search_panel = homescreen.tap_search_bar()
-        search_panel.wait_for_keyboard_visible()
+        search_panel.wait_for_everything_me_loaded()
         search_panel.type_into_search_box(test_string)
 
         search_panel.wait_for_type('Sports')


### PR DESCRIPTION
Note that I had to change the "type" that we are waiting for in the "Skyfall" test to `BrandInfo` from `Movies` as that has changed in the app. I wonder if that check is going to continue to be brittle and perhaps it should be changed to wait for something else? If so, that change could be added to this PR, or done in a separate bug/PR.
