### PR TITLE
Bug 988171 - Use a local variable 'bluetooth' in function scope for Blue...

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -182,6 +182,7 @@ var Connectivity = (function(window, document, undefined) {
    */
 
   function updateBluetooth() {
+    var bluetooth = getBluetooth();
     if (!bluetooth) {
       return;
     }


### PR DESCRIPTION
...toothManager to short its life cycle.
