### PR TITLE
[bug 906273] increase height of label wrapper to avoid clipping Arabic-s...

### DIFF
--- a/apps/homescreen/style/dragdrop.css
+++ b/apps/homescreen/style/dragdrop.css
@@ -16,7 +16,7 @@
 
 /* label wrapper */
 .draggable > div > span {
-  margin-top: 0.1rem;
+  margin-top: -0.05rem;
   /* shift left edge of text to center */
   left: 50%;
 }
@@ -24,6 +24,7 @@
 /* text label */
 .draggable > div > span > span {
   font-size: 1.3rem;
+  line-height: 2rem;
   text-shadow: 0 0.1rem 0.2rem rgba(0,0,0,1);
   /* shift left edge of text half distance to left */
   margin-left: -106%;

--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -98,6 +98,8 @@ ol > li.active > div > img {
 /* text label */
 .apps ol > li > div > span > span {
   font-size: 1.3rem;
+  line-height: 2rem; /* maintain constant line height even if font fallback
+                        gives us different fonts for non-Latin labels */
   text-shadow: 0 0.1rem 0.2rem rgba(0,0,0,1);
 }
 
@@ -120,8 +122,8 @@ ol > li.active > div > img {
   display: block;
   width: 94%; /* At least 6% of margin between labels of different apps */
   position: relative;
-  height: 1.9rem;
-  margin: 0.3rem auto 0;
+  height: 2.5rem;
+  margin: 0.1rem auto -0.4rem;
   font-weight: 500;
 }
 


### PR DESCRIPTION
...cript text

This enables us to display Arabic-script labels without clipping and without disrupting the baseline position of the label text; the margin adjustments are to maintain the existing position of the text in relation to the icon, while its display box is enlarged to allow for taller glyphs to be drawn.
