### PR TITLE
Bug 983315 - [Messages][DSDS] Provide a feedback while we're switching the data APN to send a MMS

### DIFF
--- a/apps/sms/test/unit/message_manager_test.js
+++ b/apps/sms/test/unit/message_manager_test.js
@@ -314,7 +314,6 @@ suite('message_manager.js >', function() {
 
       setup(function() {
         this.sinon.stub(Settings, 'hasSeveralSim').returns(true);
-        this.sinon.stub(Settings, 'switchMmsSimHandler');
 
         mmsOpts = {
           recipients: '123',
@@ -329,7 +328,6 @@ suite('message_manager.js >', function() {
         Settings.mmsServiceId = 0;
 
         MessageManager.sendMMS(mmsOpts);
-        sinon.assert.notCalled(Settings.switchMmsSimHandler);
 
         var smil = SMIL.generate.firstCall.returnValue;
 
@@ -350,11 +348,6 @@ suite('message_manager.js >', function() {
         Settings.mmsServiceId = 1;
 
         MessageManager.sendMMS(mmsOpts);
-        sinon.assert.calledWith(
-          Settings.switchMmsSimHandler, mmsOpts.serviceId
-        );
-
-        Settings.switchMmsSimHandler.yield();
 
         var smil = SMIL.generate.firstCall.returnValue;
 
@@ -376,7 +369,6 @@ suite('message_manager.js >', function() {
         Settings.mmsServiceId = 1;
 
         MessageManager.sendMMS(mmsOpts);
-        sinon.assert.notCalled(Settings.switchMmsSimHandler);
 
         var smil = SMIL.generate.firstCall.returnValue;
 

--- a/apps/sms/test/unit/settings_test.js
+++ b/apps/sms/test/unit/settings_test.js
@@ -286,7 +286,7 @@ suite('Settings >', function() {
 
     suite('switchSimHandler for async callback when ready', function() {
       var conn;
-      var listenerSpy, switchSimCallback;
+      var listenerSpy;
 
       // The real navigator.mozMobileConnections is not a real array
       var mockMozMobileConnections = {
@@ -321,35 +321,43 @@ suite('Settings >', function() {
 
         conn = window.navigator.mozMobileConnections[1];
         listenerSpy = this.sinon.spy(conn, 'addEventListener');
+        this.sinon.stub(conn, 'removeEventListener');
+        this.sinon.stub(console, 'error');
         Settings.init();
 
-        switchSimCallback = sinon.stub();
-        Settings.switchMmsSimHandler(1, switchSimCallback);
       });
 
-      test('callback should not be triggered if state did not change',
-        function() {
-        listenerSpy.yield();
-
-        assert.equal(
-          MockNavigatorSettings.mSettings['ril.mms.defaultServiceId'], 1
-        );
-        assert.equal(
-          MockNavigatorSettings.mSettings['ril.data.defaultServiceId'], 1
-        );
-        sinon.assert.notCalled(switchSimCallback);
+      test('Should return resolve directly if state is already registered',
+        function(done) {
+        conn.data.state = 'registered';
+        Settings.switchMmsSimHandler(1).then(function onsuccess(){
+          sinon.assert.notCalled(listenerSpy);
+        }).then(done,done);
       });
 
-      test('callback when data connection state changes', function() {
+      test('Should not be triggered if connection does not exist',
+        function(done) {
+        Settings.switchMmsSimHandler('invalid').catch(function onerror(err){
+          sinon.assert.notCalled(conn.removeEventListener);
+          assert.equal(err, 'Invalid connection');
+        }).then(done,done);
+      });
+
+      test('callback when data connection state changes', function(done) {
+        conn.data.state = 'searching';
+        Settings.switchMmsSimHandler(1).then(function onsuccess(){
+         assert.equal(
+            MockNavigatorSettings.mSettings['ril.mms.defaultServiceId'], 1
+          );
+          assert.equal(
+            MockNavigatorSettings.mSettings['ril.data.defaultServiceId'], 1
+          );
+          sinon.assert.calledOnce(conn.removeEventListener);
+        }).then(done,done);
+
         conn.data.state = 'registered';
         listenerSpy.yield();
-        assert.equal(
-          MockNavigatorSettings.mSettings['ril.mms.defaultServiceId'], 1
-        );
-        assert.equal(
-          MockNavigatorSettings.mSettings['ril.data.defaultServiceId'], 1
-        );
-        sinon.assert.calledOnce(switchSimCallback);
+ 
       });
     });
   });


### PR DESCRIPTION
- Move the NonactivateSIM checking from sendMMS to message sent failed event callback to make sure the message is saved in message DB before SIM switching complete
- Add send option for resendMessage
