### PR TITLE
bug 962535, make downloads of the build system private

### DIFF
--- a/build/download-manager.js
+++ b/build/download-manager.js
@@ -78,6 +78,7 @@ var DownloadManager = {
        source: url,
        target: tmpFile
     }).then(function(download) {
+      download.source.isPrivate = true;  // don't add to history
       logLine('download for: ' + url + ' is placed.');
       download.start().then(downloadFinished, downloadError);
     }, downloadError);


### PR DESCRIPTION
By marking the download.source as private, the toolkit module won't try
to add it to history in current gecko versions. And history fails.
