### PR TITLE
add ability to pass in serial number

### DIFF
--- a/tests/python/runner-service/runner_service/arguments.py
+++ b/tests/python/runner-service/runner_service/arguments.py
@@ -29,6 +29,11 @@ class GaiaIntegrationParser(ArgumentParser):
           "default": None,
           "help": "Path to build symbols used by crash reporting."
         }],
+        [["--serial"],
+        { "dest": "device_serial",
+          "default": None,
+          "help": "serial ID of a device to use for adb / fastboot"
+        }],
     ]
 
     def __init__(self, *args, **kwargs):

--- a/tests/python/runner-service/runner_service/handlers/runner.py
+++ b/tests/python/runner-service/runner_service/handlers/runner.py
@@ -109,9 +109,10 @@ class EmulatorHandler(MozrunnerHandler):
 class DeviceHandler(MozrunnerHandler):
 
     def __init__(self, *args, **kwargs):
+        serial = kwargs.pop('serial', None)
         MozrunnerHandler.__init__(self, *args, **kwargs)
 
-        self.runner = B2GDeviceRunner(**self.common_runner_args)
+        self.runner = B2GDeviceRunner(serial=serial, **self.common_runner_args)
         self.runner.device.connect()
 
     def start_runner(self, data):

--- a/tests/python/runner-service/runner_service/runintegration.py
+++ b/tests/python/runner-service/runner_service/runintegration.py
@@ -61,6 +61,7 @@ def cli(args=sys.argv[1:]):
 
     rhandler_args = {
         'symbols_path': args.symbols_path,
+        'serial': args.device_serial,
     }
     if args.b2g_home:
         rhandler_args['b2g_home'] = args.b2g_home


### PR DESCRIPTION
for Bug 1046713 - marionette-socket-host runner service should allow specification of a device serial
