### PR TITLE
Bug 924833 - Re-enable test_receive_call.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/phone/regions/call_screen.py
@@ -13,7 +13,9 @@ class CallScreen(Phone):
     _calling_contact_locator = (By.CSS_SELECTOR, 'div.number')
     _calling_contact_information_locator = (By.CSS_SELECTOR, 'div.additionalContactInfo')
     _outgoing_call_locator = (By.CSS_SELECTOR, '.handled-call.outgoing')
+    _incoming_call_locator = (By.CSS_SELECTOR, '.handled-call.incoming')
     _hangup_bar_locator = (By.ID, 'callbar-hang-up')
+    _answer_bar_locator = (By.ID, 'callbar-answer')
 
     def __init__(self, marionette):
         Phone.__init__(self, marionette)
@@ -30,6 +32,10 @@ class CallScreen(Phone):
         return self.marionette.find_element(*self._outgoing_call_locator).find_element(*self._calling_contact_locator).text
 
     @property
+    def incoming_calling_contact(self):
+        return self.marionette.find_element(*self._incoming_call_locator).find_element(*self._calling_contact_locator).text
+
+    @property
     def calling_contact_information(self):
         return self.marionette.find_element(*self._outgoing_call_locator).find_element(*self._calling_contact_information_locator).text
 
@@ -38,15 +44,19 @@ class CallScreen(Phone):
         self.wait_for_condition(lambda m: outgoing_call.location['y'] == 0)
         self.wait_for_condition(lambda m: self.outgoing_calling_contact != u'')
 
-    def tap_hang_up(self):
-        hang_up = self.marionette.find_element(*self._hangup_bar_locator)
-        hang_up.tap()
+    def wait_for_incoming_call(self):
+        incoming_call = self.marionette.find_element(*self._incoming_call_locator)
+        self.wait_for_condition(lambda m: incoming_call.location['y'] == 0)
+        self.wait_for_condition(lambda m: self.incoming_calling_contact != u'')
+
+    def answer_call(self):
+        self.marionette.find_element(*self._answer_bar_locator).tap()
 
     def a11y_click_hang_up(self):
         self.accessibility.click(self.marionette.find_element(*self._hangup_bar_locator))
 
     def hang_up(self):
-        self.tap_hang_up()
+        self.marionette.find_element(*self._hangup_bar_locator).tap()
         self.marionette.switch_to_frame()
         self.wait_for_element_not_displayed(*self._call_screen_locator)
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/manifest.ini
@@ -21,3 +21,7 @@ skip-if = device == "desktop"
 
 [test_dialer_find_contact.py]
 skip-if = device == "desktop"
+
+[test_dialer_receive_call.py]
+smoketest = true
+skip-if = device == "desktop"

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/test_dialer_receive_call.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/dialer/test_dialer_receive_call.py
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.wait import Wait
+
+from gaiatest import GaiaTestCase
+from gaiatest.apps.phone.regions.call_screen import CallScreen
+from gaiatest.utils.plivo.plivo_util import PlivoUtil
+
+
+class TestReceiveCall(GaiaTestCase):
+
+    def test_receive_call(self):
+        """Make a phone call from Plivo to the phone."""
+        PLIVO_TIMEOUT = 30
+
+        self.plivo = PlivoUtil(
+            self.testvars['plivo']['auth_id'],
+            self.testvars['plivo']['auth_token'],
+            self.testvars['plivo']['phone_number']
+        )
+        self.call_uuid = self.plivo.make_call(
+            to_number=self.testvars['carrier']['phone_number'].replace('+', ''),
+            timeout=PLIVO_TIMEOUT)
+
+        call_screen = CallScreen(self.marionette)
+        call_screen.wait_for_incoming_call()
+        call_screen.answer_call()
+
+        # Wait for Plivo to report the call as connected
+        Wait(self.plivo, timeout=PLIVO_TIMEOUT).until(
+            lambda p: p.is_call_connected(self.call_uuid),
+            message='The call was not connected.')
+
+        # Wait for the state to be connected
+        call_screen.wait_for_condition(
+            lambda m: self.data_layer.active_telephony_state == 'connected',
+            timeout=30)
+
+        call_screen.hang_up()
+
+        # Wait for Plivo to report the call as completed
+        Wait(self.plivo, timeout=PLIVO_TIMEOUT).until(
+            lambda p: p.is_call_completed(self.call_uuid),
+            message='The call was not completed.')
+        self.call_uuid = None
+
+    def tearDown(self):
+        # Switch back to main frame before Marionette loses track bug #840931
+        self.marionette.switch_to_frame()
+
+        # In case an assertion fails this will still kill the call
+        # An open call creates problems for future tests
+        self.data_layer.kill_active_call()
+
+        # Also ask Plivo to kill the call if needed
+        if self.call_uuid:
+            self.plivo.hangup_call(self.call_uuid)
+
+        GaiaTestCase.tearDown(self)

