### PR TITLE
Bug 1052557 - Remove the redundant href atribute r=eragonj

### DIFF
--- a/apps/settings/elements/sim_manager.html
+++ b/apps/settings/elements/sim_manager.html
@@ -10,9 +10,9 @@
         <h2 data-l10n-id="simSettings">SIM settings</h2>
       </header>
       <ul class="sim-manager-select-list">
-        <li data-href="#simpin" id="sim-manager-security-entry">
+        <li id="sim-manager-security-entry">
           <small id="sim-manager-security-desc"></small>
-          <span data-l10n-id="simSecurity" data-href="#simpin">SIM security</span>
+          <a data-l10n-id="simSecurity" data-href="#simpin">SIM security</a>
         </li>
         <li>
           <p data-l10n-id="sim-manager-outgoing-calls">Outgoing calls</p>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1052557
