### PR TITLE
Bug 998799 - alameda.js depends toString()-ing functions

### DIFF
--- a/apps/camera/build/require_config.jslike
+++ b/apps/camera/build/require_config.jslike
@@ -7,6 +7,15 @@
 
   findNestedDependencies: true,
 
+  // Be sure to normalize all define() calls by extracting
+  // dependencies so Function toString is not needed, and
+  // lower capability devices like Tarako can optimize
+  // memory by discarding function sources. This is
+  // automatically done when an 'optimize' value other than
+  // 'none' is used. This setting makes sure it happens for
+  // builds where 'none' is used for 'optimize'.
+  normalizeDirDefines: 'all',
+
   // Set to 'uglify2' to get uglify to run using the
   // uglify2 settings below.
   optimize: 'none',

--- a/apps/clock/build/require_config.jslike
+++ b/apps/clock/build/require_config.jslike
@@ -8,6 +8,15 @@
   },
   findNestedDependencies: true,
 
+  // Be sure to normalize all define() calls by extracting
+  // dependencies so Function toString is not needed, and
+  // lower capability devices like Tarako can optimize
+  // memory by discarding function sources. This is
+  // automatically done when an 'optimize' value other than
+  // 'none' is used. This setting makes sure it happens for
+  // builds where 'none' is used for 'optimize'.
+  normalizeDirDefines: 'all',
+
   // Build a separate module for each panel. Because the application
   // consistently initializes with the `startup` module, this module and all
   // its dependencies do not need to be included by the "secondary" panels

--- a/apps/email/build/email.build.js
+++ b/apps/email/build/email.build.js
@@ -12,6 +12,16 @@
     end: 'plog("@@@ END OF BUILD LAYER");'
   },
 */
+
+  // Be sure to normalize all define() calls by extracting
+  // dependencies so Function toString is not needed, and
+  // lower capability devices like Tarako can optimize
+  // memory by discarding function sources. This is
+  // automatically done when an 'optimize' value other than
+  // 'none' is used. This setting makes sure it happens for
+  // builds where 'none' is used for 'optimize'.
+  normalizeDirDefines: 'all',
+
   // Rewrite the waitSeconds config so that we never time out
   // waiting for modules to load in production. See js/mail_app.js
   // for more details.

--- a/apps/settings/build/settings.build.jslike
+++ b/apps/settings/build/settings.build.jslike
@@ -9,6 +9,15 @@
 
   findNestedDependencies: true,
 
+  // Be sure to normalize all define() calls by extracting
+  // dependencies so Function toString is not needed, and
+  // lower capability devices like Tarako can optimize
+  // memory by discarding function sources. This is
+  // automatically done when an 'optimize' value other than
+  // 'none' is used. This setting makes sure it happens for
+  // builds where 'none' is used for 'optimize'.
+  normalizeDirDefines: 'all',
+
   // optimize is now passed via Makefile's GAIA_SETTINGS_MINIFY
   // default is none if not passed at all.
   // optimize: 'none',


### PR DESCRIPTION
Makes sure to normalize define() calls even with an r.js uglify-style minification (which auto-normalizes)  is not done. Should help test scenarios for Tarako, where Function toString may not be available.

For reviewers, this change just does one of the steps that was automatically done by r.js whenever the r.js build config had a value other than `optimize: 'none'`, so this sort of change has already been tested if doing those minify-opitmized builds. This change just does that work even if optimize is set to 'none'.

If the travis build passes, that should be enough of an indication that this change is safe, as it just affects how dependencies are passed to the define() calls. So, if the module did this in source form:

``` javascript
define(function(require) {
  var a = require('a');
});
```

This setting uses an AST to find those require calls, then transform the define call to this form, for the modules placed in build_stage:

``` javascript
define(['require', 'a'], function(require) {
  var a = require('a');
});
```