--- a/tests/python/gaia-ui-tests/gaiatest/testvars_template.json
+++ b/tests/python/gaia-ui-tests/gaiatest/testvars_template.json
@@ -36,5 +36,10 @@
       "active_sync_username": ""
     }
 
+  },
+  "plivo": {
+    "auth_id": "",
+    "auth_token": "",
+    "phone_number": ""
   }
 }

--- a/tests/python/gaia-ui-tests/gaiatest/utils/plivo/plivo_util.py
+++ b/tests/python/gaia-ui-tests/gaiatest/utils/plivo/plivo_util.py
@@ -1,0 +1,98 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.wait import Wait
+import plivo
+
+
+class PlivoUtil(object):
+
+    def __init__(self, auth_id, auth_token, plivo_phone_number):
+        self.api = plivo.RestAPI(auth_id, auth_token)
+        self.from_number = plivo_phone_number
+
+    @property
+    def account_balance(self):
+        return float(self.account_details['cash_credits'])
+
+    @property
+    def account_details(self):
+        """Get the details for the account"""
+        response = self.api.get_account()
+        if response[0] == 200:
+            return response[1]
+        raise self.PlivoError('get_account', response)
+
+    def make_call(self, to_number, timeout=30):
+        """Place a call to a number and wait for the call_uuid to be available
+            Return the call_uuid
+        """
+        # Check that we have the balance available
+        if self.account_balance < 0.1:
+            raise Exception(
+                'Plivo account balance of %s is insufficient to make a call.'
+                % self.account_balance)
+        # Make the call
+        Wait(self.api, timeout).until(
+            lambda p: p.make_call({
+                'from': self.from_number,
+                'to': to_number,
+                'answer_url': "http://example.com/answer_url",
+                'hangup_url': "http://example.com/hangup_url",
+                'caller_name': 'test_call_from_Plivo',
+            })[0] == 201,
+            message='The call was not able to be made.'
+        )
+        # Wait until the call is reported back by the api
+        call = Wait(self, timeout, ignored_exceptions=self.PlivoActiveCallNotFound).until(
+            lambda p: p.get_call_for_number(to_number),
+            message='Unable to find the live call for this device.'
+        )
+        return call['call_uuid']
+
+    def get_call_for_number(self, to_number):
+        # We cannot get details directly for a number,
+        # so we need to get all live calls and look for the number
+        response = self.api.get_live_calls()
+        if response[0] != 200:
+            raise self.PlivoError('get_live_calls', response)
+        calls = response[1]['calls']
+
+        for call in calls:
+            response = self.api.get_live_call({'call_uuid': call})
+            if response[0] != 200:
+                raise self.PlivoError('get_live_call', response)
+            if str(response[1]['to']) == str(to_number):
+                return response[1]
+        raise self.PlivoActiveCallNotFound
+
+    def is_call_connected(self, call_uuid):
+        response = self.api.get_live_call({'call_uuid': call_uuid})
+        if response[0] != 200:
+            raise self.PlivoError('get_live_call', response)
+        return response[1]['call_status'] == 'in-progress'
+
+    def is_call_completed(self, call_uuid):
+        response = self.api.get_cdr({'call_uuid': call_uuid})
+        if response[0] == 200:
+            return True
+        if response[0] == 404:
+            return False
+        raise self.PlivoError('get_cdr', response)
+
+    def hangup_call(self, call_uuid):
+        response = self.api.hangup_call({'call_uuid': call_uuid})
+        if response[0] not in (204, 404):
+            raise self.PlivoError('hangup_call', response)
+
+    class PlivoError(Exception):
+        def __init__(self, method, response):
+            message = 'Plivo API method %s failed with status: %s, details: %s' \
+                           % (method, response[0], response[1])
+            Exception.__init__(self, message)
+
+    class PlivoActiveCallNotFound(Exception):
+        def __init__(self):
+            Exception.__init__(self,
+                               'No active call for the specified number can be found by Plivo.')

--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,5 +1,6 @@
 marionette_client==0.7.6
 mozdevice>=0.31
-requests
 moztest>=0.3
+plivo==0.9.6
+requests
 yoctopuce==1.01.12553


### PR DESCRIPTION
This test uses Plivo to place a call. I have updated `testvars_template.json` with the required structure, but in order to run the test you'll need Plivo credentials. You can either ping me for a PM with my credentials or you could set up your own free Plivo trial account and use your own.

I'm not sure that the latter option will work in the UK or Romania though, and you might not even be able to place calls to your own phones on those countries with a trial account. I think you need a full account to be able to call international numbers.

If we want to set up an adhoc run on CI for the test (which is a good idea) then we'll have to update the actual credentials files and I guess we can just use my test account for that for now.

Note that this code uses the Plivo API to wait for the call to be placed, connected, and completed, so we shouldn't run into issues of the test proceeding/finishing before Plivo thinks the call has been finished.
