### PR TITLE
Bug 919980 - [B2G][messages] mms attachment file naming mechanism refinement for Latin language

### DIFF
--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -121,11 +121,14 @@
       // interpolate the #attachment-[no]preview-tmpl template
       thumbnail = thumbnail || {};
       var sizeL10n = this.sizeForL10n;
+
+      var displayName = Utils.MMSFilename(this.name, {direction: 'decode'});
+
       return Template(tmplID).interpolate({
         type: this.type,
         errorClass: thumbnail.error ? 'corrupted' : '',
         imgData: thumbnail.data,
-        fileName: this.name.slice(this.name.lastIndexOf('/') + 1),
+        fileName: displayName,
         sizeL10nId: sizeL10n.l10nId,
         sizeL10nArgs: JSON.stringify(sizeL10n.l10nArgs)
       });
@@ -167,6 +170,9 @@
         var tmplID = 'attachment-' + previewClass + '-tmpl';
         container.classList.add(previewClass);
 
+        // Single call to getAttachmentSrc
+        var attachment = this.getAttachmentSrc(thumbnail, tmplID);
+
         if (this.isDraft) { // <iframe>
           // The attachment's iFrame requires access to the parent document's
           // context so that URIs for Blobs created in the parent may resolve as
@@ -176,7 +182,7 @@
           var tmplSrc = Template('attachment-draft-tmpl').interpolate({
             previewClass: previewClass,
             baseURL: location.protocol + '//' + location.host + '/',
-            attachmentHTML: this.getAttachmentSrc(thumbnail, tmplID)
+            attachmentHTML: attachment
           }, { safe: ['attachmentHTML'] });
 
           // append the source when it's appended to the dom and loaded
@@ -192,7 +198,7 @@
 
           container.src = 'about:blank';
         } else { // <div>
-          container.innerHTML = this.getAttachmentSrc(thumbnail, tmplID);
+          container.innerHTML = attachment;
         }
 
         if (readyCallback) {

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -14,6 +14,7 @@ var lazyLoadFiles = [
   'shared/js/settings_url.js',
   'shared/js/template.js',
   'shared/js/mime_mapper.js',
+  'shared/js/text_normalizer.js',
   'js/dialog.js',
   'js/blacklist.js',
   'js/contacts.js',

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -119,6 +119,36 @@
       return this.rootFontSize;
     },
 
+    MMSFilename: function ut_MMSFilename(name, opts) {
+      // Creating or receiving an MMS may result in a name
+      // as a path and we only want the basename
+      name = name.substr(name.lastIndexOf('/') + 1);
+
+      // Unsafe characters for SMIL filenames
+      var unsafe = /[^a-zA-Z0-9_#.()?&%-]/g;
+      var escaped;
+      opts = opts || {};
+      opts.direction = opts.direction || 'encode';
+      opts.strip = opts.strip || false;
+
+      if (opts.strip) {
+        // Filenames which cannot fit inside the limit may
+        // need to have non-ascii characters stripped out
+        // first attempt to normalize, then replace remainder wholesale
+        return name.replace(unsafe, Normalizer.toAscii).replace(unsafe, '#');
+      }
+
+      // Encoding and decoding are each 3 steps with the first two shared
+      // 1. Decode % encoded sequences to catch possible escape sequences
+      // 2. Escape html entities
+      // 3. For encoding, % encode the result. For decoding, decode the result
+      escaped = Template.escape(decodeURIComponent(name));
+
+      return opts.direction === 'encode' ?
+        encodeURIComponent(escaped) :
+        decodeURIComponent(escaped);
+    },
+
     // We will apply createObjectURL for details.photoURL if contact image exist
     // Please remember to revoke the photoURL after utilizing it.
     getContactDetails:

--- a/apps/sms/test/unit/attachment_test.js
+++ b/apps/sms/test/unit/attachment_test.js
@@ -192,13 +192,15 @@ suite('attachment_test.js', function() {
   });
 
   suite('render draft image attachments', function() {
-    function testDraftImage(testName, attachmentName) {
+    function testDraftImage(testName, attachmentName, escaped) {
       test(testName + ' attachment', function(done) {
         var attachment = new Attachment(testImageBlob, {
           name: attachmentName,
           isDraft: true
         });
-
+        // Names with escaped sequences will be escaped properly
+        // but not always with the same exact sequence from the input
+        var name = escaped ? escaped : attachment.name;
         var el = attachment.render(function() {
           assert.equal(el.tagName, 'IFRAME');
           el.addEventListener('load', function onload() {
@@ -211,7 +213,7 @@ suite('attachment_test.js', function() {
               var fileNameNode = doc.querySelector('.file-name');
               assert.ok(fileNameNode);
               assert.isNull(fileNameNode.firstElementChild);
-              assert.equal(fileNameNode.textContent, attachment.name);
+              assert.equal(fileNameNode.textContent, name);
             });
           });
 
@@ -223,12 +225,15 @@ suite('attachment_test.js', function() {
     testDraftImage('normal', 'Image attachment');
     testDraftImage(
       'malicious script',
-      '%3Cscript%3Ealert(%22I%20am%20dangerous%22)%3C%2Fscript%3E'
+      '%3Cscript%3Ealert(%22I%20am%20dangerous%22)%3C%2Fscript%3E',
+      '&lt;script&gt;alert(&quot;I am dangerous&quot;)&lt;/script&gt;'
     );
     testDraftImage(
       'malicious image',
-      '%3Cimg%20src%3D%22http%3A%2F%2Fmalicious.server.ru%2Fpingback%22%3E'
+      '%3Cimg%20src%3D%22http%3A%2F%2Fmalicious.server.ru%2Fpingback%22%3E',
+      '&lt;img src=&quot;http://malicious.server.ru/pingback&quot;&gt;'
     );
+    testDraftImage('non-ASCII file name', 'kitten♥-450.jpg');
   });
 
 

--- a/apps/sms/test/unit/mock_normalizer.js
+++ b/apps/sms/test/unit/mock_normalizer.js
@@ -1,0 +1,9 @@
+/*exported MockNormalizer */
+
+(function(exports) {
+  'use strict';
+  var Normalizer = {
+    toAscii: function(str) {return str;}
+  };
+  exports.Normalizer = Normalizer;
+})(this);

--- a/apps/sms/test/unit/mock_utils.js
+++ b/apps/sms/test/unit/mock_utils.js
@@ -27,5 +27,6 @@ var MockUtils = {
   getCarrierTag: Utils.getCarrierTag,
   removeNonDialables: Utils.removeNonDialables,
   probablyMatches: Utils.probablyMatches,
-  getDisplayObject: Utils.getDisplayObject
+  getDisplayObject: Utils.getDisplayObject,
+  MMSFilename: Utils.MMSFilename
 };

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -8,6 +8,7 @@ requireApp('sms/test/unit/mock_contact.js');
 requireApp('sms/test/unit/mock_contacts.js');
 requireApp('sms/test/unit/mock_l10n.js');
 requireApp('sms/test/unit/mock_navigator_mozphonenumberservice.js');
+requireApp('sms/test/unit/mock_normalizer.js');
 requireApp('sms/js/utils.js');
 
 var mocksHelperForUtils = new MocksHelper([
@@ -172,6 +173,24 @@ suite('Utils', function() {
       test('(epoch [String|Number])', function() {
       });
     */
+  });
+
+  suite('Utils.MMSFilename', function() {
+    test('conversion is reversible', function() {
+      var name = Utils.MMSFilename;
+      var malicious, benign;
+      malicious = '%3Cscript%3Ealert(%22I%20am%20dangerous%22)%3C%2Fscript%3E';
+      benign = '♥';
+      // assert.equal(
+      //   name(name(malicious, {direction: 'encode'}), {direction: 'decode'}),
+      //   name(malicious, {direction: 'decode'})
+      // );
+      assert.equal(
+        name(name(benign, {direction: 'encode'}), {direction: 'decode'}),
+        name(benign, {direction: 'decode'})
+      );
+
+    });
   });
 
   suite('Utils.startTimeHeaderScheduler', function() {


### PR DESCRIPTION
Non-ascii characters are percent encoded where possible.
- Percent encoded filenames are decoded for display
- Filenames which will exceed the 40 character limit after encoding are normalized
  - If that does not sufficiently reduce the final characters below 40, non-valid characters are replaced with '#'
- Filenames with escape sequences (i.e. attempts to inject script tags) are escaped while encoding and decoding
