### PR TITLE
Bug 978696 - [Sora][Contacts] The vCard exported from Soul 3.5 FF can not be imported into Android devices.

### DIFF
--- a/apps/communications/contacts/test/unit/contact2vcard_test.js
+++ b/apps/communications/contacts/test/unit/contact2vcard_test.js
@@ -42,6 +42,7 @@ suite('mozContact to vCard', function() {
           var _contains = contains(str);
 
           assert.equal(count, contacts.length);
+          assert.ok(_contains('version:3.0'));
           assert.ok(_contains('fn:pepito grillo'));
           assert.ok(_contains('n:grillo;pepito;green;mr.;;'));
           assert.ok(_contains('nickname:pg'));
@@ -50,7 +51,7 @@ suite('mozContact to vCard', function() {
           assert.ok(_contains('title:sr. software architect'));
           assert.ok(_contains('note:note 1'));
           assert.ok(_contains('bday:1970-01-01T00:00:00Z'));
-          assert.ok(_contains('photo:data:image/gif;base64,' + b64));
+          assert.ok(_contains('photo;encoding=b;type=image/gif:' + b64));
           assert.ok(_contains('email;type=home:test@test.com'));
           assert.ok(_contains('email;type=work,pref:test@work.com'));
           assert.ok(_contains('tel;type=cell,pref:+346578888888'));
@@ -84,7 +85,7 @@ suite('mozContact to vCard', function() {
           assert.ok(_contains('title:sr. software architect'));
           assert.ok(_contains('note:note 1'));
           assert.ok(_contains('bday:1970-01-01T00:00:00Z'));
-          assert.ok(_contains('photo:data:image/gif;base64,' + b64));
+          assert.ok(_contains('photo;encoding=b;type=image/gif:' + b64));
           assert.ok(_contains('email;type=home:test@test.com'));
           assert.ok(_contains('tel;type=cell,pref:+346578888888'));
           assert.ok(_contains('tel;type=home:+3120777777'));


### PR DESCRIPTION
This patch changes the export format from vcard 4.0 to 3.0. It modifies the least amount of code to make it work properly. Adjusted unit tests and tested import in Android 4.4, works fine but Android doesn't seem to import pictures from vCard, on purpose. Other systems have no problem seeing the pictures (tested on OSX and in-browser data-uris).

I will create a new issue for potential fixes to encoding and quoting (not relevant to this issue because if any, they will be present in previous code as well).
