### PR TITLE
Bug 991949 - Cell broadcast ETWS messages show undefined

### DIFF
--- a/apps/system/js/cell_broadcast_system.js
+++ b/apps/system/js/cell_broadcast_system.js
@@ -53,7 +53,15 @@ var CellBroadcastSystem = {
       return;
     }
 
-    CarrierInfoNotifier.show(msg.body,
+    var body = msg.body;
+
+    // XXX: 'undefined' test until bug-1021177 lands
+    if (msg.etws && (!body || (body == 'undefined'))) {
+      body = navigator.mozL10n.get('cb-etws-warningType-' +
+        (msg.etws.warningType ? msg.etws.warningType : 'other'));
+    }
+
+    CarrierInfoNotifier.show(body,
       navigator.mozL10n.get('cb-channel', { channel: msg.messageId }));
   }
 };

--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -501,6 +501,11 @@ unknown-free-space=Unknown remaining space.
 # Cell Broadcast System
 system-alert=System Alert
 cb-channel=Channel {{channel}}
+cb-etws-warningType-earthquake=Earthquake warning!
+cb-etws-warningType-tsunami=Tsunami warning!
+cb-etws-warningType-earthquake-tsunami=Earthquake-tsunami warning!
+cb-etws-warningType-test=Alert system is being tested.
+cb-etws-warningType-other=Emergency warning!
 
 # ICC / STK (= SIM Toolkit)
 icc-message-title=Operator message from SIM {{id}}


### PR DESCRIPTION
ETWS messages without a message body use a canned body depending on the
warning type.

Change-Id: I25491fd85894d334bd6a9ab63105379de495ef2a
