### PR TITLE
Bug 1052442 - [sms] We should never close the activity when viewing the message report. r=julien

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -837,11 +837,15 @@ section[role="region"].report-information > header .icon-back {
   display: none;
 }
 
-.request-activity-mode #messages-close-button {
+.request-activity-mode #messages-close-button,
+.request-activity-mode .report-information #messages-back-button,
+.request-activity-mode .participants-information #messages-back-button {
   display: block;
 }
 
-.request-activity-mode #messages-back-button {
+.request-activity-mode #messages-back-button,
+.request-activity-mode .report-information #messages-close-button,
+.request-activity-mode .participants-information #messages-close-button {
   display: none;
 }
 


### PR DESCRIPTION
Just showing ordinary back button for participants panel and _other_ close button for the report panel + hide _activity_ close button if in activity mode.
