### PR TITLE
Bug 923577 - Ensure that we remove icons of hidden roles r=crdlc

### DIFF
--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -324,6 +324,48 @@ suite('grid.js >', function() {
     });
   });
 
+  suite('install role system app >', function() {
+    var mockApp;
+    var tempIcon;
+    var appManifest = {
+      name: 'My Ringtones',
+      role: 'system'
+    };
+    var appUpdateManifest = {
+      name: 'My Ringtones'
+    };
+
+    setup(function() {
+      mockApp = new MockApp({
+        manifest: null,
+        updateManifest: appUpdateManifest
+      });
+      this.sinon.useFakeTimers();
+
+      MockAppsMgmt.mTriggerOninstall(mockApp);
+      this.sinon.clock.tick(SAVE_STATE_WAIT_TIMEOUT);
+    });
+
+    test('should have a temp icon', function() {
+      tempIcon = GridManager.getIcon(mockApp);
+      assert.ok(tempIcon);
+    });
+
+    suite('finish role system app install >', function() {
+      setup(function() {
+        this.sinon.spy(MockIcon.prototype, 'remove');
+        mockApp.manifest = appManifest;
+        mockApp.updateManifest = null;
+        mockApp.mTriggerDownloadApplied();
+        this.sinon.clock.tick(SAVE_STATE_WAIT_TIMEOUT);
+      });
+
+      test('icon remove method called', function() {
+        assert.isTrue(tempIcon.remove.calledOnce);
+      });
+    });
+  });
+
   suite('install single variant apps >', function() {
     var prevMaxIconNumber;
 


### PR DESCRIPTION
When installing an application that is hidden, we have to make sure,
when updating the icon, that we remove it. This case happens especially
with packaged role system app, like, in this bug, a ringtones app. We
end up creating a temp icon (because we only have a updateManifest at
that time and cannot decide the role of the app) while downloading,
which is not removed once the app is finally installed.
