### PR TITLE
Bug 1041967 - [Messages] do some safe lazy load to improve launch latency

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -32,59 +32,61 @@
     <link rel="resource" type="application/l10n" href="shared/locales/date.ini">
     <link rel="resource" type="application/l10n" href="shared/locales/sim_picker.ini">
     <!-- Shared code -->
-    <script defer src="shared/js/async_storage.js"></script>
     <script defer src="shared/js/l10n.js"></script>
     <script defer src="shared/js/l10n_date.js"></script>
+    <script defer src="shared/js/template.js"></script>
+    <script defer src="shared/js/performance_testing_helper.js"></script>
+    <script defer src="shared/js/async_storage.js"></script>
+    <script defer src="shared/js/lazy_loader.js"></script>
+    <script defer src="shared/js/sticky_header.js"></script>
+    <script defer src="shared/js/contact_photo_helper.js"></script>
+    <script defer src="shared/js/fb/fb_request.js"></script>
+    <script defer src="shared/js/fb/fb_data_reader.js"></script>
+    <script defer src="shared/js/fb/fb_reader_utils.js"></script>
+    <script defer src="js/navigation.js"></script>
+    <script defer src="js/event_dispatcher.js"></script>
+    <script defer src="js/time_headers.js"></script>
+    <script defer src="js/contacts.js"></script>
+    <script defer src="js/drafts.js"></script>
+    <script defer src="js/threads.js"></script>
+    <script defer src="js/thread_list_ui.js"></script>
+    <script defer src="js/utils.js"></script>
+    <script defer src="js/settings.js"></script>
+    <script defer src="js/message_manager.js"></script>
+    <script defer src="js/app.js"></script>
+    <script defer src="js/startup.js"></script>
+    <!-- Lazy load scripts
     <script defer src="shared/js/notification_helper.js"></script>
     <script defer src="shared/js/gesture_detector.js"></script>
     <script defer src="shared/js/settings_url.js"></script>
-    <script defer src="shared/js/template.js"></script>
     <script defer src="shared/js/mime_mapper.js"></script>
-    <script defer src="shared/js/contact_photo_helper.js"></script>
     <script defer src="shared/js/mobile_operator.js"></script>
     <script defer src="shared/js/settings_listener.js"></script>
     <script defer src="shared/js/sim_picker.js"></script>
     <script defer src="shared/js/multi_sim_action_button.js"></script>
     <script defer src="js/shared_components.js"></script>
-    <script defer src="js/event_dispatcher.js"></script>
-    <script defer src="js/navigation.js"></script>
     <script defer src="js/dialog.js"></script>
     <script defer src="js/task_runner.js"></script>
     <script defer src="js/silent_sms.js"></script>
-    <script defer src="js/contacts.js"></script>
-    <script defer src="js/drafts.js"></script>
     <script defer src="js/recipients.js"></script>
-    <script defer src="js/threads.js"></script>
-    <script defer src="js/message_manager.js"></script>
     <script defer src="js/attachment.js"></script>
     <script defer src="js/attachment_renderer.js"></script>
     <script defer src="js/attachment_menu.js"></script>
-    <script defer src="js/thread_list_ui.js"></script>
     <script defer src="js/thread_ui.js"></script>
     <script defer src="js/compose.js"></script>
     <script defer src="js/waiting_screen.js"></script>
-    <script defer src="js/utils.js"></script>
-    <script defer src="js/time_headers.js"></script>
     <script defer src="js/activity_picker.js"></script>
     <script defer src="js/wbmp.js"></script>
     <script defer src="js/smil.js"></script>
     <script defer src="js/link_helper.js"></script>
     <script defer src="js/action_menu.js"></script>
     <script defer src="js/link_action_handler.js"></script>
-    <script defer src="js/settings.js"></script>
     <script defer src="js/notify.js"></script>
     <script defer src="js/activity_handler.js"></script>
     <script defer src="js/contact_renderer.js"></script>
     <script defer src="js/information.js"></script>
