### PR TITLE
Bug 1030086 - Keyboard gets stuck after submitting a form by pressing

### DIFF
--- a/apps/system/js/keyboard_manager.js
+++ b/apps/system/js/keyboard_manager.js
@@ -271,6 +271,12 @@ var KeyboardManager = {
   },
 
   resizeKeyboard: function km_resizeKeyboard(evt) {
+    // Ignore mozbrowserresize event while keyboard Frame is transitioning out.
+    var transitionState = this.transitionManager.currentState;
+    if (transitionState === this.transitionManager.STATE_TRANSITION_OUT) {
+      return;
+    }
+
     var height = evt.detail.height;
 
     this._debug('resizeKeyboard: ' + height);

--- a/apps/system/test/unit/keyboard_manager_test.js
+++ b/apps/system/test/unit/keyboard_manager_test.js
@@ -592,6 +592,22 @@ suite('KeyboardManager', function() {
       sinon.assert.callCount(handleResize, 1, 'handleResize should be called');
     });
 
+    test('keyboardFrameContainer is hiding.', function() {
+      // show the keyboar first
+      KeyboardManager.setKeyboardToShow('text');
+      fakeMozbrowserResize(200);
+      dispatchTransitionEvents();
+
+      simulateInputChangeEvent('blur');
+      this.sinon.clock.tick(BLUR_CHANGE_DELAY);
+
+      // fire a resize event again after the keyboard frame is hiding
+      fakeMozbrowserResize(200);
+
+      sinon.assert.callCount(handleResize, 1,
+                             'ignore mozbrowserresize event');
+    });
+
     test('Switching keyboard.', function() {
       KeyboardManager.setKeyboardToShow('text');
       fakeMozbrowserResize(200);


### PR DESCRIPTION
the enter key.
- Ignore the resize request from Keyboard app when the keyboard frame
  is transitioning out.
