### PR TITLE
Bug 1008859 - [email] on language change, cached card templates not updated. r=jrburke

### DIFF
--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -174,6 +174,10 @@ if (appMessages.hasPending('alarm')) {
 
 // If still have a cached node, then show it.
 if (cachedNode) {
+  // l10n may not see this as it was injected before l10n.js was loaded,
+  // so let it know it needs to translate it.
+  mozL10n.translate(cachedNode);
+
   // Wire up a card implementation to the cached node.
   if (startCardId) {
     pushStartCard(startCardId);

--- a/apps/email/js/tmpl.js
+++ b/apps/email/js/tmpl.js
@@ -1,4 +1,13 @@
 define(['l10n!'], function(mozL10n) {
+  // Keep track of all translated nodes, so that they are properly
+  // updated on the fly when the language changes.
+  var nodes = [];
+  mozL10n.ready(function() {
+    nodes.forEach(function(node) {
+      mozL10n.translate(node);
+    });
+  });
+
   var tmpl = {
     pluginBuilder: './tmpl_builder',
 
@@ -12,7 +21,9 @@ define(['l10n!'], function(mozL10n) {
 
     load: function(id, require, onload, config) {
       require(['text!' + id], function(text) {
-        onload(tmpl.toDom(text));
+        var node = tmpl.toDom(text);
+        nodes.push(node);
+        onload(node);
       });
     }
   };


### PR DESCRIPTION
This is an aggregate of the fixes for bug 1005760 and bug 1034227, but without
the bits of bug 1034227 that back out bug 1005760.  (The backout happened on
trunk/v2.1 because the l10n code gained MutationObserver powers on v2.1 that
they do not have on v1.3t.)

This aggregation is assembled and tested by asuth.
