### PR TITLE
Revert "Bug 930104 - Remove localId=0 hack for the system app on firefox and correctly set permission for any app loaded in Firefox r=vingtetun"

### DIFF
--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -133,6 +133,16 @@ function fillAppManifest(webapp) {
   // appStatus == 1 means this is an installed (unprivileged) app
 
   var localId = id++;
+  // localId start from 1 in release build. For DESKTOP=1 build the system
+  // app can run inside Firefox desktop inside a regular tab and so the
+  // permissions set based on a principal are not working.
+  // To make it works the system app will be assigned an id of 0, which
+  // is the equivalent of the const NO_APP_ID.
+  if (config.DESKTOP &&
+    webappTargetDirName == ('system.' + config.GAIA_DOMAIN)) {
+    localId = 0;
+  }
+
   let url = webapp.url;
   manifests[webappTargetDirName] = {
     origin: url,

--- a/tools/extensions/browser-helper@gaiamobile.org/bootstrap.js
+++ b/tools/extensions/browser-helper@gaiamobile.org/bootstrap.js
@@ -49,46 +49,6 @@ function startup(data, reason) {
       }
     }, 'document-element-inserted', false);
 
-    // Watch for app load start in firefox tabs.
-    // We have to set the app id on each docshell where we are trying to load
-    // an app. That's because we can't set mozapp attribute on firefox iframes
-    // as Firefox is still using xul:browser.
-    let nsIWebProgressListener = Ci.nsIWebProgressListener;
-    let appsService = Cc['@mozilla.org/AppsService;1'].getService(Ci.nsIAppsService);
-    let docShellListener = {
-      onStateChange: function onStateChange(webProgress, request, flags, status) {
-        // Catch any load start request
-        if (flags & nsIWebProgressListener.STATE_START &&
-            flags & nsIWebProgressListener.STATE_IS_DOCUMENT &&
-            (request instanceof Ci.nsIChannel || 'URI' in request)) {
-          // Try to compute the manifest URL out of document URL
-          // We should end up with urls like:
-          //   http://system.gaiamobile.org:8080/manifest.webapp
-          //   app://system.gaiamobile.org/manifest.webapp
-          let manifestURL = request.URI.prePath + '/manifest.webapp';
-          let manifest = appsService.getAppByManifestURL(manifestURL);
-          if (manifest) {
-            let app = manifest.QueryInterface(Ci.mozIApplication);
-            // test-agent expects its iframes to load apps without any permissions
-            // so prevent setting the correct app id to its iframes
-            if (!webProgress.DOMWindow || !webProgress.DOMWindow.top ||
-                !webProgress.DOMWindow.top.location.host.startWith("test-agent.gaiamobile.org")) {
-              webProgress.QueryInterface(Ci.nsIDocShell).setIsApp(app.localId);
-            }
-          }
-        }
-      }
-    };
-    // Listen for loads happening in all browser windows.
-    Services.obs.addObserver(function(win) {
-      win.addEventListener('DOMContentLoaded', function loaded() {
-        win.removeEventListener('DOMContentLoaded', loaded);
-        if (win.gBrowser) {
-          win.gBrowser.addProgressListener(docShellListener);
-        }
-      });
-    }, 'domwindowopened', false);
-
     Services.obs.addObserver(function() {
       let browserWindow = Services.wm.getMostRecentWindow('navigator:browser');
 


### PR DESCRIPTION
This reverts commit 09eb15afda938974376c6e33117ac84c98353bf0.

This was breaking developer workflows as the system app no longer loads after building a clean DEBUG=1 profile.
