### PR TITLE
Optimize render time of apps in e.me

### DIFF
--- a/apps/homescreen/elements/search_page.html
+++ b/apps/homescreen/elements/search_page.html
@@ -44,6 +44,18 @@
           </menu>
         </form>
       </div>
+      <div id="bgimage-overlay">
+        <div class="img"></div>
+        <div class="content">
+          <b class="rightbutton"></b>
+          <h2></h2>
+          <div class="source">
+            <b data-l10n-id="evme-backgroundimage-source-label"></b>
+            <span></span>
+          </div>
+          <b class="close"></b>
+        </div>
+      </div>
     </div>
 
     <div id="evmeContainer" class="evmeScope empty-query">

--- a/apps/homescreen/elements/search_page.html
+++ b/apps/homescreen/elements/search_page.html
@@ -77,8 +77,8 @@
             <h1 id="search-title"></h1>
             <div id="save-search"></div>
             <div id="helper-rapper">
-              <div id="helper">
-                <ul></ul>
+              <div style="overflow-y: hidden; overflow-x: auto;" id="helper">
+                <ul><li class="label" data-l10n-id="evme-helper-default2">Enter any topic or keyword</li></ul>
               </div>
             </div>
           </div>

--- a/apps/homescreen/everything.me/css/common.css
+++ b/apps/homescreen/everything.me/css/common.css
@@ -84,6 +84,10 @@ section[role="status"] {
     display: none;
 }
 
+.evmeScope .evme-apps section[role="notification"].loading-more.show > div {
+  height: 4.1rem; /* max height of the progress, otherwise constant reflow */
+}
+
 .evmeScope:not(.connection-error) .evme-apps section[role="notification"].show progress {
   display: inline-block;
 }

--- a/apps/homescreen/everything.me/css/everything.me.css
+++ b/apps/homescreen/everything.me/css/everything.me.css
@@ -65,7 +65,7 @@
 
 .evme-keyboard-visible .evmeScope,
 .evme-suggest-collections-loading .evmeScope {
-    height: 100%;
+    height: 100%; /* todo: this causes a reflow to happen when toggline evme-keyboard-visible */
 }
 
 .evme-keyboard-visible .apps > div.evmePage ol,
@@ -93,7 +93,7 @@
 .evme-loading-from-input #bg-overlay,
 .evme-displayed.evme-keyboard-visible #bg-overlay,
 .evme-displayed.evme-has-query #bg-overlay{
-  height: 100%;
+  transform: translateY(0);
 }
 
 #loading-dialog {

--- a/apps/homescreen/everything.me/css/everything.me.css
+++ b/apps/homescreen/everything.me/css/everything.me.css
@@ -109,3 +109,7 @@
 .evme-suggest-collections-loading #evme-fullscreen-loading {
   display: none;
 }
+
+#bgimage-overlay {
+  opacity: 0;
+}

--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -388,12 +388,7 @@
     this.showDefault = function showDefault() {
       Evme.BackgroundImage.loadDefault();
 
-      if (Evme.Searchbar.getValue() == '' && !Evme.Utils.isKeyboardVisible) {
-        Evme.Helper.setTitle();
-        Evme.Helper.showTitle();
-      } else {
-        self.loadHistory();
-      }
+      self.loadHistory();
     };
 
     // transition to history items

--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -1449,7 +1449,8 @@
       }
 
       // Clear current results
-      Evme.SearchResults.clear();
+      if (options.source !== 'more')
+        Evme.SearchResults.clear();
 
       // perform search
       var type = options.type,

--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -20,8 +20,6 @@
       PAGEVIEW_SOURCES = {},
 
       TIMEOUT_BEFORE_REQUESTING_APPS_AGAIN = 500,
-      TIMEOUT_BEFORE_SHOWING_DEFAULT_IMAGE = 3000,
-      TIMEOUT_BEFORE_SHOWING_HELPER = 3000,
       TIMEOUT_BEFORE_RUNNING_APPS_SEARCH = 600,
       TIMEOUT_BEFORE_RUNNING_IMAGE_SEARCH = 800,
       TIMEOUT_BEFORE_AUTO_RENDERING_MORE_APPS = 200,
@@ -1411,7 +1409,6 @@
         requestIcons = null,
 
         timeoutShowDefaultImage = null,
-        timeoutHideHelper = null,
         timeoutSearchImageWhileTyping = null,
         timeoutSearch = null,
         timeoutSearchWhileTyping = null,
@@ -1451,6 +1448,9 @@
         return;
       }
 
+      // Clear current results
+      Evme.SearchResults.clear();
+
       // perform search
       var type = options.type,
         index = options.index,
@@ -1471,7 +1471,6 @@
          source !== SEARCH_SOURCES.SPELLING);
 
       if (exact && appsCurrentOffset === 0) {
-        window.clearTimeout(timeoutHideHelper);
 
         if (!onlyDidYouMean) {
           if (!options.automaticSearch) {
@@ -1484,8 +1483,7 @@
             Evme.SearchHistory.save(query, type);
           }
 
-          timeoutHideHelper = window.setTimeout(Evme.Helper.showTitle,
-                                                TIMEOUT_BEFORE_SHOWING_HELPER);
+          Evme.Helper.showTitle();
         }
       }
 
@@ -1545,8 +1543,6 @@
       if (requestAppsTime < lastRequestAppsTime) {
         return;
       }
-
-      window.clearTimeout(timeoutHideHelper);
 
       var _query = options.query,
       _type = options.type,
@@ -1651,7 +1647,7 @@
         return;
       }
 
-      setTimeoutForShowingDefaultImage();
+      Evme.BackgroundImage.loadDefault();
 
       requestImage && requestImage.abort && requestImage.abort();
       requestImage = Evme.DoATAPI.bgimage({
@@ -1740,13 +1736,6 @@
         Evme.Helper.showSuggestions(querySentWith);
       }
     };
-
-    function setTimeoutForShowingDefaultImage() {
-      Searcher.clearTimeoutForShowingDefaultImage();
-      timeoutShowDefaultImage =
-        window.setTimeout(Evme.BackgroundImage.loadDefault,
-                            TIMEOUT_BEFORE_SHOWING_DEFAULT_IMAGE);
-    }
 
     this.clearTimeoutForShowingDefaultImage =
       function clearTimeoutForShowingDefaultImage() {
@@ -1895,6 +1884,7 @@
         'source': source
       };
 
