### PR TITLE
Bug 1059945 - typo in gaia shared/style/icons.css r=fabrice

### DIFF
--- a/shared/style/icons.css
+++ b/shared/style/icons.css
@@ -90,7 +90,7 @@ src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg
 .icon-browser-crashedtab:before {
   content: "\e617";
 }
-.icon-browser-foward:before {
+.icon-browser-forward:before {
   content: "\e618";
 }
 .icon-browser-moretabs:before {

--- a/shared/style/icons/index.html
+++ b/shared/style/icons/index.html
@@ -109,8 +109,8 @@
         <p>icon-editcontact</p>
       </li>
       <li>
-        <aside class="gaia-icon icon-foward"></aside>
-        <p>icon-foward</p>
+        <aside class="gaia-icon icon-forward"></aside>
+        <p>icon-forward</p>
       </li>
       <li>
         <aside class="gaia-icon icon-gerneral-unlock"></aside>

--- a/shared/style/icons/selection.json
+++ b/shared/style/icons/selection.json
@@ -517,7 +517,7 @@
 				],
 				"grid": 0,
 				"tags": [
-					"browser-foward"
+					"browser-forward"
 				]
 			},
 			"properties": {
@@ -525,7 +525,7 @@
 				"id": 219,
 				"prevSize": 32,
 				"code": 58904,
-				"name": "browser-foward",
+				"name": "browser-forward",
 				"ligatures": ""
 			},
 			"setIdx": 0,


### PR DESCRIPTION
only a little typo
