### PR TITLE
Revert "Bug 1019243 - use a depth of 1 for shallow clones of Gaia"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ before_script:
 - ./node_modules/.bin/travisaction $CI_ACTION before_script
 script: ./node_modules/.bin/travisaction $CI_ACTION script
 after_script: ./node_modules/.bin/travisaction $CI_ACTION after_script
-git:
-  depth: 1
 branches:
   only:
   - master


### PR DESCRIPTION
This reverts commit 805a1af97c46d2b26fed9461b37450634401d093.

Attempting a revert due to recent grey builds.
