### PR TITLE
Bug 961942 - [DSDS][MMS] Switch data connection confirmation message contains strings failed to be localized.

### DIFF
--- a/apps/settings/js/simcard_manager_settings_helper.js
+++ b/apps/settings/js/simcard_manager_settings_helper.js
@@ -55,7 +55,7 @@
       // and should be used together, so I wrap them inside this
       // method and expose them outside the world to make sure
       // developers will not call them separately.
-      this._set(serviceName)._on(cardIndex);
+      this._set(serviceName)._on(+cardIndex);
     },
     _set: function(serviceName) {
       // cleanup old keys first

--- a/apps/settings/test/unit/simcard_manager_settings_helper_test.js
+++ b/apps/settings/test/unit/simcard_manager_settings_helper_test.js
@@ -341,5 +341,16 @@ suite('SimSettingsHelper > ', function() {
         assert.equal(mSettings['ril.data.defaultServiceId'], fakeCardIndex);
       });
     });
+
+    suite('set string index to outgoingData > ', function() {
+      setup(function() {
+        SimSettingsHelper.setServiceOnCard('outgoingData', '' + fakeCardIndex);
+      });
+
+      test('can set on service id with number successfully', function() {
+        assert.equal(mSettings['ril.mms.defaultServiceId'], fakeCardIndex);
+        assert.equal(mSettings['ril.data.defaultServiceId'], fakeCardIndex);
+      });
+    });
   });
 });


### PR DESCRIPTION
- Index value store in html element would become string. We have to make sure every value set in db should be numeric type.
