### PR TITLE
Bug 1057905 - [v1.4] Avoid activeApp is null when receiving STK message. r=Tim.

### DIFF
--- a/apps/system/js/icc_worker.js
+++ b/apps/system/js/icc_worker.js
@@ -227,7 +227,7 @@ var icc_worker = {
     var activeApp = AppWindowManager.getActiveApp();
     var settingsOrigin = document.location.protocol + '//' +
       document.location.host.replace('system', 'settings');
-    if (!options.isHighPriority && !activeApp.isHomescreen &&
+    if (!options.isHighPriority && activeApp && !activeApp.isHomescreen &&
         activeApp.origin !== settingsOrigin) {
       DUMP('Do not display the text because normal priority.');
       icc.responseSTKCommand(message, {


### PR DESCRIPTION
Avoid activeApp is null when receiving STK message. r=Tim.
