### PR TITLE
Bug 988117 - GAIA UI Test will fail if convert WifiManager to WebIDL

### DIFF
--- a/tests/atoms/gaia_data_layer.js
+++ b/tests/atoms/gaia_data_layer.js
@@ -214,7 +214,12 @@ var GaiaDataLayer = {
       callback(true);
     }
     else {
-      var req = manager.associate(aNetwork);
+      var req;
+      if (window.MozWifiNetwork === undefined) {
+        req = manager.associate(aNetwork);
+      } else {
+        req = manager.associate(new window.MozWifiNetwork(aNetwork));
+      }
 
       req.onsuccess = function() {
         console.log("waiting for connection status 'connected'");


### PR DESCRIPTION
If convert WifiManager to WebIDL, associate will require a MozWifiNetwork object as parameter, but in GAIA UI test, aNetwork parameter may be fetched from JSON file as json object. This cause the GAIA UI test file fail.

So before bug 886110 land, check if MozWifiNetwork is defined or not, remove this if check after bug 886110 land.
