### PR TITLE
Bug 1060922 - [email] can't open the account settings

### DIFF
--- a/apps/email/js/cards/account_prefs_mixins.js
+++ b/apps/email/js/cards/account_prefs_mixins.js
@@ -128,7 +128,7 @@ define(function(require) {
     updateSignatureButton: function() {
       // Allow the text to be just whitespace, but treat it as
       // empty as far as labeling is concerned.
-      var text = this.identity.signature,
+      var text = this.identity.signature || '',
           isEmpty = text.trim().length === 0,
           node = this.signatureButton.firstElementChild;
 


### PR DESCRIPTION
This bug was introduced in the changeset for bug 1052951, for determining if we should show the "Tap to Edit" default text. I just goofed and did not think through the upgrade case. I had it in my head that it would be empty string, but I think that was just the fog of last day of code changes, did not think that one through properly.

I searched other .signature uses in the front end, and this was the only one that got goofed. The other uses, mainly in signature_settings.js, are fine. 

There is one quirk where  signature_settings.js compares the text from the editor to the this.identity.signature to know if it should prompt on back save, so technically it would prompt since `'' !== null`, but I think this OK for the upgrade path, and if the user is in that card, they likely have wanted to type a signature. All it does is save an empty string vs null if they say yes, and empty string is treated the same as null as a far as signature use in the compose card -- both end up not showing a signature block.

I tested getting the failure by downgrading a phone to latest 2.0, setting up an email account, then upgrading to latest email app. I got the failure. I applied the fix, and the settings were viewable and the signature_settings card was operational. It was neat because I saw the folder upgrade messages too!
