### PR TITLE
Bug 998478 - [Camera] [Madai] The setting menu button when open doesn't

### DIFF
--- a/apps/camera/style/settings.css
+++ b/apps/camera/style/settings.css
@@ -117,8 +117,6 @@
   overflow: scroll;
 }
 
-.settings_items > .inner {}
-
 /**
  * @deg90
  */
@@ -146,7 +144,7 @@
   position: absolute;
   top: 0; right: 0;
   margin: 0;
-  border-width: 1.9rem 1.5rem;
+  border-width: 2rem 1.5rem;
   background-color: #008eab;
 }
 


### PR DESCRIPTION
overlap with the hud button
