### PR TITLE
Bug 1014426 - Re-enable the disabled marionette tests for home2 app

### DIFF
--- a/dev_apps/home2/test/marionette/bookmark_test.js
+++ b/dev_apps/home2/test/marionette/bookmark_test.js
@@ -47,9 +47,12 @@ marionette('Vertical - Bookmark', function() {
     var numIcons = home.numIcons;
     var numDividers = home.numDividers;
     var url = server.url('sample.html');
+    var homescreenFrame;
+
     bookmark.save(url, browser);
     client.switchToFrame();
-    client.apps.switchToApp(Home2.URL);
+    homescreenFrame = client.findElement('iframe[src*="' + Home2.URL + '"]');
+    client.switchToFrame(homescreenFrame);
 
     assert.equal(numIcons + 1, home.numIcons);
     assert.equal(numDividers, home.numDividers);


### PR DESCRIPTION
Please refer to http://bugzil.la/1014426.
