### PR TITLE
Bug 1059499 - [Email][QuickToTop] New message banner hides when untouched

### DIFF
--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -561,15 +561,21 @@ confirm-dialog-title=Confirmation
 # Notice that we have a space after the comma.
 senders-separation-sign=,\u0020
 
-# new-emails refers to the text shown on a notification that users
-# get when they receive new, unread email. The ui component that utilizes
-# this lives in apps/email/js/message_list_topbar.js.
-new-emails={[ plural(n) ]}
-new-emails[one]=1 New Email
-new-emails[two]={{ n }} New Emails
-new-emails[few]={{ n }} New Emails
-new-emails[many]={{ n }} New Emails
-new-emails[other]={{ n }} New Emails
+# LOCALIZATION NOTE(new-messages): refers to the text shown inside the email app
+# on the message list when new, unread messages have been received while the
+# user is looking at the messages in the message list. The ui component that
+# uses this lives in apps/email/js/message_list_topbar.js. This display differ
+# from the messages that are sent as system notifications. Those are more
+# important to distinguish that emails and not SMS messages have been received.
+# This display uses the term "Messages" since other text labels in the message
+# list also use "Messages" instead of "Emails" since the context of Email is
+# assumed as it is in the email app.
+new-messages={[ plural(n) ]}
+new-messages[one]=1 New Message
+new-messages[two]={{ n }} New Messages
+new-messages[few]={{ n }} New Messages
+new-messages[many]={{ n }} New Messages
+new-messages[other]={{ n }} New Messages
 
 # new-emails-notify-one-account is used when a system notification is generated during
 # a periodic background sync with the server. Since this goes to the system's

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -744,15 +744,24 @@ reflows. Foreground/background colors should be safe.
   display: inline-block;
   margin: 1.5rem 1.5rem 0 0;
   opacity: .8;
-  transform: translateY(-6.5rem);
+  transform: translate(0, -6.5rem);
   transition-property: transform;
   transition-duration: .6s;
   transition-timing-function: ease;
   transition-delay: 0s;
 }
 
+.message-list-topbar.no-anim {
+  transition-property: none;
+}
+
+.message-list-topbar.horiz-top,
+.message-list-topbar.closing[data-state="top"] {
+  transform: translate(0, -6.5rem);
+}
+
 .message-list-topbar[data-state="top"] {
-  transform: translateY(0);
+  transform: translate(0, 0);
   right: 0;
   width: 5rem;
   height: 5rem;
@@ -761,8 +770,14 @@ reflows. Foreground/background colors should be safe.
   font-size: 0;
 }
 
+.message-list-topbar.horiz-message,
+.message-list-topbar.closing[data-state="message"] {
+  transform: translate(-50%, -6.5rem);
+}
+
 .message-list-topbar[data-state="message"] {
-  transform: translateY(0);
+  transform: translate(-50%, 0);
+  left: 50%;
   margin: 1.5rem auto;
   padding: 0 1.3rem;
   height: 4rem;
@@ -772,11 +787,6 @@ reflows. Foreground/background colors should be safe.
   color: white;
   background-color: #a6a6a6;
   opacity: .95;
-}
-
-.message-list-topbar.closing[data-state="message"],
-.message-list-topbar.closing[data-state="top"] {
-  transform: translateY(-6.5rem);
 }
 
 .msg-reply-menu button:before {


### PR DESCRIPTION
This fixes three issues:
- [Bug 1059499](https://bugzilla.mozilla.org/show_bug.cgi?id=1059499): the "N New Messages" should stay around until the user scrolls down or taps on it. This was not in accordance with the UX spec. The old "auto hide after N seconds" logic via _hideNewMessage was kept in there by mistake.
- [Bug 1056518](https://bugzilla.mozilla.org/show_bug.cgi?id=1056518): use "N New Messages" instead of "N New Emails" to also match spec. l10n ID was changed to reflect the change in messaging.
- [Bug 1056515](https://bugzilla.mozilla.org/show_bug.cgi?id=1056515): "N New Messages" was not centered on the first showing of it, particularly when the Top Arrow was also shown at first.

The last one was the trickiest of them. It was caused by the l10n mutation stuff changing the size later, and also, the full size was not known until it became visible. So I went with the left:50%, transformX -50% solution, so that explicit sizes did not need to be calculated. However for that to work, I had to turn off animation to change the horizontal position then show it.

The end result is much better than before. However, I do notice about a 2px jump at the end of the N New Messages transition. Also, if the Top Arrow is not showing, the animation is not smooth, the N New Messages just pops in. On desktop, it is smooth, so this suggest some sort of animation drop on the device. That pop in effect happened before this changeset though too, so overall this is a better experience, and we can file follow up bugs to get it better. Most importantly, those follow up bugs do not need new l10n strings, so they could land later.
