### PR TITLE
Bug 1061096 - Fix the edit button is not disabled when downloads list are empty list

### DIFF
--- a/apps/settings/js/downloads/downloads_list.js
+++ b/apps/settings/js/downloads/downloads_list.js
@@ -43,7 +43,7 @@
       emptyDownloadsContainer.hidden = true;
     }
 
-    editButton.className = isEmpty ? 'disabled' : '';
+    editButton.disabled = isEmpty;
   }
 
   function _newDownload(download) {

--- a/apps/settings/test/unit/downloads_list_test.js
+++ b/apps/settings/test/unit/downloads_list_test.js
@@ -103,7 +103,7 @@ suite('DownloadList', function() {
     test(' > edit mode button enabled/disabled', function(done) {
       DownloadsList.init(function() {
         // Edit button is false at the beginning
-        assert.isFalse(editButton.classList.contains('disabled'));
+        assert.isFalse(editButton.disabled);
         // Edit mode
         editButton.click();
         // Select all
@@ -117,7 +117,7 @@ suite('DownloadList', function() {
             if (itemsDeleted === MockMozDownloads.mockLength) {
               // Stop the observer
               observer.disconnect();
-              assert.ok(editButton.classList.contains('disabled'));
+              assert.ok(editButton.disabled);
               done();
             }
           });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1061096
