### PR TITLE
Bug 931718 - Introduce a 'print-xulrunner-sdk' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,6 +542,10 @@ endif
 # So let's export these variables to external processes.
 export XULRUNNER_DIRECTORY XULRUNNERSDK XPCSHELLSDK
 
+.PHONY: print-xulrunner-sdk
+print-xulrunner-sdk:
+	@echo "$(XULRUNNER_DIRECTORY)"
+
 .PHONY: install-xulrunner-sdk
 install-xulrunner-sdk:
 	@echo "XULrunner directory: $(XULRUNNER_DIRECTORY)"


### PR DESCRIPTION
In order to be able to run mochitest-remote, for example on emulator, we
need to have a way to get the correct path of the XULRunner SDK.
