### PR TITLE
Bug 1022992 - Always show Find My Device's enabled state in the root Settings menu. r=arthurcc

### DIFF
--- a/apps/settings/elements/findmydevice.html
+++ b/apps/settings/elements/findmydevice.html
@@ -7,7 +7,7 @@
     </header>
 
     <div>
-      <div id="findmydevice-signin">
+      <div id="findmydevice-signin" hidden>
         <ul>
           <li class="description" data-l10n-id="findmydevice-signup-description">
           FindMyDevice allows you to locate, lock or erase your phone.

--- a/apps/settings/elements/root.html
+++ b/apps/settings/elements/root.html
@@ -106,7 +106,7 @@
           <a id="menuItem-fxa" class="menu-item" href="#fxa" data-l10n-id="fxa-accounts">Firefox Accounts</a>
         </li>
         <li data-show-name="findmydevice.ui.enabled" hidden>
-          <small id="findmydevice-desc" class="menu-item-desc"></small>
+          <small class="findmydevice-desc menu-item-desc"></small>
           <a id="menuItem-findmydevice" class="menu-item" href="#findmydevice"
             data-l10n-id="findmydevice">Find My Device</a>
         </li>

--- a/apps/settings/js/panels/root/findmydevice_item.js
+++ b/apps/settings/js/panels/root/findmydevice_item.js
@@ -1,0 +1,91 @@
+/* global SettingsListener */
+
+/**
+ * This module display Find My Device's enabled/disabled state on an
+ * element.
+ *
+ * @module panels/root/findmydevice_item
+ */
+define(function(require) {
+  'use strict';
+
+  /**
+   * @alias module:panels/root/findmydevice_item
+   * @class FindMyDeviceItem
+   * @param {HTMLElement} element
+                          The element displaying Find My Device's enabled state
+   * @returns {FindMyDeviceItem}
+   */
+  function FindMyDeviceItem(element) {
+    this._itemEnabled = false;
+    this._FMDEnabled = false;
+    this._boundRefreshText = this._refreshText.bind(this, element);
+    this._boundFMDEnabledChanged = this._onFMDEnabledChanged.bind(this);
+  }
+
+  FindMyDeviceItem.prototype = {
+    /**
+     * Refresh the text based on Find My Device's enabled state
+     *
+     * @access private
+     * @memberOf FindMyDeviceItem.prototype
+     * @param {HTMLElement} element
+                            The element showing Find My Device's enabled state
+     */
+    _refreshText: function fmd_refresh_text(element) {
+      if (!navigator.mozL10n) {
+        return;
+      }
+
+      navigator.mozL10n.localize(element,
+        this._FMDEnabled ? 'enabled' : 'disabled');
+      element.hidden = false;
+    },
+
+    /**
+     * Listener for changes in Find My Device's enabled state. Updates the
+     * text if this item is enabled.
+     *
+     * @access private
+     * @memberOf FindMyDeviceItem.prototype
+     * @param {Boolean} value
+                        The current enabled state for Find My Device
+     */
+    _onFMDEnabledChanged: function fmd_enabled_changed(value) {
+      this._FMDEnabled = value;
+      if (this._itemEnabled) {
+        this._boundRefreshText();
+      }
+    },
+
+    /**
+     * The value indicates whether the module is responding.
+     *
+     * @access public
+     * @memberOf FindMyDeviceItem.prototype
+     * @type {Boolean}
+     */
+    get enabled() {
+      return this._itemEnabled;
+    },
+
+    set enabled(value) {
+      if (this._itemEnabled === value) {
+        return;
+      }
+
+      this._itemEnabled = value;
+      if (this._itemEnabled) {
+        SettingsListener.observe('findmydevice.enabled', false,
+          this._boundFMDEnabledChanged);
+      } else {
+        SettingsListener.unobserve('findmydevice.enabled',
+          this._boundFMDEnabledChanged);
+      }
+    }
+  };
+
+  return function ctor_findMyDeviceItem(element) {
+    return new FindMyDeviceItem(element);
+  };
+});

--- a/apps/settings/js/panels/root/panel.js
+++ b/apps/settings/js/panels/root/panel.js
@@ -3,13 +3,20 @@ define(function(require) {
 
   var SettingsPanel = require('modules/settings_panel');
   var Root = require('panels/root/root');
+  var FindMyDeviceItem = require('panels/root/findmydevice_item');
 
   return function ctor_root_panel() {
     var root = Root();
+    var findMyDeviceItem;
 
     return SettingsPanel({
-      onInit: function rp_onInit() {
+      onInit: function rp_onInit(panel) {
         root.init();
+        findMyDeviceItem = FindMyDeviceItem(
+          panel.querySelector('.findmydevice-desc'));
+      },
+      onBeforeShow: function rp_onBeforeShow() {
+        findMyDeviceItem.enabled = true;
       },
       onShow: function rp_onShow() {
         // XXX: Set data-ready to true to indicate that the first panel is
@@ -17,6 +24,9 @@ define(function(require) {
         //      transitions. This should be moved to startup.js after we handle
         //      inline activities there.
         document.body.dataset.ready = true;
+      },
+      onHide: function rp_onHide() {
+        findMyDeviceItem.enabled = false;
       }
     });
   };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1022992
