### PR TITLE
Bug 996633 - {{ssid}} is displayed instead of the Wireless network name r=crh0716

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -119,8 +119,10 @@ var Connectivity = (function(window, document, undefined) {
       storeMacAddress();
       // network.connection.status has one of the following values:
       // connecting, associated, connected, connectingfailed, disconnected.
+      var networkProp = wifiManager.connection.network ?
+          {ssid: wifiManager.connection.network.ssid} : null;
       localize(wifiDesc, 'fullStatus-' + wifiManager.connection.status,
-               wifiManager.connection.network);
+               networkProp);
     } else {
       localize(wifiDesc, 'disabled');
     }

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -979,13 +979,15 @@ navigator.mozL10n.ready(function wifiSettings() {
   // update network state, called only when wifi enabled.
   function updateNetworkState() {
     var networkStatus = gWifiManager.connection.status;
+    var networkProp = gWifiManager.connection.network ?
+        {ssid: gWifiManager.connection.network.ssid} : null;
 
     // networkStatus has one of the following values:
     // connecting, associated, connected, connectingfailed, disconnected.
     gNetworkList.display(gCurrentNetwork, networkStatus);
 
     gWifiInfoBlock.textContent =
-        _('fullStatus-' + networkStatus, gWifiManager.connection.network);
+        _('fullStatus-' + networkStatus, networkProp);
 
     if (networkStatus === 'connectingfailed' && gCurrentNetwork) {
       settings.createLock().set({'wifi.connect_via_settings': false});


### PR DESCRIPTION
After changing IDL to WebIDL, network object cannot use JSON.stringify.
