### PR TITLE
Bug 966243: Fix ICC detection handlers in Settings app

### DIFF
--- a/apps/settings/js/simcard_lock.js
+++ b/apps/settings/js/simcard_lock.js
@@ -202,6 +202,7 @@
       this.simSecurityDesc = document.getElementById('simCardLock-desc');
     },
     addIccDetectedEvent: function() {
+      var self = this;
       // if there is a change that icc instance is available
       // we can update its cardstatus to make it reflect the
       // real world.
@@ -220,6 +221,7 @@
       });
     },
     addIccUndetectedEvent: function() {
+      var self = this;
       // if there is a change that icc instance is not available
       // we have to update all cards' status
       this.iccManager.addEventListener('iccundetected', function(evt) {


### PR DESCRIPTION
While running the Settings app several errors about self.\* not being
defined show up in the logcat. An example is

  E/GeckoConsole(  440): [JavaScript Error: "TypeError: self.updateSimPinsUI \
    is not a function" {file: "app://settings.gaiamobile.org/js/simcard_lock.js" \
    line: 232}]

This is caused by 'self' not being set in the event handlers for ICC
detection. As a result, the UI update does not work correctly when the
ICC changes state. Setting the variable 'self' fixes this problem.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
