### PR TITLE
Bug 928503 - Look for tests in subdirectories of 'unit', r=bkelly, a=tes...

### DIFF
--- a/tests/python/gaia-unit-tests/gaia_unit_test/main.py
+++ b/tests/python/gaia-unit-tests/gaia_unit_test/main.py
@@ -185,7 +185,8 @@ def cli():
         for root, dirs, files in os.walk(appsdir):
             for file in files:
                 # only include tests in a 'unit' directory
-                if os.path.basename(root) == 'unit':
+                roots = root.split(os.path.sep)
+                if 'unit' in roots:
                     full_path = os.path.relpath(os.path.join(root, file), appsdir)
                     if full_path.endswith('_test.js') and full_path not in disabled:
                         tests.append(full_path)


### PR DESCRIPTION
...t-only
