### PR TITLE
Bug 1061096 - [Settings] when init download list and empty list, edit button is not disabled.

### DIFF
--- a/apps/settings/js/downloads/downloads_list.js
+++ b/apps/settings/js/downloads/downloads_list.js
@@ -43,7 +43,7 @@
       emptyDownloadsContainer.hidden = true;
     }
 
-    editButton.className = isEmpty ? 'disabled' : '';
+    editButton.disabled = isEmpty ? true : false;
   }
 
   function _newDownload(download) {


### PR DESCRIPTION
Although I don't understand the intention of the original code, but now it works.
