### PR TITLE
Bug 1046068 - Add the default value for mms delivery report

### DIFF
--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -131,6 +131,7 @@
    "ril.data.suspended": false,
    "ril.iccInfo.mbdn": "",
    "ril.sms.requestStatusReport.enabled": false,
+   "ril.mms.requestReadReport.enabled": false,
    "ril.cellbroadcast.searchlist": "",
    "ril.callwaiting.enabled": null,
    "ril.cf.enabled": false,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1046068