+      /*
       requestSearch && requestSearch.abort && requestSearch.abort();
       window.clearTimeout(timeoutSearchWhileTyping);
       timeoutSearchWhileTyping = window.setTimeout(function onTimeout() {
@@ -1913,6 +1903,7 @@
           Searcher.getBackgroundImage(searchOptions);
         }, TIMEOUT_BEFORE_RUNNING_IMAGE_SEARCH);
       }
+      */
     };
 
     this.cancelRequests = function cancelRequests() {

--- a/apps/homescreen/everything.me/js/Brain.js
+++ b/apps/homescreen/everything.me/js/Brain.js
@@ -137,12 +137,14 @@
 
   // Core.js
   this.Core = new function Core() {
-    var self = this;
-
     this.init = function init() {
-      Searcher.empty();
-      Evme.Searchbar.clear();
-      Brain.Searchbar.setEmptyClass();
+      if (Evme.Searchbar.getValue() === '') {
+        Searcher.empty();
+        Brain.Searchbar.setEmptyClass();
+      }
+      if (Evme.Searchbar.isFocused()) {
+        Evme.Utils.setKeyboardVisibility(true);
+      }
       document.body.classList.add(CLASS_WHEN_EVME_READY);
     };
   };

--- a/apps/homescreen/everything.me/js/everything.me.js
+++ b/apps/homescreen/everything.me/js/everything.me.js
@@ -22,9 +22,14 @@ var EverythingME = {
         // And move the container into the searchPage thing
         gridPage.appendChild(searchPage.querySelector('#evmeContainer'));
 
-        var input = document.querySelector('#search-q');
-        input.addEventListener('focus', function onFocus(e) {
-          input.removeEventListener('focus', onFocus);
+        var inputBg = document.querySelector('#search-q-bg');
+        inputBg.addEventListener('click', function onFocus(e) {
+          inputBg.removeEventListener('click', onFocus);
+
+          e.stopPropagation();
+          e.preventDefault();
+
+          inputBg.querySelector('#search-q').focus();
 
           triggerActivateFromInput(e);
         });

--- a/apps/homescreen/everything.me/js/everything.me.js
+++ b/apps/homescreen/everything.me/js/everything.me.js
@@ -12,28 +12,28 @@ var EverythingME = {
     var gridPage = document.querySelector('#icongrid > div:first-child');
     gridPage.classList.add('evmePage');
 
-
-    // pre-evme-load pseudo searchbar
-    var activationIcon = document.createElement('div');
-    activationIcon.id = 'evme-activation-icon';
-    activationIcon.innerHTML =
-      '<input type="text" x-inputmode="verbatim"' +
-      ' data-l10n-id="evme-searchbar-default2" />';
-
-    // insert into first page
-    gridPage.insertBefore(activationIcon, gridPage.firstChild);
-
     // Append appropriate placeholder translation to pseudo searchbar
     navigator.mozL10n.ready(function loadSearchbarValue() {
-      var input = activationIcon.querySelector('input'),
-          defaultText = navigator.mozL10n.get('evme-searchbar-default2') || '';
+      // Load the searchPage HTML already
+      var searchPage = document.getElementById('search-page');
+      LazyLoader.load(searchPage, function loaded() {
+        navigator.mozL10n.translate(searchPage);
 
-      input.setAttribute('placeholder', defaultText);
+        // And move the container into the searchPage thing
+        gridPage.appendChild(searchPage.querySelector('#evmeContainer'));
+
+        var input = document.querySelector('#search-q');
+        input.addEventListener('focus', function onFocus(e) {
+          input.removeEventListener('focus', onFocus);
+
+          triggerActivateFromInput(e);
+        });
+
+        document.body.classList.add('evme-ready');
+      });
     });
 
     // add event listeners that trigger evme load
-    activationIcon.addEventListener('contextmenu', onContextMenu);
-    activationIcon.addEventListener('click', triggerActivateFromInput);
     window.addEventListener('collectionlaunch', triggerActivate);
     window.addEventListener('collectiondropapp', triggerActivate);
     window.addEventListener('suggestcollections', triggerActivate);
@@ -44,10 +44,6 @@ var EverythingME = {
       document.body.classList.add('evme-loading-from-input');
       document.body.classList.add('evme-keyboard-visible');
 
-      var activationInput = activationIcon.querySelector('input');
-      activationInput.addEventListener('blur',
-                                        EverythingME.onActivationIconBlur);
-
       triggerActivate(e);
     }
 
@@ -56,8 +52,6 @@ var EverythingME = {
       EverythingME.pendingEvent = e;
 
       // remove pre-evme-load listeners
-      activationIcon.removeEventListener('click', triggerActivateFromInput);
-      activationIcon.removeEventListener('contextmenu', onContextMenu);
       window.removeEventListener('collectionlaunch', triggerActivate);
       window.removeEventListener('collectiondropapp', triggerActivate);
       window.removeEventListener('suggestcollections', triggerActivate);
@@ -73,25 +67,12 @@ var EverythingME = {
     function loadCollectionAssets() {
       var e = EverythingME.pendingEvent;
 
-      // load styles required for Collection styling
-      LazyLoader.load([
-        'shared/style_unstable/progress_activity.css',
-        'everything.me/css/common.css',
-        'everything.me/modules/Collection/Collection.css',
-        document.getElementById('search-page')],
-        function assetsLoaded() {
-          // Activate evme load
-          // But wait a tick, so there's no flash of unstyled progress indicator
-          window.setTimeout(function() {
-            // open the collection immediately
-            if (e && e.type === 'collectionlaunch') {
-              onCollectionOpened(e.detail.id);
-            }
+      // open the collection immediately
+      if (e && e.type === 'collectionlaunch') {
+        onCollectionOpened(e.detail.id);
+      }
 
-            EverythingME.activate();
-          }, 0);
-        }
-      );
+      EverythingME.activate();
     }
 
     // show Collection loading
@@ -141,13 +122,6 @@ var EverythingME = {
     EverythingME.migrateStorage();
   },
 
-  onActivationIconBlur: function onActivationIconBlur(e) {
-    EverythingME.pendingEvent = null;
-    e.target.removeEventListener('blur', onActivationIconBlur);
-    document.body.classList.remove('evme-keyboard-visible');
-    document.body.classList.remove('evme-loading-from-input');
-  },
-
   // remove pre-evme-load changes
   onCollectionClosed: function onCollectionClosed() {
     var appsEl = document.getElementById('icongrid');
@@ -169,12 +143,8 @@ var EverythingME = {
   },
 
   activate: function EverythingME_activate() {
-    var searchPage = document.getElementById('search-page');
-    LazyLoader.load(searchPage, function loaded() {
-      document.body.classList.add('evme-loading');
-      navigator.mozL10n.translate(searchPage);
-      EverythingME.load();
-    });
+    document.body.classList.add('evme-loading');
+    EverythingME.load();
   },
 
   load: function EverythingME_load(callback) {
@@ -220,8 +190,7 @@ var EverythingME = {
           'css/common.css',
           'modules/BackgroundImage/BackgroundImage.css',
           'modules/Helper/Helper.css',
-          'modules/Results/Results.css',
-          'modules/Searchbar/Searchbar.css'
+          'modules/Results/Results.css'
         ];
 
     var head = document.head;
@@ -291,44 +260,17 @@ var EverythingME = {
   },
 
   onEvmeLoaded: function onEvmeLoaded() {
-    var page = document.getElementById('evmeContainer'),
-        gridPage = document.querySelector('#icongrid > div:first-child'),
-        activationIcon = document.getElementById('evme-activation-icon'),
-        activationIconInput = activationIcon.querySelector('input'),
-        existingQuery = activationIconInput && activationIconInput.value,
-        evmeInput = document.getElementById('search-q'),
-        closeButton = document.querySelector('#collection .close');
-
-    activationIconInput.removeEventListener('blur',
-                                            EverythingME.onActivationIconBlur);
-
-    // add evme into the first grid page
-    gridPage.appendChild(page.parentNode.removeChild(page));
+    var closeButton = document.querySelector('#collection .close');
 
     EvmeFacade.onShow();
 
     var e = EverythingME.pendingEvent;
 
-    if (e && evmeInput &&
-        (e.target === activationIcon || e.target === activationIconInput)) {
-      // set the query the user entered before loaded
-      if (existingQuery) {
-        EvmeFacade.searchFromOutside(existingQuery);
-      }
-
-      EvmeFacade.Searchbar &&
-        EvmeFacade.Searchbar.focus && EvmeFacade.Searchbar.focus();
-      evmeInput.setSelectionRange(existingQuery.length, existingQuery.length);
-    }
-
     closeButton.removeEventListener('click', EverythingME.onCollectionClosed);
-
     window.removeEventListener('hashchange', EverythingME.onCollectionClosed);
 
     document.body.classList.remove('evme-loading');
     document.body.classList.remove('evme-loading-from-input');
-
-    activationIcon.parentNode.removeChild(activationIcon);
 
     if (e && e.target) {
       e.target.dispatchEvent(e);

--- a/apps/homescreen/everything.me/js/helpers/Utils.js
+++ b/apps/homescreen/everything.me/js/helpers/Utils.js
@@ -102,8 +102,8 @@ Evme.Utils = new function Evme_Utils() {
       ms < 10 && (ms = '00' + ms) ||
         ms < 100 && (ms = '0' + ms);
 
-      console[level]('[%s EVME]: %s', [h, m, s, ms].join(':'),
-                                        Array.prototype.slice.call(arguments));
+      // console[level]('[%s EVME]: %s', [h, m, s, ms].join(':'),
+      //                                   Array.prototype.slice.call(arguments));
     };
   };
 
@@ -406,90 +406,6 @@ Evme.Utils = new function Evme_Utils() {
         });
       })(id, src);
     }
-  };
-
-  this.writeTextToCanvas = function writeTextToCanvas(options) {
-    var context = options.context,
-      text = options.text ? options.text.split(' ') : [],
-      offset = options.offset || 0,
-      lineWidth = 0,
-      currentLine = 0,
-      textToDraw = [],
-
-      WIDTH = context.canvas.width,
-      FONT_SIZE = options.fontSize || self.APPS_FONT_SIZE,
-      LINE_HEIGHT = FONT_SIZE + window.devicePixelRatio;
-
-    if (!context || !text.length) {
-      return false;
-    }
-
-    context.save();
-
-    context.textAlign = 'center';
-    context.textBaseline = 'top';
-    context.fillStyle = 'rgba(255,255,255,1)';
-    context.font = '500 ' + self.rem(FONT_SIZE) + ' sans-serif';
-
-    // text shadow
-    context.shadowOffsetX = self.APP_NAMES_SHADOW_OFFSET_X;
-    context.shadowOffsetY = self.APP_NAMES_SHADOW_OFFSET_Y;
-    context.shadowBlur = self.APP_NAMES_SHADOW_BLUR;
-    context.shadowColor = self.APP_NAMES_SHADOW_COLOR;
-
-    for (var i = 0, word; word = text[i++];) {
-      // add 1 to the word with because of the space between words
-      var size = context.measureText(word + ' ').width,
-        draw = false,
-        pushed = false;
-
-      if (lineWidth + size >= WIDTH) {
-        draw = true;
-        if (textToDraw.length === 0) {
-          textToDraw.push(word);
-          pushed = true;
-        }
-      }
-
-      if (draw) {
-        drawText(textToDraw, WIDTH / 2, offset + currentLine * LINE_HEIGHT);
-        currentLine++;
-        textToDraw = [];
-        lineWidth = 0;
-      }
-
-      if (!pushed) {
-        textToDraw.push(word);
-        lineWidth += size;
-      }
-    }
-
-    if (textToDraw.length > 0) {
-      drawText(textToDraw, WIDTH / 2, offset + currentLine * LINE_HEIGHT);
-    }
-
-    function drawText(text, x, y) {
-      var isSingleWord, size;
-
-      isSingleWord = text.length === 1;
-      text = text.join(' ');
-      size = context.measureText(text).width;
-
-      if (isSingleWord && size >= WIDTH) {
-        while (size >= WIDTH) {
-          text = text.substring(0, text.length - 1);
-          size = context.measureText(text + '…').width;
-        }
-
-        text += '…';
-      }
-
-      context.fillText(text, x, y);
-    }
-
-    context.restore();
-
-    return true;
   };
 
   this.isNewUser = function isNewUser() {

--- a/apps/homescreen/everything.me/js/plugins/Scroll.js
+++ b/apps/homescreen/everything.me/js/plugins/Scroll.js
@@ -60,7 +60,7 @@
       'onEnd': onScrollEnd
     });
 
-    updateY();
+    updateXY();
 
     this.distY = 0;
     this.distX = 0;
@@ -68,6 +68,8 @@
     this.maxY = 0;
     this.hScroll = options.hScroll;
     this.vScroll = options.vScroll;
+    this.x = 0;
+    this.y = 0;
 
     this.refresh = function refresh() {
       // for backwrads compitability with iScroll
@@ -75,8 +77,15 @@
     };
 
     this.scrollTo = function scrollTo(x, y) {
-      x !== undefined && (el.scrollLeft = x);
-      y !== undefined && (el.scrollTop = y);
+      if (x !== undefined && self.x !== x) {
+        el.scrollLeft = x;
+        self.x = x;
+      }
+
+      if (y !== undefined && self.y !== y) {
+        el.scrollTop = y;
+        self.y = y;
+      }
     };
 
     function onTouchStart(e) {
@@ -107,7 +116,6 @@
       var currPos = [el.scrollLeft, el.scrollTop],
           touch = 'touches' in e ? e.touches[0] : e;
 
-      updateY();
       self.distX = touch.pageX - startPointer[0];
       self.distY = touch.pageY - startPointer[1];
 
@@ -133,7 +141,6 @@
 
       scrollEventListener.stop();
 
-      updateY();
       optionsOnTouchEnd && optionsOnTouchEnd(e);
     }
 
@@ -143,7 +150,7 @@
     }
 
     function onScrollMove(e, first) {
-      updateY();
+      updateXY();
       first && onScrollStart(e);
       optionsOnScrollMove && optionsOnScrollMove(e);
     }
@@ -153,7 +160,8 @@
       optionsOnScrollEnd && optionsOnScrollEnd(e);
     }
 
-    function updateY() {
+    function updateXY() {
+      self.x = el.scrollLeft;
       self.y = el.scrollTop;
     }
   }

--- a/apps/homescreen/everything.me/js/plugins/Scroll.js
+++ b/apps/homescreen/everything.me/js/plugins/Scroll.js
@@ -3,7 +3,6 @@
 
   function NativeScroll(el, initOptions) {
     var self = this,
-        startPos,
         startPointer,
         positionKey,
         dirProperty,
@@ -60,8 +59,6 @@
       'onEnd': onScrollEnd
     });
 
-    updateXY();
-
     this.distY = 0;
     this.distX = 0;
     this.maxX = 0;
@@ -94,7 +91,6 @@
       el.dataset.touched = true;
 
       reportedDirection = false;
-      startPos = [el.scrollLeft, el.scrollTop];
       startPointer = [touch.pageX, touch.pageY];
       self.maxX = el.scrollWidth - el.offsetWidth;
       self.maxY = el.scrollHeight - el.offsetHeight;
@@ -113,8 +109,7 @@
       // messages panning handler to prevent it
       e.preventPanning = true;
 
-      var currPos = [el.scrollLeft, el.scrollTop],
-          touch = 'touches' in e ? e.touches[0] : e;
+      var touch = 'touches' in e ? e.touches[0] : e;
 
       self.distX = touch.pageX - startPointer[0];
       self.distY = touch.pageY - startPointer[1];

--- a/apps/homescreen/everything.me/modules/BackgroundImage/BackgroundImage.css
+++ b/apps/homescreen/everything.me/modules/BackgroundImage/BackgroundImage.css
@@ -44,17 +44,18 @@ body.evme-displayed #search-overlay:not(:empty){
     }
 
 #bgimage-overlay {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
     opacity: 0;
     transition: opacity .5s linear;
