### PR TITLE
Bug 949905 - wait until transition end to show keyboard, r=evelyn

### DIFF
--- a/apps/settings/js/phone_lock.js
+++ b/apps/settings/js/phone_lock.js
@@ -128,15 +128,27 @@ var PhoneLock = {
   },
 
   changeMode: function pl_changeMode(mode) {
+    var self = this;
+
+    function onPasscodePanelLoad(e){
+      window.removeEventListener('panelready', onPasscodePanelLoad);
+      if (e.detail.current === '#phoneLock-passcode') {
+        self.passcodeInput.focus();
+      }
+    }
+
     this.hideErrorMessage();
     this.MODE = mode;
     this.passcodePanel.dataset.mode = mode;
     if (Settings.currentPanel != '#phoneLock-passcode') {
-      Settings.currentPanel = '#phoneLock-passcode'; // show dialog box
-
-      // Open the keyboard after the UI transition. We can't listen for the
-      // ontransitionend event because some of the passcode mode changes, such
-      // as edit->new, do not trigger transition events.
+      // Open the keyboard after the UI transition. We need to wait until the
+      // passcode panel is ready, otherwise leads to a white screen.
+      // See bug 949905.
+      window.addEventListener('panelready', onPasscodePanelLoad);
+      Settings.currentPanel = '#phoneLock-passcode';
+    } else {
+      // We can't listen for the panelready event because some of the passcode
+      // mode changes, such as edit->new, do not trigger panelready event.
       setTimeout(function(self) { self.passcodeInput.focus(); }, 0, this);
     }
     this.updatePassCodeUI();

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -51,7 +51,7 @@ var Settings = {
     // the forward class helps us 'peek' in the right direction
     oldPanel.className = newPanel.className ? 'peek' : 'peek previous forward';
     newPanel.className = newPanel.className ?
-                           'current peek' : 'peek current forward';
+                           'current peek transition' : 'peek transition current forward';
 
     /**
      * Most browsers now scroll content into view taking CSS transforms into
@@ -81,8 +81,9 @@ var Settings = {
         if (oldPanel.className === 'current')
           return;
 
-        oldPanel.addEventListener('transitionend', function onTransitionEnd(e) {
-          oldPanel.removeEventListener('transitionend', onTransitionEnd);
+        newPanel.addEventListener('transitionend', function onTransitionEnd(e) {
+          newPanel.removeEventListener('transitionend', onTransitionEnd);
+          newPanel.classList.remove('transition');
           var detail = {
             previous: oldPanelHash,
             current: newPanelHash

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -45,11 +45,15 @@ section[role="region"] {
   visibility: hidden;
   transform: translateX(+100%);
   transition: transform .4s ease, visibility .4s ease;
+  pointer-events: none;
 }
 section[role="region"].peek {
   visibility: visible;
   transition: transform 1ms linear;
   transform: translateX(+0.1%);
+}
+section[role="region"].transition {
+  pointer-events: none !important;
 }
 
 section[role="region"].previous {
@@ -64,6 +68,7 @@ section[role="region"].previous.peek {
 section[role="region"].current {
   visibility: visible;
   transform: translateX(0);
+  pointer-events: auto;
 }
 section[role="region"].current.peek.forward {
   transform: translateX(99.9%);


### PR DESCRIPTION
also prevent users from interrupting the transition of panels.
