### PR TITLE
Bug 962257 - [B2G][Email][Browser] Link navigates to blank screen when s...

### DIFF
--- a/apps/email/js/app_messages.js
+++ b/apps/email/js/app_messages.js
@@ -59,7 +59,7 @@ define(function(require) {
           data.body = typeof urlParts[2] === 'string' ? urlParts[2] : null;
           data.cc = urlParts[3];
           data.bcc = urlParts[4];
-          data.attachmentBlobs = sourceData.blobs;
+          data.attachmentBlobs = sourceData.blobs || [];
           data.attachmentNames = sourceData.filenames || [];
 
           attachmentName.ensureNameList(data.attachmentBlobs,


### PR DESCRIPTION
...haring an email link in browser

A result of bug 960282, which introduced. attachmentName.ensureNameList. That method wants to cycle through blobs to ensure names exist for all blobs. However, in this case, there are no blobs passed. So, normalizing blobs data to an array, and using empty array if none found.

As bug 960282 was applied to 1.3, this bug fix should also be applied to 1.3.
