### PR TITLE
Bug 965363 - [B2G][Clock] The tab selection bar is selectable through the create an alarm page

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -63,7 +63,7 @@ li .button.icon-dialog:before {
 }
 
 .new #edit-alarm {
-  height: calc(100% - 6.5rem);
+  height: calc(100% - 5rem);
 }
 
 .new #delete-menu {


### PR DESCRIPTION
The card was just not long enough to cover the screen behind it. Perhaps the header changed size at some point. Just making the card long fixed the issue.
