### PR TITLE
bug 1007965

### DIFF
--- a/shared/js/download/download_helper.js
+++ b/shared/js/download/download_helper.js
@@ -93,18 +93,6 @@ var DownloadHelper = (function() {
     );
   });
 
-  /*
-   * Returns the relative path from the file absolute path
-   *
-   * @param{String} Absolute path
-   *
-   * @returns(String) Relative path
-   */
-  function getRelativePath(path) {
-    var storagePath = storageName + '/';
-    return path.substring(path.indexOf(storagePath) + storagePath.length);
-  }
-
  /*
   * Error auxiliary method
   */
@@ -125,25 +113,24 @@ var DownloadHelper = (function() {
    */
   function getBlob(download) {
     var req = new Request();
-    var storage = navigator.getDeviceStorage(storageName);
+    var storage = navigator.getDeviceStorage(download.storageName);
     var storeAvailableReq = storage.available();
 
     storeAvailableReq.onsuccess = function available_onsuccess(e) {
-      var path = download.path;
+      var path = download.storagePath;
       switch (storeAvailableReq.result) {
         case 'unavailable':
           sendError(req, ' Could not open the file: ' + path + ' from ' +
-                    storageName, CODE.NO_SDCARD);
+                    download.storageName, CODE.NO_SDCARD);
           break;
 
         case 'shared':
           sendError(req, ' Could not open the file: ' + path + ' from ' +
-                    storageName, CODE.UNMOUNTED_SDCARD);
+                    download.storageName, CODE.UNMOUNTED_SDCARD);
           break;
 
         default:
           try {
-            path = getRelativePath(path);
             var storeGetReq = storage.get(path);
 
             storeGetReq.onsuccess = function store_onsuccess() {
@@ -153,11 +140,11 @@ var DownloadHelper = (function() {
             storeGetReq.onerror = function store_onerror() {
               sendError(req, storeGetReq.error.name +
                         ' Could not open the file: ' + path + ' from ' +
-                        storageName, CODE.FILE_NOT_FOUND);
+                        download.storageName, CODE.FILE_NOT_FOUND);
             };
           } catch (ex) {
             sendError(req, 'Error getting the file ' + path + ' from ' +
-                      storageName, CODE.DEVICE_STORAGE);
+                      download.storageName, CODE.DEVICE_STORAGE);
           }
       }
     };

--- a/shared/js/download/download_store.js
+++ b/shared/js/download/download_store.js
@@ -216,8 +216,8 @@ var DownloadStore = (function() {
   }
 
   // These fields will be stored in our datastore
-  var fieldsToPropagate =
-    ['url', 'path', 'totalBytes', 'contentType', 'startTime', 'state'];
+  var fieldsToPropagate = ['url', 'path', 'totalBytes', 'contentType',
+                           'startTime', 'state', 'storageName', 'storagePath'];
 
   function cookDownload(download) {
     var ret = Object.create(null);


### PR DESCRIPTION
- DownloadHelper should use new 'storageName' and 'storagePath' properties on DOM Download object instead
  of munging path manually.
- DownloadStore should save 'storageName' and 'storagePath' properties to DataStore for later use.

r=crdlc
