### PR TITLE
Bug 950469 - [Setringtone][l12y] 'Set as ringtone' string is reused on t...

### DIFF
--- a/apps/setringtone/locales/setringtone.en-US.properties
+++ b/apps/setringtone/locales/setringtone.en-US.properties
@@ -1,4 +1,5 @@
-setringtone = Set as ringtone
+setringtone-header = Set as ringtone
+setringtone-button = Set as ringtone
 cancel = Cancel
 settingringtone = Setting ringtone…
 cantplay = The audio file cannot be played on this phone and can not be used as a ringtone.

--- a/apps/setringtone/share.html
+++ b/apps/setringtone/share.html
@@ -16,7 +16,7 @@
   <body>
     <form role="dialog" data-type="confirm">
       <section>
-        <h1 id="title" data-l10n-id="setringtone">set ringtone</h1>
+        <h1 id="title" data-l10n-id="setringtone-header">set ringtone</h1>
         <p id="message">
           <span id="songtitle"></span><br/><small id="artist" class="small"></small>
           <audio id="preview" preload="metadata" loop></audio>
@@ -25,7 +25,7 @@
       </section>
       <menu>
         <button type="button" id="cancel" data-l10n-id="cancel">cancel</button>
-        <button type="button" id="set" data-l10n-id="setringtone"
+        <button type="button" id="set" data-l10n-id="setringtone-button"
                 class="recommend" disabled>set ringtone</button>
       </menu>
     </form>


### PR DESCRIPTION
...itle and button

Here again, I expect the entity name to be clear enough (which one is used on the header, which one on the button), but I needed I can add l10n comment.
