### PR TITLE
Bug 1053826 - Change the parameter name in mock

### DIFF
--- a/apps/operatorvariant/test/unit/mock_navigator_moz_wifi_manager.js
+++ b/apps/operatorvariant/test/unit/mock_navigator_moz_wifi_manager.js
@@ -6,8 +6,8 @@ var MockNavigatorMozWifiManager = (function() {
   var networks;
   var knownNetworks = [];
 
-  function mwm_setNetworks(networks) {
-    networks = networks;
+  function mwm_setNetworks(aNetworks) {
+    networks = aNetworks;
   }
 
   function mwm_associate(network) {


### PR DESCRIPTION
Change the parameter name of setNetworks function in mockNavigatorMozWifiManager
