### PR TITLE
Bug 949051 - Add Firefox Accounts to Settings app r=arthurcc

### DIFF
--- a/apps/settings/elements/firefox_accounts.html
+++ b/apps/settings/elements/firefox_accounts.html
@@ -1,0 +1,95 @@
+<element name="fxa" extends="section" id="fxa-container">
+  <template>
+
+    <header>
+      <a href="#root"><span class="icon icon-back">back</span></a>
+      <h1 data-l10n-id="fxa-accounts-header">Firefox Accounts</h1>
+    </header>
+
+    <div id="fxa-logged-out" hidden>
+      <ul>
+        <li class="description">
+          <p data-l10n-id="fxa-description" id="fxa-logged-out-description">
+            Firefox lets you use a single account to log in to services like
+            Marketplace and Where's my Fox.
+          </p>
+        </li>
+        <li>
+          <label>
+            <button class="recommend" id="fxa-login">
+              <span data-l10n-id="fxa-login">Create Account or Sign In</span>
+            </button>
+          </label>
+        </li>
+      </ul>
+    </div>
+    <div id="fxa-unverified" hidden>
+      <header>
+        <h2 data-l10n-id="fxa-confirm-account">Confirm Your Account</h2>
+      </header>
+      <ul>
+        <li class="description">
+          <p data-l10n-id="fxa-verification-email-sent" id="fxa-unverified-text">
+            We've sent an email to: foo@bar.com
+          </p>
+          <p data-l10n-id="fxa-please-confirm">
+            Please confirm your account by clicking the link in your email.
+          </p>
+          <p data-l10n-id="fxa-how-to-access">
+            You can access and manage your account from your phone's settings.
+          </p>
+        </li>
+        <li>
+          <label>
+            <button class="danger" id="fxa-cancel-confirmation">
+              <span data-l10n-id="fxa-cancel-confirmation">Cancel Account Confirmation</span>
+            </button>
+          </label>
+        </li>
+      </ul>
+    </div>
+    <div id="fxa-logged-in" hidden>
+      <header>
+        <h2 data-l10n-id="fxa-myaccount">My Account</h2>
+      </header>
+      <ul>
+        <li class="description">
+          <p data-l10n-id="fxa-description">
+            Firefox lets you use a single account to log in to services like
+            Marketplace and Where’s My Fox.
+          </p>
+          <p data-l10n-id="fxa-logged-in-text" id="fxa-logged-in-text">
+            Logged in as foo@bar.com
+          </p>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="fxa-registered-apps-header">Registered Apps</h2>
+      </header>
+      <ul>
+        <li>
+          <span data-l10n-id="fxa-marketplace-app">Marketplace</span>
+        </li>
+        <li>
+          <span data-l10n-id="fxa-wheres-my-fox-app">Where’s My Fox</span>
+        </li>
+      </ul>
+
+      <header>
+        <h2 data-l10n-id="fxa-account-options">Account Options</h2>
+      </header>
+      <ul>
+        <li>
+          <label>
+            <button id="fxa-logout">
+              <span data-l10n-id="fxa-logout"> Log Out </span>
+            </button>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <script defer="" src="js/firefox_accounts/panel_loader.js"></script>
+  </template>
+</element>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -62,6 +62,9 @@
     <!-- Screen layout watcher -->
     <script defer="" src="/shared/js/screen_layout.js"></script>
 
+    <!-- Firefox Accounts status code -->
+    <script defer="" src="js/firefox_accounts/menu_loader.js"></script>
+
     <!-- Specific code -->
     <script defer="" src="js/settings.js"></script>
 
@@ -80,6 +83,8 @@
     <!--<script defer src="shared/js/settings_listener.js"></script> -->
     <!--<script defer src="shared/js/airplane_mode_helper.js"></script> -->
     <!--<script defer src="shared/js/toaster.js"></script> -->
+    <!--<script defer src="shared/js/fxa_iac_client.js"></script> -->
+    <!--<script defer src="shared/js/text_normalizer.js"></script> -->
 
     <!-- all non-#root panels will lazy-load their own scripts -->
     <link rel="import" href="/elements/wifi_status.html">
