### PR TITLE
Bug 988772 - [tarako][buri] sometimes contact index shows nothing when tap on a index

### DIFF
--- a/apps/communications/contacts/js/contacts_shortcuts.js
+++ b/apps/communications/contacts/js/contacts_shortcuts.js
@@ -122,7 +122,7 @@ if (!utils.alphaScroll) {
       }
 
       var currentY = getY(evt);
-      if (Math.abs(lastY - currentY) < offset) {
+      if (Math.abs(lastY - currentY) < offset / 2) {
         return;
       }
 
@@ -154,8 +154,16 @@ if (!utils.alphaScroll) {
     }
 
     function scrollStart(evt) {
+      var dataset = getTarget(evt).dataset;
       evt.preventDefault();
       evt.stopPropagation();
+
+      // There is no need to show overlay if the target doesn't contain
+      // any valid data for overlay block.
+      if (!dataset.letter && !dataset.img) {
+        return;
+      }
+
       offset = offset || jumper.querySelector('[data-anchor]').offsetHeight;
       overlayStyle.MozTransitionDelay = RESET_TRANSITION;
       overlayStyle.MozTransitionDuration = RESET_TRANSITION;
@@ -172,6 +180,7 @@ if (!utils.alphaScroll) {
       overlayStyle.opacity = '0';
       overlay.textContent = null;
       isScrolling = false;
+      lastY = 0;
     }
 
     // Cache images refered in 'data-img'es

--- a/apps/communications/contacts/test/marionette/contacts_shortcuts_test.js
+++ b/apps/communications/contacts/test/marionette/contacts_shortcuts_test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var Contacts = require('./lib/contacts');
+var assert = require('assert');
+var Actions = require('marionette-client').Actions;
+
+marionette('Contacts shortcuts > touch', function() {
+  var config = Contacts.config;
+  config.prefs = {
+    'dom.w3c_touch_events.enabled': 1
+  };
+  var client = marionette.client(config);
+  var subject;
+  var selectors;
+  var actions = new Actions(client);
+
+  var scrollbar,
+      overlay;
+
+  function overlayOpacity() {
+    return subject.getElementStyle(selectors.overlay, 'opacity');
+  }
+
+  setup(function() {
+    subject = new Contacts(client);
+    subject.launch();
+
+    selectors = Contacts.Selectors;
+    subject.addContact();
+    scrollbar = client.helper.waitForElement(selectors.scrollbar);
+  });
+
+  suite('touch on shortcuts', function() {
+    test('press/release on scrollbar should show/hide shortcut', function() {
+      var act = actions.press(scrollbar, 10, 200).perform();
+      overlay = client.helper.waitForElement(selectors.overlay);
+      assert.equal(overlay.text().length, 1);
+      assert.equal(overlayOpacity(), '1');
+      act.release().perform();
+      assert.equal(overlay.text().length, 0);
+      assert.equal(overlayOpacity(), '0');
+    });
+
+    test('shortcut text should change after move some distance', function() {
+      var ch, nextCh, lastCh;
+
+      var act = actions.press(scrollbar, 10, 100).perform();
+      overlay = client.helper.waitForElement(selectors.overlay);
+      ch = overlay.text();
+      assert.equal(ch.length, 1);
+
+      act.moveByOffset(0, 1).perform();
+      nextCh = overlay.text();
+      assert.equal(nextCh.length, 1);
+      assert.equal(ch, nextCh);
+
+      act.moveByOffset(0, 50).perform();
+      lastCh = overlay.text();
+      assert.equal(nextCh.length, 1);
+      assert.notEqual(lastCh, nextCh);
+
+      act.release().perform();
+    });
+
+    test('Press near the last release position should show valid shortcut',
+      function() {
+      actions.press(scrollbar, 10, 200).release().perform();
+
+      var act = actions.press(scrollbar, 10, 200).perform();
+      overlay = client.helper.waitForElement(selectors.overlay);
+      assert.equal(overlay.text().length, 1);
+      act.release().perform();
+    });
+
+    test('Press outside the scrollbar should not show shortcut',
+      function() {
+      var act = actions.press(scrollbar, -1, 200).perform();
+
+      assert.notEqual(overlayOpacity(), '1');
+      act.release().perform();
+    });
+  });
+
+});

--- a/apps/communications/contacts/test/marionette/lib/contacts.js
+++ b/apps/communications/contacts/test/marionette/lib/contacts.js
@@ -64,7 +64,10 @@ Contacts.Selectors = {
   searchLabel: '#search-start',
   searchInput: '#search-contact',
   searchCancel: '#cancel-search',
-  searchResultFirst: '#search-list .contact-item'
+  searchResultFirst: '#search-list .contact-item',
+
+  scrollbar: 'nav[data-type="scrollbar"]',
+  overlay: 'nav[data-type="scrollbar"] p'
 };
 
 Contacts.prototype = {
@@ -144,9 +147,13 @@ Contacts.prototype = {
         form = this.client.findElement(selectors.form);
     var test = function() {
       var location = form.location();
-      return location.y >= bodyHeight;
+      // Since only checking form position could not guarantee
+      // the transition is ended, add z-index checking because
+      // it will be removed after transition.
+      var zIndex = this.getElementStyle(selectors.form, 'zIndex');
+      return location.y >= bodyHeight && !zIndex;
     };
-    this.client.waitFor(test);
+    this.client.waitFor(test.bind(this));
   },
 
   enterContactDetails: function(details) {
@@ -198,6 +205,12 @@ Contacts.prototype = {
       });
       elementEl.dispatchEvent(event);
     });
+  },
+
+  getElementStyle: function(selector, type) {
+    return this.client.executeScript(function(selector, type) {
+      return document.querySelector(selector).style[type];
+    }, [selector, type]);
   }
 };
 


### PR DESCRIPTION
-  Hide overlay if touched object is not the shortcut letter or icon.
-  Reset lastY when touch end to prevent the next touch which is near the last touchend position.
-  Add integration test for scrolling behavior.
