### PR TITLE
Bug 934449 - [Messaging] Tapping on '+' to add a contact to a message shows the contact list with the keyboard

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -558,6 +558,10 @@ var ThreadUI = global.ThreadUI = {
       return;
     }
 
+    // Ensure that Recipients does not trigger focus on
+    // itself, which causes the keyboard to appear.
+    Recipients.View.isObscured = true;
+
     var activity = new MozActivity({
       name: 'pick',
       data: {
@@ -574,6 +578,8 @@ var ThreadUI = global.ThreadUI = {
         return;
       }
 
+      Recipients.View.isObscured = false;
+
       var data = Utils.basicContact(
         activity.result.tel[0].value, activity.result
       );
@@ -583,6 +589,8 @@ var ThreadUI = global.ThreadUI = {
     }).bind(this);
 
     activity.onerror = (function(e) {
+      Recipients.View.isObscured = false;
+
       console.log('WebActivities unavailable? : ' + e);
     }).bind(this);
   },

--- a/apps/sms/test/unit/mock_recipients.js
+++ b/apps/sms/test/unit/mock_recipients.js
@@ -76,3 +76,8 @@ MockRecipients.prototype.emit = function(type) {
 
   return this;
 };
+
+
+MockRecipients.View = function() {};
+
+MockRecipients.View.isObscured = false;

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3,7 +3,7 @@
          Template, MockSMIL, Utils, MessageManager, LinkActionHandler,
          LinkHelper, Attachment, MockContact, MockOptionMenu,
          MockActivityPicker, Threads, Settings, MockMessages, MockUtils,
-         MockContacts, ActivityHandler */
+         MockContacts, ActivityHandler, Recipients, MockMozActivity */
 
 'use strict';
 
@@ -3707,10 +3707,36 @@ suite('thread_ui.js >', function() {
     setup(function() {
       this.sinon.spy(ThreadUI, 'assimilateRecipients');
     });
+    teardown(function() {
+      Recipients.View.isObscured = false;
+    });
 
     test('assimilate called after mousedown on picker button', function() {
       ThreadUI.contactPickButton.dispatchEvent(new CustomEvent('mousedown'));
       assert.ok(ThreadUI.assimilateRecipients.called);
+    });
+
+    suite('Recipients.View.isObscured', function() {
+      test('true during activity', function() {
+        ThreadUI.requestContact();
+        assert.isTrue(Recipients.View.isObscured);
+      });
+
+      test('false after activity', function() {
+        this.sinon.stub(Utils, 'basicContact').returns({});
+
+        ThreadUI.requestContact();
+
+        var activity = MockMozActivity.instances[0];
+
+        activity.result = {
+          tel: [{ value: true }]
+        };
+
+        MockMozActivity.instances[0].onsuccess();
+
+        assert.isFalse(Recipients.View.isObscured);
+      });
     });
   });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=934449
- ThreadUI.requestContact sets Recipients.View.isObscured to true before creating MozActivity
- Set Recipients.View.isObscured to false when activity.onsuccess or activity.onerror are invoked.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
