### PR TITLE
Bug 996645 - Data Connection switch is not waiting for the Connection to...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -30,8 +30,6 @@ skip-if = device == "desktop"
 carrier = true
 online = true
 smoketest = true
-# Bug 996645 - Data Connection switch is not waiting for the Connection to be "active" before switching to the the on state
-expected = fail
 
 [test_settings_airplane_mode.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
... be "active" before switching to the the on state
