### PR TITLE
Bug 951566 - [Bluetooth][Bluedroid] Unknown.jpeg shown in notification after file transfer via Bluetooth

### DIFF
--- a/apps/bluetooth/manifest.webapp
+++ b/apps/bluetooth/manifest.webapp
@@ -32,6 +32,7 @@
   },
   "permissions": {
     "bluetooth":{},
+    "device-storage:sdcard":{ "access": "readonly" },
     "settings":{ "access": "readwrite" }
   }
 }


### PR DESCRIPTION
- Why:

Since camera or other apps might share blobs without name, Bluetooth app have to make sure the name is existed or not. And Bluetooth app have to send these blobs with name. Otherwise, Gecko::Bluetooth will add the default name "Unknown.jpeg" for them.
- How:

If there is no filename in the blob, query the file via filepath from device storage. Then, Bluetooth app send the file which bas the name via `sendFile()` API.
