### PR TITLE
Bug 935757 - Settings/Developer, fix strings not localizable (Chinese keyboards, Keyboard app OOP)

### DIFF
--- a/apps/settings/elements/about_more_info_developer.html
+++ b/apps/settings/elements/about_more_info_developer.html
@@ -130,7 +130,7 @@
             <input type="checkbox" name="debug.keyboard-oop.enabled"/>
             <span></span>
           </label>
-          <a>Run Keyboard app OOP</a>
+          <a data-l10n-id="debug-keyboard-oop-enabled">Run Keyboard app OOP</a>
         </li>
         <li>
           <label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -652,10 +652,15 @@ licensing-MPL    = Mozilla Public License 2.0
 licensing-Apache = Apache License 2.0
 launch-ftu=Launch first time use
 no-ftu=No first time use app found
+traditionalChinese-desc=Zhuyin
+traditionalChinese=Traditional Chinese
+simplifiedChinese-desc=Pinyin
+simplifiedChinese=Simplified Chinese
 software-button-enabled=Enable software home button
 homegesture-enabled=Home gesture enabled
 edgesgesture-enabled=Edges gesture enabled
 debug-gaia-enabled=Gaia debug traces
+debug-keyboard-oop-enabled=Run Keyboard app OOP
 
 # Device :: Battery
 battery=Battery


### PR DESCRIPTION
Extract 4 missing strings in settings.en-US.properties (Chinese keyboard names/descriptions).
Wrap "Run Keyboard app OOP" in l10n call and add it to properties file.
