### PR TITLE
Bug 1025565 - Only render the necessary icons when dragging. r=

### DIFF
--- a/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
@@ -99,11 +99,13 @@ suite('GaiaGrid > DragDrop', function() {
 
   test('rearrange uses reference of icon for position', function() {
     var subject = grid.dragdrop;
-    subject.icon = grid.items[0];
 
-    // The current positions are second -> first -> placeholder
-    // Simulate a drop past the placeholder (index 2).
-    subject.rearrange(2);
+    // Make sure the grid is in the expected state
+    assert.equal(grid.items[0].name, 'second');
+    assert.equal(grid.items[1].name, 'first');
+    assert.equal(grid.items[2].detail.type, 'placeholder');
+
+    subject.rearrange(0, 2);
 
     assert.equal(grid.items[0].name, 'first');
     assert.equal(grid.items[1].name, 'second');


### PR DESCRIPTION
Dragging an icon previously caused all icons from the first icon that needs
re-rendering to the end of the grid. This makes sure that only the icons
that are affected by the rearrangement are re-rendered.
