### PR TITLE
Bug 1021496 - [Vertical] Implement bookmark app icon design from Classic Homescreen

### DIFF
--- a/apps/collection/js/collection_icon.js
+++ b/apps/collection/js/collection_icon.js
@@ -90,10 +90,6 @@
 
     canvas.height = height;
     canvas.width = width;
-
-    // everything we draw will be cropped inside the rounded icon
-    context.arc(center, center, center, 0, 2 * Math.PI);
-    context.clip();
     context.save();
 
     this.canvas = canvas;

--- a/apps/collection/js/view_apps.js
+++ b/apps/collection/js/view_apps.js
@@ -1,5 +1,6 @@
 'use strict';
 /* global eme */
+/* global GridIconRenderer */
 
 (function(exports) {
 
@@ -49,7 +50,7 @@
               name: webapp.name,
               url: webapp.appUrl,
               icon: webapp.icon,
-              clipIcon: true
+              renderer: GridIconRenderer.TYPE.CLIP
             });
           });
 

--- a/apps/collection/view.html
+++ b/apps/collection/view.html
@@ -14,6 +14,7 @@
     <script defer src="shared/js/dedupe.js"></script>
     <script defer src="shared/js/url_helper.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_view.js"></script>
+    <script defer src="shared/elements/gaia_grid/js/grid_icon_renderer.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_layout.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_dragdrop.js"></script>
     <script defer src="shared/elements/gaia_grid/script.js"></script>

--- a/apps/search/index.html
+++ b/apps/search/index.html
@@ -11,6 +11,7 @@
 
     <!--- gaia_grid required scripts -->
     <script defer src="shared/elements/gaia_grid/js/grid_view.js"></script>
+    <script defer src="shared/elements/gaia_grid/js/grid_icon_renderer.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_layout.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_zoom.js"></script>
     <script defer src="shared/elements/gaia_grid/script.js"></script>

--- a/apps/search/js/providers/webresults.js
+++ b/apps/search/js/providers/webresults.js
@@ -1,4 +1,4 @@
-/* global eme, Search, DataGridProvider, GaiaGrid */
+/* global eme, Search, DataGridProvider, GaiaGrid, GridIconRenderer */
 
 (function() {
 
@@ -57,7 +57,7 @@
                 name: app.name,
                 url: app.appUrl,
                 icon: app.icon,
-                clipIcon: true
+                renderer: GridIconRenderer.TYPE.CLIP
               }, {
                 search: true}
               )

--- a/apps/search/test/unit/providers/local_apps_test.js
+++ b/apps/search/test/unit/providers/local_apps_test.js
@@ -8,6 +8,7 @@ requireApp('search/js/providers/grid_provider.js');
 
 // Required files for the grid and a mozapp result
 require('/shared/js/l10n.js');
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/js/grid_layout.js');
 require('/shared/elements/gaia_grid/js/grid_view.js');
 require('/shared/elements/gaia_grid/script.js');

--- a/apps/search/test/unit/providers/marketplace_test.js
+++ b/apps/search/test/unit/providers/marketplace_test.js
@@ -10,6 +10,7 @@ requireApp('search/js/providers/grid_provider.js');
 
 // Required files for the grid and a marketplaceapp result
 require('/shared/js/l10n.js');
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/js/grid_layout.js');
 require('/shared/elements/gaia_grid/js/grid_view.js');
 require('/shared/elements/gaia_grid/script.js');

--- a/apps/sharedtest/test/unit/elements/gaia_grid/grid_bookmark_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/grid_bookmark_test.js
@@ -1,6 +1,7 @@
 'use strict';
 /* global GaiaGrid */
 
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/script.js');
 require('/shared/elements/gaia_grid/js/items/grid_item.js');
 require('/shared/elements/gaia_grid/js/items/bookmark.js');

--- a/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
@@ -2,6 +2,7 @@
 /* global GaiaGrid */
 
 require('/shared/elements/gaia_grid/js/grid_dragdrop.js');
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/js/grid_layout.js');
 require('/shared/elements/gaia_grid/js/grid_view.js');
 require('/shared/elements/gaia_grid/js/grid_zoom.js');

--- a/apps/sharedtest/test/unit/elements/gaia_grid/items/grid_item_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/items/grid_item_test.js
@@ -1,6 +1,7 @@
 'use strict';
 /* global GaiaGrid */
 
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/js/grid_layout.js');
 require('/shared/elements/gaia_grid/js/grid_view.js');
 require('/shared/elements/gaia_grid/js/items/placeholder.js');

--- a/apps/verticalhome/index.html
+++ b/apps/verticalhome/index.html
@@ -35,6 +35,7 @@
     <script defer src="shared/js/url_helper.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_layout.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_dragdrop.js"></script>
