### PR TITLE
Bug 1010701 - [Tarako][Email][LMK] Email gets killed when attach multiple files to a mail

### DIFF
--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -1157,6 +1157,10 @@ Toaster = {
                                          this._timeout);
   },
 
+  isShowing: function() {
+    return !this.body.classList.contains('collapsed');
+  },
+
   hide: function() {
     this.body.classList.add('collapsed');
     this.body.classList.remove('fadeout');

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -273,6 +273,10 @@ compose-attachments[few]   = {{ n }} attachments
 compose-attachments[many]  = {{ n }} attachments
 compose-attachments[other] = {{ n }} attachments
 
+# Shown when user taps on attachment icon in compose, but the app still
+# needs a bit more time to finishing the add of the previous attachment.
+compose-attachment-still-working=One moment, still working on the previous attachment...
+
 compose-subject=Subject
 compose-draft-save=Save to Local Drafts
 compose-discard-message=Discard email?


### PR DESCRIPTION
If add attachment button is tapped before the previous attachment has fully been attached, show a toast with the message "One moment, still working on the previous attachment...", and then once the previous attachment is completed, the attachment activity is immediately triggered.

On a hamachi device, for a 380KB image (picture taken from phone camera), it took about 1.6 seconds for the toast to disappear. Factoring in the 600 ms delay used after attachment is complete, and noting that a 4MB file took around 4.7 seconds, a rough guide is about 1 second per MB.

In general, the experience seems fine. For most images like phone pictures, the time seeing the toast so short that by the time user finishes reading, the activity chooser is already up. I think it helps that the code closes the toast as soon as previous attachment is done, and that the next attachment activity automatically proceeds.
