### PR TITLE
Bug 1016320 - [Calendar] remove any reference to old .calendar-color class r=evanxd

### DIFF
--- a/apps/calendar/js/templates/month.js
+++ b/apps/calendar/js/templates/month.js
@@ -8,7 +8,7 @@
                 ' busy-length-' + this.h('length') +
                 ' busy-' + this.h('start') +
                 ' calendar-id-' + this.h('calendarId') +
-                ' calendar-color calendar-display' +
+                ' calendar-display' +
               '">' +
               '&nbsp;' +
             '</span>';

--- a/apps/calendar/js/templates/months_day.js
+++ b/apps/calendar/js/templates/months_day.js
@@ -14,8 +14,7 @@
 
       var containerClassList = [
         'container',
-        'calendar-id-' + calendarId,
-        'calendar-color'
+        'calendar-id-' + calendarId
       ].join(' ');
 
       this.eventTime = function() {


### PR DESCRIPTION
leftover from the month view visual refresh
