### PR TITLE
Bug 960546 - [v1.3] Xfail test_set_passcode_by_settings because of

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -39,6 +39,8 @@ sdcard = true
 [test_settings_wallpaper.py]
 
 [test_settings_passcode.py]
+# Bug 959193 - [v1.3]Running test_set_passcode_by_settings causes a blank screen in settings app
+expected = fail
 
 [test_settings_change_keyboard_language.py]
 


### PR DESCRIPTION
Bug 959193 - [v1.3]Running test_set_passcode_by_settings causes a blank screen in settings app
