### PR TITLE
Bug 960343 - email: minify JS

### DIFF
--- a/apps/email/Makefile
+++ b/apps/email/Makefile
@@ -6,6 +6,8 @@ ifndef XPCSHELLSDK
 $(error This Makefile needs to be run by the root gaia makefile. Use `make APP=email` from the root gaia directory.)
 endif
 
+GAIA_EMAIL_MINIFY?=uglify2
+
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 
 SHARED_SOURCES := $(call rwildcard,../../shared/,*)
@@ -27,8 +29,14 @@ clean:
 $(BUILD_DIR)/js/mail_app.js: manifest.webapp index.html $(AUTOCONFIG_SOURCES) $(JS_SOURCES) $(LOCALES_SOURCES) $(SOUNDS_SOURCES) $(STYLE_SOURCES) $(SHARED_SOURCES) $(BUILD_SOURCES)
 	@rm -rf $(BUILD_DIR)
 	@mkdir -p $(BUILD_DIR)
-	cp -rp ../../shared $(BUILD_DIR)/shared
-	$(XULRUNNERSDK) $(XPCSHELLSDK) ../../build/r.js -o build/email.build.js
+	@mkdir -p $(BUILD_DIR)/shared
+	@mkdir -p $(BUILD_DIR)/shared/js
+
+	cp -p ../../shared/js/*.js $(BUILD_DIR)/shared/js
+	cp -rp ../../shared/style $(BUILD_DIR)/shared
+	cp -rp ../../shared/style_unstable $(BUILD_DIR)/shared
+
+	$(XULRUNNERSDK) $(XPCSHELLSDK) ../../build/r.js -o build/email.build.js optimize=$(GAIA_EMAIL_MINIFY)
 	@rm -rf $(BUILD_DIR)/build
 	@rm $(BUILD_DIR)/gaia_build.json
 	@rm $(BUILD_DIR)/build.txt

--- a/apps/email/README.md
+++ b/apps/email/README.md
@@ -136,6 +136,11 @@ scanning to find shared resources too.
 For DEBUG=1 builds, the email source directory is used as-is, and the shared
 resources are magically linked in via the Gaia build system.
 
+By default, the email build runs some uglify2 minification on the files. This
+can take a while, and if you are doing multiple, rapid edit-device push cycles,
+you can pass GAIA_EMAIL_MINIFY=none to the `install-gaia` make target to skip
+the uglify work.
+
 If you want to give snapshots of builds, say for UX reviews, you should use
 the contents of the `gaia/build_stage/email` directory as it will be a fully
 functional snapshot.

--- a/apps/email/build/email.build.js
+++ b/apps/email/build/email.build.js
@@ -40,9 +40,9 @@
     }
   ],
 
-  // Set to 'uglify2' to get uglify to run using the
-  // uglify2 settings below.
-  optimize: 'none',
+  // This is now passed via Makefile's GAIA_EMAIL_MINIFY
+  // but default is uglify2 if not passed at all.
+  // optimize: 'none',
 
   // Just strip comments, no code compression or mangling.
   // Only active if optimize: 'uglify2'
@@ -51,9 +51,7 @@
     // returns and tabs spacing.
     output: {
       beautify: true
-    },
-    compress: false,
-    mangle: false
+    }
   },
 
   fileExclusionRegExp: /^\.|^test$|^build$/,


### PR DESCRIPTION
This pull request turns on uglify2 minification for email, and it contains a bypass Makefile variable, GAIA_EMAIL_MINIFY=none, that can be used in dev to skip uglification, since it can take a bit of time.

The Makefile also limits what it copies out of the /shared directory to avoid uglify2 complaining about some of the files, and to reduce the amount of work.

Here are the application.zip file size comparisons, with different uglify options:
- beautify: keep line returns and indentation
- compress: tries to optimize some code constructions
- mangle: change variables/identifiers to shorter names

Sizes in bytes:

1) 977,680 - no minification
2) 630,064 - beautify no mangle no compress (just remove comments basically)
3) 573,836 - compress, mangle, with beautify on
4) 537,023 - compress, mangle, no beautify (just long lines of JS)

I chose setting 3, so that line breaks are preserved. This gives a good savings on file size while also allowing us to get error messages with a usable line number. However, since uglify2 is modifying the code, if we ever run into trouble with that, where it introduces an error, we may fall back to setting 2, which just removes code comments.

Looking at the application.zip contents, we are pretty aggressive with unnecessary file stripping. There are a couple of things we could still do:

1) trim the .html files from the shared/style and shared/style_unstable. These just seem to be demo pages for the CSS. I did a quick manual removal and this seemed to save about 40-50KB in zip size. As this affects all gaia apps, the bulk savings may be add up, so I will file a separate bug, hopefully with a patch, later today for this.

2) trim some .html files that are inlined in the JS for email. Doing a quick hack, this might reduce the zip size by about 8KB. So I do not think it is worth pursuing this one at this time.
