### PR TITLE
Bug 1003165 - Prevent reflows when transitioning to and from the homescreen

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -495,6 +495,7 @@
                 '</div>' +
               '</div>' +
               '<div class="fade-overlay"></div>' +
+              '<div class="touch-blocker"></div>' +
            '</div>';
   };
 

--- a/apps/system/js/home_searchbar.js
+++ b/apps/system/js/home_searchbar.js
@@ -111,8 +111,12 @@
           this.handleSearchMessage(e);
           break;
       }
-    }
+    },
 
+    // Preventing the RocketBar implementation from triggering a background
+    // scale change before getting stuck because of the lack of transitionend.
+    enterHome: function() {
+    }
   };
 
   exports.HomeSearchbar = HomeSearchbar;

--- a/apps/system/style/edges/edges.css
+++ b/apps/system/style/edges/edges.css
@@ -1,5 +1,5 @@
 .gesture-panel.disabled {
-  pointer-events: none;
+  visibility: hidden;
 }
 
 #left-panel {
@@ -14,9 +14,6 @@
   background-color: red;
   opacity: 0;
 }
-#left-panel.disabled {
-  background-color: gray;
-}
 
 #right-panel {
   position: absolute;
@@ -29,9 +26,6 @@
 
   background-color: green;
   opacity: 0;
-}
-#right-panel.disabled {
-  background-color: gray;
 }
 
 #screen.edges-debug .gesture-panel {

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -11,6 +11,9 @@
   height: 100%;
   background-repeat: no-repeat;
   background-position: center center;
+
+  transform: translateX(0);
+  will-change: transform, opacity;
 }
 
 .appWindow > .appWindow {
@@ -216,13 +219,6 @@
   animation-duration: 3s;
 }
 
-.appWindow.transition-closing,
-.appWindow.transition-opening {
-  /* The animation takes .3 seconds so users cannot touch the app while the
-   * closing animation is performing */
-  pointer-events: none;
-}
-
 .appWindow.reduce {
   animation: closeApp 0.3s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
 }
@@ -352,6 +348,24 @@
 
 .appWindow.homescreen.fadeout > .fade-overlay {
   opacity: 0.8;
+}
+
+.appWindow > .touch-blocker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  visibility: hidden;
+  background: transparent;
+  pointer-events: all;
+}
+
+.appWindow.transition-closing .touch-blocker,
+.appWindow.transition-opening .touch-blocker {
+  /* The animation takes .3 seconds so users cannot touch the app while the
+   * closing animation is performing */
+  visibility: visible;
 }
 
 .appWindow > .modal-dialog,
@@ -484,6 +498,10 @@
 
 .appWindow > .appWindow {
   z-index: 65536;
+}
+
+.appWindow > .touch-blocker {
+  z-index: 1026;
 }
 
 .appWindow > .fade-overlay {
@@ -621,7 +639,6 @@
   /* in the viewport but not really */
   transform: translateX(-99.9999%);
   opacity: 1;
-  will-change: transform, opacity;
 }
 
 #screen:-moz-full-screen-ancestor > #windows .appWindow.active {

--- a/apps/system/test/marionette/homescreen_navigation_test.js
+++ b/apps/system/test/marionette/homescreen_navigation_test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+marionette('Homescreen navigation >', function() {
+  var ReflowHelper =
+      require('../../../../tests/js-marionette/reflow_helper.js');
+
+  var assert = require('assert');
+  var System = require('./lib/system.js');
+
+  var SETTINGS_APP = 'app://settings.gaiamobile.org';
+
+  var client = marionette.client({
+    prefs: {
+      'dom.w3c_touch_events.enabled': 1,
+      'devtools.debugger.forbid-certified-apps': false
+    },
+    settings: {
+      'ftu.manifestURL': null,
+      'lockscreen.enabled': false,
+      'edgesgesture.enabled': true,
+      'devtools.overlay': true,
+      'hud.reflows': true
+    }
+  });
+
+
+  var sys, settings, homescreen;
+  var reflowHelper;
+
+  function launchSettings() {
+    var settings = sys.waitForLaunch(SETTINGS_APP);
+    client.waitFor(function() {
+      return settings.displayed() && !homescreen.displayed();
+    });
+    return settings;
+  }
+
+  function goHome() {
+    sys.goHome();
+    client.waitFor(function() {
+      return !settings.displayed() && homescreen.displayed();
+    });
+  }
+
+  suiteSetup(function() {
+    sys = new System(client);
+  });
+
+  setup(function() {
+    reflowHelper = new ReflowHelper(client);
+    client.switchToFrame();
+    sys.waitForStartup();
+
+    homescreen = sys.getAppIframe('homescreen.gaiamobile.org');
+    settings = launchSettings();
+  });
+
+  test('Going to the homescreen and back to a warm app', function() {
+    // Since the clock will cause reflows we're disabling it
+    // Also disabling the developer hud because of
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=971008
+    sys.stopDevtools();
+    sys.stopClock();
+
+    goHome();
+    launchSettings();
+
+    reflowHelper.startTracking(System.URL);
+    client.switchToFrame();
+
+    goHome();
+    launchSettings();
+
+    var count = reflowHelper.getCount();
+    assert.equal(count, 0, 'we got ' + count + ' reflows instead of 0');
+    reflowHelper.stopTracking();
+  });
+});

--- a/apps/system/test/marionette/lib/system.js
+++ b/apps/system/test/marionette/lib/system.js
@@ -55,6 +55,12 @@ System.prototype = {
     });
   },
 
+  goHome: function() {
+    this.client.executeScript(function() {
+      window.wrappedJSObject.dispatchEvent(new CustomEvent('home'));
+    });
+  },
+
   stopClock: function() {
     var client = this.client;
     var clock = client.executeScript(function() {


### PR DESCRIPTION
- Disabling edge zones without causing a reflow.
- Making sure the appWindow is never without a transform to prevent a reflow..
- Making sure all app windows have will-change set to prevent reflows when going into edge mode.
- Prevent the homesearch bar from causing a weird animation during the first transition back to homescreen before getting stuck with .transitioning = true.
- Removing the pointer-events:none during app transition.
- Tweaking the homescreen zoom-in/zoom-out transitions to stay on the GPU.
