### PR TITLE
Bug 905940 - [Buri][Email] E-mail app compose UI uses a non-monospace font

### DIFF
--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -100,6 +100,7 @@ input.cmp-subject-text {
   margin: 1rem 1.5rem;
   display: block;
   padding: 0rem;
+  font-family: inherit;
   font-size: 1.7rem;
   line-height: 1.9rem;
   font-weight: normal;

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -223,9 +223,8 @@ input.msg-search-text-tease {
 }
 
 .msg-body-container {
-  font-family: monospace;
   white-space: pre-wrap;
-  font-size: 1.9rem;
+  font-size: 1.7rem;
   line-height: 2.6rem;
   margin: 1rem 1.5rem;
 }


### PR DESCRIPTION
Changes text-only emails to use default non-monospace font, and matches its size with what is used for compose. Compose also removes the use of a monospace font.
