### PR TITLE
Bug 950225 - Prevent the click event pass the under panel.

### DIFF
--- a/apps/calendar/js/views/create_account.js
+++ b/apps/calendar/js/views/create_account.js
@@ -78,6 +78,9 @@
           this.onrender();
 
       }.bind(this));
+
+      // XXX: Workaround to prevent the click event pass the under panel.
+      this._findElement('element').addEventListener('click', function() {});
     },
 
     cancel: function() {

--- a/apps/calendar/js/views/modify_account.js
+++ b/apps/calendar/js/views/modify_account.js
@@ -324,6 +324,9 @@ Calendar.ns('Views').ModifyAccount = (function() {
       var usernameType = this.model.usernameType;
       this.fields['user'].type = (usernameType === undefined) ?
           'text' : usernameType;
+
+      // XXX: Workaround to prevent the click event pass the under panel.
+      this._findElement('element').addEventListener('click', function() {});
    },
 
     destroy: function() {


### PR DESCRIPTION
Hi Gareth,

We do workaround here.
Because the click event just pass through the "create-account-view" panel to the under panel
with unknown reasons, then the bug is happened.
It might be a Gecko issue.

And the bug is just happened in real device not b2g-desktop or nightly.
So we do need to have marionette tests for it on b2g-desktop.

If we want to fix the issue without any workaround, we might fix it in Gecko not in Gaia.
But I think we could fix it in workaround way, and file a follow up bug for the possible gecko issue.

So please help me review the patch.
Thanks.
