### PR TITLE
Bug 952484 - [Messages][Drafts] We should not show the "replace draft" screen if the user has not changed the draft

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -1,7 +1,8 @@
 /* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-/*global Settings, Utils, Attachment, AttachmentMenu, MozActivity, SMIL */
+/*global Settings, Utils, Attachment, AttachmentMenu, MozActivity, SMIL,
+        MessageManager */
 /*exported Compose */
 
 'use strict';
@@ -89,6 +90,11 @@ var Compose = (function() {
 
   // anytime content changes - takes a parameter to check for image resizing
   function onContentChanged(duck) {
+    // Track when content is edited for draft replacement case
+    if (MessageManager.draft) {
+      MessageManager.draft.isEdited = true;
+    }
+
     // if the duck is an image attachment, handle resizes
     if (duck instanceof Attachment && duck.type === 'img') {
       return imageAttachmentsHandling();

--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -377,6 +377,7 @@
     this.timestamp = +draft.timestamp || Date.now();
     this.threadId = draft.threadId || null;
     this.type = draft.type;
+    this.isEdited = false;
   }
 
   function guid() {

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -271,6 +271,9 @@ var MessageManager = {
         MessageManager.launchComposer(function() {
           this.handleActivity(this.activity);
           this.handleForward(this.forward);
+          if (this.draft) {
+            this.draft.isEdited = false;
+          }
         }.bind(this));
         break;
       case '#thread-list':
@@ -310,7 +313,7 @@ var MessageManager = {
         var threadId = Threads.currentId;
         var willSlide = true;
 
-        var finishTransition = function finishTransition() {
+        var finishTransition = (function finishTransition() {
           // hashchanges from #group-view back to #thread=n
           // are considered "in thread" and should not
           // trigger a complete re-rendering of the messages
@@ -324,13 +327,14 @@ var MessageManager = {
             // Populate draft if there is one
             var thread = Threads.get(threadId);
             if (thread.hasDrafts) {
-              MessageManager.draft = thread.drafts.latest;
-              Compose.fromDraft(MessageManager.draft);
+              this.draft = thread.drafts.latest;
+              Compose.fromDraft(this.draft);
+              this.draft.isEdited = false;
             } else {
-              MessageManager.draft = null;
+              this.draft = null;
             }
           }
-        };
+        }).bind(this);
 
         // if we were previously composing a message - remove the class
         // and skip the "slide" animation

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -1,7 +1,7 @@
 /* global MocksHelper, MockAttachment, MockL10n, loadBodyHTML,
          Compose, Attachment, MockMozActivity, Settings, Utils,
          AttachmentMenu, Draft, document, XMLHttpRequest, Blob, navigator,
-         setTimeout */
+         setTimeout, MessageManager */
 
 /*jshint strict:false */
 /*jslint node: true */
@@ -21,6 +21,7 @@ requireApp('sms/test/unit/mock_recipients.js');
 requireApp('sms/test/unit/mock_settings.js');
 requireApp('sms/test/unit/mock_utils.js');
 requireApp('sms/test/unit/mock_moz_activity.js');
+requireApp('sms/test/unit/mock_message_manager.js');
 
 var mocksHelperForCompose = new MocksHelper([
   'AttachmentMenu',
@@ -28,7 +29,8 @@ var mocksHelperForCompose = new MocksHelper([
   'Recipients',
   'Utils',
   'MozActivity',
-  'Attachment'
+  'Attachment',
+  'MessageManager'
 ]).init();
 
 suite('compose_test.js', function() {
@@ -421,6 +423,30 @@ suite('compose_test.js', function() {
         var txt = Compose.getContent();
         assert.ok(txt, d2.content.join(''));
         assert.ok(txt[1] instanceof Attachment);
+      });
+    });
+
+    suite('Changing content marks draft as edited', function() {
+
+      setup(function() {
+        MessageManager.draft = {
+          isEdited: false
+        };
+      });
+
+      test('Changing message', function() {
+        Compose.append('Message');
+        assert.isTrue(MessageManager.draft.isEdited);
+      });
+
+      test('Changing subject', function() {
+        Compose.toggleSubject();
+        assert.isTrue(MessageManager.draft.isEdited);
+      });
+
+      test('Changing attachments', function() {
+        Compose.append(mockAttachment(12345));
+        assert.isTrue(MessageManager.draft.isEdited);
       });
     });
 

--- a/apps/sms/test/unit/drafts_test.js
+++ b/apps/sms/test/unit/drafts_test.js
@@ -408,6 +408,7 @@ suite('Drafts', function() {
       assert.deepEqual(draft.recipients, []);
       assert.deepEqual(draft.content, []);
       assert.equal(draft.threadId, null);
+      assert.isFalse(draft.isEdited);
     });
 
     test('Draft from Draft object', function() {
@@ -417,6 +418,7 @@ suite('Drafts', function() {
       assert.equal(draft.timestamp, 1);
       assert.equal(draft.threadId, 42);
       assert.equal(draft.type, 'sms');
+      assert.isFalse(draft.isEdited);
     });
 
     test('Draft with explicit valid id', function() {

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -623,6 +623,7 @@ suite('message_manager.js >', function() {
         sinon.assert.callOrder(ThreadUI.renderMessages, Compose.fromDraft);
         sinon.assert.calledWith(Compose.fromDraft, draft);
         assert.equal(draft, MessageManager.draft);
+        assert.isFalse(MessageManager.draft.isEdited);
       });
 
       test('Thread latest draft rendered if not in thread', function() {
@@ -642,7 +643,7 @@ suite('message_manager.js >', function() {
         sinon.assert.callOrder(ThreadUI.renderMessages, Compose.fromDraft);
         sinon.assert.calledWith(Compose.fromDraft, draft);
         assert.equal(draft, MessageManager.draft);
-
+        assert.isFalse(MessageManager.draft.isEdited);
       });
 
       test('Thread latest draft not rendered if in thread', function() {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -4301,6 +4301,7 @@ suite('thread_ui.js >', function() {
 
         test('Discard', function() {
           MessageManager.draft = {id: 3};
+          MessageManager.draft.isEdited = true;
           var spy = this.sinon.spy(ThreadListUI, 'removeThread');
           ThreadUI.back();
 
@@ -4316,53 +4317,93 @@ suite('thread_ui.js >', function() {
 
       suite('If existing draft', function() {
 
-        suiteSetup(function() {
-          MessageManager.draft = {id: 55};
+        suite('If draft edited', function() {
+
+          suiteSetup(function() {
+            MessageManager.draft = {
+              id: 55,
+              isEdited: true
+            };
+          });
+
+          test('Prompts for replacement if recipients', function() {
+            ThreadUI.back();
+
+            assert.isTrue(OptionMenu.calledOnce);
+            assert.isTrue(showCalled);
+
+            var items = OptionMenu.args[0][0].items;
+
+            // Assert the correct menu items were displayed
+            assert.equal(items[0].l10nId, 'replace-draft');
+            assert.equal(items[1].l10nId, 'discard-message');
+            assert.equal(items[2].l10nId, 'cancel');
+          });
+
+          test('Prompts for replacement if recipients & content', function() {
+            Compose.append('foo');
+            ThreadUI.back();
+
+            assert.isTrue(OptionMenu.calledOnce);
+            assert.isTrue(showCalled);
+
+            var items = OptionMenu.args[0][0].items;
+
+            // Assert the correct menu items were displayed
+            assert.equal(items[0].l10nId, 'replace-draft');
+            assert.equal(items[1].l10nId, 'discard-message');
+            assert.equal(items[2].l10nId, 'cancel');
+          });
+
+          test('Prompts for replacement if content', function() {
+            ThreadUI.recipients.remove('999');
+            Compose.append('foo');
+            ThreadUI.back();
+
+            assert.isTrue(OptionMenu.calledOnce);
+            assert.isTrue(showCalled);
+
+            var items = OptionMenu.args[0][0].items;
+
+            // Assert the correct menu items were displayed
+            assert.equal(items[0].l10nId, 'replace-draft');
+            assert.equal(items[1].l10nId, 'discard-message');
+            assert.equal(items[2].l10nId, 'cancel');
+          });
         });
 
-        test('Displays replacement prompt if recipients', function() {
-          ThreadUI.back();
+        suite('If draft not edited', function() {
 
-          assert.isTrue(OptionMenu.calledOnce);
-          assert.isTrue(showCalled);
+          setup(function() {
+            MessageManager.draft = {id: 55};
+          });
 
-          var items = OptionMenu.args[0][0].items;
+          test('No prompt for replacement if recipients', function() {
+            MessageManager.draft.isEdited = false;
+            ThreadUI.back();
 
-          // Assert the correct menu items were displayed
-          assert.equal(items[0].l10nId, 'replace-draft');
-          assert.equal(items[1].l10nId, 'discard-message');
-          assert.equal(items[2].l10nId, 'cancel');
-        });
+            assert.isFalse(OptionMenu.calledOnce);
+            assert.isFalse(showCalled);
+          });
 
-        test('Displays replacement prompt if recipients & content', function() {
-          Compose.append('foo');
-          ThreadUI.back();
+          test('No prompt for replacement if recipients & content', function() {
+            Compose.append('foo');
+            MessageManager.draft.isEdited = false;
+            ThreadUI.back();
 
-          assert.isTrue(OptionMenu.calledOnce);
-          assert.isTrue(showCalled);
+            assert.isFalse(OptionMenu.calledOnce);
+            assert.isFalse(showCalled);
+          });
 
-          var items = OptionMenu.args[0][0].items;
+          test('No prompt for replacement if content', function() {
+            ThreadUI.recipients.remove('999');
+            Compose.append('foo');
+            MessageManager.draft.isEdited = false;
+            ThreadUI.back();
 
-          // Assert the correct menu items were displayed
-          assert.equal(items[0].l10nId, 'replace-draft');
-          assert.equal(items[1].l10nId, 'discard-message');
-          assert.equal(items[2].l10nId, 'cancel');
-        });
-
-        test('Displays replacement prompt if content', function() {
-          ThreadUI.recipients.remove('999');
-          Compose.append('foo');
-          ThreadUI.back();
-
-          assert.isTrue(OptionMenu.calledOnce);
-          assert.isTrue(showCalled);
-
-          var items = OptionMenu.args[0][0].items;
-
-          // Assert the correct menu items were displayed
-          assert.equal(items[0].l10nId, 'replace-draft');
-          assert.equal(items[1].l10nId, 'discard-message');
-          assert.equal(items[2].l10nId, 'cancel');
+            assert.isFalse(OptionMenu.calledOnce);
+            assert.isFalse(showCalled);
+          });
         });
       });
     });


### PR DESCRIPTION
- `compose.js`
  - Every time content (message, subject, attachment) is changed, set draft to edited
- `drafts.js`
  - Set draft to not edited when it's first created
- `message_manager.js`
  - After a threadless draft is loaded in #new panel, set draft to not edited
  - After a threaded draft is loaded in #thread-## panel, set draft to not edited
- `thread_ui.js`
  - Do not prompt for replacement if the draft has not been marked as edited
- Tests
  - Unit tests
    - `compose_test.js`
      - Check that draft is marked as edited when content changes
    - `drafts_test.js`
      - Check that draft is not marked as edited upon creation
    - `message_manager.js`
      - Check that draft is not marked as edited after thread-less draft loads or after thread-bound draft loads
    - `thread_ui_test.js`
      - Check that replacement dialog is not called if draft was not edited
  - Manual tests
    - Thread-bound draft thread
      - Load thread, make no changes, press back => no dialog
      - Load thread, make subject change, press back => dialog
      - Load thread, make attachment change, press back => dialog
      - Load thread, make message change, press back => dialog
    - Thread-less draft thread
      - Load thread, make no changes, press back => no dialog
      - Load thread, make subject change, press back => dialog
      - Load thread, make attachment change, press back => dialog
      - Load thread, make message change, press back => dialog
      - Load thread, make recipient change, press back => dialog
- Notes
  - Dialog comes back even if the content is 'edited' but not actually changed
  - Dialog comes back if **empty** subject is added (this triggers a `Compose.onContentChanged`)
  - Since thread-less drafts are orphaned and resaved every time, they will move up in the thread list even if their content didn't change (because they are resaved)
