### PR TITLE
Bug 1042241. Avoid encoding/decoding clip canvas

### DIFF
--- a/shared/elements/gaia_grid/js/grid_icon_renderer.js
+++ b/shared/elements/gaia_grid/js/grid_icon_renderer.js
@@ -85,16 +85,9 @@
         clipCtx.drawImage(img, 0, 0,
                                clipCanvas.width, clipCanvas.height);
 
-        clipCanvas.toBlob((blob) => {
-          var clipImage = new Image();
-          clipImage.onload = () => {
-            shadowCtx.drawImage(clipImage, CANVAS_PADDING, CANVAS_PADDING,
+        shadowCtx.drawImage(clipCanvas, CANVAS_PADDING, CANVAS_PADDING,
                                 this._maxSize, this._maxSize);
-            shadowCanvas.toBlob(resolve);
-            URL.revokeObjectURL(clipImage.src);
-          };
-          clipImage.src = URL.createObjectURL(blob);
-        });
+        shadowCanvas.toBlob(resolve);
       });
     },
 


### PR DESCRIPTION
We can just paint the one canvas to the other directly. This avoids the png encoding/decoding time and will reduce peak memory.
