### PR TITLE
Bug 957932 - Add coverage execute button for test-agent web interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,4 @@ matrix:
     - env: CI_ACTION=unit-tests-in-b2g
 notifications:
   email: false
-  irc:
-    on_success: change
-    channels:
-    - irc.mozilla.org#gaia
+

--- a/test_apps/test-agent/common/vendor/test-agent/test-agent.css
+++ b/test_apps/test-agent/common/vendor/test-agent/test-agent.css
@@ -37,10 +37,9 @@ body > iframe {
   padding: none;
   border: none;
   clear: both;
-  margin-top: 50px;
   overflow: hidden;
-  margin: 0;
-  padding: 0 0 1em 0;
+  margin: 4.5rem 0 0 0;
+  padding: 0 0 1rem 0;
 
   -webkit-column-width: 350px;
      -moz-column-width: 350px;
@@ -54,25 +53,25 @@ body > iframe {
   position: relative;
 
   list-style: none;
-  padding: 0 0 0 2em;
+  padding: 0 0 0 1.5rem;
   margin: 0;
 
   cursor: pointer;
 }
 
-#test-agent-ui li:hover,
-#test-agent-ui .active {
-  text-decoration: underline;
+#test-agent-ui .active,
+#test-agent-ui li:not(.test-agent-list-head):hover {
   color: #00d;
+  text-decoration: underline;
 }
 
 #test-agent-ui .active:before {
   content: '*';
   position: absolute;
   display: block;
-  left: 1em;
-  top: .3em;
-  width: 1em;
+  left: .7rem;
+  top: .2rem;
+  width: 1rem;
 }
 
 #test-agent-ui .working {
@@ -85,12 +84,51 @@ body > iframe {
 
 #test-agent-ui button {
   clear: both;
-  font-size: 14px;
+  font-size: 1.4rem;
   width: 100%;
-  padding: 5px;
-  height: 30px;
+  padding: .5rem;
+  height: 3rem;
   border: 1px solid #E2E2E2;
-  background-color: #FAFAFA;
+}
+
+#test-agent-ui .test-agent-list-head {
+  position: relative;
+
+  width: 100%;
+  margin: 1rem 0;
+
+  font-weight: bolder;
+  font-size: 1.2rem;
+  background: #CCC;
+}
+
+#test-agent-ui .test-agent-list-head-info {
+  position: absolute;
+  right: .5rem;
+
+  font-style: italic;
+  font-weight: normal;
+}
+
+#test-agent-ui .test-agent-list-head:hover {
+  text-decoration: none;
+}
+
+#test-agent-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding-top: 1rem;
+  padding-left: 5rem;
+  background-color: rgba(250,250,250,0.7);
+  width: 100%;
+  height: 4.5rem;
+  z-index: 4;
+}
+
+#test-agent-panel .options {
+  margin-top: 0.2rem;
+  margin-left: -0.3rem;
 }
 
 @media only screen and (max-width: 480px) {
@@ -99,13 +137,22 @@ body > iframe {
   }
 
   #test-agent-ui li {
-    min-height: 3em;
+    width: 100%;
+    padding: .5rem 1rem .5rem 2rem;
     border-bottom: 1px solid #aaa;
-    padding: .5em 1em .5em 2em;
   }
 
   #test-agent-ui .active:before {
-    top: .8em;
+    top: .8rem;
+  }
+
+  #test-agent-panel {
+    padding: 1rem;
+    border-bottom: 1px solid #aaa;
+  }
+
+  #test-agent-ui .test-agent-list-head {
+    margin: 0;
   }
 }
 

--- a/test_apps/test-agent/common/vendor/test-agent/test-agent.js
+++ b/test_apps/test-agent/common/vendor/test-agent/test-agent.js
@@ -3250,6 +3250,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     WORKING: 'working',
     EXECUTE: 'execute',
 
+    tasks: {
+      test: 'run tests',
+      coverage: 'run tests with coverage',
+    },
+
     templates: {
       testList: '<ul class="test-list"></ul>',
       testItem: '<li data-url="%s">%s</li>',
@@ -3265,10 +3270,21 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     get execButton() {
-      if(!this._execButton){
+      if (!this._execButton) {
         this._execButton = this.element.querySelector('button');
       }
       return this._execButton;
+    },
+
+    get command() {
+      var covCheckbox = document.querySelector('#test-agent-coverage-checkbox'),
+          covFlag = covCheckbox ? covCheckbox.checked : false;
+
+      if (covFlag) {
+        return this.tasks.coverage;
+      } else {
+        return this.tasks.test;
+      }
     },
 
     enhance: function enhance(worker) {
@@ -3350,6 +3366,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       this.element.appendChild(fragment(templates.testRun));
 
       this.initDomEvents();
+
+      window.dispatchEvent(new CustomEvent('test-agent-list-done'));
     },
 
     initDomEvents: function initDomEvents() {
@@ -3387,10 +3405,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           }
         }
 
-        self.worker.emit('run tests', {tests: tests});
+        self.worker.emit(self.command, {tests: tests});
       });
     }
 
   };
 
 }(this));
+

--- a/test_apps/test-agent/index.html
+++ b/test_apps/test-agent/index.html
@@ -15,11 +15,17 @@
 </head>
 <body>
 
-<div id="test-agent-search">
-<form>
-  <input type="text" name="search" id="test-agent-search-input" />
-  <button type="button" id="test-agent-search-submit">Search</button>
-</form>
+<div id="test-agent-panel">
+  <form>
+    <input type="text" name="search" id="test-agent-search-input" />
+    <button type="button" id="test-agent-search-submit">Search</button>
+    <div class="options">
+      <label>
+        <input type="checkbox" id="test-agent-coverage-checkbox" />
+        Enable Coverage
+      </label>
+    </div>
+  </form>
 </div>
 
 <!-- Test Agent UI will be loaded in here -->

--- a/tools/test-agent/package.json
+++ b/tools/test-agent/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "test-agent": "0.15.0",
+    "test-agent": "0.16.0",
     "marionette-client": "0.5.4",
     "b2g-scripts": "0.3.0",
     "chai": "0.5.3",


### PR DESCRIPTION
Enable coverage only can execute from command line interface is inconvenient for testing specified unit tests. So add a coverage button and let people can execute unit tests they want is a good way.
