### PR TITLE
Bug 932491 - Intermittent test_clock_set_alarm_snooze.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -26,7 +26,11 @@ disabled = Bug 915138
 [functional/clock/test_clock_create_new_alarm.py]
 [functional/clock/test_clock_delete_alarm.py]
 [functional/clock/test_clock_set_alarm_repeat.py]
+
 [functional/clock/test_clock_set_alarm_snooze.py]
+# Bug 932491 - Intermittent test_clock_set_alarm_snooze.py
+expected = fail
+
 [functional/clock/test_clock_set_alarm_sound.py]
 [functional/clock/test_clock_set_alarm_time.py]
 disabled = Bug 877611


### PR DESCRIPTION
Xfail the test until we can figure out why it is failing so often
