### PR TITLE
bug1037171 Ensure find my device cancellation (or error) does not result...

### DIFF
--- a/apps/settings/js/findmydevice.js
+++ b/apps/settings/js/findmydevice.js
@@ -27,6 +27,7 @@ var FindMyDevice = {
           console.log('Find My Device: onready fired');
         },
         onerror: function fmd_fxa_onerror(err) {
+          self._interactiveLogin = false;
           self._togglePanel(false);
           self._loginButton.removeAttribute('disabled');
           console.error('Find My Device: onerror fired: ' + err);
@@ -56,7 +57,13 @@ var FindMyDevice = {
       return window.alert(_('findmydevice-enable-network'));
     }
     this._interactiveLogin = true;
-    navigator.mozId.request();
+    var self = this;
+    navigator.mozId.request({
+      oncancel: function fmd_fxa_oncancel() {
+        self._interactiveLogin = false;
+        console.log('Find My Device: oncancel fired');
+      }
+    });
   },
 
   _setEnabled: function fmd_set_enabled(value) {

--- a/apps/settings/test/unit/findmydevice_panel_test.js
+++ b/apps/settings/test/unit/findmydevice_panel_test.js
@@ -42,6 +42,7 @@ suite('Find My Device panel > ', function() {
       onlogout: null,
       onready: null,
       onerror: null,
+      oncancel: null,
 
       watch: function(options) {
         this.onlogin = options.onlogin;
@@ -54,8 +55,8 @@ suite('Find My Device panel > ', function() {
         });
       },
 
-      request: function() {
-        // noop
+      request: function(options) {
+        this.oncancel = options.oncancel;
       },
     };
 
@@ -166,6 +167,19 @@ suite('Find My Device panel > ', function() {
     assert.ok(navigator.mozL10n.localize.calledWith(
         trackingSection, 'findmydevice-not-tracking'));
     navigator.mozL10n.localize.reset();
+  });
+
+  test('prevent accidental auto-enable on FxA sign-in', function() {
+    MockMozId.onlogout();
+    loginButton.click();
+    assert.equal(true, window.FindMyDevice._interactiveLogin,
+      'ensure _interactiveLogin is true after login button is clicked');
+    MockMozId.oncancel();
+    assert.equal(false, window.FindMyDevice._interactiveLogin,
+      'ensure _interactiveLogin is false after FxA cancel');
+    MockMozId.onlogin();
+    assert.equal(0, MockSettingsListener.getSettingsLock().locks.length,
+      'ensure findmydevice.enabled was not set automatically on FxA login');
   });
 
   suiteTeardown(function() {


### PR DESCRIPTION
bug1037171 Ensure find my device cancellation (or error) does not result in FMD becoming enabled on subsequent FxA login r=mgoodwin
