### PR TITLE
Bug 996559 - Xfail test_gallery_flick.py due to Marionette actions faili...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/gallery/manifest.ini
@@ -12,6 +12,8 @@ skip-if = device == "desktop"
 
 [test_gallery_flick.py]
 smoketest = true
+# Bug 995989 - Actions(self.marionette).flick() has stopped working
+fail-if = device != "desktop"
 skip-if = device == "desktop"
 
 [test_gallery_delete_image.py]


### PR DESCRIPTION
...ng
