### PR TITLE
 Bug 1029798 - Auto suggest should not add a character space as it makes

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -726,12 +726,6 @@
     // Clear the list of candidates
     keyboard.sendCandidates([]);
 
-    // Send a space
-    keyboard.sendKey(SPACE);
-    inputText = inputText.substring(0, cursor) + ' ' +
-      inputText.substring(cursor);
-    cursor++;
-
     // Get rid of any autocorrection that is pending and reset the rest
     // of our state, too.
     lastSpaceTimestamp = 0;

--- a/apps/keyboard/test/unit/suggest_test.js
+++ b/apps/keyboard/test/unit/suggest_test.js
@@ -176,7 +176,7 @@ suite('Latin suggestions', function() {
     });
   });
 
-  test('dismissSuggestions hides suggestions and inserts space', function() {
+  test('dismissSuggestions hides suggestions', function() {
     im.dismissSuggestions();
 
     // Send candidates should be called once with an empty array
@@ -184,9 +184,8 @@ suite('Latin suggestions', function() {
     sinon.assert.callCount(imSettings.sendCandidates, 1);
     sinon.assert.calledWith(imSettings.sendCandidates, []);
 
-    // Also, a space should be inserted
-    sinon.assert.callCount(imSettings.sendKey, 1);
-    sinon.assert.calledWith(imSettings.sendKey, 32);
+    // Also, a space should not be inserted
+    sinon.assert.callCount(imSettings.sendKey, 0);
   });
 
   suite('handleSuggestions', function() {


### PR DESCRIPTION
 logins impossible.
- Don't append a space when you dimiss the word suggestion.
