### PR TITLE
Ignore video track `vmhd` as it may be cover image

### DIFF
--- a/apps/music/js/metadata.js
+++ b/apps/music/js/metadata.js
@@ -651,8 +651,9 @@ function parseAudioMetadata(blob, metadataCallback, errorCallback) {
             var minf = findChildAtom(mdia, 'minf');
             if (minf) {
               var vmhd = searchChildAtom(minf, 'vmhd');
-              if (vmhd)
-                throw 'Found video track in MP4 container';
+              //Commented next two lines because it causes stopping of parsing m4a file with cover embedded
+              //if (vmhd)
+                //throw 'Found video track in MP4 container';
               var smhd = searchChildAtom(minf, 'smhd');
               if (smhd) {
                 var stbl = findChildAtom(minf, 'stbl');


### PR DESCRIPTION
Why do you even care that you found video track?
I'm listening to `Above & Beyound: Group Therapy` podcast, and for example this correct AAC file: http://traffic.libsyn.com/anjunabeats/ABGT086_76345674.m4a
have `vmhd` inside, but it is only JPEG cover, and it is OK.
Moreover, `vmhd` is placed before other meta information, and having such check you get no metadata at all.
