### PR TITLE
Bug 948341 - Convert Dialer to make use of the new Notification API

### DIFF
--- a/apps/communications/dialer/js/call_log.js
+++ b/apps/communications/dialer/js/call_log.js
@@ -11,8 +11,7 @@ var CallLog = {
 
   init: function cl_init() {
     if (this._initialized) {
-      this.updateHighlight();
-      this.updateHeaders();
+      this.becameVisible();
       return;
     }
 
@@ -107,8 +106,7 @@ var CallLog = {
           if (document.hidden) {
             self.pauseHeaders();
           } else {
-            self.updateHeaders();
-            self.updateHighlight();
+            self.becameVisible();
             self.updateHeadersContinuously();
           }
         });
@@ -132,6 +130,13 @@ var CallLog = {
       self._dbupgrading = false;
       self.render();
     };
+  },
+
+  // Helper to update UI and clean notifications when we got visibility
+  becameVisible: function cl_becameVisible() {
+    this.updateHeaders();
+    this.updateHighlight();
+    this.cleanNotifications();
   },
 
   // Method for highlighting call events since last visit to call-log
@@ -952,6 +957,21 @@ var CallLog = {
     if (contact) {
       element.dataset.contactId = contact.id;
     }
+  },
+
+  cleanNotifications: function cl_cleanNotifcations() {
+    // On startup of call log, we clear all dialer notification
+    Notification.get()
+      .then(
+        function onSuccess(notifications) {
+          for (var i = 0; i < notifications.length; i++) {
+            notifications[i].close();
+          }
+        },
+        function onError(reason) {
+          console.debug('Call log Notification.get() promise error: ' + reason);
+        }
+      );
   },
 
   _getGroupFromLog: function cl_getGroupFromLog(log) {

--- a/apps/communications/dialer/js/dialer.js
+++ b/apps/communications/dialer/js/dialer.js
@@ -79,13 +79,13 @@ var CallHandler = (function callHandler() {
             var app = evt.target.result;
 
             var iconURL = NotificationHelper.getIconURI(app, 'dialer');
-
             var clickCB = function() {
               app.launch('dialer');
               window.location.hash = '#call-log-view';
             };
-
-            NotificationHelper.send(title, body, iconURL, clickCB);
+            var notification =
+              new Notification(title, {body: body, icon: iconURL});
+            notification.addEventListener('click', clickCB);
           };
         });
       });

--- a/apps/communications/dialer/test/unit/calllog_test.js
+++ b/apps/communications/dialer/test/unit/calllog_test.js
@@ -1,6 +1,7 @@
 requireApp('communications/dialer/js/call_log.js');
 requireApp('communications/dialer/js/utils.js');
 requireApp('communications/dialer/test/unit/mock_l10n.js');
+requireApp('communications/dialer/test/unit/mock_notification.js');
 
 if (!this.LazyL10n) {
   this.LazyL10n = null;
@@ -9,17 +10,21 @@ if (!this.LazyL10n) {
 suite('dialer/call_log', function() {
   var realL10n;
   var realCallLogL10n;
+  var realNotification;
 
   suiteSetup(function() {
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockMozL10n;
     realCallLogL10n = CallLog._;
     CallLog._ = MockMozL10n.get;
+    realNotification = window.Notification;
+    window.Notification = MockNotificationAPI;
   });
 
   suiteTeardown(function() {
     navigator.mozL10n = realL10n;
     CallLog._ = realCallLogL10n;
+    window.Notification = realNotification;
   });
 
   var incomingGroup = {
@@ -320,5 +325,21 @@ suite('dialer/call_log', function() {
       checkGroupDOMContactUpdated(groupDOM, null, incomingGroup.number, done);
     });
 
+  });
+
+  suite('notifications', function() {
+    var notifs;
+    var notificationSpy;
+
+    setup(function() {
+      notifs = Notification.get();
+      notificationSpy =
+        this.sinon.spy(MockNotificationObject.prototype, 'close');
+    });
+
+    test('call log should close notifications', function() {
+      CallLog.cleanNotifications();
+      sinon.assert.callCount(notificationSpy, 2);
+    });
   });
 });

--- a/apps/communications/dialer/test/unit/mock_notification.js
+++ b/apps/communications/dialer/test/unit/mock_notification.js
@@ -1,0 +1,19 @@
+function MockNotificationObject(id) {
+  this.id = id;
+}
+
+MockNotificationObject.prototype.close = function() {
+};
+
+var MockNotificationAPI = {
+  get: function mockNotificationAPI_get() {
+    return {
+      then: function(onSuccess, onError, onProgress) {
+        onSuccess([
+          new MockNotificationObject('1'),
+          new MockNotificationObject('2')
+        ]);
+      }
+    };
+  }
+};


### PR DESCRIPTION
Usage of the new API maks the code cleaner, we only depends on
NotificationHelper for getIconURI and _checkPermissions. Since bug
890440 landed, when this new API is used there is no more hack to remove
notification, so we have to handle it ourself:
- we have to close the notification in the 'click' event handler that
  we install
- when we load the call log, we check for any notification and close
  them.

The second point allows us to fix correctly bug 926318.
