### PR TITLE
Bug 1062048 - Intermittent failing test, TEST-UNEXPECTED-FAIL | /builds/slave/test/gaia/apps/calendar/test/marionette/day_view_test.js | day view before each hook AssertionError: expected '12:xx' to equal '0:xx'

### DIFF
--- a/apps/calendar/test/marionette/day_view_test.js
+++ b/apps/calendar/test/marionette/day_view_test.js
@@ -300,7 +300,8 @@ marionette('day view', function() {
       var now = new Date();
       var minutes = now.getMinutes();
       minutes = minutes < 10 ? (0 + String(minutes)) : minutes;
-      var currentTime = (now.getHours() % 12) + ':' + minutes;
+      var hours = now.getHours();
+      var currentTime = (hours > 12 ? hours - 12 : hours ) + ':' + minutes;
       assert.equal(day.currentTime.text(), currentTime);
     });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1062048
