### PR TITLE
Bug 1055981 - fix typo in teardown of homescreen_launcher_test.js

### DIFF
--- a/apps/system/test/unit/homescreen_launcher_test.js
+++ b/apps/system/test/unit/homescreen_launcher_test.js
@@ -39,7 +39,7 @@ suite('system/HomescreenLauncher', function() {
     });
 
     teardown(function() {
-      if (typeof window.homescreenLauncher !== undefined) {
+      if (typeof window.homescreenLauncher !== 'undefined') {
         window.homescreenLauncher.stop();
         window.homescreenLauncher = undefined;
       }


### PR DESCRIPTION
We accidentally leave `homescreenLauncher` instance in window object in unit test because of this typo.

https://bugzilla.mozilla.org/show_bug.cgi?id=1055981
