### PR TITLE
Bug 968382 - software home button doesn't work when rocketbar is active r=alive

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -64,7 +64,8 @@
 }
 
 /* Keyboard is shown above task manager */
-#screen.cards-view.task-manager > [data-z-index-level="keyboards"] {
+#screen.cards-view.task-manager > [data-z-index-level="keyboards"],
+#screen.cards-view.task-manager > [data-z-index-level="software-buttons"] {
   z-index: 65538;
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=968382
