### PR TITLE
Bug 987103 - Do not reflow when updating the video controls

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -786,14 +786,14 @@ function updateVideoControlSlider() {
     return;
   }
 
-  percent += '%';
+  var scale = 'scaleX(' + (percent / 100) + ')';
 
-  dom.elapsedText.textContent =
-                  MediaUtils.formatDuration(dom.player.currentTime);
-  dom.elapsedTime.style.width = percent;
+  dom.elapsedText.dataset.elapsed =
+    MediaUtils.formatDuration(dom.player.currentTime);
+  dom.elapsedTime.style.transform = scale;
   // Don't move the play head if the user is dragging it.
   if (!dragging) {
-    dom.playHead.style.left = percent;
+    dom.playHead.style.transform = 'translateX(' + percent + '%)';
   }
 }
 
@@ -1170,13 +1170,12 @@ function handleSliderTouchMove(event) {
   pos = Math.max(pos, 0);
   pos = Math.min(pos, 1);
 
-  var percent = pos * 100 + '%';
   dom.playHead.classList.add('active');
-  dom.playHead.style.left = percent;
-  dom.elapsedTime.style.width = percent;
+  dom.playHead.style.transform = 'translateX(' + (pos * 100) + '%)';
+  dom.elapsedTime.style.transform = 'scaleX(' + pos + ')';
   dom.player.currentTime = dom.player.duration * pos;
-  dom.elapsedText.textContent = MediaUtils.formatDuration(
-    dom.player.currentTime);
+  dom.elapsedText.dataset.elapsed =
+    MediaUtils.formatDuration(dom.player.currentTime);
 }
 
 function toCamelCase(str) {

--- a/apps/video/js/view.js
+++ b/apps/video/js/view.js
@@ -381,14 +381,15 @@ navigator.mozSetMessageHandler('activity', function viewVideo(activity) {
     var percent = (dom.player.currentTime / dom.player.duration) * 100;
     if (isNaN(percent)) // this happens when we end the activity
       return;
-    percent += '%';
 
-    dom.elapsedText.textContent = MediaUtils.formatDuration(
-      dom.player.currentTime);
-    dom.elapsedTime.style.width = percent;
+    var scale = 'scaleX(' + (percent / 100) + ')';
+
+    dom.elapsedText.dataset.elapsed =
+      MediaUtils.formatDuration(dom.player.currentTime);
+    dom.elapsedTime.style.transform = scale;
     // Don't move the play head if the user is dragging it.
     if (!dragging)
-      dom.playHead.style.left = percent;
+      dom.playHead.style.transform = 'translateX(' + percent + '%)';
   }
 
   function handleSliderTouchEnd(event) {
@@ -429,13 +430,12 @@ navigator.mozSetMessageHandler('activity', function viewVideo(activity) {
     pos = Math.max(pos, 0);
     pos = Math.min(pos, 1);
 
-    var percent = pos * 100 + '%';
     dom.playHead.classList.add('active');
-    dom.playHead.style.left = percent;
-    dom.elapsedTime.style.width = percent;
+    dom.playHead.style.transform = 'translateX(' + (pos * 100) + '%)';
+    dom.elapsedTime.style.transform = 'scaleX(' + pos + ')';
     dom.player.currentTime = dom.player.duration * pos;
-    dom.elapsedText.textContent = MediaUtils.formatDuration(
-      dom.player.currentTime);
+    dom.elapsedText.dataset.elapsed =
+      MediaUtils.formatDuration(dom.player.currentTime);
   }
 
   function showBanner(msg) {

--- a/apps/video/style/video.css
+++ b/apps/video/style/video.css
@@ -594,6 +594,10 @@ header .icon:after {
   width: 5.2rem;
 }
 
+#elapsed-text:after {
+  content: attr(data-elapsed)
+}
+
 #duration-text {
   width: 3.2rem;
   margin-left: 1rem;
@@ -628,6 +632,8 @@ header .icon:after {
 #elapsedTime {
   background-color: #00caf2;
   z-index: 30;
+  width: 100%;
+  transform-origin: 0 0;
 }
 
 #bufferedTime {
@@ -645,7 +651,7 @@ header .icon:after {
 #playHead {
   position: absolute;
   top: calc(50% - 1.15rem);
-  width: 2.3rem;
+  width: 100%;
   height: 2.3rem;
   border: none;
   background: none;
@@ -657,7 +663,7 @@ header .icon:after {
   content: "";
   position: absolute;
   top: calc(50% - 1.15rem);
-  left: calc(50% - 1.15rem);
+  left: 0;
   width: 2.3rem;
   height: 2.3rem;
   border-radius: 50%;
@@ -668,7 +674,7 @@ header .icon:after {
   content: "";
   position: absolute;
   top: calc(50% - 3.05rem);
-  left: calc(50% - 3.05rem);
+  left: -1.9rem;
   width: 6.1rem;
   height: 6.1rem;
   border-radius: 50%;


### PR DESCRIPTION
This removes the reflows on playHead and elapsedTime, and makes elapsedText only reflow when it's being updated.
