### PR TITLE
Bug 999286 - [Sora][Message]The content is lost after do some operations. r=julien

### DIFF
--- a/apps/sms/js/activity_picker.js
+++ b/apps/sms/js/activity_picker.js
@@ -1,4 +1,4 @@
-/*global MozActivity */
+/*global ActivityHandler, MozActivity */
 
 (function(exports) {
 'use strict';
@@ -96,16 +96,12 @@ var ActivityPicker = {
 
     tryActivity(params, onsuccess, onerror);
   },
-  sendMessage: function ap_sendMessage(phone, onsuccess, onerror) {
-    var params = {
-      name: 'new',
-      data: {
-        type: 'websms/sms',
-        number: phone
-      }
-    };
-
-    tryActivity(params, onsuccess, onerror);
+  sendMessage: function ap_sendMessage(number) {
+    // Workaround for bug 999286, emulating window activity here so that Home
+    // button press won't dismiss newly created message.
+    ActivityHandler.toView({
+      number: number
+    });
   },
   openSettings: function ap_openSettings(onsuccess, onerror) {
     var params = {

--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -374,7 +374,7 @@ var Compose = (function() {
         }.bind(this));
         this.ignoreEvents = true;
       } else {
-        this.append(message.body);
+        this.append(message.body ? message.body : '');
         this.focus();
       }
     },

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -2511,7 +2511,10 @@ var ThreadUI = global.ThreadUI = {
           method: function oMessage(param) {
             ActivityPicker.sendMessage(param);
           },
-          params: [number]
+          params: [number],
+          // As activity picker changes location.hash to '#new' we don't want
+          // to call 'complete' that updates location.hash at the same time
+          incomplete: true
         });
       }
     }

--- a/apps/sms/test/unit/activity_picker_test.js
+++ b/apps/sms/test/unit/activity_picker_test.js
@@ -1,4 +1,4 @@
-/*global MocksHelper, MockL10n, ActivityPicker, MozActivity */
+/*global MocksHelper, MockL10n, ActivityPicker, MozActivity, ActivityHandler */
 
 'use strict';
 
@@ -10,6 +10,7 @@ requireApp('sms/test/unit/mock_moz_activity.js');
 requireApp('sms/test/unit/mock_utils.js');
 
 var mocksHelperAP = new MocksHelper([
+  'ActivityHandler',
   'MozActivity',
   'Utils'
 ]).init();
@@ -288,51 +289,13 @@ suite('ActivityPicker', function() {
   suite('sendMessage', function() {
 
     test('sendMessage(phone) ', function() {
+      this.sinon.stub(ActivityHandler, 'toView');
+
       ActivityPicker.sendMessage('999');
 
-      assert.deepEqual(MozActivity.calls[0], {
-        name: 'new',
-        data: {
-          type: 'websms/sms',
-          number: '999'
-        }
-      });
-    });
-
-    test('sendMessage(phone, success) ', function() {
-      ActivityPicker.sendMessage('999', onsuccess);
-
-      assert.equal(
-        MozActivity.instances[0].onsuccess, onsuccess
-      );
-
-      assert.deepEqual(MozActivity.calls[0], {
-        name: 'new',
-        data: {
-          type: 'websms/sms',
-          number: '999'
-        }
-      });
-    });
-
-    test('sendMessage(phone, success, error) ', function() {
-      ActivityPicker.sendMessage('999', onsuccess, onerror);
-
-      assert.equal(
-        MozActivity.instances[0].onsuccess, onsuccess
-      );
-
-      assert.equal(
-        MozActivity.instances[0].onerror, onerror
-      );
-
-      assert.deepEqual(MozActivity.calls[0], {
-        name: 'new',
-        data: {
-          type: 'websms/sms',
-          number: '999'
-        }
-      });
+     sinon.assert.calledWith(ActivityHandler.toView, {
+       number: '999'
+     });
     });
   });
 

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -654,6 +654,15 @@ suite('compose_test.js', function() {
         sinon.assert.called(message.focus);
         assert.isFalse(message.classList.contains('ignoreEvents'));
       });
+
+      test('empty body', function() {
+        Compose.fromMessage({
+          type: 'sms',
+          body: null
+        });
+        sinon.assert.calledWith(Compose.append, '');
+        sinon.assert.called(message.focus);
+      });
     });
   });
 


### PR DESCRIPTION
ActivityPicker.sendMessage now doesn't use real activity, but emulates 'window' one with ActivityHandler.toView. So that new message won't be dismissed on Home button press.
