### PR TITLE
Bug 952292 - [UITests] Travis Intermittent: TEST-UNEXPECTED-FAIL | test_...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/test_geolocation_prompt.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/test_geolocation_prompt.py
@@ -19,6 +19,7 @@ class TestGeolocationPrompt(GaiaTestCase):
     def test_geolocation_prompt(self):
 
         self.app = self.apps.launch('Geoloc')
+        self.wait_for_element_displayed(*self._geoloc_start_button_locator)
         self.marionette.find_element(*self._geoloc_start_button_locator).tap()
 
         permission = PermissionDialog(self.marionette)


### PR DESCRIPTION
...geolocation_prompt.py test_geolocation_prompt.TestGeolocationPrompt.test_geolocation_prompt | TimeoutException: Element permission-dialog present but not displayed before timeout
