### PR TITLE
Bug 962761 - [email] better l10n string for default attachment name

### DIFF
--- a/apps/email/js/attachment_name.js
+++ b/apps/email/js/attachment_name.js
@@ -18,7 +18,7 @@ define(function(require) {
       if (!name) {
         count = count || 1;
         var suffix = mapper.guessExtensionFromType(blob.type);
-        name = mozL10n.get('default-attachment-name', { n: count }) +
+        name = mozL10n.get('default-attachment-filename', { n: count }) +
                        (suffix ? ('.' + suffix) : '');
       }
       return name;

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -269,14 +269,10 @@ compose-attchments-size-exceeded=The selected attachments are too large to send 
 dialog-button-ok=OK
 
 # If a file is attached to an email but it does not have a name, this
-# name is used. There could be multiple ones attached, so the count
-# of the attachment in the attachment list is used in the name
-default-attachment-name={[ plural(n) ]}
-default-attachment-name[one]=attachment1
-default-attachment-name[two]=attachment{{ n }}
-default-attachment-name[few]=attachment{{ n }}
-default-attachment-name[many]=attachment{{ n }}
-default-attachment-name[other]=attachment{{ n }}
+# name is used. There could be multiple ones attached, so a number is
+# added to the end of the default name to distinguish the files from
+# each other.
+default-attachment-filename=attachment{{ n }}
 
 attachment-size-kib={{kilobytes}}K
 


### PR DESCRIPTION
Creates a new string key, `default-attachment-filename`, to store the l10n string and removes the old string as it is no longer used.
