### PR TITLE
Bug 936283 - [B2G][Contacts] Search bar stops functioning when searching contacts in Gmail or Outlook more than once

### DIFF
--- a/apps/communications/contacts/js/views/search.js
+++ b/apps/communications/contacts/js/views/search.js
@@ -119,7 +119,7 @@ contacts.Search = (function() {
   var exitSearchMode = function exitSearchMode(evt) {
     evt.preventDefault();
     searchView.classList.remove('insearchmode');
-    if (Contacts && Contacts.navigation) {
+    if (window.Contacts && Contacts.navigation) {
       Contacts.navigation.back();
     }
 
@@ -241,7 +241,7 @@ contacts.Search = (function() {
       fillInitialSearchPage();
       inSearchMode = true;
       emptySearch = true;
-      if (Contacts && Contacts.navigation) {
+      if (window.Contacts && Contacts.navigation) {
         Contacts.navigation.go('search-view', 'none');
       }
 


### PR DESCRIPTION
In the importation case, the contacts.js library is not available and consequently accessing the undeclared |Contacts| variable throws a ReferenceError. There are several options to solve this, such as the one proposed ;-)
