### PR TITLE
Bug 1008912 - "MMS" in sms app does not translate into other language. r=julien

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -269,7 +269,7 @@
                 <div class="message-divider"></div>
               </div>
               <div class="composer-button-container">
-                <span id="messages-counter-label" data-counter="">MMS</span>
+                <span id="messages-counter-label" data-counter="" data-l10n-id="mms-label">MMS</span>
                 <button id="messages-send-button" class="icon" aria-label="send" data-l10n-id="send" type="submit"></button>
               </div>
             </form>
@@ -471,7 +471,7 @@
         <p class="name">${number}</p>
         <p class="summary">
           <time data-time-update="true" data-time-only="true" data-time="${timestamp}"></time>
-          <span class="mms-icon">MMS</span>
+          <span class="mms-icon" data-l10n-id="mms-label">MMS</span>
           <span class="body-text">${bodyHTML}</span>
         </p>
       </a>

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -218,6 +218,10 @@ expired-attachment        = Sorry, the message expired on {{date}} and cannot be
 download-attachment       = Download
 downloading-attachment    = Downloading…
 unnamed-attachment        = untitled
+# LOCALIZATION NOTE (mms-label): This label is used to identify MMS in message
+# composer (above the send button) and in the thread list for the thread with
+# MMS as the last message.
+mms-label                 = MMS
 
 # LOCALIZATION NOTE (files-too-large): the English translation does not need the
 # actual number of files. If your translation needs it, you can still add it


### PR DESCRIPTION
Using localized "MMS" label for the following panels:
- message composer;
- thread list.
