### PR TITLE
Bug 978058 - Make Firefox OS' devtools track frames instead of manifests.

### DIFF
--- a/apps/system/js/devtools_view.js
+++ b/apps/system/js/devtools_view.js
@@ -9,7 +9,7 @@
    */
   function DevtoolsView() {
     window.addEventListener('developer-hud-update', function updateHandler(e) {
-      this.display(e.detail);
+      this.display(e.target, e.detail);
       e.preventDefault();
     }.bind(this));
   }
@@ -22,14 +22,12 @@
      * @memberof DevtoolsView.prototype
      * @param {Object} data The data to update the devtools view with.
      */
-    display: function(data) {
-      var target = 'iframe[mozapp="' + data.manifestURL + '"]';
-      var iframe = document.querySelector(target);
-      if (!iframe) {
+    display: function(target, data) {
+      if (!target) {
         return;
       }
 
-      var appwindow = iframe.parentElement;
+      var appwindow = target.parentElement;
       var overlay = appwindow.querySelector('.devtools-view');
 
       if (!overlay) {

--- a/apps/system/test/unit/devtools_view_test.js
+++ b/apps/system/test/unit/devtools_view_test.js
@@ -5,7 +5,6 @@ require('/js/devtools_view.js');
 
 suite('developerHUD', function() {
 
-  var manifest = 'app://fakeapp.gaiamobile.org/fake.html';
   var subject;
 
   setup(function() {
@@ -13,15 +12,16 @@ suite('developerHUD', function() {
   });
 
   function updateMetrics(metrics) {
-    var data = {
-      detail: {manifestURL: manifest, metrics: metrics}
-    };
-    var evt = new CustomEvent('developer-hud-update', data);
-    window.dispatchEvent(evt);
+    var target = document.getElementById('target');
+    var doc = target.document || target.ownerDocument || target;
+    var event = doc.createEvent('CustomEvent');
+    event.initCustomEvent('developer-hud-update', true, true,
+      { metrics: metrics });
+    target.dispatchEvent(event);
   }
 
-  function getWidgetView() {
-    var iframe = document.querySelector('iframe[mozapp="' + manifest + '"]');
+  function getDevtoolsView() {
+    var iframe = document.getElementById('target');
     var appwindow = iframe.parentElement;
     return appwindow.querySelector('.devtools-view');
   }
@@ -29,8 +29,7 @@ suite('developerHUD', function() {
   suite('display()', function() {
 
     setup(function() {
-      document.body.innerHTML = '<div><iframe mozapp="' + manifest +
-        '"></iframe></div>';
+      document.body.innerHTML = '<div><iframe id=target></iframe></div>';
     });
 
     teardown(function() {
@@ -41,7 +40,7 @@ suite('developerHUD', function() {
       updateMetrics([
         {name: 'bugs', value: 42}
       ]);
-      var view = getWidgetView();
+      var view = getDevtoolsView();
       assert.isDefined(view);
       var widget = view.querySelector('.widget');
       assert.isDefined(widget);
@@ -53,7 +52,7 @@ suite('developerHUD', function() {
         {name: 'errors', value: 23},
         {name: 'warnings', value: 16}
       ]);
-      var view = getWidgetView();
+      var view = getDevtoolsView();
       assert.isDefined(view);
       var widgets = view.querySelectorAll('.widget');
       assert.equal(widgets.length, 2);
@@ -66,7 +65,7 @@ suite('developerHUD', function() {
         {name: 'chaos', value: 4}
       ]);
       updateMetrics();
-      assert.isNull(getWidgetView());
+      assert.isNull(getDevtoolsView());
     });
 
   });


### PR DESCRIPTION
r=vingtetun
