### PR TITLE
Bug 837677 - [e-mail] Implement new startup loading events

### DIFF
--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -16,6 +16,7 @@ var templateNode = require('tmpl!./compose.html'),
     cmpSendFailedConfirmNode = require('tmpl!./cmp/send_failed_confirm.html'),
     cmpSendingContainerNode = require('tmpl!./cmp/sending_container.html'),
     msgAttachConfirmNode = require('tmpl!./msg/attach_confirm.html'),
+    evt = require('evt'),
     common = require('mail_common'),
     Toaster = common.Toaster,
     model = require('model'),
@@ -160,6 +161,13 @@ function ComposeCard(domNode, mode, args) {
   this.playSoundOnSend = false;
 }
 ComposeCard.prototype = {
+  /**
+   * Inform Cards to not emit startup content events, this card will trigger
+   * them once data from back end has been received and the DOM is up to date
+   * with that data.
+   * @type {Boolean}
+   */
+  skipEmitContentEvents: true,
 
   /**
    * Focus our contenteditable region and position the cursor at the last
@@ -317,6 +325,14 @@ ComposeCard.prototype = {
         'noninteractive',
         /* no click handler because no navigation desired */ null);
       this.htmlIframeNode = ishims.iframe;
+    }
+
+    // There is a bit more possibility of async work done in the iframeShims
+    // internals, but this is close enough and is better than breaking open
+    // the internals of the iframeShims to get the final number.
+    if (!this._emittedContentEvents) {
+      evt.emit('metrics:contentDone');
+      this._emittedContentEvents = true;
     }
   },
 

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -228,6 +228,7 @@ function MessageListCard(domNode, mode, args) {
 
   this.curFolder = null;
   this.isIncomingFolder = true;
+  this._emittedContentEvents = false;
 
   this.usingCachedNode = !!args.cachedNode;
 
@@ -384,6 +385,14 @@ MessageListCard.prototype = {
   _distanceBetweenMessages: 0,
 
   sliceEvents: ['splice', 'change', 'status', 'complete'],
+
+  /**
+   * Inform Cards to not emit startup content events, this card will trigger
+   * them once data from back end has been received and the DOM is up to date
+   * with that data.
+   * @type {Boolean}
+   */
+  skipEmitContentEvents: true,
 
   postInsert: function() {
     this._hideSearchBoxByScrolling();
@@ -830,6 +839,16 @@ MessageListCard.prototype = {
     // so we must do this.)  If our list size is the same, this call is
     // effectively a no-op.
     this.vScroll.updateDataBind(0, [], 0);
+
+
+    // Inform that content is ready. There could actually be a small delay with
+    // vScroll.updateDataBind from rendering the final display, but it is small
+    // enough that it is not worth trying to break apart the design to
+    // accommodate this metrics signal.
+    if (!this._emittedContentEvents) {
+      evt.emit('metrics:contentDone');
+      this._emittedContentEvents = true;
+    }
   },
 
   onNewMail: function(newEmailCount) {

--- a/apps/email/js/cards/message_reader.js
+++ b/apps/email/js/cards/message_reader.js
@@ -76,6 +76,7 @@ function MessageReaderCard(domNode, mode, args) {
   this._on('msg-envelope-bar', 'click', 'onEnvelopeClick');
   this._on('msg-reader-load-infobar', 'click', 'onLoadBarClick');
 
+  this._emittedContentEvents = false;
   this.disableReply();
 
   this.scrollContainer =
@@ -106,6 +107,14 @@ MessageReaderCard.prototype = {
     REPLY: 8,
     NEW_MESSAGE: 16
   },
+
+  /**
+   * Inform Cards to not emit startup content events, this card will trigger
+   * them once data from back end has been received and the DOM is up to date
+   * with that data.
+   * @type {Boolean}
+   */
+  skipEmitContentEvents: true,
 
   // Method to help bind event listeners to method names, and ensures
   // a header object before activating the method, to protect the buttons
@@ -973,6 +982,13 @@ MessageReaderCard.prototype = {
   enableReply: function() {
     var btn = this.domNode.getElementsByClassName('msg-reply-btn')[0];
     btn.removeAttribute('aria-disabled');
+
+    // Inform that content is ready. Done here because reply is only enabled
+    // once the full body is available.
+    if (!this._emittedContentEvents) {
+      evt.emit('metrics:contentDone');
+      this._emittedContentEvents = true;
+    }
   },
 
   die: function() {

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -74,6 +74,7 @@ var appMessages = require('app_messages'),
     activityCallback = null;
 
 require('shared/js/font_size_utils');
+require('metrics');
 require('sync');
 require('wake_locks');
 

--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -2,11 +2,12 @@
  * UI infrastructure code and utility code for the gaia email app.
  **/
 /*jshint browser: true */
-/*global define, console */
+/*global define, console, startupCacheEventsSent */
 'use strict';
 define(function(require, exports) {
 
 var Cards, Toaster,
+    evt = require('evt'),
     mozL10n = require('l10n!'),
     toasterNode = require('tmpl!./cards/toaster.html'),
     confirmDialogTemplateNode = require('tmpl!./cards/confirm_dialog.html'),
@@ -173,6 +174,13 @@ Cards = {
    * cleanup, like DOM removal.
    */
   _transitionCount: 0,
+
+  /**
+   * Tracks if startup events have been emitted. The events only need to be
+   * emitted once.
+   * @type {Boolean}
+   */
+  _startupEventsEmitted: false,
 
   /**
    * Is a tray card visible, suggesting that we need to intercept clicks in the
@@ -843,9 +851,7 @@ Cards = {
       removeClass(beginNode, 'no-anim');
       removeClass(endNode, 'no-anim');
 
-      if (cardInst && cardInst.cardImpl.onCardVisible) {
-        cardInst.cardImpl.onCardVisible();
-      }
+      this._onCardVisible(cardInst);
     }
 
     // Hide toaster while active card index changed:
@@ -914,8 +920,7 @@ Cards = {
         afterTransitionAction();
       }
 
-      if (activeCard.cardImpl.onCardVisible)
-        activeCard.cardImpl.onCardVisible();
+      this._onCardVisible(activeCard);
 
       // If the card has next cards that can be preloaded, load them now.
       // Use of nextCards should be balanced with startup performance.
@@ -929,6 +934,44 @@ Cards = {
           return 'cards/' + id;
         }));
       }
+    }
+  },
+
+  /**
+   * Handles final notification of card visibility in the stack.
+   * @param  {Card} cardInst the card instance.
+   */
+  _onCardVisible: function(cardInst) {
+    if (cardInst.cardImpl.onCardVisible) {
+      cardInst.cardImpl.onCardVisible();
+    }
+    this._emitStartupEvents(cardInst.cardImpl.skipEmitContentEvents);
+  },
+
+  /**
+   * Handles emitting startup events used for performance tracking.
+   * @param  {Boolean} skipEmitContentEvents if content events should be skipped
+   * because the card itself handles it.
+   */
+  _emitStartupEvents: function(skipEmitContentEvents) {
+    if (!this._startupEventsEmitted) {
+      if (startupCacheEventsSent) {
+        // Cache already loaded, so at this point the content shown is wired
+        // to event handlers.
+        window.dispatchEvent(new CustomEvent('moz-content-interactive'));
+      } else {
+        // Cache was not used, so only now is the chrome dom loaded.
+        window.dispatchEvent(new CustomEvent('moz-chrome-dom-loaded'));
+      }
+      window.dispatchEvent(new CustomEvent('moz-chrome-interactive'));
+
+      // If a card that has a simple static content DOM, content is complete.
+      // Otherwise, like message_list, need backend data to call complete.
+      if (!skipEmitContentEvents) {
+        evt.emit('metrics:contentDone');
+      }
+
+      this._startupEventsEmitted = true;
     }
   },
 

--- a/apps/email/js/metrics.js
+++ b/apps/email/js/metrics.js
@@ -1,0 +1,52 @@
+/*global startupCacheEventsSent */
+'use strict';
+
+/**
+ * Handles sending out metrics, since final states are distributed across cards
+ * and their interior actions. Need something to coordinate the completion of
+ * certain states to know when to emit the right events. Used right now for:
+ * https://developer.mozilla.org/en-US/Apps/Build/Performance/Firefox_OS_app_responsiveness_guidelines
+ *
+ * Events tracked:
+ *
+ * apiDone: triggered when app knows data is flowing back and forth from the
+ * worker.
+ *
+ * contentDone: when a card's content is completely available. This includes
+ * any parts that were needed
+ */
+define(function(require) {
+  var evt = require('evt'),
+      apiDone = false,
+      contentDone = false;
+
+  function checkAppLoaded() {
+    if (apiDone && contentDone) {
+      window.dispatchEvent(new CustomEvent('moz-app-loaded'));
+    }
+  }
+
+  // Event listeners. Note they all unsubscribe after the first reception of
+  // that kind of event. This is because cards, who can have multiple instances,
+  // can emit the events throughout the lifetime of the app, and for the
+  // purposes of the startup events, they only need to be done once on startup.
+  evt.once('metrics:apiDone', function onApiDone() {
+    apiDone = true;
+    checkAppLoaded();
+  });
+
+  evt.once('metrics:contentDone', function() {
+    contentDone = true;
+
+    // Only need to dispatch these events if the startup cache was not used.
+    if (!startupCacheEventsSent) {
+      // Now that content is in, it is visually complete, and content is
+      // interactive, since event listeners are bound as part of content
+      // insertion.
+      window.dispatchEvent(new CustomEvent('moz-app-visually-complete'));
+      window.dispatchEvent(new CustomEvent('moz-content-interactive'));
+    }
+
+    checkAppLoaded();
+  });
+});

--- a/apps/email/js/model.js
+++ b/apps/email/js/model.js
@@ -162,6 +162,11 @@ define(function(require) {
 
           this.inited = true;
           this._callEmit('acctsSlice');
+
+          // Once the API/worker has started up and we have received account
+          // data, consider the app fully loaded: we have verified full flow
+          // of data from front to back.
+          evt.emit('metrics:apiDone');
         }).bind(this);
       }.bind(this));
     },

--- a/tests/performance/startup_events_test.js
+++ b/tests/performance/startup_events_test.js
@@ -12,6 +12,7 @@ var whitelistedApps = [
   'communications/contacts',
   'camera',
   'clock',
+  'email',
   'fm',
   'settings',
   'sms',
@@ -20,6 +21,7 @@ var whitelistedApps = [
 
 var whitelistedUnifiedApps = [
   'communications/dialer',
+  'email',
   'fm',
   'settings'
 ];


### PR DESCRIPTION
Implements the startup events described here:

https://developer.mozilla.org/en-US/Apps/Build/Performance/Firefox_OS_app_responsiveness_guidelines

It can be tested locally on a flame device by running:

```
MARIONETTE_RUNNER_HOST=marionette-device-host APP=email make test-perf
```

I generated my test builds with this command:

```
make install-gaia GAIA_DEV_PIXELS_PER_PX=1.5 GAIA_OPTIMIZE=1 APP=email
```

Implementing these events is a bit more complicated by the HTML cookie cache, and I had to do a bit of extra work to make sure to only emit the events once, since the collection seemed to favor the last vs the first event of a given type for the final time recorded.

I also inlined the custom event work from performance_testing_helper.js in html_cache_restore.js, see the comments in html_cache_restore.js for why.

I opted to generate the moz-app-loaded final event after a complete load of the backend worker and reception of the account slice data for the accounts, which is fairly late, but gives us a good marker for the total cost of a the worker and a round trip of data.

Malformed JSON paste of times that were collected:

Without an account (Email FTU):

```
  "passes": [
    {
      "title": "startup > moz-chrome-dom-loaded",
      "fullTitle": "startup event test > email > startup > moz-chrome-dom-loaded",
      "duration": 76837,
      "mozPerfDurations": [
        224.32458300000872,
        744.5959890000013,
        298.87494700000025,
        240.39578100000108,
        310.6262499999975
      ],
      "mozPerfDurationsAverage": 363.76351000000176
    },
    {
      "title": "startup > moz-app-visually-complete",
      "fullTitle": "startup event test > email > startup > moz-app-visually-complete",
      "duration": 76837,
      "mozPerfDurations": [
        225.28640700000688,
        744.9126030000007,
        299.3934369999988,
        240.9975000000013,
        311.36057299999993
      ],
      "mozPerfDurationsAverage": 364.39010400000154
    },
    {
      "title": "startup > moz-content-interactive",
      "fullTitle": "startup event test > email > startup > moz-content-interactive",
      "duration": 76837,
      "mozPerfDurations": [
        957.2794790000044,
        1460.748020000001,
        1398.1640619999998,
        1391.5358849999993,
        1047.684009999999
      ],
      "mozPerfDurationsAverage": 1251.0822912000008
    },
    {
      "title": "startup > moz-chrome-interactive",
      "fullTitle": "startup event test > email > startup > moz-chrome-interactive",
      "duration": 76837,
      "mozPerfDurations": [
        957.6970840000067,
        1461.1032290000003,
        1398.8662489999988,
        1391.887396000002,
        1048.0585409999985
      ],
      "mozPerfDurationsAverage": 1251.5224998000012
    },
    {
      "title": "startup > moz-app-loaded",
      "fullTitle": "startup event test > email > startup > moz-app-loaded",
      "duration": 76837,
      "mozPerfDurations": [
        1191.188958000006,
        1702.594583,
        1596.8138010000002,
        1607.5775520000007,
        1882.1182809999973
      ],
      "mozPerfDurationsAverage": 1596.0586350000008
    },
    {
      "title": "startup time ",
      "fullTitle": "startup test > email > startup time ",
      "duration": 80611,
      "mozPerfDurations": [
        546,
        531,
        475,
        482,
        513
      ],
      "mozPerfDurationsAverage": 509.4,
```

With one account configured and messages already fetched:

```
  "passes": [
    {
      "title": "startup > moz-chrome-dom-loaded",
      "fullTitle": "startup event test > email > startup > moz-chrome-dom-loaded",
      "duration": 78130,
      "mozPerfDurations": [
        332.96067700000276,
        369.34093700000085,
        346.67401000000245,
        432.42333300000064,
        393.89791700000023
      ],
      "mozPerfDurationsAverage": 375.05937480000136
    },
    {
      "title": "startup > moz-app-visually-complete",
      "fullTitle": "startup event test > email > startup > moz-app-visually-complete",
      "duration": 78130,
      "mozPerfDurations": [
        333.37786400000186,
        369.8980730000003,
        347.1454160000012,
        434.17729099999997,
        394.85281300000133
      ],
      "mozPerfDurationsAverage": 375.89029140000093
    },
    {
      "title": "startup > moz-content-interactive",
      "fullTitle": "startup event test > email > startup > moz-content-interactive",
      "duration": 78130,
      "mozPerfDurations": [
        1134.2292710000002,
        1722.879374,
        1498.8807810000017,
        1520.0565619999998,
        1597.597656
      ],
      "mozPerfDurationsAverage": 1494.7287288000002
    },
    {
      "title": "startup > moz-chrome-interactive",
      "fullTitle": "startup event test > email > startup > moz-chrome-interactive",
      "duration": 78130,
      "mozPerfDurations": [
        1134.5842190000003,
        1723.3298430000013,
        1499.245885000002,
        1520.3983850000004,
        1597.9224480000012
      ],
      "mozPerfDurationsAverage": 1495.096156000001
    },
    {
      "title": "startup > moz-app-loaded",
      "fullTitle": "startup event test > email > startup > moz-app-loaded",
      "duration": 78130,
      "mozPerfDurations": [
        3069.631978999998,
        4166.218853,
        3342.605520000001,
        3761.483227999999,
        3879.7354680000008
      ],
      "mozPerfDurationsAverage": 3643.9350095999994
    },
    {
      "title": "startup time ",
      "fullTitle": "startup test > email > startup time ",
      "duration": 79475,
      "mozPerfDurations": [
        790,
        1246,
        1139,
        1342,
        855
      ],
      "mozPerfDurationsAverage": 1074.4,
```
