### PR TITLE
Bug 906316 - Don't download the xulrunner SDK each time we change a bran...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,24 @@
 #                   Gaia                                                      #
 #                                                                             #
 ###############################################################################
+#                                                                             #
+# XULrunner download and location configuration                               #
+#                                                                             #
+# USE_LOCAL_XULRUNNER_SDK  : if you have a local XULrunner installation and   #
+#                            wants to use it                                  #
+#                                                                             #
+# XULRUNNER_DIRECTORY      : if you use USE_LOCAL_XULRUNNER_SDK, this is      #
+#                            where your local XULrunner installation is       #
+#                                                                             #
+# XULRUNNER_BASE_DIRECTORY : if you don't use USE_LOCAL_XULRUNNER_SDK, this   #
+#                            is where you want the automatic XULrunner        #
+#                            download to uncompress.                          #
+#                                                                             #
+# Submakes will get XULRUNNER_DIRECTORY, XULRUNNERSDK and XPCSHELLSDK as      #
+# absolute paths.                                                             #
+#                                                                             #
+###############################################################################
+
 -include local.mk
 
 # .b2g.mk recorded the make flags from Android.mk
@@ -64,6 +82,9 @@ PROFILE_FOLDER?=profile-debug
 endif
 
 PROFILE_FOLDER?=profile
+
+STAGE_FOLDER?=build_stage
+export STAGE_FOLDER
 
 LOCAL_DOMAINS?=1
 
@@ -369,12 +390,13 @@ ifneq ($(DEBUG),1)
 endif
 endif
 
+.PHONY: app-makefiles
 app-makefiles:
 	@for d in ${GAIA_APPDIRS}; \
 	do \
 		for mfile in `find $$d -mindepth 1 -maxdepth 1 -name "Makefile"` ;\
 		do \
-			make -C `dirname $$mfile`; \
+			make -C `dirname $$mfile` || exit 1 ;\
 		done; \
 	done;
 
@@ -457,7 +479,12 @@ reference-workload-x-heavy:
 
 # The install-xulrunner target arranges to get xulrunner downloaded and sets up
 # some commands for invoking it. But it is platform dependent
+# IMPORTANT: you should generally change the directory name when you change the
+# URL unless you know what you're doing
 XULRUNNER_SDK_URL=http://ftp.mozilla.org/pub/mozilla.org/xulrunner/nightly/2013/08/2013-08-07-03-02-16-mozilla-central/xulrunner-26.0a1.en-US.
+XULRUNNER_BASE_DIRECTORY?=xulrunner-sdk-26
+XULRUNNER_DIRECTORY?=$(XULRUNNER_BASE_DIRECTORY)/xulrunner-sdk
+XULRUNNER_URL_FILE=$(XULRUNNER_BASE_DIRECTORY)/.url
 
 ifeq ($(SYS),Darwin)
 # For mac we have the xulrunner-sdk so check for this directory
@@ -470,14 +497,14 @@ else
 # 64-bit
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_MAC_SDK_URL)x86_64.sdk.tar.bz2
 endif
-XULRUNNERSDK=./xulrunner-sdk/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=./xulrunner-sdk/bin/XUL.framework/Versions/Current/xpcshell
+XULRUNNERSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/run-mozilla.sh)
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/XUL.framework/Versions/Current/xpcshell)
 
 else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
 # For windows we only have one binary
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_SDK_URL)win32.sdk.zip
 XULRUNNERSDK=
-XPCSHELLSDK=./xulrunner-sdk/bin/xpcshell
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/xpcshell)
 
 else
 # Otherwise, assume linux
@@ -489,9 +516,14 @@ XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_LINUX_SDK_URL)x86_64.sdk.tar.bz2
 else
 XULRUNNER_SDK_DOWNLOAD=$(XULRUNNER_LINUX_SDK_URL)i686.sdk.tar.bz2
 endif
-XULRUNNERSDK=./xulrunner-sdk/bin/run-mozilla.sh
-XPCSHELLSDK=./xulrunner-sdk/bin/xpcshell
+XULRUNNERSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/run-mozilla.sh)
+XPCSHELLSDK=$(abspath $(XULRUNNER_DIRECTORY)/bin/xpcshell)
 endif
