### PR TITLE
Bug 1022023 - [B2G][Calendar][Week View]All day events do not display correctly in week view r=gaye

### DIFF
--- a/apps/calendar/style/week_view.css
+++ b/apps/calendar/style/week_view.css
@@ -199,6 +199,7 @@
 #week-view .sticky .event {
   margin-bottom: 0.1rem;
   padding-top: 0;
+  min-height: 2.8rem;
 }
 
 #week-view .sticky .event:last-child {


### PR DESCRIPTION
just so events without a title have the same height as events with title (keep it consistent).
