### PR TITLE
Bug 1059448 - Depend on marionette_client 0.8.3 and bump version of gaia...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/version.py
+++ b/tests/python/gaia-ui-tests/gaiatest/version.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = '0.26'
+__version__ = '0.27'

--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,4 +1,4 @@
-marionette_client==0.8.2
+marionette_client==0.8.3
 mozdevice>=0.34
 moztest>=0.6
 requests


### PR DESCRIPTION
...test to 0.27, r=zac
