### PR TITLE
Bug 962451 - [email] Start from activity, tap back from compose/message reader, empty message list

### DIFF
--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -229,6 +229,23 @@ function MessageListCard(domNode, mode, args) {
 
   this.onCurrentMessage = this.onCurrentMessage.bind(this);
   headerCursor.on('currentMessage', this.onCurrentMessage);
+
+  // If this card is created after header_cursor is set up
+  // with a messagesSlice, then need to bootstrap this card
+  // to catch up, since the normal events will not fire.
+  // Common scenarios for this case are: going back to the
+  // message list after reading a message from a notification,
+  // or from a compose triggered from an activity. However,
+  // only do this if there is a current folder. A case
+  // where there is not a folder: after deleting an account,
+  // and the UI is bootstrapping back to existing account.
+  if (this.curFolder) {
+    var items = headerCursor.messagesSlice && headerCursor.messagesSlice.items;
+    if (items && items.length) {
+      this.messages_splice(0, 0, items);
+      this.messages_complete(0);
+    }
+  }
 }
 MessageListCard.prototype = {
   /**


### PR DESCRIPTION
The comment in the code change has most of the details. The main issue: the message_list card is created after header_cursor already has a folder and a messages slice, so the message_list card will not get any event notifications of the existing messages slice data.

I had thought about triggering this sort of manual update in [mail_app's Cards.pushDefaultCard implementation](https://github.com/mozilla-b2g/gaia/blob/d425a84fd2b92389d4daaff8f57d8f5f54ef35bc/apps/email/js/mail_app.js#L107), but feel it is better if message_list is self-contained, and can generate its view without needing an exterior kick.

In my fancy future ideal, header_cursor would know to replay events for any new subscribers so that this sort of manual bootstrapping is not required, but that requires more thought, and may be more appropriate to consider as part of [bug 937959](https://bugzilla.mozilla.org/show_bug.cgi?id=937959), or may be invalidated by that work.
