### PR TITLE
Revert "Bug1046554 - B2G NFC: pass NFCPeerEvent in onpeerready"

### DIFF
--- a/apps/browser/js/nfc.js
+++ b/apps/browser/js/nfc.js
@@ -91,7 +91,7 @@ var NfcURI = {
     records.push(record);
 
     var nfcdom = window.navigator.mozNfc;
-    var nfcPeer = event.peer;
+    var nfcPeer = nfcdom.getNFCPeer(event.detail);
 
     if (!nfcPeer) {
       return null;

--- a/apps/communications/contacts/js/nfc.js
+++ b/apps/communications/contacts/js/nfc.js
@@ -32,7 +32,7 @@ contacts.NFC = (function() {
   };
 
   var handlePeerReady = function(event) {
-    mozNfcPeer = event.peer;
+    mozNfcPeer = mozNfc.getNFCPeer(event.detail);
     LazyLoader.load([
       '/shared/js/contact2vcard.js',
       '/shared/js/setImmediate.js',

--- a/apps/gallery/js/gallery.js
+++ b/apps/gallery/js/gallery.js
@@ -741,12 +741,12 @@ function setNFCSharing(enable) {
       if (fileInfo.metadata.video) {
         // share video
         getVideoFile(fileInfo.metadata.video, function(file) {
-          event.peer.sendFile(file);
+          navigator.mozNfc.getNFCPeer(event.detail).sendFile(file);
         });
       } else {
         // share photo
         photodb.getFile(fileInfo.name, function(file) {
-          event.peer.sendFile(file);
+          navigator.mozNfc.getNFCPeer(event.detail).sendFile(file);
         });
       }
     };

--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -604,7 +604,7 @@ var ModeManager = {
       // Assign the sharing function to onpeerready so that it will trigger
       // the shrinking ui to share the playing file.
       navigator.mozNfc.onpeerready = function(event) {
-        var peer = event.peer;
+        var peer = navigator.mozNfc.getNFCPeer(event.detail);
         if (peer)
           peer.sendFile(PlayerView.playingBlob);
       };

--- a/apps/video/js/video.js
+++ b/apps/video/js/video.js
@@ -937,7 +937,7 @@ function setNFCSharing(enable) {
       // The callback function is called when user confirm to share the
       // content, send it with NFC Peer.
       videodb.getFile(currentVideo.name, function(file) {
-        event.peer.sendFile(file);
+        navigator.mozNfc.getNFCPeer(event.detail).sendFile(file);
       });
     };
   } else {


### PR DESCRIPTION
Reverts mozilla-b2g/gaia#22394

https://bugzilla.mozilla.org/show_bug.cgi?id=1046554
