### PR TITLE
Bug 1064975 - [Browser Windows Manager] Pressing the Windows Manager button while in Browser does nothing

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -820,8 +820,7 @@
         break;
 
       case 'taskmanagershow':
-        var filter = (evt.detail && evt.detail.filter) || null;
-        this.show(filter);
+        this.show();
         break;
 
       case 'taskmanagerhide':


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1064975
