### PR TITLE
Bug 1029016 - [Collection app] Can't interact with pinned apps when load...

### DIFF
--- a/apps/collection/style/css/view.css
+++ b/apps/collection/style/css/view.css
@@ -1,6 +1,8 @@
 gaia-grid {
   display: block;
   width: 100%;
+  position: relative;
+  z-index: 2;
 }
 
 #edit-header {
@@ -64,12 +66,6 @@ gaia-grid {
   background-color: #333333;
 }
 
-/* making sure content elements don't get overlayed by #content:after */
-#content > * {
-  position: relative;
-  z-index: 1;
-}
-
 /* Notifications */
 #content {
   display: flex;
@@ -86,6 +82,8 @@ section[role="notification"] {
   text-align: center;
   justify-content: center;
   display: none;
+  position: relative;
+  z-index: 1;
 }
 
 section[role="notification"]#offline {


### PR DESCRIPTION
...ing web results

Bug cause:
The section[role="notification"] element (progress indicator and connection message elements) covers <gaia-grid>. That's because it's a flexbox that has the same z-index as <gaia-grid>.

Solution: z-index: 2 for gaia-grid

http://bugzil.la/1029016
