### PR TITLE
Bug 938472 - Modify usage of Pair / Unpair because of interface change

### DIFF
--- a/apps/bluetooth/js/deviceList.js
+++ b/apps/bluetooth/js/deviceList.js
@@ -228,7 +228,7 @@ navigator.mozL10n.ready(function deviceList() {
         var progress = aItem.querySelector('progress');
         progress.classList.remove('hidden');
 
-        var req = defaultAdapter.pair(device);
+        var req = defaultAdapter.pair(device.address);
         pairingMode = 'active';
         pairingAddress = device.address;
         var msg = 'pairing with address = ' + pairingAddress;

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -596,7 +596,7 @@ navigator.mozL10n.ready(function bluetoothSettings() {
         this.setAttribute('aria-disabled', true);
         stopDiscovery();
 
-        var req = defaultAdapter.pair(device);
+        var req = defaultAdapter.pair(device.address);
         pairingMode = 'active';
         pairingAddress = device.address;
         req.onerror = function bt_pairError(error) {
@@ -672,7 +672,7 @@ navigator.mozL10n.ready(function bluetoothSettings() {
         connectedAddress = null;
       }
       // backend takes responsibility to disconnect first.
-      var req = defaultAdapter.unpair(device);
+      var req = defaultAdapter.unpair(device.address);
       req.onerror = function bt_pairError() {
         showDevicePaired(true, null);
       };

--- a/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_data_layer.js
+++ b/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_data_layer.js
@@ -13,7 +13,7 @@ var GaiaDataLayer = {
       adapter.ondevicefound = function(aEvent) {
         device = aEvent.device;
         if (device.name === aDeviceName) {
-          var pair = adapter.pair(device);
+          var pair = adapter.pair(device.address);
           marionetteScriptFinished(true);
         }
       };
@@ -29,7 +29,7 @@ var GaiaDataLayer = {
       req.onsuccess = function() {
         var total = req.result.slice().length;
         for (var i = total; i > 0; i--) {
-          var up = adapter.unpair(req.result.slice()[i-1]);
+          var up = adapter.unpair(req.result.slice()[i-1].address);
         }
       };
     };


### PR DESCRIPTION
Since the parameter of Pair / Unpair will be changed from BluetoothDevice to DOMString (device address) after bug 933113 lands, Settings app has to be modified to fit this revision as well.
