### PR TITLE
Bug 985598 - [email] Double-triggering of share/new activity by clicking...

### DIFF
--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -354,6 +354,12 @@ ComposeCard.prototype = {
         return false;
     };
 
+    // If no composer, then it means the card was destroyed before full
+    // setup, which means there is nothing to save.
+    if (!this.composer) {
+      return false;
+    }
+
     // We need to save / ask about deleting the draft if:
     // There's any recipients listed, there's a subject, there's anything in the
     // body, there are attachments, or we already created a draft for this

--- a/apps/email/js/cards/confirm_dialog.html
+++ b/apps/email/js/cards/confirm_dialog.html
@@ -1,0 +1,12 @@
+<div class="card-confirm-dialog card">
+  <form role="dialog" data-type="confirm" class="collapsed confirm-dialog-form">
+    <section>
+      <h1 data-l10n-id="confirm-dialog-title">ConfirmatioN</h1>
+      <p class="confirm-dialog-message"></p>
+    </section>
+    <menu>
+      <button class="confirm-dialog-cancel" data-l10n-id="message-multiedit-cancel">CanceL</button>
+      <button class="confirm-dialog-ok recommend" data-l10n-id="dialog-button-ok">OK</button>
+    </menu>
+  </form>
+</div>

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -3,7 +3,7 @@
  * startup and eventually notifications.
  **/
 /*jshint browser: true */
-/*global define, requirejs, confirm, console, TestUrlResolver */
+/*global define, requirejs, console, TestUrlResolver */
 
 // Set up loading of scripts, but only if not in tests, which set up
 // their own config.
@@ -62,6 +62,7 @@ var appMessages = require('app_messages'),
     model = require('model'),
     headerCursor = require('header_cursor').cursor,
     Cards = common.Cards,
+    waitingForCreateAccountPrompt = false,
     activityCallback = null;
 
 require('sync');
@@ -279,6 +280,11 @@ evt.on('addAccount', function() {
 });
 
 function resetApp() {
+  // Clear any existing local state and reset UI/model state.
+  waitForAppMessage = false;
+  waitingForCreateAccountPrompt = false;
+  activityCallback = null;
+
   Cards.removeAllCards();
   model.init();
 }
@@ -321,7 +327,9 @@ evt.on('showLatestAccount', function() {
 
 model.on('acctsSlice', function() {
   if (!model.hasAccount()) {
-    resetCards('setup_account_info');
+    if (!waitingForCreateAccountPrompt) {
+      resetCards('setup_account_info');
+    }
   } else {
     model.latestOnce('foldersSlice', function() {
       if (waitForAppMessage)
@@ -337,7 +345,20 @@ model.on('acctsSlice', function() {
   }
 });
 
+var lastActivityTime = 0;
 appMessages.on('activity', function(type, data, rawActivity) {
+  // Rate limit rapid fire activity triggers, like an accidental
+  // double tap. While the card code adjusts for the taps, in
+  // the case of configured account, user can end up with multiple
+  // compose cards in the stack, which is probably confusing,
+  // and the rapid tapping is likely just an accident, or an
+  // incorrect user belief that double taps are needed for
+  // activation.
+  var activityTime = Date.now();
+  if (activityTime < lastActivityTime + 1000) {
+    return;
+  }
+  lastActivityTime = activityTime;
 
   function initComposer() {
     Cards.pushCard('compose', 'default', 'immediate', {
@@ -371,16 +392,24 @@ appMessages.on('activity', function(type, data, rawActivity) {
   }
 
   function promptEmptyAccount() {
-    var req = confirm(mozL10n.get('setup-empty-account-prompt'));
-    if (!req) {
-      rawActivity.postError('cancelled');
-    }
+    common.ConfirmDialog.show(mozL10n.get('setup-empty-account-prompt'),
+    function(confirmed) {
+      if (!confirmed) {
+        rawActivity.postError('cancelled');
+      }
 
-    // No longer need to wait for the activity to complete, it needs
-    // normal card flow
-    waitForAppMessage = false;
+      waitingForCreateAccountPrompt = false;
 
-    activityCallback = initComposer;
+      // No longer need to wait for the activity to complete, it needs
+      // normal card flow
+      waitForAppMessage = false;
+
+      activityCallback = initComposer;
+
+      // Always just reset to setup account in case the system does
+      // not properly close out the email app on a cancelled activity.
+      resetCards('setup_account_info');
+    });
   }
 
   // Remove previous cards because the card stack could get
@@ -402,6 +431,7 @@ appMessages.on('activity', function(type, data, rawActivity) {
     if (model.hasAccount()) {
       initComposer();
     } else {
+      waitingForCreateAccountPrompt = true;
       promptEmptyAccount();
     }
   } else {
@@ -410,6 +440,7 @@ appMessages.on('activity', function(type, data, rawActivity) {
     // account prompt will be triggered quickly in the next section.
     initComposer();
 
+    waitingForCreateAccountPrompt = true;
     model.latestOnce('acctsSlice', function activityOnAccount() {
       if (!model.hasAccount()) {
         promptEmptyAccount();


### PR DESCRIPTION
This change converts all ConfirmDialog uses to be backed by a card insertion instead of the document.body appendChild approach, which made it harder to clean up/reset state for those cases. That new ConfirmDialog is then used in place of the confirm() in the activity flow. This allows for cleaner app reset and avoids the double triggering of activities from freaking out the email app.

Some notes:
- With this change, it is possible for toast banners to appear in front of the ConfirmDialogs as the ConfirmDialogs are now in the card stack.
- The compose card needed a fix for when the compose card is destroyed very quickly when the email app speculates that compose should be the start card for the activity. I believe this is needed now there is no longer a confirm() that is blocking part of the flow. It seemed like a good fix to have in general too.
- There are two styles for calling ConfirmDialog.show: the old way, so that the rest of the ConfirmDialog references did not have to change, and a newer, simpler way that mimics the style of a confirm() dialog, with just a message that can be customized.
- No new l10n strings, but the simple confirm dialog uses l10n ID "message-multiedit-cancel". While not ideologically pure, other dialogs were already using it, so seemed safe to do so here too, although long term, each one of those cases should have its own cancel, or convert more of the code to use the simple ConfirmDialog approach.

It may make sense to file a separate bug to track cleaning any alert() usage to use a similar approach to this one, and then also perhaps a more invasive change that converts ConfirmDialog.show() calls to be more like the simpler approach, with maybe some more config options like button titles and styles like "danger" used in some ConfirmDialogs now.

I still may need to fix some things in the integration tests, but had trouble running them locally, so will look at it more tomorrow and the Travis result against all the tests. Thought I would start this pull request though as the approach may still need some discussion.
