### PR TITLE
Bug 1025178 - [everything.me] Search results that have globe icons don't open

### DIFF
--- a/apps/search/js/providers/webresults.js
+++ b/apps/search/js/providers/webresults.js
@@ -53,7 +53,7 @@
             results.push({
               dedupeId: app.appUrl,
               data: new GaiaGrid.Bookmark({
-                id: app.id,
+                id: app.appUrl,
                 name: app.name,
                 url: app.appUrl,
                 icon: app.icon,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1025178