+    <script defer src="shared/elements/gaia_grid/js/grid_icon_renderer.js"></script>
     <script defer src="shared/elements/gaia_grid/js/grid_view.js"></script>
     <script defer src="shared/elements/gaia_grid/script.js"></script>
     <script defer src="shared/elements/gaia_grid/js/items/grid_item.js"></script>

--- a/apps/verticalhome/test/unit/sources/application_test.js
+++ b/apps/verticalhome/test/unit/sources/application_test.js
@@ -4,6 +4,7 @@
 
 require('/shared/test/unit/load_body_html_helper.js');
 require('/shared/elements/gaia_grid/js/grid_dragdrop.js');
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/js/grid_layout.js');
 require('/shared/elements/gaia_grid/js/grid_view.js');
 require('/shared/elements/gaia_grid/js/grid_zoom.js');

--- a/apps/verticalhome/test/unit/stores/item_test.js
+++ b/apps/verticalhome/test/unit/stores/item_test.js
@@ -8,6 +8,7 @@ require('/test/unit/mock_bookmark_source.js');
 require('/test/unit/mock_collection_source.js');
 require('/test/unit/mock_configurator.js');
 
+require('/shared/elements/gaia_grid/js/grid_icon_renderer.js');
 require('/shared/elements/gaia_grid/script.js');
 require('/shared/elements/gaia_grid/js/items/grid_item.js');
 require('/shared/elements/gaia_grid/js/items/divider.js');

--- a/shared/elements/gaia_grid/js/grid_icon_renderer.js
+++ b/shared/elements/gaia_grid/js/grid_icon_renderer.js
@@ -1,0 +1,159 @@
+'use strict';
+/* global devicePixelRatio */
+/* global Promise */
+
+(function(exports) {
+
+  const SHADOW_BLUR = 1;
+  const SHADOW_OFFSET_Y = 1;
+  const SHADOW_OFFSET_X = 1;
+  const SHADOW_COLOR = 'rgba(0, 0, 0, 0.2)';
+  const DEFAULT_BACKGROUND_COLOR = 'rgb(228, 234, 238)';
+  const UNSCALED_CANVAS_PADDING = 2;
+  const CANVAS_PADDING = UNSCALED_CANVAS_PADDING * devicePixelRatio;
+
+  function IconRenderer(icon) {
+    this._icon = icon;
+  }
+
+  IconRenderer.TYPE = {
+    CLIP: 'clip',
+    FAVICON: 'favicon',
+    STANDARD: 'standard',
+  };
+
+  IconRenderer.prototype = {
+
+    // Export necessary defines.
+    unscaledCanvasPadding: UNSCALED_CANVAS_PADDING,
+
+    /**
+     * Returns the max size for an icon based on grid size and pixel ratio.
+     */
+    get _maxSize() {
+      return this._icon.grid.layout.gridIconSize * devicePixelRatio;
+    },
+
+    /**
+     * Creates a properly sized canvas to match the maxSize + padding
+     * for shadows.
+     * @return {HTMLCanvasElement}
+     */
+    _createCanvas: function() {
+      var canvas = document.createElement('canvas');
+      canvas.width = this._maxSize + (CANVAS_PADDING * 2);
+      canvas.height = this._maxSize + (CANVAS_PADDING * 2);
+      return canvas;
+    },
+
+    /**
+     * Sets definitions for the shadow canvas.
+     * @return {CanvasRenderingContext2D}
+     */
+    _decorateShadowCanvas: function(canvas) {
+      var ctx = canvas.getContext('2d');
+
+      ctx.shadowColor = SHADOW_COLOR;
+      ctx.shadowBlur = SHADOW_BLUR;
+      ctx.shadowOffsetY = SHADOW_OFFSET_Y;
+      ctx.shadowOffsetX = SHADOW_OFFSET_X;
+
+      return ctx;
+    },
+
+    /**
+     * Draws a clipped icon.
+     * A clipped icon is generally a full-sized icon, with rounded corners
+     * and a drop shadow.
+     * @param {HTMLImageElement} img An image element to display from.
+     * @return {Promise}
+     */
+    clip: function(img) {
+      return new Promise((resolve) => {
+        var shadowCanvas = this._createCanvas();
+        var shadowCtx = this._decorateShadowCanvas(shadowCanvas);
+
+        var clipCanvas = this._createCanvas();
+        var clipCtx = clipCanvas.getContext('2d');
+
+        clipCtx.beginPath();
+        clipCtx.arc(clipCanvas.width / 2, clipCanvas.height / 2,
+                    clipCanvas.height / 2,
+                    0, 2 * Math.PI);
+        clipCtx.clip();
+        clipCtx.drawImage(img, 0, 0,
+                               clipCanvas.width, clipCanvas.height);
+
+        var clipImage = new Image();
+        clipImage.onload = () => {
+          shadowCtx.drawImage(clipImage, CANVAS_PADDING,
+                              CANVAS_PADDING,
+                              this._maxSize, this._maxSize);
+          shadowCanvas.toBlob(resolve);
+        };
+        clipImage.src = clipCanvas.toDataURL();
+      });
+    },
+
+    /**
+     * Draws a favicon for the grid.
+     * Favicons are generally smaller, and drawn on top of a background.
+     * @param {HTMLImageElement} img An image element to display from.
+     * @return {Promise}
+     */
+    favicon: function(img) {
+
+      // If we have a decent sized image, we want to clip instead.
+      if (img.width > this._icon.grid.layout.gridIconSize / 2) {
+        return this.clip(img);
+      }
+
+      return new Promise((resolve) => {
+        var shadowCanvas = this._createCanvas();
+        var shadowCtx = this._decorateShadowCanvas(shadowCanvas);
+
+        var iconWidth;
+        var iconHeight;
+
+        // Draws Shadow and default background circle
+        shadowCtx.beginPath();
+        shadowCtx.arc(shadowCanvas.width / 2,
+                      shadowCanvas.height / 2,
+                      shadowCanvas.height / 2 - CANVAS_PADDING,
+                      0, 2 * Math.PI, false);
+        shadowCtx.fillStyle = DEFAULT_BACKGROUND_COLOR;
+        shadowCtx.fill();
+
+        // Draws favicon with antinaliasing disabled
+        iconWidth = iconHeight = this._maxSize * 0.55;
+        // Disable smoothing on icon resize
+        shadowCtx.shadowBlur = 0;
+        shadowCtx.shadowOffsetY = 0;
+        shadowCtx.mozImageSmoothingEnabled = false;
+        shadowCtx.drawImage(img, (shadowCanvas.width - iconWidth) / 2,
+                                      (shadowCanvas.height - iconHeight) / 2,
+                                      iconWidth, iconHeight);
+        shadowCanvas.toBlob(resolve);
+      });
+    },
+
+    /**
+     * Draws a standard icon for the grid.
+     * Normal icons maintain their shape and are only given a shadow.
+     * @param {HTMLImageElement} img An image element to display from.
+     * @return {Promise}
+     */
+    standard: function(img) {
+      return new Promise((resolve) => {
+        var shadowCanvas = this._createCanvas();
+        var shadowCtx = this._decorateShadowCanvas(shadowCanvas);
+        shadowCtx.drawImage(img, CANVAS_PADDING, CANVAS_PADDING,
+                      this._maxSize, this._maxSize);
+        shadowCanvas.toBlob(resolve);
+      });
+    }
+  };
+
+  exports.GridIconRenderer = IconRenderer;
+
+}(window));

