### PR TITLE
Bug 927002 bump minimum marionette client version to 0.6 

### DIFF
--- a/tests/python/gaia-ui-tests/setup.py
+++ b/tests/python/gaia-ui-tests/setup.py
@@ -13,7 +13,7 @@ version = {}
 execfile(os.path.join('gaiatest', 'version.py'), version)
 
 # dependencies
-deps = ['marionette_client>=0.5.36', 'mozdevice', 'py==1.4.14', 'requests']
+deps = ['marionette_client>=0.6', 'mozdevice', 'py==1.4.14', 'requests']
 
 setup(name='gaiatest',
       version=version['__version__'],


### PR DESCRIPTION
Merge this when armageddon starts.
