### PR TITLE
Bug 989831 - [Camera] [MADAI]180 (portrait upside down) the indicator se...

### DIFF
--- a/apps/camera/style/indicators.css
+++ b/apps/camera/style/indicators.css
@@ -36,6 +36,14 @@
 }
 
 /**
+ * @deg180
+ */
+
+.deg180 .indicators {
+  left: auto; right: 0;
+}
+
+/**
  * visible
  */
 


### PR DESCRIPTION
Bug 989831 - [Camera] [MADAI]180 (portrait upside down) the indicator self-timer icon remains on the left instead of moving to the right
