### PR TITLE
Bug 977268 - "Show password" checkbox label on Join hidden network is too narrow for most locales

### DIFF
--- a/apps/communications/ftu/css/style.css
+++ b/apps/communications/ftu/css/style.css
@@ -494,13 +494,15 @@ aside.connecting {
 #hidden-wifi-authentication form label,
 #configure_network_params form label {
   display: block;
-  padding: 1.5rem 1.5rem 0.5rem 1.5rem ;
+  width: 100%;
+  -moz-box-sizing: border-box;
+  padding: 1.5rem 1.5rem 0.5rem 1.5rem;
   font-size: 1.5rem;
 }
 
 #hidden-wifi-authentication form select {
   width: 100%;
-  padding: 0.5rem 1.5rem 0.5rem 1.5rem ;
+  padding: 0.5rem 1.5rem 0.5rem 1.5rem;
   font-size: 1.5rem;
 }
 
@@ -529,7 +531,7 @@ aside.connecting {
 }
 
 #hidden-wifi-authentication label p {
-  width: 12rem;
+  width: calc(100% - 2rem);
   bottom: 0.4rem;
   left: 3rem;
 }


### PR DESCRIPTION
Change the CSS to use all the space available.
