### PR TITLE
 Bug 1038630 - Split Tutorial init into init, start methods.

### DIFF
--- a/apps/ftu/config/tiny.json
+++ b/apps/ftu/config/tiny.json
@@ -38,5 +38,29 @@
         "l10nKey": "tutorial-sheets-tiny"
       }
     ]
+  },
+  "1.4..2.1": {
+    "steps": [
+      {
+        "video": "/style/images/tutorial/VerticalScroll.mp4",
+        "l10nKey": "tutorial-vertical-scroll-tiny"
+      },
+      {
+        "video": "/style/images/tutorial/Sheets.mp4",
+        "l10nKey": "tutorial-sheets-tiny"
+      }
+    ]
+  },
+  "1.3..2.1": {
+    "steps": [
+      {
+        "video": "/style/images/tutorial/VerticalScroll.mp4",
+        "l10nKey": "tutorial-vertical-scroll-tiny"
+      },
+      {
+        "video": "/style/images/tutorial/Sheets.mp4",
+        "l10nKey": "tutorial-sheets-tiny"
+      }
+    ]
   }
 }

--- a/apps/ftu/js/app.js
+++ b/apps/ftu/js/app.js
@@ -1,5 +1,5 @@
 /* global DataMobile, Navigation, SimManager, TimeManager,
-          UIManager, WifiManager, ImportIntegration, Tutorial, Promise,
+          UIManager, WifiManager, ImportIntegration, Tutorial,
           VersionHelper */
 /* exported AppManager */
 'use strict';
