### PR TITLE
Bug 961986 - [fugu][buri] it took long time to resume music play after ending a phone call

### DIFF
--- a/apps/communications/dialer/js/calls_handler.js
+++ b/apps/communications/dialer/js/calls_handler.js
@@ -806,3 +806,11 @@ window.addEventListener('load', function callSetup(evt) {
   CallScreen.init();
   KeypadManager.init(true);
 });
+
+window.addEventListener('unload', function() {
+  // When we end the call, we need to clean up the TonePlayer to reset the audio
+  // context's channel back to "normal" to let other audio start playing again.
+  // Otherwise, we'll have to wait until the cycle collector kills it, which
+  // can take a while.
+  TonePlayer.setChannel('normal');
+});


### PR DESCRIPTION
When a call starts, oncall.html opens and the KeypadManager set the priority
of the TonePlayer's audio channel "telephony" so that users can hear tones
when they tap the keypad during a call. We need to reset the channel to
"normal" when hanging up (and thus closing oncall.html) so that other apps can
resume playing audio. Otherwise, we end up waiting for the cycle collector to
kill the audio context, which can take a long time.
