### PR TITLE
[v1.2] Bug 939792 - Remove get_active_frame from keyboard app object and...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/browser/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/browser/app.py
@@ -101,6 +101,9 @@ class Browser(Base):
         self.marionette.find_element(*self._add_bookmark_to_home_screen_choice_locator).tap()
         # TODO: Remove sleep when Bug # 815115 is addressed, or if we can wait for a Javascript condition
         time.sleep(1)
+        self.switch_to_add_bookmark_frame()
+
+    def switch_to_add_bookmark_frame(self):
         # Switch to System app where the add bookmark dialog resides
         self.marionette.switch_to_frame()
         self.wait_for_element_displayed(*self._add_bookmark_to_home_screen_frame_locator)
@@ -122,7 +125,10 @@ class Browser(Base):
         element = self.marionette.find_element(*self._bookmark_title_input_locator)
         element.clear()
         element.send_keys(value)
+        # Here we must dismiss the keyboard because it obscures the elements on the page
+        # Marionette cannot scroll them into view because it is a modal frame
         self.keyboard.dismiss()
+        self.switch_to_add_bookmark_frame()
 
     def wait_for_throbber_not_visible(self, timeout=30):
         # TODO see if we can reduce this timeout in the future. >10 seconds is poor UX

--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -12,6 +12,17 @@ from gaiatest.apps.base import Base
 
 
 class Keyboard(Base):
+    '''
+    There are two underlying strategies in this class;
+    * send() method which uses logic to traverse the keyboard to type the string sent to it.
+        Send should be used in tests where the layout of the keyboard is not tested and only string input is important
+    * tap_x() or anything not send() methods which do not use logic to change keyboard panels.
+        Tap should be used where the keyboard is expected to open with that key visible
+
+    The methods in this class employ a lot of aggressive frame switching to the keyboard and back to the
+    displayed app because it predominantly acts as a utility class and thus it works best when the main focus
+    of the test is on the web app rather than the keyboard itself.
+        '''
 
     name = "Keyboard"
 
@@ -100,16 +111,15 @@ class Keyboard(Base):
 
     # this is to switch to the frame of keyboard
     def switch_to_keyboard(self):
+        self.wait_for_condition(lambda m: self.is_displayed())
         self.marionette.switch_to_frame()
         keybframe = self.marionette.find_element(*self._keyboard_frame_locator)
-        self.wait_for_condition(lambda m: self.is_displayed())
         self.marionette.switch_to_frame(keybframe, focus=False)
 
     @property
     def current_keyboard(self):
         self.marionette.switch_to_frame()
         keyboard = self.marionette.find_element(*self._keyboard_frame_locator).get_attribute('data-frame-name')
-        self.switch_to_keyboard()
         return keyboard
 
     # this is to get the locator of desired key on keyboard
@@ -149,7 +159,7 @@ class Keyboard(Base):
             action.move(extend_keys[selection - 1]).perform()
         action.release().perform()
 
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def enable_caps_lock(self):
         self.switch_to_keyboard()
@@ -157,11 +167,10 @@ class Keyboard(Base):
             self._tap(self._alpha_key)
         key_obj = self.marionette.find_element(*self._key_locator(self._upper_case_key))
         self.marionette.double_tap(key_obj)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     # this would go through fastest way to tap/click through a string
     def send(self, string):
-        frame = self.marionette.get_active_frame()
         self.switch_to_keyboard()
         for val in string:
             if ord(val) > 127:
@@ -182,8 +191,7 @@ class Keyboard(Base):
                 self._switch_to_correct_layout(val)
                 self._tap(val)
 
-        self.marionette.switch_to_frame()
-        self.marionette.switch_to_frame(frame)
+        self.apps.switch_to_displayed_app()
 
     # Switch keyboard language
     # Mapping of language code => {
@@ -208,7 +216,6 @@ class Keyboard(Base):
         # TODO At the moment this doesn't work because the UI has changed
         # An attempted repair ran into https://bugzilla.mozilla.org/show_bug.cgi?id=779284 (Modal dialog)
 
-        frame = self.marionette.get_active_frame()
         keyboard_language_locator = (By.CSS_SELECTOR, ".keyboard-row button[data-keyboard='%s']" % lang_code)
 
         self.switch_to_keyboard()
@@ -217,23 +224,24 @@ class Keyboard(Base):
         action.press(language_key).wait(1).perform()
         target_kb_layout = self.marionette.find_element(*keyboard_language_locator)
         action.move(target_kb_layout).release().perform()
-        self.marionette.switch_to_frame()
-        self.marionette.switch_to_frame(frame)
+        self.apps.switch_to_displayed_app()
 
     def tap_keyboard_language_key(self):
+        self.switch_to_keyboard()
         self.marionette.find_element(*self._language_key_locator).tap()
+        self.apps.switch_to_displayed_app()
 
     # switch to keyboard with numbers and special characters
     def switch_to_number_keyboard(self):
         self.switch_to_keyboard()
         self._tap(self._numeric_sign_key)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     # switch to keyboard with alphabetic keys
     def switch_to_alpha_keyboard(self):
         self.switch_to_keyboard()
         self._tap(self._alpha_key)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     # following are "5 functions" to substitute finish switch_to_frame()s and tap() for you
     def tap_shift(self):
