### PR TITLE
Bug 923577 - Ensure that we remove icons of hidden roles

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -16,6 +16,18 @@ var GridManager = (function() {
 
   var HIDDEN_ROLES = ['system', 'keyboard', 'homescreen'];
 
+  function isHiddenApp(role) {
+    if (!role) {
+      console.warn(
+        'Unexpected role when checking hidden app: ' + JSON.stringify(role)
+      );
+
+      return false;
+    }
+
+    return (HIDDEN_ROLES.indexOf(role) !== -1);
+  }
+
   // Holds the list of single variant apps that have been installed
   // previously already
   var svPreviouslyInstalledApps = [];
@@ -837,7 +849,7 @@ var GridManager = (function() {
       var manifest = app.manifest || app.updateManifest;
 
       if (!manifest || app.type === GridItemsFactory.TYPE.COLLECTION ||
-          (suppressHiddenRoles && HIDDEN_ROLES.indexOf(manifest.role) !== -1)) {
+          (suppressHiddenRoles && isHiddenApp(manifest.role))) {
         continue;
       }
 
@@ -1004,7 +1016,7 @@ var GridManager = (function() {
     appsByOrigin[app.origin] = app;
 
     var manifest = app.manifest ? app.manifest : app.updateManifest;
-    if (!manifest || HIDDEN_ROLES.indexOf(manifest.role) !== -1)
+    if (!manifest)
       return;
 
     var entryPoints = manifest.entry_points;
@@ -1146,8 +1158,20 @@ var GridManager = (function() {
     // let it update itself.
     var existingIcon = getIcon(descriptor);
     if (existingIcon) {
-      existingIcon.update(descriptor, app);
+      if (app.manifest && isHiddenApp(app.manifest.role)) {
+        existingIcon.remove();
+      } else {
+        existingIcon.update(descriptor, app);
+      }
       markDirtyState();
+      return;
+    }
+
+    // If we have manifest and no updateManifest, do not add the icon:
+    // this is especially the case for pre-installed hidden apps, like
+    // keyboard, system, etc.
+    if (app.manifest && !app.updateManifest &&
+        isHiddenApp(app.manifest.role)) {
       return;
     }
 

--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -329,6 +329,48 @@ suite('grid.js >', function() {
     });
   });
 
+  suite('install role system app >', function() {
+    var mockApp;
+    var tempIcon;
+    var appManifest = {
+      name: 'My Ringtones',
+      role: 'system'
+    };
+    var appUpdateManifest = {
+      name: 'My Ringtones'
+    };
+
+    setup(function() {
+      mockApp = new MockApp({
+        manifest: null,
+        updateManifest: appUpdateManifest
+      });
+      this.sinon.useFakeTimers();
+
+      MockAppsMgmt.mTriggerOninstall(mockApp);
+      this.sinon.clock.tick(SAVE_STATE_WAIT_TIMEOUT);
+    });
+
+    test('should have a temp icon', function() {
+      tempIcon = GridManager.getIcon(mockApp);
+      assert.ok(tempIcon);
+    });
+
+    suite('finish role system app install >', function() {
+      setup(function() {
+        this.sinon.spy(MockIcon.prototype, 'remove');
+        mockApp.manifest = appManifest;
+        mockApp.updateManifest = null;
+        mockApp.mTriggerDownloadApplied();
+        this.sinon.clock.tick(SAVE_STATE_WAIT_TIMEOUT);
+      });
+
+      test('icon remove method called', function() {
+        assert.isTrue(tempIcon.remove.calledOnce);
+      });
+    });
+  });
+
   suite('install single variant apps >', function() {
     var prevMaxIconNumber;
 


### PR DESCRIPTION
When installing an application that is hidden, we have to make sure,
when updating the icon, that we remove it. This case happens especially
with packaged role system app, like, in this bug, a ringtones app. We
end up creating a temp icon (because we only have a updateManifest at
that time and cannot decide the role of the app) while downloading,
which is not removed once the app is finally installed.
