### PR TITLE
Bug 1044405 - Should set a empty string if there are no text and l10n provided. r=alive

### DIFF
--- a/shared/js/lockscreen_connection_info_manager.js
+++ b/shared/js/lockscreen_connection_info_manager.js
@@ -171,6 +171,8 @@
       node.removeAttribute('data-l10n-id');
       if (text) {
         node.textContent = text;
+      } else {
+        node.textContent = '';
       }
     }
   }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1044405
