### PR TITLE
Bug 988589 - Re-enable FxA forgot password input

### DIFF
--- a/apps/system/fxa/elements/fxa-enter-password.html
+++ b/apps/system/fxa/elements/fxa-enter-password.html
@@ -4,7 +4,7 @@
       <h3 data-l10n-id="fxa-enter-password-title">Enter your password</h3>
       <p id="fxa-hello-user" data-l10n-id="fxa-hello-user">Hello, <a id="fxa-user-email">holaENTER@email.com</a></p>
       <input id="fxa-pw-input" type="password" placeholder="Password" required pattern=".{8,}" data-l10n-id="fxa-password" x-inputmode="verbatim">
-      <p class="forgot-password"><a id="fxa-forgot-password" data-l10n-id="fxa-forgot-password" class="disabled">I forgot my password</a></p>
+      <p class="forgot-password"><a id="fxa-forgot-password" data-l10n-id="fxa-forgot-password">I forgot my password</a></p>
       <div class="horizontal">
         <p data-l10n-id="fxa-show-password">Show password</p>
         <label class="pack-checkbox" for="fxa-show-pw">

--- a/apps/system/fxa/elements/fxa-refresh-auth.html
+++ b/apps/system/fxa/elements/fxa-refresh-auth.html
@@ -3,7 +3,7 @@
     <section class="vertical">
       <p id="fxa-password-refresh" data-l10n-id="fxa-password-refresh">Please enter your Firefox Account password for <a id="fxa-user-email-refresh">hola@email.com</a> to continue.</p>
       <input id="fxa-pw-input-refresh" type="password" placeholder="Password" required="" pattern=".{8,}" data-l10n-id="fxa-password">
-      <p class="forgot-password"><a id="fxa-forgot-password-refresh" data-l10n-id="fxa-forgot-password" class="disabled">I forgot my password</a></p>
+      <p class="forgot-password"><a id="fxa-forgot-password-refresh" data-l10n-id="fxa-forgot-password">I forgot my password</a></p>
       <div class="horizontal">
         <p data-l10n-id="fxa-show-password">Show password</p>
         <label class="pack-checkbox" for="fxa-show-pw-refresh">


### PR DESCRIPTION
This was accidentally overwritten in fxa-enter-password.html as part of the 897600 merge (commit: https://github.com/mozilla-b2g/gaia/commit/e5d3435).

The other file was added by a separate bug (968294), we can enable the forgot password control there at the same time.
