### PR TITLE
bug 982006

### DIFF
--- a/apps/system/js/app_modal_dialog.js
+++ b/apps/system/js/app_modal_dialog.js
@@ -212,9 +212,7 @@
     var evt = this.events[0];
 
     var message = evt.detail.message || '';
-    // XXX: Bug 916658 - Remove unused l10n resources from b2g gecko
-    // If we have removed translations from Gecko, then we can remove this.
-    var title = '';
+    var title = this._getTitle(evt.detail.title);
     var elements = this.elements;
 
     function escapeHTML(str) {
@@ -233,6 +231,7 @@
 
     switch (type) {
       case 'alert':
+        elements.alertTitle.innerHTML = title;
         elements.alertMessage.innerHTML = message;
         elements.alert.classList.add('visible');
         elements.alertOk.textContent = evt.yesText ? evt.yesText : _('ok');
@@ -242,6 +241,7 @@
       case 'prompt':
         elements.prompt.classList.add('visible');
         elements.promptInput.value = evt.detail.initialValue;
+        elements.promptTitle.innerHTML = title;
         elements.promptMessage.innerHTML = message;
         elements.promptOk.textContent = evt.yesText ? evt.yesText : _('ok');
         elements.promptCancel.textContent = evt.noText ?
@@ -251,6 +251,7 @@
 
       case 'confirm':
         elements.confirm.classList.add('visible');
+        elements.confirmTitle.innerHTML = title;
         elements.confirmMessage.innerHTML = message;
         elements.confirmOk.textContent = evt.yesText ? evt.yesText : _('ok');
         elements.confirmCancel.textContent = evt.noText ?
@@ -435,5 +436,27 @@
         evt.detail.unblock();
 
       this.processNextEvent();
+    };
+
+  AppModalDialog.prototype._getTitle =
+    function amd__getTitle(title) {
+      //
+      // XXX Bug 982006, subsystems like uriloader still report errors with
+      // titles which are important to the user for context in diagnosing
+      // issues.
+      //
+      // However, we will ignore all titles containing the application url or
+      // origin url. These types of titles simply indicate that the active
+      // application is prompting and are more confusing to the user than
+      // useful. Instead we will return the application name if there is one
+      // or an empty string.
+      //
+      if (!title ||
+          title.contains(this.app.config.url) ||
+          title.contains(this.app.config.origin)) {
+        return this.app.name || '';
+      }
+
+      return title;
     };
 }(this));

--- a/apps/system/js/download/download_notification.js
+++ b/apps/system/js/download/download_notification.js
@@ -88,13 +88,27 @@ DownloadNotification.prototype = {
   },
 
   _onError: function dn_onError() {
-    // this.download.error.name is always "DownloadError" so we have to check if
-    // the error is because of no free memory on SD card.
-    DownloadHelper.getFreeSpace((function gotFreeMemory(bytes) {
-      if (bytes === 0) {
-        DownloadUI.show(DownloadUI.TYPE['NO_MEMORY'], this.download, true);
-      }
-    }).bind(this));
+    var result = parseInt(this.download.error.message);
+
+    switch (result) {
+      case DownloadUI.ERRORS.NO_SDCARD:
+        DownloadUI.show(DownloadUI.TYPE['NO_SDCARD'],
+                        this.download,
+                        true);
+        break;
+      case DownloadUI.ERRORS.UNMOUNTED_SDCARD:
+        DownloadUI.show(DownloadUI.TYPE['UNMOUNTED_SDCARD'],
+                        this.download,
+                        true);
+        break;
+
+      default:
+        DownloadHelper.getFreeSpace((function gotFreeMemory(bytes) {
+          if (bytes === 0) {
+            DownloadUI.show(DownloadUI.TYPE['NO_MEMORY'], this.download, true);
+          }
+        }).bind(this));
+    }
   },
 
   _onSucceeded: function dn_onSucceeded() {

--- a/apps/system/test/unit/mock_download_ui.js
+++ b/apps/system/test/unit/mock_download_ui.js
@@ -3,6 +3,7 @@
 
 var MockDownloadUI = {
 
+  ERRORS: {},
   TYPE: {},
 
   show: function() {

--- a/shared/js/download/download_ui.js
+++ b/shared/js/download/download_ui.js
@@ -42,6 +42,14 @@ var DownloadUI = (function() {
     this.numberOfButtons = classes.indexOf('full') !== -1 ? 1 : 2;
   };
 
+  /**
+   * Errors reported by the Downloads API.
+   */
+  var ERRORS = {
+    NO_SDCARD: 2152857618,
+    UNMOUNTED_SDCARD: 2152857621
+  };
+
   var TYPES = {
     STOP: new DownloadType('stop', ['danger'], true),
     STOPPED: new DownloadType('stopped', ['recommend'], true),
@@ -334,6 +342,10 @@ var DownloadUI = (function() {
     showActions: showActions,
 
     hide: removeContainers,
+
+    get ERRORS() {
+      return ERRORS;
+    },
 
     get TYPE() {
       return TYPES;


### PR DESCRIPTION
- Use title in calls for alert, prompt and confirm app modal dialogs.
  
  Things like downloads will trigger issues that are deep within services
  such as the uriloader and external helper application service. These
  require the ability to communicate an appropriate context for the error
  and they do so through the title.

r=
