### PR TITLE
Bug 984841 - [Messages] The cursor and the keyboard are not shown when New message screen is opened r=schung

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -338,6 +338,7 @@ var ThreadUI = global.ThreadUI = {
    * visible.
    */
   onBeforeEnter: function thui_onBeforeEnter() {
+    Recipients.View.isFocusable = true;
     if (!this.multiSimActionButton) {
       // handles the various actions on the send button and encapsulates the
       // DSDS specific behavior

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -5152,6 +5152,12 @@ suite('thread_ui.js >', function() {
       ThreadUI.onBeforeEnter();
       sinon.assert.calledOnce(MultiSimActionButton);
     });
+
+    test('Should set the isFocusable value to \'true\'', function() {
+      Recipients.View.isFocusable = false;
+      ThreadUI.onBeforeEnter();
+      assert.isTrue(Recipients.View.isFocusable);
+    });
   });
 
   suite('Keyboard should not close when slightly missing the send button',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=984841
1. Added isFocusable to true inorder to show the focus
2. Added new test for checking whether the isFocusable value is reset to true
