### PR TITLE
Bug 1026924 - [Flame][Calendar] Current time indicator should be above event detail r=gaye

### DIFF
--- a/apps/calendar/style/day_views.css
+++ b/apps/calendar/style/day_views.css
@@ -250,10 +250,10 @@
 }
 
 #day-view .current-time:before {
-  left: 7rem;
+  left: 7.1rem;
 }
 
 #day-view .current-time:after {
-  width: calc(100% - 7rem);
-  left: 7rem;
+  width: calc(100% - 7.1rem);
+  left: 7.1rem;
 }

--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -151,6 +151,9 @@ body[data-path="/day/"] #view-selector > .day > a:active {
   border-color: transparent transparent transparent #008EAB;
   /* scale is for smooth edges and translate for centering the line */
   transform: scale(0.99) translateY(0.25rem);
+  /* z-index here so that only the arrow goes above the events, we want the
+   * line to be behind the event name and alarm icon */
+  z-index: 15;
 }
 
 .current-time:after {
@@ -159,7 +162,9 @@ body[data-path="/day/"] #view-selector > .day > a:active {
   position: absolute;
   top: 0.6rem;
   height: 0.1rem;
-  background-color: #008EAB;
+  /* we use border-top instead of background-color to avoid rouding issues on
+   * high resolution devices */
+  border-top: 0.1rem solid #008EAB;
 }
 
 /* view loading */

--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -149,9 +149,15 @@
 }
 
 #week-view .scroll-content {
+  /* XXX: z-index + position:relative is important for perf (Bug 972675) */
   position: relative;
-  background-color: #FFF;
+  z-index: 0;
   overflow: hidden;
+  /**
+   * set scrollable areas to a solid background color
+   * see bug 968478
+   */
+  background-color: #FFF;
 }
 
 
@@ -159,13 +165,6 @@
   position: relative;
   float: left;
   width: calc(100% - 2.9rem);
-  /**
-   * set scrollable areas to a solid background color
-   * see bug 968478
-   */
-  background-color: #fff;
-  /* XXX: z-index + position:relative is important for perf (Bug 972675) */
-  z-index: 0;
 }
 
 #week-view .weekday .children > section {
@@ -254,10 +253,10 @@
 }
 
 #week-view .current-time:before {
-  left: 2.9rem;
+  left: 3rem;
 }
 
 #week-view .current-time:after {
-  width: calc(100% - 2.9rem);
-  left: 2.9rem;
+  width: calc(100% - 3rem);
+  left: 3rem;
 }


### PR DESCRIPTION
![current_time_patch_1](https://cloud.githubusercontent.com/assets/155633/3315958/fe45e8c6-f6fd-11e3-9545-03d151cf96cf.png)
