### PR TITLE
Bug 937561 - get both available network list and known network list, and...

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -349,7 +349,7 @@ navigator.mozL10n.ready(function wifiSettings() {
       }
 
       scanning = true;
-      var req = gWifiManager.getNetworks();
+      var req = WifiHelper.getAvailableAndKnownNetworks();
 
       req.onsuccess = function onScanSuccess() {
         clear(false);

--- a/apps/settings/test/unit/wifi_helper_test.js
+++ b/apps/settings/test/unit/wifi_helper_test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+require('/shared/js/wifi_helper.js');
+
+suite('WifiHelper', function() {
+
+  suite('> getAvailableAndKnownNetworks()', function() {
+    var originalMozWifiManager;
+    var triggerCallback = function triggerCallback(which, successOrError) {
+      if (fakeDOMRequests[which] && fakeDOMRequests[which][successOrError]) {
+        fakeDOMRequests[which][successOrError]();
+      }
+    };
+    var fakeDOMRequests = {
+      'getNetworks': {
+        readyState: 'pending',
+        result: [
+          {
+            ssid: 'Mozilla',
+            bssid: 'xx:xx:xx:xx:xx:xx',
+            security: ['WPA-EAP'],
+            relSignalStrength: 67,
+            connected: false
+          },
+          {
+            ssid: 'Mozilla-Guest',
+            bssid: 'xx:xx:xx:xx:xx:xx',
+            security: [],
+            relSignalStrength: 50,
+            connected: false
+          }
+        ],
+        error: {
+          name: 'getNetworks error'
+        }
+      },
+      'getKnownNetworks': {
+        readyState: 'pending',
+        result: [
+         {
+            ssid: 'No broadcast',
+            bssid: 'xx:xx:xx:xx:xx:xx',
+            security: ['WEP'],
+            relSignalStrength: 89,
+            connected: false
+          }
+        ],
+        error: {
+          name: 'getKnownNetworks error'
+        }
+      }
+    };
+
+    suiteSetup(function() {
+      originalMozWifiManager = navigator.mozWifiManager;
+      navigator.mozWifiManager = {
+        getNetworks: function fakeGetNetworks() {
+          return fakeDOMRequests.getNetworks;
+        },
+        getKnownNetworks: function fakeGetKnownNetworks() {
+          return fakeDOMRequests.getKnownNetworks;
+        }
+      };
+      // Force to use our mozWifiManager instead of the stub of desktop-helper
+      WifiHelper.wifiManager = navigator.mozWifiManager;
+    });
+
+    suiteTeardown(function() {
+      navigator.mozWifiManager = originalMozWifiManager;
+    });
+
+    test('> getNetworks return 2 networks then getKnownNetworks' +
+      'return 1 network successfully', function() {
+        var req = WifiHelper.getAvailableAndKnownNetworks();
+        var callbackInvokedTimes = 0;
+        req.onsuccess = function success() {
+          callbackInvokedTimes += 1;
+          assert.isTrue(req.result !== null);
+          assert.isTrue(req.result.length === 3);
+        };
+        req.onerror = function error() {
+          assert.fail();
+        };
+        triggerCallback('getNetworks', 'onsuccess');
+        triggerCallback('getKnownNetworks', 'onsuccess');
+        assert.isTrue(callbackInvokedTimes === 1);
+      });
+
+    test('> getNetworks return 2 networks then getKnownNetworks' +
+      'return error', function() {
+        var req = WifiHelper.getAvailableAndKnownNetworks();
+        var callbackInvokedTimes = 0;
+        req.onsuccess = function success() {
+          callbackInvokedTimes += 1;
+          assert.isTrue(req.result !== null);
+          assert.isTrue(req.result.length === 2);
+        };
+        req.onerror = function error() {
+          assert.fail();
+        };
+        triggerCallback('getNetworks', 'onsuccess');
+        triggerCallback('getKnownNetworks', 'onerror');
+        assert.isTrue(callbackInvokedTimes === 1);
+      });
+
+    test('> both getNetworks and getKnownNetworks return error', function() {
+      var req = WifiHelper.getAvailableAndKnownNetworks();
+      var callbackInvokedTimes = 0;
+      req.onsuccess = function success() {
+        assert.fail();
+      };
+      req.onerror = function error() {
+        callbackInvokedTimes += 1;
+        assert.ok(req.error);
+      };
+      triggerCallback('getNetworks', 'onerror');
+      triggerCallback('getKnownNetworks', 'onerror');
+      assert.isTrue(callbackInvokedTimes === 1);
+    });
+  });
+
+});

--- a/shared/js/wifi_helper.js
+++ b/shared/js/wifi_helper.js
@@ -9,7 +9,7 @@ var WifiHelper = {
     return navigator.mozWifiManager;
   }(),
 
-  setPassword: function(network, password, identity, 
+  setPassword: function(network, password, identity,
                         eap, phase2, certificate) {
     var encType = this.getKeyManagement(network);
     switch (encType) {
@@ -158,5 +158,78 @@ var WifiHelper = {
 
   isEap: function(network) {
     return this.getKeyManagement(network).indexOf('EAP') !== -1;
+  },
+
+  // Both 'available' and 'known' are "object of networks".
+  // Each key of them is a composite key of a network,
+  // and each value is the original network object received from DOMRequest
+  // It'll be easier to compare in the form of "object of networks"
+  _unionOfNetworks: function(available, known) {
+    var allNetworks = available || {};
+    var result = [];
+    Object.keys(known).forEach(function(key) {
+      if (!allNetworks[key])
+        allNetworks[key] = known[key];
+    });
+    // However, people who use getAvailableAndKnownNetworks expect
+    // getAvailableAndKnownNetworks.result to be an array of network
+    Object.keys(allNetworks).forEach(function(key) {
+      result.push(allNetworks[key]);
+    });
+    return result;
+  },
+
+  _networksArrayToObject: function(allNetworks) {
+    var self = this;
+    var networksObject = {};
+    [].forEach.call(allNetworks, function(network) {
+      // use ssid + security as a composited key
+      var key = network.ssid + '+' +
+        self.getSecurity(network).join('+');
+      networksObject[key] = network;
+    });
+    return networksObject;
+  },
+
+  _onReqProxySuccess: function(reqProxy, availableNetworks, knownNetworks) {
+    reqProxy.result =
+      this._unionOfNetworks(availableNetworks, knownNetworks);
+    reqProxy.onsuccess();
+  },
+
+  getAvailableAndKnownNetworks: function() {
+    var self = this;
+    var reqProxy = {
+      onsuccess: function() {},
+      onerror: function() {}
+    };
+    var knownNetworks = {};
+    var availableNetworks = {};
+    var knownNetworksReq = null;
+    var availableNetworksReq = this.getWifiManager().getNetworks();
+
+    // request available networks first then known networks,
+    // since it is acceptible that error on requesting known networks
+    availableNetworksReq.onsuccess = function anrOnSuccess() {
+      availableNetworks =
+        self._networksArrayToObject(availableNetworksReq.result);
+      knownNetworksReq = self.getWifiManager().getKnownNetworks();
+      knownNetworksReq.onsuccess = function knrOnSuccess() {
+        knownNetworks = self._networksArrayToObject(knownNetworksReq.result);
+        self._onReqProxySuccess(
+          reqProxy, availableNetworks, knownNetworks);
+      };
+      knownNetworksReq.onerror = function knrOnError() {
+        // it is acceptible that no known networks found or error
+        // on requesting known networks
+        self._onReqProxySuccess(
+          reqProxy, availableNetworks, knownNetworks);
+      };
+    };
+    availableNetworksReq.onerror = function anrOnError() {
+      reqProxy.error = availableNetworksReq.error;
+      reqProxy.onerror();
+    };
+    return reqProxy;
   }
 };


### PR DESCRIPTION
... make union of them to present to settings app

r=evelynhung

Gecko provides either available network list or known network list (based on wpa_supplicant) but not both. We make a union of them and present to settings app.

https://bugzilla.mozilla.org/show_bug.cgi?id=937561
