### PR TITLE
Bug 1010690 - [Tarako][MMS][Notification] The notification of new MMS does not appear in certain cases

### DIFF
--- a/apps/sms/message-sms-received.html
+++ b/apps/sms/message-sms-received.html
@@ -18,6 +18,8 @@
     <script defer src="js/activity_handler.js"></script>
     <script defer src="js/contacts.js"></script>
     <script defer src="js/activity_startup.js"></script>
+    <script defer src="js/utils.js"></script>
+    <script defer src="js/wbmp.js"></script>
   </head>
   <body role="application">
   </body>


### PR DESCRIPTION
- Utils.js is not loaded in message-sms-received.html and cause mms without smil and subject unable to be received.
