### PR TITLE
Bug 976546 - User should not be able to pull down utility tray before unlock

### DIFF
--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -83,7 +83,7 @@ var UtilityTray = {
         break;
 
       case 'touchstart':
-        if (LockScreen.locked)
+        if (lockScreen.locked)
           return;
         if (evt.target !== this.overlay &&
             evt.currentTarget !== this.statusbar &&

--- a/apps/system/test/unit/utility_tray_test.js
+++ b/apps/system/test/unit/utility_tray_test.js
@@ -183,6 +183,20 @@ suite('system/UtilityTray', function() {
       };
     });
 
+    test('onTouchStart is not called if LockScreen is locked', function() {
+      window.lockScreen.locked = true;
+      var stub = this.sinon.stub(UtilityTray, 'onTouchStart');
+      UtilityTray.handleEvent(fakeEvt);
+      assert.ok(stub.notCalled);
+    });
+
+    test('onTouchStart is called if LockScreen is not locked', function() {
+      window.lockScreen.locked = false;
+      var stub = this.sinon.stub(UtilityTray, 'onTouchStart');
+      UtilityTray.handleEvent(fakeEvt);
+      assert.ok(stub.calledOnce);
+    });
+
     test('Test UtilityTray.active, should be true', function() {
       /* XXX: This is to test UtilityTray.active,
               it works in local test but breaks in travis. */


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=976546
