### PR TITLE
Bug 903245 : Support sharing of Contact via NFC

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -634,6 +634,48 @@ var Contacts = (function() {
       ],
       'button[type="reset"]': stopPropagation
     });
+
+    window.navigator.mozNfc.onpeerready = function(event) {
+	console.error (' NFC Peer Ready Invoke ');
+	var payload ;
+        var contact = {};
+	var str = '';
+        var count = 0;
+
+	var nfcdom = window.navigator.mozNfc;
+	var nfcPeer = nfcdom.getNFCPeer(event.detail);
+	var records = new Array();
+	var tnf  =  0x02;
+	var type =  'text/x-vCard';
+	var id	 =  '';
+
+	contact= currentContact ;
+
+	LazyLoader.load('/shared/js/contact2vcard.js', function() {
+	ContactToVcard([contact], function append(vcards, nCards) {
+	str += vcards;
+        count += nCards;
+	}, function success() {
+          payload = str;
+	});
+       }
+      );
+
+	var record = new MozNdefRecord(
+		tnf,
+		type,
+		id,
+		payload);
+	records.push(record);
+	nfcPeer.sendNDEF(records);
+
+	};
+
+	window.navigator.mozNfc.onpeerlost = function(event) {
+		console.error (' NFC Peer Lost ');
+	};
+
+
   };
 
   var onLineChanged = function() {

--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -86,7 +86,8 @@
     "idle":{},
     "storage": {},
     "device-storage:sdcard": { "access": "readcreate" },
-    "phonenumberservice": {}
+    "phonenumberservice": {},
+    "nfc":{ "access": "readwrite" }
   },
   "orientation": "default",
   "activities": {

--- a/shared/js/contact2vcard.js
+++ b/shared/js/contact2vcard.js
@@ -26,7 +26,7 @@
   /** Field list to be skipped when converting to vCard */
   var VCARD_SKIP_FIELD = ['fb_profile_photo'];
 
-  var VCARD_VERSION = '4.0';
+  var VCARD_VERSION = '2.1';
   var HEADER = 'BEGIN:VCARD\nVERSION:' + VCARD_VERSION + '\n';
   var FOOTER = 'END:VCARD\n';
 
@@ -227,7 +227,7 @@
         return;
       }
 
-      var n = 'n:' + ([
+      var n = 'N:' + ([
         ct.familyName,
         ct.givenName,
         ct.additionalName,
@@ -239,14 +239,14 @@
       }).join(''));
 
       // vCard standard does not accept contacts without 'n' or 'fn' fields.
-      if (n === 'n:;;;;;' || !ct.name) {
+      if (n === 'N:;;;;;' || !ct.name) {
         setImmediate(function() { appendVCard(''); });
         return;
       }
 
       var allFields = [
         n,
-        fromStringArray(ct.name, 'fn'),
+        fromStringArray(ct.name, 'FN'),
         fromStringArray(ct.nickname, 'nickname'),
         fromStringArray(ct.category, 'category'),
         fromStringArray(ct.org, 'org'),
@@ -256,14 +256,15 @@
       ];
 
       if (ct.bday) {
-        allFields.push('bday:' + ISODateString(ct.bday));
+        allFields.push('BDAY:' + ISODateString(ct.bday));
       }
 
-      allFields.push.apply(allFields, fromContactField(ct.email, 'email'));
-      allFields.push.apply(allFields, fromContactField(ct.url, 'url'));
-      allFields.push.apply(allFields, fromContactField(ct.tel, 'tel'));
 
-      var adrs = fromContactField(ct.adr, 'adr');
+      allFields.push.apply(allFields, fromContactField(ct.email, 'EMAIL'));
+      allFields.push.apply(allFields, fromContactField(ct.url, 'URL'));
+      allFields.push.apply(allFields, fromContactField(ct.tel, 'TEL'));
+
+      var adrs = fromContactField(ct.adr, 'ADR');
       allFields.push.apply(allFields, adrs.map(function(adrStr, i) {
         var orig = ct.adr[i];
         return adrStr + (['', '', orig.streetAddress || '', orig.locality ||
@@ -281,7 +282,7 @@
           appendVCard(joinFields(allFields));
         });
       } else {
-        setImmediate(function() { appendVCard(joinFields(allFields)); });
+         appendVCard(joinFields(allFields));
       }
     }
 


### PR DESCRIPTION
This Patch for Sharing the current contact information via NFC.
Contact application register the onpeerready event.
In Contact Application is opened a particular contact to be shared,
NFC Device Paired with another device and the contact gets shrink
and ready to share the current contact details to another device.
Swipe-up the contact. It transfers current contact information
(Name, Family-name, Address,Phone,Email).
1. Built-in contact2vcard.js for conversion contact to vCard
2. I changed Vcard Version and KEY id of Vcard from Small Case to Upper Case
3. SetImmediate() is not supporting, 
4. All the Implementation in contact.js
