### PR TITLE
Bug 1049685 - [Tarako][Settings] Ringer's name overlay Alerts in Sound s...

### DIFF
--- a/shared/style/buttons.css
+++ b/shared/style/buttons.css
@@ -137,6 +137,15 @@ li .button {
   padding: 1rem 1.2rem;
 }
 
+/* Fix Bug 1049685 - [Tarako][Settings] Ringer's name overlay Alerts in Sound setting page
+   This should be backout once bug 1010675 landed. */
+li button:not(.change) {
+  padding-left: 0;
+  text-indent: 1.2rem;
+  text-overflow: "...    ";
+  white-space: nowrap;
+}
+
 /* Press */
 li [role="button"]:active:after,
 li .button:active:after,


### PR DESCRIPTION
...etting page
- Workaround for li button in shared/style/button.css. This should be backout once bug 1010675 landed.
- Excludes 'change' buttons in FTU to prevent unnecessary ellipsis.
