### PR TITLE
Bug 1058417. Don't give the viewfinder a CSS outline (when focused). r=d...

### DIFF
--- a/apps/camera/style/viewfinder.css
+++ b/apps/camera/style/viewfinder.css
@@ -82,6 +82,7 @@
 .viewfinder-video {
   width: 100%;
   height: 100%;
+  outline: none;
 }
 
 /** Frame Grid


### PR DESCRIPTION
...marcos

This creates an extra layer and isn't even visible since the outline is outside the visible screen area!
