### PR TITLE
Bug 1022527 - [B2G][Email] address in bcc field will be truncated

### DIFF
--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -69,10 +69,6 @@ input.cmp-addr-text, input.cmp-dot-text {
   max-width: 100%;
 }
 
-input.cmp-bcc-text {
-  font-size: 1.6rem;
-}
-
 input.cmp-subject-text {
   display: table-cell;
   font-size: 1.6rem;


### PR DESCRIPTION
Just forgot an errant style for bcc only in the 2.0 refresh. the to and cc fields were fine.
