### PR TITLE
Bug 1046564 - Should display normal priority message of STK_CMD_DISPLAY_TEXT command while device is Settings, r=alive

### DIFF
--- a/apps/system/js/icc_worker.js
+++ b/apps/system/js/icc_worker.js
@@ -228,9 +228,11 @@ var icc_worker = {
     DUMP('STK_CMD_DISPLAY_TEXT:', message.command.options);
     var options = message.command.options;
 
-    // Check if device is idle
+    // Check if device is idle or settings
     var activeApp = WindowManager.getDisplayedApp();
-    if (!options.isHighPriority && activeApp !== HomescreenLauncher.origin) {
+    var settingsOrigin = window.location.origin.replace('system', 'settings');
+    if (!options.isHighPriority && activeApp !== HomescreenLauncher.origin &&
+      activeApp.origin !== settingsOrigin) {
       DUMP('Do not display the text because normal priority.');
       icc.responseSTKCommand(message, {
         resultCode:


### PR DESCRIPTION
Reverts mozilla-b2g/gaia#22720
