### PR TITLE
Bug 964725 - [Messages] Support ',' as a recipient delimiter r=julienw

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -882,11 +882,11 @@
 
         // Last character is a semi-colon, treat as an
         // "accept" of this recipient.
-        if (typed && typed[length - 1] === ';') {
+        if (typed && (typed[length - 1] === ';' || typed[length - 1] === ',')) {
           isAcceptedRecipient = true;
           isPreventingDefault = true;
 
-          typed = typed.replace(/;$/, '');
+          typed = typed.replace(/[;,]$/, '');
 
           // Display the actual typed text that we're
           // going to accept as a recipient (trimmed)

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -720,6 +720,34 @@ suite('Recipients', function() {
 
           assert.isTrue(view.lastElementChild.focus.called);
         });
+
+        test('test for comma as a recipient delimiter ', function() {
+          var view = document.getElementById('messages-recipients-list');
+          var event;
+
+          event = new CustomEvent('keyup', {
+            bubbles: true
+          });
+
+          view.lastElementChild.textContent = '963852,';
+          view.lastElementChild.dispatchEvent(event);
+
+          assert.equal(recipients.numbers[0], '963852');
+        });
+
+        test('test for semicolon as a recipient delimiter ', function() {
+          var view = document.getElementById('messages-recipients-list');
+          var event;
+
+          event = new CustomEvent('keyup', {
+            bubbles: true
+          });
+
+          view.lastElementChild.textContent = '987654;';
+          view.lastElementChild.dispatchEvent(event);
+
+          assert.equal(recipients.numbers[0], '987654');
+        });
       });
     });
 


### PR DESCRIPTION
Hi Julien,

Please review the pull request updated
1. Code changes for handling comma delimiter
2. Tests for both comma and semicolon as a recipient delimiter

https://bugzilla.mozilla.org/show_bug.cgi?id=964725

Thanks!
