### PR TITLE
Bug 934446 - Test Messages contact input validation

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -37,8 +37,11 @@ disabled = Bug 877611
 [functional/homescreen/test_homescreen_edit_mode.py]
 [functional/homescreen/test_homescreen_move_app.py]
 [functional/keyboard/test_keyboard.py]
+[functional/keyboard/test_number_keyboard.py]
 [functional/lockscreen/test_lockscreen_unlock_to_homescreen.py]
 disabled = Bug 891882
+[functional/lockscreen/test_lockscreen_notification.py]
+[functional/messages/test_sms_contact_input_validation.py]
 [functional/settings/test_settings_change_keyboard_language.py]
 [functional/settings/test_settings_change_language.py]
 [functional/settings/test_settings_do_not_track.py]
@@ -46,4 +49,5 @@ disabled = Bug 891882
 [functional/settings/test_settings_passcode.py]
 [functional/settings/test_settings_wallpaper.py]
 [functional/system/test_system_notification_bar.py]
+[functional/system/test_geolocation_prompt.py]
 [functional/ftu/test_ftu_with_tour.py]


### PR DESCRIPTION
Enable the new test on TBPL for v1.2
Also add some other tests that can be enabled on v1.2 which are currently enabled on TBPL for master
