### PR TITLE
Bug 988148 - Hide the mobile connection state if it is emergency calls only and not primary sim r=alive

### DIFF
--- a/apps/system/js/lockscreen_connection_info_manager.js
+++ b/apps/system/js/lockscreen_connection_info_manager.js
@@ -97,11 +97,11 @@
         var req2 =
           SettingsListener.getSettingsLock()
             .get('ril.telephony.defaultServiceId');
-        req.onsuccess = function() {
+        req2.onsuccess = (function() {
           this._telephonyDefaultServiceId =
             req2.result['ril.telephony.defaultServiceId'] || 0;
           this.updateConnStates();
-        };
+        }).bind(this);
       }).bind(this);
   };
 
@@ -213,6 +213,12 @@
         }
         simIDLine.hidden = true;
         return;
+      } else if (SIMSlotManager.noSIMCardConnectedToNetwork()) {
+        if (index == 0) {
+          localize(nextLine(), 'emergencyCallsOnly');
+        }
+        simIDLine.hidden = true;
+        return;
       }
 
       // If there are multiple sim slots and only one sim card inserted, we
@@ -245,8 +251,10 @@
       if (voice.emergencyCallsOnly) {
         if (this._telephonyDefaultServiceId == index) {
           localize(nextLine(), 'emergencyCallsOnly');
+          localize(nextLine(), _lockedStateMsgMap[iccObj.cardState]);
+        } else {
+          connstate.hidden = true;
         }
-        localize(nextLine(), _lockedStateMsgMap[iccObj.cardState]);
         return;
       }
 

--- a/apps/system/js/mock_simslot_manager.js
+++ b/apps/system/js/mock_simslot_manager.js
@@ -16,6 +16,7 @@ var MockSIMSlotManager = {
     return this.mInstances[i].isAbsent();
   },
   noSIMCardOnDevice: function() {},
+  noSIMCardConnectedToNetwork: function() {},
   mTeardown: function mssm_mTeardown() {
     this.mInstances = [];
   }

--- a/apps/system/js/simslot_manager.js
+++ b/apps/system/js/simslot_manager.js
@@ -92,11 +92,20 @@
      * Check there is no any sim card on device or not.
      * @return {Boolean} There is no sim card.
      */
-    noSIMCardOnDevice: function ssm_noSIMCardOnDevice(index) {
+    noSIMCardOnDevice: function ssm_noSIMCardOnDevice() {
       if (!IccManager || !IccManager.iccIds) {
         return true;
       }
       return (IccManager.iccIds.length === 0);
+    },
+
+    noSIMCardConnectedToNetwork: function ssm_noSIMCardConnectedToNetwork() {
+      if (!IccManager || !IccManager.iccIds) {
+        return true;
+      }
+      return this._instances.every(function iterator(instance) {
+        return instance.conn.voice && instance.conn.voice.emergencyCallsOnly;
+      });
     },
 
     /**

--- a/apps/system/test/unit/lockscreen_conn_info_manager_test.js
+++ b/apps/system/test/unit/lockscreen_conn_info_manager_test.js
@@ -487,6 +487,21 @@ suite('system/LockScreenConnInfoManager >', function() {
         assert.equal(simIDLine2.textContent, 'SIM 2');
       });
 
+      test('Should hide sim IDs if all sim cards are not connected to networks',
+        function() {
+          sinon.stub(SIMSlotManager, 'noSIMCardConnectedToNetwork')
+            .returns(true);
+          subject.updateConnStates();
+
+          var simIDLine1 = domConnStateList[0].domConnstateIDLine;
+          var connState1line1 = domConnStateList[0].domConnstateL1;
+          var simIDLine2 = domConnStateList[1].domConnstateIDLine;
+          assert.isTrue(simIDLine1.hidden);
+          assert.isTrue(simIDLine2.hidden);
+          assert.equal(connState1line1.textContent, 'emergencyCallsOnly');
+          SIMSlotManager.noSIMCardConnectedToNetwork.restore();
+      });
+
       test('Should show operator names on Line 1', function() {
         subject.updateConnStates();
 
@@ -505,6 +520,25 @@ suite('system/LockScreenConnInfoManager >', function() {
           MockMobileOperator.mCarrier + ' ' + MockMobileOperator.mRegion);
         assert.equal(connState2line2.textContent,
           MockMobileOperator.mCarrier + ' ' + MockMobileOperator.mRegion);
+      });
+
+      test('Should display "emergency calls only" if target sim is the ' +
+        'primary one and is emergency calls only', function() {
+          mockMobileConnections[0].voice.emergencyCallsOnly = true;
+          subject._telephonyDefaultServiceId = 0;
+          subject.updateConnStates();
+
+          var connState1line1 = domConnStateList[0].domConnstateL1;
+          assert.equal(connState1line1.textContent, 'emergencyCallsOnly');
+      });
+
+      test('Should hide the conn state of the target sim if it is not the ' +
+        'primary one but is emergency calls only', function() {
+          mockMobileConnections[0].voice.emergencyCallsOnly = true;
+          subject._telephonyDefaultServiceId = 1;
+          subject.updateConnStates();
+
+          assert.isTrue(domConnStateList[0].hidden);
       });
     });
   });

--- a/apps/system/test/unit/simslot_manager_test.js
+++ b/apps/system/test/unit/simslot_manager_test.js
@@ -48,6 +48,19 @@ suite('SIMSlotManager', function() {
     assert.isTrue(SIMSlotManager.noSIMCardOnDevice());
   });
 
+  test('noSIMCardConnectedToNetwork', function() {
+    MockIccManager.iccIds = [0, 1];
+    MockNavigatorMozMobileConnections.mAddMobileConnection();
+
+    SIMSlotManager._instances = [];
+    SIMSlotManager.init();
+    MockNavigatorMozMobileConnections[0].voice = { emergencyCallsOnly: true };
+    MockNavigatorMozMobileConnections[1].voice = { emergencyCallsOnly: true };
+    assert.isTrue(SIMSlotManager.noSIMCardConnectedToNetwork());
+    MockNavigatorMozMobileConnections[0].voice.emergencyCallsOnly = false;
+    assert.isFalse(SIMSlotManager.noSIMCardConnectedToNetwork());
+  });
+
   test('getSlotByIccId', function() {
     var card1 = document.createElement('div');
     card1.iccId = 1;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=988148
