### PR TITLE
Bug 1048539 - [B2G][Email][Drawer] The account selecter pull-down is displayed improperly in the Drawer

### DIFF
--- a/apps/email/js/cards/folder_picker.html
+++ b/apps/email/js/cards/folder_picker.html
@@ -25,7 +25,11 @@
              expanded.  The actual items live in fld-accountlist-container
              for animation reasons; see below. -->
         <a class="fld-acct-header closed" role="region">
-          <span class="fld-acct-header-account-label"></span>
+          <!--
+            The &nbsp; is on purpose, so that initial height measurement of the
+            element be correct even before this element has real content.
+          -->
+          <span class="fld-acct-header-account-label">&nbsp;</span>
           <span class="fld-acct-header-account-header"
                 data-l10n-id="drawer-accounts-header">AccountS</span>
           <span class="fld-account-switch-arrow"></span>


### PR DESCRIPTION
If the drawer is open before the account list is known, the `fld-acct-header-account-label` element is empty, and gives an incorrect, smaller height size when `this.accountHeader.getBoundingClientRect().height` is called.

This change adds some content for that first height query in the case the user taps on the menu icon before the model data is fully known. 

I did this instead of giving `fld-acct-header-account-label` a height in CSS because we want the size to be dynamic, and respond to things like font sizing for the app, which may be set not where this sort of CSS height would be set. We do not need to worry about a long email address either, the element is set up to nowrap with ellipsis. So we just need some content.

I favored using an HTML entity (some sort of non-whitespace text) over a plain or \n (or other whitespace) (with a comment inside explaining the whitespace) just in case comments and whitespace are trimmed by optimization tools at some point.
