### PR TITLE
Bug 959201 - [Messages][Drafts] Wrong Cursor position in the message compose of a Draft

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -432,6 +432,11 @@ var Compose = (function() {
       }, Compose);
 
       this.focus();
+
+      // Put the cursor at the end of the message
+      var selection = window.getSelection();
+      selection.selectAllChildren(dom.message);
+      selection.collapseToEnd();
     },
 
     /** Render message (sms or mms)


### PR DESCRIPTION
Put the cursor at the end of the message when opening a draft.
