### PR TITLE
Merge pull request #23118 from davidflanagan/bug1051172-v2.0

### DIFF
--- a/apps/camera/index.html
+++ b/apps/camera/index.html
@@ -31,6 +31,7 @@
     <!-- <script defer src="/shared/js/blobview.js"></script> -->
     <!-- <script defer src="/shared/js/custom_dialog.js"></script> -->
     <!-- <script defer src="/shared/js/format.js"></script> -->
+    <!-- <script defer src="/shared/js/stop_recording_event.js"></script> -->
 
     <link rel="stylesheet" type="text/css" href="style/main.css" />
   </head>

--- a/apps/camera/js/config/require.js
+++ b/apps/camera/js/config/require.js
@@ -24,7 +24,8 @@ requirejs.config({
     'view': '../bower_components/view/index',
     'evt': '../bower_components/evt/index',
     'drag': '../bower_components/drag/index',
-    'device-orientation': '../bower_components/device-orientation/index'
+    'device-orientation': '../bower_components/device-orientation/index',
+    'StopRecordingEvent': '../shared/js/stop_recording_event'
   },
 
   // If your package uses relative `require()` paths
@@ -83,6 +84,9 @@ requirejs.config({
     },
     'CustomDialog': {
       exports: 'CustomDialog'
+    },
+    'StopRecordingEvent': {
+      exports: 'StopRecordingEvent'
     }
   }
 });

--- a/apps/camera/js/controllers/camera.js
+++ b/apps/camera/js/controllers/camera.js
@@ -61,7 +61,6 @@ CameraController.prototype.bindEvents = function() {
   // App
   app.on('viewfinder:focuspointchanged', this.onFocusPointChanged);
   app.on('change:batteryStatus', this.onBatteryStatusChange);
-  app.on('attentionscreenopened', this.camera.stopRecording);
   app.on('settings:configured', this.onSettingsConfigured);
   app.on('previewgallery:opened', this.shutdownCamera);
   app.on('previewgallery:closed', this.onGalleryClosed);
@@ -72,6 +71,7 @@ CameraController.prototype.bindEvents = function() {
   app.on('visible', this.camera.load);
   app.on('capture', this.capture);
   app.on('hidden', this.onHidden);
+  app.on('stoprecording', this.camera.stopRecording);
 
   // Settings
   settings.recorderProfiles.on('change:selected', this.updateRecorderProfile);

--- a/apps/sharedtest/test/unit/stop_recording_event_test.js
+++ b/apps/sharedtest/test/unit/stop_recording_event_test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/* global StopRecordingEvent, MockNavigatorSettings */
+
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/js/stop_recording_event.js');
+
+suite('StopRecordingEvent', function() {
+
+  setup(function() {
+    this.realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+
+    this.handler = this.sinon.stub();
+    window.addEventListener('stoprecording', this.handler);
+
+    StopRecordingEvent.start();
+  });
+
+  teardown(function() {
+    StopRecordingEvent.stop();
+    navigator.mozSettings = this.realMozSettings;
+    window.removeEventListener('stoprecording', this.handler);
+  });
+
+  test('test runner has does not have document.hidden set', function() {
+    // The StopRecordingEvent module will not work when the document is
+    // hidden so bail out explictly if that is not the case.
+    assert.isFalse(document.hidden,
+                   'StopRecordingEvent only works when !document.hidden');
+  });
+
+  test('setting private.broadcast.stop_recording triggers event',
+       function() {
+         // Setting this property to true should send an event
+         navigator.mozSettings.createLock().set({
+           'private.broadcast.stop_recording': true
+         });
+         assert.ok(this.handler.calledOnce);
+
+         // Resetting to false should not send another event
+         navigator.mozSettings.createLock().set({
+           'private.broadcast.stop_recording': false
+         });
+         assert.ok(this.handler.calledOnce);
+       });
+
+  test('setting private.broadcast.attention_screen_opening triggers event',
+       function() {
+         // Setting this property to true should send an event
+         navigator.mozSettings.createLock().set({
+           'private.broadcast.attention_screen_opening': true
+         });
+         assert.ok(this.handler.calledOnce);
+
+         // Resetting to false should not send another event
+         navigator.mozSettings.createLock().set({
+           'private.broadcast.attention_screen_opening': false
+         });
+         assert.ok(this.handler.calledOnce);
+       });
+
+  test('no events triggered after stop() called', function() {
+    StopRecordingEvent.stop();
+    navigator.mozSettings.createLock().set({
+      'private.broadcast.attention_screen_opening': true
+    });
+    navigator.mozSettings.createLock().set({
+      'private.broadcast.stop_recording': true
+    });
+    assert.ok(this.handler.notCalled);
+  });
+});

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -124,6 +124,8 @@
 
       var that = this;
       if (appCurrent && layoutManager.keyboardEnabled) {
+        this.sendStopRecordingRequest();
+
         // Ask keyboard to hide before we switch the app.
         window.addEventListener('keyboardhidden', function onhiddenkeyboard() {
           window.removeEventListener('keyboardhidden', onhiddenkeyboard);
@@ -144,8 +146,10 @@
           that.switchApp(appCurrent, appNext, switching);
         });
       } else {
-        this.switchApp(appCurrent, appNext, switching,
-          openAnimation, closeAnimation);
+        this.sendStopRecordingRequest(function() {
+          this.switchApp(appCurrent, appNext, switching,
+                         openAnimation, closeAnimation);
+        }.bind(this));
       }
     },
 
@@ -838,6 +842,57 @@
           id: notificationId
         }
       }));
