### PR TITLE
Bug 988660 - Notification remove array item issue in notification_helper

### DIFF
--- a/shared/js/notification_helper.js
+++ b/shared/js/notification_helper.js
@@ -62,9 +62,9 @@ var NotificationHelper = {
     this._referencesArray.push(notification);
   },
   _forget: function nc_forget(notification) {
-    this._referencesArray.splice(
-      this._referencesArray.indexOf(notification), 1
-    );
+    var idx = this._referencesArray.indexOf(notification);
+    if (idx >= 0)
+      this._referencesArray.splice(idx, 1);
   }
 };
 


### PR DESCRIPTION
Problem
1. 2 or more same app notification in status bar.
2. Click any notification. visible the app.
3. Press the Home button to go to the home screen.
4. Two notification objects are deleted.

Causation
1. Come 2 event(click, close) when click notification in status bar
2. Two calls the _forget function.
3. remove the notification object. using Array.splice()
   // this._referencesArray.splice(this._referencesArray.indexOf(notification), 1);
4. delete the notification objects that match the click event.
5. but close event, delete the other notification object.
   // because, Array.splice(-1, 1); <- start < 0
   // actualStart = Max(len + relativeStart, 0.0);
