### PR TITLE
Bug 1000691 - remove APZ option for 1.3t r=crh0716

### DIFF
--- a/apps/settings/elements/about_more_info_developer.html
+++ b/apps/settings/elements/about_more_info_developer.html
@@ -126,12 +126,6 @@
         </li>
         <li>
           <label class="pack-checkbox">
-            <input type="checkbox" name="apz.force-enable"/>
-            <span data-l10n-id="apz-force-enable">Enable APZ for all content processes</span>
-          </label>
-        </li>
-        <li>
-          <label class="pack-checkbox">
             <input type="checkbox" name="layers.enable-tiles"/>
             <span data-l10n-id="layers-enable-tiles">Layers: Enable Tiles</span>
           </label>


### PR DESCRIPTION
Since we don't want user to enable APZ on this low-end device.
