### PR TITLE
Bug #944263 [Tarako]REQUEST_QUERY_FACILITY_LOCK returns 'GenericFailure'...

### DIFF
--- a/apps/settings/js/simcard_lock.js
+++ b/apps/settings/js/simcard_lock.js
@@ -84,7 +84,10 @@
         this.simPinContainer.querySelector('.simpin-enabled-' +
           cardIndex + ' input');
 
-      var isSimAvailable = icc && icc.cardState && icc.cardState !== 'unknown';
+//      var isSimAvailable = icc && icc.cardState && icc.cardState !== 'unknown';
+//     in Tarako,CLCK will return failure when pinRequired
+      var isSimAvailable = icc && icc.cardState && icc.cardState !== 'unknown' &&
+                           icc.cardState !== 'pinRequired' && icc.cardState !== 'pukRequired';
 
       // when fugu is in airplane mode, icc.cardState will not be changed ...
       // in this way, we have to use isAirplaneMode to check this situation


### PR DESCRIPTION
... when cardState is 'pinRequired'

[bug number  ] 944263
[root cause  ] REQUEST_QUERY_FACILITY_LOCK returns 'GenericFailure' when cardState is 'pinRequired'
[changes     ]
[side effects]
[self test   ] passed
[reviewers   ]
