### PR TITLE
Bug 1021946 - Transition away from using entity.textContent in Email l10n

### DIFF
--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -302,7 +302,7 @@ default-attachment-filename=attachment{{ n }}
 
 attachment-size-kib={{kilobytes}}K
 
-message-attachment-view.textContent=View
+message-attachment-view=View
 
 message-attachment-too-large=This file is too large to download.
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1021946
