### PR TITLE
Bug 940295 - Refactor test_calendar_new_event to use default date values...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/calendar/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/calendar/app.py
@@ -13,7 +13,6 @@ class Calendar(Base):
     _current_month_year_locator = (By.ID, 'current-month-year')
     _current_months_day_locator = (By.ID, 'months-day-view')
     _add_event_button_locator = (By.XPATH, "//a[@href='/event/add/']")
-    _event_title_input_locator = (By.XPATH, "//input[@data-l10n-id='event-title']")
 
     _week_display_button_locator = (By.XPATH, "//a[@href='/week/']")
     _day_display_button_locator = (By.XPATH, "//a[@href='/day/']")
@@ -34,18 +33,17 @@ class Calendar(Base):
 
     def tap_add_event_button(self):
         self.marionette.find_element(*self._add_event_button_locator).tap()
-        self.wait_for_element_displayed(*self._event_title_input_locator)
 
         from gaiatest.apps.calendar.regions.event import NewEvent
         new_event = NewEvent(self.marionette)
         new_event.wait_for_panel_to_load()
         return new_event
 
-    def click_week_display_button(self):
+    def tap_week_display_button(self):
         self.marionette.find_element(*self._week_display_button_locator).tap()
         self.wait_for_element_displayed(*self._week_view_locator)
 
-    def click_day_display_button(self):
+    def tap_day_display_button(self):
         self.marionette.find_element(*self._day_display_button_locator).tap()
         self.wait_for_element_displayed(*self._day_view_locator)
 
@@ -74,10 +72,6 @@ class Calendar(Base):
         data_date = self._get_data_date(date_time)
         return (By.CSS_SELECTOR,
                 "#week-view section.active[data-date*='%s'] ol.hour-%d" % (data_date, time_slot))
-
-    def _get_this_event_locator(self, date_time):
-        time_slot = self._get_data_hour(date_time)
-        return By.CSS_SELECTOR, '#event-list section.hour-%d span.display-hour' % time_slot
 
     @staticmethod
     def _get_data_date(date_time):

--- a/tests/python/gaia-ui-tests/gaiatest/apps/calendar/regions/event.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/calendar/regions/event.py
@@ -8,15 +8,13 @@ from gaiatest.apps.calendar.app import Calendar
 
 class NewEvent(Calendar):
 
-    _add_event_header_locator = (By.ID, 'modify-event-view')
+    _event_title_input_locator = (By.XPATH, "//input[@data-l10n-id='event-title']")
     _event_location_input_locator = (By.XPATH, "//input[@data-l10n-id='event-location']")
-    _event_start_time_input_locator = (By.XPATH, "//input[@data-l10n-id='event-start-time']")
-    _event_end_time_input_locator = (By.XPATH, "//input[@data-l10n-id='event-end-time']")
     _edit_event_button_locator = (By.CSS_SELECTOR, 'button.edit')
     _save_event_button_locator = (By.CSS_SELECTOR, 'button.save')
 
     def wait_for_panel_to_load(self):
-        return self.wait_for_element_displayed(*self._event_title_input_locator)
+        self.wait_for_element_displayed(*self._event_title_input_locator)
 
     def fill_event_title(self, title):
         event_title_input = self.marionette.find_element(*self._event_title_input_locator)
@@ -28,18 +26,6 @@ class NewEvent(Calendar):
         event_location_input.clear()
         event_location_input.send_keys(location)
 
-    def fill_event_start_time(self, start_time):
-        # FIXME when bug #877611 is fixed
-        event_start_time_input = self.marionette.find_element(*self._event_start_time_input_locator)
-        event_start_time_input.clear()
-        event_start_time_input.send_keys(start_time)
-
-    def fill_event_end_time(self, end_time):
-        # FIXME when bug #877611 is fixed
-        event_end_time_input = self.marionette.find_element(*self._event_end_time_input_locator)
-        event_end_time_input.clear()
-        event_end_time_input.send_keys(end_time)
-
     def tap_save_event(self):
         self.marionette.find_element(*self._save_event_button_locator).tap()
-        self.wait_for_element_not_displayed(*self._add_event_header_locator)
+        self.wait_for_element_not_displayed(*self._save_event_button_locator)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/manifest.ini
@@ -4,4 +4,3 @@ b2g = true
 [test_calendar_today_date.py]
 
 [test_calendar_new_event_appears_on_all_calendar_views.py]
-disabled = Bug 877611 - Make "Select time" popup, in Calendar app, more test friendly

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/test_calendar_new_event_appears_on_all_calendar_views.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/test_calendar_new_event_appears_on_all_calendar_views.py
@@ -2,44 +2,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
+from datetime import datetime, timedelta
 
 from gaiatest import GaiaTestCase
 from gaiatest.apps.calendar.app import Calendar
 
