### PR TITLE
Bug 971648 - Add warning message if there is no

### DIFF
--- a/build/utils-xpc.js
+++ b/build/utils-xpc.js
@@ -200,6 +200,7 @@ function getWebapp(app, domain, scheme, port) {
 
   // Ignore directories without manifest
   if (!manifestFile.exists() && !updateFile.exists()) {
+    log('WARNING', 'missing manifest.webapp or update.webapp in', appDir.path);
     return;
   }
 


### PR DESCRIPTION
 manifest.webapp or update.webapp in an app directory
