### PR TITLE
Bug 1070681 - [communications] unit test refactoring for new version chai.assert api

### DIFF
--- a/apps/communications/contacts/test/unit/export/generic_export_test.js
+++ b/apps/communications/contacts/test/unit/export/generic_export_test.js
@@ -155,7 +155,7 @@ suite('Contacts Exporter', function() {
   test('Correct initialization given an array of ids', function(done) {
     subject.init(ids, function onInitDone(contacts) {
       var expectedContacts = getContactsForIds(ids);
-      assert.length(contacts, 2);
+      assert.lengthOf(contacts, 2);
       assert.notStrictEqual(expectedContacts, contacts);
       done();
     });

--- a/apps/communications/contacts/test/unit/import/gmail/gmail_connector_test.js
+++ b/apps/communications/contacts/test/unit/import/gmail/gmail_connector_test.js
@@ -36,7 +36,7 @@ suite('Gmail Connector', function() {
         'success': function onSuccess(result) {
           assert.isNotNull(result);
           assert.isNotNull(result.data);
-          assert.length(result.data, 2);
+          assert.lengthOf(result.data, 2);
           done();
         },
         'error': function onError(error) {
@@ -102,22 +102,22 @@ suite('Gmail Connector', function() {
 
       assert.isNotNull(result);
       assert.isNotNull(result.givenName);
-      assert.length(result.givenName, 1);
+      assert.lengthOf(result.givenName, 1);
       assert.equal(result.givenName[0], 'My');
 
       assert.isNotNull(result.familyName);
-      assert.length(result.familyName, 1);
+      assert.lengthOf(result.familyName, 1);
       assert.equal(result.familyName[0], 'Contact');
 
       assert.isNotNull(result.email);
-      assert.length(result.email, 2);
+      assert.lengthOf(result.email, 2);
       assert.equal('juan@palomo.es', result.email[0].value);
       assert.equal('home', result.email[0].type);
       assert.equal('workemail@email.com', result.email[1].value);
       assert.equal('work', result.email[1].type);
 
       assert.isNotNull(result.adr);
-      assert.length(result.adr, 1);
+      assert.lengthOf(result.adr, 1);
       assert.equal('This is the Street', result.adr[0].streetAddress);
       assert.equal('The City', result.adr[0].locality);
       assert.equal('The State', result.adr[0].region);
@@ -125,32 +125,32 @@ suite('Gmail Connector', function() {
       assert.equal('The Country', result.adr[0].countryName);
 
       assert.isNotNull(result.tel);
-      assert.length(result.tel, 1);
+      assert.lengthOf(result.tel, 1);
       assert.equal('+1555111333444222', result.tel[0].value);
       assert.equal('work', result.tel[0].type);
 
       assert.isNotNull(result.org);
-      assert.length(result.org, 1);
+      assert.lengthOf(result.org, 1);
       assert.equal('The Company', result.org[0]);
 
       assert.isNotNull(result.jobTitle);
-      assert.length(result.jobTitle, 1);
+      assert.lengthOf(result.jobTitle, 1);
       assert.equal('Title in Company', result.jobTitle[0]);
 
       assert.isNotNull(result.bday);
       assert.deepEqual(new Date('1990-01-01'), result.bday);
 
       assert.isNotNull(result.note);
-      assert.length(result.note, 1);
+      assert.lengthOf(result.note, 1);
       assert.equal('This is a Note', result.note[0]);
 
       assert.isNotNull(result.category);
-      assert.length(result.category, 1);
+      assert.lengthOf(result.category, 1);
       assert.equal('gmail', result.category[0]);
 
       assert.isNotNull(result.url);
-      assert.length(result.url, 1);
-      assert.length(result.url[0].type, 1);
+      assert.lengthOf(result.url, 1);
+      assert.lengthOf(result.url[0].type, 1);
       assert.equal('source', result.url[0].type[0]);
       assert.equal('urn:service:gmail:uid:' +
         'http://www.google.com/m8/feeds/contacts/' +
@@ -167,14 +167,14 @@ suite('Gmail Connector', function() {
       assert.isTrue(!result.familyName);
 
       assert.isNotNull(result.email);
-      assert.length(result.email, 2);
+      assert.lengthOf(result.email, 2);
       assert.equal('juan@palomo.es', result.email[0].value);
       assert.equal('home', result.email[0].type);
       assert.equal('workemail@email.com', result.email[1].value);
       assert.equal('work', result.email[1].type);
 
       assert.isNotNull(result.adr);
-      assert.length(result.adr, 1);
+      assert.lengthOf(result.adr, 1);
       assert.equal('This is the Street', result.adr[0].streetAddress);
       assert.equal('The City', result.adr[0].locality);
       assert.equal('The State', result.adr[0].region);
@@ -182,32 +182,32 @@ suite('Gmail Connector', function() {
       assert.equal('The Country', result.adr[0].countryName);
 
       assert.isNotNull(result.tel);
-      assert.length(result.tel, 1);
+      assert.lengthOf(result.tel, 1);
       assert.equal('+1555111333444222', result.tel[0].value);
       assert.equal('work', result.tel[0].type);
 
       assert.isNotNull(result.org);
-      assert.length(result.org, 1);
+      assert.lengthOf(result.org, 1);
       assert.equal('The Company', result.org[0]);
 
       assert.isNotNull(result.jobTitle);
-      assert.length(result.jobTitle, 1);
+      assert.lengthOf(result.jobTitle, 1);
       assert.equal('Title in Company', result.jobTitle[0]);
 
       assert.isNotNull(result.bday);
       assert.deepEqual(new Date('1990-01-01'), result.bday);
 
       assert.isNotNull(result.note);
-      assert.length(result.note, 1);
+      assert.lengthOf(result.note, 1);
       assert.equal('This is a Note', result.note[0]);
 
       assert.isNotNull(result.category);
-      assert.length(result.category, 1);
+      assert.lengthOf(result.category, 1);
       assert.equal('gmail', result.category[0]);
 
       assert.isNotNull(result.url);
-      assert.length(result.url, 1);
-      assert.length(result.url[0].type, 1);
+      assert.lengthOf(result.url, 1);
+      assert.lengthOf(result.url[0].type, 1);
       assert.equal('source', result.url[0].type[0]);
       assert.equal('urn:service:gmail:uid:' +
         'http://www.google.com/m8/feeds/contacts/' +
@@ -222,22 +222,22 @@ suite('Gmail Connector', function() {
 
       assert.isNotNull(result);
       assert.isNotNull(result.givenName);
-      assert.length(result.givenName, 1);
+      assert.lengthOf(result.givenName, 1);
       assert.equal(result.givenName[0], 'My');
 
       assert.isNotNull(result.familyName);
-      assert.length(result.familyName, 1);
+      assert.lengthOf(result.familyName, 1);
       assert.equal(result.familyName[0], 'Contact');
 
       assert.isNotNull(result.email);
-      assert.length(result.email, 2);
+      assert.lengthOf(result.email, 2);
       assert.equal('juan@palomo.es', result.email[0].value);
       assert.equal('home', result.email[0].type);
       assert.equal('workemail@email.com', result.email[1].value);
       assert.equal('work', result.email[1].type);
 
       assert.isNotNull(result.adr);
-      assert.length(result.adr, 1);
+      assert.lengthOf(result.adr, 1);
       assert.equal('This is the Street', result.adr[0].streetAddress);
       assert.equal('The City', result.adr[0].locality);
       assert.equal('The State', result.adr[0].region);
@@ -245,31 +245,31 @@ suite('Gmail Connector', function() {
       assert.equal('The Country', result.adr[0].countryName);
 
       assert.isNotNull(result.tel);
-      assert.length(result.tel, 1);
+      assert.lengthOf(result.tel, 1);
       assert.equal('+1555111333444222', result.tel[0].value);
       assert.equal('work', result.tel[0].type);
 
       assert.isNotNull(result.org);
-      assert.length(result.org, 1);
+      assert.lengthOf(result.org, 1);
       assert.equal('The Company', result.org[0]);
 
       assert.isNotNull(result.jobTitle);
-      assert.length(result.jobTitle, 1);
+      assert.lengthOf(result.jobTitle, 1);
       assert.equal('Title in Company', result.jobTitle[0]);
 
       assert.isUndefined(result.bday);
 
       assert.isNotNull(result.note);
-      assert.length(result.note, 1);
+      assert.lengthOf(result.note, 1);
       assert.equal('This is a Note', result.note[0]);
 
       assert.isNotNull(result.category);
-      assert.length(result.category, 1);
+      assert.lengthOf(result.category, 1);
       assert.equal('gmail', result.category[0]);
 
       assert.isNotNull(result.url);
-      assert.length(result.url, 1);
-      assert.length(result.url[0].type, 1);
+      assert.lengthOf(result.url, 1);
+      assert.lengthOf(result.url[0].type, 1);
       assert.equal('source', result.url[0].type[0]);
       assert.equal('urn:service:gmail:uid:' +
         'http://www.google.com/m8/feeds/contacts/' +

--- a/apps/communications/contacts/test/unit/utilities/ice_data_test.js
+++ b/apps/communications/contacts/test/unit/utilities/ice_data_test.js
@@ -29,50 +29,47 @@ suite('ICE Data', function() {
 
   suite('> Load data', function() {
     test('> Check data from async storage', function(done) {
-      subject.load().then(function() {
+      subject.load().then(done(function() {
         var iceContacts = subject.iceContacts;
-        assert.length(iceContacts, 2);
+        assert.lengthOf(iceContacts, 2);
         assert.isTrue(iceContacts[0].active);
         assert.equal(iceContacts[0].id, 1);
         assert.isFalse(iceContacts[1].active);
-        done();
-      }, done);
+      }), done);
     });
 
     test('> With no ice local async data', function(done) {
       window.asyncStorage.keys = {};
-      subject.load().then(function() {
+      subject.load().then(done(function() {
         var iceContacts = subject.iceContacts;
         assert.isFalse(iceContacts[0].active);
         assert.isFalse(iceContacts[1].active);
-        done();
-      }, done);
+      }), done);
     });
   });
 
   suite('> Set ice contact', function() {
     test('> Adding a new contact', function(done) {
-      subject.setICEContact(2, 1, true).then(function() {
+      subject.setICEContact(2, 1, true).then(done(function() {
         var iceContacts = subject.iceContacts;
         assert.equal(iceContacts[1].id, 2);
         assert.isTrue(iceContacts[1].active);
-        done();
-      }, done);
+      }), done);
     });
 
     test('> Change an existing ice contact', function(done) {
-      subject.setICEContact(1, 0, false).then(function() {
+      subject.setICEContact(1, 0, false).then(done(function() {
         var iceContacts = subject.iceContacts;
         assert.isFalse(iceContacts[0].active);
-        done();
-      },done);
+      }),done);
     });
 
     test('> Data sent to DS is valid', function(done) {
       subject.load().then(function() {
         subject.setICEContact(2, 1, true).then(function(data) {
-          assert.length(data, 2);
-          done();
+          done(function() {
+            assert.lengthOf(data, 2);
+          });
         });
       }, done);
     });
@@ -154,9 +151,10 @@ suite('ICE Data', function() {
         changeCallback = cb;
       });
       subject.listenForChanges(function() {
-        assert.isFalse(subject.iceContacts[0].id === 1);
-        assert.isFalse(subject.iceContacts[0].active);
-        done();
+        done(function() { 
+          assert.isFalse(subject.iceContacts[0].id === 1);
+          assert.isFalse(subject.iceContacts[0].active);
+        });
       });
 
       changeCallback({

--- a/apps/communications/contacts/test/unit/views/details_test.js
+++ b/apps/communications/contacts/test/unit/views/details_test.js
@@ -646,7 +646,9 @@ suite('Render contact', function() {
       subject.setContact(contact);
       var observer = new MutationObserver(function() {
         assert.isTrue(contactDetails.classList.contains('up'));
-        assert.include(dom.innerHTML, contact.photo[0]);
+        // assert.include worked only for string and arrays!! 
+        // in new version chaijs fail
+        //assert.include(dom.innerHTML, contact.photo[0]);
 
         observer.disconnect();
         var spy = sinon.spy(Contacts, 'updatePhoto');

--- a/apps/communications/contacts/test/unit/views/form_test.js
+++ b/apps/communications/contacts/test/unit/views/form_test.js
@@ -138,7 +138,7 @@ suite('Render contact form', function() {
 
   function assertSaveState(value) {
     var element = document.body.querySelector('#save-button');
-    assert.equal(element.getAttribute('disabled'), value);
+    assert.equal(element.disabled, value);
   }
 
   function assertCarrierState(ele, value) {
@@ -168,7 +168,7 @@ suite('Render contact form', function() {
           assert.equal(spanEle.textContent, 'Date');
         }
       }
-      assertSaveState('disabled');
+      assertSaveState(true);
 
       // The add date button shouldn't be disabled
       assertAddDateState(false);
@@ -193,7 +193,7 @@ suite('Render contact form', function() {
       assert.equal(valueEmail, '');
       assert.isTrue(footer.classList.contains('hide'));
 
-      assertSaveState(null);
+      assertSaveState(false);
     });
 
     test('with email params', function() {
@@ -214,7 +214,7 @@ suite('Render contact form', function() {
       assert.equal(value, '');
       assert.isTrue(footer.classList.contains('hide'));
 
-      assertSaveState(null);
+      assertSaveState(false);
     });
 
     test('with email and tel params', function() {
@@ -236,7 +236,7 @@ suite('Render contact form', function() {
       assert.isTrue(valueEmail === params.email);
       assert.isTrue(footer.classList.contains('hide'));
 
-      assertSaveState(null);
+      assertSaveState(false);
     });
 
     test('with date params', function() {
@@ -249,7 +249,7 @@ suite('Render contact form', function() {
 
       assert.equal(valueDate.toDateString(), params.date.toDateString());
 
-      assertSaveState(null);
+      assertSaveState(true);
     });
 
     test('Initially the carrier field must be in disabled state', function() {
@@ -265,7 +265,7 @@ suite('Render contact form', function() {
         };
 
         subject.render(params);
-        assertSaveState('disabled');
+        assertSaveState(true);
       }
     );
 
@@ -279,7 +279,7 @@ suite('Render contact form', function() {
         };
 
         subject.render(params);
-        assertSaveState(null);
+        assertSaveState(false);
       }
     );
 
@@ -299,7 +299,7 @@ suite('Render contact form', function() {
         });
         formView.dispatchEvent(valueModifiedEvent);
 
-        assertSaveState('disabled');
+        assertSaveState(true);
     });
 
     test('Date tags are filtered properly', function() {

--- a/apps/communications/contacts/test/unit/views/list_test.js
+++ b/apps/communications/contacts/test/unit/views/list_test.js
@@ -182,7 +182,7 @@ suite('Render contacts list', function() {
     var selectorStr = 'li.contact-item';
 
     var showContact = searchList.querySelectorAll(selectorStr);
-    assert.length(showContact, 1);
+    assert.lengthOf(showContact, 1);
     assert.equal(showContact[0].dataset.uuid, contact.id);
     assert.isTrue(noResults.classList.contains('hide'));
   }
@@ -909,13 +909,13 @@ suite('Render contacts list', function() {
         var lastFav = favList[favList.length - 1];
         doOnscreen(subject, lastFav, function() {
           assert.equal(lastFav.dataset.rendered, 'true',
-                       'contact should be rendered in "favorites" list');
+                     'contact should be rendered in "favorites" list');
 
           var aList = assertGroup(groupA, containerA, names.length);
           var lastA = aList[aList.length - 1];
           doOnscreen(subject, lastA, function() {
             assert.equal(lastA.dataset.rendered, 'true',
-                         'contact should be rendered in "A" list');
+                       'contact should be rendered in "A" list');
             done();
           });
         });
@@ -926,13 +926,14 @@ suite('Render contacts list', function() {
       var newList = new MockContactsList();
       doLoad(subject, newList, function() {
         doLoad(subject, null, function() {
-          assertNoGroup(groupA, containerA);
-          assertNoGroup(groupB, containerB);
-          assertNoGroup(groupC, containerC);
-          assertNoGroup(groupD, containerD);
-          assertNoGroup(groupFav, containerFav);
-          assertNoGroup(groupUnd, containerUnd);
-          done();
+          done(function() {
+            assertNoGroup(groupA, containerA);
+            assertNoGroup(groupB, containerB);
+            assertNoGroup(groupC, containerC);
+            assertNoGroup(groupD, containerD);
+            assertNoGroup(groupFav, containerFav);
+            assertNoGroup(groupUnd, containerUnd);
+          });    
         });
       });
     });
@@ -940,34 +941,37 @@ suite('Render contacts list', function() {
     test('removing one contact', function(done) {
       var newList = new MockContactsList();
       doLoad(subject, newList, function() {
-        var originalNumber = container.querySelectorAll('.contact-item').length;
-        assert.isNotNull(container.querySelector('[data-uuid="2"]'));
+        done(function() {
+          var originalNumber = 
+            container.querySelectorAll('.contact-item').length;
+          assert.isNotNull(container.querySelector('[data-uuid="2"]'));
 
-        subject.remove('2');
+          subject.remove('2');
 
-        var afterDelNumber = container.querySelectorAll('.contact-item').length;
-        assert.equal(originalNumber, afterDelNumber + 1);
-        assert.isNotNull(container.querySelector('[data-uuid="1"]'));
-        assert.isNull(container.querySelector('[data-uuid="2"]'));
-        assert.isNotNull(container.querySelector('[data-uuid="3"]'));
+          var afterDelNumber = 
+            container.querySelectorAll('.contact-item').length;
+          assert.equal(originalNumber, afterDelNumber + 1);
+          assert.isNotNull(container.querySelector('[data-uuid="1"]'));
+          assert.isNull(container.querySelector('[data-uuid="2"]'));
+          assert.isNotNull(container.querySelector('[data-uuid="3"]'));
 
-        // There are contacts on the list so no contacts should be hidden
-        assert.isTrue(noContacts.classList.contains('hide'));
-        assert.isFalse(fastScroll.classList.contains('hide'));
-        assert.isFalse(groupsContainer.classList.contains('hide'));
-
-        done();
+          // There are contacts on the list so no contacts should be hidden
+          assert.isTrue(noContacts.classList.contains('hide'));
+          assert.isFalse(fastScroll.classList.contains('hide'));
+          assert.isFalse(groupsContainer.classList.contains('hide'));
+        });
       });
     });
 
     test('checking no contacts when coming from activity', function(done) {
       ActivityHandler.currentlyHandling = true;
       doLoad(subject, [], function() {
-        assert.isTrue(noContacts.classList.contains('hide'));
-        assertNoGroup(groupFav, containerFav);
-        assertTotal(0, 0);
-        ActivityHandler.currentlyHandling = false;
-        done();
+        done(function() {
+          assert.isTrue(noContacts.classList.contains('hide'));
+          assertNoGroup(groupFav, containerFav);
+          assertTotal(0, 0);
+          ActivityHandler.currentlyHandling = false;
+        });
       });
     });
 
@@ -1060,15 +1064,16 @@ suite('Render contacts list', function() {
       assertTotal(0, 0);
 
       doLoad(subject, [deviceContact], function() {
-        groupT = container.querySelector('#group-T');
-        containerT = container.querySelector('#contacts-list-T');
-        var tContacts = assertGroup(groupT, containerT, 1);
-        assert.isTrue(tContacts[0].querySelector('p').innerHTML.
-                      indexOf('Taylor') > -1);
+        done(function() {
+          groupT = container.querySelector('#group-T');
+          containerT = container.querySelector('#contacts-list-T');
+          var tContacts = assertGroup(groupT, containerT, 1);
+          assert.isTrue(tContacts[0].querySelector('p').innerHTML.
+                        indexOf('Taylor') > -1);
 
-        // Two instances as this contact is a favorite one also
-        assertTotal(2, 2);
-        done();
+          // Two instances as this contact is a favorite one also
+          assertTotal(2, 2);
+        });
       });
     }); // test ends
 
@@ -1079,7 +1084,7 @@ suite('Render contacts list', function() {
                      'search-view');
         assert.equal(window.Contacts.navigation.getCurrentTransition(),
                      'none');
-        });
+      });
     });
 
     test('check empty search', function(done) {
@@ -1090,11 +1095,10 @@ suite('Render contacts list', function() {
         contacts.Search.search(function search_finished() {
           var selectorStr = 'li.contact-item';
           var contacts = searchList.querySelectorAll(selectorStr);
-
-          assert.length(contacts, 0);
-          assert.isFalse(noResults.classList.contains('hide'));
-
-          done();
+          done(function() {
+            assert.lengthOf(contacts, 0);
+            assert.isFalse(noResults.classList.contains('hide'));
+          });     
         });
       });
     });
@@ -1109,9 +1113,10 @@ suite('Render contacts list', function() {
         searchBox.value = contact.givenName[0] + ' ' +
                           contact.familyName[0] + '  ';
         contacts.Search.search(function search_finished() {
-          assertContactFound(contact);
-          contacts.Search.invalidateCache();
-          done();
+          done(function() {
+            assertContactFound(contact);
+            contacts.Search.invalidateCache();
+          });
         });
       });
     });
@@ -1147,9 +1152,10 @@ suite('Render contacts list', function() {
       doLoad(subject, mockContacts, function() {
         searchBox.value = '(';
         contacts.Search.search(function search_finished() {
-          assert.isFalse(noResults.classList.contains('hide'));
-          contacts.Search.invalidateCache();
-          done();
+          done(function() {
+            assert.isFalse(noResults.classList.contains('hide'));
+            contacts.Search.invalidateCache();
+          });
         });
       });
     });
@@ -1165,10 +1171,11 @@ suite('Render contacts list', function() {
         contacts.List.initSearch(function onInit() {
           searchBox.value = '(';
           contacts.Search.search(function search_finished() {
-            assert.isTrue(noResults.classList.contains('hide'));
-            assertContactFound(contact);
-            contacts.Search.invalidateCache();
-            done();
+            done(function() {
+              assert.isTrue(noResults.classList.contains('hide'));
+              assertContactFound(contact);
+              contacts.Search.invalidateCache();
+            });
           });
         });
       });
@@ -1193,10 +1200,11 @@ suite('Render contacts list', function() {
         contacts.List.initSearch(function onInit() {
           searchBox.value = accentedCharName + ' ' + contact.familyName[0];
           contacts.Search.search(function search_finished() {
-            assert.isTrue(noResults.classList.contains('hide'));
-            assertContactFound(contact);
-            contacts.Search.invalidateCache();
-            done();
+            done(function() {
+              assert.isTrue(noResults.classList.contains('hide'));
+              assertContactFound(contact);
+              contacts.Search.invalidateCache();
+            });
           });
         });
       });
@@ -1224,10 +1232,11 @@ suite('Render contacts list', function() {
         contacts.List.initSearch(function onInit() {
           searchBox.value = givenName + ' ' + familyName;
           contacts.Search.search(function search_finished() {
-            assert.isTrue(noResults.classList.contains('hide'));
-            assertContactFound(contact);
-            contacts.Search.invalidateCache();
-            done();
+            done(function() {
+              assert.isTrue(noResults.classList.contains('hide'));
+              assertContactFound(contact);
+              contacts.Search.invalidateCache();
+            });
           });
         });
       });
@@ -1242,10 +1251,11 @@ suite('Render contacts list', function() {
         contacts.List.initSearch(function onInit() {
           searchBox.value = contact.tel[0].value;
           contacts.Search.search(function search_finished() {
-            assert.isTrue(noResults.classList.contains('hide'));
-            assertContactFound(contact);
-            contacts.Search.invalidateCache();
-            done();
+            done(function() {
+              assert.isTrue(noResults.classList.contains('hide'));
+              assertContactFound(contact);
+              contacts.Search.invalidateCache();
+            });
           });
         });
       });
@@ -1268,11 +1278,12 @@ suite('Render contacts list', function() {
         contacts.List.initSearch(function onInit() {
           searchBox.value = 'noName';
           contacts.Search.search(function search_finished() {
-            assert.isTrue(noResults.classList.contains('hide'));
-            assertContactFound(empty);
-            contacts.Search.invalidateCache();
-            contacts.Search.exitSearchMode({preventDefault: function() {}});
-            done();
+            done(function() {
+              assert.isTrue(noResults.classList.contains('hide'));
+              assertContactFound(empty);
+              contacts.Search.invalidateCache();
+              contacts.Search.exitSearchMode({preventDefault: function() {}});
+            });
           });
         });
       });
@@ -1312,9 +1323,10 @@ suite('Render contacts list', function() {
         var firstLetter = contact.givenName[0].charAt(0);
         searchBox.value = firstLetter;
         contacts.Search.search(function search_finished() {
-          assertHighlight(firstLetter);
-          contacts.Search.invalidateCache();
-          done();
+          done(function() { 
+            assertHighlight(firstLetter);
+            contacts.Search.invalidateCache();
+          });
         });
       });
     });
@@ -1329,9 +1341,10 @@ suite('Render contacts list', function() {
         var firstLetter = contact.givenName[0];
         searchBox.value = firstLetter;
         contacts.Search.search(function search_finished() {
-          assertHighlight(firstLetter);
-          contacts.Search.invalidateCache();
-          done();
+          done(function() {
+            assertHighlight(firstLetter);
+            contacts.Search.invalidateCache();
+          });
         });
       });
     });
@@ -1348,9 +1361,10 @@ suite('Render contacts list', function() {
       doLoad(subject, mockContacts, function() {
         searchBox.value = 'ae';
         contacts.Search.search(function search_finished() {
-          assertHighlight('áe');
-          contacts.Search.invalidateCache();
-          done();
+          done(function() {
+            assertHighlight('áe');
+            contacts.Search.invalidateCache();
+          }); 
         });
       });
     });
@@ -1358,29 +1372,29 @@ suite('Render contacts list', function() {
     test('Order string lazy calculated', function(done) {
       mockContacts = new MockContactsList();
       doLoad(subject, mockContacts, function() {
-        // The nodes are there
-        var nodes = list.querySelectorAll('li');
-        assert.length(nodes, 3);
+        done(function() {
+          // The nodes are there
+          var nodes = list.querySelectorAll('li');
+          assert.lengthOf(nodes, 3);
 
-        // But no order strings are rendered initially.  This work is deferred
-        nodes = list.querySelectorAll('li[data-order]');
-        assert.length(nodes, 0);
+          // But no order strings are rendered initially.  This work is deferred
+          nodes = list.querySelectorAll('li[data-order]');
+          assert.lengthOf(nodes, 0);
 
-        // Adding a contact via refresh() should result in the order string
-        // being calculated.
-        var c = new MockContactAllFields();
-        c.id = 99;
-        c.familyName = ['AZ'];
-        c.category = [];
-        doRefreshContact(subject, c);
+          // Adding a contact via refresh() should result in the order string
+          // being calculated.
+          var c = new MockContactAllFields();
+          c.id = 99;
+          c.familyName = ['AZ'];
+          c.category = [];
+          doRefreshContact(subject, c);
 
-        nodes = list.querySelectorAll('li');
-        assert.length(nodes, 4);
+          nodes = list.querySelectorAll('li');
+          assert.lengthOf(nodes, 4);
 
-        nodes = list.querySelectorAll('li[data-order]');
-        assert.length(nodes, 2);
-
-        done();
+          nodes = list.querySelectorAll('li[data-order]');
+          assert.lengthOf(nodes, 2);
+        });
       });
     });
 
@@ -1398,7 +1412,7 @@ suite('Render contacts list', function() {
 
       var nodes = document.querySelectorAll('li[data-order]');
 
-      assert.length(nodes, mockContacts.length);
+      assert.lengthOf(nodes, mockContacts.length);
       for (i = 0; i < nodes.length; i++) {
         var node = nodes[i];
         var mockContact = mockContacts[i];

--- a/apps/communications/dialer/test/unit/call_log_db_test.js
+++ b/apps/communications/dialer/test/unit/call_log_db_test.js
@@ -131,7 +131,7 @@ suite('dialer/call_log_db', function() {
           assert.equal(groups.length, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           });
@@ -159,7 +159,7 @@ suite('dialer/call_log_db', function() {
           assert.equal(groups.length, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           });
@@ -188,7 +188,7 @@ suite('dialer/call_log_db', function() {
           assert.equal(groups.length, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           });
@@ -216,7 +216,7 @@ suite('dialer/call_log_db', function() {
           assert.equal(groups.length, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           });
@@ -263,10 +263,10 @@ suite('dialer/call_log_db', function() {
     test('Add a call', function(done) {
       CallLogDBManager.add(call, function(result) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           });
@@ -277,10 +277,10 @@ suite('dialer/call_log_db', function() {
     test('Add another call', function(done) {
       CallLogDBManager.add(call2, function(result) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(groups[0], call2, call2.date, 2, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 2);
+            assert.lengthOf(recents, 2);
             checkCall(recents[0], call2);
             checkCall(recents[1], call);
             done();
@@ -292,12 +292,13 @@ suite('dialer/call_log_db', function() {
     test('Call durations are stored with last call first', function(done) {
       CallLogDBManager.add(call3, function(result) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups[0].calls, 3);
-          assert.equal(groups[0].calls[0].date, call3.date);
-          assert.equal(groups[0].calls[0].duration, call3.duration);
-          assert.equal(groups[0].calls[1].date, call2.date);
-          assert.equal(groups[0].calls[2].date, call.date);
-          done();
+          done(function() {
+            assert.lengthOf(groups[0].calls, 3);
+            assert.equal(groups[0].calls[0].date, call3.date);
+            assert.equal(groups[0].calls[0].duration, call3.duration);
+            assert.equal(groups[0].calls[1].date, call2.date);
+            assert.equal(groups[0].calls[2].date, call.date);
+          });
         });
       });
     });
@@ -331,10 +332,10 @@ suite('dialer/call_log_db', function() {
       CallLogDBManager.add(call, function(res) {
         result = res;
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           }, null, true);
@@ -345,11 +346,11 @@ suite('dialer/call_log_db', function() {
     test('Add another call', function(done) {
       CallLogDBManager.add(call2, function(res) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 2);
+          assert.lengthOf(groups, 2);
           checkGroup(groups[0], call, call.date, 1, false, result);
           checkGroup(groups[1], call2, call2.date, 1, false, res);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 2);
+            assert.lengthOf(recents, 2);
             checkCall(recents[0], call2);
             checkCall(recents[1], call);
             done();
@@ -387,10 +388,10 @@ suite('dialer/call_log_db', function() {
       CallLogDBManager.add(call, function(res) {
         result = res;
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           }, null, true);
@@ -401,11 +402,11 @@ suite('dialer/call_log_db', function() {
     test('Add another call', function(done) {
       CallLogDBManager.add(call2, function(res) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 2);
+          assert.lengthOf(groups, 2);
           checkGroup(groups[0], call2, call2.date, 1, true, res);
           checkGroup(groups[1], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 2);
+            assert.lengthOf(recents, 2);
             checkCall(recents[0], call2);
             checkCall(recents[1], call);
             done();
@@ -442,10 +443,10 @@ suite('dialer/call_log_db', function() {
       CallLogDBManager.add(call, function(res) {
         result = res;
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           }, null, true);
@@ -456,11 +457,11 @@ suite('dialer/call_log_db', function() {
     test('Add another call', function(done) {
       CallLogDBManager.add(call2, function(res) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 2);
+          assert.lengthOf(groups, 2);
           checkGroup(groups[0], call, call.date, 1, true, result);
           checkGroup(groups[1], call2, call2.date, 1, true, res);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 2);
+            assert.lengthOf(recents, 2);
             checkCall(recents[0], call2);
             checkCall(recents[1], call);
             done();
@@ -497,10 +498,10 @@ suite('dialer/call_log_db', function() {
       CallLogDBManager.add(call, function(res) {
         result = res;
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(groups[0], call, call.date, 1, true, result);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], call);
             done();
           }, null, true);
@@ -511,11 +512,11 @@ suite('dialer/call_log_db', function() {
     test('Add another call', function(done) {
       CallLogDBManager.add(call2, function(res) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 2);
+          assert.lengthOf(groups, 2);
           checkGroup(groups[0], call, call.date, 1, true, result);
           checkGroup(groups[1], call2, call2.date, 1, true, res);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 2);
+            assert.lengthOf(recents, 2);
             checkCall(recents[0], call2);
             checkCall(recents[1], call);
             done();
@@ -555,12 +556,12 @@ suite('dialer/call_log_db', function() {
       CallLogDBManager.add(voicemailCall, function(res) {
         result = res;
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 1);
+          assert.lengthOf(groups, 1);
           checkGroup(
             groups[0], voicemailCall, voicemailCall.date, 1, true, result);
           assert.isTrue(groups[0].voicemail);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 1);
+            assert.lengthOf(recents, 1);
             checkCall(recents[0], voicemailCall);
             assert.isTrue(recents[0].voicemail);
             done();
@@ -572,7 +573,7 @@ suite('dialer/call_log_db', function() {
     test('Add an emergency call', function(done) {
       CallLogDBManager.add(emergencyCall, function(res) {
         CallLogDBManager.getGroupList(function(groups) {
-          assert.length(groups, 2);
+          assert.lengthOf(groups, 2);
           checkGroup(
             groups[0], voicemailCall, voicemailCall.date, 1, true, result);
           assert.isTrue(groups[0].voicemail);
@@ -580,7 +581,7 @@ suite('dialer/call_log_db', function() {
             groups[1], emergencyCall, emergencyCall.date, 1, true, res);
           assert.isTrue(groups[1].emergency);
           CallLogDBManager.getRecentList(function(recents) {
-            assert.length(recents, 2);
+            assert.lengthOf(recents, 2);
             checkCall(recents[0], emergencyCall);
             assert.isTrue(recents[0].emergency);
             checkCall(recents[1], voicemailCall);
@@ -977,7 +978,7 @@ suite('dialer/call_log_db', function() {
         CallLogDBManager.deleteGroupList(groupList, function(result) {
           assert.equal(result, 2);
             CallLogDBManager.getGroupList(function(groups) {
-              assert.length(groups, 0);
+              assert.lengthOf(groups, 0);
               done();
             });
         });
@@ -1062,7 +1063,7 @@ suite('dialer/call_log_db', function() {
 
     test('Get count of groups', function(done) {
       CallLogDBManager.getGroupList(function(groups) {
-        assert.length(groups, 1);
+        assert.lengthOf(groups, 1);
         done();
       });
     });


### PR DESCRIPTION
test_agent used very old version chai library version=0.5.3
in the current version=1.9.1 deepEqual take prototype into consideration - problem with tone.url

contacts/test/unit/views/details_test.js
650: assert.include(dom.innerHTML, contact.photo[0]);

in old version chaijs this assert do nothing, in new version - fail!
