### PR TITLE
Bug 937336 - Remove where possible explicit frame switching

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_skip_tour.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_skip_tour.py
@@ -145,7 +145,7 @@ class TestFtu(GaiaTestCase):
                         "WiFi was not connected via FTU app")
 
         # is_wifi_connected() calls switch_to_frame()
-        self.marionette.switch_to_frame(self.app.frame)
+        self.apps.switch_to_displayed_app()
 
         # Tap next
         self.marionette.find_element(*self._next_button_locator).tap()
@@ -198,7 +198,7 @@ class TestFtu(GaiaTestCase):
         self.assertEqual(len(self.data_layer.all_contacts), import_sim_count)
 
         # all_contacts switches to top frame; Marionette needs to be switched back to ftu
-        self.marionette.switch_to_frame(self.app.frame)
+        self.apps.switch_to_displayed_app()
 
         # Tap next
         self.marionette.find_element(*self._next_button_locator).tap()
@@ -250,4 +250,4 @@ class TestFtu(GaiaTestCase):
         self.wait_for_element_not_displayed(*_close_button_locator)
 
         # now back to app
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()


### PR DESCRIPTION
Replace calls to app.frame in FTU test with apps.displayed_app.frame

@zacc: This isn't really needed, but as we are trying to clean up all the other tests that do frame switching I thought it would be worth changing this for consistency.
