### PR TITLE
Bug 939110 - [system] Usage bar not showing in utility tray due to use w... r=salva

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -38,7 +38,7 @@ var UtilityTray = {
 
     this.overlay.addEventListener('transitionend', this);
 
-    if (window.navigator.mozMobileConnection) {
+    if (window.navigator.mozMobileConnections) {
       LazyLoader.load('js/cost_control.js');
     }
   },


### PR DESCRIPTION
Please see [bug 939110](https://bugzilla.mozilla.org/show_bug.cgi?id=939110).

In [bug 814629](https://bugzilla.mozilla.org/show_bug.cgi?id=814629), WebMobileConnection API was changed to support multi-sim.

Before:
var mobileconn = navigator.mozMobileConnection;
var voiceinfo = mobileconn.voiceInfo;

After:
var mobileconn = navigator.mozMobileConnections[0];
// The same below ...
var voiceinfo =mobileconn.voiceInfo;

But in system/js/utility_tray.js, it still uses the old way to access MobileConnection API, we should correct this.
