### PR TITLE
Bug 999965 - enable DSDS tests via manifest with the Flame device name

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -63,4 +63,4 @@ wifi = true
 online = true
 
 [test_settings_sim_manager.py]
-run-if = device == "sp7710gaplus_gonk"
+run-if = device == "sp7710gaplus_gonk" || device == "msm8610"


### PR DESCRIPTION
@zacc Could you help to review this? Thanks.
