### PR TITLE
Bug 944570 - Xfail test_sms_to_dialer.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
@@ -12,6 +12,8 @@ skip-if = device == "desktop"
 
 [test_sms_to_dialer.py]
 skip-if = device == "desktop"
+# Bug 944468 - Flow from Messages app/message thread to Dialer is broken
+expected = fail
 
 [test_sms_contact_match.py]
 


### PR DESCRIPTION
test_sms_to_dialer.py failed due to Bug 944468 - Flow from Messages app/message thread to Dialer is broken
