### PR TITLE
Bug 939174 - Launch whats new FTU tutorial to demo edge gestures etc.

### DIFF
--- a/apps/ftu/config/tiny.json
+++ b/apps/ftu/config/tiny.json
@@ -14,5 +14,29 @@
         "l10nKey": "tutorial-sheets-tiny"
       }
     ]
+  },
+  "1.4..2.0": {
+    "steps": [
+      {
+        "video": "/style/images/tutorial/VerticalScroll.mp4",
+        "l10nKey": "tutorial-vertical-scroll-tiny"
+      },
+      {
+        "video": "/style/images/tutorial/Sheets.mp4",
+        "l10nKey": "tutorial-sheets-tiny"
+      }
+    ]
+  },
+  "1.3..2.0": {
+    "steps": [
+      {
+        "video": "/style/images/tutorial/VerticalScroll.mp4",
+        "l10nKey": "tutorial-vertical-scroll-tiny"
+      },
+      {
+        "video": "/style/images/tutorial/Sheets.mp4",
+        "l10nKey": "tutorial-sheets-tiny"
+      }
+    ]
   }
 }

--- a/apps/ftu/index.html
+++ b/apps/ftu/index.html
@@ -45,6 +45,7 @@
   <script src="/shared/js/l10n_date.js"></script>
   <script src="/shared/js/tz_select.js"></script>
   <script defer src="/shared/js/keyboard_helper.js"></script>
+  <script defer src="/shared/js/version_helper.js"></script>
 
   <!-- Import contacts help files -->
   <script defer src="/shared/js/contacts/import/utilities/status.js"></script>
@@ -652,6 +653,25 @@
         </button>
       </menu>
     </section>
+  </section>
+
+  <section id="update-screen" class="finish-screen-base" role="region">
+    <section class="content">
+      <h1 data-l10n-id="whatsNew">
+        What's new
+      </h1>
+      <p data-l10n-id="updatedSuccessfully">
+        Your phone has updated successfully! Start the tour to find out more about the new features.
+      </p>
+    </section>
+    <menu role="navigation">
+      <button id="update-skip-tutorial-button" class="button-left" data-l10n-id="skip">
+        Skip
+      </button>
+      <button id="update-lets-go-button" class="recommend" data-l10n-id="startTour">
+        Start Tour!
+      </button>
+    </menu>
   </section>
 
   <section id="tutorial" role="region" data-step="1">

