### PR TITLE
Bug 943103 - [B2G][Email] Subject and snippet overlap attachment and flagged icons, may cause snippet to wrap so as to not be visible. Regression from bug 917895. r=jrburke

### DIFF
--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -89,6 +89,7 @@ input.msg-search-text-tease {
   background-color: #53b8cc;
 }
 .msg-header-details-section {
+  -moz-box-sizing: border-box;
   box-sizing: border-box;
   position: absolute;
   top: 0;
@@ -377,6 +378,7 @@ input.msg-search-text-tease {
 
 .msg-reader-load-infobar {
   position: absolute;
+  -moz-box-sizing: border-box;
   box-sizing: border-box;
   color: white;
   font-size: 1.2rem;
@@ -537,6 +539,7 @@ input.msg-search-text-tease {
 }
 
 .msg-list-topbar {
+  -moz-box-sizing: border-box;
   box-sizing: border-box;
   position: absolute;
   top: 5rem;


### PR DESCRIPTION
Note that r=jrburke is coming from bug 917895 where James's review request
intent was for this but a misunderstanding resulted in the opposite of the
request happening.
