### PR TITLE
Bug 995116 - [Tarako][MMS][Gallery] SMS/MMS OOM after attach a large pix...

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -315,7 +315,7 @@ var Compose = (function() {
       }
     }
     state.resizing = true;
-    resizedImg(imgNodes[done]);
+    resizedImg(imgNodes[0]);
     onContentChanged();
   }
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -333,8 +333,9 @@
         });
         return;
       }
+
       var ratio = Math.sqrt(blob.size / limit);
-      Utils.resizeImageBlobWithRatio({
+      Utils._resizeImageBlobWithRatio({
         blob: blob,
         limit: limit,
         ratio: ratio,
@@ -345,29 +346,45 @@
     //  resizeImageBlobWithRatio have additional ratio to force image
     //  resize to smaller size to avoid edge case about quality adjustment
     //  not working.
-    resizeImageBlobWithRatio: function ut_resizeImageBlobWithRatio(obj) {
+    //  For JPG images, a ratio between 2 and 8 will be set to a close
+    //  power of 2. A ratio between 1 and 2 will be set to 2. A ratio bigger
+    //  than 8 will be rounded to the closest bigger integer.
+    //
+    _resizeImageBlobWithRatio: function ut_resizeImageBlobWithRatio(obj) {
       var blob = obj.blob;
       var callback = obj.callback;
       var limit = obj.limit;
-      var ratio = obj.ratio;
-      var qualities = [0.75, 0.5, 0.25];
+      var ratio = Math.ceil(obj.ratio);
+      var qualities = [0.65, 0.5, 0.25];
 
-      if (blob.size < limit) {
+      var sampleSize = 1;
+      var sampleSizeHash = '';
+
+      if (blob.size < limit || ratio <= 1) {
         setTimeout(function blobCb() {
           callback(blob);
         });
         return;
       }
 
+      if (blob.type === 'image/jpeg') {
+        if (ratio >= 8) {
+          sampleSize = 8;
+        } else {
+          sampleSize = ratio = Utils.getClosestSampleSize(ratio);
+        }
+
+        sampleSizeHash = '#-moz-samplesize=' + sampleSize;
+      }
+
       var img = document.createElement('img');
       var url = window.URL.createObjectURL(blob);
-      img.src = url;
+      img.src = url + sampleSizeHash;
+
       img.onload = function onBlobLoaded() {
         window.URL.revokeObjectURL(url);
-        var imageWidth = img.width;
-        var imageHeight = img.height;
-        var targetWidth = imageWidth / ratio;
-        var targetHeight = imageHeight / ratio;
+        var targetWidth = img.width * sampleSize / ratio;
+        var targetHeight = img.height * sampleSize / ratio;
 
         var canvas = document.createElement('canvas');
         canvas.width = targetWidth;
@@ -375,6 +392,7 @@
         var context = canvas.getContext('2d', { willReadFrequently: true });
 
         context.drawImage(img, 0, 0, targetWidth, targetHeight);
+        img.src = '';
         // Bug 889765: Since we couldn't know the quality of the original jpg
         // The 'resized' image might have a bigger size because it was saved
         // with quality or dpi. Here we will adjust the jpg quality(or resize
@@ -382,12 +400,22 @@
         // sure the size won't exceed the limitation.
         var level = 0;
 
+        function cleanup() {
+          canvas.width = canvas.height = 0;
+          canvas = null;
+        }
+
         function ensureSizeLimit(resizedBlob) {
           if (resizedBlob.size < limit) {
-            callback(resizedBlob);
+            cleanup();
+
+            // using a setTimeout so that used objects can be garbage collected
+            // right now
+            setTimeout(callback.bind(null, resizedBlob));
           } else {
+            resizedBlob = null; // we don't need it anymore
             // Reduce image quality for match limitation. Here we set quality
-            // to 0.75, 0.5 and 0.25 for image blob resizing.
+            // to 0.65, 0.5 and 0.25 for image blob resizing.
             // (Default image quality is 0.92 for jpeg)
             if (level < qualities.length) {
               canvas.toBlob(ensureSizeLimit, 'image/jpeg',
@@ -395,18 +423,42 @@
             } else {
               // We will resize the blob if image quality = 0.25 still exceed
               // size limitation.
-              Utils.resizeImageBlobWithRatio({
-                blob: blob,
-                limit: limit,
-                ratio: ratio * 2,
-                callback: callback
-              });
+              cleanup();
+
+              // using a setTimeout so that used objects can be garbage
+              // collected right now
+              setTimeout(
+                Utils._resizeImageBlobWithRatio.bind(Utils, {
+                  blob: blob,
+                  limit: limit,
+                  ratio: ratio * 2,
+                  callback: callback
+                })
+              );
             }
           }
         }
+
         canvas.toBlob(ensureSizeLimit, blob.type);
       };
     },
+
+    getClosestSampleSize: function ut_getClosestSampleSize(ratio) {
+      if (ratio >= 8) {
+        return 8;
+      }
+
+      if (ratio >= 4) {
+        return 4;
+      }
+
+      if (ratio >= 2) {
+        return 2;
+      }
+
+      return 1;
+    },
+
     // Return the url path with #-moz-samplesize postfix and downsampled image
     // could be loaded directly from backend graphics lib.
     getDownsamplingSrcUrl: function ut_getDownsamplingSrcUrl(options) {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -644,6 +644,7 @@ suite('thread_ui.js >', function() {
       test('disabled while resizing oversized image and ' +
         'enabled when resize complete ',
         function(done) {
+        this.sinon.stub(Utils, 'getResizedImgBlob');
 
         ThreadUI.recipients.add({
           number: '999'
@@ -659,6 +660,7 @@ suite('thread_ui.js >', function() {
         Compose.on('input', onInput);
         Compose.append(mockImgAttachment(true));
         assert.isTrue(sendButton.disabled);
+        Utils.getResizedImgBlob.yield(testImageBlob);
       });
     });
   });

--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -731,6 +731,8 @@ suite('Utils', function() {
       'default_quality_resized.jpg': null
     };
 
+    this.timeout(5000);
+
     suiteSetup(function(done) {
       // load test blobs for image resize testing
       var assetsNeeded = 0;
@@ -758,6 +760,23 @@ suite('Utils', function() {
       Object.keys(qualityTestData).forEach(loadBlob, qualityTestData);
     });
 
+    setup(function() {
+      this.sinon.spy(window.URL, 'createObjectURL');
+      this.sinon.spy(window.URL, 'revokeObjectURL');
+    });
+
+    function assertCreatedBlobUrlsAreRevoked() {
+      var createdObjectURLs = window.URL.createObjectURL.returnValues;
+      var revokedObjectURLs = window.URL.revokeObjectURL.args.map(
+        (args) => args[0]
+      );
+
+      assert.deepEqual(
+        createdObjectURLs, revokedObjectURLs,
+        'All created Blob URLs are revoked'
+      );
+    }
+
     Object.keys(typeTestData).forEach(function(filename) {
       test(filename, function(done) {
         var blob = typeTestData[filename];
@@ -765,9 +784,12 @@ suite('Utils', function() {
         var limit = Math.min(100000, (blob.size / 2));
 
         Utils.getResizedImgBlob(blob, limit, function(resizedBlob) {
-          assert.isTrue(resizedBlob.size < limit,
-            'resizedBlob is smaller than ' + limit);
-          done();
+          done(function() {
+            assert.isTrue(resizedBlob.size < limit,
+              'resizedBlob is smaller than ' + limit);
+
+            assertCreatedBlobUrlsAreRevoked();
+          });
         });
       });
     });
@@ -775,14 +797,15 @@ suite('Utils', function() {
     test('Image size is smaller than limit', function(done) {
       var blob = qualityTestData['low_quality.jpg'];
       var limit = blob.size * 2;
-      this.sinon.spy(Utils, 'resizeImageBlobWithRatio');
-      var resizeSpy = Utils.resizeImageBlobWithRatio;
+      this.sinon.spy(Utils, '_resizeImageBlobWithRatio');
 
       Utils.getResizedImgBlob(blob, limit, function(resizedBlob) {
-        assert.isTrue(resizedBlob === blob,
-          'resizedBlob and blob should be the same');
-        assert.equal(resizeSpy.callCount, 0);
-        done();
+        done(function() {
+          assert.equal(resizedBlob, blob,
+            'resizedBlob and blob should be the same');
+          sinon.assert.notCalled(Utils._resizeImageBlobWithRatio);
+          assertCreatedBlobUrlsAreRevoked();
+        });
       });
     });
 
@@ -792,7 +815,7 @@ suite('Utils', function() {
       var defaultBlob = qualityTestData['default_quality_resized.jpg'];
       var limit = blob.size / 2;
 
-      this.sinon.stub(HTMLCanvasElement.prototype,
+      var toBlobStub = this.sinon.stub(HTMLCanvasElement.prototype,
         'toBlob', function(callback, type, quality) {
           if (quality) {
             callback(resizedBlob);
@@ -801,14 +824,19 @@ suite('Utils', function() {
           }
       });
 
-      Utils.getResizedImgBlob(blob, limit, function(resizedBlob) {
-        var toBlobSpy = HTMLCanvasElement.prototype.toBlob;
-        assert.isTrue(resizedBlob.size < limit,
-          'resizedBlob is smaller than ' + limit);
-        assert.equal(toBlobSpy.callCount, 2);
-        assert.equal(toBlobSpy.args[0][2], undefined);
-        assert.equal(toBlobSpy.args[1][2], 0.75);
-        done();
+      Utils.getResizedImgBlob(blob, limit, function(result) {
+        done(function() {
+          assert.isTrue(
+            result.size < limit,
+            'result blob is smaller than ' + limit
+          );
+
+          sinon.assert.calledTwice(toBlobStub);
+
+          assert.equal(toBlobStub.args[0][2], undefined);
+          assert.equal(toBlobStub.args[1][2], 0.65);
+          assertCreatedBlobUrlsAreRevoked();
+        });
       });
     });
 
@@ -818,40 +846,43 @@ suite('Utils', function() {
       var defaultBlob = qualityTestData['default_quality_resized.jpg'];
       var limit = blob.size / 2;
 
-      this.sinon.spy(Utils, 'resizeImageBlobWithRatio');
-      var resizeSpy = Utils.resizeImageBlobWithRatio;
+      var resizeSpy = this.sinon.spy(Utils, '_resizeImageBlobWithRatio');
 
-      this.sinon.stub(HTMLCanvasElement.prototype,
-        'toBlob', function(callback, type, quality) {
-          var firstRatio = resizeSpy.firstCall.args[0].ratio;
-          var lastRatio = resizeSpy.lastCall.args[0].ratio;
-          if (lastRatio > firstRatio) {
+      this.sinon.stub(
+        HTMLCanvasElement.prototype, 'toBlob',
+        function(callback, type, quality) {
+          if (resizeSpy.callCount == 2) {
+            // return the resizedBlob only when we're trying with an higher
+            // ratio, so that we can test the whole process
             callback(resizedBlob);
           } else {
             callback(defaultBlob);
           }
-      });
+        }
+      );
 
       Utils.getResizedImgBlob(blob, limit, function(resizedBlob) {
-        assert.isTrue(resizedBlob.size < limit,
-          'resizedBlob is smaller than ' + limit);
-        var toBlobSpy = HTMLCanvasElement.prototype.toBlob;
+        done(function() {
+          assert.isTrue(resizedBlob.size < limit,
+            'resizedBlob is smaller than ' + limit);
+          var toBlobSpy = HTMLCanvasElement.prototype.toBlob;
 
-        // Image quality testing should go down 3 qulity level first
-        // than force the image rescale to smaller size.
-        assert.equal(toBlobSpy.callCount, 5);
-        assert.equal(toBlobSpy.args[0][2], undefined);
-        assert.equal(toBlobSpy.args[1][2], 0.75);
-        assert.equal(toBlobSpy.args[2][2], 0.5);
-        assert.equal(toBlobSpy.args[3][2], 0.25);
-        assert.equal(toBlobSpy.args[4][2], undefined);
+          // Image quality testing should go down 3 quality level first
+          // than force the image rescale to smaller size.
+          assert.equal(toBlobSpy.callCount, 5);
+          assert.equal(toBlobSpy.args[0][2], undefined);
+          assert.equal(toBlobSpy.args[1][2], 0.65);
+          assert.equal(toBlobSpy.args[2][2], 0.5);
+          assert.equal(toBlobSpy.args[3][2], 0.25);
+          assert.equal(toBlobSpy.args[4][2], undefined);
 
-        // Verify getResizedImgBlob is called twice and resizeRatio
-        // parameter is set in sencond calls
-        assert.equal(resizeSpy.callCount, 2);
-        assert.ok(resizeSpy.firstCall.args[0].ratio <
-          resizeSpy.lastCall.args[0].ratio);
-        done();
+          // Verify getResizedImgBlob is called twice and resize ratio
+          // parameter is changed in the second call
+          sinon.assert.calledTwice(Utils._resizeImageBlobWithRatio);
+          assert.ok(resizeSpy.firstCall.args[0].ratio <
+            resizeSpy.lastCall.args[0].ratio);
+          assertCreatedBlobUrlsAreRevoked();
+        });
       });
     });
   });
@@ -1260,3 +1291,17 @@ suite('getContactDisplayInfo', function() {
     );
   });
 });
+
+test('getClosestSampleSize', function() {
+  assert.equal(Utils.getClosestSampleSize(1), 1);
+  assert.equal(Utils.getClosestSampleSize(2), 2);
+  assert.equal(Utils.getClosestSampleSize(3), 2);
+  assert.equal(Utils.getClosestSampleSize(4), 4);
+  assert.equal(Utils.getClosestSampleSize(5), 4);
+  assert.equal(Utils.getClosestSampleSize(5.5), 4);
+  assert.equal(Utils.getClosestSampleSize(6), 4);
+  assert.equal(Utils.getClosestSampleSize(7), 4);
+  assert.equal(Utils.getClosestSampleSize(8), 8);
+  assert.equal(Utils.getClosestSampleSize(9), 8);
+});
+


### PR DESCRIPTION
...el picture from gallery r=azasypkin

This patch does the following changes:
- we use -moz-samplesize to decode the images to resize them
- we try to free data more aggressively
