### PR TITLE
Bug 1026159 - override search result label styles to wrap 2 lines

### DIFF
--- a/apps/search/style/search.css
+++ b/apps/search/style/search.css
@@ -30,7 +30,7 @@ body, a {
 
 section.suggestions {
   margin: 0 0.7rem;
-  font-size: 16px;
+  font-size: 1.4rem;
   font-style: italic;
   overflow: hidden;
   height: 3.5rem;
@@ -48,7 +48,7 @@ section.suggestions ul {
 section.suggestions ul li {
   display: inline-block;
   margin-left: 1rem;
-  padding: 0.9rem 0.7rem 0.9rem 0;
+  padding: 0.3rem 0.7rem 0.9rem 0;
   margin: 0;
 }
 
@@ -101,7 +101,7 @@ section .result * {
 
 /* web */
 section.apps {
-  padding-top: 1rem;
+  padding-top: 0.5rem;
   /* Hide the whitespace between inline elements */
   font-size: 0;
 }
@@ -217,4 +217,11 @@ gaia-grid {
   top: -0.9rem;
   left: 0;
   z-index: -1;
+}
+
+/* show up to 2-line labels in result icons */
+#search-results .icon .title {
+  text-shadow: none !important;
+  height: calc(3.88rem + 0.2rem);
+  white-space: normal !important;
 }

--- a/apps/verticalhome/style/css/search.css
+++ b/apps/verticalhome/style/css/search.css
@@ -1,6 +1,6 @@
 #search {
   height: 4.6rem;
-  margin-bottom: 1.2rem;
+  margin-bottom: 1rem;
   background-color: rgba(0, 0, 0, 0.15);
 }
 

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -68,6 +68,7 @@ apps/system/style/system/system.css 0 2
 apps/system/style/system/keyboard.css 0 1
 apps/sms/style/root.css 0 2
 apps/sms/style/sms.css 0 4
+apps/search/style/search.css 0 2
 shared/elements/gaia_grid/style.css 0 5
 shared/style/value_selector.css 0 1
 shared/style/edit_mode.css 0 2

--- a/shared/elements/gaia_grid/js/grid_layout.js
+++ b/shared/elements/gaia_grid/js/grid_layout.js
@@ -17,7 +17,7 @@
 
   const distanceBetweenIconsWithMinIconsPerRow = 36;
 
-  const distanceBetweenIconsWithMaxIconsPerRow = 36;
+  const distanceBetweenIconsWithMaxIconsPerRow = 38;
 
   var windowWidth = window.innerWidth;
 

--- a/shared/elements/gaia_grid/style.css
+++ b/shared/elements/gaia_grid/style.css
@@ -70,9 +70,9 @@
 
 .icon .title {
   display: inline-block;
-  margin-top: -0.2rem;
+  margin-top: 0.1rem;
   /* We need this rule in order not to hide the drop shadow */
-  padding: 0.2rem 0.2rem 1rem;
+  padding: 0 0.2rem 1rem;
   text-shadow: 0.1rem 0.1rem 0.3rem rgba(0, 0, 0, 0.3),
                0.2rem 0.4rem 1rem rgba(0, 0, 0, 0.4);
   font-size: 1.4rem;
@@ -82,12 +82,14 @@
   overflow: hidden;
   width: calc(100% - 0.4rem);
   box-sizing: border-box;
+  vertical-align: top;
 }
 
 [cols="4"] .icon .title {
   /* Font size is the same independent on grid configuration */
   font-size: calc(1.2rem * 1.333);
-  margin-top: 0.2rem;
+  margin-top: 0.5rem;
+  line-height: 1.94rem;
 }
 
 .divider {


### PR DESCRIPTION
Make global adjustments to grid item height (+4px)
Add override rules for the search grid items to allow line-wrapping and set height/line-height to clip after the 2nd line. As discussed with UX, removed text-shadow in this case where it is less necessary and would otherwise also get clipped. 
