### PR TITLE
Bug 936646 - [Messages][Drafts] Implement local storage for drafts

### DIFF
--- a/apps/sms/js/desktop-only/mobilemessage.js
+++ b/apps/sms/js/desktop-only/mobilemessage.js
@@ -239,6 +239,54 @@
     '101', '102', '103', '104', '105', '106', '107', '108', '109'
   ];
 
+  // Fake drafts stored in local store
+  (function() {
+    var d1, d2, d3, d4, d5;
+    d1 = new Draft({
+      recipients: ['555', '666'],
+      content: 'This is a draft message',
+      timestamp: 1,
+      threadId: 42,
+      type: 'sms'
+    });
+    d2 = new Draft({
+      recipients: ['555'],
+      content: 'This is a draft message',
+      timestamp: 2,
+      threadId: 42,
+      type: 'sms'
+    });
+    d3 = new Draft({
+      recipients: ['555', '222'],
+      content: 'This is a draft message',
+      timestamp: 3,
+      threadId: 1,
+      type: 'sms'
+    });
+    d4 = new Draft({
+      recipients: ['555', '333'],
+      content: 'This is a draft message',
+      timestamp: 4,
+      threadId: 2,
+      type: 'sms'
+    });
+    d5 = new Draft({
+      recipients: ['555', '444'],
+      content: 'This is a draft message',
+      timestamp: 5,
+      threadId: null,
+      type: 'sms'
+    });
+    Drafts.clear();
+    Drafts.add(d1);
+    Drafts.add(d2);
+    Drafts.add(d3);
+    Drafts.add(d4);
+    Drafts.add(d5);
+    Drafts.store();
+  }());
+
+
   // Fake in-memory message database
   var messagesDb = {
     id: 0,

--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -86,6 +86,35 @@
     clear: function() {
       draftIndex = new Map();
       return this;
+    },
+    /**
+     * store
+     *
+     * Store draftIndex held in memory to local storage
+     *
+     * @return {Undefined} void return.
+     */
+    store: function() {
+      // Once ES6 syntax is allowed,
+      // replace the operations below with the following line:
+      // asyncStorage.setItem('draft index', [...draftIndex]);
+      var entries = [];
+      draftIndex.forEach(function(v, k) {
+        entries.push([k, v]);
+      });
+      asyncStorage.setItem('draft index', entries);
+    },
+    /**
+     * load
+     *
+     * Load draftIndex from potentially empty local storage
+     *
+     * @return {Undefined} void return.
+     */
+    load: function() {
+      asyncStorage.getItem('draft index', function(value) {
+        draftIndex = new Map(value || []);
+      });
     }
   };
 

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -17,6 +17,7 @@ var lazyLoadFiles = [
   'js/dialog.js',
   'js/blacklist.js',
   'js/contacts.js',
+  'js/drafts.js',
   'js/recipients.js',
   'js/threads.js',
   'js/message_manager.js',

--- a/apps/sms/test/unit/drafts_test.js
+++ b/apps/sms/test/unit/drafts_test.js
@@ -2,6 +2,7 @@
 'use strict';
 
 requireApp('sms/js/drafts.js');
+require('/shared/js/async_storage.js');
 
 suite('Drafts', function() {
   var d1, d2, d3, d4, d5;
@@ -274,6 +275,51 @@ suite('Drafts', function() {
       assert.equal(draft.timestamp, 1, 'timestamp is 1');
       assert.equal(draft.threadId, 42, 'timestamp is 42');
       assert.equal(draft.type, 'sms', 'timestamp is \'sms\'');
+    });
+
+  });
+
+  suite('Storage', function() {
+    var stored = new Map();
+
+    setup(function() {
+      Drafts.clear();
+      Drafts.add(d1);
+      Drafts.add(d2);
+      Drafts.add(d5);
+
+      stored.set(d1.threadId, d1);
+      stored.set(d5.threadId, d5);
+    });
+
+    teardown(function() {
+      Drafts.clear();
+      asyncStorage.removeItem('draft index');
+    });
+
+    test('Store drafts', function() {
+      Drafts.store();
+      asyncStorage.getItem('draft index', function(value) {
+        var retrieved = new Map(value);
+        assert.deepEqual(retrieved.get(null), [d5]);
+        assert.deepEqual(retrieved.get(42), [d1, d2]);
+      });
+    });
+
+    test('Load drafts', function() {
+      var retrieved = [];
+      asyncStorage.setItem('draft index', [...stored], function() {
+        Drafts.load();
+      });
+
+      Drafts.byId(null).forEach(function(elem) {
+        assert.equal(elem, d5);
+      });
+
+      Drafts.byId(42).forEach(function(elem) {
+        retrieved.push(elem);
+      });
+      assert.deepEqual(retrieved, [d1, d2]);
     });
 
   });


### PR DESCRIPTION
- Use asyncStorage to store and retrieve the draftIndex.
- Add dummy draft messages to `desktop-only/mobilemessage.js`
- Add `drafts.js` to startup
