### PR TITLE
Bug 912010 - [Keyboard][V1.2] Default Keyboard when all keyboards are de-selected

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -119,8 +119,8 @@ class Keyboard(Base):
     # this is to tap on desired key on keyboard
     def _tap(self, val):
         try:
+            self.wait_for_condition(lambda m: m.find_element(*self._key_locator(val)).is_displayed)
             key = self.marionette.find_element(*self._key_locator(val))
-            self.wait_for_condition(lambda m: key.is_displayed)
             Actions(self.marionette).press(key).wait(0.1).release().perform()
         except (NoSuchElementException, ElementNotVisibleException):
             self.marionette.log('Key %s not found on the keyboard' % val)


### PR DESCRIPTION
Wait for element is displayed, and then find element.

https://bugzilla.mozilla.org/show_bug.cgi?id=912010#c39

```
ERROR: None
INFO -  ----------------------------------------------------------------------
INFO -  Traceback (most recent call last):
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/marionette/marionette_test.py", line 143, in run
INFO -      testMethod()
INFO -    File "/builds/slave/test/gaia/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_launch_packaged_app.py", line 26, in test_launch_packaged_app_from_search_panel
INFO -      search_panel.type_into_search_box(self.app_name)
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/gaiatest/apps/homescreen/regions/search_panel.py", line 24, in type_into_search_box
INFO -      self.keyboard.send(search_term)
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/gaiatest/apps/keyboard/app.py", line 181, in send
INFO -      self._tap(val)
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/gaiatest/apps/keyboard/app.py", line 122, in _tap
INFO -      key = self.marionette.find_element(*self._key_locator(val))
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/marionette/marionette.py", line 1100, in find_element
INFO -      response = self._send_message('findElement', 'value', **kwargs)
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/marionette/marionette.py", line 577, in _send_message
INFO -      self._handle_error(response)
INFO -    File "/builds/slave/test/build/venv/local/lib/python2.7/site-packages/marionette/marionette.py", line 598, in _handle_error
ERROR -      raise NoSuchElementException(message=message, status=status, stacktrace=stacktrace)
ERROR -  TEST-UNEXPECTED-FAIL | test_everythingme_launch_packaged_app.py test_everythingme_launch_packaged_app.TestEverythingMeSearchPanel.test_launch_packaged_app_from_search_panel | NoSuchElementException: Unable to locate element: button.keyboard-key[data-keycode="97"]
INFO -  ----------------------------------------------------------------------
```
