### PR TITLE
Bug 877255 - [calendar] Day view: 'All day' label not shown if there is an all day event in a disabled calendar r=gaye

### DIFF
--- a/apps/calendar/js/templates/day.js
+++ b/apps/calendar/js/templates/day.js
@@ -17,8 +17,7 @@
       var classes = [
         'hour',
         'hour-' + hour,
-        this.h('classes'),
-        'calendar-display'
+        this.h('classes')
       ].join(' ');
 
       return '<section class="' + classes + '" data-hour="' + hour + '">' +

--- a/apps/calendar/js/views/day_based.js
+++ b/apps/calendar/js/views/day_based.js
@@ -212,11 +212,6 @@ Calendar.ns('Views').DayBased = (function() {
         }
       }
 
-      // hour flags
-      var calendarId = this.calendarId(busytime);
-      hourRecord.flags.push(calendarId);
-      hourRecord.element.classList.add(calendarId);
-
       // increment count of event per-hour (hour -> [events] counter)
       return hourRecord.records.set(id, eventRecord);
     },
@@ -403,8 +398,7 @@ Calendar.ns('Views').DayBased = (function() {
       var el = this._insertElement(html, parent, this.hours.items, idx);
       return this.hours.set(hour, {
         element: el,
-        records: new OrderedMap(),
-        flags: []
+        records: new OrderedMap()
       });
     },
 
@@ -443,28 +437,6 @@ Calendar.ns('Views').DayBased = (function() {
 
       hours.forEach(function(number) {
         var hour = this.hours.get(number);
-
-        var calendarClass = this.calendarId(busytime);
-
-
-        // handle flags
-        var flags = hour.flags;
-
-        // we need to remove them from the list
-        // then check again to see if there
-        // are any more...
-        var idx = flags.indexOf(calendarClass);
-
-        if (idx !== -1) {
-          flags.splice(idx, 1);
-        }
-
-        // if after we have removed the flag there
-        // are no more we can remove the class
-        // from the element...
-        if (flags.indexOf(calendarClass) === -1) {
-          hour.element.classList.remove(calendarClass);
-        }
 
         // XXX: If renderAllHours is false we want to remove
         //      unsed hours.
@@ -607,25 +579,25 @@ Calendar.ns('Views').DayBased = (function() {
     /**
      * The structure of one of these cells is:
      * <div class="events">
-     *   // This will be empty if and only if we have no events
+     *   <section class="event">...</section>
+     *   <section class="event">...</section>
      * </div>
      * @param {Element} target The HTML element that got clicked.
      * @return {boolean} Whether or not we clicked on an event.
      * @private
      */
     _clickedOnEvent: function(target) {
-      // Find the div with the events class.
       var el = target;
-      while (!el.classList.contains('events')) {
-        el = el.parentNode;
-        if (!el || el.nodeType !== 1 /** ELEMENT_NODE */) {
+      while (el && el.nodeType === 1 /** ELEMENT_NODE */) {
+        if (el.classList.contains('event')) {
+          return true;
+        }
+        if (el.classList.contains('events')) {
           return false;
         }
+        el = el.parentNode;
       }
-
-      // Compute whether we found the div and it has one or more children.
-      var children = el.childNodes;
-      return children && children.length > 0;
+      return true;
     },
 
     activate: function() {

--- a/apps/calendar/test/marionette/lib/calendar.js
+++ b/apps/calendar/test/marionette/lib/calendar.js
@@ -208,9 +208,13 @@ Calendar.prototype = {
     editEvent.location = opts.location || '';
     editEvent.description = opts.description || '';
     editEvent.startDate = startDate;
-    editEvent.startTime = startDate;
     editEvent.endDate = endDate;
-    editEvent.endTime = endDate;
+    if (opts.allDay) {
+      editEvent.allDay = opts.allDay;
+    } else {
+      editEvent.startTime = startDate;
+      editEvent.endTime = endDate;
+    }
     editEvent.reminders = opts.reminders || [];
     editEvent.save();
 

--- a/apps/calendar/test/marionette/lib/views/edit_event.js
+++ b/apps/calendar/test/marionette/lib/views/edit_event.js
@@ -44,6 +44,15 @@ EditEvent.prototype = {
     this.setFormValue('endTime', value);
   },
 
+  set allDay(value) {
+    var checkbox = this.findElement('input[name="allday"]');
+    var checked = checkbox.getAttribute('checked');
+    if ((value && !checked) || (!value && checked)) {
+      // click needs to happen on label!
+      this.client.helper.closest(checkbox, 'label').click();
+    }
+  },
+
   set reminders(value) {
     // Every event gets a 5 minute alarm. Since we want to "set" the alarms
     // with the parameter value, first remove the default alarm and then

--- a/apps/calendar/test/marionette/toggle_calendar_test.js
+++ b/apps/calendar/test/marionette/toggle_calendar_test.js
@@ -10,13 +10,6 @@ marionette('toggle calendar', function() {
   setup(function() {
     app = new Calendar(client);
     app.launch({ hideSwipeHint: true });
-
-    app.createEvent({
-      title: 'Toggle Calendar Test',
-      location: 'Some Place'
-    });
-
-    toggleLocalCalendar();
   });
 
   function toggleLocalCalendar() {
@@ -36,62 +29,91 @@ marionette('toggle calendar', function() {
     client.helper.waitForElementToDisappear(el);
   }
 
-  suite('disable calendar', function() {
-    test('month view', function() {
-      var event = app.monthDay.events[0];
-      waitForElementToDisappear(event);
-      // we cannot hide hour since there might be other events from different
-      // calendars that happens at same time (which would also be hidden)
-      // this behavior is better than previous one and will be changed after we
-      // implement the visual refresh (it's a good compromise)
-      var hour = client.helper.closest(event, '.hour');
-      assert(
-        hour.displayed(),
-        'hour should be displayed on day view'
-      );
+  suite('> regular event', function() {
+    setup(function() {
+      app.createEvent({
+        title: 'Toggle Calendar Test',
+        location: 'Some Place'
+      });
+      toggleLocalCalendar();
     });
 
-    test('week view', function() {
-      app.openWeekView();
-      waitForElementToDisappear(app.week.events[0]);
+    suite('disable calendar', function() {
+      test('month view', function() {
+        var event = app.monthDay.events[0];
+        waitForElementToDisappear(event);
+        // we cannot hide hour since there might be other events from different
+        // calendars that happens at same time (which would also be hidden)
+        // this behavior is better than previous one and will be changed after
+        // we implement the visual refresh (it's a good compromise)
+        var hour = client.helper.closest(event, '.hour');
+        assert(
+          hour.displayed(),
+          'hour should be displayed on day view'
+        );
+      });
+
+      test('week view', function() {
+        app.openWeekView();
+        waitForElementToDisappear(app.week.events[0]);
+      });
+
+      test('day view', function() {
+        app.openDayView();
+        var event = app.day.events[0];
+        waitForElementToDisappear(event);
+
+        // on day view hour can't be hidden otherwise it affects events on other
+        // calendars and it also looks weird
+        var hour = client.helper.closest(event, '.hour');
+        assert(
+          hour.displayed(),
+          'hour should be displayed on day view'
+        );
+
+        // clicking on hour should trigger add event screen
+        hour.click();
+        app.editEvent.waitForDisplay();
+      });
     });
 
-    test('day view', function() {
+    suite('enable calendar', function() {
+      setup(toggleLocalCalendar);
+
+      test('month view', function() {
+        waitForElement(app.monthDay.events[0]);
+      });
+
+      test('week view', function() {
+        app.openWeekView();
+        waitForElement(app.week.events[0]);
+      });
+
+      test('day view', function() {
+        app.openDayView();
+        waitForElement(app.day.events[0]);
+      });
+    });
+  });
+
+  suite('> all day event', function() {
+    setup(function() {
+      app.createEvent({
+        title: 'Toggle Calendar Test',
+        location: 'Some Place',
+        allDay: true
+      });
+      toggleLocalCalendar();
+    });
+
+    test('should not hide all day on day view', function() {
       app.openDayView();
       var event = app.day.events[0];
       waitForElementToDisappear(event);
-
-      // on day view hour can't be hidden otherwise it affects events on other
-      // calendars and it also looks weird
-      var hour = client.helper.closest(event, '.hour');
-      assert(
-        hour.displayed(),
-        'hour should be displayed on day view'
+      assert.ok(
+        client.helper.closest(event, '.hour-allday').displayed(),
+        'all day should be displayed'
       );
-
-      // clicking on hour should trigger add event screen
-      hour.click();
-      app.editEvent.waitForDisplay();
     });
   });
-
-  suite('enable calendar', function() {
-    setup(toggleLocalCalendar);
-
-    test('month view', function() {
-      waitForElement(app.monthDay.events[0]);
-    });
-
-    test('week view', function() {
-      app.openWeekView();
-      waitForElement(app.week.events[0]);
-    });
-
-    test('day view', function() {
-      app.openDayView();
-      waitForElement(app.day.events[0]);
-    });
-
-  });
-
 });

--- a/apps/calendar/test/marionette/toggle_calendar_test.js
+++ b/apps/calendar/test/marionette/toggle_calendar_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Calendar = require('./lib/calendar');
+var assert = require('chai').assert;
 
 marionette('toggle calendar', function() {
   var app;
@@ -37,7 +38,17 @@ marionette('toggle calendar', function() {
 
   suite('disable calendar', function() {
     test('month view', function() {
-      waitForElementToDisappear(app.monthDay.events[0]);
+      var event = app.monthDay.events[0];
+      waitForElementToDisappear(event);
+      // we cannot hide hour since there might be other events from different
+      // calendars that happens at same time (which would also be hidden)
+      // this behavior is better than previous one and will be changed after we
+      // implement the visual refresh (it's a good compromise)
+      var hour = client.helper.closest(event, '.hour');
+      assert(
+        hour.displayed(),
+        'hour should be displayed on day view'
+      );
     });
 
     test('week view', function() {
@@ -47,7 +58,20 @@ marionette('toggle calendar', function() {
 
     test('day view', function() {
       app.openDayView();
-      waitForElementToDisappear(app.day.events[0]);
+      var event = app.day.events[0];
+      waitForElementToDisappear(event);
+
+      // on day view hour can't be hidden otherwise it affects events on other
+      // calendars and it also looks weird
+      var hour = client.helper.closest(event, '.hour');
+      assert(
+        hour.displayed(),
+        'hour should be displayed on day view'
+      );
+
+      // clicking on hour should trigger add event screen
+      hour.click();
+      app.editEvent.waitForDisplay();
     });
   });
 
@@ -67,6 +91,7 @@ marionette('toggle calendar', function() {
       app.openDayView();
       waitForElement(app.day.events[0]);
     });
+
   });
 
 });

--- a/apps/calendar/test/unit/views/day_based_test.js
+++ b/apps/calendar/test/unit/views/day_based_test.js
@@ -306,10 +306,6 @@ suiteGroup('Views.DayBased', function() {
       var hour = subject.hours.get(busytime._id);
       assert.ok(hour, 'has hour record');
 
-      // verify the flag
-      var idx = hour.flags.indexOf(subject.calendarId(busytime));
-      assert.ok(idx !== -1, 'has calendar id flag on hour');
-
       // verify its in the dom
       var elements = hour.element.querySelectorAll(
         '[data-id="' + busytime._id + '"]'
@@ -329,7 +325,6 @@ suiteGroup('Views.DayBased', function() {
       var max = 24 - intialHour;
       var curHour = intialHour + 1;
       var selector = '[data-id="' + busytime._id + '"]';
-      var calendarId = subject.calendarId(busytime);
 
       for (; curHour < max; curHour++) {
         subject._createRecord(curHour, busytime, event);
@@ -338,7 +333,6 @@ suiteGroup('Views.DayBased', function() {
         // verify we didn't add another element for this hour
         var eventEl = hour.element.querySelector(selector);
         assert.ok(!eventEl, 'did not add additonal event');
-        assert.include(hour.flags, calendarId);
       }
     });
 
@@ -354,7 +348,6 @@ suiteGroup('Views.DayBased', function() {
       );
 
       assert.ok(eventEl);
-      assert.include(hour.flags, subject.calendarId(busytime));
     });
 
     test('all day events', function() {
@@ -369,14 +362,6 @@ suiteGroup('Views.DayBased', function() {
 
       // verify hour
       assert.ok(hour, 'has hour');
-
-      // verify flag
-      assert.ok(hour.flags, 'has flags');
-
-      assert.include(
-        hour.flags, subject.calendarId(busytime),
-        'includes calendar id'
-      );
 
       // verify dom element
       var el = hour.element.querySelector(
@@ -467,31 +452,10 @@ suiteGroup('Views.DayBased', function() {
       var c = add(1, 'two');
 
       var hour = subject.hours.get(1);
-      var hourElement = hour.element;
-      var classList = hourElement.classList;
-      var calendarId = subject.calendarId(b.busytime);
       var records = hour.records;
 
-      assert.isTrue(classList.contains(calendarId), 'starts with id');
       subject.remove(c.busytime);
-
-      assert.isTrue(
-        classList.contains(calendarId),
-        'does not initially remove'
-      );
-
-
-      //XXX: we want to verify that the class
-      //id is not removed until all records
-      //with the classId are removed.
       subject.remove(b.busytime);
-
-      // now it should be removed as there are
-      // no more calendar-id-1 elements
-      assert.ok(
-        !classList.contains(calendarId),
-        'finally removes'
-      );
 
       assert.isFalse(records.has(b.busytime._id), 'remove b');
       assert.isFalse(records.has(c.busytime._id), 'remove c');


### PR DESCRIPTION
basically just changes the tests introduced on #18091 and add another test for all day events (and update the `app.createEvent` to support _all day_ events). That way we can consider the Bug 877255 as fixed and avoid regressions.
