### PR TITLE
Bug 959196 - [Messages][Drafts] Don't auto-save new draft when hiding app and then draft is discarded r=rwaldron

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -2543,7 +2543,11 @@ var ThreadUI = global.ThreadUI = {
    *
    * Saves the currently unsent message content or recipients
    * into a Draft object.  Preserves the currently marked
-   * draft if specified.
+   * draft if specified.  Draft preservation is intended to
+   * keep MessageManager.draft populated with the currently
+   * showing draft when the app is hidden, so when the app
+   * comes out of hiding, it knows there is a draft to continue
+   * to keep track of.
    *
    * @param {Object} opts Optional parameters for saving a draft.
    *                  - preserve, boolean whether or not to preserve draft.
@@ -2596,6 +2600,12 @@ var ThreadUI = global.ThreadUI = {
     // draft replacement case
     if (!opts || (opts && !opts.preserve)) {
       MessageManager.draft = null;
+    }
+
+    // Set the MessageManager draft if it is
+    // not already set and meant to be preserved
+    if (!MessageManager.draft && (opts && opts.preserve)) {
+      MessageManager.draft = draft;
     }
   }
 };

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3918,13 +3918,23 @@ suite('thread_ui.js >', function() {
       assert.isNull(MessageManager.draft);
     });
 
-    test('preserve draft for replacement', function() {
+    test('preserve pre-existing draft for replacement', function() {
       var draft = {id: 55};
       MessageManager.draft = draft;
       ThreadUI.saveDraft({preserve: true});
 
       assert.isNotNull(MessageManager.draft);
       assert.equal(MessageManager.draft, draft);
+    });
+
+    test('preserve new draft for replacement', function() {
+      MessageManager.draft = null;
+      ThreadUI.saveDraft({preserve: true});
+
+      assert.isNotNull(MessageManager.draft);
+      assert.deepEqual(MessageManager.draft.recipients, ['999']);
+      assert.equal(MessageManager.draft.content, 'foo');
+      assert.equal(MessageManager.draft.threadId, null);
     });
 
     test('has entered content and recipients', function() {


### PR DESCRIPTION
- `thread_ui.js`
  - If `MessageManager` is not already holding onto a draft when a brand new is auto-saved, then set it. this way preservation/discarding works as expected
- Tests
  - `thread_ui_test.js`
    - Test that `MessageManager.draft` is properly set if it didn't exist before saving a draft
