### PR TITLE
Bug 985928 - [tarako]need disable APZC by default

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -121,7 +121,7 @@ function execute(options) {
    'app.launch_path.blacklist': [],
    'app.reportCrashes': 'ask',
    'app.update.interval': 86400,
-   'apz.force-enable': true,
+   'apz.force-enable': false,
    'audio.volume.alarm': 15,
    'audio.volume.bt_sco': 15,
    'audio.volume.dtmf': 15,


### PR DESCRIPTION
Disable APZC at build time, for v1.3t only

https://bugzilla.mozilla.org/show_bug.cgi?id=985928
