### PR TITLE
Bug 1069169 - [callscreen] unittest call_sccreen_test.js incorrect using assert.include for testing existing object

### DIFF
--- a/apps/callscreen/test/unit/call_screen_test.js
+++ b/apps/callscreen/test/unit/call_screen_test.js
@@ -743,7 +743,7 @@ suite('call screen', function() {
     });
 
     test('should show the banner', function() {
-      assert.include(bannerClass, 'visible');
+      assert.isTrue(bannerClass.contains('visible'));
     });
     test('should show the text', function() {
       assert.equal(statusMessage.querySelector('p').textContent,


### PR DESCRIPTION
``` javascript
746: assert.include(bannerClass, 'visible');
```

assert.include - test inclusion of an object in another. Works for strings and Arrays, for other do nothing!!

later similar testing this property 

``` javascript
        test('should hide the banner', function() {
          assert.isFalse(bannerClass.contains('visible'));
        });
```
