### PR TITLE
Bug 966009 - Use NfcManager DOM APIs 'notifyUserAcceptedP2P' ,

### DIFF
--- a/apps/system/js/nfc_handover_manager.js
+++ b/apps/system/js/nfc_handover_manager.js
@@ -243,17 +243,9 @@ var NfcHandoverManager = {
   },
 
   dispatchSendFileStatus: function dispatchSendFileStatus(status) {
-    this.debug('In initiateFileTransfer ' + status);
-    var detail = {
-                   status: status,
-                   requestId: this.sendFileRequest.requestId,
-                   sessionToken: this.sendFileRequest.session
-                 };
-    var evt = new CustomEvent('nfc-send-file-status', {
-      bubbles: true, cancelable: true,
-      detail: detail
-    });
-    window.dispatchEvent(evt);
+    this.debug('In dispatchSendFileStatus ' + status);
+    window.navigator.mozNfc.notifySendFileStatus(status,
+                         this.sendFileRequest.requestId);
   },
 
   /*****************************************************************************
@@ -270,7 +262,7 @@ var NfcHandoverManager = {
     }
     if (this.sendFileRequest != null) {
       // This is the response to a file transfer request (negotiated handover)
-      this.doAction({callback: doFileTransfer, args: [mac]});
+      this.doAction({callback: this.doFileTransfer.bind(this), args: [mac]});
     } else {
       // This is a static handover
       this.debug('Pair with: ' + mac);

--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -321,12 +321,7 @@ var NfcManager = {
   },
 
   dispatchP2PUserResponse: function nm_dispatchP2PUserResponse(manifestURL) {
-    var detail = { manifestUrl: manifestURL };
-    var evt = new CustomEvent('nfc-p2p-user-accept', {
-      bubbles: true, cancelable: true,
-      detail: detail
-    });
-    window.dispatchEvent(evt);
+    window.navigator.mozNfc.notifyUserAcceptedP2P(manifestURL);
   },
 
   fireTagDiscovered: function nm_fireTagDiscovered(command) {


### PR DESCRIPTION
Bug 966009 - Use NfcManager DOM APIs 'notifyUserAcceptedP2P' ,
    'notifySendFileStatus' instead of dispatching events to nfc dom.
