### PR TITLE
Bug 1020045 - Turn on APZ overscrolling by default. r=kats

### DIFF
--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -11,7 +11,7 @@
    "app.update.interval": 86400,
    "app.update.url": "",
    "apz.force-enable": true,
-   "apz.overscroll.enabled": false,
+   "apz.overscroll.enabled": true,
    "audio.volume.alarm": 15,
    "audio.volume.bt_sco": 15,
    "audio.volume.dtmf": 15,


### PR DESCRIPTION
Patch has r+ at https://bugzilla.mozilla.org/show_bug.cgi?id=1020045
