### PR TITLE
Bug 996900 - [Messaging] Bring up keyboard when user taps in the middle of the Messaging screen. r=julien

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1887,21 +1887,27 @@ var ThreadUI = global.ThreadUI = {
   handleEvent: function thui_handleEvent(evt) {
     switch (evt.type) {
       case 'click':
-        if (!this.inEditMode) {
-          // if the click wasn't on an attachment check for other clicks
-          if (!thui_mmsAttachmentClick(evt.target)) {
-            this.handleMessageClick(evt);
-            LinkActionHandler.onClick(evt);
+        if (this.inEditMode) {
+          var input = evt.target.parentNode.querySelector('input');
+          if (input) {
+            this.chooseMessage(input);
+            this.checkInputs();
           }
           return;
         }
 
-        var input = evt.target.parentNode.querySelector('input');
-        if (input) {
-          this.chooseMessage(input);
-          this.checkInputs();
+        // If we're in composer, let's focus on message editor on click.
+        if (window.location.hash === '#new') {
+          Compose.focus();
+          return;
         }
-        break;
+
+        // if the click wasn't on an attachment check for other clicks
+        if (!thui_mmsAttachmentClick(evt.target)) {
+          this.handleMessageClick(evt);
+          LinkActionHandler.onClick(evt);
+        }
+        return;
       case 'contextmenu':
         evt.preventDefault();
         evt.stopPropagation();
@@ -2170,7 +2176,7 @@ var ThreadUI = global.ThreadUI = {
         'NonActiveSimCardToSendError',
         {
           confirmHandler: function() {
-            // Update messageDOM state to 'sending' while sim switching 
+            // Update messageDOM state to 'sending' while sim switching
             messageDOM.classList.remove('error');
             messageDOM.classList.add('sending');
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -5367,4 +5367,31 @@ suite('thread_ui.js >', function() {
       assert.isTrue(Recipients.View.isFocusable);
     });
   });
+
+  suite('Compose mode tests', function() {
+    teardown(function() {
+      window.location.hash = '';
+      Compose.clear();
+    });
+
+    suite('message editor focus', function() {
+      setup(function() {
+        this.sinon.spy(Compose, 'focus');
+      });
+
+      test('focus on container click if in Composer', function() {
+        window.location.hash = '#new';
+        container.click();
+
+        sinon.assert.called(Compose.focus);
+      });
+
+      test('do not focus on container click if not in Composer', function() {
+        window.location.hash = '#thread=1';
+
+        container.click();
+        sinon.assert.notCalled(Compose.focus);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Here we focus message content editable container and move caret to the end as it's not always positioned correctly after focus.
