### PR TITLE
Bug 984407 - Reflows on focus/blur in e.me

### DIFF
--- a/apps/homescreen/everything.me/css/everything.me.css
+++ b/apps/homescreen/everything.me/css/everything.me.css
@@ -65,7 +65,7 @@
 
 .evme-keyboard-visible .evmeScope,
 .evme-suggest-collections-loading .evmeScope {
-    height: 100%;
+    height: 100%; /* todo: this causes a reflow to happen when toggline evme-keyboard-visible */
 }
 
 .evme-keyboard-visible .apps > div.evmePage ol,
@@ -93,7 +93,7 @@
 .evme-loading-from-input #bg-overlay,
 .evme-displayed.evme-keyboard-visible #bg-overlay,
 .evme-displayed.evme-has-query #bg-overlay{
-  height: 100%;
+  transform: translateY(0);
 }
 
 #loading-dialog {

--- a/apps/homescreen/everything.me/js/plugins/Scroll.js
+++ b/apps/homescreen/everything.me/js/plugins/Scroll.js
@@ -60,7 +60,7 @@
       'onEnd': onScrollEnd
     });
 
-    updateY();
+    updateXY();
 
     this.distY = 0;
     this.distX = 0;
@@ -68,6 +68,8 @@
     this.maxY = 0;
     this.hScroll = options.hScroll;
     this.vScroll = options.vScroll;
+    this.x = 0;
+    this.y = 0;
 
     this.refresh = function refresh() {
       // for backwrads compitability with iScroll
@@ -75,8 +77,15 @@
     };
 
     this.scrollTo = function scrollTo(x, y) {
-      x !== undefined && (el.scrollLeft = x);
-      y !== undefined && (el.scrollTop = y);
+      if (x !== undefined && self.x !== x) {
+        el.scrollLeft = x;
+        self.x = x;
+      }
+
+      if (y !== undefined && self.y !== y) {
+        el.scrollTop = y;
+        self.y = y;
+      }
     };
 
     function onTouchStart(e) {
@@ -107,7 +116,6 @@
       var currPos = [el.scrollLeft, el.scrollTop],
           touch = 'touches' in e ? e.touches[0] : e;
 
-      updateY();
       self.distX = touch.pageX - startPointer[0];
       self.distY = touch.pageY - startPointer[1];
 
@@ -133,7 +141,6 @@
 
       scrollEventListener.stop();
 
-      updateY();
       optionsOnTouchEnd && optionsOnTouchEnd(e);
     }
 
@@ -143,7 +150,7 @@
     }
 
     function onScrollMove(e, first) {
-      updateY();
+      updateXY();
       first && onScrollStart(e);
       optionsOnScrollMove && optionsOnScrollMove(e);
     }
@@ -153,7 +160,8 @@
       optionsOnScrollEnd && optionsOnScrollEnd(e);
     }
 
-    function updateY() {
+    function updateXY() {
+      self.x = el.scrollLeft;
       self.y = el.scrollTop;
     }
   }

--- a/apps/homescreen/everything.me/modules/Helper/Helper.css
+++ b/apps/homescreen/everything.me/modules/Helper/Helper.css
@@ -31,7 +31,7 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
         font-weight: inherit;
     }
 #search-title.close {
-    display: none;
+    visibility: hidden;
 }
     #search-title .query {
         position: relative;
@@ -67,14 +67,9 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
 #helper-rapper.animate:not(.anim-disabled) {
     transition: all .3s ease;
 }
-#helper-rapper.close {
-    transform: scale(0, 0);
-    right: 1.2rem;
-    display: none;
+#helper-rapper.close, #helper-rapper.close ul {
+    visibility: hidden;
 }
-    #helper-rapper.close ul {
-        display: none;
-    }
 
     #helper-tip {
         position: absolute;
@@ -98,7 +93,6 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
         transform: rotate(45deg);
         box-shadow: -0.4rem -0.4rem 0.4rem -0.2rem rgba(0, 0, 0, .4);
     }
-
 #helper {
     position: absolute;
     top: 0;
@@ -210,7 +204,7 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
         }
 
 #save-search {
-    display: none;
+    visibility: hidden;
     position: absolute;
     right: 0.65rem;
     top: -0.4rem;
@@ -220,7 +214,7 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
     background-size: 3rem 3rem;
 }
 #search-title.visible ~ #save-search {
