### PR TITLE
Bug 963917: reduce Gallery memory use (and fix leak) while scanning

### DIFF
--- a/apps/gallery/js/MetadataParser.js
+++ b/apps/gallery/js/MetadataParser.js
@@ -44,7 +44,7 @@ var metadataParser = (function() {
       var canvas = document.createElement('canvas');
       canvas.width = THUMBNAIL_WIDTH;
       canvas.height = THUMBNAIL_HEIGHT;
-      var context = canvas.getContext('2d');
+      var context = canvas.getContext('2d', { willReadFrequently: true });
       var eltwidth = elt.width;
       var eltheight = elt.height;
       var scalex = canvas.width / eltwidth;
@@ -69,7 +69,6 @@ var metadataParser = (function() {
         // All transformation are applied to the center of the thumbnail.
         context.translate(centerX, centerY);
       }
-
       if (mirrored) {
         context.scale(-1, 1);
       }
@@ -131,7 +130,12 @@ var metadataParser = (function() {
         context.fill();
       }
 
-      canvas.toBlob(callback, 'image/jpeg');
+      canvas.toBlob(function(blob) {
+        context = null;
+        canvas.width = canvas.height = 0;
+        canvas = null;
+        callback(blob);
+      }, 'image/jpeg');
     } catch (ex) {
       // An error may be thrown when the drawImage decodes a broken/trancated
       // image.
@@ -364,7 +368,7 @@ var metadataParser = (function() {
         var canvas = document.createElement('canvas');
         canvas.width = pw;
         canvas.height = ph;
-        var context = canvas.getContext('2d');
+        var context = canvas.getContext('2d', { willReadFrequently: true });
         context.drawImage(offscreenImage, 0, 0, iw, ih, 0, 0, pw, ph);
         canvas.toBlob(function(blob) {
           offscreenImage.src = '';

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -246,8 +246,8 @@ function initDB() {
   photodb = new MediaDB('pictures', metadataParserWrapper, {
     version: 2,
     autoscan: false,     // We're going to call scan() explicitly
-    batchHoldTime: 150,  // Batch files during scanning
-    batchSize: PAGE_SIZE // Max batch size: one screenful
+    batchHoldTime: 2000, // Batch files during scanning
+    batchSize: 3         // Max batch size when scanning
   });
 
   // This is where we find videos once the photodb notifies us that a
@@ -586,42 +586,52 @@ function deleteFile(n) {
 }
 
 function fileCreated(fileinfo) {
-  var insertPosition;
   // If the new file is a video and we're handling an image pick activity
   // then we won't display the new file.
   if (pendingPick && fileinfo.metadata.video)
     return;
 
-  // If we were showing the 'no pictures' overlay, hide it
-  if (currentOverlay === 'emptygallery' || currentOverlay === 'scanning')
-    showOverlay(null);
+  // The fileinfo object that MediaDB sends us has a thumbnail blob in it,
+  // fresh from the metadata parser. This blob has been stored in the db, but
+  // the copy we have is still a memory-backed blob. We need to be using a
+  // file backed blob here so that we don't leak memory if the user scans a
+  // fresh sdcard full of hundreds of photos. So we go get the db record out
+  // of the database. It should be an exact copy of what we already have,
+  // except that the thumbnail will be file-backed instead of memory-backed.
+  photodb.getFileInfo(fileinfo.name, function(fileinfo) {
+    var insertPosition;
 
-  // Create a thumbnailItem for this image and insert it at the right spot
-  var thumbnailItem = thumbnailList.addItem(fileinfo);
-  insertPosition = getFileIndex(fileinfo.name);
-  if (insertPosition < 0)
-    return;
+    // If we were showing the 'no pictures' overlay, hide it
+    if (currentOverlay === 'emptygallery' || currentOverlay === 'scanning')
+      showOverlay(null);
 
-  // Insert the image info into the array
-  files.splice(insertPosition, 0, fileinfo);
+    // Create a thumbnailItem for this image and insert it at the right spot
+    var thumbnailItem = thumbnailList.addItem(fileinfo);
+    insertPosition = getFileIndex(fileinfo.name);
+    if (insertPosition < 0)
+      return;
 
-  if (currentFileIndex >= insertPosition)
-    currentFileIndex++;
-  if (editedPhotoIndex >= insertPosition)
-    editedPhotoIndex++;
+    // Insert the image info into the array
+    files.splice(insertPosition, 0, fileinfo);
 
-  // Redisplay the current photo if we're in photo view. The current
-  // photo should not change, but the content of the next or previous frame
-  // might. This call will only make changes if the filename to display
-  // in a frame has actually changed.
-  if (currentView === LAYOUT_MODE.fullscreen) {
-    if (hasSaved) {
-      showFile(0);
-    } else {
-      showFile(currentFileIndex);
+    if (currentFileIndex >= insertPosition)
+      currentFileIndex++;
+    if (editedPhotoIndex >= insertPosition)
+      editedPhotoIndex++;
+
+    // Redisplay the current photo if we're in photo view. The current
+    // photo should not change, but the content of the next or previous frame
+    // might. This call will only make changes if the filename to display
+    // in a frame has actually changed.
+    if (currentView === LAYOUT_MODE.fullscreen) {
+      if (hasSaved) {
+        showFile(0);
+      } else {
+        showFile(currentFileIndex);
+      }
     }
-  }
-  hasSaved = false;
+    hasSaved = false;
+  });
 }
 
 // Make the thumbnail for image n visible

--- a/shared/js/mediadb.js
+++ b/shared/js/mediadb.js
@@ -340,6 +340,12 @@
  *     named file in DeviceStorage and passes it (a Blob) to the callback.
  *     An error callback is available as an optional third argument.
  *
+ * - getFileInfo(): given a filename and a callback, this method looks up
+ *     the database record for that file and passes it to the callback. If
+ *     no such record exists and an error callback was passed as the 3rd
+ *     argument, then an error message is passed to that error callback.
+ *     Note that unlike getFile() this method does not return file content.
+ *
  * - count(): count the number of records in the database and pass the value
  *     to the specified callback. Like enumerate(), this method allows you
  *     to specify the name of an index and a key range if you only want to
@@ -882,6 +888,33 @@ var MediaDB = (function() {
       if (position === -1)
         return;
       listeners.splice(position, 1);
+    },
+
+    // Look up the database record for the specfied filename and pass it
+    // to the specified callback.
+    getFileInfo: function getFile(filename, callback, errback) {
+      if (this.state === MediaDB.OPENING)
+        throw Error('MediaDB is not ready. State: ' + this.state);
+
+      var media = this;
+
+      // First, look up the fileinfo record in the db
+      var read = media.db.transaction('files', 'readonly')
+        .objectStore('files')
+        .get(filename);
+
+      read.onerror = function() {
+        var msg = 'MediaDB.getFileInfo: unknown filename: ' + filename;
+        if (errback)
+          errback(msg);
+        else
+          console.error(msg);
+      };
+
+      read.onsuccess = function() {
+        if (callback)
+          callback(read.result);
+      };
     },
 
     // Look up the specified filename in DeviceStorage and pass the
@@ -1865,6 +1898,8 @@ var MediaDB = (function() {
     }
 
     if (details.pendingCreateNotifications.length > 0) {
+      var creations = details.pendingCreateNotifications;
+      details.pendingCreateNotifications = [];
 
       // If this is a first scan, and we have records that are not
       // in the db yet, write them to the db now
@@ -1874,11 +1909,21 @@ var MediaDB = (function() {
         for (var i = 0; i < details.records.length; i++)
           store.add(details.records[i]);
         details.records.length = 0;
-      }
 
-      var creations = details.pendingCreateNotifications;
-      details.pendingCreateNotifications = [];
-      dispatchEvent(media, 'created', creations);
+        // One of the original points of this firstscan optimization was that
+        // we could dispatch the created events without waiting for the
+        // database writes to complete. It turns out (see bug 963917) that
+        // we can't do that because the Gallery app needs to read records
+        // from the db in order to be sure it is holding file-based blobs
+        // instead of memory-based blobs. So we wait for the transaction to
+        // complete before sending the notifications.
+        transaction.oncomplete = function() {
+          dispatchEvent(media, 'created', creations);
+        };
+      }
+      else {
+        dispatchEvent(media, 'created', creations);
+      }
     }
   }
 


### PR DESCRIPTION
force software canvases for thumbnail and preview creation with willReadFrequently

Free canvas memory after creating a thumbnail

Make sure our thumbnail blobs are file-backed not memory-backed

update mediadb docs
(cherry picked from commit 4b5eaa4a2823d8961b80a3b975b1eeed92b9fcb7)

Conflicts:

```
apps/gallery/js/MetadataParser.js
apps/gallery/js/gallery.js
```
