### PR TITLE
Re-enable wifi checkbox when setting update succeeds or fails

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -43,12 +43,14 @@ navigator.mozL10n.ready(function wifiSettings() {
 
   // toggle wifi on/off
   gWifiCheckBox.onchange = function toggleWifi() {
-    settings.createLock().set({
-      'wifi.enabled': this.checked
-    }).onerror = function() {
-      // Fail to write mozSettings, return toggle control to the user.
+    function onSetOutcome() {
+      // return toggle control to the user.
       gWifiCheckBox.disabled = false;
-    };
+    }
+    var writeRequest = settings.createLock().set({
+      'wifi.enabled': this.checked
+    });
+    writeRequest.onerror = writeRequest.onsuccess = onSetOutcome;
     this.disabled = true;
   };
 


### PR DESCRIPTION
Tested in browser only. 
