### PR TITLE
Bug 960094 - Multiple CSS warnings shown when launching E-Mail app

### DIFF
--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -40,12 +40,12 @@ body {
   -moz-transition-property: transform;
   -moz-transition-duration: 0.3s;
   -moz-transition-timing-function: ease;
-  -moz-transition-delay: 0;
+  transition-delay: 0s;
 
 }
 
 .card.anim-up center {
-  transition: translateX(0);
+  transform: translateX(0);
 }
 
 .card.no-anim {
@@ -99,7 +99,6 @@ body {
 
 .top-header {
   background: -moz-linear-gradient(to top, #ffffff 0, #a3a3a3 0.5rem, #992f21 0.5rem, #992f21 0.6rem, #bb492d 0.6rem, #cc6523 100%);
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,  #cc6523), color-stop(100%, #bb492d));
   height: 5.2rem;
   width: 100%;
   padding: 0;
@@ -123,7 +122,7 @@ body {
 
 .header-btn, .header-left-btn, .header-right-btn {
   position: absolute;
-  top: 0
+  top: 0;
   height: 5.2rem;
   width: 3.2rem;
   border: none;

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -87,7 +87,6 @@ input.msg-search-text-tease {
 }
 .msg-header-details-section {
   -moz-box-sizing: border-box;
-  box-sizing: border-box;
   position: absolute;
   top: 0;
   left: 1.5rem;
@@ -376,7 +375,6 @@ input.msg-search-text-tease {
 .msg-reader-load-infobar {
   position: absolute;
   -moz-box-sizing: border-box;
-  box-sizing: border-box;
   color: white;
   font-size: 1.2rem;
   left: 0;
@@ -546,7 +544,6 @@ input.msg-search-text-tease {
 
 .msg-list-topbar {
   -moz-box-sizing: border-box;
-  box-sizing: border-box;
   position: absolute;
   top: 5rem;
   left: 0;
@@ -567,7 +564,6 @@ input.msg-search-text-tease {
   width: 3rem;
   height: 3rem;
   margin: 0.5rem 1rem 0 0;
-  background: transparent no-repeat top left 100% 100%;
 }
 
 .msg-reply-menu-reply:before {

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -7,7 +7,7 @@ section[role="region"].skin-organic {
 
 input:invalid {
   border: 0.1rem solid #ccc;
-  color: -moz-initial;
+  color: initial;
 }
 
 input:-moz-placeholder {

--- a/shared/style_unstable/tabs.css
+++ b/shared/style_unstable/tabs.css
@@ -51,7 +51,6 @@
   text-align: center;
   line-height: 4.5rem;
   border: 0;
-  border-radius: none;
   background-color: transparent;
   background-size: 3rem auto;
   background-repeat: no-repeat;


### PR DESCRIPTION
This pull request includes one change to the shared area, but it is removing a style rule that was being dropped anyway by the browser, so is safe to remove.

There are still two CSS warnings about "will-change" but that is an experimental CSS property in some gecko builds, so that one cannot be removed.
