### PR TITLE
Bug 1023259 - The contact  detail information is truncated in the contact detail dialog, r=steveck-chung

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -755,7 +755,7 @@ form[role="dialog"][data-type="action"].contact-prompt > header {
   padding: 0 0 0.7rem;
   margin: 0;
   overflow: hidden;
-
+  text-overflow: ellipsis;
   font-size: 1.5rem;
 }
 


### PR DESCRIPTION
Fixes the contact number shown incompletely in the contact detail screen of SMS conversion
