### PR TITLE
Return early if lockScreen.unlock or lockScreen.lock is undefined.

### DIFF
--- a/tests/atoms/gaia_lock_screen.js
+++ b/tests/atoms/gaia_lock_screen.js
@@ -8,6 +8,8 @@ var GaiaLockScreen = {
 
   unlock: function() {
     let lockscreen = window.wrappedJSObject.lockScreen || window.wrappedJSObject.LockScreen;
+    if(!lockscreen || !lockscreen.unlock)
+      marionetteScriptFinished('Unable to unlock screen');
     let setlock = window.wrappedJSObject.SettingsListener.getSettingsLock();
     let obj = {'screen.timeout': 0};
     setlock.set(obj);
@@ -35,6 +37,8 @@ var GaiaLockScreen = {
   lock: function() {
     let lwm = window.wrappedJSObject.lockScreenWindowManager;
     let lockscreen = window.wrappedJSObject.lockScreen || window.wrappedJSObject.LockScreen;
+    if(!lockscreen || !lockscreen.lock)
+      marionetteScriptFinished('Unable to lock screen');
     let setlock = window.wrappedJSObject.SettingsListener.getSettingsLock();
     let obj = {'screen.timeout': 0};
     let waitLock = function() {


### PR DESCRIPTION
It fixes gaia_test.py screen lock/unlock issue.
Reference bugid: 1031029

Change-Id: I7b1e5a373e041cf45911f51f5be021cd5856b88b
