### PR TITLE
Bug 958251 - Task Manager

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -344,6 +344,7 @@
     <!-- Rocketbar -->
     <script defer src="js/rocketbar.js"></script>
     <script defer src="js/title.js"></script>
+    <script defer src="shared/js/url_helper.js"></script>
     <link rel="stylesheet" type="text/css" href="style/rocketbar.css">
 
     <!-- Firefox Accounts-->
@@ -469,7 +470,9 @@
           <p>
             <input id="search-input" type="search" x-inputmode="verbatim" placeholder="Search or type address" data-l10n-id="search-or-type-address"></input>
             <button id="search-reset" type="reset"></button>
-            <a href="#" id="search-cancel" data-l10n-id="cancel">Cancel</a>
+            <a href="#" id="search-cancel">
+                <span data-l10n-id="cancel">Cancel</span>
+            </a>
           </p>
         </form>
         <div id="search-container"></div>

--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -64,7 +64,7 @@ var UtilityTray = {
       case 'simpinshow':
       case 'appopening':
         if (Rocketbar.shown) {
-          Rocketbar.hide();
+          Rocketbar.hide(evt.type);
         }
         if (this.shown) {
           this.hide();
@@ -97,10 +97,16 @@ var UtilityTray = {
         break;
 
       case 'touchmove':
-      if (!this.active)
-        return;
+        var touch = evt.touches[0];
+        if (!this.active) {
+          if (Rocketbar.enabled && !this.shown &&
+              touch.pageX < this.screenWidth * Rocketbar.triggerWidth) {
+            Rocketbar.pointerY = touch.pageY;
+          }
+          return;
+        }
 
-        this.onTouchMove(evt.touches[0]);
+        this.onTouchMove(touch);
         break;
 
       case 'touchend':
@@ -127,10 +133,13 @@ var UtilityTray = {
     // Show the rocketbar if it's enabled,
     // Give a slightly larger left area, than right.
     if (Rocketbar.enabled && !this.shown &&
-        touch.pageX < this.screenWidth * 0.65) {
+        touch.pageX < this.screenWidth * Rocketbar.triggerWidth) {
       UtilityTray.hide();
-      Rocketbar.render();
+      Rocketbar.pointerY = touch.pageY;
+      Rocketbar.render(this.screenHeight);
       return;
+    } else {
+      window.dispatchEvent(new CustomEvent('taskmanagerhide'));
     }
 
     Rocketbar.hide();

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -149,3 +149,21 @@
   background: url(close.png) no-repeat center / 2.6rem;
   transform: scale(1.3);
 }
+
+#screen.task-manager #cards-view {
+  background: transparent;
+  margin-top: 5rem;
+}
+
+#screen.task-manager #cards-view li.card {
+  transform-origin: 50% 30%;
+}
+
+#screen.task-manager #search-cancel {
+  display: none;
+}
+
+#screen.task-manager #cards-view .card > h1,
+#screen.task-manager #cards-view .card > p {
+  display: none;
+}

--- a/apps/system/style/rocketbar.css
+++ b/apps/system/style/rocketbar.css
@@ -7,6 +7,7 @@
   pointer-events: none;
   transform: translateY(-100%);
   transition: transform 0.3s ease 0.8s;
+  visibility: hidden;
 }
 
 #screen.software-button-enabled #search-bar {
@@ -14,14 +15,9 @@
 }
 
 #search-bar[data-visible] {
-  visibility: visible;
   pointer-events: auto;
   transform: translateY(0);
   transition: transform 0.3s ease;
-}
-
-#search-bar {
-  visibility: hidden;
 }
 
 #search-bar form p {
@@ -54,13 +50,19 @@
 #search-bar #search-cancel {
   position: absolute;
   right: 0;
-  top: 0.5rem;
-  border-left: 1px solid #929496;
+  top: 0;
   text-decoration: none;
+  outline: 0;
+  padding: 0.5rem 0;
+}
+
+#search-bar #search-cancel span {
+  pointer-events: none;
+  border-left: 1px solid #929496;
+  display: inline-block;
   padding: 0.7rem 0.8rem 0.5rem;
   font-size: 1.4rem;
   color: #929496;
-  outline: 0;
 }
 
 #search-bar #search-container {

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -169,7 +169,8 @@
   100% { transform: scale(1);}
 }
 
-#windows > .appWindow.to-cardview {
+/* Generally transitions, except when going into rocketbar manager */
+#screen:not(.task-manager) #windows > .appWindow.to-cardview {
   animation: closeAppTowardsCardView 0.15s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
 }
 

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -62,6 +62,13 @@
   z-index: 65535;
 }
 