@@ -82,14 +82,7 @@ var AppManager = {
 
 navigator.mozL10n.ready(function showBody() {
 
-  var versionInfo;
-  Promise.all([
-    VersionHelper.getVersionInfo().then(function(info) {
-      versionInfo = info;
-    }),
-    Tutorial.loadConfig()
-  ]).then(function() {
-
+  VersionHelper.getVersionInfo().then(function(versionInfo) {
     if (!AppManager.isInitialized) {
       AppManager.init(versionInfo.isUpgrade());
     }
@@ -101,15 +94,18 @@ navigator.mozL10n.ready(function showBody() {
       UIManager.activationScreen.classList.remove('show');
       UIManager.updateScreen.classList.add('show');
 
-      if (stepsKey && Tutorial.config[stepsKey]) {
-        Tutorial.init(stepsKey);
-      } else {
-        // play the whole tutorial if there is no specific upgrade steps
-        Tutorial.init();
-      }
+      // Load and play the what's new tutorial
+      Tutorial.init(stepsKey, function() {
+        Tutorial.start();
+      });
+
     } else {
       UIManager.initTZ();
       UIManager.mainTitle.innerHTML = _('language');
+
+      // Just prepare tutorial to be optionally triggered by user in FTU
+      Tutorial.init();
     }
+
   });
 });

--- a/apps/ftu/js/tutorial.js
+++ b/apps/ftu/js/tutorial.js
@@ -5,19 +5,11 @@
 (function(exports) {
   'use strict';
 
-  // Config for the current tutorial steps
-  var stepsConfig = {};
-
   // default layout
   var currentLayout = 'tiny';
 
-  // Keeps track of the current step
-  var currentStep = 1;
   // Most used DOM elements
   var dom = {};
-
-  // Track initialized state of tutorial
-  var initialized = false;
 
   var MSG_MIGRATE_CON = 'migrate';
   var TXT_MSG = 'migrate';
@@ -46,21 +38,21 @@
 
   function _initProgressBar() {
     dom.tutorialProgressBar.style.width =
-      'calc(100% / ' + stepsConfig.steps.length + ')';
+      'calc(100% / ' + Tutorial._stepsConfig.steps.length + ')';
   }
 
   function _setProgressBarStep(step) {
     dom.tutorialProgressBar.style.transform =
       'translate(' + ((step - 1) * 100) + '%)';
-    if (stepsConfig) {
+    if (Tutorial._stepsConfig) {
       dom.tutorialProgress.setAttribute('aria-valuetext', navigator.mozL10n.get(
         'progressbar', {
           step: step,
-          total: stepsConfig.steps.length
+          total: Tutorial._stepsConfig.steps.length
         }));
       dom.tutorialProgress.setAttribute('aria-valuemin', 1);
       dom.tutorialProgress.setAttribute('aria-valuemax',
-        stepsConfig.steps.length);
+        Tutorial._stepsConfig.steps.length);
     } else {
       dom.tutorialProgress.removeAttribute('aria-valuetext');
       dom.tutorialProgress.removeAttribute('aria-valuemin');
@@ -68,6 +60,12 @@
     }
   }
 
+  /**
+   * Helper function to load imagaes and video
+   * @param {DOMNode} mediaElement  video or image to assign new src to
+   * @param {String} src  URL for video/image resource
+   * @returns {Promise}
+   */
   function _loadMedia(mediaElement, src) {
     var isVideo = (mediaElement.nodeName === 'VIDEO');
     return new Promise(function(resolve, reject) {
@@ -122,15 +120,41 @@
     'tutorial-progress-bar'
   ];
 
+  /**
+   * Manages and controls the configuration, content and state of the tutorial
+   * @module Tutorial
+   */
   var Tutorial = {
     // A configuration object.
     config: null,
 
+    // Config for the current tutorial steps
+    _stepsConfig: {},
+
+    // Which tutorial steps to use
+    _stepsKey: '',
+
+    // Keeps track of the current step
+    _currentStep: 1,
+
+    // Track initialized state of tutorial
+    _initialized: false,
+
+    /**
+     * Initialize the tutorial. This is async as a config file must be loaded.
+     * A Sequence (array of sync or async functions) is used to manage the init
+     * tasks.
+     * When complete, the tutorial is ready to be shown via the 'start' method
+     *
+     * @param {String} stepsKey a key into the tutorial config object, i
+     *                          i.e. a version or version delta like 1.3..2.0
+     * @param {Function} onLoaded  optional callback for when init is complete
+     * @memberof Tutorial
+    */
     init: function(stepsKey, onLoaded) {
       // init is async
       // need to load config, then load the first step and its assets.
-
-      if (initialized || this._initialization) {
+      if (this._initialized || this._initialization) {
         // init already underway
         return;
       }
@@ -138,31 +162,12 @@
       var initTasks = this._initialization = new Sequence(
         // config should load or already be loaded.
         // failure should abort
-        this.ensureConfig.bind(this),
-        this._initWithConfig.bind(this, stepsKey),
-        // setStep should return promise given by _loadMedia
-        function setInitialStep() {
-          return this._setStep();
-        }.bind(this),
-        function showTutorialAndFinishInit() {
-          // Show the panel
-          dom.tutorial.classList.add('show');
-          // Custom event that can be used to apply (screen reader) visibility
-          // changes.
-          window.dispatchEvent(new CustomEvent('tutorialinitialized'));
-        }
+        this.loadConfig.bind(this),
+        this._initWithConfig.bind(this, stepsKey)
       );
-      initTasks.onabort = function() {
-        Tutorial._initialization = null;
-      };
-      initTasks.oncomplete = function(result) {
-        Tutorial._initialization = null;
-        if(typeof onLoaded === 'function') {
-          onLoaded();
-        }
-      };
-
-      initTasks.nom = '[initTasks]';
+      initTasks.onabort = this._onAbortInitialization.bind(this);
+      initTasks.oncomplete =
+        this._onCompleteInitialization.bind(this, onLoaded);
 
       // first time here: cache DOM elements
       elementIDs.forEach(function(name) {
@@ -179,9 +184,64 @@
       initTasks.next();
     },
 
+    /**
+     * Show the tutorial and play the first step
+     * May be called during or after the init process
+     * We defer rasing the 'tutorialinitialized' event until this point
+     * as it signals the tutorial step content is loaded and displayed
+     *
+     * @param {Function} onReady  optional callback for when start is complete
+     * @memberof Tutorial
+     */
+    start: function(onReady) {
+      var sequence;
+      var initInProgress = false;
+      if (this._initialization) {
+        // init still underway, tack steps onto existing sequence
+        sequence = this._initialization;
+        initInProgress = true;
+      } else {
+        // init already complete, create new sequence
+        this._initialization = sequence = new Sequence();
+        sequence.onabort = this._onAbortInitialization.bind(this);
+        sequence.oncomplete =
+          this._onCompleteInitialization.bind(this);
+      }
+      sequence.push(function setInitialStep() {
+        // setStep should return promise given by _loadMedia
+        return this._setStep();
+      }.bind(this));
+
+      sequence.push(function showTutorialAndFinishInit() {
+        // Show the panel
+        dom.tutorial.classList.add('show');
+        // Custom event that can be used to apply (screen reader) visibility
+        // changes.
+        window.dispatchEvent(new CustomEvent('tutorialinitialized'));
+      });
+
+      if(typeof onReady === 'function') {
+        sequence.push(onReady);
+      }
+
+      if (!initInProgress) {
+        // init done, starting start sequence
+        sequence.next();
+      }
+    },
+
+    /**
+     * Continue initialization once config data is loaded
+     * Called as a part of the init sequence
+     *
+     * @param {String} stepsKey a key into the tutorial config object, i
+     *                          i.e. a version or version delta like 1.3..2.0
+     * @memberof Tutorial
+     */
     _initWithConfig: function(stepsKey) {
       stepsKey = stepsKey || 'default';
-      stepsConfig = this.config[stepsKey] || this.config['default'];
+      this._stepsKey = stepsKey;
+      this._stepsConfig = this.config[stepsKey] || this.config['default'];
 
       // Add event listeners
       dom.forwardTutorial.addEventListener('click', this);
@@ -189,32 +249,48 @@
 
       // toggle the layout based number of steps and whether we'll show the
       // progress bar or not
-      if (stepsConfig.steps.length > 3) {
+      if (this._stepsConfig.steps.length > 3) {
         dom.tutorial.dataset.progressbar = true;
         _initProgressBar();
       } else {
         delete dom.tutorial.dataset.progressbar;
       }
       // Set the first step
-      currentStep = 1;
+      this._currentStep = 1;
+    },
+    _onAbortInitialization: function() {
+      this._initialization = null;
+    },
+    _onCompleteInitialization: function(onReady) {
+      this._initialization = null;
+      this._initialized = true;
+      if(typeof onReady === 'function') {
+        onReady();
+      }
     },
 
+    /**
+     * Advance the tutorial to the given step (first step if no value given)
+     *
+     * @param {Number} value number of the step to show (1-based)
+     * @memberof Tutorial
+     */
     _setStep: function (value) {
       // If value is bigger than the max, show finish screen
-      value = (typeof value === 'number') ? value : currentStep;
+      value = (typeof value === 'number') ? value : this._currentStep;
       var stepIndex = value - 1;
-      if (stepIndex >= stepsConfig.steps.length) {
+      if (stepIndex >= this._stepsConfig.steps.length) {
         return Promise.resolve().then(function() {
           Tutorial.done();
         });
       }
 
-      var stepData = stepsConfig.steps[stepIndex];
+      var stepData = this._stepsConfig.steps[stepIndex];
       if (!stepData) {
         return Promise.reject('No data for step: ' + value);
       }
       // Set the step
-      dom.tutorial.dataset.step = currentStep;
+      dom.tutorial.dataset.step = this._currentStep;
 
       // Internationalize
       navigator.mozL10n.localize(
@@ -239,10 +315,16 @@
         imgElement.hidden = false;
         videoElement.hidden = true;
       }
-      _setProgressBarStep(currentStep);
+      _setProgressBarStep(this._currentStep);
       return stepPromise;
     },
 
+    /**
+     * DOM Event handler
+     *
+     * @param {DOMEvent} evt Event object
+     * @memberof Tutorial
+     */
     handleEvent: function(evt) {
       if (evt.type === 'click') {
         switch(evt.target) {
@@ -255,18 +337,43 @@
         }
       }
     },
+
+    /**
+     * Advance to the next step in the tutorial
+     * @memberof Tutorial
+     */
     next: function() {
-      return this._setStep(++currentStep);
+      return this._setStep(++this._currentStep);
     },
+
+    /**
+     * Go back to the previous step in the tutorial
+     * @memberof Tutorial
+     */
     back: function() {
-      return this._setStep(--currentStep);
+      return this._setStep(--this._currentStep);
     },
+
+    /**
+     * Tutorial complete
+     * @memberof Tutorial
+     */
     done: function() {
       FinishScreen.init();
       dom.tutorial.classList.remove('show');
       dom.tutorialStepVideo.removeAttribute('src');
       dom.tutorialStepImage.removeAttribute('src');
     },
+
+    /**
+     * Load the config with steps and associated resources for the tutorial
+     * We have different config files for each screen category:
+     * phone is 'tiny', tablet is 'large'
+     * and corresponding tiny.json, large.json
+     *
+     * @returns {Promise}
+     * @memberof Tutorial
+     */
     loadConfig: function() {
       if (!this._configPromise) {
         // Update the value of the layout if needed
@@ -314,9 +421,12 @@
       }
       return this._configPromise;
     },
-    ensureConfig: function() {
-      return this.loadConfig();
-    },
+
+    /**
+     * Test helper to reset the tutorial to its pre-initialized state
+     * to allow init to be called again
+     * @memberof Tutorial
+     */
     reset: function() {
       if (this._initialization) {
         this._initialization.abort();
@@ -326,16 +436,30 @@
         this._configRequest.abort();
       }
       this._configPromise = null;
-      currentStep = 1;
-      stepsConfig = this.config = null;
-      if (initialized) {
-        _setProgressBarStep(currentStep);
+      this._currentStep = 1;
+      this._stepsConfig = this.config = null;
+      if (this._initialized) {
+        _setProgressBarStep(this._currentStep);
         dom.tutorial.classList.remove('show');
+        this._initialized = false;
       }
     }
   };
 
-  // Flow control for a series of steps that may return promises
+  /**
+   * Private helper class to manage a series of sync or async functions
+   *
+   * The array may be manipulated using standard array methods while the
+   * sequence runs. The sequence completes when there are no more functions or
+   * an exception is raised.
+   * At the end of the sequence, any 'oncomplete' assigned will be called with
+   * the return value from the last function
+   * Functions may return a 'thenable' to indicate async return
+   * Exceptions will be passed into the oncomplete function
+   * A Sequence may be cleanly aborted by calling abort() - no callbacks will
+   * be fired
+   * @class Sequence
+   */
   function Sequence() {
     var sequence = Array.slice(arguments);
     var aborted = false;

--- a/apps/ftu/js/ui.js
+++ b/apps/ftu/js/ui.js
@@ -115,9 +115,6 @@ var UIManager = {
   init: function ui_init() {
     _ = navigator.mozL10n.get;
 
-    // Preload the tutorial config
-    Tutorial.loadConfig();
-
     // Initialization of the DOM selectors
     this.domSelectors.forEach(function createElementRef(name) {
       this[toCamelCase(name)] = document.getElementById(name);
@@ -217,9 +214,8 @@ var UIManager = {
       // Stop Wifi Manager
       WifiManager.finish();
 
-      // Tutorial config is probably preloaded by now, but init could be
-      // async if it is still loading
-      Tutorial.init(null, function onTutorialLoaded() {
+      // Play the tutorial steps as soon as config is done loading
+      Tutorial.start(function onTutorialLoaded() {
         UIManager.activationScreen.classList.remove('show');
         UIManager.updateScreen.classList.remove('show');
         UIManager.finishScreen.classList.remove('show');

--- a/apps/ftu/test/unit/app_test.js
+++ b/apps/ftu/test/unit/app_test.js
@@ -44,6 +44,9 @@ suite('AppManager >', function() {
     realMozApps = navigator.mozApps;
     navigator.mozApps = MockNavigatormozApps;
     mocksHelperForAppManager.suiteSetup();
+    // also call setup the first time
+    mocksHelperForAppManager.setup();
+
     requireApp('ftu/js/app.js', done);
   });
 

--- a/apps/ftu/test/unit/mock_ui_manager.js
+++ b/apps/ftu/test/unit/mock_ui_manager.js
@@ -2,22 +2,25 @@
 
 var MockUIManager = {
   domSelectors: [
+    'splash-screen',
     'activation-screen',
     'progress-bar',
     'progress-bar-state',
     'finish-screen',
+    'update-screen',
     'nav-bar',
     'main-title',
     // Unlock SIM Screen
     'unlock-sim-screen',
     'unlock-sim-header',
+    'unlock-sim-back',
     // PIN Screen
     'pincode-screen',
     'pin-label',
     'pin-retries-left',
     'pin-input',
-    'pin-error',
     'back-sim-button',
+    'pin-error',
     'skip-pin-button',
     'unlock-sim-button',
     // PUK Screen
@@ -53,22 +56,57 @@ var MockUIManager = {
     'no-sim',
     'sd-import-button',
     'no-memorycard',
+    // Fxa Intro
+    'fxa-create-account',
+    'fxa-intro',
+    // Wifi
+    'networks',
+    'wifi-refresh-button',
+    'wifi-join-button',
+    'join-hidden-button',
+    // Hidden Wifi
+    'hidden-wifi-authentication',
+    'hidden-wifi-ssid',
+    'hidden-wifi-security',
+    'hidden-wifi-password',
+    'hidden-wifi-identity',
+    'hidden-wifi-identity-box',
+    'hidden-wifi-show-password',
+    //Date & Time
+    'date-configuration',
+    'time-configuration',
+    'date-configuration-label',
+    'time-configuration-label',
+    'time-form',
+    // 3G
+    'data-connection-switch',
+    // Geolocation
+    'geolocation-switch',
     // Tutorial
-    'tutorial-screen',
-    'tutorial-progress',
-    'tutorial-progress-state',
     'lets-go-button',
+    'update-lets-go-button',
     'skip-tutorial-button',
-    // Navigation
-    'back',
-    'forward',
-    'wifi-join-button'
+    'update-skip-tutorial-button',
+    // Privacy Settings
+    'share-performance',
+    'offline-error-dialog',
+    // Browser privacy newsletter subscription
+    'newsletter-form',
+    'newsletter-input',
+    'newsletter-success-screen',
+    'offline-newsletter-error-dialog',
+    'invalid-email-error-dialog'
   ],
 
   mSetup: function muim_mSuiteSetup() {
     this.domSelectors.forEach(function createElementRef(name) {
       if (name) {
-        this[toCamelCase(name)] = document.getElementById(name);
+        var element = document.getElementById(name);
+        if (!element) {
+            element = document.createElement('div');
+            element.id = name;
+        }
+        this[toCamelCase(name)] = element;
       }
     }.bind(this));
   },
@@ -85,7 +123,8 @@ var MockUIManager = {
   updateDataConnectionStatus: function(status) {return DataMobile.getStatus();},
   displayOfflineDialog: function() {},
   hideActivationScreenFromScreenReader: function() {},
-  init: function() {}
+  init: function() {},
+  initTZ: function() {}
 };
 
 function toCamelCase(str) {

--- a/apps/ftu/test/unit/tutorial_test.js
+++ b/apps/ftu/test/unit/tutorial_test.js
@@ -9,8 +9,6 @@ requireApp('ftu/test/unit/mock_finish_screen.js');
 
 requireApp('ftu/js/finish_screen.js');
 requireApp('ftu/js/utils.js');
-requireApp('ftu/js/tutorial.js');
-
 
 suite('Tutorial >', function() {
   var mocksHelperForFTU = new MocksHelper([
@@ -53,7 +51,7 @@ suite('Tutorial >', function() {
   var realMozApps;
   var realXHR;
 
-  suiteSetup(function() {
+  suiteSetup(function(done) {
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
 
@@ -64,6 +62,8 @@ suite('Tutorial >', function() {
 
     realXHR = window.XMLHttpRequest;
     window.XMLHttpRequest = MockXMLHttpRequest;
+
+    requireApp('ftu/js/tutorial.js', done);
   });
 
   suiteTeardown(function() {
@@ -79,18 +79,26 @@ suite('Tutorial >', function() {
     MockNavigatormozApps.mTeardown();
   });
 
+  test(' sanity test Tutorial', function() {
+    assert.equal(typeof Tutorial, 'object');
+    assert.equal(typeof Tutorial.loadConfig, 'function');
+    assert.equal(typeof Tutorial.init, 'function');
+    assert.equal(typeof Tutorial.start, 'function');
+  });
+
   test(' sanity test mocks', function(done) {
     MockXMLHttpRequest.mResponse = mockConfig(2);
-    Tutorial.init(null, function() {
-      done(function() {
-        assert.equal(Tutorial.config['default'].steps.length, 2);
-      });
-    });
+    Tutorial.loadConfig().then(onOutcome, onOutcome)
+                         .then(done, done);
+    function onOutcome() {
+      assert.equal(Tutorial.config['default'].steps.length, 2);
+    };
   });
 
   suite(' lifecycle', function() {
     teardown(function() {
       Tutorial.reset();
+      document.getElementById('tutorial').classList.remove('show');
     });
 
     test('reset', function(done) {
@@ -130,7 +138,30 @@ suite('Tutorial >', function() {
       }
     });
 
-    test('init despite failure to load media', function(done) {
+    test('start during init', function(done) {
+      Tutorial.init();
+      Tutorial.start(function() {
+        setTimeout(done, 0);
+        assert.ok(Tutorial.config);
+        assert.isTrue(
+          document.getElementById('tutorial').classList.contains('show')
+        );
+      });
+    });
+
+    test('start after init', function(done) {
+      Tutorial.init(null, function() {
+        Tutorial.start(function() {
+          setTimeout(done, 0);
+          assert.ok(Tutorial.config);
+          assert.isTrue(
+            document.getElementById('tutorial').classList.contains('show')
+          );
+        });
+      });
+    });
+
+    test('start despite failure to load media', function(done) {
       var tutorialWasInitialized = false;
       MockXMLHttpRequest.mResponse = {
         'default': {
@@ -143,7 +174,8 @@ suite('Tutorial >', function() {
       window.addEventListener('tutorialinitialized', function() {
         tutorialWasInitialized = true;
       });
-      Tutorial.init(null, function() {
+      Tutorial.init();
+      Tutorial.start(function() {
         done(function() {
           assert.isTrue(tutorialWasInitialized, 'tutorialinitialized fired');
         });
@@ -158,19 +190,20 @@ suite('Tutorial >', function() {
 
       MockXMLHttpRequest.mResponse = mockConfig(3);
 
-      Tutorial.init(null, function() {
+      Tutorial.init();
+      Tutorial.start(function() {
         done();
       });
     });
 
-    test(' is shown properly after Tutorial.init', function() {
+    test(' is shown properly after Tutorial.start', function() {
       // Is the tutorial shown?
       assert.isTrue(
         document.getElementById('tutorial').classList.contains('show')
       );
     });
 
-    test(' check dataset after Tutorial.init', function() {
+    test(' check dataset after Tutorial.start', function() {
       // Are we in Step 1?
       assert.equal(
         document.getElementById('tutorial').dataset.step,
@@ -248,7 +281,8 @@ suite('Tutorial >', function() {
 
     test(' dont display with 3 steps', function(done) {
       MockXMLHttpRequest.mResponse = mockConfig(3);
-      Tutorial.init(null, function() {
+      Tutorial.init();
+      Tutorial.start(function() {
         assert.equal(Tutorial.config['default'].steps.length, 3);
         var tutorialNode = document.getElementById('tutorial');
         assert.ok(!tutorialNode.hasAttribute('data-progressbar'), '');
@@ -258,7 +292,8 @@ suite('Tutorial >', function() {
 
     test(' do display with 4 steps', function(done) {
       MockXMLHttpRequest.mResponse = mockConfig(4);
-      Tutorial.init(null, function() {
+      Tutorial.init();
+      Tutorial.start(function() {
         assert.equal(Tutorial.config['default'].steps.length, 4);
         var tutorialNode = document.getElementById('tutorial');
         assert.ok(tutorialNode.hasAttribute('data-progressbar'));


### PR DESCRIPTION
- init early in FTU, call start from 'Get started' button
- Dont wait to loadConfig in ftu AppManager
- Add 1.3..2.1 and 1.4..2.1 upgrade steps for easier testing on master
- Remove unused ensureConfig
- Fix tutorial init/start logic in FTU AppManager
- Add jsdocs for Tutorial
- Remove surplus Tutorial.init call from UIManager
- Update FTU UIManager mock
