### PR TITLE
Bug 940175 - Unxfail test_setup_basic_gmail.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/email/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/email/manifest.ini
@@ -3,8 +3,6 @@ b2g = true
 online = true
 
 [test_setup_basic_gmail.py]
-# Bug 939769 - User can't setup basic email account
-expected = fail
 
 [test_setup_imap_email.py]
 


### PR DESCRIPTION
This tests needs to be unxfailed, because of fixed Bug 939769.
