### PR TITLE
Bug 1042887 - Move "overflow:auto" in SMS app from an element to its parent, to prevent flex-item min-content-based sizing from kicking in. r=fabrice

### DIFF
--- a/apps/sms/style/composer.css
+++ b/apps/sms/style/composer.css
@@ -52,6 +52,7 @@
    * information
    */
   flex: 1 0 calc(15.4% + 5.38rem);
+  overflow: auto;
 }
 
 .new #composer-messages-container {
@@ -183,8 +184,6 @@ form[role="search"] button[type="submit"]:after {
 
 #messages-container {
   height: 100%;
-
-  overflow: auto;
 }
 
 /*


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1042887
