### PR TITLE
Bug 1009913 - [E.Me]Loading into a collection shows an empty page [r=amirn]

### DIFF
--- a/apps/homescreen/everything.me/modules/Collection/Collection.js
+++ b/apps/homescreen/everything.me/modules/Collection/Collection.js
@@ -398,6 +398,7 @@ void function() {
           onCollectionVisible();
         } else {
           el.addEventListener('transitionend', onCollectionVisible);
+          el.clientLeft; // force reflow
           el.classList.add('visible');
         }
 


### PR DESCRIPTION
Browser layout grouping eliminates Collection transition occasionally. Forcing reflow fixes it.
http://bugzil.la/1009913
