### PR TITLE
Bug 1028101 - Intermittent system/test/unit/bootstrap_test.js

### DIFF
--- a/apps/system/test/unit/bootstrap_test.js
+++ b/apps/system/test/unit/bootstrap_test.js
@@ -14,6 +14,7 @@ requireApp('system/js/accessibility.js');
 requireApp('system/js/activities.js');
 requireApp('system/js/activity_window_factory.js');
 requireApp('system/js/activity_window_manager.js');
+requireApp('system/js/airplane_mode.js');
 requireApp('system/js/app_window_factory.js');
 requireApp('system/js/devtools/developer_hud.js');
 requireApp('system/js/dialer_agent.js');


### PR DESCRIPTION
Including airplane_mode.js seems to fix the issue locally. AirplaneMode is now a dependency of one of the sub-modules, so it makes sense to include it here as well.

https://bugzilla.mozilla.org/show_bug.cgi?id=1028101
