### PR TITLE
Bug 1043533 - email UI: account settings styling

### DIFF
--- a/apps/email/js/cards/settings_account.html
+++ b/apps/email/js/cards/settings_account.html
@@ -14,124 +14,129 @@
         AccounT
       </h2>
     </header>
-    <li class="list-text-with-sub">
-      <span data-l10n-id="settings-account-name" class="list-text">
-        YouR NamE</span>
-      <span class="tng-account-name list-sub-text">YouR NamE</span>
-    </li>
-    <li class="list-text-with-sub">
-      <span data-l10n-id="settings-account-display-notifications"
-            class="list-text aside start">
-        DisplaY NotificationS FoR NeW MessageS</span>
-      <em class="aside end">
-        <label class="tng-notify-mail-label pack-switch">
-          <input class="tng-notify-mail" type="checkbox">
-          <span></span>
-        </label>
-      </em>
-    </li>
-    <li class="list-text-with-sub">
-      <span data-l10n-id="settings-account-play-sound-onsend"
-            class="list-text aside start">
-        PlaY SounD AfteR MessagE SenT</span>
-      <em class="aside end">
-        <label class="tng-sound-onsend-label pack-switch">
-          <input class="tng-sound-onsend" type="checkbox">
-          <span></span>
-        </label>
-      </em>
-    </li>
-    <li>
-      <span data-l10n-id="settings-default-account"
-            class="list-text aside start">
-        SeT AS DefaulT EmaiL</span>
-      <em class="aside end">
-        <label class="pack-checkbox tng-default-label">
-          <input class="tng-default-input" type="checkbox">
-          <span></span>
-        </label>
-      </em>
-    </li>
-    <li class="settings-signature settings-input-list">
-        <span data-l10n-id="settings-account-signature-label"
-            class="list-text aside start">
-        SignaturE</span>
+    <ul class="tng-list">
+      <li class="list-text-with-sub">
+        <span data-l10n-id="settings-account-name" class="list-text">
+          YouR NamE</span>
+        <span class="tng-account-name list-sub-text">YouR NamE</span>
+      </li>
+      <li class="list-text-with-sub">
+        <span data-l10n-id="settings-account-display-notifications"
+              class="list-text aside start">
+          DisplaY NotificationS FoR NeW MessageS</span>
         <em class="aside end">
-          <label class="pack-switch tng-default-label">
-            <input class="tng-signature-input" type="checkbox">
+          <label class="tng-notify-mail-label pack-switch">
+            <input class="tng-notify-mail" type="checkbox">
             <span></span>
           </label>
         </em>
-      <button class="signature-button button icon">
-        <div class="signature-button-content"></div>
-      </button>
-    </li>
+      </li>
+      <li class="list-text-with-sub">
+        <span data-l10n-id="settings-account-play-sound-onsend"
+              class="list-text aside start">
+          PlaY SounD AfteR MessagE SenT</span>
+        <em class="aside end">
+          <label class="tng-sound-onsend-label pack-switch">
+            <input class="tng-sound-onsend" type="checkbox">
+            <span></span>
+          </label>
+        </em>
+      </li>
+      <li>
+        <span data-l10n-id="settings-default-account"
+              class="list-text aside start">
+          SeT AS DefaulT EmaiL</span>
+        <em class="aside end">
+          <label class="pack-checkbox tng-default-label">
+            <input class="tng-default-input" type="checkbox">
+            <span></span>
+          </label>
+        </em>
+      </li>
+      <li class="settings-signature settings-input-list">
+          <span data-l10n-id="settings-account-signature-label"
+              class="list-text aside start">
+          SignaturE</span>
+          <em class="aside end">
+            <label class="pack-switch tng-default-label">
+              <input class="tng-signature-input" type="checkbox">
+              <span></span>
+            </label>
+          </em>
+        <button class="signature-button button icon">
+          <div class="signature-button-content"></div>
+        </button>
+      </li>
+    </ul>
     <header class="tng-main-accounts-label">
       <h2 data-l10n-id="settings-sub-header-data">
         DatA
       </h2>
     </header>
