### PR TITLE
Bug 960344 - Enable Browser2 Icon for PRODUCTION builds

### DIFF
--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -166,7 +166,7 @@ function customizeHomescreen(options) {
     },
     'bookmarks': [
       {
-        'name': 'Browser2',
+        'name': 'Browser',
         'bookmarkURL': 'http://mozilla.org',
         'icon': 'app://homescreen.gaiamobile.org/style/icons/Aurora.png',
         'iconable': false,
@@ -281,10 +281,7 @@ function customizeHomescreen(options) {
     )
   };
 
-  // Only enable configurable bookmarks for dogfood devices
-  if (config.PRODUCTION !== '1') {
-    content.bookmarks = customize.bookmarks;
-  }
+  content.bookmarks = customize.bookmarks;
 
   return content;
 }

--- a/build/test/unit/applications-data.test.js
+++ b/build/test/unit/applications-data.test.js
@@ -89,7 +89,8 @@ suite('applications-data', function() {
 		      enabled: true,
 		      lookahead: 16  // 60fps = 16ms per frame
 		    },
-		    grid: [[]]
+		    grid: [[]],
+		    bookmarks: 'test'
 			});
 		});
 	});


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=960344
