### PR TITLE
Bug 961986 - [fugu][buri] it took long time to resume music play after ending a phone call

### DIFF
--- a/apps/communications/dialer/js/oncall.js
+++ b/apps/communications/dialer/js/oncall.js
@@ -7,3 +7,11 @@ window.addEventListener('load', function callSetup(evt) {
   CallScreen.init();
   KeypadManager.init(true);
 });
+
+window.addEventListener('unload', function() {
+  // When we end the call, we need to clean up the TonePlayer to reset the audio
+  // context's channel back to "normal" to let other audio start playing again.
+  // Otherwise, we'll have to wait until the cycle collector kills it, which
+  // can take a while.
+  TonePlayer.setChannel('normal');
+});


### PR DESCRIPTION
When a call starts, the KeypadManager increases the priority of the TonePlayer's audio channel from "normal" to "telephony" so that users can hear tones when they tap the keypad during a call. We need to reset the channel back to "normal" when hanging up so that other apps can resume playing audio.

This is a minimal fix to the issue; it might make sense to have KeypadManager have a different function for resetting the channel back to "normal", since KeypadManager.init() does quite a bit of other stuff. Nevertheless, this works.

Not sure if we need tests or where they'd go... let me know if you think this should have some tests.