+
+# It's difficult to figure out XULRUNNERSDK in subprocesses; it's complex and
+# some builders may want to override our find logic (ex: TBPL).
+# So let's export these variables to external processes.
+export XULRUNNER_DIRECTORY XULRUNNERSDK XPCSHELLSDK
 
 .PHONY: build-config-js
 build-config-js:
@@ -499,17 +531,26 @@ build-config-js:
 
 .PHONY: install-xulrunner-sdk
 install-xulrunner-sdk: build-config-js
+	@echo "XULrunner directory: $(XULRUNNER_DIRECTORY)"
 ifndef USE_LOCAL_XULRUNNER_SDK
-ifneq ($(XULRUNNER_SDK_DOWNLOAD),$(shell cat .xulrunner-url 2> /dev/null))
-	rm -rf xulrunner-sdk
+ifneq ($(XULRUNNER_SDK_DOWNLOAD),$(shell test -d $(XULRUNNER_DIRECTORY) && cat $(XULRUNNER_URL_FILE) 2> /dev/null))
+# must download the xulrunner sdk
+	rm -rf $(XULRUNNER_BASE_DIRECTORY)
+	@echo "Downloading XULRunner..."
 	$(DOWNLOAD_CMD) $(XULRUNNER_SDK_DOWNLOAD)
 ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
-	unzip xulrunner*.zip && rm xulrunner*.zip
+	mkdir "$(XULRUNNER_BASE_DIRECTORY)"
+	@echo "Unzipping XULRunner..."
+	unzip -q xulrunner*.zip -d "$(XULRUNNER_BASE_DIRECTORY)" && rm -f xulrunner*.zip
 else
-	tar xjf xulrunner*.tar.bz2 && rm xulrunner*.tar.bz2
-endif
-	@echo $(XULRUNNER_SDK_DOWNLOAD) > .xulrunner-url
-endif
+	mkdir $(XULRUNNER_BASE_DIRECTORY)
+	tar xjf xulrunner*.tar.bz2 -C $(XULRUNNER_BASE_DIRECTORY) && rm -f xulrunner*.tar.bz2 || \
+		( echo; \
+		echo "We failed extracting the XULRunner SDK archive which may be corrupted."; \
+		echo "You should run 'make really-clean' and try again." ; false )
+endif # MINGW32
+	@echo $(XULRUNNER_SDK_DOWNLOAD) > $(XULRUNNER_URL_FILE)
+endif # XULRUNNER_SDK_DOWNLOAD
 endif # USE_LOCAL_XULRUNNER_SDK
 
 define run-js-command
@@ -887,11 +928,11 @@ endif
 
 # clean out build products
 clean:
-	rm -rf profile profile-debug profile-test $(PROFILE_FOLDER)
+	rm -rf profile profile-debug profile-test $(PROFILE_FOLDER) $(STAGE_FOLDER)
 
 # clean out build products
 really-clean: clean
-	rm -rf xulrunner-sdk .xulrunner-url
+	rm -rf xulrunner-* .xulrunner-*
 
 .PHONY: install-git-hook
 install-git-hook:

--- a/apps/clock/Makefile
+++ b/apps/clock/Makefile
@@ -1,16 +1,9 @@
-SYS=$(shell uname -s)
-
-ifeq ($(SYS),Darwin)
-XULRUNNERSDK=../../xulrunner-sdk/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk/bin/XUL.framework/Versions/Current/xpcshell
-else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
-# For windows we only have one binary
-XULRUNNERSDK=
-XPCSHELLSDK=../../xulrunner-sdk/bin/xpcshell
-else
-# Otherwise, assume linux
-XULRUNNERSDK=../../xulrunner-sdk/bin/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk/bin/xpcshell
+# We can't figure out XULRUNNERSDK on our own; it's complex and some builders
+# # may want to override our find logic (ex: TBPL), so let's just leave it up to
+# # the root Makefile.  If you know what you're doing, you can manually define
+# # XULRUNNERSDK and XPCSHELLSDK on the command line.
+ifndef XPCSHELLSDK
+$(error This Makefile needs to be run by the root gaia makefile. Use `make APP=email` from the root gaia directory.)
 endif
 
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))

