### PR TITLE
Bug 1023631 - [collections] Smart collections should still display even if we cannot fetch the background image

### DIFF
--- a/apps/collection/js/view_collection.js
+++ b/apps/collection/js/view_collection.js
@@ -80,7 +80,10 @@
         } else {
           // TODO show default image?
         }
-      }, error)
+      }, function() {
+        // Bug 1023631 - Do not fail when BGImage can't be loaded
+        // TODO show default image?
+      })
       .catch(fail);
   }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1023631
