### PR TITLE
Bug 1017314: Load tutorial config in a preload method.

### DIFF
--- a/apps/ftu/config/large.json
+++ b/apps/ftu/config/large.json
@@ -1,0 +1,22 @@
+{
+  "default": {
+    "steps": [
+      {
+        "image": "/style/images/tutorial/1_large.png",
+        "l10nKey": "tutorial-step1-large-2"
+      },
+      {
+        "image": "/style/images/tutorial/2_large.png",
+        "l10nKey": "tutorial-step2-large-2"
+      },
+      {
+        "image": "/style/images/tutorial/3_large.png",
+        "l10nKey": "tutorial-step3-large-2"
+      },
+      {
+        "image": "/style/images/tutorial/4_large.png",
+        "l10nKey": "tutorial-step4-large-2"
+      }
+    ]
+  }
+}

--- a/apps/ftu/config/tiny.json
+++ b/apps/ftu/config/tiny.json
@@ -1,0 +1,30 @@
+{
+  "default": {
+    "steps": [
+      {
+        "image": "/style/images/tutorial/1.png",
+        "l10nKey": "tutorial-step1-tiny"
+      },
+      {
+        "image": "/style/images/tutorial/2.png",
+        "l10nKey": "tutorial-step2-tiny"
+      },
+      {
+        "image": "/style/images/tutorial/3.png",
+        "l10nKey": "tutorial-step3-tiny"
+      },
+      {
+        "image": "/style/images/tutorial/4.png",
+        "l10nKey": "tutorial-step4-tiny"
+      },
+      {
+        "image": "/style/images/tutorial/5.png",
+        "l10nKey": "tutorial-step5-tiny"
+      },
+      {
+        "image": "/style/images/tutorial/6.png",
+        "l10nKey": "tutorial-step6-tiny"
+      }
+    ]
+  }
+}

--- a/apps/ftu/index.html
+++ b/apps/ftu/index.html
@@ -655,7 +655,7 @@
     </section>
   </section>
 
-  <section id="tutorial" role="region" data-step="1" data-maxsteps-tiny="6" data-maxsteps-large="4">
+  <section id="tutorial" role="region" data-step="1">
     <ol id="tutorial-progress" class="step-state">
       <li id="tutorial-progress-bar" class="step-state-bar"></li>
     </ol>

