### PR TITLE
Bug 940188 - Do checking before using IccHelper and mozMobileConnection r=crh0716

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -22,9 +22,13 @@ var Connectivity = (function(window, document, undefined) {
   var bluetooth = getBluetooth();
   var mobileConnection = getMobileConnection();
 
-  mobileConnection.addEventListener('datachange', updateCarrier);
-  IccHelper.addEventListener('cardstatechange', updateCallSettings);
-  IccHelper.addEventListener('cardstatechange', updateMessagingSettings);
+  if (mobileConnection) {
+    mobileConnection.addEventListener('datachange', updateCarrier);
+  }
+  if (IccHelper) {
+    IccHelper.addEventListener('cardstatechange', updateCallSettings);
+    IccHelper.addEventListener('cardstatechange', updateMessagingSettings);
+  }
 
   // XXX if wifiManager implements addEventListener function
   // we can remove these listener lists.

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -770,7 +770,7 @@ window.addEventListener('load', function loadSettings() {
                      'data-connectivity'];
 
       // Disable SIM security item only in case of SIM absent.
-      var cardState = IccHelper.cardState;
+      var cardState = IccHelper && IccHelper.cardState;
       if (!disable || !cardState) {
         itemIds.push('simSecurity-settings');
       }


### PR DESCRIPTION
There is no mozMobileConnection and mozIccManager in flatfish, so we do checking their existence before invoke function or using property of them.

https://bugzilla.mozilla.org/show_bug.cgi?id=940188