-    <script defer src="shared/js/fb/fb_request.js"></script>
-    <script defer src="shared/js/fb/fb_data_reader.js"></script>
-    <script defer src="shared/js/fb/fb_reader_utils.js"></script>
-    <script defer src="shared/js/lazy_loader.js"></script>
     <script defer src="shared/js/font_size_utils.js"></script>
-    <script defer src="shared/js/performance_testing_helper.js"></script>
-    <script defer src="shared/js/sticky_header.js"></script>
-    <script defer src="js/app.js"></script>
-    <script defer src="js/startup.js"></script>
+    -->
     <!-- Elements -->
     <link rel="import" href="/shared/elements/sim_picker.html">
   </head>

--- a/apps/sms/js/link_action_handler.js
+++ b/apps/sms/js/link_action_handler.js
@@ -6,7 +6,6 @@
    Centralized event handling for various
    data-actions url, email, phone in a message
   */
-  var inProgress = false;
 
   var LinkActionHandler = {
     onClick: function lah_onClick(event) {
@@ -35,25 +34,14 @@
       }
 
       if (action === 'url-link') {
-        if (inProgress) {
-          return;
-        }
 
-        inProgress = true;
         var type = action.replace('-link', '');
-        // Use `LinkActionHandler.reset` (this.reset) as BOTH the
-        // success and error callback. This ensure that any
-        // activities will be freed regardless of their
-        // resulting state.
+
         ActivityPicker[type](
           dataset[type], this.reset, this.reset
         );
       }
 
-    },
-
-    reset: function lah_reset() {
-      inProgress = false;
     }
   };
 

--- a/apps/sms/js/message_manager.js
+++ b/apps/sms/js/message_manager.js
@@ -2,7 +2,7 @@
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 /*global ThreadListUI, ThreadUI, Threads, SMIL, MozSmsFilter,
-         LinkActionHandler, Settings, Navigation, ReportView
+         Settings, Navigation, ReportView
 */
 
 /*exported MessageManager */
@@ -29,8 +29,6 @@ var MessageManager = {
                                             this.onDeliverySuccess);
     this._mozMobileMessage.addEventListener('readsuccess',
                                             this.onReadSuccess);
