### PR TITLE
Bug 925184 - [B2G][Settings] The user cannot export contacts to the memory card when USB Storage is enabled

### DIFF
--- a/apps/communications/contacts/js/utilities/sdcard.js
+++ b/apps/communications/contacts/js/utilities/sdcard.js
@@ -6,7 +6,8 @@ if (!utils.sdcard) {
   var SdCard = utils.sdcard = {
     NOT_INITIALIZED: 0,
     NOT_AVAILABLE: 1,
-    AVAILABLE: 2
+    AVAILABLE: 2,
+    observers: {}
   };
 
   SdCard.status = SdCard.NOT_INITIALIZED;
@@ -15,14 +16,22 @@ if (!utils.sdcard) {
   SdCard.updateStorageState = function sd_updateStorageState(state) {
     switch (state) {
       case 'available':
-      case 'shared':
         SdCard.status = SdCard.AVAILABLE;
         break;
+      // Making the 'shared' state as NOT_AVAILABLE since we
+      // could have inconsistencies if we allow changing the sdcard
+      // content meanwhile exporting/importing
+      case 'shared':
       case 'unavailable':
       case 'deleted':
         SdCard.status = SdCard.NOT_AVAILABLE;
         break;
     }
+    Object.keys(this.observers).forEach(function onObserver(name) {
+      if (typeof(SdCard.observers[name]) === 'function') {
+        SdCard.observers[name].call(null, state);
+      }
+    });
   };
 
   if (SdCard.deviceStorage) {
@@ -103,6 +112,32 @@ if (!utils.sdcard) {
     catch (ex) {
       window.console.error('Problem reading file: ', ex.stack);
       SdCard.getTextFromFiles(fileArray, contents, cb);
+    }
+  };
+
+  // Subscribe a callback for sdcard changes. A name is needed
+  // to refer to this observer.
+  // @param {String} identifier for the observer
+  // @param {Function} the callback to be invoqued on a change
+  // @param {Boolean} if the callback exists, override it
+  SdCard.subscribeToChanges = function(name, func, force) {
+    if (this.observers[name] !== undefined && !force) {
+      return false;
+    }
+
+    this.observers[name] = func;
+    return true;
+  };
+
+  // Remove the subscription to listen to changes for the specific
+  // identifier
+  // @param {String} the identifier
+  SdCard.unsubscribeToChanges = function(name) {
+    if (this.observers[name]) {
+      delete this.observers[name];
+      return true;
+    } else {
+      return false;
     }
   };
 }

--- a/apps/communications/contacts/js/views/settings.js
+++ b/apps/communications/contacts/js/views/settings.js
@@ -56,6 +56,11 @@ contacts.Settings = (function() {
         enableStorageOptions(!evt.settingValue, 'sdUMSEnabled');
       });
     }
+
+    // Subscribe to events related to change state in the sd card
+    utils.sdcard.subscribeToChanges('check_sdcard', function(value) {
+      enableStorageOptions(utils.sdcard.checkStorageCard());
+    });
   };
 
   var hideSettings = function hideSettings() {
@@ -895,34 +900,13 @@ contacts.Settings = (function() {
     });
   };
 
-  var checkUMSEnabled = function checkUMSEnabled(cb) {
-    if (!navigator.mozSettings) {
-      return;
-    }
-
-    var req = navigator.mozSettings.createLock().get(umsSettingsKey);
-    req.onsuccess = function onUMSValue() {
-      enableStorageOptions(!req.result[umsSettingsKey], 'sdUMSEnabled');
-
-      if (typeof cb === 'function') {
-        cb();
-      }
-    };
-    req.onerror = function onUMSError() {
-      if (typeof cb === 'function') {
-        cb();
-      }
-    };
-  };
-
-  var refresh = function refresh(cb) {
+  var refresh = function refresh() {
     getData();
     checkOnline();
     checkSIMCard();
     enableStorageOptions(utils.sdcard.checkStorageCard());
     updateTimestamps();
     checkExport();
-    checkUMSEnabled(cb);
   };
 
   return {


### PR DESCRIPTION
Changed the approach to not to use UMS and settings, but just the sdcard state.

For that added the state 'SHARED' as not available to use for the import/export, since we could have
inconsistencies while using.

Now our utility for sdcard has an extra option to subscribe to changes in the sdcard.
