### PR TITLE
Bug 944692 - [v1.2] Fix test_unlock_to_camera_with_passcode

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_camera_with_passcode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_unlock_to_camera_with_passcode.py
@@ -29,8 +29,6 @@ class TestCameraUnlockWithPasscode(GaiaTestCase):
         camera = self.lock_screen.unlock_to_camera()
         self.lock_screen.wait_for_lockscreen_not_visible()
 
-        self.assertFalse(self.lockscreen.is_locked)
-
         camera.switch_to_camera_frame()
 
         self.assertFalse(camera.is_gallery_button_visible)


### PR DESCRIPTION
<code>return window.wrappedJSObject.LockScreen.locked</code> returns True
Where technically speaking the screen is still locked
