### PR TITLE
Bug 1030764 - [Flame] Searching for Facebook returns only two search res...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_launch_link.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/test_everythingme_launch_link.py
@@ -21,7 +21,7 @@ class TestEverythingMeLaunchLink(GaiaTestCase):
         search_panel = homescreen.tap_search_bar()
         search_panel.type_into_search_box(search_string)
 
-        search_panel.wait_for_everything_me_results_to_load(4)
+        search_panel.wait_for_everything_me_results_to_load(1)
 
         search_panel.confirm_suggestion_notice()
 


### PR DESCRIPTION
...ults, even though there should be far more search results available
