### PR TITLE
Bug 1062105 - [Keyboard] Alternate keys list overflows needs UI improvement.

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -600,11 +600,12 @@ var IMERender = (function() {
   // Show char alternatives.
   var showAlternativesCharMenu = function(key, altChars) {
 
-    var keyWidth = cachedWindowWidth / layoutWidth;
+    var keyWidth = (cachedWindowWidth / layoutWidth) | 0;
     var renderer = {
       ARIA_LABELS: ARIA_LABELS,
       buildKey: buildKey,
-      keyWidth: keyWidth
+      keyWidth: keyWidth,
+      screenInPortraitMode: screenInPortraitMode
     };
 
     alternativesCharMenu = new AlternativesCharMenuView(activeIme,

--- a/apps/keyboard/js/views/alternatives_char_menu.js
+++ b/apps/keyboard/js/views/alternatives_char_menu.js
@@ -15,6 +15,7 @@ function AlternativesCharMenuView(rootElement, altChars, renderer) {
   this.ARIA_LABELS = renderer.ARIA_LABELS;
   this.buildKey = renderer.buildKey;
   this.keyWidth = renderer.keyWidth;
+  this.screenInPortraitMode = renderer.screenInPortraitMode;
 
   this.menu = null;
   this._rowCount = 0;
@@ -76,11 +77,6 @@ AlternativesCharMenuView.prototype.show = function(key) {
     }
   }
 
-  // How wide (in characters) is the key that we're displaying
-  // these alternatives for?
-  var keycharwidth = key.dataset.compositeKey ?
-    key.dataset.compositeKey.length : 1;
-
   // Build a key for each alternative
   this.altChars.forEach(function(alt, index) {
     var dataset = alt.length == 1 ?
@@ -90,16 +86,16 @@ AlternativesCharMenuView.prototype.show = function(key) {
     ] :
     [ { 'key': 'compositeKey', 'value': alt } ];
 
-  // Make each of these alternative keys 75% as wide as the key that
+  // Make each of these alternative keys as wide as the key that
   // it is an alternative for, but adjust for the relative number of
   // characters in the original and the alternative.
-  // XXX: not sure if this is still necessary to keep it 75%, will ask visual
-  // to confirm.
   var width = 0;
-  if (this._rowCount === 1 ) {
-    width = 0.75 * key.offsetWidth / keycharwidth * alt.length;
+  if (alt.length == 1) {
+    width = this.keyWidth;
   } else {
-    width = this.keyWidth  / keycharwidth * alt.length;
+    // Add some padding to the composite key.
+    width = this._getCharWidth(alt) + 10;
+    width = Math.max(width, this.keyWidth);
   }
 
   var attributeList = [];
@@ -151,6 +147,16 @@ AlternativesCharMenuView.prototype.getBoundingClientRect = function() {
 AlternativesCharMenuView.prototype.getLineHeight = function() {
   var scale = parseFloat(document.documentElement.style.fontSize);
   return this.MENU_LINE_HEIGHT * scale;
+};
+
+AlternativesCharMenuView.prototype._getCharWidth = function(textContent) {
+  var scaleContext = document.createElement('canvas')
+    .getContext('2d', { willReadFrequently: true });
+
+  var fontSize = this.screenInPortraitMode() ? '2.4rem' : '2.8rem';
+  scaleContext.font = fontSize + ' sans-serif';
+
+  return scaleContext.measureText(textContent).width;
 };
 
 })(window);

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -309,7 +309,10 @@ and displays the list of alternatives. */
 
 #keyboard-accent-char-menu.kbr-menu-left {
   left: auto;
-  margin-right: -1rem; /* because the last child is wider than others */
+
+  /* because the last child is wider than others, shift 1 pixel to align with
+   * the key row. */
+  margin-right: -0.9rem;
 }
 
 #keyboard-accent-char-menu.left-edge {
@@ -322,7 +325,6 @@ and displays the list of alternatives. */
 
 /* Non keyboard key styles in menu */
 #keyboard-accent-char-menu .keyboard-key {
-  min-width: 3rem;
   transform: rotateX(180deg);
   float: left;
 }
@@ -349,12 +351,12 @@ and displays the list of alternatives. */
 #keyboard-accent-char-menu .keyboard-key > .visual-wrapper {
   height: 6rem;
   margin: 0;
-  border-right: 1px solid #0099b8;
 }
 
 #keyboard-accent-char-menu .keyboard-key > .visual-wrapper .key-element {
   background: none;
   border-radius: 0;
+  border-right: 1px solid #008eab;
 }
 
 #keyboard-accent-char-menu .keyboard-key.highlighted > .visual-wrapper:after,
@@ -364,7 +366,6 @@ and displays the list of alternatives. */
 
 /* Styles for keys in accent menu (not highlighted). */
 #keyboard-accent-char-menu .keyboard-key > .visual-wrapper > .key-element {
-  border: none;
   line-height: 6rem;
   font-weight: 500;
   color: #fff;
@@ -376,6 +377,11 @@ and displays the list of alternatives. */
 
 #keyboard-accent-char-menu .keyboard-key:last-child > .visual-wrapper > .key-element {
   padding-right: 0.5rem;
+}
+
+#keyboard-accent-char-menu.kbr-menu-left .keyboard-key > .visual-wrapper > .key-element {
+  border-left: 1px solid #008eab;
+  border-right: 0;
 }
 
 #keyboard-accent-char-menu.kbr-menu-left .keyboard-key:first-child > .visual-wrapper > .key-element {
@@ -412,23 +418,34 @@ bubble above the key when you tap and hold. */
 }
 
 #keyboard-accent-char-menu.multi-row.kbr-menu-left {
-  margin-right: 0;
+  /* To make the divider align the key row */
+  margin-right: 1px;
 }
 
 /* revert the expanded width because it won't have rounded corner */
 #keyboard-accent-char-menu.multi-row .keyboard-key:first-child,
 #keyboard-accent-char-menu.multi-row .keyboard-key:last-child {
-  min-width: 3rem;
-}
-
-#keyboard-accent-char-menu.multi-row .keyboard-key > .visual-wrapper {
-  border: 0;
+  min-width: 2.6rem;
 }
 
 #keyboard-accent-char-menu.multi-row .keyboard-key:first-child > .visual-wrapper > .key-element,
 #keyboard-accent-char-menu.multi-row .keyboard-key:last-child  > .visual-wrapper > .key-element {
   padding-left: 0;
   padding-right: 0;
+}
+
+/*
+ * Reset the margin used to align with the underneath key row, this is because
+ * generally, the key in alternatives char menu would have the same width as a
+ * normal key.
+ */
+#keyboard.landscape #keyboard-accent-char-menu {
+  margin-left: 0;
+}
+
+#keyboard.landscape #keyboard-accent-char-menu.kbr-menu-left {
+  /* Shift 1 pixel to align with the key row. */
+  margin-right: 0.1rem;
 }
 
 #keyboard.full-candidate-panel {


### PR DESCRIPTION
- Add border to multi-row alternatives char menu.
  - Adjust the positioning of the menu to align with the key row underneath.
