### PR TITLE
Bug 921390 - Display operator name for each SIM on the lockscreen of DSDS devices r=alive

### DIFF
--- a/apps/settings/test/unit/simcard_lock_test.js
+++ b/apps/settings/test/unit/simcard_lock_test.js
@@ -51,7 +51,7 @@ suite('SimPinLock > ', function() {
   suiteTeardown(function() {
     window.navigator.mozL10n = realL10n;
     window.Template = realTemplate;
-    window.navigator.mozMobileConnections.mRemoveMobileConnection();
+    MockNavigatorMozMobileConnections.mTeardown();
     window.navigator.mozMobileConnections = realMozMobileConnections;
     window.navigator.mozIccManager = realMozIccManager;
     window.navigator.mozSettings = realMozSettings;

--- a/apps/settings/test/unit/simcard_manager_settings_helper_test.js
+++ b/apps/settings/test/unit/simcard_manager_settings_helper_test.js
@@ -284,7 +284,7 @@ suite('SimSettingsHelper > ', function() {
 
   suite('SimSettingsHelper.setServiceOnCard("key", cardIndex) > ', function() {
     var fakeCardIndex = 0;
-    var mSettings = window.navigator.mozSettings.mSettings;
+    var mSettings = MockNavigatorSettings.mSettings;
 
     setup(function() {
       this.sinon.spy(SimSettingsHelper, '_set');

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -144,6 +144,7 @@
     <!-- LockScreen -->
     <link rel="stylesheet" type="text/css" href="style/lockscreen/lockscreen.css">
     <script defer src="/shared/js/lockscreen_slide.js"></script>
+    <script defer src="js/lockscreen_connection_info_manager.js"></script>
     <script defer src="js/lockscreen.js"></script>
 
     <!-- PIN Unlocking -->
@@ -1033,7 +1034,7 @@
         <div id="lockscreen-container">
           <div id="lockscreen-panel-main" class="lockscreen-panel">
             <div id="lockscreen-header">
-              <div id="lockscreen-connstate" hidden><span></span><span></span></div>
+              <div id="lockscreen-conn-states" hidden></div>
               <div id="lockscreen-mute" hidden></div>
               <div id="lockscreen-alt-camera" class="lockscreen-icon">
                 <div role="button" data-l10n-id="camera-a11y-button" aria-label="Camera"></div>

--- a/apps/system/js/cell_broadcast_system.js
+++ b/apps/system/js/cell_broadcast_system.js
@@ -25,7 +25,8 @@ var CellBroadcastSystem = {
     this._settingsDisabled = event.settingValue;
 
     if (this._settingsDisabled) {
-      LockScreen.setCellbroadcastLabel();
+      var evt = new CustomEvent('cellbroadcastmsgchanged', { detail: null });
+      window.dispatchEvent(evt);
     }
   },
 
@@ -46,7 +47,9 @@ var CellBroadcastSystem = {
     if (conn &&
         conn.voice.network.mcc === MobileOperator.BRAZIL_MCC &&
         msg.messageId === MobileOperator.BRAZIL_CELLBROADCAST_CHANNEL) {
-      LockScreen.setCellbroadcastLabel(msg.body);
+      var evt = new CustomEvent('cellbroadcastmsgchanged',
+        { detail: msg.body });
+      window.dispatchEvent(evt);
       return;
     }
 

--- a/apps/system/js/lockscreen_connection_info_manager.js
+++ b/apps/system/js/lockscreen_connection_info_manager.js
@@ -1,0 +1,282 @@
+'use strict';
+
+(function(exports) {
+  var _lockedStateMsgMap = {
+    'unknown': 'emergencyCallsOnly-unknownSIMState',
+    'pinRequired': 'emergencyCallsOnly-pinRequired',
+    'pukRequired': 'emergencyCallsOnly-pukRequired',
+    'networkLocked': 'emergencyCallsOnly-networkLocked',
+    'serviceProviderLocked': 'emergencyCallsOnly-serviceProviderLocked',
+    'corporateLocked': 'emergencyCallsOnly-corporateLocked'
+  };
+
+  /*
+  * Types of 2G Networks
+  */
+  var _NETWORKS_2G = ['gsm', 'gprs', 'edge'];
+
+  /**
+   * Constructor of LockScreenConnInfoManager. LockScreenConnInfoManager updates
+   * mobile connection related information on lockscreen.
+   *
+   * @param {HTMLElement} root The root element of connection states.
+   * @constructor LockScreenConnInfoManager
+   */
+  var LockScreenConnInfoManager = function(root) {
+    if (root) {
+      this._initialize(root);
+    }
+  };
+
+  var LockScreenConnInfoManagerPrototype = {
+    _connStates: null,
+    _settings: null,
+    _cellbroadcastLabel: null,
+    /*
+     * Telephony default service ID
+     */
+    _telephonyDefaultServiceId: 0,
+    /*
+     * Airplane mode
+     */
+    _airplaneMode: false
+  };
+
+  /**
+   * Initialize connection state elements and event handlers.
+   *
+   * @param {HTMLElement} root The root element of connection states.
+   */
+  LockScreenConnInfoManagerPrototype._initialize =
+    function lscs_initialize(root) {
+      this._connStates = root;
+      this._settings = navigator.mozSettings;
+
+      var self = this;
+
+      this._connStates.hidden = false;
+      SIMSlotManager.getSlots().forEach(function(simslot, index) {
+        // connection state
+        self._connStates.appendChild(self._createConnStateElement());
+        simslot.conn.addEventListener('voicechange',
+          function(index) {
+            self.updateConnState(simslot);
+        });
+      });
+
+      // event handlers
+      window.addEventListener('simslot-cardstatechange', function(evt) {
+        self.updateConnState(evt.detail);
+      });
+
+      window.addEventListener('simslot-iccinfochange', function(evt) {
+        self.updateConnState(evt.detail);
+      });
+
+      // Handle incoming CB messages that need to be displayed.
+      window.addEventListener('cellbroadcastmsgchanged', function(evt) {
+        self._cellbroadcastLabel = evt.detail;
+        self.updateConnStates();
+      });
+
+      this._settings.addObserver('ril.radio.disabled', function(evt) {
+        self._airplaneMode = evt.settingValue;
+        self.updateConnStates();
+      });
+
+      this._settings.addObserver('ril.telephony.defaultServiceId',
+        function(evt) {
+          self._telephonyDefaultServiceId = evt.settingValue;
+          self.updateConnStates();
+      });
+
+      // update UI
+      var req = SettingsListener.getSettingsLock().get('ril.radio.disabled');
+      req.onsuccess = function() {
+        self._airplaneMode = !!req.result['ril.radio.disabled'];
+        var req2 =
+          SettingsListener.getSettingsLock()
+            .get('ril.telephony.defaultServiceId');
+        req.onsuccess = function() {
+          self._telephonyDefaultServiceId =
+            req2.result['ril.telephony.defaultServiceId'] || 0;
+          self.updateConnStates();
+        };
+      };
+  };
+
+  /**
+   * Create connection state element.
+   *
+   * @this {LockScreenConnInfoManager}
+   */
+  LockScreenConnInfoManagerPrototype._createConnStateElement =
+    function lscs_createConnStateElement() {
+      /**
+       * <div>
+       *   <span></span>
+       *   <span class="connstate-line"></span>
+       *   <span class="connstate-line"></span>
+       * </div>
+       */
+
+      var div = document.createElement('div');
+      var span = document.createElement('span');
+      var line1 = document.createElement('span');
+      var line2 = document.createElement('span');
+
+      line1.className = line2.className = 'connstate-line';
+      div.appendChild(span);
+      div.appendChild(line1);
+      div.appendChild(line2);
+
+      return div;
+  };
+
+  /**
+   * Update states of all sim slots.
+   *
+   * @this {LockScreenConnInfoManager}
+   */
+  LockScreenConnInfoManagerPrototype.updateConnStates =
+    function lscs_updateConnStates() {
+      SIMSlotManager.getSlots().forEach((function(simslot) {
+        this.updateConnState(simslot);
+      }).bind(this));
+  };
+
+  /**
+   * Update the state of a sim slot.
+   *
+   * @param {SIMSlot} simslot
+   * @this {LockScreenConnInfoManager}
+   */
+  LockScreenConnInfoManagerPrototype.updateConnState =
+    function lscs_updateConnState(simslot) {
+      var conn = simslot.conn;
+      var index = simslot.index;
+
+      var connstate = this._connStates.children[index];
+      var simIDLine = connstate.children[0];
+      var connstateLines =
+        Array.prototype.slice.call(
+          connstate.querySelectorAll('.connstate-line'));
+      var localize = navigator.mozL10n.localize;
+      var iccObj = simslot.simCard;
+      var voice = conn.voice;
+
+      connstate.hidden = false;
+
+      // Set sim ID line
+      if (SIMSlotManager.isMultiSIM()) {
+        simIDLine.hidden = false;
+        simIDLine.textContent = 'SIM ' + (index + 1);
+      } else {
+        simIDLine.hidden = true;
+      }
+
+      // Reset Lines
+      connstateLines.forEach(function(line) {
+        localize(line);
+      });
+      var nextLine = function() {
+        for (var i = 0; i < connstateLines.length; i++) {
+          var line = connstateLines[i];
+          if (line.textContent === '') {
+            return line;
+          }
+        }
+        return connstateLines[connstateLines.length - 1];
+      };
+
+      // Airplane mode
+      if (this._airplaneMode) {
+        // Only show one airplane mode status
+        if (index == 0) {
+          localize(nextLine(), 'airplaneMode');
+        } else {
+          connstate.hidden = true;
+        }
+        simIDLine.hidden = true;
+        return;
+      }
+
+      // If there is no sim card on the device, we only show one information.
+      if (SIMSlotManager.noSIMCardOnDevice()) {
+        if (index == 0) {
+          if (voice.emergencyCallsOnly) {
+            localize(nextLine(), 'emergencyCallsOnly');
+            localize(nextLine(), 'emergencyCallsOnly-noSIM');
+          } else {
+            localize(nextLine(), 'emergencyCallsOnly-noSIM');
+          }
+        }
+        simIDLine.hidden = true;
+        return;
+      }
+
+      // If there are multiple sim slots and only one sim card inserted, we
+      // only show the state of the inserted sim card.
+      if (SIMSlotManager.isMultiSIM() &&
+          navigator.mozIccManager.iccIds.length == 1 &&
+          simslot.isAbsent()) {
+        connstate.hidden = true;
+        return;
+      }
+
+      // Possible value of voice.state are:
+      // 'notSearching', 'searching', 'denied', 'registered',
+      // where the latter three mean the phone is trying to grab the network.
+      // See https://bugzilla.mozilla.org/show_bug.cgi?id=777057
+      if (voice && 'state' in voice && voice.state == 'notSearching') {
+        localize(nextLine(), 'noNetwork');
+        return;
+      }
+
+      if (!voice.connected && !voice.emergencyCallsOnly) {
+        // "Searching"
+        // voice.state can be any of the latter three values.
+        // (it's possible that the phone is briefly 'registered'
+        // but not yet connected.)
+        localize(nextLine(), 'searching');
+        return;
+      }
+
+      if (voice.emergencyCallsOnly) {
+        if (this._telephonyDefaultServiceId == index) {
+          localize(nextLine(), 'emergencyCallsOnly');
+        }
+        localize(nextLine(), _lockedStateMsgMap[iccObj.cardState]);
+        return;
+      }
+
+      var operatorInfos = MobileOperator.userFacingInfo(conn);
+      var operator = operatorInfos.operator;
+      var is2G = _NETWORKS_2G.some(function checkConnectionType(elem) {
+        return (conn.voice.type == elem);
+      });
+
+      if (voice.roaming) {
+        var l10nArgs = { operator: operator };
+        localize(nextLine(), 'roaming', JSON.stringify(l10nArgs));
+      } else {
+        var line = nextLine();
+        line.l10nId = '';
+        line.textContent = operator;
+      }
+
+      if (this._cellbroadcastLabel && is2G) {
+        var line = nextLine();
+        line.l10nId = '';
+        line.textContent = this._cellbroadcastLabel;
+      } else if (operatorInfos.carrier) {
+        var line = nextLine();
+      line.l10nId = '';
+        line.textContent = operatorInfos.carrier + ' ' +
+          operatorInfos.region;
+      }
+  };
+
+  LockScreenConnInfoManager.prototype = LockScreenConnInfoManagerPrototype;
+  exports.LockScreenConnInfoManager = LockScreenConnInfoManager;
+})(window);

--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -153,35 +153,36 @@
   transition: none;
 }
 
-#lockscreen-connstate {
+#lockscreen-conn-states {
   width: 100%;
   display: inline-block;
   font-weight: 400;
   font-size: calc(6 * 0.226rem);
   text-shadow: 0.1rem 0.1rem 0.3rem #000000;
+  padding-bottom: 1rem;
+  border-bottom: solid 0.1rem rgba(256,256,256,.4);
 
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-#lockscreen-connstate > span {
-  display: block;
-  padding-bottom: 1rem;
-  border-bottom: solid 0.1rem rgba(256,256,256,.4);
-}
-
-#lockscreen-connstate > span:empty {
+#lockscreen-conn-states span:empty {
   display: none;
 }
 
-#lockscreen-connstate.twolines > span:first-child {
-  border-bottom: none;
-  padding-bottom: 0;
+#lockscreen-conn-states span:first-child {
+  display: inline-block;
+  width: 4rem;
+}
+
+#lockscreen-conn-states span:last-child {
+  display: block;
 }
 
 /* For some reason display: inline-block disregards hidden attribute */
-#lockscreen-connstate[hidden] {
+#lockscreen-conn-states span[hidden],
+#lockscreen-conn-states[hidden] {
   display: none;
 }
 

--- a/apps/system/test/unit/lockscreen_conn_info_manager_test.js
+++ b/apps/system/test/unit/lockscreen_conn_info_manager_test.js
@@ -1,0 +1,403 @@
+'use strict';
+
+requireApp('system/test/unit/mock_l10n.js');
+requireApp('system/test/unit/mock_simslot.js');
+requireApp('system/test/unit/mock_simslot_manager.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_icc_manager.js');
+requireApp('system/shared/test/unit/mocks/mock_mobile_operator.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
+requireApp('system/js/lockscreen_connection_info_manager.js');
+
+if (!this.MobileOperator) {
+  this.MobileOperator = null;
+}
+
+if (!this.SettingsListener) {
+  this.SettingsListener = null;
+}
+
+if (!this.SIMSlotManager) {
+  this.SIMSlotManager = null;
+}
+
+suite('system/LockScreenConnInfoManager >', function() {
+  var subject;
+  var realL10n;
+  var realMobileOperator;
+  var realSIMSlotManager;
+  var realIccManager;
+  var realSettingsListener;
+  var realMozSettings;
+  var domConnStates;
+  var DUMMYTEXT1 = 'foo';
+
+  setup(function() {
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = window.MockL10n;
+
+    realMobileOperator = window.MobileOperator;
+    window.MobileOperator = MockMobileOperator;
+
+    realIccManager = navigator.mozIccManager;
+    navigator.mozIccManager = MockNavigatorMozIccManager;
+
+    realMozSettings = window.navigator.mozSettings;
+    window.navigator.mozSettings = MockNavigatorSettings;
+
+    realSettingsListener = window.SettingsListener;
+    window.SettingsListener = MockSettingsListener;
+
+    realSIMSlotManager = window.SIMSlotManager;
+    window.SIMSlotManager = MockSIMSlotManager;
+
+    domConnStates = document.createElement('div');
+    domConnStates.id = 'lockscreen-conn-states';
+    document.body.appendChild(domConnStates);
+  });
+
+  teardown(function() {
+    navigator.mozL10n = realL10n;
+    window.MobileOperator = realMobileOperator;
+    window.navigator.mozIccManager = realIccManager;
+    window.SettingsListener = realSettingsListener;
+    window.SIMSlotManager = realSIMSlotManager;
+
+    document.body.removeChild(domConnStates);
+    MockSettingsListener.mTeardown();
+  });
+
+  suiteTeardown(function() {
+    MockSIMSlotManager.mTeardown();
+  });
+
+  suite('Single sim devices', function() {
+    var mockMobileConnection;
+    var domConnstateIDLine;
+    var domConnstateL1;
+    var domConnstateL2;
+    var iccObj;
+
+    suiteSetup(function() {
+      mockMobileConnection = MockMobileconnection();
+
+      MockMobileOperator.mOperator = 'operator';
+      MockMobileOperator.mCarrier = 'carrier';
+      MockMobileOperator.mRegion = 'region';
+
+      MockSIMSlotManager.mInstances =
+        [new MockSIMSlot(mockMobileConnection, 0)];
+      iccObj = MockSIMSlotManager.mInstances[0].simCard;
+
+      subject = new LockScreenConnInfoManager();
+    });
+
+    suiteTeardown(function() {
+      MockMobileOperator.mTeardown();
+    });
+
+    setup(function() {
+      // add a sim card
+      mockMobileConnection.iccId = 'iccid1';
+      MockNavigatorMozIccManager.addIcc('iccid1');
+
+      subject._initialize(domConnStates);
+
+      var domConnState = domConnStates.children[0];
+      domConnstateIDLine = domConnState.children[0];
+      domConnstateL1 = domConnState.children[1];
+      domConnstateL2 = domConnState.children[2];
+
+      this.sinon.stub(MockSIMSlotManager, 'isMultiSIM').returns(false);
+      this.sinon.stub(MockSIMSlotManager, 'noSIMCardOnDevice').returns(false);
+    });
+
+    teardown(function() {
+      mockMobileConnection.mTeardown();
+      MockNavigatorMozIccManager.mTeardown();
+    });
+
+    test('2G Mode: should update cell broadcast info on connstate Line 2',
+      function() {
+        mockMobileConnection.voice = {
+          connected: true,
+          type: 'gsm'
+        };
+
+        subject._cellbroadcastLabel = DUMMYTEXT1;
+        subject.updateConnStates();
+        assert.equal(domConnstateL2.textContent, DUMMYTEXT1);
+
+        subject._cellbroadcastLabel = null;
+    });
+
+    test('3G Mode: should update carrier and region info on connstate Line 2',
+      function() {
+        mockMobileConnection.voice = {
+          connected: true,
+          type: 'wcdma'
+        };
+
+        var carrier = 'TIM';
+        var region = 'SP';
+        var exceptedText = 'TIM SP';
+        MobileOperator.mCarrier = carrier;
+        MobileOperator.mRegion = region;
+
+        subject._cellbroadcastLabel = DUMMYTEXT1;
+        subject.updateConnStates();
+        assert.equal(domConnstateL2.textContent, exceptedText);
+
+        subject._cellbroadcastLabel = null;
+    });
+
+    test('Show no network', function() {
+      mockMobileConnection.voice = {
+        connected: true,
+        state: 'notSearching'
+      };
+      subject.updateConnStates();
+      assert.equal(domConnstateL1.textContent, 'noNetwork');
+    });
+
+    test('Show searching', function() {
+      mockMobileConnection.voice = {
+        connected: false,
+        emergencyCallsOnly: false
+      };
+      subject.updateConnStates();
+      assert.equal(domConnstateL1.textContent, 'searching');
+    });
+
+    test('Show roaming', function() {
+      mockMobileConnection.voice = {
+        connected: true,
+        emergencyCallsOnly: false,
+        roaming: true
+      };
+      subject.updateConnStates();
+      assert.equal(domConnstateL1.textContent,
+        'roaming"{\\"operator\\":\\"' + MockMobileOperator.mOperator + '\\"}"');
+    });
+
+    suite('Show correct card states when emergency calls only', function() {
+      test('unknown', function() {
+        mockMobileConnection.voice = {
+          connected: false,
+          emergencyCallsOnly: true
+        };
+        iccObj.cardState = 'unknown';
+
+        subject.updateConnStates();
+        assert.equal(domConnstateL1.textContent, 'emergencyCallsOnly');
+        assert.equal(domConnstateL2.textContent,
+          'emergencyCallsOnly-unknownSIMState');
+      });
+
+      test('other card state', function() {
+        mockMobileConnection.voice = {
+          connected: false,
+          emergencyCallsOnly: true
+        };
+        iccObj.cardState = 'otherCardState';
+
+        subject.updateConnStates();
+        assert.equal(domConnstateL1.textContent, 'emergencyCallsOnly');
+        assert.equal(domConnstateL2.textContent, '');
+      });
+
+      ['pinRequired', 'pukRequired', 'networkLocked',
+       'serviceProviderLocked', 'corporateLocked'].forEach(function(cardState) {
+        test(cardState, function() {
+          mockMobileConnection.voice = {
+            connected: false,
+            emergencyCallsOnly: true
+          };
+          iccObj.cardState = cardState;
+
+          subject.updateConnStates();
+          assert.equal(domConnstateL1.textContent, 'emergencyCallsOnly');
+          assert.equal(domConnstateL2.textContent,
+            'emergencyCallsOnly-' + cardState);
+        });
+      });
+    });
+  });
+
+  suite('Multiple sims devices', function() {
+    var domConnStateList;
+    var mockMobileConnections = [];
+    var iccObj1;
+    var iccObj2;
+
+    suiteSetup(function() {
+      mockMobileConnections = [
+        MockMobileconnection(),
+        MockMobileconnection()
+      ];
+
+      MockMobileOperator.mOperator = 'operator';
+      MockMobileOperator.mCarrier = 'carrier';
+      MockMobileOperator.mRegion = 'region';
+
+      MockSIMSlotManager.mInstances =
+        [new MockSIMSlot(mockMobileConnections[0], 0),
+         new MockSIMSlot(mockMobileConnections[1], 1)];
+
+      iccObj1 = MockSIMSlotManager.mInstances[0].simCard;
+      iccObj2 = MockSIMSlotManager.mInstances[1].simCard;
+
+      subject = new LockScreenConnInfoManager();
+    });
+
+    suiteTeardown(function() {
+      MockMobileOperator.mTeardown();
+    });
+
+    setup(function() {
+      mockMobileConnections[0].iccId = 'iccid1';
+      mockMobileConnections[0].voice = {};
+      MockNavigatorMozIccManager.addIcc('iccid1');
+
+      mockMobileConnections[1].iccId = 'iccid2';
+      mockMobileConnections[1].voice = {};
+      MockNavigatorMozIccManager.addIcc('iccid2');
+
+      subject._initialize(domConnStates);
+
+      domConnStateList = [];
+      Array.prototype.forEach.call(domConnStates.children,
+        function(domConnState) {
+          domConnState.domConnstateIDLine = domConnState.children[0];
+          domConnState.domConnstateL1 = domConnState.children[1];
+          domConnState.domConnstateL2 = domConnState.children[2];
+          domConnStateList.push(domConnState);
+      });
+
+      this.sinon.stub(SIMSlotManager, 'isMultiSIM').returns(true);
+    });
+
+    teardown(function() {
+      mockMobileConnections[0].mTeardown();
+      mockMobileConnections[1].mTeardown();
+      MockNavigatorMozIccManager.mTeardown();
+    });
+
+    suite('No sim card', function() {
+      setup(function() {
+        this.sinon.stub(SIMSlotManager, 'noSIMCardOnDevice').returns(true);
+      });
+
+      test('Should only show one conn state', function() {
+        subject.updateConnStates();
+
+        assert.equal(domConnStateList[0].domConnstateL1.textContent,
+          'emergencyCallsOnly-noSIM');
+        assert.equal(domConnStateList[1].domConnstateL1.textContent, '');
+        assert.equal(domConnStateList[1].domConnstateL2.textContent, '');
+      });
+
+      test('Should show emergency call text', function() {
+        mockMobileConnections[0].voice.emergencyCallsOnly = true;
+        subject.updateConnStates();
+
+        assert.equal(domConnStateList[0].domConnstateL1.textContent,
+          'emergencyCallsOnly');
+        assert.equal(domConnStateList[0].domConnstateL2.textContent,
+          'emergencyCallsOnly-noSIM');
+        assert.equal(domConnStateList[1].domConnstateL1.textContent, '');
+        assert.equal(domConnStateList[1].domConnstateL2.textContent, '');
+      });
+    });
+
+    suite('One sim card inserted', function() {
+      suiteSetup(function() {
+        mockMobileConnections[0].voice = {
+          connected: true,
+          type: 'gsm'
+        };
+        mockMobileConnections[1].voice = {};
+      });
+
+      setup(function() {
+        navigator.mozIccManager.removeIcc('iccid2');
+        MockSIMSlotManager.mInstances[1].isAbsent = function() { return true; };
+      });
+
+      test('Should show sim ID', function() {
+        subject.updateConnStates();
+
+        var simIDLine = domConnStateList[0].domConnstateIDLine;
+        assert.isFalse(simIDLine.hidden);
+        assert.equal(simIDLine.textContent, 'SIM 1');
+      });
+
+      test('Should show only one conn state', function() {
+        subject.updateConnStates();
+
+        assert.isFalse(domConnStateList[0].hidden);
+        assert.isTrue(domConnStateList[1].hidden);
+      });
+
+      test('Should show airplane mode on connstate 1 Line 1 when in ' +
+        'airplane mode', function() {
+          subject._airplaneMode = true;
+          subject.updateConnStates();
+
+          assert.isFalse(domConnStateList[0].hidden);
+          assert.isTrue(domConnStateList[0].domConnstateIDLine.hidden);
+          assert.equal(domConnStateList[0].domConnstateL1.textContent,
+            'airplaneMode');
+          assert.equal(domConnStateList[0].domConnstateL2.textContent, '');
+
+          subject._airplaneMode = false;
+      });
+    });
+
+    suite('Two sim cards inserted', function() {
+      setup(function() {
+        MockSIMSlotManager.mInstances[0].conn.voice = {
+          connected: true,
+          type: 'gsm'
+        };
+        MockSIMSlotManager.mInstances[1].conn.voice = {
+          connected: true,
+          type: 'gsm'
+        };
+        this.sinon.stub(SIMSlotManager, 'noSIMCardOnDevice').returns(false);
+      });
+
+      test('Should show sim IDs', function() {
+        subject.updateConnStates();
+
+        var simIDLine1 = domConnStateList[0].domConnstateIDLine;
+        var simIDLine2 = domConnStateList[1].domConnstateIDLine;
+        assert.isFalse(simIDLine1.hidden);
+        assert.isFalse(simIDLine2.hidden);
+        assert.equal(simIDLine1.textContent, 'SIM 1');
+        assert.equal(simIDLine2.textContent, 'SIM 2');
+      });
+
+      test('Should show operator names on Line 1', function() {
+        subject.updateConnStates();
+
+        var connState1line1 = domConnStateList[0].domConnstateL1;
+        var connState2line1 = domConnStateList[1].domConnstateL1;
+        assert.equal(connState1line1.textContent, MockMobileOperator.mOperator);
+        assert.equal(connState2line1.textContent, MockMobileOperator.mOperator);
+      });
+
+      test('Should show carrier and region on Line 2', function() {
+        subject.updateConnStates();
+
+        var connState1line2 = domConnStateList[0].domConnstateL2;
+        var connState2line2 = domConnStateList[1].domConnstateL2;
+        assert.equal(connState1line2.textContent,
+          MockMobileOperator.mCarrier + ' ' + MockMobileOperator.mRegion);
+        assert.equal(connState2line2.textContent,
+          MockMobileOperator.mCarrier + ' ' + MockMobileOperator.mRegion);
+      });
+    });
+  });
+});

--- a/apps/system/test/unit/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen_test.js
@@ -10,36 +10,26 @@ requireApp('system/js/lockscreen.js');
 });
 
 requireApp('system/test/unit/mock_l10n.js');
-requireApp('system/test/unit/mock_mobile_connection.js');
-requireApp('system/shared/test/unit/mocks/mock_mobile_operator.js');
+requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
 requireApp('system/test/unit/mock_navigator_moz_telephony.js');
 requireApp('system/test/unit/mock_ftu_launcher.js');
-
-if (!this.MobileOperator) {
-  this.MobileOperator = null;
-}
 
 if (!this.FtuLauncher) {
   this.FtuLauncher = null;
 }
 
-if (!this.IccHelper) {
-  this.IccHelper = null;
+if (!this.SettingsListener) {
+  this.SettingsListener = null;
 }
 
 suite('system/LockScreen >', function() {
   var subject;
   var realOrientationManager;
   var realL10n;
-  var realMobileOperator;
-  var realMobileConnection;
   var realMozTelephony;
-  var realIccHelper;
   var realClock;
   var realFtuLauncher;
-  var domConnstate;
-  var domConnstateL1;
-  var domConnstateL2;
+  var realSettingsListener;
   var domPasscodePad;
   var domEmergencyCallBtn;
   var domOverlay;
@@ -51,9 +41,6 @@ suite('system/LockScreen >', function() {
     subject = window.LockScreen;
     realL10n = navigator.mozL10n;
     navigator.mozL10n = window.MockL10n;
-
-    realMobileOperator = window.MobileOperator;
-    window.MobileOperator = MockMobileOperator;
 
     realOrientationManager = window.OrientationManager;
     window.OrientationManager = {
@@ -69,17 +56,8 @@ suite('system/LockScreen >', function() {
     realFtuLauncher = window.FtuLauncher;
     window.FtuLauncher = MockFtuLauncher;
 
-    realMobileConnection = window.navigator.mozMobileConnection;
-
-    realIccHelper = window.IccHelper;
-
-    domConnstate = document.createElement('div');
-    domConnstate.id = 'lockscreen-connstate';
-    domConnstateL1 = document.createElement('div');
-    domConnstateL2 = document.createElement('div');
-    domConnstate.appendChild(domConnstateL1);
-    domConnstate.appendChild(domConnstateL2);
-    document.body.appendChild(domConnstate);
+    realSettingsListener = window.SettingsListener;
+    window.SettingsListener = MockSettingsListener;
 
     domPasscodePad = document.createElement('div');
     domPasscodePad.id = 'lockscreen-passcode-pad';
@@ -92,7 +70,6 @@ suite('system/LockScreen >', function() {
     domMainScreen = document.createElement('div');
     subject.passcodePad = domPasscodePad;
 
-    subject.connstate = domConnstate;
     var mockClock = {
       stop: function() {}
     };
@@ -102,57 +79,24 @@ suite('system/LockScreen >', function() {
     subject.lock();
   });
 
-  test('2G Mode: should update cell broadcast info on connstate Line 2',
-  function() {
-    window.navigator.mozMobileConnection = {
-      voice: {
-        connected: 'true',
-        type: 'gsm'
-      }
-    };
-    window.IccHelper = {enabled: true};
-    subject.cellbroadcastLabel = DUMMYTEXT1;
-    subject.updateConnState();
-    assert.equal(domConnstateL2.textContent, DUMMYTEXT1);
-  });
-
-  test('3G Mode: should update carrier and region info on connstate Line 2',
-  function() {
-    window.navigator.mozMobileConnection = {
-      voice: {
-        connected: 'true',
-        type: 'wcdma'
-      }
-    };
-    window.IccHelper = {enabled: true};
-    var carrier = 'TIM';
-    var region = 'SP';
-    var exceptedText = 'TIM SP';
-    MobileOperator.mCarrier = carrier;
-    MobileOperator.mRegion = region;
-    subject.cellbroadcastLabel = DUMMYTEXT1;
-    subject.updateConnState();
-    assert.equal(domConnstateL2.textContent, exceptedText);
-  });
-
   test('Emergency call: should disable emergency-call button',
-  function() {
-    var stubSwitchPanel = this.sinon.stub(subject, 'switchPanel');
-    navigator.mozTelephony.calls = {length: 1};
-    var evt = {type: 'callschanged'};
-    subject.handleEvent(evt);
-    assert.isTrue(domEmergencyCallBtn.classList.contains('disabled'));
-    stubSwitchPanel.restore();
+    function() {
+      var stubSwitchPanel = this.sinon.stub(subject, 'switchPanel');
+      navigator.mozTelephony.calls = {length: 1};
+      var evt = {type: 'callschanged'};
+      subject.handleEvent(evt);
+      assert.isTrue(domEmergencyCallBtn.classList.contains('disabled'));
+      stubSwitchPanel.restore();
   });
 
   test('Emergency call: should enable emergency-call button',
-  function() {
-    var stubSwitchPanel = this.sinon.stub(subject, 'switchPanel');
-    navigator.mozTelephony.calls = {length: 0};
-    var evt = {type: 'callschanged'};
-    subject.handleEvent(evt);
-    assert.isFalse(domEmergencyCallBtn.classList.contains('disabled'));
-    stubSwitchPanel.restore();
+    function() {
+      var stubSwitchPanel = this.sinon.stub(subject, 'switchPanel');
+      navigator.mozTelephony.calls = {length: 0};
+      var evt = {type: 'callschanged'};
+      subject.handleEvent(evt);
+      assert.isFalse(domEmergencyCallBtn.classList.contains('disabled'));
+      stubSwitchPanel.restore();
   });
 
   test('Lock: can actually lock', function() {
@@ -190,15 +134,15 @@ suite('system/LockScreen >', function() {
 
   teardown(function() {
     navigator.mozL10n = realL10n;
-    window.MobileOperator = realMobileOperator;
-    window.navigator.mozMobileConnection = realMobileConnection;
     navigator.mozTelephony = realMozTelephony;
-    window.IccHelper = realIccHelper;
     window.Clock = window.realClock;
     window.FtuLauncher = realFtuLauncher;
     window.OrientationManager = window.realOrientationManager;
-    document.body.removeChild(domConnstate);
+    window.SettingsListener = realSettingsListener;
+
     document.body.removeChild(domPasscodePad);
     subject.passcodePad = null;
+
+    MockSettingsListener.mTeardown();
   });
 });

--- a/apps/system/test/unit/mock_simslot_manager.js
+++ b/apps/system/test/unit/mock_simslot_manager.js
@@ -7,6 +7,7 @@ var MockSIMSlotManager = {
   isMultiSIM: function mssm_isMultiSIM() {
     return (this.mInstances.length > 1);
   },
+  noSIMCardOnDevice: function() {},
   mTeardown: function mssm_mTeardown() {
     this.mInstances = [];
     this.length = 0;

--- a/shared/test/unit/mocks/mock_navigator_moz_icc_manager.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_icc_manager.js
@@ -3,9 +3,13 @@
 
   // container for icc instances
   var iccs = {};
+  var iccIds = [];
 
   var MockIccManager = {
     _eventListeners: {},
+    get iccIds() {
+      return iccIds;
+    },
     addEventListener: function(type, callback) {
       if (!this._eventListeners[type]) {
         this._eventListeners[type] = [];
@@ -14,10 +18,19 @@
       this._eventListeners[type][eventLength] = callback;
     },
     addIcc: function(id, object) {
+      object = object || {};
+
       // override by default
+      if (iccIds.indexOf(id) == -1) {
+        iccIds.push(id);
+      }
       iccs[id] = this._wrapIcc(object);
     },
     removeIcc: function(id) {
+      var index = iccIds.indexOf(id);
+      if (index >= 0) {
+        iccIds.splice(index, 1);
+      }
       if (iccs[id]) {
         delete iccs[id];
       }
@@ -31,7 +44,6 @@
     // we will wrap icc to add some internal
     // methods that will be called outside
     _wrapIcc: function(object) {
-
       object.getCardLock = function(type) {
         object._getCardLockType = type;
         var obj = {
@@ -63,6 +75,10 @@
       };
 
       return object;
+    },
+    mTeardown: function iccm_teardown() {
+      iccIds = [];
+      iccs = {};
     }
   };
 
@@ -73,3 +89,44 @@
 
   window.MockNavigatorMozIccManager = MockIccManager;
 })();
+
+
+/*
+var MockIccManager = {
+  _iccIds: [],
+  _iccObjs: {},
+  get iccIds() {
+    return this._iccIds;
+  },
+
+  mAddMozIccObject: function iccm_addMozIcc(iccId, iccObj) {
+    iccObj = iccObj || {
+      addEventListener: function() {},
+      removeEventListener: function() {}
+    };
+
+    if (!this._iccObjs[iccId]) {
+      this._iccObjs[iccId] = iccObj;
+      this._iccIds.push(iccId);
+    }
+  },
+
+  mRemoveMozIccObject: function iccm_removeMozIcc(iccId) {
+    var index = this._iccIds.indexOf(iccId);
+    if (index >= 0) {
+      this._iccIds.splice(index, 1);
+    }
+    this._iccObjs[iccId] = null;
+  },
+
+  mTeardown: function iccm_teardown() {
+    this._iccIds = [];
+    this._iccObjs = {};
+  },
+
+  addEventListener: function() {},
+  removeEventListener: function() {},
+  getIccById: function(iccId) {
+    return this._iccObjs[iccId];
+  }
+}*/

--- a/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js
@@ -73,7 +73,16 @@
     }
 
     function _mRemoveMobileConnection(index) {
-      _mobileConnections.splice(index, 1);
+      if (!_mobileConnections.length)
+        return;
+
+      if (index) {
+        _mobileConnections.splice(index, 1);
+        _mock[index] = null;
+      } else {
+        _mobileConnections.splice(_mobileConnections.length - 1, 1);
+        _mock[_mobileConnections.length - 1] = null;
+      }
     }
 
     function _mTeardown() {
@@ -98,5 +107,6 @@
     return _mock;
   }
 
+  window.MockMobileconnection = MockMobileconnection;
   window.MockNavigatorMozMobileConnections = MockMobileConnections();
 })();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=921390

Typically we show the sim information exactly the same as on a single devices. There are a few special cases when displaying carrier names on DSDS devices:
1. When in airplane mode, we show only one line: 
`Airplane mode`
2. When there is no sim card inserted, we show only:

```
Emergency calls only
(no SIM)
```
1. When there is only one sim card inserted, show only the information of that sim card.
2. We only show "Emergency calls only" with the sim card that has been set as primary sim.
