### PR TITLE
Bug 933709 - Write test for geolocation prompt

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/permission_dialog.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/permission_dialog.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.by import By
+from gaiatest.apps.base import Base
+
+
+class PermissionDialog(Base):
+
+    _permission_dialog_locator = (By.ID, 'permission-dialog')
+    _permission_dialog_message_locator = (By.ID, 'permission-message')
+    _permission_confirm_button_locator = (By.ID, 'permission-yes')
+    _permission_dismiss_button_locator = (By.ID, 'permission-no')
+
+    def wait_for_permission_dialog_displayed(self):
+        self.wait_for_element_displayed(*self._permission_dialog_locator)
+
+    @property
+    def permission_dialog_message(self):
+        return self.marionette.find_element(*self._permission_dialog_message_locator).text
+
+    def tap_to_confirm_permission(self):
+        self.marionette.find_element(*self._permission_confirm_button_locator).tap()
+
+    def tap_to_dismiss_permission(self):
+        self.marionette.find_element(*self._permission_dismiss_button_locator).tap()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/manifest.ini
@@ -5,3 +5,6 @@ b2g = true
 
 [test_contextmenu_activity_picker.py]
 fail-if = device == "desktop"
+
+[test_geolocation_prompt.py]
+fail-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/test_geolocation_prompt.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/test_geolocation_prompt.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.apps.camera.app import Camera
+from gaiatest.apps.homescreen.regions.permission_dialog import PermissionDialog
+
+
+class TestGeolocationPrompt(GaiaTestCase):
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+        self.apps.set_permission('Camera', 'geolocation', 'prompt')
+
+    def test_camera_geolocation_prompt(self):
+
+        camera = Camera(self.marionette)
+        camera.launch()
+
+        permission = PermissionDialog(self.marionette)
+        self.marionette.switch_to_default_content()
+        permission.wait_for_permission_dialog_displayed()
+
+        self.assertEqual(permission.permission_dialog_message,
+                         '%s would like to know your location.' % camera.name)
+
+        permission.tap_to_confirm_permission()
+
+        current_permission = self.apps.get_permission('Camera', 'geolocation')
+        self.assertEqual(current_permission, 'allow')


### PR DESCRIPTION
added test for geolocation prompt, updated system app functionality,
Moved test to tests/system/, as was suggested by @zac, and seems logical, but it still uses camera app to test prompt... Added dealing with system permission dialog prompt, could be used in other cases as well, I think...
