### PR TITLE
Bug995940 No 'data-l10n-id' for ./elements/sim_manager.html: <h2>SIM settings</h2>

### DIFF
--- a/apps/settings/elements/sim_manager.html
+++ b/apps/settings/elements/sim_manager.html
@@ -7,7 +7,7 @@
     <div>
       <ul id="sim-card-container"></ul>
       <header>
-        <h2>SIM settings</h2>
+        <h2 data-l10n-id="simSettings">SIM settings</h2>
       </header>
       <ul class="sim-manager-select-list">
         <li data-href="#simpin" id="sim-manager-security-entry">

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -544,6 +544,7 @@ simManager=SIM manager
 # in headers, you can use a shorter string here.
 simManager-header={{simManager}}
 
+simSettings=SIM settings
 sim-manager-outgoing-call=Outgoing call
 sim-manager-outgoing-call-desc=Calls will be sent from
 sim-manager-outgoing-messages=Outgoing messages


### PR DESCRIPTION
No 'data-l10n-id' for ./elements/sim_manager.html: <h2>SIM settings</h2>
