### PR TITLE
Bug 1021981 - [email] Update toast display to 2.0 visual redesign

### DIFF
--- a/apps/email/js/cards/toaster.html
+++ b/apps/email/js/cards/toaster.html
@@ -1,7 +1,4 @@
 <section role="status" class="banner customized collapsed">
-  <button class="toaster-cancel-btn header-left-btn">
-    <span class="icon icon-close"></span>
-  </button>
   <p>Toaster Title</p>
   <button data-l10n-id="toaster-undo" class="toaster-banner-undo"></button>
   <button data-l10n-id="toaster-retry" class="toaster-banner-retry"></button>

--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -1101,7 +1101,7 @@ Toaster = {
           if (this.retryCallback)
             this.retryCallback();
           this.hide();
-        } else if (classList.contains('toaster-cancel-btn')) {
+        } else {
           this.hide();
         }
         break;

--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -216,10 +216,20 @@ section[role="region"] > header:first-child menu[type="toolbar"] a[aria-disabled
 }
 
 /* Toaset banner extend class */
+
 section[role="status"].customized {
-  bottom: 4.8rem;
-  opacity: 1;
-  padding-left: 3.2rem;
+  bottom: 4.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  color: white;
+  background: #5F5F5F;
+}
+
+section[role="status"].customized p {
+  margin: 1.5rem;
+  flex: 1;
+  font-size: 1.6rem;
 }
 
 section[role="status"].fadeout {
@@ -227,19 +237,10 @@ section[role="status"].fadeout {
   opacity: 0;
 }
 
-section[role="status"][title="undo"] p,
-section[role="status"][title="retry"] p {
-  max-width: 65% !important;
-}
-
-section[role="status"] .toaster-cancel-btn {
-  height: 8rem;
-}
-
 section[role="status"] .toaster-banner-undo,
 section[role="status"] .toaster-banner-retry {
   display: none;
-  margin: 1rem;
+  margin: 1rem 1.5rem;
   width: auto;
 }
 

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -651,7 +651,7 @@ reflows. Foreground/background colors should be safe.
   font-size: 1.4rem;
   font-weight: 500;
   line-height: 2.4rem;
-  background-color: #00aacc;
+  background-color: #2fc9ec;
   z-index: 10;
 }
 

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -6,7 +6,7 @@ apps/video/style/video_tablet.css 0 1
 apps/video/style/video.css 0 7
 apps/video/style/info.css 0 2
 apps/email/style/message_cards.css 0 1
-apps/email/style/common.css 0 5
+apps/email/style/common.css 0 4
 apps/email/style/setup_cards.css 0 1
 apps/costcontrol/style/bb/input-areas/style.css 2 0
 apps/costcontrol/style/bb/menus-dialogues/valueselector/date/style.css 1 0


### PR DESCRIPTION
This converts the toast display to fit in better with the 2.0 redesign, a gray background (#5F5F5F) with white text.
- Removes the cancel button on the left, as it was just a line separator and just looked confusing. Now just tapping on the toast will dismiss it. I confirmed that tapping on one of the buttons still executes the button pathway.
- Uses flexbox to lay out the message with the button.
- Changed the .msg-list-topbar (N New Messages blue bar display) to use the same blue as the unread dot, to better match the 2.0 visual refresh. The old blue was slightly off.
