### PR TITLE
Bug 930882 - [messages] Sending mms with attachment filename over 40 chars will be failed with incorrect error message

### DIFF
--- a/apps/sms/js/smil.js
+++ b/apps/sms/js/smil.js
@@ -6,6 +6,8 @@
 (function() {
 'use strict';
 
+// Need to add reference spec here
+const FILENAME_LIMIT = 40;
 // characters not allowed in smil filenames
 var unsafeFilenamePattern = /[^a-zA-Z0-9_#.()?&%-]/g;
 
@@ -96,26 +98,47 @@ function SMIL_generateSlides(data, slide, slideIndex) {
 }
 
 function SMIL_generateUniqueLocation(data, location) {
+  var extension, name, result;
 
   // if the location is already being used by the attachment
   function SMIL_uniqueLocationMatches(attachment) {
     return attachment.location === result;
   }
 
-  // we will add our number right before the '.' if it exists
+  // Check if a file extension exists
+  // Cache index of last non-extension portion of the filename
   var index = location.lastIndexOf('.');
   if (index === -1) {
-    index = location.length;
+    name = location;
+    // Set to empty string so we can check length and append it to things
+    extension = '';
+  } else {
+    // Cache potential file extension
+    extension = location.slice(index);
+    name = location.slice(0, index);
   }
 
-  // start with the location given to us
-  var result = location;
-  var dupIndex = 2;
+  // First truncate below the limit to make de-duplicating worthwhile
+  if (name.length + extension.length > FILENAME_LIMIT) {
+    name = name.slice(0, FILENAME_LIMIT - extension.length);
+  }
+  result = name + extension;
 
-  // while any attachment already has this location:
+  var duplicateIndex = 2;
+  // If result is identical to any other attached files
+  // add a duplicate marker and recheck the length
   while (data.attachments.some(SMIL_uniqueLocationMatches)) {
-    result = location.slice(0, index) +
-        '_' + (dupIndex++) + location.slice(index);
+    let truncIndex = 0;
+    // Construct a de-deuplicated name with the extention and
+    // update duplicate index in case de-duplicated name is already chosen
+    result = name + '_' + duplicateIndex++ + extension;
+    // Truncate until the name (no longer needs to be de-duplicated)
+    // and extension are below the limit
+    while (result.length > FILENAME_LIMIT) {
+      duplicateIndex = 2;
+      name = name.slice(0, --truncIndex);
+      result = name + extension;
+    }
   }
   return result;
 }

--- a/apps/sms/test/unit/smil_test.js
+++ b/apps/sms/test/unit/smil_test.js
@@ -416,6 +416,99 @@ suite('SMIL', function() {
       assert.equal(output.attachments[2].location, 'kitten-450_2.jpg');
     });
 
+    suite('SMIL filename: length limitations', function() {
+      var bareString, extString;
+      bareString = 'dfjaksdhfkasjdhfaksjdfhksjdahfaksjdhfdfsfffff';
+      extString = 'dfjaksdhfkasjdhfaksjdfhksjdahfaksjdhfdfsf';
+      test('Filenames truncated', function() {
+        var smilTest = [{
+          text: 'Truncate filename',
+          name: bareString,
+          blob: testImageBlob
+        },{
+          text: 'With extension',
+          name: extString + '.jpg',
+          blob: testImageBlob
+        }];
+        var output = SMIL.generate(smilTest);
+        assert.equal(
+          output.attachments[0].location,
+          bareString.slice(0, 40)
+        );
+        assert.equal(
+          output.attachments[2].location,
+          extString.slice(0, 40 - 4) + '.jpg'
+        );
+        assert.ok(output.attachments.every(function(elem) {
+          return elem.location.length <= 40;
+        }));
+      });
+      suite('Clashing filenames also truncated', function() {
+        var smilTest, bare, extension;
+        var bareString = 'dfjaksdhfkasjdhfaksjdfhksjdahfaksjdhfdf';
+        var extString = bareString.slice(0, -3);
+        setup(function() {
+          smilTest = [{
+            text: 'Setup clash',
+            name: bareString,
+            blob: testImageBlob
+          },{
+            text: 'Testing first clash',
+            name: bareString,
+            blob: testImageBlob
+          },{
+            text: 'Testing second clash',
+            name: bareString,
+            blob: testImageBlob
+          }];
+          bare = SMIL.generate(smilTest);
+          smilTest.forEach(function(elem) {
+            elem.name = extString + '.jpg';
+          });
+          extension = SMIL.generate(smilTest);
+        });
+        test('First name unchanged', function() {
+          assert.equal(
+            bare.attachments[0].location,
+            bareString
+          );
+          assert.equal(
+            extension.attachments[0].location,
+            extString + '.jpg'
+          );
+        });
+        test('2nd name shortened due to potential marker length', function() {
+          assert.equal(
+            bare.attachments[2].location,
+            bareString.slice(0, -1)
+          );
+          assert.equal(
+            extension.attachments[2].location,
+            extString.slice(0, -1) + '.jpg'
+          );
+        });
+        test('Third name shortened/expanded as needed', function() {
+          assert.equal(
+            bare.attachments[4].location,
+            bareString.slice(0, -1) + '_2'
+          );
+          assert.equal(
+            extension.attachments[4].location,
+            extString.slice(0, -2) + '.jpg'
+          );
+        });
+        test('All combinations <= 40 characters', function() {
+          assert.ok(bare.attachments.every(function(elem) {
+            return elem.location.length <= 40;
+          }));
+          assert.ok(extension.attachments.every(function(elem) {
+            return elem.location.length <= 40;
+          }));
+        });
+      });
+    });
+
+
     test('Message with duplicate filename', function() {
       var smilTest = [{
         name: 'kitten-450.jpg',


### PR DESCRIPTION
Truncate MMS filenames at generation
- Filename, extension and potential marker (e.g. `_2`) all must fit inside 40 characters
- Add tests for truncation
