### PR TITLE
Bug 994002 - Bump gaiatest version to 0.22

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/version.py
+++ b/tests/python/gaia-ui-tests/gaiatest/version.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = '0.21.10'
+__version__ = '0.22'


### PR DESCRIPTION
This depends on #18114 landing. Please do not merge yet.
