### PR TITLE
Bug 948356 - [SMS] Keyboard is still opened when message options menu displayed  

### DIFF
--- a/apps/sms/js/action_menu.js
+++ b/apps/sms/js/action_menu.js
@@ -79,6 +79,8 @@ var OptionMenu = function(options) {
   this.form = document.createElement('form');
   this.form.dataset.type = options.type || 'action';
   this.form.setAttribute('role', 'dialog');
+  this.form.tabIndex = -1;
+
   var classList = this.form.classList;
 
   if (options.classes) {
@@ -167,6 +169,8 @@ OptionMenu.prototype.show = function() {
   // We translate and append the element to body
   navigator.mozL10n.translate(this.form);
   document.body.appendChild(this.form);
+  // Focus form to blur anything triggered keyboard
+  this.form.focus();
 };
 
 OptionMenu.prototype.hide = function() {

--- a/apps/sms/test/unit/action_menu_test.js
+++ b/apps/sms/test/unit/action_menu_test.js
@@ -63,6 +63,7 @@ suite('OptionMenu', function() {
 
     suite('menu.show()', function() {
       setup(function() {
+        this.sinon.spy(menu.form, 'focus');
         menu.show();
       });
 
@@ -72,7 +73,10 @@ suite('OptionMenu', function() {
         );
       });
       test('calls navigator.mozL10n.translate', function() {
-        assert.ok(navigator.mozL10n.translate.calledWith(menu.form));
+        sinon.assert.calledWith(navigator.mozL10n.translate, menu.form);
+      });
+      test('Focus form to dismiss keyboard', function() {
+        sinon.assert.called(menu.form.focus);
       });
 
       suite('menu.hide()', function() {
@@ -153,9 +157,8 @@ suite('OptionMenu', function() {
       assert.equal(buttons[0].textContent, options.items[0].name);
     });
     test('Localized button', function() {
-      assert.ok(navigator.mozL10n.localize.calledWith(
-        buttons[1], options.items[1].l10nId, options.items[1].l10nArgs
-      ), 'localized with mozL10n.localize');
+      sinon.assert.calledWith(navigator.mozL10n.localize, buttons[1],
+        options.items[1].l10nId, options.items[1].l10nArgs);
     });
     test('classes', function() {
       assert.ok(menu.form.classList.contains('class1'));


### PR DESCRIPTION
- Focus form to dismiss keyboard when action menu showed.
- Polish test cases.
