### PR TITLE
Bug 932240 - Test browser https auth login

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/browser/regions/http_authenticate.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/browser/regions/http_authenticate.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.by import By
+
+from gaiatest.apps.base import Base
+
+
+class AuthenticationDialog(Base):
+
+    _auth_dialog_locator = (By.ID, 'http-authentication-dialog')
+
+    _username_input_locator = (By.ID, 'http-authentication-username')
+    _password_input_locator = (By.ID, 'http-authentication-password')
+    _sign_in_button_locator = (By.ID, 'http-authentication-ok')
+
+    def type_username(self, text):
+        username_input = self.marionette.find_element(*self._username_input_locator)
+        username_input.send_keys(text)
+
+    def type_password(self, text):
+        username_input = self.marionette.find_element(*self._password_input_locator)
+        username_input.send_keys(text)
+
+    def authenticate(self, username, password):
+        dialog = self.marionette.find_element(*self._auth_dialog_locator)
+        self.type_username(username)
+        self.type_password(password)
+
+        sign_in_button = self.marionette.find_element(*self._sign_in_button_locator)
+        sign_in_button.tap()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/manifest.ini
@@ -19,6 +19,8 @@ lan = true
 
 [test_browser_bookmark.py]
 
+[test_browser_https_auth.py]
+
 [test_browser_play_youtube_video.py]
 # Bug 877594 - Unable to play YouTube video in B2G desktop client
 fail-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/test_browser_https_auth.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/browser/test_browser_https_auth.py
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.by import By
+
+from gaiatest import GaiaTestCase
+from gaiatest.apps.browser.app import Browser
+from gaiatest.apps.browser.regions.http_authenticate import AuthenticationDialog
+
+
+class TestBrowserHttpsAuth(GaiaTestCase):
+
+    _login_link_locator = (By.LINK_TEXT, 'Basic Authentication')
+    _auth_dialog_locator = (By.ID, 'http-authentication-dialog')
+    _success_message_locator = (By.XPATH, '/html/body/p')
+
+    _success_redirect_url = 'http://mozqa.com/data/mozqa.com/http_auth/basic/'
+
+    def setUp(self):
+        GaiaTestCase.setUp(self)
+        self.connect_to_network()
+
+    def test_browser_https_auth_login(self):
+        browser = Browser(self.marionette)
+        browser.launch()
+
+        browser.go_to_url('http://mozqa.com/data/mozqa.com/http_auth/')
+
+        browser.switch_to_content()
+
+        self.wait_for_element_present(*self._login_link_locator)
+        login_link = self.marionette.find_element(*self._login_link_locator)
+        login_link.tap()
+
+        browser.switch_to_chrome()
+
+        auth_region = AuthenticationDialog(self.marionette)
+        auth_region.authenticate('mozilla', 'mozilla')
+
+        self.wait_for_condition(lambda m: browser.url == self._success_redirect_url)
+
+        browser.switch_to_content()
+
+        self.wait_for_element_displayed(*self._success_message_locator)
+        success_message = self.marionette.find_element(*self._success_message_locator)
+        self.assertEquals('Basic Authentication is successful!', success_message.text)


### PR DESCRIPTION
adds new test for https basic auth login

what the test does now:
1 - loads browser
2 - goes to http://mozqa.com/data/mozqa.com/http_auth/
3 - fills the browser login form
4 - fails on trying to see if the user is logged in (it probably is not the
right way)

waits for success page to be loaded to verify success

adds test to manifest.ini

refactoring for authentication_dialog region
- moves login items such as username and password input to authentication
  dialog region
- uses send_keys on inputs, instead of keyboard.send
- uses authenticate method from region
- tests if correct message is displayed on correct place using xpath

oops! parameters passed were not being used

Trying to find a pattern to write the test.
- Uses By instead of root_element to find elements on page.
- Uses more efficient and human-readable names for methods inside the
  region.
- Writes the funcional test on an inline way instead of using methods.

app region has to know its root element which is its own dialog

no need to look for auth dialog on test, use it on athenticate
