### PR TITLE
 Bug 897362 - [InputMethod][Arabic]The characters overflow the keyboard when set the keyboard layouts as the Arabic.

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -99,6 +99,9 @@ const IMERender = (function() {
       container = document.createElement('div');
       container.classList.add('keyboard-type-container');
       container.classList.add(keyboardClass);
+      if (layout.specificCssRule) {
+        container.classList.add(keyboardName);
+      }
       buildKeyboard(container, flags, layout);
       ime.appendChild(container);
     }

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -648,3 +648,28 @@ bubble above the key when you tap and hold. */
   margin: 0;
   padding: 0;
 }
+
+/*
+ * Specific layout rules; When a layoutX.js has specificCssRule set to true
+ * you can use layout name (Example: ar for Arabic) as a class name.
+ * This is useful is cases where characters are outlining their containers.
+ */
+
+/* Arabic */
+
+.ar .keyboard-key > .visual-wrapper > span{
+  font-size: 1.8rem;  
+}
+
+.keyboard-key > .visual-wrapper > span[data-label="ض"],
+.keyboard-key > .visual-wrapper > span[data-label="ش"]{
+  margin-left:-.5rem;
+}
+
+.keyboard-key > .visual-wrapper > span[data-label="س"]{
+  margin-left:-.2rem;
+}
+
+.keyboard-key > .visual-wrapper > span[data-label="ص"]{
+  margin-left:-.1rem;
+}

--- a/keyboard/layouts/ar.js
+++ b/keyboard/layouts/ar.js
@@ -2,6 +2,7 @@ Keyboards.ar = {
   label: 'Arabic',
   menuLabel: 'العربية',
   secondLayout: true,
+  specificCssRule: true,
   types: ['text', 'url', 'email'],
   alternateLayoutKey: '123',
   basicLayoutKey: 'أ ب ج',


### PR DESCRIPTION
Link to bug: https://bugzilla.mozilla.org/show_bug.cgi?id=897362
