### PR TITLE
Merge pull request #22945 from nullaus/bug1053509

### DIFF
--- a/apps/system/js/download/download_notification.js
+++ b/apps/system/js/download/download_notification.js
@@ -57,7 +57,8 @@ DownloadNotification.prototype = {
   _update: function dn_update() {
     this._updateSystemDownloads();
     if (this.download.state === 'finalized') {
-      this._onFinalized();
+      // In theory we should never see this, but, we know that if we were
+      // to see this we want to do nothing.
       return;
     }
     var noNotify = this._wontNotify();
@@ -120,10 +121,6 @@ DownloadNotification.prototype = {
     this._storeDownload(this.download);
   },
 
-  _onFinalized: function dn_onFinalized() {
-    this._close();
-  },
-
   /**
    * This method stores complete downloads to share them with the download list
    * in settings app
@@ -133,16 +130,19 @@ DownloadNotification.prototype = {
   _storeDownload: function dn_storeDownload(download) {
     var req = DownloadStore.add(download);
 
-    req.onsuccess = function _storeDownloadOnSuccess() {
+    req.onsuccess = (function _storeDownloadOnSuccess(request) {
+      // We don't care about any more state changes to the download.
+      download.onstatechange = null;
+      // Update the download object to the datastore representation.
+      this.download = req.result;
+
       var mozDownloadManager = navigator.mozDownloadManager;
       if (mozDownloadManager) {
         // Once we've added the download to our data store we own it so clear
         // all references to it from the Downloads API.
         mozDownloadManager.clearAllDone();
       }
-      console.info('The download', download.id, 'was stored successfully:',
-                    download.url);
-    };
+    }).bind(this);
 
     req.onerror = function _storeDownloadOnError(e) {
       console.error('Exception storing the download', download.id, '(',

--- a/apps/system/test/unit/download_notification_test.js
+++ b/apps/system/test/unit/download_notification_test.js
@@ -295,15 +295,8 @@ suite('system/DownloadNotification >', function() {
       download.state = 'finalized';
       download.onstatechange();
 
-      sinon.assert.called(NotificationScreen.removeNotification);
-
-      var args = NotificationScreen.removeNotification.args[0];
-      var id = DownloadFormatter.getUUID(download);
-      assert.isTrue(args.indexOf(id) !== -1);
-
-      assert.isNull(notification.id);
-      assert.isNull(notification.download);
-      assert.isNull(notification.state);
+      assert.isFalse(NotificationScreen.removeNotification.called,
+                     'Notification should remain when download is finalized.');
     });
 
   });

--- a/shared/js/download/download_store.js
+++ b/shared/js/download/download_store.js
@@ -296,8 +296,9 @@ var DownloadStore = (function() {
     datastore.add(downloadCooked).then(function(id) {
       // Enriched object with the id provided by the datastore
       downloadCooked.id = id;
-      datastore.put(downloadCooked, id).then(defaultSuccess(req),
-                                             defaultError(req));
+      datastore.put(downloadCooked, id)
+               .then(function() { req.done(downloadCooked); },
+                     defaultError(req));
     }, defaultError(req));
   }
 
@@ -358,7 +359,8 @@ var DownloadStore = (function() {
     getAll: getAll,
 
     /*
-     * It adds a new download object
+     * It adds a new download object and returns the new datastore
+     * download object
      *
      * @param{Object} Download object provided by the API
      *


### PR DESCRIPTION
bug 1053509 - Use plain js download object when download succeeds. r=crd...
(cherry picked from commit 385f8b1fc9179441c9d6a6ad16ff8701edfa1faa)
