### PR TITLE
(v1.2) Bug 949315 - Travis unit test failure on v1.2: initGridManager is not defined

### DIFF
--- a/apps/homescreen/test/unit/grid_test.js
+++ b/apps/homescreen/test/unit/grid_test.js
@@ -458,10 +458,8 @@ suite('grid.js >', function() {
 
     testCases.forEach(function(testCase, i) {
       suite(testCase.name, function(done) {
-        setup(function(done) {
+        setup(function() {
           Configurator.mIsSVReady = false;
-          MockHomeState.mTestGrids = fixtures[i];
-          initGridManager(done);
           MockHomeState.mLastSavedInstalledApps = null;
         });
 


### PR DESCRIPTION
This patch must _only_ be applied on v1.2
r? @crdlc
