### PR TITLE
Bug 923574 - Ensure manifest size is valid

### DIFF
--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -403,7 +403,7 @@ var AppInstallManager = {
     newNode.querySelector('.message').textContent = message;
 
     var progressNode = newNode.querySelector('progress');
-    if (app.updateManifest) {
+    if (app.updateManifest && app.updateManifest.size) {
       progressNode.max = app.updateManifest.size;
       appInfo.hasMax = true;
     }

--- a/apps/system/test/unit/app_install_manager_test.js
+++ b/apps/system/test/unit/app_install_manager_test.js
@@ -1092,6 +1092,41 @@ suite('system/AppInstallManager >', function() {
 
     });
 
+    suite('packaged app without size >', function() {
+      setup(function() {
+        mockAppName = 'Fake packaged app';
+        mockApp = new MockApp({
+          manifest: null,
+          updateManifest: {
+            name: mockAppName,
+            developer: {
+              name: 'Fake dev',
+              url: 'http://fakesoftware.com'
+            }
+          },
+          installState: 'pending'
+        });
+
+        dispatchInstallEvent();
+      });
+
+      suite('on first progress >', function() {
+        setup(function() {
+          // resetting this mock because we want to test only the
+          // following call
+          MockNotificationScreen.mTeardown();
+          MockSystemBanner.mTeardown();
+          mockApp.mTriggerDownloadProgress(5);
+        });
+
+        test('should add a notification', function() {
+          var method = 'incExternalNotifications';
+          assert.equal(fakeNotif.childElementCount, 1);
+          assert.ok(MockNotificationScreen.wasMethodCalled[method]);
+        });
+      });
+    });
+
     suite('cancelling a download >', function() {
       setup(function() {
         mockApp = new MockApp({ installState: 'pending' });


### PR DESCRIPTION
When installing an application with an invalid/undefined size, the new
WebIDL is not happy about this and the notification stays forever. We
fix this by checking that the size is effectively defined before setting
the max value of the notification.
