### PR TITLE
Bug 983064 - fix there is no x-wap-profile filed in the mms header

### DIFF
--- a/build/applications-data.js
+++ b/build/applications-data.js
@@ -405,7 +405,7 @@ function execute(options) {
   content = {};
 
   utils.writeContent(init,
-    utils.getDistributionFileContent('wapuaprof.json', content, distDir));
+    utils.getDistributionFileContent('wapuaprof', content, distDir));
 
   // WAP Push
   init = utils.getFile(config.GAIA_DIR, 'apps', 'wappush', 'js', 'whitelist.json');


### PR DESCRIPTION
Remove unnecessary file extension ".json" such that the ODM/OEM customization UAProf json file can be read successfully during the build time
