### PR TITLE
Bug 1044265 - [B2G][Contacts] When adding a phone number the subtext letters on the keypad dissapear when long pressed

### DIFF
--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -719,6 +719,10 @@ bubble above the key when you tap and hold. */
   margin-bottom: -0.3rem;
 }
 
+.keyboard-key.bottom-symbol.highlighted > .visual-wrapper:after {
+  opacity: 1;
+}
+
 .keyboard-key.bottom-symbol[data-keycode="50"] > .visual-wrapper:after {
   content: 'ABC';
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1044265
