### PR TITLE
Bug 963695 - Blacklist search (rocket bar) as it is not a standalone app

### DIFF
--- a/tests/performance/perf.js
+++ b/tests/performance/perf.js
@@ -15,6 +15,7 @@ const excludedApps = [
   'fl', 'pdfjs', 'setringtone', // XXX activities
   'template', // XXX not a real thing.
   'homescreen', // we can't "launch" it
+  'search', // new rocketbar isn't standalone
   'system', // reboots the phone
   'system/camera' // copy of the camera app
 ];


### PR DESCRIPTION
So we don't get an error in |make test-perf|
