### PR TITLE
Bug 995116 - [Tarako][MMS][Gallery] SMS/MMS OOM after attach a large pixel picture from gallery

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -210,11 +210,12 @@ var Compose = (function() {
       if (++done === images) {
         state.resizing = false;
         onContentChanged();
+      } else {
+        resizedImg(imgNodes[done]);
       }
     }
 
-    state.resizing = true;
-    imgNodes.forEach(function(node) {
+    function resizedImg(node) {
       var item = attachments.get(node);
       if (item.blob.size < limit) {
         imageSized();
@@ -233,7 +234,9 @@ var Compose = (function() {
           imageSized();
         });
       }
-    });
+    }
+    state.resizing = true;
+    resizedImg(imgNodes[done]);
     onContentChanged();
   }
 


### PR DESCRIPTION
- Avoid image resizing tasks executed at the same time
- Use moz sample size for jpeg image for less memory consumption while image resizing
