### PR TITLE
Bug 996869 - Join hidden network gives error. r=crh0716

### DIFF
--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -953,6 +953,9 @@ navigator.mozL10n.ready(function wifiSettings() {
       function submit() {
         if (dialogID === 'wifi-joinHidden') {
           network.ssid = dialog.querySelector('input[name=ssid]').value;
+          if (window.MozWifiNetwork !== undefined) {
+            network = new window.MozWifiNetwork(network);
+          }
         }
         if (key) {
           WifiHelper.setPassword(network,


### PR DESCRIPTION
After changing idl to webidl, network object should use MozWifiNetwork object instead.
