### PR TITLE
Bug 1052428 - Intermittent email/test/unit/app_messages_test.js | Timed out after 120 seconds

### DIFF
--- a/apps/email/test/unit/app_messages_test.js
+++ b/apps/email/test/unit/app_messages_test.js
@@ -24,7 +24,6 @@ suite('appMessages', function() {
       // Make sure that we register our activity request handler.
       sinon.assert.calledWith(spy, 'activity');
       navigator.mozSetMessageHandler.restore();
-      done();
     });
   });
 


### PR DESCRIPTION
May not solve the issue, but definitely incorrect to call done() twice, since testRequire handles that already.
