### PR TITLE
Bug 1057604 - Use the hidden attribute for the save button r=dkuo

### DIFF
--- a/apps/music/style/music.css
+++ b/apps/music/style/music.css
@@ -241,7 +241,8 @@ body.picker-mode #title-player {
 }
 
 #title-player[hidden],
-#title-done[hidden] {
+#title-done[hidden],
+#title-save[hidden] {
   display: none;
 }
 


### PR DESCRIPTION
While title-player and title-done did proper use of their "hidden"
attribute to be hidden via CSS rule setting "display: none", the save
button was not part of this list. Thus, setting the "hidden" attribute
to true had no impact on the visibility of the element.
