### PR TITLE
 Bug 1033889 - unable to read cell broadcast message on lock screen. r=ferjmoreno,Michael Henretty

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -374,7 +374,8 @@ var NotificationScreen = {
     if (typeof(ScreenManager) !== 'undefined' &&
       !ScreenManager.screenEnabled) {
       // bug 915236: disable turning on the screen for email notifications
-      if (detail.manifestURL.indexOf('email.gaiamobile.org') === -1) {
+      if (!detail.manifestURL ||
+           detail.manifestURL.indexOf('email.gaiamobile.org') === -1) {
         ScreenManager.turnScreenOn();
       }
     }


### PR DESCRIPTION
 Bug 1033889 - unable to read cell broadcast message on lock screen. r=ferjmoreno,Michael Henretty
