### PR TITLE
Bug 1004710 - Totally hide the toolbar when .hide-toolbar is set

### DIFF
--- a/apps/communications/dialer/style/toolbar.css
+++ b/apps/communications/dialer/style/toolbar.css
@@ -72,6 +72,7 @@
 }
 
 #views.hide-toolbar > li {
+  background: none;
   pointer-events: none;
 }
 

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -21,6 +21,7 @@ apps/callscreen/style/oncall.css 0 2
 apps/communications/ftu/css/style.css 0 8
 apps/communications/dialer/style/call_log.css 0 3
 apps/communications/dialer/style/dialer.css 0 3
+apps/communications/dialer/style/toolbar.css 0 2
 apps/communications/contacts/style/overlay.css 0 1
 apps/communications/contacts/style/contacts.css 0 5
 apps/communications/contacts/style/status.css 0 1


### PR DESCRIPTION
I don't know why toolbar.css was not in xfail already because it has two importants.
