### PR TITLE
Bug 1024856 - [email/UI] Change hyperlink handling to explicitly trigger view activity

### DIFF
--- a/apps/email/js/app_messages.js
+++ b/apps/email/js/app_messages.js
@@ -49,16 +49,13 @@ define(function(require) {
       // Dynamically load util, since it is only needed for certain
       // pathways in this module.
       require(['attachment_name'], function(attachmentName) {
-        var data = {};
+        var data;
         if (dataType === 'url' && activityName === 'share') {
-          data.body = url;
+          data = {
+            body: url
+          };
         } else {
-          var urlParts = url ? queryURI(url) : [];
-          data.to = urlParts[0];
-          data.subject = urlParts[1];
-          data.body = typeof urlParts[2] === 'string' ? urlParts[2] : null;
-          data.cc = urlParts[3];
-          data.bcc = urlParts[4];
+          data = queryURI(url);
           data.attachmentBlobs = sourceData.blobs || [];
           data.attachmentNames = sourceData.filenames || [];
 

--- a/apps/email/js/query_uri.js
+++ b/apps/email/js/query_uri.js
@@ -1,4 +1,5 @@
 define(function() {
+  'use strict';
   // Some sites may not get URI encoding correct, so this protects
   // us from completely failing in those cases.
   function decode(value) {
@@ -13,8 +14,9 @@ define(function() {
 
   function queryURI(uri) {
     function addressesToArray(addresses) {
-      if (!addresses)
+      if (!addresses) {
         return [];
+      }
       addresses = addresses.split(/[,;]/);
       var addressesArray = addresses.filter(function notEmpty(addr) {
         return addr.trim() !== '';
@@ -22,8 +24,9 @@ define(function() {
       return addressesArray;
     }
     var mailtoReg = /^mailto:(.*)/i;
+    var obj = {};
 
-    if (uri.match(mailtoReg)) {
+    if (uri && uri.match(mailtoReg)) {
       uri = uri.match(mailtoReg)[1];
       var parts = uri.split('?');
       var subjectReg = /(?:^|&)subject=([^\&]*)/i,
@@ -31,26 +34,26 @@ define(function() {
       ccReg = /(?:^|&)cc=([^\&]*)/i,
       bccReg = /(?:^|&)bcc=([^\&]*)/i;
       // Check if the 'to' field is set and properly decode it
-      var to = parts[0] ? addressesToArray(decode(parts[0])) : [],
-      subject,
-      body,
-      cc,
-      bcc;
+      obj.to = parts[0] ? addressesToArray(decode(parts[0])) : [];
 
       if (parts.length == 2) {
         var data = parts[1];
-        if (data.match(subjectReg))
-          subject = decode(data.match(subjectReg)[1]);
-        if (data.match(bodyReg))
-          body = decode(data.match(bodyReg)[1]);
-        if (data.match(ccReg))
-          cc = addressesToArray(decode(data.match(ccReg)[1]));
-        if (parts[1].match(bccReg))
-          bcc = addressesToArray(decode(data.match(bccReg)[1]));
+        if (data.match(subjectReg)) {
+          obj.subject = decode(data.match(subjectReg)[1]);
+        }
+        if (data.match(bodyReg)) {
+          obj.body = decode(data.match(bodyReg)[1]);
+        }
+        if (data.match(ccReg)) {
+          obj.cc = addressesToArray(decode(data.match(ccReg)[1]));
+        }
+        if (parts[1].match(bccReg)) {
+          obj.bcc = addressesToArray(decode(data.match(bccReg)[1]));
+        }
       }
-        return [to, subject, body, cc, bcc];
     }
 
+    return obj;
   }
 
   return queryURI;

--- a/apps/email/test/unit/mail_app_test.js
+++ b/apps/email/test/unit/mail_app_test.js
@@ -23,24 +23,21 @@ suite('email/mail_app', function() {
   test('#to', function() {
 
     assert.deepEqual(queryURI('mailto:Email.address1@mailto.com'),
-    [['Email.address1@mailto.com'],
-    undefined, undefined, undefined, undefined],
+    { to: ['Email.address1@mailto.com'] },
     'to single address test fail');
 
     assert.deepEqual(queryURI(
     'mailto:Email.address1@mailto.com;Email.address2@mailto.com'),
-    [['Email.address1@mailto.com', 'Email.address2@mailto.com'],
-    undefined, undefined, undefined, undefined],
+    { to: ['Email.address1@mailto.com', 'Email.address2@mailto.com'] },
     'to multi-addresses test fail (separator ";")');
 
     assert.deepEqual(queryURI(
     'mailto:Email.address1@mailto.com,Email.address2@mailto.com'),
-    [['Email.address1@mailto.com', 'Email.address2@mailto.com'],
-    undefined, undefined, undefined, undefined],
+    { to: ['Email.address1@mailto.com', 'Email.address2@mailto.com'] },
     'to multi-addresses test fail (separator ",")');
 
     assert.deepEqual(queryURI('mailto:'),
-    [[], undefined, undefined, undefined, undefined],
+    { to: [] },
     'no to address test fail');
 
   });
@@ -48,16 +45,14 @@ suite('email/mail_app', function() {
   test('#cc', function() {
 
     assert.deepEqual(queryURI('mailto:?cc=EmailCc.address@mailto.com'),
-    [[], undefined, undefined, ['EmailCc.address@mailto.com'], undefined],
+    { to: [], cc: ['EmailCc.address@mailto.com'] },
     'cc single address test fail');
 
     assert.deepEqual(queryURI('mailto:?cc=EmailCc.address1@mailto.com;' +
     'EmailCc.address2@mailto.com;EmailCc.address3@mailto.com'),
-    [[], undefined, undefined, ['EmailCc.address1@mailto.com',
-    'EmailCc.address2@mailto.com',
-    'EmailCc.address3@mailto.com'], undefined],
+    { to: [], cc: ['EmailCc.address1@mailto.com', 'EmailCc.address2@mailto.com',
+    'EmailCc.address3@mailto.com'] },
     'cc multi-addresses test fail');
-
 
   });
 
@@ -65,14 +60,14 @@ suite('email/mail_app', function() {
   test('#bcc', function() {
 
     assert.deepEqual(queryURI('mailto:?bcc=EmailBcc.address@mailto.com'),
-    [[], undefined, undefined, undefined, ['EmailBcc.address@mailto.com']],
+    { to: [], bcc: ['EmailBcc.address@mailto.com'] },
     'bcc single address test');
 
     assert.deepEqual(queryURI('mailto:?bcc=EmailBcc.address1@mailto.com;' +
     'EmailBcc.address2@mailto.com;EmailBcc.address3@mailto.com'),
-    [[], undefined, undefined, undefined, ['EmailBcc.address1@mailto.com',
-    'EmailBcc.address2@mailto.com',
-    'EmailBcc.address3@mailto.com']], 'bcc multi-addresses test fail');
+    { to: [], bcc: ['EmailBcc.address1@mailto.com',
+    'EmailBcc.address2@mailto.com', 'EmailBcc.address3@mailto.com'] },
+    'bcc multi-addresses test fail');
 
   });
 
@@ -80,7 +75,7 @@ suite('email/mail_app', function() {
   test('#subject', function() {
 
     assert.deepEqual(queryURI('mailto:?subject=This is the subject line'),
-    [[], 'This is the subject line', undefined, undefined, undefined],
+    { to: [], subject: 'This is the subject line' },
     'subject test fail');
 
   });
@@ -89,7 +84,7 @@ suite('email/mail_app', function() {
   test('#body', function() {
 
     assert.deepEqual(queryURI('mailto:?body=This is the body'),
-    [[], undefined, 'This is the body', undefined, undefined],
+    { to: [], body: 'This is the body' },
     'body test fail');
 
   });
@@ -101,20 +96,27 @@ suite('email/mail_app', function() {
     'mailto:Email.address1@mailto.com;Email.address2@mailto.com?' +
     'cc=EmailCc1.address@mailto.com;EmailCc2.address@mailto.com&' +
     'bcc=EmailBCc1.address@mailto.com;EmailBCc2.address@mailto.com'),
-    [['Email.address1@mailto.com', 'Email.address2@mailto.com'],
-    undefined, undefined, ['EmailCc1.address@mailto.com',
-    'EmailCc2.address@mailto.com'], ['EmailBCc1.address@mailto.com',
-    'EmailBCc2.address@mailto.com']], 'complex 1 test fail');
+    {
+      to: ['Email.address1@mailto.com', 'Email.address2@mailto.com'],
+      cc: ['EmailCc1.address@mailto.com', 'EmailCc2.address@mailto.com'],
+      bcc: ['EmailBCc1.address@mailto.com', 'EmailBCc2.address@mailto.com']
+    },
+    'complex 1 test fail');
 
 
     assert.deepEqual(queryURI('mailto:Email.address1@mailto.com;?' +
     'cc=EmailCc1.address@mailto.com;&bcc=EmailBCc1.address@mailto.com;' +
     '&subject=This is the subject line&body=This is the text line one.' +
     ' %0AThis is the text line two'),
-    [['Email.address1@mailto.com'], 'This is the subject line',
-    'This is the text line one. \nThis is the text line two',
-    ['EmailCc1.address@mailto.com'],
-    ['EmailBCc1.address@mailto.com']],
+
+    {
+      to: ['Email.address1@mailto.com'],
+      subject: 'This is the subject line',
+      body: 'This is the text line one. \nThis is the text line two',
+      cc: ['EmailCc1.address@mailto.com'],
+      bcc: ['EmailBCc1.address@mailto.com']
+    },
+
     'complex 2 test fail');
 
   });


### PR DESCRIPTION
For links in an email, prompt as usual, but if the link starts with 'mailto:' fast path to a compose card. Otherwise, use a 'view' MozActivity.

In the process of consolidating mailto parsing, query_uri was modified to return an object with named properties instead of the more unintuitive array form. query_uri.js was also updated to pass jshint, and its unit test was updated.

Did this simpler adjustment instead of the larger suggestions around mailto links in the bug ticket so that this can easily uplift to 2.0, since there are no string changes.
