### PR TITLE
Bug 1028906 - [v2.0][v2.1] Marketplace launch test is failing at "set_pe...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/marketplace/test_marketplace_launch.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/marketplace/test_marketplace_launch.py
@@ -14,7 +14,6 @@ class TestMarketplaceLaunch(GaiaTestCase):
     
     def setUp(self):
         GaiaTestCase.setUp(self)
-        self.apps.set_permission('Homescreen', 'geolocation', 'deny')
         self.connect_to_network()
     
     def test_marketplace_launch(self):


### PR DESCRIPTION
...rmission('Homescreen', 'geolocation', 'deny')"
