### PR TITLE
Bug 891882 - Fix touch events on B2G desktop : re-enable lockscreen test...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
@@ -2,8 +2,6 @@
 b2g = true
 
 [test_lockscreen_unlock_to_homescreen.py]
-# Bug 891882 Cannot unlock lockscreen on desktop
-fail-if = device == "desktop"
 
 [test_lockscreen_unlock_to_camera.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
... r=zac
