### PR TITLE
Bug 1065884 - Do not early return if we set the default XPCSHELLSDK value

### DIFF
--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -101,7 +101,6 @@ fi
 
 if [ -z "$XPCSHELLSDK" ] ; then
   XPCSHELLSDK=$(find "$XULRUNNER_DIRECTORY" -type f -name xpcshell | sort -nr | head -n1 2> /dev/null)
-  exit 1
 fi
 
 if [ ! -e "$XPCSHELLSDK" ] ; then


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1065884
