### PR TITLE
Bug 1025727 - [email/cronysync] Failsafe abort/window.close after failed cronsync(s)

### DIFF
--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -6,7 +6,7 @@
 
 /*jshint browser: true */
 /*global define, console, MozActivity, alert */
-define(function(require) {
+define(function(require, exports, module) {
 
 var templateNode = require('tmpl!./compose.html'),
     cmpAttachmentItemNode = require('tmpl!./cmp/attachment_item.html'),
@@ -27,7 +27,8 @@ var templateNode = require('tmpl!./compose.html'),
     prettyFileSize = common.prettyFileSize,
     Cards = common.Cards,
     ConfirmDialog = common.ConfirmDialog,
-    mimeToClass = common.mimeToClass;
+    mimeToClass = common.mimeToClass,
+    dataIdCounter = 0;
 
 /**
  * Max composer attachment size is defined as 5120000 bytes.
@@ -159,6 +160,14 @@ function ComposeCard(domNode, mode, args) {
   this.sentAudio = new Audio('/sounds/sent.ogg');
   this.sentAudio.mozAudioChannelType = 'notification';
   this.playSoundOnSend = false;
+
+  // Set up unique data IDs for data-sensitive operations that could be in
+  // progress. These IDs are unique per kind of action, not unique per instance
+  // of a kind of action. However, these IDs are just used to know if a hard
+  // shutdown should be delayed a bit, and are unique enough for those purposes.
+  var dataId = module.id + '-' + (dataIdCounter += 1);
+  this._dataIdSaveDraft = dataId + '-saveDraft';
+  this._dataIdSendEmail = dataId + '-sendEmail';
 }
 ComposeCard.prototype = {
   /**
@@ -403,7 +412,13 @@ ComposeCard.prototype = {
       return;
     }
     this._saveStateToComposer();
-    this.composer.saveDraft(callback);
+    evt.emit('uiDataOperationStart', this._dataIdSaveDraft);
+    this.composer.saveDraft(function() {
+      evt.emit('uiDataOperationStop', this._dataIdSaveDraft);
+      if (callback) {
+        callback();
+      }
+    }.bind(this));
   },
 
   createBubbleNode: function(name, address) {
@@ -864,6 +879,7 @@ ComposeCard.prototype = {
 
     // Initiate the send.
     console.log('compose: initiating send');
+    evt.emit('uiDataOperationStart', this._dataIdSendEmail);
     this.composer.finishCompositionSendMessage(
       function callback(error , badAddress, sentDate) {
         // Card could have been destroyed in the meantime,
@@ -909,6 +925,7 @@ ComposeCard.prototype = {
           self.sentAudio.play();
         }
 
+        evt.emit('uiDataOperationStop', this._dataIdSendEmail);
         activityHandler();
         this._closeCard();
       }.bind(this)

--- a/apps/email/js/wake_locks.js
+++ b/apps/email/js/wake_locks.js
@@ -2,9 +2,15 @@
 /*globals define, console */
 
 define(function(require) {
+  'use strict';
   var lockTimeouts = {},
       evt = require('evt'),
       allLocks = {},
+
+      // Using an object instead of an array since dataIDs are unique
+      // strings.
+      dataOps = {},
+      dataOpsTimeoutId = 0,
 
       // Only allow keeping the locks for a maximum of 45 seconds.
       // This is to prevent a long, problematic sync from consuming
@@ -15,15 +21,78 @@ define(function(require) {
       // most likely set of failures: just a temporary really bad
       // cell network situation that once the next sync happens, the
       // issue is resolved.
-      maxLockInterval = 45000;
+      maxLockInterval = 45000,
+
+      // Allow UI-triggered data operations to complete in a wake lock timeout
+      // case, but only for a certain amount of time, because they could be the
+      // cause of the wake lock timeout.
+      dataOpsTimeout = 5000;
+
+  // START failsafe close support, bug 1025727.
+  // If the wake locks are timed out, it means sync went on too long, and there
+  // is likely a problem. Reset state via app shutdown. Allow for UI-triggered
+  // data operations to complete though before finally releasing the wake locks
+  // and shutting down.
+  function close() {
+    // Reset state in case a close does not actually happen.
+    dataOps = {};
+    dataOpsTimeoutId = 0;
+
+    // Only really close if the app is hidden.
+    if (document.hidden) {
+      console.log('email: cronsync wake locks expired, force closing app');
+      window.close();
+    } else {
+      console.log('email: cronsync wake locks expired, but app visible, ' +
+                  'not force closing');
+      // User is using the app. Just clear all locks so we do not burn battery.
+      // This means the app could still be in a bad data sync state, so just
+      // need to rely on the next sync attempt or OOM from other app usage.
+      Object.keys(allLocks).forEach(function(accountKey) {
+        clearLocks(accountKey);
+      });
+    }
+  }
+
+  function closeIfNoDataOps() {
+    var dataOpsKeys = Object.keys(dataOps);
+
+    if (!dataOpsKeys.length) {
+      // All clear, no waiting data operations, shut it down.
+      return close();
+    }
+
+    console.log('email: cronsync wake lock force shutdown waiting on email ' +
+                'data operations: ' + dataOpsKeys.join(', '));
+    // Allow data operations to complete, but also set a cap on that since
+    // they could be the ones causing the sync to fail. Give it 5 seconds.
+    dataOpsTimeoutId = setTimeout(close, dataOpsTimeout);
+  }
+
+  // Listen for data operation events that might want to delay the failsafe
+  // close switch.
+  evt.on('uiDataOperationStart', function(dataId) {
+    dataOps[dataId] = true;
+  });
+
+  evt.on('uiDataOperationStop', function(dataId) {
+    delete dataOps[dataId];
+
+    if (dataOpsTimeoutId && !Object.keys(dataOps).length) {
+      clearTimeout(dataOpsTimeoutId);
+      close();
+    }
+  });
+  // END failsafe close
 
   function clearLocks(accountKey) {
     console.log('email: clearing wake locks for "' + accountKey + '"');
 
     // Clear timer
     var lockTimeoutId = lockTimeouts[accountKey];
-    if (lockTimeoutId)
+    if (lockTimeoutId) {
       clearTimeout(lockTimeoutId);
+    }
     lockTimeouts[accountKey] = 0;
 
     // Clear the locks
@@ -57,8 +126,9 @@ define(function(require) {
 
     allLocks[accountKey] = locks;
 
-    lockTimeouts[accountKey] = setTimeout(clearLocks.bind(null, accountKey),
-                                          maxLockInterval);
+    // If timeout is reached, means app is stuck in a bad state, and just
+    // shut it down via the failsafe close.
+    lockTimeouts[accountKey] = setTimeout(closeIfNoDataOps, maxLockInterval);
   });
 
   evt.on('cronSyncStop', onCronStop);


### PR DESCRIPTION
This pull request introduces a failsafe close mechanism based on the cronsync mechanism.

The bulk of the work is done in wake_locks, since we ideally need the wake locks still active if some other UI data actions is occurring, like a mid-stream draft save or message send, and the wake lock timeout gives us a strong signal that something has gone wrong.

For the wake_lock timeout, it now uses a new function, closeIfNoDataOps, to decide if the app should be closed. If there are no in-process UI data actions, then it will proceed with closing the app if the app is currently in a hidden state. It was previously confirmed that the system will free any locks automatically for closed apps.

If the app is visible when the wake lock timeout occurs, then the locks are just cleared, and we wait for the next sync pass or regular other-app use to OOM email.

compose triggers uiDataOperationStart and uiDataOperationStop events to indicate in-process UI data actions: either saving a draft or sending a message.

If there are in-process UI data actions, there is a 5 second grace period to finish before the failsafe kills the app. This is done because one of those UI data actions could be contributing to the reason sync has gone bad, and it is more important to just shut down and reset. The odds of reaching that state should be very low, the UI data actions will likely complete in time, but we need an ultimate failsafe pathway just in case.

This will likely need to be revisited with background send. If it is an email send with a large attachment, that could also be a problem, but only if email is in the background when that happens. The most likely cause of getting into this state though, when sync fails so that this pathway is considered is if the network connections have gotten into a weird state, so sending is not likely to complete anyway.

Tests were performed by putting in an early return in sync.js at the top of its api.oncronsyncstop function, at line 108. This made it appear that syncing did not complete. Then the following things were tried, using a 60 second test interval:
- regular background sync with email closed. Saw the "force closing app" message and confirmed email was not running after that.
- regular background sync with email, but then tapping email icon so it is visible. Saw "app still visible" and email kept running.
- Changed compose to not emit the uiDataOperationStop event, then waited for a sync to start, opened a compose and saved draft, then went back to home screen. Saw the "waiting on email data operations" message with "saveDraft" mentioned, then 5 seconds later the app was closed.
