### PR TITLE
Bug 942546 (PR for v1.2 only) - Use different labels for "Add to home screen" in buttons and headers

### DIFF
--- a/apps/homescreen/locales/homescreen.en-US.properties
+++ b/apps/homescreen/locales/homescreen.en-US.properties
@@ -1,5 +1,14 @@
 # Add bookmark to homescreen
 add-to-home-screen=Add to Home Screen
+
+# LOCALIZATION NOTE (add-to-home-screen-header): if you leave the original
+# en-US value "{{add-to-home-screen}}" in the following string, the localization
+# will be automatically picked from the existing string with ID "add-to-home-screen".
+# If you need to adapt your localization to the reduced space available
+# in headers, you can use a shorter string in add-to-home-screen-header
+# (e.g. "Add link").
+add-to-home-screen-header={{add-to-home-screen}}
+
 website-name=Website name
 address=Address
 added-to-home-screen=Added to Home Screen

--- a/apps/homescreen/save-bookmark.html
+++ b/apps/homescreen/save-bookmark.html
@@ -34,7 +34,7 @@
         <button id="button-bookmark-cancel">
           <span class="icon icon-close" data-l10n-id="cancel">Cancel</span>
         </button>
-        <h1 data-l10n-id="add-to-home-screen">Add to Home Screen</h1>
+        <h1 data-l10n-id="add-to-home-screen-header">Add to Home Screen</h1>
       </header>
       <form id="bookmark-form">
         <label data-l10n-id="website-name">


### PR DESCRIPTION
Use the same approach of bug 859035 to work around string freeze.

If string is localized use the new localization, if not fallback to "add-to-home-screen". Bug 942546 includes a PR to use "Add link" for the header.
