### PR TITLE
Bug 971691 - "day view header copy should not overflow" marionette js test is failing

### DIFF
--- a/apps/calendar/test/marionette/day_view_test.js
+++ b/apps/calendar/test/marionette/day_view_test.js
@@ -1,6 +1,6 @@
 var Calendar = require('./calendar'),
     Marionette = require('marionette-client');
-    assert = require('assert');
+    assert = require('chai').assert;
 
 marionette('day view', function() {
   var app;
@@ -10,11 +10,14 @@ marionette('day view', function() {
     app = new Calendar(client);
     app.launch({ hideSwipeHint: true });
     // Go to day view
-    app.findElement('dayButton').click();
+    app.waitForElement('dayButton').click();
     client.waitFor(app.isDayViewActive.bind(app));
   });
 
   test('header copy should not overflow', function() {
-    assert.doesNotThrow(app.checkOverflow.bind(app, 'monthYearHeader'));
+    var header = app.waitForElement('monthYearHeader');
+    // XXX: we don't use app.checkOverflow() because of Bug 971691
+    // 20 chars is a "safe" limit if font-family is Fira Sans
+    assert.operator(header.text().length, '<', 21);
   });
 });


### PR DESCRIPTION
change test logic to avoid errors caused by different system font/size
