### PR TITLE
Bug 974855 - Strict or equal comparison when selecting picture size from pick activity

### DIFF
--- a/apps/camera/js/controllers/activity.js
+++ b/apps/camera/js/controllers/activity.js
@@ -76,7 +76,7 @@ function getPictureSizesSmallerThan(options, bytes) {
   return options.filter(function(option) {
     var size = option.value;
     var mp = size.width * size.height;
-    return mp < bytes;
+    return mp <= bytes;
   });
 }
 


### PR DESCRIPTION
Doing a strict comparison fails on some devices (Peak, Nexus) and
crashes the device or the Camera app when attaching to send a MMS.
