### PR TITLE
Bug 944232 - [Gaia] To support EAP-SIM and remove AKA, AKA' method.

### DIFF
--- a/apps/settings/elements/wifi_auth.html
+++ b/apps/settings/elements/wifi_auth.html
@@ -23,17 +23,11 @@
         </li>
         <li class="eap">
           <p data-l10n-id="eap">EAP method</p>
-          <span class="button icon icon-dialog">
+          <span class="button icon icon-dialog" data-eapMethod>
             <select>
-              <option value="SIM">EAP-SIM</option>
-              <option value="AKA">EAP-AKA</option>
-              <option value="AKA'">EAP-AKA'</option>
+              <option value="SIM">SIM</option>
             </select>
           </span>
-        </li>
-        <li class="simpin">
-          <p data-l10n-id="simPin">SIM PIN</p>
-          <input type="text" data-ignore name="simPin" />
         </li>
         <li class="identity">
           <p data-l10n-id="identity">identity</p>

--- a/apps/settings/elements/wifi_join_hidden.html
+++ b/apps/settings/elements/wifi_join_hidden.html
@@ -28,17 +28,11 @@
         </li>
         <li class="eap">
           <p data-l10n-id="eap">EAP method</p>
-          <span class="button icon icon-dialog">
+          <span class="button icon icon-dialog" data-eapMethod>
             <select>
-              <option value="SIM">EAP-SIM</option>
-              <option value="AKA">EAP-AKA</option>
-              <option value="AKA'">EAP-AKA'</option>
+              <option value="SIM">SIM</option>
             </select>
           </span>
