### PR TITLE
Bug 1056882: disallow cross-origin imports

### DIFF
--- a/shared/js/html_imports.js
+++ b/shared/js/html_imports.js
@@ -48,6 +48,9 @@ var HtmlImports = {
   },
 
   getImportContent: function(path, callback) {
+    // bail out if the imported resource isn't in the same origin
+    var parsedURL = new URL(path, location.href);
+    if (parsedURL.origin !== location.origin) { return }
     var xhr = new XMLHttpRequest();
     xhr.onload = function(o) {
       callback(xhr.responseText);


### PR DESCRIPTION
This should prevent the polyfill from bypassing the most CSP issues indicated in bug 1056882.
