### PR TITLE
[Music][MMS][Bug-1037315] Audio .ogg and .3gpp mimetypes are shown as video files in SMS app

### DIFF
--- a/apps/music/js/Player.js
+++ b/apps/music/js/Player.js
@@ -782,11 +782,12 @@ var PlayerView = {
         var filename = songData.name,
         name = filename.substring(filename.lastIndexOf('/') + 1),
         type = file.type;
+        var blob = getAudioTypeBlob(file);
 
         var activityData = {
           type: 'audio/*',
           number: 1,
-          blobs: [file],
+          blobs: [blob],
           filenames: [name],
           filepaths: [filename],
           // We only pass some metadata attributes so we don't share personal

--- a/apps/music/js/music.js
+++ b/apps/music/js/music.js
@@ -747,10 +747,11 @@ var TitleBar = {
             ];
             var playingBlob = PlayerView.playingBlob;
             getAlbumArtBlob(currentFileinfo, function(err, picture) {
+              var blob = getAudioTypeBlob(playingBlob);
               var currentMetadata = currentFileinfo.metadata;
               pendingPick.postResult({
-                type: playingBlob.type,
-                blob: playingBlob,
+                type: blob.type,
+                blob: blob,
                 name: currentMetadata.title || '',
                 // We only pass some metadata attributes so we don't share
                 // personal details like # of times played and ratings.

--- a/apps/music/js/utils.js
+++ b/apps/music/js/utils.js
@@ -85,3 +85,22 @@ function getAlbumArtBlob(fileinfo, callback) {
     getBlob(url, callback);
   }
 }
+
+//The .ogg and .3gp audio files have video mimetype but we force them to be
+//audio mimetype because the audio files are shown as video when user shares
+//while playing and through pick activity to SMS composer which is very
+//confusing to user.This change is for UX improvement and good user experience
+function getAudioTypeBlob(file) {
+  var map = {
+    'video/ogg': 'audio/ogg',
+    'video/3gpp': 'audio/3gpp'
+    // Probably more here?
+  };
+
+  if (file.type.indexOf('audio') === -1 && map[file.type]) {
+    return new Blob([file], {type: map[file.type]});
+  } else {
+    // Is it possible to be some other audio types?
+    return file;
+  }
+}

--- a/apps/music/manifest.webapp
+++ b/apps/music/manifest.webapp
@@ -27,7 +27,7 @@
     },
     "open": {
       "filters": {
-        "type": ["audio/mpeg", "audio/ogg", "audio/mp4", "audio/amr"]
+        "type": ["audio/mpeg", "audio/ogg", "audio/mp4", "audio/amr", "audio/3gpp"]
        },
       "disposition": "inline",
       "returnValue": true,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1037315

If the audio file received is shown as video/ogg and video/3gpp -> creating a blob and converting it to audio/ogg and audi/3gpp in music app -> so the attachment will be received from music will be shown correctly in SMS application
