### PR TITLE
Bug 1042463 - System Update prompt persists in low-battery environment

### DIFF
--- a/apps/system/js/updatable.js
+++ b/apps/system/js/updatable.js
@@ -258,7 +258,7 @@ SystemUpdatable.prototype.showApplyPromptBatteryNok = function(minBattery) {
 
   var ok = {
     title: _('ok'),
-    callback: this.declineInstall.bind(this)
+    callback: this.declineInstallBattery.bind(this)
   };
 
   UtilityTray.hide();
@@ -277,7 +277,7 @@ SystemUpdatable.prototype.showApplyPromptBatteryOk = function() {
 
   var cancel = {
     title: _('later'),
-    callback: this.declineInstall.bind(this)
+    callback: this.declineInstallWait.bind(this)
   };
 
   var confirm = {
@@ -291,12 +291,29 @@ SystemUpdatable.prototype.showApplyPromptBatteryOk = function() {
                     cancel, confirm);
 };
 
-SystemUpdatable.prototype.declineInstall = function() {
+/**
+ * Decline install of update, forwarding `reason` to UpdatePrompt.jsm.
+ * `reason` is either 'wait' or 'low-battery'. 'wait' corresponds to the user
+ * deciding to delay the update, in which case the prompt will reappear after a
+ * few minutes of idle time. 'low-battery' means the battery is currently too
+ * low for an update to take place and the update prompt will not reappear.
+ * @param {String} reason
+ */
+SystemUpdatable.prototype.declineInstall = function(reason) {
   CustomDialog.hide();
-  this._dispatchEvent('update-prompt-apply-result', 'wait');
+  this._dispatchEvent('update-prompt-apply-result', reason);
 
   UpdateManager.removeFromDownloadsQueue(this);
 };
+
+SystemUpdatable.prototype.declineInstallBattery = function() {
+  this.declineInstall('low-battery');
+};
+
+SystemUpdatable.prototype.declineInstallWait = function() {
+  this.declineInstall('wait');
+};
+
 
 SystemUpdatable.prototype.acceptInstall = function() {
   CustomDialog.hide();

--- a/apps/system/test/unit/updatable_test.js
+++ b/apps/system/test/unit/updatable_test.js
@@ -689,6 +689,17 @@ suite('system/Updatable', function() {
         assert.equal(SYSTEM_LOW_BATTERY_L10N_KEY, MockCustomDialog.mShowedMsg);
         assert.equal('ok', MockCustomDialog.mShowedCancel.title);
       });
+
+      test('battery prompt callback', function() {
+        assert.equal(subject.declineInstallBattery.name,
+                     MockCustomDialog.mShowedCancel.callback.name);
+
+        subject.declineInstallBattery();
+        assert.isFalse(MockCustomDialog.mShown);
+
+        assert.equal('update-prompt-apply-result', lastDispatchedEvent.type);
+        assert.equal('low-battery', lastDispatchedEvent.value);
+      });
     }
 
     testSystemApplyPromptBatteryOk();
@@ -701,7 +712,7 @@ suite('system/Updatable', function() {
       assert.equal(subject.declineInstall.name,
                    MockCustomDialog.mShowedCancel.callback.name);
 
-      subject.declineInstall();
+      subject.declineInstallWait();
       assert.isFalse(MockCustomDialog.mShown);
 
       assert.equal('update-prompt-apply-result', lastDispatchedEvent.type);
@@ -709,7 +720,7 @@ suite('system/Updatable', function() {
     });
 
     test('canceling should remove from downloads queue', function() {
-      subject.declineInstall();
+      subject.declineInstallWait();
 
       assert.isNotNull(MockUpdateManager.mLastDownloadsRemoval);
       assert.equal(subject, MockUpdateManager.mLastDownloadsRemoval);


### PR DESCRIPTION
Fix prompt appearing even when battery is below allowed threshold,
introducing a new update-prompt-result event type.
