### PR TITLE
Bug 1014820 - [Calendar] remove the waitForKeyboardHide from marionette tests r=gaye

### DIFF
--- a/apps/calendar/test/marionette/alarm_test.js
+++ b/apps/calendar/test/marionette/alarm_test.js
@@ -7,7 +7,16 @@ var SHARED_PATH = __dirname + '/../../../../shared/test/integration';
 
 marionette('alarm', function() {
   var app;
-  var client = marionette.client();
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true
+    }
+  });
 
   suite(' > with alarm mocks', function() {
 

--- a/apps/calendar/test/marionette/caldav_test.js
+++ b/apps/calendar/test/marionette/caldav_test.js
@@ -10,8 +10,18 @@ var ACCOUNT_USERNAME = 'firefox-os',
     DATE_PATTERN = 'yyyymmdd"T"HHMMssZ';
 
 marionette('configure CalDAV accounts', function() {
-  var client = marionette.client(),
-      serverHelper = new Radicale(),
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
+  });
+
+  var serverHelper = new Radicale(),
       app = null;
 
   setup(function(done) {

--- a/apps/calendar/test/marionette/create_event_test.js
+++ b/apps/calendar/test/marionette/create_event_test.js
@@ -6,7 +6,16 @@ var Calendar = require('./lib/calendar'),
 
 marionette('creating an event', function() {
   var app;
-  var client = marionette.client();
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
+  });
 
   var title = 'Puppy Bowl dogefortlongtextfotestloremipsumdolorsitamet',
       description = 'lorem ipsum dolor sit amet maecennas ullamcor',

--- a/apps/calendar/test/marionette/day_view_test.js
+++ b/apps/calendar/test/marionette/day_view_test.js
@@ -6,7 +6,16 @@ var Calendar = require('./lib/calendar'),
 marionette('day view', function() {
   var app;
   var day;
-  var client = marionette.client();
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
+  });
 
   setup(function() {
     app = new Calendar(client);

--- a/apps/calendar/test/marionette/lib/calendar.js
+++ b/apps/calendar/test/marionette/lib/calendar.js
@@ -162,7 +162,6 @@ Calendar.prototype = {
     });
 
     modifyAccount.save();
-    this.waitForKeyboardHide();
     modifyAccount.waitForHide();
     this.closeSettingsView();
     return this;
@@ -242,7 +241,6 @@ Calendar.prototype = {
     editEvent.reminders = opts.reminders == null ? [] : opts.reminders;
     editEvent.save();
 
-    this.waitForKeyboardHide();
     editEvent.waitForHide();
     return this;
   },
@@ -274,32 +272,6 @@ Calendar.prototype = {
       throw new Error(msg);
     }
 
-    return this;
-  },
-
-  // TODO: extract this logic into the marionette-helper repository since this
-  // can be useful for other apps as well
-  waitForKeyboardHide: function() {
-    // FIXME: keyboard might affect the click if test is being executed on
-    // a slow machine (eg. travis-ci) so we do this hack until Bug 965131 is
-    // fixed
-    var client = this.client;
-
-    // need to go back to top most frame before being able to switch to
-    // a different app!!!
-    client.switchToFrame();
-
-    var keyboardFrame = client.findElement(
-      'iframe[src*="app://keyboard.gaiamobile.org"]');
-    client.switchToFrame(keyboardFrame);
-    client.waitFor(function() {
-      return client.executeScript(function() {
-        return document.hidden;
-      });
-    });
-
-    client.switchToFrame();
-    client.apps.switchToApp(Calendar.ORIGIN);
     return this;
   },
 

--- a/apps/calendar/test/marionette/month_view_test.js
+++ b/apps/calendar/test/marionette/month_view_test.js
@@ -5,7 +5,16 @@ var Calendar = require('./lib/calendar'),
 
 marionette('month view', function() {
   var app;
-  var client = marionette.client();
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
+  });
 
   setup(function() {
     app = new Calendar(client);

--- a/apps/calendar/test/marionette/today_test.js
+++ b/apps/calendar/test/marionette/today_test.js
@@ -10,7 +10,14 @@ marionette('today', function() {
   var app;
 
   var client = marionette.client({
-    settings: { 'keyboard.ftu.enabled': false }
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
   });
 
   setup(function() {

--- a/apps/calendar/test/marionette/toggle_calendar_test.js
+++ b/apps/calendar/test/marionette/toggle_calendar_test.js
@@ -5,7 +5,16 @@ var Calendar = require('./lib/calendar'),
 
 marionette('toggle calendar', function() {
   var app;
-  var client = marionette.client();
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
+  });
 
   setup(function() {
     app = new Calendar(client);

--- a/apps/calendar/test/marionette/week_view_test.js
+++ b/apps/calendar/test/marionette/week_view_test.js
@@ -4,8 +4,18 @@ var Calendar = require('./lib/calendar'),
     assert = require('chai').assert;
 
 marionette('week view', function() {
-  var app, week,
-    client = marionette.client();
+  var app, week;
+
+  var client = marionette.client({
+    prefs: {
+      // we need to disable the keyboard to avoid intermittent failures on
+      // Travis (transitions might take longer to run and block UI)
+      'dom.mozInputMethod.enabled': false,
+      // Do not require the B2G-desktop app window to have focus (as per the
+      // system window manager) in order for it to do focus-related things.
+      'focusmanager.testmode': true,
+    }
+  });
 
   setup(function() {
     app = new Calendar(client);


### PR DESCRIPTION
executed all calendar tests more than 20+ on Travis and seems pretty stable. (https://travis-ci.org/millermedeiros/gaia/builds/26802654)

we have more than 30 calls to `createEvent` on the integration tests (some of them are subsequent calls), which means that if it didn't fail during 20 runs it probably should not fail if executed more times.
