### PR TITLE
Bug 997045 - Lock the marionette-apps version to 0.3.3 before we figure

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-jsdoc": "0.5.1",
     "jshint": "2.4.2",
     "mail-fakeservers": "0.0.15",
-    "marionette-apps": "~0.3.3",
+    "marionette-apps": "0.3.3",
     "marionette-client": "1.1.5",
     "marionette-content-script": "0.0.4",
     "marionette-device-host": "0.0.2",


### PR DESCRIPTION
out the gaia-node-modules is ok.
