### PR TITLE
Bug 1039519 - Add a show/hide rocketbar transition. r=daleharvey,kgrandon

### DIFF
--- a/apps/system/js/browser_frame.js
+++ b/apps/system/js/browser_frame.js
@@ -82,6 +82,12 @@
     this.config = config;
 
     this.element = browser;
+
+    var container = document.createElement('div');
+    container.className = 'browser-container';
+    container.scrollgrab = true;
+    container.appendChild(browser);
+    this.container = container;
   };
 
   function setMozAppType(iframe, config) {

--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -17,8 +17,6 @@ var UtilityTray = {
 
   statusbar: document.getElementById('statusbar'),
 
-  statusbarIcons: document.getElementById('statusbar-icons'),
-
   grippy: document.getElementById('utility-tray-grippy'),
 
   screen: document.getElementById('screen'),
@@ -26,8 +24,7 @@ var UtilityTray = {
   init: function ut_init() {
     var touchEvents = ['touchstart', 'touchmove', 'touchend'];
     touchEvents.forEach(function bindEvents(name) {
-      this.overlay.addEventListener(name, this);
-      this.statusbarIcons.addEventListener(name, this);
+      this.statusbar.addEventListener(name, this);
       this.grippy.addEventListener(name, this);
     }, this);
 
@@ -116,31 +113,26 @@ var UtilityTray = {
           return;
         }
 
-        if (target !== this.overlay && target !== this.grippy &&
-            evt.currentTarget !== this.statusbarIcons) {
-          return;
-        }
-
-        if (target === this.statusbarIcons || target === this.grippy) {
-          evt.preventDefault();
-        }
+        evt.preventDefault();
 
         this.onTouchStart(evt.touches[0]);
         break;
 
       case 'touchmove':
-        if (target === this.statusbarIcons || target === this.grippy) {
-          evt.preventDefault();
+        if (window.System.locked) {
+          return;
         }
 
+        evt.preventDefault();
         this.onTouchMove(evt.touches[0]);
         break;
 
       case 'touchend':
-        if (target === this.statusbarIcons || target === this.grippy) {
-          evt.preventDefault();
+        if (window.System.locked) {
+          return;
         }
 
+        evt.preventDefault();
         evt.stopImmediatePropagation();
         var touch = evt.changedTouches[0];
 

--- a/apps/system/style/rocketbar/rocketbar.css
+++ b/apps/system/style/rocketbar/rocketbar.css
@@ -4,9 +4,16 @@
   height: 4.6rem;
   left: 0;
   top: 0;
-  transition: transform 0.5s;
+  transition: transform 0.5s, opacity 0.5s;
   transform: scale(0.5);
   transform-origin: left top;
+}
+
+#rocketbar.hidden,
+#screen.locked:not(.attention) #rocketbar,
+#screen.utility-tray #rocketbar {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* RTL fixes being tracked in bug 1008013 */
@@ -16,14 +23,6 @@
 
 #rocketbar.active {
   transform: scale(1);
-}
-
-#screen.locked:not(.attention) #rocketbar {
-  display: none;
-}
-
-body:not(.rb-enabled) #rocketbar {
-  display: none;
 }
 
 #rocketbar-title, #rocketbar-form {
@@ -56,21 +55,14 @@ body:not(.rb-enabled) #rocketbar {
 }
 
 #rocketbar-title-content {
-  font-size: 1.8rem;
+  font-size: 2.4rem;
   font-style: italic;
   font-weight: 300;
-  transform: scale(1.33);
-  transform-origin: left center;
-  transition: transform 0.5s;
   overflow: hidden;
 }
 
-*[dir=rtl] #rocketbar-title-content {
-  transform-origin: right center;
-}
-
-#rocketbar.expanded #rocketbar-title-content {
-  transform: scale(1);
+#rocketbar.expanded {
+  transform: translateY(2.4rem) scale(1);
 }
 
 #rocketbar-input {
@@ -100,6 +92,7 @@ body:not(.rb-enabled) #rocketbar {
   flex: none;
 }
 
+body:not(.rb-enabled) #rocketbar,
 #rocketbar-clear {
   display: none;
 }

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -6,19 +6,25 @@
   height: 2rem;
 }
 
-#screen.rocketbar-focused .gesture-panel {
+#screen.rocketbar-focused .gesture-panel,
+#screen.rocketbar-focused #statusbar {
   pointer-events: none;
 }
 
 #statusbar-background {
   width: 100%;
-  height: 2.4rem;
+  height: 7.2rem;
   background-color: #000;
   opacity: 1;
   padding: 0;
-  transform: scaleY(1);
-  transition: transform 0.1s, opacity 0.5s;
+  transform: scaleY(0.333333);
+  transition: transform 0.5s, opacity 0.5s;
   transform-origin: left top;
+  pointer-events: none;
+}
+
+#screen.rocketbar-expanded:not(.utility-tray) #statusbar-background {
+  transform: scaleY(1.0);
 }
 
 #screen.themecolor-active #statusbar-background {
@@ -59,11 +65,14 @@ body:not(.rb-enabled) #statusbar {
   display: none;
 }
 
-#screen.locked:not(.attention) #statusbar,
+#screen.locked:not(.attention) #statusbar {
+  display: block;
+  transform: scaleY(1.0);
+}
+
 #screen.locked:not(.attention) #statusbar-background {
   background-color: transparent;
-  display: block;
-  transform: scaleY(1);
+  transform: scaleY(0.333333);
 }
 
 #screen.locked:not(.attention) #statusbar-background:before {
@@ -97,15 +106,12 @@ body:not(.rb-enabled) #statusbar {
 }
 
 #screen.rocketbar-focused:not(.locked) #statusbar-icons,
-#screen.rocketbar-expanded.cards-view #statusbar-icons,
 #screen:not(.locked).fullscreen-app #statusbar:not(.dragged) #statusbar-icons {
-  visibility: hidden;
   opacity: 0;
 }
 
 #screen.rocketbar-focused #statusbar-background {
-  visibility: hidden;
-  opacity: 0;
+  opacity: 0 !important;
 }
 
 body:not(.rb-enabled) #statusbar-icons {

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -20,10 +20,23 @@
   background-color: transparent;
 }
 
+/* Allow the rocketbar to be scrolled on/off */
+.appWindow > .browser-container {
+  overflow-y: scroll;
+  font-size: 0;
+}
+
 /* mozbrowser iframe layout */
 
-.appWindow > iframe {
+.appWindow > .browser-container > iframe {
   border: none;
+  width: 100%;
+  height: 100%;
+}
+
+/* Allow rocketbar expansion on apps with navigation */
+.appWindow.navigation > .browser-container > iframe {
+  margin-top: 4.8rem;
 }
 
 .appWindow .throbber.loading {


### PR DESCRIPTION
This is the preliminary work for showing/hiding the rocketbar in response
to user scrolling. There is still some follow-up, which will be addressed
in subsequent bugs.

Problems:
- Overscroll on non-scrollable pages is broken (Gfx bug 1040226)
- All pages with navigation can be scrolled a little (needs bug 757859)
- Overscroll should be the page background colour, isn't always
