### PR TITLE
Bug 969468: Enable NFC preference by default.

### DIFF
--- a/apps/system/js/airplane_mode.js
+++ b/apps/system/js/airplane_mode.js
@@ -93,6 +93,7 @@
       var bluetooth = window.navigator.mozBluetooth;
       var wifiManager = window.navigator.mozWifiManager;
       var fmRadio = window.navigator.mozFMRadio;
+      var nfc = window.navigator.mozNfc;
 
       // Radio is a special service (might not exist e.g. tablet)
       // if value is true,
@@ -126,7 +127,9 @@
         this._suspend('geolocation');
 
         // Turn off NFC
-        this._suspend('nfc');
+        if (nfc) {
+          this._suspend('nfc');
+        }
 
         // Turn off FM Radio.
         if (fmRadio && fmRadio.enabled) {
@@ -157,7 +160,8 @@
           this._restore('geolocation');
         }
 
-        if (!this._settings['nfc.enabled']) {
+        // Don't attempt to turn on NFC if it's already on
+        if (nfc && !this._settings['nfc.enabled']) {
           this._restore('nfc');
         }
       }

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -101,7 +101,7 @@
    "lockscreen.unlock-sound.enabled": false,
    "mail.sent-sound.enabled": true,
    "message.sent-sound.enabled": true,
-   "nfc.enabled": false,
+   "nfc.enabled": true,
    "nfc.suspended": false,
    "operatorvariant.mcc": "000",
    "operatorvariant.mnc": "00",


### PR DESCRIPTION
Flipping a flag for NFC + some additions to airplane_mode.js.

Platforms without NFC compiled in will not see the NFC settings switch, as they won't have the window.navigator.mozNfc object.
