### PR TITLE
Bug 969136: Update NFC Manager to handle Tag Discovered, empty tags, and unformatted tags.

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -225,6 +225,7 @@ var NfcManager = {
     }
     if (action == null) {
       this._debug('XX Found no ndefmessage actions. XX');
+      action = this.formatNDEFUnknown(ndefmessage);
     } else {
       action.data.records = ndefmessage;
     }
@@ -282,6 +283,15 @@ var NfcManager = {
       }
   },
 
+  handleNdefDiscoveredEmpty:
+    function nm_handleNdefDiscoveredEmpty(tech, sessionToken) {
+      var empty = new Uint8Array(0);
+      var emptyRec = [new MozNDEFRecord(NDEF.tnf_empty,
+                                        NDEF.rtd_text,
+                                        empty, empty)];
+      this.handleNdefDiscovered(tech, sessionToken, emptyRec);
+  },
+
   // NDEF only currently
   handleP2P: function handleP2P(tech, sessionToken, records) {
     if (records != null) {
@@ -327,17 +337,17 @@ var NfcManager = {
     var self = this;
     // Fire off activity to whoever is registered to handle a generic
     // binary blob.
-    var technologyTags = command.tag;
+    var techList = command.techList;
     var a = new MozActivity({
-      name: 'tag-discovered',
+      name: 'nfc-tag-discovered',
       data: {
         type: 'tag',
-        sessionId: command.sessionToken,
-        tag: technologyTags
+        sessionToken: command.sessionToken,
+        techList: techList
       }
     });
     a.onerror = function() {
-      self._debug('Firing tag-discovered failed');
+      self._debug('Firing nfc-tag-discovered failed');
     };
   },
 
@@ -386,9 +396,10 @@ var NfcManager = {
     var priority = {
       'P2P': 0,
       'NDEF': 1,
-      'NDEF_FORMATTABLE': 2,
-      'NFC_A': 3,
-      'MIFARE_ULTRALIGHT': 4
+      'NDEF_WRITEABLE': 2,
+      'NDEF_FORMATTABLE': 3,
+      'NFC_A': 4,
+      'MIFARE_ULTRALIGHT': 5
     };
     techList.sort(function sorter(techA, techB) {
       return priority[techA] - priority[techB];
@@ -400,7 +411,14 @@ var NfcManager = {
         this.handleP2P(techList[0], command.sessionToken, records);
         break;
       case 'NDEF':
-        this.handleNdefDiscovered(techList[0], command.sessionToken, records);
+        if (records) {
+          this.handleNdefDiscovered(techList[0], command.sessionToken, records);
+        } else {
+          this.handleNdefDiscoveredEmpty(techList[0], command.sessionToken);
+        }
+        break;
+      case 'NDEF_WRITEABLE':
+        this.handleNdefDiscoveredEmpty(techList[0], command.sessionToken);
         break;
       case 'NDEF_FORMATTABLE':
         this.handleNdefDiscoveredUseConnect(techList[0], command.sessionToken);
@@ -437,6 +455,15 @@ var NfcManager = {
       name: 'nfc-ndef-discovered',
       data: {
         type: 'empty'
+      }
+    };
+  },
+
+  formatNDEFUnknown: function nm_formatUnknown(record) {
+    return {
+      name: 'nfc-ndef-discovered',
+      data: {
+        type: NfcUtil.toUTF8(record.type)
       }
     };
   },


### PR DESCRIPTION
This patch does a few things. Totally factory fresh NFC tags (used tags are not always resettable to factory clean state) are supported with this patch.
- NDEF also handles the case of no records being returned (as they are not formatted)
- NDEF_WRITABLE is added to NFC Manager to handle the case where NDEF is not specified as a tech type.
- The application, will now get a nfc-tag-discovered if it hits the default case.
