### PR TITLE
Bug 1065511 - guard against falsey unfilteredStack. r=etienne

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -564,7 +564,8 @@
       app = StackManager.getCurrent() ||
             homescreenLauncher.getHomescreen(true);
     }
-    var position = this.unfilteredStack.indexOf(app);
+    var position = this.unfilteredStack ? this.unfilteredStack.indexOf(app) :
+                                          StackManager.position;
     if (position !== StackManager.position) {
       this.newStackPosition = position;
     }


### PR DESCRIPTION
Master patch with the same change wont apply cleanly. Guard against null unfilteredStack in exitToApp
