### PR TITLE
Bug 1011482 - add value and compositeKey for alt

### DIFF
--- a/apps/keyboard/js/keyboard/layout_loader.js
+++ b/apps/keyboard/js/keyboard/layout_loader.js
@@ -9,10 +9,10 @@ var Keyboards = {};
 
 Keyboards.alternateLayout = {
   alt: {
-    '0': ['º'],
-    '$': ['€', '£', '¥'],
-    '?': ['¿'],
-    '!': ['¡']
+    '0': [ { value: 'º' } ],
+    '$': [ { value: '€' }, { value: '£' }, { value: '¥' } ],
+    '?': [ { value: '¿' } ],
+    '!': [ { value: '¡' } ]
   },
   keys: [
     [
@@ -182,6 +182,15 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
           // No spaces, so all of the alternatives are single characters
           alternatives = alternatives.split('');
         }
+
+        for (var i = 0; i < alternatives.length; i++) {
+          if (alternatives[i].length > 1) {
+            alternatives[i] = { value: alternatives[i],
+              compositeKey: alternatives[i] };
+          } else {
+            alternatives[i] = { value: alternatives[i] };
+          }
+        }
       }
 
       alt[key] = alternatives;
@@ -192,8 +201,8 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
         // Creating an array for upper case too.
         // XXX: The original code does not respect layout.upperCase here.
         alt[upperCaseKey] = alternatives.map(function(key) {
-          if (key.length === 1) {
-            return key.toUpperCase();
+          if (key.value.length === 1) {
+            return { 'value': key.value.toUpperCase() };
           }
 
           // The 'l·l' key in the Catalan layout needs to be
@@ -207,11 +216,12 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
           // (e.g. R$ key) we should be able to skip this.
           needDifferentUpperCaseLockedAlternatives =
             needDifferentUpperCaseLockedAlternatives ||
-            (key.substr(1).toUpperCase() !== key.substr(1));
+            (key.value.substr(1).toUpperCase() !== key.value.substr(1));
 
           // We only capitalize the first character of the key in
           // the normalization here.
-          return key[0].toUpperCase() + key.substr(1);
+          var compositeKey = key.value[0].toUpperCase() + key.value.substr(1);
+          return { 'value': compositeKey, 'compositeKey': compositeKey };
         });
 
         // If we really need an special upper case locked alternatives,
@@ -220,7 +230,8 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
         // can't be represented in JSON so it's not visible in JSON.stringify().
         if (needDifferentUpperCaseLockedAlternatives) {
           alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
-            return key.toUpperCase();
+            var compositeKey = key.value.toUpperCase();
+            return { 'value': compositeKey, 'compositeKey': compositeKey };
           });
         }
       }

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -648,8 +648,24 @@ const IMERender = (function() {
       content.appendChild(
         buildKey(alt, '', width + 'px', dataset, null, attributeList));
     });
+    var allAltKeys = content.children;
+    var numberAllAltKeys = allAltKeys.length;
+    if (numberAllAltKeys > 5 && numberAllAltKeys < 19) {
+      var breakPosition = Math.floor(allAltKeys.length / 2);
+
+      // Fix min-width
+      allAltKeys[breakPosition].style.minWidth = '4.2rem';
+      allAltKeys[breakPosition + 1].style.minWidth = '4.2rem';
+
+      var breakBefore = allAltKeys[breakPosition];
+      content.insertBefore(document.createElement('br'), breakBefore);
+
+    }
+
     menu.innerHTML = '';
     menu.appendChild(content);
+    menu.style.lineHeight = '0rem';
+    menu.style.textAlign = 'left';
 
     // Replace with the container
     _altContainer = document.createElement('div');
@@ -666,6 +682,13 @@ const IMERender = (function() {
       .querySelectorAll('.visual-wrapper > span')[0]
       .appendChild(menu);
     menu.style.display = 'block';
+    if (numberAllAltKeys > 5 && numberAllAltKeys < 19) {
+      menu.style.top = '-12rem';
+      menu.style.height = '12rem';
+    } else {
+      menu.style.top = '-6rem';
+      menu.style.height = '6rem';
+    }
 
     function getWindowLeft(obj) {
       var left;

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -614,12 +614,15 @@ const IMERender = (function() {
 
     // Build a key for each alternative
     altChars.forEach(function(alt, index) {
-      var dataset = alt.length == 1 ?
-        [
-          { 'key': 'keycode', 'value': alt.charCodeAt(0) },
-          { 'key': 'keycodeUpper', 'value': alt.toUpperCase().charCodeAt(0) }
-        ] :
-        [{'key': 'compositeKey', 'value': alt}];
+      var dataset;
+      if (alt.compositeKey) {
+        dataset = [{ 'key': 'compositeKey', 'value': alt.compositeKey }];
+      } else {
+        dataset = [
+           { 'key': 'keycode', 'value': alt.value.charCodeAt(0) },
+           { 'key': 'keycodeUpper',
+             'value': alt.value.toUpperCase().charCodeAt(0) }];
+      }
 
       // Make each of these alternative keys 75% as wide as the key that
       // it is an alternative for, but adjust for the relative number of
@@ -646,7 +649,7 @@ const IMERender = (function() {
       });
 
       content.appendChild(
-        buildKey(alt, '', width + 'px', dataset, null, attributeList));
+        buildKey(alt.value, '', width + 'px', dataset, null, attributeList));
     });
     var allAltKeys = content.children;
     var numberAllAltKeys = allAltKeys.length;


### PR DESCRIPTION
Alternative keys can be represent as
- `'€£'` when all alternative is a single character,
- `'€ R$'` when at least one alternative is a compositeKey and
- `[{value: '€', compositeKey: '\\Euro'}, {value: '£', compositeKey:
  '\\textsterling'}]` when at least one alternative is a
  compositeKey different from the value/label to be show at the
  keyboard.
