### PR TITLE
Bug 1013802 - Include utils.js in hotspot_test.js so that openDialog is defined r=crh0716

### DIFF
--- a/apps/settings/test/unit/hotspot_test.js
+++ b/apps/settings/test/unit/hotspot_test.js
@@ -8,6 +8,7 @@ require('/test/unit/mock_navigator_settings.js');
 require('/shared/test/unit/mocks/mocks_helper.js');
 require('/shared/test/unit/mocks/mock_settings_listener.js');
 require('/test/unit/mock_l10n.js');
+require('/js/utils.js');
 
 var mocksHelperForHotspot = new MocksHelper([
     'SettingsListener'


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1013802
