### PR TITLE
Bug 927345 - The sorting of video group in gallery view is not correct

### DIFF
--- a/apps/video/js/thumbnail_date_group.js
+++ b/apps/video/js/thumbnail_date_group.js
@@ -84,7 +84,9 @@ function ThumbnailDateGroup(item) {
 ThumbnailDateGroup.getGroupID = function(item) {
   // id is group_yyyy-mm. this id will be used as a key
   var dateObj = new Date(item.date);
-  return 'group_' + dateObj.getFullYear() + '-' + (dateObj.getMonth() + 1);
+  var month = dateObj.getMonth() + 1;
+  return 'group_' + dateObj.getFullYear() + '-' +
+         (month < 10 ? '0' + month : month);
 };
 
 ThumbnailDateGroup.compareGroupID = function(id1, id2) {

--- a/apps/video/test/unit/thumbnail_date_group_test.js
+++ b/apps/video/test/unit/thumbnail_date_group_test.js
@@ -32,18 +32,23 @@ suite('Thumbnail Date Group Unit Tests', function() {
   suite('#static functions', function() {
     test('#getGroupID', function() {
       assert.equal(ThumbnailDateGroup.getGroupID({date: 1375873140000}),
-                   'group_2013-8');
+                   'group_2013-08');
+      assert.equal(ThumbnailDateGroup.getGroupID({date: 1381967318275}),
+                   'group_2013-10');
     });
 
     test('#compareGroupID', function() {
-      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-8',
-                                                     'group_2013-8'),
+      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-08',
+                                                     'group_2013-08'),
                    0);
-      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-8',
-                                                     'group_2013-7'),
+      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-08',
+                                                     'group_2013-07'),
                    1);
-      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-8',
-                                                     'group_2013-9'),
+      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-08',
+                                                     'group_2013-09'),
+                   -1);
+      assert.equal(ThumbnailDateGroup.compareGroupID('group_2013-09',
+                                                     'group_2013-10'),
                    -1);
     });
   });
@@ -189,7 +194,7 @@ suite('Thumbnail Date Group Unit Tests', function() {
     });
 
     test('#groupID', function() {
-      assert.equal(dateGroup.groupID, 'group_2013-8');
+      assert.equal(dateGroup.groupID, 'group_2013-08');
     });
 
     test('#htmlNode', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=927345

Update month of groupId as '2 -> 02 , 10 -> 10' 
