### PR TITLE
Bug 935060 - [Messages] Unable to send empty message patch

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -913,7 +913,7 @@ var ThreadUI = global.ThreadUI = {
   enableSend: function thui_enableSend() {
     this.initSentAudio();
 
-    // should disable if we have no message input
+    // should disable if compose is resizing
     var disableSendMessage = Compose.isResizing;
     var messageNotLong = this.updateCounter();
     var recipientsValue = this.recipients.inputValue;
@@ -2071,8 +2071,8 @@ var ThreadUI = global.ThreadUI = {
       recipients = Threads.active.participants;
     }
 
-    // If it's an empty message, the content is ''
-    if (Compose.isEmpty()) {
+    // If it is an empty message, the content is ''
+    if (!content.length) {
       content.push('');
       var question = navigator.mozL10n.get('confirm-empty-message');
       if (!window.confirm(question)) {

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -914,7 +914,7 @@ var ThreadUI = global.ThreadUI = {
     this.initSentAudio();
 
     // should disable if we have no message input
-    var disableSendMessage = Compose.isEmpty() || Compose.isResizing;
+    var disableSendMessage = Compose.isResizing;
     var messageNotLong = this.updateCounter();
     var recipientsValue = this.recipients.inputValue;
     var hasRecipients = false;
@@ -2046,10 +2046,6 @@ var ThreadUI = global.ThreadUI = {
   },
 
   onSendClick: function thui_onSendClick() {
-    // don't send an empty message
-    if (Compose.isEmpty()) {
-      return;
-    }
 
     // Assimilation 3 (see "Assimilations" above)
     // User may return to recipients, type a new recipient
@@ -2073,6 +2069,15 @@ var ThreadUI = global.ThreadUI = {
       recipients = this.recipients.numbers;
     } else {
       recipients = Threads.active.participants;
+    }
+
+    // If it's an empty message, the content is ''
+    if (Compose.isEmpty()) {
+      content.push('');
+      var question = navigator.mozL10n.get('confirm-empty-message');
+      if (!window.confirm(question)) {
+        return;
+      }
     }
 
     // Clean composer fields (this lock any repeated click in 'send' button)

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -143,6 +143,7 @@ sendInvalidAddressErrorTitle     = Invalid number
 sendInvalidAddressErrorBody      = Make sure the mobile number you’re sending to is valid.
 sendInvalidAddressErrorBtnOk     = OK
 deleted-sms                 = This message has already been deleted.
+confirm-empty-message       = Do you want to send an empty message?
 view-attachment-image       = View
 view-attachment-audio       = Listen
 view-attachment-video       = View


### PR DESCRIPTION
Changed the behaviour of thread_ui.js, to enable the send button for empty messages, and empty message sending. Added the warning confirmation text case on sms.en-US.properties.
