### PR TITLE
Bug 935052 - Python Remove launch() methods from homescreen tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
@@ -60,6 +60,7 @@ class Homescreen(Base):
     def touch_home_button(self):
         self.marionette.switch_to_frame()
         self.marionette.execute_script("window.wrappedJSObject.dispatchEvent(new Event('home'));")
+        self.wait_for_condition(lambda m: self.apps.displayed_app.name == self.name)
 
     def activate_edit_mode(self):
         app = self.marionette.find_element(*self._visible_icons_locator)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/test_gallery_edit_photo.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/test_gallery_edit_photo.py
@@ -19,9 +19,6 @@ class TestGalleryEditPhoto(GaiaTestCase):
         # add photo to storage
         self.push_resource('IMG_0001.jpg', destination='DCIM/100MZLLA')
 
-        # launch the Gallery app
-        self.app = self.apps.launch('Gallery')
-
     def test_gallery_edit_photo(self):
         gallery = Gallery(self.marionette)
         gallery.launch()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/test_homescreen_edit_mode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/test_homescreen_edit_mode.py
@@ -12,7 +12,7 @@ class TestEditMode(GaiaTestCase):
         GaiaTestCase.setUp(self)
 
         self.homescreen = Homescreen(self.marionette)
-        self.homescreen.launch()
+        self.homescreen.switch_to_homescreen_frame()
 
     def test_access_and_leave_edit_mode(self):
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/test_homescreen_launch_app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/test_homescreen_launch_app.py
@@ -21,7 +21,7 @@ class TestLaunchApp(GaiaTestCase):
         self.connect_to_network()
 
         self.homescreen = Homescreen(self.marionette)
-        self.homescreen.launch()
+        self.homescreen.switch_to_homescreen_frame()
 
         # Install app
         self.marionette.switch_to_frame()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/test_homescreen_move_app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/test_homescreen_move_app.py
@@ -12,7 +12,7 @@ class TestMoveApp(GaiaTestCase):
         GaiaTestCase.setUp(self)
 
         self.homescreen = Homescreen(self.marionette)
-        self.homescreen.launch()
+        self.homescreen.switch_to_homescreen_frame()
 
     def test_move_app_position(self):
         """


### PR DESCRIPTION
Uplift to v1.2
