### PR TITLE
Promisify new keyboard and fix replaceSurroundingText to new API

### DIFF
--- a/test_apps/demo-keyboard/js/autocorrect.js
+++ b/test_apps/demo-keyboard/js/autocorrect.js
@@ -1,3 +1,4 @@
+/*global InputField KeyboardTouchHandler */
 (function(exports) {
   'use strict';
 
@@ -88,13 +89,15 @@
   Suggestions.addEventListener('suggestionselected', function(e) {
     var suggestion = e.detail;
     var current = InputField.wordBeforeCursor();
-    InputField.replaceSurroundingText(suggestion, current.length, 0);
-    reversion = {
-      from: suggestion,
-      to: current
-    };
-    correction = null;
-    autocorrectDisabled = false;
+    InputField.replaceSurroundingText(suggestion,
+      -current.length, current.length).then(function() {
+        reversion = {
+          from: suggestion,
+          to: current
+        };
+        correction = null;
+        autocorrectDisabled = false;
+      });
   });
 
   Suggestions.addEventListener('suggestionsdismissed', function() {
@@ -136,10 +139,12 @@
         if (charcode === RETURN)
           charcode = 10;  // Use newline, not carriage return
         var s = correction.to + String.fromCharCode(charcode);
-        InputField.replaceSurroundingText(s, correction.from.length, 0);
+        InputField.replaceSurroundingText(s, -correction.from.length,
+          correction.from.length).then(function() {
+            reversion = { from: s, to: correction.from };
+            correction = null;
+          });
 
-        reversion = { from: s, to: correction.from };
-        correction = null;
         e.stopImmediatePropagation();
       }
       else {
@@ -151,11 +156,13 @@
       if (reversion) {
         if (InputField.textBeforeCursor.endsWith(reversion.from)) {
           InputField.replaceSurroundingText(reversion.to,
-                                            reversion.from.length, 0);
-          // XXX:
-          // if the reversion was from a word suggestion not an autocorrection
-          // then we probably should not disable autocorrect
-          autocorrectDisabled = true;
+                                            -reversion.from.length,
+                                            reversion.from.length)
+            .then(function() {
+              // if the reversion was from a word suggestion not an autocorrection
+              // then we probably should not disable autocorrect
+              autocorrectDisabled = true;
+            });
           e.stopImmediatePropagation();
         }
         reversion = null;

--- a/test_apps/demo-keyboard/js/doublespace.js
+++ b/test_apps/demo-keyboard/js/doublespace.js
@@ -1,5 +1,6 @@
 // This module registers a key event listener and handles double space.
 // It needs to run before the code that resisters the default key handler.
+/*global InputField KeyboardTouchHandler */
 (function(exports) {
   'use strict';
 
@@ -27,10 +28,11 @@
       if (lastKeyWasSpace &&
           InputField.textBeforeCursor.match(/[^\s.?!;:] $/) &&
           (e.timeStamp - lastKeyWasSpace) < DOUBLE_SPACE_INTERVAL_MS * 1000) {
-        InputField.replaceSurroundingText('. ', 1, 0);
+        InputField.replaceSurroundingText('. ', -1, 1).then(function() {
+          lastKeyWasSpace = 0;
+          convertedOnLastEvent = true;
+        });
         e.stopImmediatePropagation();
-        lastKeyWasSpace = 0;
-        convertedOnLastEvent = true;
       }
       else {
         lastKeyWasSpace = e.timeStamp;
@@ -38,10 +40,11 @@
       }
     }
     else if (keyname === 'BACKSPACE' && convertedOnLastEvent) {
-      InputField.replaceSurroundingText('  ', 2, 0);
+      InputField.replaceSurroundingText('  ', -2, 2).then(function() {
+        lastKeyWasSpace = 0;
+        convertedOnLastEvent = false;
+      });
       e.stopImmediatePropagation();
-      lastKeyWasSpace = 0;
-      convertedOnLastEvent = false;
     }
     else {
       lastKeyWasSpace = 0;

--- a/test_apps/demo-keyboard/js/key.js
+++ b/test_apps/demo-keyboard/js/key.js
@@ -1,3 +1,4 @@
+/*global KeyboardLayout */
 'use strict';
 
 function Key(keyname, pagekeys, layoutkeys) {

--- a/test_apps/demo-keyboard/js/keyboard.js
+++ b/test_apps/demo-keyboard/js/keyboard.js
@@ -1,3 +1,4 @@
+/*global KeyboardLayout KeyboardTouchHandler KeyEvent InputField */
 'use strict';
 
 var inputContext = null;
@@ -7,10 +8,6 @@ var keyboardContainer;
 var currentPage;
 var currentPageView;
 var mainpageName;
-
-var pages = {};
-var pageviews = {};
-var settings;
 
 window.addEventListener('load', init);
 
@@ -169,12 +166,11 @@ function sendKey(keycode) {
   switch (keycode) {
   case KeyEvent.DOM_VK_BACK_SPACE:
   case KeyEvent.DOM_VK_RETURN:
-    InputField.sendKey(keycode, 0, 0);
+    return InputField.sendKey(keycode, 0, 0);
     break;
 
   default:
-    var start = performance.now();
-    InputField.sendKey(0, keycode, 0);
+    return InputField.sendKey(0, keycode, 0);
     break;
   }
 }

--- a/test_apps/demo-keyboard/js/layout.js
+++ b/test_apps/demo-keyboard/js/layout.js
@@ -1,3 +1,4 @@
+/*global KeyboardPage KeyboardPageView */
 'use strict';
 
 /*

--- a/test_apps/demo-keyboard/js/page.js
+++ b/test_apps/demo-keyboard/js/page.js
@@ -1,3 +1,4 @@
+/*global Key */
 'use strict';
 
 // Build an object representing one page of a keyboard layout.

--- a/test_apps/demo-keyboard/js/pageview.js
+++ b/test_apps/demo-keyboard/js/pageview.js
@@ -162,11 +162,11 @@
     if (!rect) {
       var keyelt = this.keyelts[keyname];
       if (!keyelt)
-        throw Error('unknown key: ' + keyname);
+        throw new Error('unknown key: ' + keyname);
 
       rect = keyelt.getBoundingClientRect();
       if (rect.width === 0)
-        throw Error('KeyboardPageView is not laid out yet: ' + keyname);
+        throw new Error('KeyboardPageView is not laid out yet: ' + keyname);
 
       // In addition to the basic rectangle, the hit detector in
       // KeyboardTouchHandler also wants some additional data. We

--- a/test_apps/demo-keyboard/js/shiftkey.js
+++ b/test_apps/demo-keyboard/js/shiftkey.js
@@ -1,3 +1,4 @@
+/*global InputField KeyboardTouchHandler currentPageView */
 /*
  * This module is responsible for handling the shift key and for
  * auto-capitalization.

--- a/test_apps/demo-keyboard/js/suggestions.js
+++ b/test_apps/demo-keyboard/js/suggestions.js
@@ -63,7 +63,7 @@
     span.textContent = word;
     container.appendChild(span);
 
-    var limit = .6;  // Dont use a scale smaller than this
+    var limit = 0.6;  // Dont use a scale smaller than this
     var scale = getScale(span, container);
 
     // If the word does not fit within the scaling limit,
@@ -104,14 +104,14 @@
       var s = container.clientWidth / elementWidth;
       if (s >= 1)
         return 1;    // 10pt font "Body Large"
-      if (s >= .8)
-        return .8;   // 8pt font "Body"
-      if (s >= .7)
-        return .7;   // 7pt font "Body Medium"
-      if (s >= .65)
-        return .65;  // 6.5pt font "Body Small"
-      if (s >= .6)
-        return .6;   // 6pt font "Body Mini"
+      if (s >= 0.8)
+        return 0.8;   // 8pt font "Body"
+      if (s >= 0.7)
+        return 0.7;   // 7pt font "Body Medium"
+      if (s >= 0.65)
+        return 0.65;  // 6.5pt font "Body Small"
+      if (s >= 0.6)
+        return 0.6;   // 6pt font "Body Mini"
       return s;      // Something smaller than 6pt.
     }
   }

--- a/test_apps/demo-keyboard/js/touch_handler.js
+++ b/test_apps/demo-keyboard/js/touch_handler.js
@@ -247,6 +247,7 @@
   function dispatchKeyEvent(keyname) {
     // Before sending a new key, discard the weights used to compute this one.
     weights = null;
+    // TODO: What if the key event gets canceled?
     dispatcher.dispatchEvent(new CustomEvent('key', { detail: keyname }));
   }
 
@@ -370,7 +371,7 @@
       }
     }
     return nearestName;
-  };
+  }
 
   exports.KeyboardTouchHandler = {
     setPageView: setPageView,

--- a/test_apps/demo-keyboard/js/worker.js
+++ b/test_apps/demo-keyboard/js/worker.js
@@ -1,3 +1,4 @@
+/*global Predictions postMessage */
 //
 // The Latin input method provides word suggestions/auto completions
 // using the algorithm in predictions.js. For efficiency, however, this code

--- a/test_apps/demo-keyboard/test/unit/doublespace_test.js
+++ b/test_apps/demo-keyboard/test/unit/doublespace_test.js
@@ -1,5 +1,5 @@
 /*global requireApp suite test assert setup teardown sinon mocha
-  suiteTeardown suiteSetup */
+  suiteTeardown suiteSetup Promise */
 suite('DoubleSpace', function() {
   function eventEmitterSpy() {
     var d = document.createElement('div');
@@ -32,7 +32,10 @@ suite('DoubleSpace', function() {
 
   setup(function() {
     window.DoubleSpace.resetLastKeyWasSpace();
-    inputField.replaceSurroundingText = sinon.stub();
+    inputField.replaceSurroundingText =
+      sinon.stub().returns(new Promise(function(res) {
+        res();
+      }));
   });
 
   function sendKey(key) {
@@ -46,10 +49,12 @@ suite('DoubleSpace', function() {
       inputField.textBeforeCursor += ' ';
       sendKey('SPACE');
       if (shouldMakeDot) {
-        assert.equal(inputField.replaceSurroundingText.callCount, 1,
+        sinon.assert.callCount(inputField.replaceSurroundingText, 1,
           'replaceSurroundingText callCount');
-        assert.equal(inputField.replaceSurroundingText.calledWith('. ', 1, 0),
-          true, 'replaceSurroundingText arguments');
+
+        assert.equal(JSON.stringify(inputField.replaceSurroundingText.args[0]),
+          JSON.stringify([ '. ', -1, 1 ]),
+          'replaceSurroundingText arguments');
       }
       else {
         assert.equal(inputField.replaceSurroundingText.callCount, 0,
@@ -106,28 +111,39 @@ suite('DoubleSpace', function() {
       var spy2 = sinon.spy(ev2, 'stopImmediatePropagation');
       return [ev1, ev2, spy1, spy2];
     }
-    test('On dot insertion', function() {
+
+    test('On dot insertion', function(next) {
       let[ev1, ev2, spy1, spy2] = createSpaceEvents();
 
       inputField.textBeforeCursor = 'jan';
       keyboardTouchHelper.dispatchEvent(ev1);
-      inputField.textBeforeCursor += ' ';
-      keyboardTouchHelper.dispatchEvent(ev2);
 
-      assert.equal(spy1.callCount, 0, 'stopPropagation on event 1');
-      assert.equal(spy2.callCount, 1, 'stopPropagation on event 2');
+      setTimeout(function() {
+        inputField.textBeforeCursor += ' ';
+        keyboardTouchHelper.dispatchEvent(ev2);
+
+        assert.equal(spy1.callCount, 0, 'stopPropagation on event 1');
+        assert.equal(spy2.callCount, 1, 'stopPropagation on event 2');
+
+        next();
+      }, 0);
     });
 
-    test('On non-dot insertion', function() {
+    test('On non-dot insertion', function(next) {
       let [ev1, ev2, spy1, spy2] = createSpaceEvents();
 
       inputField.textBeforeCursor = ''; // empty string doesnt insert dot
       keyboardTouchHelper.dispatchEvent(ev1);
-      inputField.textBeforeCursor += ' ';
-      keyboardTouchHelper.dispatchEvent(ev2);
 
-      assert.equal(spy1.callCount, 0, 'stopPropagation on event 1');
-      assert.equal(spy2.callCount, 0, 'stopPropagation on event 2');
+      setTimeout(function() {
+        inputField.textBeforeCursor += ' ';
+        keyboardTouchHelper.dispatchEvent(ev2);
+
+        assert.equal(spy1.callCount, 0, 'stopPropagation on event 1');
+        assert.equal(spy2.callCount, 0, 'stopPropagation on event 2');
+
+        next();
+      }, 0);
     });
   });
 
@@ -163,29 +179,42 @@ suite('DoubleSpace', function() {
         'replaceSurroundingText callCount');
     });
 
-    test('Space then backspace', function() {
+    test('Space then backspace', function(next) {
       inputField.textBeforeCursor = 'yolo';
       sendKey('SPACE');
       inputField.textBeforeCursor += ' ';
-      let [ev, spy] = triggerBackspaceEvent();
-      assert.equal(spy.callCount, 0, 'stopImmediatePropagation callCount');
-      assert.equal(inputField.replaceSurroundingText.callCount, 0,
-        'replaceSurroundingText callCount');
+      setTimeout(function() {
+        let [ev, spy] = triggerBackspaceEvent();
+        assert.equal(spy.callCount, 0, 'stopImmediatePropagation callCount');
+        assert.equal(inputField.replaceSurroundingText.callCount, 0,
+          'replaceSurroundingText callCount');
+        next();
+      }, 0);
     });
 
-    test('Double space then backspace', function() {
+    test('Double space then backspace', function(next) {
       inputField.textBeforeCursor = 'yolo';
       sendKey('SPACE');
       inputField.textBeforeCursor += ' ';
-      sendKey('SPACE');
-      // new stub required
-      inputField.replaceSurroundingText = sinon.stub();
-      let [ev, spy] = triggerBackspaceEvent();
-      assert.equal(spy.callCount, 1, 'stopImmediatePropagation callCount');
-      assert.equal(inputField.replaceSurroundingText.callCount, 1,
-        'replaceSurroundingText callCount');
-      assert.equal(inputField.replaceSurroundingText.calledWith('  ', 2, 0),
-        true, 'replaceSurroundingText callCount');
+      setTimeout(function() {
+        sendKey('SPACE');
+
+        setTimeout(function() {
+          // new stub required
+          inputField.replaceSurroundingText = sinon.stub().returns(
+            new Promise(function(res) { res(); }));
+          let [ev, spy] = triggerBackspaceEvent();
+          assert.equal(spy.callCount, 1, 'stopImmediatePropagation callCount');
+          assert.equal(inputField.replaceSurroundingText.callCount, 1,
+            'replaceSurroundingText callCount');
+          assert.equal(
+            inputField.replaceSurroundingText.calledWith('  ', -2, 2),
+            true, 
+            'replaceSurroundingText calledWith');
+
+          next();
+        }, 0);
+      }, 0);
     });
   });
 });


### PR DESCRIPTION
- This stops keeping state internally, because this already happens on the inputcontext object. If something is wrong there we should fix in platform.
- Change replaceSurroundingText API because implementation changed last week
- Make JSHint happier
- Let InputField return promises and use them, so we don't change state when an operation fails
- Remove promise monitoring. I don't really get what this would be good for. If this is to work around something it should be fixed in platform.

Tested it in Fx Nightly and seems to work nicely. The only thing is that sometimes the eventhandlers for surroundingtextchange and selectionchange don't get attached (though gecko fires them) and I have no clue why because in mochitest all is fine. I'll try on device and see what happens.
