### PR TITLE
Bug 980461 - [MMS] Visual adjustments to attachment download indicator.

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -413,7 +413,7 @@
             data-l10n-args="${messageL10nArgs}"
             data-l10n-date="${messageL10nDate}"
             data-l10n-date-format="${messageL10nDateFormat}"></span>
-      <form><button class="download" data-l10n-id="${downloadL10nId}"></button></form>
+      <button type="button" class="download" data-l10n-id="${downloadL10nId}"></button>
       -->
     </div>
 
@@ -429,7 +429,7 @@
         </h1>
         <div class="message-content">
           <aside class="pack-end">
-            <progress></progress>
+            <progress class="light"></progress>
           </aside>
           <p>${bodyHTML}</p>
         </div>

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1418,21 +1418,21 @@ var ThreadUI = global.ThreadUI = {
   _createNotDownloadedHTML:
   function thui_createNotDownloadedHTML(message, classNames) {
     // default strings:
-    var messageL10nId = 'not-downloaded-mms';
-    var downloadL10nId = 'download';
+    var messageL10nId = 'not-downloaded-attachment';
+    var downloadL10nId = 'download-attachment';
 
     // assuming that incoming message only has one deliveryInfo
     var status = message.deliveryInfo[0].deliveryStatus;
 
     var expireFormatted = Utils.date.format.localeFormat(
-      new Date(+message.expiryDate), navigator.mozL10n.get('dateTimeFormat_%x')
+      new Date(+message.expiryDate), navigator.mozL10n.get('expiry-date-format')
     );
 
     var expired = +message.expiryDate < Date.now();
 
     if (expired) {
       classNames.push('expired');
-      messageL10nId = 'expired-mms';
+      messageL10nId = 'expired-attachment';
     }
 
     if (status === 'error') {
@@ -1440,7 +1440,7 @@ var ThreadUI = global.ThreadUI = {
     }
 
     if (status === 'pending') {
-      downloadL10nId = 'downloading';
+      downloadL10nId = 'downloading-attachment';
       classNames.push('pending');
     }
 
@@ -2270,7 +2270,7 @@ var ThreadUI = global.ThreadUI = {
 
     messageDOM.classList.add('pending');
     messageDOM.classList.remove('error');
-    navigator.mozL10n.localize(button, 'downloading');
+    navigator.mozL10n.localize(button, 'downloading-attachment');
 
     request.onsuccess = (function retrieveMMSSuccess() {
       this.removeMessageDOM(messageDOM);
@@ -2279,7 +2279,7 @@ var ThreadUI = global.ThreadUI = {
     request.onerror = (function retrieveMMSError() {
       messageDOM.classList.remove('pending');
       messageDOM.classList.add('error');
-      navigator.mozL10n.localize(button, 'download');
+      navigator.mozL10n.localize(button, 'download-attachment');
 
       // Show NonActiveSimCard/Other error dialog while retrieving MMS
       var errorCode = (request.error && request.error.name) ?
@@ -2306,7 +2306,7 @@ var ThreadUI = global.ThreadUI = {
             // ready yet.
             messageDOM.classList.add('pending');
             messageDOM.classList.remove('error');
-            navigator.mozL10n.localize(button, 'downloading');
+            navigator.mozL10n.localize(button, 'downloading-attachment');
             Settings.switchMmsSimHandler(serviceId).then(
               this.retrieveMMS.bind(this, messageDOM))
             .catch(function(err) {

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -212,13 +212,13 @@ call                    = Call
 sendEmail               = Send email
 
 # MMS message
-mms-message          = MMS message
-notDownloaded-title  = Message is not downloaded yet.
-not-downloaded-mms   = I have sent you a file. It will be available until {{date}}
-expired-mms          = Sorry, message cannot be downloaded as it expired on {{date}}
-download             = download
-downloading          = downloading
-unnamed-attachment   = untitled
+mms-message               = MMS message
+notDownloaded-title       = Message is not downloaded yet.
+not-downloaded-attachment = Attachment can be downloaded until {{date}}.
+expired-attachment        = Sorry, the message expired on {{date}} and cannot be downloaded.
+download-attachment       = Download
+downloading-attachment    = Downloading...
+unnamed-attachment        = untitled
 
 # LOCALIZATION NOTE (files-too-large): the English translation does not need the
 # actual number of files. If your translation needs it, you can still add it
@@ -239,3 +239,6 @@ message-draft-saved  = Message saved as draft
 # some DSDS related localizations
 sim-name = SIM{{id}}
 dsds-notification-title-with-sim = ({{sim}}) {{sender}}
+
+# Date formats specific for SMS app
+expiry-date-format = %A, %b %e

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -428,6 +428,31 @@ section.has-carrier .article-list header:first-child {
   background: #fff;
 }
 
+/**
+ * We're using border-bottom instead of just underline style as line is too
+ * close to the text and doesn't look similar to visual spec.
+ */
+.message .download {
+  display: block;
+  height: 3.2rem;
+  width: auto;
+  padding: 0;
+
+  background: none;
+  border: none;
+  border-bottom: 1px solid #333;
+  font-size: 1.8rem;
+}
+
+.message .download:active {
+  border-color: #038282;
+  color: #038282;
+}
+
+.message.pending .download {
+  border-bottom: none;
+}
+
 ul.message-list {
   background-color: #e4e4e4;
 }

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -2664,7 +2664,7 @@ suite('thread_ui.js >', function() {
       });
       test('message is correct', function() {
         assert.equal(notDownloadedMessage.dataset.l10nId,
-          'not-downloaded-mms',
+          'not-downloaded-attachment',
           'localization id set correctly');
         assert.equal(notDownloadedMessage.dataset.l10nArgs,
           '{"date":"date_stub"}',
@@ -2674,10 +2674,10 @@ suite('thread_ui.js >', function() {
         assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
-          'dateTimeFormat_%x');
+          'expiry-date-format');
       });
       test('button text is correct', function() {
-        assert.equal(button.dataset.l10nId, 'downloading');
+        assert.equal(button.dataset.l10nId, 'downloading-attachment');
       });
       suite('clicking', function() {
         setup(function() {
@@ -2719,7 +2719,7 @@ suite('thread_ui.js >', function() {
       });
       test('message is correct', function() {
         assert.equal(notDownloadedMessage.dataset.l10nId,
-          'not-downloaded-mms',
+          'not-downloaded-attachment',
           'localization id set correctly');
         assert.equal(notDownloadedMessage.dataset.l10nArgs,
           '{"date":"date_stub"}',
@@ -2729,10 +2729,10 @@ suite('thread_ui.js >', function() {
         assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
-          'dateTimeFormat_%x');
+          'expiry-date-format');
       });
       test('button text is correct', function() {
-        assert.equal(button.dataset.l10nId, 'download');
+        assert.equal(button.dataset.l10nId, 'download-attachment');
       });
       suite('clicking', function() {
         var showMessageErrorSpy;
@@ -2750,7 +2750,7 @@ suite('thread_ui.js >', function() {
           });
         });
         test('changes download text', function() {
-          assert.ok(localize.calledWith(button, 'downloading'));
+          assert.ok(localize.calledWith(button, 'downloading-attachment'));
         });
         test('error class absent', function() {
           assert.isFalse(element.classList.contains('error'));
@@ -2773,7 +2773,7 @@ suite('thread_ui.js >', function() {
             assert.isFalse(element.classList.contains('pending'));
           });
           test('changes download text', function() {
-            assert.ok(localize.calledWith(button, 'download'));
+            assert.ok(localize.calledWith(button, 'download-attachment'));
           });
           test('Message error dialog should not exist', function() {
             assert.equal(showMessageErrorSpy.called, false);
@@ -2813,7 +2813,7 @@ suite('thread_ui.js >', function() {
             MockErrorDialog.calls[0][1].confirmHandler();
             assert.isTrue(element.classList.contains('pending'));
             assert.isFalse(element.classList.contains('error'));
-            sinon.assert.calledWith(localize, button, 'downloading');
+            sinon.assert.calledWith(localize, button, 'downloading-attachment');
             sinon.assert.calledWith(Settings.switchMmsSimHandler, 1);
           });
 
@@ -2901,7 +2901,7 @@ suite('thread_ui.js >', function() {
       });
       test('message is correct', function() {
         assert.equal(notDownloadedMessage.dataset.l10nId,
-          'not-downloaded-mms',
+          'not-downloaded-attachment',
           'localization id set correctly');
         assert.equal(notDownloadedMessage.dataset.l10nArgs,
           '{"date":"date_stub"}',
@@ -2911,10 +2911,10 @@ suite('thread_ui.js >', function() {
         assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
-          'dateTimeFormat_%x');
+          'expiry-date-format');
       });
       test('button text is correct', function() {
-        assert.equal(button.dataset.l10nId, 'download');
+        assert.equal(button.dataset.l10nId, 'download-attachment');
       });
       suite('clicking', function() {
         setup(function() {
@@ -2924,7 +2924,7 @@ suite('thread_ui.js >', function() {
           });
         });
         test('changes download text', function() {
-          assert.ok(localize.calledWith(button, 'downloading'));
+          assert.ok(localize.calledWith(button, 'downloading-attachment'));
         });
         test('error class absent', function() {
           assert.isFalse(element.classList.contains('error'));
@@ -2947,7 +2947,7 @@ suite('thread_ui.js >', function() {
             assert.isFalse(element.classList.contains('pending'));
           });
           test('changes download text', function() {
-            assert.ok(localize.calledWith(button, 'download'));
+            assert.ok(localize.calledWith(button, 'download-attachment'));
           });
         });
         suite('response success', function() {
@@ -2991,7 +2991,7 @@ suite('thread_ui.js >', function() {
       });
       test('message is correct', function() {
         assert.equal(notDownloadedMessage.dataset.l10nId,
-          'expired-mms',
+          'expired-attachment',
           'localization id set correctly');
         assert.equal(notDownloadedMessage.dataset.l10nArgs,
           '{"date":"date_stub"}',
@@ -3001,7 +3001,7 @@ suite('thread_ui.js >', function() {
         assert.equal(+Utils.date.format.localeFormat.args[0][0],
           message.expiryDate);
         assert.equal(Utils.date.format.localeFormat.args[0][1],
-          'dateTimeFormat_%x');
+          'expiry-date-format');
       });
       suite('clicking', function() {
         setup(function() {


### PR DESCRIPTION
WIP patch, wait for bug https://bugzilla.mozilla.org/show_bug.cgi?id=963013 to be landed. Some concerns:
- Date format in message is different, if patch for bug 963013 isn't going to fix that, we need separate bug for it;
- Do we need separate hover\active styles for download button\link?
- What font is used in visual spec? Looks like it's a bit different than we use in code;
- Spinner should be updated by patch for bug 963013.
