### PR TITLE
Bug 1047143 - close apps entering task-manager, exitToApp to open/restore. r=alive

### DIFF
--- a/apps/system/js/app_transition_controller.js
+++ b/apps/system/js/app_transition_controller.js
@@ -232,7 +232,7 @@
       this.app.reviveBrowser();
       this.app.launchTime = Date.now();
       this.app.fadeIn();
-      this.app.setVisible(true);
+      this.app.requestForeground();
 
       // TODO:
       // May have orientation manager to deal with lock orientation request.
@@ -250,7 +250,7 @@
       this.resetTransition();
       this.app.element.removeAttribute('aria-hidden');
       this.app.element.classList.add('active');
-      this.app.setVisible(true);
+      this.app.requestForeground();
 
       // TODO:
       // May have orientation manager to deal with lock orientation request.

--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -1886,8 +1886,9 @@
    */
   AppWindow.prototype.enterTaskManager = function aw_enterTaskManager() {
     this._dirtyStyleProperties = {};
-    if (this.element) {
+    if (this.element && this.transitionController) {
       this.element.classList.add('in-task-manager');
+      this.close( this.isActive() ? 'to-cardview' : 'immediate' );
     }
   };
 
@@ -1897,8 +1898,10 @@
   AppWindow.prototype.leaveTaskManager = function aw_leaveTaskManager() {
     if (this.element) {
       this.element.classList.remove('in-task-manager');
-      this.unapplyStyle(this._dirtyStyleProperties);
-      this._dirtyStyleProperties = null;
+      if (this._dirtyStyleProperties) {
+        this.unapplyStyle(this._dirtyStyleProperties);
+        this._dirtyStyleProperties = null;
+      }
     }
   };
 
@@ -1973,6 +1976,10 @@
       win = win.frontWindow;
     }
     win.focus();
+  };
+
+  AppWindow.prototype.requestForeground = function aw_requestForeground() {
+    this.publish('requestforeground');
   };
 
   exports.AppWindow = AppWindow;

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -208,7 +208,7 @@
 
         appNext.open(immediateTranstion ? 'immediate' :
                       ((switching === true) ? 'invoked' : openAnimation));
-        if (appCurrent) {
+        if (appCurrent && appCurrent.instanceID !== appNext.instanceID) {
           appCurrent.close(immediateTranstion ? 'immediate' :
             ((switching === true) ? 'invoking' : closeAnimation));
         } else {
@@ -552,6 +552,7 @@
             this._activeApp.getTopMostWindow().blur();
           }
           break;
+
         case 'sheetstransitionstart':
           if (document.mozFullScreen) {
             document.mozCancelFullScreen();

--- a/apps/system/js/attention_screen.js
+++ b/apps/system/js/attention_screen.js
@@ -49,7 +49,6 @@ var AttentionScreen = {
     window.addEventListener('home', this.hide.bind(this));
     window.addEventListener('holdhome', this.hide.bind(this));
     window.addEventListener('global-search-request', this.hide.bind(this));
-    window.addEventListener('appwillopen', this.appOpenHandler.bind(this));
     window.addEventListener('launchapp', this.appLaunchHandler.bind(this));
     window.addEventListener('emergencyalert', this.hide.bind(this));
 
@@ -82,14 +81,6 @@ var AttentionScreen = {
       this.hide();
     } else {
       this.show(frame);
-    }
-  },
-
-  appOpenHandler: function as_appHandler(evt) {
-    // If the user presses the home button we will still hide the attention
-    // screen. But in the case of an app crash we'll keep it fully open
-    if (!evt.detail.isHomescreen) {
-      this.hide();
     }
   },
 

--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -182,6 +182,8 @@
 
     this._fetchElements();
     this._registerEvents();
+
+    this.app.enterTaskManager();
     this.publish('rendered');
     return elem;
   };
@@ -221,6 +223,9 @@
     var element = this.element;
     if (element && element.parentNode) {
       element.parentNode.removeChild(element);
+    }
+    if (this.app) {
+      this.app.leaveTaskManager();
     }
     this.element = this.manager = this.app = null;
     this.publish('destroyed');

--- a/apps/system/js/sound_manager.js
+++ b/apps/system/js/sound_manager.js
@@ -229,7 +229,7 @@
     window.addEventListener('appopen', this);
     window.addEventListener('ftudone', this);
     window.addEventListener('holdhome', this);
-    window.addEventListener('home', this);
+    window.addEventListener('homescreenopening', this);
     window.addEventListener('homescreenopened', this);
 
     this.initVibrationUserPref();
@@ -265,7 +265,7 @@
     window.removeEventListener('appopen', this);
     window.removeEventListener('ftudone', this);
     window.removeEventListener('holdhome', this);
-    window.removeEventListener('home', this);
+    window.removeEventListener('homescreenopening', this);
     window.removeEventListener('homescreenopened', this);
   };
 
