### PR TITLE
Bug 864395 - Correctly test send perf data checkbox;

### DIFF
--- a/apps/settings/test/marionette/app/regions/improve.js
+++ b/apps/settings/test/marionette/app/regions/improve.js
@@ -59,9 +59,11 @@ ImprovePanel.prototype = {
   },
 
   enableSubmitPerfData: function() {
+    var initialState = this.isSubmitPerfData;
     this.waitForElement('submitPerfData').tap();
     this.client.waitFor(function() {
-      return this.isSubmitPerfData;
+      // Ensure tapping the element changed its state
+      return this.isSubmitPerfData !== initialState;
     }.bind(this));
   },
 


### PR DESCRIPTION
In the Settings app test for "share performance data", if the box is already checked because the setting was already turned on, we should uncheck it first.
