### PR TITLE
Bug 980814 - Set system message handler when the test app is completely loaded.

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/testapp/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/testapp/app.py
@@ -3,11 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from gaiatest.apps.base import Base
+from marionette.by import By
 
 class TestContainer(Base):
 
     name = 'Test Container'
+    _main_frame_locator = (By.ID, 'test-container')
 
     def launch(self):
         Base.launch(self)
+        self.wait_for_element_present(*self._main_frame_locator)
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/system/manifest.ini
@@ -17,7 +17,6 @@ skip-if = device == "desktop"
 [test_quick_settings.py]
 
 [test_system_message.py]
-disabled = Bug 980814 test_system_message.py, JavaScript Error
 
 [test_power_button_long_press.py]
 smoketest = true


### PR DESCRIPTION
If we run gaia-ui-test with --restart command, test_system_message.py may fail because of the premature app launching. Add one second delay after calling GaiaApp.launch() for stability.
