### PR TITLE
Bug 930104 - Add SIMULATOR=1 to prevent shipping firefox addons in simulator profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,14 @@ DOGFOOD?=0
 TEST_AGENT_PORT?=8789
 GAIA_APP_TARGET?=engineering
 
+# Flag to ease build a simulator-compatible profile
+SIMULATOR?=0
+ifeq ($(SIMULATOR),1)
+DESKTOP=1
+NO_FTU=1
+DEVICE_DEBUG=1
+endif
+
 # Enable compatibility to run in Firefox Desktop
 DESKTOP?=$(DEBUG)
 # Disable first time experience screen
@@ -443,10 +451,10 @@ optimize-clean: webapp-zip install-xulrunner-sdk
 
 # Get additional extensions
 $(PROFILE_FOLDER)/installed-extensions.json: build/additional-extensions.json $(wildcard .build/custom-extensions.json)
-ifeq ($(DESKTOP),1)
+ifeq ($(SIMULATOR),1)
+	# Prevent installing external firefox helper addon for the simulator
+else ifeq ($(DESKTOP),1)
 	python build/additional-extensions.py --gaia-dir="$(CURDIR)" --profile-dir="$(PROFILE_FOLDER)"
-else ifeq ($(DEBUG),1)
-	touch $(PROFILE_FOLDER)/installed-extensions.json
 endif
 
 profile-dir:
@@ -633,7 +641,9 @@ extensions:
 ifeq ($(BUILD_APP_NAME),*)
 	@rm -rf $(EXT_DIR)
 	@mkdir -p $(EXT_DIR)
-ifeq ($(DESKTOP),1)
+ifeq ($(SIMULATOR),1)
+	cp -r tools/extensions/{activities@gaiamobile.org,activities,alarms@gaiamobile.org,alarms,desktop-helper,desktop-helper@gaiamobile.org,keyboard,keyboard@gaiamobile.org} $(EXT_DIR)/
+else ifeq ($(DESKTOP),1)
 	cp -r tools/extensions/* $(EXT_DIR)/
 else ifeq ($(DEBUG),1)
 	cp tools/extensions/httpd@gaiamobile.org $(EXT_DIR)/

--- a/build/utils.js
+++ b/build/utils.js
@@ -204,7 +204,6 @@ function registerProfileDirectory(profileDir) {
 }
 
 function getGaia(options) {
-  registerProfileDirectory(options.PROFILE_DIR);
   return {
     engine: options.GAIA_ENGINE,
     sharedFolder: getFile(options.GAIA_DIR, 'shared'),

--- a/tools/extensions/browser-helper@gaiamobile.org/install.rdf
+++ b/tools/extensions/browser-helper@gaiamobile.org/install.rdf
@@ -9,7 +9,7 @@
     <em:version>0.1</em:version>
     <em:targetApplication>
       <Description>
-       <em:id>toolkit@mozilla.org</em:id>
+       <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
        <em:minVersion>6.0</em:minVersion>
        <em:maxVersion>32.0.*</em:maxVersion>
      </Description>

--- a/tools/extensions/gaia-build@gaiamobile.org/install.rdf
+++ b/tools/extensions/gaia-build@gaiamobile.org/install.rdf
@@ -9,7 +9,7 @@
     <em:version>0.1</em:version>
     <em:targetApplication>
       <Description>
-       <em:id>toolkit@mozilla.org</em:id>
+       <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
        <em:minVersion>6.0</em:minVersion>
        <em:maxVersion>32.0.*</em:maxVersion>
      </Description>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=930104
