### PR TITLE
Bug 964776 - [Flatfish][Settings] No vibrating alert motor, "Vibrate" op...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ manifest.appcache
 /apps/sms/js/blacklist.json
 /apps/settings/resources/network.json
 /apps/settings/resources/support.json
-/apps/settings/resources/sensors.json
+/apps/settings/resources/device-features.json
 /apps/settings/resources/findmydevice.json
 /apps/system/resources/icc.json
 /apps/system/resources/wapuaprof.json

--- a/apps/settings/build/build.js
+++ b/apps/settings/build/build.js
@@ -42,12 +42,16 @@ SettingsAppBuilder.prototype.writeSupportsJSON = function(options) {
   utils.writeContent(file, content);
 };
 
-SettingsAppBuilder.prototype.writeSensorsJSON = function(options) {
+SettingsAppBuilder.prototype.writeDeviceFeaturesJSON = function(options) {
   var distDir = options.GAIA_DISTRIBUTION_DIR;
 
-  var file = utils.getFile(options.STAGE_APP_DIR, 'resources', 'sensors.json');
-  var defaultContent = { ambientLight: true };
-  var content = utils.getDistributionFileContent('sensors',
+  var file = utils.getFile(options.STAGE_APP_DIR, 'resources',
+                           'device-features.json');
+  var defaultContent = {
+    ambientLight: true,
+    vibration: true
+  };
+  var content = utils.getDistributionFileContent('device-features',
                                                   defaultContent, distDir);
   utils.writeContent(file, content);
 };
@@ -157,7 +161,7 @@ SettingsAppBuilder.prototype.writeGitCommit = function(options) {
 SettingsAppBuilder.prototype.execute = function(options) {
   this.executeRjs(options);
   this.writeGitCommit(options);
-  this.writeSensorsJSON(options);
+  this.writeDeviceFeaturesJSON(options);
   this.writeSupportsJSON(options);
   this.writeFindMyDeviceConfigJSON(options);
   this.overrideSearchProviders(options);

--- a/apps/settings/elements/sound.html
+++ b/apps/settings/elements/sound.html
@@ -8,7 +8,7 @@
 
     <div>
       <ul>
-        <li>
+        <li id="vibration-setting">
           <label class="pack-switch">
             <input type="checkbox" name="vibration.enabled" checked class="uninit">
             <span data-l10n-id="vibrate">Vibrate</span>

--- a/apps/settings/js/panels/display/display.js
+++ b/apps/settings/js/panels/display/display.js
@@ -20,13 +20,13 @@ define(function(require) {
 
   Display.prototype = {
     /**
-     * Init Display module with doms and data of sensors.json.
+     * Init Display module with doms and data of device-features.json.
      *
      * @access public
      * @memberOf Display.prototype
      * @param {HTMLElement} elements
      * @param {Object} data
-     *                 content of resources/sensors.json.
+     *                 content of resources/device-features.json.
      */
     init: function d_init(elements, data) {
       this.elements = elements;
@@ -39,7 +39,7 @@ define(function(require) {
      * @access public
      * @memberOf Display.prototype
      * @param {Object} data
-     *                 content of resources/sensors.json.
+     *                 content of resources/device-features.json.
      */
     initBrightnessItems: function d_init_brightness_items(data) {
       var autoBrightnessSetting = 'screen.automatic-brightness';

--- a/apps/settings/js/panels/display/panel.js
+++ b/apps/settings/js/panels/display/panel.js
@@ -31,7 +31,7 @@ define(function(require) {
 
         wallpaperElements.wallpaper.addEventListener('click',
           wallpaper.selectWallpaper.bind(wallpaper));
-        loadJSON(['/resources/sensors.json'], function(data) {
+        loadJSON(['/resources/device-features.json'], function(data) {
           display.init(displayElements, data);
         });
       },

--- a/apps/settings/js/sound.js
+++ b/apps/settings/js/sound.js
@@ -1,10 +1,22 @@
 /* global getSupportedNetworkInfo, SettingsListener, ForwardLock, URL,
-          MozActivity */
+          MozActivity, loadJSON */
 /* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
 (function() {
   'use strict';
+
+  // Bug 964776 - [Flatfish][Settings] No vibrating alert motor, "Vibrate"
+  // option should be removed from Settings
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=964776
+  //
+  // Show/Hide 'Virate' checkbox according to device-features.json
+  (function() {
+    loadJSON(['/resources/device-features.json'], function(data) {
+      var vibrationSetting = document.getElementById('vibration-setting');
+      vibrationSetting.hidden = !data.vibration;
+    });
+  })();
 
   // Setup the sliders for previewing the tones.
   (function() {

--- a/build/test/integration/distribution.test.js
+++ b/build/test/integration/distribution.test.js
@@ -79,8 +79,8 @@ suite('Distribution mechanism', function() {
       path.join(cusDir, 'support.json'), true);
 
     helper.checkFileContentByPathInZip(
-      setingsZipPath, 'resources/sensors.json',
-      path.join(cusDir, 'sensors.json'), true);
+      setingsZipPath, 'resources/device-features.json',
+      path.join(cusDir, 'device-features.json'), true);
   }
 
   function validateOperatorVariant() {

--- a/customization/device-features.json
+++ b/customization/device-features.json
@@ -1,0 +1,4 @@
+{
+    "ambientLight": false,
+    "vibration": false
+}

--- a/customization/sensors.json
+++ b/customization/sensors.json
@@ -1,1 +1,0 @@
-{ "ambientLight": false }


### PR DESCRIPTION
...tion should be removed from Settings
- Rename customization/sensors.json to customization/device-features.json
- Modify build.js to replace sensors.json with device-features.json
- Show/Hide 'Vibrate' checkbox according to the 'vibration' value in device-features.json
- Update .gitignore and integration test
