### PR TITLE
Bug 983167 - [email/POP3] broken node-crypto.js shim causes auth failure...

### DIFF
--- a/apps/email/js/ext/mailapi/worker-bootstrap.js
+++ b/apps/email/js/ext/mailapi/worker-bootstrap.js
@@ -12581,6 +12581,7 @@ exports.createHash = function(algorithm) {
   return {
     update: function(addData) {
       data += addData;
+      return this;
     },
     digest: function(encoding) {
       switch (encoding) {


### PR DESCRIPTION
... when attempting APOP auth. r=asuth
