### PR TITLE
Add default tiles pref settings to Gaia

### DIFF
--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -105,6 +105,12 @@
         </li>
         <li>
           <label class="pack-checkbox">
+            <input type="checkbox" name="layers.simple-tiles"/>
+            <span data-l10n-id="layers-simple-tiles">Layers: Simple Tiles</span>
+          </label>
+        </li>
+        <li>
+          <label class="pack-checkbox">
             <input type="checkbox" name="layers.progressive-paint"/>
             <span data-l10n-id="layers-progressive-paint">Layers: Progressive Paint</span>
           </label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -932,6 +932,7 @@ paint-flashing=Flash repainted area
 dumps-layers=Dump layers tree
 apz-force-enable=Enable APZ for all content processes
 layers-enable-tiles=Layers: Enable Tiles
+layers-simple-tiles=Layers: Simple Tiles
 layers-progressive-paint=Layers: Progressive Paint
 layers-draw-tile-borders=Layers: Draw Tile Borders
 apz-displayport-heuristics=Displayport Heuristics

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -86,6 +86,8 @@
    "language.current": "en-US",
    "layers.draw-borders": false,
    "layers.dump": false,
+   "layers.enable-tiles": true,
+   "layers.simple-tiles": false,
    "lockscreen.passcode-lock.code": "0000",
    "lockscreen.passcode-lock.timeout": 0,
    "lockscreen.passcode-lock.enabled": false,


### PR DESCRIPTION
Add default settings for enable-tiles to common-settings.json, and add a developer pref to toggle layers.simple-tiles (bug 981733)
