### PR TITLE
Bug 946744 - [Messages] Long invalid recipients makes the recipient pane...

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -838,7 +838,9 @@ generateHeightRule() (in ThreadUI/thread_ui.js) will create:
 .recipient {
   display: inline-block;
   overflow: hidden;
-  max-width: calc(100% - 2.3rem);
+  -moz-box-sizing: border-box;
+       box-sizing: border-box;
+  max-width: calc(100% - .5rem);
   height: 2.2rem;
   border: .1rem solid #4d4d4d;
   padding: 0 0.8rem;


### PR DESCRIPTION
...l horizontally scrollable r=borja

Uses box-sizing: border-box to have something consistent between recipient
states
