### PR TITLE
Bug 1004099 - FxA Settings app - remove refs to 'accountId', replace with 'email'

### DIFF
--- a/apps/settings/js/firefox_accounts/menu.js
+++ b/apps/settings/js/firefox_accounts/menu.js
@@ -27,9 +27,7 @@ var FxaMenu = (function fxa_menu() {
   // if e.verified, user is logged in & verified.
   // if !e.verified, user is logged in & unverified.
   function onStatusChange(e) {
-    // XXX FxAccountsIACHelper currently is inconsistent about response format
-    //     fix this after 981210 lands (e.accountId vs e.email)
-    var email = e ? Normalizer.escapeHTML(e.accountId || e.email) : '';
+    var email = e ? Normalizer.escapeHTML(e.email) : '';
 
     if (!e) {
       navigator.mozL10n.localize(menuStatus, 'fxa-invitation');

--- a/apps/settings/js/firefox_accounts/panel.js
+++ b/apps/settings/js/firefox_accounts/panel.js
@@ -55,9 +55,7 @@ var FxaPanel = (function fxa_panel() {
   // if e.verified, user is logged in & verified.
   // if !e.verified, user is logged in & unverified.
   function onFxAccountStateChange(e) {
-    // XXX FxAccountsIACHelper currently is inconsistent about response format
-    //     fix this after 981210 lands (e.accountId vs e.email)
-    var email = e ? Normalizer.escapeHTML(e.accountId || e.email) : '';
+    var email = e ? Normalizer.escapeHTML(e.email) : '';
 
     if (!e) {
       hideLoggedInPanel();

--- a/apps/settings/test/unit/firefox_accounts_menu_test.js
+++ b/apps/settings/test/unit/firefox_accounts_menu_test.js
@@ -56,7 +56,7 @@ suite('firefox accounts menu item > ', function() {
 
   test('show the correct status on FxaMenu init', function() {
     MockFxAccountsIACHelper.setCurrentState({
-      accountId: 'init@ialization.com',
+      email: 'init@ialization.com',
       verified: true
     });
     // init app code
@@ -81,7 +81,7 @@ suite('firefox accounts menu item > ', function() {
 
   test('show the correct status after onlogin event', function() {
     MockFxAccountsIACHelper.setCurrentState({
-      accountId: 'on@log.in',
+      email: 'on@log.in',
       verified: false
     });
     FxaMenu.init(MockFxAccountsIACHelper);
@@ -95,7 +95,7 @@ suite('firefox accounts menu item > ', function() {
 
   test('show the correct status after onverifiedlogin event', function() {
     MockFxAccountsIACHelper.setCurrentState({
-      accountId: 'on@verifiedlog.in',
+      email: 'on@verifiedlog.in',
       verified: true
     });
     FxaMenu.init(MockFxAccountsIACHelper);

--- a/apps/settings/test/unit/firefox_accounts_panel_test.js
+++ b/apps/settings/test/unit/firefox_accounts_panel_test.js
@@ -74,7 +74,7 @@ suite('firefox accounts panel > ', function() {
   test('show the correct panel and email on FxaPanel init', function() {
     // set the state in the mock
     MockFxAccountsIACHelper.setCurrentState({
-      accountId: 'init@ialization.com',
+      email: 'init@ialization.com',
       verified: true
     });
     // init FxaPanel
@@ -104,7 +104,7 @@ suite('firefox accounts panel > ', function() {
 
   test('show the correct panel and email after onlogin event', function() {
     MockFxAccountsIACHelper.setCurrentState({
-      accountId: 'on@log.in',
+      email: 'on@log.in',
       verified: false
     });
     FxaPanel.init(MockFxAccountsIACHelper);
@@ -124,7 +124,7 @@ suite('firefox accounts panel > ', function() {
   test('show the correct panel and email after onverifiedlogin event',
     function() {
       MockFxAccountsIACHelper.setCurrentState({
-        accountId: 'on@verifiedlog.in',
+        email: 'on@verifiedlog.in',
         verified: true
       });
       FxaPanel.init(MockFxAccountsIACHelper);


### PR DESCRIPTION
As always, comments and discussion are in the bugzilla bug

https://bugzilla.mozilla.org/show_bug.cgi?id=1004099
