### PR TITLE
Bug 1052256 - Block the click events before the first panel gets ready r=eragonj

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -69,6 +69,17 @@ body[data-ready="true"] section[role="region"].current {
 }
 
 /**
+ * Only accepts click events after the first panel gets ready
+ */
+body {
+  pointer-events: none;
+}
+
+body[data-ready="true"] {
+  pointer-events: auto;
+}
+
+/**
  * Headers should not scroll with the rest of the page, except for #root.
  */
 section[role="region"] > header {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1052256
