### PR TITLE
Bug 919834 - Hide advanced menu in media storage settings if there is on...

### DIFF
--- a/apps/camera/js/camera.js
+++ b/apps/camera/js/camera.js
@@ -1305,7 +1305,14 @@ var Camera = {
 
     switch (this._storageState) {
     case this.STORAGE_NOCARD:
-      this.showOverlay('nocard');
+      // if there is one or none storage, then user has nothing to
+      // choose from in media storage settings.
+      // In this case, do not show button to media settings storage
+      if (navigator.getDeviceStorages('pictures').length <= 1) {
+        this.showOverlay('nocard-nointmem');
+      } else {
+        this.showOverlay('nocard');
+      }
       break;
     case this.STORAGE_UNMOUNTED:
       this.showOverlay('pluggedin');

--- a/apps/camera/locales/camera.en-US.properties
+++ b/apps/camera/locales/camera.en-US.properties
@@ -10,6 +10,9 @@ error-recording-text  = An error prevented Camera from recording the video.
 nocard2-title = No memory card found
 nocard2-text  = Insert a memory card to take pictures or select an alternate default media location in settings.
 
+nocard-nointmem-title = No memory card found
+nocard-nointmem-text  = Insert a memory card to take pictures.
+
 pluggedin-title = Camera can not be used while plugged in
 pluggedin-text  = Unplug the phone to view pictures.
 

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -1128,12 +1128,6 @@ function showOverlay(id) {
       case 'nocard':
         title = navigator.mozL10n.get('nocard3-title');
         text = navigator.mozL10n.get('nocard3-text');
-        $('overlay-menu').classList.remove('hidden');
-        if (pendingPick) {
-          $('overlay-cancel-button').classList.remove('hidden');
-        } else {
-          $('storage-setting-button').classList.remove('hidden');
-        }
         break;
       case 'pluggedin':
         title = navigator.mozL10n.get('pluggedin2-title');

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -45,7 +45,7 @@ emptygallery2-title = No photos or videos
 emptygallery2-text  = Use the Camera app to get started.
 
 nocard3-title = No memory card
-nocard3-text  = Insert a memory card to use this app or select an alternate default media location in settings.
+nocard3-text  = Insert a memory card to use this app.
 
 pluggedin2-title = Memory card in use
 pluggedin2-text  = Unplug the phone to use this app.

--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -334,13 +334,6 @@ function showOverlay(id) {
     return;
   }
 
-  var menu = document.getElementById('overlay-menu');
-  if (id === 'nocard') {
-    menu.classList.remove('hidden');
-  } else {
-    menu.classList.add('hidden');
-  }
-
   var title, text;
   if (id === 'nocard') {
     title = navigator.mozL10n.get('nocard2-title');

--- a/apps/music/locales/music.en-US.properties
+++ b/apps/music/locales/music.en-US.properties
@@ -18,7 +18,7 @@ empty-title = Add songs to get started
 empty-text = Load songs on to the memory card.
 
 nocard2-title = No memory card found
-nocard2-text  = Insert a memory card to listen to songs or select an alternate default media location in settings.
+nocard2-text  = Insert a memory card to listen to songs.
 
 pluggedin-title = Music can not be used while phone is plugged in
 pluggedin-text  = Unplug the phone to play music.

--- a/apps/settings/elements/media_storage.html
+++ b/apps/settings/elements/media_storage.html
@@ -19,10 +19,10 @@
       </ul>
       <div id="volume-list">
       </div>
-      <header>
+      <header id="media-storage-advanced-header">
         <h2 data-l10n-id="advanced">Advanced</h2>
       </header>
-      <ul>
+      <ul id="media-storage-advanced-list">
         <li>
           <p data-l10n-id="default-media-location">Default media location</p>
           <p class="fake-select">

--- a/apps/settings/js/media_storage.js
+++ b/apps/settings/js/media_storage.js
@@ -232,7 +232,12 @@ var MediaStorage = {
 
     this.defaultMediaLocation = document.getElementById('defaultMediaLocation');
     this.defaultMediaLocation.addEventListener('click', this);
-    this.makeDefaultLocationMenu();
+    if (this._volumeList.length > 1) {
+      this.makeDefaultLocationMenu();
+      this.showAdvancedMenu(true);
+    } else {
+      this.showAdvancedMenu(false);
+    }
 
     window.addEventListener('localized', this);
 
@@ -341,6 +346,13 @@ var MediaStorage = {
     }
   },
 
+  showAdvancedMenu: function ms_showAdvancedMenu(show) {
+    var advancedUl = document.getElementById('media-storage-advanced-list');
+    var advancedMenu = document.getElementById('media-storage-advanced-header');
+    advancedUl.hidden = !show;
+    advancedMenu.hidden = !show;
+  },
+
   makeDefaultLocationMenu: function ms_makeDefaultLocationMenu() {
     var _ = navigator.mozL10n.get;
     var self = this;
@@ -367,14 +379,6 @@ var MediaStorage = {
       var button = selectionMenu.previousElementSibling;
       button.textContent = selectedOption.textContent;
       button.dataset.l10nId = selectedOption.dataset.l10nId;
-
-      // disable option menu if we have only one option
-      if (self._volumeList.length === 1) {
-        selectionMenu.disabled = true;
-        var obj = {};
-        obj[defaultMediaVolumeKey] = selectedOption.value;
-        Settings.mozSettings.createLock().set(obj);
-      }
     });
   },
   changeDefaultStorage: function ms_changeDefaultStorage() {

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -512,12 +512,6 @@ function showOverlay(id) {
   }
 
   if (id === 'nocard') {
-    dom.overlayMenu.classList.remove('hidden');
-  } else {
-    dom.overlayMenu.classList.add('hidden');
-  }
-
-  if (id === 'nocard') {
     dom.overlayTitle.textContent = navigator.mozL10n.get('nocard2-title');
     dom.overlayText.textContent = navigator.mozL10n.get('nocard2-text');
   } else {

--- a/apps/video/locales/video.en-US.properties
+++ b/apps/video/locales/video.en-US.properties
@@ -24,7 +24,7 @@ empty-title = Add videos to get started
 empty-text  = Load videos on to the memory card.
 
 nocard2-title = No memory card found
-nocard2-text  = Insert a memory card to watch videos or select an alternate default media location in settings.
+nocard2-text  = Insert a memory card to watch videos.
 
 pluggedin-title = Video can not be watched while plugged in
 pluggedin-text  = Unplug the phone to watch videos.


### PR DESCRIPTION
...ly one or no storage area

Also hide the button to media storage settings in Camera, Gallery, Music, and Video apps and change wording in these apps in case of one or no storage area on the phone.

[https://bugzilla.mozilla.org/show_bug.cgi?id=919834](https://bugzilla.mozilla.org/show_bug.cgi?id=919834)
