### PR TITLE
Bug 930929 - [Contacts] Contact's address information is not shown in the contact details view

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -318,7 +318,7 @@ var Contacts = (function() {
     var attr;
     for (var i = 0; i < fields.length; i++) {
       attr = fields[i];
-      if (obj.hasOwnProperty(attr) && obj[attr]) {
+      if (obj[attr]) {
         if (Array.isArray(obj[attr])) {
           if (obj[attr].length > 0) {
             return false;


### PR DESCRIPTION
contact.hasOwnProperty(attr) is returning false even in the case when contact is a valid mozContact instance and attr is a contact property.
