### PR TITLE
Bug 932271 - Reset context menu state at the correct moment

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1060,7 +1060,6 @@ var Browser = {
             icon: item.icon,
             label: item.label,
             callback: function() {
-              self.contextMenuHasCalled = false;
               evt.detail.contextMenuItemSelected(item.id);
             }
           });
@@ -1086,6 +1085,7 @@ var Browser = {
 
       button.addEventListener('click', function() {
         document.body.removeChild(dialog);
+        self.contextMenuHasCalled = false;
         menuitem.callback();
       });
 
@@ -1094,6 +1094,7 @@ var Browser = {
     }, this);
 
     var cancel = document.createElement('li');
+    cancel.id = 'cancel';
     cancel.appendChild(this.createButton('Cancel'));
     list.appendChild(cancel);
 

--- a/apps/browser/test/marionette/contextmenu_test.js
+++ b/apps/browser/test/marionette/contextmenu_test.js
@@ -39,19 +39,65 @@ marionette('search', function() {
       client.switchToFrame(frame);
     });
 
-    test('long press link and open context menu', function() {
+    function longTap() {
       client.helper.waitForElement('#link');
       var link = client.findElement('#link');
 
       actions.longPress(link, 1.5).perform();
 
       subject.backToApp();
+    }
 
+    function clickOpenNewTab() {
       var openItem = client.findElement('#open-in-new-tab');
       openItem.click();
+    }
 
+    function openTab() {
+      longTap();
+      clickOpenNewTab();
+    }
+
+    function openNewTab() {
+      frame = subject.currentTabFrame();
+      client.switchToFrame(frame);
+
+      longTap();
+
+      clickOpenNewTab();
+    }
+
+    function assertTabsBadge(text) {
       var tabsBadge = client.findElement('#tabs-badge');
-      assert.equal(tabsBadge.text(), '2›');
+      assert.equal(tabsBadge.text(), text);
+    }
+
+    test('long press link and open context menu', function() {
+      openTab();
+      assertTabsBadge('2›');
+    });
+
+    test('context menu opens after a context menu', function() {
+      openTab();
+      openNewTab();
+      assertTabsBadge('3›');
+    });
+
+    test('context menu opens after a cancel', function() {
+      openTab();
+
+      frame = subject.currentTabFrame();
+      client.switchToFrame(frame);
+
+      longTap();
+
+      var cancelItem = client.findElement('#cancel');
+      cancelItem.click();
+
+      assertTabsBadge('2›');
+
+      openNewTab();
+      assertTabsBadge('3›');
     });
   });
 });


### PR DESCRIPTION
Displaying the context menu in the browser app is controlled by a
barrier. We have to make sure that this barrier is correctly reset at
the right time to ensure that the context menu will work more than once:
setting the state before doing the callback is safer than relying on the
callback to handle it by itself.
