### PR TITLE
Multiple_Image_Selection_Via_Gallery_App_For_SMS/MMS

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -84,8 +84,10 @@ var ActivityHandler = {
       ThreadUI.enableActivityRequestMode();
     },
     share: function shareHandler(activity) {
+var arr = [];
       var blobs = activity.source.data.blobs,
-        names = activity.source.data.filenames;
+        names = activity.source.data.filenames,
+numbers = activity.source.data.number;
 
       function insertAttachments() {
         window.removeEventListener('hashchange', insertAttachments);
@@ -98,9 +100,13 @@ var ActivityHandler = {
           // TODO: We only allow sharing one item in a single action now.
           //       Keeping the same sequence while adding the multiple items
           //       should be considered in the future.
-          Compose.append(attachment);
-        });
-      }
+         arr.push(attachment);
+         });
+        if (arr.length == numbers) {
+          ThreadUI.cleanFields(true);
+          setTimeout(function() {Compose.appendAll(arr)},1000);
+        }
+    }
 
       // Navigating to the 'New Message' page is an asynchronous operation that
       // clears the Composition field. If the application is not already in the

--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -458,7 +458,27 @@ var Compose = (function() {
       return this;
     },
 
-    clear: function() {
+    append: function(item) {
+      var fragment = insert(item);
+
+      if (document.activeElement === dom.message) {
+        // insert element at caret position
+        var range = window.getSelection().getRangeAt(0);
+        var firstNodes = fragment.firstChild;
+        range.deleteContents();
+        range.insertNode(fragment);
+        this.scrollToTarget(range);
+        dom.message.focus();
+        range.setStartAfter(firstNodes);
+      } else {
+        // insert element at the end of the Compose area
+        dom.message.insertBefore(fragment, dom.message.lastChild);
+        this.scrollToTarget(dom.message.lastChild);
+      }
+      onContentChanged(item);
+      return this;
+    },
+clear: function() {
       dom.message.innerHTML = '<br>';
       subject.clear();
       state.resizing = state.full = false;

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -57,7 +57,7 @@
     "share": {
       "filters": {
         "type": ["image/*", "audio/*", "video/*"],
-        "number": 1
+        "number": [1,2,3,4,5]
        },
       "disposition": "window"
     }


### PR DESCRIPTION
This patch allows us to select more than one file file from the gallery app to share with SMS/MMS.

The limitation is for upto 5 image per MMS.
