### PR TITLE
Bug 921723 - Sync progress indicator persists onto day view

### DIFF
--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -128,7 +128,6 @@ body[data-path="/day/"] #view-selector > .day > a:active {
 
 #progress-indicator {
   position: absolute;
-  top: 6.9rem;
   left: 0;
   width: 100%;
   height: 0.3rem;


### PR DESCRIPTION
Move the progress indicator on the below of time-header.
And https://bug921723.bugzilla.mozilla.org/attachment.cgi?id=8377396 is the result of the patch.
