### PR TITLE
Bug 935052 - Remove remainder of spurious launch() methods in the middle of tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/test_cost_control_reset_wifi.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/test_cost_control_reset_wifi.py
@@ -42,7 +42,7 @@ class TestCostControlReset(GaiaTestCase):
         # disable wifi before reset data, wait for wifi to be closed, and switch back to the app
         self.data_layer.disable_wifi()
         time.sleep(1)
-        cost_control.launch()
+        self.apps.switch_to_displayed_app()
 
         # # go to settings section
         settings = cost_control.tap_settings()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/persona/test_persona_cookie.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/persona/test_persona_cookie.py
@@ -44,7 +44,10 @@ class TestPersonaCookie(GaiaTestCase):
         persona = Persona(self.marionette)
         persona.login(self.user.email, self.user.password)
 
-        browser.launch()
+        # wait to fall back to browser
+        self.wait_for_condition(lambda m: self.apps.displayed_app.name == browser.name)
+        self.apps.switch_to_displayed_app()
+
         browser.switch_to_content()
         self.wait_for_element_displayed(*self._logged_in_button_locator)
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_airplane_mode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_airplane_mode.py
@@ -35,7 +35,7 @@ class TestAirplaneMode(GaiaTestCase):
         self.assertFalse(self.data_layer.get_setting('geolocation.enabled'), "GPS was still connected after switching on Airplane mode")
 
         # switch back to app frame
-        settings.launch()
+        self.apps.switch_to_displayed_app()
 
         # Switch off Airplane mode
         settings.disable_airplane_mode()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_media_storage.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_media_storage.py
@@ -19,7 +19,7 @@ class TestSettingsMediaStorage(GaiaTestCase):
         self.assertEqual(media_storage_settings.pictures_size, '0 B')
         self.assertEqual(media_storage_settings.movies_size, '0 B')
 
-        # Close the settings application
+        # Close the settings application. We need to kill it to re-init the UI
         self.apps.kill(settings.app)
 
         # Push media to the device


### PR DESCRIPTION
Uplift to v1.2
