### PR TITLE
Bug 950582 - Xfail test_lockscreen_unlock_to_camera_with_passcode.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
@@ -12,6 +12,8 @@ camera = true
 [test_lockscreen_unlock_to_camera_with_passcode.py]
 skip-if = device == "desktop"
 camera = true
+# Bug 950581 - [Lockscreen] [Camera] The camera doesn't work from lockscreen with passcode
+expected = fail
 
 [test_lockscreen_unlock_to_homescreen_with_passcode.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
Xfail due to Bug 950581
