### PR TITLE
Bug 942720 - Fix test_settings_airplane_mode.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_airplane_mode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_airplane_mode.py
@@ -42,7 +42,7 @@ class TestAirplaneMode(GaiaTestCase):
         settings.toggle_airplane_mode()
 
         # Wait for wifi to be connected, because this takes the longest to connect after airplane mode is switched off
-        self.wait_for_condition(lambda s: 'Connected' in settings.wifi_menu_item_description, timeout=40)
+        self.wait_for_condition(lambda s: self.testvars['wifi']['ssid'] in settings.wifi_menu_item_description, timeout=40)
 
         # check Wifi is enabled
         self.assertTrue(self.data_layer.is_wifi_connected(self.testvars['wifi']), "WiFi was not connected after switching off Airplane mode")


### PR DESCRIPTION
The UI will 
1) display "Connected to {{ssid}}" in a short time, 
2) then change to "Connected to Mozilla Guest".

The gaia-ui-tests will pass the following statement at step 1 and failed the test:
  self.wait_for_condition(lambda s: 'Connected' in settings.wifi_menu_item_description, timeout=40)
