### PR TITLE
Bug 964862 - [Messages][Drafts][Refactoring] Move MessageManager.draft to ThreadUI.draft

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -2,7 +2,7 @@
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 /*global Settings, Utils, Attachment, AttachmentMenu, MozActivity, SMIL,
-        MessageManager */
+        ThreadUI */
 /*exported Compose */
 
 'use strict';
@@ -91,8 +91,8 @@ var Compose = (function() {
   // anytime content changes - takes a parameter to check for image resizing
   function onContentChanged(duck) {
     // Track when content is edited for draft replacement case
-    if (MessageManager.draft) {
-      MessageManager.draft.isEdited = true;
+    if (ThreadUI.draft) {
+      ThreadUI.draft.isEdited = true;
     }
 
     // if the duck is an image attachment, handle resizes

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -11,7 +11,6 @@
 'use strict';
 
 var MessageManager = {
-  draft: null,
   activity: null,
   forward: null,
   init: function mm_init(callback) {
@@ -145,7 +144,7 @@ var MessageManager = {
 
   launchComposer: function mm_launchComposer(callback) {
     ThreadUI.cleanFields(true);
-    var draft = MessageManager.draft || Drafts.get(Threads.currentId);
+    var draft = ThreadUI.draft || Drafts.get(Threads.currentId);
     // Draft recipients are added as the composer launches
     if (draft) {
       // Recipients will exist for draft messages in threads
@@ -265,8 +264,8 @@ var MessageManager = {
         MessageManager.launchComposer(function() {
           this.handleActivity(this.activity);
           this.handleForward(this.forward);
-          if (this.draft) {
-            this.draft.isEdited = false;
+          if (ThreadUI.draft) {
+            ThreadUI.draft.isEdited = false;
           }
         }.bind(this));
         break;
@@ -321,11 +320,11 @@ var MessageManager = {
             // Populate draft if there is one
             var thread = Threads.get(threadId);
             if (thread.hasDrafts) {
-              this.draft = thread.drafts.latest;
-              Compose.fromDraft(this.draft);
-              this.draft.isEdited = false;
+              ThreadUI.draft = thread.drafts.latest;
+              Compose.fromDraft(ThreadUI.draft);
+              ThreadUI.draft.isEdited = false;
             } else {
-              this.draft = null;
+              ThreadUI.draft = null;
             }
           }
         }).bind(this);

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -3,7 +3,7 @@
 
 /*global Template, Utils, Threads, Contacts, URL, FixedHeader, Threads,
          WaitingScreen, MozSmsFilter, MessageManager, TimeHeaders,
-         Drafts, Thread */
+         Drafts, Thread, ThreadUI */
 /*exported ThreadListUI */
 (function(exports) {
 'use strict';
@@ -172,7 +172,7 @@ var ThreadListUI = {
         }
 
         if ((draftId = this.draftLinks.get(event.target))) {
-          MessageManager.draft = Drafts.get(draftId);
+          ThreadUI.draft = Drafts.get(draftId);
         }
 
         break;
@@ -519,7 +519,7 @@ var ThreadListUI = {
     TimeHeaders.update(li.querySelector('time'));
 
     if (draftId) {
-      // Used in handleEvent to set the MessageManager.draft object
+      // Used in handleEvent to set the ThreadUI.draft object
       this.draftLinks.set(
         li.querySelector('a'), draftId
       );

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -60,6 +60,7 @@ var ThreadUI = global.ThreadUI = {
   BANNER_DURATION: 2000,
   // delay between 2 counter updates while composing a message
   UPDATE_DELAY: 500,
+  draft: null,
   recipients: null,
   // Set to |true| when in edit mode
   inEditMode: false,
@@ -286,8 +287,8 @@ var ThreadUI = global.ThreadUI = {
   // Initialize Recipients list and Recipients.View (DOM)
   initRecipients: function thui_initRecipients() {
     var recipientsChanged = (function recipientsChanged(length, record) {
-      if (MessageManager.draft) {
-        MessageManager.draft.isEdited = true;
+      if (this.draft) {
+        this.draft.isEdited = true;
       }
       var isOk = true;
       var strategy;
@@ -828,7 +829,7 @@ var ThreadUI = global.ThreadUI = {
       // If there is a draft and the content and recipients
       // never got edited, re-save if threadless,
       // then leave without prompting to replace
-      if (MessageManager.draft && !MessageManager.draft.isEdited) {
+      if (this.draft && !this.draft.isEdited) {
         // Thread-less drafts are orphaned at this point
         // so they need to be resaved for persistence
         if (!Threads.currentId) {
@@ -839,7 +840,7 @@ var ThreadUI = global.ThreadUI = {
       }
 
       var prompt = 'save-as-draft';
-      if (MessageManager.draft) {
+      if (this.draft) {
         prompt = 'replace-draft';
       }
 
@@ -2022,10 +2023,10 @@ var ThreadUI = global.ThreadUI = {
 
     // If there was a draft, it just got sent
     // so delete it
-    if (MessageManager.draft) {
-      ThreadListUI.removeThread(MessageManager.draft.id);
-      Drafts.delete(MessageManager.draft);
-      MessageManager.draft = null;
+    if (this.draft) {
+      ThreadListUI.removeThread(this.draft.id);
+      Drafts.delete(this.draft);
+      this.draft = null;
     }
 
     this.updateHeaderData();
@@ -2596,15 +2597,15 @@ var ThreadUI = global.ThreadUI = {
     // If we were tracking a draft
     // properly update the Drafts object
     // and ThreadList entries
-    if (MessageManager.draft) {
-      Drafts.delete(MessageManager.draft);
+    if (this.draft) {
+      Drafts.delete(this.draft);
       if (Threads.active) {
         Threads.active.timestamp = Date.now();
         ThreadListUI.updateThread(Threads.active);
       } else {
-        ThreadListUI.removeThread(MessageManager.draft.id);
+        ThreadListUI.removeThread(this.draft.id);
       }
-      MessageManager.draft = null;
+      this.draft = null;
     }
   },
 
@@ -2614,7 +2615,7 @@ var ThreadUI = global.ThreadUI = {
    * Saves the currently unsent message content or recipients
    * into a Draft object.  Preserves the currently marked
    * draft if specified.  Draft preservation is intended to
-   * keep MessageManager.draft populated with the currently
+   * keep this.draft populated with the currently
    * showing draft when the app is hidden, so when the app
    * comes out of hiding, it knows there is a draft to continue
    * to keep track of.
@@ -2637,7 +2638,7 @@ var ThreadUI = global.ThreadUI = {
       recipients = this.recipients.numbers;
     }
 
-    var draftId = MessageManager.draft ? MessageManager.draft.id : null;
+    var draftId = this.draft ? this.draft.id : null;
 
     draft = new Draft({
       recipients: recipients,
@@ -2668,13 +2669,13 @@ var ThreadUI = global.ThreadUI = {
     // not explicitly preserved for the
     // draft replacement case
     if (!opts || (opts && !opts.preserve)) {
-      MessageManager.draft = null;
+      this.draft = null;
     }
 
     // Set the MessageManager draft if it is
     // not already set and meant to be preserved
-    if (!MessageManager.draft && (opts && opts.preserve)) {
-      MessageManager.draft = draft;
+    if (!this.draft && (opts && opts.preserve)) {
+      this.draft = draft;
     }
 
     // Show draft saved banner if not an

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -1,7 +1,7 @@
 /* global MocksHelper, MockAttachment, MockL10n, loadBodyHTML,
          Compose, Attachment, MockMozActivity, Settings, Utils,
          AttachmentMenu, Draft, document, XMLHttpRequest, Blob, navigator,
-         setTimeout, MessageManager */
+         setTimeout, ThreadUI */
 
 /*jshint strict:false */
 /*jslint node: true */
@@ -21,7 +21,7 @@ requireApp('sms/test/unit/mock_recipients.js');
 requireApp('sms/test/unit/mock_settings.js');
 requireApp('sms/test/unit/mock_utils.js');
 requireApp('sms/test/unit/mock_moz_activity.js');
-requireApp('sms/test/unit/mock_message_manager.js');
+requireApp('sms/test/unit/mock_thread_ui.js');
 
 var mocksHelperForCompose = new MocksHelper([
   'AttachmentMenu',
@@ -30,7 +30,7 @@ var mocksHelperForCompose = new MocksHelper([
   'Utils',
   'MozActivity',
   'Attachment',
-  'MessageManager'
+  'ThreadUI'
 ]).init();
 
 suite('compose_test.js', function() {
@@ -429,24 +429,24 @@ suite('compose_test.js', function() {
     suite('Changing content marks draft as edited', function() {
 
       setup(function() {
-        MessageManager.draft = {
+        ThreadUI.draft = new Draft({
           isEdited: false
-        };
+        });
       });
 
       test('Changing message', function() {
         Compose.append('Message');
-        assert.isTrue(MessageManager.draft.isEdited);
+        assert.isTrue(ThreadUI.draft.isEdited);
       });
 
       test('Changing subject', function() {
         Compose.toggleSubject();
-        assert.isTrue(MessageManager.draft.isEdited);
+        assert.isTrue(ThreadUI.draft.isEdited);
       });
 
       test('Changing attachments', function() {
         Compose.append(mockAttachment(12345));
-        assert.isTrue(MessageManager.draft.isEdited);
+        assert.isTrue(ThreadUI.draft.isEdited);
       });
     });
 

--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -256,6 +256,7 @@ suite('message_manager.js >', function() {
 
     setup(function() {
       this.sinon.spy(ThreadUI, 'cleanFields');
+      ThreadUI.draft = null;
       MessageManager.launchComposer();
     });
 
@@ -275,7 +276,7 @@ suite('message_manager.js >', function() {
     suite('message drafts', function() {
 
       setup(function() {
-        MessageManager.draft = new Draft({
+        ThreadUI.draft = new Draft({
           threadId: 1234,
           recipients: []
         });
@@ -287,7 +288,7 @@ suite('message_manager.js >', function() {
       });
 
       teardown(function() {
-        MessageManager.draft = null;
+        ThreadUI.draft = null;
       });
 
       test('Calls Compose.fromDraft()', function() {
@@ -302,14 +303,14 @@ suite('message_manager.js >', function() {
       });
 
       test('with recipients', function() {
-        MessageManager.draft.recipients = ['800 732 0872', '800 555 1212'];
+        ThreadUI.draft.recipients = ['800 732 0872', '800 555 1212'];
         MessageManager.launchComposer();
         assert.ok(ThreadUI.recipients.add.calledTwice);
         assert.isFalse(ThreadUI.updateHeaderData.called);
       });
 
       test('discards draft record', function() {
-        MessageManager.draft = {
+        ThreadUI.draft = {
           recipients: []
         };
 
@@ -581,7 +582,7 @@ suite('message_manager.js >', function() {
     });
 
     teardown(function() {
-      MessageManager.draft = null;
+      ThreadUI.draft = null;
       Threads.currentId = null;
       delete MessageManager.threadMessages;
     });
@@ -593,7 +594,7 @@ suite('message_manager.js >', function() {
         MessageManager.slide.reset();
         ThreadUI.updateHeaderData.reset();
         ThreadUI.inThread = false;
-        MessageManager.draft = new Draft({
+        ThreadUI.draft = new Draft({
           content: ['i am a draft'],
           threadId: 1234
         });
@@ -603,7 +604,7 @@ suite('message_manager.js >', function() {
         MessageManager.onHashChange();
       });
       teardown(function() {
-        MessageManager.draft = null;
+        ThreadUI.draft = null;
         Threads.currentId = null;
       });
 
@@ -615,15 +616,15 @@ suite('message_manager.js >', function() {
             latest: draft
           }
         });
-        MessageManager.draft = null;
+        ThreadUI.draft = null;
 
         ThreadUI.updateHeaderData.yield();
         MessageManager.slide.yield();
 
         sinon.assert.callOrder(ThreadUI.renderMessages, Compose.fromDraft);
         sinon.assert.calledWith(Compose.fromDraft, draft);
-        assert.equal(draft, MessageManager.draft);
-        assert.isFalse(MessageManager.draft.isEdited);
+        assert.equal(draft, ThreadUI.draft);
+        assert.isFalse(ThreadUI.draft.isEdited);
       });
 
       test('Thread latest draft rendered if not in thread', function() {
@@ -642,8 +643,8 @@ suite('message_manager.js >', function() {
 
         sinon.assert.callOrder(ThreadUI.renderMessages, Compose.fromDraft);
         sinon.assert.calledWith(Compose.fromDraft, draft);
-        assert.equal(draft, MessageManager.draft);
-        assert.isFalse(MessageManager.draft.isEdited);
+        assert.equal(draft, ThreadUI.draft);
+        assert.isFalse(ThreadUI.draft.isEdited);
       });
 
       test('Thread latest draft not rendered if in thread', function() {

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -1,6 +1,6 @@
 /*global mocha, MocksHelper, loadBodyHTML, MockL10n, ThreadListUI, FixedHeader,
          MessageManager, WaitingScreen, Threads, Template, MockMessages,
-         MockThreadList, MockTimeHeaders, Draft, Drafts, Thread
+         MockThreadList, MockTimeHeaders, Draft, Drafts, Thread, ThreadUI
          */
 
 'use strict';
@@ -26,6 +26,7 @@ requireApp('sms/test/unit/mock_utils.js');
 requireApp('sms/test/unit/mock_waiting_screen.js');
 require('/test/unit/thread_list_mockup.js');
 require('/test/unit/utils_mockup.js');
+requireApp('sms/test/unit/mock_thread_ui.js');
 
 var mocksHelperForThreadListUI = new MocksHelper([
   'asyncStorage',
@@ -34,7 +35,8 @@ var mocksHelperForThreadListUI = new MocksHelper([
   'MessageManager',
   'Utils',
   'WaitingScreen',
-  'TimeHeaders'
+  'TimeHeaders',
+  'ThreadUI'
 ]).init();
 
 suite('thread_list_ui', function() {
@@ -907,9 +909,9 @@ suite('thread_list_ui', function() {
       sinon.assert.called(ThreadListUI.setContact);
     });
 
-    test('click on a draft populates MessageManager.draft', function() {
+    test('click on a draft populates ThreadUI.draft', function() {
       document.querySelector('#thread-101 a').click();
-      assert.equal(MessageManager.draft, draft);
+      assert.equal(ThreadUI.draft, draft);
     });
   });
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3892,7 +3892,7 @@ suite('thread_ui.js >', function() {
     test('Deletes draft if there was a draft', function() {
       spy = this.sinon.spy(Drafts, 'delete');
 
-      MessageManager.draft = {id: 3};
+      ThreadUI.draft = {id: 3};
       ThreadUI.recipients.add({
         number: '888'
       });
@@ -3901,13 +3901,13 @@ suite('thread_ui.js >', function() {
       ThreadUI.onSendClick();
 
       assert.isTrue(spy.calledOnce);
-      assert.isNull(MessageManager.draft);
+      assert.isNull(ThreadUI.draft);
     });
 
     test('Removes draft thread if there was a draft thread', function() {
       spy = this.sinon.spy(ThreadListUI, 'removeThread');
 
-      MessageManager.draft = {id: 3};
+      ThreadUI.draft = {id: 3};
       ThreadUI.recipients.add({
         number: '888'
       });
@@ -4085,26 +4085,26 @@ suite('thread_ui.js >', function() {
     test('do not preserve draft for replacement', function() {
       ThreadUI.saveDraft();
 
-      assert.isNull(MessageManager.draft);
+      assert.isNull(ThreadUI.draft);
     });
 
     test('preserve pre-existing draft for replacement', function() {
       var draft = {id: 55};
-      MessageManager.draft = draft;
+      ThreadUI.draft = draft;
       ThreadUI.saveDraft({preserve: true});
 
-      assert.isNotNull(MessageManager.draft);
-      assert.equal(MessageManager.draft, draft);
+      assert.isNotNull(ThreadUI.draft);
+      assert.equal(ThreadUI.draft, draft);
     });
 
     test('preserve new draft for replacement', function() {
-      MessageManager.draft = null;
+      ThreadUI.draft = null;
       ThreadUI.saveDraft({preserve: true});
 
-      assert.isNotNull(MessageManager.draft);
-      assert.deepEqual(MessageManager.draft.recipients, ['999']);
-      assert.equal(MessageManager.draft.content, 'foo');
-      assert.equal(MessageManager.draft.threadId, null);
+      assert.isNotNull(ThreadUI.draft);
+      assert.deepEqual(ThreadUI.draft.recipients, ['999']);
+      assert.equal(ThreadUI.draft.content, 'foo');
+      assert.equal(ThreadUI.draft.threadId, null);
     });
 
     test('has entered content and recipients', function() {
@@ -4153,15 +4153,15 @@ suite('thread_ui.js >', function() {
     test('saves brand new threadless draft if not within thread', function() {
       Drafts.clear();
 
-      MessageManager.draft = {id: 1};
+      ThreadUI.draft = {id: 1};
       ThreadUI.saveDraft();
       assert.equal(Drafts.byThreadId(null).length, 1);
 
-      MessageManager.draft = {id: 2};
+      ThreadUI.draft = {id: 2};
       ThreadUI.saveDraft();
       assert.equal(Drafts.byThreadId(null).length, 2);
 
-      MessageManager.draft = {id: 3};
+      ThreadUI.draft = {id: 3};
       ThreadUI.saveDraft();
       assert.equal(Drafts.byThreadId(null).length, 3);
     });
@@ -4350,8 +4350,8 @@ suite('thread_ui.js >', function() {
         });
 
         test('Discard', function() {
-          MessageManager.draft = {id: 3};
-          MessageManager.draft.isEdited = true;
+          ThreadUI.draft = {id: 3};
+          ThreadUI.draft.isEdited = true;
           var spy = this.sinon.spy(ThreadListUI, 'removeThread');
           ThreadUI.back();
 
@@ -4361,7 +4361,7 @@ suite('thread_ui.js >', function() {
           assert.equal(ThreadUI.recipients.length, 0);
           assert.equal(Compose.getContent(), '');
           assert.isTrue(spy.calledOnce);
-          assert.isNull(MessageManager.draft);
+          assert.isNull(ThreadUI.draft);
         });
       });
 
@@ -4370,7 +4370,7 @@ suite('thread_ui.js >', function() {
         suite('If draft edited', function() {
 
           suiteSetup(function() {
-            MessageManager.draft = {
+            ThreadUI.draft = {
               id: 55,
               isEdited: true
             };
@@ -4425,11 +4425,11 @@ suite('thread_ui.js >', function() {
         suite('If draft not edited', function() {
 
           setup(function() {
-            MessageManager.draft = {id: 55};
+            ThreadUI.draft = {id: 55};
           });
 
           test('No prompt for replacement if recipients', function() {
-            MessageManager.draft.isEdited = false;
+            ThreadUI.draft.isEdited = false;
             ThreadUI.back();
 
             assert.isFalse(OptionMenu.calledOnce);
@@ -4438,7 +4438,7 @@ suite('thread_ui.js >', function() {
 
           test('No prompt for replacement if recipients & content', function() {
             Compose.append('foo');
-            MessageManager.draft.isEdited = false;
+            ThreadUI.draft.isEdited = false;
             ThreadUI.back();
 
             assert.isFalse(OptionMenu.calledOnce);
@@ -4448,7 +4448,7 @@ suite('thread_ui.js >', function() {
           test('No prompt for replacement if content', function() {
             ThreadUI.recipients.remove('999');
             Compose.append('foo');
-            MessageManager.draft.isEdited = false;
+            ThreadUI.draft.isEdited = false;
             ThreadUI.back();
 
             assert.isFalse(OptionMenu.calledOnce);


### PR DESCRIPTION
- Fix
  - Add `draft` property to `ThreadUI`
  - Remove 'draft' property from `MessageManager`
  - Change instances of `MessageManager.draft` to `ThreadUI.draft`
  - Fix globals
- Tests
  - Fix `compose_test.js` to use a true `Draft` in `ThreadUI.draft` to fix CI tests
  - Fix `message_manager_test.js` to use a null `ThreadUI.draft` to fix CI tests
  - Change instances of 'MessageManager.draft`to`ThreadUI.draft` in all unit tests
  - Fix globals
