### PR TITLE
Bug 1060542 - [Calendar] Week view: changing the date should also set the selected day on month view r=gaye

### DIFF
--- a/apps/calendar/js/views/multi_day.js
+++ b/apps/calendar/js/views/multi_day.js
@@ -194,7 +194,9 @@ MultiDay.prototype = {
   },
 
   _updateBaseDateAfterScroll: function(diff) {
-    this.timeController.move(createDayDiff(this.baseDate, diff));
+    var day = createDayDiff(this.baseDate, diff);
+    this.timeController.move(day);
+    this.timeController.selectedDay = day;
   },
 
   _render: function() {

--- a/apps/calendar/test/unit/views/multi_day_test.js
+++ b/apps/calendar/test/unit/views/multi_day_test.js
@@ -50,4 +50,23 @@ suiteGroup('Views.MultiDay', function() {
     );
   });
 
+  test('#_updateBaseDateAfterScroll', function() {
+    // we need to make sure it's updating the timeController position and
+    // selectedDay after the drag so moving to day/month views have the
+    // expected output (highlight first day of the week view)
+    subject.baseDate = new Date(2014, 6, 23);
+    subject._updateBaseDateAfterScroll(-3);
+    var expected = (new Date(2014, 6, 20)).toISOString();
+    assert.equal(
+      subject.timeController.position.toISOString(),
+      expected,
+      'position'
+    );
+    assert.equal(
+      subject.timeController.selectedDay.toISOString(),
+      expected,
+      'selectedDay'
+    );
+  });
+
 });


### PR DESCRIPTION
did not write marionette tests because unit tests are faster (and more reliable) and this is enough to detect that we are setting the proper value (month view unit tests makes sure that setting the `selectedDay` triggers proper action).
