### PR TITLE
Bug 949730 - Investigate test_cleanup_scard unittest failure

### DIFF
--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,5 +1,5 @@
 marionette_client==0.7.1
-mozdevice
+mozdevice>=0.31
 py==1.4.14
 requests
 moztest>=0.3


### PR DESCRIPTION
Updating to mozbase 0.31 resolves this issue
