### PR TITLE
Bug 941951 - Missing l10n entity for Settings/NFC, r=evelyn

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -290,6 +290,9 @@ unpair-title = Unpair a connected device?
 unpair-msg   = You are currently connected to this device. Unpairing will also disconnect from it.
 pair-view-title = Bluetooth Request From
 
+# Connectivity :: NFC
+nfc = NFC
+
 # Connectivity :: Internet Sharing
 SSIDCannotBeEmpty=The SSID cannot be empty
 internetSharing=Internet sharing


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=941951
