### PR TITLE
Bug 984388 - Don't reflow when switching between pages on the homescreen

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -441,9 +441,9 @@ var GridManager = (function() {
     for (var i = 0; i < pages.length; i++) {
       var pagediv = pages[i].container;
       if (i < start || i > end) {
-        pagediv.style.display = 'none';
+        delete pagediv.dataset.visible;
       } else {
-        pagediv.style.display = 'block';
+        pagediv.dataset.visible = true;
       }
     }
   }

--- a/apps/homescreen/style/grid.css
+++ b/apps/homescreen/style/grid.css
@@ -11,8 +11,11 @@
   height: calc(100% - 7.6rem);
   text-align: center;
   margin: 0 auto;
-  overflow: hidden;
-  display: none;
+  opacity: 0;
+}
+
+.apps > div[data-visible] {
+  opacity: 1;
 }
 
 .apps ol {


### PR DESCRIPTION
Removes the reflow we do every time we switch pages on the homescreen.

It has `dataset.visible` instead of `dataset.hidden` because hidden is the default state (as we render the pages first, and then call the page visibility functions).
