### PR TITLE
Bug 1016687 - [B2G][Calendar] - Event icons / indicators (dots below the date) are still visible in month view after disabling offline calendar r=RyanVM

### DIFF
--- a/apps/calendar/elements/modify_event.html
+++ b/apps/calendar/elements/modify_event.html
@@ -69,7 +69,7 @@
 
         <li class="calendar-id">
           <span class="button icon icon-dialog">
-            <select name="calendarId">
+            <select name="calendarId" class="loading">
             </select>
           </span>
         </li>

--- a/apps/calendar/js/controllers/time.js
+++ b/apps/calendar/js/controllers/time.js
@@ -20,6 +20,7 @@ Calendar.ns('Controllers').Time = (function() {
     this._collection.createIndex('eventId');
 
     this.busytime = app.store('Busytime');
+    this.calendarStore = app.store('Calendar');
   }
 
   Time.prototype = {
@@ -112,7 +113,7 @@ Calendar.ns('Controllers').Time = (function() {
     },
 
     get timespan() {
-      return this._timespan;
+      return this._currentTimespan;
     },
 
     get scale() {
@@ -486,7 +487,10 @@ Calendar.ns('Controllers').Time = (function() {
      * @return {Array} busytimes ordered by start date.
      */
     queryCache: function(timespan) {
-      return this._collection.query(timespan);
+      return this._collection.query(timespan).filter(function(busytime) {
+        // we filter out busytimes from disabled calendars
+        return this.calendarStore.shouldDisplayCalendar(busytime.calendarId);
+      }, this);
     },
 
     /**

--- a/apps/calendar/js/templates/day.js
+++ b/apps/calendar/js/templates/day.js
@@ -47,7 +47,6 @@
       var eventClassName = [
         'event',
         'calendar-id-' + calendarId,
-        'calendar-display',
         'calendar-bg-color',
         this.h('classes')
       ].join(' ');

--- a/apps/calendar/js/templates/month.js
+++ b/apps/calendar/js/templates/month.js
@@ -8,7 +8,6 @@
                 ' busy-length-' + this.h('length') +
                 ' busy-' + this.h('start') +
                 ' calendar-id-' + this.h('calendarId') +
-                ' calendar-display' +
               '">' +
               '&nbsp;' +
             '</span>';

--- a/apps/calendar/js/templates/months_day.js
+++ b/apps/calendar/js/templates/months_day.js
@@ -8,7 +8,6 @@
       var sectionClassList = [
         'event',
         'calendar-id-' + calendarId,
-        'calendar-display',
         this.h('classes')
       ].join(' ');
 

--- a/apps/calendar/js/templates/week.js
+++ b/apps/calendar/js/templates/week.js
@@ -25,7 +25,6 @@
       var eventClassName = [
         'event',
         'calendar-id-' + this.h('calendarId'),
-        'calendar-display',
         'calendar-bg-color',
         'calendar-border-color'
       ].join(' ');

--- a/apps/calendar/js/views/calendar_colors.js
+++ b/apps/calendar/js/views/calendar_colors.js
@@ -24,7 +24,6 @@ Calendar.ns('Views').CalendarColors = (function() {
       var store = Calendar.App.store('Calendar');
       store.on('persist', this);
       store.on('remove', this);
-      store.on('preRemove', this);
     },
 
     handleEvent: function(e) {
@@ -32,9 +31,6 @@ Calendar.ns('Views').CalendarColors = (function() {
         case 'persist':
           // 1 is the model
           this.updateRule(e.data[1]);
-          break;
-        case 'preRemove':
-          this.hideCalendar(e.data[0]);
           break;
         case 'remove':
           // 0 is an id of a model
@@ -82,14 +78,6 @@ Calendar.ns('Views').CalendarColors = (function() {
       return this.calendarId(String(id));
     },
 
-    hideCalendar: function(id) {
-      this.updateRule({
-        _id: id,
-        localDisplayed: false,
-        color: '#CCC'
-      });
-    },
-
     /**
      * associates a color with a
      * calendar/calendar id with a color.
@@ -108,17 +96,10 @@ Calendar.ns('Views').CalendarColors = (function() {
       var bgStyle = map.background.style;
       var borderStyle = map.border.style;
       var textStyle = map.text.style;
-      var displayStyle = map.display.style;
 
       bgStyle.backgroundColor = this._hexToBackgroundColor(color);
       borderStyle.borderColor = color;
       textStyle.color = color;
-
-      if (calendar.localDisplayed) {
-        displayStyle.setProperty('display', 'inherit', 'important');
-      } else {
-        displayStyle.setProperty('display', 'none');
-      }
     },
 
     _createRules: function(calendar, id, color) {
@@ -137,11 +118,6 @@ Calendar.ns('Views').CalendarColors = (function() {
 
       var textColor = 'color: ' + color + ';';
       map.text = this._insertRule(id, 'calendar-text-color', textColor);
-
-      var displayBody = calendar.localDisplayed ?
-        'display: inherit !important;' :
-        'display: none;';
-      map.display = this._insertRule(id, 'calendar-display', displayBody);
     },
 
     _hexToBackgroundColor: function(hex) {

--- a/apps/calendar/js/views/day_based.js
+++ b/apps/calendar/js/views/day_based.js
@@ -635,13 +635,13 @@ Calendar.ns('Views').DayBased = (function() {
     },
 
     getScrollTop: function() {
-      var scroll = this.element.querySelectorAll('.day-events')[1];
+      var scroll = this.element.querySelectorAll('.day-events-wrapper')[0];
       var scrollTop = scroll.scrollTop;
       return scrollTop;
     },
 
     setScrollTop: function(scrollTop) {
-      var scroll = this.element.querySelectorAll('.day-events')[1];
+      var scroll = this.element.querySelectorAll('.day-events-wrapper')[0];
       scroll.scrollTop = scrollTop;
     }
 

--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -116,6 +116,15 @@ Calendar.ns('Views').ModifyEvent = (function() {
      * Build the initial list of calendar ids.
      */
     onfirstseen: function() {
+      // we need to notify users (specially automation tests) somehow that the
+      // options are still being loaded from DB, this is very important to
+      // avoid race conditions (eg.  trying to set calendar before list is
+      // built) notice that we also add the class to the markup because on some
+      // really rare occasions "onfirstseen" is called after the EventBase
+      // removed the "loading" class from the root element (seen it happen less
+      // than 1% of the time)
+      this.getEl('calendarId').classList.add(self.LOADING);
+
       var calendarStore = this.app.store('Calendar');
       calendarStore.all(function(err, calendars) {
         if (err) {
@@ -128,6 +137,8 @@ Calendar.ns('Views').ModifyEvent = (function() {
 
         function next() {
           if (!--pending) {
+            self.getEl('calendarId').classList.remove(self.LOADING);
+
             if (self.onafteronfirstseen) {
               self.onafteronfirstseen();
             }

--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -55,6 +55,7 @@ Calendar.ns('Views').Month = (function() {
 
       if (el) {
         el.classList.add(this.SELECTED);
+        this._selectedDay = date;
       }
     },
 
@@ -83,7 +84,11 @@ Calendar.ns('Views').Month = (function() {
         case 'selectedDayChange':
           this._selectDay(e.data[0]);
           break;
-
+        case 'calendarVisibilityChange':
+          // we need to mark current day after redraw (happens when user
+          // toggles the calendar visibility)
+          this._selectDay(this._selectedDay);
+          break;
         case 'monthChange':
           this._clearSelectedDay();
           this.changeDate(e.data[0]);

--- a/apps/calendar/js/views/months_day.js
+++ b/apps/calendar/js/views/months_day.js
@@ -56,6 +56,7 @@ Calendar.ns('Views').MonthsDay = (function() {
 
     _initEvents: function() {
       this.controller.on('selectedDayChange', this);
+      this.app.store('Calendar').on('calendarVisibilityChange', this);
       this.delegate(this.events, 'click', '[data-id]', function(e, target) {
         Calendar.App.router.show('/event/show/' + target.dataset.id + '/');
       });
@@ -98,6 +99,11 @@ Calendar.ns('Views').MonthsDay = (function() {
       Parent.prototype.handleEvent.apply(this, arguments);
 
       switch (e.type) {
+        case 'calendarVisibilityChange':
+          // we need to re-render the view when calendar visibility changes to
+          // keep event list in sync
+          this.changeDate(this.date, true);
+          break;
         case 'selectedDayChange':
           this.changeDate(e.data[0], true);
           break;

--- a/apps/calendar/js/views/time_parent.js
+++ b/apps/calendar/js/views/time_parent.js
@@ -37,6 +37,7 @@ Calendar.ns('Views').TimeParent = (function() {
 
     _initEvents: function() {
       this.app.timeController.on('purge', this);
+      this.app.store('Calendar').on('calendarVisibilityChange', this);
       this.element.addEventListener('swipe', this);
 
       this.gd = new GestureDetector(this.element);
@@ -62,6 +63,9 @@ Calendar.ns('Views').TimeParent = (function() {
 
     handleEvent: function(e) {
       switch (e.type) {
+        case 'calendarVisibilityChange':
+          this._onCalendarVisibilityChange();
+          break;
         case 'swipe':
           this._onswipe(e.detail);
           break;
@@ -69,6 +73,16 @@ Calendar.ns('Views').TimeParent = (function() {
           this.purgeFrames(e.data[0]);
           break;
       }
+    },
+
+    _onCalendarVisibilityChange: function() {
+      // we need to restore previous scroll position otherwise it would move
+      // back to top every time the calendar visibility is toggled which would
+      // be very confusing for the user
+      var scrollTop = this.currentFrame.getScrollTop() || 0;
+      this.purgeFrames(this.app.timeController.timespan);
+      this.changeDate(this.date);
+      this.currentFrame.setScrollTop(scrollTop);
     },
 
     /**
@@ -184,7 +198,7 @@ Calendar.ns('Views').TimeParent = (function() {
       var prev = this._previousTime(time);
 
       // add previous frame
-      prev = this.addFrame(prev);
+      this.addFrame(prev);
 
       // create & activate current frame
       var cur = this.currentFrame = this.addFrame(time);

--- a/apps/calendar/test/marionette/lib/views/day.js
+++ b/apps/calendar/test/marionette/lib/views/day.js
@@ -39,5 +39,9 @@ Day.prototype = {
 
   get currentDisplayHour() {
     return this.currentHour.findElement('.display-hour');
+  },
+
+  get allDay() {
+    return this.activeDay.findElement('.hour-allday');
   }
 };

--- a/apps/calendar/test/marionette/lib/views/day_event.js
+++ b/apps/calendar/test/marionette/lib/views/day_event.js
@@ -28,13 +28,5 @@ DayEvent.prototype = {
 
   get iconAlarm() {
     return this.findElement('.icon-alarm');
-  },
-
-  get closestHour() {
-    return this.client.helper.closest(this.element, '.hour');
-  },
-
-  get closestAllDay() {
-    return this.client.helper.closest(this.element, '.hour-allday');
   }
 };

--- a/apps/calendar/test/marionette/lib/views/edit_event.js
+++ b/apps/calendar/test/marionette/lib/views/edit_event.js
@@ -12,6 +12,26 @@ EditEvent.prototype = {
 
   selector: '#modify-event-view',
 
+  waitForDisplay: function() {
+    // event details are loaded asynchronously, so we need to wait until the
+    // "loading" class is removed from the view; this will avoid intermittent
+    // failures on Travis (caused by race condition)
+    var element = this.getElement();
+
+    var selectIsReady = function() {
+      // the calendar list is also loaded asynchronously from the database, so
+      // we need to wait until it's ready as well
+      var select = element.findElement('select[name="calendarId"]');
+      return select.getAttribute('className').indexOf('loading') === -1;
+    };
+
+    this.client.waitFor(function() {
+      return element.displayed() &&
+        element.getAttribute('className').indexOf('loading') === -1 &&
+        selectIsReady();
+    });
+  },
+
   get form() {
     return this.findElement('form');
   },

--- a/apps/calendar/test/marionette/lib/views/month.js
+++ b/apps/calendar/test/marionette/lib/views/month.js
@@ -12,8 +12,16 @@ Month.prototype = {
 
   selector: '#month-view',
 
+  get activeMonth() {
+    return this.findElement('.month.active');
+  },
+
   get currentDay() {
-    return this.findElement('.month.active .present > .day');
+    return this.activeMonth.findElement('.present > .day');
+  },
+
+  get busyDots() {
+    return this.activeMonth.findElements('.icon-dot');
   },
 
   get days() {

--- a/apps/calendar/test/marionette/lib/views/month_day_event.js
+++ b/apps/calendar/test/marionette/lib/views/month_day_event.js
@@ -56,15 +56,5 @@ MonthDayEvent.prototype = {
     return this.element.scriptWith(function(element) {
       return element.classList.contains('has-alarms');
     });
-  },
-
-  get closestHour() {
-    return +this.client.helper
-      .closest(this.element, '.hour')
-      .getAttribute('data-hour');
-  },
-
-  get closestAllDay() {
-    return this.client.helper.closest(this.element, '.hour-allday');
   }
 };

--- a/apps/calendar/test/marionette/lib/views/settings.js
+++ b/apps/calendar/test/marionette/lib/views/settings.js
@@ -35,11 +35,10 @@ Settings.prototype = {
   toggleCalendar: function(name) {
     name = name || 'Offline calendar';
     this
-      .findElements('.calendars .name')
+      .findElements('.pack-checkbox')
       .filter(function(element) {
         return element.text() === name;
       })[0]
-      .findElement('.pack-checkbox')
       .click();
   }
 };

--- a/apps/calendar/test/marionette/toggle_calendar_test.js
+++ b/apps/calendar/test/marionette/toggle_calendar_test.js
@@ -27,17 +27,6 @@ marionette('toggle calendar', function() {
     app.closeSettingsView();
   }
 
-  // the UI only gets updated after a few ms (data is persisted asynchronously
-  // and after a delay), so we need to wait "displayed" value to change - will
-  // timeout on test failure
-  function waitForEvent(event) {
-    client.helper.waitForElement(event.element);
-  }
-
-  function waitForEventToDisappear(event) {
-    client.helper.waitForElementToDisappear(event.element);
-  }
-
   suite('> regular event', function() {
     setup(function() {
       app.createEvent({
@@ -49,23 +38,28 @@ marionette('toggle calendar', function() {
 
     suite('disable calendar', function() {
       test('month view', function() {
-        var event = app.monthDay.events[0];
-        waitForEventToDisappear(event);
+        client.waitFor(function() {
+          return app.monthDay.events.length === 0;
+        });
+        assert.equal(app.month.busyDots.length, 0, 'no busy dots');
       });
 
       test('week view', function() {
         app.openWeekView();
-        waitForEventToDisappear(app.week.events[0]);
+        client.waitFor(function() {
+          return app.week.events.length === 0;
+        });
       });
 
       test('day view', function() {
         app.openDayView();
-        var event = app.day.events[0];
-        waitForEventToDisappear(event);
+        client.waitFor(function() {
+          return app.day.events.length === 0;
+        });
 
         // on day view hour can't be hidden otherwise it affects events on other
         // calendars and it also looks weird
-        var hour = event.closestHour;
+        var hour = app.day.currentHour;
         assert(
           hour.displayed(),
           'hour should be displayed on day view'
@@ -81,17 +75,23 @@ marionette('toggle calendar', function() {
       setup(toggleLocalCalendar);
 
       test('month view', function() {
-        waitForEvent(app.monthDay.events[0]);
+        client.waitFor(function() {
+          return app.monthDay.events.length;
+        });
       });
 
       test('week view', function() {
         app.openWeekView();
-        waitForEvent(app.week.events[0]);
+        client.waitFor(function() {
+          return app.week.events.length;
+        });
       });
 
       test('day view', function() {
         app.openDayView();
-        waitForEvent(app.day.events[0]);
+        client.waitFor(function() {
+          return app.day.events.length;
+        });
       });
     });
   });
@@ -108,10 +108,11 @@ marionette('toggle calendar', function() {
 
     test('should not hide all day on day view', function() {
       app.openDayView();
-      var event = app.day.events[0];
-      waitForEventToDisappear(event);
+      client.waitFor(function() {
+        return app.day.events.length === 0;
+      });
       assert.ok(
-        event.closestAllDay.displayed(),
+        app.day.allDay.displayed(),
         'all day should be displayed'
       );
     });

--- a/apps/calendar/test/marionette/toggle_calendar_test.js
+++ b/apps/calendar/test/marionette/toggle_calendar_test.js
@@ -51,15 +51,6 @@ marionette('toggle calendar', function() {
       test('month view', function() {
         var event = app.monthDay.events[0];
         waitForEventToDisappear(event);
-        // we cannot hide hour since there might be other events from different
-        // calendars that happens at same time (which would also be hidden)
-        // this behavior is better than previous one and will be changed after
-        // we implement the visual refresh (it's a good compromise)
-        var hour = event.closestHour;
-        assert(
-          hour.displayed(),
-          'hour should be displayed on month view'
-        );
       });
 
       test('week view', function() {
@@ -67,8 +58,7 @@ marionette('toggle calendar', function() {
         waitForEventToDisappear(app.week.events[0]);
       });
 
-      // Disabled bug 1007519
-      test.skip('day view', function() {
+      test('day view', function() {
         app.openDayView();
         var event = app.day.events[0];
         waitForEventToDisappear(event);

--- a/apps/calendar/test/unit/views/calendar_colors_test.js
+++ b/apps/calendar/test/unit/views/calendar_colors_test.js
@@ -103,8 +103,7 @@ suiteGroup('Views.CalendarColors', function() {
     setup(function() {
       calls = {
         add: [],
-        remove: [],
-        preremove: []
+        remove: []
       };
 
       subject.updateRule = function(item) {
@@ -114,21 +113,12 @@ suiteGroup('Views.CalendarColors', function() {
       subject.removeRule = function(item) {
         calls.remove.push(item);
       };
-
-      subject.hideCalendar = function(item) {
-        calls.preremove.push(item);
-      };
     });
 
     test('type: persist', function() {
       store.emit('persist', model._id, model);
 
       assert.deepEqual(calls.add, [model]);
-    });
-
-    test('type: preremove', function() {
-      store.emit('preRemove', model._id);
-      assert.deepEqual(calls.preremove, [model._id]);
     });
 
     test('type: remove', function() {
@@ -172,32 +162,9 @@ suiteGroup('Views.CalendarColors', function() {
       assert.match(rules[0].selectorText, /3xx/, msg);
       assert.match(rules[1].selectorText, /3xx/, msg);
 
-      assert.equal(rules.length, 4, 'should remove css rules');
+      assert.equal(rules.length, 3, 'should remove css rules');
     });
 
-  });
-
-  suite('#hideCalendar', function() {
-    setup(function() {
-      subject.hideCalendar(model._id);
-    });
-
-    test('hides display', function() {
-      // check that the actual style is flushed to the dom...
-      var bgRule = subject._styles.cssRules[0];
-
-      // it may do the RGB conversion so its not strictly equal...
-      assert.ok(
-        bgRule.style.backgroundColor,
-        'should have set background color'
-      );
-
-      var displayRule = subject._styles.cssRules[3];
-      assert.equal(
-        displayRule.style.display, 'none',
-        'should set display to none'
-      );
-    });
   });
 
   suite('#updateRule', function() {
@@ -210,11 +177,10 @@ suiteGroup('Views.CalendarColors', function() {
       assert.equal(subject.colorMap[id], model.color);
 
       // check that the actual style is flushed to the dom...
-      assert.equal(subject._styles.cssRules.length, 4);
+      assert.equal(subject._styles.cssRules.length, 3);
       var bgRule = subject._styles.cssRules[0];
       var borderRule = subject._styles.cssRules[1];
       var textRule = subject._styles.cssRules[2];
-      var displayRule = subject._styles.cssRules[3];
 
       assert.include(bgRule.selectorText, subject.getId(model._id));
       assert.include(bgRule.selectorText, 'calendar-bg-color');
@@ -225,9 +191,6 @@ suiteGroup('Views.CalendarColors', function() {
       assert.include(textRule.selectorText, subject.getId(model._id));
       assert.include(textRule.selectorText, 'calendar-text-color');
 
-      assert.include(displayRule.selectorText, subject.getId(model._id));
-      assert.include(displayRule.selectorText, 'calendar-display');
-
       // it may do the RGB conversion so its not strictly equal...
       assert.ok(
         bgRule.style.backgroundColor,
@@ -236,27 +199,6 @@ suiteGroup('Views.CalendarColors', function() {
 
       assert.ok(borderRule.style.borderColor, 'sets border color');
       assert.ok(textRule.style.color, 'sets text color');
-      assert.ok(displayRule.style.display, 'sets display');
-    });
-
-    test('first time hidden', function() {
-      model.localDisplayed = false;
-      subject.updateRule(model);
-
-      // check that the actual style is flushed to the dom...
-      var bgRule = subject._styles.cssRules[0];
-
-      // it may do the RGB conversion so its not strictly equal...
-      assert.ok(
-        bgRule.style.backgroundColor,
-        'should have set background color'
-      );
-
-      var displayRule = subject._styles.cssRules[3];
-      assert.equal(
-        displayRule.style.display, 'none',
-        'should set display to none'
-      );
     });
 
     test('second time', function() {
@@ -267,7 +209,6 @@ suiteGroup('Views.CalendarColors', function() {
       var bgStyle = rules[0].style;
       var borderStyle = rules[1].style;
       var textStyle = rules[2].style;
-      var displayStyle = rules[3].style;
 
       var oldBgColor = bgStyle.backgroundColor;
       var oldBorderColor = borderStyle.borderColor;
@@ -283,15 +224,6 @@ suiteGroup('Views.CalendarColors', function() {
         'should change border color');
       assert.notEqual(textStyle.borderColor, oldTextColor,
         'should change text color');
-
-      model.localDisplayed = false;
-      subject.updateRule(model);
-
-      assert.equal(displayStyle.display, 'none');
-
-      model.localDisplayed = true;
-      subject.updateRule(model);
-      assert.equal(displayStyle.display, 'inherit');
     });
   });
 
@@ -327,8 +259,8 @@ suiteGroup('Views.CalendarColors', function() {
     toggleN(5);
 
     var rules = subject._styles.cssRules;
-    // each calendar creates 4 rules (bg, border, text, display)
-    assert.equal(rules.length, 8, 'two calendars rules');
+    // each calendar creates 3 rules (bg, border, text)
+    assert.equal(rules.length, 6, 'two calendars rules');
 
     function verify(calendar, start, end) {
       for (var i = start; i < end; i++) {
@@ -342,8 +274,8 @@ suiteGroup('Views.CalendarColors', function() {
 
     // verify each of the kept calendars is in the right
     // spot with all the right events.
-    verify(keepOne, 0, 4);
-    verify(keepTwo, 4, 8);
+    verify(keepOne, 0, 3);
+    verify(keepTwo, 3, 6);
   });
 
 });

--- a/apps/calendar/test/unit/views/time_parent_test.js
+++ b/apps/calendar/test/unit/views/time_parent_test.js
@@ -274,6 +274,24 @@ suiteGroup('Views.TimeParent', function() {
       subject.app.timeController.emit('purge', span);
       assert.equal(calledWith[0], span);
     });
+
+    suite('calendarVisibilityChange', function() {
+      setup(function() {
+        sinon.stub(subject, '_onCalendarVisibilityChange');
+      });
+
+      teardown(function() {
+        subject._onCalendarVisibilityChange.restore();
+      });
+
+      test('event: calendarVisibilityChange', function() {
+        subject.app.store('Calendar').emit('calendarVisibilityChange');
+        assert.ok(
+          subject._onCalendarVisibilityChange.calledOnce,
+          '_onCalendarVisibilityChange'
+        );
+      });
+    });
   });
 
   suite('#purgeFrames', function() {
@@ -381,6 +399,35 @@ suiteGroup('Views.TimeParent', function() {
       );
     });
 
+  });
+
+  suite('#_onCalendarVisibilityChange', function() {
+    setup(function() {
+      sinon.stub(subject, 'purgeFrames');
+      sinon.stub(subject, 'changeDate');
+      subject.date = new Date();
+      subject.currentFrame = {
+        getScrollTop: sinon.stub().returns(100),
+        setScrollTop: sinon.stub()
+      };
+    });
+
+    teardown(function() {
+      subject.purgeFrames.restore();
+      subject.changeDate.restore();
+    });
+
+    test('redraw frame and restore scroll position', function() {
+      var timespan = subject.app.timeController.timespan;
+      var date = subject.date;
+
+      subject._onCalendarVisibilityChange();
+
+      sinon.assert.calledWithExactly(subject.purgeFrames, timespan);
+      sinon.assert.calledWithExactly(subject.changeDate, date);
+      sinon.assert.calledOnce(subject.currentFrame.getScrollTop);
+      sinon.assert.calledWithExactly(subject.currentFrame.setScrollTop, 100);
+    });
   });
 
 });

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -4,7 +4,6 @@
     "apps/calendar/test/marionette/caldav_test.js",
     "apps/calendar/test/marionette/day_view_test.js",
     "apps/calendar/test/marionette/month_view_test.js",
-    "apps/calendar/test/marionette/toggle_calendar_test.js",
     "apps/camera/test/marionette/capture_test.js",
     "apps/camera/test/marionette/hud_test.js",
     "apps/camera/test/marionette/settings_test.js",

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -4,6 +4,7 @@
     "apps/calendar/test/marionette/caldav_test.js",
     "apps/calendar/test/marionette/day_view_test.js",
     "apps/calendar/test/marionette/month_view_test.js",
+    "apps/calendar/test/marionette/toggle_calendar_test.js",
     "apps/camera/test/marionette/capture_test.js",
     "apps/camera/test/marionette/hud_test.js",
     "apps/camera/test/marionette/settings_test.js",


### PR DESCRIPTION
since we have some merge conflicts doing a new PR directly to v2.0 branch (also including commits that updates and disables the toggle calendar test).
