### PR TITLE
Bug 941852 - [B2G]Long pressing MMS attachments will cause alternate message to appear and overlap

### DIFF
--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -257,7 +257,6 @@
     iframe.removeEventListener('load', iframeLoad);
     navigator.mozL10n.translate(iframe.contentDocument.body);
     iframe.contentDocument.addEventListener('click', clickOnFrame);
-    iframe.contentDocument.addEventListener('contextmenu', clickOnFrame);
   }
 
   exports.Attachment = Attachment;


### PR DESCRIPTION
- Remove the contextmenu event listener form attachment icon for preventing the unnecessary menu shows up.
