### PR TITLE
Bug 1041904 - [Email] Customize Status Bar Color

### DIFF
--- a/apps/email/index.html
+++ b/apps/email/index.html
@@ -2,6 +2,15 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <!-- The theme color starts off blank. The card logic wants to choose a start
+  card first, since the color schemes are different for New Account vs Message
+  List. This means email starts up with a black header that fades to the correct
+  color once the card logic makes a choice. Due to the cookie cache, a black
+  status color is shown at first, then fades to the right color. This is
+  preferred to the alternative of starting up in default orange. If New Account
+  is the start card, it looks gross to have the orange on top of the white card
+  for a moment. -->
+  <meta name="theme-color" data-statuscolor="#ec7616" content="">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
   <title>Email</title>
   <link rel="stylesheet" type="text/css" href="style/mail.css">

--- a/apps/email/js/cards/compose.html
+++ b/apps/email/js/cards/compose.html
@@ -1,4 +1,4 @@
-<div class="card-compose card">
+<div class="card-compose card" data-statuscolor="default">
   <section class="cmp-compose-header" role="region">
     <header>
       <a href="#" class="cmp-back-btn">

--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -617,10 +617,12 @@ ComposeCard.prototype = {
       // Setup the marquee structure
       Marquee.setup(email, headerNode);
       // Activate marquee once the contents DOM are added to document
+      Cards.setStatusColor(contents);
       document.body.appendChild(contents);
       Marquee.activate('alternate', 'ease');
 
       var formSubmit = (function(evt) {
+        Cards.setStatusColor();
         document.body.removeChild(contents);
         switch (evt.explicitOriginalTarget.className) {
           case 'cmp-contact-menu-edit':
@@ -870,9 +872,11 @@ ComposeCard.prototype = {
     console.log('compose: back: save needed, prompting');
     var menu = cmpDraftMenuNode.cloneNode(true);
     this._savePromptMenu = menu;
+    Cards.setStatusColor(menu);
     document.body.appendChild(menu);
 
     var formSubmit = (function(evt) {
+      Cards.setStatusColor();
       document.body.removeChild(menu);
       this._savePromptMenu = null;
 

--- a/apps/email/js/cards/confirm_dialog.html
+++ b/apps/email/js/cards/confirm_dialog.html
@@ -1,5 +1,6 @@
 <div class="card-confirm-dialog card">
-  <form role="dialog" data-type="confirm" class="collapsed confirm-dialog-form">
+  <form data-statuscolor="background"
+        role="dialog" data-type="confirm" class="collapsed confirm-dialog-form">
     <section>
       <h1 data-l10n-id="confirm-dialog-title">ConfirmatioN</h1>
       <p class="confirm-dialog-message"></p>

--- a/apps/email/js/cards/folder_picker.html
+++ b/apps/email/js/cards/folder_picker.html
@@ -1,4 +1,5 @@
-<div class="card-folder-picker card anim-vertical anim-overlay one-account">
+<div class="card-folder-picker card anim-vertical anim-overlay one-account"
+     data-statuscolor="default">
   <!-- Our card does not have a header of its own; it reuses the message_list's
        header.  We want to steal clicks on its menu button too, hence this node
        and fld-header-back which is a transparent button that overlays the menu

--- a/apps/email/js/cards/message_list.html
+++ b/apps/email/js/cards/message_list.html
@@ -1,5 +1,5 @@
 <!-- Lists the messages in a folder -->
-<div class="card-message-list card" data-tray-target>
+<div class="card-message-list card" data-statuscolor="default" data-tray-target>
   <!-- Non-search header -->
   <section class="msg-list-header msg-nonsearch-only" role="region">
     <header>

--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -141,6 +141,9 @@ function MessageListCard(domNode, mode, args) {
     batchAddClass(domNode, 'msg-search-only', 'collapsed');
   } else {
     batchAddClass(domNode, 'msg-nonsearch-only', 'collapsed');
+    // Favor the use of the card background color for the status bar instead of
+    // the default color.
+    this.domNode.dataset.statuscolor = 'background';
   }
 
   this.messagesContainer =

--- a/apps/email/js/cards/message_reader.html
+++ b/apps/email/js/cards/message_reader.html
@@ -1,4 +1,4 @@
-<div class="card-message-reader card">
+<div class="card-message-reader card" data-statuscolor="default">
   <section class="msg-reader-header" role="region">
     <header>
       <a href="#" class="msg-back-btn">

--- a/apps/email/js/cards/message_reader.js
+++ b/apps/email/js/cards/message_reader.js
@@ -327,10 +327,12 @@ MessageReaderCard.prototype = {
 
   onReplyMenu: function(event) {
     var contents = msgReplyMenuNode.cloneNode(true);
+    Cards.setStatusColor(contents);
     document.body.appendChild(contents);
 
     // reply menu selection handling
     var formSubmit = (function(evt) {
+      Cards.setStatusColor();
       document.body.removeChild(contents);
       switch (evt.explicitOriginalTarget.className) {
       case 'msg-reply-menu-reply':

--- a/apps/email/js/cards/settings_signature.js
+++ b/apps/email/js/cards/settings_signature.js
@@ -44,9 +44,11 @@ SettingsSignatureCard.prototype = {
     }
     var menu = backFormNode.cloneNode(true);
     this._savePromptMenu = menu;
+    Cards.setStatusColor(menu);
     document.body.appendChild(menu);
 
     var formSubmit = (function(evt) {
+      Cards.setStatusColor();
       document.body.removeChild(menu);
       this._savePromptMenu = null;
 

--- a/apps/email/js/cards/setup_progress.html
+++ b/apps/email/js/cards/setup_progress.html
@@ -4,7 +4,7 @@
     <h1 class="sup-account-header-label"
         data-l10n-id="setup-account-header3">NeW AccounT</h1>
   </header>
-  <form role="dialog" data-type="confirm">
+  <form role="dialog" data-type="confirm" data-statuscolor="background">
     <section>
       <h1 data-l10n-id="setup-progress-wait-msg">SettinG UP AccounT</h1>
       <p class="sup-progress-container"><progress></progress></p>

--- a/apps/email/js/value_selector.js
+++ b/apps/email/js/value_selector.js
@@ -72,10 +72,14 @@ function ValueSelector(title, list) {
 
   show = function() {
     render();
+    // require call done here to avoid cycles. This will get better with
+    // the custom element refactoring.
+    require('mail_common').Cards.setStatusColor(formNode);
     formNode.classList.remove('collapsed');
   };
 
   hide = function() {
+    require('mail_common').Cards.setStatusColor();
     formNode.classList.add('collapsed');
     emptyList();
   };

--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -292,6 +292,10 @@ the list of folders.
   padding-left: 11rem;
 }
 
+.email-value-selector[role="dialog"][data-type="value-selector"] menu {
+  padding: 0 1.5rem;
+}
+
 /* Styles for errors that could appear at any time. */
 .error-card h2 {
   font-size: 1.6rem;


### PR DESCRIPTION
Updates status bar color based on card color. Cards does most of the work, but some specialized dialogs need to card the Cards.setStatusColor manually. Longer term, I think it is better to refactor those uses to fit into the Cards more. However, I want to do that work after landing the custom element work.

setStatusColor allows a few different options for choosing the color, see API docs in mail_common. The main goal is to avoid hard coding specific colors in the HTML or JavaScript, except for the meta tag itself, and setting up a default color.

I went with 'status' instead of 'theme' for the APIs and properties, since to me themes could be something different, could be something configured inside that app, and all of this right now is about setting the status bar color. Maybe that changes in the future, and status is too narrowly defined though. Open to renaming if reviewer thinks that helps. Either way, we are probably going to need to rename if in-app themes or some other status thing is introduced, or theme-color used for more than just status.

Also includes a fix for centering the Cancel button in value_selector, that is the common.css change.

The color is set before starting the card transition, since the animation performs better. If done in the transition startup logic, but after transition classes on the cards are set, our animation transition became choppy. If set after our transition completes, the status bar looks lazy, too much out of step with the UI. As it is now, the color fade in the status bar is non-optimal for our "immediate" card transitions, since that UI updates fast, but the status bar color still needs fade time. It was reviewed by UX, so that is what we will go with for now, since setting the color is the only toggle we have for that status bar color. 

I will file follow up bugs related to status bar icon colors (they don't seem to adjust well to some of our color choices) and asking for maybe a "transition immediately, no fade" option. It will help to have this landed though to give a point of reference/reproducibility for those bugs.
