### PR TITLE
Bug 1052951 - [email] signature upgrade experience

### DIFF
--- a/apps/email/js/cards/account_prefs_mixins.js
+++ b/apps/email/js/cards/account_prefs_mixins.js
@@ -90,8 +90,7 @@ define(function(require) {
 
       if (signatureButtonClassName) {
         this.signatureButton = this.nodeFromClass(signatureButtonClassName);
-        this.signatureButton.firstElementChild
-          .textContent = this.identity.signature;
+        this.updateSignatureButton();
         this.signatureButton.addEventListener('click',
           this.onClickSignature.bind(this), false);
       }
@@ -127,8 +126,20 @@ define(function(require) {
     },
 
     updateSignatureButton: function() {
-      this.signatureButton.firstElementChild
-        .textContent = this.identity.signature;
+      // Allow the text to be just whitespace, but treat it as
+      // empty as far as labeling is concerned.
+      var text = this.identity.signature,
+          isEmpty = text.trim().length === 0,
+          node = this.signatureButton.firstElementChild;
+
+      node.textContent = text;
+      node.classList.toggle('empty-placeholder', isEmpty);
+
+      if (isEmpty) {
+        mozL10n.setAttributes(node, 'settings-empty-signature-label');
+      } else {
+        node.removeAttribute('data-l10n-id');
+      }
     },
 
     onClickSignature: function(index) {

--- a/apps/email/js/cards/settings_signature.html
+++ b/apps/email/js/cards/settings_signature.html
@@ -1,5 +1,5 @@
 <!-- Per-account credentials settings menu -->
-<section class="card-settings-account-credentials card skin-organic"
+<section class="card-settings-signature card skin-organic"
   role="region">
   <header class="tng-signature-header">
     <a href="#" class="signature-back-btn tng-back-btn back-btn header-left-btn">
@@ -11,6 +11,6 @@
     <h1 class="tng-signature-header-label header-label" data-l10n-id="settings-account-signature-label">SignaturE</h1>
   </header>
   <section class="scrollregion-below-header skin-organic" role="region">
-    <div class="tng-signature-input" contenteditable="true"></div>
+    <div class="tng-signature-text" contenteditable="true"></div>
   </section>
 </section>

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -151,6 +151,12 @@ settings-account-display-notifications=Display notifications for new messages
 # after a message is sent.
 settings-account-play-sound-onsend=Play sound after message is sent
 
+# LOCALIZATION NOTE(settings-empty-signature-label): Text used for the button
+# that takes the user to edit the signature, if there is no existing signature
+# text. It should inform the user that tapping on it will lead to editing the
+# signature text.
+settings-empty-signature-label=Tap to Edit
+
 # LOCALIZATION NOTE (settings-account-signature-label): The label for the
 # signature field in the account settings card.
 settings-account-signature-label=Signature

--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -121,6 +121,7 @@ input.cmp-subject-text {
   background: #fff;
   outline: 0;
   white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 /* Attachment */

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -112,7 +112,7 @@ section[role="region"].skin-organic {
   text-align: center;
 }
 
-.tng-signature-input {
+.tng-signature-text {
   margin: 0;
   min-height: 100%;
   overflow-x: auto;
@@ -126,8 +126,8 @@ section[role="region"].skin-organic {
   box-shadow: none;
   background: white;
   outline: 0;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  white-space: pre-wrap;
+  word-wrap: break-word;
   padding: 1rem 1.5rem 0;
   font-size: 1.6rem;
 }
@@ -155,6 +155,10 @@ li button.signature-button.button.icon {
   width: 100%;
   overflow: hidden;
   margin-left: 1rem;
+}
+
+.signature-button-content.empty-placeholder {
+  color: #858585;
 }
 
 li:not([role]) {


### PR DESCRIPTION
Fixes three things:
- When no signature text, show "Tap to Edit" in gray for the button.
- When navigating to signature edit card, place the cursor at the end of the text automatically when the card is shown, so that it brings up the keyboard to show that it is editable. In order for this to look good, trailing whitespace is trimmed. Otherwise, br tags could get in, and the cursor would show up on the far right.
- For signature edit and for the compose field, allow break-word wrapping so that all text is editable on the screen. This does not insert real line breaks in the final text, it is just for display purposes.
- Fixes some small nits I should have caught before, about an incorrect card class name and that .tng-signature-input is also used for a different form control, so I switched the text edit field to be tng-signature-text.
