### PR TITLE
Bug 963917: reduce Gallery memory use (and fix leak) while scanning

### DIFF
--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -37,7 +37,7 @@ var metadataParser = (function() {
     var canvas = document.createElement('canvas');
     canvas.width = THUMBNAIL_WIDTH;
     canvas.height = THUMBNAIL_HEIGHT;
-    var context = canvas.getContext('2d');
+    var context = canvas.getContext('2d', { willReadFrequently: true });
     var eltwidth = elt.width;
     var eltheight = elt.height;
     var scalex = canvas.width / eltwidth;
@@ -124,7 +124,12 @@ var metadataParser = (function() {
       context.fill();
     }
 
-    canvas.toBlob(callback, 'image/jpeg');
+    canvas.toBlob(function(blob) {
+      context = null;
+      canvas.width = canvas.height = 0;
+      canvas = null;
+      callback(blob);
+    }, 'image/jpeg');
   }
 
   var VIDEOFILE = /DCIM\/\d{3}MZLLA\/VID_\d{4}\.jpg/;
@@ -348,7 +353,7 @@ var metadataParser = (function() {
         var canvas = document.createElement('canvas');
         canvas.width = pw;
         canvas.height = ph;
-        var context = canvas.getContext('2d');
+        var context = canvas.getContext('2d', { willReadFrequently: true });
         context.drawImage(offscreenImage, 0, 0, iw, ih, 0, 0, pw, ph);
         canvas.toBlob(function(blob) {
           offscreenImage.src = '';

--- a/shared/js/mediadb.js
+++ b/shared/js/mediadb.js
@@ -340,6 +340,12 @@
  *     named file in DeviceStorage and passes it (a Blob) to the callback.
  *     An error callback is available as an optional third argument.
  *
+ * - getFileInfo(): given a filename and a callback, this method looks up
+ *     the database record for that file and passes it to the callback. If
+ *     no such record exists and an error callback was passed as the 3rd
+ *     argument, then an error message is passed to that error callback.
+ *     Note that unlike getFile() this method does not return file content.
+ *
  * - count(): count the number of records in the database and pass the value
  *     to the specified callback. Like enumerate(), this method allows you
  *     to specify the name of an index and a key range if you only want to
@@ -882,6 +888,33 @@ var MediaDB = (function() {
       if (position === -1)
         return;
       listeners.splice(position, 1);
+    },
+
+    // Look up the database record for the specfied filename and pass it
+    // to the specified callback.
+    getFileInfo: function getFile(filename, callback, errback) {
+      if (this.state === MediaDB.OPENING)
+        throw Error('MediaDB is not ready. State: ' + this.state);
+
+      var media = this;
+
+      // First, look up the fileinfo record in the db
+      var read = media.db.transaction('files', 'readonly')
+        .objectStore('files')
+        .get(filename);
+
+      read.onerror = function() {
+        var msg = 'MediaDB.getFileInfo: unknown filename: ' + filename;
+        if (errback)
+          errback(msg);
+        else
+          console.error(msg);
+      };
+
+      read.onsuccess = function() {
+        if (callback)
+          callback(read.result);
+      };
     },
 
     // Look up the specified filename in DeviceStorage and pass the
@@ -1865,6 +1898,8 @@ var MediaDB = (function() {
     }
 
     if (details.pendingCreateNotifications.length > 0) {
+      var creations = details.pendingCreateNotifications;
+      details.pendingCreateNotifications = [];
 
       // If this is a first scan, and we have records that are not
       // in the db yet, write them to the db now
@@ -1874,11 +1909,21 @@ var MediaDB = (function() {
         for (var i = 0; i < details.records.length; i++)
           store.add(details.records[i]);
         details.records.length = 0;
-      }
 
-      var creations = details.pendingCreateNotifications;
-      details.pendingCreateNotifications = [];
-      dispatchEvent(media, 'created', creations);
+        // One of the original points of this firstscan optimization was that
+        // we could dispatch the created events without waiting for the
+        // database writes to complete. It turns out (see bug 963917) that
+        // we can't do that because the Gallery app needs to read records
+        // from the db in order to be sure it is holding file-based blobs
+        // instead of memory-based blobs. So we wait for the transaction to
+        // complete before sending the notifications.
+        transaction.oncomplete = function() {
+          dispatchEvent(media, 'created', creations);
+        };
+      }
+      else {
+        dispatchEvent(media, 'created', creations);
+      }
     }
   }
 


### PR DESCRIPTION
force software canvases for thumbnail and preview creation with willReadFrequently

Free canvas memory after creating a thumbnail

Make sure our thumbnail blobs are file-backed not memory-backed

update mediadb docs
