### PR TITLE
Bug 1011669 - [B2G][Browser]Double-tapping on plus sign (New Tab) presen...

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -439,6 +439,12 @@ var Browser = {
    * @param {Event} e
    */
   handleNewTab: function browserHandleNewTab(e) {
+    // Only respond to new tab clicks if not in transition and the current
+    // screen is TABS_Screen, prevents multiple empty tabs from created
+    if (this.inTransition || this.currentScreen !== this.TABS_SCREEN) {
+      return;
+    }
+
     this.inTransition = true;
     var tabId = this.createTab();
     this.showNewTabAnimation((function browser_showNewTabAnimation() {


### PR DESCRIPTION
...ts more New Tabs than what shows when returning to New Tab screen
- Only respond to new tab clicks if not in transition and the current screen is TABS_Screen to prevent multiple empty tabs from created
