### PR TITLE
Bug 969472 - [B2G][Calendar] Events can still be tapped on and viewed when no calendar accounts are activated r=gaye

### DIFF
--- a/apps/calendar/js/templates/week.js
+++ b/apps/calendar/js/templates/week.js
@@ -20,9 +20,11 @@
     },
 
     event: function() {
-      return '<li class="event" data-id="' + this.h('busytimeId') + '">' +
-          '<div class="container calendar-id-' + this.h('calendarId') + ' ' +
-                      'calendar-display calendar-color">' +
+      var calendarIdClass = 'calendar-id-' + this.h('calendarId');
+      return '<li class="event ' + calendarIdClass + ' calendar-display" ' +
+        'data-id="' + this.h('busytimeId') + '">' +
+          '<div class="container ' + calendarIdClass + ' ' +
+                      'calendar-color">' +
             this.h('title') +
           '</div>' +
         '</li>';

--- a/apps/calendar/test/marionette/calendar.js
+++ b/apps/calendar/test/marionette/calendar.js
@@ -27,6 +27,7 @@ Calendar.Selector = Object.freeze({
   day: '#day-view',
   week: '#week-view',
   month: '#month-view',
+  settings: '#settings',
   'event/show': '#event-view',
   'event/add': '#modify-event-view.create',
   'event/edit': '#modify-event-view.update',
@@ -66,6 +67,7 @@ Calendar.Selector = Object.freeze({
   toolbarAddAccountButton: '#settings a[href="/select-preset/"]',
   toolbarButton: '#time-header button.settings',
   toolbarSyncButton: '#settings [role="toolbar"] .sync',
+  settingsCalendarsLocal: '#calendar-local-first .pack-checkbox',
   viewEventView: '#event-view',
   viewEventViewAlarm: '#event-view .alarms > .content > div',
   viewEventViewCalendar: '#event-view .current-calendar .content',
@@ -156,6 +158,10 @@ Calendar.prototype = {
     this.client.waitFor(this.isAddEventViewActive.bind(this));
   },
 
+  waitForSettingsView: function() {
+    this.client.waitFor(this.isSettingsViewActive.bind(this));
+  },
+
   // TODO: extract this logic into the marionette-helper repository since this
   // can be useful for other apps as well
   waitForKeyboardHide: function() {
@@ -186,11 +192,7 @@ Calendar.prototype = {
    * @param {String} url the url of the CalDAV calendar.
    */
   createCalDavAccount: function(username, password, url) {
-    // Go to the Account page.
-    this.registerTransitionEndEvent('#time-views');
-    this.waitForElement('toolbarButton').click();
-    // Wait for the transition end.
-    this.waitForTransitionEnd('#time-views');
+    this.goToSettingsView();
 
     this.waitForElement('toolbarAddAccountButton').click();
     this.waitForElement('addCalDavAccountButton').click();
@@ -200,14 +202,9 @@ Calendar.prototype = {
     this.waitForElement('addAccountPasswordInput').sendKeys(password);
     this.waitForElement('addAccountUrlInput').sendKeys(url);
     this.waitForElement('addAccountSaveButton').click();
-    // Wait for the settings view is showed.
-    this._waitForViewIsActive('settings');
 
-    // Go back to the main page.
-    this.registerTransitionEndEvent('#time-views');
-    this.waitForElement('toolbarButton').click();
-    // Wait for the transition end.
-    this.waitForTransitionEnd('#time-views');
+    this.waitForSettingsView();
+    this.leaveSettingsView();
   },
 
   /**
@@ -415,6 +412,13 @@ Calendar.prototype = {
   },
 
   /**
+   * @return {boolean} Whether or not the settings view is active.
+   */
+  isSettingsViewActive: function() {
+    return this.isViewActive('settings');
+  },
+
+  /**
    * Start the calendar, save the client for future ops, and wait for the
    * calendar to finish an initial render.
    *
@@ -554,5 +558,24 @@ Calendar.prototype = {
     this.client.waitFor(function() {
       return this.isViewActive(id);
     }.bind(this));
+  },
+
+  goToSettingsView: function() {
+    this._toggleSettingsView();
+    this.waitForSettingsView();
+  },
+
+  leaveSettingsView: function() {
+    this._toggleSettingsView();
+    this.client.waitFor(function() {
+      return !this.isSettingsViewActive();
+    }.bind(this));
+  },
+
+  _toggleSettingsView: function() {
+    this.registerTransitionEndEvent('#time-views');
+    this.waitForElement('toolbarButton').click();
+    this.waitForTransitionEnd('#time-views');
   }
+
 };

--- a/apps/calendar/test/marionette/toggle_calendar_test.js
+++ b/apps/calendar/test/marionette/toggle_calendar_test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var Calendar = require('./calendar'),
+    assert = require('chai').assert;
+
+marionette('toggle calendar', function() {
+  var app;
+  var client = marionette.client();
+
+  setup(function() {
+    app = new Calendar(client);
+    app.launch({ hideSwipeHint: true });
+
+    app.createEvent({
+      title: 'Toggle Calendar Test',
+      location: 'Some Place'
+    });
+
+    toggleLocalCalendar();
+  });
+
+  function toggleLocalCalendar() {
+    app.goToSettingsView();
+    app.findElement('settingsCalendarsLocal').click();
+    app.leaveSettingsView();
+  }
+
+  suite('disable calendar', function() {
+
+    test('month view', function() {
+      assert(
+        !app.findElement('monthViewDayEvent').displayed(),
+        'event should be hidden on day view'
+      );
+    });
+
+    test('week view', function() {
+      app.waitForElement('weekButton').click();
+      app.waitForWeekView();
+      assert(
+        !app.findElement('weekViewEvent').displayed(),
+        'event should be hidden on week view'
+      );
+    });
+
+    test('day view', function() {
+      app.waitForElement('dayButton').click();
+      app.waitForDayView();
+      assert(
+        !app.findElement('dayViewEvent').displayed(),
+        'event should be hidden on day view'
+      );
+    });
+  });
+
+
+  suite('enable calendar', function() {
+
+    setup(toggleLocalCalendar);
+
+    test('month view', function() {
+      assert(
+        app.findElement('monthViewDayEvent').displayed(),
+        'event should be displayed on day view'
+      );
+    });
+
+    test('week view', function() {
+      app.waitForElement('weekButton').click();
+      app.waitForWeekView();
+      assert(
+        app.findElement('weekViewEvent').displayed(),
+        'event should be displayed on week view'
+      );
+    });
+
+    test('day view', function() {
+      app.waitForElement('dayButton').click();
+      app.waitForDayView();
+      assert(
+        app.findElement('dayViewEvent').displayed(),
+        'event should be displayed on day view'
+      );
+    });
+  });
+
+});


### PR DESCRIPTION
I created the integration tests before fixing the problem, the bug described only happened on week view; but I also found a separate bug that is also related to it on Day View (Bug 982240) and will fix as a separate pull request.

integration test coverage is increasing!
