### PR TITLE
Bug 941567 - [Keyboard][V1.2] The keyboard name of notification bar is incorrect

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -271,9 +271,6 @@ var KeyboardManager = {
       }
       self.setKeyboardToShow(group);
 
-      // We also want to show the permanent notification
-      // in the UtilityTray.
-      self.showIMESwitcher();
     }
 
     if (type === 'blur') {
@@ -395,6 +392,10 @@ var KeyboardManager = {
     } else {
       updateHeight();
     }
+
+    // Show the permanent notification in the UtilityTray.
+    // For changing keyboard layout without switch key.
+    this.showIMESwitcher();
   },
 
   handleEvent: function km_handleEvent(evt) {
@@ -668,9 +669,6 @@ var KeyboardManager = {
         // user selected a new keyboard.
         window.dispatchEvent(new CustomEvent('keyboardchanged'));
 
-        // Refresh the switcher, or the labled type and layout name
-        // won't change.
-        self.showIMESwitcher();
       }, function() {
         var showed = self.showingLayout;
         if (!self.keyboardLayouts[showed.type])

--- a/apps/system/test/unit/keyboard_manager_test.js
+++ b/apps/system/test/unit/keyboard_manager_test.js
@@ -79,6 +79,7 @@ suite('KeyboardManager', function() {
   suite('Transitions', function() {
     setup(function(next) {
       setTimeout(next, 500);
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
 
     test('showKeyboard triggers transition', function(next) {
@@ -208,6 +209,7 @@ suite('KeyboardManager', function() {
   suite('UpdateHeight', function() {
     setup(function(next) {
       setTimeout(next, 500);
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
     test('Second updateHeight evt triggers keyboardchange', function(next) {
       var kcEvent = sinon.stub();
@@ -566,6 +568,7 @@ suite('KeyboardManager', function() {
   suite('Show Keyboard', function() {
     setup(function(next) {
       KeyboardManager.keyboardFrameContainer.classList.add('hide');
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
       setTimeout(next, 100);
     });
 
@@ -603,6 +606,7 @@ suite('KeyboardManager', function() {
     var showKeyboard;
     setup(function() {
       showKeyboard = this.sinon.stub(KeyboardManager, 'showKeyboard');
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
 
     function fakeMozbrowserResize(height) {


### PR DESCRIPTION
```
-- since keyboard show timing is depends on 'mozbrowserresize' event,
so call 'showIMESwitcher' in the end of 'resizeKeyboard'
to make sure refresh latest information at each time while keyboard layout is chnaged.
```
