### PR TITLE
Bug 1068030 - Time format is not set to a proper default locale value

### DIFF
--- a/apps/ftu/js/language.js
+++ b/apps/ftu/js/language.js
@@ -13,24 +13,30 @@ var LanguageManager = {
         // the 2nd parameter is to reset the current enabled layouts
         KeyboardHelper.changeDefaultLayouts(event.settingValue, true);
       });
+    window.addEventListener('localized',
+      this.localizedEventListener.bind(this));
   },
 
   handleEvent: function handleEvent(evt) {
     if (!this.settings || evt.target.name != 'language.current') {
       return true;
     }
-    this.updateSettings(evt.target.value);
+    this.setLanguage(evt.target.value);
     return false;
   },
 
-  // update current launguage and time format settings
-  updateSettings: function settings_updateSettings(language) {
-    var _ = navigator.mozL10n.get;
-    var localeTimeFormat = _('shortTimeFormat');
-    var is12hFormat = (localeTimeFormat.indexOf('%I') >= 0);
-
+  // update current launguage settings
+  setLanguage: function settings_setLanguage(language) {
     this.settings.createLock().set({
-      'language.current': language,
+      'language.current': language
+    });
+  },
+
+  // set proper timeformat while localized
+  localizedEventListener: function settings_localizedEventListener() {
+    var localeTimeFormat = navigator.mozL10n.get('shortTimeFormat');
+    var is12hFormat = (localeTimeFormat.indexOf('%I') >= 0);
+    this.settings.createLock().set({
       'locale.hour12': is12hFormat
     });
   },

--- a/apps/ftu/test/unit/language_test.js
+++ b/apps/ftu/test/unit/language_test.js
@@ -1,3 +1,5 @@
+/*global MockL10n, MockNavigatorSettings, MockLanguageList,
+LanguageManager, LanguageList, KeyboardHelper, dispatchEvent*/
 'use strict';
 
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
@@ -39,7 +41,6 @@ suite('languages >', function() {
     LanguageManager.handleEvent(fakeEvent);
     assert.equal(MockNavigatorSettings.mSettings[fakeEvent.target.name],
                  fakeEvent.target.value);
-    assert.equal(MockNavigatorSettings.mSettings['locale.hour12'], false);
   });
 
   test('build language list', function(done) {
@@ -83,6 +84,11 @@ suite('languages >', function() {
       MockNavigatorSettings.mTriggerObservers(langKey,
                                               {settingValue: 'newLanguage'});
       assert.isTrue(KeyboardHelper.changeDefaultLayouts.called);
+    });
+
+    test('localize changed', function() {
+      dispatchEvent(new CustomEvent('localized'));
+      assert.equal(MockNavigatorSettings.mSettings['locale.hour12'], false);
     });
   });
 });

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -105,7 +105,6 @@ apps/fm/js/fm.js
 apps/fm/test/unit/fm_test.js
 apps/ftu/js/wifi.js
 apps/ftu/test/unit/data_mobile_test.js
-apps/ftu/test/unit/language_test.js
 apps/ftu/test/unit/mock_data_mobile.js
 apps/ftu/test/unit/mock_import_services.js
 apps/ftu/test/unit/mock_navigation.html.js


### PR DESCRIPTION
- keep origin language.current settings.
- listen `localized` event to set proper timeformat
- update test case
- jshint fix for language_test.js
