### PR TITLE
Bug 1022710 - Do not update the visibility of the items when the voice type is null r=eragon

### DIFF
--- a/apps/settings/js/carrier.js
+++ b/apps/settings/js/carrier.js
@@ -217,7 +217,9 @@ var CarrierSettings = (function(window, document, undefined) {
           return;
         }
         _voiceTypes[index] = newType;
-        cs_updateNetworkTypeLimitedItemsVisibility(newType);
+        if (newType) {
+          cs_updateNetworkTypeLimitedItemsVisibility(newType);
+        }
       });
     });
   }


### PR DESCRIPTION
http://bugzilla.mozilla.org/show_bug.cgi?id=1022710