@@ -241,49 +249,47 @@ class Keyboard(Base):
         if self.is_element_present(*self._key_locator(self._alpha_key)):
             self._tap(self._alpha_key)
         self._tap(self._upper_case_key)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def tap_backspace(self):
         self.switch_to_keyboard()
         backspace = self.marionette.find_element(self._button_locator[0], self._button_locator[1] % self._backspace_key)
         backspace.tap()
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def tap_space(self):
         self.switch_to_keyboard()
         self._tap(self._space_key)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def tap_enter(self):
         self.switch_to_keyboard()
         self._tap(self._enter_key)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def tap_alt(self):
         self.switch_to_keyboard()
         if self.is_element_present(*self._key_locator(self._numeric_sign_key)):
             self._tap(self._numeric_sign_key)
         self._tap(self._alt_key)
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def tap_dotcom(self):
         self.switch_to_keyboard()
         dotcom = self.marionette.find_element(*self._dotcom_key_locator)
         dotcom.tap()
-        self.marionette.switch_to_frame()
+        self.apps.switch_to_displayed_app()
 
     def dismiss(self):
-        frame = self.marionette.get_active_frame()
-        self.marionette.switch_to_frame()
         self.wait_for_condition(lambda m: self.is_displayed())
+        self.marionette.switch_to_frame()
         self.marionette.execute_script('navigator.mozKeyboard.removeFocus();')
         self.wait_for_condition(lambda m: not self.is_displayed())
-        self.marionette.switch_to_frame(frame)
+        self.apps.switch_to_displayed_app()
 
     def is_displayed(self):
-        frame = self.marionette.get_active_frame()
         self.marionette.switch_to_frame()
         keyboard = self.marionette.find_element(*self._keyboard_frame_locator)
         is_visible = keyboard.is_displayed() and keyboard.location['y'] == 0
-        self.marionette.switch_to_frame(frame)
+        self.apps.switch_to_displayed_app()
         return is_visible

--- a/tests/python/gaia-ui-tests/gaiatest/apps/ui_tests/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/ui_tests/app.py
@@ -115,6 +115,11 @@ class KeyboardPage(Base):
     _number_input_locator = (By.CSS_SELECTOR, 'input[type="number"]')
     _text_input_locator = (By.CSS_SELECTOR, 'input[type="text"]')
     _url_input_locator = (By.CSS_SELECTOR, 'input[type="url"]')
+    _frame_locator = (By.CSS_SELECTOR, "#test-iframe[src*='keyboard']")
+
+    def switch_to_frame(self):
+        keyboard_page_iframe = self.marionette.find_element(*self._frame_locator)
+        self.marionette.switch_to_frame(keyboard_page_iframe)
 
     def tap_number_input(self):
         self.marionette.find_element(*self._number_input_locator).tap()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_number_keyboard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_number_keyboard.py
@@ -17,6 +17,8 @@ class TestNumberKeyboard(GaiaTestCase):
         keyboard = keyboard_page.tap_number_input()
         keyboard.switch_to_keyboard()
         self.assertEqual(str(keyboard.current_keyboard), 'number')
+
+        keyboard.switch_to_keyboard()
         keyboard._tap('1')
         self.marionette.switch_to_frame()
         self.marionette.switch_to_frame(self.ui_tests.app.frame)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_url_keyboard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_url_keyboard.py
@@ -15,22 +15,19 @@ class TestUrlKeyboard(GaiaTestCase):
 
         # tap the field "input type=url"
         keyboard = keyboard_page.tap_url_input()
-        keyboard.switch_to_keyboard()
 
+        keyboard.switch_to_keyboard()
         # Test forward slash
         keyboard._tap('/')
-        self.marionette.switch_to_frame()
-        self.marionette.switch_to_frame(self.ui_tests.app.frame)
 
-        keyboard_page = self.ui_tests.switch_to_keyboard_page_frame()
+        self.apps.switch_to_displayed_app()
+        keyboard_page.switch_to_frame()
         typed_key = keyboard_page.url_input
         self.assertEqual(typed_key, u'/')
 
         # Test .com key
         keyboard.tap_dotcom()
 
-        self.marionette.switch_to_frame(self.ui_tests.app.frame)
-
-        keyboard_page = self.ui_tests.switch_to_keyboard_page_frame()
+        keyboard_page.switch_to_frame()
         typed_key = keyboard_page.url_input
         self.assertEqual(typed_key, u'/.com')

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_change_keyboard_language.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_change_keyboard_language.py
@@ -36,9 +36,8 @@ class TestChangeKeyboardLanguage(GaiaTestCase):
         self.wait_for_condition(lambda m: new_contact_form.keyboard.is_displayed())
 
         # Switch to keyboard frame and switch language
-        new_contact_form.keyboard.switch_to_keyboard()
         new_contact_form.keyboard.tap_keyboard_language_key()
-        self.wait_for_element_displayed(*self._special_key_locator)
+        new_contact_form.keyboard.switch_to_keyboard()
         special_key = self.marionette.find_element(*self._special_key_locator).text
 
         # Checking if exists the special key - "ñ"


### PR DESCRIPTION
... other app objects, make keyboard methods fall back to displayed_frame
