### PR TITLE
Bug 933133 - [Gaia][Messages] Handling proactive notification while message report return

### DIFF
--- a/apps/sms/js/activity_handler.js
+++ b/apps/sms/js/activity_handler.js
@@ -6,6 +6,7 @@
          ThreadUI, Notification, Settings, Navigation */
 /*exported ActivityHandler */
 
+(function(exports) {
 'use strict';
 
 /**
@@ -18,6 +19,42 @@ const ActivityDataType = {
   VIDEO: 'video/*',
   URL: 'url'
 };
+
+function getTitleFromMms(opts, callback) {
+  // If message is not downloaded notification, we need to apply
+  // specific text in notification title;
+  // If subject exist, we display subject first;
+  // If the message only has text content, display text context;
+  // If there is no subject nor text content, display
+  // 'mms message' in the field.
+  var needManualRetrieve = opts.needManualRetrieve;
+  var message = opts.message;
+
+  if (needManualRetrieve) {
+    setTimeout(function notDownloadedCb() {
+      callback(navigator.mozL10n.get('notDownloaded-title'));
+    });
+  }
+  else if (message.subject) {
+    setTimeout(function subjectCb() {
+      callback(message.subject);
+    });
+  } else {
+    SMIL.parse(message, function slideCb(slideArray) {
+      var text, slidesLength = slideArray.length;
+      for (var i = 0; i < slidesLength; i++) {
+        if (!slideArray[i].text) {
+          continue;
+        }
+
+        text = slideArray[i].text;
+        break;
+      }
+      text = text ? text : navigator.mozL10n.get('mms-message');
+      callback(text);
+    });
+  }
+}
 
 var ActivityHandler = {
   // CSS class applied to the body element when app requested via activity
@@ -42,12 +79,19 @@ var ActivityHandler = {
     );
 
     // We want to register the handler only when we're on the launch path
-    if (!window.location.hash.length) {
-      ['sms-received', 'sms-delivery-success', 'sms-read-success',
-        'notification'].forEach(function(key){
-        var handler = Utils.camelCase('on-' + key);
-        window.navigator.mozSetMessageHandler(key, this[handler].bind(this));
-      }, this);
+    if (window.location.hash.length) {
+      return;
+    }
+
+    var messageHandlers = {
+      'sms-received': this.onSmsReceived.bind(this),
+      'sms-delivery-success': this.onSmsDeliverySuccess.bind(this),
+      'sms-read-success': this.onSmsReadSuccess.bind(this),
+      'notification': this.onNotification.bind(this)
+    };
+
+    for (var key in messageHandlers) {
+      window.navigator.mozSetMessageHandler(key, messageHandlers[key]);
     }
   },
 
@@ -323,19 +367,7 @@ var ActivityHandler = {
     });
   },
 
-  /* === Incoming SMS support === */
-
-  onSmsReceived: function ah_onSmsReceived(message, messageOpt) {
-    var _ = navigator.mozL10n.get;
-
-    // Acquire the cpu wake lock when we receive an SMS.  This raises the
-    // priority of this process above vanilla background apps, making it less
-    // likely to be killed on OOM.  It also prevents the device from going to
-    // sleep before the user is notified of the new message.
-    //
-    // We'll release it once we display a notification to the user.  We also
-    // release the lock after 30s, in case we never run the notification code
-    // for some reason.
+  wakeLockSetup: function ah_wakeLockSetup() {
     var wakeLock = navigator.requestWakeLock('cpu');
     var wakeLockReleased = false;
     var timeoutID = null;
@@ -349,13 +381,117 @@ var ActivityHandler = {
         wakeLock.unlock();
       }
     }
-    timeoutID = setTimeout(releaseWakeLock, 30 * 1000);
 
-    var delivered = messageOpt && messageOpt.delivered;
-    var read = messageOpt && messageOpt.read;
-    var number = this.getPhoneNumber(message, messageOpt);
+    timeoutID = setTimeout(releaseWakeLock, 30 * 1000);
+    return releaseWakeLock;
+  },
+
+  dispatchNotification: function ah_dispatchNotification(options) {
+    var _ = navigator.mozL10n.get;
+    var message = options.message;
+    var releaseWakeLock = options.releaseWakeLock;
     var threadId = message.threadId;
     var id = message.id;
+    var number = this.getPhoneNumber(message, options);
+
+    // The SMS app is already displayed
+    if (!document.hidden) {
+      if (Navigation.isCurrentPanel('thread', { id: threadId })) {
+        Notify.ringtone();
+        Notify.vibrate();
+        releaseWakeLock();
+        return;
+      }
+    }
+
+    navigator.mozApps.getSelf().onsuccess = function(evt) {
+      var app = evt.target.result;
+      var iconURL = NotificationHelper.getIconURI(app);
+
+      // Stashing the number at the end of the icon URL to make sure
+      // we get it back even via system message
+      iconURL += '?';
+      iconURL += [
+        'threadId=' + threadId,
+        'number=' + encodeURIComponent(number),
+        'id=' + id
+      ].join('&');
+
+      function goToMessage() {
+        app.launch();
+        ActivityHandler.handleMessageNotification(message);
+      }
+
+      function continueWithNotification(sender, body) {
+        var title = sender;
+        if (Settings.hasSeveralSim() && message.iccId) {
+          var simName = Settings.getSimNameByIccId(message.iccId);
+          title = _(
+            'dsds-notification-title-with-sim',
+            { sim: simName, sender: sender }
+          );
+        }
+
+        var opts = {
+          icon: iconURL,
+          body: body,
+          tag: 'threadId:' + threadId
+        };
+
+        var notification = new Notification(title, opts);
+        notification.addEventListener('click', goToMessage);
+        releaseWakeLock();
+
+        // Close notification if we are already in thread view and view become
+        // visible.
+        if (document.hidden && threadId === Threads.currentId) {
+          document.addEventListener('visibilitychange',
+            function onVisible() {
+              document.removeEventListener('visibilitychange', onVisible);
+              notification.close();
+          });
+        }
+      }
+
+      Contacts.findByPhoneNumber(number, function gotContact(contact) {
+        var name = number;
+        if (!contact) {
+          console.error('We got a null contact for number:', number);
+        } else if (contact.length && contact[0].name &&
+          contact[0].name.length && contact[0].name[0]) {
+          name = contact[0].name[0];
+        }
+
+        if (options.delivered) {
+          // delivery success notification
+          continueWithNotification(_('message-received-by'), name);
+        } else if (options.read) {
+          // read success notification
+          continueWithNotification(_('message-read-by'), name);
+        } else if (message.type === 'sms') {
+          // sms received notification
+          continueWithNotification(name, message.body);
+        } else {
+          // mms received notification
+          getTitleFromMms(options, function textCallback(text) {
+            continueWithNotification(name, text);
+          });
+        }
+      });
+    };
+  },
+  /* === Incoming SMS support === */
+
+  onSmsReceived: function ah_onSmsReceived(message) {
+    // Acquire the cpu wake lock when we receive an SMS.  This raises the
+    // priority of this process above vanilla background apps, making it less
+    // likely to be killed on OOM.  It also prevents the device from going to
+    // sleep before the user is notified of the new message.
+    //
+    // We'll release it once we display a notification to the user.  We also
+    // release the lock after 30s, in case we never run the notification code
+    // for some reason.
+    var releaseWakeLock = this.wakeLockSetup();
 
     // Class 0 handler:
     if (message.messageClass === 'class-0') {
@@ -375,131 +511,11 @@ var ActivityHandler = {
           app.launch();
           Notify.ringtone();
           Notify.vibrate();
-          alert(number + '\n' + message.body);
+          alert(message.sender + '\n' + message.body);
           releaseWakeLock();
         });
       };
       return;
-    }
-
-    function dispatchNotification(needManualRetrieve) {
-      // The SMS app is already displayed
-      if (!document.hidden) {
-        if (Navigation.isCurrentPanel('thread', { id: threadId })) {
-          Notify.ringtone();
-          Notify.vibrate();
-          releaseWakeLock();
-          return;
-        }
-      }
-
-      navigator.mozApps.getSelf().onsuccess = function(evt) {
-        var app = evt.target.result;
-        var iconURL = NotificationHelper.getIconURI(app);
-
-        // Stashing the number at the end of the icon URL to make sure
-        // we get it back even via system message
-        iconURL += '?';
-        iconURL += [
-          'threadId=' + threadId,
-          'number=' + encodeURIComponent(number),
-          'id=' + id
-        ].join('&');
-
-        function goToMessage() {
-          app.launch();
-          ActivityHandler.handleMessageNotification(message);
-        }
-
-        function continueWithNotification(sender, body) {
-          var title = sender;
-          if (Settings.hasSeveralSim() && message.iccId) {
-            var simName = Settings.getSimNameByIccId(message.iccId);
-            title = _(
-              'dsds-notification-title-with-sim',
-              { sim: simName, sender: sender }
-            );
-          }
-
-          var options = {
-            icon: iconURL,
-            body: body,
-            tag: 'threadId:' + threadId
-          };
-
-          var notification = new Notification(title, options);
-          notification.addEventListener('click', goToMessage);
-          releaseWakeLock();
-
-          // Close notification if we are already in thread view and view become
-          // visible.
-          if (document.hidden && threadId === Threads.currentId) {
-            document.addEventListener('visibilitychange',
-              function onVisible() {
-                document.removeEventListener('visibilitychange', onVisible);
-                notification.close();
-            });
-          }
-        }
-
-        function getTitleFromMms(callback) {
-          // If message is not downloaded notification, we need to apply
-          // specific text in notification title;
-          // If subject exist, we display subject first;
-          // If the message only has text content, display text context;
-          // If there is no subject nor text content, display
-          // 'mms message' in the field.
-          if (needManualRetrieve) {
-            setTimeout(function notDownloadedCb() {
-              callback(_('notDownloaded-title'));
-            });
-          }
-          else if (message.subject) {
-            setTimeout(function subjectCb() {
-              callback(message.subject);
-            });
-          } else {
-            SMIL.parse(message, function slideCb(slideArray) {
-              var text, slidesLength = slideArray.length;
-              for (var i = 0; i < slidesLength; i++) {
-                if (!slideArray[i].text) {
-                  continue;
-                }
-
-                text = slideArray[i].text;
-                break;
-              }
-              text = text ? text : _('mms-message');
-              callback(text);
-            });
-          }
-        }
-
-        Contacts.findByPhoneNumber(number, function gotContact(
-                                                                contact) {
-          var name = ActivityHandler.getPhoneNumber(message, messageOpt);
-          if (!contact) {
-            console.error('We got a null contact for sender:', number);
-          } else if (contact.length && contact[0].name &&
-            contact[0].name.length && contact[0].name[0]) {
-            name = contact[0].name[0];
-          }
-
-          if (delivered) {
-            continueWithNotification(
-              navigator.mozL10n.get('message-received-by'), name);
-          } else if (read) {
-            continueWithNotification(
-              navigator.mozL10n.get('message-read-by'), name);
-          } else if (message.type === 'sms') {
-            continueWithNotification(name, message.body);
-          } else { // mms
-            getTitleFromMms(function textCallback(text) {
-              continueWithNotification(name, text);
-            });
-          }
-        });
-      };
     }
 
     function handleNotification(isSilent) {
@@ -512,9 +528,12 @@ var ActivityHandler = {
         // Please ref mxr for all the possible delivery status:
         // http://mxr.mozilla.org/mozilla-central/source/dom/mms/src/ril/
         // MmsService.js#62
-        if (message.type === 'sms') {
-          dispatchNotification();
-        } else {
+        var opts = {
+          message: message,
+          releaseWakeLock: releaseWakeLock
+        };
+
+        if (message.type === 'mms') {
           // Here we can only have one sender, so deliveryInfo[0].deliveryStatus
           // => message status from sender.
           var status = message.deliveryInfo[0].deliveryStatus;
@@ -524,19 +543,36 @@ var ActivityHandler = {
 
           // If the delivery status is manual/rejected/error, we need to apply
           // specific text to notify user that message is not downloaded.
-          dispatchNotification(status !== 'success');
+          opts.needManualRetrieve = status !== 'success';
         }
+        /*jshint validthis:true */
+        this.dispatchNotification(opts);
       }
     }
-    SilentSms.checkSilentModeFor(message.sender).then(handleNotification);
+    SilentSms.checkSilentModeFor(message.sender).then(
+      handleNotification.bind(this));
   },
 
   onSmsDeliverySuccess: function ah_onSmsDeliverySuccess(message) {
-    this.onSmsReceived(message, {delivered : true});
+    var releaseWakeLock = this.wakeLockSetup();
+    var opts = {
+      message: message,
+      releaseWakeLock: releaseWakeLock,
+      delivered: true
+    };
+
+    this.dispatchNotification(opts);
   },
 
   onSmsReadSuccess: function ah_onSmsReadSuccess(message) {
-    this.onSmsReceived(message, {read : true});
+    var releaseWakeLock = this.wakeLockSetup();
+    var opts = {
+      message: message,
+      releaseWakeLock: releaseWakeLock,
+      read: true
+    };
+
+    this.dispatchNotification(opts);
   },
 
   getPhoneNumber: function ah_getPhoneNumber(message, option) {
@@ -602,3 +638,7 @@ var ActivityHandler = {
     };
   }
 };
+
+exports.ActivityHandler = ActivityHandler;
+
+}(window));

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -93,6 +93,8 @@ report-from             = From:
 message-sent            = Sent:
 message-received        = Received:
 message-via             = Via:
