### PR TITLE
Bug 917674 - [Contacts] Passive matching and merging when SIM contact's name is the same than an addressbook contact's last name

### DIFF
--- a/apps/communications/contacts/js/contacts_matcher.js
+++ b/apps/communications/contacts/js/contacts_matcher.js
@@ -267,7 +267,10 @@ contacts.Matcher = (function() {
                           replace(blankRegExp, '');
           }
           // To support seamless matching of SIM contacts
-          var targetName = (targetGN || '') + (targetFN || '');
+          var targetName = Array.isArray(aContact.name) ?
+                Normalizer.toAscii(aContact.name[0].trim().toLowerCase()).
+                          replace(blankRegExp, '') :
+                ((targetGN || '') + (targetFN || ''));
 
           var mFamilyName = null;
           var mGivenName = null;
@@ -284,7 +287,10 @@ contacts.Matcher = (function() {
                           replace(blankRegExp, '');
           }
           // To support seamless matching of SIM contacts
-          var mName = (mGivenName || '') + (mFamilyName || '');
+          var mName = Array.isArray(mContact.name) ?
+                Normalizer.toAscii(mContact.name[0].trim().toLowerCase()).
+                          replace(blankRegExp, '') :
+                ((mGivenName || '') + (mFamilyName || ''));
 
           names.push({
             contact: mContact,
@@ -294,9 +300,9 @@ contacts.Matcher = (function() {
           });
 
           var matchingList = names.filter(function(obj) {
-            return ((obj.familyName === targetFN &&
-                     obj.givenName === targetGN) ||
-                    (obj.name && obj.name === targetName) && (
+            return (obj.name && obj.name === targetName ||
+                    (obj.familyName === targetFN &&
+                     obj.givenName === targetGN) && (
                     !Array.isArray(obj.contact.category) ||
                     obj.contact.category.indexOf(FB_CATEGORY) === -1));
           });
@@ -390,6 +396,7 @@ contacts.Matcher = (function() {
       });
 
       reqName.onsuccess = function() {
+        window.console.log('Results by name ready: ', reqName.result);
         resultsByName = reqName.result.filter(function(aResult) {
           return filterFacebook(aResult, options);
         });

--- a/apps/communications/contacts/test/unit/contacts_matcher_test.js
+++ b/apps/communications/contacts/test/unit/contacts_matcher_test.js
@@ -406,7 +406,71 @@ suite('Test Contacts Matcher', function() {
           MockFindMatcher.setData(contact);
           done();
         });
+    });
+
+    test('Incoming SIM contact matches with an existing SIM contact',
+      function(done) {
+        var existingSimContact = {
+          id: '1B',
+          category: ['sim'],
+          name: ['Juan Ramón del SIM'],
+          givenName: ['Juan Ramón del SIM'],
+          tel: [{
+            type: ['home'],
+            value: '676767671'
+          }],
+          email: [{
+            type: ['personal'],
+            value: 'jj@jj.com'
+          }]
+        };
+
+        var incomingSimContact = Object.create(existingSimContact);
+        incomingSimContact.id = '1234DF';
+
+        MockFindMatcher.setData(existingSimContact);
+
+        testMatch(incomingSimContact, 'passive', null, function() {
+          MockFindMatcher.setData(contact);
+          done();
+        });
+    });
+
+    test('Incoming SIM Contact matches with a normal contact. Only with '+
+         'familyName defined', function(done) {
+      var simObj = {
+        id: '678',
+        category: ['sim'],
+        name: ['Juan Ramón del SIM'],
+        givenName: ['Juan Ramón del SIM'],
+        tel: [{
+          type: ['home'],
+          value: '676767671'
+        }]
+      };
+
+      var existingContact = {
+        id: '1B',
+        givenName: [],
+        familyName: ['Juan Ramón del SIM'],
+        name: ['Juan Ramón del SIM'],
+        tel: [{
+          type: ['home'],
+          value: '676767671'
+        }],
+        email: [{
+          type: ['personal'],
+          value: 'jj@jj.com'
+        }]
+      };
+
+      MockFindMatcher.setData(existingContact);
+
+      testMatch(simObj, 'passive', null, function() {
+        MockFindMatcher.setData(contact);
+        done();
       });
+    });
   });
 
   suite('Test Contacts Matcher. Active Mode', function() {


### PR DESCRIPTION
Currently, contacts imported from the SIM card with some content in the 'name' field, this content is loaded as the contact givenName (https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/js/utilities/import_sim_contacts.js#L147). This causes that if a contact with some "Last Name" is exported to the SIM, this content is stored in the 'name' field. When reimporting the same contact, this content ("Last Name") is imported as the contact given name and according to this code https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/js/contacts_matcher.js#L299 a match is found and both contacts are merged, ending up with a new contact with given name "Last Name" and last name "Last Name".
