### PR TITLE
Bug 995116 - [Tarako][MMS][Gallery] SMS/MMS OOM after attach a large pix...

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -210,11 +210,12 @@ var Compose = (function() {
       if (++done === images) {
         state.resizing = false;
         onContentChanged();
+      } else {
+        resizedImg(imgNodes[done]);
       }
     }
 
-    state.resizing = true;
-    imgNodes.forEach(function(node) {
+    function resizedImg(node) {
       var item = attachments.get(node);
       if (item.blob.size < limit) {
         imageSized();
@@ -233,7 +234,9 @@ var Compose = (function() {
           imageSized();
         });
       }
-    });
+    }
+    state.resizing = true;
+    resizedImg(imgNodes[0]);
     onContentChanged();
   }
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -317,8 +317,10 @@
         });
         return;
       }
-      var ratio = Math.sqrt(blob.size / limit);
-      Utils.resizeImageBlobWithRatio({
+
+      // at least ratio = 2;
+      var ratio = Math.max(Math.sqrt(blob.size / limit), 2);
+      Utils._resizeImageBlobWithRatio({
         blob: blob,
         limit: limit,
         ratio: ratio,
@@ -329,27 +331,48 @@
     //  resizeImageBlobWithRatio have additional ratio to force image
     //  resize to smaller size to avoid edge case about quality adjustment
     //  not working.
-    resizeImageBlobWithRatio: function ut_resizeImageBlobWithRatio(obj) {
+    //  for jpg, we support ratio = 2, 4, 8, and more than 8.
+    _resizeImageBlobWithRatio: function ut_resizeImageBlobWithRatio(obj) {
       var blob = obj.blob;
       var callback = obj.callback;
       var limit = obj.limit;
-      var ratio = obj.ratio;
-      var qualities = [0.75, 0.5, 0.25];
+      var ratio = Math.floor(obj.ratio);
+      var qualities = [0.65, 0.5, 0.25];
 
-      if (blob.size < limit) {
+      var sampleSize = 1;
+      var sampleSizeHash = '';
+
+      if (blob.size < limit || ratio < 2) {
         setTimeout(function blobCb() {
           callback(blob);
         });
         return;
       }
 
+      if (blob.type === 'image/jpeg') {
+        // for moz-samplesize, Gecko uses only power 2, 4 or 8.
+        switch (ratio) {
+          case 3:
+            ratio = 2;
+            break;
+          case 5:
+          case 6:
+          case 7:
+            ratio = 4;
+        }
+
+        sampleSize = Math.min(ratio, 8);
+        sampleSizeHash = '#-moz-samplesize=' + sampleSize;
+      }
+
       var img = document.createElement('img');
       var url = window.URL.createObjectURL(blob);
-      img.src = url;
+      img.src = url + sampleSizeHash;
+
       img.onload = function onBlobLoaded() {
         window.URL.revokeObjectURL(url);
-        var imageWidth = img.width;
-        var imageHeight = img.height;
+        var imageWidth = img.width * sampleSize;
+        var imageHeight = img.height * sampleSize;
         var targetWidth = imageWidth / ratio;
         var targetHeight = imageHeight / ratio;
 
@@ -359,6 +382,7 @@
         var context = canvas.getContext('2d', { willReadFrequently: true });
 
         context.drawImage(img, 0, 0, targetWidth, targetHeight);
+        img.src = '';
         // Bug 889765: Since we couldn't know the quality of the original jpg
         // The 'resized' image might have a bigger size because it was saved
         // with quality or dpi. Here we will adjust the jpg quality(or resize
@@ -368,8 +392,14 @@
 
         function ensureSizeLimit(resizedBlob) {
           if (resizedBlob.size < limit) {
-            callback(resizedBlob);
+            canvas.width = canvas.height = 0;
+            canvas = null;
+
+            // using a setTimeout so that used objects can be garbage collected
+            // right now
+            setTimeout(callback.bind(null, resizedBlob));
           } else {
+            resizedBlob = null; // we don't need it anymore
             // Reduce image quality for match limitation. Here we set quality
             // to 0.75, 0.5 and 0.25 for image blob resizing.
             // (Default image quality is 0.92 for jpeg)
@@ -379,15 +409,23 @@
             } else {
               // We will resize the blob if image quality = 0.25 still exceed
               // size limitation.
-              Utils.resizeImageBlobWithRatio({
-                blob: blob,
-                limit: limit,
-                ratio: ratio * 2,
-                callback: callback
-              });
+              canvas.width = canvas.height = 0;
+              canvas = null;
+
+              // using a setTimeout so that used objects can be garbage
+              // collected right now
+              setTimeout(
+                Utils._resizeImageBlobWithRatio.bind(Utils, {
+                  blob: blob,
+                  limit: limit,
+                  ratio: ratio * 2,
+                  callback: callback
+                })
+              );
             }
           }
         }
+
         canvas.toBlob(ensureSizeLimit, blob.type);
       };
     },

--- a/build/preferences.js
+++ b/build/preferences.js
@@ -124,6 +124,7 @@ function execute(options) {
     prefs.push(['dom.w3c_touch_events.enabled', 1]);
     prefs.push(['dom.wakelock.enabled', true]);
     prefs.push(['webgl.verbose', true]);
+    prefs.push(['image.mozsamplesize.enabled', true]);
 
     // Turn off unresponsive script dialogs so test-agent can keep running...
     // https://bugzilla.mozilla.org/show_bug.cgi?id=872141


### PR DESCRIPTION
...el picture from gallery

This patch does the following changes:
- adding an image to a composer that contains already other images needs to
  resize all images. With this patch, we do this sequentially. (already in
  master)
- we use -moz-samplesize to decode the images to resize them
- we try to free data more aggressively
