### PR TITLE
Bug 971605 - Gaiatest can not restart b2g process on hamachi

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -694,7 +694,7 @@ class GaiaDevice(object):
     @property
     def is_android_build(self):
         if self.testvars.get('is_android_build') is None:
-            self.testvars['is_android_build'] = 'Android' in self.marionette.session_capabilities['platformName']
+            self.testvars['is_android_build'] = 'android' in self.marionette.session_capabilities['platformName'].lower()
         return self.testvars['is_android_build']
 
     @property


### PR DESCRIPTION
The platformName is changed from Android to ANDROID.

```
>>> marionette.session_capabilities['platformName']
u'ANDROID'
```
