### PR TITLE
 Bug 930817 - [B2G][1.2][l10n][Keyboard] Long words in the Auto Correct ...

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -295,8 +295,7 @@ const IMERender = (function() {
           var div = document.createElement('div');
           // Size the div based on the # of candidates (-2% for margins)
           div.style.width = (100 / candidates.length - 2) + '%';
-          docFragment.appendChild(div);
-
+          candidatePanel.appendChild(div);
           var text, data, correction = false;
           if (typeof candidate === 'string') {
             if (candidate[0] === '*') { // it is an autocorrection candidate
@@ -384,9 +383,9 @@ const IMERender = (function() {
         candidatePanelToggleButton.style.display = 'none';
         toggleCandidatePanel(false);
         docFragment = candidatesFragmentCode(1, candidates, true);
+        candidatePanel.appendChild(docFragment);
       }
 
-      candidatePanel.appendChild(docFragment);
     }
   };
 


### PR DESCRIPTION
...suggestion bar cut each other off

```
 -- remove docFragment method to generate candidate ele since use docFragment can get cliendwidth and getBoundingClientRect
```
