### PR TITLE
Bug 914532 - contacts export to sdcard can OOM kill the app - WIP

### DIFF
--- a/apps/communications/contacts/js/export/contacts_exporter.js
+++ b/apps/communications/contacts/js/export/contacts_exporter.js
@@ -126,7 +126,7 @@ window.ContactsExporter = function ContactsExporter(theStrategy) {
 
   //
   // Based on the strategy configure the progress display to show a
-  // determinative or indeterminate ui depending on the strategy
+  // determinate or indeterminate ui depending on the strategy
   //
   var _configureProgress = function _configureProgress() {
     determinativeProgress =

--- a/apps/communications/contacts/test/unit/contact2vcard_test.js
+++ b/apps/communications/contacts/test/unit/contact2vcard_test.js
@@ -5,7 +5,7 @@ require('/shared/test/unit/mocks/mock_contact_all_fields.js');
 require('/shared/js/contact2vcard.js');
 
 var mocksHelperForContact2vcard = new MocksHelper([
-  'mozContact'
+    'mozContact'
 ]).init();
 
 suite('mozContact to vCard', function() {
@@ -35,82 +35,93 @@ suite('mozContact to vCard', function() {
 
     test('Convert a single contact to a vcard', function(done) {
       var mc = new MockContactAllFields();
-      ContactToVcard([mc], function(vcard) {
-        assert.ok(vcard);
+      var str = '';
+      ContactToVcard([mc], function(vcard, remaining) {
+        assert.ok(vcard !== null);
+        str += vcard;
 
-        var _contains = contains(vcard);
-        assert.ok(_contains('fn:pepito grillo'));
-        assert.ok(_contains('n:grillo;pepito;green;mr.;;'));
-        assert.ok(_contains('nickname:pg'));
-        assert.ok(_contains('category:favorite'));
-        assert.ok(_contains('org:test org'));
-        assert.ok(_contains('title:sr. software architect'));
-        assert.ok(_contains('note:note 1'));
-        assert.ok(_contains('bday:1970-01-01'));
-        assert.ok(_contains('photo:data:image/gif;base64,' + b64));
-        assert.ok(_contains('email;type=home:test@test.com'));
-        assert.ok(_contains(
-          'email;type=work,pref:test@work.com'));
-        assert.ok(_contains('tel;type=cell,pref:+346578888888'));
-        assert.ok(_contains('tel;type=home:+3120777777'));
-        assert.ok(_contains('adr;type=home,pref:;;gotthardstrasse 22;' +
-                            'chemnitz;chemnitz;09034;germany'));
-        assert.ok(!_contains('url;type=fb_profile_photo:https://abcd1.jpg'));
-        done();
+        if (remaining === 0) {
+          var _contains = contains(vcard);
+          assert.ok(_contains('fn:pepito grillo'));
+          assert.ok(_contains('n:grillo;pepito;green;mr.;;'));
+          assert.ok(_contains('nickname:pg'));
+          assert.ok(_contains('category:favorite'));
+          assert.ok(_contains('org:test org'));
+          assert.ok(_contains('title:sr. software architect'));
+          assert.ok(_contains('note:note 1'));
+          assert.ok(_contains('bday:1970-01-01'));
+          assert.ok(_contains('photo:data:image/gif;base64,' + b64));
+          assert.ok(_contains('email;type=personal:test@test.com'));
+          assert.ok(_contains(
+            'email;type=personal;type=work,pref:test@work.com'));
+          assert.ok(_contains('tel;type=cell,pref:+346578888888'));
+          assert.ok(_contains('tel;type=cell,pref;type=home:+3120777777'));
+          assert.ok(_contains('adr;type=home,pref:;;gotthardstrasse 22;' +
+            'chemnitz;chemnitz;09034;germany'));
+          assert.ok(!_contains('url;type=fb_profile_photo:https://abcd1.jpg'));
+          done();
+        }
       });
     });
 
     test('Convert multiple contacts to a vcard', function(done) {
       var mc = new MockContactAllFields();
-      ContactToVcard([mc, new mozContact()], function(vcard) {
+      var str = '';
+      ContactToVcard([mc, new mozContact()], function(vcard, remaining) {
         assert.ok(vcard);
 
-        var _contains = contains(vcard);
-        assert.ok(_contains('fn:pepito grillo'));
-        assert.ok(_contains('n:grillo;pepito;green;mr.;;'));
-        assert.ok(_contains('nickname:pg'));
-        assert.ok(_contains('category:favorite'));
-        assert.ok(_contains('org:test org'));
-        assert.ok(_contains('title:sr. software architect'));
-        assert.ok(_contains('note:note 1'));
-        assert.ok(_contains('bday:1970-01-01'));
-        assert.ok(_contains('photo:data:image/gif;base64,' + b64));
-        assert.ok(_contains('email;type=home:test@test.com'));
-        assert.ok(_contains(
-          'email;type=work,pref:test@work.com'));
-        assert.ok(_contains('tel;type=cell,pref:+346578888888'));
-        assert.ok(_contains('tel;type=home:+3120777777'));
-        assert.ok(_contains('adr;type=home,pref:;;gotthardstrasse 22;' +
-                            'chemnitz;chemnitz;09034;germany'));
+        if (remaining === 0) {
+          var _contains = contains(vcard);
+          assert.ok(_contains('fn:pepito grillo'));
+          assert.ok(_contains('n:grillo;pepito;green;mr.;;'));
+          assert.ok(_contains('nickname:pg'));
+          assert.ok(_contains('category:favorite'));
+          assert.ok(_contains('org:test org'));
+          assert.ok(_contains('title:sr. software architect'));
+          assert.ok(_contains('note:note 1'));
+          assert.ok(_contains('bday:1970-01-01'));
+          assert.ok(_contains('photo:data:image/gif;base64,' + b64));
+          assert.ok(_contains('email;type=personal:test@test.com'));
+          assert.ok(_contains(
+            'email;type=personal;type=work,pref:test@work.com'));
+          assert.ok(_contains('tel;type=cell,pref:+346578888888'));
+          assert.ok(_contains('tel;type=cell,pref;type=home:+3120777777'));
+          assert.ok(_contains('adr;type=home,pref:;;gotthardstrasse 22;' +
+            'chemnitz;chemnitz;09034;germany'));
 
-        done();
+          done();
+        }
       });
     });
 
     test('Convert an empty contact to a vcard', function(done) {
       ContactToVcard([new mozContact], function(vcard) {
-        assert.strictEqual(vcard, null);
+        assert.strictEqual(vcard, '');
         done();
       });
     });
 
     test('Convert contact to vcard blob', function(done) {
       var contact = new MockContactAllFields();
+      var str = '';
       ContactToVcardBlob([contact], function(blob) {
         assert.isNotNull(blob);
         assert.equal('text/vcard', blob.type);
         // Fetch the same content as a normal vcard
-        ContactToVcard([contact], function(vcard) {
-          // Size of blob in bytes should be the length of the string
-          assert.equal(vcard.length, blob.size);
-          // Read the content and verify that is what we generate
-          var reader = new FileReader();
-          reader.addEventListener('loadend', function() {
-            var blobContent = reader.result;
-            assert.equal(blobContent, vcard);
-            done();
-          });
-          reader.readAsText(blob);
+        ContactToVcard([contact], function(vcard, remaining) {
+          str += vcard;
+          if (remaining === 0) {
+            // Size of blob in bytes should be the length of the string
+            assert.equal(vcard.length, blob.size);
+            // Read the content and verify that is what we generate
+            var reader = new FileReader();
+            reader.addEventListener('loadend', function() {
+              var blobContent = reader.result;
+              assert.equal(blobContent, vcard);
+              done();
+            });
+            reader.readAsText(blob);
+          }
         });
       });
     });

--- a/apps/communications/contacts/test/unit/export/mock_export_utils.js
+++ b/apps/communications/contacts/test/unit/export/mock_export_utils.js
@@ -9,6 +9,6 @@ var MockGetUnusedFilename = function(storage, filename, callback) {
 };
 
 var MockContactToVcarBlob = function(contacts, callback) {
-  callback({ size: contacts.length });
+  callback({ size: contacts.length }, 0);
 };
 

--- a/apps/communications/contacts/test/unit/export/sd_test.js
+++ b/apps/communications/contacts/test/unit/export/sd_test.js
@@ -63,7 +63,7 @@ suite('Sd export', function() {
       window,
       'ContactToVcardBlob',
       function(contact, callback) {
-        callback(contact[0]);
+        callback(contact[0], 0);
       }
     );
   });


### PR DESCRIPTION
This patch batchifies exporting contacts. It doesn't solve the problem, it just moves it to the API consumers, such as sd.js or bt.js, who still have to store the vcard string, but this could be handled by the solution Gabriele proposes above.

Note that the batches are not sequential now. The exporter keeps processing batches and doesn't wait for the consumers to give any signal about the processing of the previous batch being finalized. This would involve the API consumers to somehow signal the exporter that it can go on with the next batch, probably using a callback. I'd like your opinion on whether that's necessary or not.
