### PR TITLE
Bug 948193 - Increase the timeout for testing wifi disable test (gaia-ui-test)

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -320,7 +320,7 @@ class GaiaData(object):
 
     def disable_wifi(self):
         self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script("return GaiaDataLayer.disableWiFi()", special_powers=True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.disableWiFi()", special_powers=True, script_timeout=20000)
         assert result, 'Unable to disable WiFi'
 
     def connect_to_wifi(self, network=None):


### PR DESCRIPTION
Wifi disabling occasionally takes too long to complete and call back when doing test_wifi_settings.py. Simply increasing the timeout will solve this issue. But I really don't know how to pick a appropriate timeout.... 
