### PR TITLE
Bug 997924 - Make sure the preloaded callscreen doesn't keep an audio channel open

### DIFF
--- a/apps/callscreen/js/index.js
+++ b/apps/callscreen/js/index.js
@@ -7,3 +7,12 @@ window.addEventListener('load', function callSetup(evt) {
   CallScreen.init();
   KeypadManager.init(true);
 });
+
+// Don't keep an audio channel open when the callscreen is not displayed
+document.addEventListener('visibilitychange', function visibilitychanged() {
+  if (document.hidden) {
+    TonePlayer.trashAudio();
+  } else {
+    TonePlayer.ensureAudio();
+  }
+});

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -220,6 +220,8 @@ var AttentionScreen = {
 
     if (iframe.dataset.preloaded) {
       // Unload then preload again
+      iframe.setVisible(false);
+
       var src = iframe.src.split('#')[0];
       iframe.src = ''; // cocotte
       setTimeout(function nextTick() {

--- a/apps/system/js/dialer_agent.js
+++ b/apps/system/js/dialer_agent.js
@@ -47,7 +47,9 @@
     this._player.mozAudioChannelType = 'ringer';
     this._player.preload = 'metadata';
     this._player.loop = true;
-    this._callScreen = this._createCallScreen();
+    player.mozAudioChannelType = 'ringer';
+    player.preload = 'metadata';
+    player.loop = true;
   };
 
   DialerAgent.prototype.start = function da_start() {
@@ -87,11 +89,14 @@
     window.addEventListener('sleep', this);
     window.addEventListener('volumedown', this);
 
+    this._callScreen = this._createCallScreen();
     var callScreen = this._callScreen;
     callScreen.src = CSORIGIN + 'index.html';
     callScreen.dataset.preloaded = true;
     // We need the iframe in the DOM
     AttentionScreen.attentionScreen.appendChild(callScreen);
+
+    callScreen.setVisible(false);
 
     return this;
   };
@@ -192,6 +197,7 @@
               (LockScreen.locked ? 'locked' : '');
     src = src + '&timestamp=' + timestamp;
     callScreen.src = src;
+    callScreen.setVisible(true);
 
     var asRequest = {
       target: callScreen,

--- a/apps/system/js/dialer_agent.js
+++ b/apps/system/js/dialer_agent.js
@@ -47,7 +47,6 @@
     this._player.mozAudioChannelType = 'ringer';
     this._player.preload = 'metadata';
     this._player.loop = true;
-    this._callScreen = this._createCallScreen();
   };
 
   DialerAgent.prototype.start = function da_start() {
@@ -87,11 +86,14 @@
     window.addEventListener('sleep', this);
     window.addEventListener('volumedown', this);
 
+    this._callScreen = this._createCallScreen();
     var callScreen = this._callScreen;
     callScreen.src = CSORIGIN + 'index.html';
     callScreen.dataset.preloaded = true;
     // We need the iframe in the DOM
     AttentionScreen.attentionScreen.appendChild(callScreen);
+
+    callScreen.setVisible(false);
 
     return this;
   };
@@ -192,6 +194,7 @@
               (LockScreen.locked ? 'locked' : '');
     src = src + '&timestamp=' + timestamp;
     callScreen.src = src;
+    callScreen.setVisible(true);
 
     var asRequest = {
       target: callScreen,

--- a/apps/system/test/unit/dialer_agent_test.js
+++ b/apps/system/test/unit/dialer_agent_test.js
@@ -25,6 +25,7 @@ suite('system/DialerAgent', function() {
   var realTelephony, realVibrate, realLockscreen;
 
   var subject;
+  var setVisibleSpy;
 
   function callschanged() {
     MockNavigatorMozTelephony.mTriggerEvent(new CustomEvent('callschanged'));
@@ -64,6 +65,11 @@ suite('system/DialerAgent', function() {
   var CSORIGIN = window.location.origin.replace('system', 'callscreen') + '/';
 
   setup(function() {
+    if (!('setVisible' in HTMLIFrameElement.prototype)) {
+      HTMLIFrameElement.prototype.setVisible = function stub() {};
+    }
+    setVisibleSpy = this.sinon.spy(HTMLIFrameElement.prototype, 'setVisible');
+
     this.sinon.useFakeTimers();
     subject = new DialerAgent().start();
   });
@@ -142,6 +148,8 @@ suite('system/DialerAgent', function() {
 
     test('it should be hidden at first', function() {
       assert.equal(csFrame.dataset.hidden, 'true');
+      sinon.assert.calledOnce(setVisibleSpy);
+      sinon.assert.calledWith(setVisibleSpy, false);
     });
 
     test('it should be preloaded', function() {
@@ -201,6 +209,12 @@ suite('system/DialerAgent', function() {
           var src = CSORIGIN + 'index.html#locked&timestamp=0';
           assertAttentionScreen(src, attentionSpy);
         });
+      });
+
+      test('it should set the callscreen visibility to true', function() {
+        callschanged();
+        sinon.assert.calledTwice(setVisibleSpy);
+        assert.isTrue(setVisibleSpy.lastCall.args[0]);
       });
     });
 


### PR DESCRIPTION
Bug 997924 - Make sure the preloaded callscreen doesn't keep an audio channel open
