### PR TITLE
Bug 915572 - Allow data/gaia/sdcard cleanup to be overridden by tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -27,7 +27,7 @@ class LockScreen(object):
     @property
     def is_locked(self):
         self.marionette.switch_to_frame()
-        return self.marionette.execute_script('window.wrappedJSObject.LockScreen.locked')
+        return self.marionette.execute_script('return window.wrappedJSObject.LockScreen.locked')
 
     def lock(self):
         self.marionette.switch_to_frame()
@@ -312,7 +312,9 @@ class GaiaData(object):
 
     @property
     def known_networks(self):
-        return self.marionette.execute_async_script('return GaiaDataLayer.getKnownNetworks()')
+        known_networks = self.marionette.execute_async_script(
+            'return GaiaDataLayer.getKnownNetworks()')
+        return [n for n in known_networks if n]
 
     @property
     def active_telephony_state(self):
@@ -512,9 +514,7 @@ class GaiaTestCase(MarionetteTestCase):
         if self.restart and (self.device.is_android_build or self.marionette.instance):
             self.device.stop_b2g()
             if self.device.is_android_build:
-                # revert device to a clean state
-                self.device.manager.removeDir('/data/local/storage/persistent')
-                self.device.manager.removeDir('/data/b2g/mozilla')
+                self.cleanup_data()
             self.device.start_b2g()
 
         # the emulator can be really slow!
@@ -526,16 +526,29 @@ class GaiaTestCase(MarionetteTestCase):
         from gaiatest.apps.keyboard.app import Keyboard
         self.keyboard = Keyboard(self.marionette)
 
-        self.cleanUp()
+        if self.device.is_android_build:
+            self.cleanup_sdcard()
 
-    def cleanUp(self):
+        if self.restart:
+            self.cleanup_gaia(full_reset=False)
+        else:
+            self.cleanup_gaia(full_reset=True)
+
+    def cleanup_data(self):
+        self.device.manager.removeDir('/data/local/storage/persistent')
+        self.device.manager.removeDir('/data/b2g/mozilla')
+
+    def cleanup_sdcard(self):
+        self.device.manager.shellCheckOutput(['rm', '-r', '/sdcard/*'])
+        self.device.manager.removeDir('/sdcard/.gallery')
+
+    def cleanup_gaia(self, full_reset=True):
         # remove media
         if self.device.is_android_build:
             for filename in self.data_layer.media_files:
-                # filename is a fully qualified path
                 self.device.manager.removeFile(filename)
 
-        # Switch off keyboard FTU screen
+        # switch off keyboard FTU screen
         self.data_layer.set_setting("keyboard.ftu.enabled", False)
 
         # restore settings from testvars
@@ -544,24 +557,22 @@ class GaiaTestCase(MarionetteTestCase):
         # unlock
         self.lockscreen.unlock()
 
-        # If we are restarting all of these values are reset to default earlier in the setUp
-        if not self.restart:
-
-            # disable passcode before restore settings from testvars
+        if full_reset:
+            # disable passcode
             self.data_layer.set_setting('lockscreen.passcode-lock.code', '1111')
             self.data_layer.set_setting('lockscreen.passcode-lock.enabled', False)
 
-            # Change language back to English
+            # change language back to english
             self.data_layer.set_setting("language.current", "en-US")
 
-            # Switch off spanish keyboard before test
+            # switch off spanish keyboard
             self.data_layer.set_setting("keyboard.layouts.spanish", False)
 
-            # Set do not track pref back to the default
+            # reset do not track
             self.data_layer.set_setting('privacy.donottrackheader.value', '-1')
 
             if self.data_layer.get_setting('ril.radio.disabled'):
-                # enable the device radio, disable Airplane mode
+                # enable the device radio, disable airplane mode
                 self.data_layer.set_setting('ril.radio.disabled', False)
 
             # Re-set edge gestures pref to False

--- a/tests/python/gaia-ui-tests/gaiatest/runtests.py
+++ b/tests/python/gaia-ui-tests/gaiatest/runtests.py
@@ -189,7 +189,7 @@ class GaiaTestRunner(MarionetteTestRunner):
             heading = 'Warning'
             message = 'You are about to run destructive tests against a Firefox OS instance. These tests ' \
                       'will restore the target to a clean state, meaning any personal data such as contacts, ' \
-                      'messages, photos, videos, music, etc. will be removed. This may include data on the ' \
+                      'messages, photos, videos, music, etc. will be removed. This will include data on the ' \
                       'microSD card. The tests may also attempt to initiate outgoing calls, or connect to ' \
                       'services such as cellular data, wifi, gps, bluetooth, etc.'
             try:

--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -4,6 +4,7 @@ b2g = true
 [unit/settings/test_settings.py]
 [unit/test_cold_launch.py]
 [unit/test_contacts.py]
