### PR TITLE
Bug 1007573 - [Tarako][Contacts]After merge contact or add contact to my favorite, cannot edit

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -105,11 +105,12 @@ var Contacts = (function() {
         });
         break;
       default:
-        asyncStorage.getItem('draft', function onDraftGot(draft) {
+        asyncStorage.getItem('draft', function onDraft(draft) {
           if (!draft) {
             showApp();
             return;
           }
+          draft = JSON.parse(draft);
           initForm(function onInitForm() {
             var id = draft.id;
             if (!id || id === 'undefined') {

--- a/apps/communications/contacts/js/views/form.js
+++ b/apps/communications/contacts/js/views/form.js
@@ -524,8 +524,17 @@ contacts.Form = (function() {
     saveContactOrDraft(false);
   };
 
-  var saveContactOrDraft = function saveContactOrDraft(draft) {
-    if (!draft) {
+  /**
+   * Saves a contact or a draft that's being edited. This is useful for example
+   * when the user is editing a contact and the application quits for whatever
+   * reason. In this case, a draft is saved and the next time the app is
+   * opened the unsaved data will be there.
+   *
+   * @param {Boolean} isDraft Whether we are saving a draft or not. If not, we
+   * assume we are saving a contact.
+   **/
+  var saveContactOrDraft = function saveContactOrDraft(isDraft) {
+    if (!isDraft) {
       saveButton.setAttribute('disabled', 'disabled');
       showThrobber();
     }
@@ -566,9 +575,10 @@ contacts.Form = (function() {
       // and inspect address by it self.
       var fields = ['givenName', 'familyName', 'org', 'tel',
         'email', 'note', 'adr'];
+
       if (Contacts.isEmpty(myContact, fields)) {
-        if (draft) {
-          asyncStorage.setItem('draft', myContact);
+        if (isDraft) {
+          asyncStorage.setItem('draft', JSON.stringify(myContact));
         }
         return;
       }
@@ -607,8 +617,8 @@ contacts.Form = (function() {
 
       updateCategoryForImported(contact);
 
-      if (draft) {
-        asyncStorage.setItem('draft', myContact);
+      if (isDraft) {
+        asyncStorage.setItem('draft', JSON.stringify(myContact));
         return;
       }
       asyncStorage.removeItem('draft');


### PR DESCRIPTION
I believe the problem here was that IndexedDB (through AsyncStorage) tries to store an object that contains not only JS data structures, but native ones as well, such as possibly some XPCOM wrappers. At that point, it crashes.

My fix stores the stringified contact object, and that solves the problem. Whenever a 'draft' is detected in the DB upon opening the contacts app, that string is parsed.

I got the insight from https://bugzilla.mozilla.org/show_bug.cgi?id=930839#c7
