### PR TITLE
Bug 1003384 - [B2G][1.4][SMS] - The phone type "Other" is not translated in any of the languages when suggested contacts are shown in SMS.

### DIFF
--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -197,7 +197,7 @@ faxHome   = Fax home
 faxOffice = Fax office
 faxOther  = Fax other
 another   = Another
-Other     = Other
+other     = Other
 
 # Date and time
 today         = today


### PR DESCRIPTION
'Other' l10n Id replaced with 'other'
