### PR TITLE
Bug 1007598 - We should never try to format the phone number on a removed call

### DIFF
--- a/apps/callscreen/js/handled_call.js
+++ b/apps/callscreen/js/handled_call.js
@@ -22,6 +22,7 @@ function HandledCall(aCall) {
   this._initialState = this.call.state;
   this._cachedInfo = '';
   this._cachedAdditionalInfo = '';
+  this._removed = false;
 
   this.node = document.getElementById('handled-call-template').cloneNode(true);
   this.node.id = '';
@@ -230,6 +231,10 @@ HandledCall.prototype.restoreAdditionalContactInfo =
 
 HandledCall.prototype.formatPhoneNumber =
   function hc_formatPhoneNumber(ellipsisSide, maxFontSize) {
+    if (this._removed) {
+      return;
+    }
+
     // In status bar mode, we want a fixed font-size
     if (CallScreen.inStatusBarMode) {
       this.numberNode.style.fontSize = '';
@@ -277,6 +282,7 @@ HandledCall.prototype.updateDirection = function hc_updateDirection() {
 };
 
 HandledCall.prototype.remove = function hc_remove() {
+  this._removed = true;
   this.call.removeEventListener('statechange', this);
   this.photo = null;
 

--- a/apps/callscreen/test/unit/handled_call_test.js
+++ b/apps/callscreen/test/unit/handled_call_test.js
@@ -639,6 +639,14 @@ suite('dialer/handled_call', function() {
       assert.equal(subject.numberNode.style.fontSize, '');
     });
 
+    test('formatPhoneNumber should do nothing if the call was removed',
+    function() {
+      subject.remove();
+      subject.numberNode.style.fontSize = '36px';
+      subject.formatPhoneNumber();
+      assert.equal(subject.numberNode.style.fontSize, '36px');
+    });
+
     test('check replace number', function() {
       mockCall = new MockCall('888', 'incoming');
       subject = new HandledCall(mockCall);


### PR DESCRIPTION
Or we'll trigger an infinite reflow loop.
