### PR TITLE
Bug 953041 - Adding English, Chinese, and French translations for "skip" button.

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -3,6 +3,7 @@ back=Back
 help=Help
 cancel=Cancel
 close=Close
+skip=Skip
 
 # utility tray mobile states
 airplaneMode=Airplane mode

--- a/apps/system/locales/system.fr.properties
+++ b/apps/system/locales/system.fr.properties
@@ -3,6 +3,7 @@ back=Retour
 help=Aide
 cancel=Annuler
 close=Fermer
+skip=Passer
 
 # utility tray mobile states
 airplaneMode=Mode avion

--- a/apps/system/locales/system.zh-TW.properties
+++ b/apps/system/locales/system.zh-TW.properties
@@ -3,6 +3,7 @@ back=上一頁
 help=說明
 cancel=取消
 close=關閉
+skip=略過
 
 # utility tray mobile states
 airplaneMode=飛航模式


### PR DESCRIPTION
Translations were copied from a visually-similar part of the FTU app (gaia/apps/communications/ftu/locales). There's no Arabic translation yet.
