### PR TITLE
Bug 946047: Add nfc read only permissions to Settings UI to allow navigator.mozNfc DOM to be created.

### DIFF
--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -30,7 +30,8 @@
     "idle":{},
     "telephony":{},
     "audio-channel-notification":{},
-    "downloads":{}
+    "downloads":{},
+    "nfc":{ "access": "readonly" }
   },
   "activities": {
     "configure": {


### PR DESCRIPTION
This fix is needed for apps using NFC if "HasNfcSupport" is added to the navigator MozNfc WebIDL. If only that lands, NFC in SettingsUI disappears for every phone.

One thing to note is that if this pull request fix lands, NFC will appear in all affected phones in SettingsUI, and will additionally require the fix in Bug 939056 to turn it back off, configured per device outside Gecko.
