### PR TITLE
Bug 932725 - Add a test to check that the "dial" activity is working

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/messages/regions/message_thread.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/messages/regions/message_thread.py
@@ -7,11 +7,14 @@ from gaiatest.apps.base import Base
 from gaiatest.apps.base import PageRegion
 from gaiatest.apps.messages.app import Messages
 
+
 class MessageThread(Base):
 
     _all_messages_locator = (By.CSS_SELECTOR, '#messages-container li.message')
     _received_message_content_locator = (By.CSS_SELECTOR, "#messages-container li.message.received")
     _back_header_link_locator = (By.ID, 'messages-back-button')
+    _message_header_locator = (By.ID, 'messages-header-text')
+    _call_button_locator = (By.CSS_SELECTOR, 'button[data-l10n-id="call"]')
 
     def wait_for_received_messages(self, timeout=180):
         self.wait_for_element_displayed(*self._received_message_content_locator, timeout=timeout)
@@ -31,6 +34,17 @@ class MessageThread(Base):
     @property
     def all_messages(self):
         return [Message(self.marionette, message) for message in self.marionette.find_elements(*self._all_messages_locator)]
+
+    def tap_header(self):
+        self.marionette.find_element(*self._message_header_locator).tap()
+
+    def tap_call(self):
+        self.marionette.find_element(*self._call_button_locator).tap()
+        self.wait_for_element_not_displayed(*self._call_button_locator)
+        from gaiatest.apps.phone.regions.keypad import Keypad
+        keypad = Keypad(self.marionette)
+        keypad.switch_to_keypad_frame()
+        return keypad
 
 
 class Message(PageRegion):

--- a/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/keypad.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/keypad.py
@@ -22,7 +22,6 @@ class Keypad(Phone):
 
     def __init__(self, marionette):
         Phone.__init__(self, marionette)
-        self.wait_for_element_displayed(*self._keyboard_container_locator)
 
     @property
     def phone_number(self):
@@ -49,6 +48,10 @@ class Keypad(Phone):
     def tap_add_contact(self):
         self.marionette.find_element(*self._add_new_contact_button_locator).tap()
         return AddNewNumber(self.marionette)
+
+    def switch_to_keypad_frame(self):
+        app = self.apps.displayed_app
+        self.marionette.switch_to_frame(app.frame)
 
 
 class AddNewNumber(Base):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
@@ -12,3 +12,6 @@ expected = fail
 
 [test_sms_with_attachments.py]
 skip-if = device == "desktop"
+
+[test_sms_to_dialer.py]
+skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_to_dialer.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_to_dialer.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+from gaiatest import GaiaTestCase
+from gaiatest.apps.messages.app import Messages
+
+
+class TestDialerFromMessage(GaiaTestCase):
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+
+        # Launch the SMS app
+        self.messages = Messages(self.marionette)
+        self.messages.launch()
+
+    def test_dialer_from_message(self):
+
+        # Send a SMS to the device
+        _text_message_content = "Automated Test %s" % str(time.time())
+
+        # Tap new message
+        new_message = self.messages.tap_create_new_message()
+        new_message.type_phone_number(self.testvars['carrier']['phone_number'])
+
+        new_message.type_message(_text_message_content)
+
+        # Tap send
+        self.message_thread = new_message.tap_send()
+        self.message_thread.tap_header()
+        keypad = self.message_thread.tap_call()
+        self.assertEquals(keypad.phone_number, self.testvars['carrier']['phone_number'])


### PR DESCRIPTION
This will fail on master with 
TEST-UNEXPECTED-FAIL | test_sms.py test_sms.TestSms.test_sms_send | TimeoutException: Element #messages-recipients-list span.recipient present but not displayed before timeout
and it's a marionette issue. test_sms.py fails with the same stracktace.

To test this run it on aurora. The locators are the same.
