### PR TITLE
Bug 1003384 - [B2G][1.4][SMS] - The phone type "Other" is not translated in any of the languages when suggested contacts are shown in SMS

### DIFF
--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -17,6 +17,13 @@
     // TODO: For mms resizing
   };
 
+  // Maps one localizable string IDs (eg. that don't exist) to another.
+  // Introduced as workaround for bug 1003384, so that we don't need to update
+  // locale files when it's too late.
+  const l10nIdMap = {
+    other: 'Other'
+  };
+
   var Utils = {
     date: {
       shared: new Date(),
@@ -514,7 +521,9 @@
     getDisplayObject: function(theTitle, tel) {
       var number = tel.value;
       var title = theTitle || number;
-      var type = tel.type && tel.type.length ? tel.type[0] : '';
+      // Check with l10nIdMap whether we have override for phone type id.
+      var type = tel.type && tel.type.length ?
+        l10nIdMap[tel.type[0]] || tel.type[0] : '';
       var carrier = tel.carrier ? (tel.carrier + ', ') : '';
       var separator = type || carrier ? ' | ' : '';
       var data = {


### PR DESCRIPTION
Workaround for v1.4 branch that maps new 'other' phone type l10n id to old 'Other'. It was made to avoid updating localization files as it's too late.
