### PR TITLE
Bug 976986 - SettingsListener should have unobserve() method

### DIFF
--- a/apps/system/test/unit/captive_portal_test.js
+++ b/apps/system/test/unit/captive_portal_test.js
@@ -26,7 +26,6 @@ var mocksForCaptivePortal = new MocksHelper([
 
 suite('captive portal > ', function() {
   var realWifiManager;
-  var realSettingsListener;
   var realL10n;
   var realSettings;
   var realActivity;
@@ -58,7 +57,6 @@ suite('captive portal > ', function() {
 
   suiteTeardown(function() {
     navigator.mozWifiManager = realWifiManager;
-    window.SettingsListener = realSettingsListener;
     try {
       window.MozActivity = realActivity;
     } catch (e) {

--- a/apps/system/test/unit/home_gesture_test.js
+++ b/apps/system/test/unit/home_gesture_test.js
@@ -13,7 +13,6 @@ var mocksForHomegesture = new MocksHelper([
 
 
 suite('enable/disable homegesture', function() {
-  var realSettingsListener;
   var realScreenLayout;
   var realSettings;
   var fakeHomebar;
@@ -22,14 +21,11 @@ suite('enable/disable homegesture', function() {
   suiteSetup(function() {
     realSettings = navigator.mozSettings;
     navigator.mozSettings = MockNavigatorSettings;
-    realSettingsListener = window.SettingsListener;
-    window.SettingsListener = MockSettingsListener;
     realScreenLayout = window.ScreenLayout;
     window.ScreenLayout = MockScreenLayout;
   });
 
   suiteTeardown(function() {
-    window.SettingsListener = realSettingsListener;
     window.ScreenLayout = realScreenLayout;
     navigator.mozSettings = realSettings;
   });

--- a/apps/system/test/unit/settings_listener_test.js
+++ b/apps/system/test/unit/settings_listener_test.js
@@ -1,0 +1,57 @@
+'use strict';
+/* global MockNavigatorSettings, SettingsListener */
+
+mocha.globals(['SettingsListener']);
+
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/js/settings_listener.js');
+
+suite('shared/SettingsListener', function() {
+  var realSettings;
+  var onChanged;
+  var clock;
+
+  setup(function() {
+    realSettings = window.navigator.mozSettings;
+    window.navigator.mozSettings = MockNavigatorSettings;
+    onChanged = sinon.spy();
+    clock = sinon.useFakeTimers();
+  });
+
+  teardown(function() {
+    window.navigator.mozSettings.mTeardown();
+    window.navigator.mozSettings = realSettings;
+    clock.restore();
+  });
+
+  test('getSettingsLock', function() {
+    var lock = SettingsListener.getSettingsLock();
+    assert.isNotNull(lock);
+    assert.isNotNull(lock.get());
+  });
+
+  test('observe', function() {
+    var testKey = 'some.sample.key';
+    SettingsListener.observe(testKey, 'old', onChanged);
+    clock.tick(1);
+    assert.isTrue(onChanged.calledWith('old'));
+    onChanged.reset();
+    MockNavigatorSettings.mTriggerObservers(testKey,
+      {settingValue: 'new'});
+    assert.isTrue(onChanged.calledWith('new'));
+  });
+
+  test('unobserve', function() {
+    var testKey = 'some.sample.key';
+    SettingsListener.observe(testKey, 'old', onChanged);
+    clock.tick(1);
+    MockNavigatorSettings.mTriggerObservers(testKey,
+      {settingValue: 'new'});
+    assert.isTrue(onChanged.called);
+    onChanged.reset();
+    SettingsListener.unobserve(testKey, onChanged);
+    MockNavigatorSettings.mTriggerObservers(testKey,
+      {settingValue: 'new'});
+    assert.isFalse(onChanged.called);
+  });
+});

--- a/shared/js/settings_listener.js
+++ b/shared/js/settings_listener.js
@@ -10,12 +10,14 @@ var SettingsListener = {
   /* lock stores here */
   _lock: null,
 
+  /* keep record of observers in order to remove them in the future */
+  _observers: [],
+
   /**
    * getSettingsLock: create a lock or retrieve one that we saved.
    * mozSettings.createLock() is expensive and lock should be reused
    * whenever possible.
    */
-
   getSettingsLock: function sl_getSettingsLock() {
     // If there is a lock present we return that
     if (this._lock && !this._lock.closed) {
@@ -55,8 +57,25 @@ var SettingsListener = {
         req.result[name] : defaultValue);
     }));
 
-    settings.addObserver(name, function settingChanged(evt) {
+    var settingChanged = function settingChanged(evt) {
       callback(evt.settingValue);
+    };
+    settings.addObserver(name, settingChanged);
+    this._observers.push({
+      name: name,
+      callback: callback,
+      observer: settingChanged
+    });
+  },
+
+  unobserve: function sl_unobserve(name, callback) {
+    var settings = window.navigator.mozSettings;
+    var that = this;
+    this._observers.forEach(function(value, index) {
+      if (value.name === name && value.callback === callback) {
+        settings.removeObserver(name, value.observer);
+        that._observers.splice(index, 1);
+      }
     });
   }
 };


### PR DESCRIPTION
1. Add unit test of SettingsListener
2. Add unobserve() method in SettingsListener
3. Remove unnecessary MockSettingsListener in home_gesture_test.js and captive_portal_test.js since they are already using MocksHelper to do that.

https://bugzilla.mozilla.org/show_bug.cgi?id=976986
