### PR TITLE
bug 908587 - stop audio preview when user clicks home button, r=arthur

### DIFF
--- a/apps/settings/js/sound.js
+++ b/apps/settings/js/sound.js
@@ -195,5 +195,7 @@
     }
     Settings.currentPanel = '#sound-selection';
   };
+  document.addEventListener('mozvisibilitychange', stopAudioPreview);
+
 })();
 


### PR DESCRIPTION
just a quick bandage for v1.1 per partner's request.
The real problem is fixed in later release.
