### PR TITLE
Bug 1034227 - [email] cookie cache DOM not localized on app restart

### DIFF
--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -205,6 +205,10 @@ if (appMessages.hasPending('alarm')) {
 
 // If still have a cached node, then show it.
 if (cachedNode) {
+  // l10n may not see this as it was injected before l10n.js was loaded,
+  // so let it know it needs to translate it.
+  mozL10n.translateFragment(cachedNode);
+
   // Wire up a card implementation to the cached node.
   if (startCardId) {
     pushStartCard(startCardId);

--- a/apps/email/js/tmpl.js
+++ b/apps/email/js/tmpl.js
@@ -1,13 +1,4 @@
 define(['l10n!'], function(mozL10n) {
-  // Keep track of all translated nodes, so that they are properly
-  // updated on the fly when the language changes.
-  var nodes = [];
-  mozL10n.ready(function() {
-    nodes.forEach(function(node) {
-      mozL10n.translate(node);
-    });
-  });
-
   var tmpl = {
     pluginBuilder: './tmpl_builder',
 
@@ -22,7 +13,6 @@ define(['l10n!'], function(mozL10n) {
     load: function(id, require, onload, config) {
       require(['text!' + id], function(text) {
         var node = tmpl.toDom(text);
-        nodes.push(node);
         onload(node);
       });
     }


### PR DESCRIPTION
In mail_app.js, if it knows a cachedNode will be used for startup, it passes it to mozL10n.translateFragment first. This fixes the root of the issue.

The change in tmpl.js for bug 1005760 is also removed because now the l10n.js MutationObservers translate the nodes on insertion, so it is just doing extra unneeded work to do this in tmpl.js. This can be confirmed by doing the following:
- Load email with one account configured, open Compose, then close it. Assume start language is English.
- Change the Language in Settings app to "Accented English".
- Go back to email and open the Compose card, it is still correctly translated to Accented English.
