### PR TITLE
Bug 950570 - Fix test_settings_airplane_mode.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_airplane_mode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_airplane_mode.py
@@ -23,8 +23,8 @@ class TestAirplaneMode(GaiaTestCase):
         # Switch on Airplane mode
         settings.toggle_airplane_mode()
 
-        # wait for Cell Data to be disabled, this takes the longest when airplane mode is switched on
-        self.wait_for_condition(lambda s: 'SIM card not ready' in settings.cell_data_menu_item_description)
+        # wait for wifi to be disabled, this takes the longest when airplane mode is switched on
+        self.wait_for_condition(lambda s: 'Disabled' in settings.wifi_menu_item_description)
 
         # check Wifi is disabled
         self.assertFalse(self.data_layer.is_wifi_connected(self.testvars['wifi']), "WiFi was still connected after switching on Airplane mode")


### PR DESCRIPTION
It seems like wait for Cell Data to be disabled does not have enough time to enable airplane mode.
Change to wait for wifi to be disabled.
