### PR TITLE
Xfail test_cost_control_data_alert_mobile.py because of Bug 971696 - [v1...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
@@ -12,6 +12,8 @@ wifi = false
 [test_cost_control_data_alert_mobile.py]
 skip-if = device == "desktop"
 wifi = false
+# Bug 971696 - [v1.3][Cost Control] No data usage is available in notification bar or app
+expected = fail
 
 [test_cost_control_reset_wifi.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
....3][Cost Control] No data usage is available in notification bar or app
