### PR TITLE
Bug 967994 - Implement various levels of rocketness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,12 @@ DESKTOP_SHIMS?=0
 GAIA_OPTIMIZE?=0
 GAIA_DEV_PIXELS_PER_PX?=1
 DOGFOOD?=0
-ROCKETBAR?=1
+
+# Rocketbar customization
+# none - Do not enable rocketbar
+# half - Rocketbar is enabled, and so is browser app
+# full - Rocketbar is enabled, no browser app
+ROCKETBAR?=half
 TEST_AGENT_PORT?=8789
 GAIA_APP_TARGET?=engineering
 
@@ -385,7 +390,7 @@ define BUILD_CONFIG
 	"GAIA_APPDIRS" : "$(GAIA_APPDIRS)", \
 	"NOFTU" : "$(NOFTU)", \
 	"REMOTE_DEBUGGER" : "$(REMOTE_DEBUGGER)", \
-	"ROCKETBAR" : $(ROCKETBAR), \
+	"ROCKETBAR" : "$(ROCKETBAR)", \
 	"TARGET_BUILD_VARIANT" : "$(TARGET_BUILD_VARIANT)", \
 	"SETTINGS_PATH" : "$(SETTINGS_PATH)", \
 	"VARIANT_PATH" : "$(VARIANT_PATH)" \

--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -178,7 +178,7 @@ function customizeHomescreen(options) {
   };
 
   // Add the browser icon if rocketbar is not enabled
-  if (config.ROCKETBAR != 1) {
+  if (config.ROCKETBAR !== 'full') {
     customize.homescreens[0].push(['apps', 'browser']);
   }
 
@@ -288,7 +288,7 @@ function customizeHomescreen(options) {
   };
 
   // Only enable configurable bookmarks for dogfood devices
-  if (config.ROCKETBAR == 1) {
+  if (config.ROCKETBAR !== 'none') {
     content.bookmarks = customize.bookmarks;
   }
 

--- a/build/settings.js
+++ b/build/settings.js
@@ -108,7 +108,7 @@ function execute(config) {
   settings['rocketbar.searchAppURL'] = utils.gaiaOriginURL('search',
     config.GAIA_SCHEME, config.GAIA_DOMAIN, config.GAIA_PORT) + '/index.html';
 
-  if (config.ROCKETBAR) {
+  if (config.ROCKETBAR && config.ROCKETBAR !== 'none') {
     settings['rocketbar.enabled'] = true;
   }
 

--- a/build/test/integration/build.test.js
+++ b/build/test/integration/build.test.js
@@ -18,7 +18,7 @@ suite('Build Integration tests', function() {
   });
 
   test('make without rule & variable', function(done) {
-    exec('ROCKETBAR=0 make', function(error, stdout, stderr) {
+    exec('ROCKETBAR=none make', function(error, stdout, stderr) {
       helper.checkError(error, stdout, stderr);
 
       // expected values for prefs and user_prefs

--- a/build/test/unit/applications-data.test.js
+++ b/build/test/unit/applications-data.test.js
@@ -40,7 +40,7 @@ suite('applications-data', function() {
     test('normal', function () {
       var options = {
         GAIA_DISTRIBUTION_DIR: 'TESTGAIADIR',
-        ROCKETBAR: 1
+        ROCKETBAR: 'full'
       };
       var result = app.customizeHomescreen(options);
       assert.deepEqual(result, {
@@ -71,7 +71,7 @@ suite('applications-data', function() {
       var options = {
         GAIA_DISTRIBUTION_DIR: 'TESTGAIADIR',
         PRODUCTION: '1',
-        ROCKETBAR: 0
+        ROCKETBAR: 'none'
       };
       var result = app.customizeHomescreen(options);
       assert.deepEqual(result, {

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -213,9 +213,9 @@ function fillAppManifest(webapp) {
 
   if (webapp.url.indexOf('communications.' + config.GAIA_DOMAIN) !== -1) {
     fillCommsAppManifest(webapp, webappTargetDir);
-  } else if (config.ROCKETBAR && webapp.url.indexOf('browser.' + config.GAIA_DOMAIN) !== -1) {
+  } else if (config.ROCKETBAR === 'full' && webapp.url.indexOf('browser.' + config.GAIA_DOMAIN) !== -1) {
     modifyBrowserForRocketbar(webapp, webappTargetDir);
-  } else if (config.ROCKETBAR && webapp.url.indexOf('system.' + config.GAIA_DOMAIN) !== -1) {
+  } else if (config.ROCKETBAR !== 'none' && webapp.url.indexOf('system.' + config.GAIA_DOMAIN) !== -1) {
     modifySystemForRocketbar(webapp, webappTargetDir);
   }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=967994

This implements three levels of configuration for the ROCKETBAR build flag.

none - No rocketbar, everything should be the same as 1.3.
full - Full rocketbar experience, browser app is removed.
half - Rocketbar is present along with the old browser app. Tapping on links will show an activity with two options, one for the Browser, and one for the System.
