### PR TITLE
Bug 803238 - Week view: If the text to display by default in the title (e.g. dow, month, year) exceeds the view length, use short names for day of week, month, year, etc r=gaye

### DIFF
--- a/apps/calendar/js/views/time_header.js
+++ b/apps/calendar/js/views/time_header.js
@@ -1,6 +1,8 @@
+/* globals Calendar */
 Calendar.ns('Views').TimeHeader = (function() {
+  'use strict';
 
-  const SETTINGS = /settings/;
+  var SETTINGS = /settings/;
 
   function TimeHeader() {
     Calendar.View.apply(this, arguments);
@@ -33,7 +35,7 @@ Calendar.ns('Views').TimeHeader = (function() {
       // when week starts in one month and ends
       // in another, we need both of them
       // in the header
-      singleMonth: 'single-month-view-header-format'
+      multiMonth: 'multi-month-view-header-format'
     },
 
     handleEvent: function(e) {
@@ -100,38 +102,33 @@ Calendar.ns('Views').TimeHeader = (function() {
         // are in the next month we don't care about that - we have
         // only 5 days visible, and it looks odd when for example we
         // have Sep 26-30 because 31 & Oct 1 are hidden, and
-        // we use September October 2012 as a header).
-        // According to spec we display only last month's year
-        // (December January 2013, not December 2012 January 2013)
-        // and that's how it's implemented here.
+        // we use "Sep 2012 Oct 2012" as a header).
         var lastWeekday = new Date(
                 firstWeekday.getFullYear(),
                 firstWeekday.getMonth(),
                 firstWeekday.getDate() + 4
               );
         if (firstWeekday.getMonth() !== lastWeekday.getMonth()) {
-          scale = this.app.dateFormat.localeFormat(
-            firstWeekday,
-            navigator.mozL10n.get(this.scales.singleMonth)
-          );
+          scale = this._localeFormat(firstWeekday, 'multiMonth') + ' ' +
+            this._localeFormat(lastWeekday, 'multiMonth');
+        } else {
+          scale = this._localeFormat(lastWeekday, 'month');
         }
-        // Should have a space between two months
-        return scale + ' ' + this.app.dateFormat.localeFormat(
-            lastWeekday,
-            navigator.mozL10n.get(this.scales.month)
-        );
+        return scale;
       }
 
+      return this._localeFormat(this.controller.position, type || 'month');
+    },
+
+    _localeFormat: function(date, scale) {
       return this.app.dateFormat.localeFormat(
-        this.controller.position,
-        navigator.mozL10n.get(this.scales[type] || this.scales.month)
+        date,
+        navigator.mozL10n.get(this.scales[scale])
       );
     },
 
     _updateTitle: function() {
       var con = this.app.timeController;
-      var date = this.getScale(con.scale);
-
       var title = this.title;
 
       title.dataset.l10nDateFormat =

--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -205,7 +205,7 @@ hour-allday=All Day
 month-view-header-format=%B %Y
 
 # In week view when displaying multiple months (weeks that span months).
-single-month-view-header-format=%B
+multi-month-view-header-format=%b %Y
 
 # Header format used for in the day view.
 day-view-header-format=%b %e, %A

--- a/apps/calendar/test/marionette/calendar.js
+++ b/apps/calendar/test/marionette/calendar.js
@@ -15,12 +15,6 @@ function Calendar(client) {
 }
 module.exports = Calendar;
 
-/**
- * Month1 Month2 YYYY.
- * @type {RegExp}
- */
-Calendar.HEADER_PATTERN = /^([JFMASOND][a-z]+\s){2}\d{4}$/;
-
 Calendar.ORIGIN = 'app://calendar.gaiamobile.org';
 
 /**

--- a/apps/calendar/test/marionette/week_view_test.js
+++ b/apps/calendar/test/marionette/week_view_test.js
@@ -1,9 +1,10 @@
+'use strict';
+
 var Calendar = require('./calendar'),
-    Marionette = require('marionette-client');
     assert = require('chai').assert;
 
 marionette('week view', function() {
-  var app, hintSwipeToNavigate;
+  var app;
   var client = marionette.client();
 
   setup(function() {
@@ -14,11 +15,20 @@ marionette('week view', function() {
     app.findElement('weekButton').click();
   });
 
-  test('should have a space between months', function() {
-    var header;
+  test('multiple months (eg. "Dec 2013 Jan 2014")', function() {
+    // match the header on a multi week view, we just check for 2 dates since
+    // month names will have different patterns on each locale
+    var multiMonthPattern = /\d{4}.+\d{4}$/;
+    var headerText;
     do {
       app.swipe();
-      header = app.findElement('monthYearHeader');
-    } while (!Calendar.HEADER_PATTERN.test(header.text()));
+      headerText = app.waitForElement('monthYearHeader').text();
+    } while (!multiMonthPattern.test(headerText));
+
+    // we are not checking for real overflow since font is different on each
+    // environment (Travis uses a wider font) which would make test to fail
+    // https://groups.google.com/forum/#!topic/mozilla.dev.gaia/DrQzv7qexw4
+    assert.operator(headerText.length, '<', 21, 'header should not overflow');
   });
+
 });

--- a/apps/calendar/test/unit/.jshintrc
+++ b/apps/calendar/test/unit/.jshintrc
@@ -1,15 +1,19 @@
 {
   "extends": "../../../../.jshintrc",
   "predef": [
+    "Calendar",
     "assert",
     "suite",
     "test",
+    "testSupport",
     "setup",
     "teardown",
+    "suiteGroup",
     "suiteSetup",
     "suiteTeardown",
     "require",
     "requireApp",
+    "requireCommon",
     "sinon",
     "mocha",
     "loadBodyHTML"

--- a/apps/calendar/test/unit/views/time_header_test.js
+++ b/apps/calendar/test/unit/views/time_header_test.js
@@ -1,17 +1,19 @@
+'use strict';
+
 requireCommon('test/synthetic_gestures.js');
 
 suiteGroup('Views.TimeHeader', function() {
 
   var subject;
   var app;
-  var store;
   var controller;
   var date = new Date(2012, 0, 1);
-  var fmt;
+  var localeFormat;
   var monthTitle;
 
   suiteSetup(function() {
-    fmt = navigator.mozL10n.DateTimeFormat();
+    var fmt = navigator.mozL10n.DateTimeFormat();
+    localeFormat = fmt.localeFormat;
   });
 
   teardown(function() {
@@ -40,7 +42,7 @@ suiteGroup('Views.TimeHeader', function() {
     });
 
     controller.move(date);
-    monthTitle = fmt.localeFormat(
+    monthTitle = localeFormat(
       date,
       '%B %Y'
     );
@@ -73,11 +75,7 @@ suiteGroup('Views.TimeHeader', function() {
 
   test('#getScale for day', function() {
     controller.move(new Date(2012, 0, 30));
-    var compare = fmt.localeFormat(
-      new Date(2012, 0, 30),
-      // do not use hard coded values because it might change based on locale
-      navigator.mozL10n.get(subject.scales.day)
-    );
+    var compare = localeFormat(new Date(2012, 0, 30), '%b %e, %A');
     var out = subject.getScale('day');
     assert.equal(out, compare);
     // 20 chars seems to be the maximum with current layout (see bug 951423)
@@ -85,22 +83,26 @@ suiteGroup('Views.TimeHeader', function() {
       'header should not have too many chars');
   });
 
-  // When week starts in one month
-  // and ends in another we need
-  // 'Month1 Month2 Year' like header.
   test('#getScale for week', function() {
-    controller.move(new Date(2012, 0, 30));
-    var firstMonth = fmt.localeFormat(
-      new Date(2012, 0, 30),
-      '%B'
-    );
-
-    var secondMonth = fmt.localeFormat(
-      new Date(2012, 1, 1),
-      '%B %Y'
-    );
+    controller.move(new Date(2012, 0, 15));
     var out = subject.getScale('week');
-    assert.equal(out, firstMonth + ' ' + secondMonth);
+    var compare = localeFormat(new Date(2012, 0, 30), '%B %Y');
+    assert.equal(out, compare);
+  });
+
+  // When week starts in one month and ends in another we need a special format
+  test('#getScale for week - multiple months', function() {
+    controller.move(new Date(2012, 0, 30));
+    var out = subject.getScale('week');
+    var compare = localeFormat(
+      new Date(2012, 0, 30),
+      '%b %Y'
+    );
+    compare += ' ' + localeFormat(
+      new Date(2012, 1, 4),
+      '%b %Y'
+    );
+    assert.equal(out, compare);
   });
 
   test('#_updateTitle', function() {

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -88,7 +88,6 @@ apps/calendar/js/views/month.js
 apps/calendar/js/views/month_child.js
 apps/calendar/js/views/months_day.js
 apps/calendar/js/views/settings.js
-apps/calendar/js/views/time_header.js
 apps/calendar/js/views/time_parent.js
 apps/calendar/js/views/view_event.js
 apps/calendar/js/views/week.js
@@ -100,7 +99,6 @@ apps/calendar/test/marionette/calendar.js
 apps/calendar/test/marionette/create_event_test.js
 apps/calendar/test/marionette/day_view_test.js
 apps/calendar/test/marionette/today_test.js
-apps/calendar/test/marionette/week_view_test.js
 apps/calendar/test/unit/app_test.js
 apps/calendar/test/unit/calc_test.js
 apps/calendar/test/unit/calendar_test.js
@@ -181,7 +179,6 @@ apps/calendar/test/unit/views/month_child_test.js
 apps/calendar/test/unit/views/month_test.js
 apps/calendar/test/unit/views/months_day_test.js
 apps/calendar/test/unit/views/settings_test.js
-apps/calendar/test/unit/views/time_header_test.js
 apps/calendar/test/unit/views/time_parent_test.js
 apps/calendar/test/unit/views/view_event_test.js
 apps/calendar/test/unit/views/week_child_test.js


### PR DESCRIPTION
there are some intermittent bugs on the marionette tests (not related with these changes) that should be fixed when #15384 lands
