### PR TITLE
Bug 990537 - [DSDS] Messaging. Apply Visual Refresh to DSDS scenarios r=...

### DIFF
--- a/apps/communications/dialer/test/unit/multi_sim_action_button_test.js
+++ b/apps/communications/dialer/test/unit/multi_sim_action_button_test.js
@@ -339,6 +339,14 @@ suite('multi SIM action button', function() {
                                 {n: expectedCardIndex+1});
       });
 
+      test('has a localized SIM indicator with custom l10n id', function() {
+        var localizeSpy = this.sinon.spy(MockMozL10n, 'localize');
+        simIndication.dataset.l10nId= 'expected';
+        initSubject();
+        sinon.assert.calledWith(localizeSpy, simIndication, 'expected',
+                                {n: expectedCardIndex+1});
+      });
+
       test('indicator changes when settings change', function() {
         var localizeSpy = this.sinon.spy(MockMozL10n, 'localize');
 

--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -270,7 +270,9 @@
               </div>
               <div class="composer-button-container">
                 <span id="messages-counter-label" data-counter="">MMS</span>
-                <button id="messages-send-button" class="icon" aria-label="send" data-l10n-id="send" type="submit"></button>
+                <button id="messages-send-button" class="icon" aria-label="send" data-l10n-id="send" type="submit">
+                  <div class="js-sim-indication sim-indication" data-l10n-id="send-button-sim-indication"></div>
+                </button>
               </div>
             </form>
           </div>

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -238,6 +238,11 @@ message-draft-saved  = Message saved as draft
 # some DSDS related localizations
 sim-name = SIM{{id}}
 dsds-notification-title-with-sim = ({{sim}}) {{sender}}
+# LOCALIZATION NOTE (send-button-sim-indication): don't localize the
+# sim-indication itself as we use it to show the SIM number only. Yet obviously,
+# the "ariaLabel" needs to be localized.
+send-button-sim-indication = {{n}}
+send-button-sim-indication.ariaLabel = using SIM {{n}}
 
 # Date formats specific for SMS app
 

--- a/apps/sms/style/composer.css
+++ b/apps/sms/style/composer.css
@@ -290,3 +290,49 @@ form[role="search"] button[type="submit"]:after {
   top: 3rem;
 }
 
+/*
+  DSDS
+*/
+
+.sim-indication {
+  position: absolute;
+  top: 0.6rem;
+  right: 1.9rem;
+
+  display: none;
+  line-height: 1;
+
+  color: black;
+  font-size: 1.3rem;
+  font-style: normal;
+  opacity: 0.5;
+}
+
+button[disabled] .sim-indication {
+  color: inherit;
+}
+
+.has-preferred-sim .sim-indication {
+  display: block;
+}
+
+.has-preferred-sim #messages-send-button {
+  height: 4.5rem;
+  padding-top: 0.5rem;
+}
+
+.has-preferred-sim #messages-send-button:before {
+  position: absolute;
+  top: 1.2rem;
+  left: 0;
+  right: 0;
+
+  content: '...';
+  display: block;
+  width: 100%;
+
+  color: #b2b2b2;
+  text-align: center;
+  font-size: 1.8rem;
+}
+

--- a/apps/sms/style/composer.css
+++ b/apps/sms/style/composer.css
@@ -240,15 +240,13 @@ form[role="search"] button[type="submit"]:after {
   box-sizing: border-box;
   position: relative;
 
-  right: 1rem;
   left: 0;
   height: 0;
-  padding: 0 1.5rem;
 
   color: #575757;
   font-size: 0;
   font-weight: normal;
-  text-align: left;
+  text-align: center;
 }
 
 [data-message-type='mms'] #messages-counter-label {
@@ -275,7 +273,8 @@ form[role="search"] button[type="submit"]:after {
   position: absolute;
 
   top: 0;
-  left: 1.5rem;
+  left: 0;
+  width: 100%;
 
   color: #575757;
   font-size: 1.4rem;

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -546,25 +546,34 @@ section[role="region"].new > header:first-child form {
   DSDS
 */
 
-.js-sim-indication {
+.sim-indication {
   position: absolute;
-  top: 0.2rem;
-  left: 0;
+  top: 0.6rem;
+  right: 1.9rem;
 
   display: none;
   line-height: 1;
-  width: 100%;
 
+  color: black;
   font-size: 1.3rem;
+  font-style: normal;
   opacity: 0.5;
 }
 
-.has-preferred-sim .js-sim-indication {
+button[disabled] .sim-indication {
+  color: inherit;
+}
+
+.has-preferred-sim .sim-indication {
   display: block;
 }
 
+.has-preferred-sim #messages-send-button {
+  height: 4.5rem;
+  padding-top: 0.5rem;
+}
 
-.has-preferred-sim #messages-send-button:after {
+.has-preferred-sim #messages-send-button:before {
   position: absolute;
   top: 1.2rem;
   left: 0;

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -543,52 +543,6 @@ section[role="region"].new > header:first-child form {
 }
 
 /*
-  DSDS
-*/
-
-.sim-indication {
-  position: absolute;
-  top: 0.6rem;
-  right: 1.9rem;
-
-  display: none;
-  line-height: 1;
-
-  color: black;
-  font-size: 1.3rem;
-  font-style: normal;
-  opacity: 0.5;
-}
-
-button[disabled] .sim-indication {
-  color: inherit;
-}
-
-.has-preferred-sim .sim-indication {
-  display: block;
-}
-
-.has-preferred-sim #messages-send-button {
-  height: 4.5rem;
-  padding-top: 0.5rem;
-}
-
-.has-preferred-sim #messages-send-button:before {
-  position: absolute;
-  top: 1.2rem;
-  left: 0;
-  right: 0;
-
-  content: '...';
-  display: block;
-  width: 100%;
-
-  color: #b2b2b2;
-  text-align: center;
-  font-size: 1.8rem;
-}
-
-/*
   Loading screen while deleting
 */
 

--- a/shared/js/multi_sim_action_button.js
+++ b/shared/js/multi_sim_action_button.js
@@ -103,9 +103,10 @@ MultiSimActionButton.prototype._updateUI = function() {
       navigator.mozIccManager.iccIds.length > 1) {
     if (this._simIndication) {
       var self = this;
+      var l10nId = this._simIndication.dataset.l10nId || 'sim-picker-button';
       navigator.mozL10n.ready(function() {
         navigator.mozL10n.localize(self._simIndication,
-                                   'sim-picker-button',
+                                   l10nId,
                                    {n: cardIndex+1});
       });
     }


### PR DESCRIPTION
...schung
- use :before instead of :after so that we re not affected by building blocks
- add the sim indication back
- use the correct style for the sim indication
