### PR TITLE
Bug 921424 - Replace wait for landing page after unlocking with wait for displayed app to be homescreen

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
@@ -13,12 +13,10 @@ class Homescreen(Base):
 
     name = 'Homescreen'
 
-    _homescreen_iframe_locator = (By.CSS_SELECTOR, 'div.homescreen iframe')
     _homescreen_icon_locator = (By.CSS_SELECTOR, 'li.icon[aria-label="%s"]')
     _visible_icons_locator = (By.CSS_SELECTOR, 'div.page[style*="transform: translateX(0px);"] > ol > .icon')
     _edit_mode_locator = (By.CSS_SELECTOR, 'body[data-mode="edit"]')
     _search_bar_icon_locator = (By.CSS_SELECTOR, '#evme-activation-icon input')
-    _landing_page_locator = (By.ID, 'icongrid')
     _collections_locator = (By.CSS_SELECTOR, 'li.icon[data-collection-name]')
     _collection_locator = (By.CSS_SELECTOR, "li.icon[data-collection-name *= '%s']")
 
@@ -26,9 +24,8 @@ class Homescreen(Base):
         Base.launch(self)
 
     def switch_to_homescreen_frame(self):
-        self.marionette.switch_to_frame()
-        hs_frame = self.marionette.find_element(*self._homescreen_iframe_locator)
-        self.marionette.switch_to_frame(hs_frame)
+        self.wait_for_condition(lambda m: self.apps.displayed_app.name == self.name)
+        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
 
     def tap_search_bar(self):
         search_bar = self.marionette.find_element(*self._search_bar_icon_locator)
@@ -93,9 +90,6 @@ class Homescreen(Base):
         return self.marionette.execute_script("""
         var pageHelper = window.wrappedJSObject.GridManager.pageHelper;
         return pageHelper.getCurrentPageNumber() < (pageHelper.getTotalPagesNumber() - 1);""")
-
-    def wait_for_landing_page_visible(self):
-        self.wait_for_element_displayed(*self._landing_page_locator)
 
     @property
     def collections_count(self):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/test_browser_bookmark.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/test_browser_bookmark.py
@@ -33,7 +33,7 @@ class TestBrowserBookmark(GaiaTestCase):
 
         # Switch to Home Screen to look for bookmark
         homescreen = Homescreen(self.marionette)
-        self.marionette.execute_script("window.wrappedJSObject.dispatchEvent(new Event('home'));")
+        homescreen.touch_home_button()
         homescreen.switch_to_homescreen_frame()
 
         self._bookmark_added = homescreen.is_app_installed(self.bookmark_title)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_homescreen.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_homescreen.py
@@ -18,7 +18,5 @@ class TestLockScreen(GaiaTestCase):
     def test_unlock_to_homescreen(self):
         # https://moztrap.mozilla.org/manage/case/1296/
         homescreen = self.lock_screen.unlock()
-        self.lock_screen.wait_for_lockscreen_not_visible()
 
         homescreen.switch_to_homescreen_frame()
-        homescreen.wait_for_landing_page_visible()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_homescreen_with_passcode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_homescreen_with_passcode.py
@@ -28,7 +28,5 @@ class TestLockScreen(GaiaTestCase):
         """
         homescreen = self.lock_screen.unlock()
         self.lock_screen.passcode_pad.type_passcode(self._input_passcode)
-        self.lock_screen.wait_for_lockscreen_not_visible()
 
         homescreen.switch_to_homescreen_frame()
-        homescreen.wait_for_landing_page_visible()


### PR DESCRIPTION
For now I have only done the part for the unlock to homescreen tests. Needs to be done for the unlock to camera tests as well.
