### PR TITLE
Merge pull request #21571 from ian-liu/bluetooth/bug1029037_pairing_dialog_is_closing_abnormally_while_screen_is_transitioning

### DIFF
--- a/apps/bluetooth/js/pair_view.js
+++ b/apps/bluetooth/js/pair_view.js
@@ -35,7 +35,16 @@ var Pairview = {
   pinInput: document.getElementById('pin-input'),
   passkeyInput: document.getElementById('passkey-input'),
 
+  get isFullAttentionMode() {
+    return (window.innerHeight > 200);
+  },
+
   show: function pv_show() {
+    if (!this.isFullAttentionMode) {
+      this.close();
+      return;
+    }
+
     var _ = navigator.mozL10n.get;
     this.pairButton.addEventListener('click', this);
     this.closeButton.addEventListener('click', this);
@@ -146,10 +155,10 @@ var Pairview = {
         }
         break;
       case 'resize':
-      // XXX: this is hack that we have to close the attention in this case,
-      // while in most other cases, we would just change it into an active
-      // status bar
-        if (window.innerHeight < 200) {
+        // XXX: this is hack that we have to close the attention in this case,
+        // while in most other cases, we would just change it into an active
+        // status bar
+        if (!this.isFullAttentionMode) {
           this.close();
         }
         break;

--- a/apps/bluetooth/test/unit/pair_view_test.js
+++ b/apps/bluetooth/test/unit/pair_view_test.js
@@ -36,6 +36,39 @@ suite('Bluetooth app > Pairview ', function() {
     document.body.innerHTML = '';
   });
 
+  suite('isFullAttentionMode > ', function() {
+    var realWindowInnerHeight;
+    suiteSetup(function() {
+      realWindowInnerHeight = window.innerHeight;
+    });
+
+    suiteTeardown(function() {
+      switchReadOnlyProperty(window, 'innerHeight', realWindowInnerHeight);
+    });
+
+    suite('window.innerHeight is 200 > ', function() {
+      setup(function() {
+        switchReadOnlyProperty(window, 'innerHeight', 200);
+      });
+
+      test('getting the mode of full attention should be false ' +
+         'after isFullAttentionMode() is called ', function() {
+        assert.isFalse(Pairview.isFullAttentionMode);
+      });
+    });
+
+    suite('window.innerHeight is 201 > ', function() {
+      setup(function() {
+        switchReadOnlyProperty(window, 'innerHeight', 201);
+      });
+
+      test('getting the mode of full attention should be true ' +
+         'after isFullAttentionMode() is called ', function() {
+        assert.isTrue(Pairview.isFullAttentionMode);
+      });
+    });
+  });
+
   suite('init > ', function() {
     var device = {
       address: '00:11:22:AA:BB:CC',
@@ -75,6 +108,35 @@ suite('Bluetooth app > Pairview ', function() {
       window.getTruncated = this.sinon.stub();
       window.getTruncated.returns({
         addEventListener: this.sinon.stub()
+      });
+    });
+
+    suite('early return > ', function() {
+      var realWindowInnerHeight;
+
+      setup(function() {
+        realWindowInnerHeight = window.innerHeight;
+        switchReadOnlyProperty(window, 'innerHeight', 200);
+        this.sinon.stub(Pairview, 'close');
+        Pairview.show();
+      });
+
+      teardown(function() {
+        switchReadOnlyProperty(window, 'innerHeight', realWindowInnerHeight);
+      });
+
+      test('isFullAttentionMode() should be false', function() {
+        assert.isFalse(Pairview.isFullAttentionMode);
+      });
+
+      test('close() should be called while attention sceen is not in full ' +
+        'screen mode ', function() {
+        assert.isTrue(Pairview.close.called);
+      });
+
+      test('getTruncated() should not be called since early return',
+        function() {
+        assert.isFalse(window.getTruncated.called);
       });
     });
 


### PR DESCRIPTION
Bug 1029037 - [B2G][Bluetooth]Screen transitioning while reciving a pairrequest will not close the pairing dialog normally. r=@arthur
(cherry picked from commit a35527a3e3cd44e2586adbd207da5a36b9407aa6)
