### PR TITLE
Bug 981401 - [Messages] Notification does not vanish when the SMS is read when going back from sleep

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -403,6 +403,16 @@ var ActivityHandler = {
           var notification = new Notification(title, options);
           notification.addEventListener('click', goToMessage);
           releaseWakeLock();
+
+          // Close notification if we are already in thread view and view become
+          // visible.
+          if (document.hidden && threadId === Threads.currentId) {
+            document.addEventListener('visibilitychange',
+              function onVisible() {
+                document.removeEventListener('visibilitychange', onVisible);
+                notification.close();
+            });
+          }
         }
 
         function getTitleFromMms(callback) {


### PR DESCRIPTION
- Force to close the notification when message app resume to foreground and user stay in the same thread view.
