### PR TITLE
Bug 1070495 - [ringtones] unit test refactoring for new version chai.assert api

### DIFF
--- a/apps/ringtones/test/unit/custom_ringtones_test.js
+++ b/apps/ringtones/test/unit/custom_ringtones_test.js
@@ -52,6 +52,13 @@ suite('custom ringtones', function() {
   suite('non-empty database', function() {
 
     var testTone;
+    
+    var toneDeepEqual = function (test, expected, msg) {
+      assert.equal(test.name, expected.name, msg);
+      assert.equal(test.blob, expected.blob, msg);
+      assert.equal(test.id, expected.id, msg);
+      assert.equal(test.subtitle, expected.subtitle, msg);
+    };
 
     setup(function(done) {
       var info = {name: 'My ringtone', blob: testBlob};
@@ -68,8 +75,7 @@ suite('custom ringtones', function() {
         done(function() {
           assert.ok(Array.isArray(tones));
           assert.equal(tones.length, 1);
-
-          assert.deepEqual(tones[0], testTone);
+          toneDeepEqual(tones[0], testTone);
         });
       }, function(error) {
         done(error);
@@ -93,7 +99,7 @@ suite('custom ringtones', function() {
     test('get()', function(done) {
       window.customRingtones.get(testTone.id).then(function(tone) {
         done(function() {
-          assert.deepEqual(tone, testTone);
+          toneDeepEqual(tone, testTone);
         });
       }, function(error) {
         done(error);


### PR DESCRIPTION
test_agent used very old version chai library version=0.5.3
in the current version=1.9.1 deepEqual take prototype into consideration - problem with tone.url

this version working with both version chaijs
