### PR TITLE
Bug 968778 - [browser] "Cancel" is hard-coded in the dialog appearing when long tapping on a link

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1140,7 +1140,7 @@ var Browser = {
 
     var cancel = document.createElement('li');
     cancel.id = 'cancel';
-    cancel.appendChild(this.createButton('Cancel'));
+    cancel.appendChild(this.createButton(_('cancel')));
     list.appendChild(cancel);
 
     cancel.addEventListener('click', function(e) {


### PR DESCRIPTION
Use `_('cancel')` instead of hard-coded "Cancel". String is already available in browser.properties
