### PR TITLE
Bug 1038992 - FxA "forgot password" link crashes refreshAuth flow. r=ferjm

### DIFF
--- a/apps/system/fxa/js/screens/fxam_refresh_auth.js
+++ b/apps/system/fxa/js/screens/fxam_refresh_auth.js
@@ -36,9 +36,11 @@ var FxaModuleRefreshAuth = (function() {
     FxModuleServerRequest.requestPasswordReset(
       email,
       function onSuccess(response) {
-        done(response.success);
+        done();
       },
-      this.showErrorResponse
+      (function onError(response) {
+        this._showCouldNotResetPassword();
+      }).bind(this)
     );
   }
 
@@ -55,13 +57,8 @@ var FxaModuleRefreshAuth = (function() {
     _requestPasswordReset.call(
       this,
       this.email,
-      function(isRequestHandled) {
+      function() {
         FxaModuleOverlay.hide();
-        if (!isRequestHandled) {
-          _showCouldNotResetPassword.call(this);
-          return;
-        }
-
         FxaModuleStates.setState(FxaModuleStates.PASSWORD_RESET_SUCCESS);
       }
     );


### PR DESCRIPTION
...92#c12 r=_6a68
