### PR TITLE
Bug 947957 - Enable test_quick_settings.py on Travis and TBPL

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -47,6 +47,7 @@ disabled = Bug 891882
 [functional/settings/test_settings_passcode.py]
 [functional/settings/test_settings_wallpaper.py]
 [functional/system/test_system_notification_bar.py]
+[functional/system/test_quick_settings.py]
 [functional/ftu/test_ftu_with_tour.py]
 [functional/browser/test_browser_keyboard_integration.py]
 # this test runs on tbpl only


### PR DESCRIPTION
Conflicts:
    tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
