### PR TITLE
Bug 1005417 - Fix bottom space below system dialogs in Simulator

### DIFF
--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -255,14 +255,7 @@ body {
   pointer-events: none;
 }
 
-@media not all and (-moz-physical-home-button) {
-  #dialog-overlay {
-    bottom: 5rem;
-    height: calc(100% - 2.4rem - 5rem);
-  }
-}
-
-#screen.software-button-enabled #windows > #dialog-overlay {
+#screen.software-button-enabled #windows + #dialog-overlay {
   bottom: 5rem;
   height: calc(100% - 2.4rem - 5rem);
 }


### PR DESCRIPTION
The Simulator disables the software home button, but the current system dialog CSS does not catch this case, so there's an extra space at the bottom.
