### PR TITLE
Bug 917537 - Turn back on modify_event_test.js it was disabled because of intermittent failures

### DIFF
--- a/apps/calendar/test/unit/views/modify_event_test.js
+++ b/apps/calendar/test/unit/views/modify_event_test.js
@@ -7,8 +7,6 @@ requireElements('calendar/elements/show_event.html');
 mocha.globals(['InputParser']);
 
 suiteGroup('Views.ModifyEvent', function() {
-  /** disabled because of intermittent failures see bug 917537 */
-  return;
 
   var subject;
   var controller;


### PR DESCRIPTION
I was not able to reproduce bug (executed tests many times over past week), so I'm re-enabling it.
