### PR TITLE
Bug 924475 - [Messages] The context menu is missing the contact name and mobile type (1.2 ONLY)

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -817,8 +817,9 @@ generateHeightRule() (in ThreadUI/thread_ui.js) will create:
 }
 
 ul.contact-prompt {
-  position: relative;
-  z-index: 5;
+  position: absolute;
+  margin-top: 5rem;
+  z-index: 101;
   overflow-y: auto;
   overflow-x: hidden;
   max-height: calc(100% - 8rem);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=924475

This should only be applied to v1.2

Signed-off-by: Rick Waldron waldron.rick@gmail.com
