### PR TITLE
[Gallery]Bug 952651 - [Gallery][Photo Editor]Slider for brightness can slide from...r=djf

### DIFF
--- a/apps/gallery/js/ImageEditor.js
+++ b/apps/gallery/js/ImageEditor.js
@@ -183,6 +183,11 @@ var exposureSlider = (function() {
 
     // Remember the new exposure value
     currentExposure = exposure;
+
+    if (exposure === 0) {
+      //resetting to initial start value
+      sliderStartExposure = 0;
+    }
     // Convert exposure value to a unit coefficient position of thumb center
     var unitCoef = (exposure + 3) / 6;
 


### PR DESCRIPTION
... the last position the slider was in than the middle position

Mozilla Url:
https://bugzilla.mozilla.org/show_bug.cgi?id=952651