@@ -323,7 +323,7 @@
       case 'holdhome':
         CustomDialog.hide();
         break;
-      case 'home':
+      case 'homescreenopening':
       case 'homescreenopened':
         this.homescreenVisible = true;
         CustomDialog.hide();

--- a/apps/system/js/stack_manager.js
+++ b/apps/system/js/stack_manager.js
@@ -196,6 +196,10 @@ var StackManager = {
         }
         break;
       case 'home':
+        // only handle home events if task manager is not visible
+        if (window.taskManager && window.taskManager.isShown()) {
+          return;
+        }
         this._moveToTop(this.position);
         this.position = -1;
         this.commitClose();
@@ -267,7 +271,7 @@ var StackManager = {
       if (sConfig.instanceID == instanceID) {
         this._stack.splice(i, 1);
 
-        if (i <= this.position && this.position > 0) {
+        if (i <= this.position && this.position >= 0) {
           this.position--;
         }
         return;

--- a/apps/system/js/task_card.js
+++ b/apps/system/js/task_card.js
@@ -80,7 +80,6 @@
    */
   TaskCard.prototype.render = function tc_render() {
     Card.prototype.render.call(this);
-    this.app.enterTaskManager();
     return this.element;
   };
 
@@ -95,10 +94,6 @@
    * @memberof TaskCard.prototype
    */
   TaskCard.prototype.destroy = function tc_destroy() {
-    var app = this.app;
-    if (app) {
-      app.leaveTaskManager();
-    }
     Card.prototype.destroy.call(this);
   };
 

--- a/apps/system/js/visibility_manager.js
+++ b/apps/system/js/visibility_manager.js
@@ -36,7 +36,10 @@
       'utility-tray-overlayopened',
       'utility-tray-overlayclosed',
       'system-dialog-show',
-      'system-dialog-hide'
+      'system-dialog-hide',
+      'searchrequestforeground',
+      'apprequestforeground',
+      'homescreenrequestforeground'
     ];
   };
 
@@ -56,6 +59,14 @@
       clearTimeout(this._attentionScreenTimer);
     }
     switch (evt.type) {
+      case 'searchrequestforeground':
+      case 'homescreenrequestforeground':
+      case 'apprequestforeground':
+        if (!System.locked &&
+            !AttentionScreen.isFullyVisible()) {
+          evt.detail.setVisible(true);
+        }
+        break;
       // XXX: See Bug 999318.
       // Audio channel is always normal without going back to none.
       // We are actively discard audio channel state when homescreen

--- a/apps/system/test/unit/app_transition_controller_test.js
+++ b/apps/system/test/unit/app_transition_controller_test.js
@@ -89,10 +89,10 @@ suite('system/AppTransitionController', function() {
   test('Opened notification', function() {
     var app1 = new MockAppWindow(fakeAppConfig1);
     var acn1 = new AppTransitionController(app1);
-    var stubSetVisible = this.sinon.stub(app1, 'setVisible');
+    var stubRequestForeground = this.sinon.stub(app1, 'requestForeground');
     acn1._transitionState = 'opening';
     acn1.handleEvent({ type: '_opened' });
-    assert.isTrue(stubSetVisible.calledWith(true));
+    assert.isTrue(stubRequestForeground.calledOnce);
   });
 
   test('Animation start event', function() {
@@ -172,9 +172,9 @@ suite('system/AppTransitionController', function() {
     var app1 = new MockAppWindow(fakeAppConfig1);
     var acn1 = new AppTransitionController(app1);
     var stubReviveBrowser = this.sinon.stub(app1, 'reviveBrowser');
-    var stubSetVisible = this.sinon.stub(app1, 'setVisible');
+    var stubRequestForeground = this.sinon.stub(app1, 'requestForeground');
     acn1.handle_opening();
-    assert.isTrue(stubSetVisible.calledWith(true));
+    assert.isTrue(stubRequestForeground.calledOnce);
     assert.isTrue(stubReviveBrowser.called);
   });
 
@@ -248,10 +248,10 @@ suite('system/AppTransitionController', function() {
     test('Handle opened', function() {
       var app1 = new MockAppWindow(fakeAppConfig1);
       var acn1 = new AppTransitionController(app1);
-      var stubSetVisible = this.sinon.stub(app1, 'setVisible');
+      var stubRequestForeground = this.sinon.stub(app1, 'requestForeground');
       var stubSetOrientation = this.sinon.stub(app1, 'setOrientation');
       acn1.handle_opened();
-      assert.isTrue(stubSetVisible.calledWith(true));
+      assert.isTrue(stubRequestForeground.calledOnce);
       assert.isTrue(stubSetOrientation.called);
     });
   });

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1,5 +1,6 @@
 /* global AppWindow, ScreenLayout, MockOrientationManager,
-      LayoutManager, MocksHelper, MockContextMenu, layoutManager */
+      LayoutManager, MocksHelper, MockContextMenu, layoutManager,
+      MockAppTransitionController */
 'use strict';
 
 requireApp('system/test/unit/mock_orientation_manager.js');
@@ -14,11 +15,13 @@ requireApp('system/test/unit/mock_screen_layout.js');
 requireApp('system/test/unit/mock_popup_window.js');
 requireApp('system/test/unit/mock_activity_window.js');
 requireApp('system/test/unit/mock_statusbar.js');
+requireApp('system/test/unit/mock_app_transition_controller.js');
 
 var mocksForAppWindow = new MocksHelper([
   'OrientationManager', 'Applications', 'SettingsListener',
   'ManifestHelper', 'LayoutManager', 'ActivityWindow',
-  'ScreenLayout', 'AppChrome', 'PopupWindow', 'StatusBar'
+  'ScreenLayout', 'AppChrome', 'PopupWindow', 'StatusBar',
+  'AppTransitionController'
 ]).init();
 
 suite('system/AppWindow', function() {
@@ -700,13 +703,10 @@ suite('system/AppWindow', function() {
   suite('Transition', function() {
     test('Open', function() {
       var app1 = new AppWindow(fakeAppConfig1);
-      var fakeTransitionController = {
-        requireOpen: function() {},
-        requireClose: function() {}
-      };
-      app1.transitionController = fakeTransitionController;
+      var transitionController = new MockAppTransitionController();
+      app1.transitionController = transitionController;
       var stubRequireOpen =
-        this.sinon.stub(fakeTransitionController, 'requireOpen');
+        this.sinon.stub(transitionController, 'requireOpen');
       app1.open();
       assert.isTrue(stubRequireOpen.called);
       app1.open('Orz');
@@ -715,13 +715,10 @@ suite('system/AppWindow', function() {
 
     test('Close', function() {
       var app1 = new AppWindow(fakeAppConfig1);
-      var fakeTransitionController = {
-        requireOpen: function() {},
-        requireClose: function() {}
-      };
-      app1.transitionController = fakeTransitionController;
+      var transitionController = new MockAppTransitionController();
+      app1.transitionController = transitionController;
       var stubRequireClose =
-        this.sinon.stub(fakeTransitionController, 'requireClose');
+        this.sinon.stub(transitionController, 'requireClose');
       app1.close();
       assert.isTrue(stubRequireClose.called);
       app1.close('XD');
@@ -1161,15 +1158,20 @@ suite('system/AppWindow', function() {
   suite('enter/leaveTaskManager', function() {
     test('class gets added and removed', function() {
       var app = new AppWindow(fakeAppConfig1);
+      var closeStub = this.sinon.stub(app, 'close');
+
+      app.transitionController = new MockAppTransitionController();
       assert.isFalse(app.element.classList.contains('in-task-manager'));
       app.enterTaskManager();
       assert.isTrue(app.element.classList.contains('in-task-manager'));
       app.leaveTaskManager();
       assert.isFalse(app.element.classList.contains('in-task-manager'));
+      assert.isTrue(closeStub.calledOnce, 'app.close was called');
     });
 
     test('leaveTaskManager: element.style cleanup', function() {
       var app = new AppWindow(fakeAppConfig1);
+      app.transitionController = new MockAppTransitionController();
       var unapplyStyleStub = sinon.stub(app, 'unapplyStyle');
       app.applyStyle({
         fontSize: '11',

--- a/apps/system/test/unit/mock_app_transition_controller.js
+++ b/apps/system/test/unit/mock_app_transition_controller.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var MockAppTransitionController = function MockAppTransitionController(app) {
+  if (app) {
+    this.mApp = app;
+  }
+  return this;
+};
+
+MockAppTransitionController.prototype = {
+  mApp: null,
+  destroy: function() {},
+  changeTransitionState: function() {},
+  switchTransitionState: function() {},
+  focusApp: function() {},
+  requireOpen: function() {},
+  requireClose: function() {},
+  resetTransition: function() {},
+  clearTransitionClasses: function() {}
+};

--- a/apps/system/test/unit/mock_app_window.js
+++ b/apps/system/test/unit/mock_app_window.js
@@ -110,7 +110,8 @@
     transform: function() {},
     hideContextMenu: function() {},
     lockOrientation: function() {},
-    isVisible: function() {}
+    isVisible: function() {},
+    requestForeground: function() {}
   };
   MockAppWindow.mTeardown = function() {
     MockAppWindowHelper.mInstances = [];

--- a/apps/system/test/unit/sound_manager_test.js
+++ b/apps/system/test/unit/sound_manager_test.js
@@ -335,6 +335,21 @@ suite('system/sound manager', function() {
       });
     });
 
+    suite('homescreen showing', function() {
+      test('hide dialog when homescreen is opening', function() {
+        var event = new CustomEvent('homescreenopening');
+        window.dispatchEvent(event);
+        assert.isFalse(MockCustomDialog.mShown);
+        assert.isTrue(soundManager.homescreenVisible);
+      });
+      test('hide dialog when homescreen is opened', function() {
+        var event = new CustomEvent('homescreenopened');
+        window.dispatchEvent(event);
+        assert.isFalse(MockCustomDialog.mShown);
+        assert.isTrue(soundManager.homescreenVisible);
+      });
+    });
+
     suite('CE accumulator', function() {
       var fakeTimer;
 

--- a/apps/system/test/unit/stack_manager_test.js
+++ b/apps/system/test/unit/stack_manager_test.js
@@ -665,6 +665,22 @@ suite('system/StackManager >', function() {
         assert.deepEqual(StackManager.getCurrent().config, settings.config);
       });
     });
+
+  });
+
+  suite('When the last app terminates', function() {
+    setup(function() {
+      appLaunch(contact);
+      appCrash(contact);
+    });
+    test('the position should be -1',
+    function() {
+      assert.equal(StackManager.position, -1);
+    });
+    test('the stack should be empty',
+    function() {
+      assert.equal(StackManager._stack.length, 0);
+    });
   });
 
   test('open app from card should update the ordering', function() {

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -1,6 +1,6 @@
 /* global MockStackManager, MockNavigatorSettings, MockAppWindowManager,
-          TaskManager, Card, TaskCard, AppWindow,
-          MockScreenLayout, MocksHelper */
+          TaskManager, Card, TaskCard, AppWindow, HomescreenLauncher,
+          HomescreenWindow, MockScreenLayout, MocksHelper */
 'use strict';
 require('/shared/test/unit/mocks/mock_gesture_detector.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
@@ -10,6 +10,8 @@ requireApp('system/test/unit/mock_trusted_ui_manager.js');
 requireApp('system/test/unit/mock_utility_tray.js');
 requireApp('system/test/unit/mock_app_window_manager.js');
 requireApp('system/test/unit/mock_app_window.js');
+requireApp('system/test/unit/mock_homescreen_launcher.js');
+requireApp('system/test/unit/mock_homescreen_window.js');
 require('/shared/test/unit/mocks/mock_system.js');
 requireApp('system/test/unit/mock_orientation_manager.js');
 requireApp('system/test/unit/mock_rocketbar.js');
@@ -26,8 +28,10 @@ var mocksForTaskManager = new MocksHelper([
   'AppWindowManager',
   'Rocketbar',
   'sleepMenu',
+  'HomescreenLauncher',
   'OrientationManager',
   'StackManager',
+  'HomescreenWindow',
   'AppWindow',
   'System'
 ]).init();
@@ -50,7 +54,10 @@ function waitForEvent(target, name, timeout) {
 }
 
 function failOnReject(err) {
-  throw err;
+  if (err) {
+    return err;
+  }
+  assert.isTrue(false, 'Should not reject');
 }
 
 suite('system/TaskManager >', function() {
@@ -88,7 +95,7 @@ suite('system/TaskManager >', function() {
     window.dispatchEvent(evt);
   }
 
-  var apps;
+  var apps, home;
   var sms, game, game2, game3, game4;
   var taskManager;
 
@@ -333,6 +340,16 @@ suite('system/TaskManager >', function() {
       }
     };
 
+    home = new HomescreenWindow('fakeHome');
+    var homescreenLauncher = new HomescreenLauncher();
+    window.homescreenLauncher = homescreenLauncher;
+    window.homescreenLauncher.start();
+    homescreenLauncher.mFeedFixtures({
+      mHomescreenWindow: home,
+      mOrigin: 'fakeOrigin',
+      mReady: true
+    });
+
     requireApp('system/js/cards_helper.js');
     requireApp('system/js/base_ui.js');
     requireApp('system/js/card.js');
@@ -456,15 +473,17 @@ suite('system/TaskManager >', function() {
       for (var app in apps) {
         MockStackManager.mStack.push(apps[app]);
       }
+      apps.home = home;
       MockStackManager.mCurrent = 0;
 
       MockAppWindowManager.mRunningApps = apps;
-      MockAppWindowManager.mDisplayedApp = 'http://sms.gaiamobile.org';
+      MockAppWindowManager.mActiveApp = apps['http://sms.gaiamobile.org'];
     });
 
     suite('display cardsview >', function() {
       setup(function(done) {
         taskManager.hide(true);
+        MockAppWindowManager.mActiveApp = apps['http://sms.gaiamobile.org'];
         waitForEvent(window, 'cardviewshown')
           .then(function() { done(); }, failOnReject);
         taskManager.isTaskStrip = false;
@@ -503,41 +522,51 @@ suite('system/TaskManager >', function() {
                   'has no prevCard at initial position');
       });
 
-      test('transitions are removed correctly after swiping', function() {
-        var card = taskManager.getCardAtIndex(0);
-        var applyStyleStub = sinon.spy(card, 'applyStyle');
+      function undefinedProps(value) {
+        for (var key in value) {
+          if (typeof value[key] === 'undefined') {
+            return true;
+          }
+        }
+        return false;
+      }
 
-        var undefinedProps =
-          function(value) {
-            for (var key in value) {
-              if (typeof value[key] === 'undefined') {
-                return true;
-              }
-            }
-            return false;
-          };
+      test('applyStyle is called by swiping', function(done) {
+        var card = taskManager.getCardAtIndex(0);
+        var element = card.element;
+        var applyStyleSpy = this.sinon.spy(card, 'applyStyle');
+
+        waitForEvent(element, 'touchend').then(function() {
+          var callCount = applyStyleSpy.callCount;
+          assert.isTrue(callCount > 0,
+                        'card.applyStyle was called at least once');
+          assert.isFalse(applyStyleSpy.calledWith(sinon.match(undefinedProps)),
+            'card.applyStyle was not called with undefined properties');
+
+        }, failOnReject).then(function() { done(); }, done);
 
         // Simulate a drag up that doesn't remove the card
-        var element = card.element;
         element.dispatchEvent(createTouchEvent('touchstart', element, 0, 500));
         element.dispatchEvent(createTouchEvent('touchmove', element, 0, 250));
         element.dispatchEvent(createTouchEvent('touchend', element, 0, 450));
+      });
 
-        var callCount = applyStyleStub.callCount;
-        assert.isTrue(callCount > 0,
-                      'card.applyStyle was called at least once');
-        assert.isFalse(applyStyleStub.calledWith(sinon.match(undefinedProps)),
-          'card.applyStyle was not called with undefined properties');
+      test('transitions are removed correctly after swiping', function(done) {
+        var card = taskManager.getCardAtIndex(0);
+        var applyStyleSpy = this.sinon.spy(card, 'applyStyle');
+        var element = card.element;
 
         // Simulate a swipe to the side
+        waitForEvent(element, 'touchend').then(function() {
+          assert.isTrue(applyStyleSpy.callCount > 0,
+                        'card.applyStyle was called');
+          assert.isFalse(applyStyleSpy.calledWith(sinon.match(undefinedProps)),
+            'card.applyStyle was not called with undefined properties');
+        }, failOnReject).then(function() { done(); }, done);
+
         element.dispatchEvent(createTouchEvent('touchstart', element, 0, 500));
         element.dispatchEvent(createTouchEvent('touchmove', element, 100, 500));
         element.dispatchEvent(createTouchEvent('touchend', element, 100, 500));
-
-        assert.isTrue(applyStyleStub.callCount > callCount,
-                      'card.applyStyle was called more times');
-        assert.isFalse(applyStyleStub.calledWith(sinon.match(undefinedProps)),
-          'card.applyStyle was not called with undefined properties');
       });
 
       test('user can change swipe direction', function() {
@@ -698,8 +727,8 @@ suite('system/TaskManager >', function() {
                       'cardviewclosedhome event raised when touch starts');
           assert.isFalse(cardsView.classList.contains('active'));
           assert.isFalse(taskManager.isShown());
-          done();
-        }, failOnReject);
+        }, failOnReject)
+        .then(done, done);
 
         cardsView.dispatchEvent(
           createTouchEvent('touchstart', cardsView, 100, 100));
@@ -743,14 +772,15 @@ suite('system/TaskManager >', function() {
     });
 
     test('hide: raises cardviewclosed event', function(done) {
+      taskManager.newStackPosition = 1;
       waitForEvent(window, 'cardviewclosed').then(function(event) {
         assert.equal(typeof event.detail, 'object',
                     'gets event with detail object');
-        assert.equal(event.detail.newStackPosition, 0,
-                    'newStackPosition is the position passed to hide method');
-        done();
-      }, failOnReject);
-      taskManager.hide(true, 0);
+        assert.equal(event.detail.newStackPosition, 1,
+                    'event detail reflects taskManager.newStackPosition');
+        delete taskManager.newStackPosition;
+      }, failOnReject).then(done, done);
+      taskManager.hide(true);
     });
 
     test('hide: removes cards', function(done) {
@@ -921,9 +951,9 @@ suite('system/TaskManager >', function() {
 
     test('destroys the card', function() {
       var card = taskManager.getCardAtIndex(0);
+      var destroySpy = this.sinon.spy(card, 'destroy');
       assert.isTrue(card && card.element &&
                     card.element.parentNode == taskManager.cardsList);
-      var destroySpy = this.sinon.spy(card, 'destroy');
       var instanceID = card.app.instanceID;
       taskManager.closeApp(card);
       assert.isTrue(destroySpy.calledOnce);
@@ -931,6 +961,7 @@ suite('system/TaskManager >', function() {
       assert.isFalse(instanceID in taskManager.cardsByAppID);
     });
   });
+
   suite('app is killed', function() {
     setup(function(done) {
       MockStackManager.mStack = [
@@ -967,6 +998,78 @@ suite('system/TaskManager >', function() {
       assert.isTrue(destroySpy.calledOnce, 'card.destroy was called');
       assert.equal(cardsList.childNodes.length, 1);
     });
+  });
+
+  suite('exit >', function() {
+    setup(function(done) {
+      taskManager.hide(true);
+      MockAppWindowManager.mRunningApps = apps;
+      MockAppWindowManager.mActiveApp = apps['http://sms.gaiamobile.org'];
+      waitForEvent(window, 'cardviewshown')
+        .then(function() { done(); }, failOnReject);
+      taskManager.isTaskStrip = false;
+      taskManager.show();
+    });
+
+    teardown(function() {
+      taskManager.hide(true);
+    });
+
+    test('selected app is opened', function(done) {
+      var targetApp = apps['http://game.gaiamobile.org'];
+      var stub = this.sinon.stub(targetApp, 'open');
+
+      waitForEvent(window, 'cardviewclosed').then(function() {
+        assert.isTrue(stub.calledOnce, 'selected app open method was called');
+      }, failOnReject)
+      .then(function() { done(); }, done);
+
+      taskManager.exitToApp(targetApp);
+    });
+
+    test('when exitToApp is passed no app', function(done) {
+      var activeApp = MockAppWindowManager.mActiveApp;
+      var stub = this.sinon.stub(activeApp, 'open');
+
+      waitForEvent(window, 'cardviewclosed').then(function() {
+        assert.isTrue(stub.calledOnce, 'active app open method was called');
+      }, failOnReject)
+      .then(function() { done(); }, done);
+
+      taskManager.exitToApp();
+    });
+
+    test('active app is opened on home event', function(done) {
+      var activeApp = MockAppWindowManager.mActiveApp;
+      var stub = this.sinon.stub(activeApp, 'open');
+
+      waitForEvent(window, 'cardviewclosed').then(function() {
+        assert.isTrue(stub.calledOnce, 'active app open method was called');
+      }, failOnReject)
+      .then(function() { done(); }, done);
+
+      var event = new CustomEvent('home');
+      window.dispatchEvent(event);
+    });
+
+    test('newStackPosition is defined when app is selected', function(done) {
+      MockStackManager.mCurrent = 0;
+      var targetApp = apps['http://game.gaiamobile.org'];
+
+      waitForEvent(window, 'cardviewclosed').then(function(evt) {
+        var stackPosition = taskManager.stack.indexOf(targetApp);
+        assert.equal(evt.detail.newStackPosition,
+                     stackPosition,
+                     'current newStackPosition in event.detail');
+        assert.equal(taskManager.newStackPosition,
+                     stackPosition,
+                     'current newStackPosition taskManaget');
+      }, failOnReject)
+      .then(function() { done(); }, done);
+
+      taskManager.exitToApp(targetApp);
+    });
+
   });
 
 });

--- a/apps/system/test/unit/visibility_manager_test.js
+++ b/apps/system/test/unit/visibility_manager_test.js
@@ -1,15 +1,16 @@
 /* globals MocksHelper, VisibilityManager,
-           MockAttentionScreen, MockTaskManager */
+           MockAttentionScreen, MockTaskManager, MockAppWindow */
 'use strict';
 
 requireApp('system/test/unit/mock_orientation_manager.js');
 requireApp('system/test/unit/mock_task_manager.js');
 requireApp('system/shared/test/unit/mocks/mock_manifest_helper.js');
 requireApp('system/test/unit/mock_attention_screen.js');
+requireApp('system/test/unit/mock_app_window.js');
 require('/shared/test/unit/mocks/mock_system.js');
 
 var mocksForVisibilityManager = new MocksHelper([
-  'AttentionScreen', 'System'
+  'AttentionScreen', 'AppWindow', 'System'
 ]).init();
 
 suite('system/VisibilityManager', function() {
@@ -214,6 +215,53 @@ suite('system/VisibilityManager', function() {
 
       assert.isFalse(stubPublish.called);
       assert.isFalse(stubPublish.calledWith('hidewindowforscreenreader'));
+    });
+
+    test('move app to foreground', function () {
+      window.System.locked = false;
+      MockAttentionScreen.mFullyVisible = false;
+      var app = new MockAppWindow();
+      var setVisibleStub = this.sinon.stub(app, 'setVisible');
+      var event = new CustomEvent('apprequestforeground', {
+        detail: app
+      });
+      window.dispatchEvent(event);
+      assert.isTrue(setVisibleStub.calledWith(true));
+    });
+    test('move homescreen to foreground', function() {
+      var homescreen = new MockAppWindow();
+      var setVisibleStub = this.sinon.stub(homescreen, 'setVisible');
+      var event = new CustomEvent('homescreenrequestforeground', {
+        detail: homescreen
+      });
+      window.dispatchEvent(event);
+      assert.isTrue(setVisibleStub.calledWith(true));
+    });
+
+    test('dont foreground app when attentionscreen visible', function () {
+      window.System.locked = false;
+      MockAttentionScreen.mFullyVisible = true;
+      var app = new MockAppWindow();
+      this.sinon.stub(app, 'setVisible');
+
+      var event = new CustomEvent('apprequestforeground', {
+        detail: app
+      });
+      window.dispatchEvent(event);
+      assert.isFalse(app.setVisible.called);
+    });
+
+    test('dont foreground app when locked', function () {
+      window.System.locked = true;
+      MockAttentionScreen.mFullyVisible = false;
+      var app = new MockAppWindow();
+      this.sinon.stub(app, 'setVisible');
+
+      var event = new CustomEvent('apprequestforeground', {
+        detail: app
+      });
+      window.dispatchEvent(event);
+      assert.isFalse(app.setVisible.called);
     });
 
     test('system-dialog-show', function() {


### PR DESCRIPTION
- Fix assumption that home event means homescreen opens in SoundManager,
- Remove appwillopen handler in AttentionScreen, applaunch will suffice
- Also listen for search app's requestforeground event
