### PR TITLE
Bug 942575 - Translate Greek keyboard menu labels

### DIFF
--- a/keyboard/layouts/el.js
+++ b/keyboard/layouts/el.js
@@ -1,6 +1,6 @@
 Keyboards.el = {
   label: 'Greek',
-  menuLabel: 'Greek',
+  menuLabel: 'Ελληνικό',
   imEngine: 'latin',
   types: ['text', 'url', 'email'],
   autoCorrectLanguage: 'el',
@@ -44,7 +44,7 @@ Keyboards.el = {
 // it would allow 160 characters in one message
 Keyboards['el-sms'] = {
   label: 'Greek SMS',
-  menuLabel: 'Greek SMS',
+  menuLabel: 'Ελληνικό για SMS',
   imEngine: 'latin',
   keys: [
     [


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=942575