-        </li>
-        <li class="simpin">
-          <p data-l10n-id="simPin">SIM PIN</p>
-          <input type="text" data-ignore name="simPin" />
         </li>
         <li class="identity">
           <p data-l10n-id="identity">identity</p>

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -600,7 +600,7 @@ navigator.mozL10n.ready(function wifiSettings() {
       var dialog = document.getElementById(dialogID);
 
       // authentication fields
-      var identity, password, showPassword, eap, simPin;
+      var identity, password, showPassword, eap;
       if (dialogID != 'wifi-status') {
         identity = dialog.querySelector('input[name=identity]');
         identity.value = network.identity || '';
@@ -616,8 +616,6 @@ navigator.mozL10n.ready(function wifiSettings() {
         };
 
         eap = dialog.querySelector('li.eap select');
-
-        simPin = dialog.querySelector('input[name=simPin]');
       }
 
       if (dialogID === 'wifi-joinHidden') {
@@ -643,13 +641,12 @@ navigator.mozL10n.ready(function wifiSettings() {
         var checkPassword = function checkPassword() {
           dialog.querySelector('button[type=submit]').disabled =
             !WifiHelper.isValidInput(key, password.value, identity.value,
-              eap.value, simPin.value);
+              eap.value);
         };
         eap.onchange = function() {
           checkPassword();
           changeDisplay(key);
         };
-        simPin.oninput = checkPassword;
         password.oninput = checkPassword;
         identity.oninput = checkPassword;
         checkPassword();
@@ -707,28 +704,22 @@ navigator.mozL10n.ready(function wifiSettings() {
       function changeDisplay(security) {
         if (dialogID !== 'wifi-status') {
           if (security === 'WEP' || security === 'WPA-PSK') {
-            simPin.parentNode.style.display = 'none';
             identity.parentNode.style.display = 'none';
             password.parentNode.style.display = 'block';
           } else if (security === 'WPA-EAP') {
             if (eap) {
               switch (eap.value) {
                 case 'SIM':
-                case 'AKA':
-                case 'AKA\'':
-                  simPin.parentNode.style.display = 'block';
                   identity.parentNode.style.display = 'none';
                   password.parentNode.style.display = 'none';
                   break;
                 default:
-                  simPin.parentNode.style.display = 'none';
                   identity.parentNode.style.display = 'block';
                   password.parentNode.style.display = 'block';
                   break;
               }
             }
           } else {
-            simPin.parentNode.style.display = 'none';
             identity.parentNode.style.display = 'none';
             password.parentNode.style.display = 'none';
           }
@@ -741,7 +732,6 @@ navigator.mozL10n.ready(function wifiSettings() {
           gWifiManager.connectionInfoUpdate = null;
         }
         if (dialogID != 'wifi-status') {
-          simPin.value = '';
           identity.value = '';
           password.value = '';
           showPassword.checked = false;
@@ -755,7 +745,7 @@ navigator.mozL10n.ready(function wifiSettings() {
         }
         if (key) {
           WifiHelper.setPassword(network, password.value, identity.value,
-            eap.value, simPin.value);
+            eap.value);
         }
         if (callback) {
           callback();

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -163,7 +163,6 @@ ul[data-state="ready"] li > a {
 section li.password,
 section li.password[hidden],
 section li.eap,
-section li.simpin,
 section li.identity {
   display: none;
 }
@@ -171,7 +170,6 @@ section li.identity {
 section[data-security*="WEP"] li.password,
 section[data-security*="WPA"] li.password,
 section[data-security*="EAP"] li.eap,
-section[data-security*="EAP"] li.simpin,
 section[data-security*="EAP"] li.identity {
   display: block;
 }

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -9,7 +9,7 @@ function debug(msg) {
 }
 
 function execute(options) {
-  config = options
+  config = options;
   var gaia = utils.getGaia(config);
   const prefs = [];
 
@@ -29,7 +29,7 @@ function execute(options) {
   });
 
   prefs.push(['network.http.max-connections-per-server', 15]);
-  prefs.push(["dom.mozInputMethod.enabled", true]);
+  prefs.push(['dom.mozInputMethod.enabled', true]);
 
   // for https://bugzilla.mozilla.org/show_bug.cgi?id=811605 to let user know
   //what prefs is for ril debugging
@@ -38,7 +38,10 @@ function execute(options) {
   // TODO: remove this override after having vCard/vCalendar implemented in Gaia.
   // @see bug 885683 - [Messages] MMS doesn't support sending and receiving vCard attachments.
   // @see bug 905548 - [Messages] MMS doesn't support sending and receiving vCalendar attachments.
-  prefs.push(["dom.mms.version", 0x11]);
+  prefs.push(['dom.mms.version', 0x11]);
+  // TODO: Once platform enabled unsafe WPA-EAP, we have to remove this flag here.
+  // @see Bug 790056 - Enable WPA Enterprise
+  prefs.push(['b2g.wifi.allow_unsafe_wpa_eap', true]);
 
   if (config.LOCAL_DOMAINS) {
     prefs.push(['network.dns.localDomains', domains.join(',')]);

--- a/shared/js/wifi_helper.js
+++ b/shared/js/wifi_helper.js
@@ -9,7 +9,7 @@ var WifiHelper = {
     return navigator.mozWifiManager;
   }(),
 
-  setPassword: function(network, password, identity, eap, simpin) {
+  setPassword: function(network, password, identity, eap) {
     var encType = this.getKeyManagement(network);
     switch (encType) {
       case 'WPA-PSK':
@@ -17,14 +17,17 @@ var WifiHelper = {
         break;
       case 'WPA-EAP':
         network.eap = eap;
-        if (password && password.length) {
-          network.password = password;
-        }
-        if (identity && identity.length) {
-          network.identity = identity;
-        }
-        if (simpin && simpin.length) {
-          network.pin = simpin;
+        switch (eap) {
+          case 'SIM':
+            if (password && password.length) {
+              network.password = password;
+            }
+            if (identity && identity.length) {
+              network.identity = identity;
+            }
+            break;
+          default:
+            break;
         }
         break;
       case 'WEP':
@@ -83,7 +86,7 @@ var WifiHelper = {
     return key === curkey;
   },
 
-  isValidInput: function(key, password, identity, eap, simpin) {
+  isValidInput: function(key, password, identity, eap) {
     function isValidWepKey(password) {
       switch (password.length) {
         case 5:
@@ -109,10 +112,6 @@ var WifiHelper = {
       case 'WPA-EAP':
         switch (eap) {
           case 'SIM':
-          case 'AKA':
-          case 'AKA\'':
-            if (!simpin || simpin.length < 1)
-              return false;
             break;
           default:
             if (!password || password.length < 1 ||


### PR DESCRIPTION
According to Bug 926341 - [UX]To support WPA-EAP and EAP SIM options in WLAN setting:
- Rename EAP method EAP-SIM to SIM
- Remove EAP method AKA, AKA' since no device to test it
- Remove input SIM PIN
- Enabled unsafe WPA-EAP network. It will be removed once bug 790056 landed.(Platform will re-enable it!)
