### PR TITLE
Bug 936643 - [Settings] Implement ListView.destroy()

### DIFF
--- a/apps/settings/js/mvvm/models.js
+++ b/apps/settings/js/mvvm/models.js
@@ -2,6 +2,33 @@
 (function(exports) {
 'use strict';
 
+function unobserve(_eventHandlers, prop, handler) {
+
+  // arguments in reverse order to support .bind(handler) for the
+  // unbind from all case
+  function removeHandler(handler, prop) {
+    var handlers = _eventHandlers[prop];
+    if (!handlers) {
+      return;
+    }
+    var index = handlers.indexOf(handler);
+    if (index >= 0) {
+      handlers.splice(index, 1);
+    }
+  }
+
+  if (typeof prop === 'function') {
+    // remove from every key in _eventHandlers
+    Object.keys(_eventHandlers).forEach(removeHandler.bind(null, prop));
+  } else if (handler) {
+    // remove from every key in _eventHandlers
+    removeHandler(handler, prop);
+  } else if (prop in _eventHandlers) {
+    // otherwise remove all handlers for property
+    _eventHandlers[prop] = [];
+  }
+}
+
 /*
  * An Observable is able to notify its property change. It is initialized by an
  * ordinary object.
@@ -19,7 +46,11 @@ function Observable(obj) {
       if (handlers) {
         handlers.push(handler);
       }
-    }
+    },
+    /**
+     * unobserve([prop], handler) - remove handler from observeable callbacks
+     */
+    unobserve: unobserve.bind(null, _eventHandlers)
   };
 
   var _getFunctionTemplate = function(p) {
@@ -111,6 +142,8 @@ function ObservableArray(array) {
         handlers.push(handler);
       }
     },
+
+    unobserve: unobserve.bind(null, _eventHandlers),
 
     push: function oa_push(item) {
       _array.push(item);

--- a/apps/settings/js/mvvm/models.js
+++ b/apps/settings/js/mvvm/models.js
@@ -18,13 +18,13 @@ function unobserve(_eventHandlers, prop, handler) {
   }
 
   if (typeof prop === 'function') {
-    // remove from every key in _eventHandlers
+    // (handler) -- remove from every key in _eventHandlers
     Object.keys(_eventHandlers).forEach(removeHandler.bind(null, prop));
   } else if (handler) {
-    // remove from every key in _eventHandlers
+    // (prop, handler) -- remove handler from the specific prop
     removeHandler(handler, prop);
   } else if (prop in _eventHandlers) {
-    // otherwise remove all handlers for property
+    // (prop) -- otherwise remove all handlers for property
     _eventHandlers[prop] = [];
   }
 }

--- a/apps/settings/test/unit/mvvm/models_test.js
+++ b/apps/settings/test/unit/mvvm/models_test.js
@@ -9,6 +9,10 @@ suite('Observable', function() {
     var observable = Observable({});
     assert.equal(typeof observable.observe, 'function');
   });
+  test('shape: Observable({}).unobserve is a function', function() {
+    var observable = Observable({});
+    assert.equal(typeof observable.observe, 'function');
+  });
 
   suite('Creates observable properties', function() {
     var template = {
@@ -50,6 +54,53 @@ suite('Observable', function() {
           this.observable[prop] = this.newValue;
           assert.isTrue(this.spy.calledWith(this.newValue, template[prop]));
         });
+      });
+    });
+
+    suite('unobserve', function() {
+      setup(function() {
+        // bind some listeners
+        this.spies = [this.sinon.spy(), this.sinon.spy()];
+        props.forEach(function(prop) {
+          this.observable.observe(prop, this.spies[0]);
+          this.observable.observe(prop, this.spies[1]);
+        }, this);
+      });
+      test('(property, handler)', function() {
+        // remove handler for property
+        this.observable.unobserve('testNumber', this.spies[0]);
+        // change property - only other handler should be called
+        this.observable.testNumber = {};
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 1);
+        // change a different property, both handlers should be called
+        this.observable.testString = {};
+        assert.equal(this.spies[0].callCount, 1);
+        assert.equal(this.spies[1].callCount, 2);
+      });
+      test('(handler)', function() {
+        // remove handler for all properties
+        this.observable.unobserve(this.spies[0]);
+        // change property - only other handler should be called
+        this.observable.testNumber = {};
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 1);
+        // change a different property, only other handler should be called
+        this.observable.testString = {};
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 2);
+      });
+      test('(property)', function() {
+        // remove handler for all properties
+        this.observable.unobserve('testNumber');
+        // change property - neither handler should be called
+        this.observable.testNumber = {};
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 0);
+        // change a different property, both handlers should be called
+        this.observable.testString = {};
+        assert.equal(this.spies[0].callCount, 1);
+        assert.equal(this.spies[1].callCount, 1);
       });
     });
   });
@@ -271,5 +322,51 @@ suite('ObservableArray', function() {
       checkSpies({});
     });
 
+    suite('unobserve', function() {
+      setup(function() {
+        // bind some listeners
+        this.spies = [this.sinon.spy(), this.sinon.spy()];
+        events.forEach(function(event) {
+          this.observable.observe(event, this.spies[0]);
+          this.observable.observe(event, this.spies[1]);
+        }, this);
+      });
+      test('(property, handler)', function() {
+        // remove handler for property
+        this.observable.unobserve('insert', this.spies[0]);
+        // insert, only other handler should be called
+        this.observable.push({});
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 1);
+        // remove, both handlers should be called
+        this.observable.pop();
+        assert.equal(this.spies[0].callCount, 1);
+        assert.equal(this.spies[1].callCount, 2);
+      });
+      test('(handler)', function() {
+        // remove handler for all properties
+        this.observable.unobserve(this.spies[0]);
+        // insert, only other handler should be called
+        this.observable.push({});
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 1);
+        // remove, only other handler should be called
+        this.observable.pop();
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 2);
+      });
+      test('(property)', function() {
+        // remove handler for all properties
+        this.observable.unobserve('insert');
+        // insert, neither handler should be called
+        this.observable.push({});
+        assert.equal(this.spies[0].callCount, 0);
+        assert.equal(this.spies[1].callCount, 0);
+        // remove, both handlers should be called
+        this.observable.pop({});
+        assert.equal(this.spies[0].callCount, 1);
+        assert.equal(this.spies[1].callCount, 1);
+      });
+    });
   });
 });


### PR DESCRIPTION
- Adds `Observable().unobserve` as well as `ObservableArray.unobserve()`
- Adds `ListView().destroy()`
- Adds an element cache for `ListView` so that a re-used element can automatically destroy it's old `ListView`
