### PR TITLE
Bug 944881 - Gaia should interpret timestamps as long-long numbers

### DIFF
--- a/apps/sms/js/desktop-only/mobilemessage.js
+++ b/apps/sms/js/desktop-only/mobilemessage.js
@@ -79,7 +79,7 @@
         location: 'example.jpg',
         content: testImageBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
     messagesDb.messages.push({
       id: messagesDb.id++,
@@ -99,7 +99,7 @@
         location: 'example.jpg',
         content: testImageBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
   });
 
@@ -122,7 +122,7 @@
         location: 'example.ogv',
         content: testVideoBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
     messagesDb.messages.push({
       id: messagesDb.id++,
@@ -142,7 +142,7 @@
         location: 'example.ogv',
         content: testVideoBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
   });
   getTestFile('/test/unit/media/audio.oga', function(testAudioBlob) {
@@ -164,7 +164,7 @@
         location: 'example.ogg',
         content: testAudioBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
     messagesDb.messages.push({
       id: messagesDb.id++,
@@ -184,7 +184,7 @@
         location: 'example.ogg',
         content: testAudioBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
   });
 
@@ -208,7 +208,7 @@
         location: 'example.bmp',
         content: testImageBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
   });
 
@@ -232,7 +232,7 @@
         location: 'grid.wbmp',
         content: testImageBlob
       }],
-      timestamp: new Date()
+      timestamp: +new Date()
     });
   });
 
@@ -300,7 +300,7 @@
         delivery: 'sent',
         read: true,
         type: 'sms',
-        timestamp: new Date(),
+        timestamp: +new Date(),
         deliveryStatus: 'success'
       },
       {
@@ -312,7 +312,7 @@
         read: true,
         type: 'sms',
         deliveryStatus: 'not-applicable',
-        timestamp: new Date(Date.now() - 8400000000)
+        timestamp: now - 8400000000
       },
       {
         threadId: 2,
@@ -323,7 +323,7 @@
         read: true,
         type: 'sms',
         deliveryStatus: 'not-applicable',
-        timestamp: new Date(Date.now() - 172800000)
+        timestamp: now - 172800000
       },
       {
         threadId: 3,
@@ -333,7 +333,7 @@
         type: 'sms',
         deliveryStatus: 'not-applicable',
         delivery: 'sent',
-        timestamp: new Date()
+        timestamp: +new Date()
       },
       {
         threadId: 4,
@@ -346,7 +346,7 @@
         error: true,
         type: 'sms',
         deliveryStatus: 'not-applicable',
-        timestamp: new Date(Date.now() - 900000)
+        timestamp: now - 900000
       },
       {
         threadId: 4,
@@ -358,7 +358,7 @@
         delivery: 'sending',
         type: 'sms',
         deliveryStatus: 'pending',
-        timestamp: new Date(Date.now() - 800000)
+        timestamp: now - 800000
       },
       {
         threadId: 4,
@@ -370,7 +370,7 @@
         delivery: 'error',
         type: 'sms',
         deliveryStatus: 'error',
-        timestamp: new Date(Date.now() - 700000)
+        timestamp: now - 700000
       },
       {
         threadId: 4,
@@ -381,7 +381,7 @@
         delivery: 'sent',
         type: 'sms',
         deliveryStatus: 'not-applicable',
-        timestamp: new Date(Date.now() - 600000)
+        timestamp: now - 600000
        },
       {
         threadId: 4,
@@ -392,7 +392,7 @@
         delivery: 'sent',
         deliveryStatus: 'success',
         type: 'sms',
-        timestamp: new Date(Date.now() - 550000)
+        timestamp: now - 550000
        },
        {
         threadId: 4,
@@ -403,7 +403,7 @@
         delivery: 'received',
         deliveryStatus: 'success',
         type: 'sms',
-        timestamp: new Date(Date.now() - 500000)
+        timestamp: now - 500000
       },
       {
         threadId: 4,
@@ -414,7 +414,7 @@
         delivery: 'sending',
         type: 'sms',
         deliveryStatus: 'not-applicable',
-        timestamp: new Date(Date.now() - 400000)
+        timestamp: now - 400000
       },
       {
         threadId: 4,
@@ -425,7 +425,7 @@
         delivery: 'error',
         type: 'sms',
         deliveryStatus: 'error',
-        timestamp: new Date(Date.now() - 300000)
+        timestamp: now - 300000
       },
       {
         threadId: 4,
@@ -436,7 +436,7 @@
         delivery: 'sent',
         type: 'sms',
         deliveryStatus: 'success',
-        timestamp: new Date(Date.now() - 200000)
+        timestamp: now - 200000
       },
       {
         threadId: 4,
@@ -447,7 +447,7 @@
         delivery: 'sent',
         deliveryStatus: 'success',
         type: 'sms',
-        timestamp: new Date(Date.now() - 150000)
+        timestamp: now - 150000
       },
       {
         threadId: 4,
@@ -457,7 +457,7 @@
         delivery: 'received',
         type: 'sms',
         deliveryStatus: 'success',
-        timestamp: new Date(Date.now() - 100000)
+        timestamp: now - 100000
       },
       {
         threadId: 8,
@@ -466,8 +466,8 @@
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'pending'}],
         subject: 'Pending download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() + ONE_DAY_TIME)
