### PR TITLE
Bug 950404 - Missing option to disable home button vibration

### DIFF
--- a/apps/system/js/hardware_buttons.js
+++ b/apps/system/js/hardware_buttons.js
@@ -280,7 +280,9 @@
        * @event HardwareButtonsHomeState#holdhome
        */
       this.hardwareButtons.publish('holdhome');
-      navigator.vibrate(50);
+      if ('vibrate' in navigator) {
+        navigator.vibrate(50);
+      }
       this.hardwareButtons.setState('base');
     }.bind(this), this.hardwareButtons.HOLD_INTERVAL);
   };
@@ -309,7 +311,9 @@
          * @event HardwareButtonsHomeState#home
          */
         this.hardwareButtons.publish('home');
-        navigator.vibrate(50);
+	if ('vibrate' in navigator) {
+          navigator.vibrate(50);
+	}
         this.hardwareButtons.setState('base', type);
         return;
       case 'sleep-button-press':

--- a/apps/system/test/unit/hardware_buttons_test.js
+++ b/apps/system/test/unit/hardware_buttons_test.js
@@ -1,10 +1,10 @@
 'use strict';
 
 /* global HardwareButtons, MocksHelper, ScreenManager,
- *        MockNavigatorMozTelephone 
+ *        MockSettingsListener, MockNavigatorMozTelephony 
  */
 
-mocha.globals(['HardwareButtons', 'ScreenManager']);
+mocha.globals(['HardwareButtons', 'ScreenManager', 'MockSettingsListener', 'MockNavigatorMozTelephony']);
 
 requireApp('system/js/hardware_buttons.js');
 requireApp('system/test/unit/mock_screen_manager.js');
@@ -88,7 +88,7 @@ suite('system/HardwareButtons', function() {
     assert.isTrue(stubClearTimeout.calledOnce);
     assert.equal(stubClearTimeout.getCall(0).args[0],
       stubSetTimeout.getCall(0).returnValue);
-    assert.isTrue(vibrateSpy.calledWidth([50]));
+    assert.isTrue(vibrateSpy.calledWith([50]));
   });
 
   test('press and release home (screen disabled)', function() {
@@ -594,11 +594,6 @@ suite('system/HardwareButtons', function() {
     });
 
     test('it should not vibrate', function() {
-      var stubDispatchEvent = this.sinon.stub(window, 'dispatchEvent');
-      var stubSetTimeout = this.sinon.stub(window, 'setTimeout');
-      stubSetTimeout.returns(Math.floor(Math.random() * 10000));
-      var stubClearTimeout = this.sinon.stub(window, 'clearTimeout');
-
       fireChromeEvent('home-button-press');
       fireChromeEvent('home-button-release');
 

--- a/apps/system/test/unit/hardware_buttons_test.js
+++ b/apps/system/test/unit/hardware_buttons_test.js
@@ -1,10 +1,15 @@
 'use strict';
 
 /* global HardwareButtons, MocksHelper, ScreenManager,
- *        MockSettingsListener, MockNavigatorMozTelephony 
+ *        MockSettingsListener, MockNavigatorMozTelephony
  */
 
-mocha.globals(['HardwareButtons', 'ScreenManager', 'MockSettingsListener', 'MockNavigatorMozTelephony']);
+mocha.globals([
+  'HardwareButtons',
+  'ScreenManager',
+  'MockSettingsListener',
+  'MockNavigatorMozTelephony'
+]);
 
 requireApp('system/js/hardware_buttons.js');
 requireApp('system/test/unit/mock_screen_manager.js');


### PR DESCRIPTION
Since my hamachi is my only device and the simulator does not offer options to test hardware features (like vibration) I wrote the unit test as an applied carbon copy of the `dialer_ringer_test.js`. I couldn't find resources about the testing functions, so I hope, the test will pass. _6a68 offered to test it.

This is my first patch, please be kind :)

_6a68 and kgrandon were so kind and offered some help while writing it on IRC.
