### PR TITLE
Bug 942546 - Use different labels for "Add to home screen" in buttons and headers

### DIFF
--- a/apps/homescreen/locales/homescreen.en-US.properties
+++ b/apps/homescreen/locales/homescreen.en-US.properties
@@ -1,5 +1,6 @@
 # Add bookmark to homescreen
 add-to-home-screen=Add to Home Screen
+add-to-home-screen-header=Add link
 website-name=Website name
 address=Address
 added-to-home-screen=Added to Home Screen

--- a/apps/homescreen/save-bookmark.html
+++ b/apps/homescreen/save-bookmark.html
@@ -35,7 +35,7 @@
         <button id="button-bookmark-cancel">
           <span class="icon icon-close" data-l10n-id="cancel">Cancel</span>
         </button>
-        <h1 data-l10n-id="add-to-home-screen">Add to Home Screen</h1>
+        <h1 data-l10n-id="add-to-home-screen-header">Add link</h1>
       </header>
       <form id="bookmark-form">
         <label data-l10n-id="website-name">


### PR DESCRIPTION
To avoid truncation bugs in l10n. Text suggested by Matej in bug 930704
