### PR TITLE
Bug 1005862 - [Call Screen][Conference call] mozL10n.get argument must be a string

### DIFF
--- a/apps/callscreen/js/handled_call.js
+++ b/apps/callscreen/js/handled_call.js
@@ -326,7 +326,7 @@ HandledCall.prototype.disconnected = function hc_disconnected() {
   if (this._leftGroup) {
     LazyL10n.get(function localized(_) {
       CallScreen.showStatusMessage(_('caller-left-call',
-        {caller: self._cachedInfo}));
+        {caller: self._cachedInfo.toString()}));
     });
     self._leftGroup = false;
   }

--- a/apps/callscreen/test/unit/handled_call_test.js
+++ b/apps/callscreen/test/unit/handled_call_test.js
@@ -448,6 +448,8 @@ suite('dialer/handled_call', function() {
 
       test('show the banner', function() {
         assert.isTrue(MockCallScreen.mShowStatusMessageCalled);
+        var caller = MockLazyL10n.keys['caller-left-call'].caller;
+        assert.isTrue(typeof(caller) === 'string');
       });
     });
   });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1005862
