### PR TITLE
Bug 951331 - [Messages][Drafts] MMS indicator missing for MMS drafts in existing (non-threadless) threads

### DIFF
--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -452,7 +452,7 @@ var ThreadListUI = {
     // Create DOM element
     var li = document.createElement('li');
     var timestamp = +record.timestamp;
-    var lastMessageType = record.lastMessageType;
+    var type = record.lastMessageType;
     var participants = record.participants;
     var number = participants[0];
     var id = record.id;
@@ -479,6 +479,7 @@ var ThreadListUI = {
             return true;
           }
         });
+        type = draft.type;
       }
     }
 
@@ -487,7 +488,7 @@ var ThreadListUI = {
     li.id = 'thread-' + id;
     li.dataset.threadId = id;
     li.dataset.time = timestamp;
-    li.dataset.lastMessageType = lastMessageType;
+    li.dataset.lastMessageType = type;
 
     if (record.unreadCount > 0) {
       li.classList.add('unread');

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -596,31 +596,31 @@ suite('thread_list_ui', function() {
     });
 
     suite('Correctly displayed content', function() {
+      var now, message, li;
 
       setup(function() {
         this.sinon.stub(Threads, 'get').returns({
           hasDrafts: true
         });
+
+        now = Date.now();
+
+        message = MockMessages.sms({
+          delivery: 'delivered',
+          threadId: 1,
+          timestamp: now,
+          body: 'from a message'
+        });
       });
 
       test('Message newer than draft is used', function() {
-        var now = Date.now();
-
         this.sinon.stub(Drafts, 'byThreadId').returns({
           latest: {
             timestamp: now - 60000,
             content: ['from a draft']
           }
         });
-
-        var message = MockMessages.sms({
-          delivery: 'delivered',
-          threadId: 1,
-          timestamp: now,
-          body: 'from a message'
-        });
-
-        var li = ThreadListUI.createThread(
+        li = ThreadListUI.createThread(
           Thread.create(message)
         );
 
@@ -630,23 +630,14 @@ suite('thread_list_ui', function() {
       });
 
       test('Draft newer than content is used', function() {
-        var now = Date.now();
-
         this.sinon.stub(Drafts, 'byThreadId').returns({
           latest: {
             timestamp: now,
             content: ['from a draft']
           }
         });
-
-        var message = MockMessages.sms({
-          delivery: 'delivered',
-          threadId: 1,
-          timestamp: now - 60000,
-          body: 'from a message'
-        });
-
-        var li = ThreadListUI.createThread(
+        message.timestamp = now - 60000;
+        li = ThreadListUI.createThread(
           Thread.create(message)
         );
 
@@ -656,29 +647,35 @@ suite('thread_list_ui', function() {
       });
 
       test('Draft newer, but has no content', function() {
-        var now = Date.now();
-
         this.sinon.stub(Drafts, 'byThreadId').returns({
           latest: {
             timestamp: now,
             content: []
           }
         });
-
-        var message = MockMessages.sms({
-          delivery: 'delivered',
-          threadId: 1,
-          timestamp: now - 60000,
-          body: 'from a message'
-        });
-
-        var li = ThreadListUI.createThread(
+        message.timestamp = now - 60000;
+        li = ThreadListUI.createThread(
           Thread.create(message)
         );
 
         assert.equal(
           li.querySelector('.body-text').textContent, ''
         );
+      });
+
+      test('Last message type for draft', function() {
+        this.sinon.stub(Drafts, 'byThreadId').returns({
+          latest: {
+            timestamp: now,
+            content: [],
+            type: 'mms'
+          }
+        });
+        li = ThreadListUI.createThread(
+          Thread.create(message)
+        );
+
+        assert.ok(li.dataset.lastMessageType, 'mms');
       });
     });
   });


### PR DESCRIPTION
- `thread_list_ui.js
  - set the lastMessageType to the draft's message type before applying a style to the DOM element
- Tests
  - `thread_list_ui_test.js`
    - Refactored the 'Correctly displayed content' test suite
    - Added test to check that `li.dataset.lastMessageType` was properly set if draft is of type 'mms'
    - Manually tested on device
