### PR TITLE
Bug 959109: Check screen and lock state at the same time.

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -172,17 +172,10 @@ var NfcManager = {
   handleEvent: function nm_handleEvent(evt) {
     var state = this.NFC_HW_STATE_ENABLE_DISCOVERY;
     switch (evt.type) {
-      case 'screenchange':
-        if (true === this.acceptNfcEvents()) {
-          state = this.NFC_HW_STATE_ENABLE_DISCOVERY;
-        } else {
-          state = this.NFC_HW_STATE_DISABLE_DISCOVERY;
-        }
-        this.dispatchHardwareChangeEvt(state);
-        break;
       case 'lock': // Fall thorough
       case 'unlock':
-        if (evt.type === 'unlock') {
+      case 'screenchange':
+        if (evt.detail.screenEnabled && !LockScreen.locked) {
           state = this.NFC_HW_STATE_ENABLE_DISCOVERY;
         } else {
           state = this.NFC_HW_STATE_DISABLE_DISCOVERY;
@@ -359,7 +352,7 @@ var NfcManager = {
 
     if (!this.acceptNfcEvents()) {
       this._debug(
-        'Ignoring NFC technology tag message. Screen state is disabled.');
+        'Ignoring NFC technology tag message. NFC is in disabled state.');
       return;
     }
     // UX: TODO
@@ -369,7 +362,7 @@ var NfcManager = {
     this._debug('command.techList: ' + command.techList);
     var techList = command.techList;
     var records = null;
-    if (command.records.length > 0) {
+    if (command.records && (command.records.length > 0)) {
       records = command.records;
     } else {
       this._debug('No NDEF Message sent to Technology Discovered');


### PR DESCRIPTION
Make screenchange, lock, unlock into one fall through case statement.
