### PR TITLE
Bug 953033 - Add Dzongkha Input Method for B2G

### DIFF
--- a/apps/keyboard/js/layouts/dz-BT.js
+++ b/apps/keyboard/js/layouts/dz-BT.js
@@ -1,0 +1,121 @@
+Keyboards['dz-BT.js'] = {
+  label: 'Dzongkha',
+  menuLabel: 'Dzongkha',
+  alternateLayoutKey: '༡༢༣',
+  basicLayoutKey: 'ཀཁག',
+  types: ['text', 'url', 'email'],
+  width: 12,
+  keys: [
+    [
+      { value: 'ཀ' }, { value: 'ཁ' }, { value: 'ག' } , { value: 'ང' },
+      { value: 'ི' } , { value: 'ུ' }, { value: 'ེ' } , { value: 'ོ' },
+      { value: 'ཅ' }, { value: 'ཆ' }, { value: 'ཇ' }, { value: 'ཉ' }
+    ], [
+      { value: 'ཏ' }, { value: 'ཐ' }, { value: 'ད' }, { value: 'ན' },
+      { value: 'པ' } , { value: 'ཕ' }, { value: 'བ' }, { value: 'མ' },
+      { value: 'ཙ' }, { value: 'ཚ'}, { value: 'ཛ' }, { value: 'ཝ' },
+    ], [
+      { value: 'ཞ' }, { value: 'ཟ' }, { value: 'འ' }, { value: 'ཡ' }, { value: 'ར' },
+      { value: 'ལ' }, { value: 'ཤ' }, { value: 'ས' }, { value: 'ཧ' }, { value: 'ཨ' },
+      { value: '⌫', ratio: 2, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+    ], [
+      { value: '&nbsp', ratio: 6, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '་', ratio: 2 }, { value: '།' },
+      { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+    ]
+  ],
+  alt: {
+    'ཀ': 'ྐ',
+    'ཁ': 'ྑ',
+    'ག': 'ྒ',
+    'ང': 'ྔ',
+    'ི': 'ྀ',
+    'ུ': '྄',
+    'ེ': 'ཻ',
+    'ོ': 'ཽ',
+    'ཅ': 'ྕ',
+    'ཆ': 'ྖ',
+    'ཇ': 'ྗ',
+    'ཉ': 'ྙ ཨ྅',
+
+    'ཏ': 'ྟ ཊ ྚ',
+    'ཐ': 'ྠ ཋ ྛ',
+    'ད': 'ྡ ཌ ྜ',
+    'ན': 'ྣ ཎ ྞ',
+    'པ': 'ྤ',
+    'ཕ': 'ྥ',
+    'བ': 'ྦ',
+    'མ': 'ྨ ཨཾ ཨྃ ༷ ༵',
+    'ཙ': 'ྩ ༹',
+    'ཚ': 'ྪ',
+    'ཛ': 'ྫ',
+    'ཝ': 'ྭ ྺ',
+
+    'ཞ': 'ྮ',
+    'ཟ': 'ྯ',
+    'འ': 'ཱ',
+    'ཡ': 'ྱ',
+    'ར': 'ྲ ཪ',
+    'ལ': 'ླ',
+    'ཤ': 'ྴ ཥ',
+    'ས': 'ྶ',
+    'ཧ': 'ྷ',
+    'ཨ': 'ྸ ༁',
+    
+    '་': '࿒',
+    '།': '༎'
+  },
+  alternateLayout: {
+    alt: {
+      '༡': '1',
+      '༢': '2',
+      '༣': '3',
+      '༤': '4',
+      '༥': '5',
+      '༦': '6',
+      '༧': '7',
+      '༨': '8',
+      '༩': '9',
+      '༠': '0',
+      
+      '༆': '༄ ༅ @',
+      '༉': '࿑ ༊ ࿐ #',
+      '༈': '-',
+      '₨': '$ € £ ¥',
+      '༴': '྾ %',
+      'ཿ': '&',
+      '༷': '༵ *',
+      '༔': '+',
+      '༼': '(',
+      '༽': ')',
+
+      '༃': '༂ !',
+      '༑': "༏ ༐ '",
+      '྅': 'ྊ ྋ \"',
+      'ྈ': ':',
+      'ྉ': ';',
+      '࿙': '/',
+      '྿': '?'
+    },
+    keys: [
+      [
+        { value: '༡' }, { value: '༢' }, { value: '༣' } , { value: '༤' },
+        { value: '༥' } , { value: '༦' }, { value: '༧' } , { value: '༨' },
+        { value: '༩' }, { value: '༠' }
+      ], [
+        { value: '༆'}, { value: '༉' }, { value: '༈' },
+        { value: '₨' }, { value: '༴' } , { value: 'ཿ' }, { value: '༷' },
+        { value: '༔' }, { value: '༼' }, { value: '༽' }
+      ], [
+        { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+        { value: '༃' }, { value: '༑' }, { value: '྅' }, { value: 'ྈ' },
+        { value: 'ྉ' }, { value: '࿙' }, { value: '྿' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  }
+};
+

--- a/apps/keyboard/js/layouts/dz-BT.js
+++ b/apps/keyboard/js/layouts/dz-BT.js
@@ -1,4 +1,4 @@
-Keyboards['dz-BT.js'] = {
+Keyboards['dz-BT'] = {
   label: 'Dzongkha',
   menuLabel: 'Dzongkha',
   alternateLayoutKey: '༡༢༣',

--- a/apps/keyboard/js/layouts/dz-BT.js
+++ b/apps/keyboard/js/layouts/dz-BT.js
@@ -1,6 +1,6 @@
 Keyboards['dz-BT'] = {
   label: 'Dzongkha',
-  menuLabel: 'Dzongkha',
+  menuLabel: 'རྫོང་ཁ',
   alternateLayoutKey: '༡༢༣',
   basicLayoutKey: 'ཀཁག',
   types: ['text', 'url', 'email'],


### PR DESCRIPTION
I just added Dzongkha input method for B2G. Dzongkha is national language of Bhutan. This fixes the bug 95033 and also adds support for writing Tibetan (bo-CN) and some other language based on tibetan scripts.

I think the Dzongkha font should be merged before merging this PR. 
That PR is available here - https://github.com/mozilla-b2g/moztt/pull/30

and the bug details is here

https://bugzilla.mozilla.org/show_bug.cgi?id=953033
