### PR TITLE
Bug 944458 - Xfail test_cost_control_reset_wifi.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
@@ -19,5 +19,5 @@ expected = fail
 
 [test_cost_control_reset_wifi.py]
 skip-if = device == "desktop"
-# Bug 942060 - [Cost Control] There is no usage data and graph in usage app
+# Bug 944008 - [B2G][Usage] Usage reset doesn't work properly
 expected = fail


### PR DESCRIPTION
Xfail test_cost_control_reset_wifi.py due to Bug 944008 - [B2G][Usage] Usage reset doesn't work properly
