### PR TITLE
Bug 925174 - [email] webactivity-triggered compose activity does not trigger

### DIFF
--- a/apps/email/test/marionette/activity_create_email_account_complete_test.js
+++ b/apps/email/test/marionette/activity_create_email_account_complete_test.js
@@ -1,0 +1,60 @@
+/*jshint node: true */
+/*global marionette */
+'use strict';
+var Email = require('./lib/email');
+var assert = require('assert');
+var serverHelper = require('./lib/server_helper');
+
+marionette('activity create email account', function() {
+  var app,
+      client = marionette.client({
+        settings: {
+          // disable keyboard ftu because it blocks our display
+          'keyboard.ftu.enabled': false
+        }
+      }),
+      server = serverHelper.use({
+        credentials: {
+          username: 'testy1',
+          password: 'testy1'
+        }
+      }, this);
+
+  setup(function() {
+    app = new Email(client);
+
+    client.contentScript.inject(__dirname +
+      '/lib/mocks/mock_navigator_moz_set_message_handler_activity.js');
+
+    app.launch();
+  });
+
+
+  test('should complete activity after creating account', function() {
+
+    client.waitFor(function() {
+      return client.executeScript(function() {
+        var req = window.wrappedJSObject.require;
+        return req.defined('mail_common');
+      });
+    });
+
+    client.executeScript(function() {
+      window.wrappedJSObject.fireMessageHandler({
+        source: {
+          name: 'new',
+          data: {
+            type: 'mail',
+            URI: 'mailto:testy@localhost'
+          }
+        }
+      });
+    });
+
+    app.confirmWantAccount();
+    app.manualSetupImapEmail(server, 'waitForCompose');
+
+  });
+});
+
+

--- a/apps/email/test/marionette/lib/mocks/mock_navigator_moz_set_message_handler_activity.js
+++ b/apps/email/test/marionette/lib/mocks/mock_navigator_moz_set_message_handler_activity.js
@@ -1,0 +1,37 @@
+/*global Components, Services */
+'use strict';
+
+Components.utils.import('resource://gre/modules/Services.jsm');
+
+Services.obs.addObserver(function(document) {
+  if (!document || !document.location) {
+    return;
+  }
+
+  var window = document.defaultView.wrappedJSObject;
+  var messageHandler;
+
+  window.navigator.__defineGetter__('mozHasPendingMessage', function() {
+    return function(type) {
+      return type === 'activity';
+    };
+  });
+
+  window.navigator.__defineGetter__('mozSetMessageHandler', function() {
+    return function(type, callback) {
+      if (type === 'activity') {
+        messageHandler = callback;
+      }
+    };
+  });
+
+  window.__defineGetter__('fireMessageHandler', function() {
+    return function(data) {
+      if (messageHandler && typeof(messageHandler) === 'function') {
+        messageHandler(data);
+        return true;
+      }
+      return false;
+    };
+  });
+}, 'document-element-inserted', false);


### PR DESCRIPTION
If a web activity opened email, and there was no email accounts configured, the user had option to configure an email account, then continue with the compose web activity. However, what happened was that the compose action was lost once the account was set up.

This change makes sure to continue any web activity action after getting the 'showLatestAccount' event from the card setup. Since that continuation work needed to happen in two places, a new function was created to do the work for each case. the onPushed option for a card is run after the card for the current action completes.

Includes an integration test to make sure this pathway does not regress in the future.
