### PR TITLE
Bug 948992 - Give deviceSerial number to ADB's device manager.

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -798,7 +798,8 @@ class GaiaTestCase(MarionetteTestCase, B2GTestCaseMixin):
 
         self.device = GaiaDevice(self.marionette, self.testvars)
         if self.device.is_android_build:
-            self.device.add_device_manager(self.device_manager)
+            self.device.add_device_manager(
+                self.get_device_manager(deviceSerial = self.marionette.device_serial))
         if self.restart and (self.device.is_android_build or self.marionette.instance):
             self.device.stop_b2g()
             if self.device.is_android_build:


### PR DESCRIPTION
This transfer the device_serial of Marionette to the DeviceManagerADB which is using it to prefix all adb commands with the "-s <deviceSerial>" command line arguments.  Without this, one might not be able to run gaia-ui-tests if multiple devices are plugged on the computer.

This branch should only be merged as soon as the Gecko's part of it has landed.  Otherwise the function get_device_manager will not exists.
