### PR TITLE
Bug 924475 - [Messages] The context menu is missing the contact name and...

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -2490,7 +2490,9 @@ var ThreadUI = global.ThreadUI = {
         params: [email]
       });
     } else {
-      header = number;
+      if (!isContact) {
+        header = number;
+      }
 
       items.push({
         l10nId: 'call',

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3109,10 +3109,13 @@ suite('thread_ui.js >', function() {
 
           window.location.hash = '#thread=1';
 
+          var body = document.createElement('ul');
+
           ThreadUI.prompt({
             number: '999',
             contactId: contact.id,
-            isContact: true
+            isContact: true,
+            body: body
           });
 
           assert.equal(MockOptionMenu.calls.length, 1);
@@ -3120,12 +3123,12 @@ suite('thread_ui.js >', function() {
           var call = MockOptionMenu.calls[0];
           var items = call.items;
 
-          // Ensures that the OptionMenu was given
-          // the phone number to diplay
-          assert.equal(call.header, '999');
+          // Ensures that the OptionMenu does not have
+          // the phone number to display since it's a contact
+          assert.equal(call.header, '');
 
           // Only known Contact details should appear in the "section"
-          assert.equal(call.section, '');
+          assert.equal(call.section, body);
 
           assert.equal(items.length, 3);
 
@@ -3226,9 +3229,11 @@ suite('thread_ui.js >', function() {
 
           window.location.hash = '#thread=1';
 
+          var body = document.createElement('ul');
           ThreadUI.prompt({
             number: '999',
-            isContact: true
+            isContact: true,
+            body: body
           });
 
           assert.equal(MockOptionMenu.calls.length, 1);
@@ -3237,8 +3242,11 @@ suite('thread_ui.js >', function() {
           var items = call.items;
 
           // Ensures that the OptionMenu was given
-          // the phone number to diplay
-          assert.equal(call.header, '999');
+          // the contact informations to be displayed
+          assert.equal(call.section, body);
+
+          // ensures we'll show no header
+          assert.equal(call.header, '');
 
           assert.equal(items.length, 3);
 
@@ -3295,6 +3303,7 @@ suite('thread_ui.js >', function() {
 
       suite('onHeaderActivation', function() {
         test('Single known', function() {
+          this.sinon.spy(ThreadUI, 'renderContact');
 
           Threads.set(1, {
             participants: ['+12125559999']
@@ -3311,7 +3320,14 @@ suite('thread_ui.js >', function() {
           var calls = MockOptionMenu.calls;
 
           assert.equal(calls.length, 1);
-          assert.equal(calls[0].header, '+12125559999');
+
+          // contacts do not show the number in the header
+          assert.equal(calls[0].header, '');
+
+          // but do have a body
+          var body = ThreadUI.renderContact.lastCall.args[0].target;
+          assert.equal(calls[0].section, body);
+
           assert.equal(calls[0].items.length, 3);
           assert.equal(typeof calls[0].complete, 'function');
         });


### PR DESCRIPTION
... mobile

type r=rwaldron

Do not output a header if this is a known contact
