### PR TITLE
Bug 927588 - [clock] Timer - Remove seconds from timer

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -87,7 +87,16 @@
 
               <div id="time-picker" data-type="picker">
                 <div class="picker-container">
-                  <div class="picker-bar-background"></div>
+                  <div class="picker-labels">
+                    <div class="picker-label" id="hours" data-l10n-id="hours">
+                      Hours
+                    </div>
+                    <div class="picker-label" id="minutes" data-l10n-id="minutes">
+                      Minutes
+                    </div>
+                  </div>
+                  <div class="picker-bar-background">
+                  </div>
                   <div class="picker-hours-wrapper">
                     <div class="picker-hours">
                     </div>
@@ -96,14 +105,8 @@
                     <div class="picker-minutes">
                     </div>
                   </div>
-                  <div class="picker-seconds-wrapper">
-                    <div class="picker-seconds">
-                    </div>
-                  </div>
-
                   <div class="value-indicator">
                     <div class="value-indicator-colon">:</div>
-                    <div class="value-indicator-period">.</div>
                   </div>
                 </div>
               </div>

--- a/apps/clock/js/timer_panel.js
+++ b/apps/clock/js/timer_panel.js
@@ -11,17 +11,14 @@ var _ = require('l10n').get;
 
 var priv = new WeakMap();
 
