### PR TITLE
Bug 961938 - [DSDS][MMS] Switching data confirmation message will pop up twice

### DIFF
--- a/apps/sms/js/settings.js
+++ b/apps/sms/js/settings.js
@@ -76,5 +76,22 @@ var Settings = {
       'ril.mms.defaultServiceId': id,
       'ril.data.defaultServiceId': id
     });
+  },
+
+  switchSimHandler: function switchSimHandler(targetId, callback) {
+    var conn = window.navigator.mozMobileConnections[targetId];
+    if (conn && conn.data.state !== 'registered') {
+      // Listen to MobileConnections datachange to make sure we can start
+      // to retrieve mms only when data.state is registered. But we can't
+      // guarantee datachange event will work in other device.
+      conn.addEventListener('datachange', function onDataChange() {
+        if (conn.data.state === 'registered') {
+          conn.removeEventListener('datachange', onDataChange);
+          callback();
+        }
+      });
+
+      this.setSimServiceId(targetId);
+    }
   }
 };

--- a/apps/sms/test/unit/mock_settings.js
+++ b/apps/sms/test/unit/mock_settings.js
@@ -4,6 +4,9 @@
 var MockSettings = {
   mmsSizeLimitation: 300 * 1024,
   mmsServiceId: 0,
+  nonActivateMmsServiceIds: [1],
+  setSimServiceId: function() {},
+  switchSimHandler: function() {},
 
   mSetup: function() {
     MockSettings.mmsSizeLimitation = 300 * 1024;

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -5,7 +5,7 @@
          MockActivityPicker, Threads, Settings, MockMessages, MockUtils,
          MockContacts, ActivityHandler, Recipients, MockMozActivity,
          ThreadListUI, ContactRenderer, UIEvent, Drafts, OptionMenu,
-         ActivityPicker, KeyEvent */
+         ActivityPicker, KeyEvent, MockNavigatorSettings */
 
 'use strict';
 
@@ -2477,6 +2477,11 @@ suite('thread_ui.js >', function() {
 
         setup(function() {
           localize.reset();
+          if (!('mozSettings' in navigator)) {
+           navigator.mozSettings = null;
+          }
+
+          this.sinon.stub(navigator, 'mozSettings', MockNavigatorSettings);
           showMessageErrorSpy = this.sinon.spy(ThreadUI, 'showMessageError');
           ThreadUI.handleMessageClick({
             target: button
@@ -2532,6 +2537,15 @@ suite('thread_ui.js >', function() {
             assert.equal(opts.messageId, message.id);
             assert.isTrue(!!opts.confirmHandler);
             assert.equal(MockErrorDialog.prototype.show.called, true);
+          });
+
+          test('confirmHandler called with correct state', function() {
+            this.sinon.spy(Settings, 'switchSimHandler');
+            MockErrorDialog.calls[0][1].confirmHandler();
+            assert.isTrue(element.classList.contains('pending'));
+            assert.isFalse(element.classList.contains('error'));
+            sinon.assert.calledWith(localize, button, 'downloading');
+            sinon.assert.called(Settings.switchSimHandler);
           });
         });
         suite('response error with other errorCode', function() {


### PR DESCRIPTION
- Utilize mozMobileConnections ondatachange event to retrieve mms at the proper timing.
