### PR TITLE
Bug 969101: Initial implementation of a first-time use ping. r=fabrice

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -16,3 +16,4 @@ shared/js/setImmediate.js
 apps/gallery/test/unit/setImmediate_test.js
 apps/wappush/js/ext/**
 apps/keyboard/js/imes/jsavrophonetic/jsavrophonetic.js
+apps/system/js/uuid.js

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ GAIA_APP_TARGET?=engineering
 SIMULATOR?=0
 ifeq ($(SIMULATOR),1)
 DESKTOP=1
-NO_FTU=1
+NOFTU=1
+NOFTUPING=1
 DEVICE_DEBUG=1
 endif
 
@@ -89,6 +90,8 @@ endif
 DESKTOP?=$(DEBUG)
 # Disable first time experience screen
 NOFTU?=0
+# Disable first time ping
+NOFTUPING?=0
 # Automatically enable remote debugger
 REMOTE_DEBUGGER?=0
 
@@ -99,12 +102,20 @@ endif
 # We also disable FTU when running in Firefox or in debug mode
 ifeq ($(DEBUG),1)
 NOFTU=1
+NOFTUPING=1
 PROFILE_FOLDER?=profile-debug
 else ifeq ($(DESKTOP),1)
 NOFTU=1
+NOFTUPING=1
 PROFILE_FOLDER?=profile-debug
 else ifeq ($(MAKECMDGOALS),test-integration)
 PROFILE_FOLDER?=profile-test
+endif
+
+ifeq ($(NOFTUPING), 0)
+FTU_PING_URL?=https://fxos.telemetry.mozilla.org/submit/telemetry
+else
+$(warning NO_FTU_PING=1)
 endif
 
 PROFILE_FOLDER?=profile
@@ -370,7 +381,8 @@ define BUILD_CONFIG
 	"REMOTE_DEBUGGER" : "$(REMOTE_DEBUGGER)", \
 	"TARGET_BUILD_VARIANT" : "$(TARGET_BUILD_VARIANT)", \
 	"SETTINGS_PATH" : "$(SETTINGS_PATH)", \
-	"VARIANT_PATH" : "$(VARIANT_PATH)" \
+	"VARIANT_PATH" : "$(VARIANT_PATH)", \
+	"FTU_PING_URL": "$(FTU_PING_URL)" \
 }
 endef
 export BUILD_CONFIG

--- a/apps/homescreen/test/unit/mock_xmlhttprequest.js
+++ b/apps/homescreen/test/unit/mock_xmlhttprequest.js
@@ -19,14 +19,17 @@
     throwAtNextSend = false;
     objectToThrow = null;
     delete MockXMLHttpRequest.mLastOpenedUrl;
+    delete MockXMLHttpRequest.mLastSendData;
+    MockXMLHttpRequest.mHeaders = {};
     lastInstance = null;
   }
 
-  function mxhr_send() {
+  function mxhr_send(data) {
     if (throwAtNextSend) {
       throwAtNextSend = false;
       throw objectToThrow;
     }
+    MockXMLHttpRequest.mLastSendData = data;
   }
 
   function mxhr_open(method, url, opts) {
@@ -35,6 +38,10 @@
 
   function mxhr_mSendError() {
     lastInstance && lastInstance.onerror && lastInstance.onerror();
+  }
+
+  function mxhr_mSendTimeout() {
+    lastInstance && lastInstance.ontimeout && lastInstance.ontimeout();
   }
 
   function mxhr_mOnLoad(states) {
@@ -58,16 +65,22 @@
     }
   }
 
+  function mxhr_mSetRequestHeader(key, val) {
+    MockXMLHttpRequest.mHeaders[key] = val;
+  }
+
   MockXMLHttpRequest.prototype = {
     open: mxhr_open,
     send: mxhr_send,
     DONE: XMLHttpRequest.prototype.DONE,
-    overrideMimeType: function() {}
+    overrideMimeType: function() {},
+    setRequestHeader: mxhr_mSetRequestHeader
   };
 
   MockXMLHttpRequest.mThrowAtNextSend = mxhr_mThrowAtNextSend;
   MockXMLHttpRequest.mTeardown = mxhr_mTeardown;
   MockXMLHttpRequest.mSendError = mxhr_mSendError;
+  MockXMLHttpRequest.mSendTimeout = mxhr_mSendTimeout;
   MockXMLHttpRequest.mSendOnLoad = mxhr_mOnLoad;
   MockXMLHttpRequest.mSendReadyState = mxhr_mSendReadyState;
   MockXMLHttpRequest.DONE = XMLHttpRequest.DONE;

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -134,6 +134,10 @@
     <!-- FTU launcher -->
     <script defer src="js/ftu_launcher.js"></script>
 
+    <!-- FTU ping -->
+    <script defer src="js/uuid.js"></script>
+    <script defer src="js/ftu_ping.js"></script>
+
     <!-- ICC/STK -->
     <!-- This depends on ftu_launcher.js, please load it in order ;) -->
     <link rel="stylesheet" type="text/css" href="style/icc.css">

--- a/apps/system/js/ftu_launcher.js
+++ b/apps/system/js/ftu_launcher.js
@@ -134,6 +134,7 @@ var FtuLauncher = {
   // Used by Bootstrap module.
   retrieve: function fl_retrieve() {
     var self = this;
+    FtuPing.ensurePing();
     window.asyncStorage.getItem('ftu.enabled', function getItem(launchFTU) {
       if (launchFTU === false) {
         self.skip();

--- a/apps/system/js/ftu_ping.js
+++ b/apps/system/js/ftu_ping.js
@@ -1,0 +1,388 @@
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+/* global MobileOperator, uuid, dump */
+
+/**
+ * A simple ping that is kicked off on first time use
+ */
+var FtuPing = (function() {
+  var DEBUG = false;
+
+  var debug = DEBUG ? function(msg) {
+    dump('[FtuPing] ' + msg + '\n');
+  } : function() {};
+
+  var FTU_PING_ACTIVATION = 'ftu.pingActivation';
+  var FTU_PING_ENABLED = 'ftu.pingEnabled';
+  var FTU_PING_ID = 'ftu.pingID';
+  var FTU_PING_MAX_NETWORK_FAILS = 'ftu.pingMaxNetworkFails';
+  var FTU_PING_NETWORK_FAIL_COUNT = 'ftu.pingNetworkFailCount';
+  var FTU_PING_URL = 'ftu.pingURL';
+  var FTU_PING_TIMEOUT = 'ftu.pingTimeout';
+  var FTU_PING_TRY_INTERVAL = 'ftu.pingTryInterval';
+
+  var DEFAULT_TRY_INTERVAL = 60 * 60 * 1000;
+  var DEFAULT_MAX_NETWORK_FAILS = 24;
+  var DEFAULT_PING_TIMEOUT = 60 * 1000;
+
+  // Used by the telemetry server to help identify the payload format
+  var PING_PAYLOAD_VERSION = 3;
+
+  // whether or not required properties have been loaded
+  var pingReady = false;
+  var pingReadyCallback = null;
+
+  // interval timer for first time ping
+  var pingTimer = null;
+
+  // time between ping tries
+  var tryInterval = DEFAULT_TRY_INTERVAL;
+
+  // URL for first time ping
+  var pingURL = null;
+
+  // Whether or not FTU ping is enabled
+  var pingEnabled = true;
+
+  // The number of times to wait for SIM / voice network data before sending
+  // the ping anyway
+  var maxNetworkFails = DEFAULT_MAX_NETWORK_FAILS;
+
+  // Number of network failures accrued
+  var networkFailCount = 0;
+
+  // Data used in ping
+  var pingData = {};
+
+  // Timeout for ping requests
+  var pingTimeout = DEFAULT_PING_TIMEOUT;
+
+  // Settings to observe value changes for while the ping has not been sent
+  var observeSettings = ['deviceinfo.os',
+                         'deviceinfo.software',
+                         'deviceinfo.platform_build_id',
+                         'deviceinfo.platform_version',
+                         'deviceinfo.product_model',
+                         'deviceinfo.firmware_revision',
+                         'deviceinfo.hardware',
+                         'deviceinfo.update_channel'];
+
+  function reset() {
+    pingReady = false;
+    pingReadyCallback = null;
+    pingTimer = null;
+    tryInterval = DEFAULT_TRY_INTERVAL;
+    pingTimeout = DEFAULT_PING_TIMEOUT;
+
+    pingURL = null;
+    pingEnabled = true;
+
+    maxNetworkFails = DEFAULT_MAX_NETWORK_FAILS;
+    networkFailCount = 0;
+
+    pingData = {};
+  }
+
+  function initSettings(callback) {
+    reset();
+
+    pingData.ver = PING_PAYLOAD_VERSION;
+    pingData.screenHeight = window.screen.height;
+    pingData.screenWidth = window.screen.width;
+    pingData.devicePixelRatio = window.devicePixelRatio;
+    pingData.locale = window.navigator.language;
+
+    getAsyncStorageItems([FTU_PING_ID, FTU_PING_ACTIVATION, FTU_PING_ENABLED,
+                          FTU_PING_NETWORK_FAIL_COUNT], function(items) {
+
+        pingData.pingID = items[FTU_PING_ID];
+        pingData.activationTime = items[FTU_PING_ACTIVATION];
+        pingEnabled = items[FTU_PING_ENABLED];
+
+        if (!pingData.pingID) {
+          pingData.pingID = uuid();
+          window.asyncStorage.setItem(FTU_PING_ID, pingData.pingID);
+        }
+
+        if (!pingData.activationTime) {
+          pingData.activationTime = Date.now();
+          window.asyncStorage.setItem(FTU_PING_ACTIVATION,
+                                      pingData.activationTime);
+        }
+
+        if (pingEnabled === null) {
+          pingEnabled = true;
+        }
+
+        if (typeof(items[FTU_PING_NETWORK_FAIL_COUNT]) === 'number') {
+          networkFailCount = items[FTU_PING_NETWORK_FAIL_COUNT];
+        }
+
+        var allSettings = [FTU_PING_URL, FTU_PING_TRY_INTERVAL,
+                           FTU_PING_TIMEOUT, FTU_PING_MAX_NETWORK_FAILS].
+                          concat(observeSettings);
+
+        getSettings(allSettings, function(settings) {
+          pingURL = settings[FTU_PING_URL];
+          tryInterval = settings[FTU_PING_TRY_INTERVAL] || tryInterval;
+          pingTimeout = settings[FTU_PING_TIMEOUT] || pingTimeout;
+          maxNetworkFails = settings[FTU_PING_MAX_NETWORK_FAILS] ||
+                            maxNetworkFails;
+
+          var mozSettings = window.navigator.mozSettings;
+          observeSettings.forEach(function(observeSetting) {
+            pingData[observeSetting] = settings[observeSetting];
+            mozSettings.addObserver(observeSetting, onSettingChanged);
+          });
+
+          if (callback) {
+            callback();
+          }
+        });
+    });
+  }
+
+  function getAsyncStorageItems(itemKeys, callback) {
+    var itemsLeft = itemKeys.length;
+    var items = {};
+    itemKeys.forEach(function(key) {
+      window.asyncStorage.getItem(key, function(value) {
+        itemsLeft--;
+        items[key] = value;
+        if (itemsLeft === 0 && callback) {
+          callback(items);
+        }
+      });
+    });
+  }
+
+  function getSettings(settingKeys, callback) {
+    var settingsLeft = settingKeys.length;
+    var settings = {};
+    var lock = window.navigator.mozSettings.createLock();
+    settingKeys.forEach(function(key) {
+      var request = lock.get(key);
+      request.onsuccess = function(evt) {
+        var value = request.result[key];
+        settingsLeft--;
+        settings[key] = value;
+        if (settingsLeft === 0 && callback) {
+          callback(settings);
+        }
+      };
+    });
+  }
+
+  function ensurePing() {
+    initSettings(function() {
+      FtuPing.startPing();
+    });
+  }
+
+  function onSettingChanged(evt) {
+    pingData[evt.settingName] = evt.settingValue;
+  }
+
+  function startPing() {
+    if (pingEnabled === false) {
+      debug('FTU ping disabled');
+      return;
+    }
+
+    if (!pingURL) {
+      debug('No FTU ping URL');
+      return;
+    }
+    if (pingTimer !== null) {
+        return;
+    }
+
+    debug('Starting FTU ping');
+    pingTimer = setInterval(tryPing, tryInterval);
+  }
+
+  function tryPing() {
+    // Wait until we have a valid network connection
+    var conns = window.navigator.mozMobileConnections;
+    if (!conns || conns.length === 0) {
+      networkFailCount++;
+      window.asyncStorage.setItem(FTU_PING_NETWORK_FAIL_COUNT,
+                                  networkFailCount);
+
+      if (networkFailCount < maxNetworkFails) {
+        debug('No mobile connections, holding off (' + networkFailCount +
+              ' of ' + maxNetworkFails + ')');
+        return false;
+      }
+    } else {
+      var conn = conns[0];
+      var iccObj = navigator.mozIccManager.getIccById(conn.iccId);
+      var iccInfo = iccObj ? iccObj.iccInfo : null;
+      var voiceNetwork = conn.voice ? conn.voice.network : null;
+
+      if (!iccInfo && !voiceNetwork) {
+        networkFailCount++;
+        window.asyncStorage.setItem(FTU_PING_NETWORK_FAIL_COUNT,
+                                    networkFailCount);
+
+        if (networkFailCount < maxNetworkFails) {
+          debug('No SIM card or voice network, holding off (' +
+                networkFailCount + ' of ' + maxNetworkFails + ')');
+          return false;
+        }
+      } else {
+        pingData.network = MobileOperator.userFacingInfo(conn);
+        if (voiceNetwork) {
+          pingData.network.mnc = voiceNetwork.mnc;
+          pingData.network.mcc = voiceNetwork.mcc;
+        }
+
+        if (iccInfo) {
+          pingData.icc = {
+            mnc: iccInfo.mnc,
+            mcc: iccInfo.mcc,
+            spn: iccInfo.spn
+          };
+        }
+      }
+    }
+
+    if (networkFailCount >= maxNetworkFails) {
+      debug('Max number of voice network failures reached, pinging anyway!');
+      if (pingData.network === undefined) {
+        pingData.network = null;
+      }
+
+      if (pingData.icc === undefined) {
+        pingData.icc = null;
+      }
+    }
+
+    if (!pingData['deviceinfo.os']) {
+      debug('No OS information, holding off');
+      return false;
+    }
+
+    FtuPing.ping();
+    return true;
+  }
+
+  function generatePingURL() {
+    var version = pingData['deviceinfo.platform_version'] || 'unknown';
+    var updateChannel = pingData['deviceinfo.update_channel'] || 'unknown';
+    var buildId = pingData['deviceinfo.platform_build_id'] || 'unknown';
+
+    var uriParts = [
+      pingURL,
+      encodeURIComponent(pingData.pingID),
+      'ftu',                             // 'reason'
+      'FirefoxOS',                       // 'appName'
+      encodeURIComponent(version),       // 'appVersion'
+      encodeURIComponent(updateChannel), // 'appUpdateChannel'
+      encodeURIComponent(buildId)        // 'appBuildID'
+    ];
+
+    return uriParts.join('/');
+  }
+
+  function ping() {
+    var url = generatePingURL();
+    pingData.pingTime = Date.now();
+
+    debug(url);
+    debug(JSON.stringify(pingData));
+
+    var xhr = new XMLHttpRequest({ mozSystem: true, mozAnon: true });
+    xhr.timeout = pingTimeout;
+
+    xhr.onload = function() {
+      FtuPing.pingSuccess(xhr.responseText);
+    };
+
+    xhr.ontimeout = function() {
+      FtuPing.pingError('Timed out');
+    };
+
+    xhr.onerror = function() {
+      FtuPing.pingError(xhr.statusText);
+    };
+
+    xhr.open('POST', url, true);
+    xhr.setRequestHeader('Content-type', 'application/json');
+    xhr.responseType = 'text';
+    xhr.send(JSON.stringify(pingData));
+  }
+
+  function pingSuccess(result) {
+    if (result !== 'OK') {
+      debug('Ping response unexpected: ' + result);
+      return;
+    }
+
+    pingEnabled = false;
+    window.asyncStorage.setItem(FTU_PING_ENABLED, false);
+
+    var settings = window.navigator.mozSettings;
+    observeSettings.forEach(function(setting) {
+      settings.removeObserver(setting, onSettingChanged);
+    });
+
+    clearInterval(pingTimer);
+  }
+
+  function pingError(message) {
+    debug('Ping error: ' + message);
+  }
+
+  function isEnabled() {
+    return pingEnabled;
+  }
+
+  function getPingURL() {
+    return pingURL;
+  }
+
+  function getPingData() {
+    return pingData;
+  }
+
+  function getNetworkFailCount() {
+    return networkFailCount;
+  }
+
+  function getTryInterval() {
+    return tryInterval;
+  }
+
+  function getPingTimeout() {
+    return pingTimeout;
+  }
+
+  function getMaxNetworkFails() {
+    return maxNetworkFails;
+  }
+
+  return {
+    ensurePing: ensurePing,
+    generatePingURL: generatePingURL,
+    getAsyncStorageItems: getAsyncStorageItems,
+    getMaxNetworkFails: getMaxNetworkFails,
+    getNetworkFailCount: getNetworkFailCount,
+    getPingData: getPingData,
+    getPingTimeout: getPingTimeout,
+    getPingURL: getPingURL,
+    getSettings: getSettings,
+    getTryInterval: getTryInterval,
+    initSettings: initSettings,
+    isEnabled: isEnabled,
+    ping: ping,
+    pingError: pingError,
+    pingSuccess: pingSuccess,
+    reset: reset,
+    startPing: startPing,
+    tryPing: tryPing
+  };
+})();

