### PR TITLE
Bug 966516 - [B2G][Calender]Changing the month in an event doesn't update to the number associated with that month r=gaye

### DIFF
--- a/apps/calendar/test/unit/.jshintrc
+++ b/apps/calendar/test/unit/.jshintrc
@@ -2,6 +2,7 @@
   "extends": "../../../../.jshintrc",
   "predef": [
     "Calendar",
+    "InputParser",
     "assert",
     "suite",
     "test",

--- a/apps/calendar/test/unit/views/modify_event_test.js
+++ b/apps/calendar/test/unit/views/modify_event_test.js
@@ -4,6 +4,8 @@ requireLib('querystring.js');
 requireElements('calendar/elements/modify_event.html');
 requireElements('calendar/elements/show_event.html');
 
+mocha.globals(['InputParser']);
+
 suiteGroup('Views.ModifyEvent', function() {
   /** disabled because of intermittent failures see bug 917537 */
   return;
@@ -351,7 +353,7 @@ suiteGroup('Views.ModifyEvent', function() {
     });
 
 
-    // this allows to test _updateDateTimeLocale()
+    // this allows to test _setupDateTimeSync() - before user changes value
     test('date/time are displayed according to the locale', function(done) {
       remote.startDate = new Date(2012, 11, 30, 1, 2);
       remote.endDate = new Date(2012, 11, 31, 13, 4);
@@ -372,6 +374,50 @@ suiteGroup('Views.ModifyEvent', function() {
         });
       });
     });
+
+    suite('#_updateDateLocaleOnInput', function() {
+      var clock;
+      var element;
+      var evt;
+
+      setup(function() {
+        element = {};
+        evt = { target: {} };
+      });
+
+      teardown(function() {
+        clock.restore();
+      });
+
+      test('should localize date', function() {
+        var baseTimestamp = (new Date(2014, 0, 20).getTime());
+        clock = sinon.useFakeTimers(baseTimestamp);
+        evt.target.value = '2014-01-21';
+        subject._updateDateLocaleOnInput(element, evt);
+        assert.equal(element.textContent, '01/21/2014');
+      });
+
+      test('display proper month - Bug 966516', function() {
+        // it's really important to mock the Date to be able to reproduce the
+        // Bug 966516, since it only happened if system date was a day higher
+        // than next month end date (eg. Jan 31 and you pick Feb 28)
+        var baseTimestamp = (new Date(2014, 0, 31, 2, 30)).getTime();
+        clock = sinon.useFakeTimers(baseTimestamp);
+        evt.target.value = '2014-02-28';
+        subject._updateDateLocaleOnInput(element, evt);
+        assert.equal(element.textContent, '02/28/2014');
+      });
+    });
+
+    suite('#_updateTimeLocaleOnInput', function() {
+      test('should localize time', function() {
+        var element = {};
+        var evt = { target: { value: '22:31' } };
+        subject._updateTimeLocaleOnInput(element, evt);
+        assert.equal(element.textContent, '10:31 PM');
+      });
+    });
+
   });
 
   suite('#_overrideEvent', function(done) {


### PR DESCRIPTION
I wrote only unit tests (disabled because of intermittent failures on other tests), since there is no way to write marionette tests for this bug (we can't set the system time on a reliable way - b2g always use the host clock).

I also decided to split the method into many methods to make it easier to test. - easier to inject the `targetElement` and don't need to trigger the event.
