### PR TITLE
Bug 1051551 - Intermittent failing test, TEST-UNEXPECTED-FAIL | /builds/slave/test/gaia/apps/settings/test/marionette/tests/ime_uninstallation_test.js | Uninstall an ime app Uninstall the preload IME Test App

### DIFF
--- a/apps/settings/test/marionette/tests/ime_uninstallation_test.js
+++ b/apps/settings/test/marionette/tests/ime_uninstallation_test.js
@@ -49,7 +49,9 @@ marionette('Uninstall an ime app', function() {
     settingsApp.switchTo();
 
     // Make sure LOL Keyboard is not listed in app list
-    apps = appPermissionPanel.appList.filter(findImeTestApp);
-    assert.equal(apps.length, 0);
+    client.waitFor(function() {
+      apps = appPermissionPanel.appList.filter(findImeTestApp);
+      return apps.length === 0;
+    });
   });
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1051551
