### PR TITLE
Bug 948415 - Make mock_contact.py pythonic, make insert_contact convert it to API-friendly format

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -194,7 +194,8 @@ class GaiaData(object):
 
     def insert_contact(self, contact):
         self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script('return GaiaDataLayer.insertContact(%s);' % json.dumps(contact), special_powers=True)
+        mozcontact = contact.create_mozcontact()
+        result = self.marionette.execute_async_script('return GaiaDataLayer.insertContact(%s);' % json.dumps(mozcontact), special_powers=True)
         assert result, 'Unable to insert contact %s' % contact
 
     def remove_all_contacts(self):

--- a/tests/python/gaia-ui-tests/gaiatest/mocks/mock_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/mocks/mock_contact.py
@@ -4,40 +4,110 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
+import time
 
 
 class MockContact(dict):
     '''
-    The key values here match the data structure in the contacts db
-    so that the json output of this mock can be inserted directly into db
+    Mocks a contact conforming to the Mozilla contacts API as a dictionary
+    of contact properties.
+
+    Object properties containing sub-properties are themselves dictionaries.
+
+    Properties containing multiple values should be lists, but single instances
+    of a property are not required to be lists for convenience.
+
+    The properites created by default are: givenName, familyName, name, email,
+    tel, adr, note.
     '''
 
     def __init__(self, **kwargs):
-        # set your default values
-        import time
+        super(MockContact, self).__init__(self, **kwargs)
+
+        # Set default values
         curr_time = repr(time.time()).replace('.', '')
-        self['givenName'] = ['gaia%s' % curr_time[10:]]
-        self['familyName'] = ['test']
-        self['name'] = [self['givenName'][0] + " " + self['familyName'][0]]
-        self['email'] = [{
-            'type': ['Personal'],
-            'value': '%s@restmail.net' % self['givenName'][0]}]
-        # TODO this will only support one phone number
-        self['tel'] = [{
-            'type': ['Mobile'],
-            'value': '555%s' % curr_time[8:]}]
-        self['adr'] = [{
-            'type': ['Home'],
+        self['givenName'] = 'gaia%s' % curr_time[10:]
+        self['familyName'] = 'test'
+        self['name'] = '%s %s' % (self['givenName'], self['familyName'])
+        self['email'] = {
+            'type': 'Personal',
+            'value': '%s@restmail.net' % self['givenName']}
+        self['tel'] = {
+            'type': 'Mobile',
+            'value': '555%s' % curr_time[8:]}
+        self['adr'] = {
+            'type': 'Home',
             'streetAddress': '101 Testing street',
             'postalCode': '90210',
             'locality': 'London',
-            'countryName': 'UK'}]
-        self['note'] = ["Gaia automated test"]
+            'countryName': 'UK'}
+        self['note'] = 'Gaia automated test'
 
-        # update with any keyword arguments passed
+        # Update with any keyword arguments passed. Note that the __init__ call
+        # above does not call update and so it must be done seperately
         self.update(**kwargs)
 
-    # allow getting items as if they were attributes
+    # Allow getting items as if they were attributes
     def __getattr__(self, attr):
         return self[attr]
