### PR TITLE
Bug 965318 - unxfail test_cost_control_reset_wifi on v1.3 when bug 96530...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
@@ -15,5 +15,3 @@ wifi = false
 
 [test_cost_control_reset_wifi.py]
 skip-if = device == "desktop"
-# Bug 965305 - [v1.3][Cost Control] Resetting wi-fi usage from Cost Control app does not always reset to 0 B
-expected = fail


### PR DESCRIPTION
...5 is fixed
