### PR TITLE
Bug 957122 - Enable more TBPL tests - Gallery test

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
@@ -6,7 +6,6 @@ sdcard = true
 skip-if = device == "desktop"
 
 [test_gallery_empty.py]
-skip-if = device == "desktop"
 
 [test_gallery_flick.py]
 skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -29,6 +29,8 @@ disabled = Bug 946130
 [functional/contacts/test_delete_contact.py]
 [functional/contacts/test_add_contact_to_favorites.py]
 [functional/everythingme/test_everythingme_launch_packaged_app.py]
+[functional/ftu/test_ftu_with_tour.py]
+[functional/gallery/test_gallery_empty.py]
 [functional/homescreen/test_homescreen_edit_mode.py]
 [functional/homescreen/test_homescreen_move_app.py]
 [functional/keyboard/test_keyboard.py]
@@ -48,6 +50,5 @@ disabled = Bug 891882
 [functional/system/test_quick_settings.py]
 [functional/system/test_system_message.py]
 [functional/system/test_system_notification_bar.py]
-[functional/ftu/test_ftu_with_tour.py]
 [functional/browser/test_browser_keyboard_integration.py]
 # this test runs on tbpl only


### PR DESCRIPTION
Add `test_gallery_empty` to TBPL
Enable `test_gallery_empty` on Travis

Also moved `test_ftu_with_tour` so it would be in alphabetical order
