### PR TITLE
Bug 967440 - Remove some reflows on the keypad

### DIFF
--- a/apps/callscreen/index.html
+++ b/apps/callscreen/index.html
@@ -31,6 +31,7 @@
     <script defer type="application/javascript" src="/shared/js/settings_url.js"></script>
     <script defer type="application/javascript" src="/shared/js/async_storage.js"></script>
     <script defer type="application/javascript" src="/shared/js/contact_photo_helper.js"></script>
+    <script defer type="application/javascript" src="/shared/js/font_size_utils.js"></script>
 
     <script defer type="application/javascript" src="/shared/js/simple_phone_matcher.js"></script>
     <script defer type="application/javascript" src="/shared/js/dialer/contacts.js"></script>
@@ -81,7 +82,6 @@
           <div class="numberWrapper direction-status-bar">
             <div class="number font-light"></div>
           </div>
-          <div class="fake-number font-light"></div>
           <div class="additionalContactInfo font-light"></div>
           <div class="shadow">
           </div>
@@ -102,7 +102,6 @@
             <div id="group-show"></div>
             <div id="group-call-label" class="number font-light"></div>
           </div>
-          <div class="fake-number font-light"></div>
           <div id="group-call-summary" class="additionalContactInfo font-light"></div>
           <div class="duration">
             <span class="font-light"></span>
@@ -222,7 +221,6 @@
       <section id="incoming-info">
         <div class="incoming-number-info">
           <span id="incoming-number"></span>
-          <span id="fake-incoming-number"></span>
           <span id="incoming-number-additional-info" class="font-light"></span>
         </div>
         <div id="incoming-sim" class="sim"></div>

--- a/apps/callscreen/js/call_screen.js
+++ b/apps/callscreen/js/call_screen.js
@@ -45,7 +45,6 @@ var CallScreen = {
   incomingContainer: document.getElementById('incoming-container'),
   incomingInfo: document.getElementById('incoming-info'),
   incomingNumber: document.getElementById('incoming-number'),
-  fakeIncomingNumber: document.getElementById('fake-incoming-number'),
   incomingSim: document.getElementById('incoming-sim'),
   incomingNumberAdditionalInfo:
     document.getElementById('incoming-number-additional-info'),
@@ -640,11 +639,10 @@ var CallScreen = {
     var scenario;
     if (this.inStatusBarMode) {
       scenario = FontSizeManager.STATUS_BAR;
-    } else if (this.calls.querySelectorAll(
-      'section:not([hidden])').length > 1) {
-      scenario = FontSizeManager.CALL_WAITING;
-    } else {
+    } else if (this.calls.classList.contains('single-line')) {
       scenario = FontSizeManager.SINGLE_CALL;
+    } else {
+      scenario = FontSizeManager.CALL_WAITING;
     }
     return scenario;
   }

--- a/apps/callscreen/js/calls_handler.js
+++ b/apps/callscreen/js/calls_handler.js
@@ -254,11 +254,8 @@ var CallsHandler = (function callsHandler() {
 
       if (!number) {
         CallScreen.incomingNumber.textContent = _('withheld-number');
-        var scenario = (call.state === 'incoming') ?
-          FontSizeManager.SECOND_INCOMING_CALL : FontSizeManager.CALL_WAITING;
-        FontSizeManager.adaptToSpace(scenario, CallScreen.incomingNumber,
-                                     CallScreen.fakeIncomingNumber, false,
-                                     'end');
+        FontSizeManager.adaptToSpace(FontSizeManager.SECOND_INCOMING_CALL,
+          CallScreen.incomingNumber, false, 'end');
         return;
       }
 
@@ -280,11 +277,14 @@ var CallsHandler = (function callsHandler() {
           CallScreen.incomingNumber.textContent = number;
           CallScreen.incomingNumberAdditionalInfo.textContent = '';
         }
-        var scenario = (call.state === 'incoming') ?
-          FontSizeManager.SECOND_INCOMING_CALL : FontSizeManager.CALL_WAITING;
-        FontSizeManager.adaptToSpace(scenario, CallScreen.incomingNumber,
-                                     CallScreen.fakeIncomingNumber, false,
-                                     'end');
+
+        FontSizeManager.adaptToSpace(
+          FontSizeManager.SECOND_INCOMING_CALL, CallScreen.incomingNumber,
+          false, 'end');
+        if (contact && contact.name) {
+          FontSizeManager.ensureFixedBaseline(
+            FontSizeManager.SECOND_INCOMING_CALL, CallScreen.incomingNumber);
+        }
       });
     });
 

