### PR TITLE
Bug 1047645 - Use manual timeout to guard _closed event from not firing

### DIFF
--- a/apps/system/js/app_transition_controller.js
+++ b/apps/system/js/app_transition_controller.js
@@ -128,6 +128,10 @@
       }.bind(this),
       System.slowTransition ? this.SLOW_TRANSITION_TIMEOUT :
                               this.TRANSITION_TIMEOUT);
+
+      if (!this.app || !this.app.element) {
+        return;
+      }
       this.app.element.classList.add('transition-closing');
       this.app.element.classList.add(this.getAnimationName('close'));
     };
@@ -153,6 +157,10 @@
       }.bind(this),
       System.slowTransition ? this.SLOW_TRANSITION_TIMEOUT :
                               this.TRANSITION_TIMEOUT);
+
+      if (!this.app || !this.app.element) {
+        return;
+      }
       this.app.element.classList.add('transition-opening');
       this.app.element.classList.add(this.getAnimationName('open'));
     };
@@ -279,7 +287,7 @@
   AppTransitionController.prototype.clearTransitionClasses =
     function atc_removeTransitionClasses() {
       this.currentAnimation = null;
-      if (!this.app) {
+      if (!this.app || !this.app.element) {
         return;
       }
 

--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -401,11 +401,17 @@
 
     // If the app is the currently displayed app, switch to the homescreen
     if (this.isActive() && !this.isHomescreen) {
-      // XXX: Refine this in transition state controller.
-      this.element.addEventListener('_closed', (function onClosed() {
-        window.removeEventListener('_closed', onClosed);
+
+      var fallbackTimeout;
+      var onClosed = function() {
+        clearTimeout(fallbackTimeout);
+        this.element.removeEventListener('_closed', onClosed);
         this.destroy();
-      }).bind(this));
+      }.bind(this);
+
+      this.element.addEventListener('_closed', onClosed);
+      fallbackTimeout = setTimeout(onClosed,
+        this.transitionController.TRANSITION_TIMEOUT);
       this.requestClose();
     } else {
       this.destroy();

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -833,6 +833,11 @@ suite('system/AppWindow', function() {
   });
 
   suite('Event handlers', function() {
+    var fakeTransitionController = {
+      requireOpen: function() {},
+      requireClose: function() {}
+    };
+
     test('ActivityDone event', function() {
       var app1 = new AppWindow(fakeAppConfig1);
       var app2 = new AppWindow(fakeAppConfig2);

--- a/apps/system/test/unit/secure_window_test.js
+++ b/apps/system/test/unit/secure_window_test.js
@@ -79,6 +79,7 @@ suite('system/SecureWindow', function() {
       // Or the AppWindow would look for it.
       app.element = document.createElement('div');
       parentElement.appendChild(app.element);
+      app.transitionController = {};
       app.kill();
       assert.isTrue(stubDispatch.calledWithMatch(sinon.match(
           function(e) {
@@ -99,6 +100,9 @@ suite('system/SecureWindow', function() {
       // Or the AppWindow would look for it.
       app.element = document.createElement('div');
       parentElement.appendChild(app.element);
+      app.transitionController = {
+        requireClose: function() {}
+      };
       app.kill();
       app.close();
       assert.isTrue(stubDispatch.calledWithMatch(sinon.match(


### PR DESCRIPTION
Patch for v1.4.

Conflicts:
    apps/system/js/app_transition_controller.js
    apps/system/js/app_window.js
    apps/system/test/unit/app_window_test.js
    apps/system/test/unit/lockscreen_window_test.js
