### PR TITLE
Bug 1061120 - [Calllog][Dialer] Time duration format is not showing 'min...

### DIFF
--- a/apps/communications/dialer/js/call_info.js
+++ b/apps/communications/dialer/js/call_info.js
@@ -85,7 +85,8 @@
             durationElt.setAttribute('data-l10n-id', 'canceled');
           }
         } else {
-          Utils.prettyDuration(durationElt, call.duration, 'callDurationText');
+          Utils.prettyDuration(durationElt, call.duration,
+                               'callDurationTextFormat');
         }
       });
 

--- a/apps/communications/dialer/locales/dialer.en-US.properties
+++ b/apps/communications/dialer/locales/dialer.en-US.properties
@@ -106,9 +106,9 @@ delete-n-log?[other] = Delete {{ n }} logs?
 #Call duration units
 callDurationMinutes={{ m }}:{{ s }}
 callDurationHours={{ h }}:{{ m }}:{{ s}}
-callDurationTextSeconds={{ s }} s
-callDurationTextMinutes={{ m }} min {{ s }} s
-callDurationTextHours={{ h }} hr {{ m }} min {{ s }} s
+callDurationTextFormatSeconds={{ s }} s
+callDurationTextFormatMinutes={{ m }} m {{ s }} s
+callDurationTextFormatHours={{ h }} h {{ m }} m {{ s }} s
 
 #Suggestion bar
 suggestionMatches={[ plural(n) ]}

--- a/apps/communications/dialer/test/unit/call_info_test.js
+++ b/apps/communications/dialer/test/unit/call_info_test.js
@@ -415,7 +415,7 @@ suite('Call Info', function(argument) {
       var durations = document.getElementsByClassName('cd__duration');
       for (var i=1; i < durations.length; i++) {
         sinon.assert.calledWith(Utils.prettyDuration, durations[i],
-          groupReturn.calls[i].duration, 'callDurationText');
+          groupReturn.calls[i].duration, 'callDurationTextFormat');
       }
     });
 

--- a/apps/sharedtest/test/unit/dialer/utils_test.js
+++ b/apps/sharedtest/test/unit/dialer/utils_test.js
@@ -159,22 +159,24 @@ suite('dialer/utils', function() {
         var minutes = 4;
         var seconds = 2;
         var duration = hours * 60 * 60 + minutes * 60 + seconds;
-        Utils.prettyDuration(durationNode, duration * 1000, 'callDurationText');
+        Utils.prettyDuration(durationNode, duration * 1000,
+                             'callDurationTextFormat');
         sinon.assert.calledWith(MockL10n.setAttributes, durationNode,
-          'callDurationTextHours', { h: '1', m: '4', s: '2' });
+          'callDurationTextFormatHours', { h: '1', m: '4', s: '2' });
       });
 
       test('formats as minutes if less than one hour', function() {
         Utils.prettyDuration(durationNode, 60 * 60 * 1000 - 1,
-                             'callDurationText');
+                             'callDurationTextFormat');
         sinon.assert.calledWith(MockL10n.setAttributes, durationNode,
-          'callDurationTextMinutes', { h: '0', m: '59', s: '59' });
+          'callDurationTextFormatMinutes', { h: '0', m: '59', s: '59' });
       });
 
       test('formats as seconds if less than one minute', function() {
-        Utils.prettyDuration(durationNode, 60 * 1000 - 1, 'callDurationText');
+        Utils.prettyDuration(durationNode, 60 * 1000 - 1,
+                             'callDurationTextFormat');
         sinon.assert.calledWith(MockL10n.setAttributes, durationNode,
-          'callDurationTextSeconds', { h: '0', m: '0', s: '59' });
+          'callDurationTextFormatSeconds', { h: '0', m: '0', s: '59' });
       });
     });
   });

--- a/shared/js/dialer/utils.js
+++ b/shared/js/dialer/utils.js
@@ -41,7 +41,7 @@ var Utils = {
       };
     }
 
-    if (l10nPrefix === 'callDurationText' && h === 0 && m === 0) {
+    if (l10nPrefix === 'callDurationTextFormat' && h === 0 && m === 0) {
       // Special case: only display in seconds format (i.e. "5 s") with text
       // formatting, as digital formatting doesn't support this.
       l10nId += 'Seconds';


### PR DESCRIPTION
...' or 's' in 'Call Information'
