### PR TITLE
Bug 1048639 - [VerticalHomescreen] Guard against empty entry points

### DIFF
--- a/shared/elements/gaia_grid/js/items/mozapp.js
+++ b/shared/elements/gaia_grid/js/items/mozapp.js
@@ -198,7 +198,8 @@
     get descriptor() {
       var manifest = this.app.manifest || this.app.updateManifest;
 
-      if (this.entryPoint) {
+      if (this.entryPoint && manifest.entry_points &&
+        manifest.entry_points[this.entryPoint]) {
         return manifest.entry_points[this.entryPoint];
       }
       return manifest;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1048639
