### PR TITLE
Bug 960290 - email: possible to trigger off-screen compose button

### DIFF
--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -61,10 +61,7 @@ body {
 }
 
 .card.before {
-  /* Show a sliver of the before card, to kickstart
-  platform for a smooth, non-black transition: 828266.
-  Otherwise, this would just be -100% */
-  transform: translateX(calc(-100% + 0.5px));
+  transform: translateX(-100%);
 }
 
 .card.before.anim-vertical {
@@ -72,10 +69,7 @@ body {
 }
 
 .card.after {
-  /* Show a sliver of the after card, to kickstart
-  platform for a smooth, non-black transition: 828266.
-  Otherwise, this would just be 100% */
-  transform: translateX(calc(100% - 0.5px));
+  transform: translateX(100%);
 }
 
 .card.after.anim-vertical {


### PR DESCRIPTION
Remove the old hack for bug 828266, because event fluffing makes it possible to click on the "hidden" card areas now, and the hack is no longer needed with more recent gecko versions, no more black sections during card transitions.