@@ -155,6 +160,7 @@
     <link rel="import" href="/elements/help.html">
     <link rel="import" href="/elements/icc.html">
     <link rel="import" href="/elements/downloads.html">
+    <link rel="import" href="/elements/firefox_accounts.html">
   </head>
   <body class="skin-organic uninit">
     <!--
@@ -331,6 +337,9 @@
     <!-- SIM Toolkit -->
     <section is="icc" role="region" id="icc"></section>
 
+    <!-- Firefox Accounts -->
+    <section is="fxa" role="region" id="fxa"></section>
+
     <!-- Main List -->
     <section role="region" id="root" class="current" data-rendered="true">
       <header>
@@ -424,17 +433,17 @@
         </ul>
 
         <!-- Main :: Accounts -->
-        <header hidden="">
-          <h2 data-l10n-id="accounts">Accounts</h2>
-        </header>
-        <ul hidden="">
-          <li>
-            <a id="menuItem-persona" class="menu-item" href="#persona" data-l10n-id="persona">Persona</a>
-          </li>
-          <li>
-            <a id="menuItem-mail" class="menu-item" href="#mail" data-l10n-id="mail">Mail</a>
-          </li>
-        </ul>
+        <span data-show-name="identity.fxaccounts.ui.enabled" hidden>
+          <header>
+            <h2 data-l10n-id="accounts">Accounts</h2>
+          </header>
+          <ul>
+            <li>
+              <small id="fxa-desc" class="menu-item-desc"></small>
+              <a id="menuItem-fxa" class="menu-item" href="#fxa" data-l10n-id="fxa-accounts">Firefox Accounts</a>
+            </li>
+          </ul>
+        </span>
 
         <!-- Main :: Security & Privacy -->
         <header>

