### PR TITLE
Bug 875371 - a sound when locking the device

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -718,6 +718,11 @@
         document.mozCancelFullScreen();
       }
 
+      // trigerring lock sound 
+      if (this.unlockSoundEnabled) {
+        var unlockAudio = new Audio('./resources/sounds/unlock.ogg');
+        unlockAudio.play();
+      }
       // Any changes made to this,
       // also need to be reflected in apps/system/js/storage.js
       this.dispatchEvent('lock', {detail: this.locked});


### PR DESCRIPTION
Adding sound on lock button. As soon as the user clicks on the lock button, he/she should hear the lock sound.
