### PR TITLE
Bug 1019243 - use a depth of 1 for shallow clones of Gaia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_script:
 - ./node_modules/.bin/travisaction $CI_ACTION before_script
 script: ./node_modules/.bin/travisaction $CI_ACTION script
 after_script: ./node_modules/.bin/travisaction $CI_ACTION after_script
+git:
+  depth: 1
 branches:
   only:
   - master


### PR DESCRIPTION
Travis seems to default to using a --depth of 30.  We shouldn't need anything more than the most recent changeset.

Let's see if --depth=1 works
