### PR TITLE
Bug 933192 - [Settings] can join hidden wifi network without ssid name r=ejchen

### DIFF
--- a/apps/ftu/js/ui.js
+++ b/apps/ftu/js/ui.js
@@ -147,13 +147,16 @@ var UIManager = {
     this.hiddenWifiSecurity.addEventListener('change', this);
     this.wifiJoinButton.disabled = true;
 
-    this.hiddenWifiPassword.addEventListener('keyup', function() {
-      this.wifiJoinButton.disabled = !WifiHelper.isValidInput(
-        this.hiddenWifiSecurity.value,
-        this.hiddenWifiPassword.value,
-        this.hiddenWifiIdentity.value
-      );
-    }.bind(this));
+    // check the 'hidden-wifi-ssid','hidden-wifi-identity',
+    // 'hidden-wifi-password' input everytime they are changed.
+    this.hiddenWifiSsid.addEventListener('keyup',
+      this.enableJoinButton.bind(this));
+
+    this.hiddenWifiIdentity.addEventListener('keyup',
+      this.enableJoinButton.bind(this));
+
+    this.hiddenWifiPassword.addEventListener('keyup',
+      this.enableJoinButton.bind(this));
 
     this.hiddenWifiShowPassword.onchange = function togglePasswordVisibility() {
       UIManager.hiddenWifiPassword.type = this.checked ? 'text' : 'password';
@@ -248,6 +251,19 @@ var UIManager = {
       window.addEventListener(event,
         this.showActivationScreenToScreenReader.bind(this));
     }, this);
+  },
+
+  // disable the 'Join' button when any of the fields are not valid
+  // the password is too short.
+  // the ssid name is null.
+  // the user name is null.
+  enableJoinButton: function ui_enableJoinButton() {
+    this.wifiJoinButton.disabled = !WifiHelper.isValidInput(
+      this.hiddenWifiSecurity.value,
+      this.hiddenWifiPassword.value,
+      this.hiddenWifiIdentity.value,
+      this.hiddenWifiSsid.value
+    );
   },
 
   scrollToElement: function ui_scrollToElement(container, element) {
@@ -361,6 +377,10 @@ var UIManager = {
         break;
       case 'hidden-wifi-security':
         var securityType = event.target.value;
+        // everytime the securityType changed, we must check if the account
+        // inputed is validate and modify the status of the join button
+        // according to the return value of function isValidInput.
+        this.enableJoinButton();
         WifiUI.handleHiddenWifiSecurity(securityType);
         break;
       // Date & Time

--- a/apps/settings/js/wifi.js
+++ b/apps/settings/js/wifi.js
@@ -816,13 +816,14 @@ navigator.mozL10n.once(function wifiSettings() {
         description = dialog.querySelector('li.server-certificate-description');
       }
 
+      var ssid = dialog.querySelector('input[name=ssid]');
+      var ssidStr = ssid.value;
       if (dialogID === 'wifi-joinHidden') {
         network.hidden = true;
 
         // Make sure ssid length is less then 32 bytes.
-        var ssid = dialog.querySelector('input[name=ssid]');
         ssid.oninput = function() {
-          var ssidStr = ssid.value;
+          ssidStr = ssid.value;
           // Non-ASCII chars in SSID will be encoded by UTF-8, and length of
           // each char might be longer than 1 byte.
           // Use encodeURIComponent() to encode ssid, then calculate correct
@@ -831,17 +832,21 @@ navigator.mozL10n.once(function wifiSettings() {
                 .length > 32) {
             ssid.value = ssidStr.substring(0, ssidStr.length - 1);
           }
+          // disable the "OK" button if the password is too short
+          // or the name is null.
+          dialog.querySelector('button[type=submit]').disabled =
+            !WifiHelper.isValidInput(key, password.value, identity.value,
+              ssidStr, eap.value);
         };
       }
 
       // disable the "OK" button if the password is too short
+      // or the name is null.
       if (password) {
         var checkPassword = function checkPassword() {
           dialog.querySelector('button[type=submit]').disabled =
-            !WifiHelper.isValidInput(key,
-                                     password.value,
-                                     identity.value,
-                                     eap.value);
+            !WifiHelper.isValidInput(key, password.value, identity.value,
+              ssidStr, eap.value);
         };
         eap.onchange = function() {
           checkPassword();

--- a/shared/js/wifi_helper.js
+++ b/shared/js/wifi_helper.js
@@ -95,7 +95,7 @@ var WifiHelper = {
     return key === curkey;
   },
 
-  isValidInput: function(key, password, identity, eap) {
+  isValidInput: function(key, password, identity, ssid, eap) {
     function isValidWepKey(password) {
       switch (password.length) {
         case 5:
@@ -113,9 +113,13 @@ var WifiHelper = {
       }
     }
 
+    // either ssid or the password is null,return false
+    if (!ssid || !password ) {
+      return false;
+    }
     switch (key) {
       case 'WPA-PSK':
-        if (!password || password.length < 8) {
+        if (password.length < 8 ) {
           return false;
         }
         break;
@@ -128,7 +132,7 @@ var WifiHelper = {
           case 'TTLS':
             /* falls through */
           default:
-            if (!password || password.length < 1 ||
+            if (password.length < 1 ||
                 !identity || identity.length < 1) {
               return false;
             }
@@ -136,7 +140,7 @@ var WifiHelper = {
         }
         break;
       case 'WEP':
-        if (!password || !isValidWepKey(password)) {
+        if (!isValidWepKey(password)) {
           return false;
         }
         break;


### PR DESCRIPTION
a)target:prevent from joining hidden wifi network if any of the  fields are not valid:1)the ssid name2)the user name 3)the password
b)scheme:
three js files are modified during the process:shared/js/wifi_helper.js, apps/ftu/js/ui.js, apps/settings/js/wifi.js,
1)in shared/js/wifi_helper.js:
Parameter ssid is added in function isValidInput
2)apps/ftu/js/ui.js:
beside 'password' text,we also add event listener  to 'ssid' and 'user name' text boxes .the above three listeners could listen for any changes happened in the three text boxes and then disable or enable the join button
3)apps/settings/js/wifi.js:
beside 'password' text,we also add event listener  to 'ssid' text box .the above two listeners could listen for any changes happened in the two text boxes and then disable or enable the ok button
