### PR TITLE
Bug 928731 - Typo in "emergency-callback-dialog-message" in apps/system

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -365,7 +365,7 @@ icc-inputtitle=STK Query
 
 # CDMA emergency callback mode
 emergency-callback-mode=Emergency call back mode
-emergency-callback-dialog-message=Telecom services and internet are disable due to emergency call back mode. Would you like to turn off the mode?
+emergency-callback-dialog-message=Telecom services and internet are disabled due to emergency call back mode. Would you like to turn off the mode?
 
 # CDMA record information
 cdma-record-info=CDMA record information


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=928731
