### PR TITLE
Bug 950070 - Perform correct localization of the roaming notifier on lockscreen

### DIFF
--- a/apps/system/js/lockscreen_connection_info_manager.js
+++ b/apps/system/js/lockscreen_connection_info_manager.js
@@ -258,7 +258,7 @@
 
       if (voice.roaming) {
         var l10nArgs = { operator: operator };
-        localize(nextLine(), 'roaming', JSON.stringify(l10nArgs));
+        localize(nextLine(), 'roaming', l10nArgs);
       } else {
         var line = nextLine();
         line.l10nId = '';

--- a/apps/system/test/unit/lockscreen_conn_info_manager_test.js
+++ b/apps/system/test/unit/lockscreen_conn_info_manager_test.js
@@ -178,7 +178,25 @@ suite('system/LockScreenConnInfoManager >', function() {
       };
       subject.updateConnStates();
       assert.equal(domConnstateL1.textContent,
-        'roaming"{\\"operator\\":\\"' + MockMobileOperator.mOperator + '\\"}"');
+        'roaming{"operator":"' + MockMobileOperator.mOperator + '"}');
+    });
+
+    test('Show localized roaming',
+      function() {
+        mockMobileConnection.voice = {
+          connected: true,
+          emergencyCallsOnly: false,
+          roaming: true
+        };
+
+        var l10nArgs = {
+          operator: 'operator'
+        };
+
+        var l10nSpy = this.sinon.spy(navigator.mozL10n, 'localize');
+        subject.updateConnStates();
+        assert.ok(l10nSpy.calledWith(domConnstateL1, 'roaming', l10nArgs),
+          'Roaming network name displayed localized with proper string');
     });
 
     suite('Show correct card states when emergency calls only', function() {


### PR DESCRIPTION
The localize() method takes as a third argument an object, not a string.
Doing this like this results in a lockscreen not substituting correctly
and hence displaying ``{{operator}} (Roaming)'' to the user.