+
+    def create_mozcontact(self):
+        """
+        Returns the MockContact dictionary in a format compatible with the
+        MozContact API.
+
+        To be compatible with the MozContact API all properties are converted
+        to arrays (lists in Python) where required. Note that for object
+        properties with sub-properties (ex: the 'tel' property), only the
+        'type' sub-property must be an array.
+        """
+        mozcontact = {}
+        for key in self.iterkeys():
+            # Handle a MockContact property already in mozcontact format
+            if self.is_mozcontact_api_format(self[key]):
+                mozcontact[key] = self[key]
+            else:
+                # All mozcontact properties must be arrays (lists in Python)
+                if not isinstance(self[key], list):
+                    mozcontact[key] = [self[key]]
+                else:
+                    mozcontact[key] = self[key]
+                # A property that is a dictionary represents an object with
+                # sub-properties. Create mozcontact compliant objects.
+                if isinstance(mozcontact[key][0], dict):
+                    mozcontact[key] = [self._create_mozcontact_object(obj)
+                                       for obj in mozcontact[key]]
+        return mozcontact
+
+    @staticmethod
+    def is_mozcontact_api_format(prop):
+        """
+        Determines if a property is compliant with the MozContact API.
+        """
+        # All mozcontact properties must be arrays (lists in Python)
+        if not isinstance(prop, list):
+            return False
+        # Search for any object properties with sub-properties to verify
+        for obj in prop:
+            # A property that is a dictionary represents an object with
+            # sub-properties.
+            if isinstance(obj, dict):
+                for key in obj.iterkeys():
+                    # Only an object's type property should be a list
+                    if key == 'type' and not isinstance(obj[key], list):
+                        return False
+                    elif key != 'type' and isinstance(obj[key], list):
+                        return False
+        return True
+
+    @staticmethod
+    def _create_mozcontact_object(obj):
+        """
+        Returns a MockContact object property (dictionary) compatible with the
+        MozContact API.
+        """
+        mozobj = obj.copy()
+        # Only an object's type property needs to be a list
+        if 'type' in mozobj.keys() and not isinstance(mozobj['type'], list):
+            mozobj['type'] = [mozobj['type']]
+        return mozobj

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_add_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_add_contact.py
@@ -33,12 +33,12 @@ class TestEnduranceAddContact(GaiaEnduranceTestCase):
         contact['givenName'] = "%02dof%02d" % (self.iteration, self.iterations)
         new_contact_form.type_given_name(contact['givenName'])
         new_contact_form.type_family_name(contact['familyName'])
-        new_contact_form.type_phone(contact['tel'][0]['value'])
-        new_contact_form.type_email(contact['email'][0]['value'])
-        new_contact_form.type_street(contact['adr'][0]['streetAddress'])
-        new_contact_form.type_zip_code(contact['adr'][0]['postalCode'])
-        new_contact_form.type_city(contact['adr'][0]['locality'])
-        new_contact_form.type_country(contact['adr'][0]['countryName'])
+        new_contact_form.type_phone(contact['tel']['value'])
+        new_contact_form.type_email(contact['email']['value'])
+        new_contact_form.type_street(contact['adr']['streetAddress'])
+        new_contact_form.type_zip_code(contact['adr']['postalCode'])
+        new_contact_form.type_city(contact['adr']['locality'])
+        new_contact_form.type_country(contact['adr']['countryName'])
         new_contact_form.type_comment(contact['note'])
 
         # Save new contact

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_add_delete_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_add_delete_contact.py
@@ -33,12 +33,12 @@ class TestEnduranceAddDeleteContact(GaiaEnduranceTestCase):
         contact['givenName'] = "%02dof%02d" % (self.iteration, self.iterations)
         new_contact_form.type_given_name(contact['givenName'])
         new_contact_form.type_family_name(contact['familyName'])
-        new_contact_form.type_phone(contact['tel'][0]['value'])
-        new_contact_form.type_email(contact['email'][0]['value'])
-        new_contact_form.type_street(contact['adr'][0]['streetAddress'])
-        new_contact_form.type_zip_code(contact['adr'][0]['postalCode'])
-        new_contact_form.type_city(contact['adr'][0]['locality'])
-        new_contact_form.type_country(contact['adr'][0]['countryName'])
+        new_contact_form.type_phone(contact['tel']['value'])
+        new_contact_form.type_email(contact['email']['value'])
+        new_contact_form.type_street(contact['adr']['streetAddress'])
+        new_contact_form.type_zip_code(contact['adr']['postalCode'])
+        new_contact_form.type_city(contact['adr']['locality'])
+        new_contact_form.type_country(contact['adr']['countryName'])
         new_contact_form.type_comment(contact['note'])
 
         # Save new contact

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_add_edit_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_add_edit_contact.py
@@ -38,12 +38,12 @@ class TestEnduranceAddEditContact(GaiaEnduranceTestCase):
         contact['givenName'] = "%02dof%02d" % (self.iteration, self.iterations)
         new_contact_form.type_given_name(contact['givenName'])
         new_contact_form.type_family_name(contact['familyName'])
