### PR TITLE
Bug 995173 - [Messages] The in-app notification for the "message is too ...

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -180,6 +180,11 @@
           Compose field. These notifications should be hidden automatically so
           they do not prevent the user from inputting text. -->
           <div class="overlay">
+            <section id="messages-subject-max-length-notice"
+                     role="notification"
+                     class="hide">
+              <p data-l10n-id='messages-max-subject-length-text'></p>
+            </section>
             <section id="messages-max-length-notice"
                      role="notification"
                      class="hide">

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -97,7 +97,8 @@ var ThreadUI = global.ThreadUI = {
       'attach-button', 'delete-button', 'cancel-button', 'subject-input',
       'new-message-notice', 'options-icon', 'edit-mode', 'edit-form',
       'tel-form', 'header-text', 'max-length-notice', 'convert-notice',
-      'resize-notice', 'dual-sim-information'
+      'resize-notice', 'dual-sim-information',
+      'new-message-notice', 'subject-max-length-notice'
     ].forEach(function(id) {
       this[Utils.camelCase(id)] = document.getElementById('messages-' + id);
     }, this);
@@ -522,27 +523,40 @@ var ThreadUI = global.ThreadUI = {
     // Handling user warning for max character reached
     // Only show the warning when the subject field has the focus
     if (this.subjectInput.value.length === Compose.subjectMaxLength) {
-      this.showMaxLengthNotice('messages-max-subject-length-text');
+      this.showSubjectMaxLengthNotice();
     } else {
-      this.hideMaxLengthNotice();
+      this.hideSubjectMaxLengthNotice();
     }
   },
 
   onSubjectBlur: function thui_onSubjectBlur() {
-    this.hideMaxLengthNotice();
+    this.hideSubjectMaxLengthNotice();
   },
+
   showMaxLengthNotice: function thui_showMaxLengthNotice(l10nKey) {
     navigator.mozL10n.localize(
       this.maxLengthNotice.querySelector('p'), l10nKey);
     this.maxLengthNotice.classList.remove('hide');
+  },
+
+  hideMaxLengthNotice: function thui_hideMaxLengthNotice() {
+    this.maxLengthNotice.classList.add('hide');
+  },
+
+  showSubjectMaxLengthNotice: function thui_showSubjectMaxLengthNotice() {
+    this.subjectMaxLengthNotice.classList.remove('hide');
+
     if (this.timeouts.subjectLengthNotice) {
       clearTimeout(this.timeouts.subjectLengthNotice);
     }
-    this.timeouts.subjectLengthNotice =
-      setTimeout(this.hideMaxLengthNotice.bind(this), this.BANNER_DURATION);
+    this.timeouts.subjectLengthNotice = setTimeout(
+      this.hideSubjectMaxLengthNotice.bind(this),
+      this.BANNER_DURATION
+    );
   },
-  hideMaxLengthNotice: function thui_hideMaxLengthNotice() {
-    this.maxLengthNotice.classList.add('hide');
+
+  hideSubjectMaxLengthNotice: function thui_hideSubjectMaxLengthNotice() {
+    this.subjectMaxLengthNotice.classList.add('hide');
     this.timeouts.subjectLengthNotice &&
       clearTimeout(this.timeouts.subjectLengthNotice);
   },

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -1079,7 +1079,9 @@ suite('thread_ui.js >', function() {
         assert.isTrue(shouldEnableSend);
       });
 
-      test('banner is displayed', function() {
+      test('banner is displayed and stays', function() {
+        assert.isFalse(banner.classList.contains('hide'));
+        this.sinon.clock.tick(200000);
         assert.isFalse(banner.classList.contains('hide'));
       });
 
@@ -1116,7 +1118,9 @@ suite('thread_ui.js >', function() {
         assert.isFalse(shouldEnableSend);
       });
 
-      test('banner is displayed', function() {
+      test('banner is displayed and stays', function() {
+        assert.isFalse(banner.classList.contains('hide'));
+        this.sinon.clock.tick(200000);
         assert.isFalse(banner.classList.contains('hide'));
       });
 
@@ -1145,7 +1149,7 @@ suite('thread_ui.js >', function() {
           subject;
 
       setup(function() {
-        banner = document.getElementById('messages-max-length-notice');
+        banner = document.getElementById('messages-subject-max-length-notice');
         subject = document.getElementById('messages-subject-input');
         localize = this.sinon.spy(navigator.mozL10n, 'localize');
         Compose.toggleSubject();
@@ -1188,11 +1192,6 @@ suite('thread_ui.js >', function() {
 
         test('should be visible', function() {
           assert.isFalse(banner.classList.contains('hide'));
-        });
-
-        test('should be localized', function() {
-          assert.ok(localize.calledWith(banner.querySelector('p'),
-                    'messages-max-subject-length-text'));
         });
 
         test('should be hidden if focus is away', function() {


### PR DESCRIPTION
...big" state should not disappear after 2 seconds r=schung
