### PR TITLE
Bug 962935 - Unxfail test_cost_control_data_alert_mobile.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
@@ -10,8 +10,6 @@ online = false
 wifi = false
 
 [test_cost_control_data_alert_mobile.py]
-# Bug 961038 - Cost control can't detect mobile data usage
-expected = fail
 skip-if = device == "desktop"
 wifi = false
 


### PR DESCRIPTION
Unxfail test_cost_control_data_alert_mobile.py due to Bug 961007 was fixed.