-    z-index: 1;
+    z-index: 100000;
+    pointer-events: none;
 }
 #bgimage-overlay.ontop {
-    z-index: 500;
+    pointer-events: auto;
 }
 #bgimage-overlay.active {
     opacity: 1;
@@ -138,6 +139,14 @@ body.evme-displayed #search-overlay:not(:empty){
                         url('../../images/separator.png') 0% 50% / 0.1rem 3.7rem no-repeat;
             width: 5rem;
         }
+
+#bgimage-overlay.nosource .source {
+    visibility: hidden;
+}
+
+#bgimage-overlay.noquery h2 {
+    visibility: hidden;
+}
 
 .fullscreen-bgimage #search-header {
     display: none;

--- a/apps/homescreen/everything.me/modules/BackgroundImage/BackgroundImage.js
+++ b/apps/homescreen/everything.me/modules/BackgroundImage/BackgroundImage.js
@@ -13,6 +13,7 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
       active = false,
       changeOpacityTransitionCallback = null,
       defaultImage = '',
+      bgImage = null,
       TIMEOUT_BEFORE_REMOVING_OLD_IMAGE = 1500;
 
   this.init = function init(options) {
@@ -27,6 +28,35 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
   elementsToFade = Array.prototype.slice.call(elementsToFade, 0);
 
     Evme.EventHandler.trigger(NAME, 'init');
+
+    bgImage = document.querySelector('#bgimage-overlay');
+
+    Evme.$('.close, .img', bgImage, function onElement(el) {
+      el.addEventListener('touchstart', function onTouchStart(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        self._currentFullscreenCallback && self._currentFullscreenCallback();
+      });
+    });
+
+    Evme.$('.rightbutton', bgImage)[0].addEventListener('click',
+      function setWallpaper(e) {
+        e.stopPropagation();
+
+        Evme.EventHandler.trigger(NAME, 'setWallpaper', {
+          'image': currentImage.image
+        });
+      });
+
+    Evme.$('.source', bgImage)[0].addEventListener('click',
+      function openURL() {
+        if (currentImage.source) {
+          Evme.Utils.sendToOS(Evme.Utils.OSMessages.OPEN_URL, {
+            'url': currentImage.source
+          });
+        }
+      });
   };
 
   this.update = function update(oImage, isDefault) {
@@ -104,10 +134,7 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
 
   };
 
