### PR TITLE
Bug 1020948 - Stop discarding sources when using DEVICE_DEBUG. r=timdream

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -213,9 +213,6 @@ PreferencesBuilder.prototype.setDebugPref = function() {
 PreferencesBuilder.prototype.setDeviceDebugPref = function() {
   this.prefs['devtools.debugger.prompt-connection'] = false;
   this.prefs['devtools.debugger.forbid-certified-apps'] = false;
-  // Bug 1001348: This optimization prevents debugger to fetch script sources
-  // of certified apps as well as chrome code:
-  this.prefs['javascript.options.discardSystemSource'] = false;
   this.prefs['b2g.adb.timeout'] = 0;
 };
 

--- a/build/test/integration/build.test.js
+++ b/build/test/integration/build.test.js
@@ -547,7 +547,6 @@ suite('Build Integration tests', function() {
         'extensions.autoDisableScopes': 0,
         'devtools.debugger.prompt-connection': false,
         'devtools.debugger.forbid-certified-apps': false,
-        'javascript.options.discardSystemSource': false,
         'b2g.adb.timeout': 0
       };
       var userjs = fs.readFileSync(

--- a/build/test/unit/preference.test.js
+++ b/build/test/unit/preference.test.js
@@ -263,7 +263,6 @@ suite('preferences.js', function() {
       assert.deepEqual(preferences.prefs, {
         'devtools.debugger.prompt-connection': false,
         'devtools.debugger.forbid-certified-apps': false,
-        'javascript.options.discardSystemSource': false,
         'b2g.adb.timeout': 0
       });
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1020948
