### PR TITLE
Bug 948822 - Xfail test_cards_view_with_two_apps.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/manifest.ini
@@ -5,5 +5,5 @@ b2g = true
 [test_cards_view_kill_apps_with_two_apps.py]
 
 [test_cards_view_with_two_apps.py]
-#  Bug #946130 - Flick not working on select time - hour 24 picker
+# Bug 948834 - The cards_view.swipe_to_next_app() method doesn't work
 expected = fail


### PR DESCRIPTION
Failed due to Bug 948834 - The cards_view.swipe_to_next_app() method doesn't work
