### PR TITLE
Bug 958224 - [B2G][Browser] Deactivating the browser in landscape mode causes the browser screen to cut off.

### DIFF
--- a/apps/system/js/window.js
+++ b/apps/system/js/window.js
@@ -163,7 +163,8 @@
 
   AppWindow.prototype.isActive = function aw_isActive() {
     if (this._transitionState) {
-      return (this._transitionState == 'opened');
+      return (this._transitionState == 'opened' ||
+              this._transitionState == 'opening');
     } else {
       // Fallback
       return (this._visibilityState == 'foreground' ||


### PR DESCRIPTION
```
--  add new condition 'opening' for isActive method.
```
