### PR TITLE
Bug 929636 - Changed skipped Python UI tests to use fail-if

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -16,6 +16,5 @@ lan = true
 [test_browser_bookmark.py]
 [test_browser_play_youtube_video.py]
 # Bug 877594 - Unable to play YouTube video in B2G desktop client
-# TODO switch to fail-if when bug 884528 is fixed
-skip-if = device == "desktop"
+fail-if = device == "desktop"
 online = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/manifest.ini
@@ -3,10 +3,13 @@
 b2g = true
 
 [test_cards_view_launch_app.py]
+
 [test_cards_view_kill_app.py]
+
 [test_cards_view_kill_app_with_three_apps.py]
 # Bug 915138 - Cards view can have a maximum of 3 cards
-xfail = true
+fail-if = device != "desktop"
+
 [test_cards_view_with_three_apps.py]
 # Bug 915138 - Cards view can have a maximum of 3 cards
-xfail = true
+fail-if = device != "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
@@ -4,24 +4,18 @@ online = true
 
 [test_everythingme_launch_app.py]
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
-# TODO switch to fail-if when bug 884528 is fixed
-skip-if = device == "desktop"
-expected = fail
+fail-if = device == "desktop"
 
 [test_everythingme_app_install.py]
 # Bug 877604 - long_press action failing on B2G desktop client when installing an Everything.me app
-# TODO switch to fail-if when bug 884528 is fixed
-skip-if = device == "desktop"
-expected = fail
+fail-if = device == "desktop"
 
 [test_everythingme_search.py]
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
-# TODO switch to fail-if when bug 884528 is fixed
-skip-if = device == "desktop"
+fail-if = device == "desktop"
 
 [test_everythingme_search_accented.py]
 # Bug 893741 - Unable to use Everything.me on B2G desktop builds
-# TODO switch to fail-if when bug 884528 is fixed
-skip-if = device == "desktop"
+fail-if = device == "desktop"
 
 [test_everythingme_launch_packaged_app.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
@@ -3,8 +3,7 @@ b2g = true
 
 [test_lockscreen_unlock_to_homescreen.py]
 # Bug 891882 Cannot unlock lockscreen on desktop
-# TODO switch to fail-if when bug 884528 is fixed
-skip-if = device == "desktop"
+fail-if = device == "desktop"
 
 [test_lockscreen_unlock_to_camera.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
Uplifting to `v1.2`
