### PR TITLE
Larger settings title

### DIFF
--- a/apps/settings/style/settings_large.css
+++ b/apps/settings/style/settings_large.css
@@ -309,6 +309,8 @@
     line-height: 5rem;
     color: #fff;
     padding: 0 1rem 0 2rem;
+    width:100%;
+    text-align:left;
   }
 
   section[role="region"] > header:first-child menu[type="toolbar"] a,


### PR DESCRIPTION
The title block of settings pages is too small and show only the first 2 or 3 characters of the title ([bug 1041300](https://bugzilla.mozilla.org/show_bug.cgi?id=1041300)).
