### PR TITLE
Bug 1050725 - Reduce overpaint of the email app

### DIFF
--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -56,11 +56,11 @@ body {
 }
 
 .card.center {
-  transform: translateX(0);
+  transform: none;
 }
 
 .card.center.anim-vertical {
-  transform: translateY(0);
+  transform: none;
 }
 
 .card.center.anim-fade {
@@ -76,7 +76,7 @@ body {
 }
 
 .card.before.anim-fade {
-  transform: translateX(0);
+  transform: none;
   opacity: 0;
 }
 
@@ -97,7 +97,7 @@ body {
 }
 
 .card.after.anim-fade {
-  transform: translateX(0);
+  transform: none;
   opacity: 0;
 }
 


### PR DESCRIPTION
Patch from @vingtetun, with addition of changing the `translateY(0)` to `none` also. Tested and confirmed on flame device.
