### PR TITLE
Bug 958103 - [Messages][Drafts] Don't auto-save drafts when message input is empty

### DIFF
--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -106,7 +106,11 @@ var MessageManager = {
     // save a message draft if necessary
     if (document.hidden) {
       var hash = window.location.hash;
-      if (hash === '#new' || hash.startsWith('#thread=')) {
+
+      // Auto-save draft if the user has entered anything
+      // in the composer.
+      if ((hash === '#new' || hash.startsWith('#thread=')) &&
+          (!Compose.isEmpty() || ThreadUI.recipients.length)) {
         ThreadUI.saveDraft({preserve: true});
       }
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=958103
Signed-off-by: Rick Waldron waldron.rick@gmail.com