+message-received-by     = Message received by
+message-read-by         = Message read by
 
 # Search functionality
 search          = Search

--- a/apps/sms/manifest.webapp
+++ b/apps/sms/manifest.webapp
@@ -72,6 +72,8 @@
   "messages": [
      { "alarm": "/index.html" },
      { "sms-received": "/index.html" },
+     { "sms-delivery-success": "/index.html" },
+     { "sms-read-success": "/index.html" },
      { "notification": "/index.html" }
   ],
   "connections": {

--- a/apps/sms/test/unit/activity_handler_test.js
+++ b/apps/sms/test/unit/activity_handler_test.js
@@ -310,145 +310,22 @@ suite('ActivityHandler', function() {
   });
 
   suite('sms received', function() {
-    var message;
+    var message, checkSilentPromise;
 
-    setup(function(done) {
+    setup(function() {
       message = MockMessages.sms();
-      var checkSilentPromise = Promise.resolve(false);
+      checkSilentPromise = Promise.resolve(false);
 
       this.sinon.stub(MockSilentSms, 'checkSilentModeFor')
             .returns(checkSilentPromise);
-      MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
-      checkSilentPromise.then(() => done());
     });
 
     test('request the cpu wake lock', function() {
+      MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
+
       var wakeLock = MockNavigatorWakeLock.mLastWakeLock;
       assert.ok(wakeLock);
       assert.equal(wakeLock.topic, 'cpu');
-    });
-
-    suite('contact retrieved (after getSelf)', function() {
-      var contactName = '<&>'; // testing potentially unsafe characters
-      var sendSpy;
-      setup(function() {
-        sendSpy = this.sinon.spy(window, 'Notification');
-        this.sinon.stub(Contacts, 'findByPhoneNumber')
-          .yields([{name: [contactName]}]);
-
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-      });
-
-      test('passes contact name in plain text', function() {
-        sinon.assert.called(sendSpy);
-        var notification = sendSpy.firstCall.thisValue;
-        assert.equal(notification.title, contactName);
-      });
-    });
-
-    suite('contact without name (after getSelf)', function() {
-      var phoneNumber = '+1111111111';
-      var sendSpy;
-
-      setup(function() {
-        sendSpy = this.sinon.spy(window, 'Notification');
-        message.sender = phoneNumber;
-        message.delivery = 'received';
-        this.sinon.stub(Contacts, 'findByPhoneNumber')
-          .yields([{
-            name: [''],
-            tel: {'value': phoneNumber}
-          }]);
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-      });
-
-      test('phone in notification title when contact without name', function() {
-        sinon.assert.calledWith(sendSpy, phoneNumber);
-        var notification = sendSpy.firstCall.thisValue;
-        assert.equal(notification.title, phoneNumber);
-      });
-    });
-
-    suite('after getSelf', function() {
-      var sendSpy;
-      setup(function() {
-        sendSpy = this.sinon.spy(window, 'Notification');
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-      });
-
-      test('a notification is sent', function() {
-        sinon.assert.called(sendSpy);
-        var notification = sendSpy.firstCall.thisValue;
-        assert.equal(notification.body, message.body);
-        var expectedicon = 'sms?threadId=' + message.threadId + '&number=' +
-          message.sender + '&id=' + message.id;
-        assert.equal(notification.icon, expectedicon);
-      });
-
-      test('the lock is released', function() {
-        assert.ok(MockNavigatorWakeLock.mLastWakeLock.released);
-      });
-
-      suite('click on the notification', function() {
-        setup(function() {
-          var notification = sendSpy.firstCall.thisValue;
-          assert.ok(notification.mEvents.click);
-          this.sinon.stub(ActivityHandler, 'handleMessageNotification');
-          notification.mEvents.click();
-        });
-
-        test('launches the app', function() {
-          assert.ok(MockNavigatormozApps.mAppWasLaunched);
-        });
-      });
-    });
-
-    suite('Close notification', function() {
-      var closeSpy;
-      var isDocumentHidden;
-
-      suiteSetup(function(){
-        Object.defineProperty(document, 'hidden', {
-          configurable: true,
-          get: function() {
-            return isDocumentHidden;
-          }
-        });
-      });
-
-      suiteTeardown(function(){
-        delete document.hidden;
-      });
-
-      setup(function() {
-        closeSpy = this.sinon.spy(Notification.prototype, 'close');
-        this.sinon.stub(document, 'addEventListener');
-      });
-
-      test('thread view already visible', function() {
-        isDocumentHidden = false;
-        this.sinon.stub(Threads, 'currentId', message.threadId);
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-        sinon.assert.notCalled(document.addEventListener);
-        sinon.assert.notCalled(closeSpy);
-      });
-
-      test('Not in target thread view', function() {
-        isDocumentHidden = true;
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-        sinon.assert.notCalled(document.addEventListener);
-        sinon.assert.notCalled(closeSpy);
-      });
-
-      test('In target thread view and view is hidden', function() {
-        isDocumentHidden = true;
-        this.sinon.stub(Threads, 'currentId', message.threadId);
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-        sinon.assert.called(document.addEventListener);
-        sinon.assert.notCalled(closeSpy);
-        document.addEventListener.yield();
-        sinon.assert.called(closeSpy);
-      });
     });
 
     suite('receive class-0 message', function() {
@@ -471,6 +348,83 @@ suite('ActivityHandler', function() {
       test('vibrate', function() {
         var spied = Notify.vibrate;
         assert.ok(spied.called);
+      });
+    });
+
+    suite('received sms message', function() {
+      setup(function(done) {
+        this.sinon.stub(ActivityHandler, 'dispatchNotification');
+        MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
+        checkSilentPromise.then(() => done());
+      });
+
+      test('dispatch sms notification', function() {
+        sinon.assert.calledWith(ActivityHandler.dispatchNotification, {
+          message: message,
+          releaseWakeLock: sinon.match.any
+        });
+      });
+    });
+
+    suite('received mms message', function() {
+      setup(function() {
+        this.sinon.stub(ActivityHandler, 'dispatchNotification');
+      });
+
+      test('dispatch notification when delivery success', function(done) {
+        message = MockMessages.mms({
+          deliveryInfo: [{deliveryStatus: 'success'}]
+        });
+        MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
+
+        checkSilentPromise.then(function() {
+          sinon.assert.calledWith(ActivityHandler.dispatchNotification, {
+            message: message,
+            releaseWakeLock: sinon.match.any,
+            needManualRetrieve: false
+          });
+        }).then(done, done);
+      });
+
+      test('dispatch notification when delivery error', function(done) {
+        message = MockMessages.mms({
+          deliveryInfo: [{deliveryStatus: 'error'}]
+        });
+        MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
+
+        checkSilentPromise.then(function() {
+          sinon.assert.calledWith(ActivityHandler.dispatchNotification, {
+            message: message,
+            releaseWakeLock: sinon.match.any,
+            needManualRetrieve: true
+          });
+        }).then(done, done);
+      });
+
+      test('dispatch notification when not-downloaded', function(done) {
+        message = MockMessages.mms({
+          deliveryInfo: [{deliveryStatus: 'not-downloaded'}]
+        });
+        MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
+
+        checkSilentPromise.then(function() {
+          sinon.assert.calledWith(ActivityHandler.dispatchNotification, {
+            message: message,
+            releaseWakeLock: sinon.match.any,
+            needManualRetrieve: true
+          });
+        }).then(done, done);
+      });
+
+      test('Do not dispatch notification when pending', function(done) {
+        message = MockMessages.mms({
+          deliveryInfo: [{deliveryStatus: 'pending'}]
+        });
+        MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
+
+        checkSilentPromise.then(function() {
+          sinon.assert.notCalled(ActivityHandler.dispatchNotification);
+        }).then(done, done);
       });
     });
   });
@@ -504,59 +458,6 @@ suite('ActivityHandler', function() {
     });
   });
 
-  suite('Dual SIM behavior >', function() {
-    var message;
-
-    setup(function(done) {
-      message = MockMessages.sms({
-        iccId: '0'
-      });
-      var checkSilentPromise = Promise.resolve(false);
-      this.sinon.stub(MockSilentSms, 'checkSilentModeFor')
-        .returns(checkSilentPromise);
-      this.sinon.stub(Settings, 'hasSeveralSim').returns(true);
-      this.sinon.spy(window, 'Notification');
-
-      MockNavigatormozSetMessageHandler.mTrigger('sms-received', message);
-      checkSilentPromise.then(() => done());
-    });
-
-    suite('contact retrieved (after getSelf)', function() {
-      var contactName = 'contact';
-      setup(function() {
-        this.sinon.stub(Contacts, 'findByPhoneNumber')
-          .yields([{name: [contactName]}]);
-
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-      });
-
-      test('prefix the contact name with the SIM information', function() {
-        var expected = 'dsds-notification-title-with-sim' +
-          '{"sim":"sim-name-0","sender":"contact"}';
-        sinon.assert.calledWith(window.Notification, expected);
-      });
-    });
-
-    suite('contact without name (after getSelf)', function() {
-      var phoneNumber = '+1111111111';
-
-      setup(function() {
-        message.sender = phoneNumber;
-        this.sinon.stub(Contacts, 'findByPhoneNumber')
-          .yields([{
-            name: [''],
-            tel: {value: phoneNumber}
-          }]);
-        MockNavigatormozApps.mTriggerLastRequestSuccess();
-      });
-
-      test('phone in notification title when contact without name', function() {
-        var expected = 'dsds-notification-title-with-sim' +
-          '{"sim":"sim-name-0","sender":"+1111111111"}';
-        sinon.assert.calledWith(window.Notification, expected);
-      });
-    });
-  });
   suite('get phone number', function() {
     var message;
 
@@ -620,30 +521,245 @@ suite('ActivityHandler', function() {
   });
 
   suite('sms delivery success', function() {
+    var message;
+
     setup(function() {
+      message = MockMessages.sms();
+      this.sinon.stub(ActivityHandler, 'dispatchNotification');
+      this.sinon.spy(ActivityHandler, 'wakeLockSetup');
 
+      MockNavigatormozSetMessageHandler.mTrigger('sms-delivery-success',
+        message);
     });
 
-    test('single receiver delivery success', function() {
-
+    test('request the cpu wake lock', function() {
+      var wakeLock = MockNavigatorWakeLock.mLastWakeLock;
+      assert.ok(wakeLock);
+      assert.equal(wakeLock.topic, 'cpu');
     });
 
-    test('multiple receiver delivery success', function() {
-
+    test('dispatchNotification called with correct options', function() {
+      sinon.assert.calledWith(ActivityHandler.dispatchNotification, {
+        message: message,
+        releaseWakeLock: sinon.match.any,
+        delivered: true
+      });
     });
   });
 
   suite('sms read success', function() {
+    var message;
+
     setup(function() {
+      message = MockMessages.mms();
+      this.sinon.stub(ActivityHandler, 'dispatchNotification');
+      this.sinon.spy(ActivityHandler, 'wakeLockSetup');
 
+      MockNavigatormozSetMessageHandler.mTrigger('sms-read-success', message);
     });
 
-    test('single receiver read success', function() {
-
+    test('request the cpu wake lock', function() {
+      var wakeLock = MockNavigatorWakeLock.mLastWakeLock;
+      assert.ok(wakeLock);
+      assert.equal(wakeLock.topic, 'cpu');
     });
 
-    test('multiple receiver read success', function() {
+    test('dispatchNotification called with correct options', function() {
+      sinon.assert.calledWith(ActivityHandler.dispatchNotification, {
+        message: message,
+        releaseWakeLock: sinon.match.any,
+        read: true
+      });
+    });
+  });
 
+  suite('dispatch notification', function() {
+    var message, options;
+
+    setup(function() {
+      message = MockMessages.sms();
+      options = {
+        message: message,
+        releaseWakeLock: sinon.stub(),
+        needManualRetrieve: false
+      };
+    });
+
+    suite('contact retrieved (after getSelf)', function() {
+      var contactName = '<&>'; // testing potentially unsafe characters
+      var sendSpy;
+      setup(function() {
+        sendSpy = this.sinon.spy(window, 'Notification');
+        this.sinon.stub(Contacts, 'findByPhoneNumber')
+          .yields([{name: [contactName]}]);
+
+        ActivityHandler.dispatchNotification(options);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+      });
+
+      test('passes contact name in plain text', function() {
+        sinon.assert.called(sendSpy);
+        var notification = sendSpy.firstCall.thisValue;
+        assert.equal(notification.title, contactName);
+      });
+    });
+
+    suite('contact without name (after getSelf)', function() {
+      var phoneNumber = '+1111111111';
+      var sendSpy;
+
+      setup(function() {
+        sendSpy = this.sinon.spy(window, 'Notification');
+        message.sender = phoneNumber;
+        this.sinon.stub(Contacts, 'findByPhoneNumber')
+          .yields([{
+            name: [''],
+            tel: {'value': phoneNumber}
+          }]);
+
+        ActivityHandler.dispatchNotification(options);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+      });
+
+      test('phone in notification title when contact without name', function() {
+        sinon.assert.called(sendSpy);
+        var notification = sendSpy.firstCall.thisValue;
+        assert.equal(notification.title, phoneNumber);
+      });
+    });
+
+    suite('after getSelf', function() {
+      var sendSpy;
+
+      setup(function() {
+        sendSpy = this.sinon.spy(window, 'Notification');
+
+        ActivityHandler.dispatchNotification(options);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+      });
+
+      test('a notification is sent', function() {
+        sinon.assert.called(sendSpy);
+        var notification = sendSpy.firstCall.thisValue;
+        assert.equal(notification.body, message.body);
+        var expectedicon = 'sms?threadId=' + message.threadId + '&number=' +
+          message.sender + '&id=' + message.id;
+        assert.equal(notification.icon, expectedicon);
+      });
+
+      test('the lock is released', function() {
+        sinon.assert.called(options.releaseWakeLock);
+      });
+
+      suite('click on the notification', function() {
+        setup(function() {
+          var notification = sendSpy.firstCall.thisValue;
+          assert.ok(notification.mEvents.click);
+          this.sinon.stub(ActivityHandler, 'handleMessageNotification');
+          notification.mEvents.click();
+        });
+
+        test('launches the app', function() {
+          assert.ok(MockNavigatormozApps.mAppWasLaunched);
+        });
+      });
+    });
+
+    suite('Dual SIM behavior >', function() {
+
+      setup(function() {
+        message.iccId = '0';
+        this.sinon.stub(Settings, 'hasSeveralSim').returns(true);
+        this.sinon.spy(window, 'Notification');
+      });
+
+      suite('contact retrieved (after getSelf)', function() {
+        var contactName = 'contact';
+        setup(function() {
+          this.sinon.stub(Contacts, 'findByPhoneNumber')
+            .yields([{name: [contactName]}]);
+
+          ActivityHandler.dispatchNotification(options);
+          MockNavigatormozApps.mTriggerLastRequestSuccess();
+        });
+
+        test('prefix the contact name with the SIM information', function() {
+          var expected = 'dsds-notification-title-with-sim' +
+            '{"sim":"sim-name-0","sender":"contact"}';
+          sinon.assert.calledWith(window.Notification, expected);
+        });
+      });
+
+      suite('contact without name (after getSelf)', function() {
+        var phoneNumber = '+1111111111';
+
+        setup(function() {
+          message.sender = phoneNumber;
+          this.sinon.stub(Contacts, 'findByPhoneNumber')
+            .yields([{
+              name: [''],
+              tel: {value: phoneNumber}
+            }]);
+
+          ActivityHandler.dispatchNotification(options);
+          MockNavigatormozApps.mTriggerLastRequestSuccess();
+        });
+
+        test('phone number in title when contact without name', function() {
+          var expected = 'dsds-notification-title-with-sim' +
+            '{"sim":"sim-name-0","sender":"+1111111111"}';
+          sinon.assert.calledWith(window.Notification, expected);
+        });
+      });
+    });
+
+    suite('Close notification', function() {
+      var closeSpy;
+      var isDocumentHidden;
+
+      suiteSetup(function(){
+        Object.defineProperty(document, 'hidden', {
+          configurable: true,
+          get: function() {
+            return isDocumentHidden;
+          }
+        });
+      });
+
+      suiteTeardown(function(){
+        delete document.hidden;
+      });
+
+      setup(function() {
+        closeSpy = this.sinon.spy(Notification.prototype, 'close');
+        this.sinon.stub(document, 'addEventListener');
+        ActivityHandler.dispatchNotification(options);
+      });
+
+      test('thread view already visible', function() {
+        isDocumentHidden = false;
+        this.sinon.stub(Threads, 'currentId', message.threadId);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        sinon.assert.notCalled(document.addEventListener);
+        sinon.assert.notCalled(closeSpy);
+      });
+
+      test('Not in target thread view', function() {
+        isDocumentHidden = true;
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        sinon.assert.notCalled(document.addEventListener);
+        sinon.assert.notCalled(closeSpy);
+      });
+
+      test('In target thread view and view is hidden', function() {
+        isDocumentHidden = true;
+        this.sinon.stub(Threads, 'currentId', message.threadId);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        sinon.assert.called(document.addEventListener);
+        sinon.assert.notCalled(closeSpy);
+        document.addEventListener.yield();
+        sinon.assert.called(closeSpy);
+      });
     });
   });
 

--- a/apps/sms/test/unit/activity_handler_test.js
+++ b/apps/sms/test/unit/activity_handler_test.js
@@ -353,6 +353,7 @@ suite('ActivityHandler', function() {
       setup(function() {
         sendSpy = this.sinon.spy(window, 'Notification');
         message.sender = phoneNumber;
+        message.delivery = 'received';
         this.sinon.stub(Contacts, 'findByPhoneNumber')
           .yields([{
             name: [''],
@@ -362,7 +363,7 @@ suite('ActivityHandler', function() {
       });
 
       test('phone in notification title when contact without name', function() {
-        sinon.assert.called(sendSpy);
+        sinon.assert.calledWith(sendSpy, phoneNumber);
         var notification = sendSpy.firstCall.thisValue;
         assert.equal(notification.title, phoneNumber);
       });
@@ -554,6 +555,95 @@ suite('ActivityHandler', function() {
           '{"sim":"sim-name-0","sender":"+1111111111"}';
         sinon.assert.calledWith(window.Notification, expected);
       });
+    });
+  });
+  suite('get phone number', function() {
+    var message;
+
+    test('received message', function() {
+      message = MockMessages.sms();
+      assert.equal(message.sender, ActivityHandler.getPhoneNumber(message));
+    });
+
+    test('not downloaded message', function() {
+      message = MockMessages.mms({ delivery: 'not-downloaded' });
+      assert.equal(message.sender, ActivityHandler.getPhoneNumber(message));
+    });
+
+    test('sms delivery status return', function() {
+      message = MockMessages.sms({ delivery: 'sent'});
+      assert.equal(message.receiver, ActivityHandler.getPhoneNumber(message));
+    });
+
+    test('mms delivery status return(single receiver)', function() {
+      message = MockMessages.mms({ delivery: 'sent'});
+      assert.equal(message.deliveryInfo[0].receiver,
+        ActivityHandler.getPhoneNumber(message));
+    });
+
+    test('mms delivery success return(multiple receiver)', function() {
+      message = MockMessages.mms({
+        delivery: 'sent',
+        deliveryInfo: [{
+          receiver: 'receiver1',
+          deliveryStatus: 'success',
+          deliveryTimestamp: 1000000
+        },
+        {
+          receiver: 'receiver2',
+          deliveryStatus: 'success',
+          deliveryTimestamp: 1200000
+        }]
+      });
+      assert.equal(message.deliveryInfo[1].receiver,
+        ActivityHandler.getPhoneNumber(message, {delivered: true}));
+    });
+
+    test('mms read success return(multiple receiver)', function() {
+      message = MockMessages.mms({
+        delivery: 'sent',
+        deliveryInfo: [{
+          receiver: 'receiver1',
+          readStatus: 'not-applicable',
+          deliveryStatus: 'success',
+          deliveryTimestamp: 1200000
+        },
+        {
+          receiver: 'receiver2',
+          readStatus: 'success',
+          readTimestamp: 1000000
+        }]
+      });
+      assert.equal(message.deliveryInfo[1].receiver,
+        ActivityHandler.getPhoneNumber(message, {read: true}));
+    });
+  });
+
+  suite('sms delivery success', function() {
+    setup(function() {
+
+    });
+
+    test('single receiver delivery success', function() {
+
+    });
+
+    test('multiple receiver delivery success', function() {
+
+    });
+  });
+
+  suite('sms read success', function() {
+    setup(function() {
+
+    });
+
+    test('single receiver read success', function() {
+
+    });
+
+    test('multiple receiver read success', function() {
+
     });
   });
 

--- a/apps/sms/test/unit/mock_activity_handler.js
+++ b/apps/sms/test/unit/mock_activity_handler.js
@@ -11,5 +11,7 @@ var MockActivityHandler = {
   triggerNewMessage: function() {},
   toView: function() {},
   onSmsReceived: function() {},
+  onSmsDeliverySuccess: function() {},
+  onSmsReadSuccess: function() {},
   onNotification: function() {}
 };


### PR DESCRIPTION
- Add system message 'sms-delivery-success' and 'sms-read-success' for showing the notification when report return success.
- Refine the sms received part into smaller part for better using in delivery/read success notification
