### PR TITLE
Bug 1025564 - Remove 'dragging' class on transitionend to allow icon drop transitions.

### DIFF
--- a/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
@@ -69,6 +69,8 @@ suite('GaiaGrid > DragDrop', function() {
       preventDefault: function() {}
     });
 
+    grid.dragdrop.handleEvent({ type: 'transitionend' });
+
     assert.equal(grid.items[0].name, 'second');
     assert.equal(grid.items[1].name, 'first');
   });
@@ -85,6 +87,8 @@ suite('GaiaGrid > DragDrop', function() {
       stopImmediatePropagation: function() {},
       preventDefault: function() {}
     });
+
+    grid.dragdrop.handleEvent({ type: 'transitionend' });
 
     assert.isFalse(firstBookmark.classList.contains('active'));
   });

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/manifest.ini
@@ -12,4 +12,5 @@ smoketest = true
 [test_homescreen_launch_app.py]
 
 [test_homescreen_move_app.py]
+disabled = Bug 1025506
 smoketest = true

--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -61,6 +61,7 @@ skip-if = os == "linux"
 [functional/gallery/test_gallery_flick.py]
 [functional/homescreen/test_homescreen_edit_mode.py]
 [functional/homescreen/test_homescreen_move_app.py]
+disabled = Bug 1025506
 [functional/keyboard/test_email_keyboard.py]
 [functional/keyboard/test_keyboard.py]
 [functional/keyboard/test_keyboard_predictive_key.py]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1025564
