### PR TITLE
Bug 987224 - [B2G][Video]Unable to watch videos in video app after delet...

### DIFF
--- a/apps/video/js/db.js
+++ b/apps/video/js/db.js
@@ -127,6 +127,14 @@ function videoCreated(videoinfo) {
 }
 
 function videoDeleted(filename) {
+
+  // In tablet landscape mode, we use currentVideo to be the current playing
+  // video and last played video. When deleting file and the file is playing or
+  // last played video, we need to change the it to the next, previous or null.
+  if (currentVideo && filename === currentVideo.name) {
+    resetCurrentVideo();
+  }
+
   // And remove its thumbnail from the document
   thumbnailList.removeItem(filename);
 

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -563,13 +563,6 @@ function deleteFile(filename) {
       navigator.getDeviceStorage('pictures'). delete(postername);
   }
 
-  // In tablet landscape mode, we use currentVideo to be the current playing
-  // video and last played video. When deleting file and the file is playing or
-  // last played video, we need to change the it to the next, previous or null.
-  if (currentVideo && filename === currentVideo.name) {
-    resetCurrentVideo();
-  }
-
   // Whether or not there was a poster file to delete, delete the
   // actual video file. This will cause the MediaDB to send a 'deleted'
   // event, and the handler for that event will call videoDeleted() below.


### PR DESCRIPTION
...ing two videos

Move call to resetCurrentVideo to videoDeleted to ensure when there are multiple deletions the previously deleted thumbnail will be removed from thumbnail list before resetCurrentVideo is called.
