### PR TITLE
Bug 950623 - [Messages] Multi-recipient. Back button is kept as pressed after going back from recipients details list

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -47,6 +47,17 @@ section[role="region"] > header:first-child .icon.icon-attachment {
   background-image: url(images/icons/attachments.png);
 }
 
+/* Override Building Block [Header] first-child hover styles(for v1.3 fixing)
+ * TODO: We will remove this part once Bug 961572 fixing landed in master
+ */
+section[role="region"] > header:first-child > a:not([aria-disabled="true"]):hover:after {
+  background-color: #F97C17 !important;
+}
+
+section[role="region"] > header:first-child > a:not([aria-disabled="true"]):hover:active:after {
+  background-color: #dc6a0e !important;
+}
+
 /* Override Building Block [Imput areas] styles */
 form.bottom[role="search"] {
   z-index: 3;


### PR DESCRIPTION
- Override building block header first element(back) hover styling for v1.3
