### PR TITLE
Bug 981328 - [Search] XHR mock is not restored r=rickychien

### DIFF
--- a/apps/search/test/unit/providers/marketplace_test.js
+++ b/apps/search/test/unit/providers/marketplace_test.js
@@ -89,11 +89,16 @@ suite('search/providers/marketplace', function() {
     };
 
     var requests = [];
+    var xhr;
 
     setup(function() {
-      var xhr = sinon.useFakeXMLHttpRequest();
+      xhr = sinon.useFakeXMLHttpRequest();
       requests = [];
       xhr.onCreate = function(req) { requests.push(req); };
+    });
+
+    teardown(function() {
+      xhr.restore();
     });
 
     test('renders all results', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=981328
