### PR TITLE
Bug 969768: Fix "Reload application" button on the Gaia browser-helper extension

### DIFF
--- a/tools/extensions/browser-helper@gaiamobile.org/content/panel/controls.js
+++ b/tools/extensions/browser-helper@gaiamobile.org/content/panel/controls.js
@@ -63,8 +63,10 @@ function Workflow() {
 
 Workflow.prototype = {
   reload: function() {
-    var wm = tab.wrappedJSObject.WindowManager
-    var app = wm.getRunningApps()[wm.getDisplayedApp()];
+    var global = tab.wrappedJSObject;
+    var wm = global.AppWindowManager;
+    var app = wm.getActiveApp();
+
     app.reload();
   },
 


### PR DESCRIPTION
I know atleast two other people had this problem on OSX + Firefox Nightly (Feb 7) + gaia @ f8dd1f477f2362abed76aec31ff29f1c5e87ec3d. I'm not sure how wide-spread this problem is. But this fixes it atleast for us three and makes app development oh-so-much-nicer <3

:haircut: 
