### PR TITLE
Bug 1041710: ensure that wallpaper size always exactly matches screen si...

### DIFF
--- a/apps/homescreen/js/wallpaper.js
+++ b/apps/homescreen/js/wallpaper.js
@@ -14,8 +14,8 @@ const Wallpaper = (function() {
           type: ['wallpaper', 'image/*'],
           includeLocked: (secret !== null),
           // XXX: This will not work with Desktop Fx / Simulator.
-          width: window.screen.width * window.devicePixelRatio,
-          height: window.screen.height * window.devicePixelRatio
+          width: Math.ceil(window.screen.width * window.devicePixelRatio),
+          height: Math.ceil(window.screen.height * window.devicePixelRatio)
         }
       });
 

--- a/apps/settings/js/wallpaper.js
+++ b/apps/settings/js/wallpaper.js
@@ -42,8 +42,8 @@ var Wallpaper = {
             type: ['wallpaper', 'image/*'],
             includeLocked: (secret !== null),
             // XXX: This will not work with Desktop Fx / Simulator.
-            width: window.screen.width * window.devicePixelRatio,
-            height: window.screen.height * window.devicePixelRatio
+            width: Math.ceil(window.screen.width * window.devicePixelRatio),
+            height: Math.ceil(window.screen.height * window.devicePixelRatio)
           }
         });
 

