### PR TITLE
Bug 997751 - [Homescreen] Remove 'power' permission from homescreen manifest

### DIFF
--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -17,7 +17,6 @@
     "storage":{},
     "geolocation": {},
     "alarms": {},
-    "power":{},
     "contacts":{ "access": "readonly" }
   },
   "locales": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=997751
