### PR TITLE
Bug 936641 - [Messages][Drafts] Create message drafts upon user interaction

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -16,3 +16,4 @@ shared/js/setImmediate.js
 apps/gallery/test/unit/setImmediate_test.js
 apps/wappush/js/ext/**
 apps/keyboard/js/imes/jsavrophonetic/jsavrophonetic.js
+apps/sms/js/is-equal.js

--- a/apps/sms/js/desktop-only/mobilemessage.js
+++ b/apps/sms/js/desktop-only/mobilemessage.js
@@ -245,35 +245,35 @@
     var d1, d2, d3, d4, d5;
     d1 = new Draft({
       recipients: ['555', '666'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 1,
       threadId: 42,
       type: 'sms'
     });
     d2 = new Draft({
       recipients: ['555'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 2,
       threadId: 42,
       type: 'sms'
     });
     d3 = new Draft({
       recipients: ['555', '222'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 3,
       threadId: 1,
       type: 'sms'
     });
     d4 = new Draft({
       recipients: ['555', '333'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 4,
       threadId: 2,
       type: 'sms'
     });
     d5 = new Draft({
       recipients: ['555', '444'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 5,
       threadId: null,
       type: 'sms'

--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -1,7 +1,41 @@
-/*global asyncStorage */
+/*global asyncStorage, Utils, isEqual */
 (function(exports) {
   'use strict';
   var draftIndex = new Map();
+
+  /**
+   * Checks if two drafts are distinct based on
+   * the equality of the following fields:
+   *
+   * recipients
+   * content
+   * subject
+   *
+   * @param {Draft} a draft to check
+   * @param {Draft} b draft to check
+   *
+   * @return {Boolean} true if the drafts differ on those fields
+   */
+  function isDistinct(a, b) {
+    if (!a || !b) {
+      // if either or both are null
+      return true;
+    } else {
+      // if any recipient doesn't match
+      if (a.recipients.length !== b.recipients.length) {
+        return true;
+      } else {
+        for (var i = 0; i < a.recipients.length; i++) {
+          if (!Utils.probablyMatches(a.recipients[i], b.recipients[i])) {
+            return true;
+          }
+        }
+      }
+      // else check whether content or subject match
+      return !isEqual(a.content, b.content) ||
+        a.subject !== b.subject;
+    }
+  }
 
   /**
    * Drafts
@@ -31,14 +65,23 @@
     add: function(draft) {
       var id;
       var thread;
+      var stored;
+
       if (draft) {
         if (!(draft instanceof Draft)) {
           draft = new Draft(draft);
         }
         id = draft.threadId || null;
         thread = draftIndex.get(id) || [];
-        thread.push(draft);
-        draftIndex.set(id, thread);
+        stored = thread[thread.length > 1 ? thread.length - 1 : 0];
+
+        // If the new draft is distinct from the stored one
+        // then push and save a new draft
+        if (isDistinct(stored, draft)) {
+          thread.push(draft);
+          draftIndex.set(id, thread);
+          this.store();
+        }
       }
       return this;
     },
@@ -175,6 +218,7 @@
     var draft = opts || {};
     this.recipients = draft.recipients || [];
     this.content = draft.content || [];
+    this.subject = draft.subject || '';
     this.timestamp = draft.timestamp || Date.now();
     this.threadId = draft.threadId || null;
     this.type = draft.type;

--- a/apps/sms/js/is-equal.js
+++ b/apps/sms/js/is-equal.js
@@ -1,0 +1,282 @@
+// THIS FILE IS NOT SUBJECT TO CHANGE
+
+(function(exports) {
+/**
+ * Lo-Dash 2.3.0 (Custom Build) <http://lodash.com/>
+ * Build: `lodash modularize modern exports="npm" -o ./npm/`
+ * Copyright 2012-2013 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.5.2 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <http://lodash.com/license>
+ */
+
+var forIn = function(collection, callback, thisArg) {
+  var index, iterable = collection, result = iterable;
+  if (!iterable) return result;
+  if (!objectTypes[typeof iterable]) return result;
+  
+  if (thisArg) {
+    callback = callback.bind(thisArg);
+  }
+
+  for (index in iterable) {
+    if (callback(iterable[index], index, collection) === false) return result;
+  }
+  return result
+};
+
+var arrayPool = [];
+var maxPoolSize = 40;
+
+/**
+ * Gets an array from the array pool or creates a new one if the pool is empty.
+ *
+ * @private
+ * @returns {Array} The array from the pool.
+ */
+function getArray() {
+  return arrayPool.pop() || [];
+}
+
+/**
+ * Releases the given array back to the array pool.
+ *
+ * @private
+ * @param {Array} [array] The array to release.
+ */
+function releaseArray(array) {
+  array.length = 0;
+  if (arrayPool.length < maxPoolSize) {
+    arrayPool.push(array);
+  }
+}
+
+
+/** Used to determine if values are of the language type Object */
+var objectTypes = {
+  'boolean': false,
+  'function': true,
+  'object': true,
+  'number': false,
+  'string': false,
+  'undefined': false
+};
+
+/**
+ * Checks if `value` is a function.
+ *
+ * @static
+ * @memberOf _
+ * @category Objects
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if the `value` is a function, else `false`.
+ * @example
+ *
+ * _.isFunction(_);
+ * // => true
+ */
+function isFunction(value) {
+  return typeof value == 'function';
+}
+
+
+
+
+
+/** `Object#toString` result shortcuts */
+var argsClass = '[object Arguments]',
+    arrayClass = '[object Array]',
+    boolClass = '[object Boolean]',
+    dateClass = '[object Date]',
+    numberClass = '[object Number]',
+    objectClass = '[object Object]',
+    regexpClass = '[object RegExp]',
+    stringClass = '[object String]';
+
+/** Used for native method references */
+var objectProto = Object.prototype;
+
+/** Used to resolve the internal [[Class]] of values */
+var toString = objectProto.toString;
+
+/** Native method shortcuts */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * The base implementation of `_.isEqual`, without support for `thisArg` binding,
+ * that allows partial "_.where" style comparisons.
+ *
+ * @private
+ * @param {*} a The value to compare.
+ * @param {*} b The other value to compare.
+ * @param {Function} [callback] The function to customize comparing values.
+ * @param {Function} [isWhere=false] A flag to indicate performing partial comparisons.
+ * @param {Array} [stackA=[]] Tracks traversed `a` objects.
+ * @param {Array} [stackB=[]] Tracks traversed `b` objects.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ */
+function baseIsEqual(a, b, callback, isWhere, stackA, stackB) {
+  // used to indicate that when comparing objects, `a` has at least the properties of `b`
+  if (callback) {
+    var result = callback(a, b);
+    if (typeof result != 'undefined') {
+      return !!result;
+    }
+  }
+  // exit early for identical values
+  if (a === b) {
+    // treat `+0` vs. `-0` as not equal
+    return a !== 0 || (1 / a == 1 / b);
+  }
+  var type = typeof a,
+      otherType = typeof b;
+
+  // exit early for unlike primitive values
+  if (a === a &&
+      !(a && objectTypes[type]) &&
+      !(b && objectTypes[otherType])) {
+    return false;
+  }
+  // exit early for `null` and `undefined` avoiding ES3's Function#call behavior
+  // http://es5.github.io/#x15.3.4.4
+  if (a == null || b == null) {
+    return a === b;
+  }
+  // compare [[Class]] names
+  var className = toString.call(a),
+      otherClass = toString.call(b);
+
+  if (className == argsClass) {
+    className = objectClass;
+  }
+  if (otherClass == argsClass) {
+    otherClass = objectClass;
+  }
+  if (className != otherClass) {
+    return false;
+  }
+  switch (className) {
+    case boolClass:
+    case dateClass:
+      // coerce dates and booleans to numbers, dates to milliseconds and booleans
+      // to `1` or `0` treating invalid dates coerced to `NaN` as not equal
+      return +a == +b;
+
+    case numberClass:
+      // treat `NaN` vs. `NaN` as equal
+      return (a != +a)
+        ? b != +b
+        // but treat `+0` vs. `-0` as not equal
+        : (a == 0 ? (1 / a == 1 / b) : a == +b);
+
+    case regexpClass:
+    case stringClass:
+      // coerce regexes to strings (http://es5.github.io/#x15.10.6.4)
+      // treat string primitives and their corresponding object instances as equal
+      return a == String(b);
+  }
+  var isArr = className == arrayClass;
+  if (!isArr) {
+    // unwrap any `lodash` wrapped values
+    var aWrapped = hasOwnProperty.call(a, '__wrapped__'),
+        bWrapped = hasOwnProperty.call(b, '__wrapped__');
+
+    if (aWrapped || bWrapped) {
+      return baseIsEqual(aWrapped ? a.__wrapped__ : a, bWrapped ? b.__wrapped__ : b, callback, isWhere, stackA, stackB);
+    }
+    // exit for functions and DOM nodes
+    if (className != objectClass) {
+      return false;
+    }
+    // in older versions of Opera, `arguments` objects have `Array` constructors
+    var ctorA = a.constructor,
+        ctorB = b.constructor;
+
+    // non `Object` object instances with different constructors are not equal
+    if (ctorA != ctorB &&
+          !(isFunction(ctorA) && ctorA instanceof ctorA && isFunction(ctorB) && ctorB instanceof ctorB) &&
+          ('constructor' in a && 'constructor' in b)
+        ) {
+      return false;
+    }
+  }
+  // assume cyclic structures are equal
+  // the algorithm for detecting cyclic structures is adapted from ES 5.1
+  // section 15.12.3, abstract operation `JO` (http://es5.github.io/#x15.12.3)
+  var initedStack = !stackA;
+  stackA || (stackA = getArray());
+  stackB || (stackB = getArray());
+
+  var length = stackA.length;
+  while (length--) {
+    if (stackA[length] == a) {
+      return stackB[length] == b;
+    }
+  }
+  var size = 0;
+  result = true;
+
+  // add `a` and `b` to the stack of traversed objects
+  stackA.push(a);
+  stackB.push(b);
+
+  // recursively compare objects and arrays (susceptible to call stack limits)
+  if (isArr) {
+    length = a.length;
+    size = b.length;
+
+    // compare lengths to determine if a deep comparison is necessary
+    result = size == a.length;
+    if (!result && !isWhere) {
+      return result;
+    }
+    // deep compare the contents, ignoring non-numeric properties
+    while (size--) {
+      var index = length,
+          value = b[size];
+
+      if (isWhere) {
+        while (index--) {
+          if ((result = baseIsEqual(a[index], value, callback, isWhere, stackA, stackB))) {
+            break;
+          }
+        }
+      } else if (!(result = baseIsEqual(a[size], value, callback, isWhere, stackA, stackB))) {
+        break;
+      }
+    }
+    return result;
+  }
+  // deep compare objects using `forIn`, instead of `forOwn`, to avoid `Object.keys`
+  // which, in this case, is more costly
+  forIn(b, function(value, key, b) {
+    if (hasOwnProperty.call(b, key)) {
+      // count the number of properties.
+      size++;
+      // deep compare each property value.
+      return (result = hasOwnProperty.call(a, key) && baseIsEqual(a[key], value, callback, isWhere, stackA, stackB));
+    }
+  });
+
+  if (result && !isWhere) {
+    // ensure both objects have the same number of properties
+    forIn(a, function(value, key, a) {
+      if (hasOwnProperty.call(a, key)) {
+        // `size` will be `-1` if `a` has more properties than `b`
+        return (result = --size > -1);
+      }
+    });
+  }
+  if (initedStack) {
+    releaseArray(stackA);
+    releaseArray(stackB);
+  }
+  return result;
+}
+
+
+exports.isEqual = function isEqual(a, b, callback) {
+  return baseIsEqual(a, b, callback);
+};
+
+}(this));

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -117,6 +117,14 @@ var MessageManager = {
     if (!ThreadListUI.fullHeight || ThreadListUI.fullHeight === 0) {
       ThreadListUI.fullHeight = ThreadListUI.container.offsetHeight;
     }
+    // If we leave the app and are in a thread or compose window
+    // save a message draft if necessary
+    if (document.hidden) {
+      var hash = window.location.hash;
+      if (hash === '#new' || hash.startsWith('#thread=')) {
+        ThreadUI.saveMessageDraft();
+      }
+    }
   },
 
   slide: function mm_slide(direction, callback) {

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -28,6 +28,7 @@ var lazyLoadFiles = [
   'js/compose.js',
   'js/waiting_screen.js',
   'js/utils.js',
+  'js/is-equal.js',
   'js/fixed_header.js',
   'js/time_headers.js',
   'js/activity_picker.js',

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -708,19 +708,52 @@ var ThreadUI = global.ThreadUI = {
       this.stopRendering();
 
       var currentActivity = ActivityHandler.currentActivity.new;
+      var discard;
+
       if (currentActivity) {
         currentActivity.postResult({ success: true });
         ActivityHandler.resetActivity();
         return;
       }
-      if (Compose.isEmpty()) {
-        window.location.hash = '#thread-list';
-        return;
-      }
-      if (window.confirm(navigator.mozL10n.get('discard-sms'))) {
+
+      discard = (function() {
         this.cleanFields(true);
         window.location.hash = '#thread-list';
+      }).bind(this);
+
+      if (Compose.isEmpty()) {
+        discard();
+        return;
       }
+
+      var options = {
+        items: [
+          {
+            l10nId: 'save-as-draft',
+            method: function onsave() {
+              // When Draft saving is implemented,
+              // update this handler to perform that operation.
+              var recipients = this.recipients.numbers;
+              var content = Compose.getContent();
+              var timestamp = Date.now();
+
+              console.log( recipients, content );
+
+              discard();
+            }.bind(this)
+          },
+          {
+            l10nId: 'discard-message',
+            method: discard
+          },
+          {
+            l10nId: 'cancel'
+          }
+        ]
+      };
+
+      new OptionMenu(options).show();
+
     }).bind(this);
 
     // We're waiting for the keyboard to disappear before animating back

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -721,7 +721,12 @@ var ThreadUI = global.ThreadUI = {
         window.location.hash = '#thread-list';
       }).bind(this);
 
-      if (Compose.isEmpty()) {
+      // TODO Add comment about assimilation above on line #183?
+      // Need to assimilate recipients in order to check if any entered
+      this.assimilateRecipients();
+
+      if (Compose.isEmpty() && this.recipients.length === 0) {
+        // TODO Also check for empty subject
         discard();
         return;
       }
@@ -731,14 +736,7 @@ var ThreadUI = global.ThreadUI = {
           {
             l10nId: 'save-as-draft',
             method: function onsave() {
-              // When Draft saving is implemented,
-              // update this handler to perform that operation.
-              var recipients = this.recipients.numbers;
-              var content = Compose.getContent();
-              var timestamp = Date.now();
-
-              console.log( recipients, content );
-
+              this.saveMessageDraft();
               discard();
             }.bind(this)
           },
@@ -2490,6 +2488,47 @@ var ThreadUI = global.ThreadUI = {
     if (window.location.hash.substr(0, 8) === '#thread=') {
       ThreadUI.updateHeaderData();
     }
+  },
+
+  saveMessageDraft: function thui_saveMessageDraft() {
+    var draft, recipients, content, timestamp, threadId, type;
+
+    content = Compose.getContent();
+    timestamp = Date.now();
+    type = Compose.type;
+
+    // TODO Also store subject
+
+    if (Threads.active) {
+      recipients = Threads.active.participants;
+      threadId = Threads.currentId;
+    } else {
+      recipients = this.recipients.numbers;
+
+      // Pick out the threadId that matches
+      // all the recipients in this draft.
+      Threads.forEach(function(t) {
+        var p = Threads.get(t.id).participants;
+        for (var i = 0; i < p.length; i++) {
+          if (Utils.probablyMatches(p[i], recipients[i])) {
+            threadId = t.id;
+            break;
+          }
+        }
+      });
+      threadId = threadId || null;
+    }
+
+    var draft = new Draft({
+      recipients: recipients,
+      content: content,
+      timestamp: timestamp,
+      threadId: threadId,
+      type: type
+    });
+
+    Drafts.add(draft);
+
   }
 };
 

--- a/apps/sms/js/threads.js
+++ b/apps/sms/js/threads.js
@@ -49,6 +49,11 @@
     clear: function() {
       threads = new Map();
     },
+    forEach: function(callback) {
+      threads.forEach(function(v, k) {
+        callback(v, k);
+      });
+    },
     get size() {
       // support: gecko 18 - size might be a function
       if (typeof threads.size === 'function') {

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -247,6 +247,10 @@
     probablyMatches: function ut_probablyMatches(a, b) {
       var service = navigator.mozPhoneNumberService;
 
+      if (typeof a !== 'string' || typeof b !== 'string') {
+        return false;
+      }
+
       if (service && service.normalize) {
         a = service.normalize(a);
         b = service.normalize(b);

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -71,6 +71,8 @@ unknown-contact = Unknown
 carrier-unknown = Carrier unknown
 
 # Modal Dialogs
+save-as-draft               = Save as Draft
+discard-message             = Discard
 discard-sms                 = Are you sure you want to discard this message?
 discard-new-message         = Discard the message you're composing and open the new message?
 resend-confirmation         = The message could not be sent. Try again?

--- a/apps/sms/test/unit/drafts_test.js
+++ b/apps/sms/test/unit/drafts_test.js
@@ -2,45 +2,68 @@
 'use strict';
 
 requireApp('sms/js/drafts.js');
+requireApp('sms/js/is-equal.js');
+requireApp('sms/js/utils.js');
 require('/shared/js/async_storage.js');
 
 suite('Drafts', function() {
-  var d1, d2, d3, d4, d5;
+  var d1, d2, d3, d4, d5, d6, d7;
 
   suiteSetup(function() {
     d1 = new Draft({
       recipients: ['555', '666'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 1,
       threadId: 42,
+      subject: 'This is a subject',
       type: 'sms'
     });
     d2 = new Draft({
       recipients: ['555'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 2,
-      threadId: 42,
+      threadId: 44,
+      subject: 'This is a subject',
       type: 'sms'
     });
     d3 = new Draft({
       recipients: ['555', '222'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 3,
       threadId: 1,
+      subject: 'This is a subject',
       type: 'sms'
     });
     d4 = new Draft({
       recipients: ['555', '333'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 4,
       threadId: 2,
+      subject: 'This is a subject',
       type: 'sms'
     });
     d5 = new Draft({
       recipients: ['555', '444'],
-      content: 'This is a draft message',
+      content: ['This is a draft message'],
       timestamp: 5,
       threadId: null,
+      subject: 'This is a subject',
+      type: 'sms'
+    });
+    d6 = new Draft({
+      recipients: ['555', '444'],
+      content: ['This is a different draft message'],
+      timestamp: 5,
+      threadId: null,
+      subject: 'This is a subject',
+      type: 'sms'
+    });
+    d7 = new Draft({
+      recipients: ['555', '444'],
+      content: ['This is a draft message'],
+      timestamp: 5,
+      threadId: null,
+      subject: 'This is a different subject',
       type: 'sms'
     });
   });
@@ -70,16 +93,8 @@ suite('Drafts', function() {
       Drafts.byId(d1.threadId).forEach(function(e) {
         added.push(e);
       });
-      assert.deepEqual(
-        added,
-        [d1],
-        'Correct draft added at thread id in index');
-      assert.equal(
-        Drafts.byId(d1.threadId).length,
-        1,
-        'One draft added to correct thread id in index'
-      );
-
+      assert.deepEqual(added, [d1]);
+      assert.equal(Drafts.byId(d1.threadId).length, 1);
     });
 
     test('add second draft', function() {
@@ -88,15 +103,8 @@ suite('Drafts', function() {
       Drafts.byId(d2.threadId).forEach(function(e) {
         added.push(e);
       });
-      assert.deepEqual(
-        added,
-        [d1, d2],
-        'Correct drafts added at thread id in index');
-      assert.equal(
-        Drafts.byId(d2.threadId).length,
-        2,
-        'Two drafts added to correct thread id in index'
-      );
+      assert.deepEqual(added, [d2]);
+      assert.equal(Drafts.byId(d2.threadId).length, 1);
     });
 
   });
@@ -115,26 +123,17 @@ suite('Drafts', function() {
 
     test('delete first draft', function() {
       Drafts.delete(d1);
-      assert.equal(
-        Drafts.byId(d1.threadId).length,
-        1,
-        'Delete first draft from thread id 42');
+      assert.equal(Drafts.byId(d1.threadId).length, 0);
     });
 
     test('delete second draft', function() {
       Drafts.delete(d2);
-      assert.equal(
-        Drafts.byId(d2.threadId).length,
-        0,
-        'Delete second draft from thread id 42');
+      assert.equal(Drafts.byId(d2.threadId).length, 0);
     });
 
     test('delete third draft', function() {
       Drafts.delete(d3);
-      assert.equal(
-        Drafts.byId(d3.threadId).length,
-        0,
-        'Delete draft from thread id 1');
+      assert.equal(Drafts.byId(d3.threadId).length, 0);
     });
 
   });
@@ -156,22 +155,22 @@ suite('Drafts', function() {
 
     test('get drafts for id 42', function() {
       list = Drafts.byId(42);
-      assert.equal(list.length, 2, 'Two drafts returned for id 42');
+      assert.equal(list.length, 1);
     });
 
     test('get drafts for id 1', function() {
       list = Drafts.byId(1);
-      assert.equal(list.length, 1, 'One drafts returned for id 1');
+      assert.equal(list.length, 1);
     });
 
     test('get drafts for null id', function() {
       list = Drafts.byId(null);
-      assert.equal(list.length, 1, 'One drafts returned for null id');
+      assert.equal(list.length, 1);
     });
 
     test('get drafts for non-existent id', function() {
       list = Drafts.byId(10);
-      assert.equal(list.length, 0, 'No drafts returned for id 10');
+      assert.equal(list.length, 0);
     });
 
   });
@@ -190,9 +189,9 @@ suite('Drafts', function() {
       var list1 = Drafts.byId(42);
       var list2 = Drafts.byId(1);
       var list3 = Drafts.byId(2);
-      assert.equal(list1.length, 0, 'No drafts for id 42');
-      assert.equal(list2.length, 0, 'No drafts for id 1');
-      assert.equal(list3.length, 0, 'No drafts for id 2');
+      assert.equal(list1.length, 0);
+      assert.equal(list2.length, 0);
+      assert.equal(list3.length, 0);
     });
 
   });
@@ -211,17 +210,17 @@ suite('Drafts', function() {
 
     test('length of new Drafts.List', function() {
       var list = new Drafts.List();
-      assert.equal(list.length, 0, 'New Drafts.List has length of 0');
+      assert.equal(list.length, 0);
     });
 
     test('length of populated Drafts.List', function() {
       var list = new Drafts.List([d1, d2, d3, d4]);
-      assert.equal(list.length, 4, 'Drafts.List with four drafts has length 4');
+      assert.equal(list.length, 4);
     });
 
   });
 
-  suite('forEach >', function() {
+  suite('forEach() >', function() {
     var spy;
     var list;
 
@@ -232,11 +231,11 @@ suite('Drafts', function() {
     test('callback function on each draft in Drafts.List', function() {
       list = new Drafts.List([d1, d2, d3, d4]);
       list.forEach(spy);
-      assert.equal(spy.callCount, 4, 'callback called four times');
-      assert.deepEqual(spy.args[0][0], d1, 'callback called with d1');
-      assert.deepEqual(spy.args[1][0], d2, 'callback called with d2');
-      assert.deepEqual(spy.args[2][0], d3, 'callback called with d3');
-      assert.deepEqual(spy.args[3][0], d4, 'callback called with d4');
+      assert.equal(spy.callCount, 4);
+      assert.deepEqual(spy.args[0][0], d1);
+      assert.deepEqual(spy.args[1][0], d2);
+      assert.deepEqual(spy.args[2][0], d3);
+      assert.deepEqual(spy.args[3][0], d4);
     });
 
   });
@@ -251,75 +250,99 @@ suite('Drafts', function() {
 
     test('Draft from empty object', function() {
       draft = new Draft([]);
-      assert.deepEqual(
-        draft.recipients,
-        [],
-        'default recipients is empty String'
-      );
-      assert.deepEqual(draft.content, [], 'default content is empty Array');
-      assert.equal(draft.threadId, null, 'default threadId is null');
+      assert.deepEqual(draft.recipients, []);
+      assert.deepEqual(draft.content, []);
+      assert.equal(draft.threadId, null);
     });
 
     test('Draft from Draft object', function() {
       draft = new Draft(d1);
-      assert.deepEqual(
-        draft.recipients,
-        ['555', '666'],
-        'recipients is [\'555\', \'666\']'
-      );
-      assert.deepEqual(
-        draft.content,
-        'This is a draft message',
-        'content is \'This is a draft message\''
-      );
-      assert.equal(draft.timestamp, 1, 'timestamp is 1');
-      assert.equal(draft.threadId, 42, 'timestamp is 42');
-      assert.equal(draft.type, 'sms', 'timestamp is \'sms\'');
+      assert.deepEqual(draft.recipients, ['555', '666']);
+      assert.deepEqual(draft.content, ['This is a draft message']);
+      assert.equal(draft.timestamp, 1);
+      assert.equal(draft.threadId, 42);
+      assert.equal(draft.type, 'sms');
     });
 
   });
 
   suite('Storage', function() {
-    var stored = new Map();
+    var spy;
 
-    setup(function() {
+    suiteSetup(function() {
       Drafts.clear();
-      Drafts.add(d1);
-      Drafts.add(d2);
-      Drafts.add(d5);
-
-      stored.set(d1.threadId, d1);
-      stored.set(d5.threadId, d5);
+      spy = sinon.spy(Drafts, 'store');
     });
 
-    teardown(function() {
+    suiteTeardown(function() {
       Drafts.clear();
       asyncStorage.removeItem('draft index');
     });
 
-    test('Store drafts', function() {
-      Drafts.store();
-      asyncStorage.getItem('draft index', function(value) {
-        var retrieved = new Map(value);
-        assert.deepEqual(retrieved.get(null), [d5]);
-        assert.deepEqual(retrieved.get(42), [d1, d2]);
-      });
+    setup(function() {
+      spy.reset();
+    });
+
+    test('Store fresh drafts', function() {
+      Drafts.add(d1);
+      Drafts.add(d2);
+      Drafts.add(d5);
+
+      assert.isTrue(spy.calledThrice);
+
+      // TODO test that asyncstorage has the correct drafts?
+    });
+
+    test('Store duplicate drafts', function() {
+      Drafts.add(d1);
+      Drafts.add(d2);
+      Drafts.add(d5);
+
+      assert.isFalse(spy.called);
+
+      // TODO test that asyncstorage still has the correct drafts?
+    });
+
+    test('Store draft with distinct content', function() {
+      Drafts.add(d6);
+
+      assert.isTrue(spy.called);
+
+      // TODO test that asyncstorage still has the correct drafts?
+    });
+
+    test('Store draft with distinct subject', function() {
+      Drafts.add(d7);
+
+      assert.isTrue(spy.called);
+
+      // TODO test that asyncstorage still has the correct drafts?
     });
 
     test('Load drafts', function() {
-      var retrieved = [];
-      asyncStorage.setItem('draft index', [...stored], function() {
-        Drafts.load();
+      var loaded = [];
+      Drafts.load();
+
+      assert.equal(Drafts.byId(42).length, 1);
+      Drafts.byId(42).forEach(function(elem) {
+        assert.equal(elem, d1);
       });
+
+      assert.equal(Drafts.byId(44).length, 1);
+      Drafts.byId(44).forEach(function(elem) {
+        assert.equal(elem, d2);
+      });
+
+      assert.equal(Drafts.byId(null).length, 3);
 
       Drafts.byId(null).forEach(function(elem) {
-        assert.equal(elem, d5);
+        loaded.push(elem);
       });
+      assert.equal(loaded[0], d5);
+      assert.equal(loaded[1], d6);
+      assert.equal(loaded[2], d7);
 
-      Drafts.byId(42).forEach(function(elem) {
-        retrieved.push(elem);
-      });
-      assert.deepEqual(retrieved, [d1, d2]);
+      assert.equal(Drafts.byId(5).length, 0);
     });
 
   });

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -6,6 +6,7 @@
 
 requireApp('sms/js/utils.js');
 requireApp('sms/js/time_headers.js');
+requireApp('sms/js/drafts.js');
 requireApp('sms/test/unit/utils_mockup.js');
 requireApp('sms/test/unit/mock_messages.js');
 
@@ -616,4 +617,47 @@ suite('message_manager.js >', function() {
       });
     });
   });
+
+  suite('onVisibilityChange() >', function() {
+    var isDocumentHidden;
+    var spy;
+
+    suiteSetup(function() {
+      spy = sinon.spy(ThreadUI, 'saveMessageDraft');
+      Object.defineProperty(document, 'hidden', {
+        configurable: true,
+        get: function() {
+          return isDocumentHidden;
+        }
+      });
+    });
+
+    suiteTeardown(function() {
+      delete document.hidden;
+    });
+
+    teardown(function() {
+      isDocumentHidden = false;
+    });
+
+    test('draft save on visibility change from new message', function() {
+      window.location.hash = '#new';
+      isDocumentHidden = true;
+      MessageManager.onVisibilityChange();
+
+      assert.isTrue(spy.calledOnce);
+      assert.equal(ThreadUI.recipients.length, 0);
+    });
+
+    test('draft save on visibility change from thread', function() {
+      window.location.hash = '#thread-1';
+      isDocumentHidden = true;
+      MessageManager.onVisibilityChange();
+
+      assert.isTrue(spy.calledOnce);
+      assert.equal(ThreadUI.recipients.length, 0);
+    });
+
+  });
+
 });

--- a/apps/sms/test/unit/mock_thread_list_ui.js
+++ b/apps/sms/test/unit/mock_thread_list_ui.js
@@ -5,6 +5,7 @@
 var MockThreadListUI = {
   count: 0,
   inEditMode: false,
+  container: document.createElement('div'),
   init: function() {},
   updateThread: function() {},
   getAllInputs: function() {},

--- a/apps/sms/test/unit/mock_thread_ui.js
+++ b/apps/sms/test/unit/mock_thread_ui.js
@@ -82,6 +82,7 @@ var MockThreadUI = {
   promptContact: function() {},
   groupView: function() {},
   prompt: function() {},
+  saveMessageDraft: function() {},
   onCreateContact: function() {},
   isShowSendMessageErrorCalledTimes: 0,
   showSendMessageError: function() {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3703,21 +3703,105 @@ suite('thread_ui.js >', function() {
     });
   });
 
-  suite('back action', function() {
-    setup(function() {
-      this.sinon.stub(ThreadUI, 'isKeyboardDisplayed').returns(false);
-      this.sinon.stub(ThreadUI, 'stopRendering');
+  suite('Back button behaviour', function() {
+
+    suite('During activity', function() {
+      setup(function() {
+        this.sinon.stub(ThreadUI, 'isKeyboardDisplayed').returns(false);
+        this.sinon.stub(ThreadUI, 'stopRendering');
+      });
+
+      test('Call postResult when there is an activity', function() {
+        var mockActivity = {
+          postResult: sinon.stub()
+        };
+
+        ActivityHandler.currentActivity.new = mockActivity;
+
+        ThreadUI.back();
+        assert.isTrue(mockActivity.postResult.called);
+      });
     });
 
-    test('call postResult when there is an activity', function() {
-      var mockActivity = {
-        postResult: sinon.stub()
-      };
+    suite('From new message', function() {
+      var showCalled = false;
 
-      ActivityHandler.currentActivity.new = mockActivity;
+      setup(function() {
+        showCalled = false;
+        this.sinon.stub(window, 'OptionMenu').returns({
+          show: function() {
+            showCalled = true;
+          },
+          hide: function() {}
+        });
 
-      ThreadUI.back();
-      assert.isTrue(mockActivity.postResult.called);
+        this.sinon.stub(ThreadUI, 'isKeyboardDisplayed').returns(false);
+        this.sinon.stub(ThreadUI, 'stopRendering');
+
+        window.location.hash = '#new';
+
+        ThreadUI.recipients.add({
+          number: '999'
+        });
+
+        Compose.append('foo');
+      });
+
+      test('Displays OptionMenu prompt', function() {
+        ThreadUI.back();
+
+        assert.isTrue(OptionMenu.calledOnce);
+        assert.isTrue(showCalled);
+
+        var items = OptionMenu.args[0][0].items;
+
+        // Assert the correct menu items were displayed
+        assert.equal(items[0].l10nId, 'save-as-draft');
+        assert.equal(items[1].l10nId, 'discard-message');
+        assert.equal(items[2].l10nId, 'cancel');
+      });
+
+      suite('OptionMenu operations', function() {
+        test('Save as Draft', function() {
+          ThreadUI.back();
+
+          // Yes, seriously.
+          // This will be replaced when the real Draft save mechanism
+          // is implemented. Use a stub to prevent from actually logging
+          // to the console here. This is obviously restored after the
+          // test is completed.
+          this.sinon.stub(console, 'log');
+
+          OptionMenu.args[0][0].items[0].method();
+
+          // We just want to ensure that the recipients and composer
+          // contents have been collected before the new message is
+          // discarded.
+          sinon.assert.calledWithMatch(console.log, ['999'], ['foo']);
+
+          // Nothing actually happens yet, but when Draft saving is ready,
+          // this will be updated to assert that the recipients and
+          // contents of the composer were passed as arguments to the
+          // draft save mechanism.
+          assert.ok('Draft Save Mechanism');
+
+
+          // These things will be true
+          assert.equal(window.location.hash, '#thread-list');
+          assert.equal(ThreadUI.recipients.length, 0);
+          assert.equal(Compose.getContent(), '');
+        });
+
+        test('Discard', function() {
+          ThreadUI.back();
+
+          OptionMenu.args[0][0].items[1].method();
+
+          assert.equal(window.location.hash, '#thread-list');
+          assert.equal(ThreadUI.recipients.length, 0);
+          assert.equal(Compose.getContent(), '');
+        });
+      });
     });
   });
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -18,8 +18,12 @@ if (!navigator.mozContacts) {
 requireApp('sms/js/compose.js');
 requireApp('sms/js/threads.js');
 requireApp('sms/js/thread_ui.js');
+requireApp('sms/js/thread_list_ui.js');
+requireApp('sms/js/drafts.js');
+requireApp('sms/js/is-equal.js');
 requireApp('sms/js/utils.js');
 requireApp('sms/js/message_manager.js');
+require('/shared/js/async_storage.js');
 
 requireApp('sms/test/unit/mock_time_headers.js');
 requireApp('sms/test/unit/mock_alert.js');
@@ -3703,7 +3707,49 @@ suite('thread_ui.js >', function() {
     });
   });
 
-  suite('Back button behaviour', function() {
+  suite('saveMessageDraft() > ', function() {
+    var spy, arg;
+
+    setup(function() {
+      window.location.hash = '#new';
+      spy = this.sinon.spy(Drafts, 'add');
+
+      ThreadUI.recipients.add({
+        number: '999'
+      });
+
+      Compose.append('foo');
+    });
+
+    test('has entered content and recipients', function() {
+      ThreadUI.saveMessageDraft();
+      arg = spy.firstCall.args[0];
+
+      assert.deepEqual(arg.recipients, ['999']);
+      assert.deepEqual(arg.content, ['foo']);
+    });
+
+    test('has entered recipients but not content', function() {
+      Compose.clear();
+      ThreadUI.saveMessageDraft();
+      arg = spy.firstCall.args[0];
+
+      assert.deepEqual(arg.recipients, ['999']);
+      assert.deepEqual(arg.content, []);
+    });
+
+    test('has entered content but not recipients', function() {
+      ThreadUI.recipients.remove('999');
+      ThreadUI.saveMessageDraft();
+      arg = spy.firstCall.args[0];
+
+      assert.deepEqual(arg.recipients, []);
+      assert.deepEqual(arg.content, ['foo']);
+    });
+
+  });
+
+suite('Back button behaviour', function() {
 
     suite('During activity', function() {
       setup(function() {
@@ -3725,6 +3771,11 @@ suite('thread_ui.js >', function() {
 
     suite('From new message', function() {
       var showCalled = false;
+      var spy;
+
+      suiteSetup(function() {
+        spy = sinon.spy(ThreadUI, 'saveMessageDraft');
+      });
 
       setup(function() {
         showCalled = false;
@@ -3744,10 +3795,40 @@ suite('thread_ui.js >', function() {
           number: '999'
         });
 
-        Compose.append('foo');
       });
 
-      test('Displays OptionMenu prompt', function() {
+      test('Displays OptionMenu prompt if recipients', function() {
+        ThreadUI.back();
+
+        assert.isTrue(OptionMenu.calledOnce);
+        assert.isTrue(showCalled);
+
+        var items = OptionMenu.args[0][0].items;
+
+        // Assert the correct menu items were displayed
+        assert.equal(items[0].l10nId, 'save-as-draft');
+        assert.equal(items[1].l10nId, 'discard-message');
+        assert.equal(items[2].l10nId, 'cancel');
+      });
+
+      test('Displays OptionMenu prompt if recipients & content', function() {
+        Compose.append('foo');
+        ThreadUI.back();
+
+        assert.isTrue(OptionMenu.calledOnce);
+        assert.isTrue(showCalled);
+
+        var items = OptionMenu.args[0][0].items;
+
+        // Assert the correct menu items were displayed
+        assert.equal(items[0].l10nId, 'save-as-draft');
+        assert.equal(items[1].l10nId, 'discard-message');
+        assert.equal(items[2].l10nId, 'cancel');
+      });
+
+      test('Displays OptionMenu prompt if content', function() {
+        ThreadUI.recipients.remove('999');
+        Compose.append('foo');
         ThreadUI.back();
 
         assert.isTrue(OptionMenu.calledOnce);
@@ -3765,28 +3846,10 @@ suite('thread_ui.js >', function() {
         test('Save as Draft', function() {
           ThreadUI.back();
 
-          // Yes, seriously.
-          // This will be replaced when the real Draft save mechanism
-          // is implemented. Use a stub to prevent from actually logging
-          // to the console here. This is obviously restored after the
-          // test is completed.
-          this.sinon.stub(console, 'log');
-
           OptionMenu.args[0][0].items[0].method();
 
-          // We just want to ensure that the recipients and composer
-          // contents have been collected before the new message is
-          // discarded.
-          sinon.assert.calledWithMatch(console.log, ['999'], ['foo']);
-
-          // Nothing actually happens yet, but when Draft saving is ready,
-          // this will be updated to assert that the recipients and
-          // contents of the composer were passed as arguments to the
-          // draft save mechanism.
-          assert.ok('Draft Save Mechanism');
-
-
           // These things will be true
+          assert.isTrue(spy.calledOnce);
           assert.equal(window.location.hash, '#thread-list');
           assert.equal(ThreadUI.recipients.length, 0);
           assert.equal(Compose.getContent(), '');

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -588,6 +588,18 @@ suite('Utils', function() {
       );
     });
 
+    test('one number is undefined', function() {
+      assert.isFalse(
+        Utils.probablyMatches(undefined, '8889995555')
+      );
+    });
+
+    test('both numbers are undefined', function() {
+      assert.isFalse(
+        Utils.probablyMatches(undefined, undefined)
+      );
+    });
+
     suite('Varied Cases', function() {
       FixturePhones.forEach(function(fixture) {
         var title = fixture.title;


### PR DESCRIPTION
- `drafts.js`
  - `add()`
    - checked if draft being added is already stored (checking against recipients, content, subject)
    - if so, then don't push it or store it
    - call `store()` if new, unique draft is being added
  - add `subject` field to `Draft`
- `message_manager.js`
  - call to save message draft upon visibility change to hidden from new compose window or thread
- `thread_ui.js`
  - call to save message draft upon clicking back button from new compose window or thread
  - `saveMessageDraft()`
    - if there is unsent content in the composer, or recipients in the to field, then save a draft
    - assimilates the recipients first, checks for existing `threadID` based on the list of recipients
- `threads.js`
  - added `forEach` to be able to check all the thread id's and recipients
- Tests
  - `drafts_test.js`
    - added subjects to dummy drafts
    - added tests for correct storage behavior in `add()`
  - `message_manager_test.js`
    - tested calls to save draft upon visibility change from new compose window or thread
  - `thread_ui_test.js`
    - tested calls to save draft upon clicking back button from new compose window or thread
    - unit test for `saveMessageDraft()`
  - updated mocks
