### PR TITLE
Bug 942107 - Reduce locators, settings app

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/bluetooth.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/bluetooth.py
@@ -8,7 +8,6 @@ from gaiatest.apps.base import Base
 
 class Bluetooth(Base):
 
-    _bluetooth_region_visible_locator = (By.CSS_SELECTOR, '#bluetooth.current')
     _bluetooth_checkbox_locator = (By.CSS_SELECTOR, '#bluetooth-status input')
     _bluetooth_label_locator = (By.CSS_SELECTOR, '#bluetooth-status span')
 

--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/display.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/display.py
@@ -11,7 +11,6 @@ class Display(Base):
     _wallpaper_preview_locator = (By.ID, 'wallpaper-preview')
     _wallpaper_pick_locator = (By.ID, 'wallpaper')
     _wallpaper_button_locator = (By.XPATH, "//*[text()='Wallpaper']")
-    _wallpaper_title_locator = (By.CSS_SELECTOR, "h1[data-l10n-id='select-wallpaper']")
     _stock_wallpapers_locator = (By.CSS_SELECTOR, "div[class='wallpaper']")
     _wallpaper_frame_locator = (By.CSS_SELECTOR, "iframe[src^='app://wallpaper'][src$='pick.html']")
 


### PR DESCRIPTION
I eliminated a lot of locators I found in Settings app, but instead I had to add some more code to the methods that use this locators. I'm not sure if this is the best way of reducing locators. Still, I ran all the Settings tests and they all worked fine. I'm waiting for review. Thanks!
