### PR TITLE
Bug 924565: Use Applications.installedApps in gaiatest.

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_apps.js
+++ b/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_apps.js
@@ -83,34 +83,31 @@ var GaiaApps = {
       }
     }
 
-    let appsReq = navigator.mozApps.mgmt.getAll();
-    appsReq.onsuccess = function() {
-      let apps = appsReq.result;
-      let normalizedSearchName = GaiaApps.normalizeName(name);
+    let apps = window.wrappedJSObject.Applications.installedApps;
+    let normalizedSearchName = GaiaApps.normalizeName(name);
 
-      for (let i = 0; i < apps.length; i++) {
-        let app = apps[i];
-        let origin = null;
-        let entryPoints = app.manifest.entry_points;
-        if (entryPoints) {
-          for (let ep in entryPoints) {
-            let currentEntryPoint = entryPoints[ep];
-            let appName = currentEntryPoint.name;
-
-            if (normalizedSearchName === GaiaApps.normalizeName(appName)) {
-              return sendResponse(app, appName, ep);
-            }
-          }
-        } else {
-          let appName = app.manifest.name;
+    for (let manifestURL in apps) {
+      let app = apps[manifestURL];
+      let origin = null;
+      let entryPoints = app.manifest.entry_points;
+      if (entryPoints) {
+        for (let ep in entryPoints) {
+          let currentEntryPoint = entryPoints[ep];
+          let appName = currentEntryPoint.name;
 
           if (normalizedSearchName === GaiaApps.normalizeName(appName)) {
-            return sendResponse(app, appName);
+            return sendResponse(app, appName, ep);
           }
         }
+      } else {
+        let appName = app.manifest.name;
+
+        if (normalizedSearchName === GaiaApps.normalizeName(appName)) {
+          return sendResponse(app, appName);
+        }
       }
-      callback(false);
     }
+    callback(false);
   },
 
   // Returns the number of running apps.


### PR DESCRIPTION
See:  https://bugzilla.mozilla.org/show_bug.cgi?id=924565
