### PR TITLE
Bug 971521: [System2] Instantiable NfcUtils.

### DIFF
--- a/apps/communications/contacts/js/nfc.js
+++ b/apps/communications/contacts/js/nfc.js
@@ -57,11 +57,12 @@ contacts.NFC = (function() {
   };
 
   var sendContact = function() {
+     var nfcUtils = new NfcUtils();
      var NDEFRecord = new MozNDEFRecord(
        NDEF.TNF_MIME_MEDIA,
-       NfcUtils.fromUTF8('text/vcard'),
+       nfcUtils.fromUTF8('text/vcard'),
        new Uint8Array(),
-       NfcUtils.fromUTF8(vCardContact)
+       nfcUtils.fromUTF8(vCardContact)
      );
 
      var res = mozNfcPeer.sendNDEF([NDEFRecord]);

--- a/apps/communications/contacts/test/unit/nfc_test.js
+++ b/apps/communications/contacts/test/unit/nfc_test.js
@@ -25,6 +25,7 @@ mocksHelperForNFC.init();
 suite('NFC', function() {
   var realMozNfc;
   var realMozNDEFRecord;
+  var nfcUtils;
 
   suiteSetup(function(done) {
     requireApp(
@@ -40,6 +41,7 @@ suite('NFC', function() {
         requireApp('communications/contacts/js/nfc.js', done);
       }
     );
+    nfcUtils = new NfcUtils();
   });
 
   suiteTeardown(function() {
@@ -103,7 +105,7 @@ suite('NFC', function() {
 
       var pos = header.length + 2;
       var actual = payload.subarray(pos, pos + name.length);
-      assert.isTrue(NfcUtils.equalArrays(actual, name));
+      assert.isTrue(nfcUtils.equalArrays(actual, name));
 
       done();
       return {};

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -9,7 +9,7 @@
          TelephonySettings, SuspendingAppPriorityManager, TTLView,
          MediaRecording, AppWindowFactory, SystemDialogManager,
          applications, Rocketbar, LayoutManager, PermissionManager,
-         SoftwareButtonManager, Accessibility, ShrinkingUI,
+         SoftwareButtonManager, Accessibility, NfcUtils, ShrinkingUI,
          TextSelectionDialog, InternetSharing, SleepMenu, AppUsageMetrics,
          LockScreenNotifications, LockScreenPasscodeValidator */
 'use strict';
@@ -136,6 +136,7 @@ window.addEventListener('load', function startup() {
   window.lockScreenPasscodeValidator.start();
   window.layoutManager = new LayoutManager();
   window.layoutManager.start();
+  window.nfcUtils = new NfcUtils();
   window.permissionManager = new PermissionManager();
   window.permissionManager.start();
   window.places = new Places();

--- a/apps/system/js/nfc_handler.js
+++ b/apps/system/js/nfc_handler.js
@@ -19,12 +19,13 @@
     },
 
     handleEvent: function nh_handleEvent(evt) {
+      var nfcUtils = new NfcUtils();
       if (evt.type !== 'peerready') {
         return;
       }
       var currentApp = this.appWindowManager.getActiveApp();
       if (currentApp && currentApp.isBrowser() && currentApp.url) {
-        this.sendNDEFRequestToNFCPeer(NfcUtils.parseURIString(currentApp.url),
+        this.sendNDEFRequestToNFCPeer(nfcUtils.parseURIString(currentApp.url),
           evt);
       }
     },

--- a/apps/system/js/nfc_handover_manager.js
+++ b/apps/system/js/nfc_handover_manager.js
@@ -600,21 +600,22 @@ var NfcHandoverManager = {
    * @memberof NfcHandoverManager.prototype
    */
   tryHandover: function(ndefMsg, session) {
+    var nfcUtils = new NfcUtils();
     if (!Array.isArray(ndefMsg) || !ndefMsg.length) {
       return false;
     }
 
     var record = ndefMsg[0];
     if (record.tnf === NDEF.TNF_WELL_KNOWN) {
-      if (NfcUtils.equalArrays(record.type, NDEF.RTD_HANDOVER_SELECT)) {
+      if (nfcUtils.equalArrays(record.type, NDEF.RTD_HANDOVER_SELECT)) {
         this._handleHandoverSelect(ndefMsg);
         return true;
-      } else if (NfcUtils.equalArrays(record.type, NDEF.RTD_HANDOVER_REQUEST)) {
+      } else if (nfcUtils.equalArrays(record.type, NDEF.RTD_HANDOVER_REQUEST)) {
         this._handleHandoverRequest(ndefMsg, session);
         return true;
       }
     } else if ((record.tnf === NDEF.TNF_MIME_MEDIA) &&
-        NfcUtils.equalArrays(record.type, NDEF.MIME_BLUETOOTH_OOB)) {
+        nfcUtils.equalArrays(record.type, NDEF.MIME_BLUETOOTH_OOB)) {
       this._handleSimplifiedPairingRecord(ndefMsg);
       return true;
     }

--- a/apps/system/js/nfc_manager.js
+++ b/apps/system/js/nfc_manager.js
@@ -205,17 +205,18 @@ var NfcManager = {
    * @returns {Object} record - SmartPostr record or null
    */
   _getSmartPoster: function nm_getSmartPoster(records) {
+    var nfcUtils = new NfcUtils();
     if (!Array.isArray(records) || !records.length) {
       return null;
     }
 
     var smartPosters = records.filter(function isSmartPoster(r) {
-      return NfcUtils.equalArrays(r.type, NDEF.RTD_SMART_POSTER);
+      return nfcUtils.equalArrays(r.type, NDEF.RTD_SMART_POSTER);
     });
 
     if (smartPosters.length && records[0].tnf === NDEF.TNF_WELL_KNOWN &&
-        (NfcUtils.equalArrays(records[0].type, NDEF.RTD_URI) ||
-         NfcUtils.equalArrays(records[0].type, NDEF.RTD_SMART_POSTER))) {
+        (nfcUtils.equalArrays(records[0].type, NDEF.RTD_URI) ||
+         nfcUtils.equalArrays(records[0].type, NDEF.RTD_SMART_POSTER))) {
       return smartPosters[0];
     }
     return null;

--- a/apps/system/test/unit/bootstrap_test.js
+++ b/apps/system/test/unit/bootstrap_test.js
@@ -2,6 +2,8 @@
 /*global MockNavigatormozApps, MockNavigatorSettings, MocksHelper, MockL10n*/
 /*global MockApplications, Applications*/
 
+require('/shared/js/nfc_utils.js');
+
 requireApp('system/shared/js/async_storage.js');
 requireApp('system/shared/js/lazy_loader.js');
 requireApp('system/shared/js/screen_layout.js');

--- a/apps/system/test/unit/ndef_utils_test.js
+++ b/apps/system/test/unit/ndef_utils_test.js
@@ -12,8 +12,13 @@ var mocksForNfcUtils = new MocksHelper([
 ]).init();
 
 suite('NDEFUtils tests', function() {
+  var nfcUtils;
 
   mocksForNfcUtils.attachTestHelpers();
+
+  setup(function() {
+    nfcUtils = new NfcUtils();
+  });
 
   suite('Helper functions tests', function() {
     test('formatMAC()', function() {
@@ -93,7 +98,7 @@ suite('NDEFUtils tests', function() {
 
     test('Decodes AC record correctly', function() {
       var cps = 2;
-      var name = NfcUtils.fromUTF8('lorem ipsum');
+      var name = nfcUtils.fromUTF8('lorem ipsum');
       var hin = NDEFUtils.encodeHandoverSelect(mac, cps, name);
       var hout = NDEFUtils.parseHandoverNDEF(hin);
 
@@ -103,7 +108,7 @@ suite('NDEFUtils tests', function() {
       assert.equal(NDEFUtils.formatMAC(m), mac);
 
       var n = ac.subarray(10, 10 + name.length);
-      assert.equal(NfcUtils.toUTF8(n), 'lorem ipsum');
+      assert.equal(nfcUtils.toUTF8(n), 'lorem ipsum');
     });
 
     test('Parses multiple Alternative Carrier (AC) records', function() {
@@ -205,7 +210,7 @@ suite('NDEFUtils tests', function() {
 
     test('Do not attempt to parse records other that Hs/Hr', function() {
       var hin = NDEFUtils.encodeHandoverRequest(mac, 1);
-      hin[0].type = NfcUtils.fromUTF8('Xx');
+      hin[0].type = nfcUtils.fromUTF8('Xx');
       var hout = NDEFUtils.parseHandoverNDEF(hin);
 
       assert.isNull(hout);
@@ -271,7 +276,7 @@ suite('NDEFUtils tests', function() {
     });
 
     test('No BT AC present - incorrect type', function() {
-      h.ac[0].cdr.type = NfcUtils.fromUTF8('application/invalid');
+      h.ac[0].cdr.type = nfcUtils.fromUTF8('application/invalid');
       var btAC = NDEFUtils.searchForBluetoothAC(h);
       assert.isNull(btAC);
     });
@@ -315,7 +320,7 @@ suite('NDEFUtils tests', function() {
       var name = 'Lorem ipsum';
 
       var record = NDEFUtils.encodeHandoverSelect(mac, 1,
-        NfcUtils.fromUTF8(name));
+        nfcUtils.fromUTF8(name));
       var dec = NDEFUtils.parseBluetoothSSP(record[1]);
 
       assert.equal(dec.localName, name);
@@ -341,7 +346,7 @@ suite('NDEFUtils tests', function() {
 
       // Bluetooth local name (supported field).
       var name = 'Lorem ipsum';
-      var nameArr = Array.apply([], NfcUtils.fromUTF8(name));
+      var nameArr = Array.apply([], nfcUtils.fromUTF8(name));
       var nEIRType = 0x09;
       var nEIRLength = 1 + nameArr.length;
 
@@ -381,7 +386,7 @@ suite('NDEFUtils tests', function() {
       function() {
 
       var record = NDEFUtils.encodeHandoverSelect(mac, 1,
-        NfcUtils.fromUTF8('Lorem ipsum'));
+        nfcUtils.fromUTF8('Lorem ipsum'));
 
       // Make local name invalid: delete one character from it.
       // Set OOB length as if this character was missing.
@@ -469,7 +474,6 @@ suite('NDEFUtils tests', function() {
   });
 
   suite('encodeHandoverSelect() tests', function() {
-
     var cps;
     var btMac;
     var btName;
@@ -478,7 +482,7 @@ suite('NDEFUtils tests', function() {
     setup(function() {
       cps = NDEF.CPS_ACTIVE;
       btMac = '00:0D:44:E7:95:AB';
-      btName = NfcUtils.fromUTF8('UE MINI BOOM');
+      btName = nfcUtils.fromUTF8('UE MINI BOOM');
 
       /*
        * The following NDEF message contains a static handover request

--- a/apps/system/test/unit/nfc_handler_test.js
+++ b/apps/system/test/unit/nfc_handler_test.js
@@ -17,10 +17,12 @@ var mocksForNfcManager = new MocksHelper([
 suite('Nfc Manager Functions', function() {
   var nfcHandler;
   var realMozNfc;
+  var nfcUtils;
 
   mocksForNfcManager.attachTestHelpers();
 
   setup(function(done) {
+    nfcUtils = new NfcUtils();
     realMozNfc = window.navigator.mozNfc;
     window.navigator.mozNfc = MockNfc;
     requireApp('system/js/nfc_handler.js', function() {
@@ -48,7 +50,7 @@ suite('Nfc Manager Functions', function() {
     };
     MockNfc.mTriggerOnpeerready(nfcEvent);
     assert.deepEqual(stubSendNDEFRequestToNFCPeer.getCall(0).args[0],
-      NfcUtils.parseURIString('www.test.com'));
+      nfcUtils.parseURIString('www.test.com'));
     assert.deepEqual(stubSendNDEFRequestToNFCPeer.getCall(0).args[1],
       nfcEvent);
   });

--- a/apps/system/test/unit/nfc_handover_manager_test.js
+++ b/apps/system/test/unit/nfc_handover_manager_test.js
@@ -88,14 +88,16 @@ suite('Nfc Handover Manager Functions', function() {
   suite('Activity Routing for NfcHandoverManager', function() {
     var activityInjection1;
     var activityInjection2;
+    var nfcUtils;
 
     setup(function() {
+      nfcUtils = new NfcUtils();
       activityInjection1 = {
         type: 'techDiscovered',
         techList: ['NFC_A','NDEF'],
         records: NDEFUtils.encodeHandoverSelect(
                                     '00:0D:44:E7:95:AB', NDEF.CPS_ACTIVE,
-                                    NfcUtils.fromUTF8('UE MINI BOOM')),
+                                    nfcUtils.fromUTF8('UE MINI BOOM')),
         sessionToken: '{e9364a8b-538c-4c9d-84e2-e6ce524afd17}'
       };
 

--- a/apps/system/test/unit/nfc_manager_test.js
+++ b/apps/system/test/unit/nfc_manager_test.js
@@ -32,6 +32,7 @@ suite('Nfc Manager Functions', function() {
 
   var realMozSetMessageHandler;
   var realMozBluetooth;
+  var nfcUtils;
 
   mocksForNfcManager.attachTestHelpers();
 
@@ -40,6 +41,7 @@ suite('Nfc Manager Functions', function() {
     window.navigator.mozSetMessageHandler = MockMozSetMessageHandler;
     realMozBluetooth = window.navigator.mozBluetooth;
     window.navigator.mozBluetooth = window.MockBluetooth;
+    nfcUtils = new NfcUtils();
 
     requireApp('system/js/nfc_manager.js', done);
   });
@@ -165,6 +167,7 @@ suite('Nfc Manager Functions', function() {
     var sampleMimeRecord;
 
     setup(function() {
+
       sampleMsg = {
         type: 'techDiscovered',
         techList: [],
@@ -177,14 +180,14 @@ suite('Nfc Manager Functions', function() {
         tnf: NDEF.TNF_WELL_KNOWN,
         type: NDEF.RTD_URI,
         id: new Uint8Array([1]),
-        payload: NfcUtils.fromUTF8('\u0000http://mozilla.org')
+        payload: nfcUtils.fromUTF8('\u0000http://mozilla.org')
       };
 
       sampleMimeRecord = {
         tnf: NDEF.TNF_MIME_MEDIA,
-        type: NfcUtils.fromUTF8('text/vcard'),
+        type: nfcUtils.fromUTF8('text/vcard'),
         id: new Uint8Array([2]),
-        payload: NfcUtils.fromUTF8('BEGIN:VCARD\nVERSION:2.1\nN:J;\nEND:VCARD')
+        payload: nfcUtils.fromUTF8('BEGIN:VCARD\nVERSION:2.1\nN:J;\nEND:VCARD')
       };
 
     });
@@ -373,7 +376,7 @@ suite('Nfc Manager Functions', function() {
         name: 'import',
         data: {
           type: 'text/vcard',
-          blob: new Blob([NfcUtils.toUTF8(sampleMsg.records.payload)],
+          blob: new Blob([nfcUtils.toUTF8(sampleMsg.records.payload)],
                          {'type': 'text/vcard'}),
           tech: 'NDEF',
           techList: sampleMsg.techList,
@@ -451,7 +454,7 @@ suite('Nfc Manager Functions', function() {
         tnf: NDEF.TNF_WELL_KNOWN,
         type: NDEF.RTD_URI,
         id: new Uint8Array([1]),
-        payload: NfcUtils.fromUTF8('\u0000http://mozilla.org')
+        payload: nfcUtils.fromUTF8('\u0000http://mozilla.org')
       };
 
       this.sinon.stub(window, 'MozActivity');
@@ -621,21 +624,21 @@ suite('Nfc Manager Functions', function() {
         tnf: NDEF.TNF_WELL_KNOWN,
         type: NDEF.RTD_SMART_POSTER,
         id: new Uint8Array([1]),
-        paylod: NfcUtils.fromUTF8('dummy payload')
+        paylod: nfcUtils.fromUTF8('dummy payload')
       };
 
       uriRecord = {
         tnf: NDEF.TNF_WELL_KNOWN,
         type: NDEF.RTD_URI,
         id: new Uint8Array([2]),
-        payload: NfcUtils.fromUTF8('dummy uri')
+        payload: nfcUtils.fromUTF8('dummy uri')
       };
 
       mimeRecord = {
         tnf: NDEF.TNF_MIME_MEDIA,
-        type: NfcUtils.fromUTF8('text/plain'),
+        type: nfcUtils.fromUTF8('text/plain'),
         id: new Uint8Array([3]),
-        payload: NfcUtils.fromUTF8('dummy text')
+        payload: nfcUtils.fromUTF8('dummy text')
       };
     });
 

--- a/apps/system/test/unit/nfc_utils_test.js
+++ b/apps/system/test/unit/nfc_utils_test.js
@@ -16,11 +16,13 @@ suite('NFC Utils', function() {
 
   mocksForNfcUtils.attachTestHelpers();
 
+  var nfcUtils;
   var string1;
   var uint8array1;
   var urlU8a; // Uint8Array
 
   setup(function() {
+    nfcUtils = new NfcUtils();
     string1 = 'StringTestString ABCDEFGHIJKLMNOPQRSTUVWXYZ ą嗨è©';
     uint8array1 = new Uint8Array([0x53, 0x74, 0x72, 0x69, 0x6e, 0x67,
                                   0x54, 0x65, 0x73, 0x74,
@@ -48,19 +50,19 @@ suite('NFC Utils', function() {
   });
 
   test('transitive', function() {
-    var u8a = NfcUtils.fromUTF8(string1);
-    var str = NfcUtils.toUTF8(uint8array1);
-    var backStr = NfcUtils.toUTF8(u8a);
-    var backU8a = NfcUtils.fromUTF8(str);
-    var nullObj = NfcUtils.toUTF8(null);
-    var nullStr = NfcUtils.fromUTF8(null);
+    var u8a = nfcUtils.fromUTF8(string1);
+    var str = nfcUtils.toUTF8(uint8array1);
+    var backStr = nfcUtils.toUTF8(u8a);
+    var backU8a = nfcUtils.fromUTF8(str);
+    var nullObj = nfcUtils.toUTF8(null);
+    var nullStr = nfcUtils.fromUTF8(null);
 
-    var u1 = NfcUtils.equalArrays(u8a, uint8array1);
-    var s1 = NfcUtils.equalArrays(str, string1);
-    var bs1 = NfcUtils.equalArrays(string1, backStr);
-    var bs2 = NfcUtils.equalArrays(str, backStr);
-    var bu1 = NfcUtils.equalArrays(u8a, backU8a);
-    var bu2 = NfcUtils.equalArrays(uint8array1, backU8a);
+    var u1 = nfcUtils.equalArrays(u8a, uint8array1);
+    var s1 = nfcUtils.equalArrays(str, string1);
+    var bs1 = nfcUtils.equalArrays(string1, backStr);
+    var bs2 = nfcUtils.equalArrays(str, backStr);
+    var bu1 = nfcUtils.equalArrays(u8a, backU8a);
+    var bu2 = nfcUtils.equalArrays(uint8array1, backU8a);
 
     assert.equal(u1, true);
     assert.equal(s1, true);
@@ -74,22 +76,22 @@ suite('NFC Utils', function() {
 
   suite('equalArrays', function() {
     test('Accepts null arguments', function() {
-      assert.isFalse(NfcUtils.equalArrays());
-      assert.isFalse(NfcUtils.equalArrays(null));
-      assert.isFalse(NfcUtils.equalArrays(null, null));
-      assert.isFalse(NfcUtils.equalArrays(undefined, null));
+      assert.isFalse(nfcUtils.equalArrays());
+      assert.isFalse(nfcUtils.equalArrays(null));
+      assert.isFalse(nfcUtils.equalArrays(null, null));
+      assert.isFalse(nfcUtils.equalArrays(undefined, null));
     });
 
     test('Accepts non-array objects', function() {
-      assert.isFalse(NfcUtils.equalArrays({}, [1]));
+      assert.isFalse(nfcUtils.equalArrays({}, [1]));
     });
 
     test('Compares arrays', function() {
-      assert.isFalse(NfcUtils.equalArrays([1, 2, 3], [1, 3, 2]));
-      assert.isFalse(NfcUtils.equalArrays([1, 2, 3], [1]));
+      assert.isFalse(nfcUtils.equalArrays([1, 2, 3], [1, 3, 2]));
+      assert.isFalse(nfcUtils.equalArrays([1, 2, 3], [1]));
 
-      assert.isTrue(NfcUtils.equalArrays([1, 2, 3], [1, 2, 3]));
-      assert.isTrue(NfcUtils.equalArrays([1, 2, 3], new Uint8Array([1, 2, 3])));
+      assert.isTrue(nfcUtils.equalArrays([1, 2, 3], [1, 2, 3]));
+      assert.isTrue(nfcUtils.equalArrays([1, 2, 3], new Uint8Array([1, 2, 3])));
     });
   });
 
@@ -114,20 +116,20 @@ suite('NFC Utils', function() {
     );
 
     test('UTF16BytesToStr', function() {
-      assert.equal(cprght, NfcUtils.UTF16BytesToStr(cprghtUTF16BE));
-      assert.equal(cprght, NfcUtils.UTF16BytesToStr(cprghtUTF16BEBOM));
-      assert.equal(cprght, NfcUtils.UTF16BytesToStr(cprghtUTF16LEBOM));
+      assert.equal(cprght, nfcUtils.UTF16BytesToStr(cprghtUTF16BE));
+      assert.equal(cprght, nfcUtils.UTF16BytesToStr(cprghtUTF16BEBOM));
+      assert.equal(cprght, nfcUtils.UTF16BytesToStr(cprghtUTF16LEBOM));
 
-      assert.equal(plchr, NfcUtils.UTF16BytesToStr(plchrUTF16BE));
-      assert.equal(hai, NfcUtils.UTF16BytesToStr(haiUTF16BE));
-      assert.equal(foxTxt, NfcUtils.UTF16BytesToStr(foxTxtUTF16BE));
+      assert.equal(plchr, nfcUtils.UTF16BytesToStr(plchrUTF16BE));
+      assert.equal(hai, nfcUtils.UTF16BytesToStr(haiUTF16BE));
+      assert.equal(foxTxt, nfcUtils.UTF16BytesToStr(foxTxtUTF16BE));
     });
 
     test('strToUTF16Bytes', function() {
-      assert.deepEqual(cprghtUTF16BE, NfcUtils.strToUTF16Bytes(cprght));
-      assert.deepEqual(plchrUTF16BE, NfcUtils.strToUTF16Bytes(plchr));
-      assert.deepEqual(haiUTF16BE, NfcUtils.strToUTF16Bytes(hai));
-      assert.deepEqual(foxTxtUTF16BE, NfcUtils.strToUTF16Bytes(foxTxt));
+      assert.deepEqual(cprghtUTF16BE, nfcUtils.strToUTF16Bytes(cprght));
+      assert.deepEqual(plchrUTF16BE, nfcUtils.strToUTF16Bytes(plchr));
+      assert.deepEqual(haiUTF16BE, nfcUtils.strToUTF16Bytes(hai));
+      assert.deepEqual(foxTxtUTF16BE, nfcUtils.strToUTF16Bytes(foxTxt));
     });
   });
 
@@ -139,20 +141,20 @@ suite('NFC Utils', function() {
       var type    = NDEF.RTD_URI;
       var id      = new Uint8Array(); // no id.
       // Short Record, 0x3 or "http://"
-      var payload = new Uint8Array(NfcUtils.fromUTF8(
+      var payload = new Uint8Array(nfcUtils.fromUTF8(
                                    '\u0003mozilla.org'));
 
       urlNDEF = new MozNDEFRecord(tnf, type, id, payload);
     });
 
     test('Subrecord', function() {
-      var encodedNdefU8a = NfcUtils.encodeNDEF([urlNDEF]);
+      var encodedNdefU8a = nfcUtils.encodeNDEF([urlNDEF]);
       // MozNDEFRecord is abstract, and does not contain some extra bits in the
       // header for NDEF payload subrecords:
       var cpUrlU8a = new Uint8Array(encodedNdefU8a);
       cpUrlU8a[0] = cpUrlU8a[0] & NDEF.TNF;
 
-      var equals1 = NfcUtils.equalArrays(encodedNdefU8a, urlU8a);
+      var equals1 = nfcUtils.equalArrays(encodedNdefU8a, urlU8a);
       assert.equal(equals1, true);
     });
 
@@ -170,7 +172,7 @@ suite('NFC Utils', function() {
                                          new Uint8Array(),
                                          payload);
 
-      var result = NfcUtils.encodeNDEF([ndefRecord]);
+      var result = nfcUtils.encodeNDEF([ndefRecord]);
       assert.deepEqual(result, ndefMsg);
     });
 
@@ -227,14 +229,14 @@ suite('NFC Utils', function() {
                                          new Uint8Array(),
                                          payload);
 
-      var result = NfcUtils.encodeNDEF([ndefRecord]);
+      var result = nfcUtils.encodeNDEF([ndefRecord]);
       assert.deepEqual(result, ndefMsg);
     });
 
     test('No type, no paylod, no id', function() {
       var ndefMsg = new Uint8Array([0xd0, 0x00, 0x00]);
 
-      var result = NfcUtils.encodeNDEF([new MozNDEFRecord(NDEF.TNF_EMPTY)]);
+      var result = nfcUtils.encodeNDEF([new MozNDEFRecord(NDEF.TNF_EMPTY)]);
       assert.deepEqual(result, ndefMsg);
     });
 
@@ -261,7 +263,7 @@ suite('NFC Utils', function() {
                                    new Uint8Array(),
                                    payload2);
 
-      var result = NfcUtils.encodeNDEF([rec1, rec2]);
+      var result = nfcUtils.encodeNDEF([rec1, rec2]);
       assert.deepEqual(result, ndefMsg);
     });
   });
@@ -283,33 +285,33 @@ suite('NFC Utils', function() {
 
     test('Subrecord', function() {
       var buf = new NfcBuffer(urlU8a);
-      var ndefrecords = NfcUtils.parseNDEF(buf);
+      var ndefrecords = nfcUtils.parseNDEF(buf);
       var equal;
 
       // There is only one record here:
       assert.equal(ndefrecords[0].tnf, NDEF.TNF_WELL_KNOWN);
-      equal = NfcUtils.equalArrays(ndefrecords[0].type, NDEF.RTD_URI);
+      equal = nfcUtils.equalArrays(ndefrecords[0].type, NDEF.RTD_URI);
       assert.equal(equal, true, 'type');
 
-      equal = NfcUtils.equalArrays(ndefrecords[0].id, new Uint8Array());
+      equal = nfcUtils.equalArrays(ndefrecords[0].id, new Uint8Array());
       assert.equal(equal, true, 'id');
 
-      equal = NfcUtils.equalArrays(ndefrecords[0].payload,
-                                 NfcUtils.fromUTF8('\u0003mozilla.org'));
+      equal = nfcUtils.equalArrays(ndefrecords[0].payload,
+                                 nfcUtils.fromUTF8('\u0003mozilla.org'));
       assert.equal(equal, true, 'payload');
     });
 
     test('Returns null when first record has no MB bit set',
       function() {
         msg1[0] ^= 128;
-        var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+        var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
         assert.isNull(parsed);
     });
 
     test('Returns null when last record has no ME bit set',
       function() {
         msg1[17] ^= 64;
-        var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+        var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
         assert.isNull(parsed);
     });
 
@@ -317,13 +319,13 @@ suite('NFC Utils', function() {
       function() {
 
         msg1[7] ^= 64;
-        var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+        var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
         assert.isNull(parsed);
     });
 
     test('Returns null when no record has ME bit set', function() {
       msg1[17] ^= 64;
-      var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+      var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
       assert.isNull(parsed);
     });
 
@@ -331,7 +333,7 @@ suite('NFC Utils', function() {
       function() {
 
         msg1[7] ^= 128;
-        var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+        var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
         assert.isNull(parsed);
     });
 
@@ -339,12 +341,12 @@ suite('NFC Utils', function() {
       function() {
 
         msg1[0] ^= 32;
-        var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+        var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
         assert.isNull(parsed);
     });
 
     test('Decodes multi record messages', function() {
-      var parsed = NfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
+      var parsed = nfcUtils.parseNDEF(new NfcBuffer(new Uint8Array(msg1)));
       assert.isNotNull(parsed);
       assert.equal(parsed.length, 3);
 
@@ -385,13 +387,13 @@ suite('NFC Utils', function() {
                     0x7A, 0x69, 0x6C, 0x6C,
                     0x61, 0x2E, 0x6F, 0x72,
                     0x67];
-      var parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      var parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.deepEqual(parsed.id, [0x01, 0x02, 0x03, 0x04]);
     });
 
     test('Supports records without ID', function() {
-      var parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      var parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.deepEqual(parsed.id, []);
     });
@@ -404,31 +406,31 @@ suite('NFC Utils', function() {
       }
       record = record.concat(payload);
 
-      var parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      var parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.deepEqual(parsed.payload, payload);
     });
 
     test('Decodes TNF', function() {
-      var parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      var parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.equal(parsed.tnf, 1);
 
       record[0] ^= 1;
       record[0] |= 5;
-      parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.equal(parsed.tnf, 5);
     });
 
     test('Decodes type', function() {
-      var parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      var parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.deepEqual(parsed.type, [0x55]);
     });
 
     test('Decodes payload', function() {
-      var parsed = NfcUtils._parseNDEFRecord(new NfcBuffer(record));
+      var parsed = nfcUtils._parseNDEFRecord(new NfcBuffer(record));
       assert.isNotNull(parsed);
       assert.deepEqual(parsed.payload, [0x03, 0x6D, 0x6F, 0x7A, 0x69,
                                         0x6C, 0x6C, 0x61, 0x2E, 0x6F,
@@ -442,17 +444,17 @@ suite('NFC Utils', function() {
       var cps = 0x2;
       var hrNDEFs1 = NDEFUtils.encodeHandoverRequest(mac, cps);
       assert.equal(!!hrNDEFs1, true);
-      var hrNDEFU8a1 = NfcUtils.encodeNDEF(hrNDEFs1);
+      var hrNDEFU8a1 = nfcUtils.encodeNDEF(hrNDEFs1);
       assert.equal(!!hrNDEFU8a1, true);
 
       var buf = new NfcBuffer(hrNDEFU8a1);
-      var hrNDEFs2 = NfcUtils.parseNDEF(buf);
+      var hrNDEFs2 = nfcUtils.parseNDEF(buf);
       assert.equal(!!hrNDEFs2, true);
 
-      var hrNDEFU8a2 = NfcUtils.encodeNDEF(hrNDEFs2);
+      var hrNDEFU8a2 = nfcUtils.encodeNDEF(hrNDEFs2);
       assert.equal(!!hrNDEFU8a2, true);
 
-      var equal1 = NfcUtils.equalArrays(hrNDEFU8a2, hrNDEFU8a1);
+      var equal1 = nfcUtils.equalArrays(hrNDEFU8a2, hrNDEFU8a1);
       assert.equal(equal1, true);
     });
 
@@ -462,17 +464,17 @@ suite('NFC Utils', function() {
       var hsNDEFs1 = NDEFUtils.encodeHandoverSelect(mac, cps);
       assert.equal(!!hsNDEFs1, true);
 
-      var hsNDEFU8a1 = NfcUtils.encodeNDEF(hsNDEFs1);
+      var hsNDEFU8a1 = nfcUtils.encodeNDEF(hsNDEFs1);
       assert.equal(!!hsNDEFU8a1, true);
 
       var buf = new NfcBuffer(hsNDEFU8a1);
-      var hsNDEFs2 = NfcUtils.parseNDEF(buf);
+      var hsNDEFs2 = nfcUtils.parseNDEF(buf);
       assert.equal(!!hsNDEFs2, true);
 
-      var hsNDEFU8a2 = NfcUtils.encodeNDEF(hsNDEFs2);
+      var hsNDEFU8a2 = nfcUtils.encodeNDEF(hsNDEFs2);
       assert.equal(!!hsNDEFU8a2, true);
 
-      var equal1 = NfcUtils.equalArrays(hsNDEFU8a2, hsNDEFU8a1);
+      var equal1 = nfcUtils.equalArrays(hsNDEFU8a2, hsNDEFU8a1);
       assert.equal(equal1, true);
     });
   });
@@ -567,7 +569,12 @@ suite('NfcBuffer', function() {
 });
 
 suite('NDEF.payload', function() {
+  var nfcUtils;
   mocksForNfcUtils.attachTestHelpers();
+
+  setup(function() {
+    nfcUtils = new NfcUtils();
+  });
 
   suite('decode()', function() {
     test('TNF empty', function() {
@@ -716,7 +723,7 @@ suite('NDEF.payload', function() {
 
     test('mailto:', function() {
       // \u0006 is short for mailto:
-      var payload = NfcUtils.fromUTF8('\u0006jorge@borges.ar');
+      var payload = nfcUtils.fromUTF8('\u0006jorge@borges.ar');
 
       var decoded = NDEF.payload.decodeURI(payload);
       assert.deepEqual(decoded, {
@@ -727,7 +734,7 @@ suite('NDEF.payload', function() {
 
     test('tel:', function() {
       // \u0005 is short for tel:
-      var payload = NfcUtils.fromUTF8('\u00050054267437');
+      var payload = nfcUtils.fromUTF8('\u00050054267437');
 
       var decoded = NDEF.payload.decodeURI(payload);
       assert.deepEqual(decoded, {
@@ -737,7 +744,7 @@ suite('NDEF.payload', function() {
     });
 
     test('unabbreviated', function() {
-      var payload = NfcUtils.fromUTF8('\u0000http://mozilla.com');
+      var payload = nfcUtils.fromUTF8('\u0000http://mozilla.com');
 
       var decoded = NDEF.payload.decodeURI(payload);
       assert.deepEqual(decoded, {
@@ -763,13 +770,13 @@ suite('NDEF.payload', function() {
       for (var arg = 0; arg < arguments.length; arg += 3) {
         records.push({
           tnf: arguments[arg],
-          type: NfcUtils.fromUTF8(arguments[arg + 1]),
+          type: nfcUtils.fromUTF8(arguments[arg + 1]),
           payload: arguments[arg + 2],
           id: new Uint8Array()
         });
       }
 
-      var payload = NfcUtils.encodeNDEF(records);
+      var payload = nfcUtils.encodeNDEF(records);
       return [{
         tnf: NDEF.TNF_WELL_KNOWN,
         type: NDEF.RTD_SMART_POSTER,
@@ -854,7 +861,7 @@ suite('NDEF.payload', function() {
       assert.equal(decoded.text.pl, 'ąćńó');
       assert.equal(decoded.icons.length, 1);
       assert.equal(decoded.icons[0].type, 'image/png');
-      assert.isTrue(NfcUtils.equalArrays(decoded.icons[0].bytes,
+      assert.isTrue(nfcUtils.equalArrays(decoded.icons[0].bytes,
                                          recordIcon));
     });
 
@@ -893,7 +900,7 @@ suite('NDEF.payload', function() {
       var decoded;
 
       setup(function() {
-        payload = NfcUtils.fromUTF8(vcardTxt);
+        payload = nfcUtils.fromUTF8(vcardTxt);
         decoded = {
           type: 'text/vcard',
           blob: new Blob([vcardTxt], {type: 'text/vcard'})
@@ -901,26 +908,26 @@ suite('NDEF.payload', function() {
       });
 
       test('text/vcard', function() {
-        var vcard = NDEF.payload.decodeMIME(NfcUtils.fromUTF8('text/vcard'),
+        var vcard = NDEF.payload.decodeMIME(nfcUtils.fromUTF8('text/vcard'),
                                             payload);
         assert.deepEqual(decoded, vcard);
       });
 
       test('text/x-vCard', function() {
-        var vcard = NDEF.payload.decodeMIME(NfcUtils.fromUTF8('text/x-vCard'),
+        var vcard = NDEF.payload.decodeMIME(nfcUtils.fromUTF8('text/x-vCard'),
                                             payload);
         assert.deepEqual(decoded, vcard);
       });
 
       test('text/x-vcard', function() {
-        var vcard = NDEF.payload.decodeMIME(NfcUtils.fromUTF8('text/x-vcard'),
+        var vcard = NDEF.payload.decodeMIME(nfcUtils.fromUTF8('text/x-vcard'),
                                             payload);
         assert.deepEqual(decoded, vcard);
       });
     });
 
     test('other', function() {
-      var decoded = NDEF.payload.decodeMIME(NfcUtils.fromUTF8('text/plain'),
+      var decoded = NDEF.payload.decodeMIME(nfcUtils.fromUTF8('text/plain'),
                                              'payload');
       assert.deepEqual(decoded, { type: 'text/plain' });
     });

--- a/shared/js/nfc_utils.js
+++ b/shared/js/nfc_utils.js
@@ -7,644 +7,667 @@
 /* exported NDEF, NfcBuffer, NfcUtils */
 'use strict';
 
-var NfcUtils; // Pre-declaration for jshint
+(function(exports) {
 
-/**
-* NDEF (NFC Data Exchange Format) contants and common values.
-*/
-const NDEF = {
-  MB: 1 << 7,
-  ME: 1 << 6,
-  CF: 1 << 5,
-  SR: 1 << 4,
-  IL: 1 << 3,
+  /**
+  * NDEF (NFC Data Exchange Format) contants and common values.
+  */
+  const NDEF = {
+    MB: 1 << 7,
+    ME: 1 << 6,
+    CF: 1 << 5,
+    SR: 1 << 4,
+    IL: 1 << 3,
 
-  TNF: 0x07,
+    TNF: 0x07,
 
-  TNF_EMPTY: 0x00,
-  TNF_WELL_KNOWN: 0x01,
-  TNF_MIME_MEDIA: 0x02,
-  TNF_ABSOLUTE_URI: 0x03,
-  TNF_EXTERNAL_TYPE: 0x04,
-  TNF_UNKNOWN: 0x05,
-  TNF_UNCHANGED: 0x06,
-  TNF_RESERVED: 0x07,
+    TNF_EMPTY: 0x00,
+    TNF_WELL_KNOWN: 0x01,
+    TNF_MIME_MEDIA: 0x02,
+    TNF_ABSOLUTE_URI: 0x03,
+    TNF_EXTERNAL_TYPE: 0x04,
+    TNF_UNKNOWN: 0x05,
+    TNF_UNCHANGED: 0x06,
+    TNF_RESERVED: 0x07,
 
-  RTD_TEXT: 0,
-  RTD_URI: 0,
-  RTD_SMART_POSTER: 0,
-  RTD_ALTERNATIVE_CARRIER: 0,
-  RTD_COLLISION_RESOLUTION: 0,
-  RTD_HANDOVER_CARRIER: 0,
-  RTD_HANDOVER_REQUEST: 0,
-  RTD_HANDOVER_SELECT: 0,
+    RTD_TEXT: 0,
+    RTD_URI: 0,
+    RTD_SMART_POSTER: 0,
+    RTD_ALTERNATIVE_CARRIER: 0,
+    RTD_COLLISION_RESOLUTION: 0,
+    RTD_HANDOVER_CARRIER: 0,
+    RTD_HANDOVER_REQUEST: 0,
+    RTD_HANDOVER_SELECT: 0,
 
-  RTD_TEXT_IANA_LENGTH: 0x3F,
-  RTD_TEXT_ENCODING: 0x80,
-  RTD_TEXT_UTF8: 0,
-  RTD_TEXT_UTF16: 1,
+    RTD_TEXT_IANA_LENGTH: 0x3F,
+    RTD_TEXT_ENCODING: 0x80,
+    RTD_TEXT_UTF8: 0,
+    RTD_TEXT_UTF16: 1,
 
-  CPS_INACTIVE: 0,
-  CPS_ACTIVE: 1,
-  CPS_ACTIVATING: 2,
-  CPS_UNKNOWN: 3,
+    CPS_INACTIVE: 0,
+    CPS_ACTIVE: 1,
+    CPS_ACTIVATING: 2,
+    CPS_UNKNOWN: 3,
 
-  MIME_BLUETOOTH_OOB: 0,
+    MIME_BLUETOOTH_OOB: 0,
 
-  SMARTPOSTER_ACTION: 0,
+    SMARTPOSTER_ACTION: 0,
 
-  // Action Record Values:
-  DO_ACTION: 0x00,
-  SAVE_FOR_LATER_ACTION: 0x01,
-  OPEN_FOR_EDITING_ACTION: 0x02,
-  RFU_ACTION: 0x03,  // Reserved from 0x03 to 0xFF
+    // Action Record Values:
+    DO_ACTION: 0x00,
+    SAVE_FOR_LATER_ACTION: 0x01,
+    OPEN_FOR_EDITING_ACTION: 0x02,
+    RFU_ACTION: 0x03,  // Reserved from 0x03 to 0xFF
 
-  URIS: [],
+    URIS: [],
 
-  init: function ndef_init() {
-    this.RTD_TEXT = NfcUtils.fromUTF8('T');
-    this.RTD_URI = NfcUtils.fromUTF8('U');
-    this.RTD_SMART_POSTER = NfcUtils.fromUTF8('Sp');
-    this.RTD_ALTERNATIVE_CARRIER = NfcUtils.fromUTF8('ac');
-    this.RTD_COLLISION_RESOLUTION = NfcUtils.fromUTF8('cr');
-    this.RTD_HANDOVER_CARRIER = NfcUtils.fromUTF8('Hc');
-    this.RTD_HANDOVER_REQUEST = NfcUtils.fromUTF8('Hr');
-    this.RTD_HANDOVER_SELECT = NfcUtils.fromUTF8('Hs');
+    init: function ndef_init() {
+      var nfcUtils = new NfcUtils();
+      this.RTD_TEXT = nfcUtils.fromUTF8('T');
+      this.RTD_URI = nfcUtils.fromUTF8('U');
+      this.RTD_SMART_POSTER = nfcUtils.fromUTF8('Sp');
+      this.RTD_ALTERNATIVE_CARRIER = nfcUtils.fromUTF8('ac');
+      this.RTD_COLLISION_RESOLUTION = nfcUtils.fromUTF8('cr');
+      this.RTD_HANDOVER_CARRIER = nfcUtils.fromUTF8('Hc');
+      this.RTD_HANDOVER_REQUEST = nfcUtils.fromUTF8('Hr');
+      this.RTD_HANDOVER_SELECT = nfcUtils.fromUTF8('Hs');
 
-    this.MIME_BLUETOOTH_OOB =
-      NfcUtils.fromUTF8('application/vnd.bluetooth.ep.oob');
+      this.MIME_BLUETOOTH_OOB =
+        nfcUtils.fromUTF8('application/vnd.bluetooth.ep.oob');
 
-    this.MIME_VCARD_STR_ARR =
-      ['text/vcard', 'text/x-vCard', 'text/x-vcard'];
+      this.MIME_VCARD_STR_ARR =
+        ['text/vcard', 'text/x-vCard', 'text/x-vcard'];
 
-    this.SMARTPOSTER_ACTION = NfcUtils.fromUTF8('act');
+      this.SMARTPOSTER_ACTION = nfcUtils.fromUTF8('act');
 
-    this.URIS[0x00] = '';
-    this.URIS[0x01] = 'http://www.';
-    this.URIS[0x02] = 'https://www.';
-    this.URIS[0x03] = 'http://';
-    this.URIS[0x04] = 'https://';
-    this.URIS[0x05] = 'tel:';
-    this.URIS[0x06] = 'mailto:';
-    this.URIS[0x07] = 'ftp://anonymous:anonymous@';
-    this.URIS[0x08] = 'ftp://ftp.';
-    this.URIS[0x09] = 'ftps://';
-    this.URIS[0x0A] = 'sftp://';
-    this.URIS[0x0B] = 'smb://';
-    this.URIS[0x0C] = 'nfs://';
-    this.URIS[0x0D] = 'ftp://';
-    this.URIS[0x0E] = 'dav://';
-    this.URIS[0x0F] = 'news:';
-    this.URIS[0x10] = 'telnet://';
-    this.URIS[0x11] = 'imap:';
-    this.URIS[0x12] = 'rtsp://';
-    this.URIS[0x13] = 'urn:';
-    this.URIS[0x14] = 'pop:';
-    this.URIS[0x15] = 'sip:';
-    this.URIS[0x16] = 'sips:';
-    this.URIS[0x17] = 'tftp:';
-    this.URIS[0x18] = 'btspp://';
-    this.URIS[0x19] = 'btl2cap://';
-    this.URIS[0x1A] = 'btgoep://';
-    this.URIS[0x1B] = 'tcpobex://';
-    this.URIS[0x1C] = 'irdaobex://';
-    this.URIS[0x1D] = 'file://';
-    this.URIS[0x1E] = 'urn:epc:id:';
-    this.URIS[0x1F] = 'urn:epc:tag:';
-    this.URIS[0x20] = 'urn:epc:pat:';
-    this.URIS[0x21] = 'urn:epc:raw:';
-    this.URIS[0x22] = 'urn:epc:';
-    this.URIS[0x23] = 'urn:nfc:';
-  },
-
-  payload: {
-    /**
-     * Decodes NDEF record payload
-     * @see NFCForum-TS-NDEF_1.0
-     * @param {Uint8Array} tnf - record TNF
-     * @param {Uint8Array} type - record type
-     * @param {Uint8Array} payload - record payload
-     * @returns {Object} data - decoded payload or null if invalid
-     */
-    decode: function decode(tnf, type, payload) {
-      var decodedPayload = { type: 'empty' };
-
-      switch (tnf) {
-        case NDEF.TNF_WELL_KNOWN:
-          decodedPayload = this.decodeWellKnown(type, payload);
-          break;
-        case NDEF.TNF_MIME_MEDIA:
-          decodedPayload = this.decodeMIME(type, payload);
-          break;
-        case NDEF.TNF_ABSOLUTE_URI:
-        case NDEF.TNF_EXTERNAL_TYPE:
-          decodedPayload = { type: NfcUtils.toUTF8(type) };
-          break;
-        case NDEF.TNF_UNKNOWN:
-        case NDEF.TNF_RESERVED:
-          decodedPayload = {};
-          break;
-        case NDEF.TNF_UNCHANGED:
-          decodedPayload = null;
-          break;
-      }
-      return decodedPayload;
+      this.URIS[0x00] = '';
+      this.URIS[0x01] = 'http://www.';
+      this.URIS[0x02] = 'https://www.';
+      this.URIS[0x03] = 'http://';
+      this.URIS[0x04] = 'https://';
+      this.URIS[0x05] = 'tel:';
+      this.URIS[0x06] = 'mailto:';
+      this.URIS[0x07] = 'ftp://anonymous:anonymous@';
+      this.URIS[0x08] = 'ftp://ftp.';
+      this.URIS[0x09] = 'ftps://';
+      this.URIS[0x0A] = 'sftp://';
+      this.URIS[0x0B] = 'smb://';
+      this.URIS[0x0C] = 'nfs://';
+      this.URIS[0x0D] = 'ftp://';
+      this.URIS[0x0E] = 'dav://';
+      this.URIS[0x0F] = 'news:';
+      this.URIS[0x10] = 'telnet://';
+      this.URIS[0x11] = 'imap:';
+      this.URIS[0x12] = 'rtsp://';
+      this.URIS[0x13] = 'urn:';
+      this.URIS[0x14] = 'pop:';
+      this.URIS[0x15] = 'sip:';
+      this.URIS[0x16] = 'sips:';
+      this.URIS[0x17] = 'tftp:';
+      this.URIS[0x18] = 'btspp://';
+      this.URIS[0x19] = 'btl2cap://';
+      this.URIS[0x1A] = 'btgoep://';
+      this.URIS[0x1B] = 'tcpobex://';
+      this.URIS[0x1C] = 'irdaobex://';
+      this.URIS[0x1D] = 'file://';
+      this.URIS[0x1E] = 'urn:epc:id:';
+      this.URIS[0x1F] = 'urn:epc:tag:';
+      this.URIS[0x20] = 'urn:epc:pat:';
+      this.URIS[0x21] = 'urn:epc:raw:';
+      this.URIS[0x22] = 'urn:epc:';
+      this.URIS[0x23] = 'urn:nfc:';
     },
 
-    /**
-     * Decodes TNF Well Know NDEF record payload
-     * @see NFCForum-TS-NDEF_1.0
-     * @param {Uint8Array} type - record type
-     * @param {Uint8Array} payload - record payload
-     * @returns {Object} data - decoded payload or null if invalid
-     */
-    decodeWellKnown: function decodeWellKnown(type, payload) {
-      if (NfcUtils.equalArrays(type, NDEF.RTD_TEXT)) {
-        return this.decodeText(payload);
-      } else if (NfcUtils.equalArrays(type, NDEF.RTD_URI)) {
-        return this.decodeURI(payload);
-      } else if (NfcUtils.equalArrays(type, NDEF.RTD_SMART_POSTER)) {
-        return this.decodeSmartPoster(payload);
-      }
+    payload: {
+      /**
+       * Decodes NDEF record payload
+       * @see NFCForum-TS-NDEF_1.0
+       * @param {Uint8Array} tnf - record TNF
+       * @param {Uint8Array} type - record type
+       * @param {Uint8Array} payload - record payload
+       * @returns {Object} data - decoded payload or null if invalid
+       */
+      decode: function decode(tnf, type, payload) {
+        var nfcUtils = new NfcUtils();
+        var decodedPayload = { type: 'empty' };
 
-      return null;
-    },
-
-    /**
-     * Decodes TNF Well Known RTD Text NDEF record payload
-     * @see NFCForum-TS-RTD_Text_1.0
-     * @param {Uint8Array} payload - record payload
-     * @returns {Object} data - decoded payload
-     */
-    decodeText: function decodeText(payload) {
-      var decoded = { type: 'text' };
-
-      var langLen = payload[0] & NDEF.RTD_TEXT_IANA_LENGTH;
-      decoded.language = NfcUtils.toUTF8(payload.subarray(1, langLen + 1));
-
-      var encoding = (payload[0] & NDEF.RTD_TEXT_ENCODING) !== 0 ? 1 : 0;
-      if (encoding === NDEF.RTD_TEXT_UTF8) {
-        decoded.text = NfcUtils.toUTF8(payload.subarray(langLen + 1));
-        decoded.encoding = 'UTF-8';
-      } else if (encoding === NDEF.RTD_TEXT_UTF16) {
-        decoded.text = NfcUtils.UTF16BytesToStr(payload.subarray(langLen + 1));
-        decoded.encoding = 'UTF-16';
-      }
-
-      return decoded;
-    },
-
-    /**
-     * Decodes TNF Well Known RTD URI NDEF record payload
-     * @see NFCForum-TS-RTD_URI_1.0
-     * @param {Uint8Array} payload - record payload
-     * @returns {Object} data - decoded payload or null if invalid
-     */
-    decodeURI: function decodeURI(payload) {
-      var prefix = NDEF.URIS[payload[0]];
-      if (prefix === undefined) {
-        return null;
-      }
-
-      var suffix = NfcUtils.toUTF8(payload.subarray(1));
-      return { type: 'uri', uri: prefix + suffix };
-    },
-
-    /**
-     * Decodes TNF Well Known RTD Smart Poster NDEF record payload
-     * @see NFCForum-SmartPoster_RTD_1.0
-     * @param {Uint8Array} payload - record payload
-     * @returns {Object} data - decoded payload
-     */
-    decodeSmartPoster: function decodeSmartPoster(payload) {
-      var buffer = new NfcBuffer(payload);
-      var records = NfcUtils.parseNDEF(buffer);
-
-      // First, decode URI. It's treated specially, because it's the only
-      // mandatory record in a smart poster.
-      var URIRecords = records.filter(function(record) {
-        return NfcUtils.equalArrays(record.type, NDEF.RTD_URI);
-      });
-
-      if (URIRecords.length !== 1) {
-        return null;
-      }
-
-      var uriPoster = {
-        type: 'smartposter',
-        uri: NDEF.payload.decodeURI(URIRecords[0].payload).uri
-      };
-
-      // Now decode all other records and attach their data to poster.
-      return records.reduce((poster, record) => {
-        var typeStr = NfcUtils.toUTF8(record.type);
-
-        if (NfcUtils.equalArrays(record.type, NDEF.RTD_TEXT)) {
-          poster.text = poster.text || {};
-
-          var textData = NDEF.payload.decodeText(record.payload);
-
-          if (poster.text[textData.language]) {
-            // According to NFCForum-SmartPoster_RTD_1.0 3.3.2,
-            // there MUST NOT be two or more records with
-            // the same language identifier.
-            return null;
-          }
-
-          poster.text[textData.language] = textData.text;
-        } else if ('act' === typeStr) {
-          poster.action = record.payload[0];
-        } else if (NDEF.TNF_MIME_MEDIA === record.tnf) {
-          poster.icons = poster.icons || [];
-          poster.icons.push({
-            type: NfcUtils.toUTF8(record.type),
-            bytes: record.payload
-          });
+        switch (tnf) {
+          case NDEF.TNF_WELL_KNOWN:
+            decodedPayload = this.decodeWellKnown(type, payload);
+            break;
+          case NDEF.TNF_MIME_MEDIA:
+            decodedPayload = this.decodeMIME(type, payload);
+            break;
+          case NDEF.TNF_ABSOLUTE_URI:
+          case NDEF.TNF_EXTERNAL_TYPE:
+            decodedPayload = { type: nfcUtils.toUTF8(type) };
+            break;
+          case NDEF.TNF_UNKNOWN:
+          case NDEF.TNF_RESERVED:
+            decodedPayload = {};
+            break;
+          case NDEF.TNF_UNCHANGED:
+            decodedPayload = null;
+            break;
         }
-        return poster;
-      }, uriPoster);
+        return decodedPayload;
+      },
+
+      /**
+       * Decodes TNF Well Know NDEF record payload
+       * @see NFCForum-TS-NDEF_1.0
+       * @param {Uint8Array} type - record type
+       * @param {Uint8Array} payload - record payload
+       * @returns {Object} data - decoded payload or null if invalid
+       */
+      decodeWellKnown: function decodeWellKnown(type, payload) {
+        var nfcUtils = new NfcUtils();
+        if (nfcUtils.equalArrays(type, NDEF.RTD_TEXT)) {
+          return this.decodeText(payload);
+        } else if (nfcUtils.equalArrays(type, NDEF.RTD_URI)) {
+          return this.decodeURI(payload);
+        } else if (nfcUtils.equalArrays(type, NDEF.RTD_SMART_POSTER)) {
+          return this.decodeSmartPoster(payload);
+        }
+
+        return null;
+      },
+
+      /**
+       * Decodes TNF Well Known RTD Text NDEF record payload
+       * @see NFCForum-TS-RTD_Text_1.0
+       * @param {Uint8Array} payload - record payload
+       * @returns {Object} data - decoded payload
+       */
+      decodeText: function decodeText(payload) {
+        var nfcUtils = new NfcUtils();
+        var decoded = { type: 'text' };
+
+        var langLen = payload[0] & NDEF.RTD_TEXT_IANA_LENGTH;
+        decoded.language = nfcUtils.toUTF8(payload.subarray(1, langLen + 1));
+
+        var encoding = (payload[0] & NDEF.RTD_TEXT_ENCODING) !== 0 ? 1 : 0;
+        if (encoding === NDEF.RTD_TEXT_UTF8) {
+          decoded.text = nfcUtils.toUTF8(payload.subarray(langLen + 1));
+          decoded.encoding = 'UTF-8';
+        } else if (encoding === NDEF.RTD_TEXT_UTF16) {
+          decoded.text = nfcUtils.UTF16BytesToStr(payload.subarray(langLen +
+                                                                   1));
+          decoded.encoding = 'UTF-16';
+        }
+
+        return decoded;
+      },
+
+      /**
+       * Decodes TNF Well Known RTD URI NDEF record payload
+       * @see NFCForum-TS-RTD_URI_1.0
+       * @param {Uint8Array} payload - record payload
+       * @returns {Object} data - decoded payload or null if invalid
+       */
+      decodeURI: function decodeURI(payload) {
+        var nfcUtils = new NfcUtils();
+        var prefix = NDEF.URIS[payload[0]];
+        if (prefix === undefined) {
+          return null;
+        }
+
+        var suffix = nfcUtils.toUTF8(payload.subarray(1));
+        return { type: 'uri', uri: prefix + suffix };
+      },
+
+      /**
+       * Decodes TNF Well Known RTD Smart Poster NDEF record payload
+       * @see NFCForum-SmartPoster_RTD_1.0
+       * @param {Uint8Array} payload - record payload
+       * @returns {Object} data - decoded payload
+       */
+      decodeSmartPoster: function decodeSmartPoster(payload) {
+        var nfcUtils = new NfcUtils();
+        var buffer = new NfcBuffer(payload);
+        var records = nfcUtils.parseNDEF(buffer);
+
+        // First, decode URI. It's treated specially, because it's the only
+        // mandatory record in a smart poster.
+        var URIRecords = records.filter(function(record) {
+          return nfcUtils.equalArrays(record.type, NDEF.RTD_URI);
+        });
+
+        if (URIRecords.length !== 1) {
+          return null;
+        }
+
+        var uriPoster = {
+          type: 'smartposter',
+          uri: NDEF.payload.decodeURI(URIRecords[0].payload).uri
+        };
+
+        // Now decode all other records and attach their data to poster.
+        return records.reduce((poster, record) => {
+          var typeStr = nfcUtils.toUTF8(record.type);
+
+          if (nfcUtils.equalArrays(record.type, NDEF.RTD_TEXT)) {
+            poster.text = poster.text || {};
+
+            var textData = NDEF.payload.decodeText(record.payload);
+
+            if (poster.text[textData.language]) {
+              // According to NFCForum-SmartPoster_RTD_1.0 3.3.2,
+              // there MUST NOT be two or more records with
+              // the same language identifier.
+              return null;
+            }
+
+            poster.text[textData.language] = textData.text;
+          } else if ('act' === typeStr) {
+            poster.action = record.payload[0];
+          } else if (NDEF.TNF_MIME_MEDIA === record.tnf) {
+            poster.icons = poster.icons || [];
+            poster.icons.push({
+              type: nfcUtils.toUTF8(record.type),
+              bytes: record.payload
+            });
+          }
+          return poster;
+        }, uriPoster);
+      },
+
+      /**
+       * Decodes TNF MIME Media NDEF Record payload
+       * @see NFCForum-TS-NDEF_1.0
+       * @param {Uint8Array} type - record mime-type
+       * @returns {Object} data - decoded payload
+       */
+      decodeMIME: function docodeMIME(type, payload) {
+        var nfcUtils = new NfcUtils();
+        var typeStr = (typeof type === 'string') ? type : nfcUtils.toUTF8(type);
+        if (NDEF.MIME_VCARD_STR_ARR.indexOf(typeStr) !== -1) {
+          return {
+            type: 'text/vcard',
+            blob: new Blob([nfcUtils.toUTF8(payload)], {type: 'text/vcard'})
+          };
+        }
+
+        return { type: typeStr };
+      }
+    }
+  };
+
+  /**
+   * NfcBuffer wraps Uint8Array providing helper methods for accessing
+   * its elements.
+   *
+   * @param {Array} array Either a plain Array or an Uint8Array instance.
+   * @constructor
+   */
+  function NfcBuffer(array) {
+      this.uint8array = new Uint8Array(array);
+      this.offset = 0;
+  }
+
+  NfcBuffer.prototype = {
+    uint8array: null,
+
+    offset: 0,
+
+    /**
+     * Returns a single octet from the buffer advancing position
+     * by one.
+     *
+     * @returns {Number} Single element from the buffer.
+     * @memberof NfcBuffer
+     */
+    getOctet: function getOctet() {
+      if (this.offset == this.uint8array.length) {
+        throw Error('NfcBuffer too small');
+      }
+
+      return this.uint8array[this.offset++];
     },
 
     /**
-     * Decodes TNF MIME Media NDEF Record payload
-     * @see NFCForum-TS-NDEF_1.0
-     * @param {Uint8Array} type - record mime-type
-     * @returns {Object} data - decoded payload
+     * Returns an Uint8Array containing first len elements from the
+     * buffer.
+     *
+     * @param {Number} len Number of elements to return.
+     * @returns {Uint8Array} Array of len first elements from the buffer.
+     * @memberof NfcBuffer
      */
-    decodeMIME: function docodeMIME(type, payload) {
-      var typeStr = (typeof type === 'string') ? type : NfcUtils.toUTF8(type);
-      if (NDEF.MIME_VCARD_STR_ARR.indexOf(typeStr) !== -1) {
-        return {
-          type: 'text/vcard',
-          blob: new Blob([NfcUtils.toUTF8(payload)], {type: 'text/vcard'})
-        };
+    getOctetArray: function getOctetArray(len) {
+      if (typeof len !== 'number' || len < 0 ||
+        this.offset + len > this.uint8array.length) {
+
+        throw Error('NfcBuffer too small');
       }
 
-      return { type: typeStr };
-    }
-  }
-};
+      return this.uint8array.subarray(this.offset, this.offset += len);
+    },
 
-/**
- * NfcBuffer wraps Uint8Array providing helper methods for accessing
- * its elements.
- *
- * @param {Array} array Either a plain Array or an Uint8Array instance.
- * @constructor
- */
-function NfcBuffer(array) {
-    this.uint8array = new Uint8Array(array);
-    this.offset = 0;
-}
+    /**
+     * Discards len elements from the buffer.
+     *
+     * @param {Number} len Number of elements to skip over.
+     * @memberof NfcBuffer
+     */
+    skip: function skip(len) {
+      if (typeof len !== 'number' || len < 0 ||
+        this.offset + len > this.uint8array.length) {
 
-/**
- * Returns a single octet from the buffer advancing position
- * by one.
- *
- * @returns {Number} Single element from the buffer.
- * @memberof NfcBuffer
- */
-NfcBuffer.prototype.getOctet = function getOctet() {
-  if (this.offset == this.uint8array.length) {
-    throw Error('NfcBuffer too small');
-  }
-
-  return this.uint8array[this.offset++];
-};
-
-/**
- * Returns an Uint8Array containing first len elements from the
- * buffer.
- *
- * @param {Number} len Number of elements to return.
- * @returns {Uint8Array} Array of len first elements from the buffer.
- * @memberof NfcBuffer
- */
-NfcBuffer.prototype.getOctetArray = function getOctetArray(len) {
-  if (typeof len !== 'number' || len < 0 ||
-    this.offset + len > this.uint8array.length) {
-
-    throw Error('NfcBuffer too small');
-  }
-
-  return this.uint8array.subarray(this.offset, this.offset += len);
-};
-
-/**
- * Discards len elements from the buffer.
- *
- * @param {Number} len Number of elements to skip over.
- * @memberof NfcBuffer
- */
-NfcBuffer.prototype.skip = function skip(len) {
-  if (typeof len !== 'number' || len < 0 ||
-    this.offset + len > this.uint8array.length) {
-
-    throw Error('NfcBuffer too small');
-  }
-
-  this.offset += len;
-};
-
-/**
- * Returns a single octet from the buffer, but will not
- * advance a position.
- *
- * @returns {Number} Single element from the buffer.
- * @memberof NfcBuffer
- */
-NfcBuffer.prototype.peek = function peek() {
-  if (this.offset === this.uint8array.length) {
-    throw Error('NfcBuffer too small');
-  }
-
-  return this.uint8array[this.offset];
-};
-
-
-/**
- * NfcUtils offers a set of utility function to handle NDEF messages according
- * to NFCForum-TS-NDEF_1.0.
- *
- * @class NfcUtils
- */
-NfcUtils = {
-
-  DEBUG: false,
-
-  _debug: function debug(msg, optObject) {
-    if (this.DEBUG) {
-      var output = '[DEBUG] NFC-UTIL: ' + msg;
-      if (optObject) {
-        output += JSON.stringify(optObject);
+        throw Error('NfcBuffer too small');
       }
-      if (typeof dump !== 'undefined') {
-        dump(output + '\n');
-      } else {
-        console.log(output);
+
+      this.offset += len;
+    },
+
+    /**
+     * Returns a single octet from the buffer, but will not
+     * advance a position.
+     *
+     * @returns {Number} Single element from the buffer.
+     * @memberof NfcBuffer
+     */
+    peek: function peek() {
+      if (this.offset === this.uint8array.length) {
+        throw Error('NfcBuffer too small');
       }
+
+      return this.uint8array[this.offset];
     }
-  },
+  };
+
 
   /**
-   * Returns an Uint8Array representation of a string.
+   * NfcUtils offers a set of utility function to handle NDEF messages according
+   * to NFCForum-TS-NDEF_1.0.
    *
-   * @param {String} str String to convert.
-   * @return {Uint8Array}
-   * @memberof NfcUtils
+   * @class NfcUtils
    */
-  fromUTF8: function fromUTF8(str) {
-    if (!str) {
-      return null;
-    }
+  function NfcUtils() { }
 
-    var enc = new TextEncoder('utf-8');
-    return enc.encode(str);
-  },
+  NfcUtils.prototype = {
 
-  /**
-   * Returns a string representation of an Uint8Array.
-   *
-   * @param {Uint8Array} a Uint8Array instance.
-   * @return {String}
-   * @memberof NfcUtils
-   */
-  toUTF8: function toUTF8(a) {
-    if (!a) {
-      return null;
-    }
+    DEBUG: false,
 
-    // BOM removal
-    if (this.equalArrays(a.subarray(0, 3), [0xEF, 0xBB, 0xBF])) {
-      a = a.subarray(3);
-    }
-    var dec = new TextDecoder('utf-8');
-    return dec.decode(a);
-  },
+    _debug: function debug(msg, optObject) {
+      if (this.DEBUG) {
+        var output = '[DEBUG] NFC-UTIL: ' + msg;
+        if (optObject) {
+          output += JSON.stringify(optObject);
+        }
+        if (typeof dump !== 'undefined') {
+          dump(output + '\n');
+        } else {
+          console.log(output);
+        }
+      }
+    },
 
-  /**
-   * Decodes UTF-16 bytes array into a String
-   *
-   * @param {Uint8Array} array containing UTF-16 encoded bytes
-   * @return {string}
-   * @memberof NfcUtils
-   */
-  UTF16BytesToStr: function UTF16BytesToStr(array) {
-      if (!array) {
+    /**
+     * Returns an Uint8Array representation of a string.
+     *
+     * @param {String} str String to convert.
+     * @return {Uint8Array}
+     * @memberof NfcUtils
+     */
+    fromUTF8: function fromUTF8(str) {
+      if (!str) {
         return null;
       }
 
-      // if BOM not present Big-endian should be used
-      // NFCForum-TS-RTD_Text_1.0
-      var le = false;
+      var enc = new TextEncoder('utf-8');
+      return enc.encode(str);
+    },
 
-      var possibleBom = array.subarray(0, 2);
-      if (this.equalArrays(possibleBom, [0xFF, 0xFE])) {
-        array = array.subarray(2);
-        le = true;
-      } else if (this.equalArrays(possibleBom, [0xFE, 0xFF])) {
-        array = array.subarray(2);
+    /**
+     * Returns a string representation of an Uint8Array.
+     *
+     * @param {Uint8Array} a Uint8Array instance.
+     * @return {String}
+     * @memberof NfcUtils
+     */
+    toUTF8: function toUTF8(a) {
+      if (!a) {
+        return null;
       }
 
-      var encoding = (le) ? 'utf-16le' : 'utf-16be';
-      var dec = new TextDecoder(encoding);
-      return dec.decode(array);
-  },
+      // BOM removal
+      if (this.equalArrays(a.subarray(0, 3), [0xEF, 0xBB, 0xBF])) {
+        a = a.subarray(3);
+      }
+      var dec = new TextDecoder('utf-8');
+      return dec.decode(a);
+    },
 
-  /**
-   * Ecodes string into Uint8Array conating UTF-16 BE bytes without BOM.
-   * @param {string}
-   * @return {Uint8Array}
-   * @memberof NfcUtils
-   */
-  strToUTF16Bytes: function strToUTF16Bytes(str) {
-    if (!str) {
-      return null;
-    }
+    /**
+     * Decodes UTF-16 bytes array into a String
+     *
+     * @param {Uint8Array} array containing UTF-16 encoded bytes
+     * @return {string}
+     * @memberof NfcUtils
+     */
+    UTF16BytesToStr: function UTF16BytesToStr(array) {
+        if (!array) {
+          return null;
+        }
 
-    var enc = new TextEncoder('utf-16be');
-    return enc.encode(str);
-  },
+        // if BOM not present Big-endian should be used
+        // NFCForum-TS-RTD_Text_1.0
+        var le = false;
 
-  /**
-   * Compares arrays, array-like objects and typed arrays for equality.
-   *
-   * @param {Array} a1 First array
-   * @param {Array} a2 Second array
-   * @return {Boolean} True if arrays are equal, false otherwise.
-   * @memberof NfcUtils
-   */
-  equalArrays: function equalArrays(a1, a2) {
-    if (!a1 || !a2) {
-      return false;
-    }
+        var possibleBom = array.subarray(0, 2);
+        if (this.equalArrays(possibleBom, [0xFF, 0xFE])) {
+          array = array.subarray(2);
+          le = true;
+        } else if (this.equalArrays(possibleBom, [0xFE, 0xFF])) {
+          array = array.subarray(2);
+        }
 
-    if (a1.length !== a2.length) {
-      return false;
-    }
+        var encoding = (le) ? 'utf-16le' : 'utf-16be';
+        var dec = new TextDecoder(encoding);
+        return dec.decode(array);
+    },
 
-    for (var i = 0; i < a1.length; i++) {
-      if (a1[i] !== a2[i]) {
+    /**
+     * Ecodes string into Uint8Array conating UTF-16 BE bytes without BOM.
+     * @param {string}
+     * @return {Uint8Array}
+     * @memberof NfcUtils
+     */
+    strToUTF16Bytes: function strToUTF16Bytes(str) {
+      if (!str) {
+        return null;
+      }
+
+      var enc = new TextEncoder('utf-16be');
+      return enc.encode(str);
+    },
+
+    /**
+     * Compares arrays, array-like objects and typed arrays for equality.
+     *
+     * @param {Array} a1 First array
+     * @param {Array} a2 Second array
+     * @return {Boolean} True if arrays are equal, false otherwise.
+     * @memberof NfcUtils
+     */
+    equalArrays: function equalArrays(a1, a2) {
+      if (!a1 || !a2) {
         return false;
       }
-    }
 
-    return true;
-  },
-
-  /**
-   * Takes an array of NDEFRecords and returns an Array of octets
-   * representing the binary encoding of the NDEF message according
-   * to the NFC Forum.
-   * Note: support for message chunking is not implemented.
-   *
-   * @param {Array} ndefRecords Array of NDEF records to encode.
-   * @return {Array} Byte array containing encoded NDEF message.
-   * @memberof NfcUtils
-   */
-  encodeNDEF: function encodeNDEF(records) {
-    var result = [];
-
-    records.forEach((record, recordIndex) => {
-      record.payload = record.payload || [];
-      record.id = record.id || [];
-      record.type = record.type || [];
-
-      var payloadLen = record.payload.length;
-      var idLen = record.id.length;
-      var typeLen = record.type.length;
-
-      var firstOctet = record.tnf & 0x07;
-      firstOctet |= (recordIndex === 0) ? NDEF.MB : 0;
-      firstOctet |= (recordIndex === records.length - 1) ? NDEF.ME : 0;
-      firstOctet |= (idLen > 0) ? NDEF.IL : 0;
-      firstOctet |= (payloadLen <= 0xFF) ? NDEF.SR : 0;
-
-      result.push(firstOctet);
-      result.push(typeLen);
-
-      for (var p = (payloadLen > 0xFF ? 3 : 0); p >= 0; p -= 1) {
-        result.push((payloadLen >>> (8 * p)) & 0xFF);
+      if (a1.length !== a2.length) {
+        return false;
       }
 
-      if (idLen > 0) {
-        result.push(idLen);
+      for (var i = 0; i < a1.length; i++) {
+        if (a1[i] !== a2[i]) {
+          return false;
+        }
       }
 
-      result.push.apply(result, record.type);
-      result.push.apply(result, record.id);
-      result.push.apply(result, record.payload);
-    });
+      return true;
+    },
 
-    return result;
-  },
+    /**
+     * Takes an array of NDEFRecords and returns an Array of octets
+     * representing the binary encoding of the NDEF message according
+     * to the NFC Forum.
+     * Note: support for message chunking is not implemented.
+     *
+     * @param {Array} ndefRecords Array of NDEF records to encode.
+     * @return {Array} Byte array containing encoded NDEF message.
+     * @memberof NfcUtils
+     */
+    encodeNDEF: function encodeNDEF(records) {
+      var result = [];
 
-  /**
-   * Parses a NDEF message contained in a NfcBuffer instance according to
-   * NFCForum-TS-NDEF_1.0.
-   *
-   * Usage:
-   *   var buf = new NfcBuffer(<Uint8Array that contains the raw NDEF message>);
-   *   var ndefMessage = NdefCodec.parse(buf);
-   *
-   * @param {NfcBuffer} Buffer containing the NDEF message.
-   * @return {Array} Array of MozNDEFRecord instances or null if message
-   *                 couldn't be parsed.
-   * @memberof NfcUtils
-   */
-  parseNDEF: function parseNDEF(buffer) {
-    try {
-      return this._doParseNDEF(buffer);
-    } catch (err) {
-      this._debug(err);
-      return null;
-    }
-  },
+      records.forEach((record, recordIndex) => {
+        record.payload = record.payload || [];
+        record.id = record.id || [];
+        record.type = record.type || [];
 
-  _doParseNDEF: function doParseNDEF(buffer) {
-    var records = [];
-    var isFirstRecord = true;
-    var firstOctet;
+        var payloadLen = record.payload.length;
+        var idLen = record.id.length;
+        var typeLen = record.type.length;
 
-    do {
-      firstOctet = buffer.peek();
+        var firstOctet = record.tnf & 0x07;
+        firstOctet |= (recordIndex === 0) ? NDEF.MB : 0;
+        firstOctet |= (recordIndex === records.length - 1) ? NDEF.ME : 0;
+        firstOctet |= (idLen > 0) ? NDEF.IL : 0;
+        firstOctet |= (payloadLen <= 0xFF) ? NDEF.SR : 0;
 
-      if (isFirstRecord && !(firstOctet & NDEF.MB)) {
-        throw Error('MB bit not set in first NDEF record');
+        result.push(firstOctet);
+        result.push(typeLen);
+
+        for (var p = (payloadLen > 0xFF ? 3 : 0); p >= 0; p -= 1) {
+          result.push((payloadLen >>> (8 * p)) & 0xFF);
+        }
+
+        if (idLen > 0) {
+          result.push(idLen);
+        }
+
+        result.push.apply(result, record.type);
+        result.push.apply(result, record.id);
+        result.push.apply(result, record.payload);
+      });
+
+      return result;
+    },
+
+    /**
+     * Parses a NDEF message contained in a NfcBuffer instance according to
+     * NFCForum-TS-NDEF_1.0.
+     *
+     * Usage:
+     *   var buf = new NfcBuffer(<Uint8Array that contains the raw NDEF
+     *                           message>);
+     *   var ndefMessage = NdefCodec.parse(buf);
+     *
+     * @param {NfcBuffer} Buffer containing the NDEF message.
+     * @return {Array} Array of MozNDEFRecord instances or null if message
+     *                 couldn't be parsed.
+     * @memberof NfcUtils
+     */
+    parseNDEF: function parseNDEF(buffer) {
+      try {
+        return this._doParseNDEF(buffer);
+      } catch (err) {
+        this._debug(err);
+        return null;
+      }
+    },
+
+    _doParseNDEF: function doParseNDEF(buffer) {
+      var records = [];
+      var isFirstRecord = true;
+      var firstOctet;
+
+      do {
+        firstOctet = buffer.peek();
+
+        if (isFirstRecord && !(firstOctet & NDEF.MB)) {
+          throw Error('MB bit not set in first NDEF record');
+        }
+
+        if (!isFirstRecord && (firstOctet & NDEF.MB)) {
+          throw Error('MB can only be set for the first record');
+        }
+
+        if (firstOctet & NDEF.CF) {
+          throw Error('Chunked payloads are not supported');
+        }
+
+        records.push(this._parseNDEFRecord(buffer));
+        isFirstRecord = false;
+      } while (!(firstOctet & NDEF.ME));
+
+      if (buffer.offset < buffer.uint8array.length) {
+        throw Error('ME bit set on non-last record');
       }
 
-      if (!isFirstRecord && (firstOctet & NDEF.MB)) {
-        throw Error('MB can only be set for the first record');
+      return records;
+    },
+
+    _parseNDEFRecord: function parseNDEFRecord(buffer) {
+      var firstOctet = buffer.getOctet();
+      var typeLen = buffer.getOctet();
+      var payloadLen = buffer.getOctet();
+
+      if (!(firstOctet & NDEF.SR)) {
+        for (var i = 0; i < 3; i++) {
+          payloadLen <<= 8;
+          payloadLen |= buffer.getOctet();
+        }
       }
 
-      if (firstOctet & NDEF.CF) {
-        throw Error('Chunked payloads are not supported');
+      var idLen = 0;
+      if (firstOctet & NDEF.IL) {
+        idLen = buffer.getOctet();
       }
 
-      records.push(this._parseNDEFRecord(buffer));
-      isFirstRecord = false;
-    } while (!(firstOctet & NDEF.ME));
+      var tnf = firstOctet & NDEF.TNF;
+      var type = buffer.getOctetArray(typeLen);
+      var id = buffer.getOctetArray(idLen);
+      var payload = buffer.getOctetArray(payloadLen);
+      return new MozNDEFRecord(tnf, type, id, payload);
+    },
 
-    if (buffer.offset < buffer.uint8array.length) {
-      throw Error('ME bit set on non-last record');
-    }
-
-    return records;
-  },
-
-  _parseNDEFRecord: function parseNDEFRecord(buffer) {
-    var firstOctet = buffer.getOctet();
-    var typeLen = buffer.getOctet();
-    var payloadLen = buffer.getOctet();
-
-    if (!(firstOctet & NDEF.SR)) {
-      for (var i = 0; i < 3; i++) {
-        payloadLen <<= 8;
-        payloadLen |= buffer.getOctet();
+    /**
+     * Parses a URL string to MozNDEFRecord format.
+     *
+     * @param {String} url url string.
+     * @return {Array} Array of MozNDEFRecord instances.
+     * @memberof NfcUtils
+     */
+    parseURIString: function parseURIString(url) {
+      if (!url) {
+        return;
       }
-    }
-
-    var idLen = 0;
-    if (firstOctet & NDEF.IL) {
-      idLen = buffer.getOctet();
-    }
-
-    var tnf = firstOctet & NDEF.TNF;
-    var type = buffer.getOctetArray(typeLen);
-    var id = buffer.getOctetArray(idLen);
-    var payload = buffer.getOctetArray(payloadLen);
-    return new MozNDEFRecord(tnf, type, id, payload);
-  },
-
-  /**
-   * Parses a URL string to MozNDEFRecord format.
-   *
-   * @param {String} url url string.
-   * @return {Array} Array of MozNDEFRecord instances.
-   * @memberof NfcUtils
-   */
-  parseURIString: function parseURIString(url) {
-    if (!url) {
-      return;
-    }
-    var content = url;
-    for (var i = 1; i < NDEF.URIS.length; i++) {
-      var len = NDEF.URIS[i].length;
-      if (url.substring(0, len) == NDEF.URIS[i]) {
-          var uriPayload = url.substring(len);
-          content = String.fromCharCode(i) + uriPayload;
-          break;
+      var content = url;
+      for (var i = 1; i < NDEF.URIS.length; i++) {
+        var len = NDEF.URIS[i].length;
+        if (url.substring(0, len) == NDEF.URIS[i]) {
+            var uriPayload = url.substring(len);
+            content = String.fromCharCode(i) + uriPayload;
+            break;
+        }
       }
+      var payload = StringHelper.fromUTF8(content);
+      var ids = new Uint8Array(0);
+      var record = new MozNDEFRecord(NDEF.TNF_WELL_KNOWN, NDEF.RTD_URI, ids,
+        payload);
+      if (!record) {
+        return null;
+      }
+      return [record];
     }
-    var payload = StringHelper.fromUTF8(content);
-    var ids = new Uint8Array(0);
-    var record = new MozNDEFRecord(NDEF.TNF_WELL_KNOWN, NDEF.RTD_URI, ids,
-      payload);
-    if (!record) {
-      return null;
-    }
-    return [record];
-  }
-};
+  };
 
-NDEF.init();
+  NDEF.init();
+
+  exports.NfcBuffer = NfcBuffer;
+  exports.NfcUtils = NfcUtils;
+  exports.NDEF = NDEF;
+
+})(window);


### PR DESCRIPTION
This change moves classes in the nfc_utils.js file into a modular/export format.

Class NfcUtils now can be instantiated. NfcBuffer was always instanced. NDEF is still init()'ed since it is intended for mostly const usage only.

(NfcManager change is coming too. May have some conflicts: Bug 971520)
