### PR TITLE
Bug 1029902 - [Vertical Homescreen] Implement device capability configuration

### DIFF
--- a/apps/verticalhome/build/default-homescreens.json
+++ b/apps/verticalhome/build/default-homescreens.json
@@ -24,7 +24,7 @@
     ]
   ],
   "preferences": {
-    "grid.cols": 3
+    "grid.cols": 4
   },
   "bookmarks": [
     {

--- a/apps/verticalhome/js/configurator.js
+++ b/apps/verticalhome/js/configurator.js
@@ -5,6 +5,11 @@
 
 var configurator = (function() {
 
+  const CAPABILITIES = {
+    LOW: 'low',
+    HIGH: 'high'
+  };
+
   // We're going to use the mcc_mnc as a semaphore as well as to store its
   // value during the singleVariant file's processing time.
   var mcc_mnc;
@@ -163,12 +168,43 @@ var configurator = (function() {
   }
 
   function setup() {
-    var colsByDefault = conf && conf.preferences &&
+    navigator.getFeature('hardware.memory').then(mem => {
+      // If capability is defined in the build or customization.
+      var capability = conf && conf.preferences && conf.preferences.capability;
+
+      if (!capability) {
+        capability = CAPABILITIES.HIGH;
+        // Devices below 512mb are served a lower quality version.
+        // Currently the following changes are made for low capability devices:
+        // - Icons default to 4 per row.
+        // - Icon resolution is reduced.
+        // - Icon rendering does not account for devicePixelRatio.
+        if (mem < 512) {
+          capability = CAPABILITIES.LOW;
+        }
+      }
+      verticalPreferences.put('capability', capability);
+      setupColumns(capability);
+    });
+  }
+
+  /**
+   * Sets up the default columns. For low capability devices, default to four
+   * columns per row as this saves on memory.
+   */
+  function setupColumns(capability) {
+    var defaultCols = conf && conf.preferences &&
                           conf.preferences['grid.cols'] || undefined;
-    if (colsByDefault) {
+
+    // Set default capability to 4 for low-end devices.
+    if (capability === CAPABILITIES.LOW) {
+      defaultCols = 4;
+    }
+
+    if (defaultCols) {
       verticalPreferences.get('grid.cols').then(function(cols) {
         // Set the number of cols by default in preference's datastore
-        !cols && verticalPreferences.put('grid.cols', colsByDefault);
+        !cols && verticalPreferences.put('grid.cols', defaultCols);
       });
     }
   }

--- a/apps/verticalhome/manifest.webapp
+++ b/apps/verticalhome/manifest.webapp
@@ -9,6 +9,7 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "permissions": {
+    "feature-detection": {},
     "mobileconnection":{},
     "open-remote-window":{},
     "storage": {},

--- a/apps/verticalhome/test/marionette/app_uninstall_test.js
+++ b/apps/verticalhome/test/marionette/app_uninstall_test.js
@@ -59,6 +59,8 @@ marionette('Vertical - App Uninstall', function() {
       el.scrollIntoView(false);
     });
 
+    home.waitForSystemBanner();
+
     // remove the icon
     remove.click();
     // confirm the dialog to ensure it was removed.

--- a/apps/verticalhome/test/marionette/lib/home2.js
+++ b/apps/verticalhome/test/marionette/lib/home2.js
@@ -275,6 +275,16 @@ Home2.prototype = {
     return this.client.executeScript(function(selector, clazz) {
       return document.querySelector(selector).classList.contains(clazz);
     }, [selector, clazz]);
+  },
+
+  /**
+   * Waits for the system banner to go away and switches back to the homescreen
+   */
+  waitForSystemBanner: function() {
+    this.client.switchToFrame();
+    var banner = this.client.findElement('.banner.generic-dialog');
+    this.client.helper.waitForElementToDisappear(banner);
+    this.client.switchToFrame(this.system.getHomescreenIframe());
   }
 };
 

--- a/apps/verticalhome/test/unit/configurator_test.js
+++ b/apps/verticalhome/test/unit/configurator_test.js
@@ -1,10 +1,12 @@
 'use strict';
 
 /* global configurator, MockNavigatorSettings, IccHelper, App, app,
-   MocksHelper, MockVersionHelper, verticalPreferences  */
+   MocksHelper, MockVersionHelper, verticalPreferences,
+   MockNavigatorGetFeature */
 
 require('/shared/js/homescreens/vertical_preferences.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/test/unit/mocks/mock_navigator_get_feature.js');
 require('/shared/test/unit/mocks/mock_icc_helper.js');
 require('/test/unit/mock_app.js');
 require('/test/unit/mock_version_helper.js');
@@ -18,6 +20,7 @@ var mocksHelperForConfigurator = new MocksHelper([
 suite('configurator.js >', function() {
   mocksHelperForConfigurator.attachTestHelpers();
 
+  var realGetFeature;
   var realMozSettings;
   var xhr;
   var requests = [];
@@ -63,12 +66,15 @@ suite('configurator.js >', function() {
   suiteSetup(function() {
     mocksHelperForConfigurator.suiteSetup();
     realMozSettings = navigator.mozSettings;
+    realGetFeature = navigator.getFeature;
+    navigator.getFeature = MockNavigatorGetFeature;
     navigator.mozSettings = MockNavigatorSettings;
     MockNavigatorSettings.mSyncRepliesOnly = true;
   });
 
   suiteTeardown(function() {
     mocksHelperForConfigurator.suiteTeardown();
+    navigator.getFeature = realGetFeature;
     navigator.mozSettings = realMozSettings;
     MockNavigatorSettings.mSyncRepliesOnly = false;
   });

--- a/shared/elements/gaia_grid/js/grid_layout.js
+++ b/shared/elements/gaia_grid/js/grid_layout.js
@@ -8,6 +8,7 @@
 
   // 320 / 5 = 64px | 480 / 5 = 96px | 540 / 5 = 108px | ...
   const iconScaleFactorMaxIconsPerRow = 5;
+  const lowCapabilityIconDivisor = 5;
 
   const minIconsPerRow = 3;
 
@@ -24,10 +25,14 @@
     this.gridView = gridView;
 
     if (window.verticalPreferences) {
-      verticalPreferences.get('grid.cols').then(function(value) {
+      verticalPreferences.get('grid.cols').then(value => {
         this.cols = value;
+      }, this.onReady);
+
+      verticalPreferences.get('capability').then(value => {
+        this.capability = value;
         this.onReady();
-      }.bind(this), this.onReady);
+      }, this.onReady);
 
       verticalPreferences.addEventListener('updated', this);
     } else {
@@ -98,15 +103,16 @@
 
     /**
      * Returns the maximum size in pixels for an icon image. It is the size when
-     * the grid is displayed with the minimum number of columns plus the scale
-     * applied in dragdrop
+     * the grid is displayed with the minimum number of columns per row.
      */
     get gridMaxIconSize() {
-      var dragdrop = this.gridView.dragdrop;
-      var scaledSize = (windowWidth / iconScaleFactorMinIconsPerRow) *
-              (dragdrop ? dragdrop.maxActiveScale : 1);
-      scaledSize *= devicePixelRatio;
-      return scaledSize;
+      // For low capability devices, do not scale the base icon size.
+      if (this.capability === 'low') {
+        return (windowWidth / lowCapabilityIconDivisor);
+      }
+
+      var baseSize = (windowWidth / iconScaleFactorMinIconsPerRow);
+      return baseSize * devicePixelRatio;
     },
 
     /**

--- a/shared/test/unit/mocks/mock_navigator_get_feature.js
+++ b/shared/test/unit/mocks/mock_navigator_get_feature.js
@@ -1,0 +1,9 @@
+'use strict';
+/* global Promise */
+window.MockNavigatorGetFeature = function(key) {
+  return new Promise((resolve, reject) => {
+    resolve(window.MockNavigatorGetFeature._values[key]);
+  });
+};
+
+window.MockNavigatorGetFeature._values = {};


### PR DESCRIPTION
The following changes are made for low capability devices:
- Icons default to 4 per row.
- Icon resolution is reduced.
- Icon rendering does not account for devicePixelRatio.

https://bugzilla.mozilla.org/show_bug.cgi?id=1029902
