### PR TITLE
Bug 1010111 - [Build] utils.Commander cannot init path in string format

### DIFF
--- a/build/utils-xpc.js
+++ b/build/utils-xpc.js
@@ -665,20 +665,19 @@ function Commander(cmd) {
   var command =
     (getOsType().indexOf('WIN') !== -1 && cmd.indexOf('.exe') === -1) ?
     cmd + '.exe' : cmd;
-  var _path;
   var _file = null;
 
   // paths can be string or array, we'll eventually store one workable
   // path as _path.
   this.initPath = function(paths) {
     if (typeof paths === 'string') {
-      _path = paths;
+      var file = getFile(paths, command);
+      _file = file.exists() ? file : null;
     } else if (typeof paths === 'object' && paths.length) {
       for (var p in paths) {
         try {
           var result = getFile(paths[p], command);
           if (result && result.exists()) {
-            _path = paths[p];
             _file = result;
             break;
           }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1010111
