### PR TITLE
Revert "Bug 1017002 - [Homescreen] Disable intermittent Marionette JS failure on Travis: 1) Homescreen navigation > Going to the homescreen and back to a warm app: AssertionError: we got 2 reflows instead of 0"

### DIFF
--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -31,7 +31,6 @@
     "apps/settings/test/marionette/tests/hotspot_wifi_settings_test.js",
     "apps/settings/test/marionette/tests/message_settings_test.js",
     "apps/system/test/marionette/edges_gesture_test.js",
-    "apps/system/test/marionette/homescreen_navigation_test.js",
     "apps/system/test/marionette/notification_get_test.js",
     "apps/system/test/marionette/notification_resend_test.js",
     "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js"

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -30,7 +30,6 @@
     "apps/settings/test/marionette/tests/app_permission_settings_test.js",
     "apps/settings/test/marionette/tests/message_settings_test.js",
     "apps/settings/test/marionette/tests/airplane_mode_settings_test.js",
-    "apps/system/test/marionette/homescreen_navigation_test.js",
     "apps/system/test/marionette/notification_resend_test.js",
     "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js"
   ]


### PR DESCRIPTION
This reverts commit e8a553c0c6c3657a536f4cd409173e1d561263b9.

https://bugzilla.mozilla.org/show_bug.cgi?id=1017002
