### PR TITLE
Bug 1059082 - [NFC] Could not share the contact which initial imported via NFC r=jmcf

### DIFF
--- a/apps/communications/contacts/js/contacts.js
+++ b/apps/communications/contacts/js/contacts.js
@@ -865,11 +865,6 @@ var Contacts = (function() {
     }
 
     document.addEventListener('visibilitychange', function visibility(e) {
-      if (ActivityHandler.currentlyHandling && document.hidden) {
-        ActivityHandler.postCancel();
-        return;
-      }
-
       Contacts.checkCancelableActivity();
       if (document.hidden === false &&
                                 navigation.currentView() === 'view-settings') {

--- a/apps/communications/contacts/test/unit/contacts_test.js
+++ b/apps/communications/contacts/test/unit/contacts_test.js
@@ -498,14 +498,6 @@ suite('Contacts', function() {
         }
       });
 
-      test('> handling an activity, should be cancelled', function() {
-        ActivityHandler.currentlyHandling = true;
-
-        fireVisibilityChange();
-
-        sinon.assert.called(ActivityHandler.postCancel);
-        ActivityHandler.currentlyHandling = false;
-      });
     });
   });
 });


### PR DESCRIPTION
Removing the code to abort any activity if we are being hidden.

We used this trick to avoid some problems with keyboard that won't happen any more, so bug 1028502 will be fix as well with same solution.
