### PR TITLE
Bug 961495 - [Task Manager] Opening transition

### DIFF
--- a/apps/search/js/providers/local_apps.js
+++ b/apps/search/js/providers/local_apps.js
@@ -22,7 +22,6 @@
 
       var manifestURL = target.dataset.manifest;
       if (manifestURL && this.apps[manifestURL]) {
-        Search.close();
         if (target.dataset.entryPoint) {
           this.apps[manifestURL].launch(
             target.dataset.entryPoint

--- a/apps/search/js/providers/marketplace.js
+++ b/apps/search/js/providers/marketplace.js
@@ -14,7 +14,6 @@
     name: 'Marketplace',
 
     click: function(e) {
-      Search.close();
       var slug = e.target.dataset.slug;
       var activity = new MozActivity({
         name: 'marketplace-app',

--- a/apps/search/js/providers/places.js
+++ b/apps/search/js/providers/places.js
@@ -189,7 +189,6 @@
 
     click: function(e) {
       var target = e.target;
-      Search.close();
       window.open(target.dataset.url, '_blank', 'remote=true');
     },
 

--- a/apps/search/test/unit/providers/local_apps_test.js
+++ b/apps/search/test/unit/providers/local_apps_test.js
@@ -42,7 +42,6 @@ suite('search/providers/local_apps', function() {
   suite('click', function() {
     test('launches the application', function() {
       var fakeManifestURL = 'http://mozilla.org/manifest.webapp';
-      var searchCloseStub = this.sinon.stub(Search, 'close');
 
       var launchCalled = false;
       subject.apps = {};
@@ -62,7 +61,6 @@ suite('search/providers/local_apps', function() {
           }
         }
       });
-      assert.ok(searchCloseStub.calledOnce);
       assert.ok(launchCalled);
     });
   });

--- a/apps/search/test/unit/providers/marketplace_test.js
+++ b/apps/search/test/unit/providers/marketplace_test.js
@@ -32,7 +32,6 @@ suite('search/providers/marketplace', function() {
 
   suite('click', function() {
     test('creates an activity to the slug', function() {
-      var searchCloseStub = this.sinon.stub(Search, 'close');
       subject.click({
         target: {
           dataset: {
@@ -43,7 +42,6 @@ suite('search/providers/marketplace', function() {
       var activityInfo = MockMozActivity.calls[0];
       assert.equal(activityInfo.name, 'marketplace-app');
       assert.equal(activityInfo.data.slug, 'gaia');
-      assert.ok(searchCloseStub.calledOnce);
     });
   });
 

--- a/apps/system/js/rocketbar.js
+++ b/apps/system/js/rocketbar.js
@@ -16,23 +16,6 @@ var Rocketbar = {
    */
   triggerWidth: 0.65,
 
-  /**
-   * Minimum swipe to activate the task manager.
-   * This is a % of the total screen height.
-   */
-  swipeThreshold: 0.10,
-
-  /**
-   * Current pointer position of a statusbar swipe.
-   */
-  pointerY: 0,
-
-  /**
-   * Height of the screen.
-   * Currently passed into and populated by the render method.
-   */
-  screenHeight: 0,
-
   searchAppURL: null,
 
   _port: null,
@@ -90,14 +73,40 @@ var Rocketbar = {
       case 'cardchange':
         this.searchInput.value = e.detail.title;
         return;
+      case 'cardviewclosedhome':
+        // Stop listeneing for cardviewclosed if we pressed the home button.
+        // This is necessary due to keeping backwards compatability with the
+        // existing card view, without having to rewrite it.
+        // Bug 963616 has been filed to clean this up.
+        window.removeEventListener('cardviewclosed', this);
+        window.setTimeout(function nextTick() {
+          window.addEventListener('cardviewclosed', this);
+        }.bind(this));
+        this.hide();
+        return;
       case 'cardviewclosed':
-          this.searchInput.focus();
+          if (this.shown) {
+            this.searchInput.focus();
+          }
         return;
       case 'keyboardchange':
         // When the keyboard is opened make sure to not resize
         // the current app by swallowing the event.
         e.stopImmediatePropagation();
         return;
+      case 'home':
+      case 'appopened':
+        this.hide();
+        return;
+      case 'apptitlechange':
+      case 'applocationchange':
+        // Send a message to the search app to notify if
+        // of updates to places data
+        if (this._port) {
+          this._port.postMessage({
+            action: 'syncPlaces'
+          });
+        }
       default:
         break;
     }
@@ -157,10 +166,13 @@ var Rocketbar = {
 
     this.searchInput.addEventListener('blur', this);
 
-    window.addEventListener('cardchange', this);
-    window.addEventListener('cardviewclosed', this);
     window.addEventListener('apptitlechange', this);
     window.addEventListener('applocationchange', this);
+    window.addEventListener('appopened', this);
+    window.addEventListener('cardchange', this);
+    window.addEventListener('cardviewclosed', this);
+    window.addEventListener('cardviewclosedhome', this);
+    window.addEventListener('home', this);
 
     this.searchCancel.addEventListener('click', this);
     // Prevent default on mousedown
@@ -195,7 +207,7 @@ var Rocketbar = {
 
     // If there is already a search frame, tell it that it is
     // visible and bail out.
-    if (searchFrame) {
+    if (searchFrame && searchFrame.setVisible) {
       searchFrame.setVisible(true);
       return;
     }
@@ -264,35 +276,50 @@ var Rocketbar = {
    * Hides the rocketbar.
    * @param {String} event type that triggers the hide.
    */
-  hide: function(evtType) {
+  hide: function() {
     if (!this.shown)
       return;
-
-    if (evtType === 'appopening') {
-      this.searchBar.style.display = 'none';
-    }
 
     document.body.removeEventListener('keyboardchange', this, true);
 
     this.searchInput.blur();
 
     var searchFrame = this.searchContainer.querySelector('iframe');
-    if (searchFrame) {
+    if (searchFrame && searchFrame.setVisible) {
       searchFrame.setVisible(false);
     }
     delete this.searchBar.dataset.visible;
+    this.searchBar.style.display = 'none';
 
     window.dispatchEvent(new CustomEvent('rocketbarhidden'));
+
+    setTimeout(function nextTick() {
+      this._port.postMessage({
+        action: 'clear'
+      });
+    }.bind(this));
   },
 
   /**
    * Renders the rocketbar.
-   * @param {Integer} height of the screen in pixels.
+   * @param {Boolean} isTaskManager, true if we are opening in task manager.
    */
-  render: function(height) {
-    this.screenHeight = height;
+  render: function(isTaskManager) {
+    if (LockScreen.locked)
+      return;
+
     if (this.shown) {
       return;
+    }
+
+    var input = this.searchInput;
+    input.value = '';
+
+    if (isTaskManager) {
+      this.home = 'tasks';
+      window.dispatchEvent(new CustomEvent('taskmanagershow'));
+    } else {
+      this.home = 'search';
     }
 
     // If we have a port, send a message to clear the search app
@@ -306,39 +333,21 @@ var Rocketbar = {
 
     this.searchReset.classList.add('hidden');
 
-    // We need to ensure the rocketbar is visible before we transition it.
-    // This is why we wait for the next tick to start the traisition.
     this.searchBar.style.display = 'block';
-    setTimeout(this.startTransition.bind(this));
-  },
 
-  /**
-   * Starts the transition of the rocketbar
-   */
-  startTransition: function() {
     var search = this.searchBar;
     search.dataset.visible = 'true';
     search.style.visibility = 'visible';
 
-    var input = this.searchInput;
-    input.value = '';
-
     window.dispatchEvent(new CustomEvent('rocketbarshown'));
 
-    var self = this;
-    search.addEventListener('transitionend', function shown(e) {
-      search.removeEventListener(e.type, shown);
+    this.loadSearchApp();
 
-      if (self.pointerY > self.swipeThreshold * self.screenHeight) {
-        self.home = 'tasks';
-        window.dispatchEvent(new CustomEvent('taskmanagershow'));
-      } else {
-        self.home = 'search';
-        // Only focus for search views
-        input.focus();
-      }
-      self.loadSearchApp();
-    });
+    if (this.home === 'search') {
+      // Only focus for search views
+      input.focus();
+    }
+
   }
 };
 

--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -63,9 +63,6 @@ var UtilityTray = {
       case 'keyboardchangecanceled':
       case 'simpinshow':
       case 'appopening':
-        if (Rocketbar.shown) {
-          Rocketbar.hide(evt.type);
-        }
         if (this.shown) {
           this.hide();
         }
@@ -97,25 +94,23 @@ var UtilityTray = {
         break;
 
       case 'touchmove':
-        var touch = evt.touches[0];
-        if (!this.active) {
-          if (Rocketbar.enabled && !this.shown &&
-              touch.pageX < this.screenWidth * Rocketbar.triggerWidth) {
-            Rocketbar.pointerY = touch.pageY;
-          }
-          return;
-        }
-
-        this.onTouchMove(touch);
+        this.onTouchMove(evt.touches[0]);
         break;
 
       case 'touchend':
+        evt.stopImmediatePropagation();
+        var touch = evt.changedTouches[0];
+        if (Rocketbar.enabled && !this.shown && !this.active &&
+            touch.pageX < this.screenWidth * Rocketbar.triggerWidth) {
+          Rocketbar.render(true);
+        }
+
         if (!this.active)
           return;
 
         this.active = false;
 
-        this.onTouchEnd(evt.changedTouches[0]);
+        this.onTouchEnd(touch);
         break;
 
       case 'transitionend':
@@ -135,8 +130,6 @@ var UtilityTray = {
     if (Rocketbar.enabled && !this.shown &&
         touch.pageX < this.screenWidth * Rocketbar.triggerWidth) {
       UtilityTray.hide();
-      Rocketbar.pointerY = touch.pageY;
-      Rocketbar.render(this.screenHeight);
       return;
     } else {
       window.dispatchEvent(new CustomEvent('taskmanagerhide'));
@@ -152,6 +145,10 @@ var UtilityTray = {
   },
 
   onTouchMove: function ut_onTouchMove(touch) {
+    if (!this.active) {
+      return;
+    }
+
     var screenHeight = this.screenHeight;
 
     var y = touch.pageY;

--- a/apps/system/style/rocketbar/rocketbar.css
+++ b/apps/system/style/rocketbar/rocketbar.css
@@ -5,8 +5,6 @@
   width: 100%;
   height: calc(100%);
   pointer-events: none;
-  transform: translateY(-100%);
-  transition: transform 0.3s ease 0.8s;
   visibility: hidden;
 }
 
@@ -16,8 +14,6 @@
 
 #search-bar[data-visible] {
   pointer-events: auto;
-  transform: translateY(0);
-  transition: transform 0.3s ease;
 }
 
 #search-bar form p {

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -100,6 +100,10 @@
   animation: openAppFromCardView 0.15s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
 }
 
+#screen.task-manager #windows > .appWindow.from-cardview {
+  animation: openAppFromTaskManager 0.15s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
+}
+
 /* Opacity increases start up time then we don't use it anymore for opening */
 @keyframes openApp {
   0%   { transform: scale(0.2);}
@@ -118,6 +122,11 @@
 
 @keyframes openAppFromCardView {
   0%   { transform: scale(0.8); }
+  100% { transform: scale(1.0); }
+}
+
+@keyframes openAppFromTaskManager {
+  0%   { transform: scale(0.6); }
   100% { transform: scale(1.0); }
 }
 
@@ -171,9 +180,12 @@
   100% { transform: scale(1);}
 }
 
-/* Generally transitions, except when going into rocketbar manager */
-#screen:not(.task-manager) #windows > .appWindow.to-cardview {
+#windows > .appWindow.to-cardview {
   animation: closeAppTowardsCardView 0.15s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
+}
+
+#screen.task-manager #windows > .appWindow.to-cardview {
+  animation: closeAppTowardsTaskManager 0.15s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
 }
 
 /* Prebuild width/height */
@@ -224,6 +236,11 @@
 @keyframes closeAppTowardsCardView {
   0%   { transform: scale(1.0); }
   100% { transform: scale(0.8); }
+}
+
+@keyframes closeAppTowardsTaskManager {
+  0%   { transform: scale(1.0); }
+  100% { transform: scale(0.6); }
 }
 
 .appWindow.back {

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -63,13 +63,6 @@
   z-index: 65535;
 }
 
-/* Transitioning appWindow to task manager should be shown under the rocketbar */
-#screen.cards-view.task-manager > [data-z-index-level="app"] > .appWindow.active:not(.homescreen),
-#screen.cards-view.task-manager > [data-z-index-level="app"] > .appWindow.transition-closing.to-cardview:not(.homescreen),
-#screen.cards-view.task-manager > [data-z-index-level="app"] > .appWindow.transition-closing.fullscreen-app.to-cardview:not(.homescreen) {
-  z-index: 2042;
-}
-
 /* Keyboard is shown above task manager */
 #screen.cards-view.task-manager > [data-z-index-level="keyboards"] {
   z-index: 65538;

--- a/apps/system/test/unit/cards_view_test.js
+++ b/apps/system/test/unit/cards_view_test.js
@@ -11,6 +11,7 @@ requireApp('system/test/unit/mock_utility_tray.js');
 requireApp('system/test/unit/mock_app_window_manager.js');
 requireApp('system/test/unit/mock_lock_screen.js');
 requireApp('system/test/unit/mock_orientation_manager.js');
+requireApp('system/test/unit/mock_rocketbar.js');
 requireApp('system/test/unit/mock_sleep_menu.js');
 requireApp('system/test/unit/mock_popup_manager.js');
 
@@ -21,6 +22,7 @@ var mocksForCardsView = new MocksHelper([
   'UtilityTray',
   'AppWindowManager',
   'LockScreen',
+  'Rocketbar',
   'SleepMenu',
   'OrientationManager',
   'PopupManager'
@@ -174,17 +176,21 @@ suite('cards view >', function() {
     });
 
     suite('display cardsview >', function() {
+      var rocketbarRender;
+
       setup(function(done) {
+        rocketbarRender = this.sinon.stub(Rocketbar, 'render');
         sendHoldhome();
         setTimeout(function() { done(); });
       });
 
       teardown(function() {
         CardsView.hideCardSwitcher();
+        rocketbarRender.restore();
       });
 
       test('cardsview should be active', function() {
-        assert.isTrue(cardsView.classList.contains('active'));
+        assert.isTrue(rocketbarRender.calledWith(true));
       });
     });
 
@@ -245,7 +251,7 @@ suite('cards view >', function() {
 
     suite('populated task manager in rocketbar >', function() {
       setup(function(done) {
-        CardsView.showCardSwitcher(null, true);
+        CardsView.showCardSwitcher(true);
         setTimeout(done);
       });
 
@@ -266,16 +272,18 @@ suite('cards view >', function() {
 
   suite('empty cards view >', function() {
     setup(function(done) {
-      CardsView.showCardSwitcher(null, true);
+      CardsView.showCardSwitcher(true);
       setTimeout(done);
     });
 
-    test('focuses rocketbar input on empty cards view', function() {
+    test('focuses rocketbar input on empty cards view', function(done) {
       var dispatchStub = this.sinon.stub(window, 'dispatchEvent');
-      CardsView.showCardSwitcher(null, true);
-
-      var evt = dispatchStub.getCall(0).args[0];
-      assert.equal(evt.type, 'cardviewclosed');
+      CardsView.showCardSwitcher(true);
+      setTimeout(function nextTick() {
+        var evt = dispatchStub.getCall(0).args[0];
+        assert.equal(evt.type, 'cardviewclosed');
+        done();
+      });
     });
   });
 });

--- a/apps/system/test/unit/rocketbar_test.js
+++ b/apps/system/test/unit/rocketbar_test.js
@@ -4,11 +4,16 @@ requireApp('system/shared/js/url_helper.js');
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
 requireApp('system/test/unit/mock_cards_view.js');
 requireApp('system/test/unit/mock_app_window_manager.js');
+requireApp('system/test/unit/mock_lock_screen.js');
+requireApp('system/js/lockscreen.js');
 mocha.globals(['Rocketbar']);
+
+var LockScreen = { locked: false };
 
 var mocksForRocketBar = new MocksHelper([
   'AppWindowManager',
   'CardsView',
+  'LockScreen',
   'SettingsListener'
 ]).init();
 
@@ -70,18 +75,8 @@ suite('system/Rocketbar', function() {
   });
 
   suite('handleEvent', function() {
-    test('cardchange event should trigger focus if no card', function() {
-      var focusStub = this.sinon.stub(Rocketbar.searchInput, 'focus');
-      Rocketbar.render();
-      this.sinon.clock.tick(1);
-      Rocketbar.handleEvent({
-        type: 'cardviewclosed',
-        detail: {
-          title: ''
-        }
-      });
-      assert.ok(focusStub.calledOnce);
-      Rocketbar.hide();
+    setup(function() {
+      this.sinon.stub(Rocketbar, 'initSearchConnection');
     });
 
     test('cardchange event should not trigger focus if card', function() {
@@ -96,11 +91,23 @@ suite('system/Rocketbar', function() {
     });
 
     test('cardviewclosed event should trigger focus', function() {
+      Rocketbar.render();
       var focusStub = this.sinon.stub(Rocketbar.searchInput, 'focus');
+      this.sinon.clock.tick(1);
       Rocketbar.handleEvent({
         type: 'cardviewclosed'
       });
+      Rocketbar.hide();
       assert.ok(focusStub.calledOnce);
+    });
+
+    test('should not focus when closing rocketbar', function() {
+      var stub = this.sinon.stub(Rocketbar.searchInput, 'focus').returns(true);
+      Rocketbar.searchBar.dataset.visible = true;
+      Rocketbar.handleEvent({
+        type: 'cardviewclosed'
+      });
+      assert.ok(stub);
     });
 
     test('search-cancel element should hide the task manager', function() {
@@ -134,6 +141,10 @@ suite('system/Rocketbar', function() {
   });
 
   suite('render', function() {
+    setup(function() {
+      this.sinon.stub(Rocketbar, 'initSearchConnection');
+    });
+
     test('shown should be true', function() {
       Rocketbar.render();
       this.sinon.clock.tick(1);
@@ -213,14 +224,10 @@ suite('system/Rocketbar', function() {
       });
 
       test('swipe event', function() {
-
         Rocketbar.pointerY = 100;
         Rocketbar.render(200);
         this.sinon.clock.tick();
-        Rocketbar.searchBar.dispatchEvent(
-          new CustomEvent('transitionend')
-        );
-        assert.equal(cardsViewStub.getCall(1).args[0].type, 'taskmanagershow');
+        assert.equal(cardsViewStub.getCall(0).args[0].type, 'taskmanagershow');
         assert.equal(true, focusStub.notCalled);
         Rocketbar.hide();
       });
@@ -233,11 +240,9 @@ suite('system/Rocketbar', function() {
         Rocketbar.pointerY = 0;
         Rocketbar.render(100);
         this.sinon.clock.tick();
-        Rocketbar.searchBar.dispatchEvent(
-          new CustomEvent('transitionend')
-        );
         assert.equal(false, called);
-        assert.equal(true, focusStub.calledOnce);
+        assert.equal(cardsViewStub.getCall(0).args[0].type, 'taskmanagershow');
+        assert.equal(true, focusStub.notCalled);
         Rocketbar.hide();
       });
     });
@@ -260,6 +265,10 @@ suite('system/Rocketbar', function() {
   });
 
   suite('hide', function() {
+    setup(function() {
+      this.sinon.stub(Rocketbar, 'initSearchConnection');
+    });
+
     test('shown should be false', function() {
       Rocketbar.render();
       this.sinon.clock.tick();

--- a/apps/system/test/unit/utility_tray_test.js
+++ b/apps/system/test/unit/utility_tray_test.js
@@ -194,7 +194,8 @@ suite('system/UtilityTray', function() {
     setup(function() {
       fakeEvt = {
         type: 'touchend',
-        changedTouches: [0]
+        changedTouches: [0],
+        stopImmediatePropagation: function() {}
       };
       UtilityTray.active = true;
       UtilityTray.handleEvent(fakeEvt);
@@ -239,12 +240,32 @@ suite('system/UtilityTray', function() {
 
     test('should display for drag on left half of statusbar', function() {
       fakeEvt = {
-        type: 'touchstart',
-        pageX: 0
+        stopImmediatePropagation: function() {},
+        type: 'touchend',
+        changedTouches: [{
+          pageX: 0
+        }]
       };
       UtilityTray.onTouchStart(fakeEvt);
+      UtilityTray.shown = false;
+      UtilityTray.active = false;
+      UtilityTray.handleEvent(fakeEvt);
       assert.isTrue(rBarRenderStub.calledOnce);
-      assert.isTrue(uHideStub.calledOnce);
+    });
+
+    test('does not render if utility tray not active', function() {
+      fakeEvt = {
+        stopImmediatePropagation: function() {},
+        type: 'touchend',
+        changedTouches: [{
+          pageX: 0
+        }]
+      };
+      UtilityTray.onTouchStart(fakeEvt);
+      UtilityTray.shown = false;
+      UtilityTray.active = true;
+      UtilityTray.handleEvent(fakeEvt);
+      assert.isTrue(rBarRenderStub.notCalled);
     });
 
     test('should not show if we touch to the right', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=961495

This pull request makes it so that transitioning into the task manager from an open application will make it zoom out, onto the rocketbar. In addition to cleaning up the task manager, the following issues are solved here: 
- Keyboard is shown after dismissing task manager
- Tap or swipe should bring up task manager
