### PR TITLE
Bug 1022414 - [Vertical] Dragdrop improvements

### DIFF
--- a/apps/verticalhome/js/sources/application.js
+++ b/apps/verticalhome/js/sources/application.js
@@ -52,7 +52,7 @@
       // There is a last divider that is always in the list, but not rendered
       // unless in edit mode.
       // Remove this divider, append the app, then re-append the divider.
-      var lastDivider = app.grid.getLastIfDivider();
+      var lastDivider = app.grid.removeUntilDivider();
       this.addIconToGrid(application);
       var svApp = configurator.getSingleVariantApp(application.manifestURL);
       var lastElem = app.grid.getIndexLastIcon();

--- a/apps/verticalhome/js/sources/bookmark.js
+++ b/apps/verticalhome/js/sources/bookmark.js
@@ -112,7 +112,7 @@
 
       // Manually inject this book mark into the app item list for now.
       // Remove and re-append a divider if the last item is a divider
-      var lastDivider = app.grid.getLastIfDivider();
+      var lastDivider = app.grid.removeUntilDivider();
       app.grid.add(bookmark);
       app.grid.add(lastDivider);
 

--- a/apps/verticalhome/js/sources/collection.js
+++ b/apps/verticalhome/js/sources/collection.js
@@ -82,7 +82,7 @@
 
       // Manually inject this book mark into the app item list for now.
       // Remove and re-append a divider if the last item is a divider
-      var lastDivider = app.grid.getLastIfDivider();
+      var lastDivider = app.grid.removeUntilDivider();
       app.grid.add(collection);
       app.grid.add(lastDivider);
 

--- a/shared/elements/gaia_grid/js/grid_dragdrop.js
+++ b/shared/elements/gaia_grid/js/grid_dragdrop.js
@@ -202,6 +202,12 @@
       var foundIndex;
       for (var i = 0, iLen = this.gridView.items.length; i < iLen; i++) {
         var item = this.gridView.items[i];
+
+        // Do not consider dividers for dragdrop.
+        if (item.detail.type === 'divider') {
+          continue;
+        }
+
         var distance = Math.sqrt(
           (pageX - item.x) * (pageX - item.x) +
           (pageY - item.y) * (pageY - item.y));
@@ -211,7 +217,6 @@
         }
       }
 
-      // Insert at the found position
       if (foundIndex !== this.icon.detail.index) {
         clearTimeout(this.rearrangeDelay);
         this.doRearrange = this.rearrange.bind(this, foundIndex);
@@ -236,8 +241,15 @@
       this.rearrangeDelay = null;
       this.dirty = true;
       this.gridView.items.splice(tIndex, 0, toInsert);
+
+      // Render to/from the selected position. We give a render buffer of 2
+      // rows or so due to divider creation/removal. Otherwise we may
+      // end up not rendering enough depending on the actual drop and have a
+      // stale rendering of the dragged icon.
+      var renderBuffer = this.gridView.layout.cols * 2;
       this.gridView.render({
-        from: Math.min(tIndex, sIndex)
+        from: Math.min(tIndex, sIndex) - renderBuffer,
+        to: Math.max(tIndex, sIndex) + renderBuffer
       });
     },
 

--- a/shared/elements/gaia_grid/js/grid_view.js
+++ b/shared/elements/gaia_grid/js/grid_view.js
@@ -183,6 +183,15 @@
       if (!(lastItem instanceof GaiaGrid.Divider)) {
         this.items.push(new GaiaGrid.Divider());
       }
+
+      // In dragdrop also append a row of placeholders.
+      // These placeholders are used for drop detection as we ignore dividers
+      // and will create a new group when an icon is dropped on them.
+      if (this.dragdrop && this.dragdrop.inEditMode) {
+        var coords = [0, lastItem.y + 2];
+        this.createPlaceholders(coords, this.items.length, this.layout.cols,
+          true);
+      }
     },
 
     /**
@@ -219,8 +228,9 @@
      * item in grid units.
      * @param {Integer} idx The position of the first placeholder.
      * @param {Integer} idx The number of placeholders to create.
+     * @param {Boolean} createsGroup Creates a group on drop during edit mode.
      */
