### PR TITLE
Bug 1018534 - [email] switch manifest type to privileged

### DIFF
--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "E-Mail",
   "description": "Gaia E-Mail",
-  "type": "certified",
+  "type": "privileged",
   "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",

--- a/apps/email/test/marionette/lib/email.js
+++ b/apps/email/test/marionette/lib/email.js
@@ -66,7 +66,7 @@ var Selector = {
   folderListContents: '.card-folder-picker .fld-acct-scrollinner',
   settingsButton: '.fld-nav-toolbar',
   settingsDoneButton: '.card-settings-main [data-l10n-id="settings-done"]',
-  addAccountButton: '.tng-accounts-container .tng-account-add',
+  addAccountButton: '.card-settings-main .tng-account-add',
   accountListButton: '.fld-acct-header',
   accountListContainer: '.fld-accountlist-container',
   settingsMainAccountItems: '.tng-accounts-container .tng-account-item',
@@ -148,9 +148,25 @@ Email.prototype = {
     return text;
   },
 
+  // Workaround for bug 1022768, where app permissions are not auto ALLOWed
+  // for tests on desktop. If that bug is fixed, this function should be
+  // removed.
+  _acceptContactsPermission: function() {
+    if (!this._hasAcceptedContactsPermissions) {
+      this.client.switchToFrame();
+      this._tapSelector('#permission-yes');
+      this.client.switchToFrame();
+      this.client.apps.switchToApp(Email.EMAIL_ORIGIN);
+      this._hasAcceptedContactsPermissions = true;
+    }
+  },
+
   manualSetupImapEmail: function(server, finalActionName) {
     // setup a IMAP email account
     var email = server.imap.username + '@' + server.imap.hostname;
+
+    // Workaround for bug 1022768, see method definition.
+    this._acceptContactsPermission();
 
     // wait for the setup page is loaded
     this._setupTypeName(server.imap.username);


### PR DESCRIPTION
Tested on Flame via a reset-gaia with latest gaia master and a nightly mozcentral gecko flash:
- Tested contacts interaction: was correctly not prompted for Contacts permission since installed on phone as part of build, fetching contact for display in message list/reader was correct, could still compose and add from contacts.
- Tested l10n switching: the email app did get locale changes. It still had some issues, tracked already in bug 1005760, but unrelated to the privileged switch -- for already in DOM elements, the locale was updated.
- account setup, mail fetching and sending still work. Sound still plays when sending an email and that in-app pref is turned on.
