### PR TITLE
Bug 1013739 - [Dolphin][Flame][FFOS 1.4]Long touch the build-in keyboard

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -1589,6 +1589,8 @@ function hideKeyboard() {
   settingsPromiseManager.set({
     'keyboard.current': undefined
   });
+
+  clearTouchedKeys();
 }
 
 // Resize event handler
@@ -1759,6 +1761,11 @@ function clearTouchedKeys() {
 
   hideAlternatives();
   touchedKeys = {};
+
+  // Reset all the pending actions here.
+  clearTimeout(deleteTimeout);
+  clearInterval(deleteInterval);
+  clearTimeout(menuTimeout);
 }
 
 // Hide the keyboard via input method API


### PR DESCRIPTION
and income a call or alarm,the key touching is invalid.
- Reset the state when the keyboard is hidden.
