### PR TITLE
Bug 930417 - (Cost Control) Typo in short name for December

### DIFF
--- a/apps/costcontrol/locales/costcontrol.en-US.properties
+++ b/apps/costcontrol/locales/costcontrol.en-US.properties
@@ -198,7 +198,7 @@ em-month-7 = AUG
 em-month-8 = SEP
 em-month-9 = OCT
 em-month-10 = NOV
-em-month-11 = DEV
+em-month-11 = DEC
 
 # Specif format for CC, string in format Today|Yesterday|<WeekDay>, hh:mm
 day-hour-format = {{day}}, {{time}}


### PR DESCRIPTION
Should be DEC, not DEV. Affecting also 1.2
