### PR TITLE
Bug 1007094 - Log when a device is unable to connect to wifi and fails over to cell data

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -1001,6 +1001,7 @@ class GaiaTestCase(MarionetteTestCase, B2GTestCaseMixin):
             try:
                 self.connect_to_local_area_network()
             except:
+                self.marionette.log('Failed to connect to wifi, trying cell data instead.')
                 if self.device.has_mobile_connection:
                     self.data_layer.connect_to_cell_data()
                 else:


### PR DESCRIPTION
This will output both to the console and to the logcat. 
