### PR TITLE
Bug 1069808 - Make the LazyLoader.getJSON() helper invoke reject() in ca...

### DIFF
--- a/apps/sharedtest/test/unit/lazy_loader_test.js
+++ b/apps/sharedtest/test/unit/lazy_loader_test.js
@@ -47,6 +47,34 @@ suite('lazy loader', function() {
       });
   });
 
+  test('load malformed json', function(done) {
+    LazyLoader.getJSON('/apps/sharedtest/test/unit/support/malformedJson')
+      .then(function(json) {
+        done(new Error('A resolve promise was returned.' +
+                       ' Expected Reject promise'));
+      }, function(error) {
+        done(function() {
+          assert.instanceOf(error, Error);
+          assert.equal(error.message,
+                       'No valid JSON object was found (200 OK)');
+        });
+      });
+  });
+
+  test('load inexisting json', function(done) {
+    LazyLoader.getJSON('/apps/sharedtest/test/unit/support/non_existant.json')
+      .then(function(json) {
+        done(new Error('Resolve promise was returned.' +
+                       ' Expected Reject promise'));
+      }, function(error) {
+        done(function() {
+          assert.instanceOf(error, Error);
+          assert.equal(error.message,
+                       'No valid JSON object was found (404 Not Found)');
+        });
+      });
+  });
+
   test('append single js script', function(done) {
     LazyLoader.load('support/inc.js', function() {
       assert.equal(window.jsCount, 1);

--- a/apps/sharedtest/test/unit/support/malformedJson
+++ b/apps/sharedtest/test/unit/support/malformedJson
@@ -1,0 +1,3 @@
+{
+  "org" "Mozilla"
+}

--- a/shared/js/lazy_loader.js
+++ b/shared/js/lazy_loader.js
@@ -81,7 +81,12 @@ var LazyLoader = (function() {
           reject(error);
         };
         xhr.onload = function() {
-          resolve(xhr.response);
+          if (xhr.response !== null) {
+            resolve(xhr.response);
+          } else {
+            reject(new Error('No valid JSON object was found (' + 
+			     xhr.status + ' ' + xhr.statusText + ')'));
+          }
         };
 
         xhr.send();


### PR DESCRIPTION
...se of errors instead of resolving the promise to null

https://bugzilla.mozilla.org/show_bug.cgi?id=1069808