+[unit/test_cleanup_gaia.py]
 [unit/test_kill.py]
 [unit/test_killall.py]
 [unit/test_launch_twice.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/manifest.ini
@@ -14,6 +14,10 @@ wifi = false
 [test_bluetooth.py]
 skip-if = device == "desktop"
 bluetooth = true
+[test_cleanup_gaia.py]
+[test_cleanup_sdcard.py]
+skip-if = device == "desktop"
+sdcard = true
 [test_connect_to_local_area_network.py]
 skip-if = device == "desktop"
 offline = true
@@ -24,9 +28,6 @@ skip-if = device == "desktop"
 offline = true
 online = true
 [test_contacts.py]
-[test_initial_state.py]
-skip-if = device == "desktop"
-sdcard = true
 [test_kill.py]
 [test_killall.py]
 [test_cold_launch.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_cleanup_gaia.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_cleanup_gaia.py
@@ -7,64 +7,65 @@ from gaiatest import GaiaTestCase
 from gaiatest.mocks.mock_contact import MockContact
 
 
-class TestInitialState(GaiaTestCase):
+class TestCleanupGaia(GaiaTestCase):
 
     homescreen_frame_locator = (By.CSS_SELECTOR, 'div.homescreen iframe')
 
-    def test_initial_state(self):
+    def test_cleanup_gaia(self):
         self.check_initial_state()
-
-    def test_state_after_reset(self):
-        # push media files
-        self.push_resource('IMG_0001.jpg', destination='DCIM/100MZLLA')
-        self.push_resource('VID_0001.3gp', destination='DCIM/100MZLLA')
-        self.push_resource('MUS_0001.mp3')
 
         # change volume
         self.data_layer.set_volume(5)
+        self.assertEqual(self.data_layer.get_setting(
+            'audio.volume.content'), 5)
 
         # connect to wifi network
         if (self.testvars.get('wifi') and self.device.has_wifi):
             self.data_layer.connect_to_wifi()
-            self.data_layer.disable_wifi()
+            self.assertTrue(len(self.data_layer.known_networks) > 0)
 
         # insert contacts
         self.data_layer.insert_contact(MockContact())
         self.data_layer.insert_contact(MockContact())
+        self.assertEqual(len(self.data_layer.all_contacts), 2)
 
         # move away from home screen
         self.marionette.switch_to_frame(
             self.marionette.find_element(*self.homescreen_frame_locator))
-        self.marionette.execute_script('window.wrappedJSObject.GridManager.goToPage(1);')
+        self.marionette.execute_script(
+            'window.wrappedJSObject.GridManager.goToPage(1);')
+        self.assertEqual(self.marionette.execute_script("""
+var manager = window.wrappedJSObject.GridManager;
+return manager.pageHelper.getCurrentPageNumber();
+"""), 1)
         self.marionette.switch_to_frame()
 
         # lock screen
         self.lockscreen.lock()
+        self.assertTrue(self.lockscreen.is_locked)
 
-        self.cleanUp()
+        self.cleanup_gaia()
         self.check_initial_state()
 
     def check_initial_state(self):
         self.assertFalse(self.lockscreen.is_locked)
 
-        self.assertFalse(self.data_layer.is_wifi_enabled)
-        self.assertFalse(self.data_layer.is_cell_data_enabled)
-        self.assertFalse(self.device.is_online)
-
         if self.device.has_wifi:
-            self.data_layer.enable_wifi()
-            self.assertEqual(self.data_layer.known_networks, [{}])
-            self.data_layer.disable_wifi()
+            self.assertEqual(len(self.data_layer.known_networks), 0)
 
-        self.assertEqual(self.data_layer.get_setting('audio.volume.master'), 0)
+        if self.device.has_mobile_connection:
+            self.assertFalse(self.data_layer.is_cell_data_enabled)
 
-        self.assertEqual(self.data_layer.media_files, [])
+        self.assertEqual(self.data_layer.get_setting(
+            'audio.volume.content'), 0)
 
         self.assertEqual(self.data_layer.all_contacts, [])
 
         # check we're on the home screen
         self.marionette.switch_to_frame(
             self.marionette.find_element(*self.homescreen_frame_locator))
-        self.assertEqual(self.marionette.execute_script(
-            'return window.wrappedJSObject.GridManager.pageHelper.getCurrentPageNumber();'), 0)
+        self.assertEqual(self.marionette.execute_script("""
+var manager = window.wrappedJSObject.GridManager;
+return manager.pageHelper.getCurrentPageNumber();
+"""), 0)
         self.marionette.switch_to_frame()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_cleanup_sdcard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_cleanup_sdcard.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+
+
+class TestCleanupSDCard(GaiaTestCase):
+
+    def test_cleanup_scard(self):
+        self.assertEqual(len(self.data_layer.media_files), 0)
+
+        # push media files
+        self.push_resource('IMG_0001.jpg', destination='DCIM/100MZLLA')
+        self.push_resource('VID_0001.3gp', destination='DCIM/100MZLLA')
+        self.push_resource('MUS_0001.mp3')
+        self.assertEqual(len(self.data_layer.media_files), 3)
+
+        self.cleanup_sdcard()
+        self.assertEqual(len(self.data_layer.media_files), 0)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_wifi.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_wifi.py
@@ -13,6 +13,6 @@ class TestWiFi(GaiaTestCase):
         self.data_layer.connect_to_wifi()
         self.assertTrue(self.device.is_online)
         self.data_layer.forget_all_networks()
-        self.assertEqual(self.data_layer.known_networks, [{}])
+        self.assertEqual(len(self.data_layer.known_networks), 0)
         self.assertFalse(self.data_layer.is_wifi_connected())
         self.data_layer.disable_wifi()


### PR DESCRIPTION
This patch splits cleanup into data, sdcard and gaia, and allows these methods to be overridden by test classes.
