### PR TITLE
bug 952695

### DIFF
--- a/apps/system/js/download/download_manager.js
+++ b/apps/system/js/download/download_manager.js
@@ -24,6 +24,12 @@ var DownloadManager = (function() {
   var notifications = {};
   var started = false;
 
+  // Clear all previously completed downloads from the Downloads API
+  // We don't need those in there anymore since we're tracking everything
+  // in our own datastore (see download_store.js).
+  mozDownloadManager.clearAllDone();
+
+  // Set our download start handler.
   mozDownloadManager.ondownloadstart = function onDownloadStart(ev) {
     if (started) {
       createDownloadNotification(ev.download);

--- a/apps/system/test/unit/mock_navigator_moz_download_manager.js
+++ b/apps/system/test/unit/mock_navigator_moz_download_manager.js
@@ -4,7 +4,23 @@
 var realMozDownloadManager = navigator.mozDownloadManager;
 
 navigator.mozDownloadManager = {
+  // Should always be an array of DOM Download like objects.
+  mDownloads: [],
+
   mSuiteTeardown: function mdm_mSuiteTeardown() {
     window.navigator.mozDownloadManager = realMozDownloadManager;
+  },
+
+  clearAllDone: function() {
+    this.mDownloads = this.mDownloads.filter(function(download) {
+      if (download.state === 'succeeded' || download.state === 'finalized') {
+        return false;
+      }
+      return true;
+    });
+  },
+
+  getDownloads: function() {
+    return this.mDownloads;
   }
 };


### PR DESCRIPTION
- Clear all completed downloads from mozDownloadManager when Gaia Download Manager inits.

r=crdlc
