### PR TITLE
Bug 952168 - Edges gestures tests are failing on TBPL

### DIFF
--- a/apps/system/test/marionette/edges_gesture_test.js
+++ b/apps/system/test/marionette/edges_gesture_test.js
@@ -46,7 +46,7 @@ marionette('Edges gesture >', function() {
     });
   }
 
-  test('Swiping between apps left to right', function() {
+  test.skip('Swiping between apps left to right', function() {
     assert(calendar.displayed(), 'calendar is visible');
     assert(!sms.displayed(), 'sms is invisible');
 
@@ -63,7 +63,7 @@ marionette('Edges gesture >', function() {
     assert(settings.displayed(), 'settings is still visible');
   });
 
-  test('Swiping between apps right to left', function() {
+  test.skip('Swiping between apps right to left', function() {
     // Going to the beginning of the stack first
     edgeSwipeToApp(sys.leftPanel, 0, 250, sms);
     edgeSwipeToApp(sys.leftPanel, 0, 250, settings);
@@ -84,7 +84,7 @@ marionette('Edges gesture >', function() {
     assert(calendar.displayed(), 'calendar is still visible');
   });
 
-  test('Swiping vertically', function() {
+  test.skip('Swiping vertically', function() {
     // Going to the settings app first
     edgeSwipeToApp(sys.leftPanel, 0, 250, sms);
     edgeSwipeToApp(sys.leftPanel, 0, 250, settings);


### PR DESCRIPTION
https://tbpl.mozilla.org/php/getParsedLog.php?id=32223759&tree=Mozilla-Inbound
