### PR TITLE
Bug 995886 - Homescreens overlap when process is killed when screen is off

### DIFF
--- a/apps/homescreen/js/screen_helper.js
+++ b/apps/homescreen/js/screen_helper.js
@@ -6,6 +6,14 @@
   var width = window.innerWidth;
   var height = window.innerHeight;
 
+  if (!width) {
+    width = screen.width;
+  }
+  if (!height) {
+    // 20px statusbar (2rem * 10px see system/style/statusbar/statusbar.css)
+    height = screen.height - 20;
+  }
+
   function setDimensionsInternal() {
     width = window.innerWidth;
     height = window.innerHeight;

--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -539,6 +539,15 @@
     }
 
     this.element.appendChild(this.browser.element);
+
+    // Intentional! The app in the iframe gets two resize events when adding
+    // the element to the page (see bug 1007595). The first one is incorrect,
+    // thus assumptions made (media queries or rendering) can be wrong (see
+    // bug 995886). A sync reflow makes it that there will only be one resize.
+    // Please remove after 1007595 has been fixed.
+    this.browser.element.offsetWidth;
+    // End intentional
+
     this.screenshotOverlay = this.element.querySelector('.screenshot-overlay');
     this.fadeOverlay = this.element.querySelector('.fade-overlay');
 


### PR DESCRIPTION
Master edition