--- a/shared/elements/gaia_grid/js/items/bookmark.js
+++ b/shared/elements/gaia_grid/js/items/bookmark.js
@@ -1,5 +1,6 @@
 'use strict';
 /* global GaiaGrid */
+/* global GridIconRenderer */
 /* global MozActivity */
 /* jshint nonew: false */
 
@@ -19,6 +20,12 @@
   Bookmark.prototype = {
 
     __proto__: GaiaGrid.GridItem.prototype,
+
+    /**
+     * Bookmarks use a custom icon renderer because they are likely much
+     * smaller than a standard icon.
+     */
+    renderer: GridIconRenderer.TYPE.FAVICON,
 
     /**
      * Returns the height in pixels of each icon.

--- a/shared/elements/gaia_grid/js/items/collection.js
+++ b/shared/elements/gaia_grid/js/items/collection.js
@@ -1,5 +1,6 @@
 'use strict';
 /* global GaiaGrid */
+/* global GridIconRenderer */
 /* global MozActivity */
 /*jshint nonew: false */
 
@@ -26,6 +27,8 @@
   Collection.prototype = {
 
     __proto__: GaiaGrid.GridItem.prototype,
+
+    renderer: GridIconRenderer.TYPE.CLIP,
 
     /**
      * Returns the height in pixels of each icon.

--- a/shared/elements/gaia_grid/js/items/marketplace_app.js
+++ b/shared/elements/gaia_grid/js/items/marketplace_app.js
@@ -1,5 +1,6 @@
 'use strict';
 /* global GaiaGrid */
+/* global GridIconRenderer */
 /* global MozActivity */
 /* jshint nonew: false */
 
@@ -18,6 +19,8 @@
   MarketPlaceApp.prototype = {
 
     __proto__: GaiaGrid.Bookmark.prototype,
+
+    renderer: GridIconRenderer.TYPE.STANDARD,
 
     launch: function() {
       new MozActivity({


### PR DESCRIPTION
This work is based off of Diego's work found here: https://github.com/mozilla-b2g/gaia/pull/20524

This pull request creates a GridIconRenderer function which has three ways of rendering icons: standard, clip, and favicon.

https://bugzilla.mozilla.org/show_bug.cgi?id=1021496
