### PR TITLE
Bug 1017333 - Clear notifications when we open the call log

### DIFF
--- a/apps/communications/dialer/js/call_log.js
+++ b/apps/communications/dialer/js/call_log.js
@@ -107,13 +107,17 @@ var CallLog = {
           if (document.hidden) {
             self.pauseHeaders();
           } else {
-            self.becameVisible();
             self.updateHeadersContinuously();
+            if (window.location.hash === '#call-log-view') {
+              self.becameVisible();
+            }
           }
         });
 
         self.sticky = new StickyHeader(self.callLogContainer,
                                        document.getElementById('sticky'));
+
+        self.becameVisible();
       });
     });
 

--- a/apps/communications/dialer/test/unit/call_log_test.js
+++ b/apps/communications/dialer/test/unit/call_log_test.js
@@ -629,8 +629,6 @@ suite('dialer/call_log', function() {
   });
 
   suite('notifications', function() {
-    var notifs;
-    var notificationSpy;
 
     setup(function() {
       var notificationGetStub = function notificationGet() {
@@ -646,14 +644,21 @@ suite('dialer/call_log', function() {
         };
       };
       this.sinon.stub(Notification, 'get', notificationGetStub);
-      notifs = Notification.get();
-      notificationSpy =
-        this.sinon.spy(MockNotification.prototype, 'close');
+      this.sinon.spy(MockNotification.prototype, 'close');
     });
 
-    test('call log should close notifications', function() {
-      CallLog.cleanNotifications();
-      sinon.assert.callCount(notificationSpy, 2);
+    test('notifications are closed when opening the call log', function() {
+      CallLog._initialized = false;
+      CallLog.init();
+      sinon.assert.callCount(MockNotification.prototype.close, 2);
+    });
+
+    test('notifications should not be closed when keypad becomes visible',
+         function() {
+      window.location.hash = '#keyboard-view';
+      var visibilityEvent = new CustomEvent('visibilitychange');
+      document.dispatchEvent(visibilityEvent);
+      sinon.assert.notCalled(MockNotification.prototype.close);
     });
   });
 
@@ -834,6 +839,7 @@ suite('dialer/call_log', function() {
         MockNavigatorMozIccManager.addIcc('12345', {'cardState': 'ready'});
         MockNavigatorMozIccManager.addIcc('3232', {'cardState': 'ready'});
         CallLog.init();
+        window.location.hash = '#call-log-view';
       });
 
       test('should put the dual sim class on the container', function() {


### PR DESCRIPTION
Also don't clear notifications when we reopen the dialer app on another tab
