### PR TITLE
Bug 1023950 - Enable verticalhome tests now that we have an updated gecko nightly

### DIFF
--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -28,7 +28,6 @@
     "apps/settings/test/marionette/tests/message_settings_test.js",
     "apps/system/test/marionette/edges_gesture_test.js",
     "apps/system/test/marionette/notification_get_test.js",
-    "apps/verticalhome/test/marionette/app_packaged_resume_test.js",
     "apps/settings/test/marionette/tests/airplane_mode_settings_test.js"
   ]
 }

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -26,7 +26,6 @@
     "apps/homescreen/test/marionette/update_bookmark_test.js",
     "apps/search/test/marionette/places_search_test.js",
     "apps/settings/test/marionette/tests/app_permission_settings_test.js",
-    "apps/verticalhome/test/marionette/app_packaged_resume_test.js",
     "apps/settings/test/marionette/tests/message_settings_test.js",
     "apps/settings/test/marionette/tests/airplane_mode_settings_test.js"
   ]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1027458
