### PR TITLE
Bug 932753 - Update test_settings_do_not_track to use new Gecko pref helper methods

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -139,6 +139,7 @@ class GaiaApps(object):
 class GaiaData(object):
 
     def __init__(self, marionette, testvars=None):
+        self.apps = GaiaApps(marionette)
         self.marionette = marionette
         self.testvars = testvars or {}
         js = os.path.abspath(os.path.join(__file__, os.path.pardir, 'atoms', "gaia_data_layer.js"))
@@ -186,11 +187,16 @@ class GaiaData(object):
         assert result, "Unable to change setting with name '%s' to '%s'" % (name, value)
 
     def _get_pref(self, datatype, name):
-        return self.marionette.execute_script("return SpecialPowers.get%sPref('%s');" % (datatype, name), special_powers=True)
+        self.marionette.switch_to_frame()
+        pref = self.marionette.execute_script("return SpecialPowers.get%sPref('%s');" % (datatype, name), special_powers=True)
+        self.apps.switch_to_displayed_app()
+        return pref
 
     def _set_pref(self, datatype, name, value):
         value = json.dumps(value)
+        self.marionette.switch_to_frame()
         self.marionette.execute_script("SpecialPowers.set%sPref('%s', %s);" % (datatype, name, value), special_powers=True)
+        self.apps.switch_to_displayed_app()
 
     def get_bool_pref(self, name):
         """Returns the value of a Gecko boolean pref, which is different from a Gaia setting."""

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_do_not_track.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_do_not_track.py
@@ -26,22 +26,22 @@ class TestSettingsDoNotTrack(GaiaTestCase):
         do_not_track_settings.tap_disallow_tracking()
 
         # should be enabled
-        self.assertEqual(self.data_layer.get_setting('privacy.donottrackheader.enabled'), True)
+        self.assertEqual(self.data_layer.get_bool_pref('privacy.donottrackheader.enabled'), True)
         # should be 1
-        self.assertEqual(self.data_layer.get_setting('privacy.donottrackheader.value'), '1')
+        self.assertEqual(self.data_layer.get_int_pref('privacy.donottrackheader.value'), 1)
 
         # turn to "allow tracking"
         do_not_track_settings.tap_allow_tracking()
 
         # should be enabled
-        self.assertEqual(self.data_layer.get_setting('privacy.donottrackheader.enabled'), True)
+        self.assertEqual(self.data_layer.get_bool_pref('privacy.donottrackheader.enabled'), True)
         # should be 0
-        self.assertEqual(self.data_layer.get_setting('privacy.donottrackheader.value'), '0')
+        self.assertEqual(self.data_layer.get_int_pref('privacy.donottrackheader.value'), 0)
 
         # turn back to "no pref"
         do_not_track_settings.tap_do_not_have_pref_on_tracking()
 
         # should be disabled
-        self.assertEqual(self.data_layer.get_setting('privacy.donottrackheader.enabled'), False)
+        self.assertEqual(self.data_layer.get_bool_pref('privacy.donottrackheader.enabled'), False)
         # should be back to "no pref"
-        self.assertEqual(self.data_layer.get_setting('privacy.donottrackheader.value'), '-1')
+        self.assertEqual(self.data_layer.get_int_pref('privacy.donottrackheader.value'), -1)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_prefs.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_prefs.py
@@ -7,17 +7,15 @@ from gaiatest import GaiaTestCase
 
 class TestPrefs(GaiaTestCase):
 
-    def test_get_set_bool_pref(self):
-        self.data_layer.set_bool_pref('gaiauitest.pref.enabled', True)
-        test_pref = self.data_layer.get_bool_pref('gaiauitest.pref.enabled')
-        self.assertEquals(test_pref, True)
-
     def test_get_set_int_pref(self):
         self.data_layer.set_int_pref('gaiauitest.pref.int_value', 19)
         test_pref = self.data_layer.get_int_pref('gaiauitest.pref.int_value')
         self.assertEquals(test_pref, 19)
 
-    def test_get_set_char_pref(self):
-        self.data_layer.set_char_pref('gaiauitest.pref.char_value', 'bob')
-        test_pref = self.data_layer.get_char_pref('gaiauitest.pref.char_value')
-        self.assertEquals(test_pref, 'bob')
+    def test_get_set_bool_pref_from_within_an_app(self):
+        from gaiatest.apps.settings.app import Settings
+        settings = Settings(self.marionette)
+        settings.launch()
+        self.data_layer.set_bool_pref('gaiauitest.pref.enabled', True)
+        test_pref = self.data_layer.get_bool_pref('gaiauitest.pref.enabled')
+        self.assertEquals(test_pref, True)


### PR DESCRIPTION
This also fixes a problem with the get_pref and set_pref methods that wasn't caught by the initial unit tests.
