### PR TITLE
Bug 976416 - [FDN] enable the + sign in the keypad, r=vingtetun

### DIFF
--- a/apps/settings/elements/call_fdn_list_add.html
+++ b/apps/settings/elements/call_fdn_list_add.html
@@ -19,7 +19,7 @@
         </li>
         <li>
           <p data-l10n-id="fdnContact-number">Number</p>
-          <input x-inputmode="verbatim" type="number" id="fdnContact-number"/>
+          <input x-inputmode="verbatim" type="tel" id="fdnContact-number"/>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=976416
