### PR TITLE
Bug 986960 - Intermittent erroring test, should flick through images in fullscreen mode

### DIFF
--- a/apps/gallery/test/marionette/fullscreen_image_test.js
+++ b/apps/gallery/test/marionette/fullscreen_image_test.js
@@ -45,7 +45,7 @@ marionette('the gallery', function() {
     assert.ok(app.thumbnailsView.displayed());
   });
 
-  test('should flick through images in fullscreen mode', function() {
+  test.skip('should flick through images in fullscreen mode', function() {
     // Acquire a duplicate of an image by launching the editing
     // mode and saving it.
     app.thumbnail.click();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=986960

We are seeing this on travis: 

 the gallery

◦ should only have one image present: ✓ should only have one image present

◦ should display an image fullscreen and go back: ✓ should display an image fullscreen and go back (613ms)

◦ should flick through images in fullscreen mode:

No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.

The build has been terminated
