### PR TITLE
Bug 995605 - [Sora][Message][MMS]Can't add the text in content when forw...

### DIFF
--- a/apps/sms/js/desktop-only/mobilemessage.js
+++ b/apps/sms/js/desktop-only/mobilemessage.js
@@ -107,6 +107,24 @@
       }],
       timestamp: now
     });
+    messagesDb.messages.push({
+      id: messagesDb.id++,
+      threadId: 6,
+      sender: '052780',
+      type: 'mms',
+      read: true,
+      delivery: 'received',
+      deliveryInfo: [{deliveryStatus: 'success'}],
+      subject: 'Test MMS Image message',
+      smil: '<smil><body><par><img src="example.jpg"/>' +
+            '</par></body></smil>',
+      attachments: [{
+        location: 'example.jpg',
+        content: testImageBlob
+      }],
+      timestamp: now,
+      sentTimestamp: now - 100000
+    });
   });
 
   getTestFile('/test/unit/media/video.ogv', function(testVideoBlob) {

--- a/apps/sms/js/smil.js
+++ b/apps/sms/js/smil.js
@@ -195,7 +195,7 @@ window.SMIL = {
 
     function exitPoint() {
       if (!activeReaders) {
-        callback(slides);
+        setTimeout(callback.bind(null, slides));
       }
     }
 

--- a/apps/sms/test/unit/smil_test.js
+++ b/apps/sms/test/unit/smil_test.js
@@ -105,6 +105,31 @@ suite('SMIL', function() {
         done();
       });
     });
+
+    test('Image message without smil', function(done) {
+      // minimal fake data for text only message without smil
+      var messageData = {
+        attachments: [
+          {
+            content: testImageBlob,
+            location: 'example.jpg'
+          }
+        ]
+      };
+      var stub = sinon.stub();
+      SMIL.parse(messageData, function(output) {
+        // one slide returned
+        assert.equal(output.length, 1);
+        // the text should be put on the same slide as the image
+        assert.ok(!output[0].text);
+        assert.equal(output[0].blob, testImageBlob);
+        assert.equal(output[0].name, 'example.jpg');
+        sinon.assert.called(stub);
+        done();
+      });
+      stub();
+    });
+
     test('Minimal SMIL doc', function(done) {
       var testText = 'Testing 1 2 3';
       var message = {


### PR DESCRIPTION
...ard a media MMS r=schung

The issue is that in compose.js, "pointer-events: none" is added after it's
removed, in this case.

This patch ensures that SMIL.parse always calls the callback in an asynchronous way,
so that the caller does not have any surprise.
