### PR TITLE
Bug 914122: Don't use letter-spacing on grid icons, as it results in po...

### DIFF
--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -123,7 +123,6 @@ ol > li.active > div > img {
   height: 1.9rem;
   margin: 0.3rem auto 0;
   font-weight: 500;
-  letter-spacing: -0.025rem;
 }
 
 /* Alternative icons when an app is being installed */


### PR DESCRIPTION
...or glyph spacing

See bug 914122 comment 40. Using negative letter-spacing gives poor-looking text, because the glyph positions are rounded to whole pixels and therefore fine adjustments to the individual positions cannot be accurately realized; instead, we get a few abrupt, ugly whole-pixel shifts at "random" places within the string.
