### PR TITLE
Bug 958003 - [Keyboard][V1.4] FxOS cannot pops up third party keyboard after process manager kills it

### DIFF
--- a/test_apps/demo-keyboard/js/keyboard.js
+++ b/test_apps/demo-keyboard/js/keyboard.js
@@ -43,6 +43,10 @@ function init() {
     resizeWindow();
   };
 
+  inputContext = navigator.mozInputMethod.inputcontext;
+  if (!document.mozHidden && inputContext) {
+    resizeWindow();
+  }
 
   // If the variant changes, update the page view if needed
   InputField.addEventListener('inputfieldchanged', function(e) {


### PR DESCRIPTION
```
-- after OOM keyboard will not get 'oninputcontextchange' at first time while keyboard app is using
-- so can not only depens on 'oninputcontextchange' to show keyboard layouts.
```
