### PR TITLE
Bug 1055963 - [Flame][v2.1] Executing test_homescreen_delete_app.p...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/manifest.ini
@@ -8,6 +8,8 @@ smoketest = false
 [test_homescreen_delete_app.py]
 external = true
 smoketest = true
+# Bug 1055963 - [Flame][v2.1] Executing test_homescreen_delete_app.py shows "TypeError: app.manifest is undefined"
+expected = fail
 
 [test_homescreen_edit_mode.py]
 


### PR DESCRIPTION
...y shows "TypeError: app.manifest is undefined"
