### PR TITLE
Grant read/write access to the contacts from the system app

### DIFF
--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -45,7 +45,8 @@
     "nfc-manager":{},
     "downloads":{},
     "systemXHR":{},
-    "feature-detection": {}
+    "feature-detection": {},
+    "contacts":{ "access": "readwrite" }
   },
   "locales": {
     "ar": {


### PR DESCRIPTION
This is done in preparation for hiding the MozContacts API from
unprivileged contacts.  We need this in order to be able to
manipulate contacts in the gaia tests through the system app.
