### PR TITLE
Bug 1020949 - Don't kill the vertical homescreen app when killing all apps

### DIFF
--- a/tests/atoms/gaia_apps.js
+++ b/tests/atoms/gaia_apps.js
@@ -206,7 +206,7 @@ var GaiaApps = {
     let apps = GaiaApps.getApps();
     for (let id in apps) {
       let origin = apps[id].origin;
-      if (origin.indexOf('homescreen') == -1) {
+      if (!/homescreen|verticalhome/.test(origin)) {
         originsToClose.push(origin);
       }
     }


### PR DESCRIPTION
I've kept the original homescreen in the exclusions for now.
