### PR TITLE
Bug 915158 - Allow setting a marionette runner host at runtime.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 #               the offline cache. This is mostly for desktop debugging.      #
 #                                                                             #
 # REPORTER    : Mocha reporter to use for test output.                        #
+#
+# MARIONETTE_RUNNER_HOST : The Marionnette runner host.
 #                                                                             #
 # COVERAGE    : Add blanket testing coverage report to use for test output.   #
 #                                                                             #
@@ -119,6 +121,7 @@ MOCHA_REPORTER?=dot
 NPM_REGISTRY?=http://registry.npmjs.org
 # Ensure that NPM only logs warnings and errors
 export npm_config_loglevel=warn
+MARIONETTE_RUNNER_HOST?=marionette-b2gdesktop-host
 
 GAIA_INSTALL_PARENT?=/data/local
 ADB_REMOUNT?=0
@@ -685,7 +688,7 @@ b2g: node_modules/.bin/mozilla-download
 test-integration:
 	# override existing profile-test folder.
 	PROFILE_FOLDER=profile-test make
-	NPM_REGISTRY=$(NPM_REGISTRY) ./bin/gaia-marionette $(shell find . -path "*test/marionette/*_test.js") \
+	MARIONETTE_RUNNER_HOST=$(MARIONETTE_RUNNER_HOST) NPM_REGISTRY=$(NPM_REGISTRY) ./bin/gaia-marionette $(shell find . -path "*test/marionette/*_test.js") \
 		--reporter $(MOCHA_REPORTER)
 
 .PHONY: test-perf

--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -42,5 +42,6 @@ PATH=$XPCSHELL_DIR:$PATH $DIR/../node_modules/.bin/marionette-mocha \
   --ui tdd \
   --profile-builder $SHARED/profile_builder.js \
   --profile-base $SHARED/profile.js \
+  --host $MARIONETTE_RUNNER_HOST \
   $SHARED/setup.js \
   $@


### PR DESCRIPTION
Just override MARIONETTE_RUNNER_HOST in local.mk.
