### PR TITLE
Bug 906238 - [l10n] manual not localized in Cellular & Data >Network ope... r=crh0716

### DIFF
--- a/apps/settings/js/carrier.js
+++ b/apps/settings/js/carrier.js
@@ -534,8 +534,7 @@ var Carrier = {
         if (auto) {
           localize(opAutoSelectState, 'operator-networkSelect-auto');
         } else {
-          opAutoSelectState.dataset.l10nId = '';
-          opAutoSelectState.textContent = mode;
+          localize(opAutoSelectState, 'operator-networkSelect-manual');
           if (scan) {
             gOperatorNetworkList.scan();
           }

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -184,6 +184,7 @@ operator-networkType-preferEVDO=EVDO preferred
 
 operator-autoSelect=Automatic selection
 operator-networkSelect-auto=Automatic
+operator-networkSelect-manual=Manual
 operator-turnAutoSelectOff=Turn automatic selection off to view available network operators.
 operator-status-connecting       = Connecting…
 operator-status-connectingfailed = Connection failed


### PR DESCRIPTION
...rator > Automatic selection

Tested on 1.2 because RIL is currently broken on 1.3 Keon
![2013-10-30-18-44-05](https://f.cloud.github.com/assets/1294206/1442091/7e7011fa-41b6-11e3-84da-03938d45592f.png)
