### PR TITLE
Bug 1037638 - Restrict to 3MP images (CONFIG_MAX_IMAGE_PIXEL_SIZE) only ...

### DIFF
--- a/apps/camera/js/config/config.js
+++ b/apps/camera/js/config/config.js
@@ -7,7 +7,7 @@ module.exports = {
   // shared/js/media/media_frame.js
   globals : {
     // The maximum picture size that camera is allowed to take
-    CONFIG_MAX_IMAGE_PIXEL_SIZE: 3145728, // 3MP
+    CONFIG_MAX_IMAGE_PIXEL_SIZE: 5242880, // 5MP
     CONFIG_MAX_SNAPSHOT_PIXEL_SIZE: 5242880, // 5MP
 
     // Size of the exif preview embeded in images taken by camera

--- a/apps/camera/manifest.webapp
+++ b/apps/camera/manifest.webapp
@@ -16,7 +16,8 @@
     "settings":{ "access": "readonly" },
     "camera":{},
     "geolocation":{},
-    "audio-channel-notification":{}
+    "audio-channel-notification":{},
+    "feature-detection": {}
   },
   "activities": {
     "record": {


### PR DESCRIPTION
...for low-memory devices
