### PR TITLE
Bug 974292 - [Email][V1.3&V1.4] Tapping the Done button of mail settings page redirects to a blank page

### DIFF
--- a/apps/email/js/cards/setup_progress.js
+++ b/apps/email/js/cards/setup_progress.js
@@ -46,12 +46,12 @@ SetupProgressCard.prototype = {
   onBack: function(e) {
     e.preventDefault();
     this.cancelCreation();
-    Cards.removeCardAndSuccessors(this.domNode, 'animate');
+    Cards.removeCardAndSuccessors(this.domNode, 'animate', 1);
   },
 
   onCreationError: function(err, errDetails) {
     this.callingCard.showError(err, errDetails);
-    Cards.removeCardAndSuccessors(this.domNode, 'animate');
+    Cards.removeCardAndSuccessors(this.domNode, 'animate', 1);
   },
 
   onCreationSuccess: function(account) {


### PR DESCRIPTION
This is a side effect of this change:

https://github.com/mozilla-b2g/gaia/commit/f1053cc117ebf147dad7801d32746b375b5ec599#diff-3

where `Cards.removeCardAndSuccessors(this.domNode, 'animate', 1);` was changed to `Cards.removeCardAndSuccessors(this.domNode, 'animate');`

By leaving out the "how many cards" it meant "this card and all cards after it". However, since the folder_picker is added **before** message_list in the stack, it means that all the account cards are inserted between folder_picker and message_list. So when the removeCardAndSuccessors removed the progress card, it also removed message_list.

Restoring the 1 arg fixes it. I apologize for letting this slip past before, as I had it in my head that removeCardAndSuccessors defaulted to just that one card if no arg so I did not comment on it when I saw the change.
