### PR TITLE
Bug 1070006 - [calendar] unit test change chai.assert api in the new version

### DIFF
--- a/apps/calendar/test/unit/controllers/alarm_test.js
+++ b/apps/calendar/test/unit/controllers/alarm_test.js
@@ -339,7 +339,7 @@ suiteGroup('Controllers.Alarm', function() {
           subject.handleAlarm(alarm, function() {
             Calendar.nextTick(function() {
               done(function() {
-                assert.length(sent, 0);
+                assert.lengthOf(sent, 0);
                 assert.ok(lock.mIsUnlocked, 'frees lock');
                 assert.ok(worksQueue, 'works alarm queue');
               });
@@ -573,7 +573,7 @@ suiteGroup('Controllers.Alarm', function() {
           var pending = 4;
 
           function onComplete() {
-            assert.length(locks, 4, 'has correct number of locks');
+            assert.lengthOf(locks, 4, 'has correct number of locks');
 
             var freedAll = locks.every(function(lock) {
               return lock.mIsUnlocked === true;

--- a/apps/calendar/test/unit/controllers/recurring_events_test.js
+++ b/apps/calendar/test/unit/controllers/recurring_events_test.js
@@ -177,7 +177,7 @@ suiteGroup('Controllers.RecurringEvents', function() {
 
       subject.queueExpand(date);
       assert.ok(subject.pending);
-      assert.length(expandCalls, 1);
+      assert.lengthOf(expandCalls, 1);
 
       // verify right date is being expanded.
       assert.deepEqual(expandCalls[0][0], date);

--- a/apps/calendar/test/unit/controllers/sync_test.js
+++ b/apps/calendar/test/unit/controllers/sync_test.js
@@ -267,7 +267,7 @@ suiteGroup('Controllers.Sync', function() {
         });
         assertEmit('syncStart');
 
-        assert.length(calendarSyncCalls, 1, 'emits syncComplete');
+        assert.lengthOf(calendarSyncCalls, 1, 'emits syncComplete');
 
         var sync = calendarSyncCalls[0];
 

--- a/apps/calendar/test/unit/controllers/time_test.js
+++ b/apps/calendar/test/unit/controllers/time_test.js
@@ -124,7 +124,7 @@ suite('Controllers.Time', function() {
     var calledWith;
 
     subject.on('scaleChange', function() {
-      calledWith = arguments;
+      calledWith = Array.slice(arguments);
     });
 
     subject.scale = 'year';
@@ -178,7 +178,7 @@ suite('Controllers.Time', function() {
       assert.equal(event.data, busy);
 
       query = subject.queryCache(busy);
-      assert.length(query, 0);
+      assert.lengthOf(query, 0);
     });
 
     test('disabled calendar', function() {
@@ -188,7 +188,7 @@ suite('Controllers.Time', function() {
 
       // should not return busytimes from disabled calendars
       var query = subject.queryCache(span);
-      assert.length(query, 0);
+      assert.lengthOf(query, 0);
 
       // should not dispatch event for disabled calendars
       assert.equal(event, null);
@@ -323,7 +323,7 @@ suite('Controllers.Time', function() {
         done(function() {
           assert.ok(!err);
           assert.ok(data);
-          assert.length(data, 1);
+          assert.lengthOf(data, 1);
 
           assert.deepEqual(data[0], {
             busytime: busytime
@@ -335,7 +335,7 @@ suite('Controllers.Time', function() {
     test('when given a busytime id (not cached)', function(done) {
       subject.findAssociated(hasAlarm._id, function(err, data) {
         done(function() {
-          assert.length(data, 1, 'has data');
+          assert.lengthOf(data, 1, 'has data');
           var item = data[0];
 
           assert.equal(item.busytime._id, hasAlarm._id, 'has alarm');
@@ -398,7 +398,7 @@ suite('Controllers.Time', function() {
       subject.findAssociated(noAlarm, options, function(err, result) {
         done(function() {
           assert.ok(!err);
-          assert.length(result, 1);
+          assert.lengthOf(result, 1);
           assert.deepEqual(result[0], expected);
         });
       });
@@ -564,7 +564,7 @@ suite('Controllers.Time', function() {
     function cacheTest(desc, cb) {
       test(desc, function(done) {
         spans = subject._timespans;
-        assert.length(spans, spanLength);
+        assert.lengthOf(spans, spanLength);
         // sanity check
         subject.cacheEvent(Factory('event'));
         cb();
@@ -573,7 +573,7 @@ suite('Controllers.Time', function() {
           // three ranges furthest from the
           // current point.
           done(function() {
-            assert.length(subject._timespans, max);
+            assert.lengthOf(subject._timespans, max);
             assert.deepEqual(subject._eventsCache, {}, 'removes event cache');
 
             if (toBeRemoved) {
@@ -605,7 +605,7 @@ suite('Controllers.Time', function() {
 
       subject.purgeCache();
       assert.isFalse(calledWith, 'miss - purged busytimes');
-      assert.length(
+      assert.lengthOf(
         Object.keys(subject._eventsCache), 1,
         'miss - purged events'
       );
@@ -614,7 +614,7 @@ suite('Controllers.Time', function() {
 
       subject.purgeCache();
       assert.isTrue(calledWith, 'hit - busytimes');
-      assert.length(Object.keys(subject._eventsCache), 0);
+      assert.lengthOf(Object.keys(subject._eventsCache), 0);
     });
 
     cacheTest('future - previous is missing', function() {
@@ -789,7 +789,7 @@ suite('Controllers.Time', function() {
         'should remove inRange'
       );
 
-      assert.length(events.remove, 1);
+      assert.lengthOf(events.remove, 1);
       assert.equal(events.remove[0], inRange);
 
     });
@@ -804,7 +804,7 @@ suite('Controllers.Time', function() {
         span
       );
 
-      assert.length(results, 2);
+      assert.lengthOf(results, 2);
       assert.deepEqual(
         subject.queryCache(span),
         results
@@ -960,7 +960,7 @@ suite('Controllers.Time', function() {
       );
 
       var results = subject.queryCache(span);
-      assert.length(results, 3);
+      assert.lengthOf(results, 3);
 
       // trim the private variables
       results.forEach(function(item) {
@@ -1085,7 +1085,7 @@ suite('Controllers.Time', function() {
             assert.ok(!subject.pending, 'should not be pending');
             // quick sanity check to verify we are cleaning up
             // the spans that are not used.
-            assert.length(subject._timespans, subject._maxTimespans);
+            assert.lengthOf(subject._timespans, subject._maxTimespans);
           });
         });
 
@@ -1159,7 +1159,7 @@ suite('Controllers.Time', function() {
             generateSpanOfMonth(2012, 1)
           ];
 
-          assert.length(subject._timespans, 6);
+          assert.lengthOf(subject._timespans, 6);
           assert.deepEqual(subject._timespans, expected);
         });
       });

--- a/apps/calendar/test/unit/db_test.js
+++ b/apps/calendar/test/unit/db_test.js
@@ -127,7 +127,7 @@ suite('db', function() {
         test('default account', function() {
           var list = Object.keys(storeLoads.accounts);
 
-          assert.length(list, 1);
+          assert.lengthOf(list, 1);
 
           var item = storeLoads.accounts[list[0]];
 
@@ -138,7 +138,7 @@ suite('db', function() {
 
         test('default calendar', function() {
           var list = Object.keys(storeLoads.calendars);
-          assert.length(list, 1);
+          assert.lengthOf(list, 1);
 
           var item = storeLoads.calendars[list[0]];
 

--- a/apps/calendar/test/unit/load_config_test.js
+++ b/apps/calendar/test/unit/load_config_test.js
@@ -60,7 +60,7 @@ suite('load_config', function() {
           'script[src*="from_loader_test.js"]'
         );
 
-        assert.length(scripts, 1, 'only loads once');
+        assert.lengthOf(scripts, 1, 'only loads once');
       });
     });
   });
@@ -76,7 +76,7 @@ suite('load_config', function() {
       );
 
       done(function() {
-        assert.length(link, 1);
+        assert.lengthOf(link, 1);
       });
     });
   });

--- a/apps/calendar/test/unit/models/event_test.js
+++ b/apps/calendar/test/unit/models/event_test.js
@@ -221,7 +221,7 @@ suiteGroup('Models.Event', function() {
 
     function hasError(event, type) {
       var errors = event.validationErrors();
-      assert.length(errors, 1);
+      assert.lengthOf(errors, 1);
       assert.deepEqual(
         errors[0], {
           name: type

--- a/apps/calendar/test/unit/ordered_map_test.js
+++ b/apps/calendar/test/unit/ordered_map_test.js
@@ -75,7 +75,7 @@ suite('ordered_map', function() {
         subject.items[1][0], 8,
         'should not remove unrelated item'
       );
-      assert.length(subject, 2);
+      assert.lengthOf(subject, 2);
     });
 
     test('before', function() {

--- a/apps/calendar/test/unit/provider/caldav_pull_events_test.js
+++ b/apps/calendar/test/unit/provider/caldav_pull_events_test.js
@@ -515,7 +515,7 @@ suiteGroup('Provider.CaldavPullEvents', function() {
       test('event', function(done) {
         eventStore.findByIds([newEvent._id], function(err, list) {
           done(function() {
-            assert.length(Object.keys(list), 1, 'saved events');
+            assert.lengthOf(Object.keys(list), 1, 'saved events');
             assert.ok(list[newEvent._id], 'saved event id');
           });
         });
@@ -565,7 +565,7 @@ suiteGroup('Provider.CaldavPullEvents', function() {
       assert.ok(alarms, 'has alarms');
 
       stream.emit('occurrence', times[0]);
-      assert.length(subject.busytimeQueue, 1);
+      assert.lengthOf(subject.busytimeQueue, 1);
 
       // ids are unique each time
       expected._id = subject.busytimeQueue[0]._id;
@@ -614,7 +614,7 @@ suiteGroup('Provider.CaldavPullEvents', function() {
       expected.calendarId = calendar._id;
 
       stream.emit('component', data);
-      assert.length(subject.icalQueue, 1);
+      assert.lengthOf(subject.icalQueue, 1);
 
       assert.deepEqual(
         subject.icalQueue[0],
@@ -629,7 +629,7 @@ suiteGroup('Provider.CaldavPullEvents', function() {
       };
 
       stream.emit('component', data);
-      assert.length(subject.icalQueue, 1);
+      assert.lengthOf(subject.icalQueue, 1);
 
       assert.ok(
         !('lastRecurrenceId' in subject.icalQueue[0]),
@@ -645,7 +645,7 @@ suiteGroup('Provider.CaldavPullEvents', function() {
       // the results by using the same object during the test.
       var control = serviceEvent('recurringEvent');
       control = subject.formatEvent(control);
-      assert.length(control.remote.exceptions, 2);
+      assert.lengthOf(control.remote.exceptions, 2);
 
       var exceptions = control.remote.exceptions;
       delete control.remote.exceptions;
@@ -657,8 +657,8 @@ suiteGroup('Provider.CaldavPullEvents', function() {
       var event = serviceEvent('recurringEvent');
       stream.emit('event', event);
 
-      assert.length(subject.eventQueue, 3);
-      assert.length(subject.icalQueue, 1);
+      assert.lengthOf(subject.eventQueue, 3);
+      assert.lengthOf(subject.icalQueue, 1);
 
       assert.hasProperties(
         subject.icalQueue[0],
@@ -699,7 +699,7 @@ suiteGroup('Provider.CaldavPullEvents', function() {
 
       stream.emit('event', newEvent);
 
-      assert.length(
+      assert.lengthOf(
         subject.eventQueue,
         1
       );

--- a/apps/calendar/test/unit/responder_test.js
+++ b/apps/calendar/test/unit/responder_test.js
@@ -19,7 +19,7 @@ suite('responder', function() {
     var calledWith;
 
     subject.on('test', function() {
-      calledWith = arguments;
+      calledWith = Array.slice(arguments);
     });
 
     subject.respond(['test', 'one', 'two', 'three']);

--- a/apps/calendar/test/unit/service/caldav_test.js
+++ b/apps/calendar/test/unit/service/caldav_test.js
@@ -100,7 +100,7 @@ suite('service/caldav', function() {
       var calledWith;
 
       subject[event] = function() {
-        calledWith = arguments;
+        calledWith = Array.slice(arguments);
       };
 
       service.emit(event, 1, 2, 3, 4);
@@ -282,7 +282,7 @@ suite('service/caldav', function() {
         );
 
         assert.ok(!result.recurrenceId);
-        assert.length(result.exceptions, 2);
+        assert.lengthOf(result.exceptions, 2);
 
         var key;
         var exceptions = result.exceptions;
@@ -409,7 +409,7 @@ suite('service/caldav', function() {
           );
 
           var alarm = subject._displayAlarms(detail);
-          assert.length(alarm, 1, 'has alarms');
+          assert.lengthOf(alarm, 1, 'has alarms');
 
           var start = detail.startDate.clone();
           start.adjust(0, 0, -5, 0);
@@ -489,7 +489,7 @@ suite('service/caldav', function() {
         var details = icalEvent.getOccurrenceDetails(next);
 
         var alarms = subject._displayAlarms(details);
-        assert.length(alarms, 2);
+        assert.lengthOf(alarms, 2);
 
         var date = icalEvent.startDate.clone();
         date.adjust(0, 0, -30, 0);
@@ -630,15 +630,15 @@ suite('service/caldav', function() {
           }
 
           done(function() {
-            assert.length(occurrences, 1);
-            assert.length(events, 1);
+            assert.lengthOf(occurrences, 1);
+            assert.lengthOf(events, 1);
             var formatted = subject._formatEvent(
               'abcd', url,
               fixtures.singleEvent,
               icalEvent
             );
 
-            assert.length(components, 1);
+            assert.lengthOf(components, 1);
 
             assert.deepEqual(events, [formatted]);
             assert.deepEqual(
@@ -689,7 +689,7 @@ suite('service/caldav', function() {
 
             var lastOccurence = occurrences[occurrences.length - 1];
 
-            assert.length(components, 1, 'has component');
+            assert.lengthOf(components, 1, 'has component');
 
             assert.hasProperties(
               components[0],
@@ -830,7 +830,7 @@ suite('service/caldav', function() {
     test('all sent events', function() {
       var expectedKeys = Object.keys(components);
 
-      assert.length(
+      assert.lengthOf(
         events.component,
         expectedKeys.length,
         'returns same number of components sent'
@@ -1155,7 +1155,7 @@ suite('service/caldav', function() {
         done(function() {
           assert.instanceOf(event, ICAL.Event);
           var exceptions = Object.keys(event.exceptions);
-          assert.length(exceptions, 2);
+          assert.lengthOf(exceptions, 2);
         });
       });
     });
@@ -1285,7 +1285,7 @@ suite('service/caldav', function() {
             return;
           }
 
-          assert.length(actual, expected.length);
+          assert.lengthOf(actual, expected.length);
           assert.deepEqual(actual, expected, 'expected occurrences');
 
           assert.deepEqual(
@@ -1328,7 +1328,7 @@ suite('service/caldav', function() {
             return;
           }
 
-          assert.length(actual, expected.length);
+          assert.lengthOf(actual, expected.length);
           assert.deepEqual(actual, expected, 'expected occurrences');
 
           done();

--- a/apps/calendar/test/unit/service/ical_recur_expansion_test.js
+++ b/apps/calendar/test/unit/service/ical_recur_expansion_test.js
@@ -149,7 +149,7 @@ suite('service/ical_recur_expansion', function() {
             inclusiveDates[0]
           );
 
-          assert.length(sent, forEachLimit, 'limit bounds');
+          assert.lengthOf(sent, forEachLimit, 'limit bounds');
         });
 
         test('min verify exclusive', function() {
@@ -169,7 +169,7 @@ suite('service/ical_recur_expansion', function() {
             inclusiveDates[1]
           );
 
-          assert.length(sent, forEachLimit, 'limit bounds');
+          assert.lengthOf(sent, forEachLimit, 'limit bounds');
         });
       }
 
@@ -266,7 +266,7 @@ suite('service/ical_recur_expansion', function() {
         });
 
         assert.instanceOf(iter, ICAL.RecurExpansion);
-        assert.length(sent, forEachLimit);
+        assert.lengthOf(sent, forEachLimit);
 
         // test sanity we need an infinite recur iterator
         // or our tests simply suck...

--- a/apps/calendar/test/unit/store/abstract_test.js
+++ b/apps/calendar/test/unit/store/abstract_test.js
@@ -370,7 +370,7 @@ suite('store/abstract', function() {
       var results = [];
 
       function complete() {
-        assert.length(results, expected);
+        assert.lengthOf(results, expected);
 
         var idx = 1;
 

--- a/apps/calendar/test/unit/store/account_test.js
+++ b/apps/calendar/test/unit/store/account_test.js
@@ -449,7 +449,7 @@ suite('store/account', function() {
     });
 
     test('found accounts', function() {
-      assert.length(results, 1);
+      assert.lengthOf(results, 1);
       assert.equal(results[0]._id, accounts.sync._id);
     });
 

--- a/apps/calendar/test/unit/store/alarm_test.js
+++ b/apps/calendar/test/unit/store/alarm_test.js
@@ -281,7 +281,7 @@ suite('store/alarm', function() {
       });
 
       test('after', function() {
-        assert.length(added, 0);
+        assert.lengthOf(added, 0);
       });
     });
 
@@ -296,7 +296,7 @@ suite('store/alarm', function() {
       });
 
       test('after complete', function() {
-        assert.length(added, 1);
+        assert.lengthOf(added, 1);
 
         assert.deepEqual(
           added[0][0],
@@ -314,7 +314,7 @@ suite('store/alarm', function() {
       });
 
       test('after complete', function() {
-        assert.length(added, 1);
+        assert.lengthOf(added, 1);
 
         assert.deepEqual(
           added[0][0],
@@ -377,7 +377,7 @@ suite('store/alarm', function() {
       */
 
       test('after complete', function() {
-        assert.length(added, 2);
+        assert.lengthOf(added, 2);
 
         assert.deepEqual(added[0][0], new Date(2018, 0, 1, 5));
         assert.equal(

--- a/apps/calendar/test/unit/store/ical_component_test.js
+++ b/apps/calendar/test/unit/store/ical_component_test.js
@@ -87,7 +87,7 @@ suite('store/ical_component', function() {
     test('found', function(done) {
       subject.findRecurrencesBefore(max, function(err, list) {
         done(function() {
-          assert.length(list, expected.length);
+          assert.lengthOf(list, expected.length);
           assert.deepEqual(list, expected);
         });
       });

--- a/apps/calendar/test/unit/store/setting_test.js
+++ b/apps/calendar/test/unit/store/setting_test.js
@@ -53,7 +53,7 @@ suite('store/setting', function() {
 
     setup(function(done) {
       subject.on(name + 'Change', function() {
-        calledEvent = arguments;
+        calledEvent = Array.slice(arguments);
       });
       subject.set(name, 'first', done);
     });

--- a/apps/calendar/test/unit/views/advanced_settings_test.js
+++ b/apps/calendar/test/unit/views/advanced_settings_test.js
@@ -151,7 +151,7 @@ suiteGroup('Views.AdvancedSettings', function() {
           providerType: 'Local'
         }));
 
-        assert.length(children, 1, 'does not add account');
+        assert.lengthOf(children, 1, 'does not add account');
       });
     });
 

--- a/apps/calendar/test/unit/views/day_based_test.js
+++ b/apps/calendar/test/unit/views/day_based_test.js
@@ -100,11 +100,11 @@ suiteGroup('Views.DayBased', function() {
       addCalledWith = [];
 
       subject.add = function() {
-        addCalledWith.push(arguments);
+        addCalledWith.push(Array.slice(arguments));
       };
 
       controller.findAssociated = function() {
-        requestCalledWith.push(arguments);
+        requestCalledWith.push(Array.slice(arguments));
       };
     });
 
@@ -313,7 +313,7 @@ suiteGroup('Views.DayBased', function() {
         '[data-id="' + busytime._id + '"]'
       );
 
-      assert.length(elements, 1);
+      assert.lengthOf(elements, 1);
 
       var record = hour.records.get(id);
       assert.isTrue(record);
@@ -507,7 +507,7 @@ suiteGroup('Views.DayBased', function() {
     test('allday', function() {
       subject.createHour('allday');
       var parent = subject.allDayElement;
-      assert.length(parent.children, 1);
+      assert.lengthOf(parent.children, 1);
     });
 
     test('first', function() {
@@ -625,7 +625,7 @@ suiteGroup('Views.DayBased', function() {
     );
 
     displayedHours.forEach(subject.removeHour, subject);
-    assert.length(subject.hours, 0);
+    assert.lengthOf(subject.hours, 0);
 
     list.forEach(function(el) {
       assert.ok(!el.parentNode, 'removed element');

--- a/apps/calendar/test/unit/views/modify_account_test.js
+++ b/apps/calendar/test/unit/views/modify_account_test.js
@@ -193,7 +193,7 @@ suiteGroup('Views.ModifyAccount', function() {
     setup(function() {
       handler = subject.accountHandler;
       subject.showErrors = function() {
-        showErrorCall = arguments;
+        showErrorCall = Array.slice(arguments);
       };
     });
 
@@ -231,12 +231,12 @@ suiteGroup('Views.ModifyAccount', function() {
       // we don't really need to redirect
       // in the test just confirm that it does
       app.router.show = function() {
-        calledShow = arguments;
+        calledShow = Array.slice(arguments);
       };
 
       // again fake model so we do a fake remove
       store.remove = function() {
-        calledRemove = arguments;
+        calledRemove = Array.slice(arguments);
       };
     });
 

--- a/apps/calendar/test/unit/views/month_test.js
+++ b/apps/calendar/test/unit/views/month_test.js
@@ -206,7 +206,7 @@ suiteGroup('Views.Month', function() {
       subject._selectDay(select);
 
       var dayEl = selected();
-      assert.length(dayEl, 1, 'should highlight selected');
+      assert.lengthOf(dayEl, 1, 'should highlight selected');
 
       dayEl = dayEl[0];
 
@@ -218,15 +218,15 @@ suiteGroup('Views.Month', function() {
 
     test('#_clearSelectedDay', function() {
       subject.render();
-      assert.length(selected(), 0);
+      assert.lengthOf(selected(), 0);
 
       var el = subject.element.querySelector('li');
       el.classList.add('selected');
 
-      assert.length(selected(), 1);
+      assert.lengthOf(selected(), 1);
       subject._clearSelectedDay();
 
-      assert.length(selected(), 0);
+      assert.lengthOf(selected(), 0);
     });
 
   });

--- a/apps/calendar/test/unit/views/time_parent_test.js
+++ b/apps/calendar/test/unit/views/time_parent_test.js
@@ -214,7 +214,7 @@ suiteGroup('Views.TimeParent', function() {
 
       assert.ok(!curFrame.active, 'deactivated previously current');
       assert.ok(subject.frames.get(curId), 'previous id is still present');
-      assert.length(subject.frames, 4);
+      assert.lengthOf(subject.frames, 4);
     });
 
     test('max frame pruge', function() {
@@ -243,13 +243,13 @@ suiteGroup('Views.TimeParent', function() {
       next = subject.frames.get(next);
 
       // verify frames exist
-      assert.length(subject.frames, 3, 'trims extra frames when over max');
+      assert.lengthOf(subject.frames, 3, 'trims extra frames when over max');
       assert.ok(subject.frames.has(cur), 'cur');
       assert.ok(subject.frames.has(prev), 'prev');
       assert.ok(subject.frames.has(next), 'next');
 
       // verify other children where removed
-      assert.length(subject.frameContainer.children, 3);
+      assert.lengthOf(subject.frameContainer.children, 3);
     });
 
     test('the same scrollTop between day ane week views', function() {


### PR DESCRIPTION
test_agent used very old version chai library version=0.5.3
in the current version=1.9.1 same api chenged 
1. assert.length -> assert.lengthOf
2. assert.deepEqual(arguments, [x,x, ... ]) -> assert.deepEqual(Array.slice(arguments))
3. assert.include - only for string and Array - fail for other