-    <li class="syncinterval-setting select-item">
-      <label data-l10n-id="settings-account-check-mail" class="list-text">
-        ChecK FoR NeW MessageS</label>
-      <span class="button icon icon-dialog">
-        <select class="tng-account-check-interval mail-select">
-          <option value="0" data-l10n-id="settings-check-every-manual">
-            ManuallY</option>
-          <option value="300000" data-l10n-id="settings-check-every-5min">
-            5 MinuteS</option>
-          <option value="600000" data-l10n-id="settings-check-every-10min">
-            10 MinuteS</option>
-          <option value="900000" data-l10n-id="settings-check-every-15min">
-            15 MinuteS</option>
-          <option value="1800000" data-l10n-id="settings-check-every-30min">
-            30 MinuteS</option>
-          <option value="3600000" data-l10n-id="settings-check-every-60min">
-            60 MinuteS</option>
-        </select>
-      </span>
-    </li>
-    <li class="synchronize-setting select-item">
-      <label data-l10n-id="settings-account-synchronize-window"
-             class="list-text">DayS TO SynC</label>
-      <span class="button icon icon-dialog">
-        <select class="mail-select tng-account-synchronize">
-          <option value="auto" data-l10n-id="settings-synchronize-auto">
-            AutomatiC</option>
-          <option value="1d" data-l10n-id="settings-synchronize-one-day">
-            1 DaY</option>
-          <option value="3d" data-l10n-id="settings-synchronize-three-days">
-            3 DayS</option>
-          <option value="1w" data-l10n-id="settings-synchronize-one-week">
-            1 WeeK</option>
-          <option value="2w" data-l10n-id="settings-synchronize-two-weeks">
-            2 WeekS</option>
-          <option value="1m" data-l10n-id="settings-synchronize-one-month">
-            1 MontH</option>
-          <option value="all" data-l10n-id="settings-synchronize-all">
-            AlL MessageS</option>
-        </select>
-      </span>
-    </li>
-
+    <ul class="tng-list">
+      <li class="syncinterval-setting select-item">
+        <label data-l10n-id="settings-account-check-mail" class="list-text">
+          ChecK FoR NeW MessageS</label>
+        <span class="button icon icon-dialog">
+          <select class="tng-account-check-interval mail-select">
+            <option value="0" data-l10n-id="settings-check-every-manual">
+              ManuallY</option>
+            <option value="300000" data-l10n-id="settings-check-every-5min">
+              5 MinuteS</option>
+            <option value="600000" data-l10n-id="settings-check-every-10min">
+              10 MinuteS</option>
+            <option value="900000" data-l10n-id="settings-check-every-15min">
+              15 MinuteS</option>
+            <option value="1800000" data-l10n-id="settings-check-every-30min">
+              30 MinuteS</option>
+            <option value="3600000" data-l10n-id="settings-check-every-60min">
+              60 MinuteS</option>
+          </select>
+        </span>
+      </li>
+      <li class="synchronize-setting select-item">
+        <label data-l10n-id="settings-account-synchronize-window"
+               class="list-text">DayS TO SynC</label>
+        <span class="button icon icon-dialog">
+          <select class="mail-select tng-account-synchronize">
+            <option value="auto" data-l10n-id="settings-synchronize-auto">
+              AutomatiC</option>
+            <option value="1d" data-l10n-id="settings-synchronize-one-day">
+              1 DaY</option>
+            <option value="3d" data-l10n-id="settings-synchronize-three-days">
+              3 DayS</option>
+            <option value="1w" data-l10n-id="settings-synchronize-one-week">
+              1 WeeK</option>
+            <option value="2w" data-l10n-id="settings-synchronize-two-weeks">
+              2 WeekS</option>
+            <option value="1m" data-l10n-id="settings-synchronize-one-month">
+              1 MontH</option>
+            <option value="all" data-l10n-id="settings-synchronize-all">
+              AlL MessageS</option>
+          </select>
+        </span>
+      </li>
+    </ul>
     <header class="tng-main-accounts-label">
       <h2 data-l10n-id="settings-sub-header-server">
         ServeR SettingS
       </h2>
     </header>
-    <li>
-      <a href="#" data-l10n-id="settings-account-userpass"
-        class="tng-account-credentials list-text item-with-children"
-      >UsernamE AnD PassworD</a>
-    </li>
-    <li>
-      <span data-l10n-id="settings-account-type" class="list-text aside start">
-        AccounT TypE</span>
-      <div class="aside end">
-        <span class="tng-account-type list-value">AccounT TypE</span>
-      </div>
-    </li>
-    <div class="tng-account-server-container"></div>
+    <ul class="tng-list tng-account-server-container">
+      <li>
+        <a href="#" data-l10n-id="settings-account-userpass"
+          class="tng-account-credentials list-text item-with-children"
+        >UsernamE AnD PassworD</a>
+      </li>
+      <li>
+        <span data-l10n-id="settings-account-type"
+              class="list-text aside start">
+          AccounT TypE</span>
+        <div class="aside end">
+          <span class="tng-account-type list-value">AccounT TypE</span>
+        </div>
+      </li>
+    </ul>
     <button href="#" data-l10n-id="settings-account-delete"
       class="tng-account-delete danger">DeletE AccounT</button>
   </section>

