### PR TITLE
Bug 930371 - Use "inputs" instead of "entry_points" in keyboard app manifest +shepherd

### DIFF
--- a/apps/keyboard/manifest.webapp
+++ b/apps/keyboard/manifest.webapp
@@ -12,7 +12,7 @@
     "settings": { "access": "readwrite" },
     "input": {}
   },
-  "entry_points": {
+  "inputs": {
     "number": {
       "launch_path": "/index.html#numberLayout",
       "name": "Number",

--- a/apps/settings/js/keyboard.js
+++ b/apps/settings/js/keyboard.js
@@ -103,8 +103,9 @@ var KeyboardContext = (function() {
         return app[layout.layoutId];
       }
       return app[layout.layoutId] = Layout(layout.layoutId,
-        layout.manifest.name, layout.app.origin, layout.entryPoint.name,
-        layout.entryPoint.description, layout.entryPoint.types, layout.enabled);
+        layout.manifest.name, layout.app.origin, layout.inputManifest.name,
+        layout.inputManifest.description, layout.inputManifest.types,
+        layout.enabled);
     }
 
     function reduceApps(carry, layout) {
@@ -158,12 +159,12 @@ var KeyboardContext = (function() {
       _keyboards.forEach(function(keyboard) {
         var keyboardAppInstance = keyboard.app;
         var keyboardManifest = new ManifestHelper(keyboardAppInstance.manifest);
-        var entryPoints = keyboardManifest.entry_points;
+        var inputs = keyboardManifest.inputs;
         keyboard.name = keyboardManifest.name;
         keyboard.description = keyboardManifest.description;
         keyboard.layouts.forEach(function(layout) {
           var key = layout.id;
-          var layoutInstance = entryPoints[key];
+          var layoutInstance = inputs[key];
           layout.appName = keyboardManifest.name;
           layout.name = layoutInstance.name;
           layout.description = layoutInstance.description;
@@ -431,14 +432,14 @@ var DefaultKeyboardEnabledDialog = (function() {
       'mustHaveOneKeyboard',
       {
         type: l10n.get('keyboardType-' +
-          layout.entryPoint.types.sort()[0])
+          layout.inputManifest.types.sort()[0])
       }
     );
     l10n.localize(
       document.getElementById('keyboard-default-text'),
       'defaultKeyboardEnabled',
       {
-        layoutName: layout.entryPoint.name,
+        layoutName: layout.inputManifest.name,
         appName: layout.manifest.name
       }
     );

--- a/apps/settings/test/unit/keyboard_test.js
+++ b/apps/settings/test/unit/keyboard_test.js
@@ -327,7 +327,7 @@ suite('keyboard >', function() {
 
         DefaultKeyboardEnabledDialog.show({
           manifest: { name: 'appName' },
-          entryPoint: {
+          inputManifest: {
             types: ['url', 'text'],
             name: 'layoutName'
           }

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -260,10 +260,10 @@ var AppInstallManager = {
 
   showIMEList: function ai_showIMEList() {
     var app = this.setupQueue[0];
-    var entryPoints = app.manifest.entry_points;
-    if (typeof entryPoints !== 'object') {
-      console.error('entry_points must be an object for ' +
-                                          'third-party keyboard layouts');
+    var inputs = app.manifest.inputs;
+    if (typeof inputs !== 'object') {
+      console.error('inputs must be an object for ' +
+                    'third-party keyboard layouts');
       this.completedSetupTask();
       return;
     }
@@ -271,8 +271,8 @@ var AppInstallManager = {
     // build the list of keyboard layouts
     var listHtml = '';
     var imeListWrap = Template(this.imeListTemplate);
-    for (var name in entryPoints) {
-      var displayIMEName = new ManifestHelper(entryPoints[name]).name;
+    for (var name in inputs) {
+      var displayIMEName = new ManifestHelper(inputs[name]).name;
       listHtml += imeListWrap.interpolate({
         imeName: name,
         displayName: displayIMEName

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -57,7 +57,7 @@ var KeyboardManager = {
    *
    * Each element in the arrays represents a keyboard layout:
    * {
-   *    id: the unique id of the keyboard, the key of entry_point
+   *    id: the unique id of the keyboard, the key of inputs
    *    name: the keyboard layout's name
    *    appName: the keyboard app name
    *    origin: the keyboard's origin
@@ -174,7 +174,7 @@ var KeyboardManager = {
     function reduceLayouts(carry, layout) {
       enabledApps.add(layout.app.origin);
       // add the layout to each type and return the carry
-      layout.entryPoint.types.filter(KeyboardHelper.isKeyboardType)
+      layout.inputManifest.types.filter(KeyboardHelper.isKeyboardType)
         .forEach(function(type) {
           if (!carry[type]) {
             carry[type] = [];
@@ -183,14 +183,14 @@ var KeyboardManager = {
           var enabledLayout = {
             id: layout.layoutId,
             origin: layout.app.origin,
-            path: layout.entryPoint.launch_path
+            path: layout.inputManifest.launch_path
           };
 
           // define properties for name that resolve at display time
           // to the correct language via the ManifestHelper
           Object.defineProperties(enabledLayout, {
             name: {
-              get: getName.bind(layout.entryPoint),
+              get: getName.bind(layout.inputManifest),
               enumerable: true
             },
             appName: {

--- a/apps/system/test/unit/app_install_manager_test.js
+++ b/apps/system/test/unit/app_install_manager_test.js
@@ -1267,7 +1267,7 @@ suite('system/AppInstallManager >', function() {
             name: 'Fake dev',
             url: 'http://fakesoftware.com'
           },
-          entry_points: {
+          inputs: {
             'english': {
               launch_path: '/index.html#en',
               name: 'english',
@@ -1299,7 +1299,7 @@ suite('system/AppInstallManager >', function() {
             name: 'Fake dev',
             url: 'http://fakesoftware.com'
           },
-          entry_points: {
+          inputs: {
             'english': {
               launch_path: '/index.html#en',
               name: 'english',
@@ -1364,7 +1364,7 @@ suite('system/AppInstallManager >', function() {
     });
 
     test('should not show list', function() {
-      // keyboard app without entry_points
+      // keyboard app without inputs
       var badKeyboardApp = new MockApp({
         manifest: {
           name: mockAppName,

--- a/apps/system/test/unit/keyboard_helper_test.js
+++ b/apps/system/test/unit/keyboard_helper_test.js
@@ -21,7 +21,7 @@ suite('KeyboardHelper', function() {
       origin: keyboardAppOrigin,
       manifest: {
         role: 'input',
-        entry_points: {
+        inputs: {
           en: {
             types: ['url', 'text'],
             launch_path: '/index.html#en'
@@ -137,13 +137,13 @@ suite('KeyboardHelper', function() {
           origin: 'app://keyboard.gaiamobile.org',
           manifest: {
             role: 'input',
-            entry_points: {}
+            inputs: {}
           }
         }, {
           origin: 'app://keyboard2.gaiamobile.org',
           manifest: {
             role: 'input',
-            entry_points: {}
+            inputs: {}
           }
         },
         // invalid because it's system
@@ -151,10 +151,10 @@ suite('KeyboardHelper', function() {
           origin: 'app://system.gaiamobile.org',
           manifest: {
             role: 'input',
-            entry_points: {}
+            inputs: {}
           }
         },
-        // invalid because there aren't entry_points
+        // invalid because there aren't inputs
         {
           origin: 'app://keyboard.gaiamobile.org',
           manifest: { role: 'input' }
@@ -164,7 +164,7 @@ suite('KeyboardHelper', function() {
           origin: 'app://keyboard.gaiamobile.org',
           manifest: {
             role: 'notinput',
-            entry_points: {}
+            inputs: {}
           }
         }
       ];
@@ -298,7 +298,7 @@ suite('KeyboardHelper', function() {
         origin: keyboardAppOrigin,
         manifest: {
           role: 'input',
-          entry_points: {
+          inputs: {
             en: {
               types: ['text', 'url']
             },
@@ -312,7 +312,7 @@ suite('KeyboardHelper', function() {
         origin: 'app://keyboard2.gaiamobile.org',
         manifest: {
           role: 'input',
-          entry_points: {
+          inputs: {
             number: {
               types: ['number', 'url']
             }
@@ -392,10 +392,10 @@ suite('KeyboardHelper', function() {
           if (!inOrder) {
             return false;
           }
-          if (layout.entryPoint.types.length < inOrder) {
+          if (layout.inputManifest.types.length < inOrder) {
             return false;
           }
-          return layout.entryPoint.types.length;
+          return layout.inputManifest.types.length;
         }, 1));
       });
     });
@@ -433,7 +433,7 @@ suite('KeyboardHelper', function() {
       });
       test('only number keyboards', function() {
         assert.ok(this.result.every(function(layout) {
-          return layout.entryPoint.types.indexOf('number') !== -1;
+          return layout.inputManifest.types.indexOf('number') !== -1;
         }));
       });
     });
@@ -452,7 +452,7 @@ suite('KeyboardHelper', function() {
       });
       test('only url keyboards', function() {
         assert.ok(this.result.every(function(layout) {
-          return layout.entryPoint.types.indexOf('url') !== -1;
+          return layout.inputManifest.types.indexOf('url') !== -1;
         }));
       });
     });

--- a/build/keyboard-config.js
+++ b/build/keyboard-config.js
@@ -43,11 +43,11 @@ function addEntryPointsToManifest(config, manifest) {
   // Get the set of layouts
   let layouts = getLayouts(config);
 
-  // The entry_points property of the manifest object has one property
+  // The inputs property of the manifest object has one property
   // for each keyboard layout we support. The manifest file has a hard-coded
   // entry for the numeric layout, but we have to add each additional layout.
   layouts.forEach(function(layout) {
-    manifest.entry_points[layout.name] = {
+    manifest.inputs[layout.name] = {
       launch_path: '/index.html#' + layout.name,
       name: layout.label,
       description: layout.label,

--- a/shared/js/keyboard_helper.js
+++ b/shared/js/keyboard_helper.js
@@ -396,8 +396,8 @@ var KeyboardHelper = exports.KeyboardHelper = {
         if (app.origin === 'app://system.gaiamobile.org') {
           return;
         }
-        // all keyboard apps should define its layout(s) in entry_points section
-        if (!app.manifest.entry_points) {
+        // all keyboard apps should define its layout(s) in "inputs" section
+        if (!app.manifest.inputs) {
           return;
         }
         return true;
@@ -443,9 +443,9 @@ var KeyboardHelper = exports.KeyboardHelper = {
       var layouts = apps.reduce(function eachApp(result, app) {
 
         var manifest = new ManifestHelper(app.manifest);
-        for (var layoutId in manifest.entry_points) {
-          var entryPoint = manifest.entry_points[layoutId];
-          if (!entryPoint.types) {
+        for (var layoutId in manifest.inputs) {
+          var inputManifest = manifest.inputs[layoutId];
+          if (!inputManifest.types) {
             console.warn(app.origin, layoutId, 'did not declare type.');
             continue;
           }
@@ -453,7 +453,7 @@ var KeyboardHelper = exports.KeyboardHelper = {
           var layout = new KeyboardLayout({
             app: app,
             manifest: manifest,
-            entryPoint: entryPoint,
+            inputManifest: inputManifest,
             layoutId: layoutId
           });
 
@@ -469,7 +469,7 @@ var KeyboardHelper = exports.KeyboardHelper = {
             options.type = [].concat(options.type);
             // check for any type in our options to be any type in the layout
             if (!options.type.some(function(type) {
-              return entryPoint.types.indexOf(type) !== -1;
+              return inputManifest.types.indexOf(type) !== -1;
             })) {
               continue;
             }
@@ -481,7 +481,7 @@ var KeyboardHelper = exports.KeyboardHelper = {
         // sort the default query by most specific keyboard
         if (options['default']) {
           result.sort(function(a, b) {
-            return a.entryPoint.types.length - b.entryPoint.types.length;
+            return a.inputManifest.types.length - b.inputManifest.types.length;
           });
         }
         return result;

--- a/shared/test/unit/mocks/mock_keyboard_helper.js
+++ b/shared/test/unit/mocks/mock_keyboard_helper.js
@@ -11,9 +11,9 @@ var MockKeyboardHelper = {
           'settings': { 'access': 'readwrite' },
           'keyboard': {}
         },
-        role: 'keyboard',
+        role: 'input',
         launch_path: '/settings.html',
-        entry_points: {
+        inputs: {
           'en': {
             'name': 'layout1',
             'launch_path': '/index.html#layout1',
@@ -38,11 +38,11 @@ var MockKeyboardHelper = {
         description: 'app2',
         permissions: {
           'settings': { 'access': 'readwrite' },
-          'keyboard': {}
+          'input': {}
         },
-        role: 'keyboard',
+        role: 'input',
         launch_path: '/settings.html',
-        entry_points: {
+        inputs: {
           'layout1': {
             'name': 'layout1',
             'launch_path': '/index.html#layout1',
@@ -61,9 +61,9 @@ var MockKeyboardHelper = {
           'settings': { 'access': 'readwrite' },
           'keyboard': {}
         },
-        role: 'keyboard',
+        role: 'input',
         launch_path: '/settings.html',
-        entry_points: {
+        inputs: {
           'layout1': {
             'name': 'layout1',
             'launch_path': '/index.html#layout1',
@@ -82,16 +82,16 @@ var MockKeyboardHelper = {
     this.keyboards = JSON.parse(JSON.stringify(this.mKeyboards));
 
     this.layouts = this.keyboards.reduce(function(carry, keyboard) {
-      var entryPoints = Object.keys(keyboard.manifest.entry_points);
-      var layouts = entryPoints.map(function(layoutId) {
-        var entryPoint = keyboard.manifest.entry_points[layoutId];
+      var inputIds = Object.keys(keyboard.manifest.inputs);
+      var layouts = inputIds.map(function(layoutId) {
+        var inputManifest = keyboard.manifest.inputs[layoutId];
         return {
           app: keyboard,
           manifest: keyboard.manifest,
-          entryPoint: entryPoint,
+          inputManifest: inputManifest,
           layoutId: layoutId,
-          enabled: entryPoint.enabled,
-          'default': entryPoint['default']
+          enabled: inputManifest.enabled,
+          'default': inputManifest['default']
         };
 
       });

--- a/test_apps/test-keyboard-app/manifest.webapp
+++ b/test_apps/test-keyboard-app/manifest.webapp
@@ -13,7 +13,7 @@
       "description": "To send key events"
     }
   },
-  "entry_points": {
+  "inputs": {
     "english": {
       "launch_path": "/index.html#en",
       "name": "English",


### PR DESCRIPTION
I don't think I missed anything and I can rule out test failure are not result of this patch... so I am going to file review for this one.
