### PR TITLE
Bug 929479 - Close 'span' elements in lockscreen passcode pad

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1019,15 +1019,15 @@
           <div id="lockscreen-panel-passcode" class="lockscreen-panel">
             <p id="lockscreen-passcode-code"><span></span><span></span><span></span><span></span></p>
             <div id="lockscreen-passcode-pad">
-              <a role="button" href="#" data-key="1">1<span>.<span></a>
-              <a role="button" href="#" data-key="2">2<span>ABC<span></a>
-              <a role="button" href="#" data-key="3">3<span>DEF<span></a>
-              <a role="button" href="#" data-key="4">4<span>GHI<span></a>
-              <a role="button" href="#" data-key="5">5<span>JKL<span></a>
-              <a role="button" href="#" data-key="6">6<span>MNO<span></a>
-              <a role="button" href="#" data-key="7">7<span>PQRS<span></a>
-              <a role="button" href="#" data-key="8">8<span>TUV<span></a>
-              <a role="button" href="#" data-key="9">9<span>WXYZ<span></a>
+              <a role="button" href="#" data-key="1">1<span>.</span></a>
+              <a role="button" href="#" data-key="2">2<span>ABC</span></a>
+              <a role="button" href="#" data-key="3">3<span>DEF</span></a>
+              <a role="button" href="#" data-key="4">4<span>GHI</span></a>
+              <a role="button" href="#" data-key="5">5<span>JKL</span></a>
+              <a role="button" href="#" data-key="6">6<span>MNO</span></a>
+              <a role="button" href="#" data-key="7">7<span>PQRS</span></a>
+              <a role="button" href="#" data-key="8">8<span>TUV</span></a>
+              <a role="button" href="#" data-key="9">9<span>WXYZ</span></a>
               <a role="button" href="#" data-key="e" class="lockscreen-passcode-pad-func last-row"><span data-l10n-id="emergency-call-button">Emergency Call</span></a>
               <a role="button" href="#" data-key="0" class="last-row">0</a>
               <a role="button" href="#" data-key="c" class="lockscreen-passcode-pad-func last-row"><span data-l10n-id="cancel">Cancel</span></a>


### PR DESCRIPTION
Some span elements in LockScreen's passcode pad are malformed, potentially causing layout problems.
