### PR TITLE
Bug 971141 - make sure we don't leak memory when creating video thumbnai...

### DIFF
--- a/apps/video/js/metadata.js
+++ b/apps/video/js/metadata.js
@@ -138,11 +138,14 @@ function processFirstQueuedItem() {
       fileinfo.metadata = metadata;
 
       // Save it to the database
-      videodb.updateMetadata(fileinfo.name, metadata);
-
-      // Create and insert a thumbnail for the video
-      if (metadata.isVideo)
-        addVideo(fileinfo);
+      videodb.updateMetadata(fileinfo.name, metadata, function() {
+        // Create and insert a thumbnail for the video
+        if (metadata.isVideo) {
+          videodb.getFileInfo(fileinfo.name, function(dbfileinfo) {
+            addVideo(dbfileinfo);
+          });
+        }
+      });
 
       // And process the next video in the queue
       setTimeout(processFirstQueuedItem);


### PR DESCRIPTION
...ls during scanning

Change to use metadata read from db instead of from metadata parser so that we're using a file-backed blob instead of a memory-backed blob when creating the thumbnail. See bug 963917.
