### PR TITLE
Bug 930932 - [v1.2] Write a test to use the Keyboard's predictive text

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -84,6 +84,7 @@ class Keyboard(Base):
     _keyboard_locator = (By.CSS_SELECTOR, '#keyboard')
     _button_locator = (By.CSS_SELECTOR, 'button.keyboard-key[data-keycode="%s"]')
     _highlight_key_locator = (By.CSS_SELECTOR, 'div.highlighted button')
+    _predicted_word_locator = (By.CSS_SELECTOR, '.autocorrect')
 
     # find the key to long press and return
     def _find_key_for_longpress(self, input_value):
@@ -293,3 +294,9 @@ class Keyboard(Base):
         is_visible = keyboard.is_displayed() and keyboard.location['y'] == 0
         self.apps.switch_to_displayed_app()
         return is_visible
+
+    def tap_first_predictive_word(self):
+        self.switch_to_keyboard()
+        self.wait_for_element_displayed(*self._predicted_word_locator)
+        self.marionette.find_element(*self._predicted_word_locator).tap()
+        self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
@@ -6,3 +6,5 @@ b2g = true
 [test_number_keyboard.py]
 
 [test_url_keyboard.py]
+
+[test_keyboard_predictive_key.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.apps.ui_tests.app import UiTests
+
+
+class TestKeyboardPredictiveKey(GaiaTestCase):
+
+    def test_keyboard_predictive_key(self):
+        self.ui_tests = UiTests(self.marionette)
+        self.ui_tests.launch()
+
+        # go to UI/keyboard page
+        keyboard_page = self.ui_tests.tap_keyboard_option()
+        keyboard_page.switch_to_frame()
+
+        # tap the field "input type=text"
+        keyboard = keyboard_page.tap_text_input()
+
+        # type first 6 letters of the expected word
+        keyboard.switch_to_keyboard()
+        expected_word = 'keyboard '
+        keyboard.send(expected_word[:6])
+
+        # tap the first predictive word
+        keyboard.tap_first_predictive_word()
+        self.marionette.switch_to_frame()
+        self.marionette.switch_to_frame(self.ui_tests.app.frame)
+        keyboard_page.switch_to_frame()
+
+        # check if the word in the input field is the same as the expected word
+        typed_word = keyboard_page.text_input
+        self.assertEqual(typed_word, expected_word)


### PR DESCRIPTION
The test on aurora fails on this step: keyboard = keyboard_page.tap_text_input().
This method is used two times. The element is tapped first time we use the method, but it is not tapped second time, even though the locator is the right one. Does it has anything to do with the fact that we use switch_to_frame before tapping the element? 
Please run this test on your device and let me know if you find the same issue. Thanks!
