### PR TITLE
Bug 983012 - [Sora][Message][Input method]The virtual keyboard is

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -1596,6 +1596,7 @@ function switchToNextIME() {
 }
 
 function showIMEList() {
+  clearTouchedKeys();
   var mgmt = navigator.mozInputMethod.mgmt;
   mgmt.showAll();
 }
@@ -1609,6 +1610,7 @@ function resetKeyboard() {
   // separately after this function
   isUpperCase = false;
   isUpperCaseLocked = false;
+  clearTouchedKeys();
 }
 
 // This is a wrapper around inputContext.sendKey()
@@ -1943,6 +1945,27 @@ function needsCandidatePanel() {
 function isGreekSMS() {
   return (currentInputMode === '-moz-sms' &&
           keyboardName === 'el');
+}
+
+// Remove the event listeners on the touched keys and the highlighting.
+// This is because sometimes DOM element is removed before
+// touchend is fired.
+function clearTouchedKeys() {
+  for (var id in touchedKeys) {
+    if (!touchedKeys[id]) {
+      continue;
+    }
+
+    var target = touchedKeys[id].target;
+    if (target) {
+      target.removeEventListener('touchmove', onTouchMove);
+      target.removeEventListener('touchend', onTouchEnd);
+      target.removeEventListener('touchcancel', onTouchEnd);
+      IMERender.unHighlightKey(target);
+    }
+  }
+
+  touchedKeys = {};
 }
 /*
  * This is a helper to scroll the keyboard layout menu when the touch moves near


### PR DESCRIPTION
disable after switching the keyboard as pinyin.
- Remove the touchmove event listeners from the touched keys when
  switching layouts.