-        new_contact_form.type_phone(contact['tel'][0]['value'])
-        new_contact_form.type_email(contact['email'][0]['value'])
-        new_contact_form.type_street(contact['adr'][0]['streetAddress'])
-        new_contact_form.type_zip_code(contact['adr'][0]['postalCode'])
-        new_contact_form.type_city(contact['adr'][0]['locality'])
-        new_contact_form.type_country(contact['adr'][0]['countryName'])
+        new_contact_form.type_phone(contact['tel']['value'])
+        new_contact_form.type_email(contact['email']['value'])
+        new_contact_form.type_street(contact['adr']['streetAddress'])
+        new_contact_form.type_zip_code(contact['adr']['postalCode'])
+        new_contact_form.type_city(contact['adr']['locality'])
+        new_contact_form.type_country(contact['adr']['countryName'])
         new_contact_form.type_comment(contact['note'])
 
         # Save new contact
@@ -74,7 +74,7 @@ class TestEnduranceAddEditContact(GaiaEnduranceTestCase):
         contact_details = self.contacts.contact(contact['givenName']).tap()
 
         # Now assert that the values have updated
-        expected_name = contact['givenName'] + " " + contact['familyName'][0]
+        expected_name = contact['givenName'] + " " + contact['familyName']
         self.assertEqual(expected_name, contact_details.full_name)
 
         # Back to main contacts list

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_add_contact_to_favorites.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_add_contact_to_favorites.py
@@ -20,7 +20,7 @@ class TestAddContactToFavorite(GaiaTestCase):
         contacts_app.launch()
         contacts_app.wait_for_contacts()
 
-        contact_details = contacts_app.contact(self.contact['givenName'][0]).tap()
+        contact_details = contacts_app.contact(self.contact['givenName']).tap()
         contact_details.tap_add_remove_favorite()
         self.assertEqual(contact_details.add_remove_text, 'Remove as Favorite')
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_add_new_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_add_new_contact.py
@@ -23,15 +23,15 @@ class TestContacts(GaiaTestCase):
         new_contact_form.type_given_name(self.contact['givenName'])
         new_contact_form.type_family_name(self.contact['familyName'])
 
-        new_contact_form.type_phone(self.contact['tel'][0]['value'])
-        new_contact_form.type_email(self.contact['email'][0]['value'])
-        new_contact_form.type_street(self.contact['adr'][0]['streetAddress'])
-        new_contact_form.type_zip_code(self.contact['adr'][0]['postalCode'])
-        new_contact_form.type_city(self.contact['adr'][0]['locality'])
-        new_contact_form.type_country(self.contact['adr'][0]['countryName'])
+        new_contact_form.type_phone(self.contact['tel']['value'])
+        new_contact_form.type_email(self.contact['email']['value'])
+        new_contact_form.type_street(self.contact['adr']['streetAddress'])
+        new_contact_form.type_zip_code(self.contact['adr']['postalCode'])
+        new_contact_form.type_city(self.contact['adr']['locality'])
+        new_contact_form.type_country(self.contact['adr']['countryName'])
         new_contact_form.type_comment(self.contact['note'])
 
         new_contact_form.tap_done()
         self.wait_for_condition(lambda m: len(contacts_app.contacts) == 1)
 
-        self.assertEqual(contacts_app.contacts[0].name, self.contact['givenName'][0])
+        self.assertEqual(contacts_app.contacts[0].name, self.contact['givenName'])

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_add_photo_to_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_add_photo_to_contact.py
@@ -25,9 +25,9 @@ class TestContacts(GaiaTestCase):
         contacts_app.launch()
         contacts_app.wait_for_contacts()
 
-        contact_details = contacts_app.contact(self.contact['givenName'][0]).tap()
+        contact_details = contacts_app.contact(self.contact['givenName']).tap()
 
-        full_name = ' '.join([self.contact['givenName'][0], self.contact['familyName'][0]])
+        full_name = ' '.join([self.contact['givenName'], self.contact['familyName']])
 
         self.assertEqual(full_name, contact_details.full_name)
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_call_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_call_contact.py
@@ -14,9 +14,9 @@ class TestContacts(GaiaTestCase):
         GaiaTestCase.setUp(self)
 
         # Seed the contact with the remote phone number so we don't call random people
-        self.contact = MockContact(tel=[{
-            'type': ['Mobile'],
-            'value': "%s" % self.testvars['remote_phone_number']}])
+        self.contact = MockContact(tel={
+            'type': 'Mobile',
+            'value': "%s" % self.testvars['remote_phone_number']})
         self.data_layer.insert_contact(self.contact)
 
     def test_call_contact(self):
