### PR TITLE
Bug 999475 - Allows overloading SETTINGS_PATH with env variable. r=yurenju

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,8 +322,8 @@ else
 endif
 export GAIA_DISTRIBUTION_DIR
 
-SETTINGS_PATH := build/config/custom-settings.json
-KEYBOARD_LAYOUTS_PATH := build/config/keyboard-layouts.json
+SETTINGS_PATH ?= build/config/custom-settings.json
+KEYBOARD_LAYOUTS_PATH ?= build/config/keyboard-layouts.json
 
 ifdef GAIA_DISTRIBUTION_DIR
 	DISTRIBUTION_SETTINGS := $(GAIA_DISTRIBUTION_DIR)$(SEP)settings.json


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=999475
