### PR TITLE
Bug 921971 - [DSDS][FDN] Manage FDN list for both SIMs

### DIFF
--- a/apps/settings/js/call.js
+++ b/apps/settings/js/call.js
@@ -159,8 +159,9 @@ var CallSettings = (function(window, document, undefined) {
    */
   function cs_setToSettingsDB(settingKey, value, callback) {
     var done = function done() {
-      if (callback)
+      if (callback) {
         callback();
+      }
     };
 
     var getLock = _settings.createLock();
@@ -289,15 +290,17 @@ var CallSettings = (function(window, document, undefined) {
               runTask: function(func) {
                 this.taskCount++;
                 var newArgs = [];
-                for (var i = 1; i < arguments.length; i++)
+                for (var i = 1; i < arguments.length; i++) {
                   newArgs.push(arguments[i]);
+                }
                 newArgs.push(this.complete.bind(this));
                 func.apply(window, newArgs);
               },
               complete: function() {
                 this.taskCount--;
-                if (this.taskCount == 0)
+                if (this.taskCount === 0) {
                   this.finish();
+                }
               },
               finish: function() {
                 setTimeout(function() {
@@ -369,7 +372,7 @@ var CallSettings = (function(window, document, undefined) {
       mobileBusy.onerror = onerror;
     };
     unconditional.onerror = onerror;
-  };
+  }
 
   /**
    *
@@ -387,7 +390,7 @@ var CallSettings = (function(window, document, undefined) {
           return;
         }
         // Bails out in case the reason is already enabled/disabled.
-        if (_cfReasonStates[_cfReasonMapping[key]] == event.settingValue) {
+        if (_cfReasonStates[_cfReasonMapping[key]] === event.settingValue) {
           return;
         }
         var selector = 'input[data-setting="ril.cf.' + key + '.number"]';
@@ -444,18 +447,19 @@ var CallSettings = (function(window, document, undefined) {
    * Get the message to show after setting up call forwarding.
    */
   function cs_getSetCallForwardingOptionResult(rules, action) {
+    var message;
     for (var i = 0; i < rules.length; i++) {
       if (rules[i].active &&
           ((_voiceServiceClassMask & rules[i].serviceClass) != 0)) {
-        var disableAction = action == _cfAction.CALL_FORWARD_ACTION_DISABLE;
-        var message = disableAction ?
+        var disableAction = action === _cfAction.CALL_FORWARD_ACTION_DISABLE;
+        message = disableAction ?
           _('callForwardingSetForbidden') : _('callForwardingSetSuccess');
         return message;
       }
     }
     var registrationAction =
-      action == _cfAction.CALL_FORWARD_ACTION_REGISTRATION;
-    var message = registrationAction ?
+      action === _cfAction.CALL_FORWARD_ACTION_REGISTRATION;
+    message = registrationAction ?
       _('callForwardingSetError') : _('callForwardingSetSuccess');
     return message;
   }
@@ -848,12 +852,12 @@ var CallSettings = (function(window, document, undefined) {
    *
    */
   function cs_updateFdnStatus() {
-    // TODO: Add support for FDN feauture on multi ICC card devices.
-    if (!IccHelper) {
+    var iccObj = getIccByIndex();
+    if (!iccObj) {
       return;
     }
 
-    var req = IccHelper.getCardLock('fdn');
+    var req = iccObj.getCardLock('fdn');
     req.onsuccess = function spl_checkSuccess() {
       var enabled = req.result.enabled;
 

--- a/apps/settings/js/security_privacy.js
+++ b/apps/settings/js/security_privacy.js
@@ -45,10 +45,7 @@ var Security = {
 
   updateSimLockDesc: function updateSimLockDesc() {
     var _ = navigator.mozL10n.get;
-    // XXX: check bug-926169
-    // this is used to keep all tests passing while introducing multi-sim APIs
-    var mobileConnection = window.navigator.mozMobileConnection ||
-      window.navigator.mozMobileConnections &&
+    var mobileConnection = window.navigator.mozMobileConnections &&
         window.navigator.mozMobileConnections[0];
 
     if (!mobileConnection)

--- a/apps/settings/js/simcard_dialog.js
+++ b/apps/settings/js/simcard_dialog.js
@@ -415,15 +415,8 @@ function SimPinDialog(dialog) {
 
   function show(action, options) {
     options = options || {};
-    var conn = conns[options.cardIndex || 0];
 
-    if (!conn) {
-      return;
-    }
-
-    var iccId = conn.iccId;
-    icc = window.navigator.mozIccManager.getIccById(iccId);
-
+    icc = getIccByIndex(options.cardIndex);
     if (!icc) {
       return;
     }

--- a/apps/settings/js/simcard_fdn.js
+++ b/apps/settings/js/simcard_fdn.js
@@ -1,5 +1,7 @@
 /* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+/* global DsdsSettings, localize, SimPinDialog, Settings, MozActivity */
+/* global FdnAuthorizedNumbers, getIccByIndex, console */
 
 'use strict';
 
@@ -32,11 +34,13 @@ var SimFdnLock = {
   currentContact: null,
 
   updateFdnStatus: function spl_updateSimStatus() {
-    if (!IccHelper) {
-      return;
-    }
     var self = this;
-    var req = IccHelper.getCardLock('fdn');
+    var iccObj = getIccByIndex();
+    if (!iccObj) {
+      return console.error('Could not retrieve ICC object');
+    }
+
+    var req = iccObj.getCardLock('fdn');
     req.onsuccess = function spl_checkSuccess() {
       var enabled = req.result.enabled;
       localize(self.simFdnDesc, enabled ? 'enabled' : 'disabled');
@@ -47,12 +51,13 @@ var SimFdnLock = {
   },
 
   init: function spl_init() {
-    if (!IccHelper) {
-      return;
+    var iccObj = getIccByIndex();
+    if (!iccObj) {
+      return console.error('Could not retrieve ICC object');
     }
 
     var callback = this.updateFdnStatus.bind(this);
-    IccHelper.addEventListener('cardstatechange', callback);
+    iccObj.addEventListener('cardstatechange', callback);
 
     this.pinDialog = new SimPinDialog(this.dialog);
     var self = this;
@@ -62,7 +67,7 @@ var SimFdnLock = {
     this.simFdnCheckBox.disabled = true;
     this.simFdnCheckBox.onchange = function spl_togglePin2() {
       var action = this.checked ? 'enable_fdn' : 'disable_fdn';
-      if (IccHelper.cardState === 'puk2Required') {
+      if (iccObj.cardState === 'puk2Required') {
         action = 'unlock_puk2';
       }
       self.pinDialog.show(action, { onsuccess: callback, oncancel: callback });

--- a/apps/settings/js/simcard_fdn_list.js
+++ b/apps/settings/js/simcard_fdn_list.js
@@ -1,13 +1,18 @@
+/* global getIccByIndex */
+
 'use strict';
 
 var FdnAuthorizedNumbers = {
   fdnContacts: null,
 
   getContacts: function(er, cb) {
-    if (!IccHelper) {
+    var icc = getIccByIndex();
+    if (!icc) {
+      er && er(new Error('Could not retrieve ICC object'));
       return;
     }
-    var request = IccHelper.readContacts('fdn');
+
+    var request = icc.readContacts('fdn');
     request.onerror = er;
     request.onsuccess = (function onsuccess() {
       var result = this.fdnContacts = request.result;

--- a/apps/settings/test/unit/mock_dsds_settings.js
+++ b/apps/settings/test/unit/mock_dsds_settings.js
@@ -1,0 +1,18 @@
+'use strict';
+
+window.MockDsdsSettings = (function() {
+  var _iccCardIndexForCallSettings = 2;
+
+  function ds_getIccCardIndexForCallSettings() {
+    return _iccCardIndexForCallSettings;
+  }
+
+  function ds_setIccCardIndexForCallSettings(iccCardIndexForCallSettings) {
+    _iccCardIndexForCallSettings = iccCardIndexForCallSettings;
+  }
+
+  return {
+    getIccCardIndexForCallSettings: ds_getIccCardIndexForCallSettings,
+    setIccCardIndexForCallSettings: ds_setIccCardIndexForCallSettings
+  };
+})();

--- a/apps/settings/test/unit/utils_test.js
+++ b/apps/settings/test/unit/utils_test.js
@@ -1,0 +1,66 @@
+/* global suiteSetup, suite, suiteTeardown, window, navigator,
+ MockDsdsSettings, getIccByIndex, MockIccManager, MockL10n */
+
+'use strict';
+
+requireApp('settings/test/unit/mock_dsds_settings.js');
+requireApp('communications/contacts/test/unit/mock_iccmanager.js');
+requireApp('settings/test/unit/mock_l10n.js');
+
+mocha.globals(['DsdsSettings', 'reopenSettings', 'openLink', 'openDialog',
+  'loadJSON', 'FileSizeFormatter', 'DeviceStorageHelper', 'getMobileConnection',
+  'getBluetooth', 'getNfc', 'getSupportedNetworkInfo', 'isIP', 'getIccByIndex',
+  'sanitizeAddress', 'getTruncated', 'getIccByIndexalize', 'localize']);
+
+suite('Utils', function() {
+  var realDsDsSettings, realMozMobileConnections, realMozIccManager, realL10n;
+
+  suiteSetup(function(done) {
+    realDsDsSettings = window.DsdsSettings;
+    window.DsdsSettings = MockDsdsSettings;
+
+    realMozIccManager = navigator.mozIccManager;
+    navigator.mozIccManager = new MockIccManager();
+
+    realMozMobileConnections = navigator.mozMobileConnections;
+    navigator.mozMobileConnections = [
+      {iccId: 'icc1'},
+      {iccId: 'icc2'},
+      {iccId: 'icc3'},
+      {iccId: 'icc4'}
+    ];
+
+    realL10n = window.navigator.mozL10n;
+    window.navigator.mozL10n = MockL10n;
+
+    requireApp('settings/js/utils.js', done);
+  });
+
+  suiteTeardown(function() {
+    window.DsdsSettings = realDsDsSettings;
+    window.navigator.mozL10n = realL10n;
+    navigator.mozIccManager = realMozIccManager;
+    navigator.mozMobileConnections = realMozMobileConnections;
+  });
+
+  suite(' > getIccByIndex', function() {
+    test('check that index parameter is taken into account', function() {
+      var result = getIccByIndex(1);
+
+      assert.equal('icc2', result.iccInfo.iccid);
+    });
+
+    test('check that index parameter is chosen by default', function() {
+      var result = getIccByIndex();
+
+      // the default index for MockDsdsSettings is 2
+      assert.equal('icc3', result.iccInfo.iccid);
+    });
+
+    test('check that it returns undefined if index doesn\'t exist', function() {
+      var result = getIccByIndex(4);
+
+      assert.equal(undefined, result);
+    });
+  });
+});


### PR DESCRIPTION
Implemented:

AC1: I expect to have the same FDN functionality as in the single SIM implementation for each of the SIMs.
AC2: I expect to have the FDN list active only for the current default SIM for Voice
AC3: I expect SIM2 to still remember the data (though disabled) when SIM1 is the default for Voice, and vice versa.

This fix makes it possible to have independent Fixed Dialing Numbers for each SIM card in the phone. A new function `getIccByIndex` has been introduced in `utils.js` that selects the currently selected ICC object without the user having to specify the particular index, although it allows that too (used in `sim_dialog.js`, for example.

Instances of `IccHelper` have been replaced by the result of calls to `getIccByIndex`.
