### PR TITLE
Bug916183 - Fix of Done button target is off r=alive

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -59,13 +59,10 @@ var UtilityTray = {
       // When IME switcher shows, prevent the keyboard's focus getting changed.
       case 'keyboardimeswitchershow':
         this.overlay.addEventListener('mousedown', this._pdIMESwitcherShow);
-        this.statusbar.addEventListener('mousedown', this._pdIMESwitcherShow);
         break;
 
       case 'keyboardimeswitcherhide':
         this.overlay.removeEventListener('mousedown', this._pdIMESwitcherShow);
-        this.statusbar.removeEventListener('mousedown',
-                                           this._pdIMESwitcherShow);
         break;
 
 


### PR DESCRIPTION
The hit target when tapping a button in the upper right hand corner of an app is being overriden by the notifications drop down screen.   This is noticable when you launch an app that has buttons in the top right corner (ie. Contacts -- Settings gear icon, Email - Compose a new email, Music - Search Music).   It's easily reproducible if you tap the upper part of the app button, and instead of initiating that button, it brings the notifcations into focus instead.
