### PR TITLE
Bug 1045919 - JavaScript Error: "TypeError: AppWindowManager.getActiveApp(...) is null" {file: "app://system.gaiamobile.org/js/activity_window_manager.js"

### DIFF
--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -35,8 +35,14 @@
       }
     },
 
+    /**
+     * Get active app. If active app is null, we'll return homescreen as
+     * default.
+     * @return {AppWindow} The app is active.
+     */
     getActiveApp: function awm_getActiveApp() {
-      return this._activeApp;
+      return this._activeApp || (exports.homescreenLauncher ?
+        exports.homescreenLauncher.getHomescreen() : null);
     },
 
     /**

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -148,6 +148,12 @@ suite('system/AppWindowManager', function() {
     });
   }
 
+  test('Get active app when _activeApp is null', function() {
+    AppWindowManager._activeApp = null;
+    assert.deepEqual(AppWindowManager.getActiveApp(), home,
+      'should return home app');
+  });
+
   suite('Handle events', function() {
     test('localized event should be broadcasted.', function() {
       var stubBroadcastMessage =


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1045919
