### PR TITLE
Bug 964342: Send language setting to basket.

### DIFF
--- a/apps/communications/ftu/js/basket-client.js
+++ b/apps/communications/ftu/js/basket-client.js
@@ -9,6 +9,22 @@ var Basket = {
   callback: null,
   xhr: null,
   itemId: 'newsletter_email',
+  // https://github.com/mozilla/basket-client/blob/master/basket/errors.py
+  errors: {
+    NETWORK_FAILURE: 1,
+    INVALID_EMAIL: 2,
+    UNKNOWN_EMAIL: 3,
+    UNKNOWN_TOKEN: 4,
+    USAGE_ERROR: 5,
+    EMAIL_PROVIDER_AUTH_FAILURE: 6,
+    AUTH_ERROR: 7,
+    SSL_REQUIRED: 8,
+    INVALID_NEWSLETTER: 9,
+    INVALID_LANGUAGE: 10,
+    EMAIL_NOT_CHANGED: 11,
+    CHANGE_REQUEST_NOT_FOUND: 12,
+    UNKNOWN_ERROR: 99
+  },
 
   responseHandler: function b_responseHandler() {
     if (this.xhr.readyState === 4) {
@@ -48,7 +64,12 @@ var Basket = {
                               'application/x-www-form-urlencoded');
     this.xhr.setRequestHeader('Content-length', params.length);
     this.xhr.setRequestHeader('Connection', 'close');
-    this.xhr.send(params);
+    this.getLanguage(function do_send(language) {
+      if (language) {
+        params += '&lang=' + language;
+      }
+      this.xhr.send(params);
+    });
   },
 
   store: function b_store(email, callback) {
@@ -57,6 +78,26 @@ var Basket = {
         callback();
       }
     });
+  },
+
+  getLanguage: function b_getLanguage(callback) {
+    var settings = window.navigator.mozSettings;
+    if (!settings || !settings.createLock) {
+      callback();
+      return;
+    }
+
+    var s_name = 'language.current';
+    var req = settings.createLock().get(s_name);
+
+    req.onsuccess = function _onsuccess() {
+      callback(req.result[s_name]);
+    };
+
+    req.onerror = function _onerror() {
+      console.error('Error getting setting: ' + s_name);
+      callback();
+    };
   }
 
 };

--- a/apps/communications/ftu/js/ui.js
+++ b/apps/communications/ftu/js/ui.js
@@ -239,7 +239,7 @@ var UIManager = {
         if (window.navigator.onLine) {
           Basket.send(emailValue, function emailSent(err, data) {
             if (err) {
-              if (err.desc && err.desc.indexOf('email address') > -1) {
+              if (err.code && err.code === Basket.errors.INVALID_EMAIL) {
                 ConfirmDialog.show(_('invalid-email-dialog-title'),
                                    _('invalid-email-dialog-text'),
                                    {


### PR DESCRIPTION
This seems like the way it should work, but correct me if I'm wrong. I tried to ensure that the language setting wasn't required for the subscription call to happen. I'll see what I can do about adding some tests.

I also went ahead and added the [basket error codes](https://github.com/mozilla/basket-client/blob/master/basket/errors.py) to basket-client.js and used the proper code instead of searching through the error description. If this needs to be split into a separate PR let me know.

@fcampo r?
