### PR TITLE
Bug 929062 - Use b2g26_v1.2 for Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,7 +596,7 @@ b2g: node_modules
 	./node_modules/.bin/mozilla-download \
 		--verbose \
 		--channel prerelease \
-		--branch aurora \
+		--branch b2g26_v1_2 \
 		--product b2g $@
 
 .PHONY: test-integration


### PR DESCRIPTION
This depends on https://github.com/mozilla-b2g/mozilla-get-url/pull/3 landing.