@@ -29,7 +29,7 @@ class TestContacts(GaiaTestCase):
         contacts.wait_for_contacts()
 
         # tap on the created contact
-        contact_details = contacts.contact(self.contact['givenName'][0]).tap()
+        contact_details = contacts.contact(self.contact['givenName']).tap()
 
         # tap the phone number and switch to call screen frame
         call_screen = contact_details.tap_phone_number()
@@ -37,10 +37,10 @@ class TestContacts(GaiaTestCase):
         call_screen.wait_for_outgoing_call()
 
         # Check the number displayed is the one we dialed
-        self.assertIn(self.contact['tel'][0]['value'],
+        self.assertIn(self.contact['tel']['value'],
                       call_screen.calling_contact_information)
 
-        self.assertIn(self.contact['givenName'][0],
+        self.assertIn(self.contact['givenName'],
                       call_screen.outgoing_calling_contact)
 
         call_screen.hang_up()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_delete_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_delete_contact.py
@@ -30,7 +30,7 @@ class TestContacts(GaiaTestCase):
         pre_contacts_count = len(contacts_app.contacts)
         self.assertEqual(pre_contacts_count, 1, "Should insert one contact before running this test.")
 
-        contact_item = contacts_app.contact(self.contact['givenName'][0])
+        contact_item = contacts_app.contact(self.contact['givenName'])
         contact_item_detail = contact_item.tap()
         contact_item_edit = contact_item_detail.tap_edit()
         contact_item_edit.tap_delete()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_edit_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_edit_contact.py
@@ -26,34 +26,34 @@ class TestContacts(GaiaTestCase):
         contacts_app.launch()
         contacts_app.wait_for_contacts()
 
-        contact_details = contacts_app.contact(self.contact['givenName'][0]).tap()
+        contact_details = contacts_app.contact(self.contact['givenName']).tap()
 
         edit_contact = contact_details.tap_edit()
 
         # Now we'll update the mock contact and then insert the new values into the UI
-        self.contact['givenName'] = ['gaia%s' % repr(time.time()).replace('.', '')[10:]]
-        self.contact['familyName'] = ["testedit"]
-        self.contact['tel'][0]['value'] = "02011111111"
+        self.contact['givenName'] = 'gaia%s' % repr(time.time()).replace('.', '')[10:]
+        self.contact['familyName'] = "testedit"
+        self.contact['tel']['value'] = "02011111111"
 
         # self.(*self._given_name_locator)
 
-        edit_contact.type_given_name(self.contact['givenName'][0])
-        edit_contact.type_family_name(self.contact['familyName'][0])
-        edit_contact.type_phone(self.contact['tel'][0]['value'])
+        edit_contact.type_given_name(self.contact['givenName'])
+        edit_contact.type_family_name(self.contact['familyName'])
+        edit_contact.type_phone(self.contact['tel']['value'])
 
         contact_details = edit_contact.tap_update()
 
         contact_details.tap_back()
 
         self.assertEqual(len(contacts_app.contacts), 1)
-        self.assertEqual(contacts_app.contacts[0].name, self.contact['givenName'][0])
+        self.assertEqual(contacts_app.contacts[0].name, self.contact['givenName'])
 
-        contact_details = contacts_app.contact(self.contact['givenName'][0]).tap()
+        contact_details = contacts_app.contact(self.contact['givenName']).tap()
 
         # Now assert that the values have updated
-        full_name = self.contact['givenName'][0] + " " + self.contact['familyName'][0]
+        full_name = self.contact['givenName'] + " " + self.contact['familyName']
 
         self.assertEqual(contact_details.full_name,
                          full_name)
         self.assertEqual(contact_details.phone_number,
-                         self.contact['tel'][0]['value'])
+                         self.contact['tel']['value'])

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_sms_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_sms_contact.py
@@ -25,12 +25,12 @@ class TestContacts(GaiaTestCase):
         contacts.wait_for_contacts()
 
         # Tap on the created contact.
-        contact_details = contacts.contact(self.contact['givenName'][0]).tap()
+        contact_details = contacts.contact(self.contact['givenName']).tap()
         new_message = contact_details.tap_send_sms()
         new_message.wait_for_recipients_displayed()
 
-        expected_name = self.contact['givenName'][0] + " " + self.contact['familyName'][0]
-        expected_tel = self.contact['tel'][0]['value']
+        expected_name = self.contact['givenName'] + " " + self.contact['familyName']
+        expected_tel = self.contact['tel']['value']
 
         # Now check the first listed is from contacts app.
         # Name and phone number have been passed in correctly.

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_sort_contacts.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_sort_contacts.py
@@ -17,7 +17,7 @@ class TestContacts(GaiaTestCase):
 
         # insert contacts by given names
         for contact_name in self._contacts_name_list:
-            contact = MockContact(givenName=[contact_name[0]], familyName=[contact_name[1]])
+            contact = MockContact(givenName=contact_name[0], familyName=contact_name[1])
             self.data_layer.insert_contact(contact)
         # prepare the sorted-by-first-name and sorted-by-last-name lists
         self.sorted_contacts_name_by_first = sorted(self._contacts_name_list, key=lambda name: name[0])

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/test_dialer_add_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/test_dialer_add_contact.py
@@ -19,7 +19,7 @@ class TestDialerAddContact(GaiaTestCase):
 
     def test_dialer_add_contact(self):
 
-        number_to_verify = self.contact['tel'][0]['value']
+        number_to_verify = self.contact['tel']['value']
 
         # Dial number
         self.phone.keypad.dial_phone_number(number_to_verify)
@@ -34,8 +34,8 @@ class TestDialerAddContact(GaiaTestCase):
         new_contact = add_new_number.tap_create_new_contact()
 
         # Enter data into fields
-        new_contact.type_given_name(self.contact['givenName'][0])
-        new_contact.type_family_name(self.contact['familyName'][0])
+        new_contact.type_given_name(self.contact['givenName'])
+        new_contact.type_family_name(self.contact['familyName'])
 
         # Click Done button
         new_contact.tap_done()
@@ -54,7 +54,7 @@ class TestDialerAddContact(GaiaTestCase):
         contact_details = contacts.contacts[0].tap()
 
         # Verify full name
-        full_name = self.contact['givenName'][0] + " " + self.contact['familyName'][0]
+        full_name = self.contact['givenName'] + " " + self.contact['familyName']
         self.assertEqual(contact_details.full_name, full_name)
 
         # Verify phone number

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/test_dialer_find_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/test_dialer_find_contact.py
@@ -12,9 +12,9 @@ class TestDialerFindContact(GaiaTestCase):
     def setUp(self):
         GaiaTestCase.setUp(self)
         # Seed the contact with the remote phone number so we don't call random people
-        self.contact = MockContact(tel=[{
-            'type': ['Mobile'],
-            'value': "%s" % self.testvars['remote_phone_number']}])
+        self.contact = MockContact(tel={
+            'type': 'Mobile',
+            'value': "%s" % self.testvars['remote_phone_number']})
         self.data_layer.insert_contact(self.contact)
 
         # launch the Phone app
@@ -23,7 +23,7 @@ class TestDialerFindContact(GaiaTestCase):
 
     def test_dialer_find_contact(self):
 
-        number_to_verify = self.contact['tel'][0]['value']
+        number_to_verify = self.contact['tel']['value']
 
         # Dial number
         self.phone.keypad.dial_phone_number(number_to_verify[:5])
@@ -32,7 +32,7 @@ class TestDialerFindContact(GaiaTestCase):
         self.phone.keypad.wait_for_search_popup_visible()
 
         # Assert name and phone number are the ones in the saved contact
-        self.assertEqual(self.phone.keypad.suggested_name, self.contact['name'][0])
+        self.assertEqual(self.phone.keypad.suggested_name, self.contact['name'])
         self.assertEqual(self.phone.keypad.suggested_phone_number, number_to_verify)
 
         # Tap search popup suggestion

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard.py
@@ -19,7 +19,7 @@ class TestKeyboard(GaiaTestCase):
         contacts_app.launch()
 
         new_contact_form = contacts_app.tap_new_contact()
-        new_contact_form.type_phone(contact['tel'][0]['value'])
+        new_contact_form.type_phone(contact['tel']['value'])
         new_contact_form.type_comment('')
 
         # initialize the keyboard app

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_add_contact.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_add_contact.py
@@ -17,9 +17,9 @@ class TestSmsAddContact(GaiaTestCase):
         _text_message_content = "Automated Test %s" % str(time.time())
 
         # insert contact
-        self.contact = MockContact(tel=[{
-            'type': ['Mobile'],
-            'value': '555%s' % repr(time.time()).replace('.', '')[8:]}])
+        self.contact = MockContact(tel={
+            'type': 'Mobile',
+            'value': '555%s' % repr(time.time()).replace('.', '')[8:]})
         self.data_layer.insert_contact(self.contact)
 
         self.messages = Messages(self.marionette)
@@ -29,14 +29,14 @@ class TestSmsAddContact(GaiaTestCase):
         contacts_app = new_message.tap_add_recipient()
         contacts_app.wait_for_contacts()
 
-        contacts_app.contact(self.contact['givenName'][0]).tap(return_details=False)
+        contacts_app.contact(self.contact['givenName']).tap(return_details=False)
         contacts_app.wait_for_contacts_frame_to_close()
 
         # Now switch to the displayed frame which should be Messages app
         self.apps.switch_to_displayed_app()
 
-        self.assertIn(self.contact['givenName'][0], new_message.first_recipient_name)
-        self.assertEquals(self.contact['tel'][0]['value'], new_message.first_recipient_number_attribute)
+        self.assertIn(self.contact['givenName'], new_message.first_recipient_name)
+        self.assertEquals(self.contact['tel']['value'], new_message.first_recipient_number_attribute)
 
         new_message.type_message(_text_message_content)
         self.assertTrue(new_message.is_send_button_enabled)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_contact_match.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/messages/test_sms_contact_match.py
@@ -14,8 +14,8 @@ class TestContactMatch(GaiaTestCase):
     def test_contact_match(self):
 
         # insert contact
-        self.contact = MockContact(tel=[{
-            'value': '555%s' % repr(time.time()).replace('.', '')[8:]}])
+        self.contact = MockContact(tel={
+            'value': '555%s' % repr(time.time()).replace('.', '')[8:]})
         self.data_layer.insert_contact(self.contact)
 
         # launch Messages app
@@ -24,10 +24,10 @@ class TestContactMatch(GaiaTestCase):
 
         new_message = self.messages.tap_create_new_message()
         keyboard = new_message.tap_recipient_section()
-        keyboard.send(self.contact['name'][0])
+        keyboard.send(self.contact['name'])
         keyboard.tap_enter()
 
         # verify that contacts and tel number match
-        self.assertEqual(self.contact['name'][0], new_message.first_recipient_name)
-        self.assertEqual(self.contact['tel'][0]['value'], new_message.first_recipient_number_attribute)
+        self.assertEqual(self.contact['name'], new_message.first_recipient_name)
+        self.assertEqual(self.contact['tel']['value'], new_message.first_recipient_number_attribute)
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_contacts.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/unit/test_contacts.py
@@ -8,6 +8,18 @@ from gaiatest.mocks.mock_contact import MockContact
 
 class TestContacts(GaiaTestCase):
 
+    def test_create_mozcontact(self):
+        # Initialize a MockContact with the default properties
+        contact = MockContact()
+
+        # Add a list of object properties - multiple telephone numbers
+        contact['objects'] = [contact['tel'], contact['tel']]
+
+        mozcontact = contact.create_mozcontact()
+        for key in mozcontact.iterkeys():
+            self.assertFalse(contact.is_mozcontact_api_format(contact[key]))
+            self.assertTrue(contact.is_mozcontact_api_format(mozcontact[key]))
+
     def test_and_remove_contact(self):
         self.data_layer.insert_contact(MockContact())
         self.assertEqual(len(self.data_layer.all_contacts), 1)


### PR DESCRIPTION
As described on the bugzilla page, this accomplishes the following:
1. Revert mock_contact.py back to Python [1]
2. Add to mock_contact.py a method to output to mozContact API friendly format [2]
3. In GaiaData.insert_contact , convert the contact to mozContact API friendly format before passing it into the javascript atom
4. Update all functional and endurance tests to use the revised mock_contact.py
