### PR TITLE
Bug 969609 - [B2G][Email]Opening an email notification then pressing back in the email app leads to a black screen

### DIFF
--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -556,6 +556,21 @@ Cards = {
     return this._cardStack[this._findCard(query)];
   },
 
+  getCurrentCardType: function() {
+    var result = null,
+        card = this._cardStack[this.activeCardIndex];
+
+    // Favor any _pendingPush value as it is about to
+    // become current, just waiting on an async cycle
+    // to finish. Otherwise use current card value.
+    if (this._pendingPush) {
+      result = this._pendingPush;
+    } else if (card) {
+      result = [card.cardDef.name, card.cardImpl.mode];
+    }
+    return result;
+  },
+
   folderSelector: function(callback) {
     var self = this;
 


### PR DESCRIPTION
This was caused because our notification entry point, and our activity entry point, were assuming that the message list card was the likely start card, if any, in the stack. However, it is possible that the user could be viewing the folder list, or even more problematic, the settings cards, that are stacked on top of the other cards.

Just inserting a card for the notification or activity at the end of that card stack results in an unexpected flow change. In particular, the card inserted may have a "back" action that is not actually back to what was shown before the card insertion, but back in a set application flow.

So this change removes all cards when coming in from an activity or notification entry point so the stack is fresh. However, if the current card is the message_list card, it is kept, as we know it is a good start point for adding cards from an activity/notification flow.

As far as removing cards and possibly losing data, the main concern would be compose. However, compose already saves a draft on a visibility change, which is the likely in order to get to the point of clicking on the notification or starting a new activity.

Not including a test since this affects 1.3, so has a good chance to be uplifted, and that branch does not have the updated test changes that allow the tests to pass well that are in master.
