### PR TITLE
Bug 981009 - Check that we have as many timings as we have runs for startup_test.

### DIFF
--- a/tests/performance/startup_test.js
+++ b/tests/performance/startup_test.js
@@ -73,6 +73,9 @@ marionette('startup test > ' + mozTestInfo.appPath + ' >', function() {
       return element.time;
     });
 
+    // results is an Array of values, one per run.
+    assert.ok(results.length == mozTestInfo.runs, 'missing runs');
+
     PerformanceHelper.reportDuration(results);
     PerformanceHelper.reportMemory(memStats);
 


### PR DESCRIPTION
Attempt 2
