### PR TITLE
Backport fix to Bug 1004138 - Add a step to cleanup_data to eliminate remembered networks

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -890,6 +890,8 @@ class GaiaTestCase(MarionetteTestCase, B2GTestCaseMixin):
         self.device.manager.removeDir('/data/local/permissions.sqlite')
         self.device.manager.removeDir('/data/local/storage/persistent')
         self.device.manager.removeDir('/data/local/webapps')
+        # remove remembered networks
+        self.device.manager.removeFile('/data/misc/wifi/wpa_supplicant.conf')
 
     def cleanup_sdcard(self):
         # cleanup files from the device_root


### PR DESCRIPTION
Backporting https://github.com/mozilla-b2g/gaia/commit/f72db99192a78f2604b7478af235c42514b693a7
As tests are failing due to remembered networks.
