### PR TITLE
Bug 808627 - Fix ambiguity of headset type needed for FM radio

### DIFF
--- a/apps/fm/locales/fm.en-US.properties
+++ b/apps/fm/locales/fm.en-US.properties
@@ -1,4 +1,4 @@
-noAntenna          = Plug in a headset
-noAntennaMsg       = FM Radio requires a plugged in headset to receive radio signals.
+noAntenna          = Plug in a wired headset
+noAntennaMsg       = FM Radio requires a plugged in wired headset to receive radio signals.
 airplaneModeHeader = Airplane mode is on
 airplaneModeMsg    = Turn off Airplane mode to use FM Radio.


### PR DESCRIPTION
In reference to:
Bug 808627 - [radio] starting message should say it is necessary to plug headphones with wire in order to use it as an antenna
Link: https://bugzilla.mozilla.org/show_bug.cgi?id=808627
