### PR TITLE
Bug 931977 - [Keyboard] Ensure first keyboard shown is properly initialized

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -379,6 +379,9 @@ function getKeyboardSettings() {
 
     // We've got all the settings, so initialize the rest
     initKeyboard();
+
+    // initialize the current loaded layout
+    setKeyboardName(keyboardName);
   });
 }
 
@@ -470,6 +473,7 @@ function initKeyboard() {
 
   window.addEventListener('hashchange', function() {
     var inputMethodName = window.location.hash.substring(1);
+
     setKeyboardName(inputMethodName, function() {
       resetKeyboard();
       showKeyboard();
@@ -484,6 +488,7 @@ function initKeyboard() {
   // showKeyboard() when mozHidden is false and we got inputContext
   window.addEventListener('mozvisibilitychange', function visibilityHandler() {
     var inputMethodName = window.location.hash.substring(1);
+
     setKeyboardName(inputMethodName, function() {
       if (!document.mozHidden && inputContext) {
         showKeyboard();
@@ -541,6 +546,7 @@ function setKeyboardName(name, callback) {
   deactivateInputMethod();
 
   if (keyboard.imEngine) {
+
     loadIMEngine(name, function() {
       inputMethod = InputMethods[keyboard.imEngine];
       callback();

--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -36,7 +36,6 @@ disabled = Bug 877611
 [functional/contacts/test_delete_contact.py]
 [functional/contacts/test_add_contact_to_favorites.py]
 [functional/everythingme/test_everythingme_launch_packaged_app.py]
-disabled = Bug 931977
 [functional/homescreen/test_homescreen_edit_mode.py]
 [functional/homescreen/test_homescreen_move_app.py]
 [functional/keyboard/test_keyboard.py]


### PR DESCRIPTION
- use the `setKeyboardName` during first keyboard load
- Renabled TBPL test
