### PR TITLE
Bug 994176  -need to use marionette_client_mozilla_b2g28_v1_3 instead of tip marionet...

### DIFF
--- a/tests/python/gaia-ui-tests/tbpl_requirements.txt
+++ b/tests/python/gaia-ui-tests/tbpl_requirements.txt
@@ -1,1 +1,1 @@
-marionette_client
+marionette_client_mozilla_b2g28_v1_3


### PR DESCRIPTION
...te_client

Gu tests were failing, and this should fix it.
