### PR TITLE
Bug 993390 - Don't do a sync reflow if we just cleared the element

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -1377,7 +1377,7 @@ function endPress(target, coords, touchId, hasCandidateScrolled) {
   var dataset = target.dataset;
   if (dataset.selection) {
     if (!hasCandidateScrolled) {
-      IMERender.toggleCandidatePanel(false);
+      IMERender.toggleCandidatePanel(false, true);
 
       if (inputMethod.select) {
         // We use dataset.data instead of target.textContent because the
@@ -1462,7 +1462,7 @@ function endPress(target, coords, touchId, hasCandidateScrolled) {
           candidatePanel.addEventListener('scroll', candidatePanelOnScroll);
         }
 
-        IMERender.toggleCandidatePanel(true);
+        IMERender.toggleCandidatePanel(true, true);
       };
 
       if (candidatePanel.dataset.rowCount == 1) {
@@ -1501,7 +1501,7 @@ function endPress(target, coords, touchId, hasCandidateScrolled) {
         }
       }
 
-      IMERender.toggleCandidatePanel(false);
+      IMERender.toggleCandidatePanel(false, true);
     }
     break;
 

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -312,9 +312,11 @@ const IMERender = (function() {
     }
   };
 
-  var toggleCandidatePanel = function(expand) {
+  var toggleCandidatePanel = function(expand, resetScroll) {
     var candidatePanel = activeIme.querySelector('.keyboard-candidate-panel');
-    candidatePanel.scrollTop = candidatePanel.scrollLeft = 0;
+    if (resetScroll) {
+      candidatePanel.scrollTop = candidatePanel.scrollLeft = 0;
+    }
 
     if (expand) {
       ime.classList.remove('candidate-panel');
@@ -438,7 +440,7 @@ const IMERender = (function() {
         candidatePanel.innerHTML = '';
 
         candidatePanelToggleButton.style.display = 'none';
-        toggleCandidatePanel(false);
+        toggleCandidatePanel(false, false);
         docFragment = candidatesFragmentCode(1, candidates, true);
         candidatePanel.appendChild(docFragment);
       }


### PR DESCRIPTION
We do `innerHTML = ''` and then set the scrollTop and scrollLeft to 0, which forces a sync reflow. That is pretty redundant.
