### PR TITLE
Bug 924475 - [Messages] The context menu is missing the contact name and mobile type

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -855,6 +855,11 @@ ul.contact-prompt {
   line-height: normal;
 }
 
+ul.contact-prompt a {
+  z-index: 101;
+  color: white;
+}
+
 body[role="application"] form[role="dialog"][data-type="action"] > section:first-child{
   height: auto;
   border-bottom: 0.1rem solid #616262;


### PR DESCRIPTION
- Carrier name is not included in [the spec](https://bug896368.bugzilla.mozilla.org/attachment.cgi?id=786182)
- Separator is a `,` not `|`
- Some styling was being overridden by root.css (as the suggestion is in an `a` element)
- Contact photo not yet added
- Number in header not yet removed.
