### PR TITLE
Bug 1019426 - When searching in the Address Book from the Dialer a white tab is shown over the keyboard r=rik

### DIFF
--- a/apps/communications/dialer/style/toolbar.css
+++ b/apps/communications/dialer/style/toolbar.css
@@ -93,3 +93,8 @@
 #contacts-view .bb-tabpanel {
   height: calc(100% - 4.5rem);
 }
+
+/* Avoid showing the toolbar line when searching contacts*/
+.with-keyboard .bb-tablist:before {
+  bottom: 0rem;
+}


### PR DESCRIPTION
When keyboard is enabled we should'nt display the toolbar delimitator 4.5 rem from bottom
