### PR TITLE
Bug 992728 - [Calendar] in week view by double clicking can not able move Edit Event screen

### DIFF
--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -41,6 +41,7 @@
   <script defer src="/js/error.js"></script>
   <script defer src="/js/calc.js"></script>
   <script defer src="/js/template.js"></script>
+  <script defer src="/js/querystring.js"></script>
   <script defer src="/js/responder.js"></script>
   <script defer src="/js/view.js"></script>
   <script defer src="/js/router.js"></script>

--- a/apps/calendar/js/templates/week.js
+++ b/apps/calendar/js/templates/week.js
@@ -16,8 +16,11 @@
     },
 
     hour: function() {
-      return '<ol class="hour-' + this.h('hour') + ' events">' +
-          this.s('items') +
+      var hour = this.h('hour');
+
+      return '<ol class="hour hour-' + this.h('hour') +
+          ' events" data-hour="' +
+          hour + '">' + this.s('items') +
         '</ol>';
     },
 

--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -78,7 +78,10 @@ Calendar.ns('Views').Month = (function() {
           this.controller.selectedDay = date;
           break;
         case 'dbltap':
-          this.app.go('/day/');
+          var self = this;
+          window.setTimeout(function() {
+          self._createEvent(target);
+          },100);
           break;
         case 'selectedDayChange':
           this._selectDay(e.data[0]);
@@ -89,6 +92,28 @@ Calendar.ns('Views').Month = (function() {
           this.changeDate(e.data[0]);
           break;
       }
+    },
+
+    _createEvent: function(target) {
+        var startDate = Calc.dateFromId(target.dataset.date);
+        var endDate = Calc.dateFromId(target.dataset.date);
+        var temp = new Date();
+        var hour = temp.getHours();
+        hour = parseInt(hour);
+        startDate.setHours(hour + 1);
+        startDate.setMinutes(0);
+        startDate.setSeconds(0);
+        endDate.setHours(hour + 2);
+        endDate.setMinutes(0);
+        endDate.setSeconds(0);
+        var queryString = {};
+        queryString.startDate = startDate.toString();
+        queryString.endDate = endDate.toString();
+        this.app.go(
+          '/event/add/?' +
+          Calendar.QueryString.stringify(queryString)
+      );
+
     },
 
     _createChild: function(time) {

--- a/apps/calendar/style/day_views.css
+++ b/apps/calendar/style/day_views.css
@@ -26,6 +26,18 @@
   background-color: #fff;
 }
 
+.day-events .selected {
+  position: relative;
+  color: white !important;
+}
+
+.day-events .color {
+  background-color: #1BA8C6 !important;
+  background-image: url(/shared/style/headers/images/icons/add.png) !important;
+  background-repeat:no-repeat;
+  background-position:center;
+}
+
 .allday-events-wrapper .events {
   /* set scrollable areas to a solid background color. see bug 968478 */
   background-color: #f8f8f8;

--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -186,6 +186,14 @@
   z-index: 10;
 }
 
+#week-view .selected {
+  position: relative;
+  color: white !important;
+  background-color: #1BA8C6 !important;
+  background-image: url(/shared/style/headers/images/icons/add.png) !important;
+  background-repeat:no-repeat;
+  background-position:center;
+}
 #week-view .week-events .container {
   height: 100%;
   margin: 1px;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=992728
1. Double tapping in month view go to add new event page and it will not trigger value selector in add new event page.
2. The visual hint in day view is displayed as in wireframe.
3. Visual hint will disappear if user selects other view or saved event
