### PR TITLE
Bug 924793 - Make select box align with other buttons in settings app r=crh0716

### DIFF
--- a/apps/settings/style/lists.css
+++ b/apps/settings/style/lists.css
@@ -368,6 +368,8 @@ ul li p + select {
   padding: 1.1rem 0;
   margin: 0;
   height: 3.8rem;
+  left: 1.5rem;
+  width: calc(100% - 3rem);
 }
 
 .fake-select.small {


### PR DESCRIPTION
Fix the style of `fake-select` class and make it align with `ul li button`.

This problem only happens on v.1.1.0hd but not on master or v1.2. And it's hard to find which patch had this problem fixed.
So we fix this on v1.1.0hd.

[Link to Bug 924793 - [B2G][Helix][settings][chenhoulai] The drop-down box do not align with the other buttons of the same page in settings app.](https://bugzilla.mozilla.org/show_bug.cgi?id=924793)
