### PR TITLE
Bug 956276 - [ZTE]-Two or more instances of open activity will be launch...

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -242,7 +242,6 @@ var NotificationScreen = {
         id: notificationId
       }
     }));
-    window.dispatchEvent(event);
 
     // Desktop notifications are removed when they are clicked (see bug 890440)
     if (notificationNode.dataset.type === 'desktop-notification' &&


### PR DESCRIPTION
Removed the call to dispatch event which was done twice earlier.
