### PR TITLE
Bug 1053614 - [woodduck] repeatedly enter and leave camera app, then high chance camera will be black screen when entering camera.

### DIFF
--- a/apps/camera/js/lib/camera/camera.js
+++ b/apps/camera/js/lib/camera/camera.js
@@ -655,8 +655,8 @@ Camera.prototype.release = function(done) {
   function onSuccess() {
     debug('successfully released');
     self.ready();
-    self.emit('released');
     self.releasing = false;
+    self.emit('released');
     done();
   }
 

--- a/apps/camera/test/unit/lib/camera/camera_test.js
+++ b/apps/camera/test/unit/lib/camera/camera_test.js
@@ -961,6 +961,17 @@ suite('lib/camera/camera', function() {
       });
     });
 
+    test('Should change camera.releasing status before released fired',
+     function(done) {
+      var self = this;
+      this.camera.releasing = true;
+      this.camera.on('released', function() {
+        assert.isFalse(self.camera.releasing);
+        done();
+      });
+      this.camera.release();
+    });
+
     test('Should call the callback with an error argument', function(done) {
       this.mozCamera.release = sinon.stub();
       this.mozCamera.release.callsArgWithAsync(1, 'error');


### PR DESCRIPTION
cherry-pick from master (017cd120af4c2827bc2a25615cc78e742a64e6fe).
