### PR TITLE
Use requirements.txt files for tbpl use

### DIFF
--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,0 +1,6 @@
+marionette_client==0.6.2
+mozdevice
+py==1.4.14
+requests
+moztest>=0.3
+yoctopuce==1.01.12553

--- a/tests/python/gaia-ui-tests/setup.py
+++ b/tests/python/gaia-ui-tests/setup.py
@@ -13,8 +13,8 @@ version = {}
 execfile(os.path.join('gaiatest', 'version.py'), version)
 
 # dependencies
-deps = ['marionette_client>=0.6.2', 'mozdevice', 'py==1.4.14', 'requests',
-        'moztest>=0.3', 'yoctopuce==1.01.12553']
+with open('requirements.txt') as f:
+    deps = f.read().splitlines()
 
 setup(name='gaiatest',
       version=version['__version__'],

--- a/tests/python/gaia-ui-tests/tbpl_requirements.txt
+++ b/tests/python/gaia-ui-tests/tbpl_requirements.txt
@@ -1,0 +1,1 @@
+marionette_client


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=943008 - tbpl needs to use in-tree marionette client instead of a pinned version. This enables the default install to use a pinned version, and lets tbpl use tbpl_requirements.txt if need
