### PR TITLE
Bug 968122 - Add default styles for homescreen dialogs

### DIFF
--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -156,3 +156,10 @@ body[data-mode = 'normal'] ol > li span.options {
   .apps > div { height: 100% !important; }
   #bg-overlay { height: 100%;}
 }
+
+/* Default state for the dialogs.
+ * Will be overwritten when their respective CSS is lazy loaded.
+ */
+#contextmenu-dialog, #confirm-dialog {
+  display: none;
+}


### PR DESCRIPTION
So what happens on FF Nightly is that the templates for the dialogs get filled when you click everything.me bar. I don't really know why that happens. The problem is that all the styling for these elements are in CSS files that will be lazy loaded when needed, causing the elements to show up with their default styles, which is why they are visible. There is no JS logic behind it either (also lazy loaded) so you can't dismiss it.

This patch adds a default style of display: none to the dialogs in homescreen.css that will be overwritten when we load the dialog CSS on demand. Tested it on the device as well and the context menu's still work as expected.
