### PR TITLE
Bug 1044525 - Use a WeakMap to hold layout key objects, mapped from DOM elements, to avoid poking with DOM elements in various modules aside from renderer.

### DIFF
--- a/apps/keyboard/index.html
+++ b/apps/keyboard/index.html
@@ -13,6 +13,7 @@
   <script defer type="text/javascript" src="js/keyboard/active_targets_manager.js"></script>
   <script defer type="text/javascript" src="js/keyboard/layout_loader.js"></script>
   <script defer type="text/javascript" src="js/keyboard/layout_manager.js"></script>
+  <script defer type="text/javascript" src="js/keyboard/layout_normalizer.js"></script>
   <script defer type="text/javascript" src="js/render.js"></script>
   <script defer type="text/javascript" src="js/views/alternatives_char_menu.js"></script>
   <script defer type="text/javascript" src="js/keyboard/console.js"></script>

--- a/apps/keyboard/js/keyboard/active_targets_manager.js
+++ b/apps/keyboard/js/keyboard/active_targets_manager.js
@@ -143,7 +143,7 @@ ActiveTargetsManager.prototype._handlePressMove = function(press, id) {
 
   // Special handling for selection: since selections are scrollable,
   // if the press is moved, the press is consider ended and should be ignored.
-  if (press.moved && ('selection' in oldTarget.dataset)) {
+  if (press.moved && ('selection' in oldTarget)) {
     this.activeTargets.delete(id);
     this.ontargetcancelled(oldTarget);
 

--- a/apps/keyboard/js/keyboard/alternatives_char_menu_manager.js
+++ b/apps/keyboard/js/keyboard/alternatives_char_menu_manager.js
@@ -37,7 +37,8 @@ AlternativesCharMenuManager.prototype.show = function(target) {
   }
 
   // Get the targetRect before menu is shown.
-  var targetRect = target.getBoundingClientRect();
+  var targetRect =
+    IMERender.targetObjDomMap.get(target).getBoundingClientRect();
 
   // XXX: Remove reference to IMERender in the global in the future.
   this._currentMenuView = IMERender.showAlternativesCharMenu(target,
@@ -71,21 +72,21 @@ AlternativesCharMenuManager.prototype.show = function(target) {
 };
 
 AlternativesCharMenuManager.prototype._getAlternativesForTarget =
-function _getAlternativesForTarget(target) {
+function _getAlternativesForTarget(key) {
   // Handle key alternatives
   var alternatives;
   var altMap = this.app.layoutManager.currentPage.alt;
   var origKey = null;
 
   if (this.app.upperCaseStateManager.isUpperCaseLocked) {
-    origKey = target.dataset.uppercaseValue;
+    origKey = key.uppercaseValue;
     alternatives = altMap[origKey].upperCaseLocked ||
                    altMap[origKey];
   } else if (this.app.upperCaseStateManager.isUpperCase) {
-    origKey = target.dataset.uppercaseValue;
+    origKey = key.uppercaseValue;
     alternatives = altMap[origKey];
   } else {
-    origKey = target.dataset.lowercaseValue;
+    origKey = key.lowercaseValue;
     alternatives = altMap[origKey];
   }
 
@@ -120,8 +121,8 @@ AlternativesCharMenuManager.prototype.isMenuTarget = function(target) {
   }
 
   var menuContainer = this._currentMenuView.getMenuContainer();
-  return (target.parentNode === menuContainer ||
-          target === menuContainer);
+  return (IMERender.targetObjDomMap.get(target).parentNode === menuContainer ||
+          IMERender.targetObjDomMap.get(target) === menuContainer);
 };
 
 AlternativesCharMenuManager.prototype.getMenuTarget = function(press) {
@@ -138,7 +139,7 @@ AlternativesCharMenuManager.prototype.getMenuTarget = function(press) {
       press.target === this._originalTarget) {
     // Return the alternative right on the top of the target key.
     // The alternative should always be the first element in the DOM.
-    return children[0];
+    return this.app.layoutRenderingManager.getTargetObject(children[0]);
   }
 
   this._hasMovedAwayFromOriginalTarget = true;

--- a/apps/keyboard/js/keyboard/alternatives_char_menu_manager.js
+++ b/apps/keyboard/js/keyboard/alternatives_char_menu_manager.js
@@ -116,7 +116,7 @@ AlternativesCharMenuManager.prototype.hide = function() {
 };
 
 AlternativesCharMenuManager.prototype.isMenuTarget = function(target) {
-  if (!this._currentMenuView) {
+  if (!this._currentMenuView || Object.keys(target).length === 0) {
     return false;
   }
 

--- a/apps/keyboard/js/keyboard/feedback_manager.js
+++ b/apps/keyboard/js/keyboard/feedback_manager.js
@@ -100,13 +100,11 @@ SoundFeedback.prototype.triggerFeedback = function(target) {
     return;
   }
 
-  var isSpecialKey = target.classList.contains('special-key') ||
-    (parseInt(target.dataset.keyCode, 10) < 0);
-
   // Take the audio interface available, play it,
   // and create another one (so it can be readily available later)
   var clicker;
-  if (!isSpecialKey) {
+
+  if (!target.isSpecialKey) {
     clicker = this.clicker;
     this.clicker = new Audio(this.CLICK_SOUND_URL);
   } else {

--- a/apps/keyboard/js/keyboard/keyboard_app.js
+++ b/apps/keyboard/js/keyboard/keyboard_app.js
@@ -81,7 +81,7 @@ KeyboardApp.prototype._startComponents = function() {
   this.candidatePanelManager.start();
 
   // Initialize the rendering module
-  IMERender.init();
+  IMERender.init(this.layoutRenderingManager);
 
   this.stateManager = new StateManager(this);
   this.stateManager.start();

--- a/apps/keyboard/js/keyboard/layout_loader.js
+++ b/apps/keyboard/js/keyboard/layout_loader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Promise, KeyboardEvent */
+/* global Promise, KeyboardEvent, LayoutNormalizer */
 
 (function(exports) {
 
@@ -143,7 +143,9 @@ Keyboards.telLayout = {
   ]
 };
 
-var LayoutLoader = function() {
+var LayoutLoader = function(app) {
+  this.app = app;
+  this._normalizer = null;
 };
 
 LayoutLoader.prototype.SOURCE_DIR = './js/layouts/';
@@ -151,6 +153,7 @@ LayoutLoader.prototype.SOURCE_DIR = './js/layouts/';
 LayoutLoader.prototype.start = function() {
   this._initializedLayouts = {};
   this._layoutsPromises = {};
+  this._normalizer = new LayoutNormalizer();
   this.initLayouts();
 };
 
@@ -206,9 +209,13 @@ LayoutLoader.prototype._normalizeLayout = function(layoutName) {
     });
   }
 
-  // Go through each pages and inspect it's "alt" property;
+  // Normalize key properties such that other modules can deal with them easily
+  // Also, go through each pages and inspect it's "alt" property;
   // we want to normalize our existing mixed notations into arrays.
   pages.forEach(function(page) {
+    this._normalizer.normalizePageKeys(page, layout);
+
+    // XXX: move alt char normalization to the normalizer
     var alt = page.alt = page.alt || {};
     var upperCase = page.upperCase = page.upperCase || {};
     var altKeys = Object.keys(alt);

--- a/apps/keyboard/js/keyboard/layout_manager.js
+++ b/apps/keyboard/js/keyboard/layout_manager.js
@@ -216,19 +216,23 @@ LayoutManager.prototype._updateCurrentPage = function() {
       pageSwitchingKeyObject = {
         keyCode: KeyboardEvent.DOM_VK_ALT,
         value: layout.alternateLayoutKey || '12&',
+        uppercaseValue: layout.alternateLayoutKey || '12&',
         ratio: 2,
         ariaLabel: 'alternateLayoutKey',
         className: 'page-switch-key',
-        targetPage: 1
+        targetPage: 1,
+        isSpecialKey: true
       };
     } else {
       pageSwitchingKeyObject = {
         keyCode: KeyboardEvent.DOM_VK_ALT,
         value: layout.basicLayoutKey || 'ABC',
+        uppercaseValue: layout.basicLayoutKey || 'ABC',
         ratio: 2,
         ariaLabel: 'basicLayoutKey',
         className: 'page-switch-key',
-        targetPage: this.PAGE_INDEX_DEFAULT
+        targetPage: this.PAGE_INDEX_DEFAULT,
+        isSpecialKey: true
       };
     }
 
@@ -241,14 +245,17 @@ LayoutManager.prototype._updateCurrentPage = function() {
   if (needsSwitchingKey) {
     var imeSwitchKey = {
       value: '&#x1f310;', // U+1F310 GLOBE WITH MERIDIANS
+      uppercaseValue: '&#x1f310;',
       ratio: 1,
       keyCode: this.KEYCODE_SWITCH_KEYBOARD,
-      className: 'switch-key'
+      className: 'switch-key',
+      isSpecialKey: true
     };
 
     // Replace the label with short label if there is one
     if (layout.shortLabel) {
       imeSwitchKey.value = layout.shortLabel;
+      imeSwitchKey.uppercaseValue = layout.shortLabel;
       imeSwitchKey.className += ' alternate-indicator';
     }
 
@@ -281,7 +288,11 @@ LayoutManager.prototype._updateCurrentPage = function() {
     var periodKey = {
       value: '.',
       ratio: 1,
-      keyCode: 46
+      keyCode: 46,
+      keyCodeUpper: 46,
+      lowercaseValue: '.',
+      uppercaseValue: '.',
+      isSpecialKey: false
     };
     if (page.alt && page.alt['.']) {
       periodKey.className = 'alternate-indicator';
@@ -323,7 +334,11 @@ LayoutManager.prototype._updateCurrentPage = function() {
         spaceKeyRow.splice(spaceKeyCount, 0, {
           value: '/',
           ratio: 1,
-          keyCode: 47
+          keyCode: 47,
+          keyCodeUpper: 47,
+          lowercaseValue: '/',
+          uppercaseValue: '/',
+          isSpecialKey: false
         });
         spaceKeyCount++;
 
@@ -338,7 +353,11 @@ LayoutManager.prototype._updateCurrentPage = function() {
         spaceKeyRow.splice(spaceKeyCount, 0, {
           value: '@',
           ratio: 1,
-          keyCode: 64
+          keyCode: 64,
+          keyCodeUpper: 64,
+          lowercaseValue: '@',
+          uppercaseValue: '@',
+          isSpecialKey: false
         });
         spaceKeyCount++;
 
@@ -365,12 +384,19 @@ LayoutManager.prototype._updateCurrentPage = function() {
           var commaKey = {
             value: ',',
             ratio: 1,
-            keyCode: 44
+            keyCode: 44,
+            keyCodeUpper: 44,
+            lowercaseValue: ',',
+            uppercaseValue: ',',
+            isSpecialKey: false
           };
 
           if (overwrites[',']) {
             commaKey.value = overwrites[','];
             commaKey.keyCode = overwrites[','].charCodeAt(0);
+            commaKey.keyCodeUpper = overwrites[','].charCodeAt(0);
+            commaKey.lowercaseValue = overwrites[','];
+            commaKey.uppercaseValue = overwrites[','];
           }
 
           spaceKeyObject.ratio -= 1;
@@ -383,6 +409,9 @@ LayoutManager.prototype._updateCurrentPage = function() {
           if (overwrites['.']) {
             periodKey.value = overwrites['.'];
             periodKey.keyCode = overwrites['.'].charCodeAt(0);
+            periodKey.keyCodeUpper = overwrites['.'].charCodeAt(0);
+            periodKey.lowercaseValue = overwrites['.'];
+            periodKey.uppercaseValue = overwrites['.'];
           }
 
           spaceKeyObject.ratio -= 1;

--- a/apps/keyboard/js/keyboard/layout_normalizer.js
+++ b/apps/keyboard/js/keyboard/layout_normalizer.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/* global KeyEvent, KeyboardEvent */
+
+(function(exports) {
+
+/**
+ * LayoutNormalizer normalizes a layout's key objects such that
+ * Dealing business logics with them will be less painful.
+ * @class
+ * @param {Object} app the keyboard app instance
+ */
+var LayoutNormalizer = function() {
+};
+
+LayoutNormalizer.prototype._isSpecialKey = function(key) {
+  var SPECIAL_CODES = [
+    KeyEvent.DOM_VK_BACK_SPACE,
+    KeyEvent.DOM_VK_CAPS_LOCK,
+    KeyEvent.DOM_VK_RETURN,
+    KeyEvent.DOM_VK_ALT,
+    KeyEvent.DOM_VK_SPACE
+  ];
+
+  var hasSpecialCode = (key.keyCode !== KeyEvent.DOM_VK_SPACE) &&
+                        key.keyCode &&
+                       (SPECIAL_CODES.indexOf(key.keyCode) !== -1);
+  return hasSpecialCode || key.keyCode <= 0;
+};
+
+LayoutNormalizer.prototype._getUpperCaseValue = function(key, layout) {
+  if (KeyEvent.DOM_VK_SPACE === key.keyCode ||
+      this._isSpecialKey(key) ||
+      key.compositeKey) {
+    return key.value;
+  }
+
+  var upperCase = layout.upperCase || {};
+  return upperCase[key.value] || key.value.toUpperCase();
+};
+
+// normalize one key of the layout
+LayoutNormalizer.prototype._normalizeKey = function(key, layout) {
+  var keyChar = key.value;
+  var upperCaseKeyChar = this._getUpperCaseValue(key, layout);
+
+  var code = key.keyCode || keyChar.charCodeAt(0);
+  var upperCode = key.keyCode || upperCaseKeyChar.charCodeAt(0);
+
+  key.keyCode = code;
+  key.keyCodeUpper = upperCode;
+
+  key.lowercaseValue = keyChar;
+  key.uppercaseValue = upperCaseKeyChar;
+
+  key.isSpecialKey = this._isSpecialKey(key);
+
+  if (key.longPressValue) {
+    var longPressKeyCode = key.longPressKeyCode ||
+      key.longPressValue.charCodeAt(0);
+    key.longPressKeyCode = longPressKeyCode;
+  }
+
+  if (key.supportsSwitching) {
+    key.supportsSwitching = this._normalizeKey(key.supportsSwitching, layout);
+  }
+
+  if (KeyboardEvent.DOM_VK_ALT === code && !('targetPage' in key)) {
+    console.error('LayoutNormalizer: no targetPage for switching key.');
+  }
+};
+
+// normalize all keys in the page of the layout
+LayoutNormalizer.prototype.normalizePageKeys = function(page, layout) {
+  var keyRows = page.keys || [];
+
+  keyRows.forEach(function(keyRow) {
+    keyRow.forEach(function(key) {
+      this._normalizeKey(key, layout);
+    }, this);
+  }, this);
+};
+
+exports.LayoutNormalizer = LayoutNormalizer;
+
+})(window);

--- a/apps/keyboard/js/keyboard/layout_rendering_manager.js
+++ b/apps/keyboard/js/keyboard/layout_rendering_manager.js
@@ -13,6 +13,12 @@ var LayoutRenderingManager = function(app) {
   this._currentRenderingPage = null;
 
   this._resizeListenerTimer = undefined;
+
+  // a weak map from DOM elements to its abstract key object, to keep us from
+  // directly relying on DOM elements during user interactions.
+  // this should only be directly written by IMErender,
+  // and reading should always take place through |getTargetObject| below.
+  this.domObjectMap = null;
 };
 
 LayoutRenderingManager.prototype.start = function() {
@@ -26,6 +32,8 @@ LayoutRenderingManager.prototype.start = function() {
     // Handle resize events
     window.addEventListener('resize', this);
   }.bind(this), 2000);
+
+  this.domObjectMap = new WeakMap();
 };
 
 LayoutRenderingManager.prototype.stop = function() {
@@ -33,6 +41,8 @@ LayoutRenderingManager.prototype.stop = function() {
   this._resizeListenerTimer = undefined;
 
   window.removeEventListener('resize', this);
+
+  this.domObjectMap = null;
 };
 
 LayoutRenderingManager.prototype.handleEvent = function() {
@@ -205,6 +215,11 @@ LayoutRenderingManager.prototype._updateHeight = function() {
   this.app.console.timeEnd('domLoading');
 
   window.resizeTo(imeWidth, imeHeight);
+};
+
+LayoutRenderingManager.prototype.getTargetObject = function (elem) {
+  // default to an empty object such that member accessing and 'in' won't fail
+  return this.domObjectMap.get(elem) || {};
 };
 
 exports.LayoutRenderingManager = LayoutRenderingManager;

--- a/apps/keyboard/js/keyboard/layout_rendering_manager.js
+++ b/apps/keyboard/js/keyboard/layout_rendering_manager.js
@@ -218,6 +218,10 @@ LayoutRenderingManager.prototype._updateHeight = function() {
 };
 
 LayoutRenderingManager.prototype.getTargetObject = function (elem) {
+  if (!elem) {
+    return {};
+  }
+
   // default to an empty object such that member accessing and 'in' won't fail
   return this.domObjectMap.get(elem) || {};
 };

--- a/apps/keyboard/js/keyboard/target_handlers.js
+++ b/apps/keyboard/js/keyboard/target_handlers.js
@@ -4,6 +4,8 @@
 
 (function(exports) {
 
+// |target| is an abstract key object, not a DOM element
+
 var DefaultTargetHandler = function(target, app) {
   this.target = target;
   this.app = app;
@@ -18,14 +20,14 @@ DefaultTargetHandler.prototype.activate = function() {
 DefaultTargetHandler.prototype.longPress = function() {
   this.app.console.log('DefaultTargetHandler.longPress()');
   // Does the key have an long press value?
-  if (!('longPressValue' in this.target.dataset)) {
+  if (!('longPressValue' in this.target)) {
     return;
   }
 
   // Ignore any action when commit.
   this.ignoreCommitActions = true;
 
-  var keyCode = parseInt(this.target.dataset.longPressKeyCode, 10);
+  var keyCode = this.target.longPressKeyCode;
   this.app.inputMethodManager.currentIMEngine.click(keyCode);
   this.app.visualHighlightManager.hide(this.target);
 };
@@ -44,8 +46,8 @@ DefaultTargetHandler.prototype.commit = function() {
     return;
   }
 
-  var keyCode = parseInt(this.target.dataset.keycode, 10);
-  var upperCaseKeyCode = parseInt(this.target.dataset.keycodeUpper, 10);
+  var keyCode = this.target.keyCode;
+  var keyCodeUpper = this.target.keyCodeUpper;
   var engine = this.app.inputMethodManager.currentIMEngine;
 
   /*
@@ -58,11 +60,11 @@ DefaultTargetHandler.prototype.commit = function() {
    */
   if (this.app.layoutManager.currentPage.imEngine === 'latin') {
     this.app.console.log('DefaultTargetHandler.commit()::latin::engine.click',
-      keyCode, upperCaseKeyCode);
-    engine.click(keyCode, upperCaseKeyCode);
+      keyCode, keyCodeUpper);
+    engine.click(keyCode, keyCodeUpper);
   } else {
     var code =
-      this.app.upperCaseStateManager.isUpperCase ? upperCaseKeyCode : keyCode;
+      this.app.upperCaseStateManager.isUpperCase ? keyCodeUpper : keyCode;
     this.app.console.log('DefaultTargetHandler.commit()::engine.click', code);
     engine.click(code);
   }
@@ -109,12 +111,12 @@ CandidateSelectionTargetHandler.prototype =
 CandidateSelectionTargetHandler.prototype.commit = function() {
   this.app.candidatePanelManager.hideFullPanel();
 
-  // We use dataset.data instead of target.textContent because the
+  // We use the target's data instead of target.text because the
   // text actually displayed to the user might have an ellipsis in it
   // to make it fit.
   var engine = this.app.inputMethodManager.currentIMEngine;
   if (typeof engine.select === 'function') {
-    engine.select(this.target.textContent, this.target.dataset.data);
+    engine.select(this.target.text, this.target.data);
   }
 
   this.app.visualHighlightManager.hide(this.target);
@@ -198,7 +200,7 @@ CompositeTargetHandler.prototype =
 CompositeTargetHandler.prototype.commit = function() {
   // Keys with this attribute set send more than a single character
   // Like ".com" or "2nd" or (in Catalan) "l·l".
-  var compositeString = this.target.dataset.compositeKey;
+  var compositeString = this.target.compositeKey;
   var engine = this.app.inputMethodManager.currentIMEngine;
   for (var i = 0; i < compositeString.length; i++) {
     engine.click(compositeString.charCodeAt(i));
@@ -213,7 +215,7 @@ var PageSwitchingTargetHandler = function(target, app) {
 PageSwitchingTargetHandler.prototype =
   Object.create(DefaultTargetHandler.prototype);
 PageSwitchingTargetHandler.prototype.commit = function() {
-  var page = parseInt(this.target.dataset.targetPage, 10);
+  var page = this.target.targetPage;
 
   this.app.setLayoutPage(page);
   this.app.visualHighlightManager.hide(this.target);

--- a/apps/keyboard/js/keyboard/target_handlers_manager.js
+++ b/apps/keyboard/js/keyboard/target_handlers_manager.js
@@ -62,11 +62,11 @@ TargetHandlersManager.prototype.stop = function() {
 // not start or end the handler/active target, so it was not mentioned in the
 // above list.
 //
-// Please note that since we are using target (the DOM element) as the
-// identifier of handlers, we do not assign new handler if there are two touches
-// on the same element. Currently that cannot happen because of what done in
-// bug 985855, however in the future that will change (and these handlers needs
-// to) to adopt bug 985853 (Combo key).
+// Please note that since we are using target (an abstract key object associated
+// with one DOM element) as the identifier of handlers, we do not assign new
+// handler if there are two touches on the same element. Currently that cannot
+// happen because of what done in bug 985855, however in the future that will
+// change (and these handlers needs to) to adopt bug 985853 (Combo key).
 TargetHandlersManager.prototype._callTargetAction = function(action,
                                                              setHandler,
                                                              deleteHandler,
@@ -101,6 +101,7 @@ TargetHandlersManager.prototype._callTargetAction = function(action,
 // This method decide which of the TargetHandler is the right one to
 // handle the active target. It decide the TargetHandler to use and create
 // and instance of it, and return the instance.
+// |target| is an object, not a DOM element.
 TargetHandlersManager.prototype._createHandlerForTarget = function(target) {
   this.app.console.log('TargetHandlersManager._createHandlerForTarget()');
 
@@ -109,20 +110,18 @@ TargetHandlersManager.prototype._createHandlerForTarget = function(target) {
   // This is unfortunately very complex but this is essentially what's already
   // specified in keyboard.js.
   // We will need to normalize the identifier for each targets in the future.
-  if (target.classList.contains('dismiss-suggestions-button')) {
+  if ('isDismissSuggestionsButton' in target) {
     handler = new DismissSuggestionsTargetHandler(target, this.app);
-  } else if ('selection' in target.dataset) {
+  } else if ('selection' in target) {
     handler = new CandidateSelectionTargetHandler(target, this.app);
-  } else if ('compositeKey' in target.dataset) {
+  } else if ('compositeKey' in target) {
     handler = new CompositeTargetHandler(target, this.app);
-  } else if ('keycode' in target.dataset) {
-    var keyCode = parseInt(target.dataset.keycode, 10);
-    switch (keyCode) {
+  } else if ('keyCode' in target) {
+    switch (target.keyCode) {
       // Delete is a special key, it reacts when pressed not released
       case KeyEvent.DOM_VK_BACK_SPACE:
         handler = new BackspaceTargetHandler(target, this.app);
         break;
-
       case KeyEvent.DOM_VK_SPACE:
         handler = new SpaceKeyTargetHandler(target, this.app);
         break;

--- a/apps/keyboard/js/keyboard/user_press_manager.js
+++ b/apps/keyboard/js/keyboard/user_press_manager.js
@@ -13,8 +13,9 @@
 /**
  * UserPress instance represents a single user interaction, by touch or mouse.
  */
-var UserPress = function(el, coords) {
-  this.target = el;
+var UserPress = function(obj, coords) {
+  // |target| is an abstract key object, not a DOM element
+  this.target = obj;
   this.updateCoords(coords, false);
 };
 
@@ -205,7 +206,9 @@ UserPressManager.prototype.handleEvent = function(evt) {
 
 UserPressManager.prototype._handleNewPress = function(el, coords, id) {
   this.app.console.info('UserPressManager._handleNewPress()');
-  var press = new UserPress(el, coords);
+  var press =
+    new UserPress(this.app.layoutRenderingManager.getTargetObject(el),
+                  coords);
   this.presses.set(id, press);
 
   if (typeof this.onpressstart === 'function') {
@@ -216,7 +219,7 @@ UserPressManager.prototype._handleNewPress = function(el, coords, id) {
 UserPressManager.prototype._handleChangedPress = function(el, coords, id) {
   this.app.console.info('UserPressManager._handleChangedPress()');
   var press = this.presses.get(id);
-  press.target = el;
+  press.target = this.app.layoutRenderingManager.getTargetObject(el);
   press.updateCoords(coords, true);
 
   if (typeof this.onpressmove === 'function') {
@@ -227,7 +230,7 @@ UserPressManager.prototype._handleChangedPress = function(el, coords, id) {
 UserPressManager.prototype._handleFinishPress = function(el, coords, id) {
   this.app.console.info('UserPressManager._handleFinishPress()');
   var press = this.presses.get(id);
-  press.target = el;
+  press.target = this.app.layoutRenderingManager.getTargetObject(el);
   press.updateCoords(coords,
     press.moved || this._distanceReachesLimit(id, coords));
 

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -267,9 +267,17 @@ var IMERender = (function() {
         var keyElement = buildKey(outputChar, className, keyWidth + 'px',
           key, key.longPressValue, attributeList);
 
-        // dataset.keycode is retained in bug 1044525
-        // because some css relies on it
+        // a few dataset properties are retained in bug 1044525 because some css
+        // and ui/integration tests rely on them.
+        // also to not break them we spell keycode instead of keyCode in dataset
         keyElement.dataset.keycode = key.keyCode;
+        keyElement.dataset.keycodeUpper = key.keyCodeUpper;
+        if ('targetPage' in key) {
+          keyElement.dataset.targetPage = key.targetPage;
+        }
+        if ('compositeKey' in key) {
+          keyElement.dataset.compositeKey = key.compositeKey;
+        }
 
         kbRow.appendChild(keyElement);
 
@@ -413,6 +421,10 @@ var IMERender = (function() {
             text: span.textContent,
             data: data
           });
+
+          // ui/integration test needs this
+          span.dataset.data = data;
+
           if (correction)
             span.classList.add('autocorrect');
 
@@ -530,6 +542,9 @@ var IMERender = (function() {
         data: data
       });
       span.style.width = (unit * candidateUnitWidth - 2) + 'px';
+
+      // ui/integration test needs this
+      span.dataset.data = data;
 
       nowUnit += unit;
 

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -11,31 +11,21 @@
  */
 // XXX: The only thing worth to be remebered is the KEY element must be the
 // deepest interactive HTML element on the hierarchy or, if none, simply the
-// deepest element. This element must contain dataset-keycode and related
-// attributes.
+// deepest element. This element must be mapped in LayoutRenderingManager's
+// _domObjectMap in order to retrieve the key object defined and normalized in
+// layouts and to access its attributes.
 var IMERender = (function() {
 
   var ime, activeIme;
   var alternativesCharMenu = null;
   var _menuKey = null;
+  var renderingManager = null;
 
-  // Return the upper value for a key object
-  var getUpperCaseValue = function getUpperCaseValue(key, layout) {
-    var hasSpecialCode = SPECIAL_CODES.indexOf(key.keyCode) > -1;
-    if (key.keyCode < 0 || hasSpecialCode || key.compositeKey)
-      return key.value;
-
-    var upperCase = layout.upperCase || {};
-    return upperCase[key.value] || key.value.toUpperCase();
-  };
-
-  // Support function for render
-  var isSpecialKey = function isSpecialKeyObj(key) {
-    var hasSpecialCode = key.keyCode !== KeyEvent.DOM_VK_SPACE &&
-      key.keyCode &&
-      SPECIAL_CODES.indexOf(key.keyCode) !== -1;
-    return hasSpecialCode || key.keyCode <= 0;
-  };
+  // a WeakMap to map target key object onto the DOM element it's associated
+  // with; essentially the revrse mapping of |renderingManager._domObjectMap|.
+  // ideally this should only be accessed by this renderer and alt_char_menu's
+  // view.
+  var targetObjDomMap = null;
 
   var layoutWidth = 10;
 
@@ -46,14 +36,6 @@ var IMERender = (function() {
 
   var cachedWindowHeight = -1;
   var cachedWindowWidth = -1;
-
-  var SPECIAL_CODES = [
-    KeyEvent.DOM_VK_BACK_SPACE,
-    KeyEvent.DOM_VK_CAPS_LOCK,
-    KeyEvent.DOM_VK_RETURN,
-    KeyEvent.DOM_VK_ALT,
-    KeyEvent.DOM_VK_SPACE
-  ];
 
   var ARIA_LABELS = {
     '⇪': 'upperCaseKey2',
@@ -81,11 +63,15 @@ var IMERender = (function() {
   // Initialize the render. It needs some business logic to determine:
   //   1- The uppercase for a key object
   //   2- When a key is a special key
-  var init = function kr_init() {
+  var init = function kr_init(layoutRenderingManager) {
     ime = document.getElementById('keyboard');
+
+    renderingManager = layoutRenderingManager;
 
     cachedWindowHeight = window.innerHeight;
     cachedWindowWidth = window.innerWidth;
+
+    targetObjDomMap = new WeakMap();
   };
 
   var setInputMethodName = function(name) {
@@ -220,8 +206,6 @@ var IMERender = (function() {
       }
 
       row.forEach((function buildKeyboardColumns(key) {
-        var keyChar = key.value;
-
         // Keys may be hidden if the .hidden property contains the inputType
         if (key.hidden && key.hidden.indexOf(flags.inputType) !== -1)
           return;
@@ -230,18 +214,10 @@ var IMERender = (function() {
         if (key.visible && key.visible.indexOf(flags.inputType) === -1)
           return;
 
-        // We will always display keys in uppercase, per request from UX.
-        var upperCaseKeyChar = getUpperCaseValue(key, layout);
-
-        // Handle override
-        var code = key.keyCode || keyChar.charCodeAt(0);
-        // Uppercase keycode
-        var upperCode = key.keyCode || upperCaseKeyChar.charCodeAt(0);
-
         var attributeList = [];
         var className = '';
 
-        if (isSpecialKey(key)) {
+        if (key.isSpecialKey) {
           className = 'special-key';
         } else {
           // The 'key' role tells an assistive technology that these buttons
@@ -265,15 +241,9 @@ var IMERender = (function() {
         var ratio = key.ratio || 1;
         rowLayoutWidth += ratio;
 
-        var outputChar = flags.uppercase ? upperCaseKeyChar : keyChar;
+        var outputChar = flags.uppercase ? key.uppercaseValue : key.value;
 
         var keyWidth = placeHolderWidth * ratio;
-        var dataset = [];
-        dataset.push({'key': 'keycode', 'value': code});
-        dataset.push({'key': 'keycodeUpper', 'value': upperCode});
-        if (key.compositeKey) {
-          dataset.push({'key': 'compositeKey', 'value': key.compositeKey});
-        }
 
         if (key.disabled) {
           attributeList.push({
@@ -294,26 +264,16 @@ var IMERender = (function() {
           });
         }
 
-        if (key.longPressValue) {
-          var longPressKeyCode = key.longPressKeyCode ||
-            key.longPressValue.charCodeAt(0);
-          dataset.push({'key': 'longPressValue', 'value': key.longPressValue });
-          dataset.push({'key': 'longPressKeyCode', 'value': longPressKeyCode });
-        }
+        var keyElement = buildKey(outputChar, className, keyWidth + 'px',
+          key, key.longPressValue, attributeList);
 
-        if (code === KeyboardEvent.DOM_VK_ALT) {
-          if (!('targetPage' in key)) {
-            console.error('render.js: no targetPage for switching key.');
-          }
+        // dataset.keycode is retained in bug 1044525
+        // because some css relies on it
+        keyElement.dataset.keycode = key.keyCode;
 
-          dataset.push({'key': 'targetPage', 'value': key.targetPage });
-        }
+        kbRow.appendChild(keyElement);
 
-        dataset.push({'key': 'lowercaseValue', 'value': keyChar });
-        dataset.push({'key': 'uppercaseValue', 'value': upperCaseKeyChar });
-
-        kbRow.appendChild(buildKey(outputChar, className, keyWidth + 'px',
-          dataset, key.longPressValue, attributeList));
+        setDomElemTargetObject(keyElement, key);
       }));
 
       kbRow.dataset.layoutWidth = rowLayoutWidth;
@@ -340,20 +300,23 @@ var IMERender = (function() {
 
   // Highlight the key according to the case.
   var highlightKey = function kr_updateKeyHighlight(key, options) {
+    var keyElem = targetObjDomMap.get(key);
+
     options = options || {};
 
-    key.classList.add('highlighted');
+    keyElem.classList.add('highlighted');
 
     // Show lowercase pop.
     if (!options.showUpperCase) {
-      key.classList.add('lowercase');
+      keyElem.classList.add('lowercase');
     }
   };
 
   // Unhighlight a key
   var unHighlightKey = function kr_unHighlightKey(key) {
-    key.classList.remove('highlighted');
-    key.classList.remove('lowercase');
+    var keyElem = targetObjDomMap.get(key);
+    keyElem.classList.remove('highlighted');
+    keyElem.classList.remove('lowercase');
   };
 
   var toggleCandidatePanel = function(expand) {
@@ -445,8 +408,11 @@ var IMERender = (function() {
 
           var span = fitText(div, text);
           span.setAttribute('role', 'option');
-          span.dataset.selection = true;
-          span.dataset.data = data;
+          setDomElemTargetObject(span, {
+            selection: true,
+            text: span.textContent,
+            data: data
+          });
           if (correction)
             span.classList.add('autocorrect');
 
@@ -558,8 +524,11 @@ var IMERender = (function() {
 
       var span = document.createElement('span');
       span.textContent = cand;
-      span.dataset.selection = true;
-      span.dataset.data = data;
+      setDomElemTargetObject(span, {
+        selection: true,
+        text: span.textContent,
+        data: data
+      });
       span.style.width = (unit * candidateUnitWidth - 2) + 'px';
 
       nowUnit += unit;
@@ -614,14 +583,15 @@ var IMERender = (function() {
       ARIA_LABELS: ARIA_LABELS,
       buildKey: buildKey,
       keyWidth: keyWidth,
-      screenInPortraitMode: screenInPortraitMode
+      screenInPortraitMode: screenInPortraitMode,
+      renderingManager: renderingManager
     };
 
     alternativesCharMenu = new AlternativesCharMenuView(activeIme,
                                                         altChars,
                                                         renderer);
     alternativesCharMenu.show(key);
-    key.classList.add('kbr-menu-on');
+    targetObjDomMap.get(key).classList.add('kbr-menu-on');
     _menuKey = key;
 
     return alternativesCharMenu;
@@ -630,7 +600,7 @@ var IMERender = (function() {
   // Hide the alternative menu
   var hideAlternativesCharMenu = function km_hideAlternativesCharMenu() {
     alternativesCharMenu.hide();
-    _menuKey.classList.remove('kbr-menu-on');
+    targetObjDomMap.get(_menuKey).classList.remove('kbr-menu-on');
   };
 
   var _keyArray = []; // To calculate proximity info for predictive text
@@ -685,7 +655,7 @@ var IMERender = (function() {
         for (var k = 0, key; key = row.childNodes[k]; k++) {
           var visualKey = key.querySelector('.visual-wrapper');
           _keyArray.push({
-            code: key.dataset.keycode | 0,
+            code: renderingManager.getTargetObject(key).keyCode | 0,
             x: visualKey.offsetLeft,
             y: visualKey.offsetTop,
             width: visualKey.clientWidth,
@@ -800,13 +770,25 @@ var IMERender = (function() {
     suggestionContainer.setAttribute('role', 'listbox');
     candidatePanel.appendChild(suggestionContainer);
 
+    // TODO: the renderer should not be creating a bussiness logic object,
+    // let's move it to somewhere else.
+    setDomElemTargetObject(dismissButton, {isDismissSuggestionsButton: true});
+
     return candidatePanel;
   };
 
   var candidatePanelToggleButtonCode = function() {
     var toggleButton = document.createElement('span');
     toggleButton.classList.add('keyboard-candidate-panel-toggle-button');
-    toggleButton.dataset.keycode = -4;
+    // we're not getting reference of LayoutManager, so define this manually
+    var KEYCODE_TOGGLE_CANDIDATE_PANEL = -4;
+
+    // TODO: the renderer should not be creating a bussiness logic object,
+    // let's move it to somewhere else.
+    setDomElemTargetObject(toggleButton, {
+      keyCode: KEYCODE_TOGGLE_CANDIDATE_PANEL
+    });
+
     if (inputMethodName) {
       toggleButton.classList.add(inputMethodName);
     }
@@ -818,7 +800,7 @@ var IMERender = (function() {
     return toggleButton;
   };
 
-  var buildKey = function buildKey(label, className, width, dataset, altNote,
+  var buildKey = function buildKey(label, className, width, key, altNote,
                                    attributeList) {
     var altNoteNode;
     if (altNote) {
@@ -841,10 +823,6 @@ var IMERender = (function() {
       });
     }
 
-    dataset.forEach(function(data) {
-      contentNode.dataset[data.key] = data.value;
-    });
-
     var vWrapperNode = document.createElement('span');
     vWrapperNode.className = 'visual-wrapper';
 
@@ -863,7 +841,7 @@ var IMERender = (function() {
     vWrapperNode.appendChild(labelNode);
 
     labelNode = document.createElement('span');
-    labelNode.innerHTML = contentNode.dataset.lowercaseValue;
+    labelNode.innerHTML = key.lowercaseValue;
     labelNode.className = 'lowercase popup';
     vWrapperNode.appendChild(labelNode);
 
@@ -928,6 +906,14 @@ var IMERender = (function() {
     var candidatePanelHeight = candidatePanel ? candidatePanel.clientHeight : 0;
 
     return Math.ceil((ime.clientHeight - candidatePanelHeight) / rowCount);
+  };
+
+  // a helper function to set both rendering manager's forward map,
+  // and renderer's reverse map.
+  // ideally this should only be used with views (renderer & alt_char_menu.js).
+  var setDomElemTargetObject = function setDomElemTargetObject(elem, obj) {
+    renderingManager.domObjectMap.set(elem, obj);
+    targetObjDomMap.set(obj, elem);
   };
 
   // Measure the width of the element, and return the scale that
@@ -999,6 +985,7 @@ var IMERender = (function() {
     'getKeyWidth': getKeyWidth,
     'getKeyHeight': getKeyHeight,
     'getScale': getScale,
+    'setDomElemTargetObject': setDomElemTargetObject,
     'showMoreCandidates': showMoreCandidates,
     'toggleCandidatePanel': toggleCandidatePanel,
     'isFullCandidataPanelShown': isFullCandidataPanelShown,
@@ -1012,6 +999,9 @@ var IMERender = (function() {
     },
     get candidatePanel() {
       return activeIme && activeIme.querySelector('.keyboard-candidate-panel');
+    },
+    get targetObjDomMap() {
+      return targetObjDomMap;
     },
     setCachedWindowSize: function(width, height) {
       cachedWindowWidth = width;

--- a/apps/keyboard/js/views/alternatives_char_menu.js
+++ b/apps/keyboard/js/views/alternatives_char_menu.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* globals IMERender */
+
 (function(exports) {
 
 /**
@@ -16,6 +18,7 @@ function AlternativesCharMenuView(rootElement, altChars, renderer) {
   this.buildKey = renderer.buildKey;
   this.keyWidth = renderer.keyWidth;
   this.screenInPortraitMode = renderer.screenInPortraitMode;
+  this.renderingManager = renderer.renderingManager;
 
   this.menu = null;
   this._rowCount = 0;
@@ -27,11 +30,12 @@ AlternativesCharMenuView.prototype.MENU_LINE_HEIGHT = 6;   // in rem
 
 AlternativesCharMenuView.prototype.show = function(key) {
   var content = document.createDocumentFragment();
+  var keyElem = IMERender.targetObjDomMap.get(key);
 
   // XXX: should not cause reflow by ref. innerWidth
   var cachedWindowWidth = window.innerWidth;
 
-  var left = (cachedWindowWidth / 2 > key.offsetLeft);
+  var left = (cachedWindowWidth / 2 > keyElem.offsetLeft);
   this._direction = left ? 'left' : 'right';
 
   var menu = document.createElement('div');
@@ -48,7 +52,7 @@ AlternativesCharMenuView.prototype.show = function(key) {
   if (this.altChars.length > 5) {
     widthRatio = Math.ceil(this.altChars.length / 2);
 
-    menu.style.top = (key.offsetTop - this.getLineHeight() * 2)  + 'px';
+    menu.style.top = (keyElem.offsetTop - this.getLineHeight() * 2)  + 'px';
     this._columnCount = widthRatio;
     this._rowCount = 2;
 
@@ -58,21 +62,21 @@ AlternativesCharMenuView.prototype.show = function(key) {
     menu.classList.add('multi-row');
   } else {
     // menu height -  4 (top margin of the visual wrapper)
-    menu.style.top = (key.offsetTop - this.getLineHeight() + 4) +  'px';
+    menu.style.top = (keyElem.offsetTop - this.getLineHeight() + 4) +  'px';
     this._rowCount = 1;
     this._columnCount = this.altChars.length;
   }
 
   // Determine the horizontal positioning of the menu
   if (left) {
-    var keyRight = key.offsetLeft + key.offsetWidth;
+    var keyRight = keyElem.offsetLeft + keyElem.offsetWidth;
     var posLeft = keyRight - this.keyWidth;
     menu.style.left = posLeft + 'px';
     if (posLeft === 0) {
       menu.classList.add('left-edge');
     }
   } else {
-    var menuRight = key.offsetLeft + this.keyWidth;
+    var menuRight = keyElem.offsetLeft + this.keyWidth;
     var posRight = cachedWindowWidth - menuRight;
     menu.style.right =  posRight + 'px';
     if (posRight === 0) {
@@ -82,12 +86,10 @@ AlternativesCharMenuView.prototype.show = function(key) {
 
   // Build a key for each alternative
   this.altChars.forEach(function(alt, index) {
-    var dataset = alt.length == 1 ?
-    [
-      { 'key': 'keycode', 'value': alt.charCodeAt(0) },
-      { 'key': 'keycodeUpper', 'value': alt.toUpperCase().charCodeAt(0) }
-    ] :
-    [ { 'key': 'compositeKey', 'value': alt } ];
+    var altKeyObj = alt.length == 1 ? {
+      keyCode: alt.charCodeAt(0),
+      keyCodeUpper: alt.toUpperCase().charCodeAt(0)
+    } : {'compositeKey': alt };
 
     // Make each of these alternative keys as wide as the key that
     // it is an alternative for, but adjust for the relative number of
@@ -121,8 +123,12 @@ AlternativesCharMenuView.prototype.show = function(key) {
       value: 'key'
     });
 
-    content.appendChild(
-        this.buildKey(alt, '', width + 'px', dataset, null, attributeList));
+    var altKeyElement =
+      this.buildKey(alt, '', width + 'px', altKeyObj, null, attributeList);
+
+    content.appendChild(altKeyElement);
+
+    IMERender.setDomElemTargetObject(altKeyElement, altKeyObj);
   }.bind(this));
 
   menu.appendChild(content);
@@ -199,7 +205,9 @@ AlternativesCharMenuView.prototype.getMenuTarget = function(x, y) {
   }
 
   var menuContainer = this.getMenuContainer();
-  return menuContainer.children[targetIndex];
+  return this.renderingManager.getTargetObject(
+           menuContainer.children[targetIndex]
+         );
 };
 
 })(window);

--- a/apps/keyboard/js/views/alternatives_char_menu.js
+++ b/apps/keyboard/js/views/alternatives_char_menu.js
@@ -126,6 +126,14 @@ AlternativesCharMenuView.prototype.show = function(key) {
     var altKeyElement =
       this.buildKey(alt, '', width + 'px', altKeyObj, null, attributeList);
 
+    // ui/integration test needs these attributes
+    if ('compositeKey' in altKeyObj){
+      altKeyElement.dataset.compositeKey = altKeyObj.compositeKey;
+    } else {
+      altKeyElement.dataset.keycode = altKeyObj.keyCode;
+      altKeyElement.dataset.keycodeUpper = altKeyObj.keyCodeUpper;
+    }
+
     content.appendChild(altKeyElement);
 
     IMERender.setDomElemTargetObject(altKeyElement, altKeyObj);


### PR DESCRIPTION
- render.js's key properties normalization is now done in layout_key_normalizer.js. The normalization for static layouts takes place in layout loader, when the layout is loaded. Layout Manager's on-the-fly generated keys are pre-normalized.
- Also, removed parseInt() on keycodes where suitable as we now retreive "number" from the objects held by WeakMap.

We have two WeakMaps, one maps DOM element to abstract target objects ("forward" map), and one maps inversely ("reverse" map)
Policy of accessing those WeakMaps is:
- IMERender and AltCharMenu(View) can set both forward and reverse maps by calling IMERender.setDomElemTargetObject, a small helper function.
- Everyone can retrieve forward mapping (elem to obj) in layoutRenderingManager with LRM.getTargetObject.
- Only IMERender and AltCharMenu(View) can retrieve reverse mapping (obj to elem) accessible through IMERender's reverse map (targetObjDomMap).
  -- currently we need to allow AltCharMenuManager to do so 'coz their responsibility and coupling aren't very clear.
  -- we probably need some refactoring work to reassign the responsibility and coupling such that targetObjDomMap isn't unnecessarily exposed.
