### PR TITLE
Bug 960790: Fix P2P presence discovery handling.

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -369,7 +369,7 @@ var NfcManager = {
     this._debug('command.techList: ' + command.techList);
     var techList = command.techList;
     var records = null;
-    if (command.records.length > 0) {
+    if (command.records && (command.records.length > 0)) {
       records = command.records;
     } else {
       this._debug('No NDEF Message sent to Technology Discovered');


### PR DESCRIPTION
Gaia side change needed to accept a null record from nfc_worker.js (gecko).
