### PR TITLE
Revert "Bug 1052241 - Disable network activity icon in DEBUG mode"

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -931,11 +931,6 @@ var StatusBar = {
     },
 
     networkActivity: function sb_updateNetworkActivity() {
-      // XXX: Allow network activity icon to be disabled through a setting.
-      // This should be removed once bug 1054220 is fixed.
-      if (this.settingValues['statusbar.network-activity.disabled']) {
-        return;
-      }
       // Each time we receive an update, make network activity indicator
       // show up for 500ms.
 

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -193,7 +193,6 @@
    "homegesture.enabled": false,
    "edgesgesture.enabled": true,
    "continuous-transition.enabled": false,
-   "statusbar.network-activity.disabled": false,
    "support.onlinesupport.title": "",
    "support.onlinesupport.href": "",
    "support.callsupport1.title": "",

--- a/build/settings.js
+++ b/build/settings.js
@@ -252,13 +252,6 @@ function execute(config) {
     settings['debugger.remote-mode'] = 'disabled';
   }
 
-  // Disable network activity icon in debug mode because it
-  // causes unit tests to run really slowly until we
-  // can investigate and fix bug 1054220.
-  if (config.DEBUG) {
-    settings['statusbar.network-activity.disabled'] = true;
-  }
-
   settings['language.current'] = config.GAIA_DEFAULT_LOCALE;
 
   if (config.DEVICE_DEBUG) {


### PR DESCRIPTION
This reverts commit bcc84b7dcb3be974ca7a329f1aa63c9cfb1c4f91.

Conflicts:
    apps/system/js/statusbar.js
