### PR TITLE
Bug 796530 - Add Keyboard for Latin America

### DIFF
--- a/apps/keyboard/js/layouts/es-Americas.js
+++ b/apps/keyboard/js/layouts/es-Americas.js
@@ -1,0 +1,97 @@
+Keyboards['es-Americas'] = {
+  label: 'Spanish (Latin America)',
+  menuLabel: 'Español (Latinoamérica)',
+  imEngine: 'latin',
+  types: ['text', 'url', 'email'],
+  autoCorrectLanguage: 'es',
+  alt: {
+    a: 'áªàâäåãāæ',
+    c: 'ç',
+    e: 'é€èêëēęɛ',
+    i: 'íïìîīį',
+    o: 'óºöòôōœøɵ',
+    u: 'úüùûū',
+    s: '$ßš',
+    l: '£ l·l',
+    n: 'ń',
+    y: '¥',
+    '.': ',¿?¡!;:·',
+  },
+  keys: [
+    [
+      { value: 'q' }, { value: 'w' }, { value: 'e' } , { value: 'r' },
+      { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
+      { value: 'o' }, { value: 'p' }
+    ], [
+      { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
+      { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
+      { value: 'l' }, { value: 'ñ', hidden: ['email', 'url'] },
+      { value: ':', visible: ['url'] }, { value: '_', visible: ['email'] }
+    ], [
+      { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+      { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
+      { value: 'b' }, { value: 'n' }, { value: 'm' },
+      { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+    ], [
+      { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+    ]
+  ],
+  alternateLayout: {
+    alt: {
+      '$': '€ £ ¥',
+      '0': 'º',
+      '1': '1º 1ª',
+      '2': '2º 2ª',
+      '3': '3º 3ª',
+      '4': '4º 4ª',
+      '5': '5º 5ª',
+      '6': '6º 6ª',
+      '7': '7º 7ª',
+      '8': '8º 8ª',
+      '9': '9º 9ª',
+      '.': '·'
+    },
+    keys: [
+      [
+        { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
+        { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
+        { value: '9' }, { value: '0' }
+      ], [
+        { value: '-' }, { value: '/' }, { value: ':' }, { value: ';' },
+        { value: '(' } , { value: ')' }, { value: '$' }, { value: '&' },
+        { value: '@', hidden: ['email'] }, { value: '%' },
+        { value: '_', visible: ['email']}
+      ], [
+        { value: '#+=', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+        { value: '¿' }, { value: '?' }, { value: '¡' }, { value: '!' },
+        { value: '\"' }, { value: '\'' }, { value: '*' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  },
+  symbolLayout: {
+    keys: [
+      [
+        { value: '[' }, { value: ']' }, { value: '{' }, { value: '}' },
+        { value: '#' }, { value: '%' }, { value: '^' }, { value: '+' },
+        { value: '=' }, { value: '°' }
+      ], [
+        { value: '_' }, { value: '\\' }, { value: '|' }, { value: '~' },
+        { value: '<' }, { value: '>' }, { value: '€' }, { value: '£' },
+        { value: '¥' }, { value: '•' }
+      ], [
+        { value: '123', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+        { value: '¿' }, { value: '?' }, { value: '¡' }, { value: '!' },
+        { value: '\"' }, { value: '\'' }, {value: '*' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  }
+};


### PR DESCRIPTION
From "Open Web Device - Keyboard Recommendations - Release 1" [1]

```
"Numeric and symbols keyboards may be different depending on
the keyboard language."
```

Most Spanish Latin America countries use "$" as the currency
symbol instead of "€" [2]. To accomplish this a layout for Latin
America was add.

Note: This is also how Android does it.

[1] https://wiki.mozilla.org/images/2/20/Keyboard_Specs.pdf
[2] http://en.wikipedia.org/wiki/Central_banks_and_currencies_of_Central_America_and_South_America
