### PR TITLE
Bug 1061854 - Dismiss notification swiping up r=mhenretty

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1136,13 +1136,14 @@
       </div>
 
       <div id="notification-toaster" data-z-index-level="notification-toaster" role="link" aria-live="assertive" aria-atomic="true" class="notification-toaster">
-        <span id="notifications-indicator"></span>
         <img id="toaster-icon" role="presentation" class="toaster-icon"/>
         <div id="notification-container">
           <div id="toaster-title" class="toaster-title"></div>
           <div id="toaster-detail" class="toaster-detail"></div>
         </div>
       </div>
+
+      <div id="ambient-indicator" data-z-index-level="notification-toaster"></div>
 
       <!-- keyboard -->
       <div id="keyboards" class="hide" data-z-index-level="keyboards"></div>

--- a/apps/system/style/app_titlebar.css
+++ b/apps/system/style/app_titlebar.css
@@ -21,7 +21,7 @@
 }
 
 .appWindow .titlebar .notifications-shadow {
-  background-image: -moz-element(#notification-toaster);
+  background-image: -moz-element(#ambient-indicator);
   width: 100%;
   position: absolute;
   top: 0;

--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -45,10 +45,10 @@
   top: -.2rem;
   width: 100%;
   height: 5.2rem;
-  background-color: #00BCE2;
-  transform: translateY(-5.2rem);
-  transition: transform 0s ease 1s, opacity .5s ease .5s;
-  opacity: 0;
+  background-color: transparent;
+  visibility: hidden;
+  transform: translateY(-5rem);
+  transition: transform ease .3s, background-color 0s ease .3s, visibility 0s ease .3s;
 }
 
 /*
@@ -60,7 +60,7 @@
   position: relative;
 }
 
-.utility-tray #notification-toaster {
+.utility-tray #ambient-indicator {
   top: 0;
 }
 
@@ -73,16 +73,6 @@
   margin: auto;
   left: 1.5rem;
   pointer-events: none;
-}
-
-#notification-container {
-  visibility: hidden;
-  transition: visibility 0s ease .2s;
-}
-
-.displayed #notification-container {
-  visibility: visible;
-  transition: none;
 }
 
 #notification-container > div {
@@ -114,7 +104,26 @@
   white-space: nowrap;
 }
 
-#notifications-indicator {
+#notification-toaster.displayed {
+  transform: translateY(0);
+  transition: transform .2s ease 1.2s, background-color 0s ease 1.2s, visibility 0s ease 1.2s;
+  background-color: #00BCE2;
+  visibility: visible;
+}
+
+#ambient-indicator {
+  position: absolute;
+  top: -.2rem;
+  height: .2rem;
+  width: 100%;
+  opacity: 0;
+  background-color: #00BCE2;
+  transform: translateY(-.2rem);
+  transition: opacity .5s ease .5s, transform 0s ease 1s;
+}
+
+#notification-toaster.displayed:after,
+#ambient-indicator:after {
   position: absolute;
   right: 0;
   left: 0;
@@ -123,52 +132,41 @@
   border-right: 0.2rem solid transparent;
   border-top: 0.2rem solid #B3F3FF;
   bottom: 0;
-  transition: opacity 0.5s ease 0.5s;
+  content: '';
 }
 
-.displayed #notifications-indicator {
+#notification-toaster:after {
+  border-color: white;
+  visibility: visible;
+}
+
+#notification-toaster.displayed:after {
   animation-name: toaster;
   animation-duration: 1.2s;
   border-color: #00BCE2;
-}
-
-#notification-toaster.displayed {
-  visibility: visible;
-  transform: translateY(0);
-  transition: transform .2s ease 1.2s;
-  opacity: 1;
-}
-
-#notification-toaster.unread:not(.displayed) {
-  transform: translateY(-5rem);
-  transition: transform .2s ease-in-out;
-  opacity: 1;
-}
-
-:not(.unread) .displayed #notifications-indicator {
   transform: translateY(.2rem);
+  transition: border-color 0s ease 1.2s;
 }
 
-.unread #notifications-indicator,
-.unread.displayed #notifications-indicator {
-  opacity: 1;
+#ambient-indicator.unread {
   transition: none;
   transform: translateY(0);
+  opacity: 1;
 }
 
-#notifications-indicator.small {
+#ambient-indicator.small:after {
   width: 8.6rem;
 }
 
-#notifications-indicator.medium {
+#ambient-indicator.medium:after {
   width: 16.8rem;
 }
 
-#notifications-indicator.big {
+#ambient-indicator.big:after {
   width: 24.8rem;
 }
 
-#notifications-indicator.full {
+#ambient-indicator.full:after {
   width: 100%;
   background-color: white;
 }

--- a/apps/system/test/marionette/notification_test.js
+++ b/apps/system/test/marionette/notification_test.js
@@ -1,7 +1,5 @@
 var assert = require('assert'),
     NotificationTest = require('./lib/notification').NotificationTest,
-
-
     NotificationList = require('./lib/notification').NotificationList,
     Marionette = require('marionette-client'),
     util = require('util'),
@@ -15,6 +13,7 @@ marionette('notification tests', function() {
       'ftu.manifestURL': null
     }
   });
+  var actions = new Marionette.Actions(client);
   var notificationList = new NotificationList(client);
 
   test('fire notification', function() {
@@ -37,6 +36,20 @@ marionette('notification tests', function() {
               'Lock screen notification contains all fields: ' +
                JSON.stringify(notificationList.lockScreenNotifications));
               // Would be empty array...
+  });
+
+  test('swipe up should hide the toast', function() {
+    var toaster = dispatchNotification(client);
+    actions.flick(toaster, 50, 30, 50, 1, 300).perform(function() {
+      assert.equal(toaster.displayed(), false);
+    });
+  });
+
+  test('swipe right should not hide the toast', function() {
+    var toaster = dispatchNotification(client);
+    actions.flick(toaster, 10, 30, 80, 30, 300).perform(function() {
+      assert.equal(toaster.displayed(), true);
+    });
   });
 
   test('system replace notification', function() {
@@ -185,6 +198,19 @@ marionette('notification tests', function() {
                  'the phone should have vibrated once');
   });
 });
+
+function dispatchNotification(client) {
+  var details = {tag: 'test tag',
+                 title: 'test title',
+                 body: 'test body',
+                 dir: 'rtl',
+                 lang: 'en'};
+  var toaster = client.findElement('#notification-toaster');
+  var notify = new NotificationTest(client, details);
+
+  client.helper.waitForElement('#notification-toaster.displayed');
+  return toaster;
+}
 
 function dispatchVisibilityChangeEvent() {
   client.executeScript(function() {

--- a/apps/system/test/unit/notifications_test.js
+++ b/apps/system/test/unit/notifications_test.js
@@ -99,7 +99,7 @@ suite('system/NotificationScreen >', function() {
     fakeSomeNotifications = createFakeElement('span', 'notification-some');
     fakeNoNotifications = createFakeElement('span', 'notification-none');
     fakeButton = createFakeElement('button', 'notification-clear');
-    fakeAmbientIndicator = createFakeElement('span', 'notifications-indicator');
+    fakeAmbientIndicator = createFakeElement('div', 'ambient-indicator');
     fakeToasterIcon = createFakeElement('img', 'toaster-icon');
     fakeToasterTitle = createFakeElement('div', 'toaster-title');
     fakeToasterDetail = createFakeElement('div', 'toaster-detail');
@@ -220,7 +220,7 @@ suite('system/NotificationScreen >', function() {
 
   suite('updateNotificationIndicator >', function() {
     setup(function() {
-      NotificationScreen.updateNotificationIndicator(true);
+      NotificationScreen.updateNotificationIndicator();
     });
 
     test('should clear unread notifications after open tray', function() {
@@ -253,6 +253,7 @@ suite('system/NotificationScreen >', function() {
     });
 
     test('should change the read status', function() {
+      incrementNotications(1);
       assert.equal(document.body.getElementsByClassName('unread').length, 1);
     });
   });

--- a/tests/python/gaia-ui-tests/gaiatest/apps/system/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/system/app.py
@@ -16,7 +16,7 @@ class System(Base):
     _utility_tray_locator = (By.ID, 'utility-tray')
 
     _system_banner_locator = (By.CSS_SELECTOR, '.banner.generic-dialog')
-    _notification_toaster_locator = (By.ID, 'notification-container')
+    _notification_toaster_locator = (By.ID, 'notification-toaster')
     _update_manager_toaster_locator = (By.ID, 'update-manager-toaster')
 
     _software_home_button_locator = (By.ID, 'software-home-button')
@@ -55,6 +55,7 @@ class System(Base):
     def is_app_update_notification_displayed(self):
         update_manager_toaster = self.marionette.find_element(*self._update_manager_toaster_locator)
         return update_manager_toaster.location['y'] > (0 - update_manager_toaster.size['height'])
+        self.wait_for_condition(lambda m: m.find_element(*self._notification_toaster_locator).location['y'] == 0, timeout=timeout, message=message)
 
     def wait_for_app_update_to_clear(self):
         update_manager_toaster = self.marionette.find_element(*self._update_manager_toaster_locator)


### PR DESCRIPTION
With the new ambient indicator, in order to dismiss a notification, a swipe up gesture is needed. All the swipe left code has been removed in this PR.
