### PR TITLE
Bug 1007598 - We should never try to format the phone number on a remove...

### DIFF
--- a/apps/callscreen/js/handled_call.js
+++ b/apps/callscreen/js/handled_call.js
@@ -22,6 +22,7 @@ function HandledCall(aCall) {
   this._initialState = this.call.state;
   this._cachedInfo = '';
   this._cachedAdditionalInfo = '';
+  this._removed = false;
 
   this.node = document.getElementById('handled-call-template').cloneNode(true);
   this.node.id = '';
@@ -231,13 +232,7 @@ HandledCall.prototype.restoreAdditionalContactInfo =
 
 HandledCall.prototype.formatPhoneNumber =
   function hc_formatPhoneNumber(ellipsisSide, maxFontSize) {
-    /**
-     * To solve bug 1017365 the font-size in case of emergency calls is set to
-     *  the minimum one from the beginning and additional invocations of this
-     *  function (due to changes in the state of the call (on hold, ended,
-     *  etc.)) should be ignored.
-     */
-    if (this.node.classList.contains('emergency-call')) {
+    if (this._removed) {
       return;
     }
 
@@ -288,6 +283,7 @@ HandledCall.prototype.updateDirection = function hc_updateDirection() {
 };
 
 HandledCall.prototype.remove = function hc_remove() {
+  this._removed = true;
   this.call.removeEventListener('statechange', this);
   this.photo = null;
 

--- a/apps/callscreen/test/unit/handled_call_test.js
+++ b/apps/callscreen/test/unit/handled_call_test.js
@@ -655,6 +655,14 @@ suite('dialer/handled_call', function() {
       assert.equal(subject.numberNode.style.fontSize, '');
     });
 
+    test('formatPhoneNumber should do nothing if the call was removed',
+    function() {
+      subject.remove();
+      subject.numberNode.style.fontSize = '36px';
+      subject.formatPhoneNumber();
+      assert.equal(subject.numberNode.style.fontSize, '36px');
+    });
+
     test('check replace number', function() {
       mockCall = new MockCall('888', 'incoming');
       subject = new HandledCall(mockCall);


### PR DESCRIPTION
...d call.

Or we'll trigger an infinite reflow loop.
