### PR TITLE
Merge pull request #20674 from nullaus/bug1021857

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -90,7 +90,7 @@
  * there is an active attention screen not minimized in
  * the status bar */
 #screen.attention:not(.active-statusbar) > [data-z-index-level="keyboards"] {
-  z-index: 16384;
+  z-index: 16386;
 }
 
 /* Level 2: Notification toaster */
@@ -99,8 +99,10 @@
 }
 
 /* Level 3: Attention screen */
+/* Attention screens should be the top-most item (along with keyboards) when
+ * shown and not minimized in status bar */
 #screen > [data-z-index-level="attention-screen"] {
-  z-index: 16384;
+  z-index: 16386;
 }
 
 /* Level 4: Activity menu, context menu, value selector, and permissions */


### PR DESCRIPTION
bug 1021857 - Ensure z-index for AttentionScreen makes it top-most.
(cherry picked from commit f2b7236f28d528cd2a12691fba004e1a2afa929d)
