### PR TITLE
[Video]Bug 1002445 - [video]Seekbar moves in player pause state r=john hu

### DIFF
--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -1091,6 +1091,12 @@ function pause() {
   // Switch the button icon
   dom.play.classList.add('paused');
 
+  // Check the dragging is true or not before pausing
+  if (dragging) {
+    dragging = false;
+    dom.playHead.classList.remove('active');
+  }
+
   // Stop playing the video
   dom.player.pause();
   playing = false;


### PR DESCRIPTION
Mozilla URL:
https://bugzilla.mozilla.org/show_bug.cgi?id=1002445
