### PR TITLE
Bug 910999 - Correct display and removal of voicemail notification

### DIFF
--- a/apps/system/test/unit/mock_navigator_moz_voicemail.js
+++ b/apps/system/test/unit/mock_navigator_moz_voicemail.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var MockNavigatorMozVoicemail = {
+  number: '123',
+  mActive: false,
+  mCallbacks: {},
+
+  setActive: function(bool) {
+    this.mActive = bool;
+  },
+
+  getStatus: function() {
+    return {
+      hasMessages: this.mActive
+    };
+  },
+
+  addEventListener: function(name, callback) {
+    this.mCallbacks[name] = callback;
+    return;
+  },
+
+  triggerEvent: function(name) {
+    this.mCallbacks[name].handleEvent();
+  }
+};

--- a/apps/system/test/unit/voicemail_test.js
+++ b/apps/system/test/unit/voicemail_test.js
@@ -1,0 +1,52 @@
+requireApp('system/js/voicemail.js');
+
+requireApp('system/test/unit/mock_l10n.js');
+requireApp('system/test/unit/mock_navigator_moz_voicemail.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+
+suite('voicemail notification', function() {
+  var realMozVoicemail;
+  var realMozSettings;
+  var realL10n;
+
+  suiteSetup(function() {
+    realMozVoicemail = navigator.mozVoicemail;
+    navigator.mozVoicemail = MockNavigatorMozVoicemail;
+
+    realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = MockL10n;
+  });
+
+  setup(function() {
+    Voicemail.init();
+    this.sinon.useFakeTimers();
+    this.sinon.spy(window, 'Notification');
+  });
+
+  suiteTeardown(function() {
+    navigator.mozVoicemail = realMozVoicemail;
+    navigator.mozSettings = realMozSettings;
+    navigator.mozL10n = realL10n;
+  });
+
+  teardown(function() {
+    MockNavigatorSettings.mTeardown();
+  });
+
+  test('no voicemail, no notification', function() {
+    navigator.mozVoicemail.setActive(false);
+    navigator.mozVoicemail.triggerEvent('statuschanged');
+    this.sinon.clock.tick();
+    sinon.assert.notCalled(window.Notification);
+  });
+
+  test('one voicemail, one notification', function() {
+    navigator.mozVoicemail.setActive(true);
+    navigator.mozVoicemail.triggerEvent('statuschanged');
+    this.sinon.clock.tick();
+    sinon.assert.calledOnce(window.Notification);
+  });
+});


### PR DESCRIPTION
In bug 910999 we want to make sure that the voicemail notification is
not removed upon tap of the user but when the message has actually been
listened to. The process for voicemail is that when you have new
messages, carrier sends a SMS with specific bits stating the current
status of your voicemail:
- whether you have messages, i.e. should the voicemail indicator be
  turned on ;
- how much messages you have (this is optional, -1 is valid, 0 happens
  when you have no more message) ;
- a return number to call and a text message ;
  So when you have voicemail messages waiting for you, you get a sms with
  the active bit set to 1. We get this messag from Gecko through the
  statuschanged event, and the active status is read from the hasMessages
  property. When this is true, we send a notification. When this is true
  we remove the notification.

Removal was not possible until the new Notification API is available. So
now that it is available, we make use of it. We have to enhance the
notification handler of the system app, however, to disable the hacks
that we have implemented for the old API. This might be part of bug
890440.
