### PR TITLE
Bug 1026475 - Device switch from Handset/Headset to BTSCO fails during call, r=etienne

### DIFF
--- a/apps/callscreen/js/call_screen.js
+++ b/apps/callscreen/js/call_screen.js
@@ -125,7 +125,7 @@ var CallScreen = {
                                     this.hideGroupDetails.bind(this));
 
     this.switchToDeviceButton.addEventListener('click',
-                                    this.switchToDefaultOut.bind(this));
+                                    this.switchToDefaultOut.bind(this, false));
     this.switchToReceiverButton.addEventListener('click',
                                     this.switchToReceiver.bind(this));
     this.switchToSpeakerButton.addEventListener('click',

--- a/apps/callscreen/js/calls_handler.js
+++ b/apps/callscreen/js/calls_handler.js
@@ -53,8 +53,7 @@ var CallsHandler = (function callsHandler() {
     if (acm) {
       acm.addEventListener('headphoneschange', function onheadphoneschange() {
         if (acm.headphones) {
-          // Do not connect bluetooth SCO if headphone is plugged in
-          CallScreen.switchToDefaultOut(true /* do not connect */);
+          CallScreen.switchToDefaultOut();
         }
       });
     }

--- a/apps/callscreen/test/unit/calls_handler_test.js
+++ b/apps/callscreen/test/unit/calls_handler_test.js
@@ -1356,7 +1356,7 @@ suite('calls handler', function() {
       test('should switch sound to default out', function() {
         var toDefaultSpy = this.sinon.spy(MockCallScreen, 'switchToDefaultOut');
         headphonesChange.yield();
-        assert.isTrue(toDefaultSpy.calledOnce);
+        assert.isTrue(toDefaultSpy.calledWithExactly());
       });
     });
 


### PR DESCRIPTION
- Pass false as 1st parameter for mouse event case.
- Connect BT SCO even when headphone is plugged in to conform with UI button.
