### PR TITLE
Bug 1033079 - Fix up DebuggerServer test after refactoring. r=janx

### DIFF
--- a/tests/integration/devtools/server_test.js
+++ b/tests/integration/devtools/server_test.js
@@ -22,15 +22,15 @@ marionette('Dev Tools server', function() {
 
   test('is running and listening', function() {
     var debuggerServerInited = client.executeScript(function() {
-      Cu.import("resource:///modules/devtools/dbg-server.jsm");
+      Cu.import('resource:///modules/devtools/dbg-server.jsm');
       return DebuggerServer.initialized;
     });
     assert.ok(debuggerServerInited, 'Debugger server initialized');
-    var debuggerServerListening = client.executeScript(function() {
-      Cu.import("resource:///modules/devtools/dbg-server.jsm");
-      return !!DebuggerServer._listener;
+    var debuggerServerSockets = client.executeScript(function() {
+      Cu.import('resource:///modules/devtools/dbg-server.jsm');
+      return DebuggerServer.listeningSockets;
     });
-    assert.ok(debuggerServerListening, 'Debugger server listening');
+    assert.equal(debuggerServerSockets, 1, 'Debugger server listening');
   });
 
 });


### PR DESCRIPTION
The `DebuggerServer` API is changing in bug 1033079, and after this fix lands, it won't have `_listener` anymore. This updates the test to use the new API.
