### PR TITLE
Bug 948334 - Remove all trace of old notification in email app

### DIFF
--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -29,10 +29,6 @@ if (typeof TestUrlResolver === 'undefined') {
 
       'shared/js/mime_mapper': {
         exports: 'MimeMapper'
-      },
-
-      'shared/js/notification_helper': {
-        exports: 'NotificationHelper'
       }
     },
     definePrim: 'prim'

--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -131,7 +131,7 @@ define(function(require) {
                   subject,
                   body;
 
-              if (navigator.mozNotification) {
+              if (window.Notification) {
                 if (result.count > 1) {
                   dataString = fromObject({
                     type: 'message_list',

--- a/apps/email/test/config.js
+++ b/apps/email/test/config.js
@@ -24,10 +24,6 @@
 
       'shared/js/mime_mapper': {
         exports: 'MimeMapper'
-      },
-
-      'shared/js/notification_helper': {
-        exports: 'NotificationHelper'
       }
     },
     definePrim: 'prim'


### PR DESCRIPTION
While the email app makes use of the new Notification API, there were
some stale changes left behind: checking navigator.mozNotification,
reference to NotificationHelper which is unused now. This commit simply
remove thoses.
