### PR TITLE
Bug 926357 - Write a test to use the 'Number' keyboard

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -103,6 +103,13 @@ class Keyboard(Base):
         keybframe = self.marionette.find_element(*self._keyboard_frame_locator)
         self.marionette.switch_to_frame(keybframe, focus=False)
 
+    @property
+    def current_keyboard(self):
+        self.marionette.switch_to_frame()
+        keyboard = self.marionette.find_element(*self._keyboard_frame_locator).get_attribute('data-frame-name')
+        self.switch_to_keyboard()
+        return keyboard
+
     # this is to get the locator of desired key on keyboard
     def _key_locator(self, val):
         if len(val) == 1:

--- a/tests/python/gaia-ui-tests/gaiatest/apps/ui_tests/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/ui_tests/app.py
@@ -4,6 +4,7 @@
 from marionette.by import By
 from gaiatest.apps.base import Base
 
+
 UI_TESTS = "UI Tests"
 
 
@@ -18,6 +19,7 @@ class UiTests(Base):
     _app_login_event = (By.CSS_SELECTOR, 'li.login')
     _app_logout_event = (By.CSS_SELECTOR, 'li.logout')
     _app_login_assertion_text = (By.CSS_SELECTOR, 'li.login div.assertion')
+    _keyboard_locator = (By.CSS_SELECTOR, '#test-list > li:nth-child(2) > a')
 
     def __init__(self, marionette):
         Base.__init__(self, marionette)
@@ -62,3 +64,26 @@ class UiTests(Base):
 
     def wait_for_login_event(self):
         self.wait_for_element_displayed(*self._app_login_event)
+
+    def tap_keyboard_option(self):
+        self.marionette.find_element(*self._keyboard_locator).tap()
+
+    def switch_to_keyboard_page_frame(self):
+        keyboard_page_iframe = self.marionette.find_element(By.CSS_SELECTOR, "#test-iframe[src*='keyboard']")
+        self.marionette.switch_to_frame(keyboard_page_iframe)
+        return KeyboardPage(self.marionette)
+
+
+class KeyboardPage(Base):
+
+    _keyboard_iframe_locator = (By.CSS_SELECTOR, "#test-iframe[src*='keyboard']")
+    _number_input_locator =(By.CSS_SELECTOR, 'li:nth-child(4) > input')
+
+    def tap_number_input(self):
+        self.marionette.find_element(*self._number_input_locator).tap()
+        from gaiatest.apps.keyboard.app import Keyboard
+        return Keyboard(self.marionette)
+
+    @property
+    def number_input(self):
+        return self.marionette.find_element(*self._number_input_locator).get_attribute('value')

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
@@ -2,3 +2,4 @@
 b2g = true
 
 [test_keyboard.py]
+[test_number_keyboard.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_number_keyboard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_number_keyboard.py
@@ -1,0 +1,25 @@
+# -*- coding: iso-8859-15 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.apps.ui_tests.app import UiTests
+
+
+class TestNumberKeyboard(GaiaTestCase):
+
+    def test_number_keyboard(self):
+        self.ui_tests = UiTests(self.marionette)
+        self.ui_tests.launch()
+        self.ui_tests.tap_keyboard_option()
+        keyboard_page = self.ui_tests.switch_to_keyboard_page_frame()
+        keyboard = keyboard_page.tap_number_input()
+        keyboard.switch_to_keyboard()
+        self.assertEqual(str(keyboard.current_keyboard), 'number')
+        keyboard._tap('1')
+        self.marionette.switch_to_frame()
+        self.marionette.switch_to_frame(self.ui_tests.app.frame)
+        keyboard_page = self.ui_tests.switch_to_keyboard_page_frame()
+        typed_number = keyboard_page.number_input
+        self.assertEqual(typed_number, u'1')


### PR DESCRIPTION
Hi!
I followed the steps indicated in bug description, beside the 4th one: "Assert the correct keyboard is shown". I passed the "number" keyboard as a parameter when using the switch_to_keyboard mehod instead. Even though I modified that method in the keyboard.app page, it won't affect other tests that use it, because I added _default_keyboard as default parameter, which is the standard keyboard. 
Thanks! 
