### PR TITLE
Bug 920011 - [DSDS][Dialer] Dialing from call log by tapping instead of showing a menu. r=etienne

### DIFF
--- a/apps/communications/dialer/elements/add-contact-action-menu.html
+++ b/apps/communications/dialer/elements/add-contact-action-menu.html
@@ -3,7 +3,6 @@
 
     <header id="add-contact-action-title" data-l10n-id="phoneNumberInput"></header>
     <menu>
-      <button id="call-menuitem" data-l10n-id="call"> Call </button>
       <button id="send-sms-menuitem" data-l10n-id="sendSms"> Send Message </button>
       <button id="create-new-contact-menuitem" data-l10n-id="createNewContact"> Create New Contact </button>
       <button id="add-to-existing-contact-menuitem" data-l10n-id="addToExistingContact"> Add to Existing Contact </button>

--- a/apps/communications/dialer/js/call_log.js
+++ b/apps/communications/dialer/js/call_log.js
@@ -93,6 +93,7 @@ var CallLog = {
         self.allFilter.addEventListener('click',
           self.unfilter.bind(self));
         self.callLogContainer.addEventListener('click', self);
+        self.callLogContainer.addEventListener('contextmenu', self);
         self.selectAllThreads.addEventListener('click',
           self.selectAll.bind(self));
         self.deselectAllThreads.addEventListener('click',
@@ -326,7 +327,7 @@ var CallLog = {
       var parent = previousLogGroup.parentNode;
       parent.removeChild(previousLogGroup);
       this.insertInSection(logGroupDOM, parent);
-      return;
+      return logGroupDOM;
     }
 
     var groupSelector = '[data-timestamp="' + dayIndex + '"]';
@@ -337,7 +338,7 @@ var CallLog = {
       // in the right position.
       var section = sectionExists.getElementsByTagName('ol')[0];
       this.insertInSection(logGroupDOM, section);
-      return;
+      return logGroupDOM;
     }
 
     // We don't have any call for that day, so creating a new section
@@ -373,6 +374,8 @@ var CallLog = {
     }
 
     this.sticky.refresh();
+
+    return logGroupDOM;
   },
 
   // Method that places a log group in the right place inside a section
@@ -634,9 +637,7 @@ var CallLog = {
     this.callLogUpgradePercent.textContent = progress + '%';
   },
 
-  // Method that handles click events in the call log.
   // In case we are in edit mode, just update the counter of selected rows.
-  // Display the action menu, otherwise.
   handleEvent: function cl_handleEvent(evt) {
     if (document.body.classList.contains('recents-edit')) {
       this.updateHeaderCount();
@@ -649,7 +650,19 @@ var CallLog = {
     }
     var dataset = logItem.dataset;
     var phoneNumber = dataset.phoneNumber;
-    if (phoneNumber) {
+    if (!phoneNumber) {
+      return;
+    }
+
+    if (evt.type == 'click') {
+      if (navigator.mozIccManager &&
+          navigator.mozIccManager.iccIds.length > 1) {
+        KeypadManager.updatePhoneNumber(phoneNumber);
+        window.location.hash = '#keyboard-view';
+      } else {
+        CallHandler.call(phoneNumber, 0);
+      }
+    } else {
       var contactIds = (dataset.contactId) ? dataset.contactId : null;
       var contactId = null;
       if (contactIds !== null) {
@@ -663,6 +676,7 @@ var CallLog = {
         null,
         isMissedCall
       );
+      evt.preventDefault();
     }
   },
 

--- a/apps/communications/dialer/js/phone_action_menu.js
+++ b/apps/communications/dialer/js/phone_action_menu.js
@@ -1,6 +1,6 @@
 var PhoneNumberActionMenu = (function() {
 
-  var _initiated, _newPhoneNumber, _addContactActionMenu, _callMenuItem,
+  var _initiated, _newPhoneNumber, _addContactActionMenu,
     _createNewContactMenuItem, _addToExistingContactMenuItem, _sendSmsMenuItem,
     _cancelActionMenuItem, _addContactActionTitle, _optionToMenuItem;
 
@@ -39,28 +39,6 @@ var PhoneNumberActionMenu = (function() {
     _addContactActionMenu.classList.remove('visible');
   };
 
-  var _call = function _call() {
-    if (_newPhoneNumber) {
-      _updateLatestVisit();
-      if (navigator.mozIccManager.iccIds.length <= 1) {
-        CallHandler.call(_newPhoneNumber, 0);
-      } else {
-        var callFn = CallHandler.call.bind(CallHandler, _newPhoneNumber);
-
-        var key = 'ril.voicemail.defaultServiceId';
-        var req = navigator.mozSettings.createLock().get(key);
-        req.onsuccess = function() {
-          LazyLoader.load(['/shared/js/sim_picker.js'], function() {
-            LazyL10n.get(function(_) {
-              SimPicker.getOrPick(req.result[key], _newPhoneNumber, callFn);
-            });
-          });
-        };
-      }
-    }
-    _addContactActionMenu.classList.remove('visible');
-  };
-
   var _sendSms = function _sendSms() {
     if (_newPhoneNumber) {
       _updateLatestVisit();
@@ -84,7 +62,7 @@ var PhoneNumberActionMenu = (function() {
   };
 
   /*
-   * @param {Array} options Possible entries are: 'call', 'new-contact',
+   * @param {Array} options Possible entries are: 'new-contact',
    * 'add-to-existent'. If no options, include all possible options.
   */
   var _show = function _show(contactId, phoneNumber, options, isMissedCall) {
@@ -133,8 +111,6 @@ var PhoneNumberActionMenu = (function() {
       'add-contact-action-title');
     _addContactActionMenu = document.getElementById('add-contact-action-menu');
     _addContactActionMenu.addEventListener('submit', _formSubmit);
-    _callMenuItem = document.getElementById('call-menuitem');
-    _callMenuItem.addEventListener('click', _call);
     _sendSmsMenuItem = document.getElementById('send-sms-menuitem');
     _sendSmsMenuItem.addEventListener('click', _sendSms);
     _createNewContactMenuItem = document.getElementById(
@@ -146,7 +122,6 @@ var PhoneNumberActionMenu = (function() {
       _addToExistingContact);
 
     _optionToMenuItem = {
-      'call': _callMenuItem,
       'send-sms': _sendSmsMenuItem,
       'new-contact': _createNewContactMenuItem,
       'add-to-existent': _addToExistingContactMenuItem
@@ -159,7 +134,7 @@ var PhoneNumberActionMenu = (function() {
 
   return {
     /*
-     * @param {Array} options Possible entries are: 'call', 'new-contact',
+     * @param {Array} options Possible entries are: 'new-contact',
      * 'add-to-existent'. If no options, include all possible options.
     */
     show: function show(contactId, phoneNumber, options, isMissedCall) {

--- a/apps/communications/dialer/test/unit/mock_phone_number_action_menu.js
+++ b/apps/communications/dialer/test/unit/mock_phone_number_action_menu.js
@@ -1,0 +1,7 @@
+/* exported MockPhoneNumberActionMenu */
+
+'use strict';
+
+var MockPhoneNumberActionMenu = {
+  show: function() {}
+};

--- a/apps/communications/dialer/test/unit/phone_action_menu_test.js
+++ b/apps/communications/dialer/test/unit/phone_action_menu_test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 /* globals MocksHelper, MockNavigatorMozIccManager, MockNavigatorSettings,
-   PhoneNumberActionMenu, CallHandler, MockSimPicker */
+   PhoneNumberActionMenu */
 
 require('/shared/test/unit/mocks/mock_navigator_moz_icc_manager.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
-require('/dialer/test/unit/mock_call_handler.js');
 require('/dialer/test/unit/mock_lazy_loader.js');
 require('/shared/test/unit/mocks/mock_sim_picker.js');
 require('/shared/test/unit/mocks/dialer/mock_lazy_l10n.js');
@@ -13,10 +12,8 @@ require('/shared/test/unit/mocks/dialer/mock_lazy_l10n.js');
 requireApp('communications/dialer/js/phone_action_menu.js');
 
 var mocksHelperForPhoneActionMenu = new MocksHelper([
-  'CallHandler',
   'LazyLoader',
   'LazyL10n',
-  'SimPicker'
 ]).init();
 
 if (!window.asyncStorage) {
@@ -29,8 +26,8 @@ suite('phone action menu', function() {
   var realMozIccManager;
   var realMozSettings;
   var realAsyncStorage;
-  var fakeNodes = ['add-contact-action-menu', 'call-menuitem',
-                   'send-sms-menuitem', 'create-new-contact-menuitem',
+  var fakeNodes = ['add-contact-action-menu', 'send-sms-menuitem',
+                   'create-new-contact-menuitem',
                    'add-to-existing-contact-menuitem', 'cancel-action-menu',
                    'add-contact-action-title'];
 
@@ -125,48 +122,6 @@ suite('phone action menu', function() {
 
       this.sinon.clock.tick();
       assert.include(contactsIframe.src, url);
-    });
-  });
-
-  suite('call option', function() {
-    function chooseCall() {
-      var callOptionItem = document.getElementById('call-menuitem');
-      callOptionItem.click();
-    }
-
-    suite('Mono SIM', function() {
-      setup(function() {
-        MockNavigatorMozIccManager.iccIds[0] = 0;
-      });
-
-      test('should call directly', function() {
-        this.sinon.spy(CallHandler, 'call');
-        chooseCall();
-        sinon.assert.calledWith(CallHandler.call, '123', 0);
-      });
-    });
-
-    suite('Multi SIM', function() {
-      setup(function() {
-        MockNavigatorMozIccManager.iccIds[0] = 0;
-        navigator.mozIccManager.iccIds[1] = 1;
-        MockNavigatorSettings.mSettings['ril.voicemail.defaultServiceId'] = 1;
-
-        this.sinon.spy(MockSimPicker, 'getOrPick');
-        this.sinon.spy(CallHandler, 'call');
-        chooseCall();
-
-        MockNavigatorSettings.mReplyToRequests();
-      });
-
-      test('should display the sim picker', function() {
-        sinon.assert.calledWith(MockSimPicker.getOrPick, 1, '123');
-      });
-
-      test('should call with the result of the sim picker', function() {
-        MockSimPicker.getOrPick.yield(0);
-        sinon.assert.calledWith(CallHandler.call, '123', 0);
-      });
     });
   });
 });


### PR DESCRIPTION
Tapping now places a call immediately, except in the DSDS case, where we show
the keypad screen with the contact's number filled in. Long pressing shows the
old action menu, with the exception of the call button.
