### PR TITLE
Bug 1061446 - [Dolphin][v1.4]Drag and drop an icon to a new page,the pho...

### DIFF
--- a/apps/homescreen/js/dragdrop.js
+++ b/apps/homescreen/js/dragdrop.js
@@ -146,10 +146,10 @@ var DragDropManager = (function() {
             pageHelper.addPage([draggableIcon]);
           }
 
-          setDisabledCheckingLimits(true);
           if (pageHelper.getNext()) {
             transitioning = true;
             GridManager.goToNextPage(onNavigationEnd);
+            setDisabledCheckingLimits(true);
           }
 
           done();


### PR DESCRIPTION
...ne will always go to the new page automatically

The purpose of setDisabledCheckingLimits is to disable checkLimits when homescreen is making transition between pages. This can be traced long back to the 1st commit of the homescreen app in the commit df5f425, at line 591 and line 616 in apps/homescreentef/js/grid.js.

However, setDisabledCheckingLimits (at line 149) is invoked without page transition when the icon is placed at the right screen limit, which is unnecessary and causes the loop. What we need is to move the setDisabledCheckingLimits call to the 'if (pageHelper.getNext())' block.
