### PR TITLE
Bug 950588 - [Email][V1.3] Cannot get the folder list while you want to move multiple mails

### DIFF
--- a/apps/email/js/value_selector.js
+++ b/apps/email/js/value_selector.js
@@ -118,8 +118,8 @@ function ValueSelector(title, list) {
       input.setAttribute('name', 'option');
       label.classList.add('pack-radio');
       label.appendChild(input);
+      span.appendChild(text);
       label.appendChild(span);
-      label.appendChild(text);
       // Here we apply the folder-card's depth indentation to represent label.
       var depthIdx = data.list[i].depth;
       depthIdx = Math.min(FOLDER_DEPTH_CLASSES.length - 1, depthIdx);

--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -259,3 +259,39 @@ section[role="status"][title="undo"] .toaster-banner-undo,
 section[role="status"][title="retry"] .toaster-banner-retry {
   display: inline;
 }
+
+
+/*
+These folder-depth* styles are here instead of folder_cards.css
+because they are also used by the value_selector for showing
+the list of folders. folder-item specific styles so that these
+paddings override other styles in folder_cards.css
+*/
+.fld-folder-item.fld-folder-depth0,
+.fld-folder-depth0 {
+  padding-left: 1.5rem;
+}
+.fld-folder-item.fld-folder-depth1,
+.fld-folder-depth1 {
+  padding-left: 3rem;
+}
+.fld-folder-item.fld-folder-depth2,
+.fld-folder-depth2 {
+  padding-left: 4.5rem;
+}
+.fld-folder-item.fld-folder-depth3,
+.fld-folder-depth3 {
+  padding-left: 6rem;
+}
+.fld-folder-item.fld-folder-depth4,
+.fld-folder-depth4 {
+  padding-left: 6.5rem;
+}
+.fld-folder-item.fld-folder-depth5,
+.fld-folder-depth5 {
+  padding-left: 9.5rem;
+}
+.fld-folder-item.fld-folder-depth6,
+.fld-folder-depthmax {
+  padding-left: 11rem;
+}

--- a/apps/email/style/folder_cards.css
+++ b/apps/email/style/folder_cards.css
@@ -97,27 +97,10 @@
   display: none;
 }
 
-.fld-folder-depth0 {
-  padding-left: 1.5rem;
-}
-.fld-folder-depth1 {
-  padding-left: 3rem;
-}
-.fld-folder-depth2 {
-  padding-left: 4.5rem;
-}
-.fld-folder-depth3 {
-  padding-left: 6rem;
-}
-.fld-folder-depth4 {
-  padding-left: 6.5rem;
-}
-.fld-folder-depth5 {
-  padding-left: 9.5rem;
-}
-.fld-folder-depthmax {
-  padding-left: 11rem;
-}
+/*
+There are fld-folder-depth* styles in common.css because they are
+also used in value_selector.
+*/
 
 .fld-nav-settings-btn {
   background-image: url("images/icons/settings.png") !important;

--- a/apps/email/style/value_selector.css
+++ b/apps/email/style/value_selector.css
@@ -90,7 +90,11 @@ section.valueselector [role="dialog"] li > * {
 
 section.valueselector [role="dialog"] li label, section.valueselector [role="dialog"] li label span {
   color: #FFFFFF;
-  display: block;
+  /*
+  Override building blocks switch style for the span, using
+  display: inline instead of block. See bug 950588 for details.
+  */
+  display: inline;
   text-decoration: none;
 }
 


### PR DESCRIPTION
The folder_cards.css was applying to the value_selector styles for folder depth, so the bug only shows up if the folder_picker is shown before going to edit (folder_cards.css is loaded when folder_picker is shown).

Doing a quick git blame does not point to obvious point of breakage in folder_cards.css, value_selector.js or shared/switches.css. These styles have been always unspecific, and suspect this could have been broken for a long time, even as early as April 2, 2013.

Only folder_picker and value_selector use these styles, so this specificity does not affect any other cards.
