### PR TITLE
Bug 1022519 - [B2G][Calendar] wrong refresh button size

### DIFF
--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -201,7 +201,7 @@ not actually shown since the top header should be transparent.
   left: 0;
   width: 100%;
   height: 4.5rem;
-  background: url("icons/refresh.png") no-repeat 50% 50%;
+  background: url("icons/refresh.png") no-repeat 50% 50% / 3rem auto;
 }
 
 #settings [role="toolbar"] .sync:active:after {


### PR DESCRIPTION
This adds the same background-size that is on the settings icon on line 186 and fixes the problem.
