### PR TITLE
Bug 921317 - [Gaia] Transform Animation in the clock app is wrong

### DIFF
--- a/apps/clock/js/app.js
+++ b/apps/clock/js/app.js
@@ -24,7 +24,6 @@ var App = {
    */
   init: function() {
     this.tabs = new Tabs(document.getElementById('clock-tabs'));
-    this.tabs.on('selected', this.navigate.bind(this));
 
     window.addEventListener('hashchange', this);
     window.addEventListener('localized', this);

--- a/apps/clock/js/tabs.js
+++ b/apps/clock/js/tabs.js
@@ -1,7 +1,5 @@
 define(function(require) {
 'use strict';
-
-var Emitter = require('emitter');
 /**
  * Abstraction for handling the Tabs links at the bottom of the UI.
  * @param {HTMLElement} element The containing element for the Tabs UI.
@@ -12,8 +10,6 @@ function Tabs(element) {
   this.currentIndex = 0;
   this.element.addEventListener('click', this);
 }
-
-Tabs.prototype = Object.create(Emitter.prototype);
 
 /**
  * Find the clicked link in the list of links and update selected attributes.
@@ -32,12 +28,6 @@ Tabs.prototype.handleEvent = function tabsHandleEvent(event) {
     } else {
       link.parentNode.removeAttribute('aria-selected');
     }
-  });
-  this.emit('selected', {
-    link: event.target,
-    hash: event.target.hash,
-    last: this.links[lastIndex],
-    lastHash: this.links[lastIndex].hash
   });
 };
 

--- a/apps/clock/style/views.css
+++ b/apps/clock/style/views.css
@@ -67,9 +67,7 @@
   }
 }
 @keyframes slide-in-right {
-  /* This tiny percentage is a temporary workaround for Bug 921317
-   * please switch this back to `from` whenever that bug is solved! */
-  0.00001% {
+  from {
     transform: translateX(100%);
   }
   to {

--- a/apps/clock/test/unit/tabs_test.js
+++ b/apps/clock/test/unit/tabs_test.js
@@ -17,38 +17,20 @@ suite('Tabs', function() {
       '<li><a href="#link-3"></a></li>';
     this.links = this.element.querySelectorAll('a');
     this.tabs = new Tabs(this.element);
-    this.selectedSpy = this.sinon.spy();
-    this.tabs.on('selected', this.selectedSpy);
   });
 
   suite('test click link 1', function() {
     setup(function() {
       this.links[0].click();
     });
-    test('no event emitted (already selected)', function() {
-      assert.equal(this.selectedSpy.callCount, 0);
-    });
   });
   suite('test click link 2', function() {
     setup(function() {
       this.links[1].click();
     });
-    test('event emitted', function() {
-      assert.equal(this.selectedSpy.callCount, 1);
-      assert.equal(this.selectedSpy.args[0][0].hash, '#link-1');
-    });
     test('moved aria-selected', function() {
       assert.isTrue(this.links[1].parentNode.hasAttribute('aria-selected'));
       assert.equal(this.element.querySelectorAll('[aria-selected]').length, 1);
-    });
-    suite('test click link 2', function() {
-      setup(function() {
-        this.selectedSpy.reset();
-        this.links[1].click();
-      });
-      test('no event emitted (already selected)', function() {
-        assert.equal(this.selectedSpy.callCount, 0);
-      });
     });
   });
 });


### PR DESCRIPTION
- Allow hashchange to initiate navigation instead of emitting 'selected' event from tabs
- Remove emitter from tabs since it doesn't need to emit anything anymore
