### PR TITLE
Bug 941440 - The layout of Macedonian keyboard is incorrect - the space

### DIFF
--- a/keyboard/layouts/mk.js
+++ b/keyboard/layouts/mk.js
@@ -23,7 +23,7 @@ Keyboards.mk = {
       { value: 'н' }, { value: 'м' }, { value: 'ѓ' }, { value: 'ж' },
       { value: '⌫', keyCode: KeyEvent.DOM_VK_BACK_SPACE }
     ], [
-      { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '&nbsp', ratio: 9, keyCode: KeyboardEvent.DOM_VK_SPACE },
       { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
     ]
   ]


### PR DESCRIPTION
key is too small.
- Correct the width ratio of the space key
