### PR TITLE
Bug 1004329 - [Flatfish][Homescreen] Returning home (landscape) from por...

### DIFF
--- a/apps/homescreen/js/screen_helper.js
+++ b/apps/homescreen/js/screen_helper.js
@@ -26,9 +26,14 @@
     } else {
       window.matchMedia(isPortrait).addListener(function onOrientation(evt) {
         if (evt.matches) {
+          // this line doesn't work since matchMedia() returns a new object,
+          // invoking removeListener with this new object doesn't remove the
+          // previous listener,
+          // leave it unchanged incase removing the listener cause other issues
           window.matchMedia(isPortrait).removeListener(onOrientation);
-          setTimeout(setDimensionsInternal);
         }
+
+        setTimeout(setDimensionsInternal);
       });
     }
   }


### PR DESCRIPTION
...trait app causes app icons to misalign/overlap
- Fix ScreenHelper width/height error due to mediaQueryListener being fired twice right after maketplace app closed.
