### PR TITLE
Bug 920414 - [Dialer][User Story] Show "call ended" message at the end of calls.

### DIFF
--- a/apps/communications/dialer/js/fake-oncall-desktop.js
+++ b/apps/communications/dialer/js/fake-oncall-desktop.js
@@ -31,10 +31,10 @@ console.error('It just helps to fake a call.');
 
     var duration = handledCall.querySelector('.duration');
     var time = duration.querySelector('span');
-    time.classList.add('isTimer');
+    duration.classList.add('isTimer');
     time.textContent = '9:42';
 
-    CallScreen.singleLine = true;
+    CallScreen.updateSingleLine();
     CallScreen.render('connected'); // Change this for various states
     CallScreen.screen.classList.add('displayed');
     CallScreen.calls.classList.add('muted');

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -57,6 +57,7 @@ call=Call
 hold=Hold
 resume=Resume
 sendSms=Send Message
+callEnded=Call Ended
 
 ## LOCALIZATION NOTE: these labels aren't displayed but they're used for acessibility
 hangup-a11y-button.aria-label=Hang Up

--- a/apps/communications/dialer/style/oncall.css
+++ b/apps/communications/dialer/style/oncall.css
@@ -132,11 +132,12 @@
   /* call_screen.js */
   #call-screen:not([data-layout="incoming-locked"]) {
     transform: translateY(-100%);
-    transition: transform 0.5s ease;
+    transition: transform 0.5s ease 1.5s;
   }
 
   #call-screen:not([data-layout="incoming-locked"]).displayed {
     transform: translateY(0);
+    transition: transform 0.5s ease 0s;
   }
 
   #call-screen:before {
@@ -334,7 +335,7 @@
     position: absolute;
     top: 0;
     width: 100%;
-    height: 16rem;
+    height: 24rem;
 
     z-index: 500;
   }
@@ -353,6 +354,10 @@
 
     transition: background-color 0.3s linear;
     opacity: 1;
+  }
+
+  #calls > section.groupended {
+    display: none;
   }
 
   #calls > section div {
@@ -415,6 +420,7 @@
   #calls.big-duration > section .numberWrapper,
   #calls.big-duration > section .additionalContactInfo {
     background: #01c5ed;
+    transition: background-color 0.3s linear;
   }
 
   #calls.big-duration > section .numberWrapper .number {
@@ -488,7 +494,6 @@
     top: 0;
     color: black;
     font-weight: bold;
-    line-height: 6.6rem;
   }
 
   #calls.big-duration > section .duration {
@@ -524,7 +529,12 @@
     background-repeat: no-repeat;
   }
 
-  #calls > section.held {
+  #calls:not(.big-duration) > section.held,
+  #calls:not(.big-duration) > section.ended,
+  #calls.big-duration > section.held .numberWrapper,
+  #calls.big-duration > section.held .additionalContactInfo,
+  #calls.big-duration > section.ended .numberWrapper,
+  #calls.big-duration > section.ended .additionalContactInfo {
     background-color: rgba(28, 24, 24, 0.7);
   }
 
@@ -535,13 +545,8 @@
     background-repeat: no-repeat;
   }
 
-  #calls > section.held .duration,
-  #calls > section.held .additionalContactInfo,
-  #calls > section.held .numberWrapper {
-    background: none;
-  }
-
-  #calls > section.held .numberWrapper .number {
+  #calls > section.held .numberWrapper .number,
+  #calls > section.ended .numberWrapper .number {
     color: white;
   }
 
@@ -588,6 +593,22 @@
 
   #calls.big-duration .handled-call.held .direction:before {
     background-image: url('images/hold_icon.png');
+  }
+
+  #calls:not(.big-duration) > section.ended .duration .font-light {
+    font-size: 3.2rem;
+    color: white;
+  }
+
+  #calls:not(.big-duration) > section.ended .duration {
+    line-height: 8rem;
+    padding-left: 4rem;
+    left: 0;
+  }
+
+  #calls:not(.big-duration) > section.ended .numberWrapper,
+  #calls:not(.big-duration) > section.ended .additionalContactInfo {
+    display: none;
   }
 
   #incoming-container {
@@ -783,7 +804,9 @@
     visibility: hidden;
   }
 
