### PR TITLE
Bug 976999 - [Sora][Message][MMS]Some of the text content lost when forward the MMS

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -409,13 +409,15 @@ var Compose = (function() {
             if (element.text) {
               this.append(element.text);
             }
-          }, Compose);
-        });
+          }, this);
+          this.ignoreEvents = false;
+          this.focus();
+        }.bind(this));
+        this.ignoreEvents = true;
       } else {
         this.append(message.body);
+        this.focus();
       }
-
-      this.focus();
     },
 
     getText: function() {
@@ -705,6 +707,12 @@ var Compose = (function() {
   Object.defineProperty(compose, 'subjectMaxLength', {
     get: function composeGetResizeState() {
       return subject.getMaxLength();
+    }
+  });
+
+  Object.defineProperty(compose, 'ignoreEvents', {
+    set: function composeIgnoreEvents(value) {
+      dom.message.classList.toggle('ignoreEvents', value);
     }
   });
 

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -715,6 +715,10 @@ form.bottom[role="search"].messages-compose-form {
   font-size: 1.8rem;
 }
 
+#messages-input.ignoreEvents {
+  pointer-events: none;
+}
+
 #messages-input.placeholder:after,
 #messages-subject-input::-moz-placeholder {
   color: #888;


### PR DESCRIPTION
- Avoid the composer focused while MMS parsing/appending the text, It will enter insert element at caret position and delete the selected range before insertion.
- Set pointer-events to none to avoid the composer could be focused manually while mms parsing.
