### PR TITLE
Fix for bug 969996

### DIFF
--- a/apps/communications/dialer/test/unit/call_log_test.js
+++ b/apps/communications/dialer/test/unit/call_log_test.js
@@ -6,6 +6,7 @@ requireApp('communications/dialer/js/call_log.js');
 requireApp('communications/dialer/js/utils.js');
 requireApp('communications/dialer/test/unit/mock_call_log_db_manager.js');
 requireApp('communications/dialer/test/unit/mock_l10n.js');
+requireApp('communications/dialer/test/unit/mock_performance_testing_helper.js');
 requireApp('sms/test/unit/mock_async_storage.js');
 require('/shared/test/unit/mocks/mock_lazy_loader.js');
 
@@ -14,6 +15,7 @@ requireApp('communications/shared/test/unit/mocks/mock_notification.js');
 var mocksHelperForCallLog = new MocksHelper([
   'asyncStorage',
   'CallLogDBManager',
+  'PerformanceTestingHelper',
   'LazyLoader',
   'LazyL10n'
 ]).init();
@@ -191,6 +193,37 @@ suite('dialer/call_log', function() {
     }
   };
 
+  function appendAndCheckGroupDOM(count, date, callback) {
+    var groups = [];
+    for (var i = 1; i <= count; i++) {
+      var grp = JSON.parse(JSON.stringify(incomingGroup));
+      grp.id = i;
+      grp.date = date ? date : i;
+      groups.push(grp);
+      CallLogDBManager.add(grp);
+    }
+    CallLog.render();
+    setTimeout(function() {
+      var sections = CallLog.callLogContainer.getElementsByTagName('section');
+      if (date) {
+        assert.equal(sections.length, 1);
+        var groupDOM = sections[0].getElementsByTagName('ol')[0];
+        var doms = groupDOM.getElementsByTagName('li');
+        for (var i = 0; i < count; i++) {
+          checkGroupDOM(doms[i], groups[i], null);
+        }
+      } else {
+        assert.equal(sections.length, count);
+        for (var i = 0; i < count; i++) {
+          var groupDOM = sections[i].getElementsByTagName('ol')[0];
+          var doms = groupDOM.getElementsByTagName('li');
+          checkGroupDOM(doms[0], groups[i], null);
+        }
+      }
+      callback();
+    });
+  }
+
   function checkGroupDOM(groupDOM, group, callback) {
     assert.ok(groupDOM, 'groupDOM exists');
     assert.ok(groupDOM instanceof Object, 'groupDOM is an object');
@@ -284,7 +317,9 @@ suite('dialer/call_log', function() {
     if (group.retryCount > 1) {
       assert.equal(retryCount.innerHTML, '(' + group.retryCount + ')');
     }
-    callback();
+    if (callback) {
+      callback();
+    }
   }
 
   function checkGroupDOMContactUpdated(groupDOM, contact, number, callback) {
@@ -352,6 +387,70 @@ suite('dialer/call_log', function() {
 
     test('Emergency group', function(done) {
       checkGroupDOM(CallLog.createGroup(emergencyGroup), emergencyGroup, done);
+    });
+  });
+
+  suite('render', function() {
+    var renderSeveralDaysSpy;
+
+    setup(function() {
+        renderSeveralDaysSpy = this.sinon.spy(CallLog, 'renderSeveralDays');
+    });
+
+    teardown(function() {
+      CallLogDBManager.deleteAll(function() {
+        CallLog.render();
+        setTimeout(function() {});
+      });
+    });
+
+    test('Below first render threshold same day', function(done) {
+      appendAndCheckGroupDOM(5, 1, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 1);
+      });
+      done();
+    });
+
+    test('Above first render threshold same day', function(done) {
+      appendAndCheckGroupDOM(10, 1, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 1);
+      });
+      done();
+    });
+
+    test('Below first render threshold different days', function(done) {
+      appendAndCheckGroupDOM(5, null, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 1);
+      });
+      done();
+    });
+
+    test('Above first render threshold different days', function(done) {
+      appendAndCheckGroupDOM(10, null, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 2);
+      });
+      done();
+    });
+
+    test('Below batch render threshold', function(done) {
+      appendAndCheckGroupDOM(50, null, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 2);
+      });
+      done();
+    });
+
+    test('Above batch render threshold', function(done) {
+      appendAndCheckGroupDOM(100, null, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 3);
+      });
+      done();
+    });
+
+    test('Multiple batch renders', function(done) {
+      appendAndCheckGroupDOM(300, null, function() {
+        sinon.assert.callCount(renderSeveralDaysSpy, 6);
+      });
+      done();
     });
   });
 

--- a/apps/communications/dialer/test/unit/mock_call_log_db_manager.js
+++ b/apps/communications/dialer/test/unit/mock_call_log_db_manager.js
@@ -1,5 +1,9 @@
 var MockCallLogDBManager = {
   _calls: [],
+  _getGroupListCursor: 0,
+  // This is to emulate DB cursor for 'getGroupList'
+  value: null,
+  _getGroupListCallback: null,
   add: function add(recentCall, callback) {
     this._calls.push(recentCall);
     var group = new Object();
@@ -24,9 +28,24 @@ var MockCallLogDBManager = {
       callback();
     }
   },
-  getGroupList: function() {},
+  getGroupList: function getGroupList(callback) {
+    this._getGroupListCursor = 0;
+    this._getGroupListCallback = callback;
+    this.continue();
+  },
   deleteAll: function deleteAll(callback) {
     this._calls = [];
     callback();
+  },
+  continue: function mcldm_continue() {
+    if (this._calls.length > this._getGroupListCursor) {
+      this.value = this._calls[this._getGroupListCursor];
+      this._getGroupListCursor++;
+    } else {
+      this.value = null;
+    }
+    if (this._getGroupListCallback != null) {
+      this._getGroupListCallback(this);
+    }
   }
 };

--- a/apps/communications/dialer/test/unit/mock_performance_testing_helper.js
+++ b/apps/communications/dialer/test/unit/mock_performance_testing_helper.js
@@ -1,0 +1,7 @@
+'use strict';
+
+/* exported MockPerformanceTestingHelper */
+
+var MockPerformanceTestingHelper = {
+  dispatch: function() {}
+};


### PR DESCRIPTION
Delay chunk rendering by grouping chunks into larger
sets before calling renderChunk.  First set size will
be the same as the current FIRST_CHUNK_SIZE (6).  Subsequent
sets will cap at INCREMENTAL_RENDER_SIZE (60).

The goal is to reduce reflows on rendering the call log.

Also fixed the following bugs:
  _groupCounter never gets incremented if there's only one log entry per day
  Change currDate and prevDate comparison to more readable form

Added unit tests for call log rendering of various sizes.