-  #call-screen[data-layout="connected-hold"] #co-advanced {
+  #call-screen[data-layout="connected-hold"] #co-advanced,
+  #call-screen:not(.displayed) #co-advanced,
+  #call-screen:not(.displayed) #callbar {
     pointer-events: none;
     opacity: 0.4;
   }

--- a/apps/communications/dialer/test/unit/calls_handler_test.js
+++ b/apps/communications/dialer/test/unit/calls_handler_test.js
@@ -10,8 +10,8 @@ requireApp('communications/dialer/test/unit/mock_contacts.js');
 requireApp('communications/dialer/test/unit/mock_tone_player.js');
 requireApp('communications/dialer/test/unit/mock_swiper.js');
 requireApp('communications/dialer/test/unit/mock_bluetooth_helper.js');
-requireApp('communications/shared/test/unit/mocks/mock_settings_listener.js');
-requireApp('sms/shared/test/unit/mocks/mock_settings_url.js');
+require('/shared/test/unit/mocks/mock_settings_listener.js');
+require('/shared/test/unit/mocks/mock_settings_url.js');
 
 // The CallsHandler binds stuff when evaluated so we load it
 // after the mocks and we don't want it to show up as a leak.
@@ -89,11 +89,6 @@ suite('calls handler', function() {
         assert.isTrue(toggleSpy.calledOnce);
       });
 
-      test('should update the CallScreen\'s duration style', function() {
-        MockMozTelephony.mTriggerCallsChanged();
-        assert.equal(MockCallScreen.mSingleLine, true);
-      });
-
       test('should unmute', function() {
         var unmuteSpy = this.sinon.spy(MockCallScreen, 'unmute');
         MockMozTelephony.mTriggerCallsChanged();
@@ -161,11 +156,6 @@ suite('calls handler', function() {
         var playSpy = this.sinon.spy(MockTonePlayer, 'playSequence');
         MockMozTelephony.mTriggerCallsChanged();
         assert.isTrue(playSpy.calledOnce);
-      });
-
-      test('should update the CallScreen\'s duration style', function() {
-        MockMozTelephony.mTriggerCallsChanged();
-        assert.equal(MockCallScreen.mSingleLine, false);
       });
     });
 
@@ -282,20 +272,10 @@ suite('calls handler', function() {
         MockMozTelephony.calls = [firstCall];
       });
 
-      test('should hide the call', function() {
-        MockMozTelephony.mTriggerCallsChanged();
-        assert.isTrue(hideSpy.calledOnce);
-      });
-
       test('should hide the call waiting UI', function() {
         var hideSpy = this.sinon.spy(MockCallScreen, 'hideIncoming');
         MockMozTelephony.mTriggerCallsChanged();
         assert.isTrue(hideSpy.calledOnce);
-      });
-
-      test('should update the CallScreen\'s duration style', function() {
-        MockMozTelephony.mTriggerCallsChanged();
-        assert.equal(MockCallScreen.mSingleLine, true);
       });
     });
 
@@ -324,11 +304,6 @@ suite('calls handler', function() {
 
         assert.isTrue(firstHideSpy.notCalled);
         assert.isTrue(secondHideSpy.notCalled);
-      });
-
-      test('should update the CallScreen\'s duration style', function() {
-        MockMozTelephony.mTriggerCallsChanged();
-        assert.equal(MockCallScreen.mSingleLine, true);
       });
     });
 
@@ -976,13 +951,6 @@ suite('calls handler', function() {
         telephonyAddCall.call(this, firstConfCall, {trigger: true});
         secondConfCall = new MockCall('432423555', 'incoming');
         telephonyAddCall.call(this, secondConfCall, {trigger: true});
-      });
-
-      test('should check and set singleLine when exiting conference call mode',
-      function() {
-        MockMozTelephony.calls = [firstConfCall];
-        CallsHandler.checkCalls();
-        assert.isTrue(MockCallScreen.mSingleLine);
       });
     });
 

