### PR TITLE
Bug 1057396 - show page title in cards view

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -116,7 +116,7 @@
    */
   Card.prototype._populateViewData = function() {
     var app = this.app;
-    this.title = app.name,
+    this.title = (app.isBrowser() && app.title) ? app.title : app.name;
     this.subTitle = '';
     this.iconValue = 'none';
     this.closeButtonVisibility = 'visible';
@@ -338,6 +338,7 @@
 
   Card.prototype._fetchElements = function c__fetchElements() {
     this.screenshotView = this.element.querySelector('.screenshotView');
+    this.titleNode = this.element.querySelector('h1.title');
   };
 
 

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -66,6 +66,7 @@ suite('system/Card', function() {
       assert.ok(card.element, 'element node');
       assert.equal(card.element.tagName, 'LI');
       assert.ok(card.screenshotView, 'screenshotView node');
+      assert.ok(card.titleNode, 'title node');
     });
 
     test('has expected classes/elements', function(){
@@ -92,16 +93,40 @@ suite('system/Card', function() {
       assert.isTrue(stub.calledOnce, 'onOutViewport was called');
     });
 
+    test('browser app title', function() {
+      var browserCard = new Card({
+        app: makeApp({ name: 'browserwindow' }),
+        manager: mockManager
+      });
+      browserCard.app.title = 'Page title';
+      this.sinon.stub(browserCard.app, 'isBrowser', function() {
+        return true;
+      });
+      browserCard.render();
+      assert.equal(browserCard.titleNode.textContent, 'Page title');
+    });
+
+    test('app name', function() {
+      var appCard = new Card({
+        app: makeApp({ name: 'otherapp' }),
+        manager: mockManager
+      });
+      appCard.app.title = 'Some title';
+      this.sinon.stub(appCard.app, 'isBrowser', function() {
+        return false;
+      });
+      appCard.render();
+      assert.equal(appCard.titleNode.textContent, 'otherapp');
+    });
+
   });
 
   suite('destroy', function() {
     setup(function(){
-      this.cardNode = document.createElement('li');
       this.card = new Card({
         app: makeApp({ name: 'dummyapp' }),
         manager: mockManager,
-        containerElement: mockManager.cardsList,
-        element: this.cardNode
+        containerElement: mockManager.cardsList
       });
       this.card.render();
     });
@@ -110,8 +135,10 @@ suite('system/Card', function() {
     });
 
     test('removes element from parentNode', function() {
+      var cardNode = this.card.element;
+      assert.ok(cardNode.parentNode, 'cardNode has parentNode when rendered');
       this.card.destroy();
-      assert.ok(!this.cardNode.parentNode, 'cardNode has no parentNode');
+      assert.ok(!cardNode.parentNode, 'cardNode has no parentNode');
       assert.equal(cardsList.childNodes.length, 0, 'cardsList has no children');
     });
 


### PR DESCRIPTION
Card instances listen for their app's namechange and titlechange to update the title. This means browser windows display the page title in cards view, as per Task Manager spec: https://mozilla.app.box.com/s/lbw2wzw3p4jvxs24k4sg
