### PR TITLE
Bug 977619 - [Dialer] Use the correct l10n-id in oncall.html (select-audio-sources)

### DIFF
--- a/apps/communications/dialer/oncall.html
+++ b/apps/communications/dialer/oncall.html
@@ -104,7 +104,7 @@
         </menu>
       </form>
       <form id="bluetooth-menu" role="dialog" data-type="action" class="overlay">
-        <header data-l10n-id="select-audio-source">select audio source</header>
+        <header data-l10n-id="select-audio-sources">select audio sources</header>
         <menu>
           <button data-l10n-id="bluetooth-handsfree-device" id='btmenu-btdevice'>bluetooth handsfree device</button>
           <button data-l10n-id="receiver" id='btmenu-receiver'>receiver</button>


### PR DESCRIPTION
Note: this is the less invasive fix, letting us reuse existing localizations even if the id says "sources" and the actual string "source".
