### PR TITLE
Bug 1025565 - Only render the necessary icons when dragging. r=kgrandon

### DIFF
--- a/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/grid_dragdrop_test.js
@@ -100,11 +100,13 @@ suite('GaiaGrid > DragDrop', function() {
 
   test('rearrange uses reference of icon for position', function() {
     var subject = grid.dragdrop;
-    subject.icon = grid.items[0];
 
-    // The current positions are second -> first -> placeholder
-    // Simulate a drop past the placeholder (index 2).
-    subject.rearrange(2);
+    // Make sure the grid is in the expected state
+    assert.equal(grid.items[0].name, 'second');
+    assert.equal(grid.items[1].name, 'first');
+    assert.equal(grid.items[2].detail.type, 'placeholder');
+
+    subject.rearrange(0, 2);
 
     assert.equal(grid.items[0].name, 'first');
     assert.equal(grid.items[1].name, 'second');

--- a/shared/elements/gaia_grid/js/grid_dragdrop.js
+++ b/shared/elements/gaia_grid/js/grid_dragdrop.js
@@ -1,4 +1,5 @@
 'use strict';
+/* global GaiaGrid */
 
 (function(exports) {
 
@@ -48,6 +49,12 @@
     inEditMode: false,
 
     /**
+     * Whether or not a divider was crossed when rearranging.
+     * @type {boolean}
+     */
+    rearrangedDivider: false,
+
+    /**
      * Returns the maximum active scale value.
      */
     get maxActiveScale() {
@@ -73,6 +80,7 @@
 
       this.icon.noTransform = true;
       this.rearrangeDelay = null;
+      this.rearrangedDivider = false;
       this.enterEditMode();
       this.container.classList.add('dragging');
       this.target.classList.add('active');
@@ -107,7 +115,12 @@
         clearTimeout(this.rearrangeDelay);
         this.doRearrange.call(this);
       } else {
-        this.gridView.render();
+        if (this.rearrangedDivider) {
+          this.gridView.render();
+        } else {
+          this.gridView.render({from: this.icon.detail.index,
+                                to: this.icon.detail.index});
+        }
       }
 
       // Save icon state if we need to
@@ -200,7 +213,8 @@
       // and insert ours before it.
       // Todo: this could be more efficient with a binary search.
       var leastDistance;
-      var foundIndex;
+      var myIndex = this.icon.detail.index;
+      var foundIndex = myIndex;
       for (var i = 0, iLen = this.gridView.items.length; i < iLen; i++) {
         var item = this.gridView.items[i];
 
@@ -218,9 +232,10 @@
         }
       }
 
-      if (foundIndex !== this.icon.detail.index) {
+      // Insert at the found position
+      if (foundIndex !== myIndex) {
         clearTimeout(this.rearrangeDelay);
-        this.doRearrange = this.rearrange.bind(this, foundIndex);
+        this.doRearrange = this.rearrange.bind(this, myIndex, foundIndex);
         this.rearrangeDelay = setTimeout(this.doRearrange.bind(this),
                                          rearrangeDelay);
       }
@@ -228,30 +243,31 @@
 
     /**
      * Rearranges items in GridView.items
-     * @param {Integer} insertAt The position to insert our icon at.
+     * @param {Integer} sIndex The position of the item to rearrange
+     * @param {Integer} tIndex The position to insert the item at.
      */
-    rearrange: function(tIndex) {
-
-      // We get a reference to the position of this.icon within the items
-      // array. Because placeholders are shifting around while we are dragging,
-      // we can't trust the detail.index attribute. This will be fixed on every
-      // render call though.
-      var sIndex = this.gridView.items.indexOf(this.icon);
-      var toInsert = this.gridView.items.splice(sIndex, 1)[0];
+    rearrange: function(sIndex, tIndex) {
 
       this.rearrangeDelay = null;
       this.dirty = true;
-      this.gridView.items.splice(tIndex, 0, toInsert);
 
-      // Render to/from the selected position. We give a render buffer of 2
-      // rows or so due to divider creation/removal. Otherwise we may
-      // end up not rendering enough depending on the actual drop and have a
-      // stale rendering of the dragged icon.
-      var renderBuffer = this.gridView.layout.cols * 2;
-      this.gridView.render({
-        from: Math.min(tIndex, sIndex) - renderBuffer,
-        to: Math.max(tIndex, sIndex) + renderBuffer
-      });
+      var [from, to] = sIndex < tIndex ? [sIndex, tIndex] : [tIndex, sIndex];
+
+      // Check if we're dragging past a divider - if so, we need to change to
+      // to draw to the end of the grid, as this can cause every item to shift.
+      for (var i = from; i <= to; i++) {
+        if (this.gridView.items[i] instanceof GaiaGrid.Divider) {
+          to = this.gridView.items.length - 1;
+          this.rearrangedDivider = true;
+          break;
+        }
+      }
+
+      // Rearrange items
+      this.gridView.items.splice(tIndex, 0,
+        this.gridView.items.splice(sIndex, 1)[0]);
+
+      this.gridView.render({from: from, to: to});
     },
 
     enterEditMode: function() {
@@ -260,6 +276,9 @@
       document.body.classList.add('edit-mode');
       window.dispatchEvent(new CustomEvent('gaiagrid-editmode-start'));
       document.addEventListener('visibilitychange', this);
+
+      // Render and skip items to make sure placeholders are correctly setup.
+      this.gridView.render({skipItems: true});
     },
 
     exitEditMode: function() {
@@ -269,7 +288,7 @@
       window.dispatchEvent(new CustomEvent('gaiagrid-editmode-end'));
       document.removeEventListener('visibilitychange', this);
       this.removeDragHandlers();
-      this.gridView.removeAllPlaceholders();
+      this.gridView.render({skipItems: true});
 
       if (this.icon) {
         this.icon.element.removeEventListener('transitionend', this);

--- a/shared/elements/gaia_grid/js/grid_view.js
+++ b/shared/elements/gaia_grid/js/grid_view.js
@@ -179,24 +179,21 @@
         removed.remove();
       }, this);
 
-      // There should always be a divider at the end, it's hidden in CSS when
-      // not in edit mode.
       if (skipDivider) {
-        return;
-      }
-      var lastItem = this.items[this.items.length - 1];
-      if (!(lastItem instanceof GaiaGrid.Divider)) {
-        this.items.push(new GaiaGrid.Divider());
+        return null;
       }
 
-      // In dragdrop also append a row of placeholders.
-      // These placeholders are used for drop detection as we ignore dividers
-      // and will create a new group when an icon is dropped on them.
-      if (this.dragdrop && this.dragdrop.inEditMode) {
-        var coords = [0, lastItem.y + 2];
-        this.createPlaceholders(coords, this.items.length, this.layout.cols,
-          true);
+      // There should always be a divider at the end, it's hidden in CSS when
+      // not in edit mode.
+      // Recreate it each time to make sure it's the last element in the DOM,
+      // otherwise the CSS won't apply.
+      if (this.items[this.items.length - 1] instanceof GaiaGrid.Divider) {
+        this.items.splice(this.items.length - 1,1)[0].remove();
       }
+      var lastItem = new GaiaGrid.Divider();
+      this.items.push(lastItem);
+
+      return lastItem;
     },
 
     /**
@@ -273,25 +270,54 @@
      * on the grid.
      * @param {Object} options Options to render with including:
      *  - from {Integer} The index to start rendering from.
+     *  - to {Integer} The index to end rendering at.
      *  - skipDivider {Boolean} Whether or not to skip the divider
+     *  - skipItems {Boolean} Whether to skip rendering items
      */
     render: function(options) {
       var self = this;
       options = options || {};
 
+      // Bounds-check the 'from' and 'to' parameters.
+      var from =
+        Math.max(0, Math.min(this.items.length - 1, options.from || 0));
+      var to =
+        Math.max(0, Math.min(this.items.length - 1,
+          (options.to === 0) ? 0 : options.to || this.items.length - 1));
+      if (to < from) {
+        to = from;
+      }
+
+      // Store the from and to indices as items, as removing placeholders/
+      // cleaning will alter them.
+      // If either of these items are placeholders/dividers, seek outwards to
+      // the nearest non-placeholder/non-divider, as these items may end up
+      // being removed.
+      if (this.items.length > 0) {
+        var item, fromItem, toItem;
+        for (; from >= 0; from--) {
+          item = this.items[from];
+          if (item.identifier) {
+            fromItem = item;
+            break;
+          }
+        }
+        for (; to < this.items.length; to++) {
+          item = this.items[to];
+          if (item.identifier) {
+            toItem = item;
+            break;
+          }
+        }
+      }
+
       this.removeAllPlaceholders();
-      this.cleanItems(options.skipDivider);
+      var lastDivider = this.cleanItems(options.skipDivider);
 
-      // Start rendering from one before the drop target. If not,
-      // we may drop over the divider and miss rendering an icon.
-      var from = options.from - 1 || 0;
-
-      // TODO This variable should be an argument of this method. See
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1010742#c4
-      var to = this.items.length - 1;
-
-      // Reset offset steps
-      this.layout.offsetY = 0;
+      // Reset the from/to indexes until we find it again when iterating over
+      // items below.
+      from = fromItem ? this.items.length - 1 : 0;
+      to = this.items.length - 1;
 
       // Grid render coordinates
       var x = 0;
@@ -308,8 +334,13 @@
         y++;
       }
 
-      for (var idx = 0; idx <= to; idx++) {
-        var item = this.items[idx];
+      // Reset offset steps
+      this.layout.offsetY = 0;
+
+      // We have to iterate the whole list to make sure placeholders are
+      // correctly setup.
+      for (var idx = 0; idx < this.items.length; idx++) {
+        item = this.items[idx];
 
         // If the item would go over the boundary before rendering,
         // step the y-axis.
@@ -331,9 +362,30 @@
           step(lastItem);
         }
 
-        if (idx >= from) {
+        if (item == fromItem) {
+          from = idx;
+        }
+        if (item == toItem) {
+          to = idx;
+        }
+
+        // Always render the last divider to make sure its position is correct
+        if (item == lastDivider && !options.skipDivider) {
+          item.render([x, y], idx);
+
+          // In dragdrop, append a row of placeholders after the last divider.
+          // These placeholders are used for drop detection as we ignore
+          // dividers and will create a new group when an icon is dropped on
+          // them.
+          if (this.dragdrop && this.dragdrop.inEditMode) {
+            var coords = [0, lastDivider.y + 1];
+            this.createPlaceholders(coords, this.items.length, this.layout.cols,
+              true);
+          }
+        } else if (!options.skipItems && idx >= from && idx <= to) {
           item.render([x, y], idx);
         }
+
 
         // Increment the x-step by the sizing of the item.
         // If we go over the current boundary, reset it, and step the y-axis.


### PR DESCRIPTION
Dragging an icon previously caused all icons from the first icon that needs
re-rendering to the end of the grid. This makes sure that only the icons
that are affected by the rearrangement are re-rendered.
