### PR TITLE
Bug 1034210 - send correct keycode for non-latin IME.

### DIFF
--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -1545,8 +1545,21 @@ function endPress(target, coords, touchId, hasCandidateScrolled) {
       }
     }
     else {
-      inputMethod.click(parseInt(target.dataset.keycode, 10),
-                        parseInt(target.dataset.keycodeUpper, 10));
+      /*
+       * XXX: A hack to send both keycode and uppercase keycode to latin IME,
+       * since latin IME would maintain a promise queue for each key, and
+       * send correct keycode based on the current capitalization state.
+       * See bug 1013570 and bug 987809 for details.
+       * This hack should be removed and the state/input queue should be
+       * maintained in keyboard.js.
+       */
+      var activeKeyboard = Keyboards[keyboardName];
+      if (activeKeyboard.imEngine == 'latin') {
+        inputMethod.click(parseInt(target.dataset.keycode, 10),
+                          parseInt(target.dataset.keycodeUpper, 10));
+      } else {
+        inputMethod.click(keyCode);
+      }
     }
     break;
   }


### PR DESCRIPTION
- Uplift to v1.4
