### PR TITLE
Bug 923544: remove unneeded workaround that was causing problems

### DIFF
--- a/apps/ringtones/js/pick.js
+++ b/apps/ringtones/js/pick.js
@@ -54,36 +54,12 @@ navigator.mozSetMessageHandler('activity', function handler(activity) {
     xhr.responseType = 'blob';
     xhr.send();
     xhr.onload = function() {
-      /*
-       * This is a workaround for bug 914404.
-       * XXX When that bug is fixed, clean up like this:
-       *  remove makePersistentCopy
-       *  remove the deleteMe parameter below
-       *  remove the device storage permission in manifest.webapp
-       */
-      makePersistentCopy(xhr.response, function(copy, filename) {
-        activity.postResult({
-          name: selectedSoundName,
-          blob: copy,
-          deleteMe: filename
-        });
+      activity.postResult({
+        name: selectedSoundName,
+        blob: xhr.response
       });
     };
   };
-
-  function makePersistentCopy(blob, callback) {
-    var filename = 'tmp/' + Math.random().toString().substring(2) + '.ogg';
-    console.log('Bug 914404 workaround saving blob to device storage',
-                filename);
-    var storage = navigator.getDeviceStorage('music');
-    var write = storage.addNamed(blob, filename);
-    write.onsuccess = function() {
-      var read = storage.get(filename);
-      read.onsuccess = function() {
-        callback(read.result, filename);
-      };
-    };
-  }
 
   // When we start up, we first need to get the list of all sounds.
   // We also need the name of the currently selected sound.

--- a/apps/ringtones/manifest.webapp
+++ b/apps/ringtones/manifest.webapp
@@ -9,8 +9,7 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
-    "settings":{ "access": "readonly" },
-    "device-storage:music":{ "access": "readwrite" }
+    "settings":{ "access": "readonly" }
   },
   "activities": {
     "pick": {

--- a/apps/settings/js/sound.js
+++ b/apps/settings/js/sound.js
@@ -112,7 +112,6 @@
             }
           }
 
-
           // Save the sound in the settings db so that other apps can use it.
           // Also save the sound name in the db so we can display it in the
           // future.  And update the button text to the new name now.
@@ -122,20 +121,7 @@
             var values = {};
             values[tone.settingsKey] = blob;
             values[namekey] = name || '';
-            var request = navigator.mozSettings.createLock().set(values);
-            /*
-             * This is a workaround for bug 914404.
-             * XXX When that bug is fixed, clean up like this:
-             *  remove the onsuccess handler below and the request variable
-             *  switch back to readonly permission for music in the manifest
-             */
-            request.onsuccess = function() {
-              if (activity.result.deleteMe) {
-                console.log('Bug 914404: deleting', activity.result.deleteMe);
-                var storage = navigator.getDeviceStorage('music');
-                storage.delete(activity.result.deleteMe);
-              }
-            };
+            navigator.mozSettings.createLock().set(values);
           }
         };
       });

--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -13,7 +13,7 @@
     "voicemail":{},
     "bluetooth":{},
     "device-storage:pictures":{ "access": "readonly" },
-    "device-storage:music":{ "access": "readwrite" },
+    "device-storage:music":{ "access": "readonly" },
     "device-storage:videos":{ "access": "readonly" },
     "device-storage:sdcard":{ "access": "readonly" },
     "device-storage:apps":{ "access": "readonly" },

--- a/apps/sms/js/notify.js
+++ b/apps/sms/js/notify.js
@@ -37,7 +37,8 @@
     ringtonePlayer.play();
     window.setTimeout(function smsRingtoneEnder() {
       ringtonePlayer.pause();
-      ringtonePlayer.src = '';
+      ringtonePlayer.removeAttribute('src');
+      ringtonePlayer.load();
     }, 2000);
   }
 

--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -371,7 +371,8 @@ var NotificationScreen = {
       ringtonePlayer.play();
       window.setTimeout(function smsRingtoneEnder() {
         ringtonePlayer.pause();
-        ringtonePlayer.src = '';
+        ringtonePlayer.removeAttribute('src');
+        ringtonePlayer.load();
       }, 2000);
     }
 


### PR DESCRIPTION
Most of this PR just removes a workaround I had done for 914404. That bug doesn't reproduce anymore, and the workaround was apparently causing bug 923544, so this PR removes it.  

There are also two changes that fix the way we unload the notification sound so that we don't get an error in the console.
