### PR TITLE
Bug 1068929 - We can't skip shared when looking for HTML files to localize

### DIFF
--- a/build/multilocale.js
+++ b/build/multilocale.js
@@ -487,7 +487,7 @@ function execute(options) {
       return;
     }
     var files = utils.ls(webapp.buildDirectoryFile, true,
-      /^(shared|tests?)$/);
+      /^tests?$/);
 
     l10nManager.localize(files.filter(function(file) {
       return /\.html$/.test(file.path);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1068929
