### PR TITLE
Bug 1009183 - [email] activity launch, return to message list, no messages shown

### DIFF
--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -1377,6 +1377,13 @@ MessageListCard.prototype = {
       this._whenVisible = null;
       fn();
     }
+
+    // In case the vScroll was initialized when the card was not visible, like
+    // in an activity/notification flow when this card is created in the
+    // background behind the compose/reader card, let it know it is visible now
+    // in case it needs to finish initializing and initial display.
+    this.vScroll.nowVisible();
+
     // On first construction, or if done in background,
     // this card would not be visible to do the last sync
     // sizing so be sure to check it now.


### PR DESCRIPTION
Similar to previous pull request:
https://github.com/mozilla-b2g/gaia/pull/19174

but instead of doing more manual setData+visible tracking in message_list, vScroll instead tries not to do any work unless properly initialized, which means that this.itemHeight and this.innerHeight are non-zero values.

Still need a trigger from message_list when it knows it is visible because otherwise the vScroll may not get any signals from the this.list data that it needs to do work. Without that, the original bug is still there, the list is not displayed until the folder is changed or the app is restarted.
