### PR TITLE
bug 939105 - Python test_sms_contact_match - wait for keyboard to be ful...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -102,6 +102,7 @@ class Keyboard(Base):
     def switch_to_keyboard(self):
         self.marionette.switch_to_frame()
         keybframe = self.marionette.find_element(*self._keyboard_frame_locator)
+        self.wait_for_condition(lambda m: keybframe.location['y'] == 0)
         self.marionette.switch_to_frame(keybframe, focus=False)
 
     @property


### PR DESCRIPTION
...ly opened before tapping on the keyboard
