### PR TITLE
bug 1041841 - Manually trigger translation of element since l10n API doe...

### DIFF
--- a/shared/js/download/download_ui.js
+++ b/shared/js/download/download_ui.js
@@ -152,6 +152,7 @@ var DownloadUI = (function() {
     }
     // Then localize.
     element.setAttribute('data-l10n-id', l10nid);
+    navigator.mozL10n.translate(element);
     return element;
   }
 


### PR DESCRIPTION
...s not use MutationObserver in 2.0. r=crdlc
