### PR TITLE
Bug 959901 - [Calendar][Integration Test] "day_view_test.js" is permared r=gaye

### DIFF
--- a/apps/calendar/test/marionette/calendar.js
+++ b/apps/calendar/test/marionette/calendar.js
@@ -177,21 +177,36 @@ Calendar.prototype = {
     return url.indexOf(Calendar.ORIGIN) !== -1;
   },
 
-  isWeekViewActive: function() {
+  /**
+   * @param {String} id View ID
+   * @return {boolean} Whether or not view is active
+   */
+  isViewActive: function(id) {
     var actual = this.client.getUrl();
-    var expected = Calendar.ORIGIN + '/week/';
+    var expected = Calendar.ORIGIN + '/' + id + '/';
     return actual === expected;
+  },
+
+  /**
+   * @return {boolean} Whether or not week view is active
+   */
+  isWeekViewActive: function() {
+    return this.isViewActive('week');
   },
 
   /**
    * @return {boolean} Whether or not the calendar month view is active.
    */
   isMonthViewActive: function() {
-    var actual = this.client.getUrl();
-    var expected = Calendar.ORIGIN + '/month/';
-    return actual === expected;
+    return this.isViewActive('month');
   },
 
+  /**
+   * @return {boolean} Whether or not the calendar day view is active.
+   */
+  isDayViewActive: function() {
+    return this.isViewActive('day');
+  },
 
   /**
    * @return {boolean} Whether or not the read only event view is active.
@@ -250,5 +265,35 @@ Calendar.prototype = {
     this.actions
       .flick(panel, x1, y1, x2, y2)
       .perform();
+  },
+
+  /**
+   * checks if content is bigger than container. if something is wrong it
+   * throws errors. use `assert.doesNotThrow()` on your tests, it will give
+   * better error messages than a simple truthy test.
+   * @param {Marionette.Element|String} [element] the container element.
+   */
+  checkOverflow: function(element) {
+    element = this.waitForElement(element);
+
+    var wid = element.scriptWith(function(el) {
+      return {
+        content: el.scrollWidth,
+        container: el.clientWidth
+      };
+    });
+    if (!wid.content) {
+      throw new Error('invalid content width');
+    }
+    if (!wid.container) {
+      throw new Error('invalid container width');
+    }
+    // we use a buffer of 1px to account for potential rounding issues
+    // see: Bug 959901
+    if (Math.abs(wid.content - wid.container) > 1) {
+      var msg = 'content (' + wid.content + 'px) is wider than container (' +
+        wid.container + 'px)';
+      throw new Error(msg);
+    }
   }
 };

--- a/apps/calendar/test/marionette/day_view_test.js
+++ b/apps/calendar/test/marionette/day_view_test.js
@@ -11,20 +11,10 @@ marionette('day view', function() {
     app.launch({ hideSwipeHint: true });
     // Go to day view
     app.findElement('dayButton').click();
+    client.waitFor(app.isDayViewActive.bind(app));
   });
 
-  test.skip('header copy should not overflow', function() {
-    var header = app.findElement('monthYearHeader');
-    var wid = header.scriptWith(function(el) {
-      return {
-        content: el.scrollWidth,
-        container: el.getBoundingClientRect().width
-      };
-    });
-    // we need to check the widths are != 0 since element might be hidden
-    assert.ok(wid.content, 'content width is not valid');
-    assert.ok(wid.container, 'container width is not valid');
-    assert.equal(wid.content, wid.container,
-      'content is bigger than container');
+  test('header copy should not overflow', function() {
+    assert.doesNotThrow(app.checkOverflow.bind(app, 'monthYearHeader'));
   });
 });


### PR DESCRIPTION
this patch should fix the error but I'm not sure if error is caused by something that changed on gecko itself.

I could not replicate the bug locally but any build after https://travis-ci.org/mozilla-b2g/gaia/builds/16968000 fails (`scrollWidth` is always 1px wider than `clientWidth` or `getBoundingClientRect().width` based on my tests).
