### PR TITLE
Bug 1039068: Clear the _notification field when tapping a notification. ...

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -246,6 +246,8 @@ var NotificationScreen = {
     } else {
       UtilityTray.hide();
     }
+
+    delete this._notification;
   },
 
   updateTimestamps: function ns_updateTimestamps() {


### PR DESCRIPTION
...r=alive
