### PR TITLE
Bug 910854 - [Clock] Reduce analog face resizing from 4 sizes to 3 sizes

### DIFF
--- a/apps/clock/js/clock_view.js
+++ b/apps/clock/js/clock_view.js
@@ -248,17 +248,18 @@ var ClockView = {
   },
 
   calAnalogClockType: function cv_calAnalogClockType(count) {
-    if (count <= 1) {
-      count = 1;
-    } else if (count >= 4) {
-      count = 4;
+    var type = 'small';
+    if (count < 2) {
+      type = 'large';
+    } else if (count === 2) {
+      type = 'medium';
     }
-    return count;
+    return type;
   },
 
   resizeAnalogClock: function cv_resizeAnalogClock() {
-    var type = this.calAnalogClockType(AlarmList.getAlarmCount() + 1);
-    this.container.className = 'marks' + type;
+    var type = this.calAnalogClockType(AlarmList.getAlarmCount());
+    this.container.className = type;
     document.getElementById('alarms').className = 'count' + type;
   },
 

--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -85,25 +85,19 @@ html, body {
   display: block;
 }
 
-#analog-clock-container.marks1 {
+#analog-clock-container.large {
   width: 27rem;
   height: 27rem;
   margin: 6.9rem auto 0;
 }
 
-#analog-clock-container.marks2 {
-  width: 24.8rem;
-  height: 24.8rem;
-  margin: 7.8rem auto 0;
+#analog-clock-container.medium {
+  width: 21.8rem;
+  height: 21.8rem;
+  margin: 6.8rem auto 0;
 }
 
-#analog-clock-container.marks3 {
-  width: 19.8rem;
-  height: 19.8rem;
-  margin: 7.8rem auto 0;
-}
-
-#analog-clock-container.marks4 {
+#analog-clock-container.small {
   width: 14.8rem;
   height: 14.8rem;
   margin: 5.8rem auto 0;

--- a/apps/clock/test/unit/clock_view_test.js
+++ b/apps/clock/test/unit/clock_view_test.js
@@ -1,5 +1,6 @@
 suite('ClockView', function() {
   var ClockView;
+  var AlarmList;
   var asyncStorage;
 
   suiteSetup(function(done) {
@@ -10,12 +11,20 @@ suite('ClockView', function() {
     // Load before clock_view to ensure elements are initialized properly.
     loadBodyHTML('/index.html');
 
-    testRequire(['clock_view', 'mocks/mock_shared/js/async_storage'], {
+    testRequire([
+      'clock_view',
+      'mocks/mock_alarm_list',
+      'mocks/mock_shared/js/async_storage'
+      ], {
         mocks: ['alarm_list', 'shared/js/async_storage']
-      }, function(clockView, mockAsyncStorage) {
+      }, function(clockView, mockAlarmList, mockAsyncStorage) {
         ClockView = clockView;
+        AlarmList = mockAlarmList;
+
         asyncStorage = mockAsyncStorage;
+
         ClockView.init();
+        AlarmList.init();
         done();
       });
   });
@@ -332,5 +341,46 @@ suite('ClockView', function() {
 
       ClockView.digital.click();
     });
+  });
+
+  suite('resizeAnalogClock', function() {
+
+    suiteSetup(function() {
+      this.analogClockContainer = document.getElementById(
+        'analog-clock-container');
+    });
+
+    setup(function() {
+      this.getAlarmCountStub = this.sinon.stub(AlarmList, 'getAlarmCount');
+    });
+
+    test('large size when no alarms in alarms list', function() {
+      this.getAlarmCountStub.returns(0);
+      ClockView.resizeAnalogClock();
+      assert.isTrue(this.analogClockContainer.classList.contains('large'));
+    });
+
+    test('large size when 1 alarm in alarms list', function() {
+      this.getAlarmCountStub.returns(1);
+      ClockView.resizeAnalogClock();
+      assert.isTrue(this.analogClockContainer.classList.contains('large'));
+    });
+
+    test('medium size when 2 alarms in alarms list', function() {
+      this.getAlarmCountStub.returns(2);
+      ClockView.resizeAnalogClock();
+      assert.isTrue(this.analogClockContainer.classList.contains('medium'));
+    });
+
+    test('small size when 3 or more alarms in alarms list', function() {
+      this.getAlarmCountStub.returns(3);
+      ClockView.resizeAnalogClock();
+      assert.isTrue(this.analogClockContainer.classList.contains('small'));
+
+      this.getAlarmCountStub.returns(4);
+      ClockView.resizeAnalogClock();
+      assert.isTrue(this.analogClockContainer.classList.contains('small'));
+    });
+
   });
 });

--- a/apps/clock/test/unit/clock_view_test.js
+++ b/apps/clock/test/unit/clock_view_test.js
@@ -347,7 +347,8 @@ suite('ClockView', function() {
 
     suiteSetup(function() {
       this.analogClockContainer = document.getElementById(
-        'analog-clock-container');
+        'analog-clock-container'
+      );
     });
 
     setup(function() {


### PR DESCRIPTION
- `clock_view.js`
  - Changed to resize to 3 sizes instead of 4
  - Removed reference to 'marks' CSS
- `clock.css`
  - Renamed 'marks' size classes to 'small', 'medium', 'large'
- Tests
  - Tested manually on desktop and on Inari
  - Unit test in `clock_view_test.js` testing basic `resizeAnalogClock` functionality
