### PR TITLE
Bug 1028702 -  Last divider in homescreen displayed after edit mode was activated

### DIFF
--- a/shared/elements/gaia_grid/js/grid_view.js
+++ b/shared/elements/gaia_grid/js/grid_view.js
@@ -318,6 +318,9 @@
 
       this.removeAllPlaceholders();
       this.cleanItems(options.skipDivider);
+      if (options.skipItems) {
+        return;
+      }
 
       // Start rendering from one before the drop target. If not,
       // we may drop over the divider and miss rendering an icon.


### PR DESCRIPTION
Used the options.skipItems to avoid to add placeholders on the grid view
