### PR TITLE
Bug 1009793 - replace cardsByOrigin w. cardsByAppID for card/app lookup

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -161,10 +161,11 @@
     this.publish('willrender');
 
     var elem = this.element || (this.element = document.createElement('li'));
-    // we maintaine position value on the instance and on the element.dataset
+    // we maintain position value on the instance and on the element.dataset
     elem.dataset.position = this.position;
-
-    // we maintaine origin value on the instance and on the element.dataset
+    // we maintain instanceId on the card for unambiguous lookup
+    elem.dataset.appInstanceId = this.app.instanceID;
+    // keeping origin simplifies ui testing
     elem.dataset.origin = this.app.origin;
 
     this._populateViewData();

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -400,16 +400,18 @@ suite('system/TaskManager >', function() {
 
     test('creates Card instances when isTaskStrip is false', function(){
       taskManager.isTaskStrip = false;
-      taskManager.addCard(0, apps['http://sms.gaiamobile.org']);
-      var card = taskManager.getCardAtIndex(0);
+      var app = apps['http://sms.gaiamobile.org'];
+      taskManager.addCard(0, app);
+      var card = taskManager.cardsByAppID[app.instanceID];
       assert.ok(card && card instanceof Card,
                 'creates Card instances when isTaskStrip is false');
     });
 
     test('creates TaskCard instances when isTaskStrip is true', function(){
       taskManager.isTaskStrip = true;
-      taskManager.addCard(0, apps['http://sms.gaiamobile.org']);
-      var card = taskManager.getCardAtIndex(0);
+      var app = apps['http://sms.gaiamobile.org'];
+      taskManager.addCard(0, app);
+      var card = taskManager.cardsByAppID[app.instanceID];
       assert.ok(card && card instanceof TaskCard,
                 'creates TaskCard instances when isTaskStrip is true');
     });
@@ -755,7 +757,7 @@ suite('system/TaskManager >', function() {
       waitForEvent(window, 'cardviewclosed').then(function(event) {
         assert.equal(cardsList.childNodes.length, 0,
                     'all card elements are gone');
-        assert.equal(Object.keys(taskManager.cardsByOrigin).length, 0,
+        assert.equal(Object.keys(taskManager.cardsByAppID).length, 0,
                     'cards lookup is empty');
         done();
       }, failOnReject);
@@ -922,11 +924,11 @@ suite('system/TaskManager >', function() {
       assert.isTrue(card && card.element &&
                     card.element.parentNode == taskManager.cardsList);
       var destroySpy = this.sinon.spy(card, 'destroy');
-
+      var instanceID = card.app.instanceID;
       taskManager.closeApp(card);
       assert.isTrue(destroySpy.calledOnce);
       assert.equal(cardsList.childNodes.length, 1);
-      assert.isFalse('http://sms.gaiamobile.org' in taskManager.cardsByOrigin);
+      assert.isFalse(instanceID in taskManager.cardsByAppID);
     });
   });
 });


### PR DESCRIPTION
Use appWindow.instanceID to associate Card instances and their elements, replacing the cardsByOrigin dictionary with cardsByAppID. 