--- a/apps/email/Makefile
+++ b/apps/email/Makefile
@@ -1,16 +1,9 @@
-SYS=$(shell uname -s)
-
-ifeq ($(SYS),Darwin)
-XULRUNNERSDK=../../xulrunner-sdk/bin/XUL.framework/Versions/Current/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk/bin/XUL.framework/Versions/Current/xpcshell
-else ifeq ($(findstring MINGW32,$(SYS)), MINGW32)
-# For windows we only have one binary
-XULRUNNERSDK=
-XPCSHELLSDK=../../xulrunner-sdk/bin/xpcshell
-else
-# Otherwise, assume linux
-XULRUNNERSDK=../../xulrunner-sdk/bin/run-mozilla.sh
-XPCSHELLSDK=../../xulrunner-sdk/bin/xpcshell
+# We can't figure out XULRUNNERSDK on our own; it's complex and some builders
+# # may want to override our find logic (ex: TBPL), so let's just leave it up to
+# # the root Makefile.  If you know what you're doing, you can manually define
+# # XULRUNNERSDK and XPCSHELLSDK on the command line.
+ifndef XPCSHELLSDK
+$(error This Makefile needs to be run by the root gaia makefile. Use `make APP=email` from the root gaia directory.)
 endif
 
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))

--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -19,10 +19,18 @@ if [ ! -d $DIR/../profile-test ]; then
   PROFILE_FOLDER=profile-test make -C $DIR/../
 fi
 
-# find the xulrunner
-XULRUNNER=`cd $DIR/../xulrunner-sdk* && pwd`
+if [ -z "$XULRUNNER_DIRECTORY" ] ; then
+  # the xulrunner directory isn't in the environment
+  XULRUNNER_DIRECTORY=`ls -d "$DIR/../xulrunner-sdk"*/xulrunner-sdk | sort -nr | head -n1 2> /dev/null`
+fi
+
+if [ -z "$XULRUNNER_DIRECTORY" ] ; then
+  echo "Couldn't find XULrunner. Please execute this file from 'make' or install XULrunner yourself."
+  exit 1
+fi
+
 # find xpcshell and put it in the path
-XPCSHELL_DIR=$(dirname $(find $XULRUNNER/bin -type f -name "xpcshell" | head -n 1));
+XPCSHELL_DIR=$(dirname $(find "$XULRUNNER_DIRECTORY"/bin -type f -name "xpcshell" | head -n 1));
 
 # wrap marionette-mocha with gaia's defaults. We also need to alter the paths to
 # xpcshell in available for email fake servers.

--- a/tests/js/bin/runner
+++ b/tests/js/bin/runner
@@ -8,10 +8,11 @@ XPCSHELL=`which xpcshell`
 
 if [ ! -x "$XPCSHELL" ]
 then
-  PATH=$GAIA_DIR/xulrunner-sdk/bin/:$PATH;
+  PATH=$XULRUNNER_DIRECTORY/bin/:$PATH;
   if [ -n "${VERBOSE}" ]
   then
-    echo "xpcshell is not found adding xulrunner-sdk using $GAIA_DIR/xulrunner-sdk/bin/xpcshell."
+    echo "xpcshell is not found in the PATH"
+    echo "Using $XULRUNNER_DIRECTORY/bin/xpcshell."
   fi
 fi
 


### PR DESCRIPTION
...ch if their configuration are different r=yurenju,asuth,ochameau

This also shows a message when the archive file seems to be corrupted, advising
to run "make really-clean". Also changed "make really-clean" to remove all
xulrunner related files.

We now uncompress the archive directly in a specific directory that should
change when we change the URL.

We use a dot file inside the xulrunner SDK directory to keep the URL used to
download that SDK.

Now we can also define XULRUNNER_DIRECTORY from the command-line. If not
defined, it will use the default xulrunner-sdk-26/xulrunner-sdk.
We can also define XULRUNNER_BASE_DIRECTORY which is the place where the
XULRunner SDK will get uncompressed.

We export the new XULRUNNER_DIRECTORY variable along with the
existing various xulrunner program paths. These paths have been made absolute
using make's `abspath` operation.

The patch also removes the ./ prefixes to those paths as they're likely useless
and prevent from using an absolute path when defining XULRUNNER_DIRECTORY from
the command line.

This patch also remove the email's build_stage directory when running "make
clean".

This _will_ make all devs redownload XULRunner, sorry.

This make the build fail if submakes fail

Also add documentation at the top of the Makefile.

(cherry picked from commit f6df42dddb0ef62c64d90d9ca06fba779ea6cd78)

Conflicts:
    Makefile
