### PR TITLE
Bug 947217 - [Messages][Drafts] Consider removing the 'Drafts.request()' call in MessageManager's init

### DIFF
--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -44,8 +44,6 @@ var MessageManager = {
     if (typeof callback === 'function') {
       callback();
     }
-
-    Drafts.request();
   },
 
   onMessageSending: function mm_onMessageSending(e) {

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -70,38 +70,6 @@ suite('message_manager.js >', function() {
     MessageManager._mozMobileMessage = realMozMobileMessage;
   });
 
-  suite('init() > ', function() {
-    var realNavMozMobileMessage;
-
-    suiteSetup(function() {
-      realNavMozMobileMessage = navigator.mozMobileMessage;
-      navigator.mozMobileMessage = MockNavigatormozMobileMessage;
-    });
-
-    suiteTeardown(function() {
-      navigator.mozMobileMessage = realNavMozMobileMessage;
-    });
-
-    setup(function() {
-      this.sinon.stub(window, 'addEventListener');
-      this.sinon.stub(document, 'addEventListener');
-
-      this.sinon.spy(Drafts, 'request');
-
-      MessageManager.init();
-    });
-
-    teardown(function() {
-      MessageManager.initialized = false;
-      delete MessageManager.mainWrapper;
-      delete MessageManager.threadMessages;
-    });
-
-    test('calls Drafts.request', function() {
-      assert.isTrue(Drafts.request.calledOnce);
-    });
-  });
-
   suite('on message sent > ', function() {
     setup(function() {
       this.sinon.spy(ThreadUI, 'onMessageSending');


### PR DESCRIPTION
Retested this with the latest master a17a4710def9d760d9e5dc3762cdda775f1c59d0 and it's no longer necessary to make this call in MessageManager init()
- `message_manager.js`
  - removed call to `Drafts.request()`
- `message_manager_test.js`
  - removed relevant tests
