### PR TITLE
Bug 1005733 - [email/UI] Cards's click-eating logic calls stopPropagation() but not preventDefault()

### DIFF
--- a/apps/email/js/mail_common.js
+++ b/apps/email/js/mail_common.js
@@ -229,10 +229,12 @@ Cards = {
   _onMaybeIntercept: function(event) {
     if (this._eatingEventsUntilNextCard) {
       event.stopPropagation();
+      event.preventDefault();
       return;
     }
     if (this._popupActive) {
       event.stopPropagation();
+      event.preventDefault();
       this._popupActive.close();
       return;
     }
@@ -249,6 +251,7 @@ Cards = {
     // that card.
     if (this._trayActive && cardNode && cardNode.classList.contains('after')) {
       event.stopPropagation();
+      event.preventDefault();
 
       // Look for a card with a data-tray-target attribute
       var targetIndex = -1;


### PR DESCRIPTION
Change originally from :asuth, but reapplied to latest master
