### PR TITLE
Bug 949338 -The candidate panel of Asian language input methods are rend...

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -406,7 +406,7 @@ bubble above the key when you tap and hold. */
   display: block;
   background: #252220;
   padding: 0;
-  margin: -0.6rem 0rem 0.2rem 0rem;
+  margin: 0.2rem 0rem 0.2rem 0rem;
   border: none;
   border-top: 0.1rem solid #000000;
   border-bottom: 0.1rem solid #000000;
@@ -420,10 +420,10 @@ bubble above the key when you tap and hold. */
   overflow-y: auto;
 
   position: absolute;
-  top: 0.2rem;
+  top: 0.1rem;
   height: -moz-calc(100% - 0.4rem);
   z-index: 1;
-  margin: 0;
+  margin: 0.1rem 0rem 0.2rem 0rem;
 }
 
 #keyboard-candidate-panel-toggle-button {

--- a/apps/system/js/activity_window.js
+++ b/apps/system/js/activity_window.js
@@ -93,10 +93,34 @@
 
   ActivityWindow.prototype.CLASS_NAME = 'ActivityWindow';
 
+  /**
+   * Turn on this flag to dump debugging messages for all activity windows.
+   * @type {Boolean}
+   */
   ActivityWindow.prototype._DEBUG = false;
 
   ActivityWindow.prototype.openAnimation = 'slideleft';
   ActivityWindow.prototype.closeAnimation = 'slideright';
+
+  /**
+   * ActivityWindow's fullscreen state is copying from the caller
+   * instead of reading manifest so we just overwrite the
+   * isFullScreen method of AppWindow.
+   *
+   * @return {Boolean} The activity window is fullscreen or not.
+   */
+  ActivityWindow.prototype.isFullScreen = function acw_isFullScreen() {
+    if (typeof(this._fullscreen) !== 'undefined') {
+      return this._fullscreen;
+    }
+
+    this._fullscreen = this.activityCaller ?
+                       this.activityCaller.isFullScreen() :
+                       this.manifest ?
+                       !!this.manifest.fullscreen :
+                       false;
+    return this._fullscreen;
+  };
 
   /**
    * Lock or unlock orientation for this activity.
@@ -236,6 +260,11 @@
     this.iframe = this.browser.element;
     this.screenshotOverlay = this.element.querySelector('.screenshot-overlay');
     this.fadeOverlay = this.element.querySelector('.fade-overlay');
+
+    // Copy fullscreen state from caller.
+    if (this.isFullScreen()) {
+      this.element.classList.add('fullscreen-app');
+    }
 
     this._registerEvents();
     this.installSubComponents();

--- a/apps/system/test/unit/activity_window_test.js
+++ b/apps/system/test/unit/activity_window_test.js
@@ -50,7 +50,7 @@ suite('system/ActivityWindow', function() {
   });
 
   suite('activity window instance.', function() {
-    var app;
+    var app, appF;
     setup(function() {
       app = new AppWindow({
         iframe: document.createElement('iframe'),
@@ -61,6 +61,18 @@ suite('system/ActivityWindow', function() {
         name: 'fake',
         manifest: {
           orientation: 'default'
+        }
+      });
+      appF = new AppWindow({
+        iframe: document.createElement('iframe'),
+        frame: document.createElement('div'),
+        origin: 'http://fake',
+        url: 'http://fakeurl/index.html',
+        manifestURL: 'http://fakemanifesturl',
+        name: 'fake',
+        manifest: {
+          orientation: 'default',
+          fullscreen: true
         }
       });
     });
@@ -85,6 +97,11 @@ suite('system/ActivityWindow', function() {
         type: '_opened'
       });
       assert.isTrue(stubSetVisible.calledWith(false, true));
+    });
+
+    test('copy fullscreen from caller', function() {
+      var activity = new ActivityWindow(fakeConfig, appF);
+      assert.isTrue(activity.element.classList.contains('fullscreen-app'));
     });
 
     test('restore caller', function() {


### PR DESCRIPTION
The candidate panel of Asian language input methods are rendered incorrectly.
Fix the position of the down arrow when candidate panel is collapsed.Now bug is fixed.
![before fixing](https://f.cloud.github.com/assets/4078325/1777374/c55c09ea-6824-11e3-8e5b-63524237e7b3.png)
![after fixing](https://f.cloud.github.com/assets/4078325/1777392/f52fad02-6824-11e3-89f3-299f46ab7ba6.png)
