### PR TITLE
Bug 1035069 - Dont show operator name if its not available

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -657,9 +657,10 @@ var StatusBar = {
 
       var label = this.icons.label;
       var l10nArgs = JSON.parse(label.dataset.l10nArgs || '{}');
+      var operatorInfos = MobileOperator.userFacingInfo(conn);
 
       if (!conn || !conn.voice || !conn.voice.connected ||
-          conn.voice.emergencyCallsOnly) {
+          conn.voice.emergencyCallsOnly || !operatorInfos.operator) {
         delete l10nArgs.operator;
         label.dataset.l10nArgs = JSON.stringify(l10nArgs);
 
@@ -669,7 +670,6 @@ var StatusBar = {
         return;
       }
 
-      var operatorInfos = MobileOperator.userFacingInfo(conn);
       l10nArgs.operator = operatorInfos.operator;
 
       if (operatorInfos.region) {


### PR DESCRIPTION
Some time we are getting operator name as "null" from mobile connection. When we show the operator name on the status bar we are not checking the null case.
