### PR TITLE
Bug 1008859 - [tarako][l10n] Unable to change language back for New Account page in Email. r=asuth, a=blocking-b2g=v1.3t+ a=bajaj a=wchang a=lmandel

### DIFF
--- a/apps/email/js/tmpl.js
+++ b/apps/email/js/tmpl.js
@@ -2,7 +2,7 @@ define(['l10n!'], function(mozL10n) {
   // Keep track of all translated nodes, so that they are properly
   // updated on the fly when the language changes.
   var nodes = [];
-  mozL10n.ready(function() {
+  window.addEventListener('localized', function() {
     nodes.forEach(function(node) {
       mozL10n.translate(node);
     });


### PR DESCRIPTION
This is a v1.3t and v1.4 specific workaround for bug 993188 in l10n.js.
Specifically, mozL10n.ready() does not correctly add a 'localized'
listener in all cases.  In fact, because of the email app control flow,
it will never do the right thing.  This patch pierces that function to
directly add the event listener, which is always what we want.  (The
other branch that immediately invokes the callback doesn't matter to us
because at the time this method is invoked we are already using the
localization API synchronously and do the callback triggering would
simply result in the work being done twice.  (l10n is a dependency so
the locale will already have been loaded.))
