### PR TITLE
Bug 983858 - [B2G][SMS]User is given a 'Switch data connection' message when attempting to send a MMS

### DIFF
--- a/apps/sms/js/settings.js
+++ b/apps/sms/js/settings.js
@@ -18,7 +18,8 @@ var Settings = {
   _serviceIds: null,
 
   mmsSizeLimitation: 300 * 1024, // Default mms message size limitation is 300K.
-  mmsServiceId: null, // Default mms service SIM ID (only for DSDS)
+  mmsServiceId: null, // Default mms service SIM ID
+  smsServiceId: null, // Default sms service SIM ID
 
   init: function settings_init() {
     var keyHandlerSet = {

--- a/apps/sms/test/unit/settings_test.js
+++ b/apps/sms/test/unit/settings_test.js
@@ -49,6 +49,7 @@ suite('Settings >', function() {
       navigator.mozSettings = null;
       Settings.mmsSizeLimitation = 'whatever is default';
       Settings.mmsServiceId = 'no service ID';
+      Settings.smsServiceId = 'no service ID';
 
       Settings.init();
     });
@@ -59,6 +60,10 @@ suite('Settings >', function() {
 
     test('Query mmsServiceId without settings', function() {
       assert.equal(Settings.mmsServiceId, 'no service ID');
+    });
+
+    test('Query smsServiceId without settings', function() {
+      assert.equal(Settings.smsServiceId, 'no service ID');
     });
 
     test('Reports no dual SIM', function() {
@@ -222,6 +227,7 @@ suite('Settings >', function() {
       for (var prop in Settings.SERVICE_ID_KEYS) {
         var setting = Settings.SERVICE_ID_KEYS[prop];
         assert.isNull(findSettingsReq(setting));
+        assert.equal(Settings[prop], 'no service ID');
       }
       assert.isFalse(Settings.hasSeveralSim());
       assert.isFalse(Settings.isDualSimDevice());


### PR DESCRIPTION
- Set a default smsServiceId to null to sync default mmsServiceId.
