### PR TITLE
Bug 903245 : Support sharing of Contact via NFC ; r=reviews.

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -489,6 +489,52 @@ var Contacts = (function() {
     showForm();
   };
 
+  var getCurrentContact = function c_getCurrentContact(){
+	var payload ;
+
+	if (currentContact.givenName) {
+		payload       = 'BEGIN:VCARD\n';
+		payload      += 'VERSION:2.1\n';
+		payload      += 'N:' + currentContact.givenName + ';\n'  ;
+	}
+	else {
+		console.error(' Missing Name from contact list ');
+		return null;
+	}
+	if (currentContact.familyName) {
+		payload      += 'FN:' + currentContact.familyName + ';\n'  ;
+	}
+	if(currentContact.tel) {
+	var telLength = currentContact.tel.length;
+	for (var tel = 0; tel < telLength; tel++) {
+		var currentTel = currentContact.tel[tel];
+		}
+		payload += 'TEL:' + currentTel.value  + '\n';
+	}
+	if(currentContact.email) {
+	var emailLength = currentContact.email.length;
+	for (var email = 0; email < emailLength; email++) {
+		var currentEmail = currentContact.email[email];
+		}
+		payload += 'EMAIL:' + currentEmail['value']  + '\n';
+	}
+	if (currentContact.adr) {
+	for (var i = 0; i < currentContact.adr.length; i++) {
+		var currentAddress = currentContact.adr[i];
+
+		var address = currentAddress['streetAddress'];
+		var locality = currentAddress['locality'];
+		var country = currentAddress['countryName'];
+		var postalCode = currentAddress['postalCode'];
+		var addressField = address+' '+postalCode+' '+locality+' '+country;
+
+		payload += 'ADR;TYPE=home:' + addressField + '\n';
+		}
+	}
+	payload += 'END:VCARD';
+	return payload;
+  };
+
   var loadFacebook = function loadFacebook(callback) {
     if (!fbLoader.loaded) {
       fb.init(function onInitFb() {
@@ -889,6 +935,7 @@ var Contacts = (function() {
     'isEmpty': isEmpty,
     'getLength': getLength,
     'showForm': showForm,
+    'getCurrentContact':getCurrentContact,
     'setCurrent': setCurrent,
     'getTags': TAG_OPTIONS,
     'onLocalized': onLocalized,

--- a/apps/communications/contacts/js/views/details.js
+++ b/apps/communications/contacts/js/views/details.js
@@ -68,6 +68,24 @@ contacts.Details = (function() {
       '#details-back': handleDetailsBack,
       '#edit-contact-button': showEditContact
     });
+
+    window.navigator.mozNfc.onpeerready = function(event) {
+	var payload;
+	var nfcdom = window.navigator.mozNfc;
+	var nfcPeer = nfcdom.getNFCPeer(event.detail);
+	var records = new Array();
+	var tnf  =  0x02;
+	var type =  'text/x-vCard';
+	var id	 =  '';
+	payload = Contacts.getCurrentContact();
+	var record = new MozNdefRecord(
+		tnf,
+		type,
+		id,
+		payload);
+	records.push(record);
+	nfcPeer.sendNDEF(records);
+	};
   };
 
   var handleDetailsBack = function handleDetailsBack() {

--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -86,7 +86,8 @@
     "idle":{},
     "storage": {},
     "device-storage:sdcard": { "access": "readcreate" },
-    "phonenumberservice": {}
+    "phonenumberservice": {},
+    "nfc":{ "access": "readwrite" }
   },
   "orientation": "default",
   "activities": {


### PR DESCRIPTION
This Patch for Sharing the current contact information via NFC.
Contact application register the onpeerready event.
In Contact Application is opened a particular contact to be shared, 
NFC Device Paired with another device and the contact gets shrink 
and ready to share the current contact details to another device.
Swipe-up the contact. It transfers current contact information
(Name, Family-name, Address,Phone,Email).
