### PR TITLE
Bug 937336 - Remove where possible explicit frame switching

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/videoplayer/regions/fullscreen_video.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/videoplayer/regions/fullscreen_video.py
@@ -13,9 +13,7 @@ class FullscreenVideo(Base):
     _video_title_locator = (By.ID, 'video-title')
     _elapsed_text_locator = (By.ID, 'elapsed-text')
     _video_player_locator = (By.ID, 'player')
-    _video_frame_locator = (By.CSS_SELECTOR, "iframe[src^='app://video'][src$='view.html']")
     _video_player_frame_locator = (By.ID, 'player-view')
-    _spinner_overlay_locator = (By.ID, 'spinner-overlay')
 
     def wait_for_player_frame_displayed(self):
         self.wait_for_element_displayed(*self._video_player_frame_locator)
@@ -37,7 +35,3 @@ class FullscreenVideo(Base):
     @property
     def is_video_playing(self):
         return self.marionette.find_element(*self._video_player_locator).get_attribute('paused') == 'false'
-
-    def switch_to_video_frame(self):
-        self.marionette.switch_to_frame(self.marionette.find_element(*self._video_frame_locator))
-        self.wait_for_element_not_displayed(*self._spinner_overlay_locator)


### PR DESCRIPTION
Remove explicit frame switching _and_ unneeded locators from videoplayer app
