### PR TITLE
Bug 1057905 - [master] Avoid activeApp is null when receiving STK message. r=Tim.

### DIFF
--- a/apps/system/js/icc_worker.js
+++ b/apps/system/js/icc_worker.js
@@ -231,7 +231,7 @@ var icc_worker = {
     // Check if device is idle or settings
     var activeApp = AppWindowManager.getActiveApp();
     var settingsOrigin = window.location.origin.replace('system', 'settings');
-    if (!options.isHighPriority && !activeApp.isHomescreen &&
+    if (!options.isHighPriority && activeApp && !activeApp.isHomescreen &&
         activeApp.origin !== settingsOrigin) {
       DUMP('Do not display the text because normal priority.');
       icc.responseSTKCommand(message, {


### PR DESCRIPTION
Avoid activeApp is null when receiving STK message. r=Tim.
