### PR TITLE
Bug 950074 - [Messages] The "you received a message" notice has a bad la...

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -238,20 +238,22 @@ form[data-type="action"] img[src=""] {
   display: none;
 }
 
-.new-message-notice-text {
-  font-size: 1.8rem;
-}
-
 #new-message-notice-content {
+  display: flex;  
+  flex-direction: row;
+
   margin: 1rem 2rem;
   padding: 0;
-
   overflow: hidden;
 
   white-space: nowrap;
   line-height: 2rem;
   font-size: 1.8rem;
   text-align: left;
+}
+
+#new-message-notice-content a {
+  margin: 0;
 }
 
 #new-message-notice-contact {
@@ -262,12 +264,13 @@ form[data-type="action"] img[src=""] {
 }
 
 #new-message-notice-container-1 {
-  display: inline-block;
+  flex: auto;
 }
 
 #new-message-notice-container-2 {
-  vertical-align: super;
-  float: right;
+  flex: none;
+
+  padding: 0.2rem 0;
 }
 /*
   Styles for Edit mode in Thread List


### PR DESCRIPTION
...yout r=schung

For some reason the commited CSS was wrong.
Converted it to flex box so that it looks correct also on bigger screens (like
the Peak).
