### PR TITLE
Bug 967516 - Enable DEVICE_DEBUG by default for non production builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ GAIA_DOMAIN?=gaiamobile.org
 DEBUG?=0
 DEVICE_DEBUG?=0
 NO_LOCK_SCREEN?=0
+SCREEN_TIMEOUT?=undefined
 PRODUCTION?=0
 DESKTOP_SHIMS?=0
 GAIA_OPTIMIZE?=0
@@ -96,6 +97,7 @@ ifeq ($(SIMULATOR),1)
 DESKTOP=1
 NOFTU=1
 DEVICE_DEBUG=1
+NO_LOCK_SCREEN=1
 endif
 
 # Enable compatibility to run in Firefox Desktop
@@ -104,11 +106,6 @@ DESKTOP?=$(DEBUG)
 NOFTU?=0
 # Automatically enable remote debugger
 REMOTE_DEBUGGER?=0
-
-ifeq ($(DEVICE_DEBUG),1)
-REMOTE_DEBUGGER=1
-NO_LOCK_SCREEN=1
-endif
 
 # We also disable FTU when running in Firefox or in debug mode
 ifeq ($(DEBUG),1)
@@ -171,6 +168,17 @@ endif
 ifeq ($(PRODUCTION), 1)
 GAIA_OPTIMIZE=1
 GAIA_APP_TARGET=production
+else
+DEVICE_DEBUG=1
+endif
+
+ifeq ($(DEVICE_DEBUG),1)
+REMOTE_DEBUGGER=1
+SCREEN_TIMEOUT=600
+endif
+
+ifeq ($(SIMULATOR),1)
+SCREEN_TIMEOUT=0
 endif
 
 ifeq ($(DOGFOOD), 1)
@@ -371,6 +379,7 @@ define BUILD_CONFIG
 	"DESKTOP" : $(DESKTOP), \
 	"DEVICE_DEBUG" : $(DEVICE_DEBUG), \
 	"NO_LOCK_SCREEN" : $(NO_LOCK_SCREEN), \
+	"SCREEN_TIMEOUT" : $(SCREEN_TIMEOUT), \
 	"HOMESCREEN" : "$(HOMESCREEN)", \
 	"GAIA_PORT" : "$(GAIA_PORT)", \
 	"GAIA_LOCALES_PATH" : "$(GAIA_LOCALES_PATH)", \

--- a/build/settings.js
+++ b/build/settings.js
@@ -127,9 +127,12 @@ function execute(config) {
   }
 
   if (config.NO_LOCK_SCREEN) {
-    settings['screen.timeout'] = 0;
     settings['lockscreen.enabled'] = false;
     settings['lockscreen.locked'] = false;
+  }
+
+  if (typeof(config.SCREEN_TIMEOUT) == 'number') {
+    settings['screen.timeout'] = config.SCREEN_TIMEOUT;
   }
 
   var queue = utils.Q.defer();

--- a/build/test/integration/build.test.js
+++ b/build/test/integration/build.test.js
@@ -136,7 +136,10 @@ suite('Build Integration tests', function() {
       var ignoreSettings = [
         'apz.force-enable',
         'debug.console.enabled',
-        'developer.menu.enabled'
+        'developer.menu.enabled',
+        'screen.timeout',
+        'lockscreen.enabled',
+        'lockscreen.locked'
       ];
       ignoreSettings.forEach(function(key) {
         if (commonSettings[key] !== undefined) {
@@ -332,7 +335,8 @@ suite('Build Integration tests', function() {
         'installed-extensions.json');
       var expectedSettings = {
         'homescreen.manifestURL': 'http://homescreen.gaiamobile.org:8080/manifest.webapp',
-        'rocketbar.searchAppURL': 'http://search.gaiamobile.org:8080/index.html'
+        'rocketbar.searchAppURL': 'http://search.gaiamobile.org:8080/index.html',
+        'screen.timeout': 600
       };
       var expectedUserPrefs = {
         'browser.manifestURL': 'http://system.gaiamobile.org:8080/manifest.webapp',

--- a/build/test/unit/settings.test.js
+++ b/build/test/unit/settings.test.js
@@ -263,9 +263,33 @@ suite('settings.js', function() {
             config.GAIA_DOMAIN + config.GAIA_PORT + '/index.html',
           'language.current': config.GAIA_DEFAULT_LOCALE,
           'debugger.remote-mode': 'adb-devtools',
-          'screen.timeout': 0,
           'lockscreen.enabled': false,
           'lockscreen.locked': false,
+          'wallpaper.image': undefined,
+          'dialer.ringtone': undefined,
+          'notification.ringtone': undefined },
+          result);
+        done();
+      });
+    });
+
+
+    test('SCREEN_TIMEOUT === 600', function(done) {
+      config.SCREEN_TIMEOUT = 600;
+      var queue = app.execute(config);
+      queue.done(function(result) {
+        assert.deepEqual({
+          'debug.console.enabled': true,
+          'developer.menu.enabled': true,
+          'apz.force-enable': true,
+          'homescreen.manifestURL': config.GAIA_SCHEME +
+            'homescreen.' + config.GAIA_DOMAIN + config.GAIA_PORT +
+            '/manifest.webapp',
+          'rocketbar.searchAppURL': config.GAIA_SCHEME + 'search.' +
+            config.GAIA_DOMAIN + config.GAIA_PORT + '/index.html',
+          'debugger.remote-mode': 'adb-only',
+          'language.current': config.GAIA_DEFAULT_LOCALE,
+          'screen.timeout': 600,
           'wallpaper.image': undefined,
           'dialer.ringtone': undefined,
           'notification.ringtone': undefined },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=967516

For PRODUCTION=1 and SIMULATOR=1 builds, nothing changes.
For all other builds, we no enable DEVICE_DEBUG preferences so we can access the dev tools overlay, and connect to the device with app manager.
