### PR TITLE
Bug 930794 - Add an integration test against desktop-notification-close

### DIFF
--- a/apps/system/test/marionette/notification_get_test.js
+++ b/apps/system/test/marionette/notification_get_test.js
@@ -210,4 +210,55 @@ marionette('Notification.get():', function() {
     done();
   });
 
+  test('desktop-notification-close removes notification', function(done) {
+    var notificationTitle = 'Title:' + Date.now();
+
+    // switch to calendar app and send notification
+    client.apps.launch(CALENDAR_APP);
+    client.apps.switchToApp(CALENDAR_APP);
+    client.executeScript(function(title) {
+      var notification = new Notification(title);
+    }, [notificationTitle]);
+
+    // switch to system app and send desktop-notification-close
+    client.switchToFrame();
+    var error = client.executeAsyncScript(function(manifest) {
+      var container =
+        document.getElementById('desktop-notifications-container');
+      var selector = '[data-manifest-u-r-l="' + manifest + '"]';
+      var nodes = container.querySelectorAll(selector);
+      if (nodes.length === 0) {
+        marionetteScriptFinished('no node to query');
+      }
+      for (var i = nodes.length - 1; i >= 0; i--) {
+        var event = document.createEvent('CustomEvent');
+        event.initCustomEvent('mozContentEvent', true, true, {
+          type: 'desktop-notification-close',
+          id: nodes[i].dataset.notificationId
+        });
+        window.dispatchEvent(event);
+      }
+      marionetteScriptFinished(false);
+    }, [CALENDAR_APP_MANIFEST]);
+    assert.equal(error, false, 'desktop-notification-close error: ' + error);
+
+    // switch back to calendar, and fetch notifications
+    client.apps.launch(CALENDAR_APP);
+    client.apps.switchToApp(CALENDAR_APP);
+    var error = client.executeAsyncScript(function() {
+      var promise = Notification.get();
+      promise.then(function(notifications) {
+        if (notifications && notifications.length !== 0) {
+          marionetteScriptFinished('notification still present');
+        }
+        // success, return no error
+        marionetteScriptFinished(false);
+      }, function(error) {
+        marionetteScriptFinished('promise.then error: ' + error);
+      });
+    });
+    assert.equal(error, false, 'desktop-notification-close error: ' + error);
+    done();
+  });
+
 });


### PR DESCRIPTION
The goal of this integration test is to check whether
'desktop-notification-close' correctly removes the notification from the
database and from notification storage.
