### PR TITLE
Bug 959059: Abort shrinkUI if P2P link is gone.

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -271,15 +271,20 @@ var NfcManager = {
       var status = nfcdom.checkP2PRegistration(manifestURL);
       var self = this;
       status.onsuccess = function() {
-        // Top visible application's manifest Url is registered;
-        // Start Shrink / P2P UI and wait for user to accept P2P event
-        window.dispatchEvent(new CustomEvent('shrinking-start'));
+        if (status.result) {
+          // Top visible application's manifest Url is registered;
+          // Start Shrink / P2P UI and wait for user to accept P2P event
+          window.dispatchEvent(new CustomEvent('shrinking-start'));
 
-        // Setup listener for user response on P2P UI now
-        window.addEventListener('shrinking-sent', self);
-      };
-      status.onerror = function() {
-        // Do nothing!
+          // Setup listener for user response on P2P UI now
+          window.addEventListener('shrinking-sent', self);
+        } else {
+          // Clean up P2P UI events
+          self._debug('Error checking P2P Registration: ' +
+                      JSON.stringify(status.result));
+          window.removeEventListener('shrinking-sent', self);
+          window.dispatchEvent(new CustomEvent('shrinking-stop'));
+        }
       };
   },
 

--- a/apps/system/test/unit/mock_nfc.js
+++ b/apps/system/test/unit/mock_nfc.js
@@ -4,7 +4,9 @@
   var MockNfc = {
     startPoll: function() { return {}; },
     stopPoll: function() { return {}; },
-    powerOff: function() { return {}; }
+    powerOff: function() { return {}; },
+
+    checkP2PRegistration: function(manifestURL) { return {}; }
   };
 
   exports.MockNfc = MockNfc;


### PR DESCRIPTION
When Gecko indicates an error (possibly the tag or device was removed in the middle somewhere), NFC Manager should cancel the P2P UI.

Rebased to master: b53cbf445a17de2028abd20303ec23a8cce3b0e0
