### PR TITLE
Bug 1048784 - Button OK for dialog about invalid email address should be centered

### DIFF
--- a/apps/email/js/cards/cmp/invalid_addresses.html
+++ b/apps/email/js/cards/cmp/invalid_addresses.html
@@ -5,7 +5,7 @@
   </section>
   <menu>
     <button id="cmp-confirm-invalid-addresses"
-            class="confirm-dialog-ok recommend"
+            class="confirm-dialog-ok full recommend"
             data-l10n-id="dialog-button-ok">OK</button>
   </menu>
 </form>


### PR DESCRIPTION
Just missing the "full" class supported by shared/style/confirm.css that makes the button full width size.