+        timestamp: now - 150000,
+        expiryDate: now + ONE_DAY_TIME
       },
       {
         threadId: 8,
@@ -476,8 +476,8 @@
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'error'}],
         subject: 'Error download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() + ONE_DAY_TIME * 2)
+        timestamp: now - 150000,
+        expiryDate: now + ONE_DAY_TIME * 2
       },
       {
         threadId: 8,
@@ -486,8 +486,8 @@
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'error'}],
         subject: 'Error download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() - ONE_DAY_TIME)
+        timestamp: now - 150000,
+        expiryDate: now - ONE_DAY_TIME
       },
       {
         threadId: 8,
@@ -498,8 +498,8 @@
         subject: 'No attachment error',
         smil: '<smil><body><par><text src="text1"/></par></body></smil>',
         attachments: null,
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() + ONE_DAY_TIME)
+        timestamp: now - 150000,
+        expiryDate: now + ONE_DAY_TIME
       },
       {
         threadId: 10,
@@ -508,7 +508,7 @@
         body: '<html>',
         delivery: 'received',
         type: 'sms',
-        timestamp: new Date(Date.now())
+        timestamp: +now
       }
     ],
     threads: [
@@ -517,7 +517,7 @@
         participants: ['1977'],
         lastMessageType: 'sms',
         body: 'Alo, how are you today, my friend? :)',
-        timestamp: new Date(now - 172800000),
+        timestamp: now - 172800000,
         unreadCount: 0
       },
       {
@@ -525,7 +525,7 @@
         participants: ['436797'],
         lastMessageType: 'sms',
         body: 'Sending :)',
-        timestamp: new Date(Date.now() - 172800000),
+        timestamp: now - 172800000,
         unreadCount: 0
       },
       {
@@ -533,14 +533,14 @@
         participants: ['+18001114321'],
         lastMessageType: 'sms',
         body: 'I have a very long name!',
-        timestamp: new Date(),
+        timestamp: +new Date(),
         unreadCount: 0
       },
       {
         id: 4,
         participants: ['197746797'],
         body: 'short (delivery: received)',
-        timestamp: new Date(Date.now() - 172800000),
+        timestamp: now - 172800000,
         lastMessageType: 'sms',
         unreadCount: 0
       },
@@ -549,42 +549,42 @@
         participants: ['14886783487'],
         lastMessageType: 'sms',
         body: 'Hello world!',
-        timestamp: new Date(Date.now() - 600000000),
+        timestamp: now - 600000000,
         unreadCount: 2
       },
       {
         id: 6,
         participants: ['052780'],
         lastMessageType: 'mms',
-        timestamp: new Date(now - (60000000 * 10)),
+        timestamp: now - (60000000 * 10),
         unreadCount: 0
       },
       {
         id: 7,
         participants: ['999', '888', '777', '123456'],
         lastMessageType: 'mms',
-        timestamp: new Date(now),
+        timestamp: +now,
         unreadCount: 0
       },
       {
         id: 8,
         participants: ['123456'],
         lastMessageType: 'mms',
-        timestamp: new Date(Date.now() - 150000000),
+        timestamp: now - 150000000,
         unreadCount: 0
       },
       {
         id: 9,
         participants: participants,
         lastMessageType: 'mms',
-        timestamp: new Date(new Date(now) - 150000000),
+        timestamp: now - 150000000,
         unreadCount: 0
       },
       {
         id: 10,
         participants: ['+12125551234', '+15551237890'],
         lastMessageType: 'mms',
-        timestamp: new Date(Date.now()),
+        timestamp: now,
         unreadCount: 0
       }
     ]
@@ -607,7 +607,7 @@
       delivery: 'received',
       id: messagesDb.id++,
       type: 'sms',
-      timestamp: new Date(Date.now() - 60000000)
+      timestamp: now - 60000000
     });
   }
 
@@ -634,7 +634,7 @@
         location: 'text1',
         content: new Blob(['hi! this is ' + sender], { type: 'text/plain' })
       }],
-      timestamp: new Date(now - first)
+      timestamp: now - first
     });
     first -= 60000;
   }
@@ -661,7 +661,7 @@
         location: 'text1',
         content: new Blob(['hi! this is ' + sender], { type: 'text/plain' })
       }],
-      timestamp: new Date(now - first)
+      timestamp: now - first
     });
     first -= 60000;
   }
@@ -688,7 +688,7 @@
          { type: 'text/plain' }
       )
     }],
-    timestamp: new Date()
+    timestamp: +new Date()
   });
 
 
@@ -757,7 +757,7 @@
         id: messagesDb.id++,
         participants: [].concat(number),
         body: text,
-        timestamp: new Date(),
+        timestamp: +new Date(),
         unreadCount: 0,
         lastMessageType: 'sms'
       };
