### PR TITLE
Bug 960525 - [Contacts] undefined as contact's last name after merging

### DIFF
--- a/apps/communications/contacts/js/contacts_merger.js
+++ b/apps/communications/contacts/js/contacts_merger.js
@@ -1,3 +1,5 @@
+/* globals SimplePhoneMatcher, utils */
+
 'use strict';
 
 var contacts = window.contacts || {};
@@ -50,7 +52,6 @@ contacts.Merger = (function() {
 
   function mergeAll(masterContact, matchingContacts, callbacks) {
     var emailsHash;
-    var orgsHash;
     var categoriesHash;
     var telsHash;
     var mergedContact = {};
@@ -100,7 +101,7 @@ contacts.Merger = (function() {
       var theMatchingContact = aResult.matchingContact;
 
       var givenName = theMatchingContact.givenName;
-      if (Array.isArray(givenName)) {
+      if (Array.isArray(givenName) && givenName[0]) {
         if (mergedContact.givenName.indexOf(givenName[0]) === -1) {
           if (mergedContact.givenName[0] &&
               mergedContact.givenName[0].trim()) {
@@ -113,7 +114,7 @@ contacts.Merger = (function() {
       }
 
       var familyName = theMatchingContact.familyName;
-      if (Array.isArray(familyName)) {
+      if (Array.isArray(familyName) && familyName[0]) {
         if (mergedContact.familyName.indexOf(familyName[0]) === -1) {
           if (mergedContact.familyName[0] &&
               mergedContact.familyName[0].trim()) {
@@ -161,7 +162,7 @@ contacts.Merger = (function() {
 
       if (Array.isArray(theMatchingContact.tel)) {
         var theMatchings = aResult.matchings || {};
-        var telMatchings = theMatchings['tel'];
+        var telMatchings = theMatchings.tel;
         theMatchingContact.tel.forEach(function(aTel) {
           var theValue = aTel.value;
           var target = theValue, matchedValue = '';

--- a/apps/communications/contacts/test/unit/contacts_merger_test.js
+++ b/apps/communications/contacts/test/unit/contacts_merger_test.js
@@ -1,25 +1,16 @@
+/* globals contacts, MockFindMatcher */
+
+'use strict';
+
 require('/shared/js/simple_phone_matcher.js');
 requireApp('communications/contacts/js/utilities/misc.js');
 requireApp('communications/contacts/test/unit/mock_find_matcher.js');
 requireApp('communications/contacts/js/contacts_merger.js');
 
-if (!this.toMergeContacts) {
-  this.toMergeContacts = null;
-}
-
-if (!this.toMergeContact) {
-  this.toMergeContact = null;
-}
-
-if (!this.realmozContacts) {
-  this.realmozContacts = null;
-}
-
-if (!this.SimplePhoneMatcher) {
-  this.SimplePhoneMatcher = null;
-}
-
 suite('Contacts Merging Tests', function() {
+  var toMergeContacts = null,
+      toMergeContact = null,
+      realmozContacts = null;
 
   var aPhoto = new Blob();
 
@@ -151,6 +142,54 @@ suite('Contacts Merging Tests', function() {
       success: function(result) {
         assert.equal(result.givenName[0], 'Alfred');
         assert.equal(result.familyName[0], 'Müller von Bismarck');
+
+        done();
+    }});
+  });
+
+  test('Merge first name and last name. existing and incoming given names' +
+       'empty', function(done) {
+    toMergeContact.matchingContact = {
+      givenName: [],
+      familyName: ['Müller von Bismarck'],
+       tel: [{
+        type: ['work'],
+        value: '67676767'
+      }]
+    };
+
+    var masterContact = new MasterContact();
+
+    masterContact.givenName = null;
+
+    contacts.Merger.merge(masterContact, toMergeContacts, {
+      success: function(result) {
+        assert.isTrue(result.givenName.length === 0);
+        assert.equal(result.familyName[0], 'Müller');
+
+        done();
+    }});
+  });
+
+  test('Merge first name and last name. existing and incoming last names empty',
+       function(done) {
+    toMergeContact.matchingContact = {
+      givenName: ['Alfred Albert'],
+      familyName: [],
+       tel: [{
+        type: ['work'],
+        value: '67676767'
+      }]
+    };
+
+    var masterContact = new MasterContact();
+
+    masterContact.familyName = null;
+
+    contacts.Merger.merge(masterContact, toMergeContacts, {
+      success: function(result) {
+        assert.isTrue(result.familyName.length === 0);
+        assert.equal(result.givenName[0], 'Alfred');
 
         done();
     }});

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -270,7 +270,6 @@ apps/communications/contacts/js/contacts_importer.js
 apps/communications/contacts/js/contacts_matcher.js
 apps/communications/contacts/js/contacts_matching_controller.js
 apps/communications/contacts/js/contacts_matching_ui.js
-apps/communications/contacts/js/contacts_merger.js
 apps/communications/contacts/js/contacts_shortcuts.js
 apps/communications/contacts/js/contacts_tag.js
 apps/communications/contacts/js/export/bt.js
@@ -332,7 +331,6 @@ apps/communications/contacts/test/unit/contacts_activities_test.js
 apps/communications/contacts/test/unit/contacts_matcher_test.js
 apps/communications/contacts/test/unit/contacts_matching_ui_test.js
 apps/communications/contacts/test/unit/contacts_matching_ui_test_data.js
-apps/communications/contacts/test/unit/contacts_merger_test.js
 apps/communications/contacts/test/unit/contacts_tag_test.js
 apps/communications/contacts/test/unit/datastore_migrator_test.js
 apps/communications/contacts/test/unit/export/bt_test.js


### PR DESCRIPTION
The problem was due to https://github.com/mozilla-b2g/gaia/blob/master/apps/communications/contacts/js/contacts_merger.js#L123 without checking if there was any truthy value in familyName[0].

I didn't want to include the condition |familyName.length| instead to avoid cases such as [null, "someValue"], etc. I know, not really expected but who knows... :-p
