### PR TITLE
Bug 959422 - [Messages] The Messages app crashes when attaching too big images

### DIFF
--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -98,7 +98,7 @@
         var ratio = Math.max(img.width / width, img.height / height);
         canvas.width = Math.round(img.width / ratio);
         canvas.height = Math.round(img.height / ratio);
-        var context = canvas.getContext('2d');
+        var context = canvas.getContext('2d', { willReadFrequently: true });
         context.drawImage(img, 0, 0, width, height);
         var data = canvas.toDataURL(type);
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -351,7 +351,7 @@
         var canvas = document.createElement('canvas');
         canvas.width = targetWidth;
         canvas.height = targetHeight;
-        var context = canvas.getContext('2d');
+        var context = canvas.getContext('2d', { willReadFrequently: true });
 
         context.drawImage(img, 0, 0, targetWidth, targetHeight);
         // Bug 889765: Since we couldn't know the quality of the original jpg

--- a/apps/sms/js/wbmp.js
+++ b/apps/sms/js/wbmp.js
@@ -65,7 +65,7 @@ var WBMP = (function(document) {
       var canvas = document.createElement('canvas');
       canvas.setAttribute('width', width);
       canvas.setAttribute('height', height);
-      var ctx = canvas.getContext('2d');
+      var ctx = canvas.getContext('2d', { willReadFrequently: true });
       var imageData = ctx.createImageData(width, height);
       var data = imageData.data;
       // Decode the image.


### PR DESCRIPTION
...s when converting to mms r=gsvelto

This adds willReadFrequently to all our canvas contexts that are not displayed.
