### PR TITLE
Bug 928347 - Add missing strings in settings.en-US.properties

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -130,6 +130,7 @@ callerId=Caller ID
 callerId-default=Network default
 callerId-hide=Hide number
 callerId-show=Show number
+fdn=Fixed dialing numbers
 fdnSettings=Fixed dialing numbers
 fdn-authorizedNumbers=Authorized numbers
 fdn-authorizedNumbers-desc=List of numbers that can be called
@@ -643,6 +644,8 @@ licensing-Apache = Apache License 2.0
 launch-ftu=Launch first time use
 no-ftu=No first time use app found
 software-button-enabled=Enable software home button
+homegesture-enabled=Home gesture enabled
+debug-gaia-enabled=Gaia debug traces
 
 # Device :: Battery
 battery=Battery


### PR DESCRIPTION
All strings have the correct data-l10n-id but strings are not available inside the .properties file
