### PR TITLE
Bug 935428 - Mark test_geolocation_prompt.py as expected fail

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/manifest.ini
@@ -8,3 +8,5 @@ fail-if = device == "desktop"
 
 [test_geolocation_prompt.py]
 fail-if = device == "desktop"
+# Bug 935427 - Camera geolocation prompt does not appear anymore
+expected = fail


### PR DESCRIPTION
bug https://bugzilla.mozilla.org/show_bug.cgi?id=935428
