### PR TITLE
Bug 1013585 - Intermittent gaia-build "Automation Error: mozprocess time...

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -11,7 +11,7 @@ define run-build-test
     --harmony \
     --reporter $(REPORTER) \
     --ui tdd \
-    --timeout 0 \
+    --timeout 180000 \
     $(strip $1)
 endef
 


### PR DESCRIPTION
...d out after 330 seconds running ['make', 'build-test-integration', 'NPM_REGISTRY=http://npm-mirror.pub.build.mozilla.org', 'REPORTER=mocha-tbpl-reporter'] | timed out after 330 seconds of no output
