### PR TITLE
Bug 936565 - Use default symbols layout in the pt-BR keyboard

### DIFF
--- a/keyboard/layouts/pt-BR.js
+++ b/keyboard/layouts/pt-BR.js
@@ -74,26 +74,5 @@ Keyboards['pt-BR'] = {
         { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
       ]
     ]
-  },
-  symbolLayout: {
-    keys: [
-      [
-        { value: '[' }, { value: ']' }, { value: '{' }, { value: '}' },
-        { value: '#' }, { value: '%' }, { value: '^' }, { value: '+' },
-        { value: '=' }, { value: '°' }
-      ], [
-        { value: '_' }, { value: '\\' }, { value: '|' }, { value: '~' },
-        { value: '<' }, { value: '>' }, { value: '€' }, { value: '$' },
-        { value: '£' }, { value: '•' }
-      ], [
-        { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
-        { value: '?' }, {value: '!' }, { value: '«' }, { value: '»' },
-        { value: '\"' }, { value: '\'' }, { value: '*' },
-        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
-      ], [
-        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
-        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
-      ]
-    ]
   }
 };


### PR DESCRIPTION
So after looking at this more closely I'm going to make the pt-BR layout inherit the symbols section of the default layout, I don't see why it should be different.
