### PR TITLE
Bug 943227 - Stop using emergencyCallsOnly attribute r=alive

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -526,7 +526,6 @@ var StatusBar = {
         if (simslot.isAbsent()) {
           // no SIM
           delete icon.dataset.level;
-          delete icon.dataset.emergency;
           delete icon.dataset.searching;
           delete icon.dataset.roaming;
         } else if (data && data.connected && data.type.startsWith('evdo')) {
@@ -535,23 +534,20 @@ var StatusBar = {
           icon.dataset.level = Math.ceil(data.relSignalStrength / 20); // 0-5
           icon.dataset.roaming = data.roaming;
 
-          delete icon.dataset.emergency;
           delete icon.dataset.searching;
         } else if (voice.connected || self.hasActiveCall()) {
           // "Carrier" / "Carrier (Roaming)"
           icon.dataset.level = Math.ceil(voice.relSignalStrength / 20); // 0-5
           icon.dataset.roaming = voice.roaming;
 
-          delete icon.dataset.emergency;
           delete icon.dataset.searching;
         } else {
           // "No Network" / "Emergency Calls Only (REASON)" / trying to connect
           icon.dataset.level = -1;
-          // logically, we should have "&& !voice.connected" as well but we
-          // already know this.
-          icon.dataset.searching = (!voice.emergencyCallsOnly &&
-                                    voice.state !== 'notSearching');
-          icon.dataset.emergency = (voice.emergencyCallsOnly);
+          // emergencyCallsOnly is always true if voice.connected is false. Show
+          // searching icon if the device is searching. Or show the signal bars
+          // with a red "x", which stands for emergency calls only.
+          icon.dataset.searching = (voice.state === 'searching');
           delete icon.dataset.roaming;
         }
       }

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -312,7 +312,6 @@ body:not(.rb-enabled) #statusbar-icons > .sb-start {
   background-position: -2.1rem -4rem;
 }
 
-.sb-icon-signal[data-emergency="true"],
 .sb-icon-signal[data-level="0"] {
   background-position: -4.2rem -4rem;
 }

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -264,7 +264,6 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             assert.notEqual(dataset.roaming, 'true');
-            assert.notEqual(dataset.emergency, 'true');
             assert.isUndefined(dataset.level);
             assert.notEqual(dataset.searching, 'true');
           });
@@ -286,7 +285,6 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             assert.notEqual(dataset.roaming, 'true');
-            assert.notEqual(dataset.emergency, 'true');
             assert.isUndefined(dataset.level);
             assert.notEqual(dataset.searching, 'true');
           });
@@ -308,7 +306,6 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             assert.notEqual(dataset.roaming, 'true');
-            assert.notEqual(dataset.emergency, 'true');
             assert.equal(dataset.level, -1);
             assert.notEqual(dataset.searching, 'true');
           });
@@ -330,7 +327,6 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             assert.notEqual(dataset.roaming, 'true');
-            assert.notEqual(dataset.emergency, 'true');
             assert.equal(dataset.level, -1);
             assert.equal(dataset.searching, 'true');
           });
@@ -352,7 +348,6 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             assert.notEqual(dataset.roaming, 'true');
-            assert.notEqual(dataset.emergency, 'true');
             assert.isUndefined(dataset.level);
             assert.notEqual(dataset.searching, 'true');
           });
@@ -374,7 +369,6 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             assert.notEqual(dataset.roaming, 'true');
-            assert.equal(dataset.emergency, 'true');
             assert.equal(dataset.level, '-1');
             assert.notEqual(dataset.searching, 'true');
           });
@@ -401,7 +395,6 @@ suite('system/Statusbar', function() {
 
             assert.notEqual(dataset.roaming, 'true');
             assert.equal(dataset.level, 4);
-            assert.notEqual(dataset.emergency, 'true');
             assert.notEqual(dataset.searching, 'true');
           });
 
@@ -427,7 +420,6 @@ suite('system/Statusbar', function() {
 
             assert.notEqual(dataset.roaming, 'true');
             assert.equal(dataset.level, 4);
-            assert.notEqual(dataset.emergency, 'true');
             assert.notEqual(dataset.searching, 'true');
           });
 
@@ -459,7 +451,6 @@ suite('system/Statusbar', function() {
 
             assert.notEqual(dataset.roaming, 'true');
             assert.equal(dataset.level, 4);
-            assert.notEqual(dataset.emergency, 'true');
             assert.notEqual(dataset.searching, 'true');
           });
 
@@ -481,7 +472,6 @@ suite('system/Statusbar', function() {
 
             assert.notEqual(dataset.roaming, 'true');
             assert.equal(dataset.level, 4);
-            assert.notEqual(dataset.emergency, 'true');
             assert.notEqual(dataset.searching, 'true');
           });
 
@@ -503,7 +493,6 @@ suite('system/Statusbar', function() {
 
             assert.equal(dataset.roaming, 'true');
             assert.equal(dataset.level, 4);
-            assert.notEqual(dataset.emergency, 'true');
             assert.notEqual(dataset.searching, 'true');
           });
 
@@ -525,7 +514,6 @@ suite('system/Statusbar', function() {
 
             assert.notEqual(dataset.roaming, 'true');
             assert.equal(dataset.level, -1);
-            assert.equal(dataset.emergency, 'true');
             assert.notEqual(dataset.searching, 'true');
           });
 


### PR DESCRIPTION
http://bugzilla.mozilla.org/show_bug.cgi?id=943227
