### PR TITLE
Bug 1069645 - Download b2g sdk only if running desktop builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -630,6 +630,8 @@ b2g_sdk:
 	@echo "Test SDK directory: $(XULRUNNER_DIRECTORY)"
 ifndef USE_LOCAL_XULRUNNER_SDK
 ifneq ($(B2G_SDK_URL),$(shell test -d $(XULRUNNER_DIRECTORY) && cat $(B2G_SDK_URL_FILE) 2> /dev/null))
+ifeq ($(BUILDAPP),desktop)
+	@echo $(BUILDAPP)
 	rm -rf $(XULRUNNER_DIRECTORY)
 	mkdir -p "$(XULRUNNER_DIRECTORY)"
 	@echo "Downloading B2G SDK..."
@@ -648,6 +650,7 @@ else
 endif
 	@rm -rf $(B2G_SDK_TMP) $(B2G_SDK_FILE_NAME)
 	@echo $(B2G_SDK_URL) > $(B2G_SDK_URL_FILE)
+endif # ends BUILDAPP=desktop block
 endif # B2G SDK is up to date
 endif # USE_LOCAL_XULRUNNER_SDK
 	test -f $(XPCSHELLSDK)

--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -94,19 +94,20 @@ if [ -z "$XULRUNNER_DIRECTORY" ] ; then
   XULRUNNER_DIRECTORY=$(ls -d "$DIR"/../b2g_sdk/* | sort -nr | head -n1 2> /dev/null)
 fi
 
-if [ ! -d "$XULRUNNER_DIRECTORY" ] ; then
-  echo "Couldn't find B2G. Please execute this file from 'make' or install B2G yourself."
-  exit 1
+if [ "$BUILDAPP" == "desktop" ] ; then 
+  if [ ! -d "$XULRUNNER_DIRECTORY" ] ; then
+    echo "Couldn't find B2G. Please execute this file from 'make' or install B2G yourself."
+    exit 1
+  fi
+  if [ -z "$XPCSHELLSDK" ] ; then
+    XPCSHELLSDK=$(find "$XULRUNNER_DIRECTORY" -type f -name xpcshell | sort -nr | head -n1 2> /dev/null)
+  fi
+  if [ ! -e "$XPCSHELLSDK" ] ; then
+    echo "Couldn't find B2G. Please execute this file from 'make' or install B2G yourself."
+    exit 1
+  fi
 fi
 
-if [ -z "$XPCSHELLSDK" ] ; then
-  XPCSHELLSDK=$(find "$XULRUNNER_DIRECTORY" -type f -name xpcshell | sort -nr | head -n1 2> /dev/null)
-fi
-
-if [ ! -e "$XPCSHELLSDK" ] ; then
-  echo "Couldn't find B2G. Please execute this file from 'make' or install B2G yourself."
-  exit 1
-fi
 
 # find xpcshell and put it in the path
 XPCSHELL_DIR=$(dirname "$XPCSHELLSDK")


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1069645, only download the sdk if necessary
