### PR TITLE
Bug 980701 - Make sure we do not try to place more than two calls

### DIFF
--- a/apps/system/js/voicemail.js
+++ b/apps/system/js/voicemail.js
@@ -98,6 +98,17 @@ var Voicemail = {
         if (!telephony) {
           return;
         }
+
+        var openLines = telephony.calls.length +
+            ((telephony.conferenceGroup &&
+              telephony.conferenceGroup.calls.length) ? 1 : 0);
+
+        // User can make call only when there are less than 2 calls by spec.
+        // If the limit reached, return early to prevent holding active call.
+        if (openLines >= 2) {
+          return;
+        }
+
         telephony.dial(voicemailNumber);
       }
     );


### PR DESCRIPTION
We cannot open more than two lines, and mozTelephony is not able yet to
tell us that we are doing this. So we do a check ourself for now, and
bug 990472 should fix it at mozTelephony level.
