### PR TITLE
Bug 993948 - [Settings] refactor to identify root panel scope inside of ...

### DIFF
--- a/apps/settings/build/settings.build.jslike
+++ b/apps/settings/build/settings.build.jslike
@@ -10,10 +10,11 @@
   paths: {
     'prim': 'empty:',
     'settings': 'empty:',
+    'shared/async_storage': 'empty:',
+    'shared/keyboard_helper': 'empty:',
     'shared/lazy_loader': 'empty:',
-    'shared/settings_listener': 'empty:',
     'shared/manifest_helper': 'empty:',
-    'shared/keyboard_helper': 'empty:'
+    'shared/settings_listener': 'empty:',
   },
 
   findNestedDependencies: true,

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -506,7 +506,7 @@
             <a id="menuItem-downloads" class="menu-item" href="#downloads" data-l10n-id="downloads">Downloads</a>
           </li>
           <li>
-            <small id="battery-desc" class="menu-item-desc"></small>
+            <small id="battery-desc" class="menu-item-desc" hidden></small>
             <a id="menuItem-battery" class="menu-item" href="#battery" data-l10n-id="battery">Battery</a>
           </li>
           <li data-show-name="accessibility.show-settings" hidden>

--- a/apps/settings/js/battery.js
+++ b/apps/settings/js/battery.js
@@ -11,6 +11,9 @@ require(['modules/battery'], function(Battery) {
       l10n.localize(batteryDesc,
                     'batteryLevel-percent-' + Battery.state,
                     { level: Battery.level });
+      if (batteryDesc.hidden) {
+        batteryDesc.hidden = false;
+      }
     };
 
     Battery.observe('level', _refreshText);

--- a/apps/settings/js/config/require.js
+++ b/apps/settings/js/config/require.js
@@ -9,11 +9,14 @@ require.config({
     'settings': {
       exports: 'Settings'
     },
+    'shared/async_storage': {
+      exports: 'AsyncStorage'
+    },
+    'shared/keyboard_helper': {
+      exports: 'KeyboardHelper'
+    },
     'shared/lazy_loader': {
       exports: 'LazyLoader'
-    },
-    'shared/settings_listener': {
-      exports: 'SettingsListener'
     },
     'shared/manifest_helper': {
       exports: 'ManifestHelper'
@@ -21,8 +24,8 @@ require.config({
     'shared/screen_layout': {
       exports: 'ScreenLayout'
     },
-    'shared/keyboard_helper': {
-      exports: 'KeyboardHelper'
+    'shared/settings_listener': {
+      exports: 'SettingsListener'
     }
   },
   modules: [

--- a/apps/settings/js/main.js
+++ b/apps/settings/js/main.js
@@ -14,7 +14,7 @@ require(['config/require'], function() {
      * the root panel when in two column.
      * XXX: Currently we don't separate the navigation logic of one column and
      *      two column layout, so that the root panel will not be deactivated
-     *      in in one column layout.
+     *      in one column layout.
      */
     SettingsService.init('root');
 

--- a/apps/settings/js/panels/languages/languages.js
+++ b/apps/settings/js/panels/languages/languages.js
@@ -1,3 +1,4 @@
+/* global getSupportedLanguages */
 define(function(require) {
   'use strict';
 
@@ -9,7 +10,7 @@ define(function(require) {
   Languages.prototype = {
     init: function() {
       this.langSel.innerHTML = '';
-      Settings.getSupportedLanguages(function fillLanguageList(languages) {
+      getSupportedLanguages(function fillLanguageList(languages) {
         for (var lang in languages) {
           var option = document.createElement('option');
           option.value = lang;

--- a/apps/settings/js/panels/send_feedback/send_feedback.js
+++ b/apps/settings/js/panels/send_feedback/send_feedback.js
@@ -3,6 +3,8 @@ define(function(require) {
 
   var SettingsService = require('modules/settings_service');
   var SettingsCache = require('modules/settings_cache');
+  require('shared/async_storage');
+
   var SendFeedback = function(){};
   SendFeedback.prototype = {
     _SettingsCache: SettingsCache,

--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -1,3 +1,5 @@
+/* global PerformanceTestingHelper, TelephonySettingHelper,
+   getSupportedLanguages */
 'use strict';
 
 /**
@@ -6,6 +8,103 @@
  * `uncaught exception: 2147500033' message (= 0x80004001).
  */
 
+/**
+ * Handle root panel functionality
+ */
+define('Root', function() {
+  var LazyLoader = require('shared/lazy_loader');
+
+  var Root = function() {};
+
+  Root.prototype = {
+    init: function root_init() {
+      // hide telephony panels
+      if (!navigator.mozTelephony) {
+        var elements = ['call-settings',
+                        'data-connectivity',
+                        'messaging-settings',
+                        'simSecurity-settings'];
+        elements.forEach(function(el) {
+          document.getElementById(el).hidden = true;
+        });
+      }
+
+      // hide unused panel
+      if (navigator.mozMobileConnections) {
+        if (navigator.mozMobileConnections.length == 1) { // single sim
+          document.getElementById('simCardManager-settings').hidden = true;
+        } else { // dsds
+          document.getElementById('simSecurity-settings').hidden = true;
+        }
+      }
+
+      setTimeout((function nextTick() {
+        LazyLoader.load(['js/utils.js'], function() {
+          this.startupLocale();
+        }.bind(this));
+
+        /**
+         * Enable or disable the menu items related to the ICC card
+         * relying on the card and radio state.
+         */
+        LazyLoader.load([
+          'shared/js/wifi_helper.js',
+          'js/firefox_accounts/menu_loader.js',
+          'shared/js/airplane_mode_helper.js',
+          'js/airplane_mode.js',
+          'js/battery.js',
+          'shared/js/async_storage.js',
+          'js/storage.js',
+          'js/try_show_homescreen_section.js',
+          'shared/js/mobile_operator.js',
+          'shared/js/icc_helper.js',
+          'shared/js/settings_listener.js',
+          'shared/js/toaster.js',
+          'js/connectivity.js',
+          'js/security_privacy.js',
+          'js/icc_menu.js',
+          'js/nfc.js',
+          'js/dsds_settings.js',
+          'js/telephony_settings.js',
+          'js/telephony_items_handler.js'
+        ], function() {
+          TelephonySettingHelper.init();
+        });
+      }).bind(this));
+    },
+
+    // startup & language switching
+    startupLocale: function root_startupLocale() {
+      // XXX change to mozL10n.ready when https://bugzil.la/993188 is fixed
+      navigator.mozL10n.once(function startupLocale() {
+        this.initLocale();
+        window.addEventListener('localized', this.initLocale);
+      }.bind(this));
+    },
+
+    initLocale: function root_initLocale() {
+      var lang = navigator.mozL10n.language.code;
+
+      // set the 'lang' and 'dir' attributes to <html>
+      // when the page is translated
+      document.documentElement.lang = lang;
+      document.documentElement.dir = navigator.mozL10n.language.direction;
+
+      // display the current locale in the main panel
+      getSupportedLanguages(function displayLang(languages) {
+        document.getElementById('language-desc').textContent = languages[lang];
+      });
+    }
+  };
+
+  return function ctor_root() {
+    return new Root();
+  };
+});
+
+/**
+ * Main entrance of Settings App
+ */
 var Settings = {
   get mozSettings() {
     // return navigator.mozSettings when properly supported, null otherwise
@@ -19,11 +118,6 @@ var Settings = {
     return this.ScreenLayout.getCurrentLayout('tabletAndLandscaped');
   },
 
-  _panelsWithClass: function pane_with_class(targetClass) {
-    return document.querySelectorAll(
-      'section[role="region"].' + targetClass);
-  },
-
   _isTabletAndLandscapeLastTime: null,
 
   rotate: function rotate(evt) {
@@ -31,7 +125,8 @@ var Settings = {
     var panelsWithCurrentClass;
     if (Settings._isTabletAndLandscapeLastTime !==
         isTabletAndLandscapeThisTime) {
-      panelsWithCurrentClass = Settings._panelsWithClass('current');
+      panelsWithCurrentClass = document.querySelectorAll(
+        'section[role="region"].current');
       // in two column style if we have only 'root' panel displayed,
       // (left: root panel, right: blank)
       // then show default panel too
@@ -112,82 +207,41 @@ var Settings = {
     this.LazyLoader = options.LazyLoader;
     this.ScreenLayout = options.ScreenLayout;
 
+    // register web activity handler
+    navigator.mozSetMessageHandler('activity', this.webActivityHandler);
+
+    // open root panel
+    require(['Root'], function(Root) {
+      var root = Root();
+      root.init();
+    });
+
+    this.currentPanel = 'root';
+
+    // make operations not block the load time
     setTimeout((function nextTick() {
-      this.LazyLoader.load(['js/utils.js'], startupLocale);
-
-      this.LazyLoader.load(['shared/js/wifi_helper.js'], displayDefaultPanel);
-
-      /**
-       * Enable or disable the menu items related to the ICC card relying on the
-       * card and radio state.
-       */
-      this.LazyLoader.load([
-        'js/firefox_accounts/menu_loader.js',
-        'shared/js/airplane_mode_helper.js',
-        'js/airplane_mode.js',
-        'js/battery.js',
-        'shared/js/async_storage.js',
-        'js/storage.js',
-        'js/try_show_homescreen_section.js',
-        'shared/js/mobile_operator.js',
-        'shared/js/icc_helper.js',
-        'shared/js/settings_listener.js',
-        'shared/js/toaster.js',
-        'js/connectivity.js',
-        'js/security_privacy.js',
-        'js/icc_menu.js',
-        'js/nfc.js',
-        'js/dsds_settings.js',
-        'js/telephony_settings.js',
-        'js/telephony_items_handler.js'
-      ], function() {
-        TelephonySettingHelper.init();
-      });
-    }).bind(this));
-
-    function displayDefaultPanel() {
       // With async pan zoom enable, the page starts with a viewport
       // of 980px before beeing resize to device-width. So let's delay
       // the rotation listener to make sure it is not triggered by fake
       // positive.
-      Settings.ScreenLayout.watch(
+      this.ScreenLayout.watch(
         'tabletAndLandscaped',
         '(min-width: 768px) and (orientation: landscape)');
-      window.addEventListener('screenlayoutchange', Settings.rotate);
+      window.addEventListener('screenlayoutchange', this.rotate);
 
       // display of default panel(#wifi) must wait for
       // lazy-loaded script - wifi_helper.js - loaded
-      if (Settings.isTabletAndLandscape()) {
-        Settings.currentPanel = Settings.defaultPanelForTablet;
+      if (this.isTabletAndLandscape()) {
+        this.LazyLoader.load([
+          'shared/js/wifi_helper.js'
+          ], function() {
+            this.currentPanel = this.defaultPanelForTablet;
+        });
       }
-    }
 
-    if (!navigator.mozTelephony) {
-      var elements = ['call-settings',
-                      'data-connectivity',
-                      'messaging-settings',
-                      'simSecurity-settings'];
-      elements.forEach(function(el) {
-        document.getElementById(el).hidden = true;
-      });
-    }
+      window.addEventListener('keydown', this.handleSpecialKeys);
+    }).bind(this));
 
-    // we hide all entry points by default,
-    // so we have to detect and show them up
-    if (navigator.mozMobileConnections) {
-      if (navigator.mozMobileConnections.length == 1) {
-        // single sim
-        document.getElementById('simCardManager-settings').hidden = true;
-      } else {
-        // dsds
-        document.getElementById('simSecurity-settings').hidden = true;
-      }
-    }
-
-    // register web activity handler
-    navigator.mozSetMessageHandler('activity', this.webActivityHandler);
-
-    this.currentPanel = 'root';
   },
 
   // An activity can be closed either by pressing the 'X' button
@@ -244,7 +298,7 @@ var Settings = {
     switch (name) {
       case 'configure':
         section = Settings._currentActivitySection =
-                                          activityRequest.source.data.section;
+                  activityRequest.source.data.section;
 
         if (!section) {
           // If there isn't a section specified,
@@ -285,65 +339,27 @@ var Settings = {
     }
   },
 
-  getSupportedLanguages: function settings_getLanguages(callback) {
-    if (!callback)
-      return;
+  /**
+   * back button = close dialog || back to the root page
+   * + prevent the [Return] key to validate forms
+   */
+  handleSpecialKeys: function settings_handleSpecialKeys(event) {
+    if (Settings.currentPanel != '#root' &&
+        event.keyCode === event.DOM_VK_ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
 
-    if (this._languages) {
-      callback(this._languages);
-    } else {
-      var self = this;
-      var LANGUAGES = '/shared/resources/languages.json';
-      loadJSON(LANGUAGES, function loadLanguages(data) {
-        if (data) {
-          self._languages = data;
-          callback(self._languages);
-        }
-      });
+      var dialog = document.querySelector('#dialogs .active');
+      if (dialog) {
+        dialog.classList.remove('active');
+        document.body.classList.remove('dialog');
+      } else {
+        Settings.currentPanel = '#root';
+      }
+    } else if (event.keyCode === event.DOM_VK_RETURN) {
+      event.target.blur();
+      event.stopPropagation();
+      event.preventDefault();
     }
   }
 };
-
-// back button = close dialog || back to the root page
-// + prevent the [Return] key to validate forms
-window.addEventListener('keydown', function handleSpecialKeys(event) {
-  if (Settings.currentPanel != '#root' &&
-      event.keyCode === event.DOM_VK_ESCAPE) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    var dialog = document.querySelector('#dialogs .active');
-    if (dialog) {
-      dialog.classList.remove('active');
-      document.body.classList.remove('dialog');
-    } else {
-      Settings.currentPanel = '#root';
-    }
-  } else if (event.keyCode === event.DOM_VK_RETURN) {
-    event.target.blur();
-    event.stopPropagation();
-    event.preventDefault();
-  }
-});
-
-// startup & language switching
-function startupLocale() {
-  // XXX change to mozL10n.ready when https://bugzil.la/993188 is fixed
-  navigator.mozL10n.once(function startupLocale() {
-    initLocale();
-    window.addEventListener('localized', initLocale);
-  });
-}
-
-function initLocale() {
-  var lang = navigator.mozL10n.language.code;
-
-  // set the 'lang' and 'dir' attributes to <html> when the page is translated
-  document.documentElement.lang = lang;
-  document.documentElement.dir = navigator.mozL10n.language.direction;
-
-  // display the current locale in the main panel
-  Settings.getSupportedLanguages(function displayLang(languages) {
-    document.getElementById('language-desc').textContent = languages[lang];
-  });
-}

--- a/apps/settings/js/utils.js
+++ b/apps/settings/js/utils.js
@@ -87,6 +87,33 @@ function loadJSON(href, callback) {
 }
 
 /**
+ * The function return support languages.
+ * Used by root panel and language panel
+ */
+(function(exports) {
+  var languages;
+  var getSupportedLanguages = function(callback) {
+    if (!callback) {
+      return;
+    }
+
+    if (!languages) {
+      var LANGUAGES = '/shared/resources/languages.json';
+      exports.loadJSON(LANGUAGES, function loadLanguages(data) {
+        if (data) {
+          languages = data;
+          callback(languages);
+        }
+      });
+    } else {
+      callback(languages);
+    }
+  };
+
+  exports.getSupportedLanguages = getSupportedLanguages;
+})(this);
+
+/**
  * L10n helper
  */
 

--- a/apps/settings/test/marionette/app/regions/root.js
+++ b/apps/settings/test/marionette/app/regions/root.js
@@ -37,7 +37,7 @@ RootPanel.prototype = {
   },
 
   get isBatteryDescValid() {
-    return this.findElement('batteryDesc').text().search(/\d+%/) !== -1;
+    return this.waitForElement('batteryDesc').text().search(/\d+%/) !== -1;
   },
 
   get currentLanguageDesc() {

--- a/apps/settings/test/unit/modules/settings_panel_test.js
+++ b/apps/settings/test/unit/modules/settings_panel_test.js
@@ -3,6 +3,7 @@
 mocha.setup({
   globals: [
     'Settings',
+    'Root',
     'MockL10n',
     'LazyLoader',
     'startupLocale',

--- a/apps/settings/test/unit/panels/send_feedback/send_feedback_test.js
+++ b/apps/settings/test/unit/panels/send_feedback/send_feedback_test.js
@@ -3,6 +3,7 @@ mocha.globals([
   'ScreenLayout',
   'LazyLoader',
   'Settings',
+  'Root',
   'startupLocale',
   'initLocale',
   'MockL10n',

--- a/apps/settings/test/unit/utils_test.js
+++ b/apps/settings/test/unit/utils_test.js
@@ -10,7 +10,8 @@ require('/apps/settings/test/unit/mock_l10n.js');
 mocha.globals(['DsdsSettings', 'reopenSettings', 'openLink', 'openDialog',
   'loadJSON', 'FileSizeFormatter', 'DeviceStorageHelper', 'getMobileConnection',
   'getBluetooth', 'getNfc', 'getSupportedNetworkInfo', 'isIP', 'getIccByIndex',
-  'sanitizeAddress', 'getTruncated', 'getIccByIndexalize', 'localize']);
+  'sanitizeAddress', 'getTruncated', 'getIccByIndexalize', 'localize',
+  'getSupportedLanguages']);
 
 suite('Utils', function() {
   var realDsDsSettings, realMozMobileConnections, realMozIccManager, realL10n;


### PR DESCRIPTION
- Use instantiable root panel to wrap root panel related operations
- `getSupportedLanguages` is moved to utils.js for language panel reuse
- flatten some functions such as `_panelsWithClass`
- Not load telephony on non-phone device
- fix send_feedback asyncStorage dependency
- move keydown listener in nextTick
