### PR TITLE
Bug 970832 - Balance pending image loading counter

### DIFF
--- a/apps/communications/contacts/js/utilities/image_loader.js
+++ b/apps/communications/contacts/js/utilities/image_loader.js
@@ -92,6 +92,7 @@ if (!window.ImageLoader) {
       };
 
       tmp.onabort = tmp.onerror = function onerror() {
+        --imgsLoading;
         item.dataset.visited = 'false';
         tmp = null;
       };

--- a/apps/communications/contacts/test/unit/image_loader_test.js
+++ b/apps/communications/contacts/test/unit/image_loader_test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/* globals MocksHelper, MockLinkHtml, ImageLoader, UIEvent */
+
+requireApp('communications/contacts/test/unit/mock_link.html.js');
+requireApp('communications/contacts/test/unit/mock_image.js');
+requireApp('communications/contacts/js/utilities/image_loader.js');
+
+var mocksHelperForImageLoader = new MocksHelper([
+  'Image'
+]).init();
+
+suite('Image Loader Test Suite >', function() {
+
+  var imgLoader, item;
+  var mocksHelper = mocksHelperForImageLoader;
+
+  suiteSetup(function() {
+    mocksHelper.suiteSetup();
+
+    document.body.innerHTML = MockLinkHtml;
+    item = document.querySelector('#friends-list');
+    imgLoader = new ImageLoader('#mainContent',
+                                '.block-item:not([data-uuid="#uid#"])');
+  });
+
+  suiteTeardown(function() {
+    mocksHelper.suiteTeardown();
+  });
+
+  suite('imgsLoading balance >', function() {
+
+    var imageSpy, stopSpy;
+
+    setup(function() {
+      imageSpy = this.sinon.spy(window, 'Image');
+      stopSpy = this.sinon.spy(window, 'stop');
+      mocksHelper.setup();
+    });
+
+    teardown(function() {
+      mocksHelper.teardown();
+    });
+
+    function simulateImageCallback(evt) {
+      imgLoader.defaultLoad(item);
+      imageSpy.lastCall.thisValue.triggerEvent(evt);
+    }
+
+    function dispatchScroll() {
+      var event = new UIEvent('scroll', {
+        view: window,
+        detail: 0
+      });
+      document.querySelector('#mainContent').dispatchEvent(event);
+    }
+
+    test('defaultLoadImage calls new Image()', function() {
+      imgLoader.defaultLoad(item);
+      sinon.assert.calledOnce(imageSpy);
+    });
+
+    test('item marked as visited', function() {
+      simulateImageCallback('onload');
+      assert.equal('true', item.dataset.visited);
+
+      simulateImageCallback('onabort');
+      assert.equal('false', item.dataset.visited);
+
+      simulateImageCallback('onerror');
+      assert.equal('false', item.dataset.visited);
+    });
+
+    test('window.stop() not called without scroll event', function() {
+      simulateImageCallback('onload');
+      sinon.assert.callCount(stopSpy, 0);
+
+      simulateImageCallback('onabort');
+      sinon.assert.callCount(stopSpy, 0);
+
+      simulateImageCallback('onerror');
+      sinon.assert.callCount(stopSpy, 0);
+    });
+
+    test('window.stop() called with one pending request', function() {
+      imgLoader.defaultLoad(item);
+      dispatchScroll();
+      sinon.assert.callCount(stopSpy, 1);
+    });
+
+    test('window.stop() not called after onload', function() {
+      imgLoader.defaultLoad(item);
+      imageSpy.lastCall.thisValue.triggerEvent('onload');
+      dispatchScroll();
+      sinon.assert.callCount(stopSpy, 0);
+    });
+
+    test('window.stop() not called after onabort and onerror', function() {
+      imgLoader.defaultLoad(item);
+      imageSpy.lastCall.thisValue.triggerEvent('onabort');
+      dispatchScroll();
+      sinon.assert.callCount(stopSpy, 0);
+
+      imgLoader.defaultLoad(item);
+      imageSpy.lastCall.thisValue.triggerEvent('onerror');
+      dispatchScroll();
+      sinon.assert.callCount(stopSpy, 0);
+    });
+
+    test('window.stop() not called after onload and onerror', function() {
+      imgLoader.defaultLoad(item);
+      imageSpy.lastCall.thisValue.triggerEvent('onload');
+      imgLoader.defaultLoad(item);
+      imageSpy.lastCall.thisValue.triggerEvent('onerror');
+      dispatchScroll();
+      sinon.assert.callCount(stopSpy, 0);
+    });
+
+  });
+
+});

--- a/apps/communications/contacts/test/unit/mock_image.js
+++ b/apps/communications/contacts/test/unit/mock_image.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/* exported MockImage */
+
+var MockImage = function() {
+  this.complete = false;
+  this.onload = null;
+  this.onabort = null;
+  this.onerror = null;
+};
+
+MockImage.prototype.triggerEvent = function(name) {
+  var callback = this[name];
+
+  if (name === 'onload') {
+    this.complete = true;
+  }
+
+  callback && callback();
+};

--- a/apps/communications/contacts/test/unit/mock_link.html
+++ b/apps/communications/contacts/test/unit/mock_link.html
@@ -15,7 +15,7 @@
             <li data-template data-uuid="#uid#">
                 <a href="#">
                   <aside class="pack-end">
-                    <img data-src="https://graph.facebook.com/#uid#/picture?width=#picwidth#&height=#picheight#">
+                    <span data-type="img" data-src="https://graph.facebook.com/#uid#/picture?width=#picwidth#&height=#picheight#"></span>
                   </aside>
                   <p>#name#</p>
                   <p>#email#</p>


### PR DESCRIPTION
Contacts pictures were not correctly imported because the onscroll
handler was checking the |imgsLoading| counter to be able to stop
pending requests. However, decrementing this variable was only performed
in the onsuccess handler of the image loading. If for any reason you
have some that fails, they would not get accounted as not loading
anymore. Upon onscroll event, this would trigger window.stop() call,
which will at the end break in the middle your pending XHR that perform
pictures import. Thus, we also perform decrementation in the error
handler.
