### PR TITLE
Bug 947918: Support seeking to end of BlobView buffer

### DIFF
--- a/shared/js/blobview.js
+++ b/shared/js/blobview.js
@@ -8,7 +8,7 @@ var BlobView = (function() {
   // This constructor is for internal use only.
   // Use the BlobView.get() factory function or the getMore instance method
   // to obtain a BlobView object.
-  function BlobView(blob, sliceOffset, sliceLength, slice, 
+  function BlobView(blob, sliceOffset, sliceLength, slice,
                     viewOffset, viewLength, littleEndian)
   {
     this.blob = blob;                  // The parent blob that the data is from
@@ -171,7 +171,7 @@ var BlobView = (function() {
     seek: function(index) {
       if (index < 0)
         fail('negative index');
-      if (index >= this.byteLength)
+      if (index > this.byteLength)
         fail('index greater than buffer size');
       this.index = index;
     },


### PR DESCRIPTION
Reading or advancing through all bytes in a BlobView buffer sets
the index to the length of the buffer. This patch changes 'seek'
to work the same way, so it's possible to seek to the buffer's
end.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
