### PR TITLE
Bug 943777 - [Settings] button separator not visible on wide screens

### DIFF
--- a/apps/settings/style/settings_large.css
+++ b/apps/settings/style/settings_large.css
@@ -309,7 +309,7 @@
   }
 
   section[role="region"].skin-dark > header:first-child menu[type="toolbar"] a:after,
-  section[role="region"].skin-dark > header:first-child menu[type="toolbar"] button:after.
+  section[role="region"].skin-dark > header:first-child menu[type="toolbar"] button:after,
   section[role="region"].skin-organic > header:first-child menu[type="toolbar"] a:after,
   section[role="region"].skin-organic > header:first-child menu[type="toolbar"] button:after  {
     content: "";


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=943777
