### PR TITLE
Bug 989353 - [gaia build system] Follow-up to Bug 897352: escape the ':'...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ include build/common.mk
 # copy template function for each apps in build_stage, it can avoid copy again
 # if the app doesn't have any change.
 define app-makefile-template
-$(1): $(call rwildcard,$(2),*) $(XULRUNNER_BASE_DIRECTORY) | $(STAGE_DIR)
+$(1): $(subst :,\:,$(call rwildcard,$(2),*)) $(XULRUNNER_BASE_DIRECTORY) | $(STAGE_DIR)
 	@if [[ ("$(2)" =~ "${BUILD_APP_NAME}") || (${BUILD_APP_NAME} == "*") ]]; then \
 		if [[ -e "$(2)/Makefile" ]]; then \
 			echo "execute Makefile for $(shell basename $(2)) app" ; \

--- a/build/test/integration/build.test.js
+++ b/build/test/integration/build.test.js
@@ -514,6 +514,15 @@ suite('Build Integration tests', function() {
     );
   });
 
+  test('problematic files', function(done) {
+    exec('GAIA_APP_CONFIG=build/test/integration/problematic-apps.list make',
+      function(error, stdout, stderr) {
+        helper.checkError(error, stdout, stderr);
+        done();
+      }
+    );
+  });
+
   teardown(function() {
     rmrf('profile');
     rmrf('profile-debug');

--- a/build/test/integration/problematic-apps.list
+++ b/build/test/integration/problematic-apps.list
@@ -1,0 +1,1 @@
+build/test/apps/problematic-files


### PR DESCRIPTION
... character when building a target line r=yurenju
