### PR TITLE
Bug 936645 - [Messages][Drafts] Add banner message for saved draft

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" type="text/css" href="shared/style/switches.css">
     <link rel="stylesheet" type="text/css" href="shared/style/lists.css">
     <link rel="stylesheet" type="text/css" href="shared/style/progress_activity.css">
+    <link rel="stylesheet" type="text/css" href="shared/style/status.css">
     <!-- App styles -->
     <link rel="stylesheet" type="text/css" href="style/root.css">
     <link rel="stylesheet" type="text/css" href="style/common.css">
@@ -113,6 +114,10 @@
             </button>
           </menu>
         </form>
+
+        <section id="threads-draft-saved-banner" class="hide" role="status">
+          <p data-l10n-id="message-draft-saved">Message saved as draft</p>
+        </section>
       </section>
 
       <section id="thread-messages" class="panel" role="region">

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -112,7 +112,7 @@ var MessageManager = {
       // in the composer.
       if ((hash === '#new' || hash.startsWith('#thread=')) &&
           (!Compose.isEmpty() || ThreadUI.recipients.length)) {
-        ThreadUI.saveDraft({preserve: true});
+        ThreadUI.saveDraft({preserve: true, autoSave: true});
       }
     }
 

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -11,6 +11,12 @@
 var ThreadListUI = {
   draftLinks: null,
   draftRegistry: null,
+  DRAFT_SAVED_DURATION: 5000,
+
+  // Used to track timeouts
+  timeouts: {
+    onDraftSaved: null
+  },
 
   // Used to track the current number of rendered
   // threads. Updated in ThreadListUI.renderThreads
@@ -29,7 +35,7 @@ var ThreadListUI = {
       'container', 'no-messages',
       'check-all-button', 'uncheck-all-button',
       'delete-button', 'cancel-button',
-      'edit-icon', 'edit-mode', 'edit-form'
+      'edit-icon', 'edit-mode', 'edit-form', 'draft-saved-banner'
     ].forEach(function(id) {
       this[Utils.camelCase(id)] = document.getElementById('threads-' + id);
     }, this);
@@ -688,6 +694,17 @@ var ThreadListUI = {
       li.classList.remove(remove);
       li.classList.add(current);
     }
+  },
+
+  onDraftSaved: function thlui_onDraftSaved() {
+    this.draftSavedBanner.classList.remove('hide');
+
+    clearTimeout(this.timeouts.onDraftSaved);
+    this.timeouts.onDraftSaved = null;
+
+    this.timeouts.onDraftSaved = setTimeout(function hideDraftSavedBanner() {
+      this.draftSavedBanner.classList.add('hide');
+    }.bind(this), this.DRAFT_SAVED_DURATION);
   }
 };
 

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -827,7 +827,7 @@ var ThreadUI = global.ThreadUI = {
         // Thread-less drafts are orphaned at this point
         // so they need to be resaved for persistence
         if (!Threads.currentId) {
-          this.saveDraft();
+          this.saveDraft({autoSave: true});
         }
         leave();
         return;
@@ -2610,6 +2610,7 @@ var ThreadUI = global.ThreadUI = {
    *
    * @param {Object} opts Optional parameters for saving a draft.
    *                  - preserve, boolean whether or not to preserve draft.
+   *                  - autoSave, boolean whether this is an auto save.
    */
   saveDraft: function thui_saveDraft(opts) {
     var content, draft, recipients, subject, thread, threadId, type;
@@ -2663,6 +2664,12 @@ var ThreadUI = global.ThreadUI = {
     // not already set and meant to be preserved
     if (!MessageManager.draft && (opts && opts.preserve)) {
       MessageManager.draft = draft;
+    }
+
+    // Show draft saved banner if not an
+    // auto save operation
+    if (!opts || (opts && !opts.autoSave)) {
+      ThreadListUI.onDraftSaved();
     }
   }
 };

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -193,3 +193,6 @@ unnamed-attachment   = untitled
 file-too-large       = The file you have selected is too large
 resize-image         = Resizing the attached image
 no-attachment-text   = There is a problem with the attached file and it cannot be downloaded.
+
+# Draft Saved
+message-draft-saved  = Message saved as draft

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -876,7 +876,10 @@ suite('message_manager.js >', function() {
         MessageManager.onVisibilityChange();
 
         sinon.assert.calledOnce(ThreadUI.saveDraft);
-        sinon.assert.calledWithMatch(ThreadUI.saveDraft, {preserve: true});
+        sinon.assert.calledWithMatch(
+          ThreadUI.saveDraft,
+          {preserve: true, autoSave: true}
+        );
       });
 
       test('new: has message, has recipients', function() {
@@ -888,7 +891,10 @@ suite('message_manager.js >', function() {
         MessageManager.onVisibilityChange();
 
         sinon.assert.calledOnce(ThreadUI.saveDraft);
-        sinon.assert.calledWithMatch(ThreadUI.saveDraft, {preserve: true});
+        sinon.assert.calledWithMatch(
+          ThreadUI.saveDraft,
+          {preserve: true, autoSave: true}
+        );
       });
 
       test('thread: has message', function() {
@@ -899,7 +905,10 @@ suite('message_manager.js >', function() {
         MessageManager.onVisibilityChange();
 
         sinon.assert.calledOnce(ThreadUI.saveDraft);
-        sinon.assert.calledWithMatch(ThreadUI.saveDraft, {preserve: true});
+        sinon.assert.calledWithMatch(
+          ThreadUI.saveDraft,
+          {preserve: true, autoSave: true}
+        );
       });
     });
 
@@ -914,7 +923,10 @@ suite('message_manager.js >', function() {
         MessageManager.onVisibilityChange();
 
         sinon.assert.calledOnce(ThreadUI.saveDraft);
-        sinon.assert.calledWithMatch(ThreadUI.saveDraft, {preserve: true});
+        sinon.assert.calledWithMatch(
+          ThreadUI.saveDraft,
+          {preserve: true, autoSave: true}
+        );
       });
 
       test('new: no message, has recipients', function() {
@@ -927,7 +939,10 @@ suite('message_manager.js >', function() {
         MessageManager.onVisibilityChange();
 
         sinon.assert.calledOnce(ThreadUI.saveDraft);
-        sinon.assert.calledWithMatch(ThreadUI.saveDraft, {preserve: true});
+        sinon.assert.calledWithMatch(
+          ThreadUI.saveDraft,
+          {preserve: true, autoSave: true}
+        );
       });
     });
 

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -37,11 +37,13 @@ var mocksHelperForThreadListUI = new MocksHelper([
 
 suite('thread_list_ui', function() {
   var nativeMozL10n = navigator.mozL10n;
+  var draftSavedBanner;
 
   mocksHelperForThreadListUI.attachTestHelpers();
   suiteSetup(function() {
     loadBodyHTML('/index.html');
     navigator.mozL10n = MockL10n;
+    draftSavedBanner = document.getElementById('threads-draft-saved-banner');
     ThreadListUI.init();
   });
 
@@ -865,6 +867,23 @@ suite('thread_list_ui', function() {
     test('click on a draft populates MessageManager.draft', function() {
       document.querySelector('#thread-101 a').click();
       assert.equal(MessageManager.draft, draft);
+    });
+  });
+
+  suite('draftSaved', function() {
+
+    setup(function() {
+      this.sinon.useFakeTimers();
+    });
+
+    test('draft saved banner shown and hidden', function() {
+      assert.isTrue(draftSavedBanner.classList.contains('hide'));
+      ThreadListUI.onDraftSaved();
+      assert.isFalse(draftSavedBanner.classList.contains('hide'));
+      this.sinon.clock.tick(ThreadListUI.DRAFT_SAVED_DURATION -1);
+      assert.isFalse(draftSavedBanner.classList.contains('hide'));
+      this.sinon.clock.tick(1);
+      assert.isTrue(draftSavedBanner.classList.contains('hide'));
     });
   });
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -4040,12 +4040,13 @@ suite('thread_ui.js >', function() {
   });
 
   suite('saveDraft() > ', function() {
-    var addSpy, updateSpy, arg;
+    var addSpy, updateSpy, bannerSpy, arg;
 
     setup(function() {
       window.location.hash = '#new';
       addSpy = this.sinon.spy(Drafts, 'add');
       updateSpy = this.sinon.spy(ThreadListUI, 'updateThread');
+      bannerSpy = this.sinon.spy(ThreadListUI, 'onDraftSaved');
 
       ThreadUI.recipients.add({
         number: '999'
@@ -4190,6 +4191,28 @@ suite('thread_ui.js >', function() {
       ThreadUI.saveDraft();
 
       assert.equal(Threads.get(1).unreadCount, 0);
+    });
+
+    test('shows draft saved banner if not autosaved', function() {
+      Threads.set(1, {
+        participants: ['999']
+      });
+      window.location.hash = '#thread=1';
+
+      ThreadUI.saveDraft();
+
+      sinon.assert.calledOnce(bannerSpy);
+    });
+
+    test('does not show draft saved banner if autosaved', function() {
+      Threads.set(1, {
+        participants: ['999']
+      });
+      window.location.hash = '#thread=1';
+
+      ThreadUI.saveDraft({autoSave: true});
+
+      sinon.assert.notCalled(bannerSpy);
     });
   });
 


### PR DESCRIPTION
- `index.html`
  - Added markup for banner based on [http://buildingfirefoxos.com/building-blocks/status.html](http://buildingfirefoxos.com/building-blocks/status.html)
- `message_manager.js`
  - Add `autoSave` flag on draft auto save when app hides
- `thread_list_ui.js`
  - Added a draft saved duration constant for 5 seconds
  - Added a pointer to the draft saved banner markup
  - Added a draft saved function that shows the banner when called
- `thread_ui.js`
  - Calls `ThreadListUI.onDraftSaved` after a draft is saved, only if `autoSave` is false
- `sms.en-US.properties`
  - Added locale string for banner => "Message saved as draft"
- Tests
  - Unit
    - `message_manager_test.js`
      - Check that autoSave:true is used for auto save operations
    - `thread_list_ui_test.js`
      - Check that banner is hidden, shown for 5 seconds, and hidden again during `onDraftSaved()` if `autoSave` is false
    - `thread_ui_test.js`
      - Check that `onDraftSaved()` is called after draft is saved
  - Manual
    - Save a draft, look for banner
    - Replace a draft, look for banner
