### PR TITLE
Bug 1023246 - [Flame][v1.4][Gaia::Dialer]The contact’s photo is shown in...

### DIFF
--- a/apps/communications/dialer/style/call_log.css
+++ b/apps/communications/dialer/style/call_log.css
@@ -240,11 +240,7 @@ ol, ul {
 }
 
 .recents-edit .pack-end {
-  transform: translateX(6rem);
-}
-
-.recents-edit .call-log-contact-photo {
-  pointer-events: none;
+  display: none;
 }
 
 .recents-edit .log-item .pack-checkbox {


### PR DESCRIPTION
...completely in the call log edit screen.
