### PR TITLE
bug 1001702

### DIFF
--- a/apps/system/js/homescreen_window.js
+++ b/apps/system/js/homescreen_window.js
@@ -94,7 +94,7 @@
     };
 
   HomescreenWindow.REGISTERED_EVENTS =
-    ['_opening', 'mozbrowserclose', 'mozbrowsererror',
+    ['_opening', '_localized', 'mozbrowserclose', 'mozbrowsererror',
       'mozbrowservisibilitychange', 'mozbrowserloadend'];
 
   HomescreenWindow.SUB_COMPONENTS = {

--- a/apps/system/test/unit/homescreen_window_test.js
+++ b/apps/system/test/unit/homescreen_window_test.js
@@ -98,6 +98,16 @@ suite('system/HomescreenWindow', function() {
         });
         assert.isTrue(stubRestart.calledTwice);
       });
+      test('_localized event', function() {
+        var stubPublish = this.sinon.stub(homescreenWindow, 'publish');
+
+        homescreenWindow.handleEvent({
+          type: '_localized'
+        });
+
+        assert.isTrue(stubPublish.calledOnce);
+        assert.isTrue(stubPublish.calledWith('namechanged'));
+      });
     });
     suite('homescreen is crashed', function() {
       var stubRender;


### PR DESCRIPTION
- HomescreenWindow should listen to '_localized' to update it's application name when the system language changes.

r=alive
