### PR TITLE
Bug 1034926 - Key value "?12" to change number layout

### DIFF
--- a/apps/keyboard/js/keyboard/layout_manager.js
+++ b/apps/keyboard/js/keyboard/layout_manager.js
@@ -234,7 +234,7 @@ LayoutManager.prototype._updateModifiedLayout = function() {
     if (this.currentLayoutPage === this.LAYOUT_PAGE_DEFAULT) {
       spaceKeyRow.splice(spaceKeyCount, 0, {
         keyCode: this.KEYCODE_ALTERNATE_LAYOUT,
-        value: layout.alternateLayoutKey || '12&',
+        value: layout.alternateLayoutKey || '?12',
         ratio: 1.5,
         ariaLabel: 'alternateLayoutKey',
         className: 'switch-key'


### PR DESCRIPTION
The key value of android is "?123" and iphone's is "?.123". I think "?12" makes sense for normal smartphone users. Most of users want to find "?" or "!" rather than "&" :)
