### PR TITLE
Bug 996189 - Switch as privileged app.

### DIFF
--- a/apps/calendar/manifest.webapp
+++ b/apps/calendar/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Calendar",
   "description": "Gaia Calendar",
-  "type": "certified",
+  "type": "privileged",
   "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",
@@ -13,7 +13,6 @@
   ],
   "permissions": {
     "systemXHR":{},
-    "settings":{ "access": "readonly" },
     "alarms":{},
     "browser": {},
     "storage":{},


### PR DESCRIPTION
Switch the calendar app from being a certified app to a privileged app.
http://bugzil.la/996189
