### PR TITLE
Bug 1000340 - Remove obsolete codes to launch video app for RTSP

### DIFF
--- a/apps/video/manifest.webapp
+++ b/apps/video/manifest.webapp
@@ -53,7 +53,7 @@
     },
     "view" : {
       "filters": {
-        "type": ["video/webm", "video/mp4", "video/3gpp", "video/ogg", "video/rtsp"]
+        "type": ["video/webm", "video/mp4", "video/3gpp", "video/ogg"]
       },
       "href": "view.html",
       "disposition": "inline",


### PR DESCRIPTION
RTSP is rendered in the browser instead of the video app since FFOS v2.0.
So we should remove the fake MIME type "video/rtsp" added in bug 928332 (Support RTSP in Video apps), which is in order to launch the video app for RTSP URLs.
