### PR TITLE
bug 999511

### DIFF
--- a/apps/system/js/app_modal_dialog.js
+++ b/apps/system/js/app_modal_dialog.js
@@ -452,9 +452,9 @@
       // useful. Instead we will return the application name if there is one
       // or an empty string.
       //
+      var appURL = new URL(this.app.config.url);
       if (!title ||
-          title.contains(this.app.config.url) ||
-          title.contains(this.app.config.origin)) {
+          title.contains(appURL.origin)) {
         return this.app.name || '';
       }
 


### PR DESCRIPTION
- Do not use gecko provided title if it contains the origin of the URL of the application.

r=?
