### PR TITLE
Bug 981989 - [DSDS] Fixed dialing numbers page is not separated for 2 SIM card, which means that if set SIM 1 to enabled, same page of SIM 2 will become enabled as well even it's disabled in Call settings.

### DIFF
--- a/apps/settings/js/simcard_fdn.js
+++ b/apps/settings/js/simcard_fdn.js
@@ -1,6 +1,6 @@
 /* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/* global DsdsSettings, localize, SimPinDialog, Settings, MozActivity */
+/* global localize, SimPinDialog, Settings, MozActivity */
 /* global FdnAuthorizedNumbers, getIccByIndex, console */
 
 'use strict';
@@ -80,10 +80,13 @@ var SimFdnLock = {
     this.updateFdnStatus();
 
     // add|edit|remove|call FDN contact
-
     window.addEventListener('panelready', (function(e) {
       if (e.detail.current === '#call-fdnList') {
         this.renderAuthorizedNumbers();
+      } else if (e.detail.current === '#call-fdnSettings') {
+        // Refresh FDN status when the panel is reloaded, since we could be
+        // dealing with different FDNsettings on dual SIM phones.
+        this.updateFdnStatus();
       }
     }).bind(this));
 

--- a/apps/settings/test/unit/simcard_fdn_test.html
+++ b/apps/settings/test/unit/simcard_fdn_test.html
@@ -1,0 +1,20 @@
+<button id="fdnContact"></button>
+<button id="fdnAction-call"></button>
+<button id="fdnAction-edit"></button>
+<button id="fdnAction-delete"></button>
+<button id="fdnAction-cancel"></button>
+<li id="fdn-enabled">
+  <label>
+    <input type="checkbox">
+  </label>
+</li>
+<li id="fdn-resetPIN2">
+  <label>
+    <button type="checkbox"></button>
+  </label>
+</li>
+<button id="fdnContact-submit"></button>
+<h1 id="fdnContact-title"></h1>
+<input id="fdnContact-name"/>
+<input id="fdnContact-number"/>
+

--- a/apps/settings/test/unit/simcard_fdn_test.js
+++ b/apps/settings/test/unit/simcard_fdn_test.js
@@ -1,0 +1,87 @@
+/* global mocha, MockL10n, SimFdnLock, test, suite, suiteTeardown, suiteSetup,
+   setup, assert, MockSimPinDialog */
+'use strict';
+
+require('/apps/settings/test/unit/mock_l10n.js');
+require('/apps/settings/test/unit/mock_sim_pin_dialog.js');
+require('/shared/test/unit/load_body_html_helper.js');
+
+mocha.globals(['SimFdnLock', 'SimPinDialog', 'getIccByIndex']);
+
+suite('SimCardFdn > ', function() {
+  var realL10n;
+  var realSimPinDialog;
+  var MockL10nStub;
+
+  suiteSetup(function(done) {
+    realL10n = window.navigator.mozL10n;
+    // dont exec the init so quick
+    MockL10nStub = sinon.stub(MockL10n, 'ready', function() {});
+
+    window.navigator.mozL10n = MockL10n;
+
+    if (window.SimPinDialog) {
+      realSimPinDialog = window.SimPinDialog;
+    }
+    window.SimPinDialog = MockSimPinDialog;
+
+    loadBodyHTML('./simcard_fdn_test.html');
+    require('/apps/settings/js/simcard_fdn.js', done);
+  });
+
+  suiteTeardown(function() {
+    window.navigator.mozL10n = realL10n;
+    window.SimPinDialog = realSimPinDialog;
+
+    MockL10nStub.restore();
+    document.body.innerHTML = '';
+  });
+
+  suite('init > ', function() {
+    var realGetIccByIindex;
+    var updateFdnStub;
+    var renderAuthorizedNumbersStub;
+
+    setup(function() {
+      updateFdnStub = this.sinon.stub(SimFdnLock, 'updateFdnStatus');
+      renderAuthorizedNumbersStub = this.sinon.stub(
+        SimFdnLock, 'renderAuthorizedNumbers');
+
+      realGetIccByIindex = window.getIccByIndex;
+      window.getIccByIndex = this.sinon.stub();
+      window.getIccByIndex.returns({
+        addEventListener: this.sinon.stub()
+      });
+
+      SimFdnLock.init();
+    });
+
+    suiteTeardown(function() {
+      window.getIccByIndex = realGetIccByIindex;
+      updateFdnStub.restore();
+      renderAuthorizedNumbersStub.restore();
+    });
+
+    test('is panelready bound successfully', function(done) {
+      assert.isTrue(SimFdnLock.updateFdnStatus.calledOnce);
+
+      var panelreadyEvent = function(el) {
+        var ev = new CustomEvent('panelready', {
+          'detail': {
+            current: el
+          }
+        });
+        window.dispatchEvent(ev);
+      };
+
+      panelreadyEvent('#call-fdnList');
+      panelreadyEvent('#call-fdnSettings');
+
+      setTimeout(function() {
+        assert.isTrue(SimFdnLock.updateFdnStatus.calledTwice);
+        assert.isTrue(SimFdnLock.renderAuthorizedNumbers.calledOnce);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
The FDN status was not refreshed in the FDN settings page, so it always would adopt the status of the last card checked for it. This patch adds a check whenever the FDN Settings panel is ready.
