### PR TITLE
[CostcontrolBug 1062285 - [Costcontrol]Settings Panel is not translated (app is in b...r=mai

### DIFF
--- a/apps/costcontrol/js/app.js
+++ b/apps/costcontrol/js/app.js
@@ -239,6 +239,7 @@ var CostControlApp = (function() {
     isApplicationLocalized = true;
     if (initialized) {
       updateUI();
+      loadSettings();
     }
   });
 


### PR DESCRIPTION
...ackground),if the language change occurs

Bugzilla URL:
https://bugzilla.mozilla.org/show_bug.cgi?id=1062285
