### PR TITLE
Bug 937499 - [Settings] Update input type and trigger showing keyboard ...

### DIFF
--- a/apps/settings/elements/carrier_data_settings.html
+++ b/apps/settings/elements/carrier_data_settings.html
@@ -25,7 +25,7 @@
       <ul class="apnSettings-advanced">
         <li>
           <p data-l10n-id="apn">APN</p>
-          <input type="text" data-setting="ril.data.apn" />
+          <input type="text" x-inputmode="verbatim" data-setting="ril.data.apn" />
         </li>
         <li>
           <p data-l10n-id="identity">identity</p>
@@ -33,7 +33,7 @@
         </li>
         <li>
           <p data-l10n-id="password">password</p>
-          <input type="text" data-setting="ril.data.passwd" />
+          <input type="password" data-setting="ril.data.passwd" />
         </li>
         <li>
           <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>

--- a/apps/settings/elements/carrier_mms_settings.html
+++ b/apps/settings/elements/carrier_mms_settings.html
@@ -24,7 +24,7 @@
       <ul class="apnSettings-advanced">
         <li>
           <p data-l10n-id="apn">APN</p>
-          <input type="text" data-setting="ril.mms.apn" />
+          <input type="text" x-inputmode="verbatim" data-setting="ril.mms.apn" />
         </li>
         <li>
           <p data-l10n-id="identity">identity</p>
@@ -32,7 +32,7 @@
         </li>
         <li>
           <p data-l10n-id="password">password</p>
-          <input type="text" data-setting="ril.mms.passwd" />
+          <input type="password" data-setting="ril.mms.passwd" />
         </li>
         <li>
           <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>

--- a/apps/settings/elements/carrier_supl_settings.html
+++ b/apps/settings/elements/carrier_supl_settings.html
@@ -25,7 +25,7 @@
       <ul class="apnSettings-advanced">
         <li>
           <p data-l10n-id="apn">APN</p>
-          <input type="text" data-setting="ril.supl.apn" />
+          <input type="text" x-inputmode="verbatim" data-setting="ril.supl.apn" />
         </li>
         <li>
           <p data-l10n-id="identity">identity</p>
@@ -33,7 +33,7 @@
         </li>
         <li>
           <p data-l10n-id="password">password</p>
-          <input type="text" data-setting="ril.supl.passwd" />
+          <input type="password" data-setting="ril.supl.passwd" />
         </li>
         <li>
           <p data-l10n-id="httpProxyHost">HTTP Proxy Host</p>

--- a/apps/settings/elements/wifi_wps.html
+++ b/apps/settings/elements/wifi_wps.html
@@ -34,7 +34,7 @@
         </li>
         <li id="wifi-wps-pin-area">
           <p data-l10n-id="wpsPinDescription">PIN is 4 or 8 digits</p>
-          <input type="text" />
+          <input type="password" x-inputmode="digit" size="8" maxlength="8"/>
         </li>
         <li id="wifi-wps-pin-aps">
           <p data-l10n-id="wpsPinAps">Select an opposite device</p>

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -97,6 +97,10 @@ navigator.mozL10n.ready(function bluetoothSettings() {
       }
       updateNameInput.value = myName;
       updateNameDialog.hidden = false;
+      // Focus the input field to trigger showing the keyboard
+      updateNameInput.focus();
+      var cursorPos = updateNameInput.value.length;
+      updateNameInput.setSelectionRange(0, cursorPos);
     };
 
     updateNameCancelButton.onclick = function updateNameCancelClicked(evt) {

--- a/apps/settings/js/call.js
+++ b/apps/settings/js/call.js
@@ -89,12 +89,25 @@ var CallSettings = (function(window, document, undefined) {
         return;
       }
 
-      if (e.detail.current !== '#call' ||
-          e.detail.previous.startsWith('#call-cf-') ||
-          e.detail.previous === '#call-voiceMailSettings') {
-        return;
+      switch (e.detail.current) {
+        case '#call':
+          // No need to refresh the call settings items if navigated from
+          // panels not manipulating call settings.
+          if (e.detail.previous.startsWith('#call-cf-') ||
+              e.detail.previous === '#call-voiceMailSettings') {
+            return;
+          }
+          cs_refreshCallSettingItems();
+          break;
+        case '#call-voiceMailSettings':
+          // If current panel is 'Voicemail Settings', focus input field to
+          // trigger showing the keyboard
+          var voicemailNumberInput = document.getElementById('vm-number');
+          var cursorPos = voicemailNumberInput.value.length;
+          voicemailNumberInput.focus();
+          voicemailNumberInput.setSelectionRange(0, cursorPos);
+          break;
       }
-      cs_refreshCallSettingItems();
     });
 
     // We need to refresh call setting items as they can be changed in dialer.


### PR DESCRIPTION
...for certain subpanels

Use correct type and inputmode for input fields from the following panels:
- Wi-Fi->Connect with WPS
- Cellular & Data->Data settings
- Cellular & Data->Message settings
- Cellular & Data->A-GPS settings

Trigger showing the keyboard for the following subpanels:
- Call Settings->Voicemail
- Bluetooth->Rename my device