-  this.showFullScreen = function showFullScreen() {
-    Evme.$remove(elFullScreen);
-    elFullScreen = null;
-
+  this.showFullScreen = function showFullScreen(closeCallback) {
     onElementsToFade(function onElement() {
       this.classList.add('animate');
     });
@@ -117,10 +144,9 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
       });
     }, 0);
 
-    elFullScreen =
-      self.getFullscreenElement(currentImage, self.closeFullScreen);
+    closeCallback = closeCallback || self.closeFullScreen;
 
-    elFullScreenParent.appendChild(elFullScreen);
+    elFullScreen = self.getFullscreenElement(currentImage, closeCallback);
 
     window.setTimeout(function onTimeout() {
       elFullScreen.classList.add('ontop');
@@ -132,50 +158,19 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
     cbShowFullScreen();
   };
 
-  this.getFullscreenElement = function getFullscreenElement(data, onClose) {
+  this._currentFullscreenCallback;
+  this.getFullscreenElement = function getFullscreenElement(data, cb) {
     !data && (data = currentImage);
 
-    var el = Evme.$create('div', {'id': 'bgimage-overlay'},
-      '<div class="img" style="background-image: url(' + data.image +
-        ')"></div>' +
-      '<div class="content">' +
-        '<b class="rightbutton"></b>' +
-        '<span class="separator"></span>' +
-        ((data.query) ? '<h2>' + data.query + '</h2>' : '') +
-        ((data.source) ? '<div class="source"><b ' +
-          Evme.Utils.l10nAttr(NAME, 'source-label') + '></b> <span>' +
-          data.source + '</span></div>' : '') +
-        '<b class="close"></b>' +
-      '</div>');
+    var el = bgImage;
+    el.querySelector('.img').style.backgroundImage = 'url(' + data.image + ')';
+    el.querySelector('h2').textContent = data.query || '';
+    el.querySelector('.source span').textContent = data.source;
 
+    el.classList.toggle('nosource', !data.source);
+    el.classList.toggle('noquery', !data.query);
 
-
-    Evme.$('.close, .img', el, function onElement(el) {
-      el.addEventListener('touchstart', function onTouchStart(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        onClose && onClose();
-      });
-    });
-
-    Evme.$('.rightbutton', el)[0].addEventListener('click',
-      function setWallpaper(e) {
-        e.stopPropagation();
-
-        Evme.EventHandler.trigger(NAME, 'setWallpaper', {
-          'image': data.image
-        });
-      });
-
-    if (data.source) {
-      Evme.$('.source', el)[0].addEventListener('click', function openURL(e) {
-        Evme.Utils.sendToOS(Evme.Utils.OSMessages.OPEN_URL, {
-          'url': data.source
-        });
-      });
-    } else {
-      el.classList.add('nosource');
-    }
+    self._currentFullscreenCallback = cb;
 
     return el;
   };
@@ -184,10 +179,7 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
     if (elFullScreen && active) {
       self.cancelFullScreenFade();
       elFullScreen.classList.remove('active');
-
-      window.setTimeout(function onTimeout() {
-        Evme.$remove(elFullScreen);
-      }, 700);
+      elFullScreen.classList.remove('ontop');
 
       e && e.preventDefault();
       cbHideFullScreen();
@@ -268,4 +260,10 @@ Evme.BackgroundImage = new function Evme_BackgroundImage() {
   function cbHideFullScreen() {
     Evme.EventHandler.trigger(NAME, 'hideFullScreen');
   }
+
+  Object.defineProperty(this, 'elFullScreen', {
+    get: function() {
+      return elFullScreen;
+    }
+  });
 }

--- a/apps/homescreen/everything.me/modules/Collection/Collection.css
+++ b/apps/homescreen/everything.me/modules/Collection/Collection.css
@@ -74,7 +74,7 @@ body:not(.evme-loading):not(.evme-ready) #collection .evme-apps {
       border-right: 0.8rem solid transparent;
       border-bottom: 0.8rem solid #fff;
     }
-    
+
     /*
       This relates to e.me Searchbar, but have to be in grid.css
       since when a user opens a collection for the first time

--- a/apps/homescreen/everything.me/modules/Collection/Collection.css
+++ b/apps/homescreen/everything.me/modules/Collection/Collection.css
@@ -12,10 +12,19 @@ body:not(.evme-loading):not(.evme-ready) #collection .evme-apps {
     left: 0;
     right: 0;
     bottom: 0;
-    display: none;
     overflow: hidden;
     z-index: 10001;
     color: #fff;
+    transform: translateY(-100%);
+     /* this is exact as long as the header takes to animate.
+        we don't want to hide ourselves before header anim is done... */
+    transition: transform 380ms step-end;
+}
+
+.evmeScope #collection.visible {
+  transform: translateY(0);
+  /* if we go from hidden -> visible, don't animate */
+  transition: none;
 }
 
 .evmeScope #collection.renaming:before {
@@ -64,6 +73,15 @@ body:not(.evme-loading):not(.evme-ready) #collection .evme-apps {
       border-left: 0.8rem solid transparent;
       border-right: 0.8rem solid transparent;
       border-bottom: 0.8rem solid #fff;
+    }
+    
+    /*
+      This relates to e.me Searchbar, but have to be in grid.css
+      since when a user opens a collection for the first time
+      not all e.me assets are loaded
+    */
+    #icongrid.evme-collection-visible {
+      transform: translateY(-100%); /* move out of viewport */
     }
 
     .evmeScope #collection .header {
