### PR TITLE
Bug 959758 - [Messages] Long tapping any part horizontally adjacent to a message bubble brings up the message options menu

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1799,12 +1799,26 @@ var ThreadUI = global.ThreadUI = {
 
   getMessageBubble: function thui_getMessageContainer(element) {
     var node = element;
+    var bubble;
+
     do {
-      if (node.dataset && node.dataset.messageId) {
-        return {
-          id: +node.dataset.messageId,
-          node: node
-        };
+      if (node.classList.contains('bubble')) {
+        bubble = node;
+      }
+
+      // If we have a bubble and we reach the li with dataset.messageId
+      if (bubble) {
+        if (node.dataset && node.dataset.messageId) {
+          return {
+            id: +node.dataset.messageId,
+            node: bubble
+          };
+        }
+      }
+
+      // If we reach the container, quit.
+      if (node.id === 'thread-messages') {
+        return null;
       }
     } while ((node = node.parentNode));
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -4336,4 +4336,48 @@ suite('thread_ui.js >', function() {
       });
     });
   });
+
+  suite('getMessageBubble(element) > ', function() {
+    var tree, li, section, span;
+
+    setup(function() {
+      tree = document.createElement('div');
+
+      tree.innerHTML = [
+        '<div id="thread-messages">',
+          '<ul>',
+            '<li data-message-id="1">',
+              '<section class="bubble">',
+                '<span>.</span>',
+              '</section>',
+            '</li>',
+          '</ul>',
+        '</div>'
+      ].join();
+
+      span = tree.querySelector('span');
+      section = tree.querySelector('section');
+      li = tree.querySelector('li');
+    });
+
+    test('Finds the bubble (event target is lower)', function() {
+      var data = ThreadUI.getMessageBubble(span);
+
+      assert.equal(data.node, section);
+      assert.equal(data.id, 1);
+    });
+
+    test('Finds the bubble (event target is bubble)', function() {
+      var data = ThreadUI.getMessageBubble(section);
+
+      assert.equal(data.node, section);
+      assert.equal(data.id, 1);
+    });
+
+    test('Does not find the bubble (event target is higher)', function() {
+      var data = ThreadUI.getMessageBubble(li);
+
+      assert.equal(data, null);
+    });
+  });
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=959758

There are currently jshint failures, but these were created by another patch and have a different bug to address them.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
