### PR TITLE
Bug 1052465 Hide Sim icon when not active

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -922,12 +922,15 @@ var StatusBar = {
         }
 
         icon.hidden = false;
+        icon.dataset.inactive = false;
 
         if (simslot.isAbsent()) {
           // no SIM
           delete icon.dataset.level;
           delete icon.dataset.searching;
           roaming.hidden = true;
+          icon.hidden = true;
+          icon.dataset.inactive = true;
 
           icon.setAttribute('aria-label', _('noSimCard'));
         } else if (data && data.connected && data.type.startsWith('evdo')) {
@@ -1244,8 +1247,8 @@ var StatusBar = {
   },
 
   updateConnectionsVisibility: function sb_updateConnectionsVisibility() {
-    // Iterate through connections children and show the container if at least
-    // one of them is visible.
+    // Iterate through connections children and only show one icon
+    // in case no SIM card is inserted
     var conns = window.navigator.mozMobileConnections;
 
     if (!conns) {
@@ -1253,13 +1256,18 @@ var StatusBar = {
     }
 
     var icons = this.icons;
+    icons.connections.hidden = false;
+    icons.connections.dataset.multiple = (conns.length > 1);
+
     for (var index = 0; index < conns.length; index++) {
-      if (!icons.signals[index].hidden || !icons.data[index].hidden) {
-        icons.connections.hidden = false;
+      if (icons.signals[index].dataset.inactive === 'false') {
         return;
       }
     }
-    icons.connections.hidden = true;
+
+    // No SIM cards inserted
+    icons.connections.dataset.multiple = false;
+    icons.signals[0].hidden = false;
   },
 
   updateCallForwardingsVisibility: function sb_updateCallFwdingsVisibility() {

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -957,10 +957,6 @@ suite('system/Statusbar', function() {
   });
 
   suite('data connection', function() {
-    test('createConnectionsElements shouldn\'t display icons', function() {
-      StatusBar.createConnectionsElements();
-      assert.isTrue(StatusBar.icons.connections.hidden);
-    });
 
     function slotIndexTests(slotIndex) {
       suite('slot: ' + slotIndex, function() {
@@ -1302,6 +1298,11 @@ suite('system/Statusbar', function() {
         assert.include(label_content, 'Orange');
         assert.include(label_content, 'PR');
       });
+
+      test('dataset-multiple is set to false', function() {
+        StatusBar.updateConnectionsVisibility();
+        assert.equal(fakeIcons.connections.dataset.multiple, 'false');
+      });
     });
 
     suite('multiple sims', function() {
@@ -1321,6 +1322,17 @@ suite('system/Statusbar', function() {
         var label_content = fakeIcons.label.textContent;
         assert.equal(-1, label_content.indexOf('Orange'));
         assert.equal(-1, label_content.indexOf('PR'));
+      });
+
+      test('multiple is set to true if any active sim', function() {
+        fakeIcons.signals[0].dataset.inactive = 'false';
+        StatusBar.updateConnectionsVisibility();
+        assert.equal(fakeIcons.connections.dataset.multiple, 'true');
+      });
+
+      test('multiple is set to false if no SIM insterted', function() {
+        StatusBar.updateConnectionsVisibility();
+        assert.equal(fakeIcons.connections.dataset.multiple, 'false');
       });
     });
   });


### PR DESCRIPTION
- Only showing 1 'no SIM icon when no SIM cards are inserted
- Not showing 'no SIM' icons when 1 active SIM is in place
