### PR TITLE
Bug 1030310 - [B2G][Email] Device does not vibrate upon receiving an email notification while in sleep mode

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -444,15 +444,8 @@ var NotificationScreen = {
         }, 2000);
       }
 
-      if (this.vibrates) {
-        if (document.hidden) {
-          window.addEventListener('visibilitychange', function waitOn() {
-            window.removeEventListener('visibilitychange', waitOn);
-            navigator.vibrate([200, 200, 200, 200]);
-          });
-        } else {
-          navigator.vibrate([200, 200, 200, 200]);
-        }
+      if (this.vibrates && !document.hidden) {
+        navigator.vibrate([200, 200, 200, 200]);
       }
     }
 


### PR DESCRIPTION
Since the vibration would drain the battery of a frequently emailed user, the device shouldn't vibrate at all in the case where the screen is off.
