### PR TITLE
Bug 1048953 - Calendar Day view fails when hour is 00:xx JavaScript error: app://calendar.gaiamobile.org/js/views/current_time.js, line 115: displayHour is null r=gaye

### DIFF
--- a/apps/calendar/js/template.js
+++ b/apps/calendar/js/template.js
@@ -36,6 +36,10 @@
     'h': function(a) {
 
       var arg = this.arg(a);
+      // accept anything that can be converted into a string and we make sure
+      // the only falsy values that are converted into empty strings are
+      // null/undefined to avoid mistakes
+      arg = arg == null ? '' : String(arg);
 
       //only escape bad looking stuff saves
       //a ton of time
@@ -43,9 +47,7 @@
         span.textContent = arg;
         return span.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
       } else {
-        // we don't want to call String in the case of "".
-        // we emit a string version rather then an empty string.
-        return arg || '';
+        return arg;
       }
     },
 

--- a/apps/calendar/js/templates/months_day.js
+++ b/apps/calendar/js/templates/months_day.js
@@ -17,7 +17,7 @@
       ].join(' ');
 
       this.eventTime = function() {
-        return this.h('isAllDay') ?
+        return this.arg('isAllDay') ?
           '<div class="all-day" data-l10n-id="hour-allday"></div>' :
           ('<div class="start-time">' + this.h('startTime') + '</div>' +
            '<div class="end-time">' + this.h('endTime') + '</div>');

--- a/apps/calendar/test/unit/template_test.js
+++ b/apps/calendar/test/unit/template_test.js
@@ -142,6 +142,27 @@ suite('calendar/template', function() {
       assert.equal(tpl.render('bar'), '\nfoo bar');
     });
 
+    test('with numeric, null and objects', function() {
+      var tpl = new Template(function() {
+        return 'foo ' + this.h('nullish') + this.h('undefinedish') +
+          this.h('zeroish') +' '+ this.h('falseish') + ' ' +
+          this.h('objectish');
+      });
+      // null, undefined and zero caused problems previously
+      assert.equal(tpl.render({
+        nullish: null,
+        undefinededish: undefined,
+        zeroish: 0,
+        falseish: false,
+        objectish: {
+          toString: function() {
+            // this should be escaped!!!
+            return '<a>complex</a>';
+          }
+        }
+      }), 'foo 0 false &lt;a&gt;complex&lt;/a&gt;');
+    });
+
     test('no html escape', function() {
       var tpl, input, output;
 

--- a/apps/calendar/test/unit/views/day_based_test.js
+++ b/apps/calendar/test/unit/views/day_based_test.js
@@ -469,6 +469,8 @@ suiteGroup('Views.DayBased', function() {
     var children;
 
     setup(function() {
+      // hour 0 caused Bug 1048953, so it's important to test it as well
+      subject.createHour(0);
       subject.createHour(5);
       subject.createHour(7);
       subject.createHour(6);
@@ -508,27 +510,44 @@ suiteGroup('Views.DayBased', function() {
     });
 
     test('first', function() {
-      hasHour(5);
+      hasHour(0);
 
       var el = children[0];
       assert.ok(el.outerHTML);
-      assert.include(el.outerHTML, hourHTML(5));
+      assert.include(el.outerHTML, hourHTML(0));
+      // this checks bug 1048953!!
+      assert.include(el.outerHTML, 'hour-0');
+      assert.include(el.outerHTML, 'data-hour="0"');
     });
 
-    test('middle', function() {
-      hasHour(6);
+    test('middle1', function() {
+      hasHour(5);
 
       var el = children[1];
       assert.ok(el.outerHTML);
+      assert.include(el.outerHTML, hourHTML(5));
+      assert.include(el.outerHTML, 'hour-5');
+      assert.include(el.outerHTML, 'data-hour="5"');
+    });
+
+    test('middle2', function() {
+      hasHour(6);
+
+      var el = children[2];
+      assert.ok(el.outerHTML);
       assert.include(el.outerHTML, hourHTML(6));
+      assert.include(el.outerHTML, 'hour-6');
+      assert.include(el.outerHTML, 'data-hour="6"');
     });
 
     test('last', function() {
       hasHour(7);
 
-      var el = children[2];
+      var el = children[3];
       assert.ok(el.outerHTML);
       assert.include(el.outerHTML, hourHTML(7));
+      assert.include(el.outerHTML, 'hour-7');
+      assert.include(el.outerHTML, 'data-hour="7"');
     });
 
   });


### PR DESCRIPTION
improved the template HTML escape behavior and also added unit tests for day_based template to avoid regressions. this will definitely avoid headaches..