-    document.addEventListener('visibilitychange',
-                              this.onVisibilityChange.bind(this));
 
     this._mozMobileMessage.addEventListener(
       'deleted',
@@ -101,10 +99,6 @@ var MessageManager = {
     if (e.deletedThreadIds && e.deletedThreadIds.length) {
       ThreadListUI.onThreadsDeleted(e.deletedThreadIds);
     }
-  },
-
-  onVisibilityChange: function mm_onVisibilityChange(e) {
-    LinkActionHandler.reset();
   },
 
   getThreads: function mm_getThreads(options) {

--- a/apps/sms/js/navigation.js
+++ b/apps/sms/js/navigation.js
@@ -1,6 +1,7 @@
 /* global
       Promise,
-      Utils
+      Utils,
+      Startup
 */
 
 /* exported Navigation */
@@ -34,6 +35,7 @@ function nextQueuedPanel() {
 }
 
 var Navigation = window.Navigation = {
+  isReady: false,
   panelObjects: window,
 
   defaultPanel: 'thread-list',
@@ -64,6 +66,11 @@ var Navigation = window.Navigation = {
   init: function n_init() {
     this.mainWrapper = document.getElementById('main-wrapper');
     this.transitioning = false;
+
+    Startup.on('post-initialize', function() {
+      this.isReady = true;
+      nextQueuedPanel();
+    }.bind(this));
 
     return this.toPanelFromHash();
   },
@@ -136,7 +143,11 @@ var Navigation = window.Navigation = {
       return Promise.reject(new Error('Panel ' + panel + ' is unknown.'));
     }
 
-    if (this.transitioning) {
+    // put the request to a queue when:
+    //   - Panel is still transitioning
+    //   - trying to navigate when the app is not loaded completely
+    var notReadyNavigate = (panel !== this.defaultPanel && !this.isReady);
+    if (this.transitioning || notReadyNavigate) {
       queuedPanel = {
         panel: panel,
         args: args

--- a/apps/sms/js/thread_list_ui.js
+++ b/apps/sms/js/thread_list_ui.js
@@ -504,7 +504,7 @@ var ThreadListUI = {
     this.sticky.refresh();
   },
 
-  renderThreads: function thlui_renderThreads(done) {
+  renderThreads: function thlui_renderThreads(firstViewDone, allDone) {
     PerformanceTestingHelper.dispatch('will-render-threads');
 
     var hasThreads = false;
@@ -523,8 +523,8 @@ var ThreadListUI = {
       if (--firstPanelCount === 0) {
         // dispatch visually-complete and content-interactive when rendered
         // threads could fill up the top of the visiable area
+        firstViewDone();
         window.dispatchEvent(new CustomEvent('moz-app-visually-complete'));
-        window.dispatchEvent(new CustomEvent('moz-content-interactive'));
       }
     }
 
@@ -538,15 +538,15 @@ var ThreadListUI = {
       if (firstPanelCount > 0) {
         // dispatch visually-complete and content-interactive when rendering
         // ended but threads could not fill up the top of the visiable area
+        firstViewDone();
         window.dispatchEvent(new CustomEvent('moz-app-visually-complete'));
-        window.dispatchEvent(new CustomEvent('moz-content-interactive'));
       }
     }
 
     var renderingOptions = {
       each: onRenderThread.bind(this),
       end: onThreadsRendered.bind(this),
-      done: done
+      done: allDone
     };
 
     MessageManager.getThreads(renderingOptions);

--- a/apps/sms/test/unit/link_action_handler_test.js
+++ b/apps/sms/test/unit/link_action_handler_test.js
@@ -87,7 +87,6 @@ suite('LinkActionHandler', function() {
     });
 
     teardown(function() {
-      LinkActionHandler.reset();
       mocksHelperLAH.teardown();
     });
 

--- a/apps/sms/test/unit/mock_link_action_handler.js
+++ b/apps/sms/test/unit/mock_link_action_handler.js
@@ -3,7 +3,6 @@
 'use strict';
 
 var MockLinkActionHandler = {
-  reset: function() {},
   onContextMenu: function() {},
   onClick: function() {}
 };

--- a/apps/sms/test/unit/mock_startup.js
+++ b/apps/sms/test/unit/mock_startup.js
@@ -1,0 +1,9 @@
+/*exported MockStartup */
+
+'use strict';
+
+var MockStartup = {
+  init: function() {},
+  on: function(type, handler) {},
+  off: function(type, handler) {}
+};

--- a/apps/sms/test/unit/thread_list_mockup.js
+++ b/apps/sms/test/unit/thread_list_mockup.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-function MockThreadList() {
+function MockThreadList(options) {
   // These Threads are not sorted in order to check that rendering
   // is working as expected, adding each thread to the right container.
   var threadsMockup = [
@@ -46,8 +46,49 @@ function MockThreadList() {
             body: '...',
             timestamp: +getMockupedDate(3),
             unreadCount: 0
+          },
+          {
+            id: 6,
+            participants: ['1977'],
+            lastMessageType: 'sms',
+            body: 'Alo, how are you today, my friend? :)',
+            timestamp: +getMockupedDate(0),
+            unreadCount: 0
+          },
+          {
+            id: 7,
+            participants: ['436797'],
+            lastMessageType: 'sms',
+            body: 'Sending :)',
+            timestamp: +getMockupedDate(2),
+            unreadCount: 0
+          },
+          {
+            id: 8,
+            participants: ['197746797'],
+            lastMessageType: 'sms',
+            body: 'Recibido!',
+            timestamp: +getMockupedDate(1),
+            unreadCount: 0
+          },
+          {
+            id: 9,
+            participants: ['1977436979'],
+            lastMessageType: 'mms',
+            body: 'Nothing :)',
+            timestamp: +getMockupedDate(2),
+            unreadCount: 2
+          },
+          {
+            id: 10,
+            participants: ['999', '888', '777'],
+            lastMessageType: 'sms',
+            body: '...',
+            timestamp: +getMockupedDate(3),
+            unreadCount: 0
           }
         ];
 
-  return threadsMockup;
+  return options && options.fullList ?
+    threadsMockup : threadsMockup.slice(0, 5);
 }

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -942,6 +942,7 @@ suite('thread_list_ui', function() {
   });
 
   suite('renderThreads', function() {
+    var firstViewDone;
     setup(function() {
       this.sinon.spy(ThreadListUI, 'setEmpty');
       this.sinon.spy(ThreadListUI, 'prepareRendering');
@@ -953,6 +954,7 @@ suite('thread_list_ui', function() {
       this.sinon.spy(ThreadListUI, 'setContact');
       this.sinon.spy(ThreadListUI, 'renderDrafts');
       this.sinon.spy(ThreadListUI.sticky, 'refresh');
+      firstViewDone = sinon.stub();
     });
 
     test('Rendering an empty screen', function(done) {
@@ -961,8 +963,9 @@ suite('thread_list_ui', function() {
         options.done();
       });
 
-      ThreadListUI.renderThreads(function() {
+      ThreadListUI.renderThreads(firstViewDone ,function() {
         done(function checks() {
+          sinon.assert.called(firstViewDone);
           sinon.assert.called(ThreadListUI.renderDrafts);
           sinon.assert.called(ThreadListUI.sticky.refresh);
           sinon.assert.calledWith(ThreadListUI.finalizeRendering, true);
@@ -977,7 +980,9 @@ suite('thread_list_ui', function() {
 
       this.sinon.stub(MessageManager, 'getThreads',
         function(options) {
-          var threadsMockup = new MockThreadList();
+          var threadsMockup = new MockThreadList({
+            fullList : true
+          });
 
           var each = options.each;
           var end = options.end;
@@ -985,6 +990,14 @@ suite('thread_list_ui', function() {
 
           for (var i = 0; i < threadsMockup.length; i++) {
             each && each(threadsMockup[i]);
+
+            // When the returned threads reach first panel amount, firstViewDone
+            // shoule be call here instead of whole iteration finished.
+            if (i < 8) {
+              sinon.assert.notCalled(firstViewDone);
+            } else {
+              sinon.assert.calledOnce(firstViewDone);
+            }
 
             var threads = container.querySelectorAll(
                 '[data-last-message-type="sms"],' +
@@ -999,7 +1012,7 @@ suite('thread_list_ui', function() {
           done && done();
         });
 
-      ThreadListUI.renderThreads(function() {
+      ThreadListUI.renderThreads(firstViewDone, function() {
         done(function checks() {
           sinon.assert.calledWith(ThreadListUI.finalizeRendering, false);
           assert.isTrue(ThreadListUI.noMessages.classList.contains('hide'));
@@ -1013,8 +1026,8 @@ suite('thread_list_ui', function() {
           );
 
           // Check that all threads have been properly inserted in the list
-          assert.equal(mmsThreads.length, 1);
-          assert.equal(smsThreads.length, 4);
+          assert.equal(mmsThreads.length, 2);
+          assert.equal(smsThreads.length, 8);
         });
       });
     });


### PR DESCRIPTION
- Move scripts and css that not in the thread rendering call path into Lazyloader
- Add another callback for render thread while first panel is ready that we can lazyload/init the rest of part
- Prevent the body to receive any pointer events before all the UI modules init
