### PR TITLE
Bug 1003828 - Add a settings to enable settings drawer & new notifications

### DIFF
--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -112,6 +112,12 @@
             <span data-l10n-id="edges-gesture">Edges gesture</span>
           </label>
         </li>
+        <li id="settings-drawer-notifications">
+          <label class="pack-checkbox">
+            <input type="checkbox" name="settings-drawer-notifications.enabled">
+            <span data-l10n-id="settings-drawer-notifications">Settings drawer & notifications</span>
+          </label>
+        </li>
         <li id="continuoustransition">
           <label class="pack-checkbox">
             <input type="checkbox" name="continuous-transition.enabled">

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -1079,6 +1079,7 @@ rocketbar-enabled=Rocketbar enabled
 software-home-button=Software home button
 home-gesture=Home gesture
 edges-gesture=Edges gesture
+settings-drawer-notifications=Settings drawer & notifications
 continuous-transition=Continuous transition
 debug-gaia-enabled=Gaia debug traces
 app-transition=App transition

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -168,6 +168,7 @@
    "ril.data.cp.apns": "",
    "ril.callerId": "CLIR_DEFAULT",
    "rocketbar.enabled": false,
+   "settings-drawer-notifications.enabled": false,
    "screen.automatic-brightness": false,
    "screen.brightness": 1,
    "screen.timeout": 60,

--- a/build/settings.js
+++ b/build/settings.js
@@ -153,6 +153,7 @@ function execute(config) {
   if (config.HAIDA) {
     settings['rocketbar.enabled'] = true;
     settings['edgesgesture.enabled'] = true;
+    settings['settings-drawer-notifications.enabled'] = true;
   }
 
   settings['debugger.remote-mode'] = config.REMOTE_DEBUGGER ? 'adb-only'


### PR DESCRIPTION
This is a separate PR as it's needed by both the settings drawer and the new notifications.
It does nothing more than creating a new setting called `settings-drawer-notifications.enabled` (pretty verbose, feel free to propose a better name).

I also added an option to enable it from the developer menu (Rocketbar should be added there too).
