### PR TITLE
bug 968102

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -254,8 +254,8 @@
 
     <!-- Operator Variant Mechanism -->
     <script defer src="shared/js/operator_variant_helper.js"></script>
-    <script defer src="js/operator_variant/operator_variant_iccs.js"></script>
     <script defer src="js/operator_variant/operator_variant.js"></script>
+    <script defer src="js/operator_variant/operator_variant_iccs.js"></script>
 
     <!-- Crash Reporter -->
     <link rel="stylesheet" type="text/css" href="style/crash_reporter/crash_reporter.css">


### PR DESCRIPTION
- fix js load order so that OperatorVariantHandler is defined and available as expected.

r=?
