### PR TITLE
Bug 926277: Add cellbroadcast perm to test container app, r=ahal

### DIFF
--- a/dev_apps/test-container/manifest.webapp
+++ b/dev_apps/test-container/manifest.webapp
@@ -10,9 +10,11 @@
   "permissions": {
     "alarms": {},
     "browser":{},
+    "cellbroadcast":{},
     "power":{},
     "webapps-manage":{},
     "mobileconnection":{},
+    "mobilenetwork":{},
     "bluetooth":{},
     "telephony":{},
     "voicemail":{},


### PR DESCRIPTION
We have already _mobileconnection_, _telephony_, _sms_ and _voicemail_.  The only two RIL-related permissions left behind are _cellbroadcast_ and _mobilenetwork_.
