### PR TITLE
Bug 858787 - Loading css for test-container from external file

### DIFF
--- a/dev_apps/test-container/index.html
+++ b/dev_apps/test-container/index.html
@@ -1,19 +1,10 @@
 <html>
     <head>
       <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
-        <style type="text/css">
-            #test-container {
-                width: 100%;
-                height: 100%;
-                padding: 0;
-                margin: 0;
-                border: 0;
-                frameborder: "0";
-            }
-        </style>
+      <link rel="stylesheet" type="text/css" href="test_container.css" ></style>
     </head>
     <body>
-        <iframe id="test-container" mozbrowser remote="true" mozapp="http://mochi.test:8888/manifest.webapp" </iframe>
+        <iframe id="test-container" mozbrowser remote="true" mozapp="http://mochi.test:8888/manifest.webapp"> </iframe>
     </body>
 
 </html>

--- a/dev_apps/test-container/test_container.css
+++ b/dev_apps/test-container/test_container.css
@@ -1,0 +1,8 @@
+#test-container {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  frameborder: "0";
+}


### PR DESCRIPTION
Flipping pref csp.speccompliant causes tests to fail on the B2G Emulator, because test-container/index.html uses an inline-style which is blocked by CSP. Rewrite the *.html file to load the css/style information from an external file so CSP does not block it. (See bug 858787).
