### PR TITLE
Bug 974600 - update to marionette_client 0.7.5, bump version

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/version.py
+++ b/tests/python/gaia-ui-tests/gaiatest/version.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = '0.21.7'
+__version__ = '0.21.8'

--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,4 +1,4 @@
-marionette_client==0.7.3
+marionette_client==0.7.5
 mozdevice>=0.31
 requests
 moztest>=0.3


### PR DESCRIPTION
Bug 974600 (https://bugzilla.mozilla.org/show_bug.cgi?id=974600) - Bump gaiatest version to 0.21.8(?) and release to PyPI
