### PR TITLE
Bug 1044313 - EntrySheet must be a child of #screen to get correct z-ind...

### DIFF
--- a/apps/system/fxa/js/screens/fxam_enter_email.js
+++ b/apps/system/fxa/js/screens/fxam_enter_email.js
@@ -112,10 +112,11 @@ var FxaModuleEnterEmail = (function() {
       e.preventDefault();
       var url = e.target.href;
       if (this.entrySheet) {
+        this.entrySheet.close();
         this.entrySheet = null;
       }
       this.entrySheet = new EntrySheet(
-        window.top.document.getElementById('dialog-overlay'),
+        window.top.document.getElementById('screen'),
         url,
         new BrowserFrame({url: url})
       );


### PR DESCRIPTION
...ex. r=alive

See Bugzilla for discussion.
