### PR TITLE
Bug 970901 Skip test_cards_view_with_three_apps.py due to it failing intermittently...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/manifest.ini
@@ -7,5 +7,5 @@ b2g = true
 [test_cards_view_kill_apps_with_two_apps.py]
 
 [test_cards_view_with_three_apps.py]
-#  Bug 915138 - Cards view can have a maximum of 3 cards
-fail-if = device == "msm7627a"
+#  Test fails intermittently on device
+skip-if = device == "msm7627a"


### PR DESCRIPTION
... on device.

http://qa-selenium.mv.mozilla.com:8080/job/b2g.hamachi.mozilla-b2g28_v1.3.adhoc/6/
