### PR TITLE
Bug 1070731 - [sms] unit test refactoring for new version chai.assert api r=azasypkin

### DIFF
--- a/apps/sms/test/unit/localization_helper_test.js
+++ b/apps/sms/test/unit/localization_helper_test.js
@@ -118,11 +118,19 @@ suite('LocalizationHelper >', function() {
       test('correctly formats node content', function() {
         var timestamp = Date.now();
 
-        function assertChange(format) {
-          assert.equal(
-            node.textContent,
-            Utils.date.format.localeFormat(new Date(timestamp), format)
-          );
+        function assertChange(format, doNotFormat) {
+          // In case of time format change date-only elements aren't updated
+          if (doNotFormat) {
+            assert.equal(
+              node.textContent, '', 'Date-only elements should not be updated'
+            );
+          } else {
+            assert.equal(
+              node.textContent,
+              Utils.date.format.localeFormat(new Date(timestamp), format)
+            );
+          }
+
           assert.isFalse(node.hasAttribute('data-l10n-id'));
           assert.isFalse(node.hasAttribute('data-l10n-args'));
         }
@@ -131,14 +139,7 @@ suite('LocalizationHelper >', function() {
         node.dataset.l10nDateFormat = 'format';
 
         // In case of time format change date-only elements shouldn't be updated
-        if(forceUpdateMethod()) {
-          assert.throws(
-            () => assertChange(node.dataset.l10nDateFormat),
-            'Date-only elements should not be updated'
-          );
-        } else {
-          assertChange(node.dataset.l10nDateFormat);
-        }
+        assertChange(node.dataset.l10nDateFormat, forceUpdateMethod());
 
         node.dataset.l10nDateFormat12 = 'format12';
         node.dataset.l10nDateFormat24 = 'format24';
@@ -157,13 +158,21 @@ suite('LocalizationHelper >', function() {
       test('correctly formats node l10n attributes', function() {
         var timestamp = Date.now();
 
-        function assertChange(format) {
+        function assertChange(format, doNotFormat) {
           var l10nAttributes = navigator.mozL10n.getAttributes(node);
+          // In case of time format change date-only elements aren't updated
+          if (doNotFormat) {
+            assert.deepEqual(l10nAttributes.args, {
+              data: 'custom'
+            }, 'Date-only elements should not be updated');
+          } else {
+            assert.deepEqual(l10nAttributes.args, {
+              data: 'custom',
+              date: Utils.date.format.localeFormat(new Date(timestamp), format)
+            });
+          }
+
           assert.equal(l10nAttributes.id, 'custom');
-          assert.deepEqual(l10nAttributes.args, {
-            data: 'custom',
-            date: Utils.date.format.localeFormat(new Date(timestamp), format)
-          });
           assert.equal(node.textContent, 'not-changed-content');
         }
 
@@ -175,14 +184,7 @@ suite('LocalizationHelper >', function() {
         node.textContent = 'not-changed-content';
 
         // In case of time format change date-only elements shouldn't be updated
-        if(forceUpdateMethod()) {
-          assert.throws(
-            () => assertChange(node.dataset.l10nDateFormat),
-            'Date-only elements should not be updated'
-          );
-        } else {
-          assertChange(node.dataset.l10nDateFormat);
-        }
+        assertChange(node.dataset.l10nDateFormat, forceUpdateMethod());
 
         node.dataset.l10nDateFormat12 = 'format12';
         node.dataset.l10nDateFormat24 = 'format24';

--- a/apps/sms/test/unit/recipients_test.js
+++ b/apps/sms/test/unit/recipients_test.js
@@ -50,6 +50,12 @@ suite('Recipients', function() {
     return (candidate.name === value || candidate.number === value);
   }
 
+  function assertDeepEqual(test, expected) {
+    for (var key in expected) {
+      assert.deepEqual(test[key], expected[key]);
+    }
+  }
+
   setup(function() {
     this.sinon.useFakeTimers();
 
@@ -135,7 +141,7 @@ suite('Recipients', function() {
 
       recipients.add(fixture);
       recipient = recipients.list[0];
-      assert.deepEqual(recipient, fixture);
+      assertDeepEqual(recipient, fixture);
     });
 
     test('recipients.add() 2 ', function() {
@@ -189,7 +195,7 @@ suite('Recipients', function() {
       recipients.add(fixtureEmail);
       recipient = recipients.list[0];
 
-      assert.deepEqual(recipient, fixtureEmail);
+      assertDeepEqual(recipient, fixtureEmail);
     });
 
     test('recipients.remove(recipient) ', function() {
@@ -198,7 +204,7 @@ suite('Recipients', function() {
       recipients.add(fixture);
       recipient = recipients.list[0];
 
-      assert.deepEqual(recipient, fixture);
+      assertDeepEqual(recipient, fixture);
       assert.ok(isValid(recipient, '999'));
 
       recipients.remove(recipient);
@@ -230,7 +236,7 @@ suite('Recipients', function() {
       recipients.add(fixtureEmail);
       recipient = recipients.list[0];
 
-      assert.deepEqual(recipient, fixtureEmail);
+      assertDeepEqual(recipient, fixtureEmail);
       assert.ok(isValid(recipient, 'a@b.com'));
 
       recipients.remove(recipient);

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -3110,12 +3110,14 @@ suite('thread_ui.js >', function() {
       ThreadUI.appendMessage(this.targetMsg);
       ThreadUI.appendMessage(this.otherMsg);
 
-      assert.length(
+      assert.lengthOf(
         ThreadUI.container.querySelectorAll('[data-message-id="23"]'),
-        1);
-      assert.length(
+        1
+      );
+      assert.lengthOf(
         ThreadUI.container.querySelectorAll('[data-message-id="45"]'),
-        1);
+        1
+      );
 
       this.getMessageReq = {};
       this.sinon.stub(MessageManager, 'getMessage')
@@ -3135,12 +3137,14 @@ suite('thread_ui.js >', function() {
       this.getMessageReq.result = this.targetMsg;
       this.getMessageReq.onsuccess();
 
-      assert.length(
+      assert.lengthOf(
         ThreadUI.container.querySelectorAll('[data-message-id="23"]'),
-        0);
-      assert.length(
+        0
+      );
+      assert.lengthOf(
         ThreadUI.container.querySelectorAll('[data-message-id="45"]'),
-        1);
+        1
+      );
     });
 
     test('invokes MessageManager.resendMessage', function() {

--- a/apps/sms/test/unit/threads_test.js
+++ b/apps/sms/test/unit/threads_test.js
@@ -13,6 +13,12 @@ var mocksHelperForThreadsTest = new MocksHelper([
   'Drafts'
 ]).init();
 
+function assertDeepEqual(test, expected) {
+  for (var key in expected) {
+    assert.deepEqual(test[key], expected[key]);
+  }
+} 
+
 suite('Threads', function() {
 
   mocksHelperForThreadsTest.attachTestHelpers();
@@ -97,7 +103,7 @@ suite('Threads', function() {
         type: 'sms'
       });
 
-      assert.deepEqual(thread, {
+      assertDeepEqual(thread, {
         // id was used
         id: 1,
         participants: ['555'],
@@ -122,7 +128,7 @@ suite('Threads', function() {
         type: 'sms'
       });
 
-      assert.deepEqual(thread, {
+      assertDeepEqual(thread, {
         // threadId was used
         id: 44,
         participants: ['555'],
@@ -151,7 +157,7 @@ suite('Threads', function() {
 
     test('Threads.set(key, val)', function() {
       Threads.set(1, {});
-      assert.deepEqual(Threads.get(1), {
+      assertDeepEqual(Threads.get(1), {
         body: undefined,
         id: undefined,
         lastMessageSubject: undefined,
@@ -211,7 +217,7 @@ suite('Threads', function() {
       Threads.set(5, {});
       Threads.currentId = 5;
 
-      assert.deepEqual(Threads.active, { body: undefined,
+      assertDeepEqual(Threads.active, { body: undefined,
         id: undefined,
         lastMessageSubject: undefined,
         lastMessageType: undefined,
@@ -250,14 +256,14 @@ suite('Thread', function() {
 
   test('Thread', function() {
     assert.ok(Thread);
-    assert.equal(typeof Thread.prototype.drafts, 'object');
-    assert.equal(typeof Thread.prototype.hasDrafts, 'boolean');
+    assert.typeOf(Thread.prototype.drafts, 'object');
+    assert.typeOf(Thread.prototype.hasDrafts, 'boolean');
   });
 
   test('Thread object', function() {
     var thread = new Thread(fixture);
 
-    assert.deepEqual(thread, {
+    assertDeepEqual(thread, {
       id: 1,
       participants: ['555'],
       lastMessageSubject: undefined,


### PR DESCRIPTION
test_agent used very old version chai library version=0.5.3
in the current version=1.9.1 deepEqual take prototype into consideration

apps/sms/test/unit/localization_helper_test.js - plain structure
