### PR TITLE
Bug 1046564: Should display normal priority message of STK_CMD_DISPLAY_TEXT command while device is Settings

### DIFF
--- a/apps/system/js/icc_worker.js
+++ b/apps/system/js/icc_worker.js
@@ -225,8 +225,10 @@ var icc_worker = {
 
     // Check if device is idle or settings
     var activeApp = AppWindowManager.getActiveApp();
+    var settingsOrigin = document.location.protocol + '//' +
+      document.location.host.replace('system', 'settings');
     if (!options.isHighPriority && !activeApp.isHomescreen &&
-        activeApp.origin !== 'app://settings.gaiamobile.org') {
+        activeApp.origin !== settingsOrigin) {
       DUMP('Do not display the text because normal priority.');
       icc.responseSTKCommand(message, {
         resultCode:

--- a/apps/system/js/icc_worker.js
+++ b/apps/system/js/icc_worker.js
@@ -223,9 +223,10 @@ var icc_worker = {
     DUMP('STK_CMD_DISPLAY_TEXT:', message.command.options);
     var options = message.command.options;
 
-    // Check if device is idle
+    // Check if device is idle or settings
     var activeApp = AppWindowManager.getActiveApp();
-    if (!options.isHighPriority && !activeApp.isHomescreen) {
+    if (!options.isHighPriority && !activeApp.isHomescreen &&
+        activeApp.origin !== 'app://settings.gaiamobile.org') {
       DUMP('Do not display the text because normal priority.');
       icc.responseSTKCommand(message, {
         resultCode:


### PR DESCRIPTION
To show the normal priority message of STK_CMD_DISPLAY_TEXT command when the device is both HomeScreen and Settings. 
