### PR TITLE
Bug 1061221 - Intermittent failing test, TEST-UNEXPECTED-FAIL | /builds/...

### DIFF
--- a/apps/system/test/marionette/notification_events_test.js
+++ b/apps/system/test/marionette/notification_events_test.js
@@ -250,7 +250,8 @@ marionette('Notification events', function() {
     done();
   });
 
-  test('close event removes resent notification', function(done) {
+  // Disable the test, refer to http://bugzil.la/1061221
+  test.skip('close event removes resent notification', function(done) {
     var notificationTitle = 'Title:' + Date.now();
 
     // switch to calendar app and send notification


### PR DESCRIPTION
...slave/test/gaia/apps/system/test/marionette/notification_events_test.js | Notification events close event removes resent notification
