### PR TITLE
Bug 943897 - Code timeout into contacts_settings.tap_import_from_sim()

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/settings_form.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/settings_form.py
@@ -48,11 +48,12 @@ class SettingsForm(Base):
         self.marionette.find_element(*self._export_contacts_locator).tap()
         self.wait_for_condition(lambda m: m.find_element(*self._import_settings_locator).location['x'] == 0)
 
-    def tap_import_from_sim(self):
+    def tap_import_from_sim(self, number_of_contacts=1):
         self.wait_for_element_displayed(*self._import_from_sim_button_locator)
         self.marionette.find_element(*self._import_from_sim_button_locator).tap()
         from gaiatest.apps.contacts.app import Contacts
-        self.wait_for_element_displayed(*Contacts._status_message_locator)
+        self.wait_for_element_displayed(*Contacts._status_message_locator,
+                                        timeout=number_of_contacts * self.marionette.timeout)
 
     @property
     def gmail_imported_contacts(self):

--- a/tests/python/gaia-ui-tests/gaiatest/apps/ftu/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/ftu/app.py
@@ -156,8 +156,9 @@ class Ftu(Base):
     def tap_import_from_sim(self):
         self.marionette.find_element(*self._import_from_sim_locator).tap()
 
-    def wait_for_contacts_imported(self):
+    def wait_for_contacts_imported(self, number_of_sim_contacts=1):
         self.wait_for_condition(lambda m: self._pattern_contacts.match(m.find_element(*self._sim_import_feedback_locator).text) is not None,
+                                timeout=number_of_sim_contacts * self.marionette.timeout,
                                 message='Contact did not import from sim before timeout')
 
     @property

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_import_contacts_from_sim.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/contacts/test_import_contacts_from_sim.py
@@ -15,16 +15,18 @@ class TestImportContactsFromSIM(GaiaTestCase):
 
         """
 
-        self.assertGreater(len(self.data_layer.sim_contacts), 0, "There is no SIM contacts on SIM card.")
+        number_of_sim_contacts = len(self.data_layer.sim_contacts)
+
+        self.assertGreater(number_of_sim_contacts, 0, "There is no SIM contacts on SIM card.")
         contacts_app = Contacts(self.marionette)
         contacts_app.launch()
 
         # import contacts from SIM
         contacts_settings = contacts_app.tap_settings()
         contacts_settings.tap_import_contacts()
-        contacts_settings.tap_import_from_sim()
+        contacts_settings.tap_import_from_sim(number_of_sim_contacts)
         contacts_settings.tap_back_from_import_contacts()
         contacts_settings.tap_done()
 
         # all the contacts in the SIM should be imported
-        self.assertEqual(len(contacts_app.contacts), len(self.data_layer.sim_contacts))
+        self.assertEqual(number_of_sim_contacts, len(self.data_layer.sim_contacts))

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_skip_tour.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_skip_tour.py
@@ -16,6 +16,8 @@ class TestFtu(GaiaTestCase):
     def setUp(self):
         GaiaTestCase.setUp(self)
 
+        self.number_of_sim_contacts = len(self.data_layer.sim_contacts)
+
         self.ftu = Ftu(self.marionette)
         self.ftu.launch()
 
@@ -78,7 +80,7 @@ class TestFtu(GaiaTestCase):
         # Tap import from SIM
         # You can do this as many times as you like without db conflict
         self.ftu.tap_import_from_sim()
-        self.ftu.wait_for_contacts_imported()
+        self.ftu.wait_for_contacts_imported(self.number_of_sim_contacts)
         self.assertEqual(self.ftu.count_imported_contacts, len(self.data_layer.all_contacts))
 
         # all_contacts switches to top frame; Marionette needs to be switched back to ftu


### PR DESCRIPTION
I get the number of sim contacts before opening the apps because the method switches to default frame.
