### PR TITLE
Bug 961231 - [B2G][SMS]To: Text field’s subtext region is truncated

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -881,7 +881,7 @@ generateHeightRule() (in ThreadUI/thread_ui.js) will create:
   -moz-box-sizing: border-box;
        box-sizing: border-box;
   max-width: calc(100% - .5rem);
-  height: 2.2rem;
+  height: 2.4rem;
   border: .1rem solid #4d4d4d;
   padding: 0 0.8rem;
 


### PR DESCRIPTION
- Increase the height in order to avoid the truncated by box-sizing changes.
