### PR TITLE
Bug 1056192 - kill js runner if listener is killed

### DIFF
--- a/tests/python/runner-service/runner_service/listener.py
+++ b/tests/python/runner-service/runner_service/listener.py
@@ -17,7 +17,10 @@ def call_handlers(func):
         handler_name = '%s_handlers' % func.__name__[3:]
         handlers = getattr(cls, handler_name, [])
         for handler in handlers:
-            handler(data)
+            try:
+                handler(data)
+            except:
+                cls.worker.send_json({'action': 'ready_stop'})
         return func(cls, data)
     return _
 


### PR DESCRIPTION
if we send SIGINT while js is calling into python, then the SocketListener receives the SIGINT and dies, but never notifies the js process it's communicating with to shut down. This sends back a message that will stop the js runner.
