### PR TITLE
Bug 955887 -  [Buri] "Add Collection" wallpaper label missing

### DIFF
--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -110,7 +110,8 @@ function optimize_getFileContent(webapp, htmlFile, relativePath) {
       }
     // we substitute the localization properties file from gaia with the ones
     // from LOCALE_BASEDIR
-    } else if (RE_PROPS.test(relativePath) && gaia.l10nManager) {
+    } else if (RE_PROPS.test(relativePath) && gaia.l10nManager &&
+      !file.path.contains('en-US')) {
       let propFile = gaia.l10nManager.getPropertiesFile(webapp, file.path);
       if (propFile.exists()) {
         file = propFile;


### PR DESCRIPTION
the root cause is we didn't use foo.en-US.properties for en-US instead
of en-US/apps/foo/foo.properties if GAIA_CONCAT_LOCALES=1, so we need to
use the original file in gaia directory not from locale basedir.
