### PR TITLE
Bug 1069176 - [homescreen] unittest configurator_test.js incorrect using assert.include for testing existing object property

### DIFF
--- a/apps/homescreen/test/unit/configurator_test.js
+++ b/apps/homescreen/test/unit/configurator_test.js
@@ -190,7 +190,7 @@ suite('configurator.js >', function() {
    */
   test('Search provider enabled >', function() {
     sendResponseText('{ "search_page":{ "provider": "em","enabled": true } }');
-    assert.include(document.body.classList, 'searchPageEnabled');
+    assert.isTrue(document.body.classList.contains('searchPageEnabled'));
     assertHomescreen(0);
   });
 


### PR DESCRIPTION
``` javascript
193: assert.include(document.body.classList, 'searchPageEnabled');
```

assert.include - test inclusion of an object in another. Works for strings and Arrays, for other do nothing!!
