### PR TITLE
Bug 1021942 - Transition away from using entity.textContent in Calendar l10n

### DIFF
--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -88,10 +88,9 @@ drawer-sync-button=Sync
 # sync
 
 sync-frequency=Sync Calendar
-sync-frequency-manual.textContent=Manually
-sync-frequency-15min.textContent=15 min
-sync-frequency-30min.textContent=30 min
-sync-frequency-hourly.textContent=Each hour
+sync-frequency-15min=15 min
+sync-frequency-30min=30 min
+sync-frequency-manual=Manually
 
 # alarms for event view/edit
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1021942