@@ -765,7 +765,7 @@
     }
     else {
       thread.body = text;
-      thread.timestamp = new Date();
+      thread.timestamp = +new Date();
     }
 
     var sendInfo = {
@@ -778,7 +778,7 @@
         id: sendId,
         type: 'sms',
         read: true,
-        timestamp: new Date(),
+        timestamp: +new Date(),
         threadId: thread.id
       }
     };
@@ -834,7 +834,7 @@
           id: messagesDb.id++,
           type: 'sms',
           read: false,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           threadId: thread.id
         }
       };
@@ -882,12 +882,12 @@
         lastMessageType: 'mms',
         participants: params.receivers,
         body: '',
-        timestamp: new Date(),
+        timestamp: +new Date(),
         unreadCount: 0
       };
       messagesDb.threads.push(thread);
     } else {
-      thread.timestamp = new Date();
+      thread.timestamp = +new Date();
     }
 
     var sendInfo = {
@@ -904,7 +904,7 @@
         subject: '',
         smil: params.smil,
         attachments: params.attachments,
-        timestamp: new Date()
+        timestamp: +new Date()
       }
     };
 
@@ -958,7 +958,7 @@
             receiver: null,
             delivery: 'received',
             id: messagesDb.id++,
-            timestamp: new Date(),
+            timestamp: +new Date(),
             threadId: thread.id,
             type: 'mms',
             deliveryInfo: [{deliveryStatus: 'success'}],
@@ -1279,7 +1279,7 @@
       for (; idx < len; ++idx) {
         msg = msgs[idx];
         if (msg.type !== 'mms' || msg.delivery !== 'not-downloaded' ||
-          +msg.expiryDate < +Date.now()) {
+          +msg.expiryDate < +now) {
           continue;
         }
         if (msg.id === id) {

--- a/apps/sms/js/desktop-only/mobilemessage.js
+++ b/apps/sms/js/desktop-only/mobilemessage.js
@@ -79,7 +79,7 @@
         location: 'example.jpg',
         content: testImageBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
     messagesDb.messages.push({
       id: messagesDb.id++,
@@ -99,7 +99,7 @@
         location: 'example.jpg',
         content: testImageBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
   });
 
@@ -122,7 +122,7 @@
         location: 'example.ogv',
         content: testVideoBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
     messagesDb.messages.push({
       id: messagesDb.id++,
@@ -142,7 +142,7 @@
         location: 'example.ogv',
         content: testVideoBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
   });
   getTestFile('/test/unit/media/audio.oga', function(testAudioBlob) {
@@ -164,7 +164,7 @@
         location: 'example.ogg',
         content: testAudioBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
     messagesDb.messages.push({
       id: messagesDb.id++,
@@ -184,7 +184,7 @@
         location: 'example.ogg',
         content: testAudioBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
   });
 
@@ -208,7 +208,7 @@
         location: 'example.bmp',
         content: testImageBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
   });
 
@@ -232,7 +232,7 @@
         location: 'grid.wbmp',
         content: testImageBlob
       }],
-      timestamp: +new Date()
+      timestamp: now
     });
   });
 
@@ -300,7 +300,7 @@
         delivery: 'sent',
         read: true,
         type: 'sms',
-        timestamp: +new Date(),
+        timestamp: now,
         deliveryStatus: 'success'
       },
       {
@@ -333,7 +333,7 @@
         type: 'sms',
         deliveryStatus: 'not-applicable',
         delivery: 'sent',
-        timestamp: +new Date()
+        timestamp: now
       },
       {
         threadId: 4,
@@ -533,7 +533,7 @@
         participants: ['+18001114321'],
         lastMessageType: 'sms',
         body: 'I have a very long name!',
-        timestamp: +new Date(),
+        timestamp: now,
         unreadCount: 0
       },
       {
@@ -688,7 +688,7 @@
          { type: 'text/plain' }
       )
     }],
-    timestamp: +new Date()
+    timestamp: now
   });
 
 
@@ -757,7 +757,7 @@
         id: messagesDb.id++,
         participants: [].concat(number),
         body: text,
-        timestamp: +new Date(),
+        timestamp: now,
         unreadCount: 0,
         lastMessageType: 'sms'
       };
@@ -765,7 +765,7 @@
     }
     else {
       thread.body = text;
-      thread.timestamp = +new Date();
+      thread.timestamp = now;
     }
 
     var sendInfo = {
@@ -778,7 +778,7 @@
         id: sendId,
         type: 'sms',
         read: true,
-        timestamp: +new Date(),
+        timestamp: now,
         threadId: thread.id
       }
     };
@@ -834,7 +834,7 @@
           id: messagesDb.id++,
           type: 'sms',
           read: false,
-          timestamp: +new Date(),
+          timestamp: now,
           threadId: thread.id
         }
       };
@@ -882,12 +882,12 @@
         lastMessageType: 'mms',
         participants: params.receivers,
         body: '',
