### PR TITLE
Bug 1028254 - Bump marionette client dependency to 0.7.10

### DIFF
--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,4 +1,4 @@
-marionette_client==0.7.9
+marionette_client==0.7.10
 mozdevice>=0.34
 moztest>=0.3
 plivo==0.9.6


### PR DESCRIPTION
Note that this will fail until marionette client 0.7.10 is released. See the bug for details.
