### PR TITLE
Bug 1009183 - [email] activity launch, return to message list, no messages shown

### DIFF
--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -1111,6 +1111,19 @@ MessageListCard.prototype = {
     }
   },
 
+
+  /**
+   * Communicates a data change to the vscroll instance. It only does so though
+   * if the card is visible, otherwise, if this call triggers an vscroll init,
+   * the measurements for nodes may not be correct.
+   */
+  _setVScrollData: function() {
+    if (this._needVScrollData && Cards.isVisible(this)) {
+      this.vScroll.setData(this.listFunc);
+      this._needVScrollData = false;
+    }
+  },
+
   // The funny name because it is auto-bound as a listener for
   // messagesSlice events in headerCursor using a naming convention.
   messages_splice: function(index, howMany, addedItems,
@@ -1124,10 +1137,7 @@ MessageListCard.prototype = {
 
     this._clearCachedMessages();
 
-    if (this._needVScrollData) {
-      this.vScroll.setData(this.listFunc);
-      this._needVScrollData = false;
-    }
+    this._setVScrollData();
 
     this.vScroll.updateDataBind(index, addedItems, howMany);
 
@@ -1377,6 +1387,11 @@ MessageListCard.prototype = {
       this._whenVisible = null;
       fn();
     }
+
+    // A setData() for vscroll may have beend delayed until the card becomes
+    // visible, so be sure it has the latest data.
+    this._setVScrollData();
+
     // On first construction, or if done in background,
     // this card would not be visible to do the last sync
     // sizing so be sure to check it now.

--- a/apps/email/js/vscroll.js
+++ b/apps/email/js/vscroll.js
@@ -235,6 +235,9 @@ define(function(require, exports, module) {
     /**
      * Sets the list data source, and then triggers a recalculate
      * since the data changed.
+     * NOTE: this requires the vscroll instance to be visible, since
+     * it may call _init to set up heights, and only works if the
+     * vscroll instance can get accurate node measurements.
      * @param {Function} list the list data source.
      */
     setData: function(list) {


### PR DESCRIPTION
This bug was caused by the Cards.pushDefaultCard() behavior in the Cards implementation. mail_common, when finding that removing the current card would result in no cards displayed, calls Cards.pushDefaultCard().

That is implemented by mail_app, which pushes a message_list card. Then, mail_common, once the card has been pushed on the stack, removes the originally targeted card for removal. In these activity/notification cases, it would have been a compose or message_reader card.

So the issue is that the message_list card is pushed into the DOM, but **not** as the topmost, visible card. When message_list is calls vscroll's setData, it triggers the vscroll init, and vscroll's measurement of this.itemHeight is 0 because the card is hidden, and that causes havoc in the indexAtScrollPosition() method, causing a divide by 0, which leads to sadness.

So the fix was to only call setData() if the card is visible, and to also check if data needs to be set in message_list's onCardVisible() method.

Overall, I like this change because it means the vscroll avoids doing work until it is actually visible, which allows for things like other card animations to complete without the possibility of the vscroll work stealing computing resources.

In my ideal world, some of this could be hidden within vscroll, but in this case it would have mean vscroll knowing about the particulars of when cards are displayed to work, which would make vscroll more coupled to email app-specific code.
