### PR TITLE
Bug 996515 - [NFC] Screen shot does not have move back animation when vi...

### DIFF
--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -409,7 +409,7 @@ var NfcManager = {
 
     // Clean up P2P UI events
     window.removeEventListener('shrinking-sent', this);
-    window.dispatchEvent(new CustomEvent('shrinking-stop'));
+    window.dispatchEvent(new CustomEvent('shrinking-rejected'));
   },
 
   // Miscellaneous utility functions to handle formating the JSON for activities

--- a/apps/system/js/shrinking_ui.js
+++ b/apps/system/js/shrinking_ui.js
@@ -292,6 +292,8 @@
     this._sendingSlideTo('BOTTOM' , (function() {
       this._enableSlidingCover();
       this._setTip();
+      // will stop once flied back
+      this.stop();
     }).bind(this));
   }).bind(ShrinkingUI);
 
@@ -562,13 +564,13 @@
    * @this {ShrinkingUI}
    */
   ShrinkingUI._shrinkingTiltBack =
-    (function su_shrinkingTiltBack(instant, cb) {
+    (function su_shrinkingTiltBack(instant, callback) {
       // Setup the rotating animation.
       if (!instant) {
         var tsEnd = (function _tsEnd(evt) {
             this.current.appFrame.removeEventListener('transitionend', tsEnd);
-            if (cb) {
-              cb();
+            if (callback) {
+              callback();
             }
         }).bind(this);
         this.current.appFrame.style.transition = 'transform 0.3s ease';
@@ -578,8 +580,8 @@
       } else {
         this.current.appFrame.style.transition = '';
         this.current.appFrame.style.transform = 'rotateX(0.0deg)';
-        if (cb) {
-          cb();
+        if (callback) {
+          callback();
         }
       }
     }).bind(ShrinkingUI);

--- a/apps/system/test/unit/nfc_manager_test.js
+++ b/apps/system/test/unit/nfc_manager_test.js
@@ -3,9 +3,8 @@
 mocha.globals(['NfcManager', 'ScreenManager', 'SettingsListener',
       'lockScreen']);
 
-/* globals MockDOMRequest, MockNfc, MocksHelper, MozNDEFRecord, NDEF, 
+/* globals MockDOMRequest, MockNfc, MocksHelper, MozNDEFRecord, NDEF,
            NfcUtils, NfcManager */
-
 
 require('/shared/test/unit/mocks/mock_moz_ndefrecord.js');
 require('/shared/test/unit/mocks/mock_settings_listener.js');
@@ -44,7 +43,7 @@ suite('Nfc Manager Functions', function() {
     window.navigator.mozSetMessageHandler = MockMozSetMessageHandler;
     realLockScreen = window.lockScreen;
     window.lockScreen = window.MockLockScreen;
-    
+
     requireApp('system/js/nfc_manager.js', done);
   });
 
@@ -58,10 +57,10 @@ suite('Nfc Manager Functions', function() {
       var stubHandleTechnologyDiscovered =
         this.sinon.stub(NfcManager, 'handleTechnologyDiscovered');
       var stubHandleTechLost = this.sinon.stub(NfcManager, 'handleTechLost');
-      
+
       // calling init once more to register stubs as handlers
       NfcManager.init();
-      
+
       MockMessageHandlers['nfc-manager-tech-discovered']();
       assert.isTrue(stubHandleTechnologyDiscovered.calledOnce);
 
@@ -120,7 +119,7 @@ suite('Nfc Manager Functions', function() {
       assert.isTrue(stubChangeHardwareState.calledOnce);
       assert.equal(stubChangeHardwareState.getCall(0).args[0],
                    NfcManager.NFC_HW_STATE_DISABLE_DISCOVERY);
-      
+
       // no change in NfcManager.hwState
       NfcManager.hwState = NfcManager.NFC_HW_STATE_DISABLE_DISCOVERY;
       NfcManager.handleEvent(new CustomEvent('screenchange'));
@@ -132,7 +131,7 @@ suite('Nfc Manager Functions', function() {
       assert.isTrue(stubChangeHardwareState.calledTwice);
       assert.equal(stubChangeHardwareState.getCall(1).args[0],
                    NfcManager.NFC_HW_STATE_ENABLE_DISCOVERY);
-      
+
       // NFC off
       NfcManager.hwState = NfcManager.NFC_HW_STATE_OFF;
       NfcManager.handleEvent(new CustomEvent('lock'));
@@ -147,7 +146,7 @@ suite('Nfc Manager Functions', function() {
       var stubDispatchEvent = this.sinon.stub(window, 'dispatchEvent');
 
       NfcManager.handleEvent(new CustomEvent('shrinking-sent'));
-      
+
       assert.isTrue(stubRemoveEventListner.calledOnce);
       assert.equal(stubRemoveEventListner.getCall(0).args[0], 'shrinking-sent');
       assert.equal(stubRemoveEventListner.getCall(0).args[1], NfcManager);
@@ -161,14 +160,13 @@ suite('Nfc Manager Functions', function() {
   });
 
   suite('handleNdefMessage', function() {
-    
     var execCommonTest = function(message, type) {
       var activityOptions = NfcManager.handleNdefMessage(message);
 
       assert.equal(activityOptions.name, 'nfc-ndef-discovered');
       assert.equal(activityOptions.data.type, type);
       assert.equal(activityOptions.data.records, message);
-      
+
       return activityOptions;
     };
 
@@ -186,7 +184,7 @@ suite('Nfc Manager Functions', function() {
                                             NDEF.RTD_TEXT,
                                             new Uint8Array(),
                                             payload)];
-      
+
       var activityOptions = execCommonTest(dummyNdefMsg, 'text');
       assert.equal(activityOptions.data.text, 'Hey! UTF-8 en');
       assert.equal(activityOptions.data.rtd, NDEF.RTD_TEXT);
@@ -204,7 +202,7 @@ suite('Nfc Manager Functions', function() {
                                             NDEF.RTD_URI,
                                             new Uint8Array(),
                                             payload)];
-      
+
       var activityOptions = execCommonTest(dummyNdefMsg, 'url');
       assert.equal(activityOptions.data.url, 'https://wiki.mozilla.org');
     });
@@ -230,7 +228,7 @@ suite('Nfc Manager Functions', function() {
                                             type,
                                             new Uint8Array(),
                                             payload)];
-      
+
       execCommonTest(dummyNdefMsg, 'text/plain');
     });
 
@@ -245,7 +243,7 @@ suite('Nfc Manager Functions', function() {
                                             type,
                                             new Uint8Array(),
                                             new Uint8Array())];
-      
+
       execCommonTest(dummyNdefMsg, 'http://mozilla.org');
     });
 
@@ -370,7 +368,8 @@ suite('Nfc Manager Functions', function() {
       NfcManager.handleTechLost(command);
       assert.isTrue(stubDispatchEvent.calledThrice);
       assert.equal(stubDispatchEvent.getCall(1).args[0].type, 'nfc-tech-lost');
-      assert.equal(stubDispatchEvent.getCall(2).args[0].type, 'shrinking-stop');
+      assert.equal(stubDispatchEvent.getCall(2).args[0].type,
+        'shrinking-rejected');
     });
 
     test('NFC Manager P2P: checkP2PRegistration success', function() {
@@ -453,7 +452,7 @@ suite('Nfc Manager Functions', function() {
 
   // if bugs will be fixed tests should be moved into handleNdefMessage suite
   suite.skip('handleNdefMessage not supported records', function() {
-    // Bug 1003723 NfcManager not supporting UTF-16 TNF_WELL_KNOWN RTD_TEXT 
+    // Bug 1003723 NfcManager not supporting UTF-16 TNF_WELL_KNOWN RTD_TEXT
     test('TNF well known rtd text utf 16', function() {
       var payload = Uint8Array([0x82, 0x65, 0x6E, 0xFF,
                                 0xFE, 0x48, 0x00, 0x6F,

--- a/apps/system/test/unit/shrinking_ui_test.js
+++ b/apps/system/test/unit/shrinking_ui_test.js
@@ -446,6 +446,7 @@ suite('system/ShrinkingUI', function() {
     var stubEnableSlidingCover =
       this.sinon.stub(ShrinkingUI, '_enableSlidingCover');
     var stubSetTip = this.sinon.stub(ShrinkingUI, '_setTip');
+    var stubStop = this.sinon.stub(ShrinkingUI, 'stop');
     var stubSendSlideTo =
       this.sinon.stub(ShrinkingUI, '_sendingSlideTo', function(y, cb){
         assert.equal(y, 'BOTTOM');
@@ -454,10 +455,12 @@ suite('system/ShrinkingUI', function() {
 
         assert.isTrue(stubEnableSlidingCover.called);
         assert.isTrue(stubSetTip.called);
+        assert.isTrue(stubStop.called);
 
         stubEnableSlidingCover.restore();
         stubSetTip.restore();
         stubSendSlideTo.restore();
+        stubStop.restore();
 
         done();
       });


### PR DESCRIPTION
- call 'shrinking-rejected' in 'nfc-manager-tech-lost'
- have 'shrinking-rejected' call .stop() once animation finishes.
