### PR TITLE
Bug 989248 - Set debugger.remote-mode to adb-devtools when DEVICE_DEBUG=...

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -325,7 +325,7 @@ function execute(options) {
   settings['language.current'] = config.GAIA_DEFAULT_LOCALE;
 
   if (config.DEVICE_DEBUG) {
-    settings['debugger.remote-mode'] = 'adb-only';
+    settings['debugger.remote-mode'] = 'adb-devtools';
     settings['screen.timeout'] = 0;
     settings['lockscreen.enabled'] = false;
     settings['lockscreen.locked'] = false;


### PR DESCRIPTION
...1 at build time

https://bugzilla.mozilla.org/show_bug.cgi?id=989248
