### PR TITLE
Bug 964280 - Add option to override b2g start timeout duration

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -754,7 +754,7 @@ class GaiaDevice(object):
         time.sleep(2)
         self.start_b2g()
 
-    def start_b2g(self, start_timeout=60000):
+    def start_b2g(self, timeout=60000):
         if self.marionette.instance:
             # launch the gecko instance attached to marionette
             self.marionette.instance.start()
@@ -771,7 +771,7 @@ window.addEventListener('mozbrowserloadend', function loaded(aEvent) {
     window.removeEventListener('mozbrowserloadend', loaded);
     marionetteScriptFinished();
   }
-});""", script_timeout=start_timeout)
+});""", script_timeout=timeout)
             # TODO: Remove this sleep when Bug 924912 is addressed
             time.sleep(5)
         self.marionette.import_script(self.lockscreen_atom)

--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -754,7 +754,7 @@ class GaiaDevice(object):
         time.sleep(2)
         self.start_b2g()
 
-    def start_b2g(self):
+    def start_b2g(self, start_timeout=60000):
         if self.marionette.instance:
             # launch the gecko instance attached to marionette
             self.marionette.instance.start()
@@ -771,7 +771,7 @@ window.addEventListener('mozbrowserloadend', function loaded(aEvent) {
     window.removeEventListener('mozbrowserloadend', loaded);
     marionetteScriptFinished();
   }
-});""", script_timeout=60000)
+});""", script_timeout=start_timeout)
             # TODO: Remove this sleep when Bug 924912 is addressed
             time.sleep(5)
         self.marionette.import_script(self.lockscreen_atom)


### PR DESCRIPTION
Add the option to override the b2g start timeout duration. Ultimately this is for b2gpopulate as the emulator can be very slow starting up. This is the gaiatest part of the change.
