### PR TITLE
Bug 943183 - [Messages] the bad recipient markers should not be absolute...

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -834,8 +834,9 @@ generateHeightRule() (in ThreadUI/thread_ui.js) will create:
 }
 
 .recipient[contenteditable=false].attention {
-  padding-left: 1.2rem;
+  position: relative;
 
+  padding-left: 1.2rem;
   border: 0.1rem solid #b90000;
 
   background: transparent;


### PR DESCRIPTION
...ly positioned to a non-scrolled ancestor r=schung
- Add "position: relative" for the absolutely positioned marker's nearest
  ancestor.
