### PR TITLE
Bug 978005 - [email] Fix usage of Bareword DOM constructors TextDecoder and TextEncoder. r=asuth

### DIFF
--- a/apps/email/js/ext/mailapi/activesync/protocollayer.js
+++ b/apps/email/js/ext/mailapi/activesync/protocollayer.js
@@ -543,7 +543,7 @@
       this.version = ((v & 0xf0) + 1).toString() + '.' + (v & 0x0f).toString();
       this.pid = this._get_mb_uint32();
       this.charset = mib2str[this._get_mb_uint32()] || 'unknown';
-      this._decoder = TextDecoder(this.charset);
+      this._decoder = new TextDecoder(this.charset);
 
       var tbl_len = this._get_mb_uint32();
       this.strings = new StringTable(this._get_slice(tbl_len), this._decoder);
@@ -894,7 +894,7 @@
       if (charsetNum === undefined)
         throw new Error('unknown charset '+charset);
     }
-    var encoder = this._encoder = TextEncoder(charset);
+    var encoder = this._encoder = new TextEncoder(charset);
 
     this._write(v);
     this._write(pid);

--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -1611,7 +1611,7 @@ function encode(string, encoding) {
     default:
       if (!encoding)
         encoding = 'utf-8';
-      return TextEncoder(encoding, ENCODER_OPTIONS).encode(string);
+      return new TextEncoder(encoding, ENCODER_OPTIONS).encode(string);
   }
 }
 
@@ -1660,7 +1660,7 @@ function decode(view, encoding) {
     default:
       if (!encoding)
         encoding = 'utf-8';
-      return TextDecoder(encoding, ENCODER_OPTIONS).decode(view);
+      return new TextDecoder(encoding, ENCODER_OPTIONS).decode(view);
   }
 }
 


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/288
