### PR TITLE
Bug 1023190 -  [Flame][v1.4][Gaia::SMS] There is a horizontal line on “SIM1/2” word

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -797,6 +797,7 @@ form.bottom[role="search"].messages-compose-form {
 
   /* override BB, first one is separator, second one is background */
   background-position: left bottom, bottom;
+  background-size: auto 100%;
 }
 
 .has-preferred-sim #messages-send-button:after {


### PR DESCRIPTION
- Set image background size height to 100% to prevent horizontal repeat. 
