### PR TITLE
Bug 802643 - [email] Compose/share activities are unable to return to calling app once message is sent

### DIFF
--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -628,10 +628,9 @@ ComposeCard.prototype = {
       function callback(error , badAddress, sentDate) {
         var activityHandler = function() {
           if (activity) {
-            // Define activity postResult return value here:
-            if (activity.source.name == 'share') {
-              activity.postResult('shared');
-            }
+            // Just mention the action completed, but do not give
+            // specifics, to maintain some privacy.
+            activity.postResult('complete');
             activity = null;
           }
         };

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -51,7 +51,8 @@
       "filters": {
         "type": "mail"
       },
-      "disposition": "window"
+      "disposition": "window",
+      "returnValue": true
     },
     "share": {
       "filters": {
@@ -63,7 +64,9 @@
     "view": {
       "filters": {
         "type": "url",
-        "url": { "required":true, "pattern":"mailto:.{1,16384}" }
+        "url": { "required":true, "pattern":"mailto:.{1,16384}" },
+        "disposition": "window",
+        "returnValue": true
       }
     }
   },


### PR DESCRIPTION
This is the last bit of changes to complete this ticket. The 'new' and 'view' activity registration did not specify "returnValue", so even though the email app did call that activity.postX methods, they did not do anything for those cases.

The "disposition" key was set explicitly to "window" in the "view" case too, just to keep it matched with the other activity config blocks, and to also hopefully indicate our purposeful desire to use "window" instead of "inline".

Finally, since there are now three different types of activities that all trigger the compose flow, the compose.js was changed just to call `activity.postResult('complete')` always if an activity caused the compose flow, instead of just doing it for the "share" activity.

With these changes, the email app returns to the previous app in both the error and success cases. 

One exception is that the Contacts app could get killed for out of memory, and in that case, the postResult() does not do anything as the target app is no longer running, and the user stays in the email app after the email is sent. The browser app seems to do a better job of sticking around around for the return from the activity.
