### PR TITLE
Bug 902999 - [Clock] Add Time To In-Progress Timer, "+1 Min"

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -81,6 +81,11 @@
                 </button>
               </menu>
             </div>
+            <div id="timer-plus-time">
+              <a href="#timer-panel" id="timer-plus" data-value="60" datadata-l10n-id="plusMinute">
+                +1 Min
+              </a>
+            </div>
           </div>
           <div id="timer-dialog" class="panel">
 

--- a/apps/clock/js/picker/picker.js
+++ b/apps/clock/js/picker/picker.js
@@ -52,24 +52,38 @@ define(function(require) {
         values: values
       });
     }, this);
-
-    Object.defineProperties(this, {
-      value: {
-        get: function() {
-          var values = this.pickers.map(function(picker) {
-            return this.spinners[picker].value;
-          }, this);
-
-          return values.join(':');
-        }
-      }
-    });
   }
 
-  Picker.prototype.reset = function() {
-    this.pickers.forEach(function(picker) {
-      this.spinners[picker].reset();
-    }, this);
+  Picker.prototype = {
+    get value() {
+      // Protect against uninitialized [[Get]] access
+      if (typeof this.pickers === 'undefined') {
+        return null;
+      }
+
+      return this.pickers.map(function(picker) {
+        return this.spinners[picker].value;
+      }, this).join(':');
+    },
+
+    set value(value) {
+      // Protect against uninitialized [[Set]] access
+      if (typeof this.pickers === 'undefined') {
+        return null;
+      }
+
+      value.split(':').forEach(function(value, i) {
+        this.spinners[this.pickers[i]].value = value;
+      }, this);
+
+      return this.value;
+    },
+
+    reset: function() {
+      this.pickers.forEach(function(picker) {
+        this.spinners[picker].reset();
+      }, this);
+    }
   };
 
   return Picker;

--- a/apps/clock/js/timer.js
+++ b/apps/clock/js/timer.js
@@ -123,8 +123,15 @@ Timer.prototype.register = function timerRegister(callback) {
   var data = {
     type: 'timer'
   };
-  var request = navigator.mozAlarms.add(
-    new Date(Date.now() + this.remaining), 'ignoreTimezone', data);
+  var request;
+
+  // Remove previously-created mozAlarm for this alarm, if necessary.
+  this.unregister();
+
+  request = navigator.mozAlarms.add(
+    new Date(Date.now() + this.remaining), 'ignoreTimezone', data
+  );
+
   request.onsuccess = (function(ev) {
     this.id = ev.target.result;
     callback && callback(null, this);
@@ -209,6 +216,22 @@ Timer.prototype.cancel = function timerReset() {
     this.duration = this.configuredDuration;
     this.emit('end');
   }
+};
+
+/**
+ * plus Increase the duration and extend the endAt time
+ *
+ * @param {Number} seconds The time in seconds to add.
+ *
+ * @return {Timer} Timer instance.
+ */
+Timer.prototype.plus = function timerPlus(seconds) {
+  // Convert to ms
+  var ms = seconds * 1000;
+
+  this.duration += ms;
+
+  return this;
 };
 
 /**

--- a/apps/clock/js/timer_panel.js
+++ b/apps/clock/js/timer_panel.js
@@ -56,15 +56,15 @@ Timer.Panel = function(element) {
 
   // Gather elements
   [
-    'create', 'cancel', 'dialog',
-    'pause', 'start', 'sound', 'time', 'vibrate'
+    'create', 'cancel', 'dialog', 'pause', 'start', 'sound', 'time', 'vibrate',
+    'plus'
   ].forEach(function(id) {
     this.nodes[id] = this.element.querySelector('#timer-' + id);
   }, this);
 
   // Bind click events
   [
-    'create', 'cancel', 'pause', 'start'
+    'create', 'cancel', 'pause', 'start', 'plus'
   ].forEach(function(action) {
     var element = this.nodes[action];
 
@@ -224,20 +224,28 @@ Timer.Panel.prototype.pauseAlarm = function() {
  */
 Timer.Panel.prototype.onclick = function(event) {
   var meta = priv.get(event.target);
+  var value = event.target.dataset.value;
   var panel = meta.panel;
   var nodes = panel.nodes;
   var time;
 
   if (panel.timer && panel.timer[meta.action]) {
-    // meta.action => panel.timer[meta.action]()
-    //
-    // ie.
-    //
-    // if start => panel.timer.start()
-    // if pause => panel.timer.pause()
-    // if cancel => panel.timer.cancel()
-    //
-    panel.timer[meta.action]();
+    if (typeof value !== 'undefined') {
+      // meta.action === 'plus' => panel.timer.plus(+value);
+
+      panel.timer[meta.action](+value);
+      panel.update(panel.timer.remaining);
+    } else {
+      // meta.action => panel.timer[meta.action]()
+      //
+      // ie.
+      //
+      // if start => panel.timer.start()
+      // if pause => panel.timer.pause()
+      // if cancel => panel.timer.cancel()
+      //
+      panel.timer[meta.action]();
+    }
 
     if (meta.action === 'cancel' || meta.action === 'new') {
       // Restore the panel to configured duration

--- a/apps/clock/locales/clock.en-US.properties
+++ b/apps/clock/locales/clock.en-US.properties
@@ -46,6 +46,8 @@ never    = Never
 vibrateOn = On
 vibrateOff = Off
 
+plusMinute = +1 Min
+
 # see http://www.cplusplus.com/reference/clibrary/ctime/strftime/
 dateFormat = %A, %B %e
 

--- a/apps/clock/style/timer.css
+++ b/apps/clock/style/timer.css
@@ -108,6 +108,22 @@ ul li > label.pack-switch > input + span {
   text-shadow: 0 0;
 }
 
+#timer-plus-time {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+
+  margin-right: 3rem;
+  margin-bottom: 3rem;
+}
+
+#timer-plus-time a {
+  color: #CFE2E6;
+  font: 2.5rem sans-serif;
+  font-weight: normal;
+  text-decoration: none;
+}
+
 @media (min-width: 768px) {
   #timer-controls {
     width: auto;

--- a/apps/clock/test/unit/picker/picker_test.js
+++ b/apps/clock/test/unit/picker/picker_test.js
@@ -17,7 +17,9 @@ suite('Picker', function() {
 
   test('shape:prototype ', function() {
     assert.ok(Picker);
-    assert.ok(Picker.prototype.reset);
+    assert.include(Picker.prototype, 'reset');
+    assert.include(Picker.prototype, 'value');
+    assert.isNull(Picker.prototype.value);
   });
 
   test('shape:instance ', function() {
@@ -73,6 +75,27 @@ suite('Picker', function() {
     assert.equal(picker.value, '0:0');
   });
 
+  test('get and set value ', function() {
+    var picker = new Picker({
+      element: document.getElementById('time-picker'),
+      pickers: {
+        hours: {
+          range: [0, 23]
+        },
+        minutes: {
+          range: [0, 59],
+          isPadded: true
+        }
+      }
+    });
+
+    picker.value = '1:59';
+
+    var spinners = picker.spinners;
+
+    assert.equal(spinners.hours.value, '1');
+    assert.equal(spinners.minutes.value, '59');
+  });
 
   test('isPadded = true', function() {
     Spinner.args.length = 0;

--- a/apps/clock/test/unit/timer_panel_test.js
+++ b/apps/clock/test/unit/timer_panel_test.js
@@ -177,6 +177,8 @@ suite('Timer.Panel', function() {
       this.sinon.spy(panel.timer, 'start');
       this.sinon.spy(panel.timer, 'pause');
       this.sinon.spy(panel.timer, 'cancel');
+      this.sinon.spy(panel.nodes.sound, 'focus');
+      this.sinon.spy(panel.timer, 'plus');
     });
 
     test('click: start ', function() {
@@ -219,6 +221,18 @@ suite('Timer.Panel', function() {
       assert.ok(panel.onclick.called);
       // Duration from picker value
       assert.equal(panel.timer.duration, 3600000);
+    });
+
+    test('click: plus ', function() {
+      var plus = panel.nodes.plus;
+      var timer = panel.timer;
+
+
+      plus.dispatchEvent(
+        new CustomEvent('click')
+      );
+      assert.ok(panel.onclick.called);
+      assert.ok(timer.plus.called);
     });
 
     test('blur: sound', function() {
@@ -275,5 +289,4 @@ suite('Timer.Panel', function() {
       assert.isTrue(mockAudio.pause.calledTwice);
     });
   });
-
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=902999
- Moves value accessor property to Picker.prototype
  - Defines set accessor operation for Picker.prototype.value
  - Defensive accessor handling
- Defines Timer.prototype.plus(seconds)
  - Add an arbitrary number of seconds to the current timer.
  - Seconds are auto-converted to milliseconds
- Tests for
  - Picker.prototype.value
  - Timer.prototype.plus()
  - Timer.prototype.commit()
