### PR TITLE
Bug 1053647:  delete space when reverting an autocorrection and don't in...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/keyboard/test_a11y_keyboard_word_suggestions.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/accessibility/keyboard/test_a11y_keyboard_word_suggestions.py
@@ -25,9 +25,9 @@ class TestA11yKeyboardWordSuggestions(GaiaTestCase):
         # tap the field "input type=text"
         keyboard = keyboard_page.tap_text_input()
 
-        # type first 7 letters of the expected word
-        expected_word = 'keyboard '
-        keyboard.send(expected_word[:7])
+        # type first 6 letters of the expected word
+        expected_word = 'keyboard'
+        keyboard.send(expected_word[:6])
 
         keyboard.switch_to_keyboard()
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
@@ -25,9 +25,9 @@ class TestKeyboardPredictiveKey(GaiaTestCase):
         # tap the field "input type=text"
         keyboard = keyboard_page.tap_text_input()
 
-        # type first 7 letters of the expected word
-        expected_word = 'keyboard '
-        keyboard.send(expected_word[:7])
+        # type first 6 letters of the expected word
+        expected_word = 'keyboard'
+        keyboard.send(expected_word[:6])
 
         # tap the first predictive word
         keyboard.tap_first_predictive_word()


### PR DESCRIPTION
...sert space when user selects a word suggestion

update python integration tests (Rudy Lu)

properly clear autocorrect state when the user selects a word
