### PR TITLE
Bug 1044056 - [2.0] Status bar does not get opaque when changing wallpaper from the homescreen

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -123,6 +123,9 @@ var StatusBar = {
 
   playingActive: false,
 
+  _currentAppearance: null,
+  _appearanceList: [],
+
   /**
    * this keeps how many current installs/updates we do
    * it triggers the icon "systemDownloads"
@@ -249,6 +252,8 @@ var StatusBar = {
     window.addEventListener('unlock', this);
     window.addEventListener('lockpanelchange', this);
 
+    window.addEventListener('activityopened', this);
+    window.addEventListener('activitywillclose', this);
     window.addEventListener('appopened', this);
     window.addEventListener('homescreenopened', this.show.bind(this));
 
@@ -271,6 +276,16 @@ var StatusBar = {
 
   handleEvent: function sb_handleEvent(evt) {
     switch (evt.type) {
+      case 'activitywillclose':
+        var appearance = this._appearanceList.pop();
+        this.setAppearance(appearance);
+        break;
+
+      case 'activityopened':
+        this._appearanceList.push(this._currentAppearance);
+        this.setAppearance('opaque');
+        break;
+
       case 'appopened':
         this.setAppearance('opaque');
         var app = evt.detail;
@@ -1130,6 +1145,8 @@ var StatusBar = {
    * "opaque" and "semi-transparent"
    */
   setAppearance: function sb_setAppearance(value) {
+    this._currentAppearance = value;
+
     switch (value) {
       case 'opaque':
         this.background.classList.add('opaque');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1044056
