### PR TITLE
Bug 998810 - [Homescreen] remove alarms permission from manifest

### DIFF
--- a/apps/homescreen/manifest.webapp
+++ b/apps/homescreen/manifest.webapp
@@ -16,7 +16,6 @@
     "open-remote-window":{},
     "storage":{},
     "geolocation": {},
-    "alarms": {},
     "contacts":{ "access": "readonly" }
   },
   "locales": {
@@ -45,9 +44,6 @@
     "68": "/style/icons/HomeScreen_68.png"
   },
   "orientation": "default",
-  "messages": [
-    { "alarm": "/index.html" }
-  ],
   "datastores-access": {
     "bookmarks_store": {
       "readonly": false,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=998810
