### PR TITLE
Bug 1052537 - [Settings] Developer HUD toggle follow-up for localizability

### DIFF
--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -28,7 +28,7 @@
           </label>
         </li>
         <li>
-          <button class="icon icon-view" data-href="#developer-hud" data-l10n-id="hud-button">Developer HUD</button>
+          <button class="icon icon-view" data-href="#developer-hud" data-l10n-id="hud-settings-button">Developer HUD</button>
         </li>
         <li>
           <label class="pack-checkbox">

--- a/apps/settings/elements/developer_hud.html
+++ b/apps/settings/elements/developer_hud.html
@@ -5,7 +5,7 @@
       <a href="#developer">
         <span class="icon icon-back">Back</span>
       </a>
-      <h1 data-l10n-id="hud-header">Developer HUD</h1>
+      <h1 data-l10n-id="hud-settings-header">Developer HUD</h1>
     </header>
 
     <div>
@@ -23,7 +23,7 @@
           </label>
         </li>
         <header>
-          <h2 data-l10n-id="hud-devtools">Developer Tools</h2>
+          <h2 data-l10n-id="hud-devtools-header">Developer Tools</h2>
         </header>
         <li>
           <label class="pack-switch">

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -921,15 +921,20 @@ developer=Developer
 # If you need to adapt your localization to the reduced space available
 # in headers, you can use a shorter string here.
 developer-header={{developer}}
-hud=Developer HUD
-# LOCALIZATION NOTE (hud-header, hud-button): if you leave the original
-# en-US value "{{hud}}" in the following string, the localization
-# will be automatically picked from the existing string with ID "hud".
-# If you need to adapt your localizations to the available space in
-# headers or buttons, you can use different strings here.
-hud-header={{hud}}
-hud-button={{hud}}
-hud-devtools=Developer Tools
+hud-settings-button=Developer HUD
+# LOCALIZATION NOTE (hud-settings-header): if you leave the original en-US value
+# "{{hud-settings-button}}" in the following string, the localization will be
+# automatically picked from the existing string with ID "hud-settings-button". If you
+# need to adapt your localizations to the available space in headers or
+# buttons, you can use different strings here.
+hud-settings-header={{hud-settings-button}}
+hud-devtools=Developer tools
+# LOCALIZATION NOTE (hud-devtools-header): if you leave the original en-US
+# value "{{hud-devtools}}" in the following string, the localization will be
+# automatically picked from the existing string with ID "hud-devtools". If you
+# need to adapt your localizations to the available space in headers or
+# buttons, you can use different strings here.
+hud-devtools-header={{hud-devtools}}
 hud-logging=Log changes in ADB
 hud-system=Show system HUD
 hud-problems=Problems

--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -787,6 +787,11 @@ section[data-dialog] > header:first-child .icon.icon-back {
   padding: 1.9rem 4rem 1.5rem 3rem;
 }
 
+#developer ul li > label.pack-switch > span,
+#developer-hud ul li > label.pack-switch > span {
+  padding-right: 9rem;
+}
+
 #developer-hud ul li > label > span.color-preview {
   padding-left: 5rem;
 }


### PR DESCRIPTION
- Restore right padding on checkbox to make longer text wrap correctly
- Use separate strings for header and checkbox
- Remove unused string `hud`