--- a/apps/sharedtest/test/unit/image_utils_test.js
+++ b/apps/sharedtest/test/unit/image_utils_test.js
@@ -1,0 +1,579 @@
+'use strict';
+
+/* global ImageUtils */
+
+require('/shared/js/image_utils.js');
+
+suite('ImageUtils', function() {
+
+  const testImages = [
+    {
+      type: 'image/jpeg',
+      width: 25,
+      height: 24,
+      base64: '/9j/4AAQSkZJRgABAQEASABIAAD/4ge4SUNDX1BST0ZJTEUAAQEAAAeoYXBwbAIgAABtbnRyUkdCIFhZWiAH2QACABkACwAaAAthY3NwQVBQTAAAAABhcHBsAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWFwcGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtkZXNjAAABCAAAAG9kc2NtAAABeAAABWxjcHJ0AAAG5AAAADh3dHB0AAAHHAAAABRyWFlaAAAHMAAAABRnWFlaAAAHRAAAABRiWFlaAAAHWAAAABRyVFJDAAAHbAAAAA5jaGFkAAAHfAAAACxiVFJDAAAHbAAAAA5nVFJDAAAHbAAAAA5kZXNjAAAAAAAAABRHZW5lcmljIFJHQiBQcm9maWxlAAAAAAAAAAAAAAAUR2VuZXJpYyBSR0IgUHJvZmlsZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbWx1YwAAAAAAAAAeAAAADHNrU0sAAAAoAAABeGhySFIAAAAoAAABoGNhRVMAAAAkAAAByHB0QlIAAAAmAAAB7HVrVUEAAAAqAAACEmZyRlUAAAAoAAACPHpoVFcAAAAWAAACZGl0SVQAAAAoAAACem5iTk8AAAAmAAAComtvS1IAAAAWAAACyGNzQ1oAAAAiAAAC3mhlSUwAAAAeAAADAGRlREUAAAAsAAADHmh1SFUAAAAoAAADSnN2U0UAAAAmAAAConpoQ04AAAAWAAADcmphSlAAAAAaAAADiHJvUk8AAAAkAAADomVsR1IAAAAiAAADxnB0UE8AAAAmAAAD6G5sTkwAAAAoAAAEDmVzRVMAAAAmAAAD6HRoVEgAAAAkAAAENnRyVFIAAAAiAAAEWmZpRkkAAAAoAAAEfHBsUEwAAAAsAAAEpHJ1UlUAAAAiAAAE0GFyRUcAAAAmAAAE8mVuVVMAAAAmAAAFGGRhREsAAAAuAAAFPgBWAWEAZQBvAGIAZQBjAG4A/QAgAFIARwBCACAAcAByAG8AZgBpAGwARwBlAG4AZQByAGkBDQBrAGkAIABSAEcAQgAgAHAAcgBvAGYAaQBsAFAAZQByAGYAaQBsACAAUgBHAEIAIABnAGUAbgDoAHIAaQBjAFAAZQByAGYAaQBsACAAUgBHAEIAIABHAGUAbgDpAHIAaQBjAG8EFwQwBDMEMAQ7BEwEPQQ4BDkAIAQ/BEAEPgREBDAEOQQ7ACAAUgBHAEIAUAByAG8AZgBpAGwAIABnAOkAbgDpAHIAaQBxAHUAZQAgAFIAVgBCkBp1KAAgAFIARwBCACCCcl9pY8+P8ABQAHIAbwBmAGkAbABvACAAUgBHAEIAIABnAGUAbgBlAHIAaQBjAG8ARwBlAG4AZQByAGkAcwBrACAAUgBHAEIALQBwAHIAbwBmAGkAbMd8vBgAIABSAEcAQgAg1QS4XNMMx3wATwBiAGUAYwBuAP0AIABSAEcAQgAgAHAAcgBvAGYAaQBsBeQF6AXVBeQF2QXcACAAUgBHAEIAIAXbBdwF3AXZAEEAbABsAGcAZQBtAGUAaQBuAGUAcwAgAFIARwBCAC0AUAByAG8AZgBpAGwAwQBsAHQAYQBsAOEAbgBvAHMAIABSAEcAQgAgAHAAcgBvAGYAaQBsZm6QGgAgAFIARwBCACBjz4/wZYdO9k4AgiwAIABSAEcAQgAgMNcw7TDVMKEwpDDrAFAAcgBvAGYAaQBsACAAUgBHAEIAIABnAGUAbgBlAHIAaQBjA5MDtQO9A7kDugPMACADwAPBA78DxgOvA7sAIABSAEcAQgBQAGUAcgBmAGkAbAAgAFIARwBCACAAZwBlAG4A6QByAGkAYwBvAEEAbABnAGUAbQBlAGUAbgAgAFIARwBCAC0AcAByAG8AZgBpAGUAbA5CDhsOIw5EDh8OJQ5MACAAUgBHAEIAIA4XDjEOSA4nDkQOGwBHAGUAbgBlAGwAIABSAEcAQgAgAFAAcgBvAGYAaQBsAGkAWQBsAGUAaQBuAGUAbgAgAFIARwBCAC0AcAByAG8AZgBpAGkAbABpAFUAbgBpAHcAZQByAHMAYQBsAG4AeQAgAHAAcgBvAGYAaQBsACAAUgBHAEIEHgQxBEkEOAQ5ACAEPwRABD4ERAQ4BDsETAAgAFIARwBCBkUGRAZBACAGKgY5BjEGSgZBACAAUgBHAEIAIAYnBkQGOQYnBkUARwBlAG4AZQByAGkAYwAgAFIARwBCACAAUAByAG8AZgBpAGwAZQBHAGUAbgBlAHIAZQBsACAAUgBHAEIALQBiAGUAcwBrAHIAaQB2AGUAbABzAGV0ZXh0AAAAAENvcHlyaWdodCAyMDA3IEFwcGxlIEluYy4sIGFsbCByaWdodHMgcmVzZXJ2ZWQuAFhZWiAAAAAAAADzUgABAAAAARbPWFlaIAAAAAAAAHRNAAA97gAAA9BYWVogAAAAAAAAWnUAAKxzAAAXNFhZWiAAAAAAAAAoGgAAFZ8AALg2Y3VydgAAAAAAAAABAc0AAHNmMzIAAAAAAAEMQgAABd7///MmAAAHkgAA/ZH///ui///9owAAA9wAAMBs/+EAnkV4aWYAAE1NACoAAAAIAAYBEgADAAAAAQABAAABGgAFAAAAAQAAAFYBGwAFAAAAAQAAAF4BKAADAAAAAQACAAABMQACAAAAEQAAAGaHaQAEAAAAAQAAAHgAAAAAAAAASAAAAAEAAABIAAAAAUFkb2JlIEltYWdlUmVhZHkAAAACoAIABAAAAAEAAAAZoAMABAAAAAEAAAAYAAAAAP/bAEMAIBYYHBgUIBwaHCQiICYwUDQwLCwwYkZKOlB0Znp4cmZwboCQuJyAiK6KbnCg2qKuvsTO0M58muLy4MjwuMrOxv/bAEMBIiQkMCowXjQ0XsaEcITGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxv/AABEIABgAGQMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgv/xAC1EAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp6vHy8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAAAAQIDBAUGBwgJCgv/xAC1EQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/ANu5m8iEyYzjoPWsuXU5YzuJHrjHFaF/C01qyp94cgetc5JGJDtOFJ4OQcikpcstdi/Z88dNzqIZBLGrjuM1JVWxD+SGcbc4CjvirVEW2tSWrMrOblXYqoYZOAfSmZuASxhRienHSiimIlJm38Zxnpip6KKAP//Z'  // jshint ignore:line
+    },
+    {
+      type: 'image/png',
+      width: 25,
+      height: 24,
+      base64: 'iVBORw0KGgoAAAANSUhEUgAAABkAAAAYCAYAAAAPtVbGAAAEJGlDQ1BJQ0MgUHJvZmlsZQAAOBGFVd9v21QUPolvUqQWPyBYR4eKxa9VU1u5GxqtxgZJk6XtShal6dgqJOQ6N4mpGwfb6baqT3uBNwb8AUDZAw9IPCENBmJ72fbAtElThyqqSUh76MQPISbtBVXhu3ZiJ1PEXPX6yznfOec7517bRD1fabWaGVWIlquunc8klZOnFpSeTYrSs9RLA9Sr6U4tkcvNEi7BFffO6+EdigjL7ZHu/k72I796i9zRiSJPwG4VHX0Z+AxRzNRrtksUvwf7+Gm3BtzzHPDTNgQCqwKXfZwSeNHHJz1OIT8JjtAq6xWtCLwGPLzYZi+3YV8DGMiT4VVuG7oiZpGzrZJhcs/hL49xtzH/Dy6bdfTsXYNY+5yluWO4D4neK/ZUvok/17X0HPBLsF+vuUlhfwX4j/rSfAJ4H1H0qZJ9dN7nR19frRTeBt4Fe9FwpwtN+2p1MXscGLHR9SXrmMgjONd1ZxKzpBeA71b4tNhj6JGoyFNp4GHgwUp9qplfmnFW5oTdy7NamcwCI49kv6fN5IAHgD+0rbyoBc3SOjczohbyS1drbq6pQdqumllRC/0ymTtej8gpbbuVwpQfyw66dqEZyxZKxtHpJn+tZnpnEdrYBbueF9qQn93S7HQGGHnYP7w6L+YGHNtd1FJitqPAR+hERCNOFi1i1alKO6RQnjKUxL1GNjwlMsiEhcPLYTEiT9ISbN15OY/jx4SMshe9LaJRpTvHr3C/ybFYP1PZAfwfYrPsMBtnE6SwN9ib7AhLwTrBDgUKcm06FSrTfSj187xPdVQWOk5Q8vxAfSiIUc7Z7xr6zY/+hpqwSyv0I0/QMTRb7RMgBxNodTfSPqdraz/sDjzKBrv4zu2+a2t0/HHzjd2Lbcc2sG7GtsL42K+xLfxtUgI7YHqKlqHK8HbCCXgjHT1cAdMlDetv4FnQ2lLasaOl6vmB0CMmwT/IPszSueHQqv6i/qluqF+oF9TfO2qEGTumJH0qfSv9KH0nfS/9TIp0Wboi/SRdlb6RLgU5u++9nyXYe69fYRPdil1o1WufNSdTTsp75BfllPy8/LI8G7AUuV8ek6fkvfDsCfbNDP0dvRh0CrNqTbV7LfEEGDQPJQadBtfGVMWEq3QWWdufk6ZSNsjG2PQjp3ZcnOWWing6noonSInvi0/Ex+IzAreevPhe+CawpgP1/pMTMDo64G0sTCXIM+KdOnFWRfQKdJvQzV1+Bt8OokmrdtY2yhVX2a+qrykJfMq4Ml3VR4cVzTQVz+UoNne4vcKLoyS+gyKO6EHe+75Fdt0Mbe5bRIf/wjvrVmhbqBN97RD1vxrahvBOfOYzoosH9bq94uejSOQGkVM6sN/7HelL4t10t9F4gPdVzydEOx83Gv+uNxo7XyL/FtFl8z9ZAHF4bBsrEwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAmtpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuMS4yIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIj4KICAgICAgICAgPHhtcDpDcmVhdG9yVG9vbD5BZG9iZSBJbWFnZVJlYWR5PC94bXA6Q3JlYXRvclRvb2w+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjcyPC90aWZmOllSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICAgICA8dGlmZjpYUmVzb2x1dGlvbj43MjwvdGlmZjpYUmVzb2x1dGlvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CuH1si4AAAYdSURBVEgNrVVdbFTHFf5m7t296/1xDPYaNtA4XgcQApMQO45bsFkHKA4hqqPIqCAeUopC8hJFbR4jbZxWqC/NS6QGRaqqqFLbmJBEiRKFxGXXmApVYinQpJCA+XEKa7Lrv/2/d++dyZmLbUzi9Kkjje78nDnfOd/5Zi6klPhfvX9Qaugf1BazeSWR0Adpf7G9hWtMTRZtA4wPIMHj8Zit9s8DgbeTheZ82QrWeLwzsW3BK48DptpLpVKetra2qhov1n4YZNb6vYuoP3rmxovpqta3RBdNPh1G1RFlWbVHN97rezuzdvnrr61EmcwZGINLy3eQfhBk+gDbeGjjcORoru53tZq3tbN+CpN6A2ZYEI6wkS076AmZ6H2gdL7m6rl4155n3nd9M0L6Dj13gxBFiEtxZPduLTx17Nj1lQe2XvPdi3UrvhBmZIXzTH4vb+IaAk4Z09kZqWdy/I/7I3xD4zi+Sn74fOf+w4cJiFMXC5NRC/MtmXQNgCupoMTS6E8Kr2EPXjI7av7Epy46np9d/48Wzoxpk9m8Vlcs6VfSM/zM+YK5NBrA2h7n1ewFFiFn4siR3dq8UxroCydz43XR6hbTYs0zMgrd1j3lGQfthXewbukN/D67DV8Wg2g0JxGu2PjD4Gmjb7MU0TVG2JnEQ+QjHY1eUcE7c/4WZMJYLCFdJVUs9lSNrcFxnKpTEdxf/S/QGMFb4+0YvVVF08QNFNI3kfn6MlqXMViVKYq/CWOpXb3KcVvbaZtKQyq43e5kMkDqiMPVc6WABk0NOYeVr+D8uRZ8rK3GW2M5ii8PWAW0BGeAL7NY+zRHy/1MongTFy+JjmYXxi39IiBzsPQtkSC9xKpDeZqmDZ1pKJYsrOFj6F1dQZnKOvRFhSxzYBP/gDNpSr2mhHoub827URCzV/AOXa9ADjBSF7WKyc6WyIddsblHN7CyLosXmkbwessp9NcfxyMNF8CsEhAqoufBgrSmJ7Spf2exbHzqM3U+OcD0hTK+QxdpO9LeruaiXHSGKoy/XCeZ5mNSWEUvn65K/OubCo5dWIYRGGQ2jV9uz6M5+A2yKcbGz4Qw8RFLNf1GocRA1M+3OyC0lE6lXEX0X/h6+M/R+z4JMK1XQNh+SG/Iy7Ci3oP16wVWOzk83FjFj4k6+6xRLd3UvZcus/T0tH1VeR5OJkVMDWbb3ZeRFpOM6TEp7cPL71vv0ZEMh7R6j19aAZ/Q/TWSMQ9RrTH4gqA8mWNOMc/EDKvmynzP02dGjyrK41LedRm/B+KCq9qQ4a/uWb73fp/njRUhrdbrIzEQSx4CIXAlPNi2jut528yUir/49Wjmr+qski4xP1ty19vty6g2+vv750UwKKVzkGJ+E/hoSy54YJMVONjo0x8NGIxeYHqamHRI8Pm0Jb86fs164xNk3//7qlXGo/v2Vcm/GBgYcH3F4/HbGSnQxTrFwAcBDTE3kIaHgQ374O97LrRs/25/Xd8m1HaSTVidTcRi+pyP2ILx3No8XV1du5boetEwTa4ZhriVSCTc2387YaD5iSeWX+vomJTxuDW3tvDbvn37PZX0kvLnnw9anTt31gYtyzM0NDShbNy0uru3doBXfiuEtlXX8bhpGrVqs6enhyoBbNmyfW1TvnJo56cnIkQ6d7vamG203xqw5M/r66f6lC+jaD1pWax9x44dAWXiZtLVtW0XHd1HN/QQpfggqSZCXw+TnKJ2VJlDkqGRIjpF7EQllxeZQIBKqZEQ3rEs+RQF+AFj9o8458+S/i5xLv5GbFxT9XYzob+0Q5VxqGZ0jK2CkPQayRKFsIkAghR5iJ67UQHZKrg8yQTZgO2iqm4gSm6Rm7qTJz+9Sd8yBXdKCP4XW/CDmzc/tobm0gXhghnEwYmRkePnaE1h5yiis6SIMYr6Mrj8JzktkHGa7DZSpA2ksMvEhN3d3RsRHKeJsr0USCtJ+4au236yy2qa5lV0uTee9H7CMEy/Sq27+6dvcm4ZmUx4LBzOXHIcTwsBX6WDOavq9XKv2CA05wNb09K+quZXF2Ik8dlQLLbtEcacDE3H6Unt5ODvDg8fu6p8qrfye5eH1v6v7Vsdiw9i1H14XAAAAABJRU5ErkJggg=='  // jshint ignore:line
+    },
+    {
+      type: 'image/gif',
+      width: 25,
+      height: 24,
+      base64: 'R0lGODlhGQAYAPcAAAAAPAANPT0AM3oQF2MpLmksMWNFL3pnOwAASAAAViMhTD09Qj09Qz89Qjw+Qjw+Qz0+Qz0/Qz4+Qz0+RD4+RCInVgAndAAleScwZiMxalc1XmZSXm9UXmJMZHl6dpEWHJAYG5wbHZsfHIogHqIhHaMlHKMmHKQkHawjH6EsH6spHrIrH7MzH7YyH7gyH7k0Hrs0Hr03H74+GLs6HoQpJZU/KZ88KrEoILYqIKA0JbU/ILo6ILA/LcE6HcI7H8E9HcM+HsQ9H8E1IMA5I8s9IL9EDqxJKr5EILpTLZtmNdpUAMNCH8VDHsZEH8tDHMZPHMxPGctLHcxIHM1JH81PHs5PHshQH9NXHdRaHtloANp4B8RnHMJEIMVFIchNIdBDINdLIcVUIctTIs5YJMxcJMVmI89kJsdoJc5rIdhyINB9I8d+Pr56XpN0eaBgcruWL92YGuGMANyiGe23FsmUKfHLIffbNP7kKraSSquDYaScfN63TNfNevDeZP/8a//vcPrtdwArhQAuhCY9ghVEmCNDjDBKkyhRnTJWnABMpBFdriJlsy5vtzh8u1BajV9ikktoolNwrB56wRx6w4BojASP1iKG0S6O0DCJ1yOR2TCW32icxlag2lWg33Gj2ESf4kKg50eh5lal41Ok5Vul5Fuo5d3Vi//6iu3dtP//v42ZwLnHzr/HzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAK0AIf8LSUNDUkdCRzEwMTL/AAAHqGFwcGwCIAAAbW50clJHQiBYWVogB9kAAgAZAAsAGgALYWNzcEFQUEwAAAAAYXBwbAAAAAAAAAAAAAAAAAAAAAAAAPbWAAEAAAAA0y1hcHBsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALZGVzYwAAAQgAAABvZHNjbQAAAXgAAAVsY3BydAAABuQAAAA4d3RwdAAABxwAAAAUclhZWgAABzAAAAAUZ1hZWgAAB0QAAAAUYlhZWgAAB1gAAAAUclRSQwAAB2wAAAAOY2hhZAAAB3wAAAAsYlRSQwAAB2wAAAAOZ1RS/0MAAAdsAAAADmRlc2MAAAAAAAAAFEdlbmVyaWMgUkdCIFByb2ZpbGUAAAAAAAAAAAAAABRHZW5lcmljIFJHQiBQcm9maWxlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABtbHVjAAAAAAAAAB4AAAAMc2tTSwAAACgAAAF4aHJIUgAAACgAAAGgY2FFUwAAACQAAAHIcHRCUgAAACYAAAHsdWtVQQAAACoAAAISZnJGVQAAACgAAAI8emhUVwAAABYAAAJkaXRJVAAAACgAAAJ6bmJOTwAAACYAAAKia29LUgAAABYAAP8CyGNzQ1oAAAAiAAAC3mhlSUwAAAAeAAADAGRlREUAAAAsAAADHmh1SFUAAAAoAAADSnN2U0UAAAAmAAAConpoQ04AAAAWAAADcmphSlAAAAAaAAADiHJvUk8AAAAkAAADomVsR1IAAAAiAAADxnB0UE8AAAAmAAAD6G5sTkwAAAAoAAAEDmVzRVMAAAAmAAAD6HRoVEgAAAAkAAAENnRyVFIAAAAiAAAEWmZpRkkAAAAoAAAEfHBsUEwAAAAsAAAEpHJ1UlUAAAAiAAAE0GFyRUcAAAAmAAAE8mVuVVMAAAAmAAAFGGRhREsAAAAuAAAFPgBWAWEAZQBvAGIAZQD/YwBuAP0AIABSAEcAQgAgAHAAcgBvAGYAaQBsAEcAZQBuAGUAcgBpAQ0AawBpACAAUgBHAEIAIABwAHIAbwBmAGkAbABQAGUAcgBmAGkAbAAgAFIARwBCACAAZwBlAG4A6AByAGkAYwBQAGUAcgBmAGkAbAAgAFIARwBCACAARwBlAG4A6QByAGkAYwBvBBcEMAQzBDAEOwRMBD0EOAQ5ACAEPwRABD4ERAQwBDkEOwAgAFIARwBCAFAAcgBvAGYAaQBsACAAZwDpAG4A6QByAGkAcQB1AGUAIABSAFYAQpAadSgAIABSAEcAQgAggnJfaWPPj/AAUAByAG8AZgBp/wBsAG8AIABSAEcAQgAgAGcAZQBuAGUAcgBpAGMAbwBHAGUAbgBlAHIAaQBzAGsAIABSAEcAQgAtAHAAcgBvAGYAaQBsx3y8GAAgAFIARwBCACDVBLhc0wzHfABPAGIAZQBjAG4A/QAgAFIARwBCACAAcAByAG8AZgBpAGwF5AXoBdUF5AXZBdwAIABSAEcAQgAgBdsF3AXcBdkAQQBsAGwAZwBlAG0AZQBpAG4AZQBzACAAUgBHAEIALQBQAHIAbwBmAGkAbADBAGwAdABhAGwA4QBuAG8AcwAgAFIARwBCACAAcAByAG8AZgBpAGxmbpAaACAAUgBHAEIAIGPPj//wZYdO9k4AgiwAIABSAEcAQgAgMNcw7TDVMKEwpDDrAFAAcgBvAGYAaQBsACAAUgBHAEIAIABnAGUAbgBlAHIAaQBjA5MDtQO9A7kDugPMACADwAPBA78DxgOvA7sAIABSAEcAQgBQAGUAcgBmAGkAbAAgAFIARwBCACAAZwBlAG4A6QByAGkAYwBvAEEAbABnAGUAbQBlAGUAbgAgAFIARwBCAC0AcAByAG8AZgBpAGUAbA5CDhsOIw5EDh8OJQ5MACAAUgBHAEIAIA4XDjEOSA4nDkQOGwBHAGUAbgBlAGwAIABSAEcAQgAgAFAAcgBvAGYAaQBsAGkAWQBsAGX/AGkAbgBlAG4AIABSAEcAQgAtAHAAcgBvAGYAaQBpAGwAaQBVAG4AaQB3AGUAcgBzAGEAbABuAHkAIABwAHIAbwBmAGkAbAAgAFIARwBCBB4EMQRJBDgEOQAgBD8EQAQ+BEQEOAQ7BEwAIABSAEcAQgZFBkQGQQAgBioGOQYxBkoGQQAgAFIARwBCACAGJwZEBjkGJwZFAEcAZQBuAGUAcgBpAGMAIABSAEcAQgAgAFAAcgBvAGYAaQBsAGUARwBlAG4AZQByAGUAbAAgAFIARwBCAC0AYgBlAHMAawByAGkAdgBlAGwAcwBldGV4dAAAAABDb3B5cmlnaHQgMjAwrzcgQXBwbGUgSW5jLiwgYWxsIHJpZ2h0cyByZXNlcnZlZC4AWFlaIAAAAAAAAPNSAAEAAAABFs9YWVogAAAAAAAAdE0AAD3uAAAD0FhZWiAAAAAAAABadQAArHMAABc0WFlaIAAAAAAAACgaAAAVnwAAuDZjdXJ2AAAAAAAAAAEBzQAAc2YzMgAAAAAAAQxCAAAF3v//8yYAAAeSAAD9kf//+6L///2jAAAD3AAAwGwALAAAAAAZABgAAAj+AFsJHEiwoMGDCBMqJEgK1KhSojotPGgJ0yZOoUJp8rRqokAmbijl0VMp0yVJi1ih8nhESZY4bSI1msQokapUfSZSEWNGTRk2kBQhIlTIlJ+FVMBYIaNlzaNDhgZZcMTn1B6FTb54eWKkgyBBFzIk8ADoDx6FM4h06WFEAwYOGyogOGDnDh2FLIT8AAIlDJItSRQEeFNnzkQVMIA0mUFDAAAABuTAKTORBI4WPrrkKECgBpo0Y3J4DHFjxw8nUqJcwUJlh0eBH1CseBEDyJAhKV4PHABCxAkTJkboHk7c44ODx3UnJ/jg+HKCGgxGaNW8lYYHFKhTjzC9YHfmxx0KFHTAvbj58wIDAgA7'  // jshint ignore:line
+    },
+    {
+      type: 'image/bmp',
+      width: 25,
+      height: 24,
+      base64: 'Qk1WBwAAAAAAADYAAAAoAAAAGQAAABgAAAABABgAAAAAACAHAAATCwAAEwsAAAAAAAAAAAAAAAAA////////////////////////////////////////////////////////////////////////////////////////////////AP///0c5OUBAQAAAAEY+PkBAQFUrK0BAQEU9PUQ8PEBAQEY6OkRAPEBAOkNDNkY+Pkc9Pf///0M/P0BAQEBAQERAPEY+Pv///wAAAAD///9DPT1DPj7///9CPjxEPj5DPz9CPT1CPzxDQD1EPz1CPj5DPz1CPT1CPjxDPjxHPT1EQDxEPj5DPj5CPz9AQEBDPj5EPj7///8A////Qj87Qj48QTw8Qz89Qj09QT09Qz49Qz09RD49Qz89Qj48Qj87Qz09Qz09Qz48////RD4+////Qz09Qj09RDw8Qj48QTs7////AP///0M8PEM+PUM9PUI8PEM/PUI+PEQ9PUE9PUM9PUM+PEM+PkM9PUI/PEI9PUM+PkNDQ0I9PUU7O0E8PEM+PkI+PkBAQP///wAAAAD///9CPT1DPjxDPj5CPT1HOTn///9AQED///9EPj5CPT9COkoAAP8AAP////////////9EPj5DPj5EPj5CPT1DPj5EPT1GRkb///8A////////Szw8QEBAQjk5QEBA////////////////SkoggIAA////////////////////////REQzVSsr////SUk3Q0ND////////AP///////////////////////wAAAAAAqgBAAAAAAAAAMgoAXBcNaBAKVg4AOwAAAP///0BAv////////0BAQP///////////////wD///8AAABVVVVVVVVVVVX///8AAGYAAAAMAD8XEHobGJAcH5sdJKQcJaMcJqMeIIoYAEgAAAAkJEmAgID///+AgICAgID///////8A////////////////////AAD/////Fw5xHBaRHyOsHyuyHzK4Hze9HzvCHz3EIznAHyyhFCKM////////AAAA////////////////AP///////////////wAAv////x0Xlx0bnCAosR8yth06wRxDyxxIzB1Lyx1X0x5a1B9JzSA6uiIxrP///wAAgP///////////////wD///////////8AAID///////8dIaIgKrYeNLkePsMgRMIqPJ8xLGkuKWMpP5Uha84gctgkWM4lNKAhC5D///8AAID///////////8A////////////MzOZ////HCiqHimrHjS7Hj7DH0TGID+1JSmEMwA9PAAAPAAAL0VjGaLcGpjdI2bFJBuy////QEC/////////////AP///////wAA/wAAgP///x8zsyA1wR09wR9CwxlPzCFUxS1TuhxnxDVmm0whIz0NAC+WuyHL8Ra37Rh84P///wCAv////////////wD///////8AgP////////8eOrsgPcshRcUYPr4tP7BeNVdmMCdeVG9eUmZWJyJIAAA7Z3o02/cq5P4plMn///////8AAP////////8A////////AID/////////HkPFIEPQIU3IHE/GKkmsZExihC4AhSsAeSUAajEjVgAAdnp5d+36cO//SpK2////////AP//////////AP///////wD//////////x5PzSFL1x9QyCRczAd42j5+x5JiX51RKJNKMII9JnQnAI1aUHrN14r6/0y33v///////wAAAP///////wD///////////8AQL////8dVdUeT84iU8smZM8jfdAlaMdeer6iaEuuXRGcVjKYRBWMQyOL1d1r/P8A6vz///8zzMz///////////8A////////////AEC/////IjOqIES+AFTaAGjZAIzheXSTrHBTu3w4w3oct28upEwAwJmNv///ZN7wANbr////Vaqq////////////AP///////////wCA/////1VVqg5Ev3JgoIxogGGDq3ycpNaPBNmRI9COLsF6HrNlIszHv7Td7Wedx////////////////////////wD///////////////////////8AY+/BlHXRhiLXiTDGnGjaoFbmoUfin0TfljDYo3HOx7mfpsL///////8AAP////////////////8A/////////////////////////////////9eu5KVb56BC5aRT5ahb46VW36BV57qG/+Nx////////AAD/////////////////////AP///////////////////////wCA/7+AgP//////////0fO/eu22bfO7dv//tv///////8zMzP///////////////////////////wD/////////////////////////////////qlWqVQD///////////////////+/v4D/qqr///////////////////////////////8A'  // jshint ignore:line
+    }
+  ];
+
+  suite('MIME type constants', function() {
+    test('JPEG', function() { assert.equal(ImageUtils.JPEG, 'image/jpeg'); });
+    test('PNG', function() { assert.equal(ImageUtils.PNG, 'image/png'); });
+    test('GIF', function() { assert.equal(ImageUtils.GIF, 'image/gif'); });
+    test('BMP', function() { assert.equal(ImageUtils.BMP, 'image/bmp'); });
+  });
+
+
+  suite('getSizeAndType', function() {
+
+    function makeBlobFromString(binaryString, type) {
+      var buffer = new ArrayBuffer(binaryString.length);
+      var bytes = new Uint8Array(buffer);
+      for (var i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      return new Blob([buffer], { type: type });
+    }
+
+    suiteSetup(function() {
+      // Create blobs for each of the test images
+      testImages.forEach(function(image) {
+        image.blob = makeBlobFromString(atob(image.base64), image.type);
+      });
+    });
+
+    test('rejects string argument', function(done) {
+      ImageUtils.getSizeAndType('data:foo').then(null, function() { done(); });
+    });
+
+    test('rejects numeric argument', function(done) {
+      ImageUtils.getSizeAndType(1).then(null, function() { done(); });
+    });
+
+    test('rejects object argument', function(done) {
+      ImageUtils.getSizeAndType({size:100}).then(null, function() { done(); });
+    });
+
+    // Test that we can get the width and height of each test image
+    testImages.forEach(function(image) {
+      test(image.type, function(done) {
+        ImageUtils.getSizeAndType(image.blob).then(function resolve(data) {
+          try {
+            assert.equal(data.type, image.type);
+            assert.equal(data.width, image.width);
+            assert.equal(data.height, image.height);
+            done();
+          }
+          catch (e) {
+            done(e);
+          }
+        }, function reject(e) { done(new Error(e)); });
+      });
+    });
+
+    // Test that we can get the size of a JPEG file even if it has a large
+    // EXIF metadata segment before the segments that hold image size.
+    test('jpeg with large EXIF segments', function(done) {
+      // Splice some fake EXIF data in at the start of the JPEG file
+      // to force the image size data to be beyond the 32kb boundary
+      var jpeg = testImages[0];
+      var exif = new ArrayBuffer(40 * 1024);
+      var view = new DataView(exif);
+      view.setUint8(0, 0xFF);
+      view.setUint8(1, 0xE0); // APP0 segment for EXIF
+      view.setUint16(2, (40 * 1024) - 2);
+      var newblob = new Blob([jpeg.blob.slice(0, 2),
+                              exif, exif, jpeg.blob.slice(2)],
+                             { type: 'image/jpeg' });
+      ImageUtils.getSizeAndType(newblob).then(
+        function resolve(data) {
+          try {
+            assert.equal(data.type, jpeg.type);
+            assert.equal(data.width, jpeg.width);
+            assert.equal(data.height, jpeg.height);
+            done();
+          }
+          catch (e) {
+            done(e);
+          }
+        },
+        function reject(e) {
+          done(new Error(e));
+        }
+      );
+    });
+
+    test('reject zero-length blob', function(done) {
+      var empty = new Blob([''], { type: 'image/jpeg' });
+      ImageUtils.getSizeAndType(empty).then(
+        function resolve() {
+          done(new Error('failed to reject an empty blob'));
+        },
+        function reject() {
+          done();
+        }
+      );
+    });
+
+    test('reject any blob < 16 bytes', function(done) {
+      var empty = new Blob(['0123456789012345'], { type: 'image/jpeg' });
+      ImageUtils.getSizeAndType(empty).then(
+        function resolve() {
+          done(new Error('failed to reject a short blob'));
+        },
+        function reject() {
+          done();
+        }
+      );
+    });
+
+
+    // Test that if we truncate the test images we can't get their size
+    testImages.forEach(function(image) {
+      // We can't meaningfully test truncated gif files
+      if (image.type === 'image/gif') {
+        return;
+      }
+
+      test('reject truncated ' + image.type, function(done) {
+        var truncated = image.blob.slice(0, 20);
+        ImageUtils.getSizeAndType(truncated).then(
+          function resolve(data) {
+            done(new Error('failed to reject a truncated blob'));
+          },
+          function reject() {
+            done();
+          }
+        );
+      });
+    });
+
+    // Here are some files that are not image files and should be rejected
+    var bogusFiles = [
+      'This is a text file not an image file. It does not have a size',
+      'GIF85a This is not a gif: the header is not correct',
+      '\xff\xd8 Not a jpeg file because it does not have segments',
+      'BM not really a BMP file since. File length data is not correct',
+      '\x89PNG\r\n\x1a\n Not a PNG file: does not have an ihdr segment'
+    ];
+
+    bogusFiles.forEach(function(file, index) {
+      test('Reject bogus file ' + index, function(done) {
+        var bogus = makeBlobFromString(file, 'text/plain');
+        ImageUtils.getSizeAndType(bogus).then(
+          function resolve(data) {
+            done(new Error('failed to reject bogus text:' + file));
+          },
+          function reject() {
+            done();
+          }
+        );
+      });
+    });
+
+  });
+
+  suite('Downsample tests', function() {
+    test('Check API', function() {
+      assert.typeOf(ImageUtils.Downsample, 'object');
+      assert.typeOf(ImageUtils.Downsample.sizeAtLeast, 'function');
+      assert.typeOf(ImageUtils.Downsample.sizeNoMoreThan, 'function');
+      assert.typeOf(ImageUtils.Downsample.areaAtLeast, 'function');
+      assert.typeOf(ImageUtils.Downsample.areaNoMoreThan, 'function');
+      assert.typeOf(ImageUtils.Downsample.MAX_SIZE_REDUCTION, 'number');
+      assert.typeOf(ImageUtils.Downsample.MAX_AREA_REDUCTION, 'number');
+      assert.typeOf(ImageUtils.Downsample.NONE, 'object');
+      assert.equal(ImageUtils.Downsample.NONE.dimensionScale, 1);
+      assert.equal(ImageUtils.Downsample.NONE.areaScale, 1);
+      assert.equal(ImageUtils.Downsample.NONE.toString(), '');
+    });
+
+    var scales = [
+      10, 2, 1,
+      1 / 8, 2 / 8, 3 / 8, 4 / 8, 5 / 8, 6 / 8, 7 / 8,
+      0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1,
+      0.09, 0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.01
+    ];
+
+    // This is the same function we use in downsample.js
+    function round(x) {
+      return Math.round(x * 100) / 100;
+    }
+
+    test('sizeAtLeast', function() {
+      var min = 1 / ImageUtils.Downsample.MAX_SIZE_REDUCTION;
+      scales.forEach(function(scale) {
+        var ds = ImageUtils.Downsample.sizeAtLeast(scale);
+        assert.operator(ds.dimensionScale, '<=', round(Math.max(scale, min)));
+        assert.equal(ds.scale(100), ds.dimensionScale * 100);
+        assert.ok(ds === ImageUtils.Downsample.NONE ||
+                  ds.toString()[0] === '#');
+      });
+    });
+
+    test('areaAtLeast', function() {
+      var min = 1 / ImageUtils.Downsample.MAX_AREA_REDUCTION;
+      scales.forEach(function(scale) {
+        var ds = ImageUtils.Downsample.areaAtLeast(scale);
+        assert.operator(ds.areaScale, '<=', round(Math.max(scale, min)));
+
+        ds = ImageUtils.Downsample.areaAtLeast(scale * scale);
+        assert.operator(ds.areaScale, '<=',
+                        round(Math.max(scale * scale, min)));
+        assert.equal(ds.scale(100), ds.dimensionScale * 100);
+        assert.ok(ds === ImageUtils.Downsample.NONE ||
+                  ds.toString()[0] === '#');
+      });
+    });
+
+    test('sizeNoMoreThan', function() {
+      scales.forEach(function(scale) {
+        var ds = ImageUtils.Downsample.sizeNoMoreThan(scale);
+        assert.operator(ds.dimensionScale, '>=', round(Math.min(scale, 1)));
+        assert.equal(ds.scale(100), ds.dimensionScale * 100);
+        assert.ok(ds === ImageUtils.Downsample.NONE ||
+                  ds.toString()[0] === '#');
+      });
+    });
+
+    test('areaNoMoreThan', function() {
+      scales.forEach(function(scale) {
+        var ds = ImageUtils.Downsample.areaNoMoreThan(scale);
+        assert.operator(ds.areaScale, '>=', round(Math.min(scale, 1)));
+
+        ds = ImageUtils.Downsample.areaNoMoreThan(scale * scale);
+        assert.operator(ds.areaScale, '>=', round(Math.min(scale * scale, 1)));
+        assert.equal(ds.scale(100), ds.dimensionScale * 100);
+        assert.ok(ds === ImageUtils.Downsample.NONE ||
+                  ds.toString()[0] === '#');
+      });
+    });
+
+    test('max reduction amounts', function() {
+      var ds = ImageUtils.Downsample.sizeNoMoreThan(0);
+      assert.equal(ds.dimensionScale,
+                   round(1 / ImageUtils.Downsample.MAX_SIZE_REDUCTION));
+      assert.equal(ds.areaScale,
+                   round(1 / ImageUtils.Downsample.MAX_AREA_REDUCTION));
+    });
+  });
+
+
+  function runResizeAndCropToCoverTests(imageWidth, imageHeight, imageType) {
+    var suitename = 'resizeAndCropToCover ' + imageType + ' ' +
+      imageWidth + 'x' + imageHeight;
+    suite(suitename, function() {
+      const W = imageWidth, H = imageHeight;  // The size of the test image
+      const inputImageType = imageType;
+
+      suiteSetup(function(done) {
+        // We begin by creating a special image where each pixel value
+        // encodes the coordinates of that pixel. This allows us to inspect
+        // the pixels in the output image to verify that cropping
+        // was done correctly.
+        var canvas = document.createElement('canvas');
+        canvas.width = W;
+        canvas.height = H;
+        var context = canvas.getContext('2d');
+        var imageData = context.createImageData(W, H);
+        var pixels = imageData.data;
+
+        for (var x = 0; x < canvas.width; x++) {
+          for (var y = 0; y < canvas.height; y++) {
+            var offset = (x + y * canvas.width) * 4;
+            pixels[offset] = x;   // Encode x coordinate as red value
+            pixels[offset + 1] = y; // Encode y coodrdinate as green value
+            imageData.data[offset + 3] = 255; // Make it opaque
+          }
+        }
+
+        context.putImageData(imageData, 0, 0);
+
+        // Create an encoded version of the input image
+        var self = this;
+        canvas.toBlob(function(blob) {
+          self.inputBlob = blob;
+          done();
+        }, inputImageType);
+      });
+
+      // Decode the image blob and verify that its size is as expected and
+      // that its upper-left pixel has red and green values near r0 and g0
+      // and that its lower-right pixel has values near r1 and g1. We do a
+      // fuzzy match because jpeg is a lossy format and because sometimes
+      // we're working with downsampled or upscaled images.
+      function verifyImage(blob, expectedWidth, expectedHeight,
+                           r0, g0, r1, g1, tolerance, callback) {
+        var image = new Image();
+        var url = URL.createObjectURL(blob);
+        image.src = url;
+        image.onerror = function() {
+          callback(Error('failed to load image from blob'));
+        };
+
+        image.onload = function() {
+          try {
+            assert.equal(image.width, expectedWidth, 'image width');
+            assert.equal(image.height, expectedHeight, 'image height');
+
+            var canvas = document.createElement('canvas');
+            canvas.width = image.width;
+            canvas.height = image.height;
+            var context = canvas.getContext('2d');
+            context.drawImage(image, 0, 0);
+            var imageData = context.getImageData(0, 0,
+                                                 canvas.width, canvas.height);
+            var pixels = imageData.data;
+
+            isNear(pixels[0], r0, 'red component of upper-left');
+            isNear(pixels[1], g0, 'green component of upper-left');
+
+            var offset = 4 * (image.width * image.height - 1);
+            isNear(pixels[offset], r1,
+                   'red component of lower right');
+            isNear(pixels[offset + 1], g1,
+                   'green component of lower right');
+
+            image.src = '';
+            URL.revokeObjectURL(url);
+            canvas.width = 0;
+            callback();
+          }
+          catch (e) {
+            callback(e);
+          }
+        };
+
+        // Return true if x is close enough to the target
+        function isNear(x, target, message) {
+          if (target - tolerance <= x && x <= target + tolerance) {
+            return;
+          }
+          throw Error(message + ' ' + x + ' is not near ' + target);
+        }
+      }
+
+      test('test images created', function(done) {
+        assert.instanceOf(this.inputBlob, Blob, 'got Blob');
+        assert.equal(this.inputBlob.type, inputImageType);
+        verifyImage(this.inputBlob, W, H, 0, 0, W - 1, H - 1, 4, done);
+      });
+
+      test('throw for invalid input', function() {
+        var self = this;
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover();
+        }, 'no arguments');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover('not a blob');
+        }, 'not a blob');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob);
+        }, 'no dimensions');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, 0, 10);
+        }, 'zero width');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, 10, 0);
+        }, 'zero height');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, -10, 10);
+        }, 'negative width');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, 10, -10);
+        }, 'negative height');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, Infinity, 10);
+        }, 'infinite width');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, 10, Infinity);
+        }, 'infinite height');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, {}, 10);
+        }, 'NaN width');
+        assert.throws(function() {
+          ImageUtils.cropAndResizeToCover(self.inputBlob, 10, {});
+        }, 'NaN height');
+      });
+
+      // Verify that if the output size is the same as the input size then
+      // the output blob is the same as the input blob
+      test('input returned if no resize needed', function(done) {
+        var self = this;
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W, H).then(
+          function resolve(outputBlob) {
+            try {
+              assert.equal(self.inputBlob, outputBlob);
+              done();
+            }
+            catch (ex) {
+              done(ex);
+            }
+          });
+      });
+
+      test('unspecified output type', function(done) {
+        var self = this;
+        ImageUtils.resizeAndCropToCover(this.inputBlob, 10, 10)
+          .then(function resolve(outputBlob) {
+            assert.equal(outputBlob.type, self.inputBlob.type);
+            done();
+          });
+      });
+
+      test('jpeg output type', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, 10, 10, ImageUtils.JPEG)
+          .then(function resolve(outputBlob) {
+            assert.equal(outputBlob.type, ImageUtils.JPEG);
+            done();
+          });
+      });
+
+      test('png output type', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, 10, 10, ImageUtils.PNG)
+          .then(function resolve(outputBlob) {
+            assert.equal(outputBlob.type, ImageUtils.PNG);
+            done();
+          });
+      });
+
+      test('shrink no crop', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W / 3, H / 3)
+          .then(function resolve(outputBlob) {
+            verifyImage(outputBlob, Math.round(W / 3), Math.round(H / 3),
+                        0, 0, W, H, 4, done);
+          });
+      });
+
+      test('enlarge no crop', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W * 3, H * 3)
+          .then(function resolve(outputBlob) {
+            verifyImage(outputBlob, W * 3, H * 3, 0, 0, W, H, 4, done);
+          });
+      });
+
+      var delta = 100;
+
+      test('reduce height', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W, H - delta)
+          .then(function resolve(outputBlob) {
+            verifyImage(outputBlob, W, H - delta,
+                        0, delta / 2, W, H - delta / 2, 4, done);
+          });
+      });
+
+      test('reduce width', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W - delta, H)
+          .then(function resolve(outputBlob) {
+            verifyImage(outputBlob, W - delta, H,
+                        delta / 2, 0, W - delta / 2, H, 4, done);
+          });
+      });
+
+      test('enlarge height', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W, H + delta)
+          .then(function resolve(outputBlob) {
+            var ratio = (H + delta) / H;
+            var margin = ((ratio - 1) * W) / (2 * ratio);
+            verifyImage(outputBlob, W, H + delta,
+                        margin, 0, W - margin, H,
+                        4, done);
+          });
+      });
+
+      test('enlarge width', function(done) {
+        ImageUtils.resizeAndCropToCover(this.inputBlob, W + delta, H)
+          .then(function resolve(outputBlob) {
+            var ratio = (W + delta) / W;
+            var margin = ((ratio - 1) * H) / (2 * ratio);
+            verifyImage(outputBlob, W + delta, H,
+                        0, margin, W, H - margin,
+                        4, done);
+          });
+      });
+
+      suite('#-moz-samplesize', function() {
+        setup(function() {
+          this.spy = sinon.spy(ImageUtils.Downsample, 'sizeNoMoreThan');
+        });
+        teardown(function() {
+          this.spy.restore();
+        });
+
+        if (inputImageType === 'image/jpeg') {
+          test('uses it at half size', function() {
+            ImageUtils.resizeAndCropToCover(this.inputBlob, W / 2, H / 2)
+              .then(function resolve(outputBlob) {
+                assert.okay(this.spy.calledOnce);
+                assert.equal(this.spy.returnValues[0].toString(),
+                             '#-moz-samplesize=2');
+              });
+          });
+
+          test('uses it at third size', function() {
+            ImageUtils.resizeAndCropToCover(this.inputBlob, W / 3, H / 3)
+              .then(function resolve(outputBlob) {
+                assert.okay(this.spy.calledOnce);
+                assert.equal(this.spy.returnValues[0].toString(),
+                             '#-moz-samplesize=3');
+              });
+          });
+          test('uses it at fifth size', function() {
+            ImageUtils.resizeAndCropToCover(this.inputBlob, W / 5, H / 5)
+              .then(function resolve(outputBlob) {
+                assert.okay(this.spy.calledOnce);
+                assert.equal(this.spy.returnValues[0].toString(),
+                             '#-moz-samplesize=4');
+              });
+          });
+
+          test('does not use at three quarters size', function() {
+            ImageUtils.resizeAndCropToCover(this.inputBlob, W * 0.75, H * 0.75)
+              .then(function resolve(outputBlob) {
+                assert.okay(this.spy.calledOnce);
+                assert.equal(this.spy.returnValues[0].toString(),
+                             '');
+              });
+          });
+        }
+        else {
+          test('does not use for non-jpeg', function() {
+            ImageUtils.resizeAndCropToCover(this.inputBlob, W / 2, H / 2)
+              .then(function resolve(outputBlob) {
+                assert.okay(this.spy.notCalled);
+              });
+          });
+        }
+      });
+    });
+  }
+
+
+  // We run the resizeAndCropToCover test suite six times for for three
+  // different input image sizes and two different input image types
+  ([
+    [240, 180],   // 4x3
+    [180, 240],   // 3x4
+    [250, 250]   // square
+  ]).forEach(function(size) {
+    runResizeAndCropToCoverTests(size[0], size[1], 'image/jpeg');
+    runResizeAndCropToCoverTests(size[0], size[1], 'image/png');
+  });
+});

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -100,6 +100,9 @@
     <script defer src="js/system_banner.js"></script>
     <script defer src="js/home_gesture.js"></script>
     <script defer src="js/wallpaper_manager.js"></script>
