### PR TITLE
Bug 960698 - Un-xfail test_settings_change_keyboard_language

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -41,9 +41,6 @@ sdcard = true
 [test_settings_passcode.py]
 
 [test_settings_change_keyboard_language.py]
-# Bug 956761 - Marionette interprets keyboard size incorrectly when multiple keyboards enabled
-# This bug only occurs on device where OOP enabled, hence keep enabled on desktop
-fail-if = device != "desktop"
 
 [test_settings_device_info.py]
 # Many values are not populated on Desktop


### PR DESCRIPTION
Unxfailing the test as https://bugzilla.mozilla.org/show_bug.cgi?id=956761 seems to be fixed
