### PR TITLE
Bug 929027 - [Messages] Multiple image sharing from Gallery to Messages r=schung

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -84,6 +84,7 @@ var ActivityHandler = {
       ThreadUI.enableActivityRequestMode();
     },
     share: function shareHandler(activity) {
+      var arr = [];
       var blobs = activity.source.data.blobs,
         names = activity.source.data.filenames;
 
@@ -95,11 +96,10 @@ var ActivityHandler = {
             name: names[idx],
             isDraft: true
           });
-          // TODO: We only allow sharing one item in a single action now.
-          //       Keeping the same sequence while adding the multiple items
-          //       should be considered in the future.
-          Compose.append(attachment);
+          arr.push(attachment);
         });
+        ThreadUI.cleanFields(true);
+        Compose.append(arr);
       }
 
       // Navigating to the 'New Message' page is an asynchronous operation that

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -57,7 +57,9 @@
     "share": {
       "filters": {
         "type": ["image/*", "audio/*", "video/*"],
-        "number": 1
+        "number": {
+          "max": 5
+        }
        },
       "disposition": "window"
     }

--- a/apps/sms/test/unit/activity_handler_test.js
+++ b/apps/sms/test/unit/activity_handler_test.js
@@ -107,7 +107,8 @@ suite('ActivityHandler', function() {
   });
 
   suite('"share" activity', function() {
-    var shareActivity;
+    var shareActivity, blobs, names;
+    var arr = [];
 
     setup(function() {
       this.prevHash = window.location.hash;
@@ -116,8 +117,9 @@ suite('ActivityHandler', function() {
         source: {
           name: 'share',
           data: {
-            blobs: [new Blob(), new Blob()],
-            filenames: ['testBlob1', 'testBlob2']
+            blobs: [new Blob(), new Blob(), new Blob(), new Blob(), new Blob()],
+            filenames: ['testBlob1', 'testBlob2', 'testBlob3', 'testBlob4',
+                        'testBlob5']
           }
         }
       };
@@ -129,6 +131,23 @@ suite('ActivityHandler', function() {
       Compose.append = this.prevAppend;
     });
 
+    test('test for pushing an attachments to an array', function() {
+      blobs = shareActivity.source.data.blobs;
+      names = shareActivity.source.data.filenames;
+      assert.ok(arr.length === 0);
+
+      blobs.forEach(function(blob, idx) {
+        var attachment = new Attachment(blob, {
+          name: names[idx],
+          isDraft: true
+        });
+        arr.push(attachment);
+      });
+      ThreadUI.cleanFields(true);
+      //checks an array length after pushing the data to an array
+      assert.ok(arr.length > 0);
+    });
+
     test('modifies the URL "hash" when necessary', function() {
       window.location.hash = '#wrong-location';
       MockNavigatormozSetMessageHandler.mTrigger('activity', shareActivity);
@@ -137,14 +156,12 @@ suite('ActivityHandler', function() {
 
     test('Appends an attachment to the Compose field for each media file',
       function(done) {
-      this.sinon.stub(Compose, 'append', function(attachment) {
-
-        assert.instanceOf(attachment, Attachment);
-        assert.ok(Compose.append.callCount < 3);
-
-        if (Compose.append.callCount === 2) {
-          done();
-        }
+      this.sinon.stub(Compose, 'append', function(arr) {
+        assert.equal(arr.length, 5);
+        arr.forEach(function(attachment) {
+          assert.instanceOf(attachment, Attachment);
+        });
+        done();
       });
 
       MockNavigatormozSetMessageHandler.mTrigger('activity', shareActivity);

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -225,6 +225,41 @@ suite('compose_test.js', function() {
         assert.equal(txt[0], '<b>hi!</b>\ntest');
       });
 
+      test('Compose.append(array)', function() {
+        this.sinon.spy(Compose, 'append');
+
+        // The initial call and the subsequent calls for the two array items
+        // will result in 3 calls to Compose.append
+        Compose.append([1, 2]);
+
+        sinon.assert.calledThrice(Compose.append);
+      });
+
+      test('Compose.append(item, { ignoreChange: true })', function() {
+        var count = 0;
+        Compose.on('input', function() {
+          count++;
+        });
+
+        // Providing ignoreChange: true for a single item
+        // append will skip the call to onContentChanged
+        Compose.append(1, {ignoreChange: true});
+
+        assert.equal(count, 0);
+      });
+
+      test('Compose.append(array), implied ignoreChange', function() {
+        var count = 0;
+        Compose.on('input', function() {
+          count++;
+        });
+
+        // An array of items will trigger only 1 call to onContentChanged
+        Compose.append([1, 2]);
+
+        assert.equal(count, 1);
+      });
+
       test('Message prepend', function() {
         Compose.append('end');
         Compose.prepend('start');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=929027

Changes for the patch
1.Allow maximum of 5 images while sharing from  Gallery for MMS
2.To avoid the concurrent call (inorder to avoid crash),created new array, pushing all the attachments and finally calling append() by passing array.
 3.Added ThreadUI.cleanFields(true); inorder to replace the existing set of images when new set images are shared from Gallery, if the compose area already have images attached without sending.
4.Added resizedImg() inorder to make the process sequential
5.Checking containsImage flag to handle the multipart/mixed type
6.Added new test and modified the existing test cases to handle the functionality