+    <!--  WallpaperManager lazily loads this script if needed
+        <script defer src="shared/js/image_utils.js"></script>
+    -->
 
     <!-- TTL View -->
     <link rel="stylesheet" type="text/css" href="style/ttlview/ttlview.css">

--- a/apps/system/js/wallpaper_manager.js
+++ b/apps/system/js/wallpaper_manager.js
@@ -1,22 +1,47 @@
 /* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-/* global SettingsURL, SettingsListener, System */
+/* global System, ImageUtils, LazyLoader */
 
 'use strict';
 
 (function(exports) {
 
-  /**
-  * This system module monitors settings change of wallpaper,
-  * gets a blob URL from that wallpaper image source,
-  * and broadcasts the URL for related modules to change
-  * their (for example) background image.
-  *
-  * @class WallpaperManager
-  *
-  */
+  const WALLPAPER_KEY = 'wallpaper.image';
+  const WALLPAPER_VALID_KEY = 'wallpaper.image.valid';
+  const DEFAULT_WALLPAPER_URL = 'resources/images/backgrounds/default.png';
 
+  /**
+   * This system module reads the system wallpaper setting on startup
+   * and monitors changes to that setting, broadcasting a
+   * 'wallpaperchange' event with a blob: URL to tell the system and
+   * lockscreen about the new wallpaper.
+   *
+   * If the wallpaper value read from the settings DB is a URL this
+   * module converts it to a blob. If the wallpaper image does not
+   * exactly match the size of the screen, this module resizes it
+   * (lazy-loading shared/js/image_utils.js when needed). If the
+   * wallpaper value is converted to a blob or resized, the modified
+   * value is saved back to the settings DB so that it will not need
+   * to be modified the next time it is read.
+   *
+   * start(), stop(), and getBlobURL() are the only public methods,
+   * and stop() is only exposed for the benefit of unit
+   * tests. _setWallpaper() is called on startup and whenever the
+   * wallpaper.image setting changes. Each call to _setWallpaper()
+   * eventually causes a call to _publish() which broadcasts the new
+   * wallpaper event to the lockscreen and the rest of the system
+   * app. The call to _publish() does not always happen directly,
+   * however: _setWallpaper() may call _checkSize(), which calls
+   * _publish(), or it may call _toBlob() which calls _checkSize().
+   * Unless the build is mis-configured and the wallpaper in the
+   * settings db and the fallback default wallpaper is broken, every
+   * call to _setWallpaper() ends up broadcasting a 'wallpaperchange'
+   * event with a valid blob: url for a wallpaper image that has the
+   * same size as the screen.
+   *
+   * @class WallpaperManager
+   */
   function WallpaperManager() {
     this._started = false;
     this._blobURL = null;
@@ -24,34 +49,304 @@
 
   WallpaperManager.prototype = {
     /**
-     * Bootstrap the module, begin listening to wallpaper events
+     * Bootstrap the module. Read the current wallpaper from the
+     * settings db and pass it to _setWallpaper(). Also listen for
+     * changes to the wallpaper and invoke _setWallpaper() for each
+     * one.
      */
     start: function() {
       if (this._started) {
         throw 'Instance should not be start()\'ed twice.';
       }
       this._started = true;
+      debug('started');
 
-      var wallpaperURL = new SettingsURL();
+      // Query the wallpaper
+      var lock = navigator.mozSettings.createLock();
+      var query = lock.get(WALLPAPER_KEY);
+      query.onsuccess = function() {
+        var wallpaper = query.result[WALLPAPER_KEY];
+        if (!wallpaper) {
+          debug('no wallpaper found at startup; using default');
+          this._setWallpaper(DEFAULT_WALLPAPER_URL);
+        }
+        else if (wallpaper instanceof Blob) {
+          // If the wallpaper is a blob, first go see if we have already
+          // validated it size. Because if we have, we don't have to check
+          // the size again or even load the code to check its size.
+          var query2 = lock.get(WALLPAPER_VALID_KEY);
+          query2.onsuccess = function() {
+            var valid = query2.result[WALLPAPER_VALID_KEY];
+            this._setWallpaper(wallpaper, valid);
+          }.bind(this);
+        }
+        else {
+          // If the wallpaper is not a blob, just pass it to _setWallpaper
+          // and try to convert it to a blob there.
+          this._setWallpaper(wallpaper);
+        }
+      }.bind(this);
 
-      SettingsListener.observe(
-        'wallpaper.image',
-        'resources/images/backgrounds/default.png',
-        (function(value) {
-          this._blobURL = wallpaperURL.set(value);
-          System.publish('wallpaperchange', { url: this._blobURL });
-        }).bind(this)
-      );
+      // And register a listener so we'll be notified of future changes
+      // to the wallpaper
+      this.observer = function(e) {
+        this._setWallpaper(e.settingValue);
+      }.bind(this);
+      navigator.mozSettings.addObserver(WALLPAPER_KEY, this.observer);
+    },
+
+    /**
+     * Stop the module an stop listening for changes to the wallpaper setting.
+     * This method is only used by unit tests.
+     */
+    stop: function() {
+      if (!this._started) { return; }
+      navigator.mozSettings.removeObserver(WALLPAPER_KEY, this.observer);
+      this._started = false;
     },
 
     /**
      * Return the blob URL saved from earlier wallpaper change event
+     * The lockscreen may miss the event and needs to look the URL up here.
      * @returns {String} the blob URL
      */
     getBlobURL: function() {
+      if (!this._started) { return; }
       return this._blobURL;
+    },
+
+    //
+    // This method is called on startup and when the wallpaper
+    // changes. It always causes _publish() to be invoked and a
+    // "wallpaperchange" event to be broadcast to interested
+    // listeners. If the new value is a blob that is already
+    // validated, then _publish() is called directly. Otherwise, it is
+    // called indirectly by _toBlob() or _checkSize().
+    //
+    _setWallpaper: function(value, valid) {
+      if (!this._started) { return; }
+
+      // If we are called because we just saved a resized blob back
+      // to the settings db, then ignore the call.
+      if (value instanceof Blob && value.size === this.savedBlobSize) {
+        this.savedBlobSize = false;
+        return;
+      }
+
+      debug('new wallpaper', valid ? 'size already validated' : '');
+
+      if (typeof value === 'string') {
+        this._toBlob(value);
+      }
+      else if (value instanceof Blob) {
+        // If this blob has already been validated, we can just display it.
+        // Otherwise we need to check its size first
+        if (valid) {
+          this._publish(value);
+        }
+        else {
+          this._checkSize(value);
+        }
+      }
+      else {
+        // The value in the settings database is invalid, so
+        // use the default image. Note that this will update the
+        // settings db with a valid value.
+        debug('Invalid wallpaper value in settings;',
+              'reverting to default wallpaper.');
+        this._toBlob(DEFAULT_WALLPAPER_URL);
+      }
+    },
+
+    //
+    // This method expects a wallpaper URL (possibly a data: URL) and
+    // uses XHR to convert it to a blob. If it succeeds, it passes the
+    // blob to _checkSize() which resizes it if needed and calls
+    // _publish() to broadcast the new wallpaper.
+    //
+    _toBlob: function(url) {
+      if (!this._started) { return; }
+      debug('converting wallpaper url to blob');
+
+      // If we trying to convert the default wallpaper url to a blob
+      // note that because there is some error recovery code that behaves
+      // differently in that last resort case.
+      this.tryingDefaultWallpaper = (url === DEFAULT_WALLPAPER_URL);
+
+      // If the settings db had a string in it we assume it is a
+      // relative url or data: url and try to read it with XHR.
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', url);
+      xhr.responseType = 'blob';
+      xhr.send();
+      xhr.onload = function() {
+        // Once we've loaded the wallpaper as a blob, verify its size.
+        // We pass true as the second argument to force it to be saved
+        // back to the db (as a blob) even if the size is okay.
+        this._checkSize(xhr.response, true);
+      }.bind(this);
+      xhr.onerror = function() {
+        // If we couldn't load the url and if it was something other
+        // than the default wallpaper url, then try again with the default.
+        if (!this.tryingDefaultWallpaper) {
+          debug('corrupt wallpaper url in settings;',
+                'reverting to default wallpaper');
+          this._toBlob(DEFAULT_WALLPAPER_URL);
+        }
+        else {
+          // This was our last resort, and it failed, so no wallpaper
+          // image is available.
+          console.error('Cannot load wallpaper from', url);
+        }
+      }.bind(this);
+    },
+
+    //
+    // This method checks the dimensions of the image blob and crops
+    // and resizes the image if necessary so that it is exactly the
+    // same size as the screen. If the image was resized, or if it was
+    // read from a URL, then this method saves the new blob back to
+    // the settings db and marks it as valid. If the image was not
+    // resized, then the image is marked as valid so that the check
+    // does not need to be performed when the phone is rebooted. In
+    // either case, after the image is saved and/or validated, this
+    // method calls _publish() to broadcast the new wallpaper.
+    //
+    // If the blob does not hold a valid image, that will be
+    // discovered while attempting to check its size and in that case,
+    // this method falls back on the default wallpaper by calling
+    // _toBlob() with the default wallpaper URL.
+    //
+    // This method lazy-loads ImageUtils from shared/js/image_utils.js.
+    // Once a wallpaper has had its size checked once, it is marked as
+    // valid in the settings db, so these image utilities will not
+    // need to be loaded into the system app on subsequent reboots.
+    //
+    _checkSize: function(blob, needsToBeSaved) {
+      if (!this._started) { return; }
+      debug('resizing wallpaper if needed');
+
+      // How big (in device pixels) is the screen?
+      var screenWidth = Math.ceil(screen.width * window.devicePixelRatio);
+      var screenHeight = Math.ceil(screen.height * window.devicePixelRatio);
+
+      // For performance we need to guarantee that the size of the wallpaper
+      // is exactly the same as the size of the screen. LazyLoad the
+      // ImageUtils module, and call its resizeAndCropToCover() method to
+      // resize and crop the image as needed so that it is the right size.
+      // Note that this utility funtion can determine the size of an image
+      // without decoding it and if the image is already the right size
+      // it will not modify it.
+      LazyLoader.load('shared/js/image_utils.js', function() {
+        ImageUtils
+          .resizeAndCropToCover(blob, screenWidth, screenHeight, ImageUtils.PNG)
+          .then(
+            function resolve(resizedBlob) {
+              // If the blob changed or if the second argument was true
+              // then we need to save the blob back to the settings db
+              if (resizedBlob !== blob || needsToBeSaved) {
+                this._save(resizedBlob);
+              }
+              else {
+                // If the blob didn't change we don't have to save it,
+                // but we do need to mark it as valid
+                this._validate();
+              }
+
+              // Display the wallpaper
+              this._publish(resizedBlob);
+            }.bind(this),
+            function reject(error) {
+              // This will only happen if the settings db contains a blob that
+              // is not actually an image. If that happens for some reason,
+              // fall back on the default wallpaper.
+              if (!this.tryingDefaultWallpaper) {
+                debug('Corrupt wallpaper image in settings;',
+                      'reverting to default wallpaper.');
+                this._toBlob(DEFAULT_WALLPAPER_URL);
+              }
+              else {
+                // We were already trying the default wallpaper and it failed.
+                // So we just give up in this case.
+                console.error('Default wallpaper image is invalid');
+              }
+            }.bind(this)
+          );
+      }.bind(this));
+    },
+
+    //
+    // This method sets a property in the settings db to indicate that
+    // the current wallpaper is the same size as the screen. Setting
+    // this property is an optimization that allows us to skip the
+    // call to _checkSize() on subsequent startups. This method
+    // returns synchronously and does not wait for the settings db
+    // operation to complete.
+    //
+    _validate: function() {
+      if (!this._started) { return; }
+      debug('marking wallpaper as valid');
+      var settings = {};
+      settings[WALLPAPER_VALID_KEY] = true; // We've checked its size
+      navigator.mozSettings.createLock().set(settings);
+    },
+
+    //
+    // This method saves the wallpaper blob to the settings db and
+    // also marks it as valid so that we know on subsequent startups
+    // that its size has already been checked. This method returns
+    // synchronously and does not wait for the settings db operation
+    // to complete.
+    //
+    _save: function(blob) {
+      if (!this._started) { return; }
+      debug('saving converted or resized wallpaper to settings');
+
+      // Set a flag so that we don't repeat this whole process when
+      // we're notified about this save. The flag contains the size of
+      // the blob we're saving so it is very unlikely that we'll have
+      // a race condition.
+      this.savedBlobSize = blob.size;
+
+      // Now save the blob to the settings db, and also save a flag
+      // that indicates that we've already checked the size of the image.
+      // This allows us to skip the check at boot time.
+      var settings = {};
+      settings[WALLPAPER_KEY] = blob;
+      settings[WALLPAPER_VALID_KEY] = true; // We've checked its size
+      navigator.mozSettings.createLock().set(settings);
+    },
+
+    //
+    // This method creates a blob: URL for the specfied blob and publishes
+    // the URL via a 'wallpaperchange' event. If there was a previous
+    // wallpaper, its blob: URL is revoked. This method is synchronous.
+    //
+    _publish: function(blob) {
+      if (!this._started) { return; }
+      debug('publishing wallpaperchange event');
+
+      // If we have a blob:// url for previous wallpaper, release it now
+      if (this._blobURL) {
+        URL.revokeObjectURL(this._blobURL);
+      }
+
+      // Create a new blob:// url for this blob
+      this._blobURL = URL.createObjectURL(blob);
+
+      // And tell the system about it.
+      System.publish('wallpaperchange', { url: this._blobURL });
     }
   };
+
+  // Log debug messages
+  function debug(...args) {
+    if (WallpaperManager.DEBUG) {
+      args.unshift('[WallpaperManager]');
+      console.log.apply(console, args);
+    }
+  }
+  WallpaperManager.DEBUG = true; // Set to false to silence debug output
 
   /** @exports WallpaperManager */
   exports.WallpaperManager = WallpaperManager;

--- a/apps/system/test/unit/bootstrap_test.js
+++ b/apps/system/test/unit/bootstrap_test.js
@@ -3,6 +3,7 @@
 /*global MockApplications, Applications*/
 
 requireApp('system/shared/js/async_storage.js');
+requireApp('system/shared/js/lazy_loader.js');
 requireApp('system/shared/js/screen_layout.js');
 requireApp('system/shared/test/unit/mocks/mock_icc_helper.js');
 requireApp('system/shared/test/unit/mocks/mock_navigator_moz_apps.js');

--- a/apps/system/test/unit/wallpaper_manager_test.js
+++ b/apps/system/test/unit/wallpaper_manager_test.js
@@ -1,0 +1,438 @@
+'use strict';
+
+/* global WallpaperManager, LazyLoader, ImageUtils, MockNavigatorSettings */
+
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/js/image_utils.js');
+require('/apps/system/js/wallpaper_manager.js');
+
+suite('WallpaperManager', function() {
+
+  var subject;  // The WallpaperManager instance we're testing.
+  var wallpaperBlob, bigWallpaperBlob, smallWallpaperBlob;
+  var dataURL, bigDataURL, smallDataURL;
+
+  const DEFAULT_WALLPAPER = 'resources/images/backgrounds/default.png';
+
+  suiteSetup(function(done) {
+    var self = this;
+
+    // Don't display debug output
+    WallpaperManager.DEBUG = false;
+
+    // Fake URLs. Our xhr mock will recognize these strings and return blobs
+    dataURL = 'data://justright';
+    bigDataURL = 'data://toobig';
+    smallDataURL = 'data://toosmall';
+
+    // Map urls to blobs for the fake XHR
+    var urlToBlobMap = this.urlToBlobMap = {};
+
+    this.xhr = sinon.useFakeXMLHttpRequest();
+    this.xhr.onCreate = function(request) {
+      setTimeout(function() {
+        var blob = urlToBlobMap[request.url];
+        if (blob) {
+          request.response = blob;
+          request.onload();
+        }
+        else {
+          request.onerror();
+        }
+      });
+    };
+
+    // Create some image blobs
+    this.screenWidth = screen.width * window.devicePixelRatio;
+    this.screenHeight = screen.height * window.devicePixelRatio;
+
+    var canvas = document.createElement('canvas');
+    canvas.width = this.screenWidth;
+    canvas.height = this.screenHeight;
+    canvas.toBlob(function(blob) {
+      wallpaperBlob = blob;
+
+      canvas.width = self.screenWidth + 1;
+      canvas.height = self.screenHeight + 1;
+      canvas.toBlob(function(blob) {
+        bigWallpaperBlob = blob;
+
+        canvas.width = self.screenWidth >> 1;
+        canvas.height = self.screenHeight >> 1;
+        canvas.toBlob(function(blob) {
+          smallWallpaperBlob = blob;
+
+          // Now that we have the images defined, set up the URL mapping
+          urlToBlobMap[DEFAULT_WALLPAPER] = wallpaperBlob;
+          urlToBlobMap[dataURL] = wallpaperBlob;
+          urlToBlobMap[bigDataURL] = bigWallpaperBlob;
+          urlToBlobMap[smallDataURL] = smallWallpaperBlob;
+
+          done();
+        }, 'image/jpeg');
+      }, 'image/jpeg');
+    }, 'image/jpeg');
+  });
+
+  suiteTeardown(function() {
+    this.xhr.restore();
+  });
+
+
+  setup(function() {
+    var self = this;
+    // Mock settings
+    this.realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+
+    // Mock System.publish function
+    window.System = {
+      publish: function(type, data) {
+        if (self.onWallpaperChange) {
+          setTimeout(function() {
+            self.onWallpaperChange(type, data);
+          });
+        }
+      }
+    };
+
+    // Mock LazyLoader
+    window.LazyLoader = { };
+    window.LazyLoader.load = sinon.stub().callsArg(1);
+
+    // Spy on WallpaperManager methods
+    var proto = WallpaperManager.prototype;
+    this.setWallpaperSpy = sinon.spy(proto, '_setWallpaper');
+    this.toBlobSpy = sinon.spy(proto, '_toBlob');
+    this.checkSizeSpy = sinon.spy(proto, '_checkSize');
+    this.saveSpy = sinon.spy(proto, '_save');
+    this.validateSpy = sinon.spy(proto, '_validate');
+    this.publishSpy = sinon.spy(proto, '_publish');
+    subject = new WallpaperManager();
+  });
+
+  teardown(function() {
+    subject.stop();
+
+    this.setWallpaperSpy.restore();
+    this.toBlobSpy.restore();
+    this.checkSizeSpy.restore();
+    this.saveSpy.restore();
+    this.validateSpy.restore();
+    this.publishSpy.restore();
+
+    navigator.mozSettings = this.realMozSettings;
+    MockNavigatorSettings.mTeardown();
+
+    delete window.System;
+    this.onWallpaperChange = null;
+  });
+
+  test('start() throws if called twice', function() {
+    subject.start();
+    assert.throws(function() { subject.start(); });
+  });
+
+  //
+  // Test normal startup where we have a validated wallpaper blob in
+  // the settings db. Verify that a wallpaperchange event is published
+  // with a blob uri, and that the size of the image is not checked
+  // or changed, and that the lazy loader is not invoked.
+  //
+  test('start with validated blob', function(done) {
+    var self = this;
+    // Start with a validated blob in the settings db
+    MockNavigatorSettings.mSettings['wallpaper.image'] = wallpaperBlob;
+    MockNavigatorSettings.mSettings['wallpaper.image.valid'] = true;
+
+    // We do our assertions once we see a wallpaperchange event published.
+    this.onWallpaperChange = function(type, data) {
+      // Check event type
+      assert.equal(type, 'wallpaperchange');
+      // Check that we get a blob url
+      assert.equal(data.url.substring(0, 5), 'blob:');
+
+      // Check that the methods were called the expected number of times
+      assert.ok(self.setWallpaperSpy.calledOnce);
+      assert.ok(self.toBlobSpy.notCalled);
+      assert.ok(LazyLoader.load.notCalled);
+      assert.ok(self.checkSizeSpy.notCalled);
+      assert.ok(self.saveSpy.notCalled);
+      assert.ok(self.publishSpy.calledOnce);
+      done();
+    };
+
+    subject.start();
+  });
+
+  //
+  // Test normal startup followed by a change to a new wallpaper blob that
+  // is too small.  Verify that the wallpaper is changed and that the
+  // resulting wallpaper has the expected size and type. And that the
+  // LazyLoader is used
+  //
+  test('change to new small wallpaper blob', function(done) {
+    var self = this;
+    // Start with a validated blob in the settings db
+    MockNavigatorSettings.mSettings['wallpaper.image'] = wallpaperBlob;
+    MockNavigatorSettings.mSettings['wallpaper.image.valid'] = true;
+
+    // Wait 'till the initial wallpaper is published
+    this.onWallpaperChange = function(type, data) {
+      // Test assertions when we get the changed wallpaper
+      self.onWallpaperChange = function(type, data) {
+        // Check event type
+        assert.equal(type, 'wallpaperchange');
+        // Check that we get a blob url
+        assert.equal(data.url.substring(0, 5), 'blob:');
+        // Check that the methods were called the expected number of times
+
+        // 3 times: initial, changed, and saved wallpapers
+        assert.equal(self.setWallpaperSpy.callCount, 3);
+
+        assert.ok(self.toBlobSpy.notCalled, '_toBlob called');
+        assert.ok(LazyLoader.load.calledOnce);
+        assert.ok(self.checkSizeSpy.calledOnce, 'checkSize called');
+        assert.ok(self.saveSpy.calledOnce, 'save called');
+        assert.ok(self.validateSpy.notCalled,
+                  'validate not called');
+        assert.equal(self.publishSpy.callCount, 2, 'publish called');
+        assert.notEqual(MockNavigatorSettings.mSettings['wallpaper.image'],
+                        smallWallpaperBlob);
+        assert.notEqual(MockNavigatorSettings.mSettings['wallpaper.image'],
+                        wallpaperBlob);
+        assert.equal(MockNavigatorSettings.mSettings['wallpaper.image.valid'],
+                     true);
+
+        var blob = MockNavigatorSettings.mSettings['wallpaper.image'];
+        assert.equal(blob.type, ImageUtils.PNG);
+        ImageUtils.getSizeAndType(blob).then(function resolve(data) {
+          assert.equal(data.type, ImageUtils.PNG);
+          assert.equal(data.width, self.screenWidth);
+          assert.equal(data.height, self.screenHeight);
+          done();
+        });
+      };
+
+      navigator.mozSettings.createLock().set({
+        'wallpaper.image': smallWallpaperBlob
+      });
+    };
+
+    subject.start();
+  });
+
+  //
+  // Test normal startup followed by a change to a new wallpaper blob that
+  // is the right size.  Verify that the wallpaper is changed and that the
+  // resulting wallpaper has the expected size and type. And that the
+  // LazyLoader is used
+  //
+  test('change to new right-size wallpaper blob', function(done) {
+    var self = this;
+    // Start with a validated blob in the settings db
+    MockNavigatorSettings.mSettings['wallpaper.image'] = wallpaperBlob;
+    MockNavigatorSettings.mSettings['wallpaper.image.valid'] = true;
+
+    // Wait 'till the initial wallpaper is published
+    this.onWallpaperChange = function(type, data) {
+      // Test assertions when we get the changed wallpaper
+      self.onWallpaperChange = function(type, data) {
+        // Check event type
+        assert.equal(type, 'wallpaperchange');
+        // Check that we get a blob url
+        assert.equal(data.url.substring(0, 5), 'blob:');
+        // Check that the methods were called the expected number of times
+
+        assert.equal(self.setWallpaperSpy.callCount, 2);
+        assert.ok(self.toBlobSpy.notCalled, '_toBlob called');
+        assert.ok(LazyLoader.load.calledOnce);
+        assert.ok(self.checkSizeSpy.calledOnce, 'checkSize called');
+        assert.ok(self.saveSpy.notCalled, 'save not called');
+        assert.ok(self.validateSpy.calledOnce, 'validate called');
+        assert.equal(self.publishSpy.callCount, 2, 'publish called');
+        assert.equal(MockNavigatorSettings.mSettings['wallpaper.image'],
+                     wallpaperBlob);
+        assert.equal(MockNavigatorSettings.mSettings['wallpaper.image.valid'],
+                     true);
+        done();
+      };
+
+      navigator.mozSettings.createLock().set({
+        'wallpaper.image': wallpaperBlob
+      });
+    };
+
+    subject.start();
+  });
+
+  //
+  // Test the startup process with a blob that has not been validated yet.
+  // This seems to be what happens on first boot (Somewhere in the build
+  // system the data uri is converted to a real blob.)
+  //
+  test('start with non-validated right-size blob', function(done) {
+    var self = this;
+    // Start with an unvalidated blob in the settings db
+    MockNavigatorSettings.mSettings['wallpaper.image'] = wallpaperBlob;
+
+    // We do our assertions once we see a wallpaperchange event published.
+    this.onWallpaperChange = function(type, data) {
+      // Check event type
+      assert.equal(type, 'wallpaperchange');
+      // Check that we get a blob url
+      assert.equal(data.url.substring(0, 5), 'blob:');
+      // Check that the methods were called the expected number of times
+      assert.ok(self.setWallpaperSpy.calledOnce);
+      assert.ok(self.toBlobSpy.notCalled);
+      assert.ok(LazyLoader.load.calledOnce);
+      assert.ok(self.checkSizeSpy.calledOnce);
+      assert.ok(self.saveSpy.notCalled);
+      assert.ok(self.validateSpy.calledOnce);
+      assert.ok(self.publishSpy.calledOnce);
+      assert.equal(MockNavigatorSettings.mSettings['wallpaper.image'],
+                   wallpaperBlob);
+      assert.equal(MockNavigatorSettings.mSettings['wallpaper.image.valid'],
+                   true);
+      done();
+    };
+
+    subject.start();
+  });
+
+  //
+  // Test the startup process with a blob that has not been validated yet
+  // and is not the right size. (This happens on first boot if we use a
+  // FWVGA wallpaper on an WVGA device or vice versa, e.g.)
+  //
+  test('start with non-validated wrong-size blob', function(done) {
+    var self = this;
+    // Start with an unvalidated blob in the settings db
+    MockNavigatorSettings.mSettings['wallpaper.image'] = bigWallpaperBlob;
+
+    // We do our assertions once we see a wallpaperchange event published.
+    this.onWallpaperChange = function(type, data) {
+      // Check event type
+      assert.equal(type, 'wallpaperchange');
+      // Check that we get a blob url
+      assert.equal(data.url.substring(0, 5), 'blob:');
+      // Check that the methods were called the expected number of times
+      assert.ok(self.toBlobSpy.notCalled, '_toBlob not called');
+      assert.ok(LazyLoader.load.calledOnce);
+      assert.ok(self.checkSizeSpy.calledOnce, 'checkSize called');
+      assert.ok(self.saveSpy.calledOnce, 'save called');
+      assert.ok(self.validateSpy.notCalled, 'validate not called');
+      assert.ok(self.publishSpy.calledOnce, 'publish called');
+      assert.notEqual(MockNavigatorSettings.mSettings['wallpaper.image'],
+                      wallpaperBlob);
+      assert.equal(MockNavigatorSettings.mSettings['wallpaper.image.valid'],
+                   true);
+
+      var blob = MockNavigatorSettings.mSettings['wallpaper.image'];
+      assert.equal(blob.type, ImageUtils.PNG);
+      ImageUtils.getSizeAndType(blob).then(function resolve(data) {
+        assert.equal(data.type, ImageUtils.PNG);
+        assert.equal(data.width, self.screenWidth);
+        assert.equal(data.height, self.screenHeight);
+        done();
+      });
+    };
+
+    subject.start();
+  });
+
+  //
+  // The tests that follow call this utility function and test what happens
+  // when we use URLs and invalid values as the wallpaper value.
+  //
+  function testWallpaperValue(self, input, expectedOutput, done,
+                              toBlobCallCount,
+                              checkSizeCallCount) {
+    MockNavigatorSettings.mSettings['wallpaper.image'] = input;
+
+    // We do our assertions once we see a wallpaperchange event published.
+    self.onWallpaperChange = function(type, data) {
+      try {
+        // Check that the methods were called the expected number of times
+        assert.equal(self.toBlobSpy.callCount,
+                  toBlobCallCount || 1,
+                  'convert to blob call count');
+        assert.ok(LazyLoader.load.called,
+                  'lazy loader used');
+        assert.equal(self.checkSizeSpy.callCount,
+                     checkSizeCallCount || 1,
+                     'check wallpaper called');
+        assert.ok(self.saveSpy.calledOnce,
+                 'save called once');
+        assert.ok(self.publishSpy.calledOnce, 'publish called once');
+        assert.equal(MockNavigatorSettings.mSettings['wallpaper.image.valid'],
+                     true);
+
+        var blob = MockNavigatorSettings.mSettings['wallpaper.image'];
+        if (expectedOutput) {
+          assert.equal(blob, expectedOutput, 'saved blob is as expected');
+          done();
+        }
+        else {
+          ImageUtils.getSizeAndType(blob).then(function resolve(data) {
+            assert.equal(data.width, self.screenWidth);
+            assert.equal(data.height, self.screenHeight);
+            done();
+          });
+        }
+      }
+      catch(ex) {
+        done(ex);
+      }
+    };
+
+    subject.start();
+  }
+
+  // No value in the settings db at all
+  test('undefined wallpaper', function(done) {
+    testWallpaperValue(this, undefined, wallpaperBlob, done);
+  });
+
+  // Non-blob, non-URL value in the settings db
+  test('invalid wallpaper', function(done) {
+    testWallpaperValue(this, 1, wallpaperBlob, done);
+  });
+
+  // default wallpaper url in settings db
+  test('default wallpaper url', function(done) {
+    testWallpaperValue(this, DEFAULT_WALLPAPER, wallpaperBlob, done);
+  });
+
+  // Data url that resolves to a right-size image 
+  test('right-size data uri', function(done) {
+    testWallpaperValue(this, this.dataURL, wallpaperBlob, done);
+  });
+
+  // Data url that resolves to a small image
+  test('small data uri', function(done) {
+    testWallpaperValue(this, this.smallDataURL, null, done);
+  });
+
+  // Data url that resolves to a big image
+  test('big data uri', function(done) {
+    testWallpaperValue(this, this.bigDataURL, null, done);
+  });
+
+  // URL that causes an XHR error and forces fallback on default
+  test('broken URL', function(done) {
+    testWallpaperValue(this, '/foo/bar', wallpaperBlob, done, 2);
+  });
+
+  // Invalid image blob that forces fallback on default
+  test('broken image blob', function(done) {
+    var badBlob = new Blob(['GIF89a'], { type: 'image/gif' });
+    testWallpaperValue(this, badBlob, wallpaperBlob, done, 1, 2);
+  });
+
+  // default wallpaper is wrong size
+  test('default wallpaper url', function(done) {
+    this.urlToBlobMap[DEFAULT_WALLPAPER] = smallWallpaperBlob;
+    testWallpaperValue(this, DEFAULT_WALLPAPER, null, done);
+  });
+});

--- a/apps/verticalhome/js/wallpaper.js
+++ b/apps/verticalhome/js/wallpaper.js
@@ -19,8 +19,8 @@
             type: ['wallpaper', 'image/*'],
             includeLocked: (secret !== null),
             // XXX: This will not work with Desktop Fx / Simulator.
-            width: window.screen.width * window.devicePixelRatio,
-            height: window.screen.height * window.devicePixelRatio
+            width: Math.ceil(window.screen.width * window.devicePixelRatio),
+            height: Math.ceil(window.screen.height * window.devicePixelRatio)
           }
         });
 

