### PR TITLE
Bug 1023044 - Show the signal bar for a locked sim only when making emergency calls using the sim. r=alive

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -724,8 +724,14 @@ var StatusBar = {
           icon.dataset.roaming = data.roaming;
 
           delete icon.dataset.searching;
-        } else if (voice.connected || self.hasActiveCall()) {
+        } else if (voice.connected || self.hasActiveCall() &&
+            navigator.mozTelephony.active.serviceId === index) {
           // "Carrier" / "Carrier (Roaming)"
+          // If voice.connected is false but there is an active call, we should
+          // check whether the service id of that call equals the current index
+          // of the target sim card. If yes, that means the user is making an
+          // emergency call using the target sim card. In such case we should
+          // also display the signal bar as the normal cases.
           icon.dataset.level = Math.ceil(voice.relSignalStrength / 20); // 0-5
           icon.dataset.roaming = voice.roaming;
 
@@ -733,8 +739,8 @@ var StatusBar = {
         } else if (simslot.isLocked()) {
           // SIM locked
           // We check if the sim card is locked after checking hasActiveCall
-          // because we still need to show the siganl bars in this case even
-          // the sim card is locked.
+          // because we still need to show the siganl bars in the case of
+          // making emergency calls when the sim card is locked.
           icon.hidden = true;
         } else {
           // "No Network" / "Emergency Calls Only (REASON)" / trying to connect

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -441,7 +441,8 @@ suite('system/Statusbar', function() {
             sinon.stub(mockSimSlots[slotIndex], 'isLocked').returns(true);
 
             MockNavigatorMozTelephony.active = {
-              state: 'connected'
+              state: 'connected',
+              serviceId: slotIndex
             };
 
             StatusBar.update.signal.call(StatusBar);
@@ -467,7 +468,8 @@ suite('system/Statusbar', function() {
             sinon.stub(mockSimSlots[slotIndex], 'isLocked').returns(true);
 
             MockNavigatorMozTelephony.active = {
-              state: 'dialing'
+              state: 'dialing',
+              serviceId: slotIndex
             };
 
             StatusBar.update.signal.call(StatusBar);
@@ -495,7 +497,8 @@ suite('system/Statusbar', function() {
             StatusBar.update.signal.call(StatusBar);
 
             var activeCall = {
-              state: 'dialing'
+              state: 'dialing',
+              serviceId: slotIndex
             };
 
             MockNavigatorMozTelephony.active = activeCall;

--- a/apps/system/test/unit/wifi_test.js
+++ b/apps/system/test/unit/wifi_test.js
@@ -183,6 +183,17 @@ suite('WiFi > ', function() {
   });
 
   suite('maybeToggleWifi', function() {
+    var realMozAlarms;
+
+    suiteSetup(function() {
+      realMozAlarms = navigator.mozAlarms;
+      navigator.mozAlarms = {};
+    });
+
+    suiteTeardown(function() {
+      navigator.mozAlarms = realMozAlarms;
+    });
+
     test('Test turn wifi back on', function() {
       SettingsListener.mCallbacks['wifi.screen_off_timeout'](100);
       Wifi.wifiDisabledByWakelock = true;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1023044
