### PR TITLE
Bug 1026792 - [Rocketbar] Rocketbar search should be cancelled when the device sleeps, or gets locked

### DIFF
--- a/apps/search/js/search.js
+++ b/apps/search/js/search.js
@@ -93,6 +93,8 @@
       if ('geolocation' in navigator) {
         navigator.geolocation.getCurrentPosition(function(){});
       }
+
+      document.addEventListener('visibilitychange', this);
     },
 
     /**
@@ -312,6 +314,16 @@
         'input': input
       });
       this.expandSearch(input);
+    },
+
+    handleEvent: function(e) {
+      switch(e.type) {
+        case 'visibilitychange':
+          if (document.hidden) {
+            this.close();
+          }
+          break;
+      }
     }
   };
 

--- a/apps/search/test/unit/search_test.js
+++ b/apps/search/test/unit/search_test.js
@@ -92,6 +92,23 @@ suite('search/search', function() {
     });
   });
 
+  suite('handleEvent', function() {
+    test('visibilitychange will call close', function() {
+      var closeStub = this.sinon.stub(Search, 'close');
+      Object.defineProperty(document, 'hidden', {
+        configurable: true,
+        get: function() {
+          return true;
+        }
+      });
+
+      Search.handleEvent({
+        type: 'visibilitychange'
+      });
+      assert.ok(closeStub.calledOnce);
+    });
+  });
+
   suite('provider', function() {
     test('increments number of providers', function() {
       function numProviders() {

--- a/apps/system/js/rocketbar.js
+++ b/apps/system/js/rocketbar.js
@@ -883,6 +883,7 @@
         case 'hide':
           this.hideResults();
           this.collapse();
+          this.deactivate();
           break;
       }
     },

--- a/apps/system/test/unit/rocketbar_test.js
+++ b/apps/system/test/unit/rocketbar_test.js
@@ -784,6 +784,7 @@ suite('system/Rocketbar', function() {
       'initSearchConnection');
     var hideResultsStub = this.sinon.stub(subject, 'hideResults');
     var collapseStub = this.sinon.stub(subject, 'collapse');
+    var deactivateStub = this.sinon.stub(subject, 'deactivate');
 
     // Input message
     var event = {
@@ -806,6 +807,7 @@ suite('system/Rocketbar', function() {
     subject.handleSearchMessage(event);
     assert.ok(hideResultsStub.calledOnce);
     assert.ok(collapseStub.calledOnce);
+    assert.ok(deactivateStub.calledOnce);
 
     // No _port
     subject._port = null;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1026792
