### PR TITLE
Bug 941567 - [Keyboard][V1.2] The keyboard name of notification bar is i...

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -271,9 +271,6 @@ var KeyboardManager = {
       }
       self.setKeyboardToShow(group);
 
-      // We also want to show the permanent notification
-      // in the UtilityTray.
-      self.showIMESwitcher();
     }
 
     if (type === 'blur') {
@@ -365,6 +362,10 @@ var KeyboardManager = {
   },
 
   resizeKeyboard: function km_resizeKeyboard(evt) {
+    // ignore mozbrowserresize event while keyboard Frame is hidding
+    if (this.keyboardFrameContainer.dataset.transitionOut === 'true')
+      return;
+
     this.keyboardHeight = parseInt(evt.detail.height);
     this._debug('resizeKeyboard: ' + this.keyboardHeight);
     if (this.keyboardHeight <= 0)
@@ -389,12 +390,15 @@ var KeyboardManager = {
     };
 
     // If the keyboard is hidden, or when transitioning is not finished
-    if (this.keyboardFrameContainer.classList.contains('hide') &&
-             this.keyboardFrameContainer.dataset.transitionOut !== 'true') {
+    if (this.keyboardFrameContainer.classList.contains('hide')) {
       this.showKeyboard(updateHeight);
     } else {
       updateHeight();
     }
+
+    // update latest keyboard info to notification bar
+    // for swiching other keyboard layouts.
+    this.showIMESwitcher();
   },
 
   handleEvent: function km_handleEvent(evt) {
@@ -670,7 +674,6 @@ var KeyboardManager = {
 
         // Refresh the switcher, or the labled type and layout name
         // won't change.
-        self.showIMESwitcher();
       }, function() {
         var showed = self.showingLayout;
         if (!self.keyboardLayouts[showed.type])

--- a/apps/system/test/unit/keyboard_manager_test.js
+++ b/apps/system/test/unit/keyboard_manager_test.js
@@ -79,6 +79,7 @@ suite('KeyboardManager', function() {
   suite('Transitions', function() {
     setup(function(next) {
       setTimeout(next, 500);
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
 
     test('showKeyboard triggers transition', function(next) {
@@ -207,6 +208,7 @@ suite('KeyboardManager', function() {
   suite('UpdateHeight', function() {
     setup(function(next) {
       setTimeout(next, 500);
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
     test('Second updateHeight evt triggers keyboardchange', function(next) {
       var kcEvent = sinon.stub();
@@ -566,6 +568,7 @@ suite('KeyboardManager', function() {
     setup(function(next) {
       KeyboardManager.keyboardFrameContainer.classList.add('hide');
       setTimeout(next, 100);
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
 
     test('Hide immediately after show should destroy', function(next) {
@@ -602,6 +605,7 @@ suite('KeyboardManager', function() {
     var showKeyboard;
     setup(function() {
       showKeyboard = this.sinon.stub(KeyboardManager, 'showKeyboard');
+      this.sinon.stub(KeyboardManager, 'showIMESwitcher');
     });
 
     function fakeMozbrowserResize(height) {


### PR DESCRIPTION
...ncorrect

```
 -- since keyboard show timing is depends on 'mozbrowserresize' event,
    so call 'showIMESwitcher' in the end of 'resizeKeyboard'
    to make sure refresh latest information at each time while keyboard layout is chnaged.
 -- ignore mozbrowserresize event while keyboard Frame is hidding.
```

(cherry picked from commit fc3ef53f0bbaf297e9177ece1d4390fd8788233b)
