### PR TITLE
Bug 918998 - [1.2][email] Grouped notifications should not show email address when only one email account is configured.

### DIFF
--- a/apps/email/js/model.js
+++ b/apps/email/js/model.js
@@ -72,9 +72,7 @@ define(function(require) {
      * called after inited is true.
      */
     hasAccount: function() {
-      return !!(model.acctsSlice &&
-                model.acctsSlice.items &&
-                model.acctsSlice.items.length);
+      return (model.getAccountCount() > 0);
     },
 
     /**
@@ -95,6 +93,23 @@ define(function(require) {
       });
 
       return targetAccount;
+    },
+
+    /**
+     * Get the numbers of configured account.
+     * Should only be called after this.inited is true.
+     * @return {Number} numbers of account.
+     */
+    getAccountCount: function() {
+      var count = 0;
+
+      if (model.acctsSlice &&
+          model.acctsSlice.items &&
+          model.acctsSlice.items.length) {
+        count = model.acctsSlice.items.length;
+      }
+
+      return count;
     },
 
     /**

--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -87,7 +87,7 @@ define(function(require) {
         if (froms.indexOf(info.from) === -1)
           froms.push(info.from);
       });
-      return froms.join(', ');
+      return froms.join(mozL10n.get('senders-separation-sign'));
     }
 
     /*
@@ -127,7 +127,9 @@ define(function(require) {
               if (!model.getAccount(result.id).notifyOnNew)
                 return;
 
-              var dataString;
+              var dataString,
+                  subject,
+                  body;
 
               if (navigator.mozNotification) {
                 if (result.count > 1) {
@@ -136,12 +138,24 @@ define(function(require) {
                     accountId: result.id
                   });
 
+                  if (model.getAccountCount() === 1) {
+                    subject = mozL10n.get(
+                      'new-emails-notify-one-account',
+                      { n: result.count }
+                    );
+                  } else {
+                    subject = mozL10n.get(
+                      'new-emails-notify-multiple-accounts',
+                      {
+                        n: result.count,
+                        accountName: result.address
+                      }
+                    );
+                  }
+
                   sendNotification(
                     result.id,
-                    mozL10n.get('new-emails-notify', {
-                      n: result.count,
-                      accountName: result.address
-                    }),
+                    subject,
                     makeNotificationDesc(result.latestMessageInfos.sort(
                                            function(a, b) {
                                              return b.date - a.date;
@@ -151,16 +165,36 @@ define(function(require) {
                   );
                 } else {
                   result.latestMessageInfos.forEach(function(info) {
-                      dataString = fromObject({
-                        type: 'message_reader',
-                        accountId: info.accountId,
-                        messageSuid: info.messageSuid
-                      });
+                    dataString = fromObject({
+                      type: 'message_reader',
+                      accountId: info.accountId,
+                      messageSuid: info.messageSuid
+                    });
+
+                    if (model.getAccountCount() === 1) {
+                      subject = info.subject;
+                      body = info.from;
+                    } else {
+                      subject = mozL10n.get(
+                        'new-emails-notify-multiple-accounts',
+                        {
+                          n: result.count,
+                          accountName: result.address
+                        }
+                      );
+                      body = mozL10n.get(
+                        'new-emails-notify-multiple-accounts-body',
+                        {
+                          from: info.from,
+                          subject: info.subject
+                        }
+                      );
+                    }
 
                     sendNotification(
                       result.id,
-                      info.subject,
-                      info.from,
+                      subject,
+                      body,
                       iconUrl + '#' + dataString
                     );
                   });

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -412,6 +412,10 @@ toaster-retryable-syncfailed=Unable to connect to server
 form-clear-input=Remove text
 confirm-dialog-title=Confirmation
 
+# senders-separation-sign separates the email accounts of senders.
+# Notice that we have a space after the comma.
+senders-separation-sign=, 
+
 # new-emails refers to the text shown on a notification that users
 # get when they receive new, unread email. The ui component that utilizes
 # this lives in apps/email/js/message_list_topbar.js.
@@ -422,13 +426,28 @@ new-emails[few]={{ n }} New Emails
 new-emails[many]={{ n }} New Emails
 new-emails[other]={{ n }} New Emails
 
-# new-emails-notify is used when a system notification is generatef during
+# new-emails-notify-one-account is used when a system notification is generated during
 # a periodic background sync with the server. Since this goes to the system's
-# notification area and the user could have more than one account configured
-# with the email app, this notification includes the email address.
-new-emails-notify={[ plural(n) ]}
-new-emails-notify[one]=1 New Email - {{ accountName }}
-new-emails-notify[two]={{ n }} New Emails - {{ accountName }}
-new-emails-notify[few]={{ n }} New Emails - {{ accountName }}
-new-emails-notify[many]={{ n }} New Emails - {{ accountName }}
-new-emails-notify[other]={{ n }} New Emails - {{ accountName }}
+# notification area, and user has only one account configured with the email App.
+new-emails-notify-one-account={[ plural(n) ]}
+new-emails-notify-one-account[one]=1 New Email
+new-emails-notify-one-account[two]={{ n }} New Emails
+new-emails-notify-one-account[few]={{ n }} New Emails
+new-emails-notify-one-account[many]={{ n }} New Emails
+new-emails-notify-one-account[other]={{ n }} New Emails
+
+# new-emails-notify-multiple-accounts is used in the same situation
+# as new-emails-notify-one-account.
+# In this case, the user has more than one account configured
+# with the email app.
+new-emails-notify-multiple-accounts={[ plural(n) ]}
+new-emails-notify-multiple-accounts[one]=1 New Email ({{ accountName }})
+new-emails-notify-multiple-accounts[two]={{ n }} New Emails ({{ accountName }})
+new-emails-notify-multiple-accounts[few]={{ n }} New Emails ({{ accountName }})
+new-emails-notify-multiple-accounts[many]={{ n }} New Emails ({{ accountName }})
+new-emails-notify-multiple-accounts[other]={{ n }} New Emails ({{ accountName }})
+
+# new-emails-notify-multiple-accounts-body is used in the same situation
+# as new-emails-notify-multiple-accounts.
+# This is the body part of the notification.
+new-emails-notify-multiple-accounts-body={{ from }} “{{ subject }}”


### PR DESCRIPTION
Hide email info in notification bar when there is only one configured account.
Show email info when there are one more accounts.

http://bugzil.la/918998
