### PR TITLE
Bug 1027950 - [Settings][Find My Device] Do not attach handlers inside onerror callback

### DIFF
--- a/apps/settings/elements/findmydevice.html
+++ b/apps/settings/elements/findmydevice.html
@@ -16,7 +16,7 @@
           </li>
           <li>
           <button class="icon icon-view" id="findmydevice-login"
-            data-l10n-id="findmydevice-create-account">
+            data-l10n-id="findmydevice-create-account" disabled>
             Create account or sign in
           </button>
           </li>

--- a/apps/settings/js/findmydevice.js
+++ b/apps/settings/js/findmydevice.js
@@ -8,33 +8,36 @@ var FindMyDevice = {
   // login process began with the user clicking our login button
   // since in that case we also want to enable Find My Device
   _interactiveLogin: false,
+  _loginButton: null,
 
   init: function fmd_init() {
     var self = this;
-    var loginButton = document.getElementById('findmydevice-login');
+    self._loginButton = document.getElementById('findmydevice-login');
 
     loadJSON('/resources/findmydevice.json', function(data) {
       self._audienceURL = data.audience_url;
 
-      // Note: either onready or onerror will always fire immediately.
       navigator.mozId.watch({
         wantIssuer: 'firefox-accounts',
         audience: self._audienceURL,
         onlogin: self._onChangeLoginState.bind(self, true),
         onlogout: self._onChangeLoginState.bind(self, false),
         onready: function fmd_fxa_onready() {
-          loginButton.addEventListener('click', self._onLoginClick.bind(self));
+          self._loginButton.removeAttribute('disabled');
+          console.log('Find My Device: onready fired');
         },
         onerror: function fmd_fxa_onerror(err) {
-          loginButton.addEventListener('click', self._onLoginClick.bind(self));
           self._togglePanel(false);
-          console.error(err);
+          self._loginButton.removeAttribute('disabled');
+          console.error('Find My Device: onerror fired: ' + err);
         }
       });
     });
 
     SettingsListener.observe('findmydevice.tracking', false,
       this._setTracked.bind(this));
+    self._loginButton.addEventListener('click', self._onLoginClick.bind(self));
+
     SettingsListener.observe('findmydevice.enabled', false,
       this._setEnabled.bind(this));
 
@@ -45,6 +48,9 @@ var FindMyDevice = {
   _onLoginClick: function fmd_on_login_click(e) {
     e.stopPropagation();
     e.preventDefault();
+    if (this._loginButton.disabled) {
+      return;
+    }
     var _ = navigator.mozL10n.get;
     if (!window.navigator.onLine) {
       return window.alert(_('findmydevice-enable-network'));

--- a/apps/settings/test/unit/findmydevice_panel_test.js
+++ b/apps/settings/test/unit/findmydevice_panel_test.js
@@ -82,8 +82,11 @@ suite('Find My Device panel > ', function() {
       signinSection = document.getElementById('findmydevice-signin');
       settingsSection = document.getElementById('findmydevice-settings');
       trackingSection = document.getElementById('findmydevice-tracking');
-      loginButton = document.getElementById('findmydevice-login');
       checkbox = document.querySelector('#findmydevice-enabled input');
+      loginButton = document.getElementById('findmydevice-login');
+
+      // manually enable the loginButton
+      loginButton.removeAttribute('disabled');
 
       require('/js/findmydevice.js', function() {
         subject = FindMyDevice;
@@ -110,6 +113,26 @@ suite('Find My Device panel > ', function() {
     MockMozId.onlogin();
     assert.isFalse(settingsSection.hidden);
     assert.isTrue(signinSection.hidden);
+  });
+
+  test('ignore clicks when button is disabled', function() {
+    loginButton.disabled = true;
+    var onLoginClickSpy = sinon.spy(FindMyDevice, '_onLoginClick');
+    loginButton.click();
+    sinon.assert.notCalled(onLoginClickSpy);
+    FindMyDevice._onLoginClick.restore();
+  });
+
+  test('enable button after watch fires onready', function() {
+    loginButton.disabled = true;
+    MockMozId.onready();
+    assert.isFalse(!!loginButton.disabled);
+  });
+
+  test('enable button after watch fires onerror', function() {
+    loginButton.disabled = true;
+    MockMozId.onerror();
+    assert.isFalse(!!loginButton.disabled);
   });
 
   test('auto-enable when logging in using the login button', function() {


### PR DESCRIPTION
See Bugzilla bug for discussion.
