### PR TITLE
Bug 927999 - Feedback error messages need rewriting in proper English

### DIFF
--- a/apps/settings/elements/improve_browser_os_send_feedback.html
+++ b/apps/settings/elements/improve_browser_os_send_feedback.html
@@ -30,8 +30,8 @@
         </label>
       </li>
       <li id="feedback-emailbar" hidden="false">
-        <p class="description" data-l10n-id="email-address">
-          Email address :
+        <p class="description" data-l10n-id="email-address1">
+          Email address:
         </p>
         <p>
           <input id="feedback-email" type="email" />

--- a/apps/settings/js/feedback.js
+++ b/apps/settings/js/feedback.js
@@ -178,7 +178,7 @@ var Feedback = {
       this.feedbackDone.hidden = false;
     } else {
       this.keepAllInputs();
-      this.feedbackAlertMsg.textContent = _('feedback-error-' + type);
+      this.feedbackAlertMsg.textContent = _('feedback-errormessage-' + type);
       this.feedbackAlert.hidden = false;
       this.sendButton.disabled = false;
     }

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -696,15 +696,15 @@ feedback_whyfeel_sad=Why do you feel sad?
 feedback-mood-explain=Please tell us in detail.
 feedback-public-description=The content of your feedback will be public, so please be sure not include any personal information.
 feedback-contactyou=Check here to let us contact you from your email.
-email-address=Email address :
+email-address1=Email address:
 email-keepprivate=Don't worry. Your email will always be kept private.
 feedback-sendbtn=Send Feedback
-feedback-error-connect-error=Sorry, because of data connection error. System can't send out your suggestion now. Please fix data connection problem and send again.
-feedback-error-server-off=Sorry, because the server shutting down. System can't send out your suggestion now. Please wait a moment and send again.
-feedback-error-timeout=Sorry, because time out. System can't send out your suggestion now. Please reboot and send again.
-feedback-error-wrong-email=Sorry, because the email address is empty or format error. System can't send out your suggestion now. Please use correct email address and send again.
-feedback-error-empty-comment=Sorry, because the comment field is empty. System can't send out your suggestion now. Please fill the form out and send again.
-feedback-error-just-sent=Sorry, because you already sent us feedback. System can't send out your suggestion now. Please try our next software update and send again.
+feedback-errormessage-connect-error=Sorry, the system can't send your suggestion due to a data connection error. Please try again when the issue is resolved.
+feedback-errormessage-server-off=Sorry, the system can't send your suggestion because the server shut down. Please wait a moment and try again.
+feedback-errormessage-timeout=Sorry, the system can't send your suggestion because of a timeout. Please restart and try again.
+feedback-errormessage-wrong-email=Sorry, the system can't send your suggestion because the email address is missing or due to a formatting error. Please use a valid email address and try again.
+feedback-errormessage-empty-comment=Sorry, the system can't send your suggestion because the comment field is empty. Please enter some text and try again.
+feedback-errormessage-just-sent=Sorry, the system can't send your suggestion because you already sent us feedback. Please try our next software update and send again.
 feedback-done-msg=Thanks for the feedback! We will use it to help us create a better experience in future release of Firefox OS.
 
 # Device :: Help


### PR DESCRIPTION
New strings provided by Matej, consider the blank space before ":" in "Email address :" as a typo.
