### PR TITLE
Bug 1004567 - update app to use new get/setThumbnail/PictureSize() methods

### DIFF
--- a/apps/camera/js/lib/camera/camera.js
+++ b/apps/camera/js/lib/camera/camera.js
@@ -529,7 +529,7 @@ Camera.prototype.setPictureSize = function(size, options) {
     }
   }
 
-  this.mozCamera.pictureSize = size;
+  this.mozCamera.setPictureSize(size);
   this.pictureSize = size;
   this.setThumbnailSize();
 
@@ -591,9 +591,9 @@ Camera.prototype.getRecorderProfile = function() {
 
 Camera.prototype.setThumbnailSize = function() {
   var sizes = this.mozCamera.capabilities.thumbnailSizes;
-  var pictureSize = this.mozCamera.pictureSize;
+  var pictureSize = this.mozCamera.getPictureSize();
   var picked = this.pickThumbnailSize(sizes, pictureSize);
-  if (picked) { this.mozCamera.thumbnailSize = picked; }
+  if (picked) { this.mozCamera.setThumbnailSize(picked); }
 };
 
 /**


### PR DESCRIPTION
The 'pictureSize' and 'thumbnailSize' attributes were deprecated as of bug 987954. This patch removes the Camera app's use of them, so that those attributes can be removed altogether (in bug 1004588).
