### PR TITLE
Bug 1000701 - Display  file name in nocrop option mode

### DIFF
--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -755,9 +755,11 @@ function cropPickedImage(fileinfo) {
   var nocrop = pendingPick.source.data.nocrop;
 
   if (nocrop) {
-    // If we're not cropping we don't want the word "Crop" in the title bar
+    // If we're not cropping show file name in the title bar
     // XXX: UX will probably get rid of this title bar soon, anyway.
-    $('crop-header').textContent = '';
+    var filename = pickedFile.name.split('/').pop();
+    $('crop-header').textContent = filename.substr(0,
+                                   filename.lastIndexOf('.')) || filename;
   }
 
   setView(LAYOUT_MODE.crop);


### PR DESCRIPTION
Mozilla Url : https://bugzilla.mozilla.org/show_bug.cgi?id=1000701
