### PR TITLE
Bug 947001 - bump marionette-client and gaiatest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: CI_ACTION=jshint
-    - env: CI_ACTION=gaia_ui_tests
 notifications:
   email: false
   irc:

--- a/tests/python/gaia-ui-tests/gaiatest/version.py
+++ b/tests/python/gaia-ui-tests/gaiatest/version.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = '0.20'
+__version__ = '0.21'

--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,4 +1,4 @@
-marionette_client==0.6.2
+marionette_client==0.7.0
 mozdevice
 py==1.4.14
 requests


### PR DESCRIPTION
Once https://bugzilla.mozilla.org/show_bug.cgi?id=925398 lands, then we'll need to update the marionette client used and the gaiatest version
