### PR TITLE
Bug 944279 - marionette_js reporter should be more verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -729,7 +729,7 @@ test-integration:
 	PROFILE_FOLDER=profile-test make
 	NPM_REGISTRY=$(NPM_REGISTRY) ./bin/gaia-marionette $(shell find . -path "*test/marionette/*_test.js") \
 		--host $(MARIONETTE_RUNNER_HOST) \
-		--reporter $(MOCHA_REPORTER)
+		--reporter $(REPORTER)
 
 .PHONY: test-perf
 test-perf:


### PR DESCRIPTION
Show the list of test name and result for each js marionette test.
http://bugzil.la/944279