+/* Transitioning appWindow to task manager should be shown under the rocketbar */
+#screen.cards-view.task-manager > [data-z-index-level="app"] > .appWindow.active:not(.homescreen),
+#screen.cards-view.task-manager > [data-z-index-level="app"] > .appWindow.transition-closing.to-cardview:not(.homescreen),
+#screen.cards-view.task-manager > [data-z-index-level="app"] > .appWindow.transition-closing.fullscreen-app.to-cardview:not(.homescreen) {
+  z-index: 2042;
+}
+
 #screen > [data-z-index-level="keyboards"] {
 
   /* It should lower than UtilityTray's, to let the tray overlay it

--- a/apps/system/test/unit/cards_view_test.js
+++ b/apps/system/test/unit/cards_view_test.js
@@ -10,6 +10,7 @@ requireApp('system/test/unit/mock_trusted_ui_manager.js');
 requireApp('system/test/unit/mock_utility_tray.js');
 requireApp('system/test/unit/mock_app_window_manager.js');
 requireApp('system/test/unit/mock_lock_screen.js');
+requireApp('system/test/unit/mock_orientation_manager.js');
 requireApp('system/test/unit/mock_sleep_menu.js');
 requireApp('system/test/unit/mock_popup_manager.js');
 
@@ -21,6 +22,7 @@ var mocksForCardsView = new MocksHelper([
   'AppWindowManager',
   'LockScreen',
   'SleepMenu',
+  'OrientationManager',
   'PopupManager'
 ]).init();
 
@@ -237,6 +239,25 @@ suite('cards view >', function() {
                                         'rotate-180'));
     });
 
+  });
+
+  suite('task manager in rocketbar >', function() {
+    setup(function(done) {
+      CardsView.showCardSwitcher(null, true);
+      setTimeout(done);
+    });
+
+    test('has correct classes', function() {
+      var screen = document.getElementById('screen');
+      assert.isTrue(cardsView.classList.contains('active'));
+      assert.isTrue(screen.classList.contains('task-manager'));
+    });
+
+    test('removes task-manager class', function() {
+      var screen = document.getElementById('screen');
+      CardsView.hideCardSwitcher();
+      assert.isFalse(screen.classList.contains('task-manager'));
+    });
   });
 });
 

--- a/apps/system/test/unit/mock_cards_view.js
+++ b/apps/system/test/unit/mock_cards_view.js
@@ -1,0 +1,7 @@
+var MockCardsView = {
+  showCardSwitcher: function() {},
+  hideCardSwitcher: function() {},
+  cardSwitcherIsShown: function() {},
+  handleEvent: function() {},
+  _escapeHTML: function() {}
+};

--- a/apps/system/test/unit/mock_rocketbar.js
+++ b/apps/system/test/unit/mock_rocketbar.js
@@ -1,4 +1,5 @@
 MockRocketbar = {
+  triggerWidth: 0.5,
   render: function() {},
   enabled: true,
   hide: function() {}

--- a/apps/system/test/unit/rocketbar_test.js
+++ b/apps/system/test/unit/rocketbar_test.js
@@ -1,9 +1,11 @@
 'use strict';
 
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
+requireApp('system/test/unit/mock_cards_view.js');
 mocha.globals(['Rocketbar']);
 
 var mocksForRocketBar = new MocksHelper([
+  'CardsView',
   'SettingsListener'
 ]).init();
 
@@ -18,16 +20,19 @@ suite('system/Rocketbar', function() {
     fakeElement.style.cssText = 'height: 100px; display: block;';
     stubById = this.sinon.stub(document, 'getElementById')
                           .returns(fakeElement.cloneNode(true));
+    this.sinon.useFakeTimers();
     requireApp('system/js/rocketbar.js', done);
   });
 
   teardown(function() {
     stubById.restore();
+    this.sinon.clock.restore();
   });
 
   suite('render', function() {
     test('shown should be true', function() {
       Rocketbar.render();
+      this.sinon.clock.tick(1);
       assert.equal(Rocketbar.shown, true);
       Rocketbar.hide();
     });
@@ -36,7 +41,9 @@ suite('system/Rocketbar', function() {
       var eventListenerStub = this.sinon.stub(window.document.body,
         'addEventListener');
       Rocketbar.render();
+      this.sinon.clock.tick();
       Rocketbar.render();
+      this.sinon.clock.tick();
       assert.isTrue(eventListenerStub.withArgs('keyboardchange').calledOnce);
       Rocketbar.hide();
     });
@@ -44,6 +51,7 @@ suite('system/Rocketbar', function() {
     test('resets the value', function() {
       Rocketbar.searchInput.value = 'foo';
       Rocketbar.render();
+      this.sinon.clock.tick();
       assert.equal(Rocketbar.searchInput.value, '');
       Rocketbar.hide();
     });
@@ -54,6 +62,7 @@ suite('system/Rocketbar', function() {
         called = true;
       });
       Rocketbar.render();
+      this.sinon.clock.tick();
       assert.equal(called, true);
       Rocketbar.hide();
     });
@@ -66,6 +75,7 @@ suite('system/Rocketbar', function() {
         }
       };
       Rocketbar.render();
+      this.sinon.clock.tick();
       assert.equal('clear', message.action);
       Rocketbar.hide();
     });
@@ -81,11 +91,58 @@ suite('system/Rocketbar', function() {
       Rocketbar.hide();
       searchAppStub.restore();
     });
+
+    suite('interactions', function() {
+      var searchAppStub, cardsViewStub, focusStub;
+
+      setup(function() {
+        searchAppStub = this.sinon.stub(Rocketbar, 'loadSearchApp')
+                            .returns(true);
+        cardsViewStub = this.sinon.stub(window, 'dispatchEvent');
+        focusStub = this.sinon.stub(Rocketbar.searchBar, 'focus');
+      });
+
+      teardown(function() {
+        cardsViewStub.restore();
+        searchAppStub.restore();
+        focusStub.restore();
+      });
+
+      test('swipe event', function() {
+
+        Rocketbar.pointerY = 100;
+        Rocketbar.render(200);
+        this.sinon.clock.tick();
+        Rocketbar.searchBar.dispatchEvent(
+          new CustomEvent('transitionend')
+        );
+        assert.equal(cardsViewStub.getCall(1).args[0].type, 'taskmanagershow');
+        assert.equal(true, focusStub.notCalled);
+        Rocketbar.hide();
+      });
+
+      test('tap event', function() {
+        var called = false;
+        window.addEventListener('taskmanagershow', function() {
+          called = true;
+        });
+        Rocketbar.pointerY = 0;
+        Rocketbar.render(100);
+        this.sinon.clock.tick();
+        Rocketbar.searchBar.dispatchEvent(
+          new CustomEvent('transitionend')
+        );
+        assert.equal(false, called);
+        assert.equal(true, focusStub.calledOnce);
+        Rocketbar.hide();
+      });
+    });
   });
 
   suite('hide', function() {
     test('shown should be false', function() {
       Rocketbar.render();
+      this.sinon.clock.tick();
       Rocketbar.hide();
       assert.equal(Rocketbar.shown, false);
     });
@@ -94,6 +151,7 @@ suite('system/Rocketbar', function() {
       var eventListenerStub = this.sinon.stub(window.document.body,
         'removeEventListener');
       Rocketbar.render();
+      this.sinon.clock.tick();
       Rocketbar.hide();
       assert.isTrue(eventListenerStub.withArgs('keyboardchange').calledOnce);
     });
@@ -102,6 +160,7 @@ suite('system/Rocketbar', function() {
       var inputBlurStub = this.sinon.stub(Rocketbar.searchInput, 'blur')
                           .returns(true);
       Rocketbar.render();
+      this.sinon.clock.tick();
       Rocketbar.hide();
       assert.equal(true, inputBlurStub.calledWith());
       inputBlurStub.restore();
@@ -113,6 +172,7 @@ suite('system/Rocketbar', function() {
         called = true;
       });
       Rocketbar.render();
+      this.sinon.clock.tick();
       Rocketbar.hide();
       assert.equal(called, true);
     });


### PR DESCRIPTION
User accesses Task manager by swiping down from the top of the display.

Features:
- A task manager is displayed when you pull down from the top of the screen. (Rocketbar must be enabled).
- The default rocketbar view remains when you tap on the statusbar.
- The task manager will show a list of cards, each card corresponding to an active application or browser.
- Rocketbar title is updated with each card title as you swipe through cards.
- When focusing on the title, the title should clear if it's an application.
- When focusing on the title, if the title is a URL, it will remain populated.
- The cancel button is hidden while in task manager mode.
- When pressing cancel after focusing, the view will revert to showing the task manager.
- When pressing cancel after focusing, the rocketbar will close if there are no open apps.

https://bugzilla.mozilla.org/show_bug.cgi?id=958251
