### PR TITLE
Bug 1027185 - [email] switch manifest type back to certified

### DIFF
--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "E-Mail",
   "description": "Gaia E-Mail",
-  "type": "privileged",
+  "type": "certified",
   "launch_path": "/index.html",
   "developer": {
     "name": "The Gaia Team",

--- a/apps/email/test/marionette/lib/email.js
+++ b/apps/email/test/marionette/lib/email.js
@@ -148,25 +148,9 @@ Email.prototype = {
     return text;
   },
 
-  // Workaround for bug 1022768, where app permissions are not auto ALLOWed
-  // for tests on desktop. If that bug is fixed, this function should be
-  // removed.
-  _acceptContactsPermission: function() {
-    if (!this._hasAcceptedContactsPermissions) {
-      this.client.switchToFrame();
-      this._tapSelector('#permission-yes');
-      this.client.switchToFrame();
-      this.client.apps.switchToApp(Email.EMAIL_ORIGIN);
-      this._hasAcceptedContactsPermissions = true;
-    }
-  },
-
   manualSetupImapEmail: function(server, finalActionName) {
     // setup a IMAP email account
     var email = server.imap.username + '@' + server.imap.hostname;
-
-    // Workaround for bug 1022768, see method definition.
-    this._acceptContactsPermission();
 
     // wait for the setup page is loaded
     this._setupTypeName(server.imap.username);


### PR DESCRIPTION
Because reasons. Very similar to a reverse of the [changeset switching to privileged](https://github.com/mozilla-b2g/gaia/pull/19948/files) but keeps the addAccountButton fix.
