### PR TITLE
Bug 943260 - Initialize status bar only once r=alive

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -904,5 +904,8 @@ if (navigator.mozL10n.readyState == 'complete' ||
     navigator.mozL10n.readyState == 'interactive') {
   StatusBar.init();
 } else {
-  window.addEventListener('localized', StatusBar.init.bind(StatusBar));
+  window.addEventListener('localized', function statusbar_init() {
+    window.removeEventListener('localized', statusbar_init);
+    StatusBar.init();
+  });
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=943260
