### PR TITLE
Bug 1051795 - [CMAS] Handle the setting that enables/disables CMAS alerts

### DIFF
--- a/apps/network-alerts/attention.html
+++ b/apps/network-alerts/attention.html
@@ -9,6 +9,7 @@
     <link media="(max-height: 4.5rem)" rel="stylesheet" href="style/attention-small.css">
 
     <script defer src="shared/js/l10n.js"></script>
+    <script defer src="shared/js/notification_helper.js"></script>
     <script defer src="js/utils.js"></script>
     <script defer src="js/attention/attention.js"></script>
     <script defer src="js/attention/startup.js"></script>
@@ -25,7 +26,7 @@
         <p></p>
       </section>
       <menu>
-        <button class="full recommend" data-l10n-id="ok">OK</button>
+        <button class="full recommend" data-l10n-id="btn-ok">OK</button>
       </menu>
     </form>
   </body>

--- a/apps/network-alerts/js/notification/notification.js
+++ b/apps/network-alerts/js/notification/notification.js
@@ -29,7 +29,6 @@ function onNotification(message) {
   ].join('');
 
   window.open(url, '_blank', 'attention');
-  closeWindow();
 }
 
 exports.NotificationHandler = {

--- a/apps/network-alerts/manifest.webapp
+++ b/apps/network-alerts/manifest.webapp
@@ -17,7 +17,8 @@
   "permissions": {
     "attention":{},
     "desktop-notification":{},
-    "cellbroadcast":{}
+    "cellbroadcast":{},
+    "settings":{ "access": "readonly" }
   },
   "default_locale": "en-US",
   "orientation": "default",

--- a/apps/network-alerts/notification.html
+++ b/apps/network-alerts/notification.html
@@ -1,10 +1,11 @@
 <!doctype html>
 <html>
   <head>
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial	-scale=1">
-	<meta charset='UTF-8'>
-	<script src='js/utils.js'></script>
-	<script src='js/notification/notification.js'></script>
-	<script src='js/notification/startup.js'></script>
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
+    <meta charset="UTF-8">
+
+    <script src="js/utils.js"></script>
+    <script src="js/notification/notification.js"></script>
+    <script src="js/notification/startup.js"></script>
   </head>
 </html>

--- a/apps/network-alerts/test/unit/index_test.js
+++ b/apps/network-alerts/test/unit/index_test.js
@@ -1,8 +1,13 @@
+/* global MockNavigatorSettings
+*/
 'use strict';
 
+require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 
 suite('Network Alerts - cellbroadcast system message handling', function() {
   var handlerStub;
+  var realSettings = navigator.mozSettings;
+  var CMAS_KEY = 'cmas.enabled';
 
   suiteSetup(function(done) {
     if (!window.navigator.mozSetMessageHandler) {
@@ -17,15 +22,65 @@ suite('Network Alerts - cellbroadcast system message handling', function() {
   setup(function() {
     this.sinon.stub(window, 'close');
     this.sinon.stub(window, 'open');
+
+    navigator.mozSettings = MockNavigatorSettings;
+    MockNavigatorSettings.mSyncRepliesOnly = true;
   });
 
-  test('opens an attention screen if message is CMAS', function() {
+  teardown(function() {
+    navigator.mozSettings = realSettings;
+    MockNavigatorSettings.mTeardown();
+  });
+
+  test('do not open attention screen if error returns from settings DB',
+    function() {
+
     var message = {
+      serviceId: 0,
       messageId: 4370,
       body: 'Some body'
     };
 
     handlerStub.withArgs('cellbroadcast-received').yield(message);
+    MockNavigatorSettings.mRequests[0].onerror();
+
+    sinon.assert.notCalled(window.open);
+    sinon.assert.called(window.close);
+  });
+
+  test('do not open attention screen if CMAS in settings DB is off',
+    function() {
+
+    var message = {
+      serviceId: 0,
+      messageId: 4370,
+      body: 'Some body'
+    };
+
+    handlerStub.withArgs('cellbroadcast-received').yield(message);
+    MockNavigatorSettings.mRequests[0].result[CMAS_KEY] = {
+      0: false,
+      1: false
+    };
+    MockNavigatorSettings.mReplyToRequests();
+
+    sinon.assert.notCalled(window.open);
+    sinon.assert.called(window.close);
+  });
+
+  test('opens an attention screen if message is CMAS', function() {
+    var message = {
+      serviceId: 0,
+      messageId: 4370,
+      body: 'Some body'
+    };
+
+    handlerStub.withArgs('cellbroadcast-received').yield(message);
+    MockNavigatorSettings.mRequests[0].result[CMAS_KEY] = {
+      0: true,
+      1: false
+    };
+    MockNavigatorSettings.mReplyToRequests();
 
     var expectedUrl = [
       'attention.html?',
@@ -37,13 +92,14 @@ suite('Network Alerts - cellbroadcast system message handling', function() {
       window.open,
       expectedUrl, '_blank', 'attention'
     );
-    sinon.assert.called(window.close);
+    sinon.assert.notCalled(window.close);
   });
 
   test('do not open attention screen if message is other cellbroadcast',
     function() {
 
     var message = {
+      serviceId: 0,
       messageId: 4401,
       body: 'Some body'
     };

--- a/apps/network-alerts/test/unit/notification/notification_test.js
+++ b/apps/network-alerts/test/unit/notification/notification_test.js
@@ -51,7 +51,7 @@ suite('Network Alerts - Notification handling', function() {
       window.open,
       expectedUrl, '_blank', 'attention'
     );
-    sinon.assert.called(window.close);
+    sinon.assert.notCalled(window.close);
   });
 
   test('only closes window if user dismisses the notification', function() {


### PR DESCRIPTION
- Add settings permission and check the CMAS option before opening attention screen.
- Use Notification helper and mozApp to get icon url instead of using hard-coded string.
- Fix some error in Bug 1051793
