### PR TITLE
Bug 942424 - Fix broken comment format, fix "ﬁle"

### DIFF
--- a/shared/locales/download/download.en-US.properties
+++ b/shared/locales/download/download.en-US.properties
@@ -21,23 +21,20 @@ delete_download_left_button   = Cancel
 delete_download_right_button  = Delete
 
 unsupported_file_type_download_title           = Unable to open
-unsupported_file_type_download_message         = There isn’t an app that can open {{name}}. Would you like to save the ﬁle or delete it?
+unsupported_file_type_download_message         = There isn’t an app that can open {{name}}. Would you like to save the file or delete it?
 unsupported_file_type_download_left_button     = Keep File
 unsupported_file_type_download_right_button    = Delete
 
 file_not_found_download_title                  = File not found
-file_not_found_download_message                = The ﬁle wasn’t found on the device
+file_not_found_download_message                = The file wasn’t found on the device
 file_not_found_download_right_button           = OK
 
 file_open_error_download_title                 = Unable to open
-file_open_error_download_message               = There is a problem opening {{name}}. Would you like to save the ﬁle or delete it?
+file_open_error_download_message               = There is a problem opening {{name}}. Would you like to save the file or delete it?
 file_open_error_download_left_button           = Keep File
 file_open_error_download_right_button          = Delete
 
-/*
- * File sizes
- */
-
+# File sizes
 byteUnit-B                    = B
 byteUnit-KB                   = KB
 byteUnit-MB                   = MB


### PR DESCRIPTION
Font used in the title doesn't help, but replacing replace ﬁle (3 character) with file (4 characters)
