### PR TITLE
Bug 975293 - Make sure we have _containerElement defined in the context ...

### DIFF
--- a/apps/settings/js/simcard_lock.js
+++ b/apps/settings/js/simcard_lock.js
@@ -148,7 +148,7 @@
               } else {
                 toast = {
                   messageL10nId: 'simPinChangedSuccessfullyWithIndex',
-                  messageL10nArgs: {'index': cardIndex + 1},
+                  messageL10nArgs: {'index': +(cardIndex) + 1},
                   latency: 3000,
                   useTransition: true
                 };

--- a/apps/settings/test/unit/mock_toaster.js
+++ b/apps/settings/test/unit/mock_toaster.js
@@ -1,0 +1,21 @@
+'use strict';
+
+(function(exports) {
+  var MockToaster = {
+    _mInited: false,
+    _lastToast: undefined,
+    isInitialized: function mt_isInitialized() {
+      return this._mInited;
+    },
+    showToast: function mt_showToast(options) {
+      this._lastToast = options;
+    },
+    mSetup: function mt_mSetup() {
+      this._mInited = true;
+    },
+    mTeardown: function mt_mTeardown() {
+      this._mInited = false;
+    }
+  };
+  exports.MockToaster = MockToaster;
+}(window));

--- a/apps/settings/test/unit/simcard_lock_test.js
+++ b/apps/settings/test/unit/simcard_lock_test.js
@@ -1,6 +1,6 @@
 /* global mocha, MockL10n, MockTemplate, Template,
    MockNavigatorMozIccManager, MockNavigatorMozMobileConnections, SimPinLock,
-   MockSimPinDialog
+   MockSimPinDialog, MockToaster
 */
 'use strict';
 
@@ -13,8 +13,11 @@ requireApp(
 requireApp('settings/test/unit/mock_l10n.js');
 requireApp('settings/test/unit/mock_template.js');
 requireApp('settings/test/unit/mock_sim_pin_dialog.js');
+requireApp('settings/test/unit/mock_toaster.js');
 
 mocha.globals(['Template', 'SimPinLock', 'SimPinDialog']);
+
+var mocksForSimPinLock = new MocksHelper(['Toaster']).init();
 
 suite('SimPinLock > ', function() {
   var realL10n;
@@ -327,6 +330,23 @@ suite('SimPinLock > ', function() {
       test('called successfully', function() {
         assert.ok(SimPinLock.simPinDialog.show.called);
         assert.equal(SimPinLock.simPinDialog.show.args[0][1].cardIndex, '0');
+      });
+    });
+
+    suite('changeSimPin 2 > ', function() {
+      mocksForSimPinLock.attachTestHelpers();
+      setup(function() {
+        fakeDom.dataset.type = 'changeSimPin';
+        fakeDom.dataset.simIndex = '1';
+        this.sinon.stub(SimPinLock.simPinDialog, 'show');
+        SimPinLock.handleEvent.call(SimPinLock, fakeEvt);
+      });
+      test('called successfully', function() {
+        assert.ok(SimPinLock.simPinDialog.show.called);
+        assert.equal(SimPinLock.simPinDialog.show.args[0][1].cardIndex, '1');
+        assert.ok(SimPinLock.simPinDialog.show.args[0][1].onsuccess);
+        SimPinLock.simPinDialog.show.args[0][1].onsuccess();
+        assert.equal(MockToaster._lastToast.messageL10nArgs.index, 2);
       });
     });
   });

--- a/shared/js/toaster.js
+++ b/shared/js/toaster.js
@@ -50,8 +50,9 @@ var Toaster = {
   },
 
   _onTransitionEnd: function t_onTransitionEnd(e) {
-    if (!this._containerElement.classList.contains(this._toastVisibleClass)) {
-      this._hideContainerElement();
+    if (!Toaster._containerElement.classList.contains(
+        Toaster._toastVisibleClass)) {
+      Toaster._hideContainerElement();
     }
   },
 


### PR DESCRIPTION
...of _onTransitionEnd r=crh0716
1. Make sure we have `_containerElement` defined in the context of `_onTransitionEnd()`
2. Coerce `cardIndex` to number for l10n usage (otherwise we'll get string like **SIM 11** instead of **SIM 2**)
3. Add test case for checking sim card index

https://bugzilla.mozilla.org/show_bug.cgi?id=975293
