### PR TITLE
Bug 929525: Email manual setup 'account' fields make automatic spelling corrections

### DIFF
--- a/apps/email/js/cards/setup_manual_config.html
+++ b/apps/email/js/cards/setup_manual_config.html
@@ -67,6 +67,8 @@
           <p>
             <input class="sup-manual-imap-username" type="text"
                    data-l10n-id="setup-manual-username"
+                   x-inputmode="verbatim"
+                   inputmode="verbatim"
                    data-maybe-required />
             <button type="reset"></button>
           </p>
@@ -103,6 +105,8 @@
           <p>
             <input class="sup-manual-smtp-username" type="text"
                    data-l10n-id="setup-manual-username"
+                   x-inputmode="verbatim"
+                   inputmode="verbatim"
                    data-maybe-required />
             <button type="reset"></button>
           </p>


### PR DESCRIPTION
Added x-inputmode="verbatim" inputmode="verbatim" on username fields to keep them from spontaneously correcting your username to random words.
