### PR TITLE
Bug 1061563 - TEST-UNEXPECTED-FAIL | /builds/slave/test/gaia/build/test/integration/build.test.js | Build Integration tests make with GAIA_OPTIMIZE=1 BUILD_DEBUG=1 Timout 

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -11,7 +11,7 @@ define run-build-test
     --harmony \
     --reporter $(REPORTER) \
     --ui tdd \
-    --timeout 180000 \
+    --timeout 300000 \
     $(strip $1)
 endef
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1061563
