### PR TITLE
Bug 985476 Back out Firefox Accounts strings from 1.4

### DIFF
--- a/apps/communications/ftu/locales/ftu.en-US.properties
+++ b/apps/communications/ftu/locales/ftu.en-US.properties
@@ -184,13 +184,6 @@ mobile = Mobile
 afterFbImport   = You can import and edit Facebook friends anytime in Contacts settings
 
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
-# Fxa Intro
-#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
-firefox-accounts = Firefox Accounts
-fxa-intro.innerHTML = Firefox lets you use a single account to log in to services like <strong>Marketplace</strong> and <strong>Where's My Fox</strong>.
-fxa-create-account-or-sign-in = Create Account or Sign In
-fxa-logged = Now your email {{email}} have settled your account with Firefox Accounts! You can set your preferences through Settings App.
-#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
 # About your rights
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
 


### PR DESCRIPTION
I think this should cover all needed changes.

The other fxa strings in 1.4 are in a separate imported file, `apps/system/fxa/fxa.properties`, and shouldn't be picked up by the migration (per @Pike in IRC).
