### PR TITLE
Bug 934916 - [WAP push][CP] If a CP message is opened, newly coming CP or WAP push messages can still be opened but content is not displayed.

### DIFF
--- a/apps/wappush/js/cp_screen_helper.js
+++ b/apps/wappush/js/cp_screen_helper.js
@@ -142,13 +142,17 @@ var CpScreenHelper = (function() {
     // process when this process was performed by gecko
     isDocumentValid = message.provisioning.authInfo.pass;
 
+    var help = document.getElementById('cp-accept-help');
     if (showPINInput) {
       // If the document has not been authenticated yet and the PIN code is
       // needed, show some info and the PIN input element to the user.
-      var help = document.getElementById('cp-accept-help');
       help.textContent = _('cp-accept-help-pin');
       pin.type = 'text';
       pin.focus();
+    } else {
+      help.textContent = _('cp-accept-help');
+      pin.type = 'hidden';
+      pin.blur();
     }
 
     title.textContent = message.sender;

--- a/apps/wappush/test/unit/wappush_test.js
+++ b/apps/wappush/test/unit/wappush_test.js
@@ -205,7 +205,7 @@ suite('WAP Push', function() {
   });
 
   suite('receiving and displaying a CP message', function() {
-    var message;
+    var messages;
 
      // UI elements
     var screen;
@@ -221,16 +221,30 @@ suite('WAP Push', function() {
       );
       WapPushManager.init(done);
 
-      message = {
-        sender: '22997',
-        contentType: 'text/vnd.wap.connectivity-xml',
-        content: '<wap-provisioningdoc></wap-provisioningdoc>',
-        authInfo: {
-           pass: true,
-           checked: true,
-           sec: 'NETWPIN',
-           mac: 'FAKEMAC',
-           data: 'FAKEDATA'
+      messages = {
+        netwpin: {
+          sender: '22997',
+          contentType: 'text/vnd.wap.connectivity-xml',
+          content: '<wap-provisioningdoc></wap-provisioningdoc>',
+          authInfo: {
+             pass: true,
+             checked: true,
+             sec: 'NETWPIN',
+             mac: 'FAKEMAC',
+             data: 'FAKEDATA'
+          }
+        },
+        userpin: {
+          sender: '22997',
+          contentType: 'text/vnd.wap.connectivity-xml',
+          content: '<wap-provisioningdoc></wap-provisioningdoc>',
+          authInfo: {
+             pass: true,
+             checked: true,
+             sec: 'USERPIN',
+             mac: 'FAKEMAC',
+             data: 'FAKEDATA'
+          }
         }
       };
     });
@@ -248,40 +262,75 @@ suite('WAP Push', function() {
 
     test('the notification is sent', function() {
       var notificationSpy = this.sinon.spy(window, 'Notification');
-      MockNavigatormozSetMessageHandler.mTrigger('wappush-received', message);
+      MockNavigatormozSetMessageHandler.mTrigger(
+        'wappush-received',
+        messages.netwpin
+      );
       MockNavigatormozApps.mTriggerLastRequestSuccess();
       assert.isTrue(notificationSpy.calledOnce);
     });
 
     test('Notification.get() called with correct tag', function() {
-      MockNavigatormozSetMessageHandler.mTrigger('wappush-received', message);
+      MockNavigatormozSetMessageHandler.mTrigger(
+        'wappush-received',
+        messages.netwpin
+      );
       MockNavigatormozApps.mTriggerLastRequestSuccess();
       WapPushManager.displayWapPushMessage(0);
       assert.ok(Notification.get.calledWith({tag: 0}));
     });
 
-    test('the display is populated with the message contents', function() {
-      closeButton = document.getElementById('close');
-      title = document.getElementById('title');
-      screen = document.getElementById('cp-screen');
-      acceptButton = document.getElementById('accept');
-      pin = screen.querySelector('input');
+    test('the display is populated with the NETWPIN message contents',
+      function() {
+        closeButton = document.getElementById('close');
+        title = document.getElementById('title');
+        screen = document.getElementById('cp-screen');
+        acceptButton = document.getElementById('accept');
+        pin = screen.querySelector('input');
 
-      var retrieveSpy = this.sinon.spy(MockMessageDB, 'retrieve');
+        var retrieveSpy = this.sinon.spy(MockMessageDB, 'retrieve');
 
-      MockNavigatormozSetMessageHandler.mTrigger('wappush-received', message);
-      MockNavigatormozApps.mTriggerLastRequestSuccess();
-      WapPushManager.displayWapPushMessage(0);
-      retrieveSpy.yield(ParsedMessage.from(message, 0));
-      assert.equal(title.textContent, message.sender);
-      assert.equal(acceptButton.hidden, false);
-      assert.equal(pin.type, 'hidden');
+        MockNavigatormozSetMessageHandler.mTrigger(
+          'wappush-received',
+          messages.netwpin
+        );
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        WapPushManager.displayWapPushMessage(0);
+        retrieveSpy.yield(ParsedMessage.from(messages.netwpin, 0));
+        assert.equal(title.textContent, messages.netwpin.sender);
+        assert.equal(acceptButton.hidden, false);
+        assert.equal(pin.type, 'hidden');
+    });
+
+    test('the display is populated with the USERPIN message contents',
+      function() {
+        closeButton = document.getElementById('close');
+        title = document.getElementById('title');
+        screen = document.getElementById('cp-screen');
+        acceptButton = document.getElementById('accept');
+        pin = screen.querySelector('input');
+
+        var retrieveSpy = this.sinon.spy(MockMessageDB, 'retrieve');
+
+        MockNavigatormozSetMessageHandler.mTrigger(
+          'wappush-received',
+          messages.netwpin
+        );
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        WapPushManager.displayWapPushMessage(0);
+        retrieveSpy.yield(ParsedMessage.from(messages.userpin, 0));
+        assert.equal(title.textContent, messages.netwpin.sender);
+        assert.equal(acceptButton.hidden, false);
+        assert.equal(pin.type, 'text');
     });
 
     test('Notification is closed', function() {
       var closeSpy = this.sinon.spy(MockNotification.prototype, 'close');
 
-      MockNavigatormozSetMessageHandler.mTrigger('wappush-received', message);
+      MockNavigatormozSetMessageHandler.mTrigger(
+        'wappush-received',
+        messages.netwpin
+      );
       MockNavigatormozApps.mTriggerLastRequestSuccess();
       WapPushManager.displayWapPushMessage(0);
       sinon.assert.called(closeSpy);


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=934916 please.