+    },
+
+    /**
+     * Abuse the settings database to notify interested certified apps
+     * that the current foreground window is about to close.  This is a
+     * hack implemented to fix bug 1051172 so that apps can be notified
+     * that they will be closing without having to wait for the
+     * visibilitychange event that does not arrive until after the app
+     * has been hidden.
+     *
+     * This function is called from display() above to handle switching
+     * from an app to the homescreen or to the task switcher. It is also
+     * called from stack_manager.js to handle edge gestures. I tried calling
+     * it from screen_manager.js to handle screen blanking and the sleep
+     * button, but the visibiltychange event arrived before the will hide
+     * notification did in that case, so it was not necessary.
+     *
+     * We ought to be able to remove this function and the code that
+     * calls it when bug 1034001 is fixed.
+     *
+     * See also bugs 995540 and 1006200 and the
+     * private.broadcast.attention_screen_opening setting hack in
+     * attention_screen.js
+     */
+    sendStopRecordingRequest: function sendStopRecordingRequest(callback) {
+      // If we are not currently recording anything, just call
+      // the callback synchronously
+      if (!window.mediaRecording.isRecording) {
+        if (callback) { callback(); }
+        return;
+      }
+
+      // Otherwise, if we are recording something, then send a
+      // "stop recording" signal via the settings db before
+      // calling the callback.
+      var setRequest = navigator.mozSettings.createLock().set({
+        'private.broadcast.stop_recording': true
+      });
+      setRequest.onerror = function() {
+        // If the set request failed for some reason, just call the callback
+        if (callback) { callback(); }
+      };
+      setRequest.onsuccess = function() {
+        // When the setting has been set, reset it as part of a separate
+        // transaction.
+        navigator.mozSettings.createLock().set({
+          'private.broadcast.stop_recording': false
+        });
+        // And meanwhile, call the callback
+        if (callback) { callback(); }
+      };
     }
   };
 

--- a/apps/system/js/stack_manager.js
+++ b/apps/system/js/stack_manager.js
@@ -301,6 +301,10 @@ var StackManager = {
       appOut.queueHide();
     }
 
+    if (this._broadcastTimeout === null) {
+      AppWindowManager.sendStopRecordingRequest();
+    }
+
     clearTimeout(this._broadcastTimeout);
     this._broadcastTimeout = setTimeout(this._broadcast.bind(this), 800);
   },

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -47,6 +47,7 @@ suite('system/AppWindowManager', function() {
     });
 
     window.layoutManager = new window.LayoutManager();
+    window.mediaRecording = { isRecording: false };
 
     home = new HomescreenWindow('fakeHome');
     window.homescreenLauncher = new HomescreenLauncher();
