### PR TITLE
Bug 943760 - Remove outline of dropdown menu when clicked

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -665,3 +665,10 @@ section[data-dialog] > header:first-child .icon.icon-back {
   background-image: url(/shared/style/headers/images/icons/close.png);
 }
 
+/**
+ * Remove outline of dropdown menu when clicked
+ */
+select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=943760
