### PR TITLE
Bug 942220 - Add explicit wait in tap_back in contact_details.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/contact_details.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/contact_details.py
@@ -57,7 +57,9 @@ class ContactDetails(Base):
         return EditContact(self.marionette)
 
     def tap_back(self):
+        self.wait_for_element_displayed(*self._back_button_locator)
         self.marionette.find_element(*self._back_button_locator).tap()
+        self.wait_for_element_not_displayed(*self._back_button_locator)
         from gaiatest.apps.contacts.app import Contacts
         return Contacts(self.marionette)
 


### PR DESCRIPTION
I added a wait before tapping the back button because I ran <code>test_edit_contact.py</code> many times and I noticed that sometimes that button is pressed really quick, so we can't actually see the moment when it does it. Instead of <code>self.wait_for_element_not_displayed(_self._back_button_locator)</code> I could add <code>self.wait_for_condition(lambda m: m.find_element(_self._back_button_locator).location['x'] == 320)</code>
Let me know which option you think is the best. Thanks!
