### PR TITLE
Bug 941511 - Add CDMA 1x networks to CDMA types r=alive

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -92,9 +92,10 @@ var StatusBar = {
     '1xrtt': '1x', 'is95a': '1x', 'is95b': '1x' // 2G CDMA
   },
 
-  cdmaTypes: {
-    'evdo0': true, 'evdoa': true,
-    'evdob': true, 'ehrpd': true
+  // CDMA types that can support either data call or voice call simultaneously.
+  dataExclusiveCDMATypes: {
+    'evdo0': true, 'evdoa': true, 'evdob': true, // data call only
+    '1xrtt': true, 'is95a': true, 'is95b': true  // data call or voice call
   },
 
   geolocationActive: false,
@@ -572,7 +573,7 @@ var StatusBar = {
         icon.textContent = '';
         icon.classList.remove('sb-icon-data-circle');
         if (type) {
-          if (self.cdmaTypes[data.type]) {
+          if (self.dataExclusiveCDMATypes[data.type]) {
             // If the current data connection is CDMA types, we need to check
             // if there exist any calls. If yes, we have to set the status
             // text to empty.
@@ -778,7 +779,7 @@ var StatusBar = {
       emergencyCallsOnly = emergencyCallsOnly ||
         (conn && conn.voice && conn.voice.emergencyCallsOnly);
       cdmaConnection = cdmaConnection ||
-        (conn && conn.data && !!self.cdmaTypes[conn.data.type]);
+        (conn && conn.data && !!self.dataExclusiveCDMATypes[conn.data.type]);
     });
 
     if (emergencyCallsOnly || cdmaConnection) {

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -710,7 +710,7 @@ suite('system/Statusbar', function() {
             });
 
             // CDMA related to calls
-            suite('ehrpd, evdo0, evdoa, evdob when there is a call',
+            suite('CDMA network types when there is a call',
               function() {
                 test('type ehrpd', function() {
                   MockNavigatorMozTelephony.calls = [{}];
@@ -719,7 +719,8 @@ suite('system/Statusbar', function() {
                     type: 'ehrpd'
                   };
                   StatusBar.update.data.call(StatusBar);
-                  assert.equal(StatusBar.icons.data[slotIndex].textContent, '');
+                  assert.equal(StatusBar.icons.data[slotIndex].textContent,
+                               '4G');
               });
 
               test('type evdo0', function() {
@@ -751,9 +752,39 @@ suite('system/Statusbar', function() {
                 StatusBar.update.data.call(StatusBar);
                 assert.equal(StatusBar.icons.data[slotIndex].textContent, '');
               });
+
+              test('type 1xrtt', function() {
+                MockNavigatorMozTelephony.calls = [{}];
+                MockNavigatorMozMobileConnections[slotIndex].data = {
+                  connected: true,
+                  type: '1xrtt'
+                };
+                StatusBar.update.data.call(StatusBar);
+                assert.equal(StatusBar.icons.data[slotIndex].textContent, '');
+              });
+
+              test('type is95a', function() {
+                MockNavigatorMozTelephony.calls = [{}];
+                MockNavigatorMozMobileConnections[slotIndex].data = {
+                  connected: true,
+                  type: 'is95a'
+                };
+                StatusBar.update.data.call(StatusBar);
+                assert.equal(StatusBar.icons.data[slotIndex].textContent, '');
+              });
+
+              test('type is95b', function() {
+                MockNavigatorMozTelephony.calls = [{}];
+                MockNavigatorMozMobileConnections[slotIndex].data = {
+                  connected: true,
+                  type: 'is95b'
+                };
+                StatusBar.update.data.call(StatusBar);
+                assert.equal(StatusBar.icons.data[slotIndex].textContent, '');
+              });
             });
 
-            suite('ehrpd, evdo0, evdoa, evdob when there is no call',
+            suite('CDMA network types when there is no call',
               function() {
                 test('type ehrpd', function() {
                   MockNavigatorMozMobileConnections[slotIndex].data = {
@@ -790,6 +821,33 @@ suite('system/Statusbar', function() {
                 };
                 StatusBar.update.data.call(StatusBar);
                 assert.equal(StatusBar.icons.data[slotIndex].textContent, 'Ev');
+              });
+
+              test('type 1xrtt', function() {
+                MockNavigatorMozMobileConnections[slotIndex].data = {
+                  connected: true,
+                  type: '1xrtt'
+                };
+                StatusBar.update.data.call(StatusBar);
+                assert.equal(StatusBar.icons.data[slotIndex].textContent, '1x');
+              });
+
+              test('type is95a', function() {
+                MockNavigatorMozMobileConnections[slotIndex].data = {
+                  connected: true,
+                  type: 'is95a'
+                };
+                StatusBar.update.data.call(StatusBar);
+                assert.equal(StatusBar.icons.data[slotIndex].textContent, '1x');
+              });
+
+              test('type is95b', function() {
+                MockNavigatorMozMobileConnections[slotIndex].data = {
+                  connected: true,
+                  type: 'is95b'
+                };
+                StatusBar.update.data.call(StatusBar);
+                assert.equal(StatusBar.icons.data[slotIndex].textContent, '1x');
               });
             });
           });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=941511

The table `dataExclusiveCDMATypes` records network types that only support data call or voice call at the same time. As 'ehrpd' supports both calls at the same time, remove it from the table. And add CDMA 1x network types to the table.
