### PR TITLE
Bug 1064185 - Call enterTaskManager on cardviewbeforeshow to add fadeout class

### DIFF
--- a/apps/system/js/homescreen_launcher.js
+++ b/apps/system/js/homescreen_launcher.js
@@ -196,7 +196,7 @@
         case 'cardviewbeforeshow':
           // Fade out the homescreen before showing the cards view to avoid
           // having it bleed through during the transition animation.
-          this.getHomescreen().fadeOut();
+          this.getHomescreen().enterTaskManager();
           break;
         case 'cardviewbeforeclose':
           // Fade homescreen back in before the cards view closes.

--- a/apps/system/js/homescreen_window.js
+++ b/apps/system/js/homescreen_window.js
@@ -232,5 +232,14 @@
     this.fadeOverlay.classList.remove('hidden');
   };
 
+  /**
+   * override AppWindow, respond to display of the task manager,
+   */
+  HomescreenWindow.prototype.enterTaskManager = function aw_enterTaskManager() {
+    if (this.element) {
+      this.element.classList.add('fadeout');
+    }
+  };
+
   exports.HomescreenWindow = HomescreenWindow;
 }(window));

--- a/apps/system/test/unit/homescreen_launcher_test.js
+++ b/apps/system/test/unit/homescreen_launcher_test.js
@@ -172,12 +172,12 @@ suite('system/HomescreenLauncher', function() {
     test('cards view before shown, then closed', function() {
       MockSettingsListener.mCallbacks['homescreen.manifestURL']('first.home');
       homescreen = window.homescreenLauncher.getHomescreen();
-      var stubFadeOut = this.sinon.stub(homescreen, 'fadeOut');
+      var stubEnterTM = this.sinon.stub(homescreen, 'enterTaskManager');
       window.homescreenLauncher.handleEvent({
         type: 'cardviewbeforeshow'
       });
-      assert.isTrue(stubFadeOut.called);
-      stubFadeOut.restore();
+      assert.isTrue(stubEnterTM.called);
+      stubEnterTM.restore();
 
       var stubFadeIn = this.sinon.stub(homescreen, 'fadeIn');
       window.homescreenLauncher.handleEvent({

--- a/apps/system/test/unit/homescreen_window_test.js
+++ b/apps/system/test/unit/homescreen_window_test.js
@@ -185,5 +185,12 @@ suite('system/HomescreenWindow', function() {
         homescreenWindow.fadeOverlay = originalOverlay;
       });
     });
+
+    suite('task manager interactions', function() {
+      test('enter taskmanager', function() {
+        homescreenWindow.enterTaskManager();
+        assert.isTrue(homescreenWindow.element.classList.contains('fadeout'));
+      });
+    });
   });
 });

--- a/apps/system/test/unit/mock_homescreen_window.js
+++ b/apps/system/test/unit/mock_homescreen_window.js
@@ -43,4 +43,7 @@ var MockHomescreenWindow = function(value) {
   this.isOOP = function() { return true; };
   this.ensure = function() { return this; };
   this.isDead = function() { return false};
+
+  this.enterTaskManager = function() {};
+  this.leaveTaskManager = function() {};
 };


### PR DESCRIPTION
Note, we do want the homescreen in the task switcher eventually, so I think this makes more sense than for example adding some 'force' param to fadeOut.
