### PR TITLE
Bug 992666 - [Bluetooth] fix deviceList.js error message r=kgrandon

### DIFF
--- a/apps/bluetooth/js/deviceList.js
+++ b/apps/bluetooth/js/deviceList.js
@@ -347,7 +347,7 @@ navigator.mozL10n.ready(function deviceList() {
         searchingItem.hidden = true;
       };
       req.onerror = function bt_discoveryStopFailed() {
-        console.error('Can not stop discover nearby device');
+        console.error('Failed to stop discovery of nearby devices');
         searchAgainBtn.disabled = true;
         searchingItem.hidden = false;
       };


### PR DESCRIPTION
Error message in bt_discoveryStopFailed() clarified to be understandable.

https://bugzilla.mozilla.org/show_bug.cgi?id=992666
