### PR TITLE
Bug 929317 - [Message] Message waiting UI was flicked while start up

### DIFF
--- a/apps/sms/style/root.css
+++ b/apps/sms/style/root.css
@@ -20,6 +20,7 @@ body {
   line-height: 2.2rem;
   text-align: center;
   vertical-align: middle;
+  background-color: #FFF;
 }
 
 /* Text conventions */


### PR DESCRIPTION
- Set app body background color to prevent the unexpected screen shows up.
