### PR TITLE
Bug 1007657: Support string constants in MozIccManager

### DIFF
--- a/apps/system/js/icc.js
+++ b/apps/system/js/icc.js
@@ -137,7 +137,13 @@ var icc = {
       return DUMP('FTU is running, delaying STK...');
     }
 
-    var cmdId = '0x' + message.command.typeOfCommand.toString(16);
+    /* TODO: cleanup branching after bug 819831 landed */
+    var cmdId;
+    if (typeof message.command.typeOfCommand === 'string') {
+      cmdId = message.command.typeOfCommand;
+    } else {
+      cmdId = '0x' + message.command.typeOfCommand.toString(16);
+    }
     if (icc_worker[cmdId]) {
       return icc_worker[cmdId](message);
     }

--- a/apps/system/test/unit/icc_worker_test.js
+++ b/apps/system/test/unit/icc_worker_test.js
@@ -101,6 +101,10 @@ suite('STK (icc_worker) >', function() {
 
   function launchStkCommand(cmd) {
     function stkCmd(CMD) {
+      /* TODO: cleanup this function after bug 819831 landed */
+      if (typeof CMD === 'string') {
+        return CMD;
+      }
       return '0x' + CMD.toString(16);
     }
     icc_worker[stkCmd(cmd.command.typeOfCommand)](cmd);


### PR DESCRIPTION
Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
