### PR TITLE
Bug 928968 - Add a command to the gaia command line tool to print the applications installed

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_apps.js
+++ b/tests/python/gaia-ui-tests/gaiatest/atoms/gaia_apps.js
@@ -10,6 +10,13 @@ var GaiaApps = {
     return name.replace(/[- ]+/g, '').toLowerCase();
   },
 
+  getInstalledApps: function() {
+    let req = navigator.mozApps.mgmt.getAll();
+    req.onsuccess = function() {
+      marionetteScriptFinished(req.result);
+    }
+  },
+
   getRunningApps: function() {
     let runningApps = window.wrappedJSObject.WindowManager.getRunningApps();
     // Return a simplified version of the runningApps object which can be

--- a/tests/python/gaia-ui-tests/gaiatest/gcli.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gcli.py
@@ -58,6 +58,12 @@ class GCli(object):
                      'nargs': argparse.REMAINDER,
                      'help': 'Name of app to launch'}],
                 'help': 'Launch an application'},
+            'listallapps': {
+                'function': self.list_all_apps,
+                'help': 'List all apps'},
+            'listrunningapps': {
+                'function': self.list_running_apps,
+                'help': 'List the running apps'},
             'lock': {
                 'function': self.lock,
                 'help': 'Lock screen'},
@@ -188,6 +194,16 @@ class GCli(object):
     def launch_app(self, args):
         for name in args.name:
             self.apps.launch(name)
+
+    def list_all_apps(self, args):
+        for i, app in enumerate(sorted(self.apps.installed_apps,
+                                       key=lambda a: a.name.lower())):
+            print '%d: %s' % (i + 1, app.name)
+
+    def list_running_apps(self, args):
+        for i, app in enumerate(sorted(self.apps.running_apps,
+                                       key=lambda a: a.name.lower())):
+            print '%d: %s' % (i + 1, app.name)
 
     def lock(self, args):
         self.lock_screen.lock()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_background_apps.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_background_apps.py
@@ -39,18 +39,13 @@ class TestEnduranceBackgroundApps(GaiaEnduranceTestCase):
     def background_apps(self):
         # Verify each app is running
         self.marionette.switch_to_frame()
-        running_apps = self.apps.runningApps()
-        currently_running_apps = ''.join(running_apps)
+        running_apps = [a.name.lower() for a in self.apps.running_apps]
 
         for expected_app in self.app_list:
-            if expected_app == "phone":
-                expected_app = "dialer"
-            elif expected_app == "messages":
-                expected_app = "sms"
-            self.assertTrue(expected_app in currently_running_apps, "%s app should be running!" %expected_app)
+            self.assertTrue(expected_app in running_apps, '%s app should be running!' % expected_app)
 
         # Also ensure homescreen still running
-        self.assertTrue("homescreen" in currently_running_apps, "homescreen app should be running!")
+        self.assertTrue("homescreen" in running_apps, "homescreen app should be running!")
 
         # Just leave apps running in background
         time.sleep(60)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_kill.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_kill.py
@@ -6,6 +6,7 @@ import time
 
 from gaiatest import GaiaTestCase
 
+
 class TestKill(GaiaTestCase):
 
     def test_kill(self):
@@ -27,7 +28,5 @@ class TestKill(GaiaTestCase):
         self.check_no_apps_running()
 
     def check_no_apps_running(self):
-        runningApps = self.apps.runningApps()
-        for origin in runningApps.keys():
-            if 'homescreen' not in origin:
-                self.fail('%s still running' % origin)
+        self.assertEqual(
+            [a.name.lower() for a in self.apps.running_apps], ['homescreen'])

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_killall.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_killall.py
@@ -38,7 +38,5 @@ class TestKillAll(GaiaTestCase):
         self.apps.kill_all()
 
     def check_no_apps_running(self):
-        runningApps = self.apps.runningApps()
-        for origin in runningApps.keys():
-            if 'homescreen' not in origin:
-                self.fail('%s still running' % origin)
+        self.assertEqual(
+            [a.name.lower() for a in self.apps.running_apps], ['homescreen'])


### PR DESCRIPTION
Adds an `installed_apps` property to `GaiaApps` and a `listallapps` command to gcli. Also modified the `runningApps` method to be a property and return a list of `GaiaApp` objects. I have updated all places this method is called, and checked that it's not used in any package (that I'm aware of) that depends on gaiatest.

Output looks like:

```
$ gcli listallapps
1: Browser
2: Calendar
3: Camera
...
```

```
$ gcli listrunningapps
1: Homescreen
2: Messages
3: Phone
...
```
