### PR TITLE
Bug 1023312 - [Vertical homescreen] Smart collection viewing fails on th...

### DIFF
--- a/shared/js/everythingme/api.js
+++ b/shared/js/everythingme/api.js
@@ -133,8 +133,11 @@
         return Request('Search', 'suggestions', options);
       },
       bgimage: function bgimage(options) {
-        options.width = eme.device.screen.width;
-        options.height = eme.device.screen.height;
+        // Some devices contain fractions in dimensions
+        // which the eme api server does not accept
+        // so Math.ceil (http://bugzil.la/1023312)
+        options.width = Math.ceil(eme.device.screen.width);
+        options.height = Math.ceil(eme.device.screen.height);
 
         return Request('Search', 'bgimage', options);
       }


### PR DESCRIPTION
...e flame because e.me server fails to return background. [r=amirn]

http://bugzil.la/1023312
