### PR TITLE
Bug 1070688 - [settings] unit test refactoring for new version chai.assert api

### DIFF
--- a/apps/settings/test/unit/modules/mvvm/list_view_test.js
+++ b/apps/settings/test/unit/modules/mvvm/list_view_test.js
@@ -338,7 +338,10 @@ suite('ListView', function() {
               assert.equal(this.template.called, 0);
             });
             test('does not change elements', function() {
-              assert.deepEqual(this.container.children, this.originalElements);
+              for (var i = 0; i < this.container.children.length; i++) {
+                assert.equal(this.container.children[i], 
+                  this.originalElements[i]);
+              }
             });
             suite('.enabled = true', function() {
               setup(function() {

--- a/apps/settings/test/unit/panels/keyboard_enabled_default/dialog_test.js
+++ b/apps/settings/test/unit/panels/keyboard_enabled_default/dialog_test.js
@@ -87,22 +87,20 @@ suite('KeyboardEnabledDefaultDialog', function() {
       // gets localized string for type
       assert.isTrue(this.get.calledWith('keyboardType-text'));
       // localizes element
-      assert.deepEqual(this.setAttributes.args[0], [
-        this.title,
-        'mustHaveOneKeyboard',
-        { type: 'keyboardType-text' }
-      ]);
+      assert.equal(this.setAttributes.args[0][0], this.title);
+      assert.equal(this.setAttributes.args[0][1], 'mustHaveOneKeyboard');
+      assert.deepEqual(this.setAttributes.args[0][2], 
+        { type: 'keyboardType-text' });  
     });
 
     test('localizes text with layout details', function() {
       // gets localized string for type
       assert.isTrue(this.get.calledWith('keyboardType-text'));
       // localizes element
-      assert.deepEqual(this.setAttributes.args[1], [
-        this.title,
-        'defaultKeyboardEnabled',
-        { appName: 'appName', layoutName: 'layoutName' }
-      ]);
+      assert.equal(this.setAttributes.args[1][0], this.text);
+      assert.equal(this.setAttributes.args[1][1], 'defaultKeyboardEnabled');
+      assert.deepEqual(this.setAttributes.args[1][2], 
+        { appName: 'appName', layoutName: 'layoutName' });  
     });
 
     test('should navigate back to the origin when submitted', function() {


### PR DESCRIPTION
test_agent used very old version chai library version=0.5.3
in the current version=1.9.1 deepEqual take prototype into consideration

``` javascript
apps/settings/test/unit/panels/keyboard_enabled_default/dialog_test.js
102: this.title, - must this.test,
```

old version chaijs incorrect deepEqual - internal for testing object equivalence used Object.keys(this.title) -> Array[0]!! and test OK for any objects!
New version used for testing for (var key in this.title) pattern
