### PR TITLE
Bug 930044 - Python UI tests Enhance wait in test_sms_with_attachments to wait for messages app to resize the attached image

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/messages/regions/new_message.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/messages/regions/new_message.py
@@ -15,6 +15,7 @@ class NewMessage(Messages):
     _attach_button_locator = (By.ID, 'messages-attach-button')
     _message_sending_locator = (By.CSS_SELECTOR, "li.message.outgoing.sending")
     _thread_messages_locator = (By.ID, 'thread-messages')
+    _message_resize_notice_locator = (By.ID, 'messages-resize-notice')
 
     def __init__(self, marionette):
         Base.__init__(self, marionette)
@@ -35,6 +36,7 @@ class NewMessage(Messages):
         message_field.send_keys(value)
 
     def tap_send(self, timeout=120):
+        self.wait_for_condition(lambda m: m.find_element(*self._send_message_button_locator).is_enabled())
         self.marionette.find_element(*self._send_message_button_locator).tap()
         self.wait_for_element_not_present(*self._message_sending_locator, timeout=timeout)
         from gaiatest.apps.messages.regions.message_thread import MessageThread
@@ -47,6 +49,9 @@ class NewMessage(Messages):
 
     def wait_for_recipients_displayed(self):
         self.wait_for_element_displayed(*self._receiver_input_locator)
+
+    def wait_for_resizing_to_finish(self):
+        self.wait_for_element_not_displayed(*self._message_resize_notice_locator)
 
     @property
     def first_recipient_name(self):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_with_attachments.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_with_attachments.py
@@ -36,6 +36,7 @@ class TestSmsWithAttachments(GaiaTestCase):
 
         # switch back to messages app frame
         messages.switch_to_messages_frame()
+        new_message.wait_for_resizing_to_finish()
 
         #click send
         self.message_thread = new_message.tap_send(timeout=300)


### PR DESCRIPTION
Uplifting to `v1.2`

Note that this depends on https://github.com/mozilla-b2g/gaia/pull/13309 being merged first.