--- a/apps/settings/js/firefox_accounts/menu.js
+++ b/apps/settings/js/firefox_accounts/menu.js
@@ -1,0 +1,66 @@
+/* global FxAccountsIACHelper, Normalizer */
+/* exported FxaMenu */
+
+'use strict';
+
+var FxaMenu = (function fxa_menu() {
+  var fxaHelper,
+    menuStatus;
+
+  function init(helper) {
+    // allow mock to be passed in for unit testing
+    fxaHelper = helper || FxAccountsIACHelper;
+    menuStatus = document.getElementById('fxa-desc');
+
+    // listen for status updates
+    onVisibilityChange();
+    // start by asking for current status
+    refreshStatus();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
+
+  function refreshStatus() {
+    fxaHelper.getAccounts(onStatusChange, onStatusError);
+  }
+
+  // if e == null, user is logged out.
+  // if e.verified, user is logged in & verified.
+  // if !e.verified, user is logged in & unverified.
+  function onStatusChange(e) {
+    // XXX FxAccountsIACHelper currently is inconsistent about response format
+    //     fix this after 981210 lands (e.accountId vs e.email)
+    var email = e ? Normalizer.escapeHTML(e.accountId || e.email) : '';
+
+    if (!e) {
+      navigator.mozL10n.localize(menuStatus, 'fxa-login');
+    } else if (e.verified) {
+      navigator.mozL10n.localize(menuStatus, 'fxa-logged-in-text', {
+        email: email
+      });
+    } else { // unverified
+      navigator.mozL10n.localize(menuStatus, 'fxa-check-email', {
+        email: email
+      });
+    }
+  }
+
+  function onStatusError(err) {
+    console.error('FxaMenu: Error getting Firefox Account: ' + err.error);
+  }
+
+  function onVisibilityChange() {
+    if (document.hidden) {
+      fxaHelper.removeEventListener('onlogin', refreshStatus);
+      fxaHelper.removeEventListener('onverifiedlogin', refreshStatus);
+      fxaHelper.removeEventListener('onlogout', refreshStatus);
+    } else {
+      fxaHelper.addEventListener('onlogin', refreshStatus);
+      fxaHelper.addEventListener('onverifiedlogin', refreshStatus);
+      fxaHelper.addEventListener('onlogout', refreshStatus);
+    }
+  }
+
+  return {
+    init: init
+  };
+})();

--- a/apps/settings/js/firefox_accounts/menu_loader.js
+++ b/apps/settings/js/firefox_accounts/menu_loader.js
@@ -1,0 +1,26 @@
+/* global FxAccountsIACHelper, FxaMenu, LazyLoader, Settings */
+
+'use strict';
+
+navigator.mozL10n.ready(function loadWhenIdle() {
+  Settings.getSettings(function(results) {
+    var enabled = results['identity.fxaccounts.ui.enabled'];
+    if (!enabled) {
+      return;
+    }
+    var idleObserver = {
+      time: 4,
+      onidle: function() {
+        navigator.removeIdleObserver(idleObserver);
+        LazyLoader.load([
+          '/shared/js/fxa_iac_client.js',
+          '/shared/js/text_normalizer.js',
+          'js/firefox_accounts/menu.js'
+        ], function fxa_menu_loaded() {
+          FxaMenu.init(FxAccountsIACHelper);
+        });
+      }
+    };
+    navigator.addIdleObserver(idleObserver);
+  });
+});

--- a/apps/settings/js/firefox_accounts/panel.js
+++ b/apps/settings/js/firefox_accounts/panel.js
@@ -1,0 +1,135 @@
+/* global Normalizer */
+/* exported FxaPanel */
+
+'use strict';
+
+var FxaPanel = (function fxa_panel() {
+  var fxaContainer,
+    loggedOutPanel,
+    loggedInPanel,
+    unverifiedPanel,
+    cancelBtn,
+    loginBtn,
+    logoutBtn,
+    loggedInEmail,
+    unverifiedEmail,
+    fxaHelper;
+
+  function init(fxAccountsIACHelper) {
+    // allow mock to be passed in for unit testing
+    fxaHelper = fxAccountsIACHelper;
+    fxaContainer = document.getElementById('fxa');
+    loggedOutPanel = document.getElementById('fxa-logged-out');
+    loggedInPanel = document.getElementById('fxa-logged-in');
+    unverifiedPanel = document.getElementById('fxa-unverified');
+    cancelBtn = document.getElementById('fxa-cancel-confirmation');
+    loginBtn = document.getElementById('fxa-login');
+    logoutBtn = document.getElementById('fxa-logout');
+    loggedInEmail = document.getElementById('fxa-logged-in-text');
+    unverifiedEmail = document.getElementById('fxa-unverified-text');
+
+    // listen for changes
+    onVisibilityChange();
+    // start by checking current status
+    refreshStatus();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
+
+  function onVisibilityChange() {
+    if (document.hidden) {
+      fxaHelper.removeEventListener('onlogin', refreshStatus);
+      fxaHelper.removeEventListener('onverifiedlogin', refreshStatus);
+      fxaHelper.removeEventListener('onlogout', refreshStatus);
+    } else {
+      fxaHelper.addEventListener('onlogin', refreshStatus);
+      fxaHelper.addEventListener('onverifiedlogin', refreshStatus);
+      fxaHelper.addEventListener('onlogout', refreshStatus);
+    }
+  }
+
+  function refreshStatus() {
+    fxaHelper.getAccounts(onFxAccountStateChange, onFxAccountError);
+  }
+
+  // if e == null, user is logged out.
+  // if e.verified, user is logged in & verified.
+  // if !e.verified, user is logged in & unverified.
+  function onFxAccountStateChange(e) {
+    // XXX FxAccountsIACHelper currently is inconsistent about response format
+    //     fix this after 981210 lands (e.accountId vs e.email)
+    var email = e ? Normalizer.escapeHTML(e.accountId || e.email) : '';
+
+    if (!e) {
+      hideLoggedInPanel();
+      hideUnverifiedPanel();
+      showLoggedOutPanel();
+    } else if (e.verified) {
+      hideLoggedOutPanel();
+      hideUnverifiedPanel();
+      showLoggedInPanel(email);
+    } else {
+      hideLoggedOutPanel();
+      hideLoggedInPanel();
+      showUnverifiedPanel(email);
+    }
+  }
+
+  function onFxAccountError(err) {
+    console.error('FxaPanel: Error getting Firefox Account: ' + err.error);
+  }
+
+  function hideLoggedOutPanel() {
+    loginBtn.onclick = null;
+    loggedOutPanel.hidden = true;
+  }
+
+  function showLoggedOutPanel() {
+    loginBtn.onclick = onLoginClick;
+    loggedOutPanel.hidden = false;
+  }
+
+  function hideLoggedInPanel() {
+    loggedInPanel.hidden = true;
+    loggedInEmail.textContent = '';
+    logoutBtn.onclick = null;
+  }
+
+  function showLoggedInPanel(email) {
+    navigator.mozL10n.localize(loggedInEmail, 'fxa-logged-in-text', {
+      email: email
+    });
+    loggedInPanel.hidden = false;
+    logoutBtn.onclick = onLogoutClick;
+  }
+
+  function hideUnverifiedPanel() {
+    unverifiedPanel.hidden = true;
+    unverifiedEmail.textContent = '';
+    cancelBtn.onclick = null;
+  }
+
+  function showUnverifiedPanel(email) {
+    unverifiedPanel.hidden = false;
+    cancelBtn.onclick = onLogoutClick;
+    navigator.mozL10n.localize(unverifiedEmail, 'fxa-verification-email-sent', {
+      email: email
+    });
+  }
+
+  function onLogoutClick(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    fxaHelper.logout(onFxAccountStateChange, onFxAccountError);
+  }
+
+  function onLoginClick(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    fxaHelper.openFlow(onFxAccountStateChange, onFxAccountError);
+  }
+
+  return {
+    init: init
+  };
+
+})();

--- a/apps/settings/js/firefox_accounts/panel_loader.js
+++ b/apps/settings/js/firefox_accounts/panel_loader.js
@@ -1,0 +1,20 @@
+/* global FxaPanel, FxAccountsIACHelper, LazyLoader */
+
+'use strict';
+
+navigator.mozL10n.ready(function onL10nReady() {
+  function onPanelReady(evt) {
+    if (evt.detail.current !== '#fxa') {
+      return;
+    }
+    window.removeEventListener('panelready', onPanelReady);
+    LazyLoader.load([
+      '/shared/js/fxa_iac_client.js',
+      '/shared/js/text_normalizer.js',
+      'js/firefox_accounts/panel.js'
+    ], function fxa_panel_loaded() {
+      FxaPanel.init(FxAccountsIACHelper);
+    });
+  }
+  window.addEventListener('panelready', onPanelReady);
+});

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -643,12 +643,41 @@ keyboardType-number=number
 defaultKeyboardEnabled={{appName}} {{layoutName}} is set as default input method
 
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
-# Accounts (N/A)
+# Accounts
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
 
-accounts=Accounts
-persona=Persona
-mail=Mail
+fxa=Firefox Accounts
+accounts=Account Management
+fxa-accounts=Firefox Accounts
+# LOCALIZATION NOTE (fxa-accounts-header): if you leave the original
+# en-US value "{{fxa-accounts}}" in the following string, the localization
+# will be automatically picked from the existing string with ID "fxa-accounts".
+# If you need to adapt your localization to the reduced space available
+# in headers, you can use a shorter string here.
+fxa-accounts-header={{fxa-accounts}}
+
+# Panel: logged out
+fxa-description=Firefox lets you use a single account to log in to services like Marketplace and Where’s My Fox.
+fxa-login=Create Account or Sign In
+
+# Panel: logged in, unverified
+fxa-confirm-account=Confirm Your Account
+fxa-verification-email-sent=We’ve sent an email to: {{email}}.
+fxa-please-confirm=Please confirm your account by clicking the link in your email.
+fxa-how-to-access=You can access and manage your account from your phone’s settings.
+fxa-cancel-confirmation=Cancel Account Confirmation
+
+# Panel: logged in, verified
+fxa-myaccount=My Account
+fxa-logged-in-text=Signed in as {{email}}
+fxa-registered-apps-header=Registered Apps
+fxa-marketplace-app=Marketplace
+fxa-wheres-my-fox-app=Where’s My Fox
+fxa-account-options=Account Options
+fxa-logout=Log Out
+
+# Additional menu states
+fxa-check-email=Please verify {{email}}
 
 
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#

--- a/apps/settings/style/icons.css
+++ b/apps/settings/style/icons.css
@@ -89,7 +89,7 @@ li:active:not([aria-disabled="true"]) .menu-item::before,
   background-position: -3rem -6rem;
 }
 
-#menuItem-persona::before {
+#menuItem-fxa::before {
   background-position: -6rem -6rem;
 }
 

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -788,4 +788,3 @@ html[dir="rtl"] #feedback-happy {
 html[dir="rtl"] #feedback-sad {
   float: left;
 }
