### PR TITLE
Added listener when sleeping for search bar to deactivate Bug 1028668 r=vingtetun

### DIFF
--- a/apps/system/js/home_searchbar.js
+++ b/apps/system/js/home_searchbar.js
@@ -50,6 +50,7 @@
       window.addEventListener('home', this);
       window.addEventListener('appopened', this);
       window.addEventListener('searchcrashed', this);
+      window.addEventListener('visibilitychange', this);
 
       // Listen for events from Rocketbar
       this.input.addEventListener('focus', this);
@@ -106,6 +107,11 @@
           break;
         case 'searchcrashed':
           this.handleSearchCrashed(e);
+          break;
+        case 'visibilitychange':
+          if(document.hidden){
+            this.deactivate();
+          }
           break;
         case 'submit':
           this.handleSubmit(e);


### PR DESCRIPTION
Use case : 
-type something in the search bar from the homescreen
-wait for the screen to turn off or lock the device with the sleep button

When "coming back" : we should be on the home screen and not be on an empty search screen
