### PR TITLE
Bug 1020109 - Cell broadcast search list is not set correctly. r=arthurcc

### DIFF
--- a/apps/system/js/operator_variant/operator_variant.js
+++ b/apps/system/js/operator_variant/operator_variant.js
@@ -355,7 +355,7 @@
               break;
           }
 
-          if (Object.keys(item)) {
+          if (Object.keys(item).length) {
             transaction.set(item);
           }
         }


### PR DESCRIPTION
The current code attempts to protect against empty objects incorrectly
since empty arrays are truthy in JavaScript. The result is empty objects
get passed to SettingsLock.set() which seems to break all subsequent
settings change observers.
