### PR TITLE
Bug 938500 : Create a new contact should be disabled if saved contact number is dailed in dialer.

### DIFF
--- a/apps/communications/dialer/js/keypad.js
+++ b/apps/communications/dialer/js/keypad.js
@@ -229,11 +229,21 @@ var KeypadManager = {
     var number = this._phoneNumber;
     if (!number)
       return;
+    if(this.callBarAddContact.classList.contains('disabled'))
+      return;
     LazyLoader.load(['/dialer/js/phone_action_menu.js'],
       function hk_showPhoneNumberActionMenu() {
         PhoneNumberActionMenu.show(null, number,
           ['new-contact', 'add-to-existent']);
     });
+  },
+
+  enableAddContact: function kh_enableAddContactNumber() {
+    this.callBarAddContact.classList.remove('disabled');
+  },
+
+  disableAddContact: function kh_disableAddContactNumber() {
+    this.callBarAddContact.classList.add('disabled');
   },
 
   callbarBackAction: function hk_callbarBackAction(event) {

--- a/apps/communications/dialer/js/suggestion_bar.js
+++ b/apps/communications/dialer/js/suggestion_bar.js
@@ -198,6 +198,12 @@ var SuggestionBar = {
     var markedNumber = this._markMatched(matchedTel.value, query);
     this._setItem(node, markedNumber, matchedTel.type,
                     contact.name[0]);
+    if(this._phoneNumber == matchedTel.value) {
+        KeypadManager.disableAddContact();
+    }
+    else {
+        KeypadManager.enableAddContact();
+    }
   },
 
   _createItem: function sb_createItem() {


### PR DESCRIPTION
Created enable/disable - add contact method in Keypad manager. 

Calling these methods from suggestions bar when a match is found from saved contacts.
