### PR TITLE
Bug 984328 - [Keyboard][V1.3T] The alternative char menu cannot be

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -41,6 +41,9 @@ const IMERender = (function() {
     isSpecialKey = keyTest;
     ime = document.getElementById('keyboard');
     menu = document.getElementById('keyboard-accent-char-menu');
+
+    cachedWindowHeight = window.innerHeight;
+    cachedWindowWidth = window.innerWidth;
   };
 
   var setInputMethodName = function(name) {

--- a/apps/keyboard/test/unit/keyboard_test.js
+++ b/apps/keyboard/test/unit/keyboard_test.js
@@ -3,11 +3,13 @@
 suite('keyboard.js', function() {
 
   requireApp('keyboard/js/keyboard.js');
-  var mockMozInputMethod;
   var realMozInputMethod;
 
   suiteSetup(function() {
-    realMozInputMethod = window.navigator.mozInputMethod;
+    if ('mozInputMethod' in window.navigator) {
+      realMozInputMethod = window.navigator.mozInputMethod;
+    }
+
     window.navigator.mozInputMethod = {
       mgmt: {
         showAll: sinon.stub()
@@ -16,7 +18,11 @@ suite('keyboard.js', function() {
   });
 
   suiteTeardown(function() {
-    window.navigator.mozInputMethod = realMozInputMethod;
+    if (realMozInputMethod) {
+      window.navigator.mozInputMethod = realMozInputMethod;
+    } else {
+      delete window.navigator.mozInputMethod;
+    }
   });
 
   suite('clearTouchedKeys', function() {


### PR DESCRIPTION
displayed
- To set initial value of cached window height/width when the keyboard
  is relaunched after memory pressure.
