### PR TITLE
Bug 984328 - [Keyboard][V1.3T] The alternative char menu cannot be

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -41,6 +41,9 @@ const IMERender = (function() {
     isSpecialKey = keyTest;
     ime = document.getElementById('keyboard');
     menu = document.getElementById('keyboard-accent-char-menu');
+
+    cachedWindowHeight = window.innerHeight;
+    cachedWindowWidth = window.innerWidth;
   };
 
   var setInputMethodName = function(name) {


### PR DESCRIPTION
displayed
- To set initial value of cached window height/width when the keyboard
  is relaunched after memory pressure.
