### PR TITLE
Bug 930624 - Unpair device: fix localizability of "Confirmation" title

### DIFF
--- a/apps/settings/elements/bluetooth.html
+++ b/apps/settings/elements/bluetooth.html
@@ -81,7 +81,7 @@
 
     <form role="dialog" data-type="confirm" id="unpair-device" hidden>
       <section>
-        <h1>Confirmation</h1>
+        <h1 data-l10n-id="device-option-unpair-confirmation">Confirmation</h1>
         <p data-l10n-id="device-option-unpair-device">Unpair Device?</p>
       </section>
       <menu>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -256,6 +256,7 @@ device-status-connected-media       = Connected to media audio
 device-status-connected-phone-media = Connected to phone/media audio
 device-option-unpair      = Unpair
 device-option-confirm     = Confirm
+device-option-unpair-confirmation = Confirmation
 device-option-unpair-device = Unpair Device?
 device-option-connect     = Connect
 device-option-disconnect  = Disconnect


### PR DESCRIPTION
Add data-l10n-id to title and add string to en-US properties file
