### PR TITLE
Bug 978130 - [FDN] Misleading SMS message

### DIFF
--- a/apps/sms/js/dialog.js
+++ b/apps/sms/js/dialog.js
@@ -174,7 +174,7 @@ var ERRORS = {
     hasHandler: false
   },
   FdnCheckError: {
-    prefix: 'fdnBlocked',
+    prefix: 'fdnBlocked2',
     showRecipient: true,
     showDsdsStatus: false,
     hasHandler: false

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -122,14 +122,18 @@ sendMissingSimCardBtnOk     = OK
 sendFlightModeTitle         = Airplane mode activated
 sendFlightModeBody          = Turn off airplane mode to send messages.
 sendFlightModeBtnOk         = OK
-fdnBlockedTitle             = FDN active
-fdnBlockedBody.innerHTML    = {[ plural(n) ]}
-fdnBlockedBody.innerHTML[one]   = FDN is enabled and the following recipient is not in your FDN list:<br />{{ numbers }}
-fdnBlockedBody.innerHTML[two]   = FDN is enabled and the following recipients are not in your FDN list:<br />{{ numbers }}
-fdnBlockedBody.innerHTML[few]   = FDN is enabled and the following recipients are not in your FDN list:<br />{{ numbers }}
-fdnBlockedBody.innerHTML[many]  = FDN is enabled and the following recipients are not in your FDN list:<br />{{ numbers }}
-fdnBlockedBody.innerHTML[other] = FDN is enabled and the following recipients are not in your FDN list:<br />{{ numbers }}
-fdnBlockedBtnOk             = OK
+fdnBlocked2Title                 = FDN active
+#LOCALIZATION NOTE (fdnBlocked2Body): the English translation does not need the
+# actual number of phone numbers. If your translation needs it, you can still add it
+# using the parameter {{ n }}. Also take into account that you could add HTML so be
+# careful with the content, it may affect to the whole app.
+fdnBlocked2Body.innerHTML        = {[ plural(n) ]}
+fdnBlocked2Body.innerHTML[one]   = FDN (Fixed Dialing Numbers) is activated. Make sure the SMS center and the following recipient are in your FDN list:<br />{{ numbers }}
+fdnBlocked2Body.innerHTML[two]   = FDN (Fixed Dialing Numbers) is activated. Make sure the SMS center and the following recipients are in your FDN list:<br />{{ numbers }}
+fdnBlocked2Body.innerHTML[few]   = FDN (Fixed Dialing Numbers) is activated. Make sure the SMS center and the following recipients are in your FDN list:<br />{{ numbers }}
+fdnBlocked2Body.innerHTML[many]  = FDN (Fixed Dialing Numbers) is activated. Make sure the SMS center and the following recipients are in your FDN list:<br />{{ numbers }}
+fdnBlocked2Body.innerHTML[other] = FDN (Fixed Dialing Numbers) is activated. Make sure the SMS center and the following recipients are in your FDN list:<br />{{ numbers }}
+fdnBlocked2BtnOk                 = OK
 nonActiveSimTitle           = Switch data connection
 nonActiveSimBody            = Switch the data connection to {{ nonactive }} to retrieve the MMS. The current data transfer on {{ active }} will be suspended. Continue anyway?
 nonActiveSimBtnOk           = Later

--- a/apps/sms/test/unit/dialog_test.js
+++ b/apps/sms/test/unit/dialog_test.js
@@ -328,9 +328,9 @@ suite('Dialog', function() {
 
       var opt = dialogSpy.firstCall.args[1];
       assert.equal(opt.title.l10nId,
-                  'fdnBlockedTitle');
+                  'fdnBlocked2Title');
       assert.equal(opt.body.l10nId,
-                  'fdnBlockedBody');
+                  'fdnBlocked2Body');
       assert.deepEqual(opt.body.l10nArgs,
       {
         n: 3,


### PR DESCRIPTION
If the SMS call center is not in the FDN list, no SMS can be sent
- no matter if the recipients are in the FDN list or not.
  Here is a less misleading error message.
