### PR TITLE
Revert "Bug 970138 - [Tooling] Add a commit hook to unify the file permission

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -86,20 +86,4 @@ if [ $gjslint_result -ne 0 -o $jshint_result -ne 0 ] ; then
   exit 1
 fi
 
-# check out the files permission
-for file in $(git diff --staged --name-only); do
-  if [ $(uname) = "Linux" ] || [[ $(uname) = MINGW* ]];then
-    if [ $(stat -c %a $file) -ne 644 ];then
-      echo "You must change the file permission of $file to 644"
-      exit 1
-    fi	
-  fi
-  if [ $(uname) = "Darwin" ];then
-    if [ $(stat -f %Lp $file) -ne 644 ];then
-      echo "You must change the file permission of $file to 644"
-      exit 1
-    fi	
-  fi
-done
-
 echo "No errors - committing"


### PR DESCRIPTION
This reverts commit 26cec18074b99c169d1bdf76c8a4a80b0acc4c83.
