### PR TITLE
Bug 998025 - Put overscrolling behind a developer pref. r=vingtetun

### DIFF
--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -49,6 +49,11 @@
         </li>
         <li>
           <label class="pack-checkbox">
+            <input type="checkbox" name="apz.overscroll.enabled">
+            <span data-l10n-id="apz-overscroll">Overscrolling</span>
+          </label>
+        <li>
+          <label class="pack-checkbox">
             <input type="checkbox" name="layers.enable-tiles">
             <span data-l10n-id="tiling">Tiling</span>
           </label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -967,6 +967,7 @@ hardware-composer=Hardware composer
 paint-flashing=Flash repainted area
 dumps-layers=Dump layers tree
 apz=Async Pan/Zoom
+apz-overscroll=Overscrolling
 tiling=Tiling
 simple-tiling=Simple tiling
 draw-tile-borders=Draw tile borders

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -11,6 +11,7 @@
    "app.update.interval": 86400,
    "app.update.url": "",
    "apz.force-enable": true,
+   "apz.overscroll.enabled": false,
    "audio.volume.alarm": 15,
    "audio.volume.bt_sco": 15,
    "audio.volume.dtmf": 15,


### PR DESCRIPTION
r+ given in https://bugzilla.mozilla.org/show_bug.cgi?id=998025#c87.
