### PR TITLE
Bug 868345 - [system] 'What's in a crash report?' shown after crash not ...

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -595,16 +595,19 @@
           <!-- "Crash Reports" information page -->
           <section role="region" class="skin-dark">
             <header>
-              <menu type="toolbar">
-                <button id="crash-reports-done" data-l10n-id="done">Done</button>
-              </menu>
+              <button id="crash-reports-close"><span class="icon icon-close">close</span></button>
               <h1 data-l10n-id="crashReports">Crash Reports</h1>
             </header>
-            <p data-l10n-id="crash-reports-description-1"></p>
-            <p data-l10n-id="crash-reports-description-2"></p>
-            <p>
-              <span data-l10n-id="crash-reports-description-3-start"></span><span data-l10n-id="crash-reports-description-3-privacy"></span><span data-l10n-id="crash-reports-description-3-end"></span>
-            </p>
+            <div>
+              <ul>
+                <li class="description" data-l10n-id="crash-reports-description-1">
+                A crash report contains some details about the crash and your device, as well as a snapshot of the state of your device when it crashed.</li>
+                <li class="description" data-l10n-id="crash-reports-description-2">This may include things like open pages and apps, text typed into forms and the content of open messages, recent browsing history, or geolocation used by an open app.</li>
+                <li class="description">
+                  <span data-l10n-id="crash-reports-description-3-start">We use crash reports to try to fix problems and improve our products. We handle your information as we describe in our</span><span data-l10n-id="crash-reports-description-3-privacy">privacy policy</span><span data-l10n-id="crash-reports-description-3-end">.</span>
+                </li>
+              </ul>
+            </div>
           </section>
         </div>
 

--- a/apps/system/js/crash_reporter.js
+++ b/apps/system/js/crash_reporter.js
@@ -58,7 +58,7 @@ var CrashReporter = (function() {
     var crashInfoLink = document.getElementById('crash-info-link');
     crashInfoLink.addEventListener('click', function onLearnMoreClick() {
       var dialog = document.getElementById('crash-dialog');
-      document.getElementById('crash-reports-done').
+      document.getElementById('crash-reports-close').
                addEventListener('click', function onDoneClick() {
         this.removeEventListener('click', onDoneClick);
         dialog.classList.remove('learn-more');

--- a/apps/system/style/crash_reporter/crash_reporter.css
+++ b/apps/system/style/crash_reporter/crash_reporter.css
@@ -10,7 +10,7 @@
   border-top: none;
 }
 
-#crash-dialog  a {
+#crash-dialog a {
   text-decoration: underline;
   margin-top: 2rem;
 }
@@ -24,6 +24,21 @@
 }
 
 /* "Crash Reports" information page */
+section[role="region"] > header {
+  position: absolute;
+}
+
+section[role="region"] > div {
+  position: absolute;
+  top: 5rem;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: calc(100% - 5rem);
+  overflow-y: scroll;
+}
+
 #crash-dialog > section {
   background-color: #fff;
   color: #000;
@@ -35,8 +50,16 @@
   bottom: 0;
 }
 
-#crash-dialog > section > p {
-  padding: 1rem 3rem;
+#crash-dialog > section > div > ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#crash-dialog .description {
   font-size: 1.5rem;
+  word-wrap: break-word;
+  -moz-hyphens: auto;
   white-space: normal;
+  padding: 1rem 3rem;
 }


### PR DESCRIPTION
...scrollable

Before: page not scrollable, title truncated

![2013-10-26-02-07-38](https://f.cloud.github.com/assets/1294206/1441181/bd05a682-41a7-11e3-9365-082f54a5dded.png)

After: page scrollable, more space for title (I added some random characters)
![2013-10-30-17-14-16](https://f.cloud.github.com/assets/1294206/1441231/9193a2a0-41a8-11e3-93f4-c8d3572a9358.png)
