### PR TITLE
Bug 1020065 - Break the dependency from connectivity.js to settings.js r=eragon

### DIFF
--- a/apps/settings/js/connectivity.js
+++ b/apps/settings/js/connectivity.js
@@ -33,7 +33,7 @@ var Connectivity = (function(window, document, undefined) {
   var wifiEnabledListeners = [updateWifi];
   var wifiDisabledListeners = [updateWifi];
   var wifiStatusChangeListeners = [updateWifi];
-  var settings = Settings.mozSettings;
+  var settings = navigator.mozSettings;
 
   //
   // Now register callbacks to track the state of the wifi hardware


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1020065
- Replace Settings.mozSettings with navigator.mozSettings.
