### PR TITLE
Bug 1021096 - The built-in keyboard app icon is present on the vertical homescreen, but should not be there

### DIFF
--- a/apps/verticalhome/js/app.js
+++ b/apps/verticalhome/js/app.js
@@ -4,7 +4,7 @@
 (function(exports) {
 
   // Hidden manifest roles that we do not show
-  const HIDDEN_ROLES = ['system', 'keyboard', 'homescreen', 'search'];
+  const HIDDEN_ROLES = ['system', 'input', 'homescreen', 'search'];
 
   function App() {
     this.scrollable = document.querySelector('.scrollable');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1021096
