### PR TITLE
Bug 1038992 - FxA "forgot password" link crashes refreshAuth flow. r=fer...

### DIFF
--- a/apps/system/fxa/js/screens/fxam_refresh_auth.js
+++ b/apps/system/fxa/js/screens/fxam_refresh_auth.js
@@ -4,6 +4,7 @@
 /* global FxaModuleStates, FxaModuleUI, FxaModule, FxModuleServerRequest,
    FxaModuleOverlay */
 /* exported FxaModuleRefreshAuth */
+/* jshint unused:false */
 
 'use strict';
 
@@ -36,9 +37,11 @@ var FxaModuleRefreshAuth = (function() {
     FxModuleServerRequest.requestPasswordReset(
       email,
       function onSuccess(response) {
-        done(response.success);
+        done();
       },
-      this.showErrorResponse
+      function onError(response) {
+        this._showCouldNotResetPassword();
+      }.bind(this)
     );
   }
 
@@ -55,13 +58,8 @@ var FxaModuleRefreshAuth = (function() {
     _requestPasswordReset.call(
       this,
       this.email,
-      function(isRequestHandled) {
+      function() {
         FxaModuleOverlay.hide();
-        if (!isRequestHandled) {
-          _showCouldNotResetPassword.call(this);
-          return;
-        }
-
         FxaModuleStates.setState(FxaModuleStates.PASSWORD_RESET_SUCCESS);
       }
     );


### PR DESCRIPTION
...jm

Same pull request, removed the unnecessary parens from around the onError function, and added a jshint option to disable complaints about the function not being used.
