### PR TITLE
Bug 1003158 - gaiatest: update minimum required mozdevice version to 0.3...

### DIFF
--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,5 +1,5 @@
 marionette_client==0.7.7
-mozdevice>=0.31
+mozdevice>=0.34
 moztest>=0.3
 plivo==0.9.6
 requests


### PR DESCRIPTION
...4 to use new logic
