### PR TITLE
Bug 1045345 - Use existing strings for the upgrade tutorial

### DIFF
--- a/apps/ftu/index.html
+++ b/apps/ftu/index.html
@@ -657,12 +657,12 @@
 
   <section id="update-screen" class="finish-screen-base" role="region">
     <section class="content">
-      <h1 data-l10n-id="whatsNew">
-        What's new
+      <h1 data-l10n-id="startYourPhone" class="for-tiny">
+        Start your Phone Tour!
       </h1>
-      <p data-l10n-id="updatedSuccessfully">
-        Your phone has updated successfully! Start the tour to find out more about the new features.
-      </p>
+      <h1 data-l10n-id="startYourTablet" class="for-large">
+        Start your tablet tour!
+      </h1>
     </section>
     <menu role="navigation">
       <button id="update-skip-tutorial-button" class="button-left" data-l10n-id="skip">

--- a/apps/ftu/js/app.js
+++ b/apps/ftu/js/app.js
@@ -1,6 +1,6 @@
 /* global DataMobile, Navigation, SimManager, TimeManager,
           UIManager, WifiManager, ImportIntegration, Tutorial, Promise,
-          VersionHelper */
+          VersionHelper, FinishScreen */
 /* exported AppManager */
 'use strict';
 
@@ -100,6 +100,8 @@ navigator.mozL10n.ready(function showBody() {
       UIManager.splashScreen.classList.remove('show');
       UIManager.activationScreen.classList.remove('show');
       UIManager.updateScreen.classList.add('show');
+
+      FinishScreen.isUpgrade = true;
 
       if (stepsKey && Tutorial.config[stepsKey]) {
         Tutorial.init(stepsKey);

--- a/apps/ftu/js/finish_screen.js
+++ b/apps/ftu/js/finish_screen.js
@@ -14,6 +14,7 @@
   var initialized = false;
 
   var FinishScreen = {
+    isUpgrade: false,
     init: function () {
       if (initialized) {
         return;
@@ -29,7 +30,11 @@
       // Show finish panel
       var finishPanel = document.getElementById(panelSelector);
       finishPanel.classList.add('show');
-      
+
+      if (this.isUpgrade) {
+        finishPanel.classList.add('upgrade-tour');
+      }
+
       // Cache non-layout-related DOM elements
       elementIDs.forEach(function (name) {
         dom[Utils.camelCase(name)] = document.getElementById(name);

--- a/apps/ftu/style/style.css
+++ b/apps/ftu/style/style.css
@@ -567,6 +567,11 @@ aside.connecting {
   line-height: 2rem;
 }
 
+/* Bug 1045345: hide h2 after upgrade tour */
+.tutorial-finish-base.upgrade-tour h2[data-l10n-id="enjoyYourPhone"] {
+  display: none;
+}
+
 .finish-screen-base p, .tutorial-finish-base p {
   margin: 0;
   color: white;


### PR DESCRIPTION
2.0 patch to avoid using non-localized strings for "what's new" upgrade tutorial. 
