### PR TITLE
Bug 907625 - Prevent keyboard blocks incoming callscreen when keyboard i...

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -131,6 +131,7 @@ var KeyboardManager = {
     // when an inline activity goes away.
     window.addEventListener('appwillclose', this);
     window.addEventListener('activitywillclose', this);
+    window.addEventListener('attentionscreenshow', this);
 
     // To handle keyboard layout switching
     window.addEventListener('mozChromeEvent', function(evt) {
@@ -396,9 +397,17 @@ var KeyboardManager = {
   },
 
   handleEvent: function km_handleEvent(evt) {
+    var self = this;
     switch (evt.type) {
       case 'mozbrowserresize':
         this.resizeKeyboard(evt);
+        break;
+      case 'attentionscreenshow':
+        // If we call hideKeyboardImmediately synchronously,
+        // attention screen will not show up.
+        setTimeout(function hideKeyboardAsync() {
+          self.hideKeyboardImmediately();
+        }, 0);
         break;
       case 'activitywillclose':
       case 'appwillclose':


### PR DESCRIPTION
...s on

Hide keyboard immediately when keyboard manager hear 'attentionscreenshow' event.

https://bugzilla.mozilla.org/show_bug.cgi?id=907625
