### PR TITLE
Bug 1061120 - [Calllog][Dialer] Time duration format is not showing 'min...

### DIFF
--- a/apps/communications/dialer/js/call_info.js
+++ b/apps/communications/dialer/js/call_info.js
@@ -79,7 +79,8 @@
             duration.setAttribute('data-l10n-id', 'canceled');
           }
         } else {
-          duration.textContent = Utils.prettyDuration(call.duration);
+          duration.textContent =
+            Utils.prettyDuration(call.duration, 'callDurationText');
         }
       });
 

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -104,6 +104,9 @@ delete-n-log?[other] = Delete {{ n }} logs?
 #Call duration units
 callDurationMinutes={{ m }}:{{ s }}
 callDurationHours={{ h }}:{{ m }}:{{ s}}
+callDurationTextSeconds={{ s }} s
+callDurationTextMinutes={{ m }} min {{ s }} s
+callDurationTextHours={{ h }} hr {{ m }} min {{ s }} s
 
 #Suggestion bar
 suggestionMatches={[ plural(n) ]}

--- a/apps/sharedtest/test/unit/dialer/utils_test.js
+++ b/apps/sharedtest/test/unit/dialer/utils_test.js
@@ -126,7 +126,7 @@ suite('dialer/utils', function() {
   suite('prettyDuration', function() {
     test('formats as minutes if less than one hour', function() {
       var pretty = Utils.prettyDuration(60 * 60 * 1000 - 1);
-      assert.equal(pretty, 'callDurationMinutes{"h":"00","m":59,"s":59}');
+      assert.equal(pretty, 'callDurationMinutes{"h":"00","m":"59","s":"59"}');
     });
 
     test('formats with hours if more than one hour', function() {
@@ -141,6 +141,31 @@ suite('dialer/utils', function() {
       var duration = hours * 60 * 60 + minutes * 60 + seconds;
       var pretty = Utils.prettyDuration(duration * 1000);
       assert.equal(pretty, 'callDurationHours{"h":"02","m":"04","s":"07"}');
+    });
+
+    suite('When using text format', function() {
+      test('single digits are not padded', function() {
+        var hours = 1;
+        var minutes = 4;
+        var seconds = 2;
+        var duration = hours * 60 * 60 + minutes * 60 + seconds;
+        var pretty = Utils.prettyDuration(duration * 1000,
+                                          'callDurationText');
+        assert.equal(pretty, 'callDurationTextHours{"h":"1","m":"4","s":"2"}');
+      });
+
+      test('formats as minutes if less than one hour', function() {
+        var pretty = Utils.prettyDuration(60 * 60 * 1000 - 1,
+                                          'callDurationText');
+        assert.equal(pretty,
+                     'callDurationTextMinutes{"h":"0","m":"59","s":"59"}');
+      });
+
+      test('formats as seconds if less than one minute', function() {
+        var pretty = Utils.prettyDuration(60 * 1000 - 1, 'callDurationText');
+        assert.equal(pretty,
+                     'callDurationTextSeconds{"h":"0","m":"0","s":"59"}');
+      });
     });
   });
 });

--- a/shared/js/dialer/utils.js
+++ b/shared/js/dialer/utils.js
@@ -11,20 +11,44 @@ var Utils = {
     return dtf.localeFormat(new Date(time), timeFormat);
   },
 
-  prettyDuration: function(duration) {
-    function padNumber(n) {
-      return n > 9 ? n : '0' + n;
+  /**
+   * Return a translated string which represents a time duration
+   * @param {Number} time duration in ms
+   * @param {String} l10nPrefix prefix used to select the right l10n id.
+   *        Default value 'callDuration'.
+   */
+  prettyDuration: function(duration, l10nPrefix) {
+    var elapsed = new Date(duration);
+    var h = elapsed.getUTCHours();
+    var m = elapsed.getUTCMinutes();
+    var s = elapsed.getUTCSeconds();
+
+    var durationFormat = l10nPrefix || 'callDuration';
+    var durationArgs = {
+      h: h + '',
+      m: m + '',
+      s: s + ''
+    };
+
+    if (durationFormat === 'callDuration') {
+      // Pad the args with a leading 0 if we're displaying them in purely
+      // digital format.
+      durationArgs = {
+        h: (h > 9 ? '' : '0') + h,
+        m: (m > 9 ? '' : '0') + m,
+        s: (s > 9 ? '' : '0') + s
+      };
     }
 
-    var elapsed = new Date(duration);
-    var durationL10n = {
-      h: padNumber(elapsed.getUTCHours()),
-      m: padNumber(elapsed.getUTCMinutes()),
-      s: padNumber(elapsed.getUTCSeconds())
-    };
-    var durationFormat = elapsed.getUTCHours() > 0 ?
-      'callDurationHours' : 'callDurationMinutes';
-    return navigator.mozL10n.get(durationFormat, durationL10n);
+    if (l10nPrefix === 'callDurationText' && h === 0 && m === 0) {
+      // Special case: only display in seconds format (i.e. "5 s") with text
+      // formatting, as digital formatting doesn't support this.
+      durationFormat += 'Seconds';
+    } else {
+      durationFormat += h > 0 ? 'Hours' : 'Minutes';
+    }
+
+    return navigator.mozL10n.get(durationFormat, durationArgs);
   },
 
   headerDate: function ut_headerDate(time) {


### PR DESCRIPTION
...' or 's' in 'Call Information'
