### PR TITLE
Bug 942865 - [Settings][WiFi] In wifi settings, 'Show Password' checkbox makes the keyboard disappear

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -217,6 +217,9 @@ section li.password > p {
   line-height: 3.3rem;
 }
 
+#pwd-auth {
+  -moz-user-focus: ignore;
+}
 
 /******************************************************************************
 * Media Storage settings


### PR DESCRIPTION
This patch fixes the issue with a proper solution using `-moz-user-focus: ignore`, but since there is another bug related to focus and touch events (894383), this patch also includes a solution which refocus the cursor in the textfield whenever the user changes the checkbox.