--- a/apps/ftu/js/tutorial.js
+++ b/apps/ftu/js/tutorial.js
@@ -68,7 +68,6 @@
     }
 
     if (stepData.video) {
-
       if (typeof callback === 'function') {
         videoElement.addEventListener('loadeddata', onVideoLoadOrError, false);
         videoElement.addEventListener('error', onVideoLoadOrError, false);
@@ -104,6 +103,9 @@
 
     init: function(stepsKey, onLoaded) {
       if (initialized) {
+        if (typeof onLoaded == 'function') {
+          this._configPromise.then(onLoaded);
+        }
         return;
       }
       // Cache DOM elements

--- a/apps/ftu/js/ui.js
+++ b/apps/ftu/js/ui.js
@@ -19,6 +19,7 @@ var UIManager = {
     'progress-bar',
     'progress-bar-state',
     'finish-screen',
+    'update-screen',
     'nav-bar',
     'main-title',
     // Unlock SIM Screen
@@ -92,9 +93,11 @@ var UIManager = {
     'data-connection-switch',
     // Geolocation
     'geolocation-switch',
-    // Before Tutorial
+    // Tutorial
     'lets-go-button',
+    'update-lets-go-button',
     'skip-tutorial-button',
+    'update-skip-tutorial-button',
     // Privacy Settings
     'share-performance',
     'offline-error-dialog',
@@ -195,7 +198,7 @@ var UIManager = {
           this.invalidEmailErrorDialog.classList.remove('visible');
         }.bind(this));
 
-    this.skipTutorialButton.addEventListener('click', function() {
+    var skipTutorialAction = function() {
       // Stop Wifi Manager
       WifiManager.finish();
       // For tiny devices
@@ -205,9 +208,9 @@ var UIManager = {
         // for large devices
         FinishScreen.init();
       }
-    });
+    };
 
-    this.letsGoButton.addEventListener('click', function() {
+    var startTutorialAction = function(evt) {
       // Stop Wifi Manager
       WifiManager.finish();
 
@@ -215,9 +218,16 @@ var UIManager = {
       // async if it is still loading
       Tutorial.init(null, function onTutorialLoaded() {
         UIManager.activationScreen.classList.remove('show');
+        UIManager.updateScreen.classList.remove('show');
         UIManager.finishScreen.classList.remove('show');
       });
-    });
+    };
+
+    this.skipTutorialButton.addEventListener('click', skipTutorialAction);
+    this.updateSkipTutorialButton.addEventListener('click', skipTutorialAction);
+
+    this.letsGoButton.addEventListener('click', startTutorialAction);
+    this.updateLetsGoButton.addEventListener('click', startTutorialAction);
 
     // Enable sharing performance data (saving to settings)
     this.sharePerformance.addEventListener('click', this);

--- a/apps/sharedtest/test/unit/version_helper_test.js
+++ b/apps/sharedtest/test/unit/version_helper_test.js
@@ -1,0 +1,125 @@
+/* global VersionHelper, MockNavigatorSettings */
+'use strict';
+
+require('/shared/js/version_helper.js');
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+
+// test that:
+//  API has expected behaviour: ready,
+suite('VersionHelper > ', function() {
+  var realSettings;
+	suiteSetup(function() {
+    realSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+  });
+  suiteTeardown(function() {
+    navigator.mozSettings = realSettings;
+    realSettings = null;
+  });
+
+  test('getVersionInfo', function(done) {
+    var promise = VersionHelper.getVersionInfo();
+    assert.equal(typeof promise.then, 'function',
+                'getVersionInfo returns a then-able');
+    function onOutcome(info) {
+      assert.ok(info && !(info instanceof Error));
+      assert.ok('current' in info);
+      assert.equal(typeof info.isUpgrade, 'function');
+      assert.equal(typeof info.delta, 'function');
+    }
+    promise.then(onOutcome, onOutcome).then(done, done);
+  });
+
+  suite('unknown previous version > ', function() {
+    setup(function(done) {
+      navigator.mozSettings.mSettings['deviceinfo.os'] = '2.0.1';
+      var fixture = this;
+      VersionHelper.getVersionInfo().then(function(result) {
+        fixture.versionInfo = result;
+        done();
+      });
+    });
+
+    test('settings are reflected properly', function() {
+      var info = this.versionInfo;
+      assert.equal(info.current.major, 2);
+      assert.equal(info.current.minor, 0);
+      assert.ok(!info.previous, 'previous version is falsey');
+    });
+    test('delta', function() {
+      var delta = this.versionInfo.delta();
+      assert.equal(delta, '..2.0');
+    });
+    test('version toString', function() {
+      assert.equal(this.versionInfo.current.toString(),
+                   '2.0.1');
+    });
+    test('isUpgrade', function() {
+      assert.isFalse(this.versionInfo.isUpgrade());
+    });
+  });
+
+  suite('known previous version > ', function() {
+    setup(function(done) {
+      var req = navigator.mozSettings.createLock().set({
+        'deviceinfo.os': '2.1.0',
+        'deviceinfo.previous_os': '1.4.1',
+      });
+      var fixture = this;
+      req.onsuccess = function() {
+        VersionHelper.getVersionInfo().then(function(info) {
+          fixture.versionInfo = info;
+          done();
+        });
+      };
+      req.onerror = function() {
+        throw new Error('Failed to setup deviceinfo.* setting on mock');
+      };
+    });
+
+    test('settings are reflected properly', function() {
+      var info = this.versionInfo;
+      assert.equal(info.previous.major, 1);
+      assert.equal(info.previous.minor, 4);
+    });
+    test('delta', function() {
+      var delta = this.versionInfo.delta();
+      assert.equal(delta, '1.4..2.1');
+    });
+    test('isUpgrade', function() {
+      assert.isTrue(this.versionInfo.isUpgrade());
+    });
+  });
+
+  suite('update > ', function() {
+    setup(function(done) {
+      var fixture = this;
+      var req = navigator.mozSettings.createLock().set({
+        'deviceinfo.os': '2.0.1',
+        'deviceinfo.previous_os': '1.4.1',
+      });
+      req.onsuccess = function() {
+        VersionHelper.getVersionInfo().then(function(result) {
+          fixture.versionInfo = result;
+          done();
+        });
+      };
+      req.onerror = function() {
+        throw new Error('Failed to setup deviceinfo.* setting on mock');
+      };
+    });
+
+    test('previous_os', function(done){
+      var fixture = this;
+      VersionHelper.updatePrevious().then(function(){
+        assert.equal(navigator.mozSettings.mSettings['deviceinfo.previous_os'],
+                    '2.0.1', 'setting is updated');
+        assert.equal(fixture.versionInfo.previous.toString(),
+                    '1.4.1', 'previous in-memory version is maintained after' +
+                    ' updatePrevious()');
+      }, function() {
+        assert.isFalse('fail at comparing previous_os settings');
+      }).then(done, done);
+    });
+  });
+});

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -28,6 +28,7 @@
     <script defer src="shared/js/iac_handler.js"></script>
     <script defer src="shared/js/apn_helper.js"></script>
     <script defer src="js/touch_forwarder.js"></script>
+    <script defer src="shared/js/version_helper.js"></script>
 
     <script defer src="js/system.js"></script>
     <script defer src="js/base_ui.js"></script>

--- a/apps/system/test/unit/ftu_launcher_test.js
+++ b/apps/system/test/unit/ftu_launcher_test.js
@@ -1,0 +1,124 @@
+/* global FtuLauncher,
+          MockasyncStorage, MockNavigatorSettings */
+'use strict';
+
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/js/version_helper.js');
+require('/apps/system/test/unit/mock_asyncStorage.js');
+requireApp('system/js/ftu_launcher.js');
+
+suite('launch ftu >', function() {
+  var realAsyncStorage, realMozSettings, realFtuPing;
+  var MockFtuPing = {
+    ensurePing: function(){}
+  };
+
+  suiteSetup(function() {
+    realFtuPing = window.FtuPing;
+    realAsyncStorage = window.asyncStorage;
+    realMozSettings = navigator.mozSettings;
+    window.asyncStorage = MockasyncStorage;
+    navigator.mozSettings = MockNavigatorSettings;
+    window.FtuPing = MockFtuPing;
+
+  });
+
+  suiteTeardown(function() {
+    window.asyncStorage = realAsyncStorage;
+    navigator.mozSettings = realMozSettings;
+    window.FtuPing = realFtuPing;
+  });
+
+  suite('ftu.enabled >', function() {
+    setup(function() {
+      navigator.mozSettings.mSettings['deviceinfo.os'] = '2.0.1.whatever';
+    });
+    test('launch when enabled (upgrade)', function(done) {
+      MockasyncStorage.mItems['ftu.enabled'] = true;
+      navigator.mozSettings
+        .mSettings['deviceinfo.previous_os'] = '1.4.1.whatever';
+      function onOutcome(name) {
+        assert.equal(name, 'launch', 'FtuLauncher.launch was called');
+        done();
+      }
+      this.sinon.stub(FtuLauncher, 'launch', function() {
+        onOutcome('launch');
+      });
+      this.sinon.stub(FtuLauncher, 'skip', function() {
+        onOutcome('skip');
+      });
+      FtuLauncher.retrieve();
+    });
+    test('launch when enabled (no upgrade)', function(done) {
+      MockasyncStorage.mItems['ftu.enabled'] = true;
+      navigator.mozSettings
+        .mSettings['deviceinfo.previous_os'] = '2.0.1.whatever';
+      function onOutcome(name) {
+        assert.equal(name, 'launch', 'FtuLauncher.launch was called');
+        done();
+      }
+      this.sinon.stub(FtuLauncher, 'launch', function() {
+        onOutcome('launch');
+      });
+      this.sinon.stub(FtuLauncher, 'skip', function() {
+        onOutcome('skip');
+      });
+      FtuLauncher.retrieve();
+    });
+    test('dont launch when not enabled (no upgrade)', function(done) {
+      MockasyncStorage.mItems['ftu.enabled'] = false;
+      navigator.mozSettings
+        .mSettings['deviceinfo.previous_os'] = '2.0.1.whatever';
+      function onOutcome(name) {
+        assert.equal(name, 'skip', 'FtuLauncher.skip was called');
+        done();
+      }
+      this.sinon.stub(FtuLauncher, 'launch', function() {
+        onOutcome('launch');
+      });
+      this.sinon.stub(FtuLauncher, 'skip', function() {
+        onOutcome('skip');
+      });
+      FtuLauncher.retrieve();
+    });
+    test('launch when not enabled (upgrade)', function(done) {
+      MockasyncStorage.mItems['ftu.enabled'] = false;
+      navigator.mozSettings
+        .mSettings['deviceinfo.previous_os'] = '1.4.1.whatever';
+      function onOutcome(name) {
+        assert.equal(name, 'launch', 'FtuLauncher.launch was called');
+        done();
+      }
+      this.sinon.stub(FtuLauncher, 'launch', function() {
+        onOutcome('launch');
+      });
+      this.sinon.stub(FtuLauncher, 'skip', function() {
+        onOutcome('skip');
+      });
+      FtuLauncher.retrieve();
+    });
+  });
+
+  suite('whats new ftu >', function() {
+    setup(function() {
+      MockasyncStorage.mItems['ftu.enabled'] = false;
+      var mockSettings = navigator.mozSettings.mSettings;
+      mockSettings['deviceinfo.previous_os'] = '1.3.0.prerelease';
+      mockSettings['deviceinfo.os'] = '2.0.1.whatever';
+    });
+
+    test(' upgrade tutorial launched', function(done) {
+      function onOutcome(name) {
+        assert.equal(name, 'launch', 'FtuLauncher.launch was called');
+        done();
+      }
+      this.sinon.stub(FtuLauncher, 'launch', function() {
+        onOutcome('launch');
+      });
+      this.sinon.stub(FtuLauncher, 'skip', function() {
+        onOutcome('skip');
+      });
+      FtuLauncher.retrieve();
+    });
+  });
+});

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -40,6 +40,7 @@
    "deviceinfo.hardware": "",
    "deviceinfo.mac": "",
    "deviceinfo.os": "",
+   "deviceinfo.previous_os": "",
    "deviceinfo.platform_build_id": "",
    "deviceinfo.platform_version": "",
    "deviceinfo.product_model": "",

--- a/shared/js/version_helper.js
+++ b/shared/js/version_helper.js
@@ -1,0 +1,136 @@
+/* global Promise */
+/* exported VersionHelper */
+'use strict';
+
+(function(exports) {
+
+  // Helper to work with version strings
+  // e.g. 2.0.0.1-prerelease becomes { major: 2, minor: 0 }
+  function Version(str) {
+    str = str || '0.0';
+    var parts = str.split('.');
+    this.major = parts[0];
+    this.minor = parts[1];
+    this.toString = function() {
+      return '' + str;
+    };
+  }
+
+  function InfoResult(current, previous) {
+    this.current = current;
+    this.previous = previous;
+  }
+
+  InfoResult.prototype.isUpgrade = function() {
+    var prev = this.previous,
+        curr = this.current,
+        isUpgrade = false;
+    // dont treat lack of previous version info as an upgrade
+    if (prev && curr) {
+      isUpgrade = curr.major > prev.major || curr.minor > prev.minor;
+    }
+    return isUpgrade;
+  };
+
+  InfoResult.prototype.delta = function() {
+    var prev = this.previous,
+        curr = this.current;
+    var delta = '';
+
+    if (prev) {
+      delta += prev.major + '.' +prev.minor;
+    }
+    delta += '..';
+    if (curr) {
+      delta += curr.major + '.' + curr.minor;
+    }
+    return delta;
+  };
+
+  // Helper to get settings
+  function getSetting(setting, cb, errback) {
+    var req = navigator.mozSettings.createLock().get(setting);
+    req.onsuccess = function() {
+      var value = req.result[setting];
+      if(typeof cb === 'function') {
+        cb(value);
+      }
+    };
+    req.onerror = function() {
+      if(typeof errback === 'function') {
+        errback(req.error);
+      }
+    };
+  }
+
+  function getCurrent() {
+    return new Promise(function(resolve, reject) {
+      getSetting('deviceinfo.os', function(value) {
+        resolve(value ? new Version(value) : null);
+      }, function(err) {
+        reject(err);
+      });
+    });
+  }
+
+  function getPrevious() {
+    return new Promise(function(resolve, reject) {
+      // XXX: we return null version when previous_os lookup fails
+      getSetting('deviceinfo.previous_os', function(value) {
+        resolve(value ? new Version(value) : null);
+      }, function(err) {
+        resolve(null);
+      });
+    });
+  }
+
+  function updatePrevious(str) {
+    var currentPromise = str ? Promise.resolve(new Version(str)) :
+                                getCurrent();
+    var setPromise = new Promise(function(resolve, reject) {
+      currentPromise.then(function(version) {
+        // guard against empty deviceinfo.os
+        if (version) {
+          var req = navigator.mozSettings.createLock().set({
+            'deviceinfo.previous_os': version.toString()
+          });
+          req.onsuccess = function() {
+            resolve(version);
+          };
+          req.onerror = function() {
+            var reason = req.error;
+            reject(reason);
+          };
+        } else {
+          resolve(null);
+        }
+      }, function(err) {
+        reject('Error getting previous version: ', err);
+      });
+    });
+    return setPromise;
+  }
+
+  function getVersionInfo() {
+    var info = new InfoResult();
+    var infoPromise = new Promise(function(resolve, reject) {
+      Promise.all([
+        getCurrent().then(function(version) {
+          info.current = version;
+        }),
+        getPrevious().then(function(version) {
+          info.previous = version;
+        })
+      ]).then(function() {
+        resolve(info);
+      }, reject);
+    });
+    return infoPromise;
+  }
+
+  exports.VersionHelper = {
+    updatePrevious: updatePrevious,
+    getVersionInfo: getVersionInfo
+  };
+
+})(window);


### PR DESCRIPTION
- Add shared VersionHelper
- Unit tests for VersionHelper, FTULauncher
- Check and set device.previous_os in FTULauncher/FTU app
- Launch full ftu when ftu.enabled always
- Launch 'whats new' ftu tutorial when upgrade detected
- Add config for 1.3-2.0 and 1.4-2.0 upgrade tutorial