-

--- a/apps/settings/test/unit/firefox_accounts_menu_test.js
+++ b/apps/settings/test/unit/firefox_accounts_menu_test.js
@@ -1,0 +1,105 @@
+/* globals FxaMenu, loadBodyHTML, MockFxAccountsIACHelper, MockL10n */
+
+'use strict';
+
+mocha.globals([
+  'FxaMenu',
+  'loadBodyHTML',
+  'MockFxAccountsIACHelper',
+  'MockL10n'
+]);
+
+// require helpers for managing html
+require('/shared/test/unit/load_body_html_helper.js');
+require('/shared/js/html_imports.js');
+
+// mocks and globals
+require('mock_fx_accounts_iac_helper.js');
+require('/shared/js/text_normalizer.js');
+requireApp('settings/test/unit/mock_l10n.js');
+
+// source the code we care about
+requireApp('settings/js/firefox_accounts/menu.js');
+
+suite('firefox accounts menu item > ', function() {
+  var suiteSandbox = sinon.sandbox.create(),
+    fxaDescEl,
+    realL10n;
+
+  suiteSetup(function() {
+    // attach mock html to page, so it inits without complaint
+    loadBodyHTML('/index.html');
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = MockL10n;
+  });
+
+  suiteTeardown(function() {
+    suiteSandbox.restore();
+    navigator.mozL10n = realL10n;
+    document.body.innerHTML = '';
+    MockFxAccountsIACHelper.resetListeners();
+  });
+
+  test('check the html loaded correctly', function() {
+    fxaDescEl = document.getElementById('fxa-desc');
+    assert.isNotNull(fxaDescEl, 'failed to load settings page html');
+  });
+
+  test('show the correct status on FxaMenu init', function() {
+    var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+    MockFxAccountsIACHelper.setCurrentState({
+      accountId: 'init@ialization.com',
+      verified: true
+    });
+    // init app code
+    FxaMenu.init(MockFxAccountsIACHelper);
+    // test localize was called with correct args
+    assert.deepEqual(localizeSpy.args[0], [
+      fxaDescEl,
+      'fxa-logged-in-text',
+      { email: 'init@ialization.com' }
+    ]);
+    navigator.mozL10n.localize.restore();
+  });
+
+  test('show the correct status after onlogout event', function() {
+    var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+    MockFxAccountsIACHelper.setCurrentState(null);
+    MockFxAccountsIACHelper.fireEvent('onlogout');
+    assert.deepEqual(localizeSpy.args[0], [
+      fxaDescEl,
+      'fxa-login'
+    ]);
+    navigator.mozL10n.localize.restore();
+  });
+
+  test('show the correct status after onlogin event', function() {
+    var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+    MockFxAccountsIACHelper.setCurrentState({
+      accountId: 'on@log.in',
+      verified: false
+    });
+    MockFxAccountsIACHelper.fireEvent('onlogin');
+    assert.deepEqual(localizeSpy.args[0], [
+      fxaDescEl,
+      'fxa-check-email',
+      { email: 'on@log.in' }
+    ]);
+    navigator.mozL10n.localize.restore();
+  });
+
+  test('show the correct status after onverifiedlogin event', function() {
+    var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+    MockFxAccountsIACHelper.setCurrentState({
+      accountId: 'on@verifiedlog.in',
+      verified: true
+    });
+    MockFxAccountsIACHelper.fireEvent('onverifiedlogin');
+    assert.deepEqual(localizeSpy.args[0], [
+      fxaDescEl,
+      'fxa-logged-in-text',
+      { email: 'on@verifiedlog.in' }
+    ]);
+    navigator.mozL10n.localize.restore();
+  });
+});

