### PR TITLE
Bug 990148 - [Calendar] increase specificity of Day View events selector on marionette tests r=gaye

### DIFF
--- a/apps/calendar/test/marionette/lib/views/day.js
+++ b/apps/calendar/test/marionette/lib/views/day.js
@@ -13,7 +13,8 @@ Day.prototype = {
   selector: '#day-view',
 
   get events() {
-    return this.findElements('.event');
+    // FIXME: use a very specific selector because of Bug 988079
+    return this.findElements('section[data-date].active .event');
   }
 
 };


### PR DESCRIPTION
:rage1: 
