### PR TITLE
Bug 951252 - Remove warning on undefined role when checking hidden status

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -21,13 +21,8 @@ var GridManager = (function() {
 
   function isHiddenApp(role) {
     if (!role) {
-      console.warn(
-        'Unexpected role when checking hidden app: ' + JSON.stringify(role)
-      );
-
       return false;
     }
-
     return (HIDDEN_ROLES.indexOf(role) !== -1);
   }
 


### PR DESCRIPTION
There is too much output because in the default case, role is undefined.
As per bug 951252, let's disable the output.
