### PR TITLE
Bug 1059142 - [Text selection] set hasCutOrCopied to false in pasteHandler 

### DIFF
--- a/apps/system/js/text_selection_dialog.js
+++ b/apps/system/js/text_selection_dialog.js
@@ -134,6 +134,7 @@
   TextSelectionDialog.prototype.pasteHandler =
     function tsd_pasteHandler(evt) {
       this._doCommand(evt, 'paste');
+      this._hasCutOrCopied = false;
       window.clearTimeout(this._resetCutOrCopiedTimeout);
   };
 

--- a/apps/system/test/unit/text_selection_dialog_test.js
+++ b/apps/system/test/unit/text_selection_dialog_test.js
@@ -146,6 +146,7 @@ suite('system/TextSelectionDialog', function() {
     var stubClearTimeout = this.sinon.stub(window, 'clearTimeout');
     td._resetCutOrCopiedTimeout = 'testtimer';
     td.pasteHandler(null);
+    assert.isFalse(td._hasCutOrCopied);
     assert.isTrue(stubDoCommand.calledWith(null, 'paste'));
     assert.isTrue(stubClearTimeout.calledWith(td._resetCutOrCopiedTimeout));
   });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1059142
