### PR TITLE
Bug 902296 - Ensure that settings from range value are Numbers

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -568,7 +568,12 @@ var Settings = {
         value = input.checked; // boolean
         break;
       case 'range':
-        value = parseFloat(input.value).toFixed(1); // float
+        // Bug 906296:
+        //   We parseFloat() once to be able to round to 1 digit, then
+        //   we parseFloat() again to make sure to store a Number and
+        //   not a String, otherwise this will make Gecko unable to
+        //   apply new settings.
+        value = parseFloat(parseFloat(input.value).toFixed(1)); // float
         break;
       case 'select-one':
       case 'radio':


### PR DESCRIPTION
When storing the settings that comes from a range input, we do some
rounding using toFixed(). Unfortunately, toFixed() returns a String.
Changes in the Gecko handling of some of the settings (namely, audio
policy) makes usage of String impossible and we need to ensure that we
pass some Number. We thus change the code to perform a supplementary
parseFloat() after toFixed() to ensure this.
