### PR TITLE
Bug 796474 - [email] quasi-infinite scroll may hitch under OMTC

### DIFF
--- a/apps/email/build/email.build.js
+++ b/apps/email/build/email.build.js
@@ -12,6 +12,16 @@
     end: 'plog("@@@ END OF BUILD LAYER");'
   },
 */
+
+  // Be sure to normalize all define() calls by extracting
+  // dependencies so Function toString is not needed, and
+  // lower capability devices like Tarako can optimize
+  // memory by discarding function sources. This is
+  // automatically done when an 'optimize' value other than
+  // 'none' is used. This setting makes sure it happens for
+  // builds where 'none' is used for 'optimize'.
+  normalizeDirDefines: 'all',
+
   // Rewrite the waitSeconds config so that we never time out
   // waiting for modules to load in production. See js/mail_app.js
   // for more details.

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -1,5 +1,7 @@
 /*jshint browser: true */
 /*global define, console */
+'use strict';
+
 define(function(require) {
 
 var templateNode = require('tmpl!./message_list.html'),
@@ -12,6 +14,7 @@ var templateNode = require('tmpl!./message_list.html'),
     htmlCache = require('html_cache'),
     MessageListTopbar = require('message_list_topbar'),
     mozL10n = require('l10n!'),
+    VScroll = require('vscroll'),
     Cards = common.Cards,
     Toaster = common.Toaster,
     ConfirmDialog = common.ConfirmDialog,
@@ -23,21 +26,32 @@ var templateNode = require('tmpl!./message_list.html'),
     prettyDate = common.prettyDate,
     accessibilityHelper = require('shared/js/accessibility_helper');
 
-/**
- * Try and keep at least this many display heights worth of undisplayed
- * messages.
- */
-var SCROLL_MIN_BUFFER_SCREENS = 2;
-/**
- * Keep around at most this many display heights worth of undisplayed messages.
- */
-var SCROLL_MAX_RETENTION_SCREENS = 7;
-
-/**
- * Time to wait between scroll events. Initially 150 & 325 where tried but
- * because we wait between snippet requests 50 feels about right...
- */
-var SCROLL_DELAY = 50;
+// Default data used for the VScroll component, when data is not
+// loaded yet for display in the virtual scroll listing.
+var defaultVScrollData = {
+  'isPlaceholderData': true,
+  'id': 'INVALID',
+  'author': {
+    'name': '',
+    'address': '',
+    'contactId': null
+  },
+  'to': [
+    {
+      'name': ' ',
+      'address': ' ',
+      'contactId': null
+    }
+  ],
+  'cc': null,
+  'bcc': null,
+  'date': '',
+  'hasAttachments': false,
+  'snippet': ' ',
+  'isRead': true,
+  'isStarred': false,
+  'subject': '...'
+};
 
 /**
  * Minimum number of items there must be in the message slice
@@ -54,13 +68,6 @@ var MAXIMUM_MS_BETWEEN_SNIPPET_REQUEST = 6000;
  * Fetch up to 4kb while scrolling
  */
 var MAXIMUM_BYTES_PER_MESSAGE_DURING_SCROLL = 4 * 1024;
-
-/**
- * Number of messages to grow the list by in a single event.  A value
- * of 1 will result in the GELAM default of 15 being used.
- */
-var MIN_MESSAGE_GROWTH_SIZE = 2;
-var MAX_MESSAGE_GROWTH_SIZE = 8;
 
 /**
  * List messages for listing the contents of folders ('nonsearch' mode) and
@@ -115,10 +122,11 @@ function MessageListCard(domNode, mode, args) {
   this.mode = mode;
   this.scrollNode = domNode.getElementsByClassName('msg-list-scrollouter')[0];
 
-  if (mode === 'nonsearch')
+  if (mode === 'nonsearch') {
     batchAddClass(domNode, 'msg-search-only', 'collapsed');
-  else
+  } else {
     batchAddClass(domNode, 'msg-nonsearch-only', 'collapsed');
+  }
 
   this.messagesContainer =
     domNode.getElementsByClassName('msg-messages-container')[0];
@@ -133,11 +141,9 @@ function MessageListCard(domNode, mode, args) {
     // press-and-hold shows the single-message mutation options
     this.onHoldMessage.bind(this));
 
-  // - less-than-infinite scrolling
   this.scrollContainer =
     domNode.getElementsByClassName('msg-list-scrollouter')[0];
-  this.scrollContainer.addEventListener('scroll', this.onScroll.bind(this),
-                                        false);
+
   this.syncingNode =
     domNode.getElementsByClassName('msg-messages-syncing')[0];
   this.syncMoreNode =
@@ -150,6 +156,10 @@ function MessageListCard(domNode, mode, args) {
     .addEventListener('click', this.onShowFolders.bind(this), false);
   domNode.getElementsByClassName('msg-compose-btn')[0]
     .addEventListener('click', this.onCompose.bind(this), false);
+
+  // search bar, non-edit mode
+  this.searchBar =
+                 this.domNode.getElementsByClassName('msg-search-tease-bar')[0];
 
   // - toolbar: non-edit mode
   this.toolbar = {};
@@ -201,9 +211,6 @@ function MessageListCard(domNode, mode, args) {
       'input', this.onSearchTextChange.bind(this), false);
   }
 
-  // convenience wrapper for context.
-  this._onScroll = this._onScroll.bind(this);
-
   this.editMode = false;
   this.selectedMessages = null;
 
@@ -211,6 +218,84 @@ function MessageListCard(domNode, mode, args) {
   this.isIncomingFolder = true;
 
   this.usingCachedNode = !!args.cachedNode;
+
+
+  // Set up the list data source for VScroll
+  var listFunc = (function(index) {
+     return headerCursor.messagesSlice.items[index];
+  }.bind(this));
+
+  listFunc.size = function() {
+    // This method could get called during VScroll updates triggered
+    // by messages_splice. However at that point, the headerCount may
+    // not be correct, like when fetching more messages from the
+    // server. So approximate by using the size of slice.items.
+    var slice = headerCursor.messagesSlice;
+    return Math.max(slice.headerCount, slice.items.length);
+  };
+  this.listFunc = listFunc;
+
+  // Wire up the VScroll and data related to its state.
+  this.nextChunkHighestIndex = 0;
+  this.waitingOnChunk = false;
+  this._needVScrollData = false;
+  this.vScroll = new VScroll(this.messagesContainer,
+                             this.scrollNode,
+                             msgHeaderItemNode,
+                             defaultVScrollData);
+
+  // Called by VScroll wants to bind some data to a node it wants to
+  // display in the DOM.
+  this.vScroll.bindData = (function(model, node) {
+    model.element = node;
+    if (this.mode === 'nonsearch') {
+      node.message = model;
+      this.updateMessageDom(true, model);
+    } else {
+      node.message = model.header;
+      this.updateMatchedMessageDom(true, model);
+    }
+  }).bind(this);
+
+  // Called by VScroll when it detects it will need more data in the near
+  // future. VScroll does not know if it already asked for this information,
+  // so this function needs to be sure it actually needs to ask for more
+  // from the back end.
+  this.vScroll.prepareData = (function(index, amount) {
+    var items = headerCursor.messagesSlice && headerCursor.messagesSlice.items,
+        headerCount = headerCursor.messagesSlice.headerCount,
+        endIndex = index + amount;
+
+    if (!items || !amount) {
+      return;
+    }
+
+    // Make sure total amount stays within possible range.
+    if (endIndex > headerCount - 1) {
+      endIndex = headerCount - 1;
+    }
+
+    // If the start and end of the range have data, then it
+    // indicates that segment of data has already been fetched.
+    if (items[index] && items[endIndex]) {
+      return;
+    }
+
+    this.loadNextChunk(endIndex);
+  }.bind(this));
+
+  this._hideSearchBoxByScrolling = this._hideSearchBoxByScrolling.bind(this);
+  this._onVScrollStopped = this._onVScrollStopped.bind(this);
+
+  // Event listeners for VScroll events.
+  this.vScroll.on('inited', this._hideSearchBoxByScrolling);
+  this.vScroll.on('dataChanged', this._hideSearchBoxByScrolling);
+  this.vScroll.on('scrollStopped', this._onVScrollStopped);
+  this.vScroll.on('recalculated', function(calledFromTop) {
+    if (calledFromTop) {
+      this._hideSearchBoxByScrolling();
+    }
+  }.bind(this));
 
   // Binding "this" to some functions as they are used for
   // event listeners.
@@ -278,16 +363,23 @@ MessageListCard.prototype = {
   sliceEvents: ['splice', 'change', 'status', 'complete'],
 
   postInsert: function() {
+    // Get the height of the search box and tell vScroll about it,
+    // but only do this once the DOM is displayed so the ClientRect
+    // gives an actual height.
+    this.vScroll.visibleOffset = this.searchBar.getBoundingClientRect().height;
+
     this._hideSearchBoxByScrolling();
 
-    if (this.mode === 'search')
+    if (this.mode === 'search') {
       this.searchInput.focus();
+    }
   },
 
   onSearchButton: function() {
     // Do not bother if there is no current folder.
-    if (!this.curFolder)
+    if (!this.curFolder) {
       return;
+    }
 
     Cards.pushCard(
       'message_list', 'search', 'animate',
@@ -299,10 +391,13 @@ MessageListCard.prototype = {
   setEditMode: function(editMode) {
     // Do not bother if this is triggered before
     // a folder has loaded.
-    if (!this.curFolder)
+    if (!this.curFolder) {
       return;
+    }
 
-    var domNode = this.domNode;
+    var i,
+        domNode = this.domNode;
+
     // XXX the manual DOM play here is now a bit overkill; we should very
     // probably switch top having the CSS do this for us or at least invest
     // some time in cleanup.
@@ -326,16 +421,17 @@ MessageListCard.prototype = {
 
       this.selectedMessages = [];
       var cbs = this.messagesContainer.querySelectorAll('input[type=checkbox]');
-      for (var i = 0; i < cbs.length; i++) {
+      for (i = 0; i < cbs.length; i++) {
         cbs[i].checked = false;
       }
       this.selectedMessagesUpdated();
     }
     else {
-      if (this.mode === 'nonsearch')
+      if (this.mode === 'nonsearch') {
         normalHeader.classList.remove('collapsed');
-      else
+      } else {
         searchHeader.classList.remove('collapsed');
+      }
       normalToolbar.classList.remove('collapsed');
       editHeader.classList.add('collapsed');
       editToolbar.classList.add('collapsed');
@@ -346,7 +442,7 @@ MessageListCard.prototype = {
       // longer have a domNode around.)
       var selectedMsgNodes =
         domNode.getElementsByClassName('msg-header-item-selected');
-      for (var i = selectedMsgNodes.length - 1; i >= 0; i--) {
+      for (i = selectedMsgNodes.length - 1; i >= 0; i--) {
         selectedMsgNodes[i].classList.remove('msg-header-item-selected');
       }
 
@@ -378,10 +474,12 @@ MessageListCard.prototype = {
     var numStarred = 0, numRead = 0;
     for (var i = 0; i < this.selectedMessages.length; i++) {
       var msg = this.selectedMessages[i];
-      if (msg.isStarred)
+      if (msg.isStarred) {
         numStarred++;
-      if (msg.isRead)
+      }
+      if (msg.isRead) {
         numRead++;
+      }
     }
 
     // Unstar if everything is starred, otherwise star
@@ -390,27 +488,26 @@ MessageListCard.prototype = {
     // Mark read if everything is unread, otherwise unread
     this.setAsRead = (this.selectedMessages.length && numRead === 0);
 
-    if (!this.setAsStarred)
+    if (!this.setAsStarred) {
       starBtn.classList.add('msg-btn-active');
-    else
+    } else {
       starBtn.classList.remove('msg-btn-active');
+    }
 
-    if (this.setAsRead)
+    if (this.setAsRead) {
       readBtn.classList.add('msg-btn-active');
-    else
+    } else {
       readBtn.classList.remove('msg-btn-active');
+    }
   },
 
   _hideSearchBoxByScrolling: function() {
     // scroll the search bit out of the way
-    var searchBar =
-      this.domNode.getElementsByClassName('msg-search-tease-bar')[0];
 
     // Search bar could have been collapsed with a cache load, make sure
     // it is visible
-    searchBar.classList.remove('collapsed');
-
-    this.scrollNode.scrollTop = searchBar.offsetHeight;
+    this.searchBar.classList.remove('collapsed');
+    this.scrollNode.scrollTop = this.searchBar.offsetHeight;
   },
 
   onShowFolders: function() {
@@ -451,14 +548,16 @@ MessageListCard.prototype = {
    * we did nothing because we were already in the folder.
    */
   showFolder: function(folder, forceNewSlice) {
-    if (folder === this.curFolder && !forceNewSlice)
+    if (folder === this.curFolder && !forceNewSlice) {
       return false;
+    }
 
     // If using a cache, do not clear the HTML as it will
     // be cleared once real data has been fetched.
     if (!this.usingCachedNode) {
-      this.messagesContainer.innerHTML = '';
+      this.vScroll.clearDisplay();
     }
+    this._needVScrollData = true;
 
     this.curFolder = folder;
 
@@ -501,12 +600,13 @@ MessageListCard.prototype = {
     console.log('sf: showSearch. phrase:', phrase, phrase.length);
 
     this.curFolder = model.folder;
-    this.messagesContainer.innerHTML = '';
+    this.vScroll.clearDisplay();
     this.curPhrase = phrase;
     this.curFilter = filter;
 
-    if (phrase.length < 1)
+    if (phrase.length < 1) {
       return false;
+    }
 
     // We are creating a new slice, so any pending snippet requests are moot.
     this._snippetRequestPending = false;
@@ -541,40 +641,38 @@ MessageListCard.prototype = {
   },
 
   onGetMoreMessages: function() {
-    if (!headerCursor.messagesSlice)
+    if (!headerCursor.messagesSlice) {
       return;
+    }
 
     headerCursor.messagesSlice.requestGrowth(1, true);
-    // Provide instant feedback that they pressed the button by hiding the
-    // button.  However, don't show 'synchronizing' because that might not
-    // actually happen.
-    this.syncMoreNode.classList.add('collapsed');
   },
 
   // The funny name because it is auto-bound as a listener for
   // messagesSlice events in headerCursor using a naming convention.
   messages_status: function(newStatus) {
-    switch (newStatus) {
-      case 'synchronizing':
-      case 'syncblocked':
+    if (headerCursor.searchMode !== this.mode) {
+      return;
+    }
+
+    if (newStatus === 'synchronizing' ||
+       newStatus === 'syncblocked') {
         this.syncingNode.classList.remove('collapsed');
         this.syncMoreNode.classList.add('collapsed');
         this.hideEmptyLayout();
 
         this.toolbar.refreshBtn.dataset.state = 'synchronizing';
-        break;
-      case 'syncfailed':
+    } else if (newStatus === 'syncfailed' ||
+               newStatus === 'synced') {
+      if (newStatus === 'syncfailed') {
         // If there was a problem talking to the server, notify the user and
         // provide a means to attempt to talk to the server again.  We have made
         // onRefresh pretty clever, so it can do all the legwork on
         // accomplishing this goal.
         Toaster.logRetryable(newStatus, this.onRefresh.bind(this));
-
-        // Fall through...
-      case 'synced':
-        this.toolbar.refreshBtn.dataset.state = 'synchronized';
-        this.syncingNode.classList.add('collapsed');
-        break;
+      }
+      this.toolbar.refreshBtn.dataset.state = 'synchronized';
+      this.syncingNode.classList.add('collapsed');
     }
   },
 
@@ -613,10 +711,15 @@ MessageListCard.prototype = {
    * messagesSlice events in headerCursor using a naming convention.
    */
   messages_complete: function(newEmailCount) {
-    if (headerCursor.messagesSlice.userCanGrowDownwards)
+    if (headerCursor.searchMode !== this.mode) {
+      return;
+    }
+
+    if (headerCursor.messagesSlice.userCanGrowDownwards) {
       this.syncMoreNode.classList.remove('collapsed');
-    else
+    } else {
       this.syncMoreNode.classList.add('collapsed');
+    }
 
     // Show empty layout, unless this is a slice with fake data that
     // will get changed soon.
@@ -624,19 +727,24 @@ MessageListCard.prototype = {
       this.showEmptyLayout();
     }
 
+    // Search does not trigger normal conditions for a folder changed,
+    // so if vScroll is missing its data, set it up now.
+    if (this.mode === 'search' && !this.vScroll.list) {
+      this.vScroll.setData(this.listFunc);
+    }
+
     this.onNewMail(newEmailCount);
 
-    // Consider requesting more data or discarding data based on scrolling that
-    // has happened since we issued the request.  (While requests were pending,
-    // onScroll ignored scroll events.)
-    this.onScroll(null);
+    // Load next chunk if waiting to send one.
+    this.waitingOnChunk = false;
+    this.loadNextChunk(-1);
   },
 
   onNewMail: function(newEmailCount) {
     var inboxFolder = model.foldersSlice.getFirstFolderWithType('inbox');
 
     if (inboxFolder.id === this.curFolder.id &&
-        newEmailCount && newEmailCount !== NaN && newEmailCount !== 0) {
+        newEmailCount && newEmailCount > 0) {
       if (!Cards.isVisible(this)) {
         this._whenVisible = this.onNewMail.bind(this, newEmailCount);
         return;
@@ -659,95 +767,22 @@ MessageListCard.prototype = {
     }
   },
 
-  onScroll: function(evt) {
-    if (this._pendingScrollEvent) {
-      return;
-    }
-
-    this._pendingScrollEvent = true;
-    this._scrollTimer = setTimeout(this._onScroll, SCROLL_DELAY, evt);
-  },
-
   /**
-   * Handle scrolling by requesting more messages when we have less than the
-   * minimum buffer space and trimming messages when we have more than the max.
-   *
-   * We don't care about the direction of scrolling, which is helpful since this
-   * also lets us handle cases where message deletion might have done bad things
-   * to us.  (It does, however, open the door to foolishness where we request
-   * data and then immediately discard some of it.)
+   * Waits for scrolling to stop before fetching snippets.
    */
-  _onScroll: function(event) {
-    if (this._pendingScrollEvent) {
-      this._pendingScrollEvent = false;
+  _onVScrollStopped: function() {
+    // Give any pending requests in the slice priority.
+    if (!headerCursor.messagesSlice ||
+        headerCursor.messagesSlice.pendingRequestCount) {
+      return;
     }
 
-
-    // Defer processing until any pending requests have completed;
-    // `onSliceRequestComplete` will call us.
-    if (!headerCursor.messagesSlice ||
-        headerCursor.messagesSlice.pendingRequestCount)
-      return;
-
-    if (!this._hasSnippetRequest()) {
+    // Do not bother fetching snippets if this card is not in view.
+    // The card could still have a scroll event triggered though
+    // by the next/previous work done in message_reader.
+    if (Cards.isVisible(this) && !this._hasSnippetRequest()) {
       this._requestSnippets();
     }
-
-    var curScrollTop = this.scrollContainer.scrollTop,
-        viewHeight = this.scrollContainer.clientHeight;
-
-    var preScreens = curScrollTop / viewHeight,
-        postScreens = (this.scrollContainer.scrollHeight -
-                       (curScrollTop + viewHeight)) /
-                      viewHeight;
-
-    var shrinkLowIncl = 0,
-        shrinkHighIncl = headerCursor.messagesSlice.items.length - 1,
-        messageNode = null, targOff;
-    if (preScreens < SCROLL_MIN_BUFFER_SCREENS &&
-        !headerCursor.messagesSlice.atTop) {
-      headerCursor.messagesSlice.requestGrowth(
-        -1 * this._getGrowth(preScreens));
-      return;
-    }
-    else if (preScreens > SCROLL_MAX_RETENTION_SCREENS) {
-      // Take off one screen at a time.
-      targOff = curScrollTop -
-                (viewHeight * (SCROLL_MAX_RETENTION_SCREENS - 1));
-      for (messageNode = this.messagesContainer.firstElementChild;
-           messageNode.offsetTop + messageNode.clientHeight < targOff;
-           messageNode = messageNode.nextElementSibling) {
-        shrinkLowIncl++;
-      }
-    }
-
-    if (postScreens < SCROLL_MIN_BUFFER_SCREENS &&
-        !headerCursor.messagesSlice.atBottom) {
-      headerCursor.messagesSlice.requestGrowth(this._getGrowth(postScreens));
-    }
-    else if (postScreens > SCROLL_MAX_RETENTION_SCREENS) {
-      targOff = curScrollTop +
-                this.scrollContainer.clientHeight +
-                (viewHeight * (SCROLL_MAX_RETENTION_SCREENS - 1));
-      for (messageNode = this.messagesContainer.lastElementChild;
-           messageNode.offsetTop > targOff;
-           messageNode = messageNode.previousElementSibling) {
-        shrinkHighIncl--;
-      }
-    }
-
-    if (shrinkLowIncl !== 0 ||
-        shrinkHighIncl !== headerCursor.messagesSlice.items.length - 1) {
-      headerCursor.messagesSlice.requestShrinkage(shrinkLowIncl,
-                                                  shrinkHighIncl);
-    }
-
-  },
-
-  _getGrowth: function(screens) {
-    var percentEmpty = 1 - (screens / SCROLL_MIN_BUFFER_SCREENS);
-    var range = MAX_MESSAGE_GROWTH_SIZE - MIN_MESSAGE_GROWTH_SIZE;
-    return ~~(MIN_MESSAGE_GROWTH_SIZE + (percentEmpty * range));
   },
 
   _hasSnippetRequest: function() {
@@ -782,24 +817,13 @@ MessageListCard.prototype = {
     this._snippetRequestPending = false;
   },
 
-  // the distance between items. It is expected to remain fairly constant
-  // throughout the list so we only need to calculate it once.
-  _getDistance: function() {
-    var items = headerCursor.messagesSlice.items;
-    if (!this._distanceBetweenMessages && items.length > 1) {
-      this._distanceBetweenMessages =
-        items[1].element.getBoundingClientRect().top -
-        items[0].element.getBoundingClientRect().top;
-    }
-    return this._distanceBetweenMessages;
-  },
-
   _requestSnippets: function() {
     var items = headerCursor.messagesSlice.items;
     var len = items.length;
 
-    if (!len)
+    if (!len) {
       return;
+    }
 
     var clearSnippets = this._clearSnippetRequest.bind(this);
     var options = {
@@ -814,27 +838,17 @@ MessageListCard.prototype = {
       return;
     }
 
-    // Distance will always be non-zero here because we ensure the list
-    // is populated above.
-    var distance = this._getDistance();
+    var visibleIndices = this.vScroll.getVisibleIndexRange();
 
-    // starting offset to begin fetching snippets
-    var startOffset = Math.floor(this.scrollContainer.scrollTop / distance);
-
-    this._snippetsPerScrollTick = (
-      this._snippetsPerScrollTick ||
-      Math.ceil(this.scrollContainer.getBoundingClientRect().height / distance)
-    );
-
-
-    this._pendingSnippetRequest();
-    headerCursor.messagesSlice.maybeRequestBodies(
-      startOffset,
-      startOffset + this._snippetsPerScrollTick,
-      options,
-      clearSnippets
-    );
-
+    if (visibleIndices) {
+      this._pendingSnippetRequest();
+      headerCursor.messagesSlice.maybeRequestBodies(
+        visibleIndices[0],
+        visibleIndices[1],
+        options,
+        clearSnippets
+      );
+    }
   },
 
   /**
@@ -869,30 +883,26 @@ MessageListCard.prototype = {
 
     var cacheNode = this.domNode.cloneNode(true);
 
-
     // Hide search field as it will not operate and gets scrolled out
     // of view after real load.
     var removableCacheNode = cacheNode.querySelector('.msg-search-tease-bar');
-    if (removableCacheNode)
+    if (removableCacheNode) {
       removableCacheNode.classList.add('collapsed');
+    }
 
     // Hide "new mail" topbar too
     removableCacheNode = cacheNode
                            .querySelector('.' + MessageListTopbar.CLASS_NAME);
-    if (removableCacheNode)
+    if (removableCacheNode) {
       removableCacheNode.classList.add('collapsed');
-
-    // Trim the message list to _cacheListLimit.
-    if (this.messagesContainer.children.length > this._cacheListLimit) {
-      var msgContainer = cacheNode
-                        .getElementsByClassName('msg-messages-container')[0];
-      for (var childIndex = msgContainer.children.length - 1;
-                            childIndex > this._cacheListLimit - 1;
-                            childIndex--) {
-        var childNode = msgContainer.children[childIndex];
-        childNode.parentNode.removeChild(childNode);
-      }
     }
+
+    // Trim vScroll containers that are not in play
+    VScroll.trimMessagesForCache(
+      cacheNode.querySelector('.msg-messages-container'),
+      this._cacheListLimit
+    );
+
     htmlCache.saveFromNode(cacheNode);
   },
 
@@ -907,8 +917,9 @@ MessageListCard.prototype = {
     if (!this._cacheDomTimeoutId &&
         // card visible state is appropriate
         this._isCacheableCardState() &&
-        // if our slice is showing the newest messages in the folder and
-        headerCursor.messagesSlice.atTop &&
+        // if the scroll area is at the top (otherwise the
+        // virtual scroll may be showing non-top messages)
+        this.vScroll.currentIndex === 0 &&
         // if actually got a numeric index and
         (index || index === 0) &&
         // if it affects the data we cache
@@ -937,94 +948,88 @@ MessageListCard.prototype = {
     }
   },
 
+  /**
+   * Loads the next chunk of data from the slice. Only tries to
+   * do this up to highestIndex, and only if there is a data gap
+   * @param  {Number} highestIndex the highest index in the total
+   * size of the data available, indicated by headerCursor's
+   * messagesSlice.headerCount.
+   */
+  loadNextChunk: function(highestIndex) {
+    if (highestIndex > this.nextChunkHighestIndex) {
+      this.nextChunkHighestIndex = highestIndex;
+    }
+
+    // Do not bother asking for more chunks yet until any previous
+    // chunk is being loaded or if waiting for a recalculation because
+    // of a data change.
+    if (!this.vScroll.waitingForRecalculate &&
+        !this.waitingOnChunk && this.nextChunkHighestIndex) {
+      // Do not bother asking for more than what is already
+      // fetched
+      var items = headerCursor.messagesSlice.items,
+          lastIndex = this.nextChunkHighestIndex;
+
+      // In case there was a recalculate and the item list is now
+      // smaller than the highest desired index, then walk it back
+      if (lastIndex > headerCursor.headerCount - 1) {
+        lastIndex = headerCursor.headerCount - 1;
+      }
+
+      for (var i = lastIndex; i > -1; i--) {
+        if (items[i]) {
+          break;
+        }
+      }
+
+      var amount = lastIndex - i;
+
+      console.log('message_list loadNextChunk growing: ' + i + ', ' + amount);
+
+      headerCursor.messagesSlice.requestGrowth(amount, true);
+      this.nextChunkHighestIndex = 0;
+      this.waitingOnChunk = true;
+    }
+  },
+
   // The funny name because it is auto-bound as a listener for
   // messagesSlice events in headerCursor using a naming convention.
   messages_splice: function(index, howMany, addedItems,
                              requested, moreExpected, fake) {
-    // If no work to do, just skip it.
-    if (index === 0 && howMany === 0 && !addedItems.length)
+
+    // If no work to do, or wrong mode, just skip it.
+    if (headerCursor.searchMode !== this.mode ||
+       (index === 0 && howMany === 0 && !addedItems.length)) {
       return;
-
-    // XXX: This function should be re-written to cache the current scrollTop
-    //      and calculate changes to it in-memory without touching the DOM.
-    //      The scrollTop should only be written back to the DOM when
-    //      absolutely necessary.  Touching thins like scrollTop, offsetTop,
-    //      getBoundingClientRect(), can trigger sync reflows.
-
-    var prevHeight;
-    // - removed messages
-    if (howMany) {
-      if (fake && index === 0 &&
-          headerCursor.messagesSlice.items.length === howMany &&
-          !addedItems.length) {
-      } else {
-        // Regular remove for current call.
-        // Plan to fixup the scroll position if we are deleting a message that
-        // starts before the (visible) scrolled area.  (We add the container's
-        // start offset because it is as big as the occluding header bar.)
-        prevHeight = null;
-        if (headerCursor.messagesSlice.items[index].element.offsetTop <
-            this.scrollContainer.scrollTop + this.messagesContainer.offsetTop) {
-          prevHeight = this.messagesContainer.clientHeight;
-        }
-
-        for (var i = index + howMany - 1; i >= index; i--) {
-          var message = headerCursor.messagesSlice.items[i];
-          message.element.parentNode.removeChild(message.element);
-        }
-
-        // If fixup is requred, adjust.
-        if (prevHeight !== null) {
-          this.scrollContainer.scrollTop -=
-            (prevHeight - this.messagesContainer.clientHeight);
-        }
-
-        // Check the message count after deletion:
-        if (this.messagesContainer.children.length === 0) {
-          this.showEmptyLayout();
-        }
-      }
     }
 
     this._clearCachedMessages();
 
-    // - added/existing
-    var insertBuddy, self = this;
-    if (index >= this.messagesContainer.childElementCount)
-      insertBuddy = null;
-    else
-      insertBuddy = this.messagesContainer.children[index];
-    if (insertBuddy &&
-        (insertBuddy.offsetTop <=
-         this.scrollContainer.scrollTop + this.messagesContainer.offsetTop))
-      prevHeight = this.messagesContainer.clientHeight;
-    else
-      prevHeight = null;
+    if (this._needVScrollData) {
+      this.vScroll.setData(this.listFunc);
+      this._needVScrollData = false;
+    }
+
+    var baseSliceIndex = index - howMany;
+
+    this.vScroll.updateDataBind(baseSliceIndex, addedItems, howMany);
 
     // Remove the no message text while new messages added:
     if (addedItems.length > 0) {
       this.hideEmptyLayout();
     }
 
-    addedItems.forEach(function(message, i) {
-      var domMessage;
-      domMessage = message.element = msgHeaderItemNode.cloneNode(true);
-
-      if (self.mode === 'nonsearch') {
-        domMessage.message = message;
-        self.updateMessageDom(true, message);
-      }
-      else {
-        domMessage.message = message.header;
-        self.updateMatchedMessageDom(true, message);
-      }
-
-      self.messagesContainer.insertBefore(domMessage, insertBuddy);
-    });
-
-    if (prevHeight) {
-      this.scrollContainer.scrollTop +=
-        (this.messagesContainer.clientHeight - prevHeight);
+    // If the end result is no more messages, then show empty layout.
+    // This is needed mostly because local drafts do not trigger
+    // a messages_complete callback when removing the last draft
+    // from the compose triggered in that view. The scrollStopped
+    // is used to avoid a flash where the old message is briefly visible
+    // before cleared, and having the empty layout overlay it.
+    if (headerCursor.messagesSlice.items.length + addedItems.length - howMany <
+        1) {
+      this.vScroll.once('scrollStopped', function() {
+        this.showEmptyLayout();
+      }.bind(this));
     }
 
     // Only cache if it is an add or remove of items
@@ -1036,6 +1041,10 @@ MessageListCard.prototype = {
   // The funny name because it is auto-bound as a listener for
   // messagesSlice events in headerCursor using a naming convention.
   messages_change: function(message, index) {
+    if (headerCursor.searchMode !== this.mode) {
+      return;
+    }
+
     if (this.mode === 'nonsearch') {
       this.onMessagesChange(message, index);
     } else {
@@ -1059,6 +1068,15 @@ MessageListCard.prototype = {
   updateMessageDom: function(firstTime, message) {
     var msgNode = message.element;
 
+    if (!msgNode) {
+      return;
+    }
+
+    // If the placeholder data, indicate that in case VScroll
+    // wants to go back and fix later.
+    var classAction = message.isPlaceholderData ? 'add': 'remove';
+    msgNode.classList[classAction](this.vScroll.itemDefaultDataClass);
+
     // ID is stored as a data- attribute so that it can survive
     // serialization to HTML for storing in the HTML cache, and
     // be usable before the actual data from the backend has
@@ -1071,18 +1089,19 @@ MessageListCard.prototype = {
     var dateNode = msgNode.getElementsByClassName('msg-header-date')[0];
     if (firstTime) {
       var listPerson;
-      if (this.isIncomingFolder)
+      if (this.isIncomingFolder) {
         listPerson = message.author;
       // XXX This is not to UX spec, but this is a stop-gap and that would
       // require adding strings which we cannot justify as a slipstream fix.
-      else if (message.to && message.to.length)
+      } else if (message.to && message.to.length) {
         listPerson = message.to[0];
-      else if (message.cc && message.cc.length)
+      } else if (message.cc && message.cc.length) {
         listPerson = message.cc[0];
-      else if (message.bcc && message.bcc.length)
+      } else if (message.bcc && message.bcc.length) {
         listPerson = message.bcc[0];
-      else
+      } else {
         listPerson = message.author;
+      }
 
       // author
       listPerson.element =
@@ -1090,15 +1109,17 @@ MessageListCard.prototype = {
       listPerson.onchange = this._updatePeepDom;
       listPerson.onchange(listPerson);
       // date
-      dateNode.dataset.time = message.date.valueOf();
-      dateNode.textContent = prettyDate(message.date);
+      var dateTime = message.date.valueOf();
+      dateNode.dataset.time = dateTime;
+      dateNode.textContent = dateTime ? prettyDate(message.date) : '';
       // subject
       displaySubject(msgNode.getElementsByClassName('msg-header-subject')[0],
                      message);
       // attachments
-      if (message.hasAttachments)
+      if (message.hasAttachments) {
         msgNode.getElementsByClassName('msg-header-attachments')[0]
           .classList.add('msg-header-attachments-yes');
+      }
     }
 
     // snippet
@@ -1112,23 +1133,38 @@ MessageListCard.prototype = {
     if (message.isRead) {
       unreadNode.classList.remove('msg-header-unread-section-unread');
       dateNode.classList.remove('msg-header-date-unread');
-    }
-    else {
+    } else {
       unreadNode.classList.add('msg-header-unread-section-unread');
       dateNode.classList.add('msg-header-date-unread');
     }
     // star
     var starNode = msgNode.getElementsByClassName('msg-header-star')[0];
-    if (message.isStarred)
+    if (message.isStarred) {
       starNode.classList.add('msg-header-star-starred');
-    else
+    } else {
       starNode.classList.remove('msg-header-star-starred');
+    }
+
+    // edit mode select state
+    if (this.editMode) {
+      var checkbox = msgNode.querySelector('input[type=checkbox]');
+      checkbox.checked = this.selectedMessages.indexOf(message) !== -1;
+    }
   },
 
   updateMatchedMessageDom: function(firstTime, matchedHeader) {
     var msgNode = matchedHeader.element,
         matches = matchedHeader.matches,
         message = matchedHeader.header;
+
+    if (!msgNode) {
+      return;
+    }
+
+    // If the placeholder data, indicate that in case VScroll
+    // wants to go back and fix later.
+    var classAction = message.isPlaceholderData ? 'add': 'remove';
+    msgNode.classList[classAction](this.vScroll.itemDefaultDataClass);
 
     // Even though updateMatchedMessageDom is only used in searches,
     // which likely will not be cached, the dataset.is is set to
@@ -1142,6 +1178,7 @@ MessageListCard.prototype = {
       // author
       var authorNode = msgNode.getElementsByClassName('msg-header-author')[0];
       if (matches.author) {
+        authorNode.textContent = '';
         appendMatchItemTo(matches.author, authorNode);
       }
       else {
@@ -1157,22 +1194,27 @@ MessageListCard.prototype = {
 
       // subject
       var subjectNode = msgNode.getElementsByClassName('msg-header-subject')[0];
-      if (matches.subject)
+      if (matches.subject) {
+        subjectNode.textContent = '';
         appendMatchItemTo(matches.subject[0], subjectNode);
-      else
+      } else {
         displaySubject(subjectNode, message);
+      }
 
       // snippet
       var snippetNode = msgNode.getElementsByClassName('msg-header-snippet')[0];
-      if (matches.body)
-       appendMatchItemTo(matches.body[0], snippetNode);
-      else
+      if (matches.body) {
+        snippetNode.textContent = '';
+        appendMatchItemTo(matches.body[0], snippetNode);
+      } else {
         snippetNode.textContent = message.snippet;
+      }
 
       // attachments
-      if (message.hasAttachments)
+      if (message.hasAttachments) {
         msgNode.getElementsByClassName('msg-header-attachments')[0]
           .classList.add('msg-header-attachments-yes');
+      }
     }
 
     // unread (we use very specific classes directly on the nodes rather than
@@ -1189,10 +1231,17 @@ MessageListCard.prototype = {
     }
     // starmail
     var starNode = msgNode.getElementsByClassName('msg-header-star')[0];
-    if (message.isStarred)
+    if (message.isStarred) {
       starNode.classList.add('msg-header-star-starred');
-    else
+    } else {
       starNode.classList.remove('msg-header-star-starred');
+    }
+
+    // edit mode select state
+    if (this.editMode) {
+      var checkbox = msgNode.querySelector('input[type=checkbox]');
+      checkbox.checked = this.selectedMessages.indexOf(message) !== -1;
+    }
   },
 
   /**
@@ -1208,7 +1257,23 @@ MessageListCard.prototype = {
   },
 
   onClickMessage: function(messageNode, event) {
+    // Find the node that has the header info.
+    messageNode = event.originalTarget;
+    while (messageNode && !messageNode.classList.contains('msg-header-item')) {
+      messageNode = messageNode.parentNode;
+    }
+
+    if (!messageNode) {
+      return;
+    }
+
     var header = messageNode.message;
+
+    // Skip nodes that are default/placeholder ones.
+    if (header && header.isPlaceholderData) {
+      return;
+    }
+
     if (this.editMode) {
       var idx = this.selectedMessages.indexOf(header);
       var cb = messageNode.querySelector('input[type=checkbox]');
@@ -1251,8 +1316,14 @@ MessageListCard.prototype = {
 
     if (header) {
       headerCursor.setCurrentMessage(header);
-    } else {
+    } else if (messageNode.dataset.id) {
+      // a case where header was not set yet, like clicking on a
+      // cookie cached node, or virtual scroll item that is no
+      // longer backed by a header.
       headerCursor.setCurrentMessageBySuid(messageNode.dataset.id);
+    } else {
+      // Not an interesting click, bail
+      return;
     }
 
     // If the message is really big, warn them before they open it.
@@ -1286,45 +1357,32 @@ MessageListCard.prototype = {
   /**
    * Scroll to make sure that the current message is in our visible window.
    *
-   * @param {MessageCursor.CurrentMessage} currentMessage representation of the
+   * @param {header_cursor.CurrentMessage} currentMessage representation of the
    *     email we're currently reading.
+   * @param {Number} index the index of the message in the messagesSlice
    */
-  onCurrentMessage: function(currentMessage) {
+  onCurrentMessage: function(currentMessage, index) {
     if (!currentMessage) {
       return;
     }
 
-    var id = currentMessage.header.id;
-    var selector = '.msg-messages-container ' +
-                   '.msg-header-item[data-id="' + id + '"]';
-    var element = document.querySelector(selector);
-
-    // Element may not be there if current message is fired
-    // before the notification of a folder change happens,
-    // which could be the case when entering from a notification.
-    if (!element) {
-      return;
+    var visibleIndices = this.vScroll.getVisibleIndexRange();
+    if (visibleIndices &&
+        (index < visibleIndices[0] || index > visibleIndices[1])) {
+      this.vScroll.scrollToIndex(index);
     }
-
-    // Check whether or not the current message is in the visible window.
-    var top = this.scrollContainer.scrollTop;
-    var bottom = this.scrollContainer.scrollTop +
-                 this.scrollContainer.getBoundingClientRect().bottom;
-    if (element.offsetTop >= top && element.offsetTop <= bottom) {
-      return;
-    }
-
-    this.scrollContainer.scrollTop = element.offsetTop;
   },
 
   onHoldMessage: function(messageNode, event) {
-    if (this.curFolder)
+    if (this.curFolder) {
       this.setEditMode(true);
+    }
   },
 
   onRefresh: function() {
-    if (!headerCursor.messagesSlice)
+    if (!headerCursor.messagesSlice) {
       return;
+    }
 
     switch (headerCursor.messagesSlice.status) {
       // If we're still synchronizing, then the user is not well served by
@@ -1340,10 +1398,11 @@ MessageListCard.prototype = {
       // know about any messages.  Otherwise let's just create a new slice by
       // forcing reentry into the folder.
       case 'syncfailed':
-        if (headerCursor.messagesSlice.items.length)
+        if (headerCursor.messagesSlice.items.length) {
           headerCursor.messagesSlice.refresh();
-        else
+        } else {
           this.showFolder(this.curFolder, /* force new slice */ true);
+        }
         break;
     }
   },
@@ -1425,8 +1484,9 @@ MessageListCard.prototype = {
     // a change in the current account, before this listener is called.
     // So skip this work if no foldersSlice, this method will be called
     // again soon.
-    if (!model.foldersSlice)
+    if (!model.foldersSlice) {
       return;
+    }
 
     // Folder could have changed because account changed. Make sure
     // the cacheableFolderId is still set correctly.
@@ -1454,6 +1514,8 @@ MessageListCard.prototype = {
     model.removeListener('folder', this._folderChanged);
     model.removeListener('newInboxMessages', this.onNewMail);
     headerCursor.removeListener('currentMessage', this.onCurrentMessage);
+
+    this.vScroll.destroy();
   }
 };
 

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -32,7 +32,7 @@ var defaultVScrollData = {
   'isPlaceholderData': true,
   'id': 'INVALID',
   'author': {
-    'name': '',
+    'name': '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583',
     'address': '',
     'contactId': null
   },
@@ -45,12 +45,16 @@ var defaultVScrollData = {
   ],
   'cc': null,
   'bcc': null,
-  'date': '',
+  'date': '0',
   'hasAttachments': false,
-  'snippet': ' ',
+  'snippet': '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583',
   'isRead': true,
   'isStarred': false,
-  'subject': '...'
+  'subject': '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583'
 };
 
 /**

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -924,6 +924,8 @@ MessageListCard.prototype = {
         this._isCacheableCardState() &&
         // if the scroll area is at the top (otherwise the
         // virtual scroll may be showing non-top messages)
+        // XXX this is overly conservative since a non-current NodeCache may
+        // have dataIndex === 0.
         this.vScroll.currentIndex === 0 &&
         // if actually got a numeric index and
         (index || index === 0) &&

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -367,12 +367,13 @@ MessageListCard.prototype = {
   sliceEvents: ['splice', 'change', 'status', 'complete'],
 
   postInsert: function() {
-    // Get the height of the search box and tell vScroll about it,
-    // but only do this once the DOM is displayed so the ClientRect
-    // gives an actual height.
-    this.vScroll.visibleOffset = this.searchBar.getBoundingClientRect().height;
-
     this._hideSearchBoxByScrolling();
+
+    // Now that _hideSearchBoxByScrolling has activated the display
+    // of the search box, get the height of the search box and tell
+    // vScroll about it, but only do this once the DOM is displayed
+    // so the ClientRect gives an actual height.
+    this.vScroll.visibleOffset = this.searchBar.getBoundingClientRect().height;
 
     if (this.mode === 'search') {
       this.searchInput.focus();
@@ -1373,7 +1374,7 @@ MessageListCard.prototype = {
     var visibleIndices = this.vScroll.getVisibleIndexRange();
     if (visibleIndices &&
         (index < visibleIndices[0] || index > visibleIndices[1])) {
-      this.vScroll.scrollToIndex(index);
+      this.vScroll.jumpToIndex(index);
     }
   },
 

--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -2701,6 +2701,12 @@ MailAPI.prototype = {
   _fireSplice: function(splice, slice, transformedItems, fake) {
     var i, stopIndex, items, tempMsg;
 
+    // - update header count, but only if have a 0 or greater
+    // number value.
+    if (splice.headerCount > -1) {
+      slice.headerCount = splice.headerCount;
+    }
+
     // - generate slice 'onsplice' notification
     if (slice.onsplice) {
       try {

--- a/apps/email/js/ext/mailapi/main-frame-setup.js
+++ b/apps/email/js/ext/mailapi/main-frame-setup.js
@@ -2701,9 +2701,9 @@ MailAPI.prototype = {
   _fireSplice: function(splice, slice, transformedItems, fake) {
     var i, stopIndex, items, tempMsg;
 
-    // - update header count, but only if have a 0 or greater
-    // number value.
-    if (splice.headerCount > -1) {
+    // - update header count, but only if the splice tracks a
+    // headerCount.
+    if (splice.headerCount !== undefined) {
       slice.headerCount = splice.headerCount;
     }
 

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -4,6 +4,7 @@
  **/
 /*jshint browser: true */
 /*global define, requirejs, console, TestUrlResolver */
+'use strict';
 
 // Set up loading of scripts, but only if not in tests, which set up
 // their own config.
@@ -154,8 +155,9 @@ var startCardArgs = {
 
 function pushStartCard(id, addedArgs) {
   var args = startCardArgs[id];
-  if (!args)
+  if (!args) {
     throw new Error('Invalid start card: ' + id);
+  }
 
   //Add in cached node to use (could be null)
   args[3].cachedNode = cachedNode;
@@ -264,8 +266,9 @@ document.addEventListener('visibilitychange', function onVisibilityChange() {
 evt.on('accountModified', function(accountId, data) {
   model.latestOnce('acctsSlice', function() {
     var account = model.getAccount(accountId);
-    if (account)
+    if (account) {
       account.modifyAccount(data);
+    }
   });
 });
 
@@ -332,8 +335,9 @@ model.on('acctsSlice', function() {
     }
   } else {
     model.latestOnce('foldersSlice', function() {
-      if (waitForAppMessage)
+      if (waitForAppMessage) {
         return;
+      }
 
       // If an activity was waiting for an account, trigger it now.
       if (activityContinued()) {
@@ -368,16 +372,21 @@ appMessages.on('activity', function(type, data, rawActivity) {
           var attachmentBlobs = data.attachmentBlobs;
           /* to/cc/bcc/subject/body all have default values that shouldn't
           be clobbered if they are not specified in the URI*/
-          if (data.to)
+          if (data.to) {
             composer.to = data.to;
-          if (data.subject)
+          }
+          if (data.subject) {
             composer.subject = data.subject;
-          if (data.body)
+          }
+          if (data.body) {
             composer.body = { text: data.body };
-          if (data.cc)
+          }
+          if (data.cc) {
             composer.cc = data.cc;
-          if (data.bcc)
+          }
+          if (data.bcc) {
             composer.bcc = data.bcc;
+          }
           if (attachmentBlobs) {
             for (var iBlob = 0; iBlob < attachmentBlobs.length; iBlob++) {
               composer.addAttachment({

--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -889,8 +889,8 @@ Cards = {
       removeClass(beginNode, 'no-anim');
       removeClass(endNode, 'no-anim');
 
-      if (cardInst && cardInst.onCardVisible)
-        cardInst.onCardVisible();
+      if (cardInst && cardInst.cardImpl.onCardVisible)
+        cardInst.cardImpl.onCardVisible();
     }
 
     // Hide toaster while active card index changed:

--- a/apps/email/js/vscroll.js
+++ b/apps/email/js/vscroll.js
@@ -1,0 +1,822 @@
+'use strict';
+
+define(function(require, exports, module) {
+
+  var evt = require('evt'),
+      slice = Array.prototype.slice,
+      nodeCacheIdCounter = 0;
+
+  /**
+   * Indirection for setting the top of a node. Used to allow
+   * experimenting with either a transform or using top
+   */
+  function setTop(node, value, useTransform) {
+    if (useTransform) {
+      node.style.transform = 'translateY(' + value + 'px)';
+    } else {
+      node.style.top = value + 'px';
+    }
+  }
+
+  // NodeCache ------------------------------------------------------
+  /**
+   * Holds a set of nodes. VScroll holds a list of NodeCache
+   * instances which in turn holds a list of nodes that actually show
+   * items in the VScroll instance. The purpose of using this
+   * NodeCache collection is to hopefully avoid the number of node
+   * repositioning of direct VScroll children, and to match more
+   * closely the way data is returned from the email backend, in
+   * slice chunks, and so a few item nodes would be updated when the
+   * chunk is received by the email front end.
+   *
+   * @param {Boolean} useTransform whether to use transforms instead
+   * of style positioning.
+   */
+  function NodeCache(useTransform) {
+    this.container = new NodeCache.Node();
+    this.id = nodeCacheIdCounter++;
+    this.container.dataset.cacheid = this.id;
+    this.nodes = [];
+    this.useTransform = useTransform;
+
+    this.dataIndex = -1;
+
+    // Used by VScroll to track position so DOM
+    // does not have to be queried for it.
+    this.topPx = 0;
+  }
+
+  /**
+   * Encapsulates the actual DOM used inside the NodeCache
+   * as the container for the item nodes.
+   */
+  NodeCache.Node = function () {
+    var node = document.createElement('div');
+    node.classList.add(NodeCache.Node.className);
+    return node;
+  };
+
+  NodeCache.Node.className = 'vscroll-cachelist';
+
+  NodeCache.prototype = {
+    setTop: function(top) {
+      setTop(this.container, top, this.useTransform);
+      this.topPx = top;
+    }
+  };
+
+  // VScroll --------------------------------------------------------
+  /**
+   * Creates a new VScroll instance. Needs .setData() called on it
+   * to actually show content, the constructor just wires up nodes
+   * and sets starting state.
+   *
+   * @param {Node} container the DOM node that will show the items.
+   *
+   * @param {Node} scrollingContainer the scrolling DOM node, which
+   * contains the `container` node. Note that in email, there are
+   * other nodes in the scrollingContainer besides just container.
+   *
+   * @param {Node} template a DOM node that is cloned to provide
+   * the DOM node to use for an item that is shown on the screen.
+   * The clones of this node are cached and reused for multiple
+   * data items.
+   *
+   * @param {Object} defaultData a placeholder data object to use
+   * if list(index) does not return an object. Usually shows up when
+   * the scroll gets to a place in the list that does not have data
+   * loaded yet from the back end.
+   */
+  function VScroll(container, scrollingContainer, template, defaultData) {
+    evt.Emitter.call(this);
+
+    this.container = container;
+    this.scrollingContainer = scrollingContainer;
+    this.template = template;
+    this.defaultData = defaultData;
+
+    this.currentIndex = 0;
+
+    this._limited = false;
+
+    // Stores the list of DOM nodes to reuse.
+    this.nodeCacheList = [];
+    this.nodeCacheId = 0;
+
+    this.scrollTop = 0;
+    this.visibleOffset = 0;
+
+    this.oldListSize = 0;
+
+    this._lastEventTime = 0;
+
+    // Bind to this to make reuse in functional APIs easier.
+    this.onEvent = this.onEvent.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this._scrollTimeoutPoll = this._scrollTimeoutPoll.bind(this);
+  }
+
+  /**
+   * Given a node that is handled by VScroll, trim it down for use
+   * in a string cache, like email's cookie cache. Modifies the
+   * node in place.
+   * @param  {Node} node the containerNode that is bound to
+   * a VScroll instance.
+   * @param  {Number} itemLimit number of items to cache. If greater
+   * than the length of items in a NodeCache, the NodeCache item
+   * length will be used.
+   */
+  VScroll.trimMessagesForCache = function(container, itemLimit) {
+    // Find the NodeCache that is at the top
+    var keptNode,
+        nodeCaches = container.querySelectorAll('.' + NodeCache.Node.className);
+
+    slice.call(nodeCaches).forEach(function (nodeCache) {
+      if (!keptNode && parseInt(nodeCache.style.top, 10) === 0) {
+        keptNode = nodeCache;
+      } else {
+        nodeCache.parentNode.removeChild(nodeCache);
+      }
+    });
+
+    if (keptNode) {
+      // Then trim out items that are larger than the limit.
+      for (var childIndex = keptNode.children.length - 1;
+                            childIndex > itemLimit - 1;
+                            childIndex--) {
+        keptNode.removeChild(keptNode.children[childIndex]);
+      }
+    }
+  };
+
+  VScroll.prototype = {
+    // rate limit for event handler, in milliseconds, so that
+    // it does not do work for every event received. If set to
+    // zero, it means always do the work for every scroll event.
+    // If this code continues to use 0, then the onEvent/onChange
+    // duality could be removed, and just use onChange directly.
+    // A non-zero value, like 50 subjectively seems to result in
+    // more checkerboarding of half the screen every so often.
+    eventRateLimit: 0,
+
+    // How much to multiply the visible node range by to allow for
+    // smoother scrolling transitions without white gaps.
+    rangeMultipler: 2,
+
+    // What fraction of the height to use to trigger the render of
+    // the next node cache. If scroll position goes past this point,
+    // the next node cache work is triggered.
+    heightFractionTrigger: 8 / 10,
+
+    // Detach cache dom when doing item updates and reattach when done.
+    // If this value stays at false for a while, it can be removed later.
+    detachForUpdates: false,
+
+    // number of NodeCache objects to use
+    nodeCacheListSize: 3,
+
+    // The class to find items that have their default data set,
+    // in the case where a scroll into a cache has skipped updates
+    // because a previous fast scroll skipped the updates since they
+    // were not visible at the time of that fast scroll.
+    itemDefaultDataClass: 'default-data',
+
+    // Use transformY instead of top to position node caches. If this
+    // value stays as false, this code and its use can be removed.
+    useTransform: false,
+
+    /**
+     * Hook that is implemented by the creator of a VScroll instance.
+     * Called when the VScroll thinks it will need the next set of
+     * data, but before the VScroll actually shows that section of
+     * data. Passed the index and a count of items from that index
+     * that should be fetched for use later.
+     */
+    prepareData: function(index, count) {},
+
+    /**
+     * Hook that is implemented by the creator of a VScroll instance.
+     * Called when the VScroll wants to bind a model object to a
+     * display node.
+     */
+    bindData: function(model, node) {},
+
+    /**
+     * Sets the list data source, and then triggers a recalculate
+     * since the data changed.
+     * @param {Function} list the list data source.
+     */
+    setData: function(list) {
+      this.list = list;
+      if (this._inited) {
+        if (!this.waitingForRecalculate) {
+          this._recalculate(0);
+        }
+        this.emit('dataChanged');
+      } else {
+        this._render(0);
+      }
+    },
+
+    /**
+     * Called by code that created the VScroll instance, when that
+     * code has data fetched and wants to let the VScroll know
+     * about it. This is useful from removing the display of
+     * defaultData and showing the finally fetched data.
+     * @param  {Number} index the list item index for which the
+     * data update is available
+     * @param  {Array} dataList the list of data items that are
+     * now available. The first item in that list corresponds to
+     * the data list index given in the first argument.
+     * @param  {number} removedCount the count of any items removed.
+     * Used mostly to know if a recalculation needs to be done.
+     */
+    updateDataBind: function(index, dataList, removedCount) {
+      if (!this._inited) {
+        return;
+      }
+
+      var cache;
+
+      // If the list contents are different, wait until scrolling
+      // stops then recalculate.
+      if (this.oldListSize !== this.list.size() || removedCount) {
+        if (!this.waitingForRecalculate) {
+          this.waitingForRecalculate = true;
+          this.once('scrollStopped', function() {
+            this._recalculate(index);
+          }.bind(this));
+        }
+        return;
+      }
+
+      for (var i = 0; i < dataList.length; i++) {
+        var data = dataList[i],
+            absoluteIndex = index + i;
+
+        if (!cache ||
+            absoluteIndex > cache.dataIndex + cache.nodes.length - 1) {
+          cache = this._getCacheForIndex(absoluteIndex);
+          // The index is outside the range that is currently needed.
+          if (!cache) {
+            return;
+          }
+        }
+
+       var node = cache.nodes[absoluteIndex - cache.dataIndex];
+        if (node) {
+          this.bindData(data, node);
+        }
+      }
+    },
+
+    /**
+     * Handles events fired, and allows rate limiting the work if
+     * this.eventRateLimit has been set. Otherwise just calls
+     * directly to onChange.
+     */
+    onEvent: function() {
+      this._lastEventTime = Date.now();
+
+      if (!this.eventRateLimit) {
+        return this.onChange();
+      }
+
+      if (this._limited) {
+        return;
+      }
+      this._limited = true;
+      setTimeout(this.onChange, this.eventRateLimit);
+    },
+
+    /**
+     * Handles changes in the scroll or resize of scrollContainer.
+     */
+    onChange: function() {
+      // Rate limit is now expired since doing actual work.
+      this._limited = false;
+
+      var startDataIndex,
+          cache = this.currentNodeCache,
+          scrollTop = this.scrollingContainer.scrollTop,
+          topDistance = scrollTop - cache.topPx,
+          bottomDistance = (cache.topPx + this.cacheContainerHeight) -
+                            scrollTop,
+          scrollDown = scrollTop >= this.scrollTop;
+
+      this.scrollTop = scrollTop;
+
+      // If topDistance is past the triggerHeight, send out an event
+      // about needing more data, in the appropriate direction.
+
+      if (scrollDown && (topDistance > 0 &&
+          topDistance > this.cacheTriggerHeight)) {
+        startDataIndex = cache.dataIndex + this.nodeRange;
+
+        // Render next cache segment but only if not already at the end.
+        if (startDataIndex < this.list.size()) {
+          // Do not ask for data past the size of the data list.
+          var totalCount = this.list.size();
+          var count = this.nodeRange;
+          if (startDataIndex + count > totalCount) {
+            count = totalCount - startDataIndex;
+          }
+          this.prepareData(startDataIndex, count);
+
+          this._render(startDataIndex);
+        }
+      } else if (!scrollDown && (bottomDistance > 0 &&
+                 bottomDistance > this.cacheTriggerHeight)) {
+        startDataIndex = cache.dataIndex - this.nodeRange;
+        if (startDataIndex < 0) {
+          startDataIndex = 0;
+        }
+
+        // Render next segment but only if not already at the top.
+        if (startDataIndex !== 0 || cache.topPx !== 0) {
+          this.prepareData(startDataIndex, this.nodeRange);
+          this._render(startDataIndex);
+        }
+      }
+
+      this._startScrollStopPolling();
+    },
+
+    /**
+     * Returns the start index and end index of the list items that
+     * are currently visible to the user.
+     * @return {Array} first and last index. Array could be undefined
+     * if the VScroll is not in a position to show data yet.
+     */
+    getVisibleIndexRange: function() {
+      // Do not bother if itemHeight has not bee initialized yet.
+      if (this.itemHeight === undefined) {
+        return undefined;
+      }
+
+      var top = this.scrollTop;
+
+      return [
+        Math.floor(top / this.itemHeight),
+        Math.floor((top +
+                    this.scrollingContainer.getBoundingClientRect().height -
+                    this.visibleOffset) /
+                    this.itemHeight)
+      ];
+    },
+
+    /**
+     * Given the list index, scroll to the top of that item.
+     * @param  {Number} index the list item index.
+     */
+    scrollToIndex: function(index) {
+      this.scrollingContainer.scrollTop = (index * this.itemHeight) +
+                                          this.visibleOffset;
+    },
+
+    /**
+     * Removes items from display in the container. Just a visual
+     * change, does not change data in any way.
+     */
+    clearDisplay: function() {
+      this.container.innerHTML = '';
+      this.container.style.height = '0px';
+      this._cleared = true;
+    },
+
+    /**
+     * Call this method before the VScroll instance will be destroyed.
+     * Used to clean up the VScroll.
+     */
+    destroy: function() {
+      this.scrollingContainer.removeEventListener('scroll', this.onEvent);
+      this.scrollingContainer.removeEventListener('resize', this.onEvent);
+      if (this._scrollTimeoutPoll) {
+        clearTimeout(this._scrollTimeoutPoll);
+        this._scrollTimeoutPoll = 0;
+      }
+    },
+
+    /**
+     * Does the heavy lifting of showing the items that should appear
+     * starting with the given index.
+     * @param  {Number} index the index into the list data that
+     * should be used to start the render.
+     */
+    _render: function(index) {
+      var i;
+
+      this.currentIndex = index;
+
+      if (!this._inited) {
+        this._init();
+      } else {
+        if (this._cleared) {
+          this.nodeCacheList.forEach(function(cache, cacheIndex) {
+            this.container.appendChild(cache.container);
+          }.bind(this));
+          this._cleared = false;
+        }
+
+        // Disregard the render request an existing cache set already has
+        // that index generated.
+        for (i = 0; i < this.nodeCacheList.length; i++) {
+          if (i !== this.nodeCacheId &&
+              this.nodeCacheList[i].dataIndex === index) {
+            this.currentNodeCache = this.nodeCacheList[i];
+            this.nodeCacheId = i;
+            return;
+          }
+        }
+
+        // Update which nodeCache to use. Want one that is not
+        // currently visible.
+        var cacheId = -1;
+        for (i = this.nodeCacheId + 1; cacheId === -1; i++) {
+          if (i > this.nodeCacheList.length - 1) {
+            i = 0;
+          }
+
+          var cacheItemIndex = this.nodeCacheList[i].dataIndex;
+          if ((cacheItemIndex === -1) || !this._isCacheVisible(i)) {
+            cacheId = i;
+          }
+        }
+        this.nodeCacheId = cacheId;
+      }
+
+      var cache = this.nodeCacheList[this.nodeCacheId],
+          nodes = cache.nodes,
+          listSize = this.list.size();
+
+      cache.dataIndex = index;
+
+      // Store the index on DOM node container index, to
+      // allow easier query selectors for tests.
+      cache.container.dataset.index = index;
+
+      this.currentNodeCache = cache;
+      this.currentNodeCache.dataIndex = this.currentIndex;
+
+      // Pull the node cache container out of the DOM to
+      // allow for the updates to happen quicker without
+      // triggering reflows in the middle? Experimental.
+      if (this.detachForUpdates) {
+        this.container.removeChild(cache.container);
+      }
+
+      var length = index + nodes.length;
+      for (i = index; i < length; i++) {
+        var node = nodes[i - index];
+        if (i < listSize) {
+          var data = this.list(i);
+          if (!data) {
+            data = this.defaultData;
+          }
+          this.bindData(data, node);
+        }
+      }
+
+      // Reposition the cache at the new location and insert
+      // back into the DOM
+      cache.setTop(index * this.itemHeight);
+      if (this.detachForUpdates) {
+        this.container.appendChild(cache.container);
+      }
+    },
+
+    /**
+     * Handles final initialization, once the VScroll is expected
+     * to actually show data.
+     */
+    _init: function() {
+
+      this.scrollingContainer.addEventListener('scroll', this.onEvent);
+      this.scrollingContainer.addEventListener('resize', this.onEvent);
+
+      for (var i = 0; i < this.nodeCacheListSize; i++) {
+        this.nodeCacheList.push(new NodeCache(this.useTransform));
+      }
+
+      // Render the data item at index, to get sizes of things,
+      // and create the cache of nodes.
+      var node = this.template.cloneNode(true),
+          cache = this.nodeCacheList[0];
+
+      cache.nodes.push(node);
+
+      cache.container.appendChild(node);
+      cache.setTop(0);
+
+      // Clear out any previous container contents. For example, a
+      // cached HTML of a previous card may have been used to init
+      // this VScroll instance.
+      this.container.innerHTML = '';
+
+      this.container.appendChild(cache.container);
+
+      this.itemHeight = node.clientHeight;
+      // Using window here because asking for this.container.clientHeight
+      // will be zero since it has not children that are in the flow.
+      // innerHeight is fairly close though as the list content is the
+      // majority of the display area.
+      this.innerHeight = window.innerHeight;
+      this.itemsPerDisplay = Math.ceil(this.innerHeight /
+                                       this.itemHeight);
+      this.nodeRange = Math.floor(this.itemsPerDisplay * this.rangeMultipler);
+      this.cacheContainerHeight = this.nodeRange * this.itemHeight;
+
+      this.cacheTriggerHeight = this.cacheContainerHeight -
+                                (this.cacheContainerHeight *
+                                 this.heightFractionTrigger);
+
+      // Generate as set of DOM nodes to reuse.
+      // The - 1 is because the init node used to calculate itemHeight
+      // is already in the cache.
+      this.nodeCacheList.forEach(function(cache, cacheIndex) {
+        var nodes = cache.nodes,
+            i = 0,
+            length = this.nodeRange;
+
+        // If the first pass through, already added test div to get
+        // item height, so exclude that one from the count.
+        if (cacheIndex === 0) {
+          i = 1;
+        }
+
+        // Set explicit height on on the cache container, in the hopes
+        // that this helps layout, but not proven yet.
+        cache.container.style.height = this.cacheContainerHeight + 'px';
+        cache.setTop(cacheIndex * this.cacheContainerHeight);
+
+        if (cacheIndex > 0) {
+          // The NodeCache container needs to be inserted into the DOM
+          this.container.appendChild(cache.container);
+        }
+
+        // Set up the cache nodes inside the container.
+        for (; i < length; i++) {
+          var newNode = this.template.cloneNode(true);
+          setTop(newNode, (i * this.itemHeight), this.useTransform);
+          cache.container.appendChild(newNode);
+          nodes.push(newNode);
+        }
+      }.bind(this));
+
+      this._calculateTotalHeight();
+      this._inited = true;
+      this.emit('inited');
+    },
+
+    /**
+     * Recalculates the size of the container, and resets the
+     * display of items in the container. Maintains the scroll
+     * position inside the list.
+     * @param {Number} refIndex a reference index that spawned
+     * the recalculate. If that index is "above" the targeted
+     * computed index found by recalculate, then it means the
+     * the absolute scroll position may need to change.
+     */
+    _recalculate: function(refIndex) {
+      var index = Math.floor(this.scrollTop / this.itemHeight),
+          remainder = this.scrollTop % this.itemHeight,
+          sizeDiff = this.list.size() - this.oldListSize;
+
+      // If this recalculate was spawned from the top and more
+      // items, then new messages from the top, and account for
+      // them so the scroll position does not jump. Only do this
+      // though if old size was not 0, which is common on first
+      // folder sync, or if the reference index that spawned the
+      // recalculate is "above" the target index, since that
+      // means the contents above the target index shifted.
+      if (refIndex && refIndex < index && sizeDiff > 0 &&
+          this.oldListSize !== 0 && index !== 0) {
+        index += sizeDiff;
+      }
+
+      console.log('VSCROLL scrollTop: ' + this.scrollTop +
+                  ', RECALCULATE: ' + index + ', ' + remainder);
+
+      this._calculateTotalHeight();
+
+      // Now clear the caches from the visible area
+      this.nodeCacheList.forEach(function(cache) {
+        cache.setTop(this.totalHeight + 1);
+        cache.dataIndex = -1;
+        cache.container.dataset.index = -1;
+      }.bind(this));
+
+      this._render(index);
+
+      // Reposition the scroll
+      //
+      this.scrollingContainer.scrollTop = (this.itemHeight * index) + remainder;
+
+      this.waitingForRecalculate = false;
+
+      this.emit('recalculated', index === 0);
+    },
+
+    /**
+     * Sets the total height of the container.
+     */
+    _calculateTotalHeight: function() {
+      // Size the scrollable area to the full height if all items
+      // were rendered inside of it, so that there is no weird
+      // scroll bar grow/shrink effects and so that inertia
+      // scrolling is not artificially truncated.
+      var newListSize = this.list.size();
+
+      // Do not bother if same size, or if the container was set to 0 height,
+      // most likely by a clearDisplay.
+      if (this.oldListSize !== newListSize ||
+        parseInt(this.container.style.height, 10) === 0) {
+        this.totalHeight = this.itemHeight * newListSize;
+        this.container.style.height = this.totalHeight + 'px';
+        this.oldListSize = newListSize;
+      }
+    },
+
+    /**
+     * Indicates if the NodeCache at the given index is visible in
+     * the container.
+     * @param  {number}  index the index of the NodeCache in
+     * the VScroll's set of NodeCache instances.
+     * @return {Boolean}
+     */
+    _isCacheVisible: function(index) {
+      var top = this.nodeCacheList[index].topPx,
+          bottom = top + this.cacheContainerHeight,
+          scrollTop = this.scrollTop,
+          scrollBottom = scrollTop + this.innerHeight;
+
+      if (bottom > this.totalHeight) {
+        bottom = this.totalHeight;
+      }
+      if (scrollBottom > this.totalHeight) {
+        scrollBottom = this.totalHeight;
+      }
+
+      // If the scrollTop/Bottom intersects the top/bottom,
+      // then it is visible
+      if ((scrollTop >= top && scrollTop <= bottom) ||
+          (scrollBottom >= top && scrollBottom <= bottom) ||
+          (top >= scrollTop && top <= scrollBottom) ||
+          (bottom >= scrollTop && bottom <= scrollBottom)) {
+        return true;
+      }
+      return false;
+    },
+
+    /**
+     * Given the list index, get the NodeCache instance to use for
+     * it.
+     * @param  {Number} index the list item index.
+     * @return {NodeCache} could be undefined if the item at that
+     * index is not currently targeted for display in a NodeCache.
+     */
+    _getCacheForIndex: function(index) {
+      var cache,
+          startId = this.nodeCacheId,
+          i = startId;
+
+      do {
+        cache = this.nodeCacheList[i];
+        if (index >= cache.dataIndex &&
+            index < cache.dataIndex + cache.nodes.length) {
+          return cache;
+        }
+        i += 1;
+        if (i > this.nodeCacheList.length - 1) {
+          i = 0;
+        }
+      } while(i !== startId);
+    },
+
+    /**
+     * Handles checking for the end of a scroll, based on a time
+     * delay since the last scroll event.
+     */
+    _scrollTimeoutPoll: function() {
+      this._scrollStopTimeout = 0;
+      if (Date.now() > this._lastEventTime + 300) {
+        // Scan for items that have default data but maybe should
+        // have real data by now.
+        this.nodeCacheList.forEach(function(cache, i) {
+          if (this._isCacheVisible(i) && cache.dataIndex > -1) {
+            var nodes = cache.nodes;
+            nodes.forEach(function(node, j) {
+              if (node.classList.contains(this.itemDefaultDataClass)) {
+                this.bindData(
+                  this.list(cache.dataIndex + j) || this.defaultData,
+                  node
+                );
+              }
+            }.bind(this));
+          }
+        }.bind(this));
+
+        this.emit('scrollStopped');
+      } else {
+        this._scrollStopTimeout = setTimeout(this._scrollTimeoutPoll, 300);
+      }
+    },
+
+    /**
+     * Starts checking for the end of scroll events.
+     */
+    _startScrollStopPolling: function() {
+      if (!this._scrollStopTimeout) {
+        // "this" binding for _scrollTimeoutPoll done in constructor
+        this._scrollStopTimeout = setTimeout(this._scrollTimeoutPoll, 300);
+      }
+    }
+  };
+
+  evt.mix(VScroll.prototype);
+
+  // Override on() to allow for a lazy firing of scrollStopped,
+  // particularly when the list is not scrolling, so the stop
+  // polling is not currently running. This is useful for "once"
+  // listeners that just want to be sure to do work when scroll
+  // is not in action.
+  var originalOn = VScroll.prototype.on;
+  VScroll.prototype.on = function(id, fn) {
+    if (id === 'scrollStopped') {
+      this._startScrollStopPolling();
+    }
+
+    return originalOn.apply(this, slice.call(arguments));
+  };
+
+  // Introspection tools --------------------------------------------
+  // uncomment this section to use them. Useful for tracing how the
+  // code is called.
+  /*
+  var logQueue = [],
+      logTimeoutId = 0,
+      // 16 ms threshold for 60 fps, set to 0 to just log all calls,
+      // without timings. Unless set to 0, log calls are batched
+      // and written to the console later, so they will not appear
+      // in the correct order as compared to console logs done outside
+      // this module. Plus they will appear out of order since the log
+      // call does not complete until after the wrapped function
+      // completes. So if other function calls complete inside that
+      // function, they will be logged before the containing function
+      // is logged.
+      perfLogThreshold = 0;
+
+  function logPerf() {
+    logQueue.forEach(function(msg) {
+      console.log(msg);
+    });
+    logQueue = [];
+    logTimeoutId = 0;
+  }
+
+  function queueLog(prop, time, arg0) {
+    var arg0Type = typeof arg0;
+    logQueue.push(module.id + ': ' + prop +
+      (arg0Type === 'number' ||
+       arg0Type === 'boolean' ||
+       arg0Type === 'string' ?
+       ': (' + arg0 + ')' : '') +
+      (perfLogThreshold === 0 ? '' : ': ' + time));
+    if (perfLogThreshold === 0) {
+      logPerf();
+    } else {
+      if (!logTimeoutId) {
+        logTimeoutId = setTimeout(logPerf, 2000);
+      }
+    }
+  }
+
+  function perfWrap(prop, fn) {
+    return function() {
+      var start = performance.now();
+      if (perfLogThreshold === 0) {
+        queueLog(prop, 0, arguments[0]);
+      }
+      var result = fn.apply(this, arguments);
+      var end = performance.now();
+
+      var time = end - start;
+      if (perfLogThreshold > 0 && time > perfLogThreshold) {
+        queueLog(prop, end - start, arguments[0]);
+      }
+      return result;
+    };
+  }
+
+  if (perfLogThreshold > -1) {
+    Object.keys(VScroll.prototype).forEach(function (prop) {
+      var proto = VScroll.prototype;
+      if (typeof proto[prop] === 'function') {
+        proto[prop] = perfWrap(prop, proto[prop]);
+      }
+    });
+  }
+  */
+
+  return VScroll;
+});

--- a/apps/email/js/vscroll.js
+++ b/apps/email/js/vscroll.js
@@ -104,6 +104,11 @@ define(function(require, exports, module) {
     this.nodeCacheId = 0;
 
     this.scrollTop = 0;
+
+    // Any visible height offset to where container sits in relation
+    // to scrollingContainer. Expected to be set by owner of the
+    // VScroll instance. In email, the search box height is an
+    // example of a visibleOffset.
     this.visibleOffset = 0;
 
     this.oldListSize = 0;
@@ -157,7 +162,7 @@ define(function(require, exports, module) {
     // duality could be removed, and just use onChange directly.
     // A non-zero value, like 50 subjectively seems to result in
     // more checkerboarding of half the screen every so often.
-    eventRateLimit: 0,
+    eventRateLimitMillis: 0,
 
     // How much to multiply the visible node range by to allow for
     // smoother scrolling transitions without white gaps.
@@ -272,13 +277,13 @@ define(function(require, exports, module) {
 
     /**
      * Handles events fired, and allows rate limiting the work if
-     * this.eventRateLimit has been set. Otherwise just calls
+     * this.eventRateLimitMillis has been set. Otherwise just calls
      * directly to onChange.
      */
     onEvent: function() {
       this._lastEventTime = Date.now();
 
-      if (!this.eventRateLimit) {
+      if (!this.eventRateLimitMillis) {
         return this.onChange();
       }
 
@@ -286,7 +291,7 @@ define(function(require, exports, module) {
         return;
       }
       this._limited = true;
-      setTimeout(this.onChange, this.eventRateLimit);
+      setTimeout(this.onChange, this.eventRateLimitMillis);
     },
 
     /**
@@ -357,7 +362,7 @@ define(function(require, exports, module) {
       var top = this.scrollTop;
 
       return [
-        Math.floor(top / this.itemHeight),
+        Math.floor((top - this.visibleOffset)/ this.itemHeight),
         Math.floor((top +
                     this.scrollingContainer.getBoundingClientRect().height -
                     this.visibleOffset) /
@@ -369,7 +374,7 @@ define(function(require, exports, module) {
      * Given the list index, scroll to the top of that item.
      * @param  {Number} index the list item index.
      */
-    scrollToIndex: function(index) {
+    jumpToIndex: function(index) {
       this.scrollingContainer.scrollTop = (index * this.itemHeight) +
                                           this.visibleOffset;
     },

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -4,6 +4,11 @@
   overflow-x: hidden;
   will-change: scroll-position;
 }
+
+[data-mode="search"] .msg-list-scrollouter {
+  height: calc(100% - 13.5rem);
+}
+
 .msg-list-scrollinner {
   /* Give it a z-index of 0 so that all its contents are forced into a single stacking
      context. This simplifies display list construction because our many positioned
@@ -60,12 +65,21 @@ input.msg-search-text-tease {
   font-style: italic;
 }
 
+.vscroll-cachelist {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  overflow: hidden;
+  background-color: white;
+}
+
 /* Sections horizontally chop up the item: unread, details, icons, avatar.
  * We have 320 horizontal pixels to play with.
  */
 .msg-header-item {
   display: block;
-  position: relative;
+  position: absolute;
+  width: 100%;
   height: 8rem;
 }
 .msg-header-item:active {
@@ -477,7 +491,9 @@ input.msg-search-text-tease {
   * opaque background to optimize Gecko.
   * See Bug 962699. */
 .msg-messages-container {
-   background-color: #fff;
+  position: relative;
+  background-color: #fff;
+  overflow: hidden;
 }
 
 .msg-delete-btn {

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -169,7 +169,6 @@ reflows. Foreground/background colors should be safe.
   display: table-cell;
   width: -moz-min-content;
   white-space: nowrap;
-  margin-left: 1ch;
 }
 .msg-header-date-unread {
   color: #1D8399;

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -85,6 +85,25 @@ input.msg-search-text-tease {
 .msg-header-item:active {
   background-color: #b1f1ff;
 }
+
+/*
+Default data placeholder items. To limit scrolling
+impact, these styles should not be ones that trigger
+reflows. Foreground/background colors should be safe.
+ */
+.msg-header-item.default-data .msg-header-author {
+  color: #e7e8e9;
+}
+.msg-header-item.default-data .msg-header-subject {
+  color: #e7e8e9;
+}
+.msg-header-item.default-data .msg-header-snippet {
+  color: #e7e8e9;
+}
+.msg-header-item.default-data .msg-header-date {
+  color: white;
+}
+
 .msg-header-unread-section {
   position: absolute;
   top: 50%;

--- a/apps/email/test/marionette/lib/email.js
+++ b/apps/email/test/marionette/lib/email.js
@@ -1,4 +1,5 @@
 /*jshint node: true, browser: true */
+'use strict';
 function Email(client) {
   this.client = client.scope({ searchTimeout: 20000 });
 }
@@ -32,7 +33,8 @@ var Selector = {
   msgDownBtn: '.card-message-reader .msg-down-btn',
   msgListScrollOuter: '.card-message-list .msg-list-scrollouter',
   editMode: '.card-message-list .msg-edit-btn',
-  editModeCheckBoxes: '.card-message-list label.pack-checkbox',
+  editModeCheckBoxes:
+    '.card-message-list .vscroll-cachelist[data-index="0"] label.pack-checkbox',
   editModeTrash: '.card-message-list button.msg-delete-btn',
   msgUpBtn: '.card-message-reader .msg-up-btn',
   msgEnvelopeSubject: '.card-message-reader .msg-envelope-subject',
@@ -48,7 +50,8 @@ var Selector = {
   composeDraftDiscard: '#cmp-draft-discard',
   composeDraftSave: '#cmp-draft-save',
   refreshButton: '.card.center .msg-refresh-btn',
-  messageHeaderItem: '.msg-messages-container .msg-header-item',
+  messageHeaderItem:
+  '.msg-messages-container .vscroll-cachelist[data-index="0"] .msg-header-item',
   cardMessageReader: '.card-message-reader',
   currentCardInputs: '.card.center input[type="text"]',
   replyMenuButton: '.msg-reply-btn',
@@ -103,7 +106,9 @@ Email.prototype = {
   },
 
   tapNotificationBar: function() {
-    this.notificationBar.click();
+    var notificationBar = this.notificationBar;
+    notificationBar.click();
+    this.client.helper.waitForElementToDisappear(notificationBar);
   },
 
   get msgDownBtn() {
@@ -300,11 +305,12 @@ Email.prototype = {
    * future if we inline various affordances proposed by UX.
    */
   getComposeBody: function() {
-    return client.executeScript(function() {
+    return this.client.executeScript(function() {
       var Cards = window.wrappedJSObject.require('mail_common').Cards,
           card = Cards._cardStack[Cards.activeCardIndex];
-      if (card.cardDef.name !== 'compose')
+      if (card.cardDef.name !== 'compose') {
         throw new Error('active card should be compose!');
+      }
 
       var composeCard = card.cardImpl;
       return composeCard.fromEditor();
@@ -316,11 +322,11 @@ Email.prototype = {
    * Waits for an edit checkbox to appear.
    */
   editMode: function() {
-    client.helper
+    this.client.helper
       .waitForElement(Selector.editMode)
       .tap();
 
-    client.helper
+    this.client.helper
       .waitForElement(Selector.editModeCheckBoxes);
   },
 
@@ -328,7 +334,7 @@ Email.prototype = {
    * Returns the edit mode checkboxes.
    */
   editModeCheckboxes: function() {
-    var elements = client.findElements(Selector.editModeCheckBoxes);
+    var elements = this.client.findElements(Selector.editModeCheckBoxes);
     return elements;
   },
 
@@ -336,7 +342,7 @@ Email.prototype = {
    * Taps the trash button in edit mode.
    */
   editModeTrash: function() {
-    client.helper
+    this.client.helper
       .waitForElement(Selector.editModeTrash)
       .tap();
   },
@@ -429,14 +435,14 @@ Email.prototype = {
     client.apps.close(Email.EMAIL_ORIGIN);
   },
 
-  getHeaderAtIndex: function(index) {
-    var client = this.client;
-    var elements = client.findElements(Selector.messageHeaderItem);
-    return client.helper.waitForElement(elements[index]);
+  getHeaderWithId: function(id) {
+    var element = this.client.findElement(Selector.messageHeaderItem +
+                                             '[data-id="' + id + '"]');
+    return this.client.helper.waitForElement(element);
   },
 
-  tapEmailAtIndex: function(index) {
-    var element = this.getHeaderAtIndex(index);
+  tapEmailWithId: function(id) {
+    var element = this.getHeaderWithId(id);
     element.tap();
     this.waitForMessageReader();
   },
@@ -446,8 +452,9 @@ Email.prototype = {
     // we see one.  Then tap on it.
     this.client.waitFor(function() {
       var element = this.getEmailBySubject(subject);
-      if (!element)
+      if (!element) {
         return false;
+      }
 
       element.tap();
       this._waitForTransitionEnd(cardId);
@@ -490,6 +497,8 @@ Email.prototype = {
       whichButton = Selector.replyMenuForward;
       break;
     case 'reply':
+      whichButton = Selector.replyMenuReply;
+      break;
     default:
       whichButton = Selector.replyMenuReply;
       break;
@@ -627,8 +636,9 @@ Email.prototype = {
 
   _tapNext: function(selector, cardId) {
     this._tapSelector(selector);
-    if (cardId)
+    if (cardId) {
       this._waitForTransitionEnd(cardId);
+    }
   },
 
   _clearAndSendKeys: function(selector, value) {

--- a/apps/email/test/marionette/next_previous_test.js
+++ b/apps/email/test/marionette/next_previous_test.js
@@ -1,3 +1,4 @@
+'use strict';
 var Email = require('./lib/email');
 var assert = require('assert');
 var serverHelper = require('./lib/server_helper');
@@ -17,7 +18,11 @@ function isHeaderButtonEnabled(button) {
 }
 
 marionette('email next previous', function() {
-  var app;
+  var app,
+      idsFromTop = [
+        '0/0/1',
+        '0/0/0'
+      ];
 
   var client = marionette.client({
     settings: {
@@ -39,45 +44,45 @@ marionette('email next previous', function() {
   });
 
   test('should grey out up when no message above', function() {
-    app.tapEmailAtIndex(0);
+    app.tapEmailWithId(idsFromTop[0]);
     var el = app.msgUpBtn;
     assert.ok(!isHeaderButtonEnabled(el));
   });
 
   test('should grey out down when no message below', function() {
-    app.tapEmailAtIndex(1);
+    app.tapEmailWithId(idsFromTop[1]);
     var el = app.msgDownBtn;
     assert.ok(!isHeaderButtonEnabled(el));
   });
 
   test('should not grey out up when message above', function() {
-    app.tapEmailAtIndex(1);
+    app.tapEmailWithId(idsFromTop[1]);
     var el = app.msgUpBtn;
     assert.ok(isHeaderButtonEnabled(el));
   });
 
   test('should not grey out down when message below', function() {
-    app.tapEmailAtIndex(0);
+     app.tapEmailWithId(idsFromTop[0]);
     var el = app.msgDownBtn;
     assert.ok(isHeaderButtonEnabled(el));
   });
 
   test('should move up when up tapped', function() {
-    app.tapEmailAtIndex(1);
+    app.tapEmailWithId(idsFromTop[1]);
     app.advanceMessageReader(true);
     var subject = app.getMessageReaderSubject();
     assert.strictEqual(subject, 'Two');
   });
 
   test('should move down when down tapped', function() {
-    app.tapEmailAtIndex(0);
+     app.tapEmailWithId(idsFromTop[0]);
     app.advanceMessageReader(false);
     var subject = app.getMessageReaderSubject();
     assert.strictEqual(subject, 'One');
   });
 
   test('should not move up when up tapped if greyed out', function() {
-    app.tapEmailAtIndex(0);
+     app.tapEmailWithId(idsFromTop[0]);
     try {
       app.advanceMessageReader(true);
     } catch (err) {
@@ -91,7 +96,7 @@ marionette('email next previous', function() {
   });
 
   test('should not move down when down tapped if greyed out', function() {
-    app.tapEmailAtIndex(1);
+    app.tapEmailWithId(idsFromTop[1]);
     try {
       app.advanceMessageReader(false);
     } catch (err) {
@@ -105,6 +110,17 @@ marionette('email next previous', function() {
   });
 
   suite('scroll', function() {
+    var idsFromTop = [
+      '0/0/7',
+      '0/0/6',
+      '0/0/5',
+      '0/0/4',
+      '0/0/3',
+      '0/0/2',
+      '0/0/1',
+      '0/0/0'
+    ];
+
     setup(function() {
       // We need more messages to exercise scrolling.
       app.sendAndReceiveMessages([
@@ -119,7 +135,7 @@ marionette('email next previous', function() {
 
     test('should scroll up when up tapped', function() {
       // Start by scrolling to the bottom of the scroll container.
-      var header = app.getHeaderAtIndex(7);
+      var header = app.getHeaderWithId(idsFromTop[7]);
       var offsetTop = header.getAttribute('offsetTop');
       client.executeScript(function(scrollTo) {
         var scrollContainer =
@@ -129,7 +145,7 @@ marionette('email next previous', function() {
 
       var scrollContainer = app.msgListScrollOuter;
       var initial = parseInt(scrollContainer.getAttribute('scrollTop'), 10);
-      app.tapEmailAtIndex(7);
+      app.tapEmailWithId(idsFromTop[7]);
 
       // Advance up to the first message.
       while (true) {
@@ -149,7 +165,7 @@ marionette('email next previous', function() {
     test('should scroll down when down tapped', function() {
       var scrollContainer = app.msgListScrollOuter;
       var initial = parseInt(scrollContainer.getAttribute('scrollTop'), 10);
-      app.tapEmailAtIndex(0);
+       app.tapEmailWithId(idsFromTop[0]);
 
       // Advance down to the last message.
       while (true) {

--- a/apps/email/test/marionette/reply_imap_email_test.js
+++ b/apps/email/test/marionette/reply_imap_email_test.js
@@ -29,7 +29,7 @@ marionette('reply to an e-mail', function() {
     app.sendAndReceiveMessages([
       { to: 'testy@localhost', subject: 'test email', body: BODY_TEXT }
     ]);
-    app.tapEmailAtIndex(0);
+    app.tapEmailWithId('0/0/0');
   });
 
   test('should be able to reply to an email', function() {

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -5,7 +5,7 @@
 apps/video/style/video_tablet.css 0 1
 apps/video/style/video.css 0 7
 apps/video/style/info.css 0 2
-apps/email/style/compose_cards.css 0 6
+apps/email/style/compose_cards.css 1 6
 apps/email/style/message_cards.css 1 15
 apps/email/style/folder_cards.css 0 1
 apps/email/style/common.css 0 5

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -6,7 +6,7 @@ apps/video/style/video_tablet.css 0 1
 apps/video/style/video.css 0 7
 apps/video/style/info.css 0 2
 apps/email/style/compose_cards.css 1 6
-apps/email/style/message_cards.css 1 15
+apps/email/style/message_cards.css 0 15
 apps/email/style/folder_cards.css 0 1
 apps/email/style/common.css 0 5
 apps/email/style/setup_cards.css 0 2

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -107,7 +107,6 @@ apps/email/js/cards/account_picker.js
 apps/email/js/cards/account_prefs_mixins.js
 apps/email/js/cards/compose.js
 apps/email/js/cards/folder_picker.js
-apps/email/js/cards/message_list.js
 apps/email/js/cards/message_reader.js
 apps/email/js/cards/settings_account.js
 apps/email/js/cards/settings_account_credentials.js
@@ -127,13 +126,11 @@ apps/email/js/css.js
 apps/email/js/date.js
 apps/email/js/evt.js
 apps/email/js/folder_depth_classes.js
-apps/email/js/header_cursor.js
 apps/email/js/html_cache.js
 apps/email/js/html_cache_restore.js
 apps/email/js/iframe_shims.js
 apps/email/js/input_areas.js
 apps/email/js/l10n.js
-apps/email/js/mail_app.js
 apps/email/js/mail_common.js
 apps/email/js/marquee.js
 apps/email/js/message_list_topbar.js


### PR DESCRIPTION
This ticket introduces a virtual scroll mechanism, where not all message item divs are rendered at once, but just a subset that is near and in the visible area, with that set updating as scroll position is changed.

message_list now uses vscroll to handle the message items shown in the messages_list. vscroll uses a set of NodeCache objects that each have a set of reusable nodes to use for messages, and as the scroll happens, the NodeCache divs are repositioned as needed and their contents updated. As the user scrolls across the current NodeCache, after it is scrolled by about 20% of its size, a "prepareData" call is used to ask the back end to load more data.

That approach was used since the backend prefers to load data in chunks, and it was hoped that the fewer, bigger divs to move around in the scroll area was better overall. That needs to be balanced though by how much processing power the back end needs to fetch those chunks, and if the updates to those NodeCache sets touch enough nodes as to create a drag on performance.

It seems to work out well with APZC turned on. However, with APZC turned off, it does not perform as quite as nice, and those workloads may need to be tuned if there is a case where this code is used in a non-APZC, low capability device.

There are some changes to these files that are just jshint fixes, see the jshint/xfail.list for the ones that have the changes. Those changes were done in files that had a big enough changeset already that the extra jshint changes should hopefully be smaller noise.

worker-bootstrap.js shows a whitespace change in there, related to CRLF conversions. I am unclear yet on why I am seeing that now, as I do not recall changing my GELAM or Gaia settings in that regard.
