### PR TITLE
Bug 1058362 - Temporarily disable perma-failures on b-i, ime_uninstallation_test.js, uninstallation_test.js

### DIFF
--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -1,5 +1,8 @@
 {
   "blacklist": {
+    "apps/keyboard/test/marionette/uninstallation_test.js": "Bug 1058362 - Temporary disabling",
+    "apps/settings/test/marionette/tests/ime_uninstallation_test.js": "Bug 1058362 - Temporary disabling",
+
     "apps/calendar/test/marionette/alarm_test.js": "Bug 994976 - Perma-red TBPL test, alarm > without alarm mocks create two events with simultaneous reminders",
     "apps/calendar/test/marionette/caldav_test.js": "Bug 972631 - CalDAV setup causing tbpl timeouts",
     "apps/calendar/test/marionette/server_test.js": "",

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -1,5 +1,8 @@
 {
   "blacklist": {
+    "apps/keyboard/test/marionette/uninstallation_test.js": "Bug 1058362 - Temporary disabling",
+    "apps/settings/test/marionette/tests/ime_uninstallation_test.js": "Bug 1058362 - Temporary disabling",
+
     "apps/calendar/test/marionette/alarm_test.js": "Bug 994976 - Perma-red TBPL test, alarm > without alarm mocks create two events with simultaneous reminders",
     "apps/calendar/test/marionette/caldav_test.js": "Bug 972631 - CalDAV setup causing tbpl timeouts",
     "apps/calendar/test/marionette/server_test.js": "",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1058362
