### PR TITLE
Bug 938207 - [Dialer] Intermittent Travis Unit Test Failure: dialer/call...

### DIFF
--- a/apps/communications/dialer/test/unit/call_log_db_test.js
+++ b/apps/communications/dialer/test/unit/call_log_db_test.js
@@ -83,6 +83,10 @@ suite('dialer/call_log_db', function() {
 
     realContacts = window.Contacts;
     window.Contacts = MockContacts;
+
+    // we use an asynchronous IndexedDB API and we want to really test it, so
+    // let's increase mocha's timeout a lot
+    this.timeout(20000);
   });
 
   teardown(function() {


### PR DESCRIPTION
..._log_db Two calls, same group, different hour Add a call: Error: timeout of 2000ms exceeded r=etienne
- increase the timeout for the call_log_db tests because we're using an
  asynchronous IndexedDB API and we really want to use it even in the tests
- rename calllog_db_test to call_log_db_test so that the tests will be run when
  saving call_log_db.js
