### PR TITLE
Bug 937068 - Unxfail and enhance wait in test_contact_add_photo

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/contact_form.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/contact_form.py
@@ -22,7 +22,7 @@ class ContactForm(Base):
     _comment_locator = (By.ID, 'note_0')
 
     _add_picture_link_locator = (By.ID, 'thumbnail-photo')
-    _picture_loaded_locator = (By.CSS_SELECTOR, '#thumbnail-photo[style*="background-image"] ')
+    _picture_loaded_locator = (By.CSS_SELECTOR, '#thumbnail-photo[style*="background-image"]')
 
     def __init__(self, marionette):
         Base.__init__(self, marionette)
@@ -144,6 +144,7 @@ class EditContact(ContactForm):
         self.wait_for_element_displayed(*self._update_locator)
 
     def tap_update(self):
+        self.wait_for_update_button_enabled()
         self.marionette.find_element(*self._update_locator).tap()
         from gaiatest.apps.contacts.regions.contact_details import ContactDetails
         return ContactDetails(self.marionette)
@@ -168,6 +169,9 @@ class EditContact(ContactForm):
         self.marionette.find_element(*self._confirm_delete_locator).tap()
         from gaiatest.apps.contacts.app import Contacts
         return Contacts(self.marionette)
+
+    def wait_for_update_button_enabled(self):
+        self.wait_for_condition(lambda m: self.marionette.find_element(*self._update_locator).is_enabled())
 
 
 class NewContact(ContactForm):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
@@ -17,7 +17,7 @@ carrier = true
 
 [test_add_photo_to_contact.py]
 skip-if = device == "desktop"
-# Bug 921205 - [B2G][Contacts]User unable to add picture from gallery to New Contact consistently
+# Bug 934537 - [Contacts] Trying to edit a contact generates a "Duplicate found" message
 expected = fail
 sdcard = true
 


### PR DESCRIPTION
The test is failing for me with issue in bug 934537 after I run the test more than once.

https://bugzilla.mozilla.org/show_bug.cgi?id=934537 - [Contacts] Trying to edit a contact generates a "Duplicate found" message
