### PR TITLE
Bug 1068559

### DIFF
--- a/apps/camera/js/lib/camera/focus.js
+++ b/apps/camera/js/lib/camera/focus.js
@@ -145,23 +145,10 @@ Focus.prototype.suspendContinuousFocus = function(ms) {
 };
 
 Focus.prototype.onAutoFocusMoving = function(moving) {
-  var self = this;
-  if (moving) {
-    this.onAutoFocusChanged('focusing');
-    this.mozCamera.autoFocus(onSuccess, onError);
-    return;
-  }
-  function onError(err) {
-    if (err !== 'AutoFocusInterrupted') {
-      self.onAutoFocusChanged('error');
-      self.mozCamera.resumeContinuousFocus();
-    }
-  }
-  function onSuccess(state) {
-    state = state ? 'focused' : 'fail';
-    self.onAutoFocusChanged(state);
-    self.mozCamera.resumeContinuousFocus();
-  }
+  // Only need to update the UI because this is only triggered in
+  // continuous-video or continuous-picture focus modes where
+  // the driver handles the focus operations
+  this.onAutoFocusChanged(moving ? 'focusing' : 'focused');
 };
 
 Focus.prototype.onAutoFocusChanged = function(state) {

--- a/apps/camera/test/unit/lib/camera/focus_test.js
+++ b/apps/camera/test/unit/lib/camera/focus_test.js
@@ -263,23 +263,9 @@ suite('lib/camera/focus', function() {
 
     test('should call onAutoFocusChanged', function() {
       this.focus.onAutoFocusMoving(true);
-      assert.ok(this.focus.onAutoFocusChanged.called);
-      assert.ok(this.mozCamera.autoFocus.called);
-      this.mozCamera.autoFocus.callsArgWith(0, 1);
-      assert.ok(this.focus.onAutoFocusChanged.called);
-    });
-
-    test('should call onAutoFocusChanged after error', function() {
-      this.focus.onAutoFocusMoving(true);
-      assert.ok(this.focus.onAutoFocusChanged.called);
-      assert.ok(this.mozCamera.autoFocus.called);
-      this.mozCamera.autoFocus.callsArgWith(1, 'GeneralFailure');
-      assert.ok(this.focus.onAutoFocusChanged.called);
-    });
-
-    test('should not call onAutoFocusChanged', function() {
+      assert.ok(this.focus.onAutoFocusChanged.calledWith('focusing'));
       this.focus.onAutoFocusMoving(false);
-      assert.ok(!this.focus.onAutoFocusChanged.called);
+      assert.ok(this.focus.onAutoFocusChanged.calledWith('focused'));
     });
   });
 


### PR DESCRIPTION
Bug 1068559 - When auto focus is moving, only update the UI, don't trigger an auto focus.