@@ -190,6 +208,7 @@ body:not(.evme-loading):not(.evme-ready) #collection .evme-apps {
       }
         .evmeScope #collection .evme-apps ul.static li .icon {
             transform: scale(1);
+            /* dimensions get set from code */
         }
 
     .evmeScope #collection #bgimage-overlay {

--- a/apps/homescreen/everything.me/modules/Collection/Collection.js
+++ b/apps/homescreen/everything.me/modules/Collection/Collection.js
@@ -424,11 +424,7 @@ void function() {
     this.setBackground = function setBackground(newBg) {
       if (!currentSettings) { return; }
 
-      self.clearBackground();
-
       elImage.style.backgroundImage = 'url(' + newBg.image + ')';
-
-      Evme.BackgroundImage.update(newBg);
 
       self.update(currentSettings, {'bg': newBg});
 

--- a/apps/homescreen/everything.me/modules/Helper/Helper.css
+++ b/apps/homescreen/everything.me/modules/Helper/Helper.css
@@ -32,7 +32,7 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
         font-weight: inherit;
     }
 #search-title.close {
-    display: none;
+    visibility: hidden;
 }
     #search-title .query {
         position: relative;
@@ -68,14 +68,9 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
 #helper-rapper.animate:not(.anim-disabled) {
     transition: all .3s ease;
 }
-#helper-rapper.close {
-    transform: scale(0, 0);
-    right: 1.2rem;
-    display: none;
+#helper-rapper.close, #helper-rapper.close ul {
+    visibility: hidden;
 }
-    #helper-rapper.close ul {
-        display: none;
-    }
 
     #helper-tip {
         position: absolute;
@@ -99,7 +94,6 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
         transform: rotate(45deg);
         box-shadow: -0.4rem -0.4rem 0.4rem -0.2rem rgba(0, 0, 0, .4);
     }
-
 #helper {
     position: absolute;
     top: 0;
@@ -212,7 +206,7 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
         }
 
 #save-search {
-    display: none;
+    visibility: hidden;
     position: absolute;
     right: 0.65rem;
     top: -0.4rem;
@@ -222,7 +216,7 @@ body:not(.evme-keyboard-visible) .empty-query #helper-header {
     background-size: 3rem 3rem;
 }
 #search-title.visible ~ #save-search {
-    display: block;
+    visibility: visible;
 }
 #save-search[data-saved-as-collection='true'] {
     background-image: url('/everything.me/images/bookmarked.png');

