### PR TITLE
Bug 1046799 - Include an option to manually configure email accounts without SSL

### DIFF
--- a/apps/email/js/cards/setup_manual_config.html
+++ b/apps/email/js/cards/setup_manual_config.html
@@ -104,6 +104,8 @@
                   SsL</option>
                 <option value="STARTTLS" data-l10n-id="setup-manual-socket-starttls">
                   StarttlS</option>
+                <option value="PLAIN" data-l10n-id="setup-manual-socket-plain">
+                  PlaiN</option>
               </select>
             </span>
           </li>
@@ -153,6 +155,8 @@
                   SsL</option>
                 <option value="STARTTLS" data-l10n-id="setup-manual-socket-starttls">
                   StarttlS</option>
+                <option value="PLAIN" data-l10n-id="setup-manual-socket-plain">
+                  PlaiN</option>
               </select>
             </span>
           </li>

--- a/apps/email/js/cards/tng/plain_socket_warning.html
+++ b/apps/email/js/cards/tng/plain_socket_warning.html
@@ -1,0 +1,15 @@
+<form role="dialog" class="tng-plain-socket-confirm" data-type="confirm">
+  <section>
+    <h1 data-l10n-id="tng-plain-socket-warning-title">CautioN</h1>
+    <p data-l10n-id="tng-plain-socket-warning-message">MessagE</p>
+    <p data-l10n-id="tng-plain-socket-warning-message-options">OptionS</p>
+  </section>
+  <menu>
+    <button class="ok-btn recommend tng-plain-socket-learn-more"
+            data-href="https://support.mozilla.org/kb/how-switch-secure-email-provider-firefox-os"
+            data-l10n-id="tng-plain-socket-learn-more">LearN MorE</button>
+    <button class="ok-btn confirm-dialog-ok"
+            data-l10n-id="tng-plain-socket-warning-ok">UnderstanD</button>
+
+  </menu>
+</form>

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -126,6 +126,13 @@ setup-manual-socket-starttls=STARTTLS
 # by screen readers and not shown on the screen.
 setup-manual-socket-select.ariaLabel=Connection security
 
+# LOCALIZATION NOTE (setup-manual-socket-plain): In manual config account setup,
+# the socket connect type that is not using an encrypted connection and
+# therefore can be insecure to use: hackers or bad actors could easily intercept
+# the email credentials and email messages. Choosing this option will also
+# result in showing a dialog with the tng-plain-socket-warning-* localizations.
+setup-manual-socket-plain=Unencrypted (insecure)
+
 setup-manual-hostname.placeholder=Hostname
 setup-manual-port.placeholder=Port Number
 setup-manual-username.placeholder=Username
@@ -688,3 +695,27 @@ new-emails-notify-multiple-accounts[other]={{ n }} New Emails ({{ accountName }}
 # as new-emails-notify-multiple-accounts.
 # This is the body part of the notification.
 new-emails-notify-multiple-accounts-body={{ from }} “{{ subject }}”
+
+# LOCALIZATION NOTE(tng-plain-socket-warning-title): When the user selects an
+# PLAIN socket connection type for the email connections in manual config, a
+# dialog is shown with this title.
+tng-plain-socket-warning-title=Are you sure?
+
+# LOCALIZATION NOTE(tng-plain-socket-warning-message): On the PLAIN socket
+# connection warning dialog, explains the hazards of using that option.
+tng-plain-socket-warning-message=Other people may be able to see your passwords and emails or control your account.
+
+# LOCALIZATION NOTE(tng-plain-socket-warning-message-options): On the PLAIN
+# socket connection warning dialog, lets the user know there are better, free
+# options for more secure email.
+tng-plain-socket-warning-message-options=There are multiple, free email providers that offer more secure, encrypted connections.
+
+# LOCALIZATION NOTE(tng-plain-socket-learn-more): The button in the PLAIN
+# socket connection warning dialog that explains more about the risks and about
+# alternative email providers that have better connection options.
+tng-plain-socket-learn-more=Learn more
+
+# LOCALIZATION NOTE(tng-plain-socket-warning-ok): The button the user taps to
+# indicate they understand the warning dialog about the PLAIN socket connection
+# type. This button also dismisses the dialog.
+tng-plain-socket-warning-ok=I understand


### PR DESCRIPTION
Started from a pull request from @acperez, but modified for email code idioms and bug feedback.