--- a/shared/js/image_utils.js
+++ b/shared/js/image_utils.js
@@ -1,0 +1,568 @@
+/*
+ * This shared module defines a single ImageUtils object in the global scope.
+ *
+ * ImageUtils.getSizeAndType() takes a Blob as its argument and
+ * returns a Promise. If the promise resolves, the resolve method is
+ * passed an object with width, height, and type properties. Width and
+ * height specify the width and height of the image in pixels. Type
+ * specifies the MIME type of the image. If the promise is rejected,
+ * the reject method will be passed a string error message.
+ *
+ * Supported image types are JPEG, PNG, GIF and BMP. The MIME type
+ * strings returned when a promise resolves are "image/jpeg",
+ * "image/png", "image/gif", and "image/bmp".
+ *
+ * If you pass a blob that holds an image of some other type (or a
+ * blob that is not an image at all) then promise will be rejected.
+ *
+ * getSizeAndType() does not decode the image to determine its size
+ * because can require large amounts of memory. Instead, it parses the
+ * image file to determine its size and typically only needs to read a
+ * prefix of the file into memory.
+ *
+ * getSizeAndType() differs from the getImageSize() function defined
+ * in shared/js/media/immage_size.js. That function is similar but
+ * also parses EXIF metadata for JPEG images and is only suitable if
+ * you need to access EXIF data.
+ */
+(function(exports) {
+  'use strict';
+  /* global Promise */
+
+  var ImageUtils = exports.ImageUtils = {};
+
+  // Define constants for the MIME types we use
+  const JPEG = 'image/jpeg';
+  const PNG = 'image/png';
+  const GIF = 'image/gif';
+  const BMP = 'image/bmp';
+
+  // Export them
+  ImageUtils.JPEG = JPEG;
+  ImageUtils.PNG = PNG;
+  ImageUtils.GIF = GIF;
+  ImageUtils.BMP = BMP;
+
+  ImageUtils.getSizeAndType = function getSizeAndType(imageBlob) {
+    if (!(imageBlob instanceof Blob)) {
+      return Promise.reject(new TypeError('argument is not a Blob'));
+    }
+
+    return new Promise(function(resolve, reject) {
+      if (imageBlob.size <= 16) {
+        reject('corrupt image file');
+        return;
+      }
+
+      // Start off assuming that we'll read the first 32kb of the file
+      var bytesToRead = 32 * 1024;
+
+      // But if the blob indicates that this is a PNG, GIF, or BMP, then
+      // we can read less since the size information is always close to the
+      // start of the file for those formats.
+      if (imageBlob.type === PNG ||
+          imageBlob.type === GIF ||
+          imageBlob.type === BMP) {
+        bytesToRead = 512;
+      }
+
+      // Try to find the information we want in the first bytes of the file
+      findSizeAndType(imageBlob, bytesToRead, success, tryagain);
+
+      // If we got the size and type data, resolve the promise
+      function success(data) {
+        resolve(data);
+      }
+
+      // If we didn't find it, try again for JPEG files
+      function tryagain(data) {
+        // If we were able to verify that this blob is a jpeg file
+        // then we will try again because in JPEG files, the size
+        // comes after the EXIF data so if there is a large preview image,
+        // the size might be more than 32kb into the file
+        if (data.type === JPEG) {
+          findSizeAndType(imageBlob, imageBlob.size, success, failure);
+        }
+        // For all other known image types the type and size data is
+        // near the start of the file, if we didn't find it on this first
+        // try we need to give up now.
+        else {
+          reject(data.error);
+        }
+      }
+
+      // If we didn't find the data even after a second attempt then reject.
+      function failure(data) {
+        reject(data.error);
+      }
+    });
+
+    // This is the internal helper function that actually reads the blob
+    // and finds type and size information.
+    function findSizeAndType(imageBlob, amountToRead, success, failure) {
+      var slice = imageBlob.slice(0, Math.min(amountToRead, imageBlob.size));
+      var reader = new FileReader();
+      reader.readAsArrayBuffer(slice);
+      reader.onloadend = function() {
+        parseImageData(reader.result);
+      };
+
+      function parseImageData(buffer) {
+        var header = new Uint8Array(buffer, 0, 16);
+        var view = new DataView(buffer);
+
+        if (header[0] === 0x89 &&
+            header[1] === 0x50 && /* P */
+            header[2] === 0x4e && /* N */
+            header[3] === 0x47 && /* G */
+            header[4] === 0x0d && /* \r */
+            header[5] === 0x0a && /* \n */
+            header[6] === 0x1A &&
+            header[7] === 0x0a &&
+            header[12] === 0x49 && /* I */
+            header[13] === 0x48 && /* H */
+            header[14] === 0x44 && /* D */
+            header[15] === 0x52)   /* R */
+        {
+          // This is a PNG file
+          try {
+            success({
+              type: PNG,
+              width: view.getUint32(16, false),  // 32 bit big endian width
+              height: view.getUint32(20, false) // 32 bit big endian height
+            });
+          }
+          catch (ex) {
+            failure({ error: ex.toString()});
+          }
+        }
+        else if (header[0] === 0x47 &&   /* G */
+                 header[1] === 0x49 &&   /* I */
+                 header[2] === 0x46 &&   /* F */
+                 header[3] === 0x38 &&   /* 8 */
+                 (header[4] === 0x37 ||  /* 7 */
+                  header[4] === 0x39) && /* or 9 */
+                 header[5] === 0x61)     /* a */
+        {
+          // This is a GIF file
+          try {
+            success({
+              type: GIF,
+              width: view.getUint16(6, true),  // 16-bit little endian width
+              height: view.getUint16(8, true)  // 16-big little endian height
+            });
+          }
+          catch (ex) {
+            failure({ error: ex.toString() });
+          }
+        }
+        else if (header[0] === 0x42 && /* B */
+                 header[1] === 0x4D && /* M */
+                 view.getUint16(2, true) === imageBlob.size)
+        {
+          // This is a BMP file
+          try {
+            var width, height;
+
+            if (view.getUint16(14, true) === 12) { // check format version
+              width = view.getUint16(18, true);  // 16-bit little endian width
+              height = view.getUint16(20, true); // 16-bit little endian height
+            }
+            else { // newer versions of the format use 32-bit ints
+              width = view.getUint32(18, true);  // 32-bit little endian width
+              height = view.getUint32(22, true); // 32-bit little endian height
+            }
+
+            success({
+              type: BMP,
+              width: width,
+              height: height
+            });
+          }
+          catch (ex) {
+            failure({ error: ex.toString() });
+          }
+        }
+        else if (header[0] === 0xFF &&
+                 header[1] === 0xD8) {
+          var value = {
+            type: JPEG
+          };
+
+          // This is a JPEG file. To find its width and height we need
+          // to skip past the EXIF data and find the start of image data.
+          try {
+            var offset = 2;
+
+            // Loop through the segments of the file until we find an SOF
+            // segment with image size or until we reach the end of our data.
+            for (;;) {
+              // The byte at the current offset should be 0xFF marking
+              // the start of a new segment.
+              if (view.getUint8(offset) !== 0xFF) {
+                failure({ error: 'corrupt JPEG file' });
+              }
+              var segmentType = view.getUint8(offset + 1);
+              var segmentSize = view.getUint16(offset + 2) + 2;
+
+              // If we found an SOF "Start of Frame" segment, we can get
+              // the image size from it.
+              if ((segmentType >= 0xC0 && segmentType <= 0xC3) ||
+                  (segmentType >= 0xC5 && segmentType <= 0xC7) ||
+                  (segmentType >= 0xC9 && segmentType <= 0xCB) ||
+                  (segmentType >= 0xCD && segmentType <= 0xCF))
+              {
+                // 16-bit big-endian dimensions, height first
+                value.height = view.getUint16(offset + 5, false);
+                value.width = view.getUint16(offset + 7, false);
+                success(value);
+                break;
+              }
+
+              // Otherwise, move on to the next segment
+              offset += segmentSize;
+
+              // We may not have read the entire file into our array buffer
+              // so we have to make sure we have not gone past the end of
+              // the buffer before looping again. Note that in this case
+              // the object we pass to the failure callback includes the
+              // image type. This is a signal to getSizeAndType that it
+              // should try again with a larger ArrayBuffer.
+              if (offset + 9 > view.byteLength) {
+                value.error = 'corrupt JPEG file';
+                failure(value);
+                break;
+              }
+            }
+          }
+          catch (ex) {
+            failure({ error: ex.toString() });
+          }
+        }
+        else {
+          failure({ error: 'unknown image type' });
+        }
+      }
+    }
+  };
+
+  //
+  // Given a blob containing an image file, this function returns a
+  // Promise that will resolve to a blob for an image file that has
+  // the specified width and height. If the blob already has that
+  // size, it is returned unchanged. If the image is bigger than the
+  // specified size, then it will be shrunk and cropped as necessary
+  // to fit the specified dimensions.  If the image is smaller than
+  // the specified size, it will be enlarged and cropped to fit. The
+  // cropping is done in the same way as with the CSS
+  // background-size:cover attribute.
+  //
+  // If the image is resized and outputType is "image/jpeg" or
+  // "image/png" then that type will be used for the resized image. If
+  // a JPEG or PNG image is resized and outputType is not specified,
+  // then the output image will have the same type as the input image.
+  // In all other cases, a resized image will be encoded as a PNG image.
+  // Note that when an image does not need to be resized its type is not
+  // changed, even if outputType is specified.
+  //
+  ImageUtils.resizeAndCropToCover = function(inputImageBlob,
+                                             outputWidth, outputHeight,
+                                             outputType)
+  {
+    if (!outputWidth || !isFinite(outputWidth) || outputWidth <= 0 ||
+        !outputHeight || !isFinite(outputHeight || outputHeight <= 0)) {
+      return Promise.reject(new TypeError('invalid output dimensions'));
+    }
+    outputWidth = Math.round(outputWidth);
+    outputHeight = Math.round(outputHeight);
+
+    return ImageUtils.getSizeAndType(inputImageBlob).then(
+      function resolve(data) {
+        var inputWidth = data.width;
+        var inputHeight = data.height;
+
+        // If the image already has the desired size, just return it unchanged
+        if (inputWidth === outputWidth && inputHeight === outputHeight) {
+          return inputImageBlob;
+        }
+
+        // Otherwise, return a promise for the resized image
+        return resize(data);
+      },
+      function reject(error) {
+        // If we couldn't determine the image size and type for some
+        // reason we are still going to assume that it is a valid image,
+        // just one we don't know about. If gecko can decode it we'll
+        // use it and won't reject unless gecko refuses it.
+        return resize({});
+      }
+    );
+
+    // Decode the image in an <img> element, resize and/or crop it into a
+    // <canvas> and the re-encode it to a blob again. Returns a Promise
+    // that resolves to the encoded blob.
+    function resize(data) {
+      var inputType = data.type;
+      var inputWidth = data.width;
+      var inputHeight = data.height;
+
+      // Ignore invalid outputType parameters
+      if (outputType && outputType !== JPEG && outputType !== PNG) {
+        console.warn('Ignoring unsupported outputType', outputType);
+        outputType = undefined;
+      }
+
+      // Determine the output type if none was specified.
+      if (!outputType) {
+        if (inputType === JPEG || inputType === PNG) {
+          outputType = inputType;
+        }
+        else {
+          outputType = PNG;
+        }
+      }
+
+      // Get a URL for the image blob so we can ask gecko to decode it.
+      var url = URL.createObjectURL(inputImageBlob);
+
+      // If we can downsample the image while decoding it, then add a
+      // #-moz-samplesize media fragment to the URL. For large JPEG inputs
+      // this can save megabytes of memory.
+      var mediaFragment;
+      if (inputType === JPEG &&
+          inputWidth > outputWidth && inputHeight > outputHeight) {
+        // How much would we like to scale the image by while decoding?
+        var reduction = Math.max(outputWidth / inputWidth,
+                                 outputHeight / inputHeight);
+        // Get a media fragment that will downsample the image by up to
+        // this amount.
+        mediaFragment = ImageUtils.Downsample.sizeNoMoreThan(reduction);
+      }
+      else {
+        mediaFragment = '';
+      }
+
+      // The next step is to decode (while possibly downsampling) the
+      // image, but that is asynchronous, so we'll have to return a
+      // Promise to handle that
+      return new Promise(function(resolve, reject) {
+        var offscreenImage = new Image();
+        offscreenImage.src = url + mediaFragment;
+
+        offscreenImage.onerror = function(e) {
+          cleanupImage();
+          reject('failed to decode image');
+        };
+
+        offscreenImage.onload = function() {
+          // The image has been decoded now, so we know its actual size.
+          // If getSizeAndType failed, or if we used a media fragment then
+          // this may be different than the inputWidth and inputHeight
+          // values we used previously.
+          var actualWidth = offscreenImage.width;
+          var actualHeight = offscreenImage.height;
+
+          // Now figure how much we have to scale the decoded image down
+          // (or up) so that it covers the specified output dimensions.
+          var widthScale = outputWidth / actualWidth;
+          var heightScale = outputHeight / actualHeight;
+          var scale = Math.max(widthScale, heightScale);
+
+          // Scaling the output dimensions by this much tells us the
+          // dimensions of the crop area on the decoded image
+          var cropWidth = Math.round(outputWidth / scale);
+          var cropHeight = Math.round(outputHeight / scale);
+
+          // Now center that crop region within the decoded image
+          var cropLeft = Math.floor((actualWidth - cropWidth) / 2);
+          var cropTop = Math.floor((actualHeight - cropHeight) / 2);
+
+          // Set up the canvas we need to copy the crop region into
+          var canvas = document.createElement('canvas');
+          canvas.width = outputWidth;
+          canvas.height = outputHeight;
+          var context = canvas.getContext('2d', { willReadFrequently: true });
+
+          // Copy the image into the canvas
+          context.drawImage(offscreenImage,
+                            cropLeft, cropTop, cropWidth, cropHeight,
+                            0, 0, outputWidth, outputHeight);
+
+          // We're done with the image now: try to release the decoded
+          // image memory as fast as we can
+          cleanupImage();
+
+          // Now encode the pixels in the canvas as an image blob
+          canvas.toBlob(function(blob) {
+            // We've got the encoded image in the blob, so we don't need
+            // the pixels in the canvas anymore. Try to release that memory
+            // right away, too.
+            canvas.width = 0;
+            resolve(blob);
+          }, outputType);
+        };
+
+        function cleanupImage() {
+          offscreenImage.onerror = offscreenImage.onload = '';
+          offscreenImage.src = '';
+          URL.revokeObjectURL(url);
+        }
+      });
+    }
+  };
+
+  //
+  // This module defines a Downsample object with static
+  // methods that return objects representing media fragments for
+  // downsampling images while they are decoded. The current implementation
+  // is based on the #-moz-samplesize media fragment. But because of
+  // problems with that fragment (see bug 1004908) it seems likely that a
+  // new syntax or new fragment will be introduced. If that happens, we can
+  // just change this module and not have to change anything else that
+  // depends on it.
+  //
+  // The method Downsample.areaAtLeast(scale) returns an object
+  // representing a media fragment to use to decode an image downsampled by
+  // at least as much as the specified scale.  If you are trying to preview
+  // an 8mp image and don't want to use more than 2mp of image memory, for
+  // example, you would pass a scale of .25 (2mp/8mp) here, and the
+  // resulting media fragment could be appended to the url to make the
+  // image decode at a size equal to or smaller than 2mp.
+  //
+  // The method Downsample.sizeNoMoreThan(scale) returns a media fragment
+  // object that you can use to reduce the dimensions of an image as much
+  // as possible without exceeding the specified scale. If you have a
+  // 1600x1200 image and want to decode it to produce an image that is as
+  // small as possible but at least 160x120, you would pass a scale of 0.1.
+  //
+  // The returned objects have a dimensionScale property that specifies how
+  // they affect the dimensions of the image and an areaScale property that
+  // specifies how much they affect the area (number of pixels) in an
+  // image. (The areaScale is just the square of the scale.) To avoid
+  // floating-point rounding issues, the values of these scale properties
+  // are rounded to the nearest hundredth.
+  //
+  // The returned objects also have a scale() method that scales a
+  // dimension with proper rounding (it rounds up to the nearest integer
+  // just as libjpeg does).
+  //
+  // Each object also has a toString() method that returns the required
+  // media fragment (including the hash mark) so you can simply use
+  // string concatentation to append one of these objects to the URL of
+  // the image you want to decode.
+  //
+  // Downsample.NONE is a no-op media fragment object with scale set to
+  // 1, and a toString() method that returns the empty string.
+  //
+  (function(exports) {
+    'use strict';  // jshint ignore:line
+
+    // Round to the nearest hundredth to combat floating point rounding errors
+    function round(x) {
+      return Math.round(x * 100) / 100;
+    }
+
+    //
+    // A factory method for returning an object that represents a
+    // #-moz-samplesize media fragment. The use of Math.ceil() in the
+    // scale method is from jpeg_core_output_dimensions() in
+    // media/libjpeg/jdmaster.c and jdiv_round_up() in media/libjpeg/jutils.c
+    //
+    function MozSampleSize(n, scale) {
+      return Object.freeze({
+        dimensionScale: round(scale),
+        areaScale: round(scale * scale),
+        toString: function() { return '#-moz-samplesize=' + n; },
+        scale: function(x) { return Math.ceil(x * scale); }
+      });
+    }
+
+    // A fragment object that represents no downsampling with no fragment
+    var NONE = Object.freeze({
+      dimensionScale: 1,
+      areaScale: 1,
+      toString: function() { return ''; },
+      scale: function(x) { return x; }
+    });
+
+    //
+    // The five possible #-moz-samplesize values.
+    // The mapping from sample size to scale comes from:
+    // the moz-samplesize code in /image/decoders/nsJPEGDecoder.cpp and
+    // the jpeg_core_output_dimensions() function in media/libjpeg/jdmaster.c
+    //
+    var fragments = [
+      NONE,
+      // samplesize=2 reduces size by 1/2 and area by 1/4, etc.
+      MozSampleSize(2, 1 / 2),
+      MozSampleSize(3, 3 / 8),
+      MozSampleSize(4, 1 / 4),
+      MozSampleSize(8, 1 / 8)
+    ];
+
+    // Return the fragment object that has the largest scale and downsamples the
+    // dimensions of an image at least as much as the specified scale.
+    // If none of the choices scales enough, return the one that comes closest
+    function sizeAtLeast(scale) {
+      scale = round(scale);
+      for (var i = 0; i < fragments.length; i++) {
+        var f = fragments[i];
+        if (f.dimensionScale <= scale) {
+          return f;
+        }
+      }
+      return fragments[fragments.length - 1];
+    }
+
+    // Return the fragment object that downsamples an image as far as possible
+    // without going beyond the specified scale. This might return NONE.
+    function sizeNoMoreThan(scale) {
+      scale = round(scale);
+      for (var i = fragments.length - 1; i >= 0; i--) {
+        var f = fragments[i];
+        if (f.dimensionScale >= scale) {
+          return f;
+        }
+      }
+      return NONE;
+    }
+
+    // Return the fragment object that has the largest scale and downsamples the
+    // area of an image at least as much as the specified scale.
+    // If none of the choices scales enough, return the one that comes closest
+    function areaAtLeast(scale) {
+      scale = round(scale);
+      for (var i = 0; i < fragments.length; i++) {
+        var f = fragments[i];
+        if (f.areaScale <= scale) {
+          return f;
+        }
+      }
+      return fragments[fragments.length - 1];
+    }
+
+    // Return the fragment object that downsamples the area of an image
+    // as far as possible without going beyond the specified scale. This
+    // might return NONE.
+    function areaNoMoreThan(scale) {
+      scale = round(scale);
+      for (var i = fragments.length - 1; i >= 0; i--) {
+        var f = fragments[i];
+        if (f.areaScale >= scale) {
+          return f;
+        }
+      }
+      return NONE;
+    }
+
+    exports.Downsample = {
+      sizeAtLeast: sizeAtLeast,
+      sizeNoMoreThan: sizeNoMoreThan,
+      areaAtLeast: areaAtLeast,
+      areaNoMoreThan: areaNoMoreThan,
+      NONE: NONE,
+      MAX_SIZE_REDUCTION: 1 / fragments[fragments.length - 1].dimensionScale,
+      MAX_AREA_REDUCTION: 1 / fragments[fragments.length - 1].areaScale
+    };
+  }(exports.ImageUtils));
+})(window);


### PR DESCRIPTION
...ze

when computing screen size for wallpaper pick activity use Math.ceil to get 854 instead of 853.5 for FWVGA

Unit tests for wallpaper_manager.js plus fix a broken bootstrap test

address review comments

address review comments
(cherry picked from commit 7815e901b5ccec40b22987a10d002bb1225d8d17)

Conflicts:

```
apps/settings/js/panels/display/wallpaper.js
```
