### PR TITLE
Bug 939791 - [settings] keyboard: {{type}} in mustHaveOneKeyboard is empty for text keyboards

### DIFF
--- a/apps/settings/js/keyboard.js
+++ b/apps/settings/js/keyboard.js
@@ -87,9 +87,9 @@ var KeyboardContext = (function() {
 
   var _waitForLayouts;
 
-  function notifyDefaultEnabled(layouts) {
+  function notifyDefaultEnabled(layouts, missingTypes) {
     _defaultEnabledCallbacks.forEach(function withCallbacks(callback) {
-      callback(layouts[0]);
+      callback(layouts[0], missingTypes[0]);
     });
   }
 
@@ -448,14 +448,13 @@ var InstalledLayoutsPanel = (function() {
 })();
 
 var DefaultKeyboardEnabledDialog = (function() {
-  function showDialog(layout) {
+  function showDialog(layout, missingType) {
     var l10n = navigator.mozL10n;
     l10n.localize(
       document.getElementById('keyboard-default-title'),
       'mustHaveOneKeyboard',
       {
-        type: l10n.get('keyboardType-' +
-          layout.inputManifest.types.sort()[0])
+        type: l10n.get('keyboardType-' + missingType)
       }
     );
     l10n.localize(

--- a/apps/settings/test/unit/keyboard_test.js
+++ b/apps/settings/test/unit/keyboard_test.js
@@ -280,7 +280,9 @@ suite('keyboard >', function() {
         setup(function() {
           layouts[0][0].enabled = false;
           this.defaultCallback = this.sinon.spy();
-          KeyboardContext.defaultKeyboardEnabled(this.defaultCallback);
+          this.missingTypes = [];
+          KeyboardContext.defaultKeyboardEnabled(this.defaultCallback,
+            this.missingTypes);
         });
         test('calls checkDefaults', function() {
           assert.isTrue(this.checkDefaults.called);
@@ -288,7 +290,7 @@ suite('keyboard >', function() {
         suite('default enabled', function() {
           setup(function() {
             this.layout = {};
-            this.checkDefaults.yield([this.layout]);
+            this.checkDefaults.yield([this.layout], [this.missingTypes]);
           });
           test('calls callback with enabled layout', function() {
             assert.ok(this.defaultCallback.calledWith(this.layout));
@@ -331,7 +333,7 @@ suite('keyboard >', function() {
             types: ['url', 'text'],
             name: 'layoutName'
           }
-        });
+        }, ['text']);
       });
       teardown(function() {
         document.body.removeChild(this.title);

--- a/shared/js/keyboard_helper.js
+++ b/shared/js/keyboard_helper.js
@@ -565,6 +565,7 @@ var KeyboardHelper = exports.KeyboardHelper = {
    */
   checkDefaults: function kh_checkDefaults(callback) {
     var layoutsEnabled = [];
+    var missingTypes = [];
     ['text', 'url', 'number'].forEach(function eachType(type) {
       // getLayouts is sync when we already have data
       var enabled;
@@ -572,6 +573,7 @@ var KeyboardHelper = exports.KeyboardHelper = {
         enabled = layouts.length;
       });
       if (!enabled) {
+        missingTypes.push(type);
         this.getLayouts({ type: type, 'default': true }, function(layouts) {
           if (layouts[0]) {
             layouts[0].enabled = true;
@@ -583,7 +585,7 @@ var KeyboardHelper = exports.KeyboardHelper = {
 
     if (layoutsEnabled.length) {
       if (callback) {
-        callback(layoutsEnabled);
+        callback(layoutsEnabled, missingTypes);
       }
     }
   },


### PR DESCRIPTION
Example from en.js layout

`types: ['text', 'url', 'email']`

This line of code tries to use `keyboardType-email` instead of `keyboardType-text`, generating also a warning in console for missing l10n key.
