### PR TITLE
Bug 1037194 - Intermittent gaia-integration | TEST-UNEXPECTED-FAIL | /builds/slave/test/gaia/apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js | Vertical Home - Hosted app cached icon fetch fallback to default icon

### DIFF
--- a/apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js
+++ b/apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js
@@ -37,7 +37,7 @@ marionette('Vertical Home - Hosted app cached icon fetch', function() {
     server.close(done);
   });
 
-  test('fallback to default icon', function() {
+  test.only('fallback to default icon', function() {
     var iconURL = server.manifest.icons['128'];
     // correctly install the app...
     client.switchToFrame();
@@ -62,6 +62,8 @@ marionette('Vertical Home - Hosted app cached icon fetch', function() {
       return hasSource && isCached;
     });
 
+    console.log('INITIAL Icon src is:', iconSrc(icon));
+
     // ensure http falls so we use the cached icon
     server.fail(iconURL);
 
@@ -71,6 +73,7 @@ marionette('Vertical Home - Hosted app cached icon fetch', function() {
 
     // check for the cached icon...
     client.waitFor(function() {
+      console.log('Icon src is:', iconSrc(icon), ' waiting for: blobcache');
       return iconSrc(icon) === 'blobcache';
     });
 

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -35,7 +35,6 @@
     "apps/system/test/marionette/homescreen_navigation_test.js": "Bug 1043870 - TEST-UNEXPECTED-FAIL | Homescreen navigation > Going to the homescreen and back to a warm app",
     "apps/system/test/marionette/notification_get_test.js": "Bug 960126 - TEST-UNEXPECTED-FAIL | Notification.get(): should work across domains",
     "apps/system/test/marionette/notification_resend_test.js": " Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
-    "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
     "apps/verticalhome/test/marionette/bookmark_uninstall_test.js": "Bug 1033223 - [Vertical homescreen] Intermittent MarionetteJS failure on Travis: 1) Vertical - Bookmark Uninstall removal of bookmark: NoSuchElement: (7) Unable to locate element: gaia-confirm[data-type=\"remove\"]"
   }
 }

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -33,7 +33,6 @@
     "apps/system/test/marionette/edges_gesture_test.js": "Bug 1045729 - Intermittent failing test, Edges gesture > before each hook",
     "apps/system/test/marionette/homescreen_navigation_test.js": "Bug 1043870 - TEST-UNEXPECTED-FAIL | Homescreen navigation > Going to the homescreen and back to a warm app",
     "apps/system/test/marionette/notification_resend_test.js": " Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
-    "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
     "apps/verticalhome/test/marionette/bookmark_uninstall_test.js": "Bug 1033223 - [Vertical homescreen] Intermittent MarionetteJS failure on Travis: 1) Vertical - Bookmark Uninstall removal of bookmark: NoSuchElement: (7) Unable to locate element: gaia-confirm[data-type=\"remove\"]"
   }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1037194
