### PR TITLE
Bug 990998 - Use correct object scope when calling _doSetRadioEnabled

### DIFF
--- a/apps/system/js/radio.js
+++ b/apps/system/js/radio.js
@@ -114,17 +114,17 @@
           conn.radioState !== null) {
         this._doSetRadioEnabled(conn, enabled);
       } else {
-        conn.addEventListener('radiostatechange',
-          function radioStateChangeHandler() {
-            if (conn.radioState == 'enabling' ||
-                conn.radioState == 'disabling' ||
-                conn.radioState == null) {
-              return;
-            }
-            conn.removeEventListener('radiostatechange',
-              radioStateChangeHandler);
-            this._doSetRadioEnabled(conn, enabled);
-        });
+        var radioStateChangeHandler = (function radioStateChangeHandler() {
+          if (conn.radioState == 'enabling' ||
+              conn.radioState == 'disabling' ||
+              conn.radioState == null) {
+            return;
+          }
+          conn.removeEventListener('radiostatechange',
+            radioStateChangeHandler);
+          this._doSetRadioEnabled(conn, enabled);
+        }).bind(this);
+        conn.addEventListener('radiostatechange', radioStateChangeHandler);
       }
     },
 

--- a/apps/system/test/unit/radio_test.js
+++ b/apps/system/test/unit/radio_test.js
@@ -36,6 +36,20 @@ suite('Radio > ', function() {
     Radio._mozMobileConnections = null;
   });
 
+  suite('internal _doSetRadioEnabled', function() {
+    setup(function() {
+      Radio.enabled = true;
+      setConnection(0, 'enabled');
+      this.sinon.spy(Radio, '_doSetRadioEnabled');
+    });
+
+    test('is called', function() {
+      var conn = MockNavigatorMozMobileConnections[0];
+      conn.triggerEventListeners('radiostatechange');
+      sinon.assert.called(Radio._doSetRadioEnabled);
+    });
+  });
+
   suite('set enabled to true', function() {
     // make conn count back to 1 at first
     suiteSetup(function() {


### PR DESCRIPTION
Some code path to call this._doSetRadioEnabled() is not referring to the
correct object, this making the call to fail with 'this is undefined'.
