### PR TITLE
Bug 1021592 - Update wifi_test.js of Gaia unit tests to be compatible with WebIDL migration on Alarm API.

### DIFF
--- a/apps/system/test/unit/wifi_test.js
+++ b/apps/system/test/unit/wifi_test.js
@@ -97,6 +97,13 @@ suite('WiFi > ', function() {
     });
     navigator.mozPower = MockMozPower;
 
+    // Ensure |navigator| has property |mozAlarm| to create sinon stubs.
+    if (!navigator.hasOwnProperty('mozAlarms')) {
+      Object.defineProperty(navigator, 'mozAlarms', {
+        writable: true
+      });
+    }
+
     requireApp('system/js/wifi.js', done);
   });
 


### PR DESCRIPTION
Bug 1021592 - Update wifi_test.js of Gaia unit tests to be compatible with WebIDL migration on Alarm API.
