### PR TITLE
Bug 1046167: limit the allowable size of progressive jpegs

### DIFF
--- a/shared/js/media/image_size.js
+++ b/shared/js/media/image_size.js
@@ -57,7 +57,18 @@ function getImageSize(blob, callback, error) {
     else if (magic.substring(0, 2) === '\xFF\xD8') {
       parseJPEGMetadata(blob,
                         function(metadata) {
-                          metadata.type = 'jpeg';
+                          if (metadata.progressive) {
+                            // If the jpeg parser tells us that this is
+                            // a progressive jpeg, then treat that as a
+                            // distinct image type because pjpegs have
+                            // such different memory requirements than
+                            // regular jpegs.
+                            delete metadata.progressive;
+                            metadata.type = 'pjpeg';
+                          }
+                          else {
+                            metadata.type = 'jpeg';
+                          }
                           callback(metadata);
                         },
                         error);

--- a/shared/js/media/jpeg_metadata_parser.js
+++ b/shared/js/media/jpeg_metadata_parser.js
@@ -81,6 +81,12 @@ function parseJPEGMetadata(file, metadataCallback, metadataError) {
         metadata.height = data.getUint16(5);
         metadata.width = data.getUint16(7);
 
+        if (type === 0xC2) {
+          // pjpeg files can't be efficiently downsampled while decoded
+          // so we need to distinguish them from regular jpegs
+          metadata.progressive = true;
+        }
+
         // We're done. All the EXIF data will come before this segment
         // So call the callback
         metadataCallback(metadata);


### PR DESCRIPTION
make the pjpeg image size limit stricter than for other image sizes
