### PR TITLE
Bug 962969 -- [email] build: make_gaia_shared.js should use source dir for shared dependency scanning

### DIFF
--- a/apps/email/build/make_gaia_shared.js
+++ b/apps/email/build/make_gaia_shared.js
@@ -86,8 +86,10 @@ requirejs.tools.useLib(function(require) {
         jsExtRegExp = /\.js$/,
         backendRegExp = /[\\\/]js[\\\/]ext[\\\/]/;
 
-    // Find all the HTML and JS files.
-    var files = file.getFilteredFileList(buildDir + 'js', /\.js$|\.html$/);
+    // Find all the HTML and JS files. Use the srcDir instead of
+    // buildDir since uglification can mangle the files such that
+    // the dependency scanning fails.
+    var files = file.getFilteredFileList(srcDir + 'js', /\.js$|\.html$/);
     files.forEach(function(fileName) {
       var contents = file.readFile(fileName);
 
@@ -96,9 +98,14 @@ requirejs.tools.useLib(function(require) {
       // If JS, scan for shared resources.
       if (jsExtRegExp.test(fileName) && !backendRegExp.test(fileName)) {
         var deps = parse.findDependencies(fileName, contents);
+
         deps.forEach(function (dep) {
           if (dep.indexOf('shared/') === 0) {
-            shared.js.push(dep.replace(/shared\/js\//, '') + '.js');
+            var sharedDep = dep.replace(/shared\/js\//, '') + '.js';
+            // Avoid duplicate entries for cleanliness
+            if (shared.js.indexOf(sharedDep) === -1) {
+              shared.js.push(sharedDep);
+            }
           }
         });
       }


### PR DESCRIPTION
Uses srcDir instead of buildDir, and makes sure a shared resource is only added once to the shared.js array.
