### PR TITLE
Bug 929078: Re-enable gaia-ui-tests hidden for webidl bustage.

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
@@ -1,22 +1,14 @@
 [test_add_new_contact.py]
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_call_contact.py]
 skip-if = device == "desktop"
 carrier = true
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_edit_contact.py]
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_sms_contact.py]
 skip-if = device == "desktop"
 carrier = true
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_add_photo_to_contact.py]
 skip-if = device == "desktop"
@@ -27,8 +19,6 @@ xfail = true
 [test_sort_contacts.py]
 
 [test_delete_contact.py]
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_add_contact_to_favorites.py]
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
@@ -10,8 +10,6 @@ skip-if = device == "desktop"
 skip-if = device == "desktop"
 [test_dialer_add_contact.py]
 skip-if = device == "desktop"
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_call_log_all_calls.py]
 skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/manifest.ini
@@ -6,7 +6,5 @@ online = true
 
 [test_ftu_skip_tour.py]
 skip-if = device == "desktop"
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_ftu_with_tour.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
@@ -2,7 +2,5 @@
 b2g = true
 
 [test_keyboard.py]
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_number_keyboard.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
@@ -8,8 +8,6 @@ carrier = true
 [test_sms_add_contact.py]
 skip-if = device == "desktop"
 carrier = true
-# Bug 928915 - Mark contacts gaia-ui-tests as xfail until they are fixed.
-xfail = true
 
 [test_sms_with_attachments.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
See:  https://bugzilla.mozilla.org/show_bug.cgi?id=929078
