### PR TITLE
[Costcontrol] Bug 1003049 - [Costcontrol]The Usage line(Green/red) moves continuously ...r=lodr

### DIFF
--- a/apps/costcontrol/js/settings/autosettings.js
+++ b/apps/costcontrol/js/settings/autosettings.js
@@ -16,7 +16,7 @@ var AutoSettings = (function() {
           parent.insertBefore(span, parent.firstChild);
         }
       }
-      guiWidget.addEventListener('change', function _onSelectChange() {
+      guiWidget.addEventListener('blur', function _onSelectChange() {
         debug('Value:', guiWidget.value);
         settings.option(optionName, guiWidget.value);
       });


### PR DESCRIPTION
...if user selects the Reset Report(Monthly,Weekly,Never) randomly

Mozilla URL:
https://bugzilla.mozilla.org/show_bug.cgi?id=1003049