-DAYS_OF_WEEK = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY']
-
 
 class TestCalendar(GaiaTestCase):
 
-    def setUp(self):
-        GaiaTestCase.setUp(self)
-
-        if self.device.is_android_build:
-
-            # Setting the time on the device back to 12:00am of the current day
-            # this way the event created will always be on this day and we can check it easily
-            _seconds_since_epoch = self.marionette.execute_script("""
-                    var today = new Date();
-                    var yr = today.getFullYear();
-                    var mth = today.getMonth();
-                    var day = today.getDate();
-                    return new Date(yr, mth, day, 0, 0, 0).getTime();""")
-
-            self.today = datetime.datetime.fromtimestamp(_seconds_since_epoch / 1000)
-
-            # set the system date to the time
-            self.data_layer.set_time(_seconds_since_epoch)
-        else:
-            self.today = datetime.datetime.now()
 
     def test_that_new_event_appears_on_all_calendar_views(self):
 
-        event_title = 'Event Title %s' % str(self.today.time())
-        event_location = 'Event Location %s' % str(self.today.time())
-        event_start_date_time = self.today.replace(hour=1, minute=0, second=0)
-        event_end_date_time = self.today.replace(hour=2, minute=0, second=0)
-        EVENT_DATE_TIME_TO_STRING_PATTERN = '%H:%M:%S'
+        # We get the actual time of the device
+        _seconds_since_epoch = self.marionette.execute_script("return Date.now();")
+        now = datetime.fromtimestamp(_seconds_since_epoch / 1000)
+
+        # We know that the default event time will be rounded up 1 hour
+        event_start_date_time = now + timedelta(hours=1)
+
+        event_title = 'Event Title %s' % str(event_start_date_time.time())
+        event_location = 'Event Location %s' % str(event_start_date_time.time())
 
         calendar = Calendar(self.marionette)
         calendar.launch()
@@ -48,8 +30,7 @@ class TestCalendar(GaiaTestCase):
         # create a new event
         new_event.fill_event_title(event_title)
         new_event.fill_event_location(event_location)
-        new_event.fill_event_start_time(event_start_date_time.strftime(EVENT_DATE_TIME_TO_STRING_PATTERN))
-        new_event.fill_event_end_time(event_end_date_time.strftime(EVENT_DATE_TIME_TO_STRING_PATTERN))
+
         new_event.tap_save_event()
 
         # assert that the event is displayed as expected in month view
@@ -57,10 +38,10 @@ class TestCalendar(GaiaTestCase):
         self.assertIn(event_location, calendar.displayed_events_in_month_view(event_start_date_time))
 
         # switch to the week display
-        calendar.click_week_display_button()
+        calendar.tap_week_display_button()
         self.assertIn(event_title, calendar.displayed_events_in_week_view(event_start_date_time))
 
         # switch to the day display
-        calendar.click_day_display_button()
+        calendar.tap_day_display_button()
         self.assertIn(event_title, calendar.displayed_events_in_day_view(event_start_date_time))
         self.assertIn(event_location, calendar.displayed_events_in_day_view(event_start_date_time))

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/test_calendar_today_date.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/test_calendar_today_date.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
+from datetime import datetime
 
 from gaiatest import GaiaTestCase
 from gaiatest.apps.calendar.app import Calendar
@@ -10,24 +10,14 @@ from gaiatest.apps.calendar.app import Calendar
 
 class TestCalendar(GaiaTestCase):
 
-    def setUp(self):
-        GaiaTestCase.setUp(self)
-
-        if self.device.is_android_build:
-            # Setting the time on the device back to 12:00am of the current day
-            # this way the event created will always be on this day and we can check it easily
-            _seconds_since_epoch = self.marionette.execute_script("return Date.now();")
-
-            self.today = datetime.datetime.fromtimestamp(_seconds_since_epoch / 1000)
-
-            # set the system date to the time
-            self.data_layer.set_time(_seconds_since_epoch)
-        else:
-            self.today = datetime.date.today()
-
     def test_check_today_date(self):
+
+        # We get the actual time of the device
+        _seconds_since_epoch = self.marionette.execute_script("return Date.now();")
+        now = datetime.fromtimestamp(_seconds_since_epoch / 1000)
+
         calendar = Calendar(self.marionette)
         calendar.launch()
 
-        self.assertEquals(self.today.strftime('%B %Y'), calendar.current_month_year)
-        self.assertIn(self.today.strftime('%a %b %d %Y'), calendar.current_month_day)
+        self.assertEquals(now.strftime('%B %Y'), calendar.current_month_year)
+        self.assertIn(now.strftime('%a %b %d %Y'), calendar.current_month_day)


### PR DESCRIPTION
.... Also clean up calendar app locators

Conflicts:
    tests/python/gaia-ui-tests/gaiatest/tests/functional/calendar/manifest.ini
