### PR TITLE
Bug_974725: [B2G][NFC] Support different vcard mime types for Contacts

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -362,6 +362,20 @@ var NfcManager = {
 
   // Miscellaneous utility functions to handle formating the JSON for activities
 
+  isTypeMatch: function nm_isTypeMatch(type, stringTypeArray) {
+    var strType = NfcUtils.toUTF8(type);
+    if (stringTypeArray && stringTypeArray.length) {
+      for (var i = 0; i < stringTypeArray.length; i++) {
+        if (strType === stringTypeArray[i]) {
+          this._debug('Found a type match.');
+          return true;
+        }
+      }
+    }
+    this._debug('Did not find a match.');
+    return false;
+  },
+
   formatEmpty: function nm_formatEmpty(record) {
     this._debug('Activity for empty tag.');
     return {
@@ -480,7 +494,8 @@ var NfcManager = {
     var activityText = null;
 
     this._debug('HandleMimeMedia');
-    if (NfcUtils.equalArrays(record.type, NfcUtils.fromUTF8('text/vcard'))) {
+    if (this.isTypeMatch(record.type,
+                         ['text/vcard', 'text/x-vCard', 'text/x-vcard'])) {
       activityText = this.formatVCardRecord(record);
     } else {
       activityText = {


### PR DESCRIPTION
In the bugzilla entry, there was a choice to have NFC manager resolve legacy mime-type issues with vcards, or have the app try to do so (and repeatedly across all interested apps). NFC manager can't generically figure it out for the app, thus the version in the data in the vcard data itself is the only true way find out if the apps supports the vcard.

This bug then, just treats text/vcard, text/x-vcard, text/x-vCard the same. If it fails, the user can just try again with another contacts app with better vcard import support.

UX/Decision feedback is welcome.

Some additional cleanup in the unit tests for stray error messages on mock objects.
