### PR TITLE
Bug 1028055 - Sender's email is not displayed In the details page of a received email

### DIFF
--- a/apps/email/js/cards/message_reader.html
+++ b/apps/email/js/cards/message_reader.html
@@ -12,8 +12,7 @@
           <span class="icon icon-down"></span>
         </button>
       </menu>
-      <h1 class="msg-reader-header-label"
-        data-l10n-id="reader-header">ReaD</h1>
+      <h1 class="msg-reader-header-label"></h1>
     </header>
   </section>
   <div class="scrollregion-below-header scrollregion-horizontal-too">

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -260,8 +260,6 @@ envelope-to=To
 envelope-cc=Cc
 envelope-bcc=Bcc
 
-reader-header=Read
-
 compose-header=Compose message
 compose-header-short=Compose
 compose-send=Send


### PR DESCRIPTION
[Bug 992473](https://bugzilla.mozilla.org/show_bug.cgi?id=992473) switched the l10n code to use Mutation Observers for doing localizations, and that code was running after our setting of the title in message_reader's buildHeaderDom, overwriting the name with the localization for the generic card name.

Since we always set that value anyway, the localization for that header is not needed, so I just removed it.

I did a quick nav through the UI to see if this affected other headers, but they seem fine, for instance, the settings screen for an individual account are fine (because it does not have an l10n attribute on that field).

This would not be seen in the 2.0 branch, only on master, which is confirmed by the information the bug reporter provided.
