### PR TITLE
Bug 1038325 - [B2G][Email] Reply button icon is not displayed.

### DIFF
--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -605,7 +605,7 @@ reflows. Foreground/background colors should be safe.
   background-image: url("images/icons/forward.png");
 }
 
-pp.bb-tablist .msg-reply-btn {
+.bb-tablist .msg-reply-btn {
   background-image: url("images/icons/reply.png");
 }
 


### PR DESCRIPTION
The pp was apparently a typo, since the selector breaks with it and there is no "pp" tag anywhere in the document.
