### PR TITLE
Bug 988768 - [Sora][Message][MMS] Can't send messages with an attachment...

### DIFF
--- a/apps/sms/js/settings.js
+++ b/apps/sms/js/settings.js
@@ -6,7 +6,10 @@
 var Settings = {
   MMS_SERVICE_ID_KEY: 'ril.mms.defaultServiceId',
 
-  mmsSizeLimitation: 300 * 1024, // Default mms message size limitation is 300K.
+  // we evaluate to 5KB the size overhead of wrapping a payload in a MMS
+  MMS_SIZE_OVERHEAD: 5 * 1024,
+
+  mmsSizeLimitation: 295 * 1024, // Default mms message size limitation is 300K.
   mmsServiceId: null, // Default mms service SIM ID (only for DSDS)
   get nonActivateMmsServiceIds() { // Non activate mms ID (only for DSDS)
     var serviceIds = this.serviceIds.slice();
@@ -16,7 +19,7 @@ var Settings = {
 
   init: function settings_init() {
     var keyHandlerSet = {
-      'dom.mms.operatorSizeLimitation': Settings.initMmsSizeLimitation
+      'dom.mms.operatorSizeLimitation': this.initMmsSizeLimitation.bind(this)
     };
     var settings = navigator.mozSettings;
     var conns = navigator.mozMobileConnections;
@@ -53,7 +56,7 @@ var Settings = {
   // MessageManager and return nothing if we can't get size limitation from db
   initMmsSizeLimitation: function initMmsSizeLimitation(size) {
     if (size && !isNaN(size)) {
-      Settings.mmsSizeLimitation = size;
+      this.mmsSizeLimitation = size - this.MMS_SIZE_OVERHEAD;
     }
   },
 

--- a/apps/sms/js/utils.js
+++ b/apps/sms/js/utils.js
@@ -298,13 +298,13 @@
       });
     },
 
-    // Default image size limitation is set to 300KB for MMS user story.
-    // If limit is not given or bigger than default 300KB, default value need
+    // Default image size limitation is set to 295KB for MMS user story.
+    // If limit is not given or bigger than default 295KB, default value need
     // to be applied here for size checking. Parameters could be:
-    // (blob, callback) : Resizing image to default limit 300k.
+    // (blob, callback) : Resizing image to default limit 295k.
     // (blob, limit, callback) : Resizing image to given limitation.
     getResizedImgBlob: function ut_getResizedImgBlob(blob, limit, callback) {
-      var defaultLimit = 300 * 1024;
+      var defaultLimit = 295 * 1024;
       if (typeof limit === 'function') {
         callback = limit;
         limit = defaultLimit;

--- a/apps/sms/test/unit/attachment_test.js
+++ b/apps/sms/test/unit/attachment_test.js
@@ -73,7 +73,7 @@ suite('attachment_test.js', function() {
       req.send();
     }
     getAsset('/test/unit/media/kitten-450.jpg', function(blob) {
-      testImageBlob_small = blob; // image < 300 kB => create thumbnail
+      testImageBlob_small = blob; // image < 295 kB => create thumbnail
     });
     getAsset('/test/unit/media/IMG_0554.jpg', function(blob) {
       testImageBlob = blob;

--- a/apps/sms/test/unit/mock_settings.js
+++ b/apps/sms/test/unit/mock_settings.js
@@ -2,14 +2,14 @@
 'use strict';
 
 var MockSettings = {
-  mmsSizeLimitation: 300 * 1024,
+  mmsSizeLimitation: 295 * 1024,
   mmsServiceId: 0,
   nonActivateMmsServiceIds: [1],
   setSimServiceId: function() {},
   switchSimHandler: function() {},
 
   mSetup: function() {
-    MockSettings.mmsSizeLimitation = 300 * 1024;
+    MockSettings.mmsSizeLimitation = 295 * 1024;
     MockSettings.mmsServiceId = 0;
   }
 };

--- a/apps/sms/test/unit/settings_test.js
+++ b/apps/sms/test/unit/settings_test.js
@@ -14,7 +14,7 @@ suite('Message App settings Unit-Test', function() {
   var nativeSettings = navigator.mozSettings;
   teardown(function() {
     navigator.mozSettings = nativeSettings;
-    Settings.mmsSizeLimitation = 300 * 1024;
+    Settings.mmsSizeLimitation = 295 * 1024;
   });
 
   suite('Init fetches settings', function() {
@@ -60,13 +60,16 @@ suite('Message App settings Unit-Test', function() {
         var lock = navigator.mozSettings.createLock.returnValues[0];
         assert.equal(lock.get.returnValues.length, 1);
 
+        var setting = 500 * 1024;
+        var expected = setting - 5 * 1024;
+
         var req = lock.get.returnValues[0];
         req.result = {
-          'dom.mms.operatorSizeLimitation': 512000
+          'dom.mms.operatorSizeLimitation': setting
         };
         req.onsuccess();
 
-        assert.equal(Settings.mmsSizeLimitation, 500 * 1024);
+        assert.equal(Settings.mmsSizeLimitation, expected);
       });
 
       test('Query mmsServiceId with settings exist(ID=0)', function() {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -523,7 +523,7 @@ suite('thread_ui.js >', function() {
             number: '999'
           });
 
-          Compose.append(mockAttachment(300 * 1024));
+          Compose.append(mockAttachment(295 * 1024));
 
           assert.isFalse(sendButton.disabled);
           Compose.append('Hola');


### PR DESCRIPTION
... between 295 and 299KB r=schung

This changes the default setting in Gaia from 300KB to 295KB. This also
substracts 5KB from the setting taken in Gecko.

(cherry picked from commit f250750c9b8381560fa33b2383737736e4dbdff5)

Conflicts:
    apps/sms/js/settings.js
    apps/sms/test/unit/mock_settings.js
    apps/sms/test/unit/settings_test.js
