### PR TITLE
Bug 989151 - Enable firefox accounts in gaia

### DIFF
--- a/apps/communications/ftu/test/marionette/ftu_test.js
+++ b/apps/communications/ftu/test/marionette/ftu_test.js
@@ -32,6 +32,7 @@ marionette('First Time Use >', function() {
     clickThruPanel('#date_and_time', '#forward');
     clickThruPanel('#geolocation', '#forward');
     clickThruPanel('#import_contacts', '#forward');
+    clickThruPanel('#firefox_accounts', '#forward');
     clickThruPanel('#welcome_browser', '#forward');
     clickThruPanel('#browser_privacy', '#forward');
     clickThruPanel('#finish-screen', undefined);

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -79,7 +79,7 @@
    "icc.goBackTimeout": 1000,
    "icc.selectTimeout": 150000,
    "identity.fxaccounts.reset-password.url": "https://accounts.firefox.com/reset_password",
-   "identity.fxaccounts.ui.enabled": false,
+   "identity.fxaccounts.ui.enabled": true,
    "keyboard.vibration": true,
    "keyboard.clicksound": false,
    "keyboard.autocorrect": true,


### PR DESCRIPTION
This was previously f+ as pull request #17733, but Travis wasn't detecting pushes, so reopened as a new pull. Same code.
