### PR TITLE
Bug 943794 - Hide keyboard when setup-installed-app-dialog poped up r=alive

### DIFF
--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -248,6 +248,7 @@ var AppInstallManager = {
     navigator.mozL10n.localize(this.setupAppName,
                               'app-install-success', { appName: appName });
     this.setupInstalledAppDialog.classList.add('visible');
+    window.dispatchEvent(new CustomEvent('applicationsetupdialogshow'));
   },
 
   handleSetupCancelAction: function ai_handleSetupCancelAction() {

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -135,6 +135,7 @@ var KeyboardManager = {
     window.addEventListener('activitywillclose', this);
     window.addEventListener('attentionscreenshow', this);
     window.addEventListener('mozbrowsererror', this);
+    window.addEventListener('applicationsetupdialogshow', this);
 
     // To handle keyboard layout switching
     window.addEventListener('mozChromeEvent', function(evt) {
@@ -410,6 +411,7 @@ var KeyboardManager = {
           self.hideKeyboardImmediately();
         }, 0);
         break;
+      case 'applicationsetupdialogshow':
       case 'activitywillclose':
       case 'appwillclose':
         this.hideKeyboardImmediately();


### PR DESCRIPTION
Hide keyboard when setup-installed-app-dialog poped up

https://bugzilla.mozilla.org/show_bug.cgi?id=943794
