### PR TITLE
Bug 941901 - [settings] Use correct entity name for Cell broadcast r=crh0716

### DIFF
--- a/apps/settings/elements/messaging.html
+++ b/apps/settings/elements/messaging.html
@@ -53,7 +53,7 @@
         <li id="menuItem-cellBroadcast" aria-disabled="true">
           <label class="pack-switch checkbox-label">
             <input type="checkbox" data-ignore disabled />
-            <span data-l10n-id="callBroadcast">Cell broadcast</span>
+            <span data-l10n-id="cellBroadcast">Cell broadcast</span>
           </label>
         </li>
       </ul>


### PR DESCRIPTION
Mispelled data-l10n-id (callBroadcast instead of cellBroadcast)