-        timestamp: +new Date(),
+        timestamp: now,
         unreadCount: 0
       };
       messagesDb.threads.push(thread);
     } else {
-      thread.timestamp = +new Date();
+      thread.timestamp = now;
     }
 
     var sendInfo = {
@@ -904,7 +904,7 @@
         subject: '',
         smil: params.smil,
         attachments: params.attachments,
-        timestamp: +new Date()
+        timestamp: now
       }
     };
 
@@ -958,7 +958,7 @@
             receiver: null,
             delivery: 'received',
             id: messagesDb.id++,
-            timestamp: +new Date(),
+            timestamp: now,
             threadId: thread.id,
             type: 'mms',
             deliveryInfo: [{deliveryStatus: 'success'}],
@@ -1279,7 +1279,7 @@
       for (; idx < len; ++idx) {
         msg = msgs[idx];
         if (msg.type !== 'mms' || msg.delivery !== 'not-downloaded' ||
-          +msg.expiryDate < +now) {
+          +msg.expiryDate < now) {
           continue;
         }
         if (msg.id === id) {

--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -72,7 +72,7 @@
      *
      * @param  {Number}  id thread id of the drafts to return.
      *
-     * @return {Draft.List}  return Draft.List containing drafts for thread id
+     * @return {Draft.List}  return Draft.List containing drafts for thread id.
      */
     byId: function(id) {
       return new Drafts.List(draftIndex.get(id));
@@ -169,13 +169,13 @@
    * message content to be stored temporarily
    * in a Drafts collection.
    *
-   * @param {Object}  draft  Draft or empty object
+   * @param {Object}  draft  Draft or empty object.
    */
   function Draft(opts) {
     var draft = opts || {};
     this.recipients = draft.recipients || [];
     this.content = draft.content || [];
-    this.timestamp = draft.timestamp || Date.now();
+    this.timestamp = draft.timestamp || +Date.now();
     this.threadId = draft.threadId || null;
     this.type = draft.type;
   }

--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -175,7 +175,7 @@
     var draft = opts || {};
     this.recipients = draft.recipients || [];
     this.content = draft.content || [];
-    this.timestamp = draft.timestamp || +Date.now();
+    this.timestamp = +draft.timestamp || Date.now();
     this.threadId = draft.threadId || null;
     this.type = draft.type;
   }

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -77,7 +77,7 @@ window.addEventListener('localized', function localized() {
       }
       var args = JSON.parse(element.dataset.l10nArgs);
       var format = navigator.mozL10n.get(element.dataset.l10nDateFormat);
-      var date = new Date(element.dataset.l10nDate);
+      var date = new Date(+element.dataset.l10nDate);
       args.date = Utils.date.format.localeFormat(date, format);
 
       navigator.mozL10n.localize(element, element.dataset.l10nId, args);

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -360,7 +360,7 @@ var ThreadListUI = {
   createThread: function thlui_createThread(thread) {
     // Create DOM element
     var li = document.createElement('li');
-    var timestamp = thread.timestamp.getTime();
+    var timestamp = +thread.timestamp;
     var lastMessageType = thread.lastMessageType;
     var participants = thread.participants;
     var number = participants[0];
@@ -416,7 +416,7 @@ var ThreadListUI = {
     var existingThreadElement = document.getElementById('thread-' + thread.id);
 
     // New message is older than the latest one?
-    var timestamp = message.timestamp.getTime();
+    var timestamp = +message.timestamp;
     if (existingThreadElement &&
       existingThreadElement.dataset.time > timestamp) {
       // If the received SMS it's older that the latest one
@@ -443,7 +443,7 @@ var ThreadListUI = {
   },
 
   appendThread: function thlui_appendThread(thread) {
-    var timestamp = thread.timestamp.getTime();
+    var timestamp = +thread.timestamp;
     // We create the DOM element of the thread
     var node = this.createThread(thread);
 

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1336,7 +1336,7 @@ var ThreadUI = global.ThreadUI = {
     var status = message.deliveryInfo[0].deliveryStatus;
 
     var expireFormatted = Utils.date.format.localeFormat(
-      new Date(message.expiryDate), navigator.mozL10n.get('dateTimeFormat_%x')
+      new Date(+message.expiryDate), navigator.mozL10n.get('dateTimeFormat_%x')
     );
 
     var expired = +message.expiryDate < Date.now();
@@ -1358,7 +1358,7 @@ var ThreadUI = global.ThreadUI = {
     return this.tmpl.notDownloaded.interpolate({
       messageL10nId: messageL10nId,
       messageL10nArgs: JSON.stringify({ date: expireFormatted }),
-      messageL10nDate: message.expiryDate.toString(),
+      messageL10nDate: +message.expiryDate,
       messageL10nDateFormat: 'dateTimeFormat_%x',
       downloadL10nId: downloadL10nId
     });

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1336,7 +1336,7 @@ var ThreadUI = global.ThreadUI = {
     var status = message.deliveryInfo[0].deliveryStatus;
 
     var expireFormatted = Utils.date.format.localeFormat(
-      message.expiryDate, navigator.mozL10n.get('dateTimeFormat_%x')
+      new Date(message.expiryDate), navigator.mozL10n.get('dateTimeFormat_%x')
     );
 
     var expired = +message.expiryDate < Date.now();
@@ -1452,7 +1452,7 @@ var ThreadUI = global.ThreadUI = {
   },
 
   appendMessage: function thui_appendMessage(message, hidden) {
-    var timestamp = message.timestamp.getTime();
+    var timestamp = +message.timestamp;
 
     // look for an old message and remove it first - prevent anything from ever
     // double rendering for now

--- a/apps/sms/js/threads.js
+++ b/apps/sms/js/threads.js
@@ -49,7 +49,7 @@
         id: message.threadId,
         participants: participants,
         body: message.body,
-        timestamp: message.timestamp,
+        timestamp: +message.timestamp,
         unreadCount: (options && !options.read) ? 1 : 0,
         lastMessageType: message.type || 'sms'
       };

--- a/apps/sms/test/unit/messages_mockup.js
+++ b/apps/sms/test/unit/messages_mockup.js
@@ -14,7 +14,7 @@ function MockThreadMessages() {
       error: true,
       id: 47,
       threadId: 1,
-      timestamp: getMockupedDate(0)
+      timestamp: +getMockupedDate(0)
     },
     {
       sender: null,
@@ -23,7 +23,7 @@ function MockThreadMessages() {
       delivery: 'sent',
       id: 46,
       threadId: 1,
-      timestamp: getMockupedDate(0)
+      timestamp: +getMockupedDate(0)
     },
     {
       sender: '197746797',
@@ -31,7 +31,7 @@ function MockThreadMessages() {
       delivery: 'received',
       id: 40,
       threadId: 1,
-      timestamp: getMockupedDate(2)
+      timestamp: +getMockupedDate(2)
     },
     {
       sender: null,
@@ -40,7 +40,7 @@ function MockThreadMessages() {
       delivery: 'error',
       id: 460,
       threadId: 1,
-      timestamp: getMockupedDate(6)
+      timestamp: +getMockupedDate(6)
     },
     {
       sender: null,
@@ -49,7 +49,7 @@ function MockThreadMessages() {
       delivery: 'error',
       id: 461,
       threadId: 1,
-      timestamp: getMockupedDate(6)
+      timestamp: +getMockupedDate(6)
     }];
 
   messagesMockup.sort(function(a, b) {

--- a/apps/sms/test/unit/mock_messages.js
+++ b/apps/sms/test/unit/mock_messages.js
@@ -22,7 +22,7 @@ var MockMessages = {
       deliveryStatus: 'success',
       type: 'sms',
       messageClass: 'normal',
-      timestamp: +new Date(),
+      timestamp: Date.now(),
       read: true
     };
 

--- a/apps/sms/test/unit/mock_messages.js
+++ b/apps/sms/test/unit/mock_messages.js
@@ -22,7 +22,7 @@ var MockMessages = {
       deliveryStatus: 'success',
       type: 'sms',
       messageClass: 'normal',
-      timestamp: new Date(),
+      timestamp: +new Date(),
       read: true
     };
 
@@ -49,12 +49,12 @@ var MockMessages = {
       delivery: 'received',
       deliveryInfo: [{receiver: 'receiver', deliveryStatus: 'success'}],
       type: 'mms',
-      timestamp: now,
+      timestamp: +now,
       read: true,
       subject: '',
       smil: this.smilMockup,
       attachments: [new Blob(['body'], {type: 'text/plain'})],
-      expiryDate: tomorrow
+      expiryDate: +tomorrow
     };
 
     for (var key in message) {

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -196,7 +196,7 @@ suite('SMS App Unit-Test', function() {
               threadId: thread.id,
               sender: thread.participants[0],
               delivery: 'received',
-              timestamp: thread.timestamp,
+              timestamp: +thread.timestamp,
               type: thread.lastMessageType === 'mms' ? 'sms' : 'mms'
             };
             MessageManager.onMessageReceived({
@@ -242,7 +242,7 @@ suite('SMS App Unit-Test', function() {
         var date = getMockupedDate(2);
         var threadsContainer =
           document.getElementById('threadsContainer_' +
-            Utils.getDayDate(date.getTime()));
+            Utils.getDayDate(+date));
         assertNumberOfElementsInContainerByTag(threadsContainer, 2, 'li');
       });
 
@@ -318,7 +318,7 @@ suite('SMS App Unit-Test', function() {
           participants: ['287138'],
           body: 'Recibidas!',
           id: 9999,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           type: 'sms',
           channel: 'sms'
         });
@@ -351,7 +351,7 @@ suite('SMS App Unit-Test', function() {
           participants: ['287138'],
           body: 'Recibidas!',
           id: 9999,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           type: 'sms',
           channel: 'sms'
         });
@@ -368,7 +368,7 @@ suite('SMS App Unit-Test', function() {
           participants: ['287138'],
           body: 'Recibidas!',
           id: 9999,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           channel: 'sms'
         });
 
@@ -475,7 +475,7 @@ suite('SMS App Unit-Test', function() {
           body: 'Recibidas!',
           delivery: 'received',
           id: 9999,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           type: 'sms',
           channel: 'sms'
         };
@@ -530,7 +530,7 @@ suite('SMS App Unit-Test', function() {
           body: 'Recibidas!',
           delivery: 'received',
           id: 9999,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           channel: 'sms'
         });
 
@@ -547,7 +547,7 @@ suite('SMS App Unit-Test', function() {
           body: 'Recibidas!',
           delivery: 'received',
           id: 9999,
-          timestamp: new Date(),
+          timestamp: +new Date(),
           channel: 'sms'
         });
 

--- a/apps/sms/test/unit/sms_test.js
+++ b/apps/sms/test/unit/sms_test.js
@@ -318,7 +318,7 @@ suite('SMS App Unit-Test', function() {
           participants: ['287138'],
           body: 'Recibidas!',
           id: 9999,
-          timestamp: +new Date(),
+          timestamp: Date.now(),
           type: 'sms',
           channel: 'sms'
         });
@@ -351,7 +351,7 @@ suite('SMS App Unit-Test', function() {
           participants: ['287138'],
           body: 'Recibidas!',
           id: 9999,
-          timestamp: +new Date(),
+          timestamp: Date.now(),
           type: 'sms',
           channel: 'sms'
         });
@@ -368,7 +368,7 @@ suite('SMS App Unit-Test', function() {
           participants: ['287138'],
           body: 'Recibidas!',
           id: 9999,
-          timestamp: +new Date(),
+          timestamp: Date.now(),
           channel: 'sms'
         });
 
@@ -475,7 +475,7 @@ suite('SMS App Unit-Test', function() {
           body: 'Recibidas!',
           delivery: 'received',
           id: 9999,
-          timestamp: +new Date(),
+          timestamp: Date.now(),
           type: 'sms',
           channel: 'sms'
         };
@@ -530,7 +530,7 @@ suite('SMS App Unit-Test', function() {
           body: 'Recibidas!',
           delivery: 'received',
           id: 9999,
-          timestamp: +new Date(),
+          timestamp: Date.now(),
           channel: 'sms'
         });
 
@@ -547,7 +547,7 @@ suite('SMS App Unit-Test', function() {
           body: 'Recibidas!',
           delivery: 'received',
           id: 9999,
-          timestamp: +new Date(),
+          timestamp: Date.now(),
           channel: 'sms'
         });
 

--- a/apps/sms/test/unit/thread_list_mockup.js
+++ b/apps/sms/test/unit/thread_list_mockup.js
@@ -12,7 +12,7 @@ function MockThreadList() {
             participants: ['1977'],
             lastMessageType: 'sms',
             body: 'Alo, how are you today, my friend? :)',
-            timestamp: getMockupedDate(0),
+            timestamp: +getMockupedDate(0),
             unreadCount: 0
           },
           {
@@ -20,7 +20,7 @@ function MockThreadList() {
             participants: ['436797'],
             lastMessageType: 'sms',
             body: 'Sending :)',
-            timestamp: getMockupedDate(2),
+            timestamp: +getMockupedDate(2),
             unreadCount: 0
           },
           {
@@ -28,7 +28,7 @@ function MockThreadList() {
             participants: ['197746797'],
             lastMessageType: 'sms',
             body: 'Recibido!',
-            timestamp: getMockupedDate(1),
+            timestamp: +getMockupedDate(1),
             unreadCount: 0
           },
           {
@@ -36,7 +36,7 @@ function MockThreadList() {
             participants: ['1977436979'],
             lastMessageType: 'mms',
             body: 'Nothing :)',
-            timestamp: getMockupedDate(2),
+            timestamp: +getMockupedDate(2),
             unreadCount: 2
           },
           {
@@ -44,7 +44,7 @@ function MockThreadList() {
             participants: ['999', '888', '777'],
             lastMessageType: 'sms',
             body: '...',
-            timestamp: getMockupedDate(3),
+            timestamp: +getMockupedDate(3),
             unreadCount: 0
           }
         ];

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -477,7 +477,7 @@ suite('thread_list_ui', function() {
         lastMessageType: 'sms',
         participants: ['1234'],
         body: payload,
-        timestamp: +new Date()
+        timestamp: Date.now()
       };
       return o;
     }
@@ -488,7 +488,7 @@ suite('thread_list_ui', function() {
         lastMessageType: 'mms',
         participants: ['1234', '5678'],
         body: payload,
-        timestamp: +new Date()
+        timestamp: Date.now()
       };
       return o;
     }

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -248,7 +248,7 @@ suite('thread_list_ui', function() {
         var nextDate = new Date(2013, 1, 2);
         message = MockMessages.sms({
           threadId: 2,
-          timestamp: nextDate
+          timestamp: +nextDate
         });
 
         ThreadListUI.updateThread(message);
@@ -266,7 +266,7 @@ suite('thread_list_ui', function() {
         var newDate = new Date(2013, 1, 2);
         var newMessage = MockMessages.sms({
           threadId: 20,
-          timestamp: newDate
+          timestamp: +newDate
         });
         ThreadListUI.updateThread(newMessage, {read: false});
         // As this is a new message we dont have to remove threads
@@ -290,7 +290,7 @@ suite('thread_list_ui', function() {
         var nextDate = new Date(2013, 1, 2);
         message = MockMessages.sms({
           threadId: 2,
-          timestamp: nextDate
+          timestamp: +nextDate
         });
         thread = Threads.createThreadMockup(message);
         ThreadListUI.updateThread(message);
@@ -322,7 +322,7 @@ suite('thread_list_ui', function() {
         var nextDate = new Date(2013, 1, 2);
         message = MockMessages.sms({
           threadId: 3,
-          timestamp: nextDate
+          timestamp: +nextDate
         });
         thread = Threads.createThreadMockup(message);
         ThreadListUI.updateThread(message);
@@ -358,7 +358,7 @@ suite('thread_list_ui', function() {
         var prevDate = new Date(2013, 1, 0);
         message = MockMessages.sms({
           threadId: 2,
-          timestamp: prevDate
+          timestamp: +prevDate
         });
         ThreadListUI.updateThread(message, {read: false});
       });
@@ -477,7 +477,7 @@ suite('thread_list_ui', function() {
         lastMessageType: 'sms',
         participants: ['1234'],
         body: payload,
-        timestamp: new Date()
+        timestamp: +new Date()
       };
       return o;
     }
@@ -488,7 +488,7 @@ suite('thread_list_ui', function() {
         lastMessageType: 'mms',
         participants: ['1234', '5678'],
         body: payload,
-        timestamp: new Date()
+        timestamp: +new Date()
       };
       return o;
     }
@@ -542,7 +542,7 @@ suite('thread_list_ui', function() {
         var nextDate = new Date(2013, 1, 2);
         var message = MockMessages.sms({
           threadId: 3,
-          timestamp: nextDate
+          timestamp: +nextDate
         });
 
         thread = Threads.createThreadMockup(message);
@@ -550,7 +550,7 @@ suite('thread_list_ui', function() {
       });
 
       test('show up in a new container', function() {
-        var newContainerId = 'threadsContainer_' + thread.timestamp.getTime();
+        var newContainerId = 'threadsContainer_' + (+thread.timestamp);
         var newContainer = document.getElementById(newContainerId);
         assert.ok(newContainer);
         assert.ok(newContainer.querySelector('li'));
@@ -569,7 +569,7 @@ suite('thread_list_ui', function() {
         var nextDate = new Date(2013, 1, 2);
         var message = MockMessages.sms({
           threadId: 2,
-          timestamp: nextDate
+          timestamp: +nextDate
         });
 
         thread = Threads.createThreadMockup(message);
@@ -577,7 +577,7 @@ suite('thread_list_ui', function() {
       });
 
       test('show up in a new container', function() {
-        var newContainerId = 'threadsContainer_' + thread.timestamp.getTime();
+        var newContainerId = 'threadsContainer_' + (+thread.timestamp);
         var newContainer = document.getElementById(newContainerId);
         assert.ok(newContainer);
         assert.ok(newContainer.querySelector('li'));

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -2036,7 +2036,7 @@ suite('thread_ui.js >', function() {
         receivers: this.receivers,
         body: 'This is a test',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       };
       ThreadUI.appendMessage(this.targetMsg);
       this.original = ThreadUI.container.querySelector(
@@ -2656,7 +2656,7 @@ suite('thread_ui.js >', function() {
         receivers: this.receivers,
         body: 'This is a test',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       };
       this.otherMsg = {
         id: 45,
@@ -2664,7 +2664,7 @@ suite('thread_ui.js >', function() {
         receivers: this.receivers,
         body: 'this test',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       };
       ThreadUI.appendMessage(this.targetMsg);
       ThreadUI.appendMessage(this.otherMsg);
@@ -2723,7 +2723,7 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a error sms',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       };
       ThreadUI.appendMessage(message);
 
@@ -2766,7 +2766,7 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a test with 123123123',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       });
       // Retrieve DOM element for executing the event
       var messageDOM = document.getElementById('message-' + messageId);
@@ -2896,7 +2896,7 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a test with 123123123',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       });
       // Retrieve DOM element for executing the event
       messageDOM = document.getElementById('message-' + messageId);
@@ -2944,14 +2944,14 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a test',
         delivery: 'error',
-        timestamp: +new Date()
+        timestamp: Date.now()
       });
       ThreadUI.appendMessage({
         id: 45,
         type: 'sms',
         body: 'This is another test',
         delivery: 'sent',
-        timestamp: +new Date()
+        timestamp: Date.now()
       });
       this.sinon.stub(window, 'confirm');
       this.sinon.stub(ThreadUI, 'resendMessage');

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -2036,7 +2036,7 @@ suite('thread_ui.js >', function() {
         receivers: this.receivers,
         body: 'This is a test',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       };
       ThreadUI.appendMessage(this.targetMsg);
       this.original = ThreadUI.container.querySelector(
@@ -2124,8 +2124,8 @@ suite('thread_ui.js >', function() {
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'pending'}],
         subject: 'Pending download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() + ONE_DAY_TIME)
+        timestamp: +new Date(Date.now() - 150000),
+        expiryDate: +new Date(Date.now() + ONE_DAY_TIME)
       },
       {
         id: 2,
@@ -2135,8 +2135,8 @@ suite('thread_ui.js >', function() {
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'manual'}],
         subject: 'manual download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() + ONE_DAY_TIME * 2)
+        timestamp: +new Date(Date.now() - 150000),
+        expiryDate: +new Date(Date.now() + ONE_DAY_TIME * 2)
       },
       {
         id: 3,
@@ -2146,8 +2146,8 @@ suite('thread_ui.js >', function() {
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'error'}],
         subject: 'error download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() + ONE_DAY_TIME * 2)
+        timestamp: +new Date(Date.now() - 150000),
+        expiryDate: +new Date(Date.now() + ONE_DAY_TIME * 2)
       },
       {
         id: 4,
@@ -2157,8 +2157,8 @@ suite('thread_ui.js >', function() {
         delivery: 'not-downloaded',
         deliveryInfo: [{receiver: null, deliveryStatus: 'error'}],
         subject: 'Error download',
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now() - ONE_DAY_TIME)
+        timestamp: +new Date(Date.now() - 150000),
+        expiryDate: +new Date(Date.now() - ONE_DAY_TIME)
       }];
 
       return testMessages[index];
@@ -2211,7 +2211,7 @@ suite('thread_ui.js >', function() {
           'localization arguments set correctly');
       });
       test('date is correctly determined', function() {
-        assert.equal(Utils.date.format.localeFormat.args[0][0],
+        assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
           'dateTimeFormat_%x');
@@ -2266,7 +2266,7 @@ suite('thread_ui.js >', function() {
           'localization arguments set correctly');
       });
       test('date is correctly determined', function() {
-        assert.equal(Utils.date.format.localeFormat.args[0][0],
+        assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
           'dateTimeFormat_%x');
@@ -2415,7 +2415,7 @@ suite('thread_ui.js >', function() {
           'localization arguments set correctly');
       });
       test('date is correctly determined', function() {
-        assert.equal(Utils.date.format.localeFormat.args[0][0],
+        assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
           'dateTimeFormat_%x');
@@ -2505,7 +2505,7 @@ suite('thread_ui.js >', function() {
           'localization arguments set correctly');
       });
       test('date is correctly determined', function() {
-        assert.equal(Utils.date.format.localeFormat.args[0][0],
+        assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
           'dateTimeFormat_%x');
@@ -2536,8 +2536,8 @@ suite('thread_ui.js >', function() {
         smil: '<smil><body><par><text src="cid:1"/>' +
               '</par></body></smil>',
         attachments: null,
-        timestamp: new Date(Date.now() - 150000),
-        expiryDate: new Date(Date.now())
+        timestamp: +new Date(Date.now() - 150000),
+        expiryDate: +new Date(Date.now())
       },
       {
         id: 2,
@@ -2550,8 +2550,8 @@ suite('thread_ui.js >', function() {
         smil: '<smil><body><par><text src="cid:1"/>' +
               '</par></body></smil>',
         attachments: [],
-        timestamp: new Date(Date.now() - 100000),
-        expiryDate: new Date(Date.now())
+        timestamp: +new Date(Date.now() - 100000),
+        expiryDate: +new Date(Date.now())
       }];
 
       return testMessages[index];
@@ -2656,7 +2656,7 @@ suite('thread_ui.js >', function() {
         receivers: this.receivers,
         body: 'This is a test',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       };
       this.otherMsg = {
         id: 45,
@@ -2664,7 +2664,7 @@ suite('thread_ui.js >', function() {
         receivers: this.receivers,
         body: 'this test',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       };
       ThreadUI.appendMessage(this.targetMsg);
       ThreadUI.appendMessage(this.otherMsg);
@@ -2723,7 +2723,7 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a error sms',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       };
       ThreadUI.appendMessage(message);
 
@@ -2766,7 +2766,7 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a test with 123123123',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       });
       // Retrieve DOM element for executing the event
       var messageDOM = document.getElementById('message-' + messageId);
@@ -2896,7 +2896,7 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a test with 123123123',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       });
       // Retrieve DOM element for executing the event
       messageDOM = document.getElementById('message-' + messageId);
@@ -2944,14 +2944,14 @@ suite('thread_ui.js >', function() {
         type: 'sms',
         body: 'This is a test',
         delivery: 'error',
-        timestamp: new Date()
+        timestamp: +new Date()
       });
       ThreadUI.appendMessage({
         id: 45,
         type: 'sms',
         body: 'This is another test',
         delivery: 'sent',
-        timestamp: new Date()
+        timestamp: +new Date()
       });
       this.sinon.stub(window, 'confirm');
       this.sinon.stub(ThreadUI, 'resendMessage');


### PR DESCRIPTION
- Force timestamp related properties to long int format
- Change timestamp related test cases and mock message
- Change for desktop testing
