### PR TITLE
Bug 926105 - When there are no apps to show in the app switcher, show a text saying "No recent apps"

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1076,6 +1076,7 @@
       <div id="cards-view" data-z-index-level="cards-view">
         <ul>
         </ul>
+        <span class="no-recent-apps" data-l10n-id="no-recent-apps">No recent apps</span>
       </div>
 
       <!-- icc / stk -->

--- a/apps/system/js/cards_view.js
+++ b/apps/system/js/cards_view.js
@@ -172,6 +172,13 @@ var CardsView = (function() {
       cardsView.addEventListener('mousedown', CardsView);
     }
 
+    // If there is no running app, show "no recent apps" message
+    if (Object.keys(runningApps).length > 1) {
+      cardsView.classList.remove('empty');
+    } else {
+      cardsView.classList.add('empty');
+    }
+
     // Make sure we're in default orientation
     screen.mozLockOrientation(ScreenLayout.defaultOrientation);
 

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -33,6 +33,27 @@
   transition: none;
 }
 
+#cards-view .no-recent-apps {
+  display: none;
+  position: absolute;
+  top: calc(50% - 1rem);
+  left: 3rem;
+  width: calc(100% - 6rem);
+  height: 2rem;
+  text-align: center;
+  color: #52b6cc;
+  font-weight: 500;
+  font-size: 2rem;
+}
+
+#cards-view.empty .no-recent-apps {
+  display: block;
+}
+
+#cards-view.empty {
+  background-color: rgba(0, 0, 0, .8);
+}
+
 #cards-view ul {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
As reported by @elad661 at Bugzilla:

> Steps to reproduce:
> 1) Long press the home button
> 
> Actual results:
> Screen darkens. Nothing shows on the darkened screen.
> 
> Expected results:
> I'd expect some text informing me that there are no apps to show, instead of an empty semi transparent overlay.
