### PR TITLE
Bug 935561 - [Messaging] Attach icon is kept like pressed when tapping o...

### DIFF
--- a/apps/system/js/activities.js
+++ b/apps/system/js/activities.js
@@ -76,6 +76,9 @@ var Activities = {
 
     choices.forEach(function(choice, index) {
       var app = Applications.getByManifestURL(choice.manifest);
+      if (!app)
+        return;
+
       items.push({
         label: new ManifestHelper(app.manifest).name,
         icon: choice.icon,


### PR DESCRIPTION
...n it and cancel selecting a content to attach. r=fabrice
