### PR TITLE
[bug 1032754] Just use font-family:sans-serif

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -174,7 +174,7 @@ a.alarm-item > .time {
   top: 1.0rem;
   left: 1.7rem;
   font-size: 2.8rem;
-  font-family: 'Fira Sans', sans-serif;
+  font-family: sans-serif;
   font-weight: 300;
   color: #cfe2e5;
 }
@@ -190,7 +190,7 @@ a.alarm-item > .label {
   left: 12.5rem;
   right: 4.5rem;
   top: 2.35rem;
-  font-family: 'Fira Sans', sans-serif;
+  font-family: sans-serif;
   font-weight: normal;
   color: #737D80;
   white-space: nowrap;
@@ -202,7 +202,7 @@ a.alarm-item > .repeat {
   position: absolute;
   top: 4.2rem;
   left: 1.7rem;
-  font-family: 'Fira Sans', sans-serif;
+  font-family: sans-serif;
   font-weight: normal;
   text-overflow: ellipsis;
   color: #A1B0B2;

--- a/apps/sms/style/report_view.css
+++ b/apps/sms/style/report_view.css
@@ -9,7 +9,7 @@
 }
 
 .report-view  p, .report-view  span {
-  font-family: 'Fira Sans', sans-serif;
+  font-family: sans-serif;
 }
 
 .report-view .description > .type {

--- a/apps/system/fxa/style/fxa.css
+++ b/apps/system/fxa/style/fxa.css
@@ -123,7 +123,7 @@ ul {
 
 .ff_account,
 .screen {
-  font-family: 'Fira Sans', sans-serif;
+  font-family: sans-serif;
   font-size: 1.6rem;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
... rather than explicitly naming Fira Sans in Gaia CSS.
