### PR TITLE
Bug 1002932 - [email] cookie cache no longer working with GAIA_OPTIMIZE=1

### DIFF
--- a/apps/email/build/make_gaia_shared.js
+++ b/apps/email/build/make_gaia_shared.js
@@ -145,17 +145,12 @@ requirejs.tools.useLib(function(require) {
 
     // Update the cache value based on digest values of all files.
     var finalDigest = getDigest(digests.join(',')),
-        cacheRegExp = /var\s*CACHE_VERSION\s*=\s*'[^']+'/;
-
-    [
-      buildDir + 'js/html_cache_restore.js',
-      buildDir + 'js/mail_app.js'
-    ].forEach(function (fileName) {
-      var contents = file.readFile(fileName);
-      contents = contents.replace(cacheRegExp,
-                                 'var CACHE_VERSION = \'' + finalDigest + '\'');
-      file.saveFile(fileName, contents);
-    });
+        cacheRegExp = /HTML_COOKIE_CACHE_VERSION\s*=\s*["'][^"']+["']/,
+        cacheFileName = buildDir + 'js/html_cache_restore.js',
+        contents = file.readFile(cacheFileName);
+    contents = contents.replace(cacheRegExp,
+                               'HTML_COOKIE_CACHE_VERSION = \'' + finalDigest + '\'');
+    file.saveFile(cacheFileName, contents);
 
   });
 });

--- a/apps/email/js/html_cache.js
+++ b/apps/email/js/html_cache.js
@@ -1,13 +1,8 @@
-/*global document, console, setTimeout, define: true */
+// HTML_COOKIE_CACHE_VERSION is set in html_cache_restore as a global.
+/*global document, console, setTimeout, HTML_COOKIE_CACHE_VERSION,
+  define: true */
 
 define(function(require, exports) {
-
-/**
- * Version number for cache, allows expiring cache.
- * Set by build process, value must match the value
- * in html_cache_restore.js.
- */
-var CACHE_VERSION = '1';
 
 /**
  * Saves a JS object to document.cookie using JSON.stringify().
@@ -15,7 +10,7 @@ var CACHE_VERSION = '1';
  * /htmlc(\d+)/
  */
 exports.save = function htmlCacheSave(html) {
-  html = encodeURIComponent(CACHE_VERSION + ':' + html);
+  html = encodeURIComponent(HTML_COOKIE_CACHE_VERSION + ':' + html);
 
   // Set to 20 years from now.
   var expiry = Date.now() + (20 * 365 * 24 * 60 * 60 * 1000);

--- a/apps/email/js/html_cache_restore.js
+++ b/apps/email/js/html_cache_restore.js
@@ -6,6 +6,12 @@ function plog(msg) {
   console.log(msg + ' ' + (performance.now() - _xstart));
 }
 
+/**
+ * Version number for cache, allows expiring cache.
+ * Set by build process. Set as a global because it
+ * is also used in html_cache.js.
+ */
+var HTML_COOKIE_CACHE_VERSION = '1';
 
 // Use a global to work around issue with
 // navigator.mozHasPendingMessage only returning
@@ -13,13 +19,7 @@ function plog(msg) {
 window.htmlCacheRestorePendingMessage = [];
 
 (function() {
-  /**
-   * Version number for cache, allows expiring cache.
-   * Set by build process, value must match the value
-   * in html_cache.js.
-   */
-  var CACHE_VERSION = '1',
-      selfNode = document.querySelector('[data-loadsrc]'),
+  var selfNode = document.querySelector('[data-loadsrc]'),
       loader = selfNode.dataset.loader,
       loadSrc = selfNode.dataset.loadsrc;
 
@@ -51,7 +51,9 @@ window.htmlCacheRestorePendingMessage = [];
       value = value.substring(index + 1);
     }
 
-    if (version !== CACHE_VERSION) {
+    if (version !== HTML_COOKIE_CACHE_VERSION) {
+      console.log('Skipping cookie cache, out of date. Expected ' +
+                  HTML_COOKIE_CACHE_VERSION + ' but found ' + version);
       value = '';
     }
 


### PR DESCRIPTION
Switch to using a global, HTML_COOKIE_CACHE_VERSION, set up in html_cache_restore.js, and only modify that one global in that one file.

I have a strong aversion to globals, but since this value is used before we have a module system available, and because we want the value to be the same there as well as in the html_cache.js file, the global makes sense. This also avoids issues with minification trying to rename it, and means we only need to stamp one file in make_gaia_shared.js.

How I verified the fix:

   make install-gaia GAIA_OPTIMIZE=1 APP=email

then in build_stage/email, I make sure that js/mail_app.js still has a HTML_COOKIE_CACHE_VERSION reference in the 'html_cache' module (so it survived minification) and that in js/html_cache_restore.js, the HTML_COOKIE_CACHE_VERSION value is stamped with the digest generated from the source files.

It also worked on the device. :)

If you want to test this locally, you will want to get the l10n.js fix that is in [bug 1002920](https://bugzilla.mozilla.org/show_bug.cgi?id=1002920). This bug is not dependent on that fix, however, to see that the constant survives minification, that fix is necessary for mail_app.js to be minified on master at the moment.
