### PR TITLE
Bug 974163 - Turn off rocketbar by default in 1.4 build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ DOGFOOD?=0
 # none - Do not enable rocketbar
 # half - Rocketbar is enabled, and so is browser app
 # full - Rocketbar is enabled, no browser app
-ROCKETBAR?=half
+ROCKETBAR?=none
 TEST_AGENT_PORT?=8789
 GAIA_APP_TARGET?=engineering
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
@@ -11,7 +11,6 @@ skip-if = device == "desktop"
 skip-if = device == "desktop"
 
 [test_everythingme_app_install.py]
-disabled = Bug 962795 - Rocketbar UI Testing
 # Bug 877604 - long_press action failing on B2G desktop client when installing an Everything.me app
 skip-if = device == "desktop"
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=974163