--- a/apps/settings/test/unit/firefox_accounts_panel_test.js
+++ b/apps/settings/test/unit/firefox_accounts_panel_test.js
@@ -1,0 +1,136 @@
+/* globals FxaPanel, HtmlImports, loadBodyHTML, MockFxAccountsIACHelper,
+  MockL10n */
+
+'use strict';
+
+mocha.globals([
+  'FxaPanel',
+  'loadBodyHTML',
+  'HtmlImports',
+  'MockFxAccountsIACHelper',
+  'MockL10n'
+]);
+
+// require helpers for managing html
+require('/shared/test/unit/load_body_html_helper.js');
+require('/shared/js/html_imports.js');
+
+// mocks and globals
+require('mock_fx_accounts_iac_helper.js');
+require('/shared/js/text_normalizer.js');
+requireApp('settings/test/unit/mock_l10n.js');
+
+// source the code we care about
+requireApp('settings/js/firefox_accounts/panel.js');
+
+suite('firefox accounts panel > ', function() {
+  var suiteSandbox = sinon.sandbox.create(),
+    realL10n,
+    loggedOutScreen,
+    unverifiedScreen,
+    loggedInScreen;
+
+  suiteSetup(function(done) {
+    realL10n = navigator.mozL10n;
+    navigator.mozL10n = MockL10n;
+
+    // first, load settings app
+    loadBodyHTML('/index.html');
+
+    // next, insert fxa panel into page
+    var importHook = document.createElement('link');
+    importHook.setAttribute('rel', 'import');
+    importHook.setAttribute('href', '/elements/firefox_accounts.html');
+    document.head.appendChild(importHook);
+    HtmlImports.populate(function onDOMReady() {
+      // double-check panel is ready
+      if (null == document.getElementById('fxa-logged-out')) {
+        throw new Error('failed to load fxa panel into page');
+      }
+      // grab pointers to useful elements
+      loggedOutScreen = document.getElementById('fxa-logged-out');
+      unverifiedScreen = document.getElementById('fxa-unverified');
+      loggedInScreen = document.getElementById('fxa-logged-in');
+      done();
+    });
+  });
+  suiteTeardown(function() {
+    suiteSandbox.restore();
+    // TODO: should we try to destroy FxaPanel? remove mock html from page?
+    navigator.mozL10n = realL10n;
+    document.body.innerHTML = '';
+    MockFxAccountsIACHelper.resetListeners();
+  });
+
+  test('show the correct panel and email on FxaPanel init', function() {
+    var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+    // set the state in the mock
+    MockFxAccountsIACHelper.setCurrentState({
+      accountId: 'init@ialization.com',
+      verified: true
+    });
+    // init FxaPanel
+    FxaPanel.init(MockFxAccountsIACHelper);
+
+    // check the right screen is visible
+    assert.isTrue(loggedOutScreen.hidden);
+    assert.isTrue(unverifiedScreen.hidden);
+    assert.isFalse(loggedInScreen.hidden);
+
+    // test localize was called with correct args
+    assert.deepEqual(localizeSpy.args[0], [
+      document.getElementById('fxa-logged-in-text'),
+      'fxa-logged-in-text',
+      { email: 'init@ialization.com' }
+    ]);
+    navigator.mozL10n.localize.restore();
+  });
+
+  test('show the correct panel and email after onlogout event', function() {
+    MockFxAccountsIACHelper.setCurrentState(null);
+    MockFxAccountsIACHelper.fireEvent('onlogout');
+    assert.isFalse(loggedOutScreen.hidden);
+    assert.isTrue(unverifiedScreen.hidden);
+    assert.isTrue(loggedInScreen.hidden);
+  });
+
+  test('show the correct panel and email after onlogin event', function() {
+    var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+    MockFxAccountsIACHelper.setCurrentState({
+      accountId: 'on@log.in',
+      verified: false
+    });
+    MockFxAccountsIACHelper.fireEvent('onlogin');
+    assert.isTrue(loggedOutScreen.hidden);
+    assert.isFalse(unverifiedScreen.hidden);
+    assert.isTrue(loggedInScreen.hidden);
+
+    // test localize was called with correct args
+    assert.deepEqual(localizeSpy.args[0], [
+      document.getElementById('fxa-unverified-text'),
+      'fxa-verification-email-sent',
+      { email: 'on@log.in' }
+    ]);
+    navigator.mozL10n.localize.restore();
+  });
+
+  test('show the correct panel and email after onverifiedlogin event',
+    function() {
+      var localizeSpy = sinon.spy(navigator.mozL10n, 'localize');
+      MockFxAccountsIACHelper.setCurrentState({
+        accountId: 'on@verifiedlog.in',
+        verified: true
+      });
+      MockFxAccountsIACHelper.fireEvent('onverifiedlogin');
+      assert.isTrue(loggedOutScreen.hidden);
+      assert.isTrue(unverifiedScreen.hidden);
+      assert.isFalse(loggedInScreen.hidden);
+      // test localize was called with correct args
+      assert.deepEqual(localizeSpy.args[0], [
+        document.getElementById('fxa-logged-in-text'),
+        'fxa-logged-in-text',
+        { email: 'on@verifiedlog.in' }
+      ]);
+      navigator.mozL10n.localize.restore();
+  });
+});

