### PR TITLE
Bug 957122 - Enable more TBPL tests - Calendar tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -12,8 +12,8 @@ b2g = true
 [unit/test_permissions.py]
 [unit/test_warm_launch.py]
 
+[functional/calendar/test_calendar_flick_through_months.py]
 [functional/calendar/test_calendar_new_event_appears_on_all_calendar_views.py]
-disabled = Bug 877611
 [functional/calendar/test_calendar_today_date.py]
 [functional/cards_view/test_cards_view_kill_apps_with_two_apps.py]
 [functional/cards_view/test_cards_view_with_two_apps.py]


### PR DESCRIPTION
Add test_calendar_flick_through_months and re-enable test_calendar_new_event_appears_on_all_calendar_views