-function duration(value) {
-  var hm = value.split(':');
-  var duration = 0;
-  var unit;
-
-  for (var i = 0; i < hm.length; i++) {
-    unit = Math.pow(60, hm.length - 1 - i);
-    duration += unit * 1000 * hm[i];
-  }
-
-  return duration;
+function timeFromPicker(value) {
+  var hm, ms;
+  hm = value.split(':');
+  ms = Utils.dateMath.toMS({
+        hours: hm[0],
+        minutes: hm[1]
+       });
+  return ms;
 }
 
 /**
@@ -45,10 +42,6 @@ Timer.Panel = function(element) {
         range: [0, 23]
       },
       minutes: {
-        range: [0, 59],
-        isPadded: true
-      },
-      seconds: {
         range: [0, 59],
         isPadded: true
       }
@@ -100,7 +93,6 @@ Timer.Panel.prototype = Object.create(Panel.prototype);
 
 Timer.Panel.prototype.onvisibilitychange = function(isVisible) {
   var nodes = this.nodes;
-  var dialog = View.instance(this.nodes.dialog);
   var timer = this.timer;
   var isPaused = false;
 
@@ -246,7 +238,7 @@ Timer.Panel.prototype.onclick = function(event) {
       // Reset shared timer object
       panel.timer = null;
 
-      // Restore the panel to 00:00
+      // Restore the panel to 00:00:00
       panel.update(0);
 
       // Show new timer dialog
@@ -268,7 +260,7 @@ Timer.Panel.prototype.onclick = function(event) {
 
     if (meta.action === 'create') {
 
-      time = duration(panel.picker.value);
+      time = timeFromPicker(panel.picker.value);
 
       if (!time) {
         return;
@@ -278,7 +270,7 @@ Timer.Panel.prototype.onclick = function(event) {
       // selected duration time.
       panel.timer = new Timer({
         sound: nodes.sound.value,
-        duration: duration(panel.picker.value),
+        duration: time,
         vibrate: nodes.vibrate.checked
       });
 

--- a/apps/clock/locales/clock.en-US.properties
+++ b/apps/clock/locales/clock.en-US.properties
@@ -3,11 +3,13 @@ start  = Start
 stop   = Stop
 cancel = Cancel
 
-hour   = Hour
-minute = Minute
-enable = Enable
-back   = Back
-label  = Label
+hour    = Hour
+hours   = Hours
+minute  = Minute
+minutes = Minutes
+enable  = Enable
+back    = Back
+label   = Label
 
 alarm                 = Alarm
 timer                 = Timer

--- a/apps/clock/style/picker/picker.css
+++ b/apps/clock/style/picker/picker.css
@@ -25,50 +25,46 @@
 [data-type="picker"] .picker-container {
   -moz-box-sizing: border-box;
   position: relative;
-  width: calc(100% - 5rem);
+  width: calc(100% - 5.5rem);
   height: 22.5rem;
-  margin: 2.5rem;
+  margin: 1.8rem auto;
   padding-top: 8.8rem;
   border-left:  0.1rem solid #111;
   border-right: 0.1rem solid #111;
   overflow: hidden;
+  border: 1px solid black;
 }
 
-[data-type="picker"] .picker-container:before {
-  content: '';
+[data-type="picker"] .picker-labels {
   position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  border-top: solid 0.7rem;
-  -moz-border-top-colors:
-    rgba(0, 0, 0, 0.5) rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.3)
-    rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.15) rgba(0, 0, 0, 0.1)
-    rgba(0, 0, 0, 0.05);
-  z-index: 10;
+  top: 0px;
+  width: 100%;
+  z-index: 2;
 }
 
-[data-type="picker"] .picker-container:after {
-  content: '';
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  border-bottom: solid 0.7rem;
-  -moz-border-bottom-colors:
-    rgba(0, 0, 0, 0.5) rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.3)
-    rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.15) rgba(0, 0, 0, 0.1)
-    rgba(0, 0, 0, 0.05);
-  z-index: 10;
+[data-type="picker"] .picker-label {
+  background: #333;
+  height: 3rem;
+  font-size: 1.4rem;
+  line-height: 3rem;
+  text-align: center;
+  width: 50%;
+}
+
+[data-type="picker"] #hours {
+  float: left;
+}
+
+[data-type="picker"] #minutes {
+  float: right;
 }
 
 [data-type="picker"] .picker-bar-background {
   position: absolute;
   top: 0;
   right: 0;
-  width: calc(100% / 3);
+  width: calc(100% / 2);
   height: 100%;
-  background: url(/style/picker/images/ui/pattern-time.png);
 }
 
 #time-picker.picker-bar-background {
@@ -76,34 +72,29 @@
 }
 
 [data-type="picker"] .picker-hours-wrapper,
-[data-type="picker"] .picker-minutes-wrapper,
-[data-type="picker"] .picker-seconds-wrapper {
+[data-type="picker"] .picker-minutes-wrapper {
   -moz-box-sizing: border-box;
   position: absolute;
   top: 0;
   left: 0;
-  width: calc(100% / 3);
+  width: calc(100% / 2);
   height: 100%;
   padding-top: 8.3rem;
+}
+
+[data-type="picker"] .picker-hours-wrapper {
   border-right: solid 0.2rem;
   -moz-border-right-colors: #1d1d1d #4a4a4a;
 }
 
 [data-type="picker"] .picker-minutes-wrapper {
-  left: calc(100% / 3);
-}
-
-[data-type="picker"] .picker-seconds-wrapper {
-  left: auto;
-  right: 0;
-  border: none;
+  left: calc(100% / 2);
 }
 
 [data-type="picker"] .picker-hours-wrapper,
 [data-type="picker"] .picker-minutes-wrapper,
-[data-type="picker"] .picker-seconds-wrapper,
 [data-type="picker"] .picker-bar-background {
-  width: 33.3333%;
+  width: 50%;
 }
 
 /*[data-type="picker"] .picker-minutes-wrapper {
@@ -112,21 +103,9 @@
   border: none;
 }*/
 
-[data-type="picker"] .picker-seconds-wrapper {
-  left: auto;
-  right: 0;
-  border: none;
-}
 
-
-
-/*[data-type="picker"] .picker-seconds-wrapper {
-  display: none;
-}
-*/
 [data-type="picker"] .picker-hours,
-[data-type="picker"] .picker-minutes,
-[data-type="picker"] .picker-seconds {
+[data-type="picker"] .picker-minutes {
   -moz-user-select: none;
   position: relative;
   width: 100%;
@@ -146,7 +125,7 @@
 [data-type="picker"] .value-indicator-colon {
   float: left;
   position: relative;
-  width: calc(100% / 3);
+  width: calc(100% / 2);
   height: 100%;
   font: 2.2rem/4.4rem Sans-serif;
   text-align: right;
@@ -158,7 +137,7 @@
 [data-type="picker"] .value-indicator-period {
   float: left;
   position: relative;
-  width: calc(100% / 3);
+  width: calc(100% / 2);
   height: 100%;
   font: 2.2rem/4.4rem Sans-serif;
   text-align: right;

--- a/apps/clock/test/unit/mocks/mock_picker/picker.js
+++ b/apps/clock/test/unit/mocks/mock_picker/picker.js
@@ -21,20 +21,19 @@ function MockPicker(setup) {
       reset: function() {}
     };
   }, this);
-
-  Object.defineProperties(this, {
-    value: {
-      get: function() {
-        return '0:00:00';
-      }
-    }
-  });
 }
 
-MockPicker.prototype.reset = function() {
-  this.pickers.forEach(function(picker) {
-    this.spinners[picker].reset();
-  }, this);
+MockPicker.prototype = {
+  reset: function() {
+    this.pickers.forEach(function(picker) {
+      this.spinners[picker].reset();
+    }, this);
+  },
+  // Mock non-zero value so create event doesn't return without
+  // instantiating a new Timer()
+  get value() {
+    return '1:00';
+  }
 };
 
 return MockPicker;

--- a/apps/clock/test/unit/picker/picker_test.js
+++ b/apps/clock/test/unit/picker/picker_test.js
@@ -69,6 +69,8 @@ suite('Picker', function() {
     assert.equal(spinners.minutes.lower, 0);
     assert.equal(spinners.minutes.upper, 59);
     assert.equal(spinners.minutes.range, 60);
+
+    assert.equal(picker.value, '0:0');
   });
 
 

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -218,6 +218,15 @@ suite('Timer.Panel', function() {
       assert.ok(sound.focus.called);
     });
 
+    test('click: create ', function() {
+      panel.nodes.create.dispatchEvent(
+        new CustomEvent('click')
+      );
+      assert.ok(panel.onclick.called);
+      // Duration from picker value
+      assert.equal(panel.timer.duration, 3600000);
+    });
+
     test('blur: sound', function() {
       var menu = panel.nodes.menu;
       var sound = panel.nodes.sound;


### PR DESCRIPTION
Remove seconds from timer picker while retaining displayed seconds in elapsed time. Use `Utils.dateMath` for computation from picker.
