### PR TITLE
bug 925970

### DIFF
--- a/apps/homescreen/everything.me/css/everything.me.css
+++ b/apps/homescreen/everything.me/css/everything.me.css
@@ -4,24 +4,23 @@
 
 #evme-activation-icon {
   position: absolute;
-  background: rgba(0, 0, 0, 0.4);
+  background: url('/everything.me/images/search-icon.png') 28.3rem 50% no-repeat rgba(0, 0, 0, 0.4);
+  background-size: 3rem;
   height: 5rem;
   width: 100%;
   z-index: 200;
 }
   #evme-activation-icon input {
-    height: 100%;
-    width: 100%;
+    background: transparent;
+    width: 84%;
     position: absolute;
-    top: 0;
-    left: 0;
+    top: 1.25rem;
+    left: 1.1rem;
     border: none;
     padding: 0;
-    background: url('/everything.me/images/search-icon.png') 28.3rem 50% no-repeat transparent;
-    background-size: 3rem;
     color: #eee;
+    font-family: 'Fira Sans Light', 'Fira Sans', 'Feura Sans';
     font-size: 1.9rem;
-    text-indent: 1.1rem;
   }
   #evme-activation-icon input::-moz-placeholder {
     color: #eee;

--- a/apps/homescreen/everything.me/modules/Helper/Helper.css
+++ b/apps/homescreen/everything.me/modules/Helper/Helper.css
@@ -10,7 +10,7 @@
 
 #search-title {
     position: absolute;
-    top: -0.1rem;
+    top: 0rem;
     left: 1.3rem;
     right: 0.6rem;
     color: #fff;
@@ -102,7 +102,7 @@
 
 #helper {
     position: absolute;
-    top: -0.2rem;
+    top: 0;
     left: 0;
     right: 0;
     height: 130%;

--- a/apps/homescreen/everything.me/modules/Searchbar/Searchbar.css
+++ b/apps/homescreen/everything.me/modules/Searchbar/Searchbar.css
@@ -43,13 +43,13 @@
         background: transparent;
         border: none;
         width: 84%;
-        top: 1.4rem;
+        top: 1.35rem;
         left: 1.1rem;
         display: inline;
         color: #fff;
         font-size: 1.9rem;
         font-style: normal;
-        font-weight: normal;
+        font-weight: 400;
     }
 
     #evmeContainer #search-q-bg {
@@ -92,11 +92,12 @@
     
     #evmeContainer #default-text {
         position: absolute;
-        top: 1.1rem;
-        left: 1.1rem;
+        top: 1.25rem;
+        left: 1.2rem;
         text-transform: none;
         display: none;
         color: #858585;
+        font-family: 'Fira Sans Light', 'Fira Sans', 'Feura Sans';
         font-style: italic;
         font-size: 1.9rem;
         font-weight: 300;


### PR DESCRIPTION
- Get rid of slight shift from placeholder e.me elements and actual when in use.
- Specify font-family to use, this is unfortunately a must as we do not map our light font versions to CSS standard names.
- Degrade to older known fonts to support devices from partners that use incorrect fonts (and there are many).

r=peterla
