### PR TITLE
Bug 941030 - Merge pull request #14653 from fcampo/mms-forward-subject-941030

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -1,7 +1,7 @@
 /* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-/*global Settings, Utils, Attachment, AttachmentMenu, MozActivity */
+/*global Settings, Utils, Attachment, AttachmentMenu, MozActivity, SMIL */
 /*exported Compose */
 
 'use strict';
@@ -44,25 +44,46 @@ var Compose = (function() {
   };
 
   var subject = {
-    showing: false,
+    isVisible: false,
     toggle: function sub_toggle() {
-      dom.subject.classList.toggle('hide');
-      // show / hide subject and change the focus
-      (this.showing = !this.showing) ?
-        dom.subject.focus() : dom.message.focus();
+      this.isVisible ? this.hide() : this.show();
+    },
+    show: function sub_show() {
+      dom.subject.classList.remove('hide');
+      this.isVisible = true;
+      dom.subject.focus();
+      Compose.updateType();
+      onContentChanged();
+    },
+    hide: function sub_hide() {
+      dom.subject.classList.add('hide');
+      this.isVisible = false;
+      dom.message.focus();
       Compose.updateType();
       onContentChanged();
     },
     clear: function sub_clear() {
       dom.subject.value = '';
       dom.subject.classList.add('hide');
-      this.showing = false;
+      this.isVisible = false;
+    },
+    getContent: function sub_getContent() {
+      // Only send value if subject is showing. If not, send empty string
+      // We need to transform any linebreak or into a single space
+      return subject.isShowing ?
+             dom.subject.value.replace(/\n\s*/g, ' ') : '';
+    },
+    setContent: function sub_setContent(content) {
+      dom.subject.value = content;
+    },
+    getMaxLength: function sub_getMaxLength() {
+      return dom.subject.maxLength;
     },
     get isEmpty() {
       return !dom.subject.value.length;
     },
     get isShowing() {
-      return this.showing;
+      return this.isVisible;
     }
   };
 
@@ -273,17 +294,6 @@ var Compose = (function() {
       }
     },
 
-    toggleSubject: function() {
-      subject.toggle();
-    },
-
-    getSubject: function() {
-      // Only send value if subject is showing. If not, send empty string
-      // We need to transform any linebreak or into a single space
-      return subject.isShowing ?
-               dom.subject.value.replace(/\n\s*/g, ' ') : '';
-    },
-
     getContent: function() {
       var content = [];
       var node;
@@ -323,6 +333,48 @@ var Compose = (function() {
       }
 
       return content;
+    },
+
+    getSubject: function() {
+      return subject.getContent();
+    },
+
+    toggleSubject: function() {
+      subject.toggle();
+    },
+
+    /** Render message (sms or mms)
+     *
+     * @param {message} message Full message to be loaded into the composer.
+     *
+     */
+    fromMessage: function(message) {
+      this.clear();
+
+      if (message.type === 'mms') {
+        if (message.subject) {
+          subject.setContent(message.subject);
+          subject.show();
+        }
+        SMIL.parse(message, function(elements) {
+          elements.forEach(function(element) {
+            if (element.blob) {
+              var attachment = new Attachment(element.blob, {
+                name: element.name,
+                isDraft: true
+              });
+              this.append(attachment);
+            }
+            if (element.text) {
+              this.append(element.text);
+            }
+          }, Compose);
+        });
+      } else {
+        this.append(message.body);
+      }
+
+      this.focus();
     },
 
     getText: function() {
@@ -603,15 +655,15 @@ var Compose = (function() {
     }
   });
 
-  Object.defineProperty(compose, 'SUBJECT_MAX_LENGTH', {
-    get: function composeGetSubjectMaxLength() {
-      return 40;
+  Object.defineProperty(compose, 'isSubjectVisible', {
+    get: function composeGetResizeState() {
+      return subject.isShowing;
     }
   });
 
-  Object.defineProperty(compose, 'isSubjectShowing', {
-    get: function composeGetSubjectShowing() {
-      return subject.isShowing;
+  Object.defineProperty(compose, 'subjectMaxLength', {
+    get: function composeGetResizeState() {
+      return subject.getMaxLength();
     }
   });
 

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -2,7 +2,7 @@
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 /*global ThreadListUI, ThreadUI, Threads, SMIL, MozSmsFilter, Compose,
-         Utils, LinkActionHandler, Contacts, Attachment */
+         Utils, LinkActionHandler, Contacts */
 /*exported MessageManager */
 
 'use strict';
@@ -148,26 +148,8 @@ var MessageManager = {
     var request = MessageManager.getMessage(+forward.messageId);
 
     request.onsuccess = (function() {
-      var message = request.result;
-      if (message.type === 'sms') {
-        ThreadUI.setMessageBody(message.body);
-      } else {
+      Compose.fromMessage(request.result);
 
-        SMIL.parse(message, function(parsedArray) {
-          parsedArray.forEach(function(mmsElement) {
-            if (mmsElement.blob) {
-              var attachment = new Attachment(mmsElement.blob, {
-                name: mmsElement.name,
-                isDraft: true
-              });
-              Compose.append(attachment);
-            }
-            if (mmsElement.text) {
-              Compose.append(mmsElement.text);
-            }
-          });
-        });
-      }
       // Focus en recipients
       ThreadUI.recipients.focus();
     }).bind(this);
@@ -205,7 +187,7 @@ var MessageManager = {
         findByPhoneNumber, number, function onData(data) {
           data.source = 'contacts';
           ThreadUI.recipients.add(data);
-          ThreadUI.setMessageBody(activity.body);
+          Compose.fromMessage(activity);
         }
       );
     } else {
@@ -217,7 +199,7 @@ var MessageManager = {
           source: 'manual'
         });
       }
-      ThreadUI.setMessageBody(activity.body);
+      Compose.fromMessage(activity);
     }
 
     // Clean activity object

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -398,15 +398,6 @@ var ThreadUI = global.ThreadUI = {
     }
   },
 
-  // Method for setting the body of a SMS/MMS from activity
-  setMessageBody: function thui_setMessageBody(value) {
-    Compose.clear();
-    if (value) {
-      Compose.append(value);
-    }
-    Compose.focus();
-  },
-
   messageComposerInputHandler: function thui_messageInputHandler(event) {
     this.updateSubjectHeight();
     this.updateElementsHeight();
@@ -442,12 +433,13 @@ var ThreadUI = global.ThreadUI = {
     Compose.updateType();
     // Handling user warning for max character reached
     // Only show the warning when the subject field has the focus
-    if (this.subjectInput.value.length === Compose.SUBJECT_MAX_LENGTH) {
+    if (this.subjectInput.value.length === Compose.subjectMaxLength) {
       this.showMaxLengthNotice('messages-max-subject-length-text');
     } else {
       this.hideMaxLengthNotice();
     }
   },
+
   onSubjectBlur: function thui_onSubjectBlur() {
     this.hideMaxLengthNotice();
   },
@@ -1546,7 +1538,7 @@ var ThreadUI = global.ThreadUI = {
 
     // Subject management
     params.items.push({
-      l10nId: Compose.isSubjectShowing ? 'remove-subject' : 'add-subject',
+      l10nId: Compose.isSubjectVisible ? 'remove-subject' : 'add-subject',
       method: function tSubject() {
         Compose.toggleSubject();
         ThreadUI.updateSubjectHeight();

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -1,8 +1,4 @@
-/*
-  Compose Tests
-*/
-
-/*global MocksHelper, MockAttachment, MockL10n, loadBodyHTML,
+/* global MocksHelper, MockAttachment, MockL10n, loadBodyHTML,
          Compose, Attachment, MockMozActivity, Settings, Utils,
          AttachmentMenu */
 
@@ -96,17 +92,29 @@ suite('compose_test.js', function() {
         Compose.clear();
       });
 
-      test('Toggle change the visibility', function() {
+      test('Toggle field', function() {
         assert.isTrue(subject.classList.contains('hide'));
+        // Show
         Compose.toggleSubject();
         assert.isFalse(subject.classList.contains('hide'));
+        // Hide
         Compose.toggleSubject();
         assert.isTrue(subject.classList.contains('hide'));
       });
 
+      test('Get content from subject field', function() {
+        var content = 'Title';
+        subject.value = content;
+        // We need to show the subject to get content
+        Compose.toggleSubject();
+        assert.equal(Compose.getSubject(), content);
+      });
+
       test('Sent subject doesnt have line breaks (spaces instead)', function() {
+        // Set the value
         subject.value = 'Line 1\nLine 2\n\n\n\nLine 3';
-        Compose.toggleSubject(); // we need to show the subject to get content
+        // We need to show the subject to get content
+        Compose.toggleSubject();
         var text = Compose.getSubject();
         assert.equal(text, 'Line 1 Line 2 Line 3');
       });

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -276,7 +276,7 @@ suite('message_manager.js >', function() {
 
     setup(function() {
       ThreadUI.initRecipients();
-      this.sinon.stub(ThreadUI, 'setMessageBody');
+      this.sinon.spy(Compose, 'fromMessage');
       MessageManager.threadMessages = document.createElement('div');
     });
 
@@ -293,7 +293,7 @@ suite('message_manager.js >', function() {
 
       assert.equal(ThreadUI.recipients.numbers.length, 1);
       assert.equal(ThreadUI.recipients.numbers[0], '998');
-      assert.ok(ThreadUI.setMessageBody.calledWith());
+      assert.ok(Compose.fromMessage.calledWith(activity));
     });
 
     test('from activity with known contact', function() {
@@ -304,7 +304,7 @@ suite('message_manager.js >', function() {
 
       assert.equal(ThreadUI.recipients.numbers.length, 1);
       assert.equal(ThreadUI.recipients.numbers[0], '+346578888888');
-      assert.ok(ThreadUI.setMessageBody.calledWith());
+      assert.ok(Compose.fromMessage.calledWith(activity));
     });
 
     test('with message body', function() {
@@ -314,7 +314,7 @@ suite('message_manager.js >', function() {
         body: 'test'
       };
       MessageManager.handleActivity(activity);
-      assert.ok(ThreadUI.setMessageBody.calledWith('test'));
+      assert.ok(Compose.fromMessage.calledWith(activity));
     });
 
     test('No contact and no number', function() {
@@ -325,27 +325,27 @@ suite('message_manager.js >', function() {
       };
       MessageManager.handleActivity(activity);
       assert.equal(ThreadUI.recipients.numbers.length, 0);
-      assert.ok(ThreadUI.setMessageBody.calledWith('Youtube url'));
+      assert.ok(Compose.fromMessage.calledWith(activity));
     });
   });
 
   suite('handleForward() >', function() {
-
+    var message;
     setup(function() {
-      this.sinon.spy(ThreadUI, 'setMessageBody');
-      this.sinon.spy(Compose, 'append');
+      this.sinon.spy(Compose, 'fromMessage');
       this.sinon.stub(MessageManager, 'getMessage', function(id) {
-        var result;
         switch (id) {
           case 1:
-            result = MockMessages.sms();
+            message = MockMessages.sms();
             break;
           case 2:
-            result = MockMessages.mms();
+            message = MockMessages.mms();
             break;
+          case 3:
+            message = MockMessages.mms({subject: 'Title'});
         }
         var request = {
-          result: result,
+          result: message,
           set onsuccess(cb) {
             cb();
           },
@@ -368,7 +368,7 @@ suite('message_manager.js >', function() {
       MessageManager.handleForward(forward);
       assert.ok(MessageManager.getMessage.calledOnce);
       assert.ok(MessageManager.getMessage.calledWith(1));
-      assert.ok(ThreadUI.setMessageBody.called);
+      assert.ok(Compose.fromMessage.called);
     });
 
     test(' forward MMS with attachment', function() {
@@ -378,8 +378,17 @@ suite('message_manager.js >', function() {
       MessageManager.handleForward(forward);
       assert.ok(MessageManager.getMessage.calledOnce);
       assert.ok(MessageManager.getMessage.calledWith(2));
-      assert.isFalse(ThreadUI.setMessageBody.called);
-      assert.ok(Compose.append.called);
+      assert.isTrue(Compose.fromMessage.calledWith(message));
+    });
+
+    test(' forward MMS with subject', function() {
+      var forward = {
+        messageId: 3
+      };
+      MessageManager.handleForward(forward);
+      assert.ok(MessageManager.getMessage.calledOnce);
+      assert.ok(MessageManager.getMessage.calledWith(3));
+      assert.isTrue(Compose.fromMessage.calledWith(message));
     });
   });
 

--- a/apps/sms/test/unit/mock_compose.js
+++ b/apps/sms/test/unit/mock_compose.js
@@ -3,25 +3,39 @@
 'use strict';
 
 var MockCompose = {
-  clear: function() {
-    this.mEmpty = true;
-  },
-
-  focus: function() {},
-
-  append: function(aContent) {
-    this.mEmpty = false;
-  },
-
+  init: function() {},
+  on: function(type, handler) {},
+  off: function(type, handler) {},
+  clearListeners: function() {},
+  getContent: function() {},
+  getText: function() {},
   isEmpty: function() {
     return this.mEmpty;
   },
+  disable: function(state) {},
+  scrollToTarget: function(target) {},
+  scrollMessageContent: function() {},
+  prepend: function(item) {},
+  append: function(aContent) {
+    this.mEmpty = false;
+  },
+  clear: function() {
+    this.mEmpty = true;
+  },
+  focus: function() {},
+  updateType: function() {},
 
-  getText: function() {},
+  getSubject: function() {},
+  toggleSubject: function() {},
+  fromMessage: function() {},
 
   mEmpty: true,
+  mSubjectEmpty: true,
+  mSubjectShowing: false,
 
   mSetup: function() {
     this.mEmpty = true;
+    this.mSubjectEmpty = true;
+    this.mSubjectShowing = false;
   }
 };

--- a/apps/sms/test/unit/mock_thread_ui.js
+++ b/apps/sms/test/unit/mock_thread_ui.js
@@ -25,7 +25,6 @@ var MockThreadUI = {
   resetActivityRequestMode: function() {},
   getAllInputs: function() {},
   getSelectedInputs: function() {},
-  setMessageBody: function() {},
   messageComposerInputHandler: function() {},
   assimilateRecipients: function() {},
   messageComposerTypeHandler: function() {},

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3767,52 +3767,6 @@ suite('thread_ui.js >', function() {
     });
   });
 
-  suite('setMessageBody', function() {
-    setup(function() {
-      this.sinon.stub(Compose, 'clear');
-      this.sinon.stub(Compose, 'append');
-      this.sinon.stub(Compose, 'focus');
-    });
-
-    suite('with data', function() {
-      var testText = 'testing';
-      setup(function() {
-        ThreadUI.setMessageBody(testText);
-      });
-
-      test('calls clear', function() {
-        assert.ok(Compose.clear.called);
-      });
-
-      test('calls append with correct data', function() {
-        assert.ok(Compose.append.calledWith(testText));
-      });
-
-      test('calls focus', function() {
-        assert.ok(Compose.focus.called);
-      });
-    });
-
-    suite('without data', function() {
-      var testText = '';
-      setup(function() {
-        ThreadUI.setMessageBody(testText);
-      });
-
-      test('calls clear', function() {
-        assert.ok(Compose.clear.called);
-      });
-
-      test('does not call append with empty data', function() {
-        assert.isFalse(Compose.append.called);
-      });
-
-      test('calls focus', function() {
-        assert.ok(Compose.focus.called);
-      });
-    });
-  });
-
   suite('recipient handling >', function() {
     var localize;
     setup(function() {


### PR DESCRIPTION
Bug 941030 - [Messages] Follow up Bug 919966 - Ensure that forwarding a MMS with a subject fills in the subject in the composer
(cherry picked from commit 4df4a5b17839fc6ce748029fc1e79bb2bde3cc87)

Conflicts:
    apps/sms/js/compose.js
    apps/sms/js/message_manager.js
    apps/sms/test/unit/compose_test.js
    apps/sms/test/unit/mock_compose.js
        apps/sms/test/unit/message_manager_test.js
