### PR TITLE
Bug 934429 - Remove layout/style reflows from the startup path

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -5,27 +5,22 @@
     <meta charset="utf-8">
     <title>Messages</title>
     <!-- Stable Building blocks -->
-    <link rel="stylesheet" type="text/css" href="shared/style/headers.css">
-    <link rel="stylesheet" type="text/css" href="shared/style/edit_mode.css">
+    <link rel="stylesheet" type="text/css" href="shared/style/action_menu.css">
     <link rel="stylesheet" type="text/css" href="shared/style/buttons.css">
-    <link rel="stylesheet" type="text/css" href="shared/style_unstable/lists.css">
-    <!--
+    <link rel="stylesheet" type="text/css" href="shared/style/confirm.css">
+    <link rel="stylesheet" type="text/css" href="shared/style/edit_mode.css">
+    <link rel="stylesheet" type="text/css" href="shared/style/headers.css">
     <link rel="stylesheet" type="text/css" href="shared/style/input_areas.css">
     <link rel="stylesheet" type="text/css" href="shared/style/switches.css">
-    <link rel="stylesheet" type="text/css" href="shared/style/confirm.css">
-    <link rel="stylesheet" type="text/css" href="shared/style_unstable/progress_activity.css">
     <link rel="stylesheet" type="text/css" href="shared/style_unstable/lists.css">
-    <link rel="stylesheet" type="text/css" href="shared/style/switches.css">
-    <link rel="stylesheet" type="text/css" href="shared/style/confirm.css">
     <link rel="stylesheet" type="text/css" href="shared/style_unstable/progress_activity.css">
-    <link rel="stylesheet" type="text/css" href="/shared/style/action_menu.css">
-    -->
     <!-- App styles -->
     <link rel="stylesheet" type="text/css" href="style/root.css">
     <link rel="stylesheet" type="text/css" href="style/common.css">
     <link rel="stylesheet" type="text/css" href="style/sms.css">
-    <link rel="stylesheet" type="text/css" href="style/attachment.css">
+    <link rel="stylesheet" type="text/css" href="style/notification.css">
     <link rel="stylesheet" type="text/css" href="style/report_view.css">
+    <link rel="stylesheet" type="text/css" href="style/attachment.css">
     <!-- Localization -->
     <link rel="resource" type="application/l10n" href="locales/locales.ini">
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini">

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -102,11 +102,6 @@ var MessageManager = {
 
   onVisibilityChange: function mm_onVisibilityChange(e) {
     LinkActionHandler.reset();
-    // If we receive a message with screen off, the height is
-    // set to 0 and future checks will fail. So we update if needed
-    if (!ThreadListUI.fullHeight || ThreadListUI.fullHeight === 0) {
-      ThreadListUI.fullHeight = ThreadListUI.container.offsetHeight;
-    }
     // If we leave the app and are in a thread or compose window
     // save a message draft if necessary
     if (document.hidden) {

--- a/apps/sms/js/startup.js
+++ b/apps/sms/js/startup.js
@@ -43,13 +43,7 @@ var lazyLoadFiles = [
   'js/information.js',
   'shared/js/fb/fb_request.js',
   'shared/js/fb/fb_data_reader.js',
-  'shared/js/fb/fb_reader_utils.js',
-  'shared/style/input_areas.css',
-  'shared/style/switches.css',
-  'shared/style/confirm.css',
-  'shared/style_unstable/progress_activity.css',
-  'shared/style/action_menu.css',
-  'style/notification.css'
+  'shared/js/fb/fb_reader_utils.js'
 ];
 
 window.addEventListener('localized', function localized() {

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -37,7 +37,6 @@ var ThreadListUI = {
     this.mainWrapper = document.getElementById('main-wrapper');
 
     this.delNumList = [];
-    this.fullHeight = this.container.offsetHeight;
 
     this.checkAllButton.addEventListener(
       'click', this.toggleCheckedAll.bind(this, true)

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -838,8 +838,11 @@ var ThreadUI = global.ThreadUI = {
   },
 
   isKeyboardDisplayed: function thui_isKeyboardDisplayed() {
-    // minimal keyboard height is 150px
-    return (this.container.offsetHeight < ThreadListUI.fullHeight - 150);
+    /* XXX: Detect if the keyboard is visible. The keyboard minimal height is
+     * 150px; when in reduced attention screen mode however the difference
+     * between window height and the screen height will be larger than 150px
+     * thus correctly yielding false here. */
+    return ((window.screen.height - window.innerHeight) > 150);
   },
 
   enableSend: function thui_enableSend() {


### PR DESCRIPTION
- Do not lazy load CSS files as those trigger a reflow
- Do not read the height of the thread list container when starting up