--- a/apps/callscreen/js/conference_group_handler.js
+++ b/apps/callscreen/js/conference_group_handler.js
@@ -7,7 +7,6 @@
 var ConferenceGroupHandler = (function() {
   var groupLine = document.getElementById('group-call');
   var groupLabel = document.getElementById('group-call-label');
-  var fakeNumber = groupLine.querySelector('.fake-number');
   var groupDetails = document.getElementById('group-call-details');
   var groupDetailsHeader = groupDetails.querySelector('header');
   // FIXME/bug 1007148: Refactor duration element structure
@@ -74,8 +73,8 @@ var ConferenceGroupHandler = (function() {
     });
     groupLine.classList.add('ended');
     groupLine.classList.remove('held');
-    FontSizeManager.adaptToSpace(CallScreen.getScenario(), groupLabel,
-                                 fakeNumber, false, 'end');
+    FontSizeManager.adaptToSpace(
+      CallScreen.getScenario(), groupLabel, false, 'end');
     CallScreen.stopTicker(groupDuration);
 
     setTimeout(function(evt) {

--- a/apps/callscreen/js/handled_call.js
+++ b/apps/callscreen/js/handled_call.js
@@ -44,8 +44,6 @@ function HandledCall(aCall) {
   this.numberNode = this.node.querySelector('.numberWrapper .number');
   this.groupCallNumberNode =
     document.getElementById('group-call-label');
-  this.groupCallFakeNumberNode =
-    document.querySelector('#group-call .fake-number');
   this.additionalInfoNode = this.node.querySelector('.additionalContactInfo');
   this.hangupButton = this.node.querySelector('.hangup-button');
   this.hangupButton.onclick = (function() {
@@ -262,8 +260,10 @@ HandledCall.prototype.formatPhoneNumber =
       scenario = FontSizeManager.SECOND_INCOMING_CALL;
     }
     FontSizeManager.adaptToSpace(
-      scenario, this.numberNode, this.node.querySelector('.fake-number'),
-      false, ellipsisSide);
+      scenario, this.numberNode, false, ellipsisSide);
+    if (this.node.classList.contains('additionalInfo')) {
+      FontSizeManager.ensureFixedBaseline(scenario, this.numberNode);
+    }
 };
 
 HandledCall.prototype.replacePhoneNumber =

--- a/apps/callscreen/test/unit/conference_group_handler_test.js
+++ b/apps/callscreen/test/unit/conference_group_handler_test.js
@@ -50,7 +50,6 @@ suite('conference group handler', function() {
                             '<div id="group-call-label" ' +
                               'class="number font-light"></div>' +
                           '</div>' +
-                          '<div class="fake-number font-light"></div>' +
                           '<div id="group-call-summary" ' +
                             'class="additionalContactInfo font-light"></div>' +
                           '<div class="duration">' +
@@ -291,14 +290,13 @@ suite('conference group handler', function() {
          function() {
       MockCallScreen.mScenario = FontSizeManager.SINGLE_CALL;
       var view = fakeDOM.querySelector('#group-call-label');
-      var fakeView = fakeDOM.querySelector('.fake-number');
 
       MockNavigatorMozTelephony.conferenceGroup.state = '';
       MockNavigatorMozTelephony.mTriggerGroupStateChange();
 
       sinon.assert.calledWith(
         FontSizeManager.adaptToSpace, FontSizeManager.SINGLE_CALL, view,
-        fakeView, false, 'end');
+        false, 'end');
     });
 
     test('should add the held class once held', function() {

--- a/apps/callscreen/test/unit/handled_call_test.js
+++ b/apps/callscreen/test/unit/handled_call_test.js
@@ -507,8 +507,8 @@ suite('dialer/handled_call', function() {
     });
 
     test('AudioCompetingHelper leaveCompetition gets called when held',
-      function() {
-	sinon.assert.called(AudioCompetingHelper.leaveCompetition);
+    function() {
+      sinon.assert.called(AudioCompetingHelper.leaveCompetition);
     });
   });
 
@@ -698,8 +698,27 @@ suite('dialer/handled_call', function() {
       subject.formatPhoneNumber('end');
       sinon.assert.calledWith(
         FontSizeManager.adaptToSpace, MockCallScreen.mScenario,
-        subject.numberNode, subject.node.querySelector('.fake-number'),
-        false, 'end');
+        subject.numberNode, false, 'end');
+    });
+
+    test('should ensureFixedBaseline with a contact', function() {
+      mockCall = new MockCall('888', 'dialing');
+      subject = new HandledCall(mockCall);
+      this.sinon.spy(FontSizeManager, 'ensureFixedBaseline');
+      subject.formatPhoneNumber('end');
+      sinon.assert.calledWith(
+        FontSizeManager.ensureFixedBaseline,
+        MockCallScreen.mScenario,
+        subject.numberNode
+      );
+    });
+
+    test('should not ensureFixedBaseline without a contact', function() {
+      mockCall = new MockCall('111', 'dialing');
+      subject = new HandledCall(mockCall);
+      this.sinon.spy(FontSizeManager, 'ensureFixedBaseline');
+      subject.formatPhoneNumber('end');
+      sinon.assert.notCalled(FontSizeManager.ensureFixedBaseline);
     });
 
     test('check replace number', function() {

--- a/apps/callscreen/test/unit/mock_call_screen.js
+++ b/apps/callscreen/test/unit/mock_call_screen.js
@@ -107,7 +107,6 @@ var MockCallScreen = {
   incomingContainer: document.createElement('div'),
   incomingInfo: document.createElement('div'),
   incomingNumber: document.createElement('div'),
-  fakeIncomingNumber: document.createElement('div'),
   incomingSim: document.createElement('div'),
   incomingNumberAdditionalInfo: document.createElement('span'),
 
@@ -135,7 +134,6 @@ var MockCallScreen = {
     this.incomingContainer = document.createElement('div');
     this.incomingInfo = document.createElement('div');
     this.incomingNumber = document.createElement('div');
-    this.fakeIncomingNumber = document.createElement('div');
     this.incomingNumberAdditionalInfo = document.createElement('span');
     this.mGroupDetailsShown = false;
     this.mRemoveCallCalled = false;

--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -145,7 +145,6 @@
           <div id="phone-number-view-container">
             <div class="phone-number-view-wrapper-input">
               <input id="phone-number-view" type="text" class="phone-number-font font-light" readonly="readonly" data-l10n-id="phoneNumberInput">
-              <div id="fake-phone-number-view" class="phone-number-font font-light"></div>
             </div>
             <button id="keypad-delete" class="reset-button" data-value="delete" data-l10n-id="keypadDelete">
             </button>

--- a/apps/communications/dialer/test/marionette/keypad_test.js
+++ b/apps/communications/dialer/test/marionette/keypad_test.js
@@ -76,7 +76,7 @@ marionette('Dialer > Keypad', function() {
     var number = subject.client.findElement(selectors.phoneNumber);
     assert.equal(number.getAttribute('value'), '123');
     var reflowCount = reflowHelper.getCount();
-    assert.equal(reflowCount, 9, 'the reflow count is not equal to 9');
+    assert.equal(reflowCount, 3);
     reflowHelper.stopTracking();
   });
 

--- a/apps/communications/dialer/test/unit/keypad_test.js
+++ b/apps/communications/dialer/test/unit/keypad_test.js
@@ -92,7 +92,6 @@ suite('dialer/keypad', function() {
 
   setup(function() {
     this.sinon.useFakeTimers();
-    this.sinon.spy(FontSizeManager, 'adaptToSpace');
   });
 
   teardown(function() {
@@ -208,10 +207,11 @@ suite('dialer/keypad', function() {
     });
 
     test('FontSizeManager is invoked with the right parameters', function() {
+      this.sinon.spy(FontSizeManager, 'adaptToSpace');
       subject.updatePhoneNumber('1234567890', 'begin', false);
       sinon.assert.calledWith(
         FontSizeManager.adaptToSpace, FontSizeManager.DIAL_PAD,
-        subject.phoneNumberView, subject.fakePhoneNumberView, false, 'begin');
+        subject.phoneNumberView, false, 'begin');
     });
 
     suite('Audible and DTMF tones when composing numbers', function() {

--- a/apps/communications/dialer/test/unit/utils_test.js
+++ b/apps/communications/dialer/test/unit/utils_test.js
@@ -1,9 +1,9 @@
-require('/shared/js/dialer/utils.js');
-require('/shared/test/unit/mocks/dialer/mock_contacts.js');
+/* global MockContacts, Utils */
 
-if (!this.SettingsListener) {
-  this.SettingsListener = null;
-}
+'use strict';
+
+require('/shared/test/unit/mocks/dialer/mock_contacts.js');
+require('/shared/js/dialer/utils.js');
 
 suite('dialer/utils', function() {
   var realL10n;

--- a/apps/sharedtest/test/unit/dialer/font_size_manager_test.js
+++ b/apps/sharedtest/test/unit/dialer/font_size_manager_test.js
@@ -1,191 +1,102 @@
-/* globals FontSizeManager, MocksHelper */
+/* globals FontSizeManager, FontSizeUtils, MocksHelper */
 
 'use strict';
 
-require('/shared/test/unit/mocks/dialer/mock_lazy_l10n.js');
+require('/shared/test/unit/mocks/mock_font_size_utils.js');
 require('/shared/js/dialer/font_size_manager.js');
 
 var mocksHelperForCallScreen = new MocksHelper([
-  'LazyL10n'
+  'FontSizeUtils'
 ]).init();
 
 suite('font size manager', function() {
-  /**
-   * Maximum and minimum font sizes depending on the scenario as defined in
-   *  FontSizeManager.
-   */
-  var _MAX_FONT_SIZE_DIAL_PAD = 4.1,
-      _MIN_FONT_SIZE_DIAL_PAD = 2.6,
-      _MAX_FONT_SIZE_SINGLE_CALL = 3.4,
-      _MIN_FONT_SIZE_SINGLE_CALL = 2.3,
-      _MAX_FONT_SIZE_CALL_WAITING = 2.5,
-      _MIN_FONT_SIZE_CALL_WAITING = 2.3,
-      _MAX_FONT_SIZE_STATUS_BAR = 1.7,
-      _MIN_FONT_SIZE_STATUS_BAR = 1.7;
 
   var ROOT_FONT_SIZE = 10;
 
-  var CONTAINER_WIDTH = 20;
-
-  var container,
-      view,
-      fakeView;
+  var view;
 
   mocksHelperForCallScreen.attachTestHelpers();
 
   setup(function() {
     document.documentElement.style.fontSize = ROOT_FONT_SIZE + 'px';
-    document.documentElement.style.fontFamily = 'Arial';
-    container = document.createElement('div');
-    container.style.fontSize = ROOT_FONT_SIZE + 'px';
-    container.style.width = CONTAINER_WIDTH + 'rem';
     view = document.createElement('div');
-    view.id = 'view';
-    view.style.width = '100%';
-    view.style.overflow = 'hidden';
-    container.appendChild(view);
-    fakeView = document.createElement('div');
-    fakeView.id = 'fakeView';
-    fakeView.style.position = 'absolute';
-    container.appendChild(fakeView);
-    document.body.appendChild(container);
+    view.textContent = 'foobar';
+    document.body.appendChild(view);
   });
 
   teardown(function() {
-    document.body.removeChild(container);
+    document.body.innerHTML = '';
   });
 
-  suite('Dial pad scenario', function() {
-    test('Should force the maximum font size', function() {
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.DIAL_PAD, view, fakeView, true, 'end');
-      assert.equal(
-        view.style.fontSize, _MAX_FONT_SIZE_DIAL_PAD * ROOT_FONT_SIZE + 'px');
+  suite('adaptToSpace', function() {
+    setup(function() {
+      this.sinon.stub(FontSizeUtils, 'getMaxFontSizeInfo');
     });
 
-    test('Should reduce the font size but not add an ellipsis at the begining',
-         function() {
-      view.textContent = '1234567890';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.DIAL_PAD, view, fakeView, false, 'begin');
-      assert.isTrue(
-        view.style.fontSize < _MAX_FONT_SIZE_DIAL_PAD * ROOT_FONT_SIZE + 'px');
-      assert.isTrue(
-        view.style.fontSize > _MIN_FONT_SIZE_DIAL_PAD * ROOT_FONT_SIZE + 'px');
-      assert.equal(view.textContent.indexOf('\u2026'), -1);
+    var scenarios = [0,  // FontSizeManager.DIAL_PAD
+                     1,  // FontSizeManager.SINGLE_CALL
+                     2,  // FontSizeManager.CALL_WAITING
+                     3,  // FontSizeManager.STATUS_BAR
+                     4]; // FontSizeManager.SECOND_INCOMING_CALL
+    scenarios.forEach(function(scenario) {
+      test('does nothing for empty inputs, scenario ' + scenario, function() {
+        view = document.createElement('input');
+        document.body.appendChild(view);
+        FontSizeManager.adaptToSpace(scenario, view);
+        assert.equal(view.style.fontSize, '');
+      });
+
+      test('does nothing for empty elements, scenario ' + scenario, function() {
+        view.textContent = '';
+        FontSizeManager.adaptToSpace(scenario, view);
+        assert.equal(view.style.fontSize, '');
+      });
     });
 
-    test('Should set the minimum font size and add an ellipsis at the begining',
-         function() {
-      view.textContent = '123456789012345678901234567890';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.DIAL_PAD, view, fakeView, false, 'begin');
-      assert.equal(
-        view.style.fontSize, _MIN_FONT_SIZE_DIAL_PAD * ROOT_FONT_SIZE + 'px');
-      assert.equal(view.textContent.indexOf('\u2026'), 0);
-    });
-  });
-
-  suite('Single call scenario', function() {
-    test('Should force the maximum font size', function() {
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.SINGLE_CALL, view, fakeView, true, 'end');
-      assert.equal(
-        view.style.fontSize, _MAX_FONT_SIZE_SINGLE_CALL * ROOT_FONT_SIZE +
-        'px');
+    test('calls FSU with the proper arguments', function() {
+      FontSizeUtils.getMaxFontSizeInfo.returns({fontSize: 10, overflow: false});
+      view.style.fontFamily = 'Arial';
+      view.style.width = '200px';
+      FontSizeManager.adaptToSpace(FontSizeManager.DIAL_PAD, view);
+      sinon.assert.calledWith(
+        FontSizeUtils.getMaxFontSizeInfo, view.textContent,
+        [26, 30, 34, 38, 41], view.style.fontFamily, 200);
     });
 
-    test('Should reduce the font size but not add an ellipsis at the end',
-         function() {
-      view.textContent = '1234567890123';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.SINGLE_CALL, view, fakeView, false, 'end');
-      assert.isTrue(
-        view.style.fontSize < _MAX_FONT_SIZE_SINGLE_CALL * ROOT_FONT_SIZE +
-        'px');
-      assert.isTrue(
-        view.style.fontSize > _MIN_FONT_SIZE_SINGLE_CALL * ROOT_FONT_SIZE +
-        'px');
-      assert.equal(view.textContent.indexOf('\u2026'), -1);
+    test('changes the font size', function() {
+      FontSizeUtils.getMaxFontSizeInfo.returns({fontSize: 42, overflow: false});
+      FontSizeManager.adaptToSpace(FontSizeManager.DIAL_PAD, view);
+      assert.equal(view.style.fontSize, '42px');
     });
 
-    test('Should set the minimum font size and add an ellipsis at the end',
-         function() {
-      view.textContent = '123456789012345678901234567890';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.SINGLE_CALL, view, fakeView, false, 'end');
-      assert.equal(
-        view.style.fontSize, _MIN_FONT_SIZE_SINGLE_CALL * ROOT_FONT_SIZE +
-        'px');
-      assert.equal(
-        view.textContent.indexOf('\u2026'), view.textContent.length - 1);
+    test('forces maxfontsize', function() {
+      FontSizeUtils.getMaxFontSizeInfo.returns({fontSize: 10, overflow: false});
+      FontSizeManager.adaptToSpace(FontSizeManager.DIAL_PAD, view, true);
+      sinon.assert.calledWith(
+        FontSizeUtils.getMaxFontSizeInfo, view.textContent, [41]);
+    });
+
+    test('adds ellipsis', function() {
+      FontSizeUtils.getMaxFontSizeInfo.returns({fontSize: 10, overflow: true});
+      this.sinon.stub(FontSizeUtils, 'getOverflowCount').returns(2);
+      FontSizeManager.adaptToSpace(FontSizeManager.DIAL_PAD, view, true);
+      assert.equal(view.textContent, '\u2026ar');
+    });
+
+    test('adds ellipsis to the correct side', function() {
+      FontSizeUtils.getMaxFontSizeInfo.returns({fontSize: 10, overflow: true});
+      this.sinon.stub(FontSizeUtils, 'getOverflowCount').returns(2);
+      FontSizeManager.adaptToSpace(FontSizeManager.DIAL_PAD, view, true, 'end');
+      assert.equal(view.textContent, 'fo\u2026');
     });
   });
 
-  suite('Call waiting scenario', function() {
-    test('Should force the maximum font size', function() {
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.CALL_WAITING, view, fakeView, true, 'end');
-      assert.equal(
-        view.style.fontSize, _MAX_FONT_SIZE_CALL_WAITING * ROOT_FONT_SIZE +
-        'px');
-    });
+  test('ensureFixedBaseline', function() {
+    FontSizeManager.ensureFixedBaseline(FontSizeManager.SINGLE_CALL, view);
+    assert.equal(view.style.lineHeight, '49px');
 
-    test('Should reduce the font size but not add an ellipsis at the end',
-         function() {
-      view.textContent = '1111111111111';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.CALL_WAITING, view, fakeView, false, 'end');
-      assert.isTrue(
-        view.style.fontSize <= _MAX_FONT_SIZE_CALL_WAITING * ROOT_FONT_SIZE +
-        'px');
-      assert.isTrue(
-        view.style.fontSize >= _MIN_FONT_SIZE_CALL_WAITING * ROOT_FONT_SIZE +
-        'px');
-      assert.equal(view.textContent.indexOf('\u2026'), -1);
-    });
-
-    test('Should set the minimum font size and add an ellipsis at the end',
-         function() {
-      view.textContent = '123456789012345678901234567890';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.CALL_WAITING, view, fakeView, false, 'end');
-      assert.equal(
-        view.style.fontSize, _MIN_FONT_SIZE_CALL_WAITING * ROOT_FONT_SIZE +
-        'px');
-      assert.equal(
-        view.textContent.indexOf('\u2026'), view.textContent.length - 1);
-    });
-  });
-
-  suite('Status bar scenario', function() {
-    test('Should force the maximum font size', function() {
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.STATUS_BAR, view, fakeView, true, 'end');
-      assert.equal(
-        view.style.fontSize, _MAX_FONT_SIZE_STATUS_BAR * ROOT_FONT_SIZE + 'px');
-    });
-
-    test('Should use the fixed font size but not add an ellipsis at the end',
-         function() {
-      view.textContent = '1234567890123';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.STATUS_BAR, view, fakeView, false, 'end');
-      assert.isTrue(
-        view.style.fontSize == _MAX_FONT_SIZE_STATUS_BAR * ROOT_FONT_SIZE +
-        'px');
-      assert.equal(view.textContent.indexOf('\u2026'), -1);
-    });
-
-    test('Should set the minimum font size and add an ellipsis at the end',
-         function() {
-      view.textContent = '123456789012345678901234567890';
-      FontSizeManager.adaptToSpace(
-        FontSizeManager.STATUS_BAR, view, fakeView, false, 'end');
-      assert.equal(
-        view.style.fontSize, _MIN_FONT_SIZE_STATUS_BAR * ROOT_FONT_SIZE + 'px');
-      assert.equal(
-        view.textContent.indexOf('\u2026'), view.textContent.length - 1);
-    });
+    view.style.fontSize = '100px';
+    FontSizeManager.ensureFixedBaseline(FontSizeManager.SINGLE_CALL, view);
+    assert.equal(view.style.lineHeight, '4px');
   });
 });

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -32,7 +32,6 @@ apps/communications/dialer/test/unit/mock_confirm_dialog.js
 apps/communications/dialer/test/unit/mock_dialer_index.html.js
 apps/communications/dialer/test/unit/mock_icc_helper.js
 apps/communications/dialer/test/unit/mock_mozVoicemail.js
-apps/communications/dialer/test/unit/utils_test.js
 apps/communications/dialer/test/unit/voicemail_test.js
 apps/communications/facebook/js/console.js
 apps/communications/facebook/js/fb_sync.js

--- a/shared/js/dialer/font_size_manager.js
+++ b/shared/js/dialer/font_size_manager.js
@@ -1,35 +1,10 @@
-/* globals LazyL10n */
+/* globals FontSizeUtils */
 
 /* exported FontSizeManager */
 
 'use strict';
 
 var FontSizeManager = (function fontSizeManager() {
-  var _K_FONT_STEP = 1;
-
-  /**
-   * The following font sizes are in rems.
-   */
-  var _MAX_FONT_SIZE_DIAL_PAD = 4.1,
-      _MIN_FONT_SIZE_DIAL_PAD = 2.6,
-      _MAX_FONT_SIZE_SINGLE_CALL = 3.4,
-      _MIN_FONT_SIZE_SINGLE_CALL = 2.3,
-      _MAX_FONT_SIZE_CALL_WAITING = 2.5,
-      _MIN_FONT_SIZE_CALL_WAITING = 2.3,
-      _MAX_FONT_SIZE_STATUS_BAR = 1.7,
-      _MIN_FONT_SIZE_STATUS_BAR = 1.7,
-      _MAX_FONT_SIZE_SECOND_INCOMING_CALL = 2.5,
-      _MIN_FONT_SIZE_SECOND_INCOMING_CALL = 2.3;
-
-  /**
-   * These are the line-heights for the single call and call waiting scenarios
-   *  needed to keep the baseline of the text no matter the font size (see
-   *  bug 1010104).
-   */
-  var _SINGLE_CALL_LINE_HEIGHT = 3.7,
-      _CALL_WAITING_LINE_HEIGHT = 1.5,
-      _SECOND_INCOMING_CALL_LINE_HEIGHT = 3.7;
-
   /**
    * Possible scenarios in which the dialer and call screen can be in.
    */
@@ -39,9 +14,19 @@ var FontSizeManager = (function fontSizeManager() {
       STATUS_BAR = 3,
       SECOND_INCOMING_CALL = 4;
 
+  /**
+   * The following font sizes are in rems.
+   */
+  var _sizes = {};
+  _sizes[DIAL_PAD] = {min: 2.6, max: 4.1};
+  _sizes[SINGLE_CALL] = {min: 2.3, max: 3.4, line: 3.7};
+  _sizes[CALL_WAITING] = {min: 2.3, max: 2.5, line: 1.5};
+  _sizes[STATUS_BAR] = {min: 1.7, max: 1.7};
+  _sizes[SECOND_INCOMING_CALL] = {min: 2.3, max: 2.5, line: 3.7};
+
   var _defaultFontSize;
 
-  function _getDefaultFontSize() {
+  function _getRootFontSize() {
     _defaultFontSize = _defaultFontSize ||
       parseInt(window.getComputedStyle(document.body, null).
                getPropertyValue('font-size'));
@@ -49,176 +34,101 @@ var FontSizeManager = (function fontSizeManager() {
   }
 
   function _getMinFontSize(scenario) {
-    var minFontSize;
-    switch (scenario) {
-    case DIAL_PAD:
-      minFontSize = _MIN_FONT_SIZE_DIAL_PAD;
-      break;
-    case SINGLE_CALL:
-      minFontSize = _MIN_FONT_SIZE_SINGLE_CALL;
-      break;
-    case CALL_WAITING:
-      minFontSize = _MIN_FONT_SIZE_CALL_WAITING;
-      break;
-    case STATUS_BAR:
-      minFontSize = _MIN_FONT_SIZE_STATUS_BAR;
-      break;
-    case SECOND_INCOMING_CALL:
-      minFontSize = _MIN_FONT_SIZE_SECOND_INCOMING_CALL;
-      break;
-    }
-    return Math.round(minFontSize * _getDefaultFontSize());
+    return Math.round(_sizes[scenario].min * _getRootFontSize());
   }
 
   function _getMaxFontSize(scenario) {
-    var maxFontSize;
-    switch (scenario) {
-    case DIAL_PAD:
-      maxFontSize = _MAX_FONT_SIZE_DIAL_PAD;
-      break;
-    case SINGLE_CALL:
-      maxFontSize = _MAX_FONT_SIZE_SINGLE_CALL;
-      break;
-    case CALL_WAITING:
-      maxFontSize = _MAX_FONT_SIZE_CALL_WAITING;
-      break;
-    case STATUS_BAR:
-      maxFontSize = _MAX_FONT_SIZE_STATUS_BAR;
-      break;
-    case SECOND_INCOMING_CALL:
-      maxFontSize = _MAX_FONT_SIZE_SECOND_INCOMING_CALL;
-      break;
-    }
-    return Math.round(maxFontSize * _getDefaultFontSize());
+    return Math.round(_sizes[scenario].max * _getRootFontSize());
   }
 
-  function _addEllipsis(view, fakeView, ellipsisSide) {
-    var side = ellipsisSide || 'begin';
-    LazyL10n.get(function localized(_) {
-      var localizedSide;
-      if (navigator.mozL10n.language.direction === 'rtl') {
-        localizedSide = (side === 'begin' ? 'right' : 'left');
-      } else {
-        localizedSide = (side === 'begin' ? 'left' : 'right');
-      }
-      var computedStyle = window.getComputedStyle(view, null);
-      var currentFontSize = parseInt(
-        computedStyle.getPropertyValue('font-size')
-      );
-      var viewWidth = view.getBoundingClientRect().width;
-      fakeView.style.fontSize = currentFontSize + 'px';
-      fakeView.style.fontWeight = computedStyle.getPropertyValue('font-weight');
-      var value = fakeView.innerHTML = view.value ? view.value : view.innerHTML;
-
-      // Guess the possible position of the ellipsis in order to minimize
-      // the following while loop iterations:
-      var counter = value.length -
-        (viewWidth *
-         (fakeView.textContent.length /
-           fakeView.getBoundingClientRect().width));
-
-      var newPhoneNumber;
-      while (fakeView.getBoundingClientRect().width > viewWidth) {
-
-        if (localizedSide == 'left') {
-          newPhoneNumber = '\u2026' + value.substr(-value.length + counter);
-        } else if (localizedSide == 'right') {
-          newPhoneNumber = value.substr(0, value.length - counter) + '\u2026';
-        }
-
-        fakeView.innerHTML = newPhoneNumber;
-        counter++;
-      }
-
-      if (newPhoneNumber) {
-        if (view.value) {
-          view.value = newPhoneNumber;
-        } else {
-          view.innerHTML = newPhoneNumber;
-        }
-      }
-    });
+  // Returns an array containing each number between scenario.minsize and
+  // scenario.maxsize in steps of 4,
+  // e.g.[minsize, minsize + 4, minsize + 8, ..., maxsize]
+  function _getAllowedFontSizes(scenario) {
+    var minFontSize = _getMinFontSize(scenario);
+    var maxFontSize = _getMaxFontSize(scenario);
+    var allowedSizes = [];
+    for (var size = minFontSize; size <= maxFontSize; size +=4) {
+      allowedSizes.push(size);
+    }
+    if (allowedSizes.indexOf(maxFontSize) === -1) {
+      allowedSizes.push(maxFontSize);
+    }
+    return allowedSizes;
   }
 
-  function _getNextFontSize(view, fakeView, minFontSize, maxFontSize) {
-    var computedStyle = window.getComputedStyle(view, null);
-    var fontSize = parseInt(computedStyle.getPropertyValue('font-size'));
-    if (fontSize >= maxFontSize) {
-      fontSize = maxFontSize;
-    } else if (fontSize <= minFontSize) {
-      fontSize = minFontSize;
-    }
-    var viewWidth = view.getBoundingClientRect().width;
-    fakeView.style.fontSize = fontSize + 'px';
-    fakeView.innerHTML = (view.value ? view.value : view.innerHTML);
-
-    var rect = fakeView.getBoundingClientRect();
-
-    while ((rect.width < viewWidth) && (fontSize < maxFontSize)) {
-      fontSize = Math.min(fontSize + _K_FONT_STEP, maxFontSize);
-      fakeView.style.fontSize = fontSize + 'px';
-      rect = fakeView.getBoundingClientRect();
-    }
-
-    while ((rect.width > viewWidth) && (fontSize > minFontSize)) {
-      fontSize = Math.max(fontSize - _K_FONT_STEP, minFontSize);
-      fakeView.style.fontSize = fontSize + 'px';
-      rect = fakeView.getBoundingClientRect();
-    }
-
-    return fontSize;
-  }
-
-  function adaptToSpace(scenario, view, fakeView, forceMaxFontSize,
-                        ellipsisSide) {
-    var maxFontSize = _getMaxFontSize(scenario),
-        minFontSize,
-        initialLineHeight;
-
-    // We consider the case where the delete button may have
-    // been used to delete the whole phone number.
-    if (view.value === '') {
-      view.style.fontSize = maxFontSize;
+  /* The font size of the view will be modified to fit its width. The scenario
+     provides the sizing contraints.
+     If the content is still too large within the size contraints, it will add
+     an ellipsis */
+  function adaptToSpace(scenario, view, forceMaxFontSize, ellipsisSide) {
+    // We don't care about the font size of empty views
+    if (view.value === '' || view.textContent === '') {
       return;
     }
 
-    var newFontSize;
+    var viewWidth = view.getBoundingClientRect().width;
+    var viewFont = window.getComputedStyle(view).fontFamily;
+
+    var allowedSizes;
     if (forceMaxFontSize) {
-      newFontSize = maxFontSize;
+      allowedSizes = [_getMaxFontSize(scenario)];
     } else {
-      minFontSize = _getMinFontSize(scenario);
-      newFontSize =
-        _getNextFontSize(view, fakeView, minFontSize, maxFontSize);
+      allowedSizes = _getAllowedFontSizes(scenario);
     }
-    if (view.style.fontSize !== minFontSize &&
-        view.style.fontSize !== newFontSize) {
+
+    var infos = FontSizeUtils.getMaxFontSizeInfo(
+      view.value || view.textContent, allowedSizes, viewFont, viewWidth);
+    var newFontSize = infos.fontSize;
+    if (view.style.fontSize !== newFontSize) {
       view.style.fontSize = newFontSize + 'px';
-      // The baseline should be the same no matter the font size.
-      if (view.parentNode.parentNode.classList.contains('additionalInfo')) {
-        switch (scenario) {
-        case SINGLE_CALL:
-          initialLineHeight = _SINGLE_CALL_LINE_HEIGHT;
-          break;
-        case CALL_WAITING:
-          initialLineHeight = _CALL_WAITING_LINE_HEIGHT;
-          break;
-        case SECOND_INCOMING_CALL:
-          initialLineHeight = _SECOND_INCOMING_CALL_LINE_HEIGHT;
-          break;
-        default:
-          initialLineHeight = 0;
-          break;
-        }
-        if (initialLineHeight) {
-          // Taking the line height for the maximum font size case for each
-          //  scenario as the reference, we need to adjust it adding half of
-          //  the decrease to the final calculated font size in pixels.
-          view.style.lineHeight = initialLineHeight * _getDefaultFontSize() +
-            (maxFontSize - newFontSize) / 2 + 'px';
-        }
-      }
     }
-    _addEllipsis(view, fakeView, ellipsisSide);
+
+    if (infos && infos.overflow) {
+      var overflowCount = FontSizeUtils.getOverflowCount(
+        view.value || view.textContent, newFontSize, viewFont, viewWidth);
+      _useEllipsis(view, overflowCount, ellipsisSide);
+    }
+  }
+
+  function _useEllipsis(view, overflowCount, ellipsisSide) {
+    // Add two characters to the overflowcount to account for "…" width
+    overflowCount += 2;
+    var side = ellipsisSide || 'begin';
+    var localizedSide;
+    if (navigator.mozL10n.language.direction === 'rtl') {
+      localizedSide = (side === 'begin' ? 'right' : 'left');
+    } else {
+      localizedSide = (side === 'begin' ? 'left' : 'right');
+    }
+
+    var value = view.value || view.textContent;
+    if (localizedSide == 'left') {
+      value = '\u2026' + value.substr(-value.length + overflowCount);
+    } else if (localizedSide == 'right') {
+      value = value.substr(0, value.length - overflowCount) + '\u2026';
+    }
+
+    if (view.value) {
+      view.value = value;
+    } else {
+      view.textContent = value;
+    }
+  }
+
+  function ensureFixedBaseline(scenario, view) {
+    var initialLineHeight = _sizes[scenario].line;
+    if (!initialLineHeight) {
+      return;
+    }
+
+    var maxFontSize = _getMaxFontSize(scenario);
+    var fontSize = parseInt(window.getComputedStyle(view).fontSize, 10);
+    // Taking the line height for the maximum font size case for each
+    //  scenario as the reference, we need to adjust it adding half of
+    //  the decrease to the final calculated font size in pixels.
+    view.style.lineHeight = initialLineHeight * _getRootFontSize() +
+                            (maxFontSize - fontSize) / 2 + 'px';
   }
 
   return {
@@ -227,6 +137,7 @@ var FontSizeManager = (function fontSizeManager() {
     CALL_WAITING: CALL_WAITING,
     STATUS_BAR: STATUS_BAR,
     SECOND_INCOMING_CALL: SECOND_INCOMING_CALL,
-    adaptToSpace: adaptToSpace
+    adaptToSpace: adaptToSpace,
+    ensureFixedBaseline: ensureFixedBaseline
   };
 })();

--- a/shared/js/dialer/keypad.js
+++ b/shared/js/dialer/keypad.js
@@ -80,13 +80,6 @@ var KeypadManager = {
     return this.phoneNumberView;
   },
 
-  get fakePhoneNumberView() {
-    delete this.fakePhoneNumberView;
-    this.fakePhoneNumberView =
-      document.getElementById('fake-phone-number-view');
-    return this.fakePhoneNumberView;
-  },
-
   get phoneNumberViewContainer() {
     delete this.phoneNumberViewContainer;
     this.phoneNumberViewContainer =
@@ -576,8 +569,8 @@ var KeypadManager = {
       this.moveCaretToEnd(this.phoneNumberView);
 
       FontSizeManager.adaptToSpace(
-        FontSizeManager.DIAL_PAD, this.phoneNumberView,
-        this.fakePhoneNumberView, forceMaxFontSize, ellipsisSide);
+        FontSizeManager.DIAL_PAD, this.phoneNumberView, forceMaxFontSize,
+        ellipsisSide);
     }
 
     if (this.onValueChanged) {

--- a/shared/js/font_size_utils.js
+++ b/shared/js/font_size_utils.js
@@ -175,7 +175,7 @@
      * @param {Array} allowedSizes A list of fontSizes allowed.
      * @param {String} fontFamily The font family of the string we're measuring.
      * @param {Integer} maxWidth The maximum number of pixels before overflow.
-     * @return {Object} Dict containing max fontSize and overflow flag.
+     * @return {Object} Dict containing fontSize, overflow and textWidth.
      */
     getMaxFontSizeInfo: function(string, allowedSizes, fontFamily, maxWidth) {
       var fontSize;

--- a/shared/style/dialer/keypad.css
+++ b/shared/style/dialer/keypad.css
@@ -51,13 +51,6 @@
   pointer-events: none;
 }
 
-#fake-phone-number-view {
-  position: absolute;
-  left: 2rem;
-  line-height: 0;
-  visibility: hidden;
-}
-
 #keypad-delete {
   margin-bottom: 4.5rem;
   padding: 0 2.5rem 0 0;

--- a/shared/test/unit/mocks/dialer/mock_font_size_manager.js
+++ b/shared/test/unit/mocks/dialer/mock_font_size_manager.js
@@ -12,5 +12,6 @@ var MockFontSizeManager = {
   STATUS_BAR: 3,
   SECOND_INCOMING_CALL: 4,
 
-  adaptToSpace: function() {}
+  adaptToSpace: function() {},
+  ensureFixedBaseline: function() {}
 };

--- a/shared/test/unit/mocks/mock_font_size_utils.js
+++ b/shared/test/unit/mocks/mock_font_size_utils.js
@@ -1,0 +1,8 @@
+/* exported MockFontSizeUtils */
+
+'use strict';
+
+var MockFontSizeUtils = {
+  getMaxFontSizeInfo: function() {},
+  getOverflowCount: function() {}
+};


### PR DESCRIPTION
- Uses shared FontSizeUtils to compute the new sizes
- Splits the font size changes and baseline into two different functions
- Removes fake nodes from previous algorithm
- call_screen.js use the single-line class rather than a test that could change
- calls_handler.js and handled_call.js now have the responsability to call ensureFixedBaseline when necessary (aka when they are displaying a known contact)
- In calls_handler.js scenario is always a second incoming call, the first one is handled by handled_call.js
- utils_test.js has been cleaned and moved to jshint
