### PR TITLE
Bug 930223 - Use os version instead of build ID r=evelyn

### DIFF
--- a/apps/settings/js/feedback.js
+++ b/apps/settings/js/feedback.js
@@ -127,7 +127,7 @@ var Feedback = {
     var currentSetting = Settings.settingsCache;
     var feedbackUrl = currentSetting['feedback.url'];
     this.feedbackObj.version =
-      currentSetting['deviceinfo.platform_build_id'];
+      currentSetting['deviceinfo.os'];
     this.feedbackObj.device =
       currentSetting['deviceinfo.hardware'];
     this.feedbackObj.locale =


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=930223
