### PR TITLE
Merge pull request #21602 from RudyLu/keyboard/Bug1034210_commit

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -1421,9 +1421,21 @@ function endPress(target, coords, touchId, hasCandidateScrolled) {
       }
     }
     else {
-      inputMethodManager.currentIMEngine.click(
-        parseInt(target.dataset.keycode, 10),
-        parseInt(target.dataset.keycodeUpper, 10));
+      /*
+       * XXX: A hack to send both keycode and uppercase keycode to latin IME,
+       * since latin IME would maintain a promise queue for each key, and
+       * send correct keycode based on the current capitalization state.
+       * See bug 1013570 and bug 987809 for details.
+       * This hack should be removed and the state/input queue should be
+       * maintained in keyboard.js.
+       */
+      if (keyboard.imEngine == 'latin') {
+        inputMethodManager.currentIMEngine.click(
+          parseInt(target.dataset.keycode, 10),
+          parseInt(target.dataset.keycodeUpper, 10));
+      } else {
+        inputMethodManager.currentIMEngine.click(keyCode);
+      }
     }
     break;
   }

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -748,7 +748,7 @@ bubble above the key when you tap and hold. */
 }
 
 @media (orientation:portrait) {
-  .special-key > .visual-wrapper > span[data-label="அஆஇ"] {
+  .special-key > .visual-wrapper > .key-element[data-label="அஆஇ"] {
     font-size: 1.1rem;
   }
 
@@ -784,7 +784,7 @@ bubble above the key when you tap and hold. */
 
 @media (orientation:landscape) {
   #keyboard.landscape .special-key > .visual-wrapper >
-    span[data-label="அஆஇ"] {
+    .key-element[data-label="அஆஇ"] {
     font-size: 1.7rem;
   }
 


### PR DESCRIPTION
Bug 1034210 - send correct keycode for non-latin IME. r=timdream. a=2.0+
(cherry picked from commit 8a7fb294444869ddaf869a58b21588752b9ce561)
