### PR TITLE
Bug 932385 - Calling moztelephony.active is hanging the device, try UI level solution instead

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py
@@ -39,12 +39,8 @@ class CallScreen(Phone):
     def tap_hang_up(self):
         hang_up = self.marionette.find_element(*self._hangup_bar_locator)
         hang_up.tap()
-        # TODO Bug 877397 - [b2g] switch to frame failing after tap
-        time.sleep(0.5)
 
     def hang_up(self):
         self.tap_hang_up()
         self.marionette.switch_to_frame()
-        self.wait_for_condition(lambda m:
-                                not self.marionette.execute_script('return window.navigator.mozTelephony.active;'),
-                                timeout=30)
+        self.wait_for_element_not_present(*self._call_screen_locator)


### PR DESCRIPTION
This PR has been created to uplift this change from `master` to `v1.2`, but I'm not sure that it needs to be done. If we determine that this "fix" isn't needed for v1.2 we should close this PR.
