### PR TITLE
Bug 1017614 - [gaia_dialer] DTMF will never be stopped once the max length of pone number inputed on a call

### DIFF
--- a/apps/communications/dialer/test/unit/keypad_test.js
+++ b/apps/communications/dialer/test/unit/keypad_test.js
@@ -303,6 +303,23 @@ suite('dialer/keypad', function() {
           this.sinon.clock.tick(1);
           sinon.assert.calledTwice(MockNavigatorMozTelephony.stopTone);
         });
+
+        test('should stop DTMF tone when the max length phoneNumber reached',
+          function() {
+            MockSettingsListener.mCallbacks['phone.dtmf.type']('long');
+
+            for (var index = 0; index < 50; index++) {
+              subject._touchStart('1');
+              this.sinon.clock.tick(200);
+              subject._touchEnd('1');
+            }
+
+            subject._touchStart('1');
+            this.sinon.spy(MockNavigatorMozTelephony, 'stopTone');
+            this.sinon.clock.tick(1000);
+            subject._touchEnd('1');
+            sinon.assert.calledOnce(MockNavigatorMozTelephony.stopTone);
+        });
       });
 
       suite('then during a conference group', function() {

--- a/shared/js/dialer/keypad.js
+++ b/shared/js/dialer/keypad.js
@@ -528,6 +528,10 @@ var KeypadManager = {
 
     // If user input number more 50 digits, app shouldn't accept.
     if (key != 'delete' && this._phoneNumber.length >= 50) {
+      if (key == this._lastPressedKey && this._dtmfTone) {
+        this._stopDtmfTone();
+        this._lastPressedKey = null;
+      }
       return;
     }
 


### PR DESCRIPTION
Under the current processing mechanism of long type dtmf tone, we should force to _stopDtmfTone to stop dtmf tone once input number reached 50 and to reset _lastPressedKey as null at the same time.
