### PR TITLE
use correct parameter for CustomEvent constructor; r=jedp

### DIFF
--- a/apps/system/js/fxa_manager.js
+++ b/apps/system/js/fxa_manager.js
@@ -118,7 +118,7 @@ var FxAccountsManager = {
   },
 
   _sendContentEvent: function fxa_mgmt_sendContentEvent(msg) {
-    var event = new CustomEvent('mozFxAccountsRPContentEvent', msg);
+    var event = new CustomEvent('mozFxAccountsRPContentEvent', {detail: msg});
     window.dispatchEvent(event);
   },
 


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent, the second parameter to the constructor requires certain keywords. This change correctly uses one of them.
