### PR TITLE
Bug 1069184 - [ftu] unittest navigation_test.js incorrect using assert.include for testing existing object property

### DIFF
--- a/apps/ftu/test/unit/navigation_test.js
+++ b/apps/ftu/test/unit/navigation_test.js
@@ -176,7 +176,7 @@ suite('navigation >', function() {
     UIManager.activationScreen.classList.add('show');
 
     Navigation.forward();
-    assert.include(UIManager.finishScreen.classList, 'show');
+    assert.isTrue(UIManager.finishScreen.classList.contains('show'));
     assert.isFalse(UIManager.activationScreen.classList.contains('show'));
   });
 


### PR DESCRIPTION
``` javascript
178: Navigation.forward();
     assert.include(UIManager.finishScreen.classList, 'show');
     assert.isFalse(UIManager.activationScreen.classList.contains('show'));
```

assert.include - test inclusion of an object in another. Works for strings and Arrays, for other do nothing!! You may set any string - draft_draft for example and test OK!
