### PR TITLE
Bug 994571 - [System2] Remove the pattern to return self in start()

### DIFF
--- a/apps/system/js/app_usage_metrics.js
+++ b/apps/system/js/app_usage_metrics.js
@@ -153,9 +153,6 @@
 
     SettingsListener.observe(AUM.TELEMETRY_ENABLED_KEY,
                              false, this.metricsEnabledListener);
-
-    // Return this so we can write |var aum = new AppUsageMetrics().start();|
-    return this;
   };
 
   // This method shuts everything down and is only exposed for unit testing.

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -108,18 +108,23 @@ window.addEventListener('load', function startup() {
   window.activities = new Activities();
   window.accessibility = new Accessibility();
   window.accessibility.start();
-  window.appUsageMetrics = new AppUsageMetrics().start();
+  window.appUsageMetrics = new AppUsageMetrics();
+  window.appUsageMetrics.start();
   window.appWindowFactory = new AppWindowFactory();
   window.appWindowFactory.start();
-  window.developerHUD = new DeveloperHUD().start();
-  window.dialerAgent = new DialerAgent().start();
-  window.homeGesture = new HomeGesture().start();
+  window.developerHUD = new DeveloperHUD();
+  window.developerHUD.start();
+  window.dialerAgent = new DialerAgent();
+  window.dialerAgent.start();
+  window.homeGesture = new HomeGesture();
+  window.homeGesture.start();
   window.homescreenLauncher = new HomescreenLauncher();
   window.homeSearchbar = new HomeSearchbar();
   window.internetSharing = new InternetSharing();
   window.internetSharing.start();
   window.lockScreenNotifications = new LockScreenNotifications();
-  window.layoutManager = new LayoutManager().start();
+  window.layoutManager = new LayoutManager();
+  window.layoutManager.start();
   window.permissionManager = new PermissionManager();
   window.permissionManager.start();
   window.places = new Places();
@@ -128,21 +133,24 @@ window.addEventListener('load', function startup() {
   window.rocketbar = new Rocketbar();
   window.sleepMenu = new SleepMenu();
   window.sleepMenu.start();
-  window.softwareButtonManager = new SoftwareButtonManager().start();
+  window.softwareButtonManager = new SoftwareButtonManager();
+  window.softwareButtonManager.start();
   window.sourceView = new SourceView();
   window.taskManager = new TaskManager();
   window.taskManager.start();
   window.telephonySettings = new TelephonySettings();
   window.telephonySettings.start();
   window.ttlView = new TTLView();
-  window.visibilityManager = new VisibilityManager().start();
+  window.visibilityManager = new VisibilityManager();
+  window.visibilityManager.start();
   window.wallpaperManager = new window.WallpaperManager();
   window.wallpaperManager.start();
 
   // unit tests call init() manually
   if (navigator.mozL10n) {
     navigator.mozL10n.once(function l10n_ready() {
-      window.mediaRecording = new MediaRecording().start();
+      window.mediaRecording = new MediaRecording();
+      window.mediaRecording.start();
     });
   }
 

--- a/apps/system/js/devtools/developer_hud.js
+++ b/apps/system/js/devtools/developer_hud.js
@@ -16,7 +16,6 @@
 
     start: function() {
       window.addEventListener('developer-hud-update', this);
-      return this;
     },
 
     stop: function() {

--- a/apps/system/js/dialer_agent.js
+++ b/apps/system/js/dialer_agent.js
@@ -97,8 +97,6 @@
     AttentionScreen.attentionScreen.appendChild(callScreen);
 
     callScreen.setVisible(false);
-
-    return this;
   };
 
   DialerAgent.prototype.stop = function da_stop() {

--- a/apps/system/js/home_gesture.js
+++ b/apps/system/js/home_gesture.js
@@ -82,8 +82,6 @@
             this.toggle(value);
           }.bind(this));
       }
-
-      return this;
     },
 
     /**

--- a/apps/system/js/homescreen_launcher.js
+++ b/apps/system/js/homescreen_launcher.js
@@ -110,9 +110,8 @@
      */
     start: function hl_start() {
       if (this._started) {
-        return this;
+        return;
       }
-
       this._started = true;
       if (applications.ready) {
         this._fetchSettings();
@@ -131,7 +130,6 @@
       window.addEventListener('shrinking-stop', this);
       window.addEventListener('software-button-enabled', this);
       window.addEventListener('software-button-disabled', this);
-      return this;
     },
 
     /**

--- a/apps/system/js/layout_manager.js
+++ b/apps/system/js/layout_manager.js
@@ -111,7 +111,6 @@
       window.addEventListener('mozfullscreenchange', this);
       window.addEventListener('software-button-enabled', this);
       window.addEventListener('software-button-disabled', this);
-      return this;
     },
 
     handleEvent: function lm_handleEvent(evt) {

--- a/apps/system/js/media_recording.js
+++ b/apps/system/js/media_recording.js
@@ -33,7 +33,6 @@
       this.container = document.getElementById('media-recoding-status-list');
 
       window.addEventListener('mozChromeEvent', this);
-      return this;
     },
 
     /**

--- a/apps/system/js/software_button_manager.js
+++ b/apps/system/js/software_button_manager.js
@@ -8,7 +8,7 @@
   /**
    * SoftwareButtonManager manages a home button for devides without
    * physical home buttons. The software home button will display at the bottom
-   * of the screen and is meant to function in the same way as a hardware 
+   * of the screen and is meant to function in the same way as a hardware
    * home button.
    * @class SoftwareButtonManager
    * @requires ScreenLayout
@@ -108,8 +108,6 @@
       window.addEventListener('mozfullscreenchange', this);
       window.addEventListener('homegesture-enabled', this);
       window.addEventListener('homegesture-disabled', this);
-
-      return this;
     },
 
     /**

--- a/apps/system/js/visibility_manager.js
+++ b/apps/system/js/visibility_manager.js
@@ -47,7 +47,6 @@
     this.overlayEvents.forEach(function overlayEventIterator(event) {
       window.addEventListener(event, this);
     }, this);
-    return this;
   };
 
   VisibilityManager.prototype.handleEvent = function vm_handleEvent(evt) {

--- a/apps/system/test/unit/app_usage_metrics_test.js
+++ b/apps/system/test/unit/app_usage_metrics_test.js
@@ -208,7 +208,8 @@ suite('AppUsageMetrics:', function() {
       activitySpy = this.sinon.spy(proto, 'recordActivity');
 
       // Create and initialize an AUM instance. It won't start automatically
-      aum = new AppUsageMetrics().start();
+      aum = new AppUsageMetrics();
+      aum.start();
 
       // Start it up so it is ready to handle events
       aum.startCollecting(done);
@@ -544,7 +545,8 @@ suite('AppUsageMetrics:', function() {
       XHR.onCreate = function(instance) { xhr = instance; };
 
       // Create an AUM instance
-      aum = new AppUsageMetrics().start();
+      aum = new AppUsageMetrics();
+      aum.start();
       aum.startCollecting(done);
 
       transmit = this.sinon.spy(AppUsageMetrics.prototype, 'transmit');

--- a/apps/system/test/unit/app_window_factory_test.js
+++ b/apps/system/test/unit/app_window_factory_test.js
@@ -120,7 +120,8 @@ suite('system/AppWindowFactory', function() {
 
     stubById = this.sinon.stub(document, 'getElementById');
     stubById.returns(document.createElement('div'));
-    window.homescreenLauncher = new HomescreenLauncher().start();
+    window.homescreenLauncher = new HomescreenLauncher();
+    window.homescreenLauncher.start();
 
     requireApp('system/js/system.js');
     requireApp('system/js/browser_config_helper.js');

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -46,7 +46,8 @@ suite('system/AppWindowManager', function() {
     window.layoutManager = new window.LayoutManager();
 
     home = new HomescreenWindow('fakeHome');
-    window.homescreenLauncher = new HomescreenLauncher().start();
+    window.homescreenLauncher = new HomescreenLauncher();
+    window.homescreenLauncher.start();
     homescreenLauncher.mFeedFixtures({
       mHomescreenWindow: home,
       mOrigin: 'fakeOrigin',

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -28,7 +28,8 @@ suite('system/AppWindow', function() {
   setup(function(done) {
     this.sinon.useFakeTimers();
 
-    window.layoutManager = new LayoutManager().start();
+    window.layoutManager = new LayoutManager();
+    window.layoutManager.start();
 
     stubById = this.sinon.stub(document, 'getElementById');
     stubById.returns(document.createElement('div'));

--- a/apps/system/test/unit/developer_hud_test.js
+++ b/apps/system/test/unit/developer_hud_test.js
@@ -15,7 +15,8 @@ suite('developerHUD', function() {
 
   mocksForDeveloperHUD.attachTestHelpers();
   setup(function() {
-    subject = new DeveloperHUD().start();
+    subject = new DeveloperHUD();
+    subject.start();
   });
 
   function updateMetrics(metrics) {

--- a/apps/system/test/unit/dialer_agent_test.js
+++ b/apps/system/test/unit/dialer_agent_test.js
@@ -67,7 +67,8 @@ suite('system/DialerAgent', function() {
     setVisibleSpy = this.sinon.spy(HTMLIFrameElement.prototype, 'setVisible');
 
     this.sinon.useFakeTimers();
-    subject = new DialerAgent().start();
+    subject = new DialerAgent();
+    subject.start();
   });
 
   teardown(function() {

--- a/apps/system/test/unit/edge_swipe_detector_test.js
+++ b/apps/system/test/unit/edge_swipe_detector_test.js
@@ -1,4 +1,12 @@
 'use strict';
+/* global Event */
+/* global MocksHelper */
+/* global HomescreenLauncher */
+/* global EdgeSwipeDetector */
+/* global MockSettingsListener */
+/* global MockStackManager */
+/* global MockSheetsTransition */
+/* global MockTouchForwarder */
 
 requireApp('system/js/edge_swipe_detector.js');
 
@@ -23,7 +31,8 @@ suite('system/EdgeSwipeDetector >', function() {
   var screen;
 
   setup(function() {
-    window.homescreenLauncher = new HomescreenLauncher().start();
+    window.homescreenLauncher = new HomescreenLauncher();
+    window.homescreenLauncher.start();
     // DOM
     EdgeSwipeDetector.previous = document.createElement('div');
     EdgeSwipeDetector.previous.classList.add('gesture-panel');
@@ -295,7 +304,7 @@ suite('system/EdgeSwipeDetector >', function() {
     function swipe(clock, panel, fromX, toX, fromY, toY, duration, noEnd) {
       var events = [];
 
-      var duration = duration || 350;
+      duration = duration || 350;
       events.push(touchStart(panel, [fromX], [fromY]));
 
       var diffX = Math.abs(toX - fromX);
@@ -337,12 +346,12 @@ suite('system/EdgeSwipeDetector >', function() {
 
       var screenWidth = window.innerWidth;
 
-      var duration = duration || 350;
+      duration = duration || 350;
       events.push(touchStart(panel, [0, screenWidth], [toY, toY]));
 
       var delta = Math.abs(toX);
 
-      var x = 0, y = 0;
+      var x = 0;
       var tick = duration / delta;
       for (var i = 0; i < delta; i++) {
         events.push(touchMove(panel, [x, (screenWidth - x)], [toY, toY]));
@@ -498,7 +507,6 @@ suite('system/EdgeSwipeDetector >', function() {
 
       test('it should snap the sheets in place whithout waiting', function() {
         var snapSpy = this.sinon.spy(MockSheetsTransition, 'snapInPlace');
-        var endSpy = this.sinon.spy(MockSheetsTransition, 'end');
         swipe(this.sinon.clock, panel, 3, 7, 20, halfScreen,
               25, true /* no touchend */);
         assert.isTrue(snapSpy.calledOnce);

--- a/apps/system/test/unit/home_gesture_test.js
+++ b/apps/system/test/unit/home_gesture_test.js
@@ -59,7 +59,8 @@ suite('enable/disable homegesture', function() {
     ScreenLayout.setDefault({
       tiny: true
     });
-    subject = new HomeGesture().start();
+    subject = new HomeGesture();
+    subject.start();
     assert.equal(
       MockNavigatorSettings.mSettings['homegesture.enabled'], false);
   });
@@ -68,7 +69,8 @@ suite('enable/disable homegesture', function() {
     ScreenLayout.setDefault({
       tiny: false
     });
-    subject = new HomeGesture().start();
+    subject = new HomeGesture();
+    subject.start();
     assert.equal(
       subject.homeBar.classList.contains('visible'),
       true);

--- a/apps/system/test/unit/homescreen_launcher_test.js
+++ b/apps/system/test/unit/homescreen_launcher_test.js
@@ -1,5 +1,9 @@
 'use strict';
-
+/* global MocksHelper */
+/* global HomescreenLauncher */
+/* global MockSettingsListener */
+/* global MockApplications */
+/* global MockTrustedUIManager */
 
 requireApp('system/test/unit/mock_homescreen_window.js');
 requireApp('system/test/unit/mock_applications.js');
@@ -15,7 +19,7 @@ var mocksForHomescreenLauncher = new MocksHelper([
 ]).init();
 
 suite('system/HomescreenLauncher', function() {
-  var homescreen, realApplications;
+  var realApplications;
 
   setup(function() {
     realApplications = window.applications;
@@ -47,7 +51,8 @@ suite('system/HomescreenLauncher', function() {
         window.removeEventListener('homescreen-ready', homescreenReady);
         ready = true;
       });
-      window.homescreenLauncher = new HomescreenLauncher().start();
+      window.homescreenLauncher = new HomescreenLauncher();
+      window.homescreenLauncher.start();
       MockSettingsListener.mCallbacks['homescreen.manifestURL']('first.home');
       homescreen = window.homescreenLauncher.getHomescreen();
       assert.isTrue(homescreen.isHomescreen);
@@ -61,7 +66,8 @@ suite('system/HomescreenLauncher', function() {
 
     setup(function() {
       MockApplications.ready = true;
-      window.homescreenLauncher = new HomescreenLauncher().start();
+      window.homescreenLauncher = new HomescreenLauncher();
+      window.homescreenLauncher.start();
     });
 
     teardown(function() {
@@ -130,7 +136,7 @@ suite('system/HomescreenLauncher', function() {
     test('trustedUI hidden', function() {
       MockSettingsListener.mCallbacks['homescreen.manifestURL']('first.home');
       homescreen = window.homescreenLauncher.getHomescreen();
-      var stubToggle = this.sinon.stub(homescreen, 'toggle');
+      this.sinon.stub(homescreen, 'toggle');
       window.homescreenLauncher.handleEvent({
         type: 'trusteduihide'
       });

--- a/apps/system/test/unit/homescreen_window_test.js
+++ b/apps/system/test/unit/homescreen_window_test.js
@@ -27,7 +27,8 @@ suite('system/HomescreenWindow', function() {
 
   setup(function(done) {
     this.sinon.useFakeTimers();
-    window.homescreenLauncher = new HomescreenLauncher().start();
+    window.homescreenLauncher = new HomescreenLauncher();
+    window.homescreenLauncher.start();
     stubById = this.sinon.stub(document, 'getElementById');
     stubById.returns(document.createElement('div'));
     requireApp('system/js/system.js');

--- a/apps/system/test/unit/layout_manager_test.js
+++ b/apps/system/test/unit/layout_manager_test.js
@@ -21,7 +21,8 @@ suite('system/LayoutManager >', function() {
   var layoutManager;
   setup(function() {
     window.lockScreen = MockLockScreen;
-    layoutManager = new LayoutManager().start();
+    layoutManager = new LayoutManager();
+    layoutManager.start();
   });
 
   suite('handle events', function() {

--- a/apps/system/test/unit/lockscreen_window_test.js
+++ b/apps/system/test/unit/lockscreen_window_test.js
@@ -35,7 +35,8 @@ suite('system/LockScreenWindow', function() {
     // Differs from the existing mock which is expected by other components.
     window.LockScreen = function() {};
     window.LockScreen.prototype.init = this.sinon.stub();
-    window.layoutManager = new LayoutManager().start();
+    window.layoutManager = new LayoutManager();
+    window.layoutManager.start();
 
     realL10n = window.navigator.mozL10n;
     window.navigator.mozL10n = MockL10n;

--- a/apps/system/test/unit/mock_homescreen_launcher.js
+++ b/apps/system/test/unit/mock_homescreen_launcher.js
@@ -1,7 +1,7 @@
 'use strict';
 
 (function(exports) {
-  var mHomescreenInstance = undefined;
+  var mHomescreenInstance;
   var mOrigin;
   var mReady;
 
@@ -10,9 +10,7 @@
   };
 
   MockHomescreenLauncher.prototype = {
-    start: function mhl_start() {
-      return this;
-    },
+    start: function mhl_start() {},
 
     getHomescreen: function mhl_getHomescreen() {
       return mHomescreenInstance;

--- a/apps/system/test/unit/sheets_transition_test.js
+++ b/apps/system/test/unit/sheets_transition_test.js
@@ -1,4 +1,9 @@
 'use strict';
+/* global MocksHelper */
+/* global MockHomescreenLauncher */
+/* global MockStackManager */
+/* global SheetsTransition */
+
 requireApp('system/js/sheets_transition.js');
 
 requireApp('system/test/unit/mock_stack_manager.js');
@@ -34,7 +39,8 @@ suite('system/SheetsTransition >', function() {
   var getPrevStub, getNextStub;
 
   setup(function() {
-    window.homescreenLauncher = new MockHomescreenLauncher().start();
+    window.homescreenLauncher = new MockHomescreenLauncher();
+    window.homescreenLauncher.start();
     getPrevStub = this.sinon.stub(MockStackManager, 'getPrev');
     getPrevStub.returns(dialer);
     dialerFrame = document.createElement('div');

--- a/apps/system/test/unit/stack_manager_test.js
+++ b/apps/system/test/unit/stack_manager_test.js
@@ -24,7 +24,8 @@ suite('system/StackManager >', function() {
   setup(function() {
     this.sinon.useFakeTimers();
 
-    window.homescreenLauncher = new HomescreenLauncher().start();
+    window.homescreenLauncher = new HomescreenLauncher();
+    window.homescreenLauncher.start();
     dialer = new AppWindow({
       url: 'app://communications.gaiamobile.org/dialer/index.html',
       origin: 'app://communications.gaiamobile.org/',

--- a/apps/system/test/unit/text_selection_dialog_test.js
+++ b/apps/system/test/unit/text_selection_dialog_test.js
@@ -16,7 +16,8 @@ suite('system/TextSelectionDialog', function() {
   mocksForTextSelectionDialog.attachTestHelpers();
   var mockDetail = {};
   setup(function(done) {
-    window.layoutManager = new LayoutManager().start();
+    window.layoutManager = new LayoutManager();
+    window.layoutManager.start();
     window.layoutManager.width = 360;
     window.layoutManager.height = 480;
     mockDetail = {

--- a/apps/system/test/unit/visibility_manager_test.js
+++ b/apps/system/test/unit/visibility_manager_test.js
@@ -22,7 +22,8 @@ suite('system/VisibilityManager', function() {
     stubById = this.sinon.stub(document, 'getElementById');
     stubById.returns(document.createElement('div'));
     requireApp('system/js/visibility_manager.js', function() {
-      visibilityManager = new VisibilityManager().start();
+      visibilityManager = new VisibilityManager();
+      visibilityManager.start();
       done();
     });
   });

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -396,7 +396,6 @@ apps/system/test/unit/carrier_info_notifier_test.js
 apps/system/test/unit/date_picker_test.js
 apps/system/test/unit/download_manager_test.js
 apps/system/test/unit/download_notification_test.js
-apps/system/test/unit/edge_swipe_detector_test.js
 apps/system/test/unit/entery_sheet_test.js
 apps/system/test/unit/fxa_client_test.js
 apps/system/test/unit/fxa_iac_client_test.js
@@ -414,7 +413,6 @@ apps/system/test/unit/fxa_test/screens/fxam_refresh_auth_test.js
 apps/system/test/unit/fxa_test/screens/fxam_set_password_test.js
 apps/system/test/unit/fxa_test/screens/fxam_signin_success_test.js
 apps/system/test/unit/fxa_test/screens/fxam_signup_success_test.js
-apps/system/test/unit/homescreen_launcher_test.js
 apps/system/test/unit/iac_handler_test.js
 apps/system/test/unit/identity_test.js
 apps/system/test/unit/keyboard_helper_test.js
@@ -436,7 +434,6 @@ apps/system/test/unit/mock_download_ui.js
 apps/system/test/unit/mock_ftu_launcher.js
 apps/system/test/unit/mock_fxa_client.js
 apps/system/test/unit/mock_fxa_ui.js
-apps/system/test/unit/mock_homescreen_launcher.js
 apps/system/test/unit/mock_homescreen_window.js
 apps/system/test/unit/mock_iac_handler.js
 apps/system/test/unit/mock_iachandler.js
@@ -462,7 +459,6 @@ apps/system/test/unit/orientation_manager_test.js
 apps/system/test/unit/quick_settings_test.js
 apps/system/test/unit/screen_manager_test.js
 apps/system/test/unit/settings_helper_test.js
-apps/system/test/unit/sheets_transition_test.js
 apps/system/test/unit/spin_date_picker_test.js
 apps/system/test/unit/storage_watcher_test.js
 apps/system/test/unit/updatable_test.js


### PR DESCRIPTION
- Remove 'var module = new Module().start()' pattern.
- Remove 'return this;' expression in start() function definitions.
