### PR TITLE
Bug 1026528 - [Messages] Corrupted attachments do not display correctly. r=julienw

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -496,9 +496,8 @@
 
     <div id="attachment-nopreview-tmpl" class="hide">
       <!--
-      <div class="attachment">
+      <div class="attachment ${errorClass}">
         <div class="thumbnail-placeholder ${type}-placeholder">
-          <div class="${errorClass}"></div>
         </div>
         <div class="size-indicator" data-l10n-id="${sizeL10nId}" data-l10n-args="${sizeL10nArgs}"></div>
       </div>

--- a/apps/sms/js/desktop-only/mobilemessage.js
+++ b/apps/sms/js/desktop-only/mobilemessage.js
@@ -654,6 +654,48 @@
         type: 'sms',
         timestamp: now - 3600000,
         sentTimestamp: now - 3700000
+      },
+      {
+        threadId: 12,
+        receiver: ['06660'],
+        type: 'mms',
+        read: true,
+        delivery: 'sent',
+        deliveryInfo: [{
+          receiver: '052780',
+          deliveryStatus: 'success',
+          deliveryTimestamp: now,
+          readStatus: 'success',
+          readTimestamp: now
+        }],
+        subject: 'Test MMS Image message',
+        smil: '<smil><body><par><text src="text1"/></par>' +
+              '<par><img src="corrupted.jpg"/></par></body></smil>',
+        attachments: [{
+          location: 'text1',
+          content: new Blob(['sent image message'], { type: 'text/plain' })
+        },{
+          location: 'corrupted.jpg',
+          // Corrupt image blob
+          content: new Blob(['corrupted'], {type : 'image/jpg'})
+        }],
+        timestamp: now
+      },
+      {
+        threadId: 12,
+        sender: '06660',
+        type: 'mms',
+        delivery: 'received',
+        deliveryInfo: [{deliveryStatus: 'success'}],
+        subject: 'Test MMS Image message',
+        smil: '<smil><body><par><img src="corrupted.jpg"/>' +
+              '</par></body></smil>',
+        attachments: [{
+          location: 'corrupted.jpg',
+          content: new Blob(['corrupted'], {type : 'image/jpg'})
+        }],
+        timestamp: now,
+        sentTimestamp: now - 100000
       }
     ],
     threads: [
@@ -741,7 +783,14 @@
         lastMessageType: 'sms',
         timestamp: now - 60000,
         unreadCount: 0
-      }
+      },
+      {
+        id: 12,
+        participants: ['06660'],
+        lastMessageType: 'mms',
+        timestamp: now - (60000000 * 10),
+        unreadCount: 0
+      },
     ]
   };
 

--- a/apps/sms/style/attachment.css
+++ b/apps/sms/style/attachment.css
@@ -197,13 +197,16 @@
   background-position: right -24rem;
 }
 
-.corrupted {
-  width: 100%;
-  height: 100%;
+.attachment.corrupted .thumbnail-placeholder:after {
+  display: block;
 
-  background-image: url('icons/corrupted.png');
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: 82px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+
+  content: '';
+  background: url('icons/corrupted.png') no-repeat center center / 82px;
 }
 


### PR DESCRIPTION
- Removed redundant element that is used for "corrupted" case only as it's more styling than content;
- Corrupted class moved to ".attachment" container as it's more appropriate here.
