### PR TITLE
Bug 963377 - [B2G][Keyboard] Keyboard blocks "cancel" / "ok" options

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -607,6 +607,7 @@ var KeyboardManager = {
   hideKeyboard: function km_hideKeyboard() {
     // prevent hidekeyboard trigger again while 'appwillclose' is fired.
     if (this.keyboardFrameContainer.classList.contains('hide')) {
+      this.resetShowingKeyboard();
       return;
     }
 


### PR DESCRIPTION
- Still reset keyboard state when the keyboard frame is hidden, so that
  the keyboard won't be triggered by the keyboard app after it has
  been dismissed.
