### PR TITLE
Bug 1038698 - only start running system a11y visibility tests when the l...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -560,6 +560,15 @@ class GaiaDevice(object):
         Wait(self.marionette, timeout).until(expected.element_present(
             By.CSS_SELECTOR, '#homescreen[loading-state=false]'))
 
+        # Wait for logo to be hidden
+        self.marionette.set_search_timeout(0)
+        try:
+            Wait(self.marionette, timeout, ignored_exceptions=StaleElementException).until(
+                lambda m: not m.find_element(By.ID, 'os-logo').is_displayed())
+        except NoSuchElementException:
+            pass
+        self.marionette.set_search_timeout(self.marionette.timeout or 10000)
+
     @property
     def is_b2g_running(self):
         return 'b2g' in self.manager.shellCheckOutput(['toolbox', 'ps'])

--- a/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/system/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/system/manifest.ini
@@ -10,7 +10,5 @@ skip-if = device == "desktop"
 [test_a11y_utility_tray_notifications.py]
 [test_a11y_utility_tray_settings.py]
 [test_a11y_utility_tray_visibility.py]
-disabled = Bug 1038698 perma-red failure on TBPL
-
 [test_a11y_volume_buttons.py]
 [test_a11y_volume_buttons_panel_visibility.py]

--- a/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/system/test_a11y_utility_tray_visibility.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/system/test_a11y_utility_tray_visibility.py
@@ -25,6 +25,7 @@ class TestUtilityTrayVisibilityAccessibility(GaiaTestCase):
         self.assertTrue(self.accessibility.is_hidden(utility_tray_container))
 
         self.status_bar.a11y_wheel_status_bar_time()
+        self.utility_tray.wait_for_notification_container_displayed()
 
         # Utility tray should now be visible.
         self.assertTrue(self.accessibility.is_visible(utility_tray_container))

--- a/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/tbpl-manifest.ini
@@ -34,8 +34,6 @@ disabled = Bug 1022132 Intermittent Failure on TBPL
 [accessibility/system/test_a11y_utility_tray_notifications.py]
 [accessibility/system/test_a11y_utility_tray_settings.py]
 [accessibility/system/test_a11y_utility_tray_visibility.py]
-disabled = Bug 1038698 perma-red failure on TBPL
-
 [accessibility/system/test_a11y_volume_buttons.py]
 [accessibility/system/test_a11y_volume_buttons_panel_visibility.py]
 


### PR DESCRIPTION
...ogo is completely hidden.
