### PR TITLE
Bug 1048792 - Don't autocorrect if first suggestion has different length (counting alpha chars) than input

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -122,6 +122,11 @@
   // this much more highly weighted than the second suggested word.
   var AUTO_CORRECT_THRESHOLD = 1.30;
 
+  // If the length doesn't match between input and first suggestion.
+  // The min. frequency the first suggestion needs to have if we turn it into
+  // an autocorrect action
+  var MIN_LENGTH_MISMATCH_THRESHOLD = 5;
+
   /*
    * Since inputContext.sendKey is an async fuction that will return a promise,
    * and we need to update the current state (capitalization, input value)
@@ -658,6 +663,20 @@
     // Now get an array of just the suggested words
     var words = suggestions.map(function(x) { return x[0]; });
 
+    // see whether words[0] and input have same length
+    var lengthMismatch;
+    switch (Math.abs(input.length - words[0].length)) {
+    case 0:
+      lengthMismatch = false;
+      break;
+    case 1:
+      lengthMismatch = suggestions[0][1] < MIN_LENGTH_MISMATCH_THRESHOLD;
+      break;
+    default:
+      lengthMismatch = true;
+      break;
+    }
+
     // Decide whether the first word is going to be an autocorrection.
     // If the user's input is already a valid word, then don't
     // autocorrect unless the first suggested word is more common than
@@ -673,7 +692,8 @@
         !correctionDisabled &&
         (!inputIsSuggestion ||
           suggestions[0][1] > inputWeight * AUTO_CORRECT_THRESHOLD) &&
-        (input.length > 1 || words[0].length === 1)) {
+        (input.length > 1 || words[0].length === 1) &&
+        !lengthMismatch) {
       // Remember the word to use if the next character is a space.
       autoCorrection = words[0];
       // Mark the auto-correction so the renderer can highlight it

--- a/apps/keyboard/test/unit/suggest_test.js
+++ b/apps/keyboard/test/unit/suggest_test.js
@@ -289,5 +289,43 @@ suite('Latin suggestions', function() {
       sinon.assert.calledWith(imSettings.sendCandidates,
                               ['his', 'HUD', 'hide']);
     });
+
+    suite('Suggestion length mismatch', function() {
+      test('Length mismatch, low freq', function() {
+        testPrediction('zoolgy', 'zoolgy', [
+          ['zoology', 4.2],
+          ['Zoology\'s', 0.09504000000000001]
+        ]);
+
+        sinon.assert.callCount(imSettings.sendCandidates, 1);
+        sinon.assert.calledWith(imSettings.sendCandidates,
+                                ['zoology', 'Zoology\'s']);
+      });
+
+      test('Length mismatch, medium freq', function() {
+        testPrediction('Folow', 'Folow', [
+          ['Follow', 6.237],
+          ['Follows', 2.4948],
+          ['Followed', 1.0454400000000001],
+          ['Follower', 0.7603200000000001]
+        ]);
+
+        sinon.assert.callCount(imSettings.sendCandidates, 1);
+        sinon.assert.calledWith(imSettings.sendCandidates,
+                                ['*Follow', 'Follows', 'Followed']);
+      });
+
+      test('Length mismatch, high freq', function() {
+        testPrediction('awesomeo', 'awesomeo', [
+            ['awesome', 31],
+            ['trahlah', 8],
+            ['moarstu', 7]
+          ]);
+
+        sinon.assert.callCount(imSettings.sendCandidates, 1);
+        sinon.assert.calledWith(imSettings.sendCandidates,
+                                ['*awesome', 'trahlah', 'moarstu']);
+      });
+    });
   });
 });

--- a/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/keyboard/test_a11y_keyboard_word_suggestions.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/keyboard/test_a11y_keyboard_word_suggestions.py
@@ -25,9 +25,9 @@ class TestA11yKeyboardWordSuggestions(GaiaTestCase):
         # tap the field "input type=text"
         keyboard = keyboard_page.tap_text_input()
 
-        # type first 6 letters of the expected word
+        # type first 7 letters of the expected word
         expected_word = 'keyboard '
-        keyboard.send(expected_word[:6])
+        keyboard.send(expected_word[:7])
 
         keyboard.switch_to_keyboard()
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
@@ -25,9 +25,9 @@ class TestKeyboardPredictiveKey(GaiaTestCase):
         # tap the field "input type=text"
         keyboard = keyboard_page.tap_text_input()
 
-        # type first 6 letters of the expected word
+        # type first 7 letters of the expected word
         expected_word = 'keyboard '
-        keyboard.send(expected_word[:6])
+        keyboard.send(expected_word[:7])
 
         # tap the first predictive word
         keyboard.tap_first_predictive_word()


### PR DESCRIPTION
Let's try again
