### PR TITLE
Bug 1050431 - Fix video.css to use new "main-size" keyword instead of "auto", for flex-basis. r=djf

### DIFF
--- a/apps/video/style/video.css
+++ b/apps/video/style/video.css
@@ -696,20 +696,20 @@ body.pick-activity #thumbnails-bottom {
 
 .thumbnail .details .title {
   order: 1;
-  flex: 0 1 auto;
+  flex: 0 1 main-size;
   align-self: auto;
   word-break: break-all;
 }
 
 .thumbnail .details .duration-text {
   order: 2;
-  flex: 0 1 auto;
+  flex: 0 1 main-size;
   align-self: auto;
 }
 
 .thumbnail .details .size-type-group {
   order: 3;
-  flex: 0 1 auto;
+  flex: 0 1 main-size;
   align-self: auto;
 }
 


### PR DESCRIPTION
Patch for [bug 1050431](https://bugzilla.mozilla.org/show_bug.cgi?1050431)

As discussed in gecko [bug 1032922](https://bugzilla.mozilla.org/show_bug.cgi?id=1032922), the flex-basis "auto" keyword has been renamed to "main-size" in the [editor's draft of the flexbox spec](http://dev.w3.org/csswg/css-flexbox/#flex-basis-property). This patch fixes up some instances of "flex: 0 1 auto" [where "auto" is the flex-basis component] to use the new "main-size" keyword.

IMPORTANT: This should _not_ be merged until [bug 1032922](https://bugzilla.mozilla.org/show_bug.cgi?id=1032922) has landed in mozilla-central.
