### PR TITLE
Bug 951159 - Convert Gaia UI Tests to new notification API

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_notification.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_notification.py
@@ -19,7 +19,7 @@ class TestLockScreen(GaiaTestCase):
 
     def test_lock_screen_notification(self):
         lock_screen = LockScreen(self.marionette)
-        self.marionette.execute_script('navigator.mozNotification.createNotification("%s", "%s").show();'
+        self.marionette.execute_script('Notification("%s", {body: "%s"});'
                                        % (self._notification_title, self._notification_body))
 
         self.assertEqual(len(lock_screen.notifications), 1)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_wake_with_notification.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/test_lockscreen_wake_with_notification.py
@@ -23,7 +23,7 @@ class TestLockScreenNotification(GaiaTestCase):
         # Check if the screen is turned off
         self.assertFalse(self.device.is_screen_enabled)
 
-        self.marionette.execute_script('navigator.mozNotification.createNotification("%s", "%s").show();'
+        self.marionette.execute_script('Notification("%s", {body: "%s"});'
                                        % (self._notification_title, self._notification_body))
         lock_screen.wait_for_notification()
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/test_system_notification_bar.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/test_system_notification_bar.py
@@ -16,7 +16,7 @@ class TestNotificationBar(GaiaTestCase):
         system = System(self.marionette)
 
         # Push a notification
-        self.marionette.execute_script('navigator.mozNotification.createNotification("%s", "%s").show();'
+        self.marionette.execute_script('Notification("%s", {body: "%s"});'
                                        % (self._notification_title, self._notification_body))
 
         system.wait_for_notification_toaster_displayed()


### PR DESCRIPTION
Converting Gaia UI tests to the new notification API (see: https://developer.mozilla.org/en-US/docs/Web/API/notification#Methods).