--- a/apps/email/js/cards/settings_account.js
+++ b/apps/email/js/cards/settings_account.js
@@ -68,7 +68,10 @@ function SettingsAccountCard(domNode, mode, args) {
     synchronizeNode.addEventListener(
       'change', this.onChangeSynchronize.bind(this), false);
   } else {
-    this.nodeFromClass('synchronize-setting').style.display = 'none';
+    // Remove it from the DOM so that css selectors for last-child can work
+    // efficiently. Also, it just makes the overall DOM smaller.
+    var syncSettingNode = this.nodeFromClass('synchronize-setting');
+        syncSettingNode.parentNode.removeChild(syncSettingNode);
   }
 
   this.account.servers.forEach(function(server, index) {

--- a/apps/email/js/cards/settings_debug.html
+++ b/apps/email/js/cards/settings_debug.html
@@ -29,25 +29,27 @@
   <section class="scrollregion-below-header skin-organic" role="region">
     <button href="#" class="tng-dbg-reset">Reset App</button>
     <header><h2>Logging</h2></header>
-    <li class="select-item">
-      <label class="list-text">Logging Mode</label>
-      <span class="button icon icon-dialog">
-        <select class="tng-dbg-logging">
-          <option value="">
-            No logging.
-          </option>
-          <option value="safe">
-            Circular: Safe data: no passwords or message contents logged.
-          </option>
-          <option value="dangerous">
-            Circular: Dangerous data: passwords and message contents logged.
-          </option>
-          <option value="realtime-dangerous">
-            Realtime + Circular: Dangerous data: passwords and message contents logged.
-          </option>
-        </select>
-      </span>
-    </li>
+    <ul class="tng-list">
+      <li class="select-item">
+        <label class="list-text">Logging Mode</label>
+        <span class="button icon icon-dialog">
+          <select class="tng-dbg-logging">
+            <option value="">
+              No logging.
+            </option>
+            <option value="safe">
+              Circular: Safe data: no passwords or message contents logged.
+            </option>
+            <option value="dangerous">
+              Circular: Dangerous data: passwords and message contents logged.
+            </option>
+            <option value="realtime-dangerous">
+              Realtime + Circular: Dangerous data: passwords and message contents logged.
+            </option>
+          </select>
+        </span>
+      </li>
+    </ul>
     <button href="#" class="tng-dbg-dump-storage">Dump circular log buffer to sdcard</button>
     <header><h2>More Settings!</h2></header>
     <button href="#" class="tng-dbg-fastsync">Enable faster sync options</button>

--- a/apps/email/js/cards/settings_main.html
+++ b/apps/email/js/cards/settings_main.html
@@ -16,30 +16,6 @@
     </ul>
     <button href="#" data-l10n-id="settings-account-add"
       class="tng-account-add">AdD AccounT</button>
-    <!-- Hide for v1: Hide general setting section to reduce effort-->
-    <header class="tng-main-about-label collapsed">
-      <h2 data-l10n-id="settings-general-section">GeneraL SettingS</h2>
-    </header>
-      <li class="collapsed">
-        <span data-l10n-id="settings-show-images" class="list-text">
-          AlwayS ShoW ImageS</span>
-        <em class="aside end">
-          <label class="pack-switch">
-            <input type="checkbox" checked="checked">
-            <span></span>
-          </label>
-        </em>
-      </li>
-      <li class="collapsed">
-        <span data-l10n-id="settings-download-attachments"
-          class="list-text">DownloaD AttachmentS</span>
-        <em class="aside end">
-          <label class="pack-switch">
-            <input type="checkbox" checked="checked">
-            <span></span>
-          </label>
-        </em>
-      </li>
     <a class="tng-email-lib-version list-text">v1</a>
   </section>
 </section>

--- a/apps/email/js/cards/setup_account_prefs.html
+++ b/apps/email/js/cards/setup_account_prefs.html
@@ -10,61 +10,64 @@
         data-l10n-id="setup-account-header3">NeW AccounT</h1>
   </header>
   <section class="scrollregion-below-header skin-organic" role="region">
-    <li class="syncinterval-setting select-item">
-      <label data-l10n-id="settings-account-check-mail" class="list-text">
-        ChecK FoR NeW MessageS</label>
-      <span class="button icon icon-dialog">
-        <select class="tng-account-check-interval mail-select">
-          <option value="0" data-l10n-id="settings-check-every-manual">
-            ManuallY</option>
-          <option value="300000" data-l10n-id="settings-check-every-5min">
-            5 MinuteS</option>
-          <option value="600000" data-l10n-id="settings-check-every-10min">
-            10 MinuteS</option>
-          <option value="900000" data-l10n-id="settings-check-every-15min">
-            15 MinuteS</option>
-          <option value="1800000" data-l10n-id="settings-check-every-30min">
-            30 MinuteS</option>
-          <option value="3600000" data-l10n-id="settings-check-every-60min">
-            60 MinuteS</option>
-        </select>
-      </span>
-    </li>
-    <li class="list-text-with-sub">
-      <span data-l10n-id="settings-account-display-notifications"
-            class="list-text aside start">
-        DisplaY NotificationS FoR NeW MessageS</span>
-      <em class="aside end">
-        <label class="tng-notify-mail-label pack-switch">
-          <input class="tng-notify-mail" type="checkbox">
-          <span></span>
-        </label>
-      </em>
-    </li>
-    <li class="list-text-with-sub">
-      <span data-l10n-id="settings-account-play-sound-onsend"
-            class="list-text aside start">
-        PlaY SounD AfteR MessagE SenT</span>
-      <em class="aside end">
-        <label class="tng-sound-onsend-label pack-switch">
-          <input class="tng-sound-onsend" type="checkbox">
-          <span></span>
-        </label>
-      </em>
-    </li>
-    <li class="settings-signature settings-input-list">
-        <span data-l10n-id="settings-account-signature-label"
-            class="list-text aside start">
-          SignaturE</span>
+    <ul class="tng-list">
+      <li class="syncinterval-setting select-item">
+        <label data-l10n-id="settings-account-check-mail" class="list-text">
+          ChecK FoR NeW MessageS</label>
+        <span class="button icon icon-dialog">
+          <select class="tng-account-check-interval mail-select">
+            <option value="0" data-l10n-id="settings-check-every-manual">
+              ManuallY</option>
+            <option value="300000" data-l10n-id="settings-check-every-5min">
+              5 MinuteS</option>
+            <option value="600000" data-l10n-id="settings-check-every-10min">
+              10 MinuteS</option>
+            <option value="900000" data-l10n-id="settings-check-every-15min">
+              15 MinuteS</option>
+            <option value="1800000" data-l10n-id="settings-check-every-30min">
+              30 MinuteS</option>
+            <option value="3600000" data-l10n-id="settings-check-every-60min">
+              60 MinuteS</option>
+          </select>
+        </span>
+      </li>
+      <li class="list-text-with-sub">
+        <span data-l10n-id="settings-account-display-notifications"
+              class="list-text aside start">
+          DisplaY NotificationS FoR NeW MessageS</span>
         <em class="aside end">
-          <label class="pack-switch tng-default-label">
-            <input class="tng-signature-input" type="checkbox">
+          <label class="tng-notify-mail-label pack-switch">
+            <input class="tng-notify-mail" type="checkbox">
             <span></span>
           </label>
         </em>
-        <button class="signature-button button icon">
-          <div class="signature-button-content"></div>
-        </button>
-    </li>
+
+      </li>
+      <li class="list-text-with-sub">
+        <span data-l10n-id="settings-account-play-sound-onsend"
+              class="list-text aside start">
+          PlaY SounD AfteR MessagE SenT</span>
+        <em class="aside end">
+          <label class="tng-sound-onsend-label pack-switch">
+            <input class="tng-sound-onsend" type="checkbox">
+            <span></span>
+          </label>
+        </em>
+      </li>
+      <li class="settings-signature settings-input-list">
+          <span data-l10n-id="settings-account-signature-label"
+              class="list-text aside start">
+            SignaturE</span>
+          <em class="aside end">
+            <label class="pack-switch tng-default-label">
+              <input class="tng-signature-input" type="checkbox">
+              <span></span>
+            </label>
+          </em>
+          <button class="signature-button button icon">
+            <div class="signature-button-content"></div>
+          </button>
+      </li>
+    </ul>
   </section>
 </section>

--- a/apps/email/js/cards/tng/account_item.html
+++ b/apps/email/js/cards/tng/account_item.html
@@ -1,4 +1,4 @@
 <li class="tng-account-item">
-  <a href="#" class="tng-account-item-label list-text"></a>
+  <a href="#" class="tng-account-item-label list-text item-with-children"></a>
   <!-- we may want to expose some other info in this row -->
 </li>

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -132,13 +132,18 @@ section[role="region"].skin-organic {
   font-size: 1.6rem;
 }
 
+.tng-list {
+  margin: 0;
+  padding: 0;
+}
+
 li button.signature-button.icon:before {
   background-image: url('../shared/style/buttons/images/next.png');
   right: 0;
 }
 
 li button.signature-button.button.icon {
-  width: calc(100% - 3rem);
+  width: 100%;
   margin: 0 auto 2rem auto;
   padding-right: 3rem;
   padding-left: 0;
@@ -154,10 +159,20 @@ li button.signature-button.button.icon {
 
 li:not([role]) {
   position: relative;
-  width: 100%;
-  min-height: 5.5rem;
   border-bottom: solid 0.1rem #dbd9d9;
   list-style-type: none;
+}
+
+.tng-list li:last-child {
+  border-bottom: 0;
+}
+
+/* Special override because delete button follows the
+   tng-acccount-server-container, and cannot place the button inside that ul
+   since items are dynamically appended to it. So just explicitly state the
+   desire for a bottom border in that case. */
+.tng-list.tng-account-server-container li:last-child {
+  border-bottom: solid 0.1rem #dbd9d9;
 }
 
 li a:active {
@@ -166,7 +181,7 @@ li a:active {
 }
 
 .list-text-with-sub {
-  padding: 2rem 0 1rem 0;
+  padding: 1.5rem 0;
 }
 
 .list-text-with-sub .list-text {
@@ -183,8 +198,8 @@ li.select-item {
   overflow: hidden;
   text-overflow: ellipsis;
   color: #000;
+  padding-left: 1.5rem;
   line-height: 5.5rem;
-  padding-left: 3rem;
   font-size: 1.8rem;
   outline: 0 none;
 }
@@ -209,21 +224,16 @@ li.select-item {
   white-space: nowrap;
   color: #5b5b5b;
   font-size: 1.6rem;
-  padding-left: 3rem;
+  padding-left: 1.5rem;
 }
 
 li .aside.start {
   float: left;
-  width: calc(100% - 13.5rem);
+  width: calc(100% - 9.5rem);
 }
 
 li .aside.end {
   float: right;
-}
-
-.aside.end .pack-switch {
-  padding-right: 3rem;
-  margin-right: 1.5rem;
 }
 
 li.align-center {
@@ -236,7 +246,7 @@ li.align-center {
   height: 3rem;
   position: absolute;
   top: calc(50% - 1.5rem);
-  right: 0.5rem;
+  right: 0;
   background: url(/shared/style/buttons/images/next.png) no-repeat center / 3rem auto;
 }
 
@@ -271,15 +281,7 @@ li.settings-input-list {
 }
 
 .tng-accounts-container li {
-  min-height: 6rem;
-  text-align: center;
-}
-
-.tng-accounts-container li > a {
-  padding: 0 3rem;
-  text-align: left;
-  font-size: 1.9rem;
-  line-height: 6rem;
+  margin: 0 1.5rem;
 }
 
 .settings-button {
@@ -292,9 +294,8 @@ li.settings-input-list {
 }
 
 section.card-settings-account-common li {
-  margin: 0 auto;
+  margin: 0 1.5rem;
   overflow: hidden;
-  width: 100%;
 }
 
 section.card-settings-account-common li.syncinterval-setting label,
@@ -307,7 +308,6 @@ section.card-settings-account-common li.synchronize-setting label {
 section.card-settings-account-common li span.button {
   display: block;
   margin: 0 auto 1rem auto;
-  width: calc(100% - 3rem);
 }
 
 section.card-settings-account-common li .pack-checkbox {


### PR DESCRIPTION
This changeset looks bigger than it actually is because of HTML whitespace indenting, so it may be better to review this using `?w=1` on the pull request URL to cut out those differences.

The whitespace changes come from using a `<ul class="tng-list">` to hold the li elements in the settings screens. It has bothered me they were free floating lis and by doing this, then we can target :last-child selectors to not show the bottom borders in those cases.

The settings_account.js is related to that change: instead of just hiding an element section that does not apply, the DOM element is removed.

I also removed some dead HTML in settings_main.html since it is not wired to anything, and it is more likely to cause confusion, be out of date HTML whenever we do have app-wide (and not account specific) user-configurable settings.
