### PR TITLE
Bug 962445 - Calendar events, that span 15 minutes (or less) are not displayed correctly in Week view. r=gaye

### DIFF
--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -191,6 +191,7 @@
   height: 100%;
   margin: 1px;
   line-height: 1.4rem;
+  min-height: 1.8rem;
   font-size: 120%;
   padding: 0.2rem;
   overflow: hidden;


### PR DESCRIPTION
just setting the minimum height since it's the simplest solution and matches behavior of day view
