### PR TITLE
Bug 963039 - [B2G][Settings] Developer settings are too hard to access

### DIFF
--- a/apps/settings/elements/about_more_info.html
+++ b/apps/settings/elements/about_more_info.html
@@ -72,12 +72,9 @@
       </header>
       <ul>
         <li>
-          <label>
-            <button class="icon icon-view"
-                    data-href="#about-moreInfo-developer"
-                    data-l10n-id="developer">
-              Developer
-            </button>
+          <label class="pack-checkbox">
+            <input type="checkbox" name="developer.menu.enabled">
+            <span data-l10n-id="developer-menu">Developer menu</span>
           </label>
         </li>
       </ul>

--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -1,10 +1,8 @@
-<element name="about-moreInfo-developer" extends="section">
+<element name="developer" extends="section">
   <template>
 
     <header>
-      <button type="reset">
-        <span data-l10n-id="back" class="icon icon-back">Back</span>
-      </button>
+      <a href="#root"><span class="icon icon-back">Back</span></a>
       <h1 data-l10n-id="developer-header"> Developer </h1>
     </header>
 
@@ -13,12 +11,6 @@
         <h2 data-l10n-id="debug">Debug</h2>
       </header>
       <ul>
-        <li>
-          <label class="pack-checkbox">
-            <input type="checkbox" name="developer.menu.enabled">
-            <span data-l10n-id="developer-menu">Developer menu</span>
-          </label>
-        </li>
         <li>
           <label class="pack-checkbox">
             <input type="checkbox" name="debug.grid.enabled">
@@ -163,7 +155,7 @@
       </ul>
     </div>
 
-    <script src="js/about_more_info_developer.js"></script>
+    <script src="js/developer.js"></script>
 
   </template>
 </element>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -133,7 +133,6 @@
     <link rel="import" href="/elements/app_permissions_details.html">
     <link rel="import" href="/elements/app_permissions.html">
     <link rel="import" href="/elements/do_not_track.html">
-    <link rel="import" href="/elements/about_more_info_developer.html">
     <link rel="import" href="/elements/about_more_info.html">
     <link rel="import" href="/elements/about_your_rights.html">
     <link rel="import" href="/elements/about_your_privacy.html">
@@ -145,6 +144,7 @@
     <link rel="import" href="/elements/application_storage.html">
     <link rel="import" href="/elements/media_storage.html">
     <link rel="import" href="/elements/accessibility.html">
+    <link rel="import" href="/elements/developer.html">
     <link rel="import" href="/elements/crash_reports.html">
     <link rel="import" href="/elements/improve_browser_os_send_feedback.html">
     <link rel="import" href="/elements/improve_browser_os_choose_feedback.html">
@@ -282,8 +282,6 @@
     <!-- Security :: Do Not Track -->
     <section is="doNotTrack" role="region" id="doNotTrack"></section>
 
-    <!-- Device :: Information :: More Information :: Developer -->
-    <section is="about-moreInfo-developer" role="region" id="about-moreInfo-developer"></section>
     <!-- Device :: Information :: More Information -->
     <section is="about-moreInfo" role="region" id="about-moreInfo"></section>
     <!-- Device :: Information :: Your Rights -->
@@ -308,6 +306,8 @@
     <section is="mediaStorage" role="region" id="mediaStorage"></section>
     <!-- Device :: Accessibility -->
     <section is="accessibility" role="region" id="accessibility"></section>
+    <!-- Device :: Developer -->
+    <section is="developer" role="region" id="developer"></section>
     <!-- Device :: Improve Browser OS :: Crash Reports-->
     <section is="crashReports" role="region" id="crashReports"></section>
     <!-- Device :: Send Feedback -->
@@ -485,8 +485,11 @@
             <small id="battery-desc" class="menu-item-desc"></small>
             <a id="menuItem-battery" class="menu-item" href="#battery" data-l10n-id="battery">Battery</a>
           </li>
-          <li hidden="">
+          <li hidden>
             <a id="menuItem-accessibility" class="menu-item" href="#accessibility" data-l10n-id="accessibility">Accessibility</a>
+          </li>
+          <li hidden>
+            <a id="menuItem-developer" class="menu-item" href="#developer" data-l10n-id="developer">Developer</a>
           </li>
           <li>
             <a id="menuItem-improveBrowserOS" class="menu-item" href="#improveBrowserOS" data-l10n-id="improveBrowserOS">Improve Browser OS</a>

--- a/apps/settings/js/developer.js
+++ b/apps/settings/js/developer.js
@@ -1,6 +1,8 @@
+/* global ScreenLayout, Settings */
+
 'use strict';
 
-var AboutMoreInfoDev = {
+var Developer = {
 
   init: function about_init() {
     document.getElementById('ftuLauncher').onclick = this.launchFTU;
@@ -9,15 +11,17 @@ var AboutMoreInfoDev = {
     if (!ScreenLayout.getCurrentLayout('hardwareHomeButton')) {
       document.getElementById('software-home-button').style.display = 'none';
       // always set homegesture enabled on tablet, so hide the setting
-      if (!ScreenLayout.getCurrentLayout('tiny'))
+      if (!ScreenLayout.getCurrentLayout('tiny')) {
         document.getElementById('homegesture').style.display = 'none';
+      }
     }
   },
 
   launchFTU: function about_launchFTU() {
     var settings = Settings.mozSettings;
-    if (!settings)
+    if (!settings) {
       return;
+    }
 
     var key = 'ftu.manifestURL';
     var req = settings.createLock().get(key);
@@ -52,4 +56,4 @@ var AboutMoreInfoDev = {
   }
 };
 
-navigator.mozL10n.ready(AboutMoreInfoDev.init.bind(AboutMoreInfoDev));
+navigator.mozL10n.ready(Developer.init.bind(Developer));

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -252,7 +252,7 @@ var Settings = {
       return;
     }
 
-    // hide telephony related entries if not supportted
+    // hide telephony related entries if not supported
     if (!navigator.mozTelephony) {
       var elements = ['call-settings',
                       'data-connectivity',
@@ -839,6 +839,14 @@ window.addEventListener('load', function loadSettings() {
       'js/telephony_items_handler.js'
     ], function() {
       TelephonySettingHelper.init();
+
+      // show the developer menu only when enabled
+      SettingsListener.observe('developer.menu.enabled', false,
+        function(value) {
+          var item = document.getElementById('menuItem-developer');
+          item.parentElement.hidden = !value;
+        }
+      );
     });
   });
 

--- a/apps/settings/style/icons.css
+++ b/apps/settings/style/icons.css
@@ -141,6 +141,10 @@ li:active:not([aria-disabled="true"]) .menu-item::before,
   background-position: -6rem -12rem;
 }
 
+#menuItem-developer::before {
+  background-position: -6rem -12rem;
+}
+
 #menuItem-improveBrowserOS::before {
   background-position: -3rem -15rem;
 }

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -877,7 +877,6 @@ apps/search/test/unit/search_test.js
 apps/setringtone/js/share.js
 apps/settings/js/about.js
 apps/settings/js/about_more_info.js
-apps/settings/js/about_more_info_developer.js
 apps/settings/js/airplane_mode.js
 apps/settings/js/app_storage.js
 apps/settings/js/apps.js


### PR DESCRIPTION
- Move the developer settings from `Settings > Device Information > More Information > Developer` to `Settings > Developer`.
- Show/hide the developer settings depending on the `Settings > Device Information > More Information > Developer menu` checkbox (pref `developer.menu.enabled`).

FIXME:
- Developer menu shouldn't have the same icon as Accessibility.
- Tests?
