### PR TITLE
Bug 916850: Skip multi-page Ogg meta data

### DIFF
--- a/apps/music/js/metadata.js
+++ b/apps/music/js/metadata.js
@@ -480,6 +480,7 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
       }
       if (!valid) {
         errorCallback('malformed ogg comment packet');
+        return;
       }
 
       var vendor_string_length = page.readUnsignedInt(true);
@@ -492,7 +493,15 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
       // we've seen in the file separately.
       var seen_fields = {};
       for (var i = 0; i < num_comments; i++) {
+        if (page.remaining() < 4) { // 4 bytes for comment-length variable
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment_length = page.readUnsignedInt(true);
+        if (comment_length > page.remaining()) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment = page.readUTF8Text(comment_length);
         var equal = comment.indexOf('=');
         if (equal !== -1) {

--- a/shared/js/blobview.js
+++ b/shared/js/blobview.js
@@ -8,7 +8,7 @@ var BlobView = (function() {
   // This constructor is for internal use only.
   // Use the BlobView.get() factory function or the getMore instance method
   // to obtain a BlobView object.
-  function BlobView(blob, sliceOffset, sliceLength, slice, 
+  function BlobView(blob, sliceOffset, sliceLength, slice,
                     viewOffset, viewLength, littleEndian)
   {
     this.blob = blob;                  // The parent blob that the data is from
@@ -167,6 +167,9 @@ var BlobView = (function() {
     // Methods to get and set the current position
     tell: function() {
       return this.index;
+    },
+    remaining: function() {
+      return this.byteLength - this.index;
     },
     seek: function(index) {
       if (index < 0)

--- a/test_apps/music2/js/metadata.js
+++ b/test_apps/music2/js/metadata.js
@@ -466,6 +466,7 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
       }
       if (!valid) {
         errorCallback('malformed ogg comment packet');
+        return;
       }
 
       var vendor_string_length = page.readUnsignedInt(true);
@@ -473,7 +474,15 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
 
       var num_comments = page.readUnsignedInt(true);
       for (var i = 0; i < num_comments; i++) {
+        if (page.remaining() < 4) { // 4 bytes for comment-length variable
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment_length = page.readUnsignedInt(true);
+        if (comment_length > page.remaining()) {
+          // TODO: handle metadata that uses multiple pages
+          break;
+        }
         var comment = page.readUTF8Text(comment_length);
         var equal = comment.indexOf('=');
         if (equal !== -1) {


### PR DESCRIPTION
Ogg files are split into multiple segments, called pages. Currently
we only support meta data in a single page. This can result in parser
errors when meta data fields span multiple pages, and the inability
to listen to the Ogg file.

With this patch, the parser simply stops in these cases. We don't get
the respective information from the file, but the file will at least
be available for playing in the Music player.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
