### PR TITLE
Bug 993952 - Position inactive keyboards off screen instead of display: none

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -119,10 +119,8 @@ const IMERender = (function() {
 
     if (activeIme !== container) {
       if (activeIme) {
-        activeIme.style.display = 'none';
         delete activeIme.dataset.active;
       }
-      container.style.display = 'block';
       container.dataset.active = true;
 
       activeIme = container;

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -38,7 +38,6 @@ button::-moz-focus-inner {
   bottom: 0;
   z-index: 15;
   width: 100%;
-  border-top: 0.1rem solid #a1a5a8;
   background-color: #606b6e;
   pointer-events: auto;
   visibility: visible;
@@ -46,6 +45,18 @@ button::-moz-focus-inner {
 
 #keyboard[data-hidden=true] {
   visibility: hidden;
+}
+
+.keyboard-type-container {
+  position: absolute;
+  bottom: 0;
+  background-color: #606b6e;
+  border-top: 0.1rem solid #a1a5a8;
+  transform: translateY(100%);
+}
+
+.keyboard-type-container[data-active] {
+  transform: translateY(0);
 }
 
 /* Row styles */

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -52,7 +52,7 @@ button::-moz-focus-inner {
   bottom: 0;
   background-color: #606b6e;
   border-top: 0.1rem solid #a1a5a8;
-  transform: translateY(100%);
+  transform: translateY(9999px);
 }
 
 .keyboard-type-container[data-active] {


### PR DESCRIPTION
Memory info. Load nl, en, zh-Hans, zh-Hant, nl-alternate, en-alternate, zh-Hant-alternate onto the DOM (open them all once, and make sure the elements are on the DOM). These numbers come from Tarako device, tested in the browser URL bar, no suggestions etc. Startup -> Open browser -> Toggle between keyboards.

_With this patch_

```
                          |     megabytes     |
           NAME  PID PPID CPU(s) NICE  USS  PSS  RSS VSIZE OOM_ADJ USER
            b2g 3999    1   40.1    0 36.9 40.4 47.3 140.3       0 root
         (Nuwa) 4054 3999    0.9    0  0.6  2.5  7.2  50.7       0 root
     Homescreen 4069 4054    3.0   18  6.8 10.5 17.9  65.8       8 app_4069
(Preallocated a 4134 4054    0.9   18  5.7  8.2 14.3  58.7       1 root
```

_On upstream/v1.3t_

```
                          |     megabytes     |
           NAME  PID PPID CPU(s) NICE  USS  PSS  RSS VSIZE OOM_ADJ USER
            b2g 3764    1   33.1    0 36.8 40.0 47.6 141.7       0 root
         (Nuwa) 3818 3764    0.9    0  0.1  2.0  7.6  50.7       0 root
     Homescreen 3833 3818    3.0   18  5.1  8.4 17.0  65.8       8 app_3833
        Browser 3882 3818    1.0   18  4.4  6.6 14.1  59.7      10 app_3882
(Preallocated a 3904 3818    0.8   18  5.1  7.2 14.5  59.7       1 root
```
