### PR TITLE
Bug 1001629: email notification clear triggers failure in startup

### DIFF
--- a/apps/email/js/app_messages.js
+++ b/apps/email/js/app_messages.js
@@ -72,8 +72,10 @@ define(function(require) {
       // "click". The system app will also notify this method of
       // any close events for notificaitons, which are not at all
       // interesting, at least for the purposes here.
-      if (!msg.clicked)
+      if (!msg.clicked) {
+        this.emitWhenListener('notificationClosed');
         return;
+      }
 
       // Need to manually get all notifications and close the one
       // that triggered this event due to fallout from 890440 and

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -195,6 +195,7 @@ if (appMessages.hasPending('activity') ||
   // and block normal first card selection, wait for activity.
   cachedNode = null;
   waitForAppMessage = true;
+  console.log('email waitForAppMessage');
 }
 
 if (appMessages.hasPending('alarm')) {
@@ -202,6 +203,7 @@ if (appMessages.hasPending('alarm')) {
   // as we were woken up just for the alarm.
   cachedNode = null;
   startedInBackground = true;
+  console.log('email startedInBackground');
 }
 
 // If still have a cached node, then show it.
@@ -463,6 +465,7 @@ appMessages.on('activity', gateEntry(function(type, data, rawActivity) {
       initComposer();
     } else {
       waitingForCreateAccountPrompt = true;
+      console.log('email waitingForCreateAccountPrompt');
       promptEmptyAccount();
     }
   } else {
@@ -472,11 +475,24 @@ appMessages.on('activity', gateEntry(function(type, data, rawActivity) {
     initComposer();
 
     waitingForCreateAccountPrompt = true;
+    console.log('email waitingForCreateAccountPrompt');
     model.latestOnce('acctsSlice', function activityOnAccount() {
       if (!model.hasAccount()) {
         promptEmptyAccount();
       }
     });
+  }
+}));
+
+appMessages.on('notificationClosed', gateEntry(function(data) {
+  // The system notifies the app of closed messages. This really is not helpful
+  // for the email app, but since it wakes up the app, if we do not at least try
+  // to show a usable UI, the user could end up with a blank screen. As the app
+  // could also have been awakened by sync or just user action and running in
+  // the background, we cannot just close the app. So just make sure there is
+  // some usable UI.
+  if (waitForAppMessage && !Cards.getCurrentCardType()) {
+    resetApp();
   }
 }));
 


### PR DESCRIPTION
If a notification for email is cleared from the notification tray, and the email app is not already running, the email app is launched.

Since it was a launch for a notification, the startup logic in mail_app sets waitForAppMessage to true, and that holds off the insertion of a card until more information about the notification is known, since the notification could be to go to the message_list or message_reader.

However, in app_messages, if the notification was not a 'clicked' message, it was discarded. This causes a problem because mail_app was waiting to hear back from app_messages to know what to do.

So now, if it is just a close of a notification, and not one that was clicked on, app_messages sends out a 'notificationClosed' event. mail_app listens for it, and if it was in that waiting state and there are no cards, the front end of the app is reset, which will lead to the insertion of the message_list card.