--- a/apps/ftu/js/tutorial.js
+++ b/apps/ftu/js/tutorial.js
@@ -1,52 +1,53 @@
-/* global ScreenLayout,
+/* global ScreenLayout, Promise,
           Utils, FinishScreen */
 /* exported Tutorial */
 
 (function(exports) {
-
   'use strict';
+
+  // Config for the current tutorial steps
+  var stepsConfig = {};
+
+  // default layout
+  var currentLayout = 'tiny';
+
   // Keeps track of the current step
   var currentStep = 1;
-  // Keeps in memory the max. length taking into account the layout
-  var stepsLength = {
-    tiny: 0,
-    large: 0
-  };
-  // Defaut layout is 'tiny', the one for mobile device
-  var currentLayout = 'tiny';
   // Most used DOM elements
   var dom = {};
-  // Suffix for the styles, taking into account the layout.
-  var l10nSuffix, imgSuffix;
 
   function _initProgressBar() {
     dom.tutorialProgressBar.style.width =
-      'calc(100% / ' + stepsLength[currentLayout] + ')';
+      'calc(100% / ' + stepsConfig.steps.length + ')';
   }
 
   function _setProgressBarStep(step) {
     dom.tutorialProgressBar.style.transform =
-        'translate(' + ((step - 1) * 100) + '%)';
+      'translate(' + ((step - 1) * 100) + '%)';
   }
 
-  function _setStep(value) {
+  function _setStep(value, callback) {
     // If value is bigger than the max, show finish screen
-    if (value > +stepsLength[currentLayout]) {
+    var stepIndex = value - 1;
+    if (stepIndex >= stepsConfig.steps.length) {
       Tutorial.done();
       return;
     }
+    var stepData = stepsConfig.steps[stepIndex];
     // Set the step
     dom.tutorial.dataset.step = currentStep;
 
     // Internationalize
     navigator.mozL10n.localize(
       dom.tutorialStepTitle,
-      'tutorial-step' + currentStep + l10nSuffix
+      stepData.l10nKey
     );
 
+    if (typeof callback === 'function') {
+      dom.tutorialStepImage.querySelector('img').onload = callback;
+    }
     // Update the image
-    dom.tutorialStepImage.querySelector('img').src =
-      'style/images/tutorial/' + currentStep + imgSuffix + '.png';
+    dom.tutorialStepImage.querySelector('img').src = stepData.image;
 
     _setProgressBarStep(currentStep);
   }
@@ -62,58 +63,59 @@
 
   var initialized = false;
   var Tutorial = {
-    init: function() {
+    // A configuration object.
+    config: null,
+
+    init: function(stepsKey, onLoaded) {
       if (initialized) {
         return;
       }
-      // Update the value of the layout if needed
-      // 'ScreenLayout' give us 4 different values
-      // tiny: '(max-width: 767px)',
-      // small: '(min-width: 768px) and (max-width: 991px)',
-      // medium: '(min-width: 992px) and (max-width: 1200px)',
-      // large: '(min-width: 1201px)',
-      //
-      // Currently we are taking into account only 'tiny', and we are
-      // going to consider 'tablet' as 'large'. If we want to add more
-      // or specific features for 'small' & 'medium', we should add more
-      // logic here.
-
-      if (ScreenLayout.getCurrentLayout() !== 'tiny') {
-        currentLayout = 'large';
-      }
-
       // Cache DOM elements
-      elementIDs.forEach(function (name) {
+      elementIDs.forEach(function(name) {
         dom[Utils.camelCase(name)] = document.getElementById(name);
       }, this);
 
-      // Cache max steps taking into account the layout
-      stepsLength.tiny = dom.tutorial.dataset.maxstepsTiny;
-      stepsLength.large = dom.tutorial.dataset.maxstepsLarge;
+      this.ensureConfig().then(function() {
+        if (!stepsKey) {
+          stepsKey = 'default';
+        }
+        if (!this.config) {
+          throw new Error('Tutorial.init: config not loaded');
+        }
+        stepsConfig = this.config[stepsKey] || this.config['default'];
 
-      // Add event listeners
-      dom.forwardTutorial.addEventListener(
-        'click',
-        this.next.bind(this)
-      );
-      dom.backTutorial.addEventListener(
-        'click',
-        this.back.bind(this)
-      );
-      // Set suffix according to the layout
-      l10nSuffix = (currentLayout === 'tiny') ? '-tiny': '-large-2';
-      imgSuffix = (currentLayout === 'tiny') ? '': '_large';
+        // Add event listeners
+        dom.forwardTutorial.addEventListener('click', this);
+        dom.backTutorial.addEventListener('click', this);
 
-      // Avoid to reset this
+        _initProgressBar();
+
+        // Set the first step
+        currentStep = 1;
+        _setStep(currentStep, function onFirstResourceLoaded() {
+          if (typeof onLoaded === 'function') {
+            onLoaded();
+          }
+          // Show the panel
+          dom.tutorial.classList.add('show');
+        });
+      }.bind(this), function Tutorial_configLoadError(err) {
+        throw new Error('Tutorial config load error: ' + err.statusText);
+      });
+      // Init in progress
       initialized = true;
-
-      _initProgressBar();
-
-      // Set the first step
-      currentStep = 1;
-      _setStep(currentStep);
-      // Show the panel
-      dom.tutorial.classList.add('show');
+    },
+    handleEvent: function(evt) {
+      if (evt.type === 'click') {
+        switch(evt.target) {
+          case dom.forwardTutorial:
+            this.next(evt);
+            break;
+          case dom.backTutorial:
+            this.back(evt);
+            break;
+        }
+      }
     },
     next: function() {
       _setStep(++currentStep);
@@ -123,6 +125,62 @@
     },
     done: function() {
       FinishScreen.init();
+      dom.tutorial.classList.remove('show');
+    },
+    loadConfig: function() {
+      if (!this._configPromise) {
+        // Update the value of the layout if needed
+        // 'ScreenLayout' give us 4 different values
+        // tiny: '(max-width: 767px)',
+        // small: '(min-width: 768px) and (max-width: 991px)',
+        // medium: '(min-width: 992px) and (max-width: 1200px)',
+        // large: '(min-width: 1201px)',
+        //
+        // Currently we are taking into account only 'tiny', and we are
+        // going to consider 'tablet' as 'large'. If we want to add more
+        // or specific features for 'small' & 'medium', we should add more
+        // logic here.
+
+        currentLayout = ScreenLayout.getCurrentLayout() == 'tiny' ?
+                              'tiny' : 'large';
+
+        var configUrl = '/config/' + currentLayout + '.json';
+
+        this._configPromise = new Promise(function(resolve, reject) {
+          var xhr = Tutorial._configRequest = new XMLHttpRequest();
+          xhr.open('GET', configUrl, true);
+          xhr.responseType = 'json';
+
+          xhr.onload = function() {
+            Tutorial._configRequest = null;
+            Tutorial.config = xhr.response;
+            resolve(Tutorial.config);
+          };
+
+          xhr.onerror = function(err) {
+            Tutorial._configRequest = null;
+            reject(err);
+          };
+          xhr.send(null);
+        });
+      }
+      return this._configPromise;
+    },
+    ensureConfig: function() {
+      return this.loadConfig();
+    },
+    reset: function() {
+      if (this._configRequest) {
+        this._configRequest.abort();
+      }
+      this._configPromise = null;
+      if (!initialized) {
+        return;
+      }
+      currentStep = 0;
+      stepsConfig = Tutorial.config = null;
+      initialized = false;
+      _setProgressBarStep(currentStep);
       dom.tutorial.classList.remove('show');
     }
   };

--- a/apps/ftu/js/ui.js
+++ b/apps/ftu/js/ui.js
@@ -109,6 +109,9 @@ var UIManager = {
   init: function ui_init() {
     _ = navigator.mozL10n.get;
 
+    // Preload the tutorial config
+    Tutorial.loadConfig();
+
     // Initialization of the DOM selectors
     this.domSelectors.forEach(function createElementRef(name) {
       this[toCamelCase(name)] = document.getElementById(name);
@@ -207,9 +210,13 @@ var UIManager = {
     this.letsGoButton.addEventListener('click', function() {
       // Stop Wifi Manager
       WifiManager.finish();
-      UIManager.activationScreen.classList.remove('show');
-      UIManager.finishScreen.classList.remove('show');
-      Tutorial.init();
+
+      // Tutorial config is probably preloaded by now, but init could be
+      // async if it is still loading
+      Tutorial.init(null, function onTutorialLoaded() {
+        UIManager.activationScreen.classList.remove('show');
+        UIManager.finishScreen.classList.remove('show');
+      });
     });
 
     // Enable sharing performance data (saving to settings)

--- a/apps/ftu/test/unit/mock_tutorial.js
+++ b/apps/ftu/test/unit/mock_tutorial.js
@@ -7,5 +7,12 @@ var MockTutorial = {
   init: function() {},
   jumpTo: function() {},
   jumpToExitStep: function() {},
-  manageStep: function() {}
+  manageStep: function() {},
+  loadConfig: function() {
+    return {
+      then: function(cb) {
+        cb();
+      }
+    };
+  }
 };

--- a/apps/ftu/test/unit/tutorial_test.js
+++ b/apps/ftu/test/unit/tutorial_test.js
@@ -1,4 +1,4 @@
-/* global Tutorial, MockFinishScreen*/
+/* global Tutorial, MockFinishScreen */
 'use strict';
 
 requireApp('ftu/test/unit/mock_l10n.js');
@@ -8,6 +8,7 @@ requireApp('ftu/test/unit/mock_finish_screen.js');
 requireApp('ftu/js/finish_screen.js');
 requireApp('ftu/js/utils.js');
 requireApp('ftu/js/tutorial.js');
+
 
 suite('Tutorial >', function() {
   var mocksHelperForFTU = new MocksHelper([
@@ -20,85 +21,125 @@ suite('Tutorial >', function() {
   var realL10n;
 
   suiteSetup(function() {
+
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
 
     loadBodyHTML('/index.html');
-
-    Tutorial.init();
   });
 
   suiteTeardown(function() {
     navigator.mozL10n = realL10n;
     realL10n = null;
-
     document.body.innerHTML = '';
   });
 
-  test(' is shown properly after Tutorial.init', function() {
-    // Is the tutorial shown?
-    assert.isTrue(
-      document.getElementById('tutorial').classList.contains('show')
-    );
+  suite(' lifecycle', function() {
+    teardown(function() {
+      Tutorial.reset();
+    });
+    test('init before loadConfig', function() {
+      Tutorial.init();
+      assert.ok(!Tutorial.config, 'Tutorial.config not yet defined');
+    });
+
+    test('promised config', function(done) {
+      var result = Tutorial.loadConfig();
+      assert.equal(typeof result.then, 'function',
+                  'return value has a then method');
+
+      result.then(function() {
+        assert.ok(Tutorial.config);
+        done();
+      });
+    });
+
+    test('reset', function(done) {
+      Tutorial.loadConfig().then(function() {
+        Tutorial.init();
+        assert.ok(Tutorial.config);
+        Tutorial.reset();
+        assert.ok(!Tutorial.config);
+        done();
+      });
+    });
   });
 
-  test(' check dataset after Tutorial.init', function() {
-    // Are we in Step 1?
-    assert.equal(
-      document.getElementById('tutorial').dataset.step,
-      1
-    );
+  suite(' post-init', function() {
+    suiteSetup(function(done) {
+      Tutorial.loadConfig().then(function() {
+        Tutorial.init(null, done);
+      });
+    });
+
+    test(' is shown properly after Tutorial.init', function() {
+      // Is the tutorial shown?
+      assert.isTrue(
+        document.getElementById('tutorial').classList.contains('show')
+      );
+    });
+
+    test(' check dataset after Tutorial.init', function() {
+      // Are we in Step 1?
+      assert.equal(
+        document.getElementById('tutorial').dataset.step,
+        1
+      );
+    });
+
+    test(' forward', function() {
+      Tutorial.next();
+       // Are we in Step 2?
+      assert.equal(
+        document.getElementById('tutorial').dataset.step,
+        2
+      );
+    });
+
+    test(' back', function() {
+      Tutorial.back();
+       // Are we in Step 1?
+      assert.equal(
+        document.getElementById('tutorial').dataset.step,
+        1
+      );
+    });
+
+    test(' text & image are the right ones for the current step (2)',
+      function() {
+      // Spy the l10n
+      this.sinon.spy(navigator.mozL10n, 'localize');
+      // Move forwad again
+      Tutorial.next();
+       // Are we in Step 2?
+      assert.equal(
+        document.getElementById('tutorial').dataset.step,
+        2
+      );
+      // We are in step 2 and taking into account the current layout
+      var l10nKey = 'tutorial-step2-' + MockScreenLayout._currentDevice;
+      assert.equal(navigator.mozL10n.localize.args[0][1], l10nKey);
+      // Now we check the image.
+      // As we are in 'tiny' (default layout in the mock) there is no prefix
+      var imgSRC =
+        document.getElementById('tutorial-step-image').querySelector('img').src;
+      assert.isTrue(imgSRC.contains('2.png'));
+    });
+
+    test(' hide the tutorial when done and move to FinishScreen', function() {
+      this.sinon.spy(FinishScreen, 'init');
+      // Call to 'done' method
+      Tutorial.done();
+      // Is the tutorial hidden now?
+      assert.isFalse(
+        document.getElementById('tutorial').classList.contains('show')
+      );
+      // Have we called to FinishScreen?
+      assert.isTrue(FinishScreen.init.calledOnce);
+      // Reset the spy
+      FinishScreen.init.reset();
+    });
+
   });
 
-  test(' forward', function() {
-    Tutorial.next();
-     // Are we in Step 2?
-    assert.equal(
-      document.getElementById('tutorial').dataset.step,
-      2
-    );
-  });
-
-  test(' back', function() {
-    Tutorial.back();
-     // Are we in Step 1?
-    assert.equal(
-      document.getElementById('tutorial').dataset.step,
-      1
-    );
-  });
-
-  test(' text & image are the right ones for the current step (2)', function() {
-    // Spy the l10n
-    this.sinon.spy(navigator.mozL10n, 'localize');
-    // Move forwad again
-    Tutorial.next();
-     // Are we in Step 2?
-    assert.equal(
-      document.getElementById('tutorial').dataset.step,
-      2
-    );
-    // We are in step 2 and taking into account the current layout
-    var l10nKey = 'tutorial-step2-' + MockScreenLayout._currentDevice;
-    assert.equal(navigator.mozL10n.localize.args[0][1], l10nKey);
-    // Now we check the image. As we are in 'tiny' (default layout in the mock)
-    // there is no prefix
-    var imgSRC =
-      document.getElementById('tutorial-step-image').querySelector('img').src;
-    assert.isTrue(imgSRC.contains('2.png'));
-  });
-
-  test(' hide the tutorial when done and move to FinishScreen', function() {
-    this.sinon.spy(FinishScreen, 'init');
-    // Call to 'done' method
-    Tutorial.done();
-    // Is the tutorial hidden now?
-    assert.isFalse(
-      document.getElementById('tutorial').classList.contains('show')
-    );
-    // Have we called to FinishScreen?
-    assert.isTrue(FinishScreen.init.calledOnce);
-    // Reset the spy
-    FinishScreen.init.reset();
-  });
 });


### PR DESCRIPTION
- .. plus new unit tests and a missing(?) setup.js to load MocksHelper and loadBodyHTML,
- start tutorial preload in ftu UIManager.init

Expecting some (ostensibly unrelated) FTU unit tests might fail, I'm confused about how they are passing at all without the setup.js this PR adds? 

Some of the tutorial.js changes were necessitated by the addition of the Tutorial.reset() method, which in turn is really only required by the need to test the preload() method. The patch could be simplified if that's not necessary here. Though I think it might be a good thing in the long run, as it would be great to be able to allow users to re-run the tutorial at any time