--- a/apps/communications/dialer/test/unit/handled_call_test.js
+++ b/apps/communications/dialer/test/unit/handled_call_test.js
@@ -328,10 +328,16 @@ suite('dialer/handled_call', function() {
 
     suite('from a regular call', function() {
       setup(function() {
+        this.sinon.useFakeTimers();
         mockCall._disconnect();
       });
       test('should save the recents entry', function() {
         assert.equal(subject.recentsEntry, MockCallsHandler.mLastEntryAdded);
+      });
+
+      test('should show call ended', function() {
+        assert.equal(
+          subject.node.querySelector('.duration').textContent, 'callEnded');
       });
 
       test('should remove listener on the call', function() {
@@ -351,12 +357,17 @@ suite('dialer/handled_call', function() {
       });
 
       test('should remove the node from the dom', function() {
-        assert.isNull(node.parentNode);
+        assert.isFalse(MockCallScreen.mRemoveCallCalled);
+        this.sinon.clock.tick(2000);
+        assert.isTrue(MockCallScreen.mRemoveCallCalled);
       });
 
       test('should nullify the node', function() {
+        assert.isNotNull(subject.node);
+        this.sinon.clock.tick(2000);
         assert.isNull(subject.node);
       });
+
       test('it does not show the banner', function() {
         assert.isFalse(MockCallScreen.mShowStatusMessageCalled);
       });
@@ -365,9 +376,11 @@ suite('dialer/handled_call', function() {
     suite('from a group', function() {
       setup(function() {
         mockCall.group = null;
+        mockCall.mChangeState('disconnecting');
         mockCall.ongroupchange(mockCall);
         mockCall._disconnect();
       });
+
       test('show the banner', function() {
         assert.isTrue(MockCallScreen.mShowStatusMessageCalled);
       });
@@ -821,10 +834,20 @@ suite('dialer/handled_call', function() {
       assert.isFalse(subject.node.hidden);
     });
 
+    test('calling show should update singleLine status', function() {
+      subject.show();
+      assert.isTrue(MockCallScreen.mUpdateSingleLineCalled);
+    });
+
     test('calling hide should hide the node', function() {
       subject.node.hidden = false;
       subject.hide();
       assert.isTrue(subject.node.hidden);
+    });
+
+    test('calling hide should update singleLine status', function() {
+      subject.show();
+      assert.isTrue(MockCallScreen.mUpdateSingleLineCalled);
     });
 
     suite('when the node got nullified', function() {

--- a/apps/communications/dialer/test/unit/mock_call_screen.js
+++ b/apps/communications/dialer/test/unit/mock_call_screen.js
@@ -1,6 +1,9 @@
 var MockCallScreen = {
+  callEndPromptTime: 2000,
+
   insertCall: function() {},
   moveToGroup: function() {},
+  setCallsEndedInGroup: function() {},
   toggle: function(cb) {
     if (typeof(cb) == 'function') {
       cb();
@@ -51,19 +54,18 @@ var MockCallScreen = {
   hideGroupDetails: function() {
     this.mGroupDetailsShown = false;
   },
-
   createTicker: function(node) {
     this.mCalledCreateTicker = true;
   },
-
   stopTicker: function(node) {
     this.mCalledStopTicker = true;
   },
-
-  set singleLine(value) {
-    this.mSingleLine = value;
+  updateSingleLine: function() {
+    this.mUpdateSingleLineCalled = true;
   },
-  mSingleLine: null,
+  removeCall: function() {
+    this.mRemoveCallCalled = true;
+  },
 
   set holdAndAnswerOnly(enabled) {
     this.mHoldAndAnswerOnly = enabled;
@@ -104,12 +106,13 @@ var MockCallScreen = {
     this.mShowStatusMessageCalled = false;
     this.mCalledCreateTicker = false;
     this.mCalledStopTicker = false;
+    this.mUpdateSingleLineCalled = false;
     this.calls = document.createElement('div');
     this.screen = document.createElement('div');
     this.incomingContainer = document.createElement('div');
     this.incomingNumber = document.createElement('div');
-    this.mSingleLine = null;
     this.mGroupDetailsShown = false;
+    this.mRemoveCallCalled = false;
   }
 };
 


### PR DESCRIPTION
Important changes on this bug:
- Removed `CallScreen.singleLine` and add `CallScreen.updateSingleLine()`. Since all calls have 2 seconds of transitions after hanging up, it's now required to let `CallScreen` query remaining visible calls at certain time to inform `CallScreen` update its `single-line` style. The style is determined by `CallScreen` itself by doing query select so no parameter is needed now.
