### PR TITLE
Bug 948817 - [fugu][buri][contact] tap on 'enter' on keyboard will clear all input in custom label (r=jmcanterafonseca)

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -447,7 +447,10 @@ var Contacts = (function() {
     });
   };
 
-  var handleCustomTag = function handleCustomTag() {
+  var handleCustomTag = function handleCustomTag(ev) {
+    if (ev.keyCode === 13) {
+      ev.preventDefault();
+    }
     ContactsTag.touchCustomTag();
   };
 


### PR DESCRIPTION
Sincerely I do not like to solve bugs when I do not totally understand what is going on and this is one of these :( For some reason, when clicking on the return key when the focus is on the custom field, the click event of the "Mobile" tag is fired :-O (see https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/js/contacts_tag.js#L35) and this provokes the "Mobile" tag to be selected and the custom tag content to be deleted in case there was content on it (as a consequence of https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/js/contacts_tag.js#L63)

The solution is to prevent the default behaviour when typing the return key when the focus is on the custom tag input field.

BTW, clicking on the return key when the focus is on the custom tag input field will basically do nothing. It will not close the keyboard as suggested by pcheng since this is out of the scope of the Contacts app. In fact, it is the same behaviour as clicking on the search bar in the Contacts app to enter the search mode and clicking on the return key in the keyboard, it basically does nothing.
