### PR TITLE
Bug 934402 - Write an atom to send SMS using 'MozSMS' API

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_data_layer.js
+++ b/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_data_layer.js
@@ -426,6 +426,31 @@ var GaiaDataLayer = {
     };
   },
 
+  sendSMS: function (recipient, content, aCallback) {
+    var callback = aCallback || marionetteScriptFinished;
+    console.log('sending sms message to number: ' + recipient);
+
+    SpecialPowers.addPermission('sms', true, document);
+    SpecialPowers.setBoolPref('dom.sms.enabled', true);
+    let sms = window.navigator.mozMobileMessage;
+
+    let request = sms.send(recipient, content);
+
+    request.onsuccess = function() {
+      console.log('sms message sent successfully');
+      SpecialPowers.removePermission('sms', document);
+      SpecialPowers.clearUserPref('dom.sms.enabled');
+      callback(true);
+    };
+
+    request.onerror = function () {
+      console.log('sms message not sent');
+      SpecialPowers.removePermission('sms', document);
+      SpecialPowers.clearUserPref('dom.sms.enabled');
+      callback(false);
+    };
+  },
+
   deleteAllSms: function(aCallback) {
     var callback = aCallback || marionetteScriptFinished;
     console.log('searching for sms messages');

--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -337,6 +337,13 @@ class GaiaData(object):
             return [filename for filename in files if filename.endswith(extension)]
         return files
 
+    def send_sms(self, number, message):
+        import json
+        number = json.dumps(number)
+        message = json.dumps(message)
+        result = self.marionette.execute_async_script('return GaiaDataLayer.sendSMS(%s, %s)' % (number, message), special_powers=True)
+        assert result, 'Unable to send SMS to recipient %s with text %s' % (number, message)
+
 
 class GaiaDevice(object):
 
@@ -516,7 +523,6 @@ class GaiaTestCase(MarionetteTestCase):
             # Set do not track pref back to the default
             self.data_layer.set_setting('privacy.donottrackheader.value', '-1')
 
-
             if self.data_layer.get_setting('ril.radio.disabled'):
                 # enable the device radio, disable Airplane mode
                 self.data_layer.set_setting('ril.radio.disabled', False)
@@ -543,7 +549,6 @@ class GaiaTestCase(MarionetteTestCase):
 
         # disable sound completely
         self.data_layer.set_volume(0)
-
 
     def install_marketplace(self):
         _yes_button_locator = (By.ID, 'app-install-install-button')
@@ -806,8 +811,8 @@ class GaiaEnduranceTestCase(GaiaTestCase):
         # Calculate the average b2g_rss
         total = 0
         for b2g_mem_value in b2g_rss_list:
-            total+=int(b2g_mem_value)
-        avg_rss = total/len(b2g_rss_list)
+            total += int(b2g_mem_value)
+        avg_rss = total / len(b2g_rss_list)
 
         # Create a summary text file
         summary_name = self.log_name.replace('.log', '_summary.log')

--- a/tests/python/gaia-ui-tests/gaiatest/gcli.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gcli.py
@@ -61,6 +61,17 @@ class GCli(object):
             'lock': {
                 'function': self.lock,
                 'help': 'Lock screen'},
+            'screenshot': {
+                'function': self.screenshot,
+                'help': 'Take a screenshot'},
+            'sendsms': {
+                'function': self.send_sms,
+                'args': [
+                    {'name': 'number',
+                     'help': 'Phone number of recipient'},
+                    {'name': 'message',
+                     'help': 'Message content'}],
+                'help': 'Send an SMS'},
             'setsetting': {
                 'function': self.set_setting,
                 'args': [
@@ -69,9 +80,6 @@ class GCli(object):
                     {'name': 'value',
                      'help': 'New value for setting'}],
                 'help': 'Change the value of a setting'},
-            'screenshot': {
-                'function': self.screenshot,
-                'help': 'Take a screenshot'},
             'sleep': {
                 'function': self.sleep,
                 'help': 'Enter sleep mode'},
@@ -184,12 +192,15 @@ class GCli(object):
     def lock(self, args):
         self.lock_screen.lock()
 
-    def set_setting(self, args):
-        self.data_layer.set_setting(args.name, args.value)
-
     def screenshot(self, args):
         self.marionette.execute_script(
             "window.wrappedJSObject.dispatchEvent(new Event('home+sleep'));")
+
+    def send_sms(self, args):
+        self.data_layer.send_sms(args.number, args.message)
+
+    def set_setting(self, args):
+        self.data_layer.set_setting(args.name, args.value)
 
     def sleep(self, args):
         self.marionette.execute_script(


### PR DESCRIPTION
1) Created atom for sending sms text on specified number (currently only one number supported).
Used mozMobileMessage instead of mozSms mentioned in bug, since it outdated as stated in MDN docs...

2) Added for testing purposes send_sms method to gcli tool 

3) Fixed some existing pep8 errors