-    display: block;
+    visibility: visible;
 }
 #save-search[data-saved-as-collection='true'] {
     background-image: url('/everything.me/images/bookmarked.png');

--- a/apps/homescreen/everything.me/modules/Helper/Helper.js
+++ b/apps/homescreen/everything.me/modules/Helper/Helper.js
@@ -328,8 +328,12 @@ Evme.Helper = new function Evme_Helper() {
     title = newTitle;
 
     if (!title) {
-      elTitle.innerHTML =
-        '<b ' + Evme.Utils.l10nAttr(NAME, 'title-empty') + '></b>';
+      var b = elTitle.querySelector('b');
+      if (!b) {
+        b = document.createElement('b');
+        elTitle.appendChild(b);
+      }
+      b.setAttribute('data-l10n-id', Evme.Utils.l10n(NAME, 'title-empty'));
       return false;
     }
 

--- a/apps/homescreen/everything.me/modules/Searchbar/Searchbar.css
+++ b/apps/homescreen/everything.me/modules/Searchbar/Searchbar.css
@@ -2,15 +2,15 @@
     background: rgba(0, 0, 0, 0.4);
     position: relative;
     z-index: 50;
-    min-height: 5rem;
-    -moz-transition: all .2s linear;
-    transition: all .2s linear;
+    min-height: 8rem; /* 5rem + 3rem */
+    transition: transform .2s linear, background .2s linear;
+    transform: translateY(-3rem);
 }
 
 #evmeContainer:not(.empty-query) #header,
 .evme-keyboard-visible #header {
     background: rgba(0, 0, 0, 0.8) !important;
-    min-height: 8rem !important;
+    transform: translateY(0) !important;
 }
 
 #evmeContainer #search-header {
@@ -100,4 +100,17 @@
     -moz-transition: all .2s linear;
     transition: all .2s linear;
     opacity: 0 !important;
+}
+
+/* empty query and not in search screen? don't get any pointer events.
+   the reason is that we have content that is translated so this div
+   can overlap homescreen */
+body:not(.evme-keyboard-visible) #evmeContainer.empty-query {
+    pointer-events: none;
+}
+
+/* all children in #search should have normal behavior again,
+   so you can tap the search input field */
+#evmeContainer #search > * {
+    pointer-events: auto;
 }

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -74,11 +74,12 @@ li:active {
 
 #bg-overlay {
   width: 100%;
-  height: calc(100% - 7.5rem);
+  height: 100%;
   position: fixed;
   top: 0;
   left: 0;
   background-color: rgba(0,0,0,0.1);
+  transform: translateY(-7.5rem);
 }
 
 /* === Repaint Helper === */
@@ -143,7 +144,7 @@ body[data-mode = 'edit'] .apps ol > li[data-type = "bookmark"] > div > span > sp
 }
 @media (min-width: 768px) {
   #bg-overlay {
-    height: calc(100% - 16.9rem);
+    transform: translateY(-16.9rem);
   }
 }
 /* This is a dirty hack to hide the bottom toolbar while
@@ -165,9 +166,9 @@ body[data-mode = 'edit'] .apps ol > li[data-type = "bookmark"] > div > span > sp
        /* For the Twist , 960x540 */
        (device-height: 540px) and (max-height: 450px),
        (device-height: 960px) and (max-height: 870px) {
-  footer { display: none !important; }
+  footer { opacity: 0; pointer-events: none; }
   .apps > div { height: 100% !important; }
-  #bg-overlay { height: 100%;}
+  #bg-overlay { transform: translateY(0); }
 }
 
 /* Default state for the dialogs.


### PR DESCRIPTION
Same patch as #17295, no clue what happened.

Here is the comment from the other issue:

> Perhaps we can remove updateY() altogether and implement a getter instead. Something like:

No, the thing is that we should only ever call `scrollTop` the moment that a `scroll` event comes in on the element. Because at that moment retrieving the info is 'free'. Whereas normally it causes a sync reflow. 
So we really need to cache here.

> Side effect - when returning to homescreen, the Evme searchbar overlaps the grid icons due to it's 8rem height, not allowing to click on them.

Yeah, that's not good ;-) I've fixed it in the last commit. The div is still too high but it doesn't steal pointer events anymore.
