### PR TITLE
Bug 964530 - [B2G][Email] non-folders are selectable

### DIFF
--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -572,6 +572,7 @@ Cards = {
         for (var i = 0; i < folders.length; i++) {
           var folder = folders[i];
           self.folderPrompt.addToList(folder.name, folder.depth,
+            folder.selectable,
             function(folder) {
               return function() {
                 self.folderPrompt.hide();

--- a/apps/email/js/value_selector.js
+++ b/apps/email/js/value_selector.js
@@ -14,7 +14,8 @@ How to:
     }
   ]);
 
-  prompt1.addToList('Another button', function(){alert('Another action');});
+  prompt1.addToList('Another button', 'depth0',
+                    true, function(){alert('Another action');});
   prompt1.show();
 */
 /*jshint browser: true */
@@ -23,6 +24,9 @@ define(function(require) {
 
 var FOLDER_DEPTH_CLASSES = require('folder_depth_classes'),
     mozL10n = require('l10n!');
+
+// Used for empty click handlers.
+function noop() {}
 
 function ValueSelector(title, list) {
   var init, show, hide, render, setTitle, emptyList, addToList,
@@ -124,7 +128,13 @@ function ValueSelector(title, list) {
       var depthIdx = data.list[i].depth;
       depthIdx = Math.min(FOLDER_DEPTH_CLASSES.length - 1, depthIdx);
       label.classList.add(FOLDER_DEPTH_CLASSES[depthIdx]);
-      li.addEventListener('click', data.list[i].callback, false);
+
+      // If not selectable use an empty click handler. Because of event
+      // fuzzing, we want to have something registered, otherwise an
+      // adjacent list item may receive the click.
+      var callback = data.list[i].selectable ? data.list[i].callback : noop;
+      li.addEventListener('click', callback, false);
+
       li.appendChild(label);
       list.appendChild(li);
     }
@@ -138,10 +148,11 @@ function ValueSelector(title, list) {
     data.list = [];
   };
 
-  addToList = function(label, depth, callback) {
+  addToList = function(label, depth, selectable, callback) {
     data.list.push({
       label: label,
       depth: depth,
+      selectable: selectable,
       callback: callback
     });
   };


### PR DESCRIPTION
Some background on the cause of the bug:

Cards.folderSelector() in mail_common shows a list of folders as what would be displayed in the folder_picker. However, some folder entries, like [Gmail], are not actually selectable since they are just for hierarchical display purposes, not real folders.

However, email's value_selector does not check if folder.selectable is true, and allows any item to be tapped. This leads to a bad folder getting passed to the back end, and the back end blows up.

This pull request modified value_selector to not allow clicks for non-selectable folders. It seems desirable to show the hierarchy in the value_selector, so that it matches the display in the folder_picker card, but similar to that card, those items do not trigger any actions if they are tapped.

A deeper fix could be to also have the back end recover if this sort of data is passed to the back end and not to get stuck, but some front end fix is needed regardless, to give better feedback to the user.
