### PR TITLE
Bug 930882 - [messages] Sending mms with attachment filename over 40 chars will be failed with incorrect error message [reopened]

### DIFF
--- a/apps/sms/test/unit/smil_test.js
+++ b/apps/sms/test/unit/smil_test.js
@@ -416,6 +416,99 @@ suite('SMIL', function() {
       assert.equal(output.attachments[2].location, 'kitten-450_2.jpg');
     });
 
+    suite('SMIL filename: length limitations', function() {
+      var bareString, extString;
+      bareString = 'dfjaksdhfkasjdhfaksjdfhksjdahfaksjdhfdfsfffff';
+      extString = 'dfjaksdhfkasjdhfaksjdfhksjdahfaksjdhfdfsf';
+      test('Filenames truncated', function() {
+        var smilTest = [{
+          text: 'Truncate filename',
+          name: bareString,
+          blob: testImageBlob
+        },{
+          text: 'With extension',
+          name: extString + '.jpg',
+          blob: testImageBlob
+        }];
+        var output = SMIL.generate(smilTest);
+        assert.equal(
+          output.attachments[0].location,
+          bareString.slice(0, 40)
+        );
+        assert.equal(
+          output.attachments[2].location,
+          extString.slice(0, 40 - 4) + '.jpg'
+        );
+        assert.ok(output.attachments.every(function(elem) {
+          return elem.location.length <= 40;
+        }));
+      });
+      suite('Clashing filenames also truncated', function() {
+        var smilTest, bare, extension;
+        var bareString = 'dfjaksdhfkasjdhfaksjdfhksjdahfaksjdhfdf';
+        var extString = bareString.slice(0, -3);
+        setup(function() {
+          smilTest = [{
+            text: 'Setup clash',
+            name: bareString,
+            blob: testImageBlob
+          },{
+            text: 'Testing first clash',
+            name: bareString,
+            blob: testImageBlob
+          },{
+            text: 'Testing second clash',
+            name: bareString,
+            blob: testImageBlob
+          }];
+          bare = SMIL.generate(smilTest);
+          smilTest.forEach(function(elem) {
+            elem.name = extString + '.jpg';
+          });
+          extension = SMIL.generate(smilTest);
+        });
+        test('First name unchanged', function() {
+          assert.equal(
+            bare.attachments[0].location,
+            bareString
+          );
+          assert.equal(
+            extension.attachments[0].location,
+            extString + '.jpg'
+          );
+        });
+        test('2nd name shortened due to potential marker length', function() {
+          assert.equal(
+            bare.attachments[2].location,
+            bareString.slice(0, -1)
+          );
+          assert.equal(
+            extension.attachments[2].location,
+            extString.slice(0, -1) + '.jpg'
+          );
+        });
+        test('Third name shortened/expanded as needed', function() {
+          assert.equal(
+            bare.attachments[4].location,
+            bareString.slice(0, -1) + '_2'
+          );
+          assert.equal(
+            extension.attachments[4].location,
+            extString.slice(0, -2) + '.jpg'
+          );
+        });
+        test('All combinations <= 40 characters', function() {
+          assert.ok(bare.attachments.every(function(elem) {
+            return elem.location.length <= 40;
+          }));
+          assert.ok(extension.attachments.every(function(elem) {
+            return elem.location.length <= 40;
+          }));
+        });
+      });
+    });
+
+
     test('Message with duplicate filename', function() {
       var smilTest = [{
         name: 'kitten-450.jpg',


### PR DESCRIPTION
Truncate MMS filenames at generation
- Filename, extension and potential marker (e.g. `_2`) all must fit inside 40 characters
- Add tests for truncation
- Use `var` rather than `let` or `const` until behavior in Gecko is standardized
