### PR TITLE
Bug 951423 - [B2G][Calendar][Day View]Header displays truncated if date exceeds eighteen characters.

### DIFF
--- a/apps/calendar/locales/calendar.ar.properties
+++ b/apps/calendar/locales/calendar.ar.properties
@@ -93,7 +93,7 @@ month-view-header-format=%B %Y
 single-month-view-header-format=%B
 
 # Header format used for in the day view.
-day-view-header-format=%A %B %e
+day-view-header-format=%b %e, %A
 
 #errors
 error-start-after-end=تاريخ الانتهاء يجب أن يكون بعد تاريخ البدء

--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -208,7 +208,7 @@ month-view-header-format=%B %Y
 single-month-view-header-format=%B
 
 # Header format used for in the day view.
-day-view-header-format=%A %B %e
+day-view-header-format=%b %e, %A
 
 #errors
 error-start-after-end=End date must come after start date

--- a/apps/calendar/locales/calendar.fr.properties
+++ b/apps/calendar/locales/calendar.fr.properties
@@ -204,7 +204,7 @@ month-view-header-format=%B %Y
 single-month-view-header-format=%B 
 
 # Header format used for in the day view.
-day-view-header-format=%A %e %Eb
+day-view-header-format=%A %e %b
 
 #errors
 error-start-after-end=La date de fin doit être postérieure à celle de début

--- a/apps/calendar/test/marionette/calendar.js
+++ b/apps/calendar/test/marionette/calendar.js
@@ -65,6 +65,7 @@ Calendar.HEADER_PATTERN = /^([JFMASOND][a-z]+\s){2}\d{4}$/;
 Calendar.Selector = Object.freeze({
   addEventButton: 'a[href="/event/add/"]',
   weekButton: 'a[href="/week/"]',
+  dayButton: 'a[href="/day/"]',
   hintSwipeToNavigate: '#hint-swipe-to-navigate',
   editEventForm: '#modify-event-view form',
   editEventAlarm: '#modify-event-view select[name="alarm[]"]',

--- a/apps/calendar/test/marionette/day_view_test.js
+++ b/apps/calendar/test/marionette/day_view_test.js
@@ -1,0 +1,34 @@
+var Calendar = require('./calendar'),
+    Marionette = require('marionette-client');
+    assert = require('assert');
+
+marionette('day view', function() {
+  var app;
+  var client = marionette.client();
+
+  setup(function() {
+    app = new Calendar(client);
+    app.launch();
+
+    // Hide the hint
+    app.findElement('hintSwipeToNavigate').click();
+
+    // Go to day view
+    app.findElement('dayButton').click();
+  });
+
+  test('header copy should not overflow', function() {
+    var header = app.findElement('monthYearHeader');
+    var wid = header.scriptWith(function(el) {
+      return {
+        content: el.scrollWidth,
+        container: el.getBoundingClientRect().width
+      };
+    });
+    // we need to check the widths are != 0 since element might be hidden
+    assert.ok(wid.content, 'content width is not valid');
+    assert.ok(wid.container, 'container width is not valid');
+    assert.equal(wid.content, wid.container,
+      'content is bigger than container');
+  });
+});

--- a/apps/calendar/test/unit/views/time_header_test.js
+++ b/apps/calendar/test/unit/views/time_header_test.js
@@ -71,6 +71,20 @@ suiteGroup('Views.TimeHeader', function() {
     );
   });
 
+  test('#getScale for day', function() {
+    controller.move(new Date(2012, 0, 30));
+    var compare = fmt.localeFormat(
+      new Date(2012, 0, 30),
+      // do not use hard coded values because it might change based on locale
+      navigator.mozL10n.get(subject.scales.day)
+    );
+    var out = subject.getScale('day');
+    assert.equal(out, compare);
+    // 20 chars seems to be the maximum with current layout (see bug 951423)
+    assert.operator(out.length, '<', 21,
+      'header should not have too many chars');
+  });
+
   // When week starts in one month
   // and ends in another we need
   // 'Month1 Month2 Year' like header.


### PR DESCRIPTION
change L10n files to use abbreviated month name to avoid char cap. (eg: "Dec 31, Wednesday")

also added integration and unit tests to avoid regressions.

![proposal screenshot](https://bug951423.bugzilla.mozilla.org/attachment.cgi?id=8356691)

**notes:**
- according to my tests the char limit was in fact 20 chars instead of 18.
- `zh-TW` locale did not require any changes.
- needs approval by the design team.

/cc @gaye
