### PR TITLE
Bug 950563 - Xfail test_gallery_crop_photo.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
@@ -25,3 +25,5 @@ skip-if = device == "desktop"
 
 [test_gallery_crop_photo.py]
 skip-if = device == "desktop"
+# Bug 934358 - [Buri][Gallery]The Gallery always crash when save pictures
+expected = fail


### PR DESCRIPTION
Due to gallery will crash when save picture (Bug 934358), xfail this test.
