### PR TITLE
Bug 890440 - Disable system workarounds for notification sent with the deprecated API

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -164,7 +164,9 @@ var NotificationScreen = {
     var nodes = this.container.querySelectorAll(selector);
 
     for (var i = nodes.length - 1; i >= 0; i--) {
-      this.closeNotification(nodes[i]);
+      if (nodes[i].dataset.obsoleteAPI === 'true') {
+        this.closeNotification(nodes[i]);
+      }
     }
   },
 
@@ -243,7 +245,8 @@ var NotificationScreen = {
     window.dispatchEvent(event);
 
     // Desktop notifications are removed when they are clicked (see bug 890440)
-    if (notificationNode.dataset.type === 'desktop-notification') {
+    if (notificationNode.dataset.type === 'desktop-notification' &&
+        notificationNode.dataset.obsoleteAPI === 'true') {
       this.removeNotification(notificationId, false);
     }
 
@@ -299,6 +302,11 @@ var NotificationScreen = {
     notificationNode.className = 'notification';
 
     notificationNode.dataset.notificationId = detail.id;
+    notificationNode.dataset.obsoleteAPI = 'false';
+    if (typeof detail.id === 'string' &&
+        detail.id.indexOf('app-notif-') === 0) {
+      notificationNode.dataset.obsoleteAPI = 'true';
+    }
     var type = notificationNode.dataset.type = detail.type ||
                                               'desktop-notification';
     notificationNode.dataset.manifestURL = detail.manifestURL || '';

--- a/apps/system/test/unit/notifications_test.js
+++ b/apps/system/test/unit/notifications_test.js
@@ -218,4 +218,24 @@ suite('system/NotificationScreen >', function() {
     });
   });
 
+  suite('differentiating api >', function() {
+    test('identifying deprecated API', function() {
+      var node = NotificationScreen.addNotification({
+        id: 'app-notif-1',
+        title: '',
+        message: ''
+      });
+      assert.equal('true', node.dataset.obsoleteAPI);
+    });
+
+    test('identifying new API', function() {
+      var node = NotificationScreen.addNotification({
+        id: 'app://notif',
+        title: '',
+        message: ''
+      });
+      assert.equal('false', node.dataset.obsoleteAPI);
+    });
+  });
+
 });


### PR DESCRIPTION
Notification which have been sent with the old API should not be treated
with the hacks and workarounds we implemented to circumvent its
limitations. So we detect whether a notification was sent from this
deprecated API based on the form of the id property.
