### PR TITLE
Allow gaia_ui_tests to fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: CI_ACTION=gaia_ui_tests
     - env: CI_ACTION=jshint
 notifications:
   email: false


### PR DESCRIPTION
We can plan to disallow this once we can demonstrate that the probability of a random failure is near 0.
