### PR TITLE
Bug 1014262 - Airplane mode icon in status bar is not responsive [r=ettiene]

### DIFF
--- a/apps/system/js/airplane_mode.js
+++ b/apps/system/js/airplane_mode.js
@@ -205,6 +205,10 @@
      */
     watchEvents: function(value, checkedActions) {
       var self = this;
+      // We don't want to wait until the first event reacts in order to
+      // update the status, because we can set the status to 'enabling' or
+      // 'disabling' already through `_updateAirplaneModeStatus`.
+      self._updateAirplaneModeStatus(checkedActions);
       for (var serviceName in this._checkedActionsMap) {
 
         // if we are waiting for specific service
@@ -233,10 +237,10 @@
      */
     set enabled(value) {
       if (value !== this._enabled) {
+        this._enabled = value;
+
         // start watching events
         this.watchEvents(value, this._getCheckedActions(value));
-
-        this._enabled = value;
 
         // tell services to do their own operations
         this._serviceHelper.updateStatus(value);

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -119,8 +119,9 @@ var QuickSettings = {
       // Set to the initializing state to block user interaction until the
       // operation completes. (unless we are being called for the first time,
       // where Bluetooth is already initialize
-      if (!btFirstSet)
+      if (!btFirstSet) {
         self.bluetooth.dataset.initializing = 'true';
+      }
       btFirstSet = false;
 
       self.setAccessibilityAttributes(self.bluetooth, 'bluetoothButton');
@@ -176,14 +177,26 @@ var QuickSettings = {
 
   monitorAirplaneModeChange: function() {
     var self = this;
-    SettingsListener.observe('ril.radio.disabled', false, function(value) {
-      self.data.dataset.airplaneMode = value;
-      if (value) {
-        self.data.classList.add('quick-settings-airplane-mode');
-        self.airplaneMode.dataset.enabled = 'true';
-      } else {
-        self.data.classList.remove('quick-settings-airplane-mode');
-        delete self.airplaneMode.dataset.enabled;
+    SettingsListener.observe('airplaneMode.status', false, function(value) {
+      delete self.airplaneMode.dataset.enabling;
+      delete self.airplaneMode.dataset.disabling;
+
+      self.data.dataset.airplaneMode = (value === 'enabled');
+      switch (value) {
+        case 'enabled':
+          self.data.classList.add('quick-settings-airplane-mode');
+          self.airplaneMode.dataset.enabled = 'true';
+          break;
+        case 'disabled':
+          self.data.classList.remove('quick-settings-airplane-mode');
+          delete self.airplaneMode.dataset.enabled;
+          break;
+        case 'enabling':
+          self.airplaneMode.dataset.enabling = 'true';
+          break;
+        case 'disabling':
+          self.airplaneMode.dataset.disabling = 'true';
+          break;
       }
       self.setAccessibilityAttributes(self.airplaneMode, 'airplaneMode');
     });

--- a/apps/system/style/quick_settings/quick_settings.css
+++ b/apps/system/style/quick_settings/quick_settings.css
@@ -134,6 +134,13 @@
 #quick-settings-airplane-mode[data-enabled] {
   background-image: url(images/airplane-mode-on.png);
 }
+#quick-settings-airplane-mode[data-enabling] {
+  background-image: url(images/airplane-mode-on.png);
+  opacity: 0.5;
+}
+#quick-settings-airplane-mode[data-disabling] {
+  background-image: url(images/airplane-mode-off.png);
+}
 #quick-settings-full-app {
   background-image: url(images/settings-off.png);
 }

--- a/apps/system/test/unit/airplane_mode_test.js
+++ b/apps/system/test/unit/airplane_mode_test.js
@@ -106,7 +106,7 @@ suite('system/airplane_mode.js', function() {
         });
         test('no further steps because we are waiting for other events',
           function() {
-            assert.isFalse(AirplaneMode._updateAirplaneModeStatus.called);
+            assert.isTrue(AirplaneMode._updateAirplaneModeStatus.called);
         });
       });
 
@@ -120,7 +120,7 @@ suite('system/airplane_mode.js', function() {
         });
         test('no further steps because we are waiting for other events',
           function() {
-            assert.isFalse(AirplaneMode._updateAirplaneModeStatus.called);
+            assert.isTrue(AirplaneMode._updateAirplaneModeStatus.called);
         });
       });
 

--- a/apps/system/test/unit/mock_airplane_mode.js
+++ b/apps/system/test/unit/mock_airplane_mode.js
@@ -1,0 +1,8 @@
+/* exported MockAirplaneMode */
+'use strict';
+
+var MockAirplaneMode = {
+  set enabled(v) {
+    return v;
+  }
+};

--- a/apps/system/test/unit/quick_settings_test.js
+++ b/apps/system/test/unit/quick_settings_test.js
@@ -4,12 +4,15 @@
 require('/test/unit/mock_activity.js');
 require('/test/unit/mock_l10n.js');
 require('/test/unit/mock_wifi_manager.js');
+require('/test/unit/mock_airplane_mode.js');
 require('/shared/test/unit/mocks/mock_settings_helper.js');
 require('/shared/test/unit/mocks/mock_settings_listener.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js');
 
 require('/js/quick_settings.js');
+
+mocha.globals(['AirplaneMode']);
 
 var mocksForQuickSettings = new MocksHelper([
   'MozActivity',
@@ -24,6 +27,7 @@ suite('quick settings > ', function() {
   var realSettings;
   var realMozMobileConnections;
   var fakeQuickSettingsNode;
+  var realAirplaneMode;
 
   mocksForQuickSettings.attachTestHelpers();
 
@@ -36,6 +40,8 @@ suite('quick settings > ', function() {
     navigator.mozL10n = MockL10n;
     realMozMobileConnections = navigator.mozMobileConnections;
     navigator.mozMobileConnections = MockNavigatorMozMobileConnections;
+    realAirplaneMode = window.AirplaneMode;
+    window.AirplaneMode = MockAirplaneMode;
   });
 
   suiteTeardown(function() {
@@ -43,6 +49,7 @@ suite('quick settings > ', function() {
     navigator.MozMobileConnections = realMozMobileConnections;
     navigator.mozL10n = realL10n;
     navigator.mozSettings = realSettings;
+    window.AirplaneMode = realAirplaneMode;
   });
 
   setup(function() {
@@ -118,6 +125,66 @@ suite('quick settings > ', function() {
     });
     assert.equal(
       MockNavigatorSettings.mSettings['wifi.connect_via_settings'], false);
+  });
+
+  test('system/quick settings/enable airplane mode', function() {
+    MockSettingsListener.mCallbacks['airplaneMode.status']('enabled');
+    QuickSettings.handleEvent({
+      type: 'click',
+      target: QuickSettings.airplaneMode,
+      preventDefault: function() {}
+    });
+    assert.equal(
+      QuickSettings.airplaneMode.dataset.enabled, 'true');
+
+    assert.equal(
+      QuickSettings.data.classList.contains(
+        'quick-settings-airplane-mode'), true);
+  });
+
+  test('system/quick settings/disable airplane mode', function() {
+    MockSettingsListener.mCallbacks['airplaneMode.status']('disabled');
+    QuickSettings.handleEvent({
+      type: 'click',
+      target: QuickSettings.airplaneMode,
+      preventDefault: function() {}
+    });
+    assert.equal(
+      QuickSettings.airplaneMode.dataset.enabled, undefined);
+
+    assert.equal(
+      QuickSettings.data.classList.contains(
+        'quick-settings-airplane-mode'), false);
+  });
+
+  test('system/quick settings/disabling airplane mode', function() {
+    MockSettingsListener.mCallbacks['airplaneMode.status']('disabling');
+    QuickSettings.handleEvent({
+      type: 'click',
+      target: QuickSettings.airplaneMode,
+      preventDefault: function() {}
+    });
+
+    assert.equal(
+      QuickSettings.airplaneMode.dataset.disabling, 'true');
+
+    assert.equal(
+      QuickSettings.airplaneMode.dataset.enabling, undefined);
+  });
+
+  test('system/quick settings/enabling airplane mode', function() {
+    MockSettingsListener.mCallbacks['airplaneMode.status']('enabling');
+    QuickSettings.handleEvent({
+      type: 'click',
+      target: QuickSettings.airplaneMode,
+      preventDefault: function() {}
+    });
+
+    assert.equal(
+      QuickSettings.airplaneMode.dataset.enabling, 'true');
+
+    assert.equal(
+      QuickSettings.airplaneMode.dataset.disabling, undefined);
   });
 
   suite('datachange > ', function() {


### PR DESCRIPTION
This fixes perceived performance and responsiveness on the Airplane Mode activation/deactivation in the status bar. It adds a "initializing" state while airplane mode is being turned on, and it shows immediate feedback (greying out the icon) when it is turned off.
