### PR TITLE
Bug 965765 - Force a cardstatechange publish to ensure SIM PIN dialog is displayed r=alive

### DIFF
--- a/apps/system/js/sim_lock.js
+++ b/apps/system/js/sim_lock.js
@@ -32,6 +32,14 @@ var SimLock = {
       self.showIfLocked(evt.detail.index);
     });
 
+    // In some case, we can have 'iccdetected' and then 'iccinfochange'
+    // happening after 'cardstatechange'. We add a listener on
+    // 'simslot-iccinfochange' and if the SIM is locked, we will display the SIM
+    // PIN UI.
+    window.addEventListener('simslot-iccinfochange', function(evt) {
+      self.showIfLocked(evt.detail.index);
+    });
+
     // Listen to callscreenwillopen and callscreenwillclose event
     // to discard the cardstatechange event.
     window.addEventListener('callscreenwillopen', this);


### PR DESCRIPTION
In some cases, we can have 'iccdetected' triggered after
'cardstatechange'. This makes the handler not installed in time and thus
we miss the event and are not able to display the SIM PIN unlock
interface. We add checking on the locked state of the SIM card, and if
it is locked then we force issue a 'cardstatechange' event.
