### PR TITLE
Bug 941502 - Unxfail test_export_contacts_to_sdcard.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
@@ -32,8 +32,6 @@ skip-if = device == "desktop"
 carrier = true
 
 [test_export_contacts_to_sdcard.py]
-# Bug 936494 - String not showing correctly after export to SD card
-expected = fail
 skip-if = device == "desktop"
 sdcard = true
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_export_contacts_to_sdcard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_export_contacts_to_sdcard.py
@@ -30,7 +30,7 @@ class TestExportContactsToSDCard(GaiaTestCase):
         contacts_app.tap_select_all()
         contacts_app.tap_export()
 
-        self.assertIn('1 out of 1 exported', contacts_app.status_message)
+        self.assertIn('1/1 friends exported', contacts_app.status_message)
 
         vcf_files = self.data_layer.sdcard_files('.vcf')
 


### PR DESCRIPTION
unxfail test_export_contacts_to_sdcard.py due to Bug 936494 be fixed.

Fix assertion base on https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/locales/contacts.en-US.properties#L109
