### PR TITLE
Bug 922238 - Call log does not record missed calls when in the lockscreen

### DIFF
--- a/apps/communications/dialer/js/call_screen.js
+++ b/apps/communications/dialer/js/call_screen.js
@@ -133,16 +133,20 @@ var CallScreen = {
     var screen = this.screen;
     screen.classList.toggle('displayed');
 
-    if (!callback) {
+    if (!callback || typeof(callback) !== 'function') {
+      return;
+    }
+
+    // We have no opening transition for incoming locked
+    if (this.screen.dataset.layout === 'incoming-locked') {
+      setTimeout(callback);
       return;
     }
 
     /* We need CSS transitions for the status bar state and the regular state */
     screen.addEventListener('transitionend', function trWait() {
       screen.removeEventListener('transitionend', trWait);
-      if (typeof(callback) == 'function') {
-        callback();
-      }
+      callback();
     });
   },
 

--- a/apps/communications/dialer/js/calls_handler.js
+++ b/apps/communications/dialer/js/calls_handler.js
@@ -16,7 +16,6 @@ var CallsHandler = (function callsHandler() {
 
   var displayed = false;
   var closing = false;
-  var animating = false;
   var ringing = false;
 
   /* === Settings === */
@@ -308,11 +307,8 @@ var CallsHandler = (function callsHandler() {
   /* === Call Screen === */
   function toggleScreen() {
     displayed = !displayed;
-    animating = true;
 
     CallScreen.toggle(function transitionend() {
-      animating = false;
-
       // We did animate the call screen off the viewport
       // now closing the window.
       if (!displayed) {
@@ -338,9 +334,8 @@ var CallsHandler = (function callsHandler() {
 
     postToMainWindow('closing');
 
-
     // If the screen is not displayed yet we close the window directly
-    if (animate && !animating && displayed) {
+    if (animate && displayed) {
       toggleScreen();
     } else {
       closeWindow();

--- a/apps/communications/dialer/js/handled_call.js
+++ b/apps/communications/dialer/js/handled_call.js
@@ -155,12 +155,14 @@ HandledCall.prototype.updateCallNumber = function hc_updateCallNumber() {
     return;
   }
 
+  var self = this;
   Voicemail.check(number, function(isVoicemailNumber) {
     if (isVoicemailNumber) {
       LazyL10n.get(function localized(_) {
         node.textContent = _('voiceMail');
         self._cachedInfo = _('voiceMail');
       });
+      self.recentsEntry.voicemail = true;
     } else {
       Contacts.findByNumber(number, lookupContact);
       checkICCMessage();
@@ -326,7 +328,6 @@ HandledCall.prototype.connected = function hc_connected() {
 };
 
 HandledCall.prototype.disconnected = function hc_disconnected() {
-  var entry = this.recentsEntry;
   var self = this;
   if (this._leftGroup) {
     LazyL10n.get(function localized(_) {
@@ -336,22 +337,18 @@ HandledCall.prototype.disconnected = function hc_disconnected() {
     self._leftGroup = false;
   }
 
-  if (entry) {
-    if (entry.contactInfo) {
-      if (typeof entry.contactInfo.contact === 'string') {
-        entry.contactInfo.contact = JSON.parse(entry.contactInfo.contact);
-      }
-      if (typeof entry.contactInfo.matchingTel === 'string') {
-        var tel = entry.contactInfo.matchingTel;
-        entry.contactInfo.matchingTel = JSON.parse(tel);
-      }
+  var entry = this.recentsEntry;
+  if (entry.contactInfo) {
+    if (typeof entry.contactInfo.contact === 'string') {
+      entry.contactInfo.contact = JSON.parse(entry.contactInfo.contact);
     }
-
-    Voicemail.check(entry.number, function(isVoicemailNumber) {
-      entry.voicemail = isVoicemailNumber;
-      CallsHandler.addRecentEntry(entry);
-    });
+    if (typeof entry.contactInfo.matchingTel === 'string') {
+      var tel = entry.contactInfo.matchingTel;
+      entry.contactInfo.matchingTel = JSON.parse(tel);
+    }
   }
+
+  CallsHandler.addRecentEntry(entry);
 
   this.remove();
 };

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -139,15 +139,6 @@
     transform: translateY(0);
   }
 
-  #call-screen[data-layout="incoming-locked"] {
-    opacity: 0;
-    transition: opacity 1s ease;
-  }
-
-  #call-screen[data-layout="incoming-locked"].displayed {
-    opacity: 1;
-  }
-
   #call-screen:before {
     background: url("images/mask.png") no-repeat scroll 50% 50% / cover transparent;
   }

--- a/apps/communications/dialer/test/unit/call_screen_test.js
+++ b/apps/communications/dialer/test/unit/call_screen_test.js
@@ -226,6 +226,30 @@ suite('call screen', function() {
         });
       });
     });
+
+    suite('when opening in incoming-locked mode', function() {
+      var addEventListenerSpy;
+      var spyCallback;
+
+      setup(function() {
+        CallScreen.screen.dataset.layout = 'incoming-locked';
+        addEventListenerSpy = this.sinon.spy(screen, 'addEventListener');
+        spyCallback = this.sinon.spy();
+
+        CallScreen.toggle(spyCallback);
+      });
+
+      test('should not listen for transitionend', function() {
+        assert.isFalse(addEventListenerSpy.called);
+      });
+
+      test('should call the callback', function(done) {
+        setTimeout(function() {
+          assert.isTrue(spyCallback.called);
+          done();
+        });
+      });
+    });
   });
 
   suite('toggleMute', function() {

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -593,14 +593,12 @@ suite('dialer/handled_call', function() {
       test('is voicemail call', function() {
         mockCall = new MockCall('123', 'dialing');
         subject = new HandledCall(mockCall);
-        mockCall._disconnect();
         assert.isTrue(subject.recentsEntry.voicemail);
       });
 
       test('is not voicemail call', function() {
         mockCall = new MockCall('111', 'dialing');
         subject = new HandledCall(mockCall);
-        mockCall._disconnect();
         assert.isFalse(subject.recentsEntry.voicemail);
       });
     });


### PR DESCRIPTION
We were closing the call screen before executing the Voicemail.check callback
- Store the voicemail info in recentsEntry earlier than at closing
- Remove the opacity animation when showing/hiding the call screen (it was not really working)
- Remove the animating flag since it was preventing closing animations to not run if the opening animation did not run
