### PR TITLE
[bug 988747] email body text should not use Fira Mono font

### DIFF
--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -100,7 +100,8 @@ input.cmp-subject-text {
   margin: 1rem 1.5rem;
   display: block;
   padding: 0rem;
-  font-size: 1.7rem;
+  font-family: sans-serif;
+  font-size: 1.6rem;
   line-height: 1.9rem;
   font-weight: normal;
   border: none;


### PR DESCRIPTION
The email body is a <textarea>, which defaults to monospaced; but we should display it with our normal sans-serif font instead.
I also adjusted the font-size to better match other elements on the page, now that it's the same font.
Not sure if a corresponding line-height adjustment would also be appropriate; I have not actually built and tested this change yet.
