### PR TITLE
Bug 937367 - Fix links broken in Legal Information

### DIFF
--- a/apps/settings/resources/obtaining_source_code.html
+++ b/apps/settings/resources/obtaining_source_code.html
@@ -17,7 +17,7 @@ their obligations under the open source licenses.
 <p>
 Instructions for downloading and compiling the open source code for copies
 of Boot2Gecko made available by Mozilla can be found on the
-<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Building_and_installing_Firefox_OS">Mozilla Developer Network</a>.
+<a href="https://developer.mozilla.org/docs/Mozilla/Firefox_OS/Building_and_installing_Firefox_OS" target="_blank">Mozilla Developer Network</a>.
 <p>
 
 </body>

--- a/apps/settings/resources/open_source_license.html
+++ b/apps/settings/resources/open_source_license.html
@@ -31,12 +31,12 @@
 <body>
 <h1>Open Source Licensing Information</h1>
 
-<p> The <a href="http://www.opensource.org/docs/definition.php">open source</a> and
-<a href="http://www.gnu.org/philosophy/free-sw.html">free software</a> in
+<p> The <a href="http://www.opensource.org/docs/definition.php" target="_blank">open source</a> and
+<a href="http://www.gnu.org/philosophy/free-sw.html" target="_blank">free software</a> in
 this product is available under one of the following licenses. These licenses
 give you the freedom to run the software, study it, change it to meet your
 needs, and share your changes with others. You can
-<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Boot_to_Gecko/Building_and_installing_Firefox_OS">download the source code</a>
+<a href="https://developer.mozilla.org/docs/Mozilla/Boot_to_Gecko/Building_and_installing_Firefox_OS" target="_blank">download the source code</a>
 from Mozilla. Please consult the source to see which license applies to which
 parts of the code.
 </p>
@@ -348,12 +348,12 @@ liability.</p>
         <p>This product contains code from the following LGPLed libraries:</p>
 
 <ul>
-<li><a href="http://www.libsdl.org/">SDL</a>
-<li>Headers from <a href="http://www.yaffs.net/">yaffs2</a>
-<li><a href="http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2">iAccessible2</a>
-<li><a href="http://www.infradead.org/~tgr/libnl/">libnl</a>
-<li><a href="http://developer.gnome.org/glib/">glib</a>
-<li><a href="http://www.bluez.org/">bluez</a>
+<li><a href="http://www.libsdl.org/" target="_blank">SDL</a>
+<li>Headers from <a href="http://www.yaffs.net/" target="_blank">yaffs2</a>
+<li><a href="http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2" target="_blank">iAccessible2</a>
+<li><a href="http://www.infradead.org/~tgr/libnl/" target="_blank">libnl</a>
+<li><a href="http://developer.gnome.org/glib/" target="_blank">glib</a>
+<li><a href="http://www.bluez.org/" target="_blank">bluez</a>
 </ul>
 
 <pre>


### PR DESCRIPTION
Open external links in a new window to avoid overwriting or cannot be displayed.
