### PR TITLE
Bug 1023259 - [Flame][v1.4][Gaia::SMS] The contact number is shown incom...

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -803,6 +803,7 @@ form[role="dialog"][data-type="action"].contact-prompt > header {
   padding: 0 0 0.7rem;
   margin: 0;
   overflow: hidden;
+  text-overflow: ellipsis;
 
   font-size: 1.5rem;
 }


### PR DESCRIPTION
...pletely in the contact detail screen of SMS conversion when the contact phone label is more than 19 characters.
