### PR TITLE
Bug 971617 - [Sora]Switching accounts,and select the folder to move the mail,the current account folder list display error

### DIFF
--- a/apps/email/js/model.js
+++ b/apps/email/js/model.js
@@ -61,8 +61,18 @@ define(function(require) {
     **/
     folder: null,
 
+    /**
+     * emits an event based on a property value. Since the
+     * event is based on a property value that is on this
+     * object, *do not* use emitWhenListener, since, due to
+     * the possibility of queuing old values with that
+     * method, it could cause bad results (bug 971617), and
+     * it is not needed since the latest* methods will get
+     * the latest value on this object.
+     * @param  {String} id event ID/property name
+     */
     _callEmit: function(id) {
-      this.emitWhenListener(id, this[id]);
+      this.emit(id, this[id]);
     },
 
     inited: false,


### PR DESCRIPTION
This occurred because model.js was using evt.emitWhenListener('foldersSlice') to emit events about a foldersSlice change. With two account changes right in a row, there were two events queued up for 'foldersSlice', the one for the incorrect one was first.

So when mail_common's ValueSelector use asked for model.latestOnce(), it got the first, out of date, event in the _pendingEvents queue.

On further inspection, model should not have been using emitWhenListener because it was only using that for generating events based on property IDs, and the `evt.latest*` methods check for property names on the object with that name already.

So the only concern would be for consumers of `model` that were using `model.on()` to get notified of a change and they register too late to receive that change. However, the `evt.latest*` methods were constructed specifically for the `model` uses where code just wants the latest value on the object, or get notified when it arrives.

This bore out when searching the email code for `model.on()`: the only cases where it is used care only about change events, not the "get current value or wait until there is one" cases where `latest` is used:
- mail_app calls `model.on('acctsSlice', ...)` and does so before model is inited, so gets all the change events.
  - message_list calls `model.on('newInboxMessages', ...)`, and 'newInboxMessages' is only emitted via `model.emit`, not `emitWhenListener`, so this changes does not affect it. Similarly, in my drawer branch, the 'foldersSliceOnChange' is a `model.on()` and 'model.emit()` pairing.

So while this code change has the potential to affect a few pathways, it most likely fixes them vs. breaking them.
