### PR TITLE
bug 922006 - [Dialer] Refactor onload event listener to make dialer.js testable

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" type="text/css" href="/shared/style_unstable/tabs.css">
 
     <!-- JS -->
+    <script defer src="/dialer/js/index.js"></script>
     <script defer src="/dialer/js/utils.js"></script>
     <script defer src="/dialer/js/tone_player.js"></script>
     <script defer src="/dialer/js/keypad.js"></script>

--- a/apps/communications/dialer/js/calls_handler.js
+++ b/apps/communications/dialer/js/calls_handler.js
@@ -827,10 +827,3 @@ var CallsHandler = (function callsHandler() {
   };
 })();
 
-window.addEventListener('load', function callSetup(evt) {
-  window.removeEventListener('load', callSetup);
-
-  CallsHandler.setup();
-  CallScreen.init();
-  KeypadManager.init(true);
-});

--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -12,23 +12,6 @@ var CallHandler = (function callHandler() {
   /* === Settings === */
   var screenState = null;
 
-  // Add the listener onload
-  window.addEventListener('load', function getSettingsListener() {
-    window.removeEventListener('load', getSettingsListener);
-
-    setTimeout(function nextTick() {
-      LazyLoader.load('/shared/js/settings_listener.js', function() {
-        SettingsListener.observe('lockscreen.locked', null, function(value) {
-          if (value) {
-            screenState = 'locked';
-          } else {
-            screenState = 'unlocked';
-          }
-        });
-      });
-    });
-  });
-
   /* === WebActivity === */
   function handleActivity(activity) {
     // Workaround here until the bug 787415 is fixed
@@ -40,22 +23,11 @@ var CallHandler = (function callHandler() {
     currentActivity = activity;
 
     var number = activity.source.data.number;
-    var fillNumber = function actHandleDisplay() {
-      if (number) {
-        KeypadManager.updatePhoneNumber(number, 'begin', false);
-        if (window.location.hash != '#keyboard-view') {
-          window.location.hash = '#keyboard-view';
-        }
+    if (number) {
+      KeypadManager.updatePhoneNumber(number, 'begin', false);
+      if (window.location.hash != '#keyboard-view') {
+        window.location.hash = '#keyboard-view';
       }
-    };
-
-    if (document.readyState == 'complete') {
-      fillNumber();
-    } else {
-      window.addEventListener('load', function loadWait() {
-        window.removeEventListener('load', loadWait);
-        fillNumber();
-      });
     }
   }
 
@@ -372,8 +344,8 @@ var CallHandler = (function callHandler() {
     btCommandsToForward = [];
   }
 
-  /* === MMI === */
   function init() {
+    /* === MMI === */
     LazyLoader.load(['/shared/js/mobile_operator.js',
                      '/dialer/js/mmi.js',
                      '/dialer/js/mmi_ui.js',
@@ -399,11 +371,18 @@ var CallHandler = (function callHandler() {
               request.result.launch('dialer');
             };
           }
-
           MmiManager.handleMMIReceived(evt.message, evt.sessionEnded);
         });
       }
-
+    });
+    LazyLoader.load('/shared/js/settings_listener.js', function() {
+      SettingsListener.observe('lockscreen.locked', null, function(value) {
+        if (value) {
+          screenState = 'locked';
+        } else {
+          screenState = 'unlocked';
+        }
+      });
     });
   }
 
@@ -513,38 +492,6 @@ var NavbarManager = {
     views.classList.remove('hide-toolbar');
   }
 };
-
-var dialerStartup = function startup(evt) {
-  window.removeEventListener('load', dialerStartup);
-
-  KeypadManager.init();
-  NavbarManager.init();
-
-  setTimeout(function nextTick() {
-    var lazyPanels = ['add-contact-action-menu',
-                      'confirmation-message',
-                      'edit-mode'];
-
-    var lazyPanelsElements = lazyPanels.map(function toElement(id) {
-      return document.getElementById(id);
-    });
-    LazyLoader.load(lazyPanelsElements);
-
-    CallHandler.init();
-    LazyL10n.get(function loadLazyFilesSet() {
-      LazyLoader.load(['/shared/js/fb/fb_request.js',
-                       '/shared/js/fb/fb_data_reader.js',
-                       '/shared/js/fb/fb_reader_utils.js',
-                       '/shared/style/confirm.css',
-                       '/contacts/js/utilities/confirm.js',
-                       '/dialer/js/newsletter_manager.js',
-                       '/shared/style/edit_mode.css',
-                       '/shared/style/headers.css']);
-      lazyPanelsElements.forEach(navigator.mozL10n.translate);
-    });
-  });
-};
-window.addEventListener('load', dialerStartup);
 
 // Listening to the keyboard being shown
 // Waiting for issue 787444 being fixed

--- a/apps/communications/dialer/js/index.js
+++ b/apps/communications/dialer/js/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+window.addEventListener('load', function dialerSetup() {
+  window.removeEventListener('load', dialerSetup);
+
+  KeypadManager.init();
+  NavbarManager.init();
+
+  setTimeout(function nextTick() {
+    var lazyPanels = ['add-contact-action-menu',
+                      'confirmation-message',
+                      'edit-mode'];
+
+    var lazyPanelsElements = lazyPanels.map(function toElement(id) {
+      return document.getElementById(id);
+    });
+    LazyLoader.load(lazyPanelsElements);
+
+    CallHandler.init();
+    LazyL10n.get(function loadLazyFilesSet() {
+      LazyLoader.load(['/shared/js/fb/fb_request.js',
+                       '/shared/js/fb/fb_data_reader.js',
+                       '/shared/js/fb/fb_reader_utils.js',
+                       '/shared/style/confirm.css',
+                       '/contacts/js/utilities/confirm.js',
+                       '/dialer/js/newsletter_manager.js',
+                       '/shared/style/edit_mode.css',
+                       '/shared/style/headers.css']);
+      lazyPanelsElements.forEach(navigator.mozL10n.translate);
+    });
+  });
+});

--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -1,0 +1,9 @@
+'use strict';
+
+window.addEventListener('load', function callSetup(evt) {
+  window.removeEventListener('load', callSetup);
+
+  CallsHandler.setup();
+  CallScreen.init();
+  KeypadManager.init(true);
+});

--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -22,6 +22,7 @@
     <script type="application/javascript" src="/shared/js/l10n_date.js"></script>
     -->
 
+    <script defer type="application/javascript" src="/dialer/js/oncall.js"></script>
     <script defer type="application/javascript" src="/shared/js/settings_listener.js"></script>
     <script defer type="application/javascript" src="/shared/js/settings_url.js"></script>
     <script defer type="application/javascript" src="/shared/js/async_storage.js"></script>

--- a/apps/communications/dialer/test/unit/dialer_test.js
+++ b/apps/communications/dialer/test/unit/dialer_test.js
@@ -1,6 +1,4 @@
-requireApp('communications/dialer/js/dialer.js', function() {
-  window.removeEventListener('load', dialerStartup);
-});
+requireApp('communications/dialer/js/dialer.js');
 
 suite('navigation bar', function() {
   var domOptionRecents;

--- a/apps/communications/dialer/test/unit/keypad_test.js
+++ b/apps/communications/dialer/test/unit/keypad_test.js
@@ -1,7 +1,7 @@
 /* globals CallHandler, CallLogDBManager, gTonesFrequencies, KeypadManager,
            MockCall, MockCallsHandler, MockDialerIndexHtml, MockMozTelephony,
            MockSettingsListener, MocksHelper, MockTonePlayer,
-           observePreferences, telephonyAddCall */
+           telephonyAddCall */
 
 'use strict';
 
@@ -142,7 +142,7 @@ suite('dialer/keypad', function() {
       });
 
       setup(function() {
-        observePreferences();
+        subject._observePreferences();
         MockSettingsListener.mCallbacks['phone.ring.keypad'](true);
       });
 
@@ -198,7 +198,6 @@ suite('dialer/keypad', function() {
         mockCall = new MockCall('12334', 'connected');
         mockHC = telephonyAddCall.call(this, mockCall);
         MockCallsHandler.mActiveCall = mockHC;
-        observePreferences();
         MockSettingsListener.mCallbacks['phone.ring.keypad'](true);
 
         this.clock = this.sinon.useFakeTimers();


### PR DESCRIPTION
- Move out all `onload` listener from `dialer` and `keypad.js` to individual `index.js`
- Move out all `onload` listener from `calls_handler.js` to individual `oncall.js`

Some `onload` listener are merged into `init()`, or just taken away if they are already called after `onload`.
