### PR TITLE
Bug 1030704 - [Collection app] Divider under pinned apps hidden

### DIFF
--- a/apps/verticalhome/style/css/app.css
+++ b/apps/verticalhome/style/css/app.css
@@ -72,3 +72,12 @@ gaia-grid {
 #contextmenu-dialog {
   display: none;
 }
+
+.divider:last-of-type {
+  visibility: hidden;
+  padding-bottom: 1.4rem;
+}
+
+.edit-mode .divider:last-of-type {
+  visibility: visible;
+}

--- a/apps/verticalhome/test/marionette/collection_test.js
+++ b/apps/verticalhome/test/marionette/collection_test.js
@@ -183,6 +183,10 @@ marionette('Vertical - Collection', function() {
       return currentDividers === numDividers + 1;
     });
 
+    // Bug 1030704 - Ensure the divider is visible
+    var firstDivider = client.helper.waitForElement(selectors.allDividers);
+    assert.ok(firstDivider.displayed());
+
     // Compare the position of the first pinned icon to the first web result.
     // The pinned icon should be higher than the web result.
     var firstWebPosition = client.findElement(selectors.firstWebResultPinned)

--- a/shared/elements/gaia_grid/style.css
+++ b/shared/elements/gaia_grid/style.css
@@ -104,11 +104,6 @@
   height: 0.2rem
 }
 
-.divider:last-of-type {
-  visibility: hidden;
-  padding-bottom: 1.4rem;
-}
-
 .dragging .icon.active {
   z-index: 4;
   opacity: 0.65;
@@ -118,10 +113,6 @@
 .dragging .icon:not(.active),
 .dropped {
   transition: transform 0.5s, opacity 0.5s;
-}
-
-.edit-mode .divider:last-of-type {
-  visibility: visible;
 }
 
 .edit-mode .icon .remove {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1030704

It does not really make sense to have these styles anywhere else besides the homescreen at this point. Moving them and adding a test. We should also probably fix the automatic divider insertion, but let's do that in another bug.
