### PR TITLE
Bug 948842 - Re-enable test_sms_with_attachments.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/manifest.ini
@@ -10,8 +10,6 @@ skip-if = device == "desktop"
 [test_sms_with_attachments.py]
 camera = true
 skip-if = device == "desktop"
-# Bug 945774 - Messages app is closing while resizing an image for MMS from the Camera
-expected = fail
 
 [test_sms_to_dialer.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
Re-enable test_sms_with_attachments.py due to the test passed.
