### PR TITLE
Bug 983459 - Notify of no voicemail number when tapping voicemail notification

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -259,6 +259,7 @@
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini">
     <link rel="resource" type="application/l10n" href="shared/locales/permissions.ini">
     <link rel="resource" type="application/l10n" href="shared/locales/download.ini">
+    <link rel="resource" type="application/l10n" href="shared/locales/voicemail.ini">
 
     <!-- Payment -->
     <script defer src="js/payment.js"></script>

--- a/apps/system/style/modal_dialog/modal_dialog.css
+++ b/apps/system/style/modal_dialog/modal_dialog.css
@@ -57,6 +57,7 @@
 .modal-dialog-message-container p {
   display:inline !important;
   word-wrap: break-word;
+  padding: 0;
 }
 
 /* Select one dialog */

--- a/apps/system/test/unit/mock_modal_dialog.js
+++ b/apps/system/test/unit/mock_modal_dialog.js
@@ -1,7 +1,7 @@
 var MockModalDialog = {
 
   mMethods: [
-    'alert'
+    'alert', 'confirm'
   ],
 
   mPopulate: function mmd_mPopulate() {

--- a/shared/locales/voicemail.ini
+++ b/shared/locales/voicemail.ini
@@ -1,0 +1,1 @@
+@import url(voicemail/voicemail.en-US.properties)

--- a/shared/locales/voicemail/voicemail.en-US.properties
+++ b/shared/locales/voicemail/voicemail.en-US.properties
@@ -1,0 +1,5 @@
+# Voicemail lacks of a number set
+voicemailNoNumberTitle = Voicemail number is unavailable
+voicemailNoNumberText = Unable to call the voicemail. Set up the voicemail number to place the call.
+voicemailNoNumberSettings = Settings
+voicemailNoNumberCancel = Cancel


### PR DESCRIPTION
If we don't have any voicemail number (on the SIM card nor configured in
Settings), when the user is tapping on the voicemail notification,
nothing will happen. This is confusing, so we implement a modal dialog
to notify of the lack of voicemail number configured, and we add a link
to the Settings app to configure it.
