### PR TITLE
Bug 952164 - [B2G][Camera] Camera on lock screen allows user to take pic...

### DIFF
--- a/apps/camera/js/filmstrip.js
+++ b/apps/camera/js/filmstrip.js
@@ -37,6 +37,12 @@ var Filmstrip = (function() {
   shareButton.onclick = shareCurrentItem;
   mediaFrame.addEventListener('swipe', handleSwipe);
 
+  // bug/952164: 'click's on certain parts of
+  // the preview element can trigger a 'click'
+  // event on the capture button. Setting an event
+  // listener seems to prevent this behaviour :-/
+  preview.onclick = function() {};
+
   // Create the MediaFrame for previews
   var frame = new MediaFrame(mediaFrame);
 


### PR DESCRIPTION
...ture after clicking thumbnail preview despite no camera button being present
