### PR TITLE
Bug 951532 - [OPEN C_1.3]After PIN code function open ,In PIN code input...

### DIFF
--- a/apps/system/js/system_dialog.js
+++ b/apps/system/js/system_dialog.js
@@ -66,7 +66,7 @@ function SystemDialog(id, options) {
       case 'home':
       case 'holdhome':
         // Automatically hide the dialog on home button press
-        if (SystemScreen.isVisible(screenName)) {
+        if (SystemScreen.isVisible(screenName) && !SimPinDialog.visible) {
           hide(evt.type);
           // Prevent AppWindowManager to shift homescreen to the first page
           // when the dialog is on top of the homescreen


### PR DESCRIPTION
... interface ,press the homebutton to dive into Homescreen

[#951532](https://bugzilla.mozilla.org/show_bug.cgi?id=951532)
