### PR TITLE
Bug 942012 - Xfail test_add_photo_to_contact.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/manifest.ini
@@ -17,7 +17,7 @@ carrier = true
 
 [test_add_photo_to_contact.py]
 skip-if = device == "desktop"
-# Bug 934537 - [Contacts] Trying to edit a contact generates a "Duplicate found" message
+# Bug 942010 - The test_add_photo_to_contact.py gets Duplicates Found screen
 expected = fail
 sdcard = true
 


### PR DESCRIPTION
test_add_photo_to_contact.py should be xfailed by new Bug 942010, due to the Bug 921205 was fixed.