-    createPlaceholders: function(coordinates, idx, count) {
+    createPlaceholders: function(coordinates, idx, count, createsGroup) {
       for (var i = 0; i < count; i++) {
         var itemCoords = [
           coordinates[0] + i,
@@ -228,6 +238,7 @@
         ];
 
         var item = new GaiaGrid.Placeholder();
+        item.createsGroupOnDrop = createsGroup;
         this.items.splice(idx + i, 0, item);
         item.render(itemCoords, idx + i);
       }

--- a/shared/elements/gaia_grid/js/items/divider.js
+++ b/shared/elements/gaia_grid/js/items/divider.js
@@ -39,8 +39,8 @@
      */
     render: function(coordinates, index) {
       // Generate the content if we need to
-      if (!this.divider) {
-        var divider = this.divider = document.createElement('div');
+      if (!this.element) {
+        var divider = this.element = document.createElement('div');
         divider.className = 'divider';
 
         var span = document.createElement('span');
@@ -50,15 +50,15 @@
       }
 
       var y = this.grid.layout.offsetY;
-      this.divider.style.transform = 'translate(0 ,' + y + 'px)';
+      this.element.style.transform = 'translate(0 ,' + y + 'px)';
 
       this.detail.index = index;
       this.y = y;
     },
 
     remove: function() {
-      if (this.divider) {
-        this.divider.parentNode.removeChild(this.divider);
+      if (this.element) {
+        this.element.parentNode.removeChild(this.element);
       }
     }
   };

--- a/shared/elements/gaia_grid/js/items/placeholder.js
+++ b/shared/elements/gaia_grid/js/items/placeholder.js
@@ -22,8 +22,23 @@
      * Returns the height in pixels of each icon.
      */
     get pixelHeight() {
-      return this.grid.layout.gridItemHeight;
+      var itemHeight = this.grid.layout.gridItemHeight;
+
+      // For placeholders which are there for edge group creation, give them
+      // the minimum height necessary to render. The divider will already
+      // have a spacing buffer.
+      if (this.createsGroupOnDrop) {
+        itemHeight = 1;
+      }
+
+      return itemHeight;
     },
+
+    /**
+     * When the placeholder is rendered in the last row, for group creation
+     * purposes, there is special handling required for height.
+     */
+    createsGroupOnDrop: false,
 
     /**
      * Width in grid units for each icon.
@@ -50,9 +65,8 @@
       // Generate an element if we need to
       if (!this.element) {
         var tile = document.createElement('div');
-        //tile.style.backgroundColor = '#ff0000'; // Useful for debugging.
         tile.className = 'icon placeholder';
-        tile.style.height = this.grid.layout.gridItemHeight + 'px';
+        tile.style.height = this.pixelHeight + 'px';
         this.element = tile;
         this.grid.element.appendChild(tile);
       }

--- a/shared/elements/gaia_grid/script.js
+++ b/shared/elements/gaia_grid/script.js
@@ -111,19 +111,25 @@ window.GaiaGrid = (function(win) {
   };
 
   /**
-   * Returns the last item if a divider, otherwise returns null.
-   * This is useful for operations which append to the end of the items array
-   * as we always have a divider at the end of the list, but often want
-   * to add to the last group.
+   * Reoves placeholders from the list until we encounter a divider. Once we
+   * find a divider, we return that item. If we do not find a divider, we
+   * return null. This is useful for operations which append to the end of the
+   * items array as we always have a divider at the end of the list, but often
+   * want to add to the last group.
    */
-  proto.getLastIfDivider = function() {
+  proto.removeUntilDivider = function() {
     var items = this._grid.items;
-    var lastItem = items[items.length - 1];
-    if (lastItem instanceof GaiaGrid.Divider) {
-      var divider = items.pop();
-      return divider;
+    for (var i = items.length - 1; i > 0; i--) {
+      var item = items[i];
+      if (item instanceof GaiaGrid.Placeholder) {
+        items.pop();
+        continue;
+      } else if (item instanceof GaiaGrid.Divider) {
+        return items.pop();
+      } else {
+        return null;
+      }
     }
-    return null;
   };
 
   Object.defineProperty(proto, 'maxIconSize', {


### PR DESCRIPTION
Improvements to drag drop in vertical homescreen including:
- Ignores dividers during distance calculation and relys only on icons or placeholders to determine proper drop target.
- Render a row of placeholders after the last divider. This ensures we have a valid drop target even if we ignore dividers.
- The last row of placeholders have a smaller size are are only for divider creation.
- Buffers from/to indexes to have slightly better performance and prevent the stuck icon situation.

https://bugzilla.mozilla.org/show_bug.cgi?id=1022414
