### PR TITLE
Bug 987966 - [contacts] placeholder for date fields in add/edit mode is ...

### DIFF
--- a/apps/communications/contacts/elements/form.html
+++ b/apps/communications/contacts/elements/form.html
@@ -74,7 +74,7 @@
         </legend>
         <section>
           <p class="setbox-item">
-            <span id="date-text_#i#" data-l10n-id="date.placeholder" class="datetime placeholder">
+            <span id="date-text_#i#" data-l10n-id="date-span-placeholder" class="datetime placeholder">
               Date
             </span>
             <input placeholder="date" data-l10n-id="date" name="date[#i#][value]" class="textfield hidden-input" type="date" id="date_#i#">

--- a/apps/communications/contacts/locales/contacts.en-US.properties
+++ b/apps/communications/contacts/locales/contacts.en-US.properties
@@ -45,6 +45,7 @@ comment.placeholder       = Comment
 org.placeholder           = Company
 custom.placeholder        = Custom
 date                      = Date
+date-span-placeholder     = Date
 date.placeholder          = Date
 
 birthday                  = Birthday

--- a/apps/communications/contacts/locales/contacts.fr.properties
+++ b/apps/communications/contacts/locales/contacts.fr.properties
@@ -44,6 +44,7 @@ comment.placeholder       = Commentaire
 org.placeholder           = Entreprise
 custom.placeholder        = Personnalisé
 date                      = Date
+date-span-placeholder     = Date
 date.placeholder          = Date
 
 birthday                  = Anniversaire


### PR DESCRIPTION
...always in English: 'Date'
