### PR TITLE
Bug 969193 - [Cost Control] The string "Ok" is not localizable when launching cost control with a locked SIM

### DIFF
--- a/apps/costcontrol/index.html
+++ b/apps/costcontrol/index.html
@@ -124,7 +124,7 @@ the overlays) and we should distinguish between TABS and OVERLAY VIEWS -->
       <progress></progress>
     </div>
     <menu>
-      <button class="full" data-l10n-id="confirm">Ok</button>
+      <button class="full" data-l10n-id="ok">Ok</button>
     </menu>
   </section>
 </body>


### PR DESCRIPTION
Button is using a non existent string ID `confirm`. Existing string with id “ok” seems to be unused in other contexts, so it should be safe to use it here.
