### PR TITLE
Bug 994819 - [Cost Control] invoke passed callbacks when everything is r...

### DIFF
--- a/apps/costcontrol/js/config/config_manager.js
+++ b/apps/costcontrol/js/config/config_manager.js
@@ -168,10 +168,9 @@ var ConfigManager = (function() {
       if (settings === null) {
         settings = deepCopy(DEFAULT_SETTINGS);
         debug('Storing default settings for ICCID:', currentICCID);
-        asyncStorage.setItem(currentICCID, JSON.stringify(settings));
-      }
-
-      if (callback) {
+        asyncStorage.setItem(currentICCID, JSON.stringify(settings),
+                             callback && callback.bind(null, settings));
+      } else if (callback) {
         callback(settings);
       }
     });
@@ -230,10 +229,10 @@ var ConfigManager = (function() {
                                      settings);
             }
           }
+          if (callback) {
+            callback();
+          }
         });
-        if (callback) {
-          callback();
-        }
       }
     );
   }

--- a/apps/costcontrol/js/message_handler.js
+++ b/apps/costcontrol/js/message_handler.js
@@ -329,8 +329,7 @@
         var title = _('data-limit-notification-title2', { limit: limitText });
         var message = _('data-limit-notification-text2');
         NotificationHelper.send(title, message, iconURL, goToDataUsage);
-        ConfigManager.setOption({ 'dataUsageNotified': true });
-        closeIfProceeds();
+        ConfigManager.setOption({ 'dataUsageNotified': true }, closeIfProceeds);
         return;
       });
     };


### PR DESCRIPTION
...eady. r=salva

1) apps/costcontrol/js/config/config_manager.js, function
requestSettings, callback may be invoked while a companion
asyncStorage.setItem() call is on going.

2) apps/costcontrol/js/config/config_manager.js, function setOption,
callback may be invoked while a companion requestSettings() call is on
going.

3) apps/costcontrol/js/message_handler.js, function _onNetworkAlarm,
function closeIfProceeds may be invoked while a companion
ConfigManager.setOption() call is on going.
