### PR TITLE
Bug 1030417 - aria role key for number keyboard keys

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -244,11 +244,24 @@ const IMERender = (function() {
         // Uppercase keycode
         var upperCode = key.keyCode || upperCaseKeyChar.charCodeAt(0);
 
+        var attributeList = [];
         var className = '';
+
         if (isSpecialKey(key)) {
           className = 'special-key';
-        } else if (layout.keyClassName) {
-          className = layout.keyClassName;
+        } else {
+          // The 'key' role tells an assistive technology that these buttons
+          // are used for composing text or numbers, and should be easier to
+          // activate than usual buttons. We keep special keys, like backspace,
+          // as buttons so that their activation is not performed by mistake.
+          attributeList.push({
+            key: 'role',
+            value: 'key'
+          });
+
+          if (layout.keyClassName) {
+            className = layout.keyClassName;
+          }
         }
 
         if (key.className) {
@@ -268,7 +281,6 @@ const IMERender = (function() {
           dataset.push({'key': 'compositeKey', 'value': key.compositeKey});
         }
 
-        var attributeList = [];
         if (key.disabled) {
           attributeList.push({
             key: 'disabled',
@@ -634,6 +646,11 @@ const IMERender = (function() {
         });
       }
 
+      attributeList.push({
+        key: 'role',
+        value: 'key'
+      });
+
       content.appendChild(
         buildKey(alt, '', width + 'px', dataset, null, attributeList));
     });
@@ -949,14 +966,6 @@ const IMERender = (function() {
     dataset.forEach(function(data) {
       contentNode.dataset[data.key] = data.value;
     });
-
-    if (!contentNode.classList.contains('special-key')) {
-      // The 'key' role tells an assistive technology that these buttons
-      // are used for composing text or numbers, and should be easier to
-      // activate than usual buttons. We keep special keys, like backsapce, as
-      // buttons so that their activation is not performed by mistake.
-      contentNode.setAttribute('role', 'key');
-    }
 
     var vWrapperNode = document.createElement('span');
     vWrapperNode.className = 'visual-wrapper';


### PR DESCRIPTION
Keys in number keyboard now have role="key".
The problem was: special keys shouldn't have role="key", so it was checking that key element has 'special-key' CSS class in order to add the role attribute or not. But seems that 'special-key' CSS class is used also for other kind of keys (for example number keys in the number layout)
I'm checking against the isSpecialKey function instead, that seems more reliable to know if the key is really a special key or not. 
