### PR TITLE
Bug 1022644 - [Messages] Can't open the recipient panel if there are only 2 lines of recipients

### DIFF
--- a/apps/sms/js/recipients.js
+++ b/apps/sms/js/recipients.js
@@ -15,6 +15,9 @@
   var relation = new WeakMap();
   var rdigit = /^\d/;
 
+  // See recipients list container's transform for singleline
+  const MIN_HEIGHT = 45;
+
   function Recipient(opts) {
     var number;
 
@@ -388,16 +391,7 @@
         isTransitioning: false,
         visible: 'singleline'
       },
-      dims: {
-        inner: {
-          height: 0,
-          width: 0
-        },
-        outer: {
-          height: 0,
-          width: 0
-        }
-      }
+      minHeight: MIN_HEIGHT
     });
 
     clone = inner.cloneNode(true);
@@ -737,17 +731,6 @@
       length = typed.length;
     }
 
-    // Make sure that height of the displayed list is
-    // being tracked. If no previously known height is set,
-    // or it's just zero, update it.
-    if (!view.dims.inner.height) {
-      view.dims.inner.height = view.inner.offsetHeight;
-    }
-
-    if (!view.dims.outer.height) {
-      view.dims.outer.height = view.outer.offsetHeight;
-    }
-
     switch (event.type) {
 
       case 'pan':
@@ -755,12 +738,13 @@
         //
         //  1. The recipients in the list have caused the
         //      container to grow enough to require the
-        //      additional viewable area.
-        //      (>1 visible lines or 1.5x the original size)
+        //      additional viewable area and the view is singleline
+        //      mode originally.
         //  2. The user is "pulling down" the recipient list.
 
         // #1
-        if (view.inner.scrollHeight > (view.dims.inner.height * 1.5)) {
+        if (view.state.visible === 'singleline' &&
+            view.inner.scrollHeight > view.minHeight) {
           // #2
           if (event.detail.absolute.dy > 0) {
             this.visible('multiline');

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -2,7 +2,7 @@
          MockDialog, Template, MockL10n */
 'use strict';
 
-requireApp('system/test/unit/mock_gesture_detector.js');
+require('/shared/js/gesture_detector.js');
 
 requireApp('sms/js/recipients.js');
 requireApp('sms/js/utils.js');
@@ -13,7 +13,6 @@ requireApp('sms/test/unit/mock_l10n.js');
 
 var mocksHelperForRecipients = new MocksHelper([
   'Dialog',
-  'GestureDetector',
   'Utils'
 ]);
 
@@ -733,6 +732,81 @@ suite('Recipients', function() {
           view.lastElementChild.dispatchEvent(event);
 
           assert.isTrue(view.lastElementChild.focus.called);
+        });
+      });
+
+      suite('Pan gesture on recipient view', function() {
+        var outer, inner, visible, options;
+
+        setup(function() {
+          outer = document.getElementById('messages-to-field');
+          inner = document.getElementById('messages-recipients-list');
+          visible = Recipients.View.prototype.visible;
+          options = {
+            detail: {
+              absolute: {
+                dy: 10
+              }
+            }
+          };
+        });
+
+        test('swipe down on singleline, inner height <= min container height',
+         function() {
+          inner.style.height = '10px';
+
+          outer.dispatchEvent(
+            new CustomEvent('pan', options)
+          );
+
+          sinon.assert.notCalled(visible);
+        });
+
+        test('swipe down on singleline, inner height > min container height',
+          function() {
+          inner.style.height = '100px';
+
+          outer.dispatchEvent(
+            new CustomEvent('pan', options)
+          );
+
+          sinon.assert.calledWith(visible, 'multiline');
+        });
+
+        test('swipe down on multiline view', function() {
+          inner.style.height = '100px';
+          recipients.visible('multiline');
+          visible.reset();
+
+          outer.dispatchEvent(
+            new CustomEvent('pan', options)
+          );
+
+          sinon.assert.notCalled(visible);
+        });
+
+        test('swipe up on singleline view', function() {
+          inner.style.height = '10px';
+          options.detail.absolute.dy = -10;
+
+          outer.dispatchEvent(
+            new CustomEvent('pan', options)
+          );
+
+          sinon.assert.notCalled(visible);
+        });
+
+        test('swipe up on multiline view', function() {
+          inner.style.height = '100px';
+          options.detail.absolute.dy = -10;
+          recipients.visible('multiline');
+          visible.reset();
+
+          outer.dispatchEvent(
+            new CustomEvent('pan', options)
+          );
+
+          sinon.assert.notCalled(visible);
         });
       });
     });


### PR DESCRIPTION
- Use a hardcode value for minheigt because the visible container height for recipient list is different than the container in mater.
