### PR TITLE
Bug 913326 - Set voice privacy mode at startup r=alive, jaoo

### DIFF
--- a/apps/settings/elements/call.html
+++ b/apps/settings/elements/call.html
@@ -104,6 +104,7 @@
       </menu>
     </form>
 
+    <script src="shared/js/voice_privacy_settings_helper.js"></script>
     <script src="js/call.js"></script>
 
   </template>

--- a/apps/settings/js/call.js
+++ b/apps/settings/js/call.js
@@ -784,6 +784,7 @@ var CallSettings = (function(window, document, undefined) {
         return;
       }
 
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
       var privacyModeItem =
         document.getElementById('menuItem-voicePrivacyMode');
       var privacyModeInput =
@@ -806,6 +807,10 @@ var CallSettings = (function(window, document, undefined) {
         function vpm_inputChanged() {
           var originalValue = !this.checked;
           var setReq = _mobileConnection.setVoicePrivacyMode(this.checked);
+          setReq.onsuccess = function set_vpm_success() {
+            var targetIndex = DsdsSettings.getIccCardIndexForCallSettings();
+            voicePrivacyHelper.setEnabled(targetIndex, !originalValue);
+          };
           setReq.onerror = function get_vpm_error() {
             // restore the value if failed.
             privacyModeInput.checked = originalValue;

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -16,6 +16,7 @@
     <script defer src="shared/js/async_storage.js"></script>
     <script defer src="shared/js/mobile_operator.js"></script>
     <script defer src="shared/js/manifest_helper.js"></script>
+    <script defer src="shared/js/voice_privacy_settings_helper.js"></script>
     <script defer src="shared/js/icc_helper.js"></script>
     <script defer src="shared/js/mime_mapper.js"></script>
     <script defer src="shared/js/settings_url.js"></script>
@@ -318,6 +319,9 @@
 
     <!-- Call Forwarding  -->
     <script defer src="js/call_forwarding.js"></script>
+
+    <!-- Call Settings  -->
+    <script defer src="js/call_settings.js"></script>
 
     <!-- Internet Sharing  -->
     <script defer src="js/internet_sharing.js"></script>

--- a/apps/system/js/call_settings.js
+++ b/apps/system/js/call_settings.js
@@ -1,0 +1,25 @@
+'use strict';
+
+(function() {
+  var mobileConnections = navigator.mozMobileConnections;
+  if (!mobileConnections) {
+    return;
+  }
+
+  var voicePrivacyHelper = VoicePrivacySettingsHelper();
+  var initVoicePrivacy = function vp(conn, index) {
+    voicePrivacyHelper.getEnabled(index, function gotEnabled(enabled) {
+      var setReq = conn.setVoicePrivacyMode(enabled);
+      setReq.onerror = function set_vpm_error() {
+        if (setReq.error.name === 'RequestNotSupported' ||
+            setReq.error.name === 'GenericFailure') {
+          console.log('Request not supported.');
+        } else {
+          console.error('Error setting voice privacy.');
+        }
+      };
+    });
+  };
+
+  Array.prototype.forEach.call(mobileConnections, initVoicePrivacy);
+})();

--- a/apps/system/test/unit/voice_privacy_settings_helper_test.js
+++ b/apps/system/test/unit/voice_privacy_settings_helper_test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js');
+requireApp('system/shared/js/voice_privacy_settings_helper.js');
+
+suite('VoicePrivacySettingsHelper', function() {
+  var VOICE_PRIVACY_KEY = 'ril.voicePrivacy.enabled';
+  var realMozSettings, realMozMobileConnections;
+
+  // A helper function
+  var assertAndDone = function(expectedValue, done, value) {
+    assert.equal(value, expectedValue);
+    done();
+  };
+
+  suiteSetup(function() {
+    realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+    realMozMobileConnections = navigator.mozMobileConnections;
+    navigator.mozMobileConnections = MockNavigatorMozMobileConnections;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozSettings = realMozSettings;
+    navigator.mozMobileConnections = realMozMobileConnections;
+  });
+
+  teardown(function() {
+    MockNavigatorSettings.mTeardown();
+    MockNavigatorMozMobileConnections.mTeardown();
+  });
+
+  suite('Should be initialized correctly without mozSettings', function() {
+    // All settings should be false when 'ril.voicePrivacy.enabled' is null.
+    test('one mobile connection', function(done) {
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.getEnabled(0, assertAndDone.bind(null, false, done));
+    });
+
+    test('two mobile connections', function(done) {
+      MockNavigatorMozMobileConnections.mAddMobileConnection();
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+
+      var returnCount = 0;
+      var checkDone = function() {
+        returnCount++;
+        if (returnCount == MockNavigatorMozMobileConnections.length) {
+          done();
+        }
+      };
+
+      voicePrivacyHelper.getEnabled(0,
+        assertAndDone.bind(null, false, checkDone));
+
+      voicePrivacyHelper.getEnabled(1,
+        assertAndDone.bind(null, false, checkDone));
+    });
+  });
+
+  suite('Should be initialized correctly with mozSettings', function() {
+    setup(function() {
+      MockNavigatorSettings.mSettings[VOICE_PRIVACY_KEY] = [false, true];
+    });
+
+    test('index 0', function(done) {
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.getEnabled(0, assertAndDone.bind(null, false, done));
+    });
+
+    test('index 1', function(done) {
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.getEnabled(1, assertAndDone.bind(null, true, done));
+    });
+  });
+
+  suite('Should set to mozSettings with correct value', function() {
+    test('Set enabled to true', function(done) {
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.setEnabled(0, true, function() {
+        var settings = MockNavigatorSettings.mSettings[VOICE_PRIVACY_KEY];
+
+        assert.equal(settings[0], true);
+        voicePrivacyHelper.getEnabled(0, assertAndDone.bind(null, true, done));
+      });
+    });
+
+    test('Set enabled to false', function(done) {
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.setEnabled(0, false, function() {
+        var settings = MockNavigatorSettings.mSettings[VOICE_PRIVACY_KEY];
+
+        assert.equal(settings[0], false);
+        voicePrivacyHelper.getEnabled(0, assertAndDone.bind(null, false, done));
+      });
+    });
+  });
+
+  suite('Shoule reflect mozSettings changes', function() {
+    test('Set enabled to true', function(done) {
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.getEnabled(0, function(enabled) {
+        // Default false
+        assert.equal(enabled, false);
+
+        var obj = {};
+        obj[VOICE_PRIVACY_KEY] = [true];
+        var req = MockNavigatorSettings.createLock().set(obj);
+        req.onsuccess = function() {
+          voicePrivacyHelper.getEnabled(0,
+            assertAndDone.bind(null, true, done));
+        };
+      });
+    });
+
+    test('Set enabled to false', function(done) {
+      MockNavigatorSettings.mSettings[VOICE_PRIVACY_KEY] = [true];
+      var voicePrivacyHelper = VoicePrivacySettingsHelper();
+      voicePrivacyHelper.getEnabled(0, function(enabled) {
+        // Default false
+        assert.equal(enabled, true);
+
+        var obj = {};
+        obj[VOICE_PRIVACY_KEY] = [false];
+        var req = MockNavigatorSettings.createLock().set(obj);
+        req.onsuccess = function() {
+          voicePrivacyHelper.getEnabled(0,
+            assertAndDone.bind(null, false, done));
+        };
+      });
+    });
+  });
+});

--- a/shared/js/voice_privacy_settings_helper.js
+++ b/shared/js/voice_privacy_settings_helper.js
@@ -1,0 +1,128 @@
+'use strict';
+
+(function(exports) {
+  /**
+   * VoicePrivacySettingsHelper provides functions for managing the
+   * 'ril.voicePrivacy.enabled' settings of mobile connections. Note that the
+   * helper does not call the corresponding API for you.
+   * @module VoicePrivacySettingsHelper
+   */
+  var VoicePrivacySettingsHelper = function() {
+    var VOICE_PRIVACY_KEY = 'ril.voicePrivacy.enabled';
+
+    var _settings = navigator.mozSettings;
+    var _mobileConnections = navigator.mozMobileConnections || [];
+
+    var _voicePrivacyValues = null;
+    var _voicePrivacyDefaultValues =
+      Array.prototype.map.call(_mobileConnections, function() {
+        return false;
+      });
+
+    var _isReady = false;
+    var _callbacks = [];
+
+    var _return = function vph_return(callback) {
+      if (!callback) {
+        return;
+      }
+      callback.apply(null, Array.prototype.slice.call(arguments, 1));
+    };
+
+    var _ready = function vph_ready(callback) {
+      if (!callback)
+        return;
+
+      if (_isReady) {
+        callback();
+      } else {
+        _callbacks.push(callback);
+      }
+    };
+
+    /**
+     * Get the value of the key VOICE_PRIVACY_KEY.
+     *
+     * @access private
+     * @param {Function} callback The callback function.
+     * @memberOf module:VoicePrivacySettingsHelper
+     */
+    var _getValue = function vph_getValue(callback) {
+      var req = _settings.createLock().get(VOICE_PRIVACY_KEY);
+      req.onsuccess = function() {
+        _return(callback, req.result[VOICE_PRIVACY_KEY]);
+      };
+      req.onerror = function() {
+        console.error('Error getting voice privacy settings.');
+        _return(callback, null);
+      };
+    };
+
+    /**
+     * Set the value of the key VOICE_PRIVACY_KEY.
+     *
+     * @access private
+     * @param {Array} value Voice privacy settings.
+     * @param {Function} callback The callback function.
+     * @memberOf module:VoicePrivacySettingsHelper
+     */
+    var _setValue = function vph_setValue(value, callback) {
+      var obj = {};
+      obj[VOICE_PRIVACY_KEY] = value;
+      var req = _settings.createLock().set(obj);
+      req.onsuccess = function() {
+        _return(callback);
+      };
+      req.onerror = function() {
+        console.error('Error setting voice privacy settings.');
+        _return(callback);
+      };
+    };
+
+    /**
+     * Initialize the object based on the current settings.
+     *
+     * @access private
+     * @param {Function} callback The callback function.
+     * @memberOf module:VoicePrivacySettingsHelper
+     */
+    var _init = function vph_init(callback) {
+      _getValue(function(value) {
+        _voicePrivacyValues = value || _voicePrivacyDefaultValues;
+        _return(callback);
+      });
+
+      _settings.addObserver(VOICE_PRIVACY_KEY, function vpChanged(e) {
+        _voicePrivacyValues = e.settingValue;
+      });
+    };
+
+    _init(function() {
+      _isReady = true;
+      _callbacks.forEach(function(callback) {
+        callback();
+      });
+    });
+
+    return {
+      getEnabled: function(index, callback) {
+        _ready(function() {
+          _return(callback, _voicePrivacyValues[index] || false);
+        });
+      },
+      setEnabled: function(index, enabled, callback) {
+        _ready(function() {
+          if (index < _voicePrivacyValues.length) {
+            var cloneValues = JSON.parse(JSON.stringify(_voicePrivacyValues));
+            cloneValues[index] = enabled;
+            _setValue(cloneValues, _return.bind(null, callback));
+          } else {
+            _return(callback);
+          }
+        });
+      }
+    };
+  };
+
+  exports.VoicePrivacySettingsHelper = VoicePrivacySettingsHelper;
+})(this);

--- a/shared/test/unit/mocks/mock_navigator_moz_settings.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_settings.js
@@ -25,7 +25,18 @@
       );
     }
 
-    return {};
+    var req = {
+      onsuccess: null,
+      onerror: null
+    };
+
+    setTimeout(function() {
+      if (req.onsuccess) {
+        req.onsuccess();
+      }
+    });
+
+    return req;
   }
 
   function mns_clearRequests() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=913326
- Add a helper maintaining the settings value. We can use it to get the current voice privacy settings.
- For all call related settings (for example roaming preference in the upcoming patch) we will put them in system/js/call_settings.js so that we can restore user settings at startup.
