### PR TITLE
Bug 965771 - validate RTL locale support in gaia-ui tests; r=zacc

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -9,6 +9,8 @@ smoketest = false
 
 [test_settings_change_language.py]
 
+[test_settings_change_language_rtl.py]
+
 [test_settings_gps.py]
 
 [test_settings_do_not_track.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_change_language_rtl.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/test_settings_change_language_rtl.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gaiatest import GaiaTestCase
+from gaiatest.apps.settings.app import Settings
+
+
+class TestChangeLanguageRTL(GaiaTestCase):
+
+    def test_change_language_settings_rtl(self):
+        lang_name = u'عربي'
+        expected_header = u'الاعدادات'
+
+        settings = Settings(self.marionette)
+        settings.launch()
+
+        language_settings = settings.open_language_settings()
+        language_settings.select_language(lang_name)
+        language_settings.go_back()
+
+        # Verify that language has changed
+        self.wait_for_condition(lambda m: settings.header_text == expected_header)
+        self.assertEqual(self.data_layer.get_setting('language.current'), 'ar')


### PR DESCRIPTION
test for https://bugzilla.mozilla.org/show_bug.cgi?id=965771
