### PR TITLE
Bug 957708 - [Messages][Drafts] Draft status indicator not accurate when app loads

### DIFF
--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -180,6 +180,33 @@
       return draft;
     },
     /**
+     * forEach
+     *
+     * Call the callback on each draft in the
+     * draft index (the latest draft for a valid
+     * threadId and all the drafts for a null
+     * threadId).
+     *
+     * @return {Undefined}
+     */
+    forEach: function(callback, thisArg) {
+      if (thisArg) {
+        callback = callback.bind(thisArg);
+      }
+      draftIndex.forEach(function(drafts, threadId) {
+        if (threadId) {
+          var latest = drafts[drafts.length - 1];
+          callback(latest, threadId);
+        } else {
+          // All the null threadId drafts are
+          // valid thread-less drafts
+          drafts.forEach(function(draft) {
+            callback(draft, null);
+          });
+        }
+      });
+    },
+    /**
      * clear
      *
      * Delete drafts from the map.

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -347,22 +347,28 @@ var ThreadListUI = {
   },
 
   renderDrafts: function thlui_renderDrafts() {
-    // Request and render all thread-less drafts.
+    // Request and render all threads with drafts
+    // or thread-less drafts.
     Drafts.request(function() {
-      var threadless = Drafts.byThreadId(null);
+      Drafts.forEach(function(draft, threadId) {
+        if (threadId) {
+          // Find draft-containing threads that have already been rendered
+          // and update them so they mark themselves appropriately
+          var el = document.getElementById('thread-' + threadId);
+          if (el) {
+            this.updateThread(Threads.get(threadId));
+          }
+        } else {
+          // Safely assume there is a threadless draft
+          this.setEmpty(false);
 
-      if (threadless.length) {
-        this.setEmpty(false);
-      }
-      // `threadless` is an instance of Drafts.List
-      // and only exposes a length property and a forEach method.
-      threadless.forEach(function(draft) {
-        // If there is currently no list item rendered for this
-        // draft, then proceed.
-        if (!this.draftRegistry[draft.id]) {
-          this.appendThread(
-            Thread.create(draft)
-          );
+          // If there is currently no list item rendered for this
+          // draft, then proceed.
+          if (!this.draftRegistry[draft.id]) {
+            this.appendThread(
+              Thread.create(draft)
+            );
+          }
         }
       }, this);
 

--- a/apps/sms/test/unit/drafts_test.js
+++ b/apps/sms/test/unit/drafts_test.js
@@ -281,6 +281,10 @@ suite('Drafts', function() {
       });
     });
 
+    suiteTeardown(function() {
+      Drafts.clear();
+    });
+
     test('get draft for id 101', function() {
       var draft = Drafts.get(id);
 
@@ -293,6 +297,40 @@ suite('Drafts', function() {
 
       assert.equal(typeof draft, 'undefined');
     });
+  });
+
+  suite('forEach()>', function() {
+
+    var spy;
+
+    suiteSetup(function() {
+      [d1, d2, d3, d4, d5, d6, d7].forEach(Drafts.add, Drafts);
+    });
+
+    suiteTeardown(function() {
+      Drafts.clear();
+    });
+
+    setup(function() {
+      spy = sinon.spy();
+    });
+
+    test('callback called on each draft', function() {
+      Drafts.forEach(spy);
+      assert.equal(spy.callCount, 7);
+
+      // threadId = Number
+      assert.deepEqual(spy.args[0][0], d1);
+      assert.deepEqual(spy.args[1][0], d2);
+      assert.deepEqual(spy.args[2][0], d3);
+      assert.deepEqual(spy.args[3][0], d4);
+      assert.deepEqual(spy.args[4][0], d5);
+
+      // threadId = null
+      assert.deepEqual(spy.args[5][0], d7);
+      assert.deepEqual(spy.args[6][0], d6);
+    });
+
   });
 
   suite('clear() >', function() {
@@ -317,7 +355,6 @@ suite('Drafts', function() {
     setup(function() {
       spy = sinon.spy();
     });
-
 
     test('Drafts.List', function() {
       var list = new Drafts.List();

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -787,12 +787,38 @@ suite('thread_list_ui', function() {
 
   suite('renderDrafts', function() {
     var draft;
+    var thread, threadDraft;
 
     setup(function() {
       this.sinon.spy(ThreadListUI, 'renderThreads');
       this.sinon.spy(ThreadListUI, 'appendThread');
       this.sinon.spy(ThreadListUI, 'createThread');
+      this.sinon.spy(ThreadListUI, 'updateThread');
       this.sinon.spy(ThreadListUI, 'setContact');
+
+      var someDate = new Date(2013, 1, 1).getTime();
+      insertMockMarkup(someDate);
+
+      var nextDate = new Date(2013, 1, 2);
+      var message = MockMessages.sms({
+        threadId: 3,
+        timestamp: +nextDate
+      });
+
+      Threads.registerMessage(message);
+      thread = Threads.get(3);
+      ThreadListUI.appendThread(thread);
+
+      threadDraft = new Draft({
+        id: 102,
+        threadId: 3,
+        recipients: [],
+        content: ['An explicit id'],
+        timestamp: Date.now(),
+        type: 'sms'
+      });
+
+      Drafts.add(threadDraft);
 
       draft = new Draft({
         id: 101,
@@ -806,7 +832,7 @@ suite('thread_list_ui', function() {
       Drafts.add(draft);
 
       this.sinon.stub(Drafts, 'request', function(callback) {
-        callback([draft]);
+        callback([draft, threadDraft]);
       });
 
       ThreadListUI.draftLinks = new Map();
@@ -829,6 +855,10 @@ suite('thread_list_ui', function() {
 
     test('ThreadListUI.createThread is called', function() {
       sinon.assert.called(ThreadListUI.createThread);
+    });
+
+    test('ThreadListUI.updateThread is called', function() {
+      sinon.assert.called(ThreadListUI.updateThread);
     });
 
     test('ThreadListUI.setContact is called', function() {


### PR DESCRIPTION
- `drafts.js`
  - added a `forEach` that calls a callback on the latest draft per non-null `threadId` and all the drafts with a null `threadId`
- `thread_list_ui.js`
  - after `Drafts.request` returns, go through all the drafts, and for those that have a valid `threadId` and there is a rendered thread element for that `threadId`, update them so they mark themselves appropriately as having drafts
- Tests:
  - `drafts.js`
    - verify that a callback is called on all latest drafts per valid `threadId` and all null `threadId` drafts
  - `thread_list_ui_test.js`
    - verify that `updateThread` is called on existing threads that have drafts
  - Tested manually on device
