### PR TITLE
Bug 952719 - Reenable notification click message reader test

### DIFF
--- a/apps/email/test/marionette/notification_click_test.js
+++ b/apps/email/test/marionette/notification_click_test.js
@@ -65,8 +65,7 @@ marionette('email notifications, click', function() {
     app.launch();
   });
 
-  test.skip('show message_reader for 1 message notification',
-  function() {
+  test('show message_reader for 1 message notification', function() {
     configureAndSend(1);
 
     sync.triggerSync();


### PR DESCRIPTION
Initially this was disabled because of an unresponsive build (perhaps a b2g crash)? The error may have been transient so testing for flakiness here.
