### PR TITLE
Bug 1061932 - [Email] Cannot edit Email body when using an Outlook account

### DIFF
--- a/apps/email/build/gelam_worker.build.js
+++ b/apps/email/build/gelam_worker.build.js
@@ -78,7 +78,8 @@
         'axe',
         'errorutils',
         'db/folder_info_rep',
-        'mimetypes'
+        'mimetypes',
+        'mimefuncs'
       ]
     },
     {
@@ -87,7 +88,8 @@
     },
     {
       name: 'activesync/configurator',
-      exclude: ['worker-bootstrap']
+      // activesync/protocol needed for autodiscovery.
+      exclude: ['worker-bootstrap', 'activesync/protocol']
     }
   ],
 


### PR DESCRIPTION
Caused by the changes for bug 885110. When I was constructing the build layers, I had trouble testing activesync accounts, and when talking in IRC with :mcav at the time, it was a temporary issue with my local branch/account but I forgot to back and test sending afterwards, even though I did test the message_list view with the Activesync account.

The issue: mimefuncs was not in the worker-boostrap build layer, but since the composite/configurator layer had an explicit dependency on 'mimefuncs', it was combined in that layer. Since `removeCombined` is used in the build config to remove files that end up in a layer, to save on app zip space, this meant the file was not there if loading just an ActiveSync account, and then going to Compose, which dynamically loads 'mimefuncs' when needed.

The fix was just to put the module in the common worker-bootstrap layer, since it is needed by all account branches. Tested on flame device, both saving a draft and sending later and using the contacts and attachments activities to construct emails and send them.
