### PR TITLE
Bug 929785 - [Clock] Unable to scroll in Timer panel

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -6,7 +6,6 @@ html, body {
 ul, ol {
   margin: 0;
   padding: 0;
-  overflow: auto;
   list-style: none;
 }
 
@@ -50,13 +49,16 @@ ul, ol {
 
 /* ----------- Alarm List ---------- */
 #alarms {
+  position: absolute;
+  bottom: 0rem;
+
   width: 100%;
   height: auto;
   max-height: calc(100% - 22rem);
-  position: absolute;
-  bottom: 0rem;
+
   background-color: transparent;
   background-image: none;
+  overflow-y: auto;
 }
 
 ul#alarms li.alarm-cell:before {

--- a/apps/clock/style/stopwatch.css
+++ b/apps/clock/style/stopwatch.css
@@ -34,6 +34,7 @@
 
   background-color: transparent;
   background-image: none;
+  overflow-y: auto;
 }
 
 .stopwatch-laps li.lap-cell {


### PR DESCRIPTION
Only certain UL elements should declared `overflow: auto`--those that
are explicitly intended to render with scrollbars when their content
exceeds their dimensions.

Other UL elements (i.e. the element that contains Timer settings in the
Timer panel) should not receive this declaration.

r=iliu
