### PR TITLE
Bug 999537 - [Music2] Icon paths are wrong

### DIFF
--- a/dev_apps/music2/manifest.webapp
+++ b/dev_apps/music2/manifest.webapp
@@ -36,9 +36,9 @@
   },
   "default_locale": "en-US",
   "icons": {
-    "60": "/style/icons/60/Music.png",
-    "120": "/style/icons/Music.png",
-    "320": "/style/icons/320/Music.png"
+    "60": "/style/icons/Music_60.png",
+    "90": "/style/icons/Music_90.png",
+    "120": "/style/icons/Music_120.png"
   },
   "orientation": "default"
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=999537
