### PR TITLE
Bug 1057452 - Fix the spelling in l10nId for Wifi link speed

### DIFF
--- a/apps/settings/js/panels/wifi_status/panel.js
+++ b/apps/settings/js/panels/wifi_status/panel.js
@@ -37,7 +37,7 @@ define(function(require) {
         var info = wifiManager.connectionInformation || {};
         elements.ip.textContent = info.ipAddress || '';
         navigator.mozL10n.setAttributes(elements.speed,
-                                        'linkSpeedMba',
+                                        'linkSpeedMbs',
                                         { linkSpeed: info.linkSpeed });
       }
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1057452
