### PR TITLE
Bug 987437 - FM Radio Unit Tests fails on B2G Desktop r=timdream

### DIFF
--- a/apps/fm/test/unit/fm_test.js
+++ b/apps/fm/test/unit/fm_test.js
@@ -4,6 +4,16 @@ var PerformanceTestingHelper = {
   dispatch: function() { }
 };
 
+// fake mozSettings at the global level because fm.js uses it before any `setup`
+// function is called.
+navigator.mozSettings = {
+  addObserver: function() {},
+  createLock: function() {
+    return {
+      get: function() {}
+    };
+  }
+};
 
 suite('FM', function() {
   var tempNode;


### PR DESCRIPTION
Add a fake mozSettings at global level to prevent init from running at an
awkward moment.
