### PR TITLE
Bug 984274 - add required permission for mochitest. r=fabrice

### DIFF
--- a/dev_apps/mochitest/manifest.webapp
+++ b/dev_apps/mochitest/manifest.webapp
@@ -17,6 +17,7 @@
     "voicemail":{},
     "device-storage:music":{ "access": "readwrite" },
     "device-storage:pictures":{ "access": "readwrite" },
+    "device-storage:sdcard":{ "access": "readwrite" },
     "settings":{ "access": "readwrite" },
     "storage":{},
     "camera":{},
@@ -24,7 +25,9 @@
     "desktop-notification":{},
     "idle":{},
     "network-events":{},
-    "embed-apps":{}
+    "embed-apps":{},
+    "audio-channel-content":{},
+    "audio-channel-alarm":{}
   },
   "locales": {
     "en-US": {


### PR DESCRIPTION
Add permissions required by test_mozaudiochannel.html, test_overrideDir.html, and test_fs_appendFile.html.
