### PR TITLE
Bug 969287 - Keyboard click sound should not be enabled by default r=janjongboom

### DIFF
--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -64,7 +64,7 @@
    "icc.goBackTimeout": 1000,
    "icc.selectTimeout": 150000,
    "keyboard.vibration": true,
-   "keyboard.clicksound": true,
+   "keyboard.clicksound": false,
    "keyboard.autocorrect": true,
    "keyboard.wordsuggestion": true,
    "keyboard.current": null,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=969287
