### PR TITLE
Bug 924893 - Use contextchange chrome event instead of mozKeyboard.onfocuschange in value selector

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -256,17 +256,6 @@ const keyboardHashKey = [
   'numberLayout'
 ];
 
-// If we get a focuschange event from mozKeyboard for an element with
-// one of these types, we'll just ignore it.
-const ignoredFormElementTypes = {
-  'select-one': true,
-  'select-multiple': true,
-  'date': true,
-  'time': true,
-  'datetime': true,
-  'datetime-local': true
-};
-
 // Special key codes
 const BASIC_LAYOUT = -1;
 const ALTERNATE_LAYOUT = -2;


### PR DESCRIPTION
Gaia part for bug 924893. Doesn't get rid of the other instances of mozKeyboard in value_selector but now we can get rid of the onfocuschange event.