--- a/apps/system/js/uuid.js
+++ b/apps/system/js/uuid.js
@@ -1,0 +1,235 @@
+//     node-uuid/uuid.js
+//
+//     Copyright (c) 2010 Robert Kieffer
+//     Dual licensed under the MIT and GPL licenses.
+//     Documentation and details at https://github.com/broofa/node-uuid
+(function() {
+  var _global = this;
+
+  // Unique ID creation requires a high quality random # generator, but
+  // Math.random() does not guarantee "cryptographic quality".  So we feature
+  // detect for more robust APIs, normalizing each method to return 128-bits
+  // (16 bytes) of random data.
+  var mathRNG, nodeRNG, whatwgRNG;
+
+  // Math.random()-based RNG.  All platforms, very fast, unknown quality
+  var _rndBytes = new Array(16);
+  mathRNG = function() {
+    var r, b = _rndBytes, i = 0;
+
+    for (var i = 0, r; i < 16; i++) {
+      if ((i & 0x03) == 0) r = Math.random() * 0x100000000;
+      b[i] = r >>> ((i & 0x03) << 3) & 0xff;
+    }
+
+    return b;
+  }
+
+  // Node.js crypto-based RNG - http://nodejs.org/docs/v0.6.2/api/crypto.html
+  // Node.js only, moderately fast, high quality
+  try {
+    var _rb = require('crypto').randomBytes;
+    nodeRNG = _rb && function() {
+      return _rb(16);
+    };
+  } catch (e) {}
+
+  // Select RNG with best quality
+  var _rng = nodeRNG || whatwgRNG || mathRNG;
+
+  // Buffer class to use
+  var BufferClass = typeof(Buffer) == 'function' ? Buffer : Array;
+
+  // Maps for number <-> hex string conversion
+  var _byteToHex = [];
+  var _hexToByte = {};
+  for (var i = 0; i < 256; i++) {
+    _byteToHex[i] = (i + 0x100).toString(16).substr(1);
+    _hexToByte[_byteToHex[i]] = i;
+  }
+
+  // **`parse()` - Parse a UUID into it's component bytes**
+  function parse(s, buf, offset) {
+    var i = (buf && offset) || 0, ii = 0;
+
+    buf = buf || [];
+    s.toLowerCase().replace(/[0-9a-f]{2}/g, function(oct) {
+      if (ii < 16) { // Don't overflow!
+        buf[i + ii++] = _hexToByte[oct];
+      }
+    });
+
+    // Zero out remaining bytes if string was short
+    while (ii < 16) {
+      buf[i + ii++] = 0;
+    }
+
+    return buf;
+  }
+
+  // **`unparse()` - Convert UUID byte array (ala parse()) into a string**
+  function unparse(buf, offset) {
+    var i = offset || 0, bth = _byteToHex;
+    return  bth[buf[i++]] + bth[buf[i++]] +
+            bth[buf[i++]] + bth[buf[i++]] + '-' +
+            bth[buf[i++]] + bth[buf[i++]] + '-' +
+            bth[buf[i++]] + bth[buf[i++]] + '-' +
+            bth[buf[i++]] + bth[buf[i++]] + '-' +
+            bth[buf[i++]] + bth[buf[i++]] +
+            bth[buf[i++]] + bth[buf[i++]] +
+            bth[buf[i++]] + bth[buf[i++]];
+  }
+
+  // **`v1()` - Generate time-based UUID**
+  //
+  // Inspired by https://github.com/LiosK/UUID.js
+  // and http://docs.python.org/library/uuid.html
+
+  // random #'s we need to init node and clockseq
+  var _seedBytes = _rng();
+
+  // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
+  var _nodeId = [
+    _seedBytes[0] | 0x01,
+    _seedBytes[1], _seedBytes[2], _seedBytes[3], _seedBytes[4], _seedBytes[5]
+  ];
+
+  // Per 4.2.2, randomize (14 bit) clockseq
+  var _clockseq = (_seedBytes[6] << 8 | _seedBytes[7]) & 0x3fff;
+
+  // Previous uuid creation time
+  var _lastMSecs = 0, _lastNSecs = 0;
+
+  // See https://github.com/broofa/node-uuid for API details
+  function v1(options, buf, offset) {
+    var i = buf && offset || 0;
+    var b = buf || [];
+
+    options = options || {};
+
+    var clockseq = options.clockseq != null ? options.clockseq : _clockseq;
+
+    // UUID timestamps are 100 nano-second units since the Gregorian epoch,
+    // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
+    // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
+    // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
+    var msecs = options.msecs != null ? options.msecs : new Date().getTime();
+
+    // Per 4.2.1.2, use count of uuid's generated during the current clock
+    // cycle to simulate higher resolution clock
+    var nsecs = options.nsecs != null ? options.nsecs : _lastNSecs + 1;
+
+    // Time since last uuid creation (in msecs)
+    var dt = (msecs - _lastMSecs) + (nsecs - _lastNSecs)/10000;
+
+    // Per 4.2.1.2, Bump clockseq on clock regression
+    if (dt < 0 && options.clockseq == null) {
+      clockseq = clockseq + 1 & 0x3fff;
+    }
+
+    // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
+    // time interval
+    if ((dt < 0 || msecs > _lastMSecs) && options.nsecs == null) {
+      nsecs = 0;
+    }
+
+    // Per 4.2.1.2 Throw error if too many uuids are requested
+    if (nsecs >= 10000) {
+      throw new Error('uuid.v1(): Can\'t create more than 10M uuids/sec');
+    }
+
+    _lastMSecs = msecs;
+    _lastNSecs = nsecs;
+    _clockseq = clockseq;
+
+    // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
+    msecs += 12219292800000;
+
+    // `time_low`
+    var tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
+    b[i++] = tl >>> 24 & 0xff;
+    b[i++] = tl >>> 16 & 0xff;
+    b[i++] = tl >>> 8 & 0xff;
+    b[i++] = tl & 0xff;
+
+    // `time_mid`
+    var tmh = (msecs / 0x100000000 * 10000) & 0xfffffff;
+    b[i++] = tmh >>> 8 & 0xff;
+    b[i++] = tmh & 0xff;
+
+    // `time_high_and_version`
+    b[i++] = tmh >>> 24 & 0xf | 0x10; // include version
+    b[i++] = tmh >>> 16 & 0xff;
+
+    // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
+    b[i++] = clockseq >>> 8 | 0x80;
+
+    // `clock_seq_low`
+    b[i++] = clockseq & 0xff;
+
+    // `node`
+    var node = options.node || _nodeId;
+    for (var n = 0; n < 6; n++) {
+      b[i + n] = node[n];
+    }
+
+    return buf ? buf : unparse(b);
+  }
+
+  // **`v4()` - Generate random UUID**
+
+  // See https://github.com/broofa/node-uuid for API details
+  function v4(options, buf, offset) {
+    // Deprecated - 'format' argument, as supported in v1.2
+    var i = buf && offset || 0;
+
+    if (typeof(options) == 'string') {
+      buf = options == 'binary' ? new BufferClass(16) : null;
+      options = null;
+    }
+    options = options || {};
+
+    var rnds = options.random || (options.rng || _rng)();
+
+    // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+    rnds[6] = (rnds[6] & 0x0f) | 0x40;
+    rnds[8] = (rnds[8] & 0x3f) | 0x80;
+
+    // Copy bytes to buffer, if provided
+    if (buf) {
+      for (var ii = 0; ii < 16; ii++) {
+        buf[i + ii] = rnds[ii];
+      }
+    }
+
+    return buf || unparse(rnds);
+  }
+
+  // Export public API
+  var uuid = v4;
+  uuid.v1 = v1;
+  uuid.v4 = v4;
+  uuid.parse = parse;
+  uuid.unparse = unparse;
+  uuid.BufferClass = BufferClass;
+
+  // Export RNG options
+  uuid.mathRNG = mathRNG;
+  uuid.nodeRNG = nodeRNG;
+  uuid.whatwgRNG = whatwgRNG;
+
+  if (typeof(module) != 'undefined') {
+    // Play nice with node.js
+    module.exports = uuid;
+  } else {
+    // Play nice with browsers
+    var _previousRoot = _global.uuid;
+
+    // **`noConflict()` - (browser only) to reset global 'uuid' var**
+    uuid.noConflict = function() {
+      _global.uuid = _previousRoot;
+      return uuid;
+    }
+    _global.uuid = uuid;
+  }
+}());

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -42,7 +42,8 @@
     "input":{},
     "input-manage":{},
     "nfc":{ "access": "readonly" },
