### PR TITLE
Bug 950171 - [settings] "Improve Firefox OS" title displayed as "Improve {{brandShortName}}"

### DIFF
--- a/apps/settings/elements/improve_browser_os.html
+++ b/apps/settings/elements/improve_browser_os.html
@@ -3,7 +3,7 @@
 
     <header>
       <a href="#root"><span class="icon icon-back">back</span></a>
-      <h1 data-l10n-id="improveBrowserOS-header">Improve Browser OS</h1>
+      <h1 data-l10n-id="improveBrowserOSTitle">Improve Browser OS</h1>
     </header>
 
     <div>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -1005,12 +1005,7 @@ screenReader=Screen reader
 
 # Device :: Improve Browser OS
 improveBrowserOS=Improve {{brandShortName}}
-# LOCALIZATION NOTE (improveBrowserOS): if you leave the original
-# en-US value "{{improveBrowserOS}}" in the following string, the localization
-# will be automatically picked from the existing string with ID "improveBrowserOS".
-# If you need to adapt your localization to the reduced space available
-# in headers, you can use a shorter string here.
-improveBrowserOS-header={{improveBrowserOS}}
+improveBrowserOSTitle=Improve {{brandShortName}}
 sendMozillaFeedback=Send Mozilla Feedback
 performanceData=Performance data
 performanceDataInfo=Help us improve {{brandShortName}} by sharing data about your phone.


### PR DESCRIPTION
Remove double substitution introduced in bug 944749 (not supported by l10n.js), change string ID.
