### PR TITLE
Bug 977399 -[B2G][Cost Control] 'Reset report' picker cannot be changed ...

### DIFF
--- a/apps/costcontrol/js/settings/settings.js
+++ b/apps/costcontrol/js/settings/settings.js
@@ -103,8 +103,7 @@ var Settings = (function() {
       });
 
       function _setResetTimeToDefault(value, old, key, settings) {
-        var firstWeekDay = parseInt(navigator.mozL10n.get('weekStartsOnMonday'),
-                                    10);
+        var firstWeekDay = parseInt(_('weekStartsOnMonday'), 10);
         var defaultResetTime = (settings.trackingPeriod === 'weekly') ?
                                                                   firstWeekDay :
                                                                   1;


### PR DESCRIPTION
...after data reset
