### PR TITLE
Bug 1038060 - [v2.1] Fix test_import_contacts_from_gmail failure

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/gmail.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/gmail.py
@@ -25,6 +25,7 @@ class GmailLogin(Base):
         self.marionette.find_element(*self._email_locator).send_keys(user)
         self.marionette.find_element(*self._password_locator).tap()
         self.marionette.find_element(*self._password_locator).send_keys(passwd)
+        self.keyboard.dismiss()
         self.marionette.find_element(*self._sign_in_locator).tap()
 
     def tap_grant_access(self):


### PR DESCRIPTION
Added a keyboard.dismiss before tapping on the sign in button.
