### PR TITLE
Bug 949779 - Modify the SMS app to use the new downsample-and-decode image feature when resizing images

### DIFF
--- a/apps/sms/js/attachment.js
+++ b/apps/sms/js/attachment.js
@@ -77,7 +77,11 @@
       // as soon as the image width and height are known, the container can be
       // extended up to 120px, either horizontally or vertically.
       var img = new Image();
-      img.src = window.URL.createObjectURL(this.blob);
+      img.src = Utils.getDownsamplingSrcUrl({
+        url: window.URL.createObjectURL(this.blob),
+        size: this.blob.size,
+        type: 'thumbnail'
+      });
       img.onload = function onBlobLoaded() {
         window.URL.revokeObjectURL(img.src);
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -9,6 +9,13 @@
   var rescape = /[.?*+^$[\]\\(){}|-]/g;
   var rparams = /([^?=&]+)(?:=([^&]*))?/g;
   var rnondialablechars = /[^,#+\*\d]/g;
+  var downsamplingRefSize = {
+    // Estimate average Thumbnail size:
+    // 120 X 60 (max pixel) X 3 (full color) / 20 (average jpeg compress ratio)
+    // = 1080 (byte)
+    'thumbnail' : 1080
+    // TODO: For mms resizing
+  };
 
   var Utils = {
     date: {
@@ -272,9 +279,9 @@
      * Check multi-repients without regard to order
      *
      * @param {(String|string[])} a First recipient field.
-     * @param {(String|string[])} b Second recipient field
+     * @param {(String|string[])} b Second recipient field.
      *
-     * @return {Boolean} Return true if all recipients match
+     * @return {Boolean} Return true if all recipients match.
      */
     multiRecipientMatch: function ut_multiRecipientMatch(a, b) {
       // When ES6 syntax is allowed, replace with
@@ -388,6 +395,23 @@
         }
         canvas.toBlob(ensureSizeLimit, blob.type);
       };
+    },
+    // Return the url path with #-moz-samplesize postfix and downsampled image
+    // could be loaded directly from backend graphics lib.
+    getDownsamplingSrcUrl: function ut_getDownsamplingSrcUrl(options) {
+      var newUrl = options.url;
+      var size = options.size;
+      var ref = downsamplingRefSize[options.type];
+
+      if (size && ref) {
+        // Estimate average Thumbnail size
+        var ratio = Math.min(Math.sqrt(size / ref), 16);
+
+        if (ratio >= 2) {
+          newUrl += '#-moz-samplesize=' + Math.floor(ratio);
+        }
+      }
+      return newUrl;
     },
     camelCase: function ut_camelCase(str) {
       return str.replace(rdashes, function replacer(str, p1) {

--- a/apps/sms/test/unit/mock_utils.js
+++ b/apps/sms/test/unit/mock_utils.js
@@ -21,6 +21,7 @@ var MockUtils = {
   getContactDisplayInfo: Utils.getContactDisplayInfo,
   getContactDetails: Utils.getContactDetails,
   getResizedImgBlob: Utils.getResizedImgBlob,
+  getDownsamplingSrcUrl: Utils.getDownsamplingSrcUrl,
   getCarrierTag: Utils.getCarrierTag,
   removeNonDialables: Utils.removeNonDialables,
   multiRecipientMatch: Utils.multiRecipientMatch,

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -831,6 +831,60 @@ suite('Utils', function() {
     });
   });
 
+  suite('Utils.getDownsamplingSrcUrl', function() {
+    var testOptions;
+
+    setup(function() {
+      testOptions = {
+        url: 'test url',
+        size: 300 * 1024,
+        type: 'thumbnail'
+      };
+    });
+    test('no size information', function() {
+      testOptions = {
+        url: 'test url',
+        type: 'thumbnail'
+      };
+      assert.equal(Utils.getDownsamplingSrcUrl(testOptions), testOptions.url);
+    });
+    test('no downsampling reference type ', function() {
+      testOptions = {
+        url: 'test url',
+        size: 300 * 1024
+      };
+      assert.equal(Utils.getDownsamplingSrcUrl(testOptions), testOptions.url);
+    });
+    test('No need to add -moz-samplesize postfix when ratio < 2', function() {
+      testOptions = {
+        url: 'test url',
+        size: 1,
+        type: 'thumbnail'
+      };
+      assert.equal(Utils.getDownsamplingSrcUrl(testOptions), testOptions.url);
+    });
+    test('Add -moz-samplesize postfix with ratio when ratio >= 2', function() {
+      testOptions = {
+        url: 'test url',
+        size: 300 * 1024,
+        type: 'thumbnail'
+      };
+      var result =
+        Utils.getDownsamplingSrcUrl(testOptions).split('#-moz-samplesize=');
+      assert.equal(testOptions.url, result[0]);
+      assert.isTrue(+result[1] > 0 && Number.isInteger(+result[1]));
+    });
+    test('Maximum samplesize ratio reached', function() {
+      testOptions = {
+        url: 'test url',
+        size: Number.MAX_VALUE,
+        type: 'thumbnail'
+      };
+      assert.equal(Utils.getDownsamplingSrcUrl(testOptions),
+        testOptions.url + '#-moz-samplesize=16');
+    });
+  });
+
   suite('Utils.typeFromMimeType', function() {
     var tests = {
       'text/plain': 'text',


### PR DESCRIPTION
- Utilize #-moz-samplesize postfix to get downsampling image direct to avoid unnecessary memory usage and reduce the image load time.
