### PR TITLE
Bug 1027349 - [Calendar] month view week day names should be a single char r=gaye

### DIFF
--- a/apps/calendar/js/templates/month.js
+++ b/apps/calendar/js/templates/month.js
@@ -22,7 +22,7 @@
     },
 
     weekDaysHeaderDay: function() {
-      return '<li data-l10n-id="weekday-' + this.h('day') + '-short">' +
+      return '<li data-l10n-id="' + this.h('l10n') + '">' +
           this.h('dayName') +
         '</li>';
     },

--- a/apps/calendar/js/views/month_child.js
+++ b/apps/calendar/js/views/month_child.js
@@ -198,12 +198,12 @@
               day = 0;
             }
           }
-          var l10n = 'weekday-' + day + '-short';
+          var l10n = 'weekday-' + day + '-single-char';
 
           name = navigator.mozL10n.get(l10n);
           html += template.weekDaysHeaderDay.render({
-            day: String(day),
-            dayName: name[0]
+            l10n: l10n,
+            dayName: name
           });
         }
 

--- a/apps/calendar/locales/calendar.en-US.properties
+++ b/apps/calendar/locales/calendar.en-US.properties
@@ -235,3 +235,13 @@ error-account-exist=This account already exists.
 notification-error-sync-title=Calendar sync error
 notification-error-sync-description=Tap for more info
 
+# Used in month view as column header, each single char represents a week day
+# (from 0-Sunday to 6-Saturday)
+weekday-0-single-char = S
+weekday-1-single-char = M
+weekday-2-single-char = T
+weekday-3-single-char = W
+weekday-4-single-char = T
+weekday-5-single-char = F
+weekday-6-single-char = S
+

--- a/apps/calendar/test/unit/views/month_child_test.js
+++ b/apps/calendar/test/unit/views/month_child_test.js
@@ -158,7 +158,7 @@ suiteGroup('Views.MonthChild', function() {
     assert.ok(result);
 
     for (; i < days; i++) {
-      id = 'weekday-' + i + '-short';
+      id = 'weekday-' + i + '-single-char';
 
       assert.include(
         result,


### PR DESCRIPTION
created a different locale key instead of slicing the first char since I believe the slice wouldn't work well with all languages and would need custom JS logic to update the values every time the locale changed.
