### PR TITLE
Bug 946740 - [Messages] the bad recipient markers should not be absolute...

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -887,22 +887,14 @@ generateHeightRule() (in ThreadUI/thread_ui.js) will create:
 }
 
 .recipient[contenteditable=false].attention {
-  position: relative;
-
-  padding-left: 1.2rem;
+  padding-left: 0;
   border: 0.1rem solid #b90000;
 
   background: transparent;
 }
 
 .recipient[contenteditable=false].attention::before {
-  position: absolute;
-
-  border-bottom-left-radius: 0.3rem;
-  border-top-left-radius: 0.3rem;
-  padding: 0.2rem 0.2rem 0 0.2rem;
-  margin-left: -1.2rem;
-  margin-top: -0.1rem;
+  padding: 0.3rem;
 
   background-color: #b90000;
   color: #fff;


### PR DESCRIPTION
...ly positioned r=schung
- Doesn't use absolute positioning anymore