--- a/apps/settings/test/unit/mock_fx_accounts_iac_helper.js
+++ b/apps/settings/test/unit/mock_fx_accounts_iac_helper.js
@@ -1,0 +1,70 @@
+/* exported MockFxAccountsIACHelper */
+
+'use strict';
+
+var MockFxAccountsIACHelper = (function() {
+  var listeners = {
+    'onlogin': [],
+    'onverifiedlogin': [],
+    'onlogout': []
+  };
+
+  var currentState = null;
+
+  function getAccounts(cb) {
+    cb(currentState);
+  }
+
+  function resetListeners() {
+    listeners.onlogin = [];
+    listeners.onverifiedlogin = [];
+    listeners.onlogout = [];
+  }
+
+  function addEventListener(eventType, cb) {
+    if (!(eventType in listeners)) {
+      throw new Error('tried to add wrong event type');
+    }
+    listeners[eventType].push(cb);
+  }
+
+  function removeEventListener(eventType, cb) {
+    if (!(eventType in listeners)) {
+      throw new Error('tried to remove wrong event type');
+    }
+    for (var i = 0; i < listeners[eventType].length; i++) {
+      if (cb == listeners[eventType][i]) {
+        listeners[eventType].splice(i, 1);
+      }
+    }
+  }
+
+  function fireEvent(eventType) {
+    if (!(eventType in listeners)) {
+      throw new Error('tried to fire wrong event type');
+    }
+
+    for (var i = 0; i < listeners[eventType].length; i++) {
+      listeners[eventType][i](eventType);
+    }
+  }
+
+  function setCurrentState(x) {
+    currentState = x;
+  }
+
+  function getCurrentState() {
+    return currentState;
+  }
+
+  return {
+    getAccounts: getAccounts,
+    setCurrentState: setCurrentState,
+    getCurrentState: getCurrentState,
+    addEventListener: addEventListener,
+    removeEventListener: removeEventListener,
+    fireEvent: fireEvent,
+    listeners: listeners,
+    resetListeners: resetListeners
+  };
+})();


### PR DESCRIPTION
Mondo patch to add a firefox accounts menu item to the main settings panel, and also add a firefox accounts panel.

(Original description: WIP but would appreciate preliminary review. This is my first large gaia change, want to make sure I'm on the right track.)

_Description updated to reflect new status of this pull request_
