### PR TITLE
Bug 946678 - [Messaging] Creating a new message from contacts does not o...

### DIFF
--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -44,6 +44,7 @@
   "orientation": "default",
   "activities": {
     "new": {
+      "href": "/index.html#activity-new",
       "filters": {
         "type": "websms/sms",
         "number": {


### PR DESCRIPTION
...pen the messaging composer when Messaging app is in background r=borja

Adds a hash for the "new" activity. This will have the side-effect of not
registering the notification and sms-received system message handlers which is a
good thing.
