### PR TITLE
Bug 1013929 - Use the languagechange event instead of a mozSettings observer. r=stas

### DIFF
--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -1335,12 +1335,9 @@
 
   function initLocale() {
     this.ctx.requestLocales(navigator.language);
-    // mozSettings won't be required here when https://bugzil.la/780953 lands
-    if (navigator.mozSettings) {
-      navigator.mozSettings.addObserver('language.current', function(event) {
-        navigator.mozL10n.language.code = event.settingValue;
-      });
-    }
+    window.addEventListener('languagechange', function l10n_langchange() {
+      navigator.mozL10n.language.code = navigator.language;
+    });
   }
 
   function onReady() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1013929
