### PR TITLE
Bug 1052861 - uncomment inlineLocales (turned off by default). r=stas

### DIFF
--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -1399,15 +1399,13 @@
     nodeObserver.observe(document, moConfig);
 
     if (pretranslate) {
-      //XXX: bring back if bug 994370 gets reverted
-      //inlineLocalization.call(navigator.mozL10n);
+      inlineLocalization.call(navigator.mozL10n);
       initResources.call(navigator.mozL10n);
     } else {
       window.setTimeout(initResources.bind(navigator.mozL10n));
     }
   }
 
-  /*
   function inlineLocalization() {
     var locale = this.ctx.getLocale(navigator.language);
     var scriptLoc = locale.isPseudo ? this.ctx.defaultLocale : locale.id;
@@ -1435,7 +1433,6 @@
     // the visible DOM is now pretranslated
     isPretranslated = true;
   }
-  */
 
   function initResources() {
     var resLinks = document.head


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1052861
