### PR TITLE
Bug 929895 - Blacklist some apps of notifications removal

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -146,9 +146,20 @@ var NotificationScreen = {
     }
   },
 
+  // TODO: Workaround for bug 929895 until bug 890440 is addressed
+  clearBlacklist: [
+    window.location.protocol + '//wappush.gaiamobile.org/manifest.webapp'
+  ],
+
   handleAppopen: function ns_handleAppopen(evt) {
     var manifestURL = evt.detail.manifestURL,
         selector = '[data-manifest-u-r-l="' + manifestURL + '"]';
+
+    var isBlacklisted = (this.clearBlacklist.indexOf(manifestURL) >= 0);
+
+    if (isBlacklisted) {
+      return;
+    }
 
     var nodes = this.container.querySelectorAll(selector);
 


### PR DESCRIPTION
Until bug 890440 is addressed, the system app clears all notifications
related to an application when it is launched/displayed. This is not
what we want for a couple of applications. We add a temporary hack to
blacklist those, thus avoiding to clear notifications.
