### PR TITLE
Bug 958035 - [Keyboard][V1.4] The previous keyboard shows briefly if you

### DIFF
--- a/apps/system/js/homescreen_launcher.js
+++ b/apps/system/js/homescreen_launcher.js
@@ -55,6 +55,7 @@
       window.addEventListener('trusteduishow', this);
       window.addEventListener('trusteduihide', this);
       window.addEventListener('appopening', this);
+      window.addEventListener('keyboardchange', this);
     },
 
     handleEvent: function hl_handleEvent(evt) {
@@ -72,6 +73,11 @@
               evt.detail.rotatingDegree === 270) {
             this.getHomescreen().fadeOut();
           }
+          break;
+        case 'keyboardchange':
+          // Fade out the homescreen, so that it won't be seen when showing/
+          // hiding/switching keyboard.
+          this.getHomescreen().fadeOut();
           break;
       }
     },

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -272,7 +272,8 @@ var KeyboardManager = {
     // So if that's the case, wait a bit and see if a focus comes in
     clearTimeout(this.focusChangeTimeout);
 
-    function showKeyboard() {
+    // Set one of the keyboard layout for the specific group as active.
+    function activateKeyboard() {
       // if we already have layouts for the group, no need to check default
       if (!self.keyboardLayouts[group]) {
         KeyboardHelper.checkDefaults(function changedDefaults() {
@@ -285,11 +286,15 @@ var KeyboardManager = {
       if (!self.keyboardLayouts[group]) {
         group = 'text';
       }
-      if (group !== self.showingLayout.type) {
-        self.resetShowingKeyboard();
-      }
+
+      var previousFrame = self.showingLayout.frame;
       self.setKeyboardToShow(group);
 
+      // We need to reset the previous frame nly when we switch to a new frame
+      if (previousFrame && previousFrame != self.showingLayout.frame) {
+        self._debug('reset previousFrame.');
+        self.resetKeyboardFrame(previousFrame);
+      }
     }
 
     if (type === 'blur') {
@@ -306,9 +311,9 @@ var KeyboardManager = {
       // if target group (input type) does not exist, use text for default
       if (!self.keyboardLayouts[group]) {
         // ensure the helper has apps and settings data first:
-        KeyboardHelper.getLayouts(showKeyboard);
+        KeyboardHelper.getLayouts(activateKeyboard);
       } else {
-        showKeyboard();
+        activateKeyboard();
       }
     }
   },
@@ -318,8 +323,11 @@ var KeyboardManager = {
       this._debug('this layout is running');
       return this.runningLayouts[layout.manifestURL][layout.id];
     }
+
     var layoutFrame = null;
+    // The layout is in a keyboard app that has been launched.
     if (this.isRunningKeyboard(layout)) {
+      // Re-use the iframe by changing its src.
       var runningKeybaord = this.runningLayouts[layout.manifestURL];
       for (var name in runningKeybaord) {
         var oldPath = runningKeybaord[name].dataset.framePath;
@@ -334,14 +342,19 @@ var KeyboardManager = {
         }
       }
     }
-    if (!layoutFrame)
+
+    // Create a new frame to load this new layout.
+    if (!layoutFrame) {
       layoutFrame = this.loadKeyboardLayout(layout);
-    // TODO make sure setLayoutFrameActive function is ready
-    this.setLayoutFrameActive(layoutFrame, false);
-    layoutFrame.hidden = true;
+      // TODO make sure setLayoutFrameActive function is ready
+      this.setLayoutFrameActive(layoutFrame, false);
+      layoutFrame.hidden = true;
+      layoutFrame.dataset.frameManifestURL = layout.manifestURL;
+    }
+
     layoutFrame.dataset.frameName = layout.id;
-    layoutFrame.dataset.frameManifestURL = layout.manifestURL;
     layoutFrame.dataset.framePath = layout.path;
+
     if (!(layout.manifestURL in this.runningLayouts)) {
       this.runningLayouts[layout.manifestURL] = {};
     }
@@ -591,15 +604,25 @@ var KeyboardManager = {
     this.fakenoti.classList.add('activated');
   },
 
+  // Reset the current keyboard frame
   resetShowingKeyboard: function km_resetShowingKeyboard() {
-    if (!this.showingLayout.frame) {
+    if (!this.showingLayout) {
       return;
     }
-    this.showingLayout.frame.hidden = true;
-    this.setLayoutFrameActive(this.showingLayout.frame, false);
-    this.showingLayout.frame.removeEventListener(
-        'mozbrowserresize', this, true);
+
+    this.resetKeyboardFrame(this.showingLayout.frame);
     this.showingLayout.reset();
+  },
+
+  // Reset the specified keyboard frame.
+  resetKeyboardFrame: function km_resetKeyboardFrame(frame) {
+    if (!frame) {
+      return;
+    }
+
+    frame.hidden = true;
+    this.setLayoutFrameActive(frame, false);
+    frame.removeEventListener('mozbrowserresize', this, true);
   },
 
   hideIMESwitcher: function km_hideIMESwitcher() {
@@ -688,6 +711,7 @@ var KeyboardManager = {
     }, SWITCH_CHANGE_DELAY);
   },
 
+  // Show the input method menu
   showAll: function km_showAll() {
     clearTimeout(this.switchChangeTimeout);
 
@@ -746,6 +770,10 @@ var KeyboardManager = {
   },
 
   setLayoutFrameActive: function km_setLayoutFrameActive(frame, active) {
+    this._debug('setLayoutFrameActive: ' +
+                frame.dataset.frameManifestURL +
+                frame.dataset.framePath + ', active: ' + active);
+
     if (frame.setVisible) {
       frame.setVisible(active);
     }

--- a/apps/system/test/unit/homescreen_launcher_test.js
+++ b/apps/system/test/unit/homescreen_launcher_test.js
@@ -128,4 +128,15 @@ suite('system/HomescreenLauncher', function() {
     assert.isTrue(stubToggle.calledWith(false));
     stubToggle.restore();
   });
+
+  test('keyboard showed', function() {
+    MockSettingsListener.mCallbacks['homescreen.manifestURL']('first.home');
+    homescreen = HomescreenLauncher.getHomescreen();
+    var stubFadeOut = this.sinon.stub(homescreen, 'fadeOut');
+    HomescreenLauncher.handleEvent({
+      type: 'keyboardchange'
+    });
+    assert.isTrue(stubFadeOut.called);
+    stubFadeOut.restore();
+  });
 });

--- a/apps/system/test/unit/keyboard_manager_test.js
+++ b/apps/system/test/unit/keyboard_manager_test.js
@@ -8,6 +8,7 @@ require('/shared/test/unit/mocks/mock_keyboard_helper.js');
 require('/shared/test/unit/mocks/mock_settings_listener.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 require('/test/unit/mock_applications.js');
+require('/test/unit/mock_homescreen_launcher.js');
 requireApp('system/js/keyboard_manager.js');
 
 var mocksHelperForKeyboardManager = new MocksHelper([
@@ -263,7 +264,7 @@ suite('KeyboardManager', function() {
 
         sinon.assert.calledWith(KeyboardManager.setKeyboardToShow, 'text');
         sinon.assert.calledWith(KeyboardManager.setKeyboardToShow, 'number');
-        sinon.assert.callCount(KeyboardManager.resetShowingKeyboard, 1);
+        sinon.assert.callCount(KeyboardManager.resetShowingKeyboard, 0);
       });
 
       test('Switching from "text" to "text"', function() {


### PR DESCRIPTION
switch keyboard between number field and text field.
- Not to invoke keyboardFrame.setVisible(false) when we reuse the
  frame.
- Invoke homescreen.fadeOut() to solve the homesreen leak issue when
  showing/switching/hiding keyboard.
