### PR TITLE
Bug 950573 - Built-in Keyboard app could not input keys after it resumed

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -411,9 +411,9 @@ function initKeyboard() {
 
   // Initialize the current layout according to
   // the hash this page is loaded with.
+  var inputMethodName = '';
   if (window.location.hash !== '') {
-    var inputMethodName = window.location.hash.substring(1);
-    setKeyboardName(inputMethodName);
+    inputMethodName = window.location.hash.substring(1);
   } else {
     console.error('This page should never be loaded without an URL hash.');
   }
@@ -422,7 +422,10 @@ function initKeyboard() {
   // have already focused, the keyboard should show right away.
   inputContext = navigator.mozInputMethod.inputcontext;
   if (!document.mozHidden && inputContext) {
-    showKeyboard();
+    // show Keyboard after the input method has been initialized
+    setKeyboardName(inputMethodName, showKeyboard);
+  } else {
+    setKeyboardName(inputMethodName);
   }
 }
 


### PR DESCRIPTION
from OOM
- Correct the keyboard app init flow, so that it would show the
  keyboard after input method engine has bee loaded