@@ -76,6 +77,8 @@ suite('system/AppWindowManager', function() {
   teardown(function() {
     AppWindowManager.uninit();
     delete window.layoutManager;
+    delete window.mediaRecording;
+
     // MockHelper won't invoke mTeardown() for us
     // since MockHomescreenLauncher is instantiable now
     window.homescreenLauncher.mTeardown();
@@ -615,7 +618,11 @@ suite('system/AppWindowManager', function() {
       injectRunningApps(app1, app2);
       AppWindowManager._activeApp = app1;
       var stubSwitchApp = this.sinon.stub(AppWindowManager, 'switchApp');
+      var spySendStopRecording = this.sinon.spy(AppWindowManager,
+                                                'sendStopRecordingRequest');
+
       AppWindowManager.display(app2);
+      assert.isTrue(spySendStopRecording.calledOnce);
       assert.isTrue(stubSwitchApp.called);
       assert.deepEqual(stubSwitchApp.getCall(0).args[0], app1);
       assert.deepEqual(stubSwitchApp.getCall(0).args[1], app2);

--- a/apps/system/test/unit/mock_app_window_manager.js
+++ b/apps/system/test/unit/mock_app_window_manager.js
@@ -45,5 +45,11 @@ var MockAppWindowManager = {
   broadcastMessage: function() {
   },
 
+  sendStopRecordingRequest: function(callback) {
+    if (callback) {
+      callback();
+    }
+  },
+
   init: function() {}
 };

--- a/apps/system/test/unit/stack_manager_test.js
+++ b/apps/system/test/unit/stack_manager_test.js
@@ -1,4 +1,4 @@
-/* global StackManager, AppWindow, Event, MocksHelper,
+/* global StackManager, AppWindow, AppWindowManager, Event, MocksHelper,
           MockAppWindowManager, HomescreenLauncher, MockSheetsTransition */
 'use strict';
 
@@ -350,6 +350,7 @@ suite('system/StackManager >', function() {
     suite('> blasting through history', function() {
       var dialerBroadcast, contactBroadcast, settingsBroadcast;
       var dialerQueueShow, contactCancelQueuedShow, settingsQueueHide;
+      var sendStopRecordingRequest;
 
       setup(function() {
         dialerBroadcast = this.sinon.stub(dialer, 'broadcast');
@@ -359,6 +360,9 @@ suite('system/StackManager >', function() {
         dialerQueueShow = this.sinon.stub(dialer, 'queueShow');
         contactCancelQueuedShow = this.sinon.stub(contact, 'cancelQueuedShow');
         settingsQueueHide = this.sinon.stub(settings, 'queueHide');
+
+        sendStopRecordingRequest = this.sinon.stub(AppWindowManager,
+                                                   'sendStopRecordingRequest');
 
         StackManager.goPrev();
         StackManager.goPrev();
@@ -386,6 +390,10 @@ suite('system/StackManager >', function() {
         sinon.assert.calledWith(dialerBroadcast, 'swipein');
         sinon.assert.notCalled(contactBroadcast);
         sinon.assert.calledWith(settingsBroadcast, 'swipeout');
+      });
+
+      test('it should call sendStopRecordingRequest', function() {
+        sinon.assert.calledOnce(sendStopRecordingRequest);
       });
 
       suite('if we\'re back to the same place', function() {

--- a/shared/js/stop_recording_event.js
+++ b/shared/js/stop_recording_event.js
@@ -1,0 +1,74 @@
+//
+// While the app is visible, listen for magic settings changes that
+// are signals from the system app that we will soon be hidden, and
+// emit a synthetic 'stoprecording' event when these settings changes
+// occur. For apps like Camera, the visiblitychange event can arrive
+// too late (see bugs 995540 and 1051172) and we need an event that
+// tells us more promptly when to stop recording.
+//
+// Note that this hack is needed when the phone is under heavy
+// memory pressure and is swapping. So we want to be really careful
+// to only listen for settings events when we actually are the
+// foreground app. We don't want a bunch of background apps to have
+// to wake up and handle an event every time the user presses the
+// Home button: that would just make the swapping issues worse!
+//
+(function(exports) {
+  'use strict';
+
+  const stopRecordingKey = 'private.broadcast.stop_recording';
+  const attentionScreenKey = 'private.broadcast.attention_screen_opening';
+
+  function start() {
+    // If we are visible, start listening to settings events
+    if (!document.hidden) {
+      listen();
+    }
+
+    // And listen and unlisten as our visibility changes
+    window.addEventListener('visibilitychange', visibilityChangeHandler);
+  }
+
+  function stop() {
+    // Stop tracking visibility
+    window.removeEventListener('visibilitychange', visibilityChangeHandler);
+
+    // And stop listening to the settings db
+    unlisten();
+  }
+
+  function visibilityChangeHandler() {
+    if (document.hidden) {
+      unlisten();  // If hidden, ignore setings changes
+    }
+    else {
+      listen();    // If visible, respond to settings changes
+    }
+  }
+
+  function listen() {
+    navigator.mozSettings.addObserver(stopRecordingKey,
+                                      stopRecordingObserver);
+    navigator.mozSettings.addObserver(attentionScreenKey,
+                                      stopRecordingObserver);
+  }
+
+  function unlisten() {
+    navigator.mozSettings.removeObserver(stopRecordingKey,
+                                         stopRecordingObserver);
+    navigator.mozSettings.removeObserver(attentionScreenKey,
+                                         stopRecordingObserver);
+  }
+
+  function stopRecordingObserver(event) {
+    if (event.settingValue) {
+      window.dispatchEvent(new CustomEvent('stoprecording'));
+    }
+  }
+
+  exports.StopRecordingEvent = {
+    start: start,
+    stop: stop
+  };
+
+}(window));


### PR DESCRIPTION
Bug 1051172: a stoprecording event hack so the camera can stop recording more quickly on app transitions. r=kgrandon,justindarc a=2.0+(cherry picked from commit 4ea69f01f52f472331d12b001ec1e37631bff575)

Conflicts:

```
apps/camera/index.html
apps/camera/js/app.js
apps/camera/js/config/require.js
apps/camera/js/controllers/camera.js
apps/camera/test/unit/setup.js
apps/system/js/app_window_manager.js
```

remove unused listenForAttentionScreen function
