### PR TITLE
Bug 953277 - Tap 'inbox' with Google Mail account causes all of the emails to be listed twice

### DIFF
--- a/apps/email/js/model.js
+++ b/apps/email/js/model.js
@@ -209,12 +209,16 @@ define(function(require) {
     /**
      * Just changes the folder property tracked by the model.
      * Assumes the folder still belongs to the currently tracked
-     * account.
+     * account. It also does not result in any state changes or
+     * event emitting if the new folder is the same as the
+     * currently tracked folder.
      * @param  {Object} folder the folder object to use.
      */
     changeFolder: function(folder) {
-      this.folder = folder;
-      this._callEmit('folder');
+      if (folder && (!this.folder || folder.id !== this.folder.id)) {
+        this.folder = folder;
+        this._callEmit('folder');
+      }
     },
 
     /**


### PR DESCRIPTION
This is bug resulted from the code changes in 1.4 to add next/previous navigation, bug 918303, which added `message_cursor`. However the bug is triggered by an existing weakness in `model` that dates back to 1.2 days. To be clear though, this bug does not manifest in 1.2 or 1.3.

The `folder_picker` called `model.changeFolder` even though the folder selection has not changed.

`model` then did not check for if the folder was actually different, and that triggered a 'folder' event to be emitted.

`message_list` received that event in `_folderChanged`, which called `showFolder`. `showFolder` noticed the folders were the same and disregarded the notification, so it did not clear the message list.

`message_cursor` also received the `folder` event from `model`, and it did not check to see if the folder was different and asked for a new messages slice. In 1.2/1.3 code, the messages slice was handled by `message_list`'s `showFolder` method, which did detect for actual folder changes, and it is why the bug is not present there.

The new messages slice in `header_cursor` triggered new messages slice events, which `message_list` was listening for, so it added the duplicates to the list.

So the fix, instead of asking all consumers of that event if the folder is actually different is for `model` to not emit a folder event if the folder selection is not actually different.
