### PR TITLE
Bug 975268: [System][NFC] Reset the screen idle timeout when a NFC tag/device is detected.

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -89,7 +89,7 @@ var NfcManager = {
   handleEvent: function nm_handleEvent(evt) {
     var state;
     switch (evt.type) {
-      case 'lock': // Fall thorough
+      case 'lock': // Fall through
       case 'unlock':
       case 'screenchange':
         if (this.hwState == this.NFC_HW_STATE_OFF) {
@@ -272,7 +272,7 @@ var NfcManager = {
   handleTechnologyDiscovered: function nm_handleTechnologyDiscovered(command) {
     this._debug('Technology Discovered: ' + JSON.stringify(command));
 
-    // UX: TODO
+    window.dispatchEvent(new CustomEvent('nfc-tech-discovered'));
     window.navigator.vibrate([25, 50, 125]);
 
     // Check for tech types:
@@ -350,14 +350,13 @@ var NfcManager = {
 
   handleTechLost: function nm_handleTechLost(command) {
     this._debug('Technology Lost: ' + JSON.stringify(command));
-    // TODO: Do something with the UI/UX to indicate the tag is gone.
-    // TODO: Dismiss activity chooser?
+
+    window.navigator.vibrate([125, 50, 25]);
+    window.dispatchEvent(new CustomEvent('nfc-tech-lost'));
 
     // Clean up P2P UI events
     window.removeEventListener('shrinking-sent', this);
     window.dispatchEvent(new CustomEvent('shrinking-stop'));
-
-    window.navigator.vibrate([125, 50, 25]);
   },
 
   // Miscellaneous utility functions to handle formating the JSON for activities

--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -106,6 +106,8 @@ var ScreenManager = {
   init: function scm_init() {
     window.addEventListener('sleep', this);
     window.addEventListener('wake', this);
+    window.addEventListener('nfc-tech-discovered', this);
+    window.addEventListener('nfc-tech-lost', this);
     window.addEventListener('requestshutdown', this);
 
     // User is unlocking by sliding or other methods.
@@ -209,6 +211,11 @@ var ScreenManager = {
 
       case 'wake':
         this.turnScreenOn();
+        break;
+
+      case 'nfc-tech-discovered':
+      case 'nfc-tech-lost':
+        this._reconfigScreenTimeout();
         break;
 
       case 'unlocking-start':

--- a/apps/system/test/unit/screen_manager_test.js
+++ b/apps/system/test/unit/screen_manager_test.js
@@ -208,6 +208,16 @@ suite('system/ScreenManager', function() {
       assert.isTrue(stubTurnOn.called);
     });
 
+    test('Testing nfc-tech-discovered and nfc-tech-lost event', function() {
+      var stubReconfigScreenTimeout = this.sinon.stub(
+                                         ScreenManager,
+                                         '_reconfigScreenTimeout');
+      ScreenManager.handleEvent({'type': 'nfc-tech-discovered'});
+      assert.isTrue(stubReconfigScreenTimeout.called);
+      ScreenManager.handleEvent({'type': 'nfc-tech-lost'});
+      assert.isTrue(stubReconfigScreenTimeout.called);
+    });
+
     suite('Testing userproximity event', function() {
       var stubTelephony, stubBluetooth, stubStatusBar, stubTurnOn, stubTurnOff;
 


### PR DESCRIPTION
Feature adds a feature to Screen Manager and NFC Manager to handle the case where an NFC tag or device presence can reset the idle timer. Unit test cases added to screen manager as well.
