### PR TITLE
Bug 1042241 - Avoid unnecessarily encoding and decoding a canvas to png image before painting it

### DIFF
--- a/shared/elements/gaia_grid/js/grid_icon_renderer.js
+++ b/shared/elements/gaia_grid/js/grid_icon_renderer.js
@@ -85,16 +85,9 @@
         clipCtx.drawImage(img, 0, 0,
                                clipCanvas.width, clipCanvas.height);
 
-        clipCanvas.toBlob((blob) => {
-          var clipImage = new Image();
-          clipImage.onload = () => {
-            shadowCtx.drawImage(clipImage, CANVAS_PADDING, CANVAS_PADDING,
+        shadowCtx.drawImage(clipCanvas, CANVAS_PADDING, CANVAS_PADDING,
                                 this._maxSize, this._maxSize);
-            shadowCanvas.toBlob(resolve);
-            URL.revokeObjectURL(clipImage.src);
-          };
-          clipImage.src = URL.createObjectURL(blob);
-        });
+        shadowCanvas.toBlob(resolve);
       });
     },
 


### PR DESCRIPTION
Everytime there's an iframe that we might need to draw we go down a
relatively expensive path (Telling the background color to compositor
shows up). Avoid that by making the oauth frame hidden.
