### PR TITLE
Bug 937079 - test_gallery_view.py is not switching to landscape view

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/test_gallery_view.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/test_gallery_view.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import time
+
 from gaiatest import GaiaTestCase
 from gaiatest.apps.gallery.app import Gallery
 
@@ -31,6 +33,9 @@ class TestGallery(GaiaTestCase):
 
         #  Change the screen orientation to landscape mode and verify that the screen is in landscape mode
         self.change_orientation('landscape-primary')
+
+        # Here we sleep only to give visual feedback when observing the test run
+        time.sleep(1)
         self.assertTrue(image.is_photo_toolbar_displayed)
         self.assertEqual('landscape-primary', self.screen_orientation)
         self.assertEqual(self.screen_width, image.photo_toolbar_width)
@@ -40,6 +45,9 @@ class TestGallery(GaiaTestCase):
 
         #  Change the screen orientation back to portrait-primary and verify the screen is in portrait mode
         self.change_orientation('portrait-primary')
+
+        # Here we sleep only to give visual feedback when observing the test run
+        time.sleep(1)
         self.assertTrue(image.is_photo_toolbar_displayed)
         self.assertEqual('portrait-primary', self.screen_orientation)
         self.assertEqual(self.screen_width, image.photo_toolbar_width)


### PR DESCRIPTION
The differences are not seen because the wait added is not on a UI level, 
I tried also waiting for 
<code>screen_width == image.photo_toolbar_width</code>
or 
<code>initial_image_scale != current_image_scale</code>
both with the same results.
But if you add a wait, (<code>time.wait(2)</code>)you can see that the orientation switch is done.  
