### PR TITLE
Bug 960039 - [system] Remove `charging` attribute

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -428,7 +428,7 @@
 
           <!-- Status -->
           <div id="statusbar-battery" class="sb-icon sb-icon-battery"
-            data-level="100" charging hidden></div>
+            data-level="100" hidden></div>
           <div id="statusbar-wifi" class="sb-icon sb-icon-wifi"
             data-level="4" hidden></div>
           <div id="statusbar-flight-mode" class="sb-icon sb-icon-flight-mode" hidden></div>


### PR DESCRIPTION
Remove unused, non-standard `charging` attribute from the markup for the
battery icon.