--- a/apps/homescreen/everything.me/modules/Helper/Helper.js
+++ b/apps/homescreen/everything.me/modules/Helper/Helper.js
@@ -328,8 +328,12 @@ Evme.Helper = new function Evme_Helper() {
     title = newTitle;
 
     if (!title) {
-      elTitle.innerHTML =
-        '<b ' + Evme.Utils.l10nAttr(NAME, 'title-empty') + '></b>';
+      var b = elTitle.querySelector('b');
+      if (!b) {
+        b = document.createElement('b');
+        elTitle.appendChild(b);
+      }
+      b.setAttribute('data-l10n-id', Evme.Utils.l10n(NAME, 'title-empty'));
       return false;
     }
 

--- a/apps/homescreen/everything.me/modules/Results/Result.js
+++ b/apps/homescreen/everything.me/modules/Results/Result.js
@@ -15,8 +15,7 @@
   var NAME = 'Result';
 
   Evme.Result = function Evme_Result() {
-    var self = this,
-        image = new Image();
+    var self = this;
 
     this.type = 'NOT_SET';
     this.cfg = {};
@@ -24,42 +23,36 @@
     this.elName = null;
 
     this.drawAppName = function drawAppName() {
-      var canvas = document.createElement('canvas'),
-          context = canvas.getContext('2d');
-
-      canvas.width = TEXT_WIDTH;
-      canvas.height = APP_NAME_HEIGHT;
-
-      Evme.Utils.writeTextToCanvas({
-        'text': self.cfg.name,
-        'context': context,
-        'offset': TEXT_MARGIN
-      });
-
-      self.elName.src = canvas.toDataURL();
+      this.elName.textContent = self.cfg.name;
     };
 
-    this.draw = function draw(iconObj) {
+    this.draw = function draw(iconObj, callback) {
       self.cfg.icon = iconObj;
 
       if (self.el) {
         self.el.setAttribute('data-name', self.cfg.name);
 
+        var a = +new Date;
         self.drawAppName();
+
+        self.elIcon.onload = self.elIcon.onerror = function() {
+          self.el.dataset.loaded = true;
+
+          if (callback) {
+            callback();
+          }
+        };
 
         if (Evme.Utils.isBlob(iconObj)) {
           Evme.Utils.blobToDataURI(iconObj, function onDataReady(src) {
-            setImageSrc(src);
+            self.elIcon.src = src;
           });
         } else {
-          var src = Evme.Utils.formatImageData(iconObj);
-          setImageSrc(src);
+          self.elIcon.src = Evme.Utils.formatImageData(iconObj);
         }
       }
-
-      function setImageSrc(src) {
-        image.onload = self.onAppIconLoad;
-        image.src = src;
+      else {
+        callback();
       }
     };
 
@@ -70,51 +63,6 @@
     this.setIconSrc = function(src) {
       self.el.dataset.iconId = this.cfg.id;
       self.el.dataset.iconSrc = src;
-    };
-
-    // @default
-    this.onAppIconLoad = function onAppIconLoad() {
-      var canvas = self.initIcon(Evme.Utils.getOSIconSize()),
-          context = canvas.getContext('2d'),
-          width = canvas.width,
-          height = canvas.height,
-          SHADOW = INSTALLED_APPS_SHADOW_OFFSET;
-
-      // account for shadow - pad the canvas from the bottom,
-      // and move the name back up
-      canvas.height += SHADOW;
-
-      context.drawImage(image,
-          (width - image.width) / 2,
-          (height - image.height) / 2);
-
-      self.finalizeIcon(canvas);
-      self.setIconSrc(image.src);
-    };
-
-    // @default
-    this.initIcon = function initIcon(height) {
-      var canvas = document.createElement('canvas'),
-          context = canvas.getContext('2d');
-
-      canvas.width = TEXT_WIDTH;
-      canvas.height = height;
-
-      return canvas;
-    };
-
-    // @default
-    this.finalizeIcon = function finalizeIcon(canvas) {
-      var icon = self.elIcon;
-
-      var img = new Image();
-      img.addEventListener('load', function load() {
-        img.removeEventListener('load', load);
-
-        icon.style.backgroundImage = 'url(' + img.src + ')';
-        self.el.dataset.loaded = true;
-      });
-      img.src = canvas.toDataURL();
     };
 
     // @default
@@ -204,23 +152,22 @@
   Evme.Result.prototype.init = function Result_init(cfg) {
     this.cfg = cfg;
 
-    var el = this.el = Evme.$create('li', {
-      'id': 'app_' + cfg.id,
-      'data-name': cfg.name
-    }, '<img class="icon" />' +
-       '<img class="name" />');
+    // Create Elements
+    var el = this.el = document.createElement('li');
+    el.id = 'app_' + cfg.id;
+    el.dataset.name = cfg.name;
 
-    this.elIcon = el.querySelector('.icon');
-    this.elName = el.querySelector('.name');
+    var elIcon = this.elIcon = document.createElement('img');
+    elIcon.classList.add('icon');
+    el.appendChild(elIcon);
 
-    this.elName.setAttribute('width', TEXT_WIDTH);
-    this.elName.setAttribute('height', APP_NAME_HEIGHT);
+    var elName = this.elName = document.createElement('div');
+    elName.classList.add('name');
+    el.appendChild(elName);
 
-    this.elIcon.setAttribute('width', TEXT_WIDTH);
-    this.elIcon.setAttribute('height',
-      Evme.Utils.getOSIconSize() + INSTALLED_APPS_SHADOW_OFFSET);
-
-    this.elIcon.style.marginBottom = (-INSTALLED_APPS_SHADOW_OFFSET) + 'px';
+    // Apply styles and event handlers
+    this.elName.style.width = TEXT_WIDTH + 'px';
+    this.elName.style.height = (APP_NAME_HEIGHT - TEXT_MARGIN) + 'px';
 
     this.elIcon.setAttribute('aria-label', cfg.name);
     this.elName.setAttribute('aria-label', cfg.name);

--- a/apps/homescreen/everything.me/modules/Results/ResultManager.js
+++ b/apps/homescreen/everything.me/modules/Results/ResultManager.js
@@ -88,9 +88,9 @@ Evme.ResultManager = function Evme_ResultsManager() {
       });
 
       scroll = new Scroll(el, {
-        'onTouchStart': touchStart,
-        'onTouchMove': touchMove,
-        'onTouchEnd': touchEnd,
+        // 'onTouchStart': touchStart,
+        // 'onTouchMove': touchMove,
+        // 'onTouchEnd': touchEnd,
         'onScrollEnd': scrollEnd
       });
 
@@ -370,8 +370,8 @@ Evme.ResultManager = function Evme_ResultsManager() {
     if (apiHasMoreCloudApps) {
 
       // kept separate for performance reasons
-      var reachedBottom =
-        scrollableEl.offsetHeight - el.offsetHeight <= scroll.y;
+      var reachedBottom = scroll.maxY === scroll.y;
+
       if (reachedBottom) {
         cbScrolledToEnd();
       }

--- a/apps/homescreen/everything.me/modules/Results/Results.css
+++ b/apps/homescreen/everything.me/modules/Results/Results.css
@@ -29,8 +29,11 @@
     display: none;
 }
 .evmeScope .evme-apps ul li img {
-  visibility: hidden;
-	transition: transform .2s linear;
+    visibility: hidden;
+    transition: transform .2s linear;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
 }
 .evmeScope .evme-apps ul li[data-loaded="true"] img {
   visibility: visible;

--- a/apps/homescreen/everything.me/modules/Results/Results.css
+++ b/apps/homescreen/everything.me/modules/Results/Results.css
@@ -34,7 +34,19 @@
     display: block;
     margin-left: auto;
     margin-right: auto;
+    width: 6.4rem;
+    height: 6.4rem;
 }
+
+.evmeScope .evme-apps ul.cloud li img {
+    border-radius: 50%;
+    width: 6rem;
+    height: 6rem;
+
+    /* todo, make sure this is correct */
+    box-shadow: 0.2rem 0.2rem 0.4rem rgba(0, 0, 0, 0.9);
+}
+
 .evmeScope .evme-apps ul li[data-loaded="true"] img {
   visibility: visible;
 }
@@ -61,6 +73,12 @@
   margin: 0;
   display: inline;
 }
+
+.evmeScope .evme-apps .loading-images, 
+.evmeScope .evme-apps .loading-images li[data-loaded="true"] img {
+  visibility: hidden;
+}
+
 .evmeScope .evme-apps ul.cloud {
   min-height: 0.1rem; /* meant for when there's no content */
 }
@@ -76,6 +94,18 @@
   z-index: 2;
   background: url(/resources/images/delete.png) no-repeat left top;
   display: none;
+}
+
+.evmeScope .evme-apps li .name {
+  text-shadow: 0 0.1rem 0.4rem rgba(0, 0, 0, 0.9);
+  font-size: 1.3rem;
+  margin-top: 0.6rem;
+  color: white;
+  overflow: hidden;
+}
+
+.evmeScope .evme-apps li .name .download {
+  font-size: 1.1rem;
 }
 
 /* Loading an app */

--- a/apps/homescreen/everything.me/modules/Results/providers/CloudApps.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/CloudApps.js
@@ -5,10 +5,20 @@ Evme.CloudAppResult = function Evme_CloudAppsResult(query) {
 
   this.type = Evme.RESULT_TYPE.CLOUD;
 
-  var SHADOW_OFFSET = 2 * window.devicePixelRatio,
-      SHADOW_BLUR = 2 * window.devicePixelRatio,
-
+  var SHADOW_OFFSET = Icon.prototype.SHADOW_OFFSET_Y,
+      SHADOW_BLUR = Icon.prototype.SHADOW_BLUR,
+      SHADOW_COLOR = Icon.prototype.SHADOW_COLOR,
       self = this;
+
+  // @override
+  this.init = function CloudResult_init() {
+    var res = Evme.Result.prototype.init.apply(this, arguments);
+
+    this.elIcon.setAttribute('height', Evme.Utils.getOSIconSize());
+    this.elIcon.style.marginBottom = '0';
+
+    return res;
+  };
 
   // @override
   // manipulate the icon (clipping, shadow, resize)
@@ -41,8 +51,7 @@ Evme.CloudAppResult = function Evme_CloudAppsResult(query) {
             canvas = self.initIcon(height + padding),
             context = canvas.getContext('2d'),
             canvasHeight = canvas.height,
-            canvasWidth = canvas.width,
-            SHADOW_SIZE = (SHADOW_OFFSET + SHADOW_BLUR);
+            canvasWidth = canvas.width;
 
         // account for shadow - pad the canvas from the bottom,
         // and move the name back up

--- a/apps/homescreen/everything.me/modules/Results/providers/CloudApps.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/CloudApps.js
@@ -8,6 +8,7 @@ Evme.CloudAppResult = function Evme_CloudAppsResult(query) {
   var SHADOW_OFFSET = Icon.prototype.SHADOW_OFFSET_Y,
       SHADOW_BLUR = Icon.prototype.SHADOW_BLUR,
       SHADOW_COLOR = Icon.prototype.SHADOW_COLOR,
+      SHADOW_SIZE = (SHADOW_OFFSET + SHADOW_BLUR),
       self = this;
 
   // @override
@@ -47,25 +48,19 @@ Evme.CloudAppResult = function Evme_CloudAppsResult(query) {
         var osIconSize = Evme.Utils.getOSIconSize(),
             width = osIconSize,
             height = osIconSize,
-            padding = Evme.Utils.OS_ICON_PADDING,
-            canvas = self.initIcon(height + padding),
+            padding = 0,
+            canvas = self.initIcon(height),
             context = canvas.getContext('2d'),
             canvasHeight = canvas.height,
             canvasWidth = canvas.width;
-
-        // account for shadow - pad the canvas from the bottom,
-        // and move the name back up
-        canvas.height += SHADOW_SIZE;
-        self.elIcon.style.cssText += 'margin-bottom: ' + -SHADOW_SIZE + 'px;';
 
         // shadow
         context.shadowOffsetX = 0;
         context.shadowOffsetY = SHADOW_OFFSET;
         context.shadowBlur = SHADOW_BLUR;
-        context.shadowColor = 'rgba(0, 0, 0, 0.6)';
+        context.shadowColor = SHADOW_COLOR;
         context.drawImage(fixedImage,
-                          (canvasWidth - width + padding) / 2, padding,
-                          width - padding, height - padding);
+          (canvasWidth - width) / 2, 0, width, height);
 
         self.finalizeIcon(canvas);
       };
@@ -76,21 +71,13 @@ Evme.CloudAppResult = function Evme_CloudAppsResult(query) {
 
   // @override
   this.launch = function launchCloudApp() {
-    // first resize the icon to the OS size
-    // this includes a 2px padding around the icon
-    Evme.Utils.padIconForOS({
+    EvmeManager.openCloudApp({
+      'url': self.cfg.appUrl,
+      'originUrl': self.getFavLink(),
+      'title': self.cfg.name,
       'icon': self.cfg.icon,
-      'resize': true,
-      'callback': function onIconResized(icon) {
-        EvmeManager.openCloudApp({
-          'url': self.cfg.appUrl,
-          'originUrl': self.getFavLink(),
-          'title': self.cfg.name,
-          'icon': icon,
-          'urlTitle': query,
-          'useAsyncPanZoom': self.cfg.isWeblink
-        });
-      }
+      'urlTitle': query,
+      'useAsyncPanZoom': self.cfg.isWeblink
     });
   };
 };

--- a/apps/homescreen/everything.me/modules/Results/providers/MarketApps.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/MarketApps.js
@@ -17,6 +17,16 @@
     this.slug = slug;
 
     // @override
+    this.init = function CloudResult_init() {
+      var res = Evme.Result.prototype.init.apply(this, arguments);
+
+      this.elName.setAttribute('height',
+        APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE);
+
+      return res;
+    };
+
+    // @override
     this.drawAppName = function drawAppName() {
       var canvas = document.createElement('canvas'),
           context = canvas.getContext('2d'),

--- a/apps/homescreen/everything.me/modules/Results/providers/MarketApps.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/MarketApps.js
@@ -20,38 +20,29 @@
     this.init = function CloudResult_init() {
       var res = Evme.Result.prototype.init.apply(this, arguments);
 
-      this.elName.setAttribute('height',
-        APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE);
+      this.elName.style.height =
+        (APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE) + 'px';
 
       return res;
     };
 
     // @override
     this.drawAppName = function drawAppName() {
-      var canvas = document.createElement('canvas'),
-          context = canvas.getContext('2d'),
-          downloadLabel = Evme.Utils.l10n('apps', 'market-download');
+      var downloadLabel = Evme.Utils.l10n('apps', 'market-download');
 
-      canvas.width = TEXT_WIDTH;
-      canvas.height = APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE;
+      var download = document.createElement('span');
+      download.classList.add('download');
+      download.textContent = downloadLabel;
 
-      Evme.Utils.writeTextToCanvas({
-        'text': downloadLabel,
-        'context': context,
-        'offset': TEXT_MARGIN,
-        'fontSize': DOWNLOAD_LABEL_FONT_SIZE
-      });
+      var text = document.createTextNode(this.cfg.name);
 
-      Evme.Utils.writeTextToCanvas({
-        'text': this.cfg.name,
-        'context': context,
-        'offset': TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE + SCALE_RATIO
-      });
+      self.elName.appendChild(download);
+      self.elName.appendChild(document.createElement('br'));
+      self.elName.appendChild(text);
 
       var ariaLabel = downloadLabel + ' ' + this.cfg.name;
       self.elIcon.setAttribute('aria-label', ariaLabel);
       self.elName.setAttribute('aria-label', ariaLabel);
-      self.elName.src = canvas.toDataURL();
     };
 
     // @override
@@ -111,15 +102,24 @@
     function _render(apps) {
       var docFrag = document.createDocumentFragment();
 
+      containerEl.classList.add('loading-images');
+
+      var loaded = 0;
+      function next() {
+        if (++loaded === apps.length) {
+          containerEl.classList.remove('loading-images');
+        }
+      }
+
       for (var i = 0, app; app = apps[i++];) {
         var result = new Evme.MarketResult(app.slug),
         el = result.init(app);
 
         if (app.icon) {
-          getMarketIcon(app, result);
+          getMarketIcon(app, result, next);
         } else {
           app.icon = DEFAULT_ICON;
-          result.draw(app.icon);
+          result.draw(app.icon, next);
         }
 
         // used for result filtering
@@ -137,17 +137,17 @@
      * see http://www.w3.org/TR/2011/WD-html5-20110525/
      *                     the-canvas-element.html#security-with-canvas-elements
      */
-    function getMarketIcon(app, result) {
+    function getMarketIcon(app, result, appDrawCallback) {
       Evme.Utils.systemXHR({
         'url': app.icon.data,
         'responseType': 'blob',
         'onSuccess': function onIconSuccess(response) {
           app.icon = response;
-          result.draw(app.icon);
+          result.draw(app.icon, appDrawCallback);
         },
         'onError': function onIconError(e) {
           app.icon = DEFAULT_ICON;
-          result.draw(app.icon);
+          result.draw(app.icon, appDrawCallback);
         }
       });
     }

--- a/apps/homescreen/everything.me/modules/Results/providers/MarketSearch.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/MarketSearch.js
@@ -17,6 +17,17 @@
     this.type = Evme.RESULT_TYPE.MARKET_SEARCH;
 
     // @override
+    this.init = function CloudResult_init() {
+      var res = Evme.Result.prototype.init.apply(this, arguments);
+
+      this.elName.setAttribute('height',
+        APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE);
+
+      return res;
+    };
+
+
+    // @override
     this.drawAppName = function drawAppName() {
       var canvas = document.createElement('canvas'),
           context = canvas.getContext('2d'),

--- a/apps/homescreen/everything.me/modules/Results/providers/MarketSearch.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/MarketSearch.js
@@ -20,8 +20,8 @@
     this.init = function CloudResult_init() {
       var res = Evme.Result.prototype.init.apply(this, arguments);
 
-      this.elName.setAttribute('height',
-        APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE);
+      this.elName.style.height =
+        (APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE) + 'px';
 
       return res;
     };
@@ -29,30 +29,20 @@
 
     // @override
     this.drawAppName = function drawAppName() {
-      var canvas = document.createElement('canvas'),
-          context = canvas.getContext('2d'),
-          downloadLabel = Evme.Utils.l10n('apps', 'market-download');
+      var downloadLabel = Evme.Utils.l10n('apps', 'market-download');
+      var download = document.createElement('span');
+      download.classList.add('download');
+      download.textContent = downloadLabel;
 
-      canvas.width = TEXT_WIDTH;
-      canvas.height = APP_NAME_HEIGHT + TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE;
+      var text = document.createTextNode(label);
 
-      Evme.Utils.writeTextToCanvas({
-        'text': downloadLabel,
-        'context': context,
-        'offset': TEXT_MARGIN,
-        'fontSize': DOWNLOAD_LABEL_FONT_SIZE
-      });
-
-      Evme.Utils.writeTextToCanvas({
-        'text': label,
-        'context': context,
-        'offset': TEXT_MARGIN + DOWNLOAD_LABEL_FONT_SIZE + SCALE_RATIO
-      });
+      self.elName.appendChild(download);
+      self.elName.appendChild(document.createElement('br'));
+      self.elName.appendChild(text);
 
       var ariaLabel = downloadLabel + ' ' + label;
       self.elIcon.setAttribute('aria-label', ariaLabel);
       self.elName.setAttribute('aria-label', ariaLabel);
-      self.elName.src = canvas.toDataURL();
     };
 
     // @override
@@ -98,12 +88,17 @@
     };
 
     function render(data) {
+      containerEl.classList.add('loading-images');
+
       self.clear();
 
       var marketSearchResult = new Evme.MarketSearchResult(data),
       el = marketSearchResult.init(app);
 
-      marketSearchResult.draw(app.icon);
+      marketSearchResult.draw(app.icon, function() {
+        containerEl.classList.remove('loading-images');
+      });
+
       containerEl.appendChild(el);
     }
   };

--- a/apps/homescreen/everything.me/modules/Results/providers/StaticApps.js
+++ b/apps/homescreen/everything.me/modules/Results/providers/StaticApps.js
@@ -62,7 +62,7 @@ Evme.StaticAppsRenderer = function Evme_StaticAppsRenderer() {
     containerEl.appendChild(el);
   }
 
-  function renderApp(app) {
+  function renderApp(app, callback) {
     app.isRemovable = true;
     app.isStatic = true;
 
@@ -80,7 +80,7 @@ Evme.StaticAppsRenderer = function Evme_StaticAppsRenderer() {
     }
 
     el = result.init(app);
-    result.draw(app.icon || DEFAULT_ICON);
+    result.draw(app.icon || DEFAULT_ICON, callback);
 
     return el;
   }
@@ -88,8 +88,17 @@ Evme.StaticAppsRenderer = function Evme_StaticAppsRenderer() {
   function renderDocFrag(apps) {
     var docFrag = document.createDocumentFragment();
 
+    containerEl.classList.add('loading-images');
+
+    var loaded = 0;
+    function next() {
+      if (++loaded === apps.length) {
+        containerEl.classList.remove('loading-images');
+      }
+    }
+
     for (var i = 0, app; app = apps[i++];) {
-      var el = renderApp(app);
+      var el = renderApp(app, next);
       docFrag.appendChild(el);
     }
 

--- a/apps/homescreen/everything.me/modules/Searchbar/Searchbar.css
+++ b/apps/homescreen/everything.me/modules/Searchbar/Searchbar.css
@@ -2,15 +2,15 @@
     background: rgba(0, 0, 0, 0.4);
     position: relative;
     z-index: 50;
-    min-height: 5rem;
-    -moz-transition: all .2s linear;
-    transition: all .2s linear;
+    min-height: 8rem; /* 5rem + 3rem */
+    transition: transform .2s linear, background .2s linear;
+    transform: translateY(-3rem);
 }
 
 #evmeContainer:not(.empty-query) #header,
 .evme-keyboard-visible #header {
     background: rgba(0, 0, 0, 0.8) !important;
-    min-height: 8rem !important;
+    transform: translateY(0) !important;
 }
 
 #evmeContainer #search-header {
@@ -100,4 +100,17 @@
     -moz-transition: all .2s linear;
     transition: all .2s linear;
     opacity: 0 !important;
+}
+
+/* empty query and not in search screen? don't get any pointer events.
+   the reason is that we have content that is translated so this div
+   can overlap homescreen */
+body:not(.evme-keyboard-visible) #evmeContainer.empty-query {
+    pointer-events: none;
+}
+
+/* all children in #search should have normal behavior again,
+   so you can tap the search input field */
+#evmeContainer #search > * {
+    pointer-events: auto;
 }

--- a/apps/homescreen/everything.me/modules/Searchbar/Searchbar.js
+++ b/apps/homescreen/everything.me/modules/Searchbar/Searchbar.js
@@ -51,6 +51,8 @@ Evme.Searchbar = new function Evme_Searchbar() {
       clearButtonClick();
     });
 
+    isFocused = this.isFocused();
+
     Evme.EventHandler.trigger(NAME, 'init');
   };
 

--- a/apps/homescreen/everything.me/modules/Searchbar/Searchbar.js
+++ b/apps/homescreen/everything.me/modules/Searchbar/Searchbar.js
@@ -23,6 +23,7 @@ Evme.Searchbar = new function Evme_Searchbar() {
 
     el = options.el;
     elForm = options.elForm;
+    value = options.el.value;
 
     if (typeof options.setFocusOnClear === 'boolean') {
       SET_FOCUS_ON_CLEAR = options.setFocusOnClear;
@@ -58,7 +59,7 @@ Evme.Searchbar = new function Evme_Searchbar() {
   };
 
   this.isFocused = function getIsFocused() {
-    return isFocused;
+    return document.activeElement === el;
   };
 
   this.setValue = function setValue(newValue, bPerformSearch, bDontBlur) {

--- a/apps/homescreen/index.html
+++ b/apps/homescreen/index.html
@@ -9,6 +9,14 @@
     <link rel="stylesheet" type="text/css" href="style/dock.css">
     <link rel="stylesheet" type="text/css" href="everything.me/css/everything.me.css">
 
+    <!-- Evme modules CSS (todo: get rid of everything but common & SearchBar, defaults should be good enough) -->
+    <link rel="stylesheet" type="text/css" href="everything.me/css/common.css">
+    <link rel="stylesheet" type="text/css" href="everything.me/modules/Searchbar/Searchbar.css">
+    <link rel="stylesheet" type="text/css" href="everything.me/modules/Collection/Collection.css">
+    <link rel="stylesheet" type="text/css" href="everything.me/modules/Results/Results.css">
+    <link rel="stylesheet" type="text/css" href="everything.me/modules/Helper/Helper.css">
+    <link rel="stylesheet" type="text/css" href="shared/style_unstable/progress_activity.css">
+
     <!-- Shared code -->
     <script type="text/javascript" src="shared/js/l10n.js"></script>
     <script type="text/javascript" defer src="shared/js/screen_layout.js"></script>

--- a/apps/homescreen/style/dragdrop.css
+++ b/apps/homescreen/style/dragdrop.css
@@ -27,6 +27,10 @@
   margin-left: -0.15rem;
 }
 
+#collection .draggable img {
+  display: block;
+}
+
 #collection .draggable > div > span {
   margin-left: 0.2rem;
   margin-top: -0.2rem;

--- a/apps/homescreen/style/homescreen.css
+++ b/apps/homescreen/style/homescreen.css
@@ -71,11 +71,12 @@ li:active {
 
 #bg-overlay {
   width: 100%;
-  height: calc(100% - 7.5rem);
+  height: 100%;
   position: fixed;
   top: 0;
   left: 0;
   background-color: rgba(0,0,0,0.1);
+  transform: translateY(-7.5rem);
 }
 
 /* === Repaint Helper === */
@@ -129,7 +130,7 @@ body[data-mode = 'normal'] ol > li span.options {
 }
 @media (min-width: 768px) {
   #bg-overlay {
-    height: calc(100% - 16.9rem);
+    transform: translateY(-16.9rem);
   }
 }
 /* This is a dirty hack to hide the bottom toolbar while
@@ -151,7 +152,7 @@ body[data-mode = 'normal'] ol > li span.options {
        /* For the Twist , 960x540 */
        (device-height: 540px) and (max-height: 450px),
        (device-height: 960px) and (max-height: 870px) {
-  footer { display: none !important; }
+  footer { opacity: 0; pointer-events: none; }
   .apps > div { height: 100% !important; }
-  #bg-overlay { height: 100%;}
+  #bg-overlay { transform: translateY(0); }
 }


### PR DESCRIPTION
Based off of #18596. Just look at the last commit. This is a work in progress!

This patch makes rendering the apps in e.me faster. A comparison video is here: http://youtu.be/KGB6PBCCy0g. On the left you see Tarako running e.me version from #18596, on the right this version. All the time between the moment the horizontal rule appears, up until the moment all apps are displayed is wasted on creating canvases and preloading images etc. We can drastically bring that down as the video shows. Video is taken right after startup of device, nothing preloaded.

Second thing is that we wait until all apps are loaded in a category before displaying. Before it could happen that apps start popping up one by one which didn't look nice.

It's not pixel perfect, but it works pretty well. All categories in e.me work (marketplace / static / cloud / etc.).
