### PR TITLE
Bug 1043518 - Typing a long message or contact-name in SMS app will push the "send" / "add contact" buttons offscreen

### DIFF
--- a/apps/sms/style/composer.css
+++ b/apps/sms/style/composer.css
@@ -194,6 +194,7 @@ form[role="search"] button[type="submit"]:after {
   flex: auto;
   position: relative;
   min-height: 4rem;
+  min-width: 0;
 
   margin-left: 1.5rem;
 }

--- a/apps/sms/style/message.css
+++ b/apps/sms/style/message.css
@@ -76,6 +76,7 @@
 .message .message-body {
   flex: 1;
   padding: 1.5rem 1.5rem 1rem;
+  min-width: 0;
 }
 
 .message.incoming .message-body {

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -647,6 +647,7 @@ section[role="region"].new #messages-to-field.multiline {
 
 #messages-recipients-list-container {
   min-height: 4rem;
+  min-width: 0;
   box-sizing: border-box;
 
   flex-grow: 1;


### PR DESCRIPTION
This pull request fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1043518 by suppressing the (new, default) min-content-sizing flex item behavior on the flex items that contain the (user-editable) message body & recipient fields, in the SMS compose view.
