### PR TITLE
Bug 937336 - Remove where possible explicit frame switching

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/base.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/base.py
@@ -142,7 +142,7 @@ class Base(object):
         self.wait_for_element_not_displayed(*_close_button_locator)
 
         # now back to app
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()
 
     @property
     def keyboard(self):

--- a/tests/python/gaia-ui-tests/gaiatest/apps/gallery/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/gallery/app.py
@@ -65,5 +65,5 @@ class Gallery(Base):
         switch_to_camera_button.tap()
         camera_app = gaiatest.apps.camera.app.Camera(self.marionette)
         self.wait_for_condition(lambda m: self.apps.displayed_app.name == camera_app.name)
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()
         return camera_app

--- a/tests/python/gaia-ui-tests/gaiatest/apps/gallery/regions/fullscreen_image.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/gallery/regions/fullscreen_image.py
@@ -63,7 +63,7 @@ class FullscreenImage(Base):
         from gaiatest.apps.gallery.app import Gallery
         gallery = Gallery(self.marionette)
         self.wait_for_condition(lambda m: self.apps.displayed_app.name == gallery.name)
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()
         return gallery
 
     def tap_edit_button(self):

--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/app.py
@@ -134,7 +134,7 @@ class Homescreen(Base):
             expected_name = self.name
             self.root_element.tap()
             self.wait_for_condition(lambda m: self.apps.displayed_app.name.lower() == expected_name.lower())
-            self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+            self.apps.switch_to_displayed_app()
 
         def tap_delete_app(self):
             """Tap on (x) to delete app"""

--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/collections.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/collections.py
@@ -48,7 +48,7 @@ class Collection(Base):
             self.root_element.tap()
             # Wait for the displayed app to be that we have tapped
             self.wait_for_condition(lambda m: self.apps.displayed_app.name == app_name)
-            self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+            self.apps.switch_to_displayed_app()
 
             # Wait for title to load (we cannot be more specific because the aut may change)
             self.wait_for_condition(lambda m: m.title)

--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
@@ -67,7 +67,7 @@ class SearchPanel(Base):
             self.root_element.tap()
             # Wait for the displayed app to be that we have tapped
             self.wait_for_condition(lambda m: self.apps.displayed_app.name == app_name)
-            self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+            self.apps.switch_to_displayed_app()
 
             # Wait for title to load (we cannot be more specific because the aut may change)
             self.wait_for_condition(lambda m: m.title)
@@ -83,4 +83,4 @@ class SearchPanel(Base):
             self.root_element.tap()
             self.wait_for_condition(
                 lambda m: self.apps.displayed_app.name.lower() == expected_name.lower())
-            self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+            self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/display.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/display.py
@@ -47,4 +47,4 @@ class Display(Base):
         self.wait_for_element_not_present(*self._wallpaper_frame_locator)
 
         # switch to the setting app
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/language.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/language.py
@@ -46,4 +46,4 @@ class Language(Base):
         close_button.tap()
 
         # now back to app
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/phone_lock.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/phone_lock.py
@@ -24,8 +24,7 @@ class PhoneLock(Base):
             self.keyboard.send("".join(passcode))
 
         # switch to settings frame
-        self.marionette.switch_to_frame()
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()
 
         # create passcode
         self.wait_for_element_displayed(*self._phone_lock_passcode_section_locator)

--- a/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/activities.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/activities.py
@@ -36,7 +36,7 @@ class Activities(Base):
 
     def tap_cancel(self):
         self.marionette.find_element(*self._cancel_button_locator).tap()
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame_id)
+        self.apps.switch_to_displayed_app()
 
     @property
     def options_count(self):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/test_cost_control_ftu.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/test_cost_control_ftu.py
@@ -26,5 +26,5 @@ class TestCostControlFTU(GaiaTestCase):
         ftu_step3.select_when_use_is_above_unit_and_value(u'MB', '0.1')
         ftu_step3.tap_lets_go()
 
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()
         self.assertTrue(cost_control.is_mobile_data_tracking_on)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_skip_tour.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_skip_tour.py
@@ -250,4 +250,4 @@ class TestFtu(GaiaTestCase):
         self.wait_for_element_not_displayed(*_close_button_locator)
 
         # now back to app
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_add_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_add_contact.py
@@ -33,7 +33,7 @@ class TestSmsAddContact(GaiaTestCase):
         contacts_app.wait_for_contacts_frame_to_close()
 
         # Now switch to the displayed frame which should be Messages app
-        self.marionette.switch_to_frame(self.apps.displayed_app.frame)
+        self.apps.switch_to_displayed_app()
 
         self.assertIn(self.contact['givenName'][0], new_message.first_recipient_name)
         self.assertEquals(self.contact['tel'][0]['value'], new_message.first_recipient_number_attribute)


### PR DESCRIPTION
Replacing explicit frame switching calls to use the encapsulated switch_to_displayed_app method
