### PR TITLE
Bug 1050431: Remove unnecessary 'flex' decls from video.css (equivalent to default values). r=djf

### DIFF
--- a/apps/video/style/video.css
+++ b/apps/video/style/video.css
@@ -703,20 +703,17 @@ body.pick-activity #thumbnails-bottom {
 
 .thumbnail .details .title {
   order: 1;
-  flex: 0 1 auto;
   align-self: auto;
   word-break: break-all;
 }
 
 .thumbnail .details .duration-text {
   order: 2;
-  flex: 0 1 auto;
   align-self: auto;
 }
 
 .thumbnail .details .size-type-group {
   order: 3;
-  flex: 0 1 auto;
   align-self: auto;
 }
 


### PR DESCRIPTION
Here's an updated pull request for [bug 1050431](https://bugzilla.mozilla.org/show_bug.cgi?id=1050431) which just removes the unnecessary flex declarations.
