### PR TITLE
bug 975850

### DIFF
--- a/apps/system/js/stack_manager.js
+++ b/apps/system/js/stack_manager.js
@@ -70,7 +70,7 @@ var StackManager = {
   },
 
   _stack: [],
-  _current: 0,
+  _current: -1,
 
   handleEvent: function sm_handleEvent(e) {
     switch (e.type) {

--- a/apps/system/test/unit/cards_view_test.js
+++ b/apps/system/test/unit/cards_view_test.js
@@ -46,7 +46,8 @@ var apps =
     getScreenshot: function(callback) {
       callback();
     },
-    origin: 'http://sms.gaiamobile.org'
+    origin: 'http://sms.gaiamobile.org',
+    blur: function() {}
   },
   'http://game.gaiamobile.org': {
     launchTime: 4,
@@ -63,7 +64,8 @@ var apps =
     getScreenshot: function(callback) {
       callback();
     },
-    origin: 'http://game.gaiamobile.org'
+    origin: 'http://game.gaiamobile.org',
+    blur: function() {}
   },
   'http://game2.gaiamobile.org': {
     launchTime: 3,
@@ -80,7 +82,8 @@ var apps =
     getScreenshot: function(callback) {
       callback();
     },
-    origin: 'http://game2.gaiamobile.org'
+    origin: 'http://game2.gaiamobile.org',
+    blur: function() {}
   },
   'http://game3.gaiamobile.org': {
     launchTime: 2,
@@ -97,7 +100,8 @@ var apps =
     getScreenshot: function(callback) {
       callback();
     },
-    origin: 'http://game3.gaiamobile.org'
+    origin: 'http://game3.gaiamobile.org',
+    blur: function() {}
   },
   'http://game4.gaiamobile.org': {
     launchTime: 1,
@@ -114,7 +118,8 @@ var apps =
     getScreenshot: function(callback) {
       callback();
     },
-    origin: 'http://game4.gaiamobile.org'
+    origin: 'http://game4.gaiamobile.org',
+    blur: function() {}
   }
 };
 
@@ -197,6 +202,25 @@ suite('cards view >', function() {
     });
 
     suite('display cardsview >', function() {
+      setup(function(done) {
+        CardsView.showCardSwitcher(false);
+        setTimeout(done);
+      });
+
+      test('cardsview should be active', function() {
+        assert.isTrue(cardsView.classList.contains('active'));
+      });
+
+      test('cardsview should have no recent apps', function() {
+        assert.isFalse(cardsView.classList.contains('empty'));
+      });
+
+      teardown(function() {
+        CardsView.hideCardSwitcher();
+      });
+    });
+
+    suite('display cardsview (in rocketbar) >', function() {
       var rocketbarRender;
 
       setup(function(done) {

--- a/apps/system/test/unit/stack_manager_test.js
+++ b/apps/system/test/unit/stack_manager_test.js
@@ -102,6 +102,18 @@ suite('system/StackManager >', function() {
     return config;
   }
 
+  suite('Homescreen', function() {
+    setup(function(done) {
+      home();
+      setTimeout(done);
+    });
+
+    test('the position indicates we are on the homescreen',
+    function() {
+      assert.equal(StackManager.position, -1, 'position should be -1');
+    });
+  });
+
   suite('Stack vs System App', function() {
     setup(function() {
       appLaunch(system);


### PR DESCRIPTION
- Stack Manager should start up with _current set to -1 since we launch the homescreen by default.
- Cards View should show most recently used application (last on stack) when the homescreen is being shown.
- Added tests for showing cards view from homescreen in default running state (eg. no recent apps)
- Added tests for stack manager to ensure that position is always -1 initially.
- Seperated the tests for cards view active, one set for in the rocketbar, one set for outside of the rocketbar.
  *\* The original test covered the default running state case, it was updated for the task manager being shown in
  rocketbar but we did _not_ backout that change when disabling the rocketbar in 1.4.

r=?
