### PR TITLE
Bug 1004329 - [Flatfish][Homescreen] Returning home (landscape) from por...

### DIFF
--- a/apps/homescreen/js/screen_helper.js
+++ b/apps/homescreen/js/screen_helper.js
@@ -14,23 +14,9 @@
     height = screen.height - 20;
   }
 
-  function setDimensionsInternal() {
+  function setDimensions() {
     width = window.innerWidth;
     height = window.innerHeight;
-  }
-
-  function setDimensions() {
-    var isPortrait = '(orientation: portrait)';
-    if (window.matchMedia(isPortrait).matches) {
-      setDimensionsInternal();
-    } else {
-      window.matchMedia(isPortrait).addListener(function onOrientation(evt) {
-        if (evt.matches) {
-          window.matchMedia(isPortrait).removeListener(onOrientation);
-          setTimeout(setDimensionsInternal);
-        }
-      });
-    }
   }
 
   if (document.hidden) {


### PR DESCRIPTION
...trait app causes app icons to misalign/overlap
- Remove the window.matchMedia event handler which updates the width and height cache every time the orientation is changed to portrait.
