### PR TITLE
Bug 998137 - When Passcode is disabled, give more room to date/time

### DIFF
--- a/apps/system/style/lockscreen/lockscreen.css
+++ b/apps/system/style/lockscreen/lockscreen.css
@@ -157,6 +157,7 @@
 
 [data-panel="main"] #lockscreen-alt-camera {
   visibility: hidden;
+  position: absolute;
 }
 
 [data-panel="passcode"] #lockscreen-alt-camera {


### PR DESCRIPTION
Use positioning on the hidden camera button to free space.
