### PR TITLE
Bug 1047645 - Use manual timeout to guard _closed event from not firing

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -428,10 +428,18 @@
 
     // If the app is the currently displayed app, switch to the homescreen
     if (this.isActive() && !this.isHomescreen) {
-      this.element.addEventListener('_closed', (function onClosed() {
-        window.removeEventListener('_closed', onClosed);
+
+      var fallbackTimeout;
+      var onClosed = function() {
+        clearTimeout(fallbackTimeout);
+        this.element.removeEventListener('_closed', onClosed);
         this.destroy();
-      }).bind(this));
+      }.bind(this);
+
+      this.element.addEventListener('_closed', onClosed);
+      fallbackTimeout = setTimeout(onClosed,
+        this.transitionController.CLOSING_TRANSITION_TIMEOUT);
+
       if (this.previousWindow) {
         this.previousWindow.getBottomMostWindow().open('in-from-left');
         this.close('out-to-right');

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1206,6 +1206,11 @@ suite('system/AppWindow', function() {
   });
 
   suite('Event handlers', function() {
+    var fakeTransitionController = {
+      requireOpen: function() {},
+      requireClose: function() {}
+    };
+
     test('ActivityDone event', function() {
       var app1 = new AppWindow(fakeAppConfig1);
       var app2 = new AppWindow(fakeAppConfig2);
@@ -1363,6 +1368,7 @@ suite('system/AppWindow', function() {
       var stubCloseSelf = this.sinon.stub(app1, 'close');
       stubIsActive.returns(true);
 
+      app1.transitionController = fakeTransitionController;
       app1.kill();
       assert.isTrue(stubOpenParent.calledWith('in-from-left'));
       assert.isTrue(stubCloseSelf.calledWith('out-to-right'));
@@ -1373,6 +1379,24 @@ suite('system/AppWindow', function() {
       /** global */
       app1.element.dispatchEvent(new CustomEvent('_closed'));
       assert.isTrue(stubDestroy.called);
+    });
+
+    test('kill guards against missed transitions', function() {
+      var app = new AppWindow(fakeAppConfig1);
+
+      // Ensure that the closed event does not trigger the destroy method.
+      this.sinon.stub(app.element, 'addEventListener');
+
+      this.sinon.stub(app, 'isActive').returns(true);
+      var destroyStub = this.sinon.stub(app, 'destroy');
+
+      app.transitionController = fakeTransitionController;
+      app.kill();
+      assert.ok(destroyStub.notCalled);
+
+      var fallbackTimeout = 1000;
+      this.sinon.clock.tick(fallbackTimeout);
+      assert.ok(destroyStub.calledOnce);
     });
 
     test('Load event', function() {

--- a/apps/system/test/unit/lockscreen_window_test.js
+++ b/apps/system/test/unit/lockscreen_window_test.js
@@ -83,6 +83,7 @@ suite('system/LockScreenWindow', function() {
       // Or the AppWindow would look for it.
       app.element = document.createElement('div');
       parentElement.appendChild(app.element);
+      app.transitionController = {};
       app.kill();
       assert.isTrue(stubDispatch.calledWithMatch(sinon.match(
           function(e) {
@@ -101,6 +102,9 @@ suite('system/LockScreenWindow', function() {
       // Or the AppWindow would look for it.
       app.element = document.createElement('div');
       parentElement.appendChild(app.element);
+      app.transitionController = {
+        requireClose: function() {}
+      };
       app.kill();
       app.close();
       assert.isTrue(stubDispatch.calledWithMatch(sinon.match(

--- a/apps/system/test/unit/secure_window_test.js
+++ b/apps/system/test/unit/secure_window_test.js
@@ -77,6 +77,7 @@ suite('system/SecureWindow', function() {
       // Or the AppWindow would look for it.
       app.element = document.createElement('div');
       parentElement.appendChild(app.element);
+      app.transitionController = {};
       app.kill();
       assert.isTrue(stubDispatch.calledWithMatch(sinon.match(
           function(e) {
@@ -97,6 +98,9 @@ suite('system/SecureWindow', function() {
       // Or the AppWindow would look for it.
       app.element = document.createElement('div');
       parentElement.appendChild(app.element);
+      app.transitionController = {
+        requireClose: function() {}
+      };
       app.kill();
       app.close();
       assert.isTrue(stubDispatch.calledWithMatch(sinon.match(


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1047645
