### PR TITLE
Revert "Bug 929636 - Python set device tests to fail on device type, rem...

### DIFF
--- a/tests/python/gaia-ui-tests/README.md
+++ b/tests/python/gaia-ui-tests/README.md
@@ -114,7 +114,7 @@ Add the line `user_pref('marionette.force-local', true);` to your gaia/profile/u
 
 Because we’re running against the desktop client we must filter out all tests that are unsuitable. To run the tests, use the following command:
 
-`gaiatest --address=localhost:2828 --type=b2g-antenna-bluetooth-carrier-camera-sdcard-wifi gaiatest/tests/manifest.ini`
+`gaiatest --address=localhost:2828 --type=b2g-antenna-bluetooth-carrier-camera-sdcard-wifi-xfail gaiatest/tests/manifest.ini`
 
 You should then start to see the tests running.
 
@@ -139,6 +139,7 @@ Here is a list of the types used, and when to use them:
 * qemu - these tests require the Firefox OS emulator to run.
 * sdcard - a storage device must be present.
 * wifi - this means a WiFi connection is required.
+* xfail - a special type that indicates the test is expected to fail.
 
 You may be thinking that there is only WiFi or cell data, and why the need for the 'lan' test type. Well, these tests
 aren't only run on mobile devices... We also run then on single-board computers known as

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/manifest.ini
@@ -10,6 +10,7 @@ online = false
 offline = false
 wifi = false
 camera = false
+xfail = false
 panda = true
 
 [test_endurance_background_apps.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -2,6 +2,7 @@
 b2g = true
 carrier = false
 online = true
+xfail = false
 
 [test_browser_cell_data.py]
 skip-if = device == "desktop"
@@ -14,7 +15,7 @@ lan = true
 [test_browser_navigation.py]
 [test_browser_bookmark.py]
 # Bug 930545 - [Browser] Adding a bookmark to home screen test fails
-expected = fail
+fail-if = true
 [test_browser_play_youtube_video.py]
 # Bug 877594 - Unable to play YouTube video in B2G desktop client
 fail-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/manifest.ini
@@ -2,4 +2,5 @@
 
 [test_calendar_today_date.py]
 [test_calendar_new_event_appears_on_all_calendar_views.py]
-disabled = Bug 877611 - Make "Select time" popup, in Calendar app, more test friendly
+# Bug #877611 - Make "Select time" popup, in Calendar app, more test friendly
+xfail = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/camera/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/camera/manifest.ini
@@ -9,5 +9,5 @@ skip-if = device == "desktop"
 skip-if = device == "desktop"
 [test_camera_multiple_shots.py]
 skip-if = device == "desktop"
-# Bug 911387 [Camera] Frequent "Picture not saved errors" when running nightly on Hamachi
-fail-if = device == "msm7627a"
+# Bug 911387 [Camera] Frequent "Picture not saved errors" when running nightly
+xfail = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/clock/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/clock/manifest.ini
@@ -1,6 +1,7 @@
 [DEFAULT]
 # Test requires B2G
 b2g = true
+xfail = false
 
 [test_clock_all_items_present_new_alarm.py]
 [test_clock_create_new_alarm.py]
@@ -12,4 +13,5 @@ b2g = true
 [test_clock_set_alarm_sound.py]
 [test_clock_set_alarm_snooze.py]
 [test_clock_set_alarm_time.py]
-disabled = Bug 877611 - Make "Select time" popup, in Calendar app, more test friendly
+# Bug 877611 - Make "Select time" popup, in Calendar app, more test friendly
+xfail = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
@@ -14,7 +14,7 @@ carrier = true
 skip-if = device == "desktop"
 sdcard = true
 # Bug 921205 - [B2G][Contacts]User unable to add picture from gallery to New Contact consistently
-expected = fail
+xfail = true
 
 [test_sort_contacts.py]
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
@@ -15,6 +15,6 @@ skip-if = device == "desktop"
 [test_gallery_edit_photo.py]
 skip-if = device == "desktop"
 # Bug 915876 - [B2G] [Buri] [1.2] [Gallery] Attempts to edit pictures do not get saved
-expected = fail
+xfail = true
 [test_gallery_return_to_tile_view.py]
 skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/marketplace/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/marketplace/manifest.ini
@@ -5,6 +5,7 @@ online = true
 
 offline = false
 
+xfail = false
 
 [test_marketplace_login.py]
 [test_marketplace_search_and_install_app.py]
@@ -14,8 +15,9 @@ offline = true
 online = true
 [test_marketplace_search_for_paid_apps.py]
 # Bug 859484 - [B2G] Free app appearing in paid filtered search results
-expected = fail
-disabled = Filter functionality has been removed
+xfail = true
+# Filter functionality has been removed
+disabled = true
 [test_marketplace_add_review.py]
 [test_marketplace_feedback_anonymous.py]
 [test_marketplace_feedback_login.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/music/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/music/manifest.ini
@@ -2,7 +2,7 @@
 skip-if = device == "desktop"
 sdcard = true
 # Bug 862156 - Marionette thinks that the play button in the music app is not displayed
-expected = fail
+xfail = true
 [test_music_empty.py]
 skip-if = device == "desktop"
 sdcard = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -1,5 +1,6 @@
 [DEFAULT]
 b2g = true
+xfail = false
 
 [test_settings_change_language.py]
 [test_settings_gps.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/videoplayer/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/videoplayer/manifest.ini
@@ -20,4 +20,4 @@ sdcard = true
 skip-if = device == "desktop"
 sdcard = true
 # Bug 874897 - Video player can't identify mp4 and ogg files on the SD card
-expected = fail
+xfail = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/manifest.ini
@@ -32,6 +32,9 @@ wifi = false
 # Test requires a hardware camera
 camera = false
 
+# Expected to fail
+xfail = false
+
 # Unit test
 unit = false
 

--- a/tests/travis_ci/gaia_ui_tests/script
+++ b/tests/travis_ci/gaia_ui_tests/script
@@ -10,5 +10,5 @@ gaiatest="python $root/cli.py"
 $gaiatest --app=b2gdesktop \
           --binary=$b2g \
           --profile=$profile \
-          --type=b2g \
+          --type=b2g-xfail \
           --restart $root/tests/manifest.ini


### PR DESCRIPTION
...ove final traces of xfail. r=dhunt r=rwood"

This reverts commit afbf45f26a73b7cd5e0a831bea48087331975286.
