### PR TITLE
Bug 994045 - [settings][rtl] Downloads: Restart button overlays download title/name in rtl/right-to-left languages like Arabic

### DIFF
--- a/apps/settings/style/icons.css
+++ b/apps/settings/style/icons.css
@@ -323,6 +323,11 @@ html[dir="rtl"] aside.pack-end {
   text-align: left;
 }
 
+html[dir="rtl"] section#downloads aside.pack-end {
+  left: auto;
+  right: 0;
+}
+
 html[dir="rtl"] #menuItem-callWaiting .alert-label > span {
   left: 1.5rem;
   right: auto;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=994045
This fixes both Cancel and Restart buttons and any other button we want to keep LTR'ed in Downloads section.
