### PR TITLE
BUG 1061290 chai add interfaces expect and should

### DIFF
--- a/dev_apps/test-agent/common/test/helper.js
+++ b/dev_apps/test-agent/common/test/helper.js
@@ -111,6 +111,8 @@
     chai.Assertion.includeStack = true;
     patchChai(chai.Assertion);
     window.assert = chai.assert;
+    window.expect = chai.expect;
+    window.should = chai.should();
   });
 
   // mocha helpers

--- a/dev_apps/test-agent/test/unit/chai_test.js
+++ b/dev_apps/test-agent/test/unit/chai_test.js
@@ -1,0 +1,21 @@
+suite('chai', function() {
+
+  test('expect interface', function() {
+    assert.isFunction(expect, 'expect enable');
+    expect(true).to.be.ok;
+    expect(false).to.not.be.ok;
+    expect('test').to.have.property('length', 4);
+    expect('asd').to.have.property('constructor', String);
+    expect({ 'foo.bar': 'baz' }).to.have.property('foo.bar');
+  });
+
+  test('should interface', function() {
+    expect('test').to.have.property('should');
+    true.should.be.ok;
+    false.should.not.be.ok;
+    'test'.should.have.property('length', 4);
+    'asd'.should.have.property('constructor', String);
+    ({ 'foo.bar': 'baz' }).should.have.property('foo.bar');
+  });
+
+});


### PR DESCRIPTION
Now available only assert interface from chai assertion library.

In assert interface not available methods for testing property. Same unit tests used for in assert.include - this assert worked only for strings and Arrays, for objects this method in used version chai do nothing.
