### PR TITLE
Bug 1014142 - URL Keyboard follow the specs

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -564,18 +564,9 @@ function modifyLayout(keyboardName) {
       switch (currentInputType) {
         // adds . / and .com
       case 'url':
-        space.ratio -= 5;
-        row.splice(c, 1, // delete space
-                   defaultPeriodSymbol,
-                   { value: '/', ratio: 2, keyCode: 47 },
-                   // As we are removing the space we need to assign
-                   // the extra space (i.e to .com)
-                   { value: '.com',
-                     ratio: 2 + space.ratio,
-                     compositeKey: '.com'
-                   }
-                  );
-
+        space.ratio -= 2;
+        row.splice(c, 0, { value: '/', ratio: 1, keyCode: 47 });
+        row.splice(c + 2, 0, defaultPeriodSymbol);
         break;
 
         // adds @ and .

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_url_keyboard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_url_keyboard.py
@@ -27,10 +27,3 @@ class TestUrlKeyboard(GaiaTestCase):
         keyboard_page.switch_to_frame()
         typed_key = keyboard_page.url_input
         self.assertEqual(typed_key, u'/')
-
-        # Test .com key
-        keyboard.tap_dotcom()
-
-        keyboard_page.switch_to_frame()
-        typed_key = keyboard_page.url_input
-        self.assertEqual(typed_key, u'/.com')


### PR DESCRIPTION
Make the URL keyboard be more closer to the recommendation one.
- Instead of `~` it has `:`. More information at
  https://bugzilla.mozilla.org/show_bug.cgi?id=824740
- `_` is available as alternative key to `-`.
