### PR TITLE
Bug 1009111 - Enable vertical homescreen by default

### DIFF
--- a/apps/homescreen/test/marionette/active_icons_test.js
+++ b/apps/homescreen/test/marionette/active_icons_test.js
@@ -7,7 +7,9 @@ marionette('Active icons', function() {
   var client = marionette.client({
     settings: {
       'ftu.manifestURL': null,
-      'lockscreen.enabled': false
+      'lockscreen.enabled': false,
+      'homescreen.manifestURL':
+        'app://homescreen.gaiamobile.org/manifest.webapp'
     }
   });
 

--- a/apps/system/test/marionette/homescreen_navigation_test.js
+++ b/apps/system/test/marionette/homescreen_navigation_test.js
@@ -51,7 +51,7 @@ marionette('Homescreen navigation >', function() {
     client.switchToFrame();
     sys.waitForStartup();
 
-    homescreen = sys.getAppIframe('homescreen.gaiamobile.org');
+    homescreen = sys.getAppIframe('verticalhome.gaiamobile.org');
     settings = launchSettings();
   });
 

--- a/build/config/phone/apps-production.list
+++ b/build/config/phone/apps-production.list
@@ -27,6 +27,7 @@ apps/setringtone
 apps/settings
 apps/sms
 apps/system
+apps/verticalhome
 apps/video
 apps/wallpaper
 apps/wappush

--- a/build/settings.js
+++ b/build/settings.js
@@ -166,7 +166,7 @@ function overrideSettings(settings, config) {
 
 function setHomescreenURL(settings, config) {
   // 'homescreen' as default value of homescreen.appName
-  let appName = 'homescreen';
+  let appName = 'verticalhome';
 
   if (typeof(settings['homescreen.appName']) !== 'undefined') {
     appName = settings['homescreen.appName'];

--- a/build/test/integration/build.test.js
+++ b/build/test/integration/build.test.js
@@ -508,7 +508,7 @@ suite('Build Integration tests', function() {
       var installedExtsPath = path.join('profile-debug',
         'installed-extensions.json');
       var expectedSettings = {
-        'homescreen.manifestURL': 'http://homescreen.gaiamobile.org:8080/manifest.webapp',
+        'homescreen.manifestURL': 'http://verticalhome.gaiamobile.org:8080/manifest.webapp',
         'rocketbar.searchAppURL': 'http://search.gaiamobile.org:8080/index.html'
       };
       var expectedUserPrefs = {

--- a/build/test/unit/settings.test.js
+++ b/build/test/unit/settings.test.js
@@ -207,7 +207,7 @@ suite('settings.js', function() {
       config.GAIA_DOMAIN = 'gaiamobile.com';
       config.GAIA_PORT = ':8080';
       var settings = {};
-      var testResult = mockUtils.gaiaManifestURL('homescreen',
+      var testResult = mockUtils.gaiaManifestURL('verticalhome',
                     config.GAIA_SCHEME, config.GAIA_DOMAIN, config.GAIA_PORT);
       app.setHomescreenURL(settings, config);
       assert.equal(settings['homescreen.manifestURL'], testResult);
@@ -263,7 +263,7 @@ suite('settings.js', function() {
           'debug.console.enabled': true,
           'developer.menu.enabled': true,
           'homescreen.manifestURL': config.GAIA_SCHEME +
-            'homescreen.' + config.GAIA_DOMAIN + config.GAIA_PORT +
+            'verticalhome.' + config.GAIA_DOMAIN + config.GAIA_PORT +
             '/manifest.webapp',
           'rocketbar.searchAppURL': config.GAIA_SCHEME + 'search.' +
             config.GAIA_DOMAIN + config.GAIA_PORT + '/index.html',
@@ -293,7 +293,7 @@ suite('settings.js', function() {
       queue.done(function(result) {
         assert.deepEqual({
           'homescreen.manifestURL': config.GAIA_SCHEME +
-            'homescreen.' + config.GAIA_DOMAIN + config.GAIA_PORT +
+            'verticalhome.' + config.GAIA_DOMAIN + config.GAIA_PORT +
             '/manifest.webapp',
           'rocketbar.searchAppURL': config.GAIA_SCHEME + 'search.' +
             config.GAIA_DOMAIN + config.GAIA_PORT + '/index.html',
@@ -326,7 +326,7 @@ suite('settings.js', function() {
       queue.done(function(result) {
         assert.deepEqual({
           'homescreen.manifestURL': config.GAIA_SCHEME +
-            'homescreen.' + config.GAIA_DOMAIN + config.GAIA_PORT +
+            'verticalhome.' + config.GAIA_DOMAIN + config.GAIA_PORT +
             '/manifest.webapp',
           'rocketbar.searchAppURL': config.GAIA_SCHEME + 'search.' +
             config.GAIA_DOMAIN + config.GAIA_PORT + '/index.html',
@@ -358,7 +358,7 @@ suite('settings.js', function() {
       queue.done(function(result) {
         assert.deepEqual({
           'homescreen.manifestURL': config.GAIA_SCHEME +
-            'homescreen.' + config.GAIA_DOMAIN + config.GAIA_PORT +
+            'verticalhome.' + config.GAIA_DOMAIN + config.GAIA_PORT +
             '/manifest.webapp',
           'rocketbar.searchAppURL': config.GAIA_SCHEME + 'search.' +
             config.GAIA_DOMAIN + config.GAIA_PORT + '/index.html',

--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -719,6 +719,9 @@ class GaiaTestCase(MarionetteTestCase, B2GTestCaseMixin):
             else:
                 self.data_layer.set_char_pref(name, value)
 
+        # set homescreen origin
+        self.data_layer.set_setting('homescreen.manifestURL', 'app://homescreen.gaiamobile.org/manifest.webapp')
+
         # unlock
         self.device.unlock()
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1009111

On try: https://tbpl.mozilla.org/?tree=Try&rev=4108119e9bae
On try again: https://tbpl.mozilla.org/?tree=Try&rev=5d11434b3718
And again: https://tbpl.mozilla.org/?tree=Try&rev=9899570a1992
