### PR TITLE
Bug 976481: remove the useless and buggy Media Storage Settings button from the media apps

### DIFF
--- a/apps/camera/js/controllers/overlay.js
+++ b/apps/camera/js/controllers/overlay.js
@@ -66,7 +66,6 @@ OverlayController.prototype.insertOverlay = function(type) {
 
   overlay
     .appendTo(document.body)
-    .on('click:storage-settings-btn', this.onStorageSettingsClick)
     .on('click:close-btn', function() {
       overlay.destroy();
       activity.cancel();
@@ -90,7 +89,7 @@ OverlayController.prototype.getOverlayData = function(type) {
   switch (type) {
     case 'unavailable':
       data.title = l10n.get('nocard2-title');
-      data.body = l10n.get('nocard2-text');
+      data.body = l10n.get('nocard3-text');
     break;
     case 'nospace':
       data.title = l10n.get('nospace2-title');
@@ -105,27 +104,8 @@ OverlayController.prototype.getOverlayData = function(type) {
   }
 
   data.closeButtonText = l10n.get('close-button');
-  data.storageButtonText = l10n.get('storage-setting-button');
 
   return data;
-};
-
-/**
- * Click to open the media
- * storage panel when the default
- * storage is unavailable.
- *
- * @return {undefined}
- */
-OverlayController.prototype.onStorageSettingsClick = function() {
-  var MozActivity = window.MozActivity;
-  this.mozActivity = new MozActivity({
-    name: 'configure',
-    data: {
-      target: 'device',
-      section: 'mediaStorage'
-    }
-  });
 };
 
 /**

--- a/apps/camera/js/views/overlay.js
+++ b/apps/camera/js/views/overlay.js
@@ -30,12 +30,10 @@ module.exports = View.extend({
 
     // Pick out elements
     this.els.buttons = {
-      storage: find('.js-storage-btn', this.el),
       close: find('.js-close-btn', this.el)
     };
 
     // Attach event listeners
-    bind(this.els.buttons.storage, 'click', this.onButtonClick);
     bind(this.els.buttons.close, 'click', this.onButtonClick);
   },
 
@@ -49,10 +47,6 @@ module.exports = View.extend({
       '<menu class="overlay-menu-close">' +
         '<button class="full js-close-btn" type="button" name="close-btn">' +
         data.closeButtonText + '</button>' +
-      '</menu>' +
-      '<menu class="overlay-menu-storage">' +
-        '<button class="full js-storage-btn" type="button"' +
-        'name="storage-settings-btn">' + data.storageButtonText + '</button>' +
       '</menu>' +
     '</form>';
   },

--- a/apps/camera/locales/camera.en-US.properties
+++ b/apps/camera/locales/camera.en-US.properties
@@ -8,7 +8,7 @@ error-recording-title = Video not recorded
 error-recording-text  = An error prevented Camera from recording the video.
 
 nocard2-title = No memory card found
-nocard2-text  = Insert a memory card to take pictures or select an alternate default media location in settings.
+nocard3-text  = Insert a memory card to take pictures.
 
 pluggedin-title = Camera can not be used while plugged in
 pluggedin-text  = Unplug the phone to view pictures.
@@ -22,5 +22,3 @@ close-button  = Close
 
 delete-photo? = Delete photo?
 delete-video? = Delete video?
-
-storage-setting-button = Media storage settings

--- a/apps/camera/test/unit/controllers/overlay_test.js
+++ b/apps/camera/test/unit/controllers/overlay_test.js
@@ -40,7 +40,7 @@ suite('controllers/overlay', function() {
 
     navigator.mozL10n = { get: sinon.stub() };
     navigator.mozL10n.get.withArgs('nocard2-title').returns('nocard title');
-    navigator.mozL10n.get.withArgs('nocard2-text').returns('nocard body');
+    navigator.mozL10n.get.withArgs('nocard3-text').returns('nocard body');
     navigator.mozL10n.get.withArgs('nospace2-title').returns('nospace title');
     navigator.mozL10n.get.withArgs('nospace2-text').returns('nospace body');
     navigator.mozL10n.get.withArgs(

--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -236,8 +236,6 @@
         <p id="overlay-text">ter</p>
       </section>
       <menu id="overlay-menu" class="hidden">
-        <button type="button" id="storage-setting-button" class="hidden full"
-                data-l10n-id="storage-setting-button">Media storage settings</button>
         <button type="button" id="overlay-camera-button" class="hidden full"
                 data-l10n-id="overlay-camera-button">Go to Camera</button>
         <button type="button" id="overlay-cancel-button" data-l10n-id="cancel" class="full">Cancel</button>

--- a/apps/gallery/js/dialogs.js
+++ b/apps/gallery/js/dialogs.js
@@ -68,7 +68,6 @@ var Dialogs = {
     LazyLoader.load('shared/style/confirm.css', function() {
 
       // hide any special elements
-      $('storage-setting-button').classList.add('hidden');
       $('overlay-camera-button').classList.add('hidden');
       $('overlay-cancel-button').classList.add('hidden');
       $('overlay-menu').classList.add('hidden');
@@ -80,12 +79,10 @@ var Dialogs = {
           return;
         case 'nocard':
           title = _('nocard3-title');
-          text = _('nocard3-text');
-          $('overlay-menu').classList.remove('hidden');
+          text = _('nocard4-text');
           if (pendingPick) {
             $('overlay-cancel-button').classList.remove('hidden');
-          } else {
-            $('storage-setting-button').classList.remove('hidden');
+            $('overlay-menu').classList.remove('hidden');
           }
           break;
         case 'pluggedin':

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -178,17 +178,6 @@ function init() {
   // Clicking on the share button in select mode shares all selected images
   $('thumbnails-share-button').onclick = shareSelectedItems;
 
-  // Click to open the media storage panel when the default storage
-  // is unavailable.
-  $('storage-setting-button').onclick = function() {
-    var activity = new MozActivity({
-      name: 'configure',
-      data: {
-        target: 'device',
-        section: 'mediaStorage'
-      }
-    });
-  };
   $('overlay-cancel-button').onclick = function() {
     cancelPick();
   };

--- a/apps/gallery/locales/gallery.en-US.properties
+++ b/apps/gallery/locales/gallery.en-US.properties
@@ -49,7 +49,7 @@ emptygallery2-text  = Use the Camera app to get started.
 emptygallery2-title-pick = No photos
 
 nocard3-title = No memory card
-nocard3-text  = Insert a memory card to use this app or select an alternate default media location in settings.
+nocard4-text  = Insert a memory card to use this app.
 
 pluggedin2-title = Memory card in use
 pluggedin2-text  = Unplug the phone to use this app.
@@ -69,7 +69,6 @@ imageinvalid = Image is invalid or corrupt and cannot be displayed.
 
 saved = {{filename}} saved to Gallery
 
-storage-setting-button = Media storage settings
 overlay-camera-button = Go to Camera
 
 name-label = Name

--- a/apps/music/index.html
+++ b/apps/music/index.html
@@ -174,8 +174,8 @@
         <p id="overlay-text"></p>
       </section>
       <menu id="overlay-menu" class="hidden">
-        <button type="button" id="storage-setting-button" class="full"
-                data-l10n-id="storage-setting-button">Media storage settings</button>
+        <button type="button" id="overlay-cancel-button" class="full"
+                data-l10n-id="overlay-cancel-button">Cancel</button>
       </menu>
     </form>
     <!-- display this at startup while we load music -->

--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -307,18 +307,13 @@ function init() {
     }
   };
 
-  // Click to open the media storage panel when the default storage
-  // is unavailable.
-  document.getElementById('storage-setting-button').
-    addEventListener('click', function() {
-      var activity = new MozActivity({
-      name: 'configure',
-      data: {
-        target: 'device',
-        section: 'mediaStorage'
+  // If the overlay is displayed during a pick, let the user get out of it
+  document.getElementById('overlay-cancel-button')
+    .addEventListener('click', function() {
+      if (pendingPick) {
+        pendingPick.postError('pick cancelled');
       }
     });
-  });
 }
 
 //
@@ -347,7 +342,7 @@ function showOverlay(id) {
   }
 
   var menu = document.getElementById('overlay-menu');
-  if (id === 'nocard') {
+  if (pendingPick) {
     menu.classList.remove('hidden');
   } else {
     menu.classList.add('hidden');
@@ -356,7 +351,7 @@ function showOverlay(id) {
   var title, text;
   if (id === 'nocard') {
     title = navigator.mozL10n.get('nocard2-title');
-    text = navigator.mozL10n.get('nocard2-text');
+    text = navigator.mozL10n.get('nocard3-text');
   } else {
     title = navigator.mozL10n.get(id + '-title');
     text = navigator.mozL10n.get(id + '-text');

--- a/apps/music/locales/music.en-US.properties
+++ b/apps/music/locales/music.en-US.properties
@@ -18,7 +18,7 @@ empty-title = Add songs to get started
 empty-text = Load songs on to the memory card.
 
 nocard2-title = No memory card found
-nocard2-text  = Insert a memory card to listen to songs or select an alternate default media location in settings.
+nocard3-text  = Insert a memory card to listen to songs.
 
 pluggedin-title = Music can not be used while phone is plugged in
 pluggedin-text  = Unplug the phone to play music.
@@ -46,6 +46,6 @@ saved = Saved {{title}} to Music
 
 audioinvalid = Audio cannot be played: format is unsupported or file is invalid.
 
-storage-setting-button = Media storage settings
+overlay-cancel-button = Cancel
 
 music-paused-notification = Music paused during the call

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -746,7 +746,7 @@ function showOverlay(id) {
 
   if (id === 'nocard') {
     dom.overlayTitle.textContent = _('nocard2-title');
-    dom.overlayText.textContent = _('nocard2-text');
+    dom.overlayText.textContent = _('nocard3-text');
   } else {
     dom.overlayTitle.textContent = _(id + '-title');
     dom.overlayText.textContent = _(id + '-text');

--- a/apps/video/locales/video.en-US.properties
+++ b/apps/video/locales/video.en-US.properties
@@ -24,7 +24,7 @@ empty-title = Add videos to get started
 empty-text  = Load videos on to the memory card.
 
 nocard2-title = No memory card found
-nocard2-text  = Insert a memory card to watch videos or select an alternate default media location in settings.
+nocard3-text  = Insert a memory card to watch videos.
 
 pluggedin-title = Video can not be watched while plugged in
 pluggedin-text  = Unplug the phone to watch videos.
@@ -45,7 +45,6 @@ error-network = The video could not be downloaded because of a network error.
 error-unsupported = Video cannot be played: either because the server or network failed or because the format is not supported.
 error-unknown = An unknown video error occurred.
 
-storage-setting-button = Media storage settings
 overlay-cancel-button = Cancel
 overlay-camera-button = Go to Camera
 


### PR DESCRIPTION
and update the text displayed when there is no sdcard.
Also ensure that all media apps have a cancel button if invoked for a pick
activity when there is no sdcard.

remove storage setting button and update dialog text for Gallery app

modify the nocard message in the Video app

Remove storage settings button from Music app overlay, change overlay message, and add a Cancel button for pick activities

Remove unused string from Gallery locale file

Remove unused string from Video locale file

Remove the storage settings button and text from the Camera overlay
