### PR TITLE
 Bug 1023045 - [Settings][Ringtone][V2.0] The "<" icon of

### DIFF
--- a/apps/ringtones/js/manage.js
+++ b/apps/ringtones/js/manage.js
@@ -14,8 +14,9 @@
     var activity = new MozActivity({
       name: 'configure',
       data: {
-        target: 'device',
-        section: 'sound'
+        target: 'device'
+        // No need to specify section here, because we assume settings app
+        // is already launched (caller of this app), and we could go back to it.
       }
     });
   });


### PR DESCRIPTION
 sound settings page becomes "X" icon after back from ringtone app.
- Don't specify "section" when invoking the settings app activity.
