### PR TITLE
Bug 975486 - [B2G][l12y][Settings]Serbian-Cyrillic: Keyboard title is

### DIFF
--- a/apps/keyboard/js/layouts/sr-Cyrl.js
+++ b/apps/keyboard/js/layouts/sr-Cyrl.js
@@ -1,6 +1,6 @@
 Keyboards['sr-Cyrl'] = {
   label: 'Serbian (Cyrillic)',
-  menuLabel: 'Српски (ћирилица)',
+  menuLabel: 'Српски',
   imEngine: 'latin',
   types: ['text', 'url', 'email'],
   autoCorrectLanguage: 'sr-Cyrl',


### PR DESCRIPTION
truncated in 'Selected Keyboards' list.
- Shorten the string of Serbian Cyrillic.
