### PR TITLE
Bug 1011274 - Intermittent utils_test.js | Utils Utils.getResizedImgBlob "before all" hook | timeout of 5000ms exceeded

### DIFF
--- a/apps/sms/test/unit/utils_test.js
+++ b/apps/sms/test/unit/utils_test.js
@@ -739,8 +739,6 @@ suite('Utils', function() {
       'default_quality_resized.jpg': null
     };
 
-    this.timeout(5000);
-
     suiteSetup(function(done) {
       // load test blobs for image resize testing
       var assetsNeeded = 0;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1011274
