### PR TITLE
Fix for bug 973407

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -423,7 +423,6 @@ var ThreadUI = global.ThreadUI = {
 
   messageComposerInputHandler: function thui_messageInputHandler(event) {
     this.updateSubjectHeight();
-    this.updateElementsHeight();
     this.enableSend();
 
     if (Compose.type === 'sms') {
@@ -1056,18 +1055,17 @@ var ThreadUI = global.ThreadUI = {
   // TODO this function probably triggers synchronous workflows, we should
   // remove them (Bug 891029)
   updateElementsHeight: function thui_updateElementsHeight() {
+    // we need to set it back to auto so that we know its "natural size"
+    // this will trigger a sync reflow when we get its scrollHeight below,
+    // so we should try to find something better maybe in Bug 888950
+    this.input.style.height = 'auto';
+
     // First of all we retrieve all CSS info which we need
     var verticalMargin = this.INPUT_MARGIN;
     var inputMaxHeight = parseInt(this.input.style.maxHeight, 10);
     var buttonHeight = this.sendButton.offsetHeight;
     var subjectHeight = this.subjectInput.offsetHeight;
     var availableHeight = window.innerHeight - this.HEADER_HEIGHT;
-
-    // we need to set it back to auto so that we know its "natural size"
-    // this will trigger a sync reflow when we get its scrollHeight at the next
-    // line, so we should try to find something better
-    // maybe in Bug 888950
-    this.input.style.height = 'auto';
 
     // the new height is different whether the current height is bigger than the
     // max height
@@ -1780,9 +1778,11 @@ var ThreadUI = global.ThreadUI = {
   },
 
   cancelEdit: function thlui_cancelEdit() {
-    this.inEditMode = false;
-    this.updateElementsHeight();
-    this.mainWrapper.classList.remove('edit');
+    if (this.inEditMode) {
+      this.inEditMode = false;
+      this.updateElementsHeight();
+      this.mainWrapper.classList.remove('edit');
+    }
   },
 
   chooseMessage: function thui_chooseMessage(target) {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -4815,4 +4815,30 @@ suite('thread_ui.js >', function() {
       assert.equal(data, null);
     });
   });
+
+  suite('Edit mode tests', function() {
+    var mainWrapper;
+
+    setup(function() {
+      mainWrapper = document.getElementById('main-wrapper');
+    });
+
+    test('Enter edit mode', function() {
+      ThreadUI.startEdit();
+      assert.isTrue(mainWrapper.classList.contains('edit'));
+    });
+
+    test('Exit edit mode', function() {
+      ThreadUI.cancelEdit();
+      assert.isTrue(!mainWrapper.classList.contains('edit'));
+    });
+
+    test('Exit edit mode is idempotent', function() {
+      ThreadUI.startEdit();
+      assert.isTrue(mainWrapper.classList.contains('edit'));
+      ThreadUI.cancelEdit();
+      assert.isTrue(!mainWrapper.classList.contains('edit'));
+      assert.isTrue(!mainWrapper.classList.contains('edit'));
+    });
+  });
 });


### PR DESCRIPTION
1. remove updateElementsHeight() call in messageComposerInputHandler(),
   since updateSubjectHeight() already calls it
2. in cancelEdit(), only call updateElementsHeight() if in edit mode
3. in updateElementsHeight(), move code to set input width to 'auto' up
   to avoid extra reflow if layout has changed prior to call
