### PR TITLE
Bug 1007568 - Follow symlinks when copying apps into STAGE_DIR, r=yurenj...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,7 +504,7 @@ app-makefiles: $(XULRUNNER_BASE_DIRECTORY) keyboard-layouts $(STAGE_DIR)/setting
     		STAGE_APP_DIR="../../build_stage/$$APP" make -C "$$appdir" ; \
     	else \
     		echo "copy $$APP to build_stage/" ; \
-    		cp -r "$$appdir" $(STAGE_DIR) && \
+    		cp -LR "$$appdir" $(STAGE_DIR) && \
     		if [ -r "$$appdir/build/build.js" ]; then \
     			echo "execute $$APP/build/build.js"; \
     			export APP_DIR=$$appdir; \


### PR DESCRIPTION
...u

Directories under GAIA_APPDIRS might contain symlinks
(e.g. outoftree_apps). When copying the symlinked apps
into STAGE_DIR without -L option, clear-stage-app
will remove the files in the target directory.
