### PR TITLE
Bug 948622 - Improve activate_edit_mode()

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
@@ -14,7 +14,7 @@ class Homescreen(Base):
     name = 'Homescreen'
 
     _homescreen_icon_locator = (By.CSS_SELECTOR, 'li.icon[aria-label="%s"]')
-    _visible_icons_locator = (By.CSS_SELECTOR, 'div.page[style*="transform: translateX(0px);"] > ol > .icon')
+    _visible_icons_locator = (By.CSS_SELECTOR, '.page[style*="translateX(0px);"] .icon')
     _edit_mode_locator = (By.CSS_SELECTOR, 'body[data-mode="edit"]')
     _search_bar_icon_locator = (By.CSS_SELECTOR, '#evme-activation-icon input')
     _landing_page_locator = (By.ID, 'icongrid')
@@ -66,7 +66,7 @@ class Homescreen(Base):
             wait(3).\
             release().\
             perform()
-        self.wait_for_element_displayed(By.CSS_SELECTOR, 'div.dockWrapper ol[style*="transition: -moz-transform 0.5ms ease 0s;"]')
+        self.wait_for_condition(lambda m: self.marionette.execute_script("return window.wrappedJSObject.Homescreen.isInEditMode()"))
 
     def open_context_menu(self):
         test = self.marionette.find_element(*self._landing_page_locator)


### PR DESCRIPTION
I updated the locators here and the wait. Not sure if you like _visible_icons_locator, but I think it looks better than the old locator. Another way to write this locator would be by using nth-child. 
I ran the affected tests multiple times and they worked fine, except test_homescreen_delete_app.py, which fails inttermitently with this error: https://pastebin.mozilla.org/3761783. I will log a bug and try to fix it. 
