### PR TITLE
Bug 944784 - [l12y][browser] Bookmarks: "Edit Bookmark", use separate strings for button and dialog header

### DIFF
--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -164,7 +164,7 @@
         <menu type="toolbar">
           <button id="bookmark-entry-sheet-done" data-l10n-id="done">Done</button>
         </menu>
-        <h1 data-l10n-id="edit-bookmark">Edit Bookmark</h1>
+        <h1 data-l10n-id="edit-bookmark-header">Edit Bookmark</h1>
       </header>
       <label data-l10n-id="page-title">
         Page Title <input type="text" id="bookmark-title"></input>

--- a/apps/browser/locales/browser.en-US.properties
+++ b/apps/browser/locales/browser.en-US.properties
@@ -55,6 +55,7 @@ bookmarks=Bookmarks
 bookmark=Bookmark
 unbookmark=Unbookmark
 edit-bookmark=Edit bookmark
+edit-bookmark-header=Edit bookmark
 page-title=Page title
 address=Address
 add-to-home-screen=Add to home screen


### PR DESCRIPTION
In this way localizers could use a shorter string in the header
