### PR TITLE
Bug 1070825 - Remove the check of not dialing the same number twice r=rik

### DIFF
--- a/apps/communications/dialer/js/telephony_helper.js
+++ b/apps/communications/dialer/js/telephony_helper.js
@@ -74,16 +74,6 @@ var TelephonyHelper = (function() {
       return;
     }
 
-    // Making sure we're not dialing the same number twice
-    var alreadyDialed = telephony.calls.some(function callIterator(call) {
-      var number = call.id ? call.id.number : call.number;
-
-      return (number == sanitizedNumber);
-    });
-    if (alreadyDialed) {
-      return;
-    }
-
     LazyLoader.load('/shared/js/icc_helper.js', function() {
       var cardState = IccHelper.cardState;
       var emergencyOnly = conn.voice.emergencyCallsOnly;

--- a/apps/communications/dialer/test/unit/telephony_helper_test.js
+++ b/apps/communications/dialer/test/unit/telephony_helper_test.js
@@ -92,15 +92,6 @@ suite('telephony helper', function() {
     sinon.assert.calledWith(navigator.mozTelephony.dial, '0145345520');
   });
 
-  test('should not dial the same number twice', function() {
-    var dialNumber = '0145345520';
-    MockNavigatorMozTelephony.calls = [{number: dialNumber}];
-
-    subject.call(dialNumber, 0);
-
-    sinon.assert.notCalled(navigator.mozTelephony.dial);
-  });
-
   suite('Emergency dialing >', function() {
     var initialState;
 


### PR DESCRIPTION
Because of promise architecture of mozTelephony.dial(), it is fine to remove the check of not dialing the same number twice in call without regression of bug 917222.
