### PR TITLE
Bug 1036380 - Use English keyboard for pseudolanguages

### DIFF
--- a/build/config/keyboard-layouts.json
+++ b/build/config/keyboard-layouts.json
@@ -141,6 +141,12 @@
     "pt-BR": [
         {"layoutId": "pt-BR", "app": ["apps", "keyboard"]}
     ],
+    "qps-ploc": [
+        {"layoutId": "en", "app": ["apps", "keyboard"]}
+    ],
+    "qps-plocm": [
+        {"layoutId": "en", "app": ["apps", "keyboard"]}
+    ],
     "ro": [
         {"layoutId": "ro", "app": ["apps", "keyboard"]}
     ],


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1036380
