### PR TITLE
Revert "Bug 930542 - Fail test_browser_bookmark.py because of bug 930545...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -13,8 +13,6 @@ lan = true
 [test_browser_search.py]
 [test_browser_navigation.py]
 [test_browser_bookmark.py]
-# Bug 930545 - [Browser] Adding a bookmark to home screen test fails
-expected = fail
 [test_browser_play_youtube_video.py]
 # Bug 877594 - Unable to play YouTube video in B2G desktop client
 fail-if = device == "desktop"


### PR DESCRIPTION
..."

This reverts commit d0a48341b9f258f9971d79f225ceba58e382eceb.

Conflicts:
    tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
