### PR TITLE
Bug 947001 - bump marionette-client and gaiatest versions redux

### DIFF
--- a/tests/python/gaia-ui-tests/MANIFEST.in
+++ b/tests/python/gaia-ui-tests/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include gaiatest/atoms *.js
 recursive-include gaiatest/resources *.*
 exclude MANIFEST.in
+include requirements.txt

--- a/tests/python/gaia-ui-tests/gaiatest/version.py
+++ b/tests/python/gaia-ui-tests/gaiatest/version.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = '0.21'
+__version__ = '0.21.1'


### PR DESCRIPTION
Add requirements.txt to MANIFEST.in file so it gets packaged to pypi, and it required a version bump.