-    "nfc-manager":{}
+    "nfc-manager":{},
+    "systemXHR":{}
   },
   "locales": {
     "ar": {

--- a/apps/system/test/unit/ftu_ping_test.js
+++ b/apps/system/test/unit/ftu_ping_test.js
@@ -1,0 +1,418 @@
+'use strict';
+
+/* global MockNavigatorSettings, MockasyncStorage,
+          MockNavigatorMozMobileConnections, MockNavigatorMozIccManager,
+          MockMobileOperator, FtuPing, sinon */
+
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js');
+require('/shared/test/unit/mocks/mock_navigator_moz_icc_manager.js');
+require('/shared/test/unit/mocks/mock_mobile_operator.js');
+
+requireApp('system/test/unit/mock_asyncStorage.js');
+requireApp('system/js/uuid.js');
+requireApp('system/js/ftu_ping.js');
+
+if (!window.asyncStorage) {
+  window.asyncStorage = null;
+}
+
+if (!window.MobileOperator) {
+  window.MobileOperator = null;
+}
+
+suite('FtuPing', function() {
+  var realMozSettings, realAsyncStorage;
+  var realMobileConnections, realIccManager;
+  var realMobileOperator;
+
+  suiteSetup(function() {
+    realMozSettings = navigator.mozSettings;
+    realAsyncStorage = window.asyncStorage;
+    realMobileConnections = navigator.mozMobileConnections;
+    realIccManager = navigator.mozIccManager;
+    realMobileOperator = window.MobileOperator;
+
+    navigator.mozSettings = MockNavigatorSettings;
+    window.asyncStorage = MockasyncStorage;
+
+    navigator.mozMobileConnections = MockNavigatorMozMobileConnections;
+    navigator.mozIccManager = MockNavigatorMozIccManager;
+    window.MobileOperator = MockMobileOperator;
+  });
+
+  suiteTeardown(function() {
+    navigator.mozSettings = realMozSettings;
+    window.asyncStorage = realAsyncStorage;
+    navigator.mozMobileConnections = realMobileConnections;
+    navigator.mozIccManager = realIccManager;
+    window.MobileOperator = realMobileOperator;
+  });
+
+  teardown(function() {
+    MockNavigatorSettings.mTeardown();
+    MockasyncStorage.mTeardown();
+    MockNavigatorMozMobileConnections.mTeardown();
+    MockMobileOperator.mTeardown();
+    FtuPing.reset();
+  });
+
+  suite('generatePingURL', function() {
+    setup(function() {
+      MockNavigatorSettings.mSettings['ftu.pingURL'] = 'test_url';
+      MockasyncStorage.mItems['ftu.pingID'] = 'test_id';
+    });
+
+    test('returns expected url', function(done) {
+      var mockSettings = MockNavigatorSettings.mSettings;
+      mockSettings['deviceinfo.platform_version'] = 'test_version';
+      mockSettings['deviceinfo.update_channel'] = 'test_channel';
+      mockSettings['deviceinfo.platform_build_id'] = 'test_build_id';
+
+      FtuPing.initSettings(function() {
+        var url = FtuPing.generatePingURL();
+        assert.equal(url, 'test_url/test_id/ftu/FirefoxOS/test_version/' +
+                          'test_channel/test_build_id');
+        done();
+      });
+    });
+
+    test('returns unknown for empty properties', function(done) {
+      FtuPing.initSettings(function() {
+        var url = FtuPing.generatePingURL();
+        assert.equal(url, 'test_url/test_id/ftu/FirefoxOS/unknown/unknown/' +
+                          'unknown');
+        done();
+      });
+    });
+
+    test('encodes URI parameters', function(done) {
+      var mockSettings = MockNavigatorSettings.mSettings;
+      mockSettings['deviceinfo.platform_version'] = 'i have/';
+      mockSettings['deviceinfo.update_channel'] = 'lots of:';
+      mockSettings['deviceinfo.platform_build_id'] = 'spaces man?';
+      FtuPing.initSettings(function() {
+        var url = FtuPing.generatePingURL();
+        assert.equal(url, 'test_url/test_id/ftu/FirefoxOS/i%20have%2F/' +
+                          'lots%20of%3A/spaces%20man%3F');
+        done();
+      });
+    });
+  });
+
+  test('getAsyncStorageItems gets all items', function(done) {
+    this.timeout(5000);
+    MockasyncStorage.mItems.a = 1;
+    MockasyncStorage.mItems.b = 2;
+    MockasyncStorage.mItems.c = 3;
+    FtuPing.getAsyncStorageItems(['a', 'b', 'c'], function(items) {
+      assert.equal(items.a, 1);
+      assert.equal(items.b, 2);
+      assert.equal(items.c, 3);
+      done();
+    });
+  });
+
+  test('getSettings gets all settings', function(done) {
+    this.timeout(5000);
+    MockNavigatorSettings.mSettings.a = 1;
+    MockNavigatorSettings.mSettings.b = 2;
+    MockNavigatorSettings.mSettings.c = 3;
+    FtuPing.getSettings(['a', 'b', 'c'], function(settings) {
+      assert.equal(settings.a, 1);
+      assert.equal(settings.b, 2);
+      assert.equal(settings.c, 3);
+      done();
+    });
+  });
+
+  suite('ensurePing', function() {
+    var realStartPing;
+    var doneCallback;
+
+    setup(function() {
+      realStartPing = FtuPing.startPing;
+      FtuPing.startPing = function() {
+        if (doneCallback) {
+          doneCallback();
+        }
+      };
+      MockNavigatorSettings.mSettings['ftu.pingURL'] = 'test_url';
+    });
+
+    teardown(function() {
+      FtuPing.startPing = realStartPing;
+      doneCallback = null;
+    });
+
+    test('window properties are set', function(done) {
+      this.timeout(3000);
+      doneCallback = function() {
+        var pingData = FtuPing.getPingData();
+        assert.equal(pingData.screenHeight, window.screen.height);
+        assert.equal(pingData.screenWidth, window.screen.width);
+        assert.equal(pingData.devicePixelRatio, window.devicePixelRatio);
+        assert.equal(pingData.locale, navigator.language);
+        done();
+      };
+      FtuPing.ensurePing();
+    });
+
+    test('empty settings are generated', function(done) {
+      this.timeout(3000);
+      doneCallback = function() {
+        var pingData = FtuPing.getPingData();
+        assert.equal(pingData.ver, 3);
+        assert.ok(pingData.pingID);
+        assert.equal(pingData.pingID, MockasyncStorage.mItems['ftu.pingID']);
+
+        assert.ok(pingData.activationTime);
+        assert.equal(pingData.activationTime,
+                     MockasyncStorage.mItems['ftu.pingActivation']);
+
+        assert.ok(FtuPing.isEnabled());
+        assert.equal(FtuPing.getNetworkFailCount(), 0);
+
+        assert.equal(FtuPing.getTryInterval(), 60 * 60 * 1000);
+        assert.equal(FtuPing.getPingTimeout(), 60 * 1000);
+        assert.equal(FtuPing.getMaxNetworkFails(), 24);
+        done();
+      };
+      FtuPing.ensurePing();
+    });
+
+    test('existing settings are set', function(done) {
+      this.timeout(3000);
+      MockasyncStorage.mItems['ftu.pingID'] = 'test_ping_id';
+      MockasyncStorage.mItems['ftu.pingActivation'] = 'test_activation';
+      MockasyncStorage.mItems['ftu.pingEnabled'] = false;
+      MockasyncStorage.mItems['ftu.pingNetworkFailCount'] = 10;
+
+      var mockSettings = MockNavigatorSettings.mSettings;
+      mockSettings['ftu.pingTryInterval'] = 10000;
+      mockSettings['ftu.pingTimeout'] = 1000;
+      mockSettings['ftu.pingMaxNetworkFails'] = 100;
+      mockSettings['deviceinfo.os'] = 'test_os';
+      mockSettings['deviceinfo.software'] = 'test_software';
+      mockSettings['deviceinfo.platform_build_id'] = 'test_build_id';
+      mockSettings['deviceinfo.platform_version'] = 'test_version';
+      mockSettings['deviceinfo.product_model'] = 'test_model';
+      mockSettings['deviceinfo.firmware_revision'] = 'test_revision';
+      mockSettings['deviceinfo.hardware'] = 'test_hardware';
+      mockSettings['deviceinfo.update_channel'] = 'test_channel';
+
+      doneCallback = function() {
+        var pingData = FtuPing.getPingData();
+        assert.equal(pingData.pingID, 'test_ping_id');
+        assert.equal(pingData.activationTime, 'test_activation');
+        assert.equal(FtuPing.isEnabled(), false);
+        assert.equal(FtuPing.getNetworkFailCount(), 10);
+        assert.equal(FtuPing.getPingURL(), 'test_url');
+        assert.equal(FtuPing.getTryInterval(), 10000);
+        assert.equal(FtuPing.getPingTimeout(), 1000);
+        assert.equal(FtuPing.getMaxNetworkFails(), 100);
+
+        assert.equal(pingData['deviceinfo.os'], 'test_os');
+        assert.equal(pingData['deviceinfo.software'], 'test_software');
+        assert.equal(pingData['deviceinfo.platform_build_id'], 'test_build_id');
+        assert.equal(pingData['deviceinfo.platform_version'], 'test_version');
+        assert.equal(pingData['deviceinfo.product_model'], 'test_model');
+        assert.equal(pingData['deviceinfo.firmware_revision'], 'test_revision');
+        assert.equal(pingData['deviceinfo.hardware'], 'test_hardware');
+        assert.equal(pingData['deviceinfo.update_channel'], 'test_channel');
+        done();
+      };
+      FtuPing.ensurePing();
+    });
+
+    test('startPing is called from ensurePing', function(done) {
+      this.timeout(3000);
+      doneCallback = done;
+      FtuPing.ensurePing();
+    });
+  });
+
+  suite('tryPing', function() {
+    var realPing, pingCallback;
+    setup(function() {
+      realPing = FtuPing.ping;
+      FtuPing.ping = function() {
+        if (pingCallback) {
+          pingCallback();
+        }
+      };
+    });
+
+    teardown(function() {
+      FtuPing.ping = realPing;
+      pingCallback = null;
+    });
+
+    test('fails with no mobile connections', function() {
+      assert.ok(!FtuPing.tryPing());
+      assert.equal(FtuPing.getNetworkFailCount(), 1);
+    });
+
+    test('max mobile failures pings anyway', function(done) {
+      MockasyncStorage.mItems['ftu.pingNetworkFailCount'] = 1;
+      MockNavigatorSettings.mSettings['ftu.pingMaxNetworkFails'] = 1;
+      MockNavigatorSettings.mSettings['deviceinfo.os'] = 'test_os';
+
+      FtuPing.initSettings(function() {
+        assert.ok(FtuPing.tryPing());
+
+        var pingData = FtuPing.getPingData();
+        assert.ok(!pingData.network);
+        assert.ok(!pingData.icc);
+        done();
+      });
+    });
+
+    test('no deviceinfo.os fails', function(done) {
+      MockasyncStorage.mItems['ftu.pingNetworkFailCount'] = 1;
+      MockNavigatorSettings.mSettings['ftu.pingMaxNetworkFails'] = 1;
+      FtuPing.initSettings(function() {
+        assert.ok(!FtuPing.tryPing());
+        done();
+      });
+    });
+
+    test('iccinfo and voice network make it into pingData', function(done) {
+      MockNavigatorSettings.mSettings['deviceinfo.os'] = 'test_os';
+      MockNavigatorMozMobileConnections.mAddMobileConnection();
+
+      var mockConn = MockNavigatorMozMobileConnections[0];
+      mockConn.iccId = 'test_icc';
+      mockConn.voice = {
+        network: {
+          mnc: 'voice_mnc',
+          mcc: 'voice_mcc'
+        }
+      };
+
+      var mockIcc = {
+        iccInfo: {
+          mnc: 'icc_mnc',
+          mcc: 'icc_mcc',
+          spn: 'icc_spn'
+        }
+      };
+
+      MockNavigatorMozIccManager.addIcc('test_icc', mockIcc);
+      MockMobileOperator.mOperator = 'test_operator';
+      MockMobileOperator.mCarrier = 'test_carrier';
+      MockMobileOperator.mRegion = 'test_region';
+
+      FtuPing.initSettings(function() {
+        assert.ok(FtuPing.tryPing());
+
+        var pingData = FtuPing.getPingData();
+        assert.ok(pingData.icc);
+        assert.equal(pingData.icc.mnc, 'icc_mnc');
+        assert.equal(pingData.icc.mcc, 'icc_mcc');
+        assert.equal(pingData.icc.spn, 'icc_spn');
+
+        assert.ok(pingData.network);
+        assert.equal(pingData.network.mnc, 'voice_mnc');
+        assert.equal(pingData.network.mcc, 'voice_mcc');
+        assert.equal(pingData.network.operator, 'test_operator');
+        assert.equal(pingData.network.carrier, 'test_carrier');
+        assert.equal(pingData.network.region, 'test_region');
+        done();
+      });
+    });
+  });
+
+  suite('ping', function() {
+    var xhr, xhrRequests;
+
+    setup(function() {
+      MockNavigatorSettings.mSettings['ftu.pingURL'] = 'test_url';
+      MockasyncStorage.mItems['ftu.pingEnabled'] = true;
+      MockasyncStorage.mItems['ftu.pingID'] = 'test_id';
+
+      xhr = sinon.useFakeXMLHttpRequest();
+      xhrRequests = [];
+      xhr.onCreate = function(request) {
+        xhrRequests.push(request);
+        request.onreadystatechange = function() {
+          if (request.readyState == 4) {
+            if (request.status == 200 && request.onload) {
+              request.onload.call(request);
+            } else if (request.onerror) {
+              request.onerror.call(request);
+            }
+          }
+        };
+      };
+    });
+
+    teardown(function() {
+      xhr.restore();
+    });
+
+    test('pingData and url are valid', function(done) {
+      MockNavigatorSettings.mSettings['deviceinfo.os'] = 'test_os';
+
+      FtuPing.initSettings(function() {
+        FtuPing.ping();
+        assert.equal(xhrRequests.length, 1);
+        assert.equal(xhrRequests[0].url,
+                     'test_url/test_id/ftu/FirefoxOS/unknown/unknown/unknown');
+        assert.equal(xhrRequests[0].requestHeaders['Content-type'],
+                     'application/json');
+
+        var data = JSON.parse(xhrRequests[0].requestBody);
+        assert.equal(data['deviceinfo.os'], 'test_os');
+        done();
+      });
+    });
+
+    test('OK clears enabled flag', function(done) {
+      FtuPing.initSettings(function() {
+        FtuPing.ping();
+
+        assert.equal(xhrRequests.length, 1);
+        xhrRequests[0].respond(200, { 'Content-Type': 'text/plain' }, 'OK');
+        assert.equal(MockasyncStorage.mItems['ftu.pingEnabled'], false);
+        assert.equal(FtuPing.isEnabled(), false);
+        done();
+      });
+    });
+
+    test('bad response doesn\'t clear flag', function(done) {
+      FtuPing.initSettings(function() {
+        FtuPing.ping();
+
+        assert.equal(xhrRequests.length, 1);
+        xhrRequests[0].respond(200, { 'Content-Type': 'text/plain' }, 'bla');
+        assert.equal(MockasyncStorage.mItems['ftu.pingEnabled'], true);
+        assert.equal(FtuPing.isEnabled(), true);
+        done();
+      });
+    });
+
+    test('error doesn\'t clear flag', function(done) {
+      FtuPing.initSettings(function() {
+        FtuPing.ping();
+        xhrRequests[0].respond(404, {}, '');
+        assert.equal(MockasyncStorage.mItems['ftu.pingEnabled'], true);
+        assert.equal(FtuPing.isEnabled(), true);
+        done();
+      });
+    });
+
+    test('timeout doesn\'t clear flag', function(done) {
+      MockNavigatorSettings.mSettings['ftu.pingTimeout'] = 1;
+
+      FtuPing.initSettings(function() {
+        FtuPing.ping();
+        setTimeout(function() {
+          assert.equal(MockasyncStorage.mItems['ftu.pingEnabled'], true);
+          assert.equal(FtuPing.isEnabled(), true);
+          done();
+        }, 500);
+      });
+    });
+  });
+});

--- a/apps/system/test/unit/home_gesture_test.js
+++ b/apps/system/test/unit/home_gesture_test.js
@@ -35,6 +35,7 @@ suite('enable/disable homegesture', function() {
   });
 
   setup(function() {
+    MockNavigatorSettings.mSettings['homegesture.enabled'] = false;
     fakeHomebar = document.createElement('div');
     fakeHomebar.id = 'bottom-panel';
     document.body.appendChild(fakeHomebar);

--- a/build/settings.js
+++ b/build/settings.js
@@ -314,6 +314,9 @@ function execute(options) {
       config.GAIA_SCHEME, config.GAIA_DOMAIN, config.GAIA_PORT);
   }
 
+  // Set the ftu ping URL -- we set this regardless of NOFTU for now
+  settings['ftu.pingURL'] = config.FTU_PING_URL;
+
   if (config.PRODUCTION === '1') {
     settings['feedback.url'] = 'https://input.mozilla.org/api/v1/feedback/';
   }


### PR DESCRIPTION
v1.3 uplift
https://bugzilla.mozilla.org/show_bug.cgi?id=969101

Cherry picked from my 1.4 commit. The only non-minor conflict was the necessary use of `requireApp` in the FTU ping unit test, which passes locally. Using this function in master caused TBPL to fail, so I have a scheduled run here to make sure there is no bustage:

https://tbpl.mozilla.org/?tree=Try&rev=7a16ab65335e
