### PR TITLE
Bug 1038836 - [email/backend] Mailing list text/plain footers added (with a multipart/mixed container) to text/html parts are detected as unnamed attachments. r=asuth

### DIFF
--- a/apps/email/js/ext/mailapi/chewlayer.js
+++ b/apps/email/js/ext/mailapi/chewlayer.js
@@ -1227,7 +1227,10 @@ function chewStructure(msg) {
       // If it exists, keep it the same, except in the case of inline
       // disposition without a content id.
       if (partInfo.disposition.type.toLowerCase() == 'inline') {
-        if (partInfo.id) {
+      // Displaying text-parts inline is not a problem for us, but we need a
+      // content id for other embedded content.  (Currently only images are
+      // supported, but that is enforced in a subsequent check.)
+        if (partInfo.type === 'text' || partInfo.id) {
           disposition = 'inline';
         } else {
           disposition = 'attachment';

--- a/apps/email/js/ext/mailapi/composite/configurator.js
+++ b/apps/email/js/ext/mailapi/composite/configurator.js
@@ -6409,7 +6409,10 @@ function chewStructure(msg) {
       // If it exists, keep it the same, except in the case of inline
       // disposition without a content id.
       if (partInfo.disposition.type.toLowerCase() == 'inline') {
-        if (partInfo.id) {
+      // Displaying text-parts inline is not a problem for us, but we need a
+      // content id for other embedded content.  (Currently only images are
+      // supported, but that is enforced in a subsequent check.)
+        if (partInfo.type === 'text' || partInfo.id) {
           disposition = 'inline';
         } else {
           disposition = 'attachment';

--- a/apps/email/js/ext/mailapi/pop3/probe.js
+++ b/apps/email/js/ext/mailapi/pop3/probe.js
@@ -678,7 +678,10 @@ function chewStructure(msg) {
       // If it exists, keep it the same, except in the case of inline
       // disposition without a content id.
       if (partInfo.disposition.type.toLowerCase() == 'inline') {
-        if (partInfo.id) {
+      // Displaying text-parts inline is not a problem for us, but we need a
+      // content id for other embedded content.  (Currently only images are
+      // supported, but that is enforced in a subsequent check.)
+        if (partInfo.type === 'text' || partInfo.id) {
           disposition = 'inline';
         } else {
           disposition = 'attachment';

--- a/apps/email/js/ext/pop3/pop3.js
+++ b/apps/email/js/ext/pop3/pop3.js
@@ -2408,7 +2408,10 @@ function chewStructure(msg) {
       // If it exists, keep it the same, except in the case of inline
       // disposition without a content id.
       if (partInfo.disposition.type.toLowerCase() == 'inline') {
-        if (partInfo.id) {
+      // Displaying text-parts inline is not a problem for us, but we need a
+      // content id for other embedded content.  (Currently only images are
+      // supported, but that is enforced in a subsequent check.)
+        if (partInfo.type === 'text' || partInfo.id) {
           disposition = 'inline';
         } else {
           disposition = 'attachment';


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/322
