### PR TITLE
Bug 860424 - Show first 8 characters only

### DIFF
--- a/apps/settings/js/about_more_info.js
+++ b/apps/settings/js/about_more_info.js
@@ -40,7 +40,7 @@ var AboutMoreInfo = {
 
           var d = new Date(parseInt(data[1] + '000', 10));
           dispDate.textContent = dateToUTC(d);
-          dispHash.textContent = data[0];
+          dispHash.textContent = data[0].substr(0, 8);
         } else {
           console.error('Failed to fetch gaia commit: ', req.statusText);
         }


### PR DESCRIPTION
Bug: 'Git commit info' value cropped/shortened by ellipsis
Fixed: Show first 8 characters only

Signed-off-by: Carl X. Su bcbcarl@gmail.com
