### PR TITLE
Bug 961635 - Listen to click instead of touchstart on the lockscreen (with code) camera button

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1047,7 +1047,7 @@
               <div id="lockscreen-conn-states" hidden></div>
               <div id="lockscreen-mute" hidden></div>
               <div id="lockscreen-alt-camera" class="lockscreen-icon">
-                <div role="button" data-l10n-id="camera-a11y-button" aria-label="Camera"></div>
+                <div id="lockscreen-alt-camera-button" role="button" data-l10n-id="camera-a11y-button" aria-label="Camera"></div>
               </div>
               <div class="lockscreen-clock">
                 <span id="lockscreen-clock-numbers"></span>

--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -233,7 +233,7 @@ var LockScreen = {
     this.area.addEventListener('touchstart', this);
     this.areaCamera.addEventListener('click', this);
     this.areaUnlock.addEventListener('click', this);
-    this.altCamera.addEventListener('touchstart', this);
+    this.altCameraButton.addEventListener('click', this);
     this.iconContainer.addEventListener('touchstart', this);
 
     /* Unlock & camera panel clean up */
@@ -404,6 +404,12 @@ var LockScreen = {
           this.handleIconClick(evt.target);
           break;
         }
+
+        if (this.altCameraButton === evt.target) {
+          this.handleIconClick(evt.target);
+          break;
+        }
+
         if (!evt.target.dataset.key)
           break;
 
@@ -419,11 +425,6 @@ var LockScreen = {
           ('success' === this.overlay.dataset.passcodeStatus);
         if (passcodeValid)
           return;
-        if (evt.target === this.altCamera) {
-          evt.preventDefault();
-          this.handleIconClick(evt.target);
-          break;
-        }
 
         var leftTarget = this.areaCamera;
         var rightTarget = this.areaUnlock;
@@ -545,7 +546,7 @@ var LockScreen = {
     var self = this;
     switch (target) {
       case this.areaCamera:
-      case this.altCamera:
+      case this.altCameraButton:
         this._activateCamera();
         break;
       case this.areaUnlock:

--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -309,7 +309,7 @@ button::-moz-focus-inner {
   background: none;
 }
 
-#lockscreen-alt-camera,
+#lockscreen-alt-camera-button,
 #lockscreen-area-camera > div {
   background-image: url('./images/icon-camera.png');
   background-position: center;
@@ -327,6 +327,15 @@ button::-moz-focus-inner {
   pointer-events: auto;
   opacity: 0.1;
   transition: opacity 0.5s ease;
+}
+
+#lockscreen-alt-camera-button {
+  width: 100%;
+  height: 100%;
+
+  border-radius: 50%;
+
+  pointer-events: auto;
 }
 
 [data-panel="emergency-call"] #lockscreen-panel-passcode {


### PR DESCRIPTION
to prevent accidental launch of the camera.
