### PR TITLE
Bug 943844 - [v1.2] Intermittent failures of test_browser_bookmark.py on Travis on v1.2

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/browser/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/browser/app.py
@@ -124,7 +124,8 @@ class Browser(Base):
     def type_bookmark_title(self, value):
         element = self.marionette.find_element(*self._bookmark_title_input_locator)
         element.clear()
-        element.send_keys(value)
+        element.tap()
+        self.keyboard.send(value)
         # Here we must dismiss the keyboard because it obscures the elements on the page
         # Marionette cannot scroll them into view because it is a modal frame
         self.keyboard.dismiss()


### PR DESCRIPTION
I reproduced this failure locally using b2g desktop. Sometimes they keyboard just doesn't appear when `sendkeys()` is called. I don't know why, and don't think that's necessarily a bug. This should fix the intermittent failures we are seeing, but I'm not sure if it's what we really want to do.

Looking for feedback.
