### PR TITLE
Bug 942061 - Fix test_send_imap_email.py and test_setup_imap_email.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/email/regions/setup.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/email/regions/setup.py
@@ -55,9 +55,9 @@ class ManualSetupEmail(Base):
 
     _account_type_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-account-type')
 
-    _imap_username_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-imap-username')
-    _imap_hostname_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-imap-hostname')
-    _imap_port_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-imap-port')
+    _imap_username_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-composite-username')
+    _imap_hostname_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-composite-hostname')
+    _imap_port_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-composite-port')
 
     _smtp_username_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-smtp-username')
     _smtp_hostname_locator = (By.CSS_SELECTOR, 'section.card-setup-manual-config .sup-manual-smtp-hostname')


### PR DESCRIPTION
The "sup-manual-imap-_" be replaced by "sup-manual-composite-_".

ref: https://github.com/mozilla-b2g/gaia/commit/92b708ea62c0494350446041a76940f2400b26b8
