### PR TITLE
Bug 986992 - Remove navigator.mozKeyboard

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -1641,7 +1641,7 @@ function replaceSurroundingText(text, offset, length) {
 }
 
 // Set up the keyboard and its input method.
-// This is called when we get an event from mozKeyboard.
+// This is called when we get an event from mozInputMethod.
 // The state argument is the data passed with that event, and includes
 // the input field type, its inputmode, its content, and the cursor position.
 function showKeyboard() {

--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// If we get a focuschange event from mozKeyboard for an element with
+// If we get a inputmethod-contextchange chrome event for an element with
 // one of these types, we'll just ignore it.
 // XXX we won't skip these types in the future when we move value selector
 // to an app.

--- a/apps/system/js/value_selector/value_selector.js
+++ b/apps/system/js/value_selector/value_selector.js
@@ -12,6 +12,7 @@ var ValueSelector = {
   _currentPickerType: null,
   _currentInputType: null,
   _currentDatetimeValue: '',
+  _im: navigator.mozInputMethod,
 
   debug: function(msg) {
     var debugFlag = false;
@@ -216,7 +217,7 @@ var ValueSelector = {
       if (selectee.length > 0)
         singleOptionIndex = selectee[0].dataset.optionIndex;
 
-      window.navigator.mozKeyboard.setSelectedOption(singleOptionIndex);
+      this._im.setSelectedOption(singleOptionIndex);
 
     } else if (this._currentPickerType === 'select-multiple') {
       // Multiple select case
@@ -226,7 +227,7 @@ var ValueSelector = {
         optionIndices.push(index);
       }
 
-      window.navigator.mozKeyboard.setSelectedOptions(optionIndices);
+      this._im.setSelectedOptions(optionIndices);
     }
 
   },
@@ -251,7 +252,7 @@ var ValueSelector = {
 
   cancel: function vs_cancel() {
     this.debug('cancel invoked');
-    window.navigator.mozKeyboard.removeFocus();
+    this._im.removeFocus();
     this.hide();
   },
 
@@ -262,7 +263,7 @@ var ValueSelector = {
       case 'time':
         var timeValue = TimePicker.getTimeValue();
         this.debug('output value: ' + timeValue);
-        window.navigator.mozKeyboard.setValue(timeValue);
+        this._im.setValue(timeValue);
         break;
 
       case 'date':
@@ -270,7 +271,7 @@ var ValueSelector = {
         // The format should be 2012-09-19
         dateValue = dateValue.toLocaleFormat('%Y-%m-%d');
         this.debug('output value: ' + dateValue);
-        window.navigator.mozKeyboard.setValue(dateValue);
+        this._im.setValue(dateValue);
         break;
 
       case 'datetime':
@@ -322,12 +323,12 @@ var ValueSelector = {
                             selectedDate.getMilliseconds();
           }
           this.debug('output value: ' + datetimeValue);
-          window.navigator.mozKeyboard.setValue(datetimeValue);
+          this._im.setValue(datetimeValue);
         }
         break;
     }
 
-    window.navigator.mozKeyboard.removeFocus();
+    this._im.removeFocus();
     this.hide();
   },
 

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -40,7 +40,6 @@
     "audio-channel-content":{},
     "audio-channel-ringer":{},
     "cellbroadcast":{},
-    "input":{},
     "input-manage":{},
     "nfc":{ "access": "readonly" },
     "nfc-manager":{},

--- a/apps/system/test/unit/value_selector_test.js
+++ b/apps/system/test/unit/value_selector_test.js
@@ -31,14 +31,14 @@ suite('value selector/value selector', function() {
       document.querySelector('#time-picker .picker-container');
     timeSeparator = document.getElementById('hours-minutes-separator');
 
-    realKeyboard = window.navigator.mozKeyboard;
-    window.navigator.mozKeyboard = sinon.stub();
+    realKeyboard = window.navigator.mozInputMethod;
+    window.navigator.mozInputMethod = sinon.stub();
   });
 
   suiteTeardown(function() {
     navigator.mozSettings = realSettings;
     navigator.mozL10n = realL10n;
-    window.navigator.mozKeyboard = realKeyboard;
+    window.navigator.mozInputMethod = realKeyboard;
     document.body.innerHTML = '';
   });
 

--- a/shared/js/keyboard_helper.js
+++ b/shared/js/keyboard_helper.js
@@ -644,11 +644,6 @@ var KeyboardHelper = exports.KeyboardHelper = {
           return;
         }
 
-        //XXX remove this hard code check if one day system app no longer
-        //    use mozKeyboard API
-        if (app.origin === 'app://system.gaiamobile.org') {
-          return;
-        }
         // all keyboard apps should define its layout(s) in "inputs" section
         if (!app.manifest.inputs) {
           return;

--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -323,7 +323,7 @@ class Keyboard(Base):
 
     def dismiss(self):
         self.marionette.switch_to_frame()
-        self.marionette.execute_script('navigator.mozKeyboard.removeFocus();')
+        self.marionette.execute_script('navigator.mozInputMethod.removeFocus();')
         keyboards = self.marionette.find_element(*self._keyboards_locator)
         Wait(self.marionette).until(
             lambda m: 'hide' in keyboards.get_attribute('class') and


### PR DESCRIPTION
Merge navigator.mozKeyboard into navigator.mozInputMethod. The methods from mozKeyboard must be accessed with input-manage permssion.
