### PR TITLE
Update notifications.js

### DIFF
--- a/apps/system/js/notifications.js
+++ b/apps/system/js/notifications.js
@@ -3,42 +3,6 @@
 
 'use strict';
 
-(function appCacheIcons() {
-  // Caching the icon for notification if appCache is in effect
-  var appCache = window.applicationCache;
-  if (!appCache)
-    return;
-
-  var addIcons = function addIcons(app) {
-    if (!app.manifest)
-      return;
-    var icons = app.manifest.icons;
-    if (icons) {
-      Object.keys(icons).forEach(function iconIterator(key) {
-        var url = app.origin + icons[key];
-        appCache.mozAdd(url);
-      });
-    }
-  };
-
-  var removeIcons = function removeIcons(app) {
-    var icons = app.manifest.icons;
-    if (icons) {
-      Object.keys(icons).forEach(function iconIterator(key) {
-        var url = app.origin + icons[key];
-        appCache.mozRemove(url);
-      });
-    }
-  };
-
-  window.addEventListener('applicationinstall', function bsm_oninstall(evt) {
-    addIcons(evt.detail.application);
-  });
-
-  window.addEventListener('applicationuninstall', function bsm_oninstall(evt) {
-    removeIcons(evt.detail.application);
-  });
-}());
 
 var NotificationScreen = {
   TOASTER_TIMEOUT: 5000,


### PR DESCRIPTION
Regarding the bug no. 1006990 .
Gaia apps was loaded with app cache, and we have switched to packaged app long time ago. However, there are still redundant code in the top of apps/system/js/notification.js on saving notification icons.
So removing the app cache code.
