### PR TITLE
add make target for gaia-integration device testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,13 +163,17 @@ BUILD_APP_NAME=$(APP)
 endif
 endif
 
-REPORTER?=spec
 # BUILDAPP variable defines the target b2g platform (eg desktop, device)
 # and exports it for the gaia-marionette script
 BUILDAPP?=desktop
 export BUILDAPP
 # Ensure that NPM only logs warnings and errors
 export npm_config_loglevel=warn
+ifneq ($(BUILDAPP),desktop)
+REPORTER?=mocha-socket-reporter
+MARIONETTE_RUNNER_HOST?=marionette-socket-host
+endif
+REPORTER?=spec
 MARIONETTE_RUNNER_HOST?=marionette-b2gdesktop-host
 TEST_MANIFEST?=./shared/test/integration/local-manifest.json
 MOZPERFOUT?=""

--- a/bin/gaia-marionette
+++ b/bin/gaia-marionette
@@ -127,6 +127,25 @@ if [ "$RUNTIME" ]; then
   RUNTIME_OPTS="--runtime=$RUNTIME"
 fi
 
+# start runner-service if we're testing against device/emulator
+SPAWNED_PID=""
+if [ "$BUILDAPP" != "desktop" ]; then
+  ADDITIONAL_OPTS=""
+  if [ "$B2G_HOME" ]; then
+    ADDITIONAL_OPTS="--b2g-home $B2G_HOME"
+  fi
+  if [ "$SYMBOLS" ]; then
+    ADDITIONAL_OPTS="$ADDITIONAL_OPTS --symbols-path $SYMBOLS"
+  fi
+  if [ "$DEVICE_SERIAL" ]; then
+    ADDITIONAL_OPTS="$ADDITIONAL_OPTS --serial $DEVICE_SERIAL"
+  fi
+  gaia-integration --buildapp $BUILDAPP $ADDITIONAL_OPTS &
+  SPAWNED_PID=$!
+  trap "kill $SPAWNED_PID" SIGINT SIGKILL SIGTERM
+  echo "spawned PID: $SPAWNED_PID"
+fi
+
 # wrap marionette-mocha with gaia's defaults. We also need to alter the paths to
 # xpcshell in available for email fake servers.
 PATH=$XPCSHELL_DIR:$PATH $DIR/../node_modules/.bin/marionette-mocha \
@@ -140,3 +159,11 @@ PATH=$XPCSHELL_DIR:$PATH $DIR/../node_modules/.bin/marionette-mocha \
   $SHARED/setup.js \
   $TEST_FILES \
   $@
+
+if [ $SPAWNED_PID ]; then
+  ps ux | grep $SPAWNED_PID | grep -v grep
+  if [ $? -eq 0 ]; then
+    echo "killing $SPAWNED_PID"
+    kill $SPAWNED_PID
+  fi
+fi

--- a/tests/python/runner-service/runner_service/arguments.py
+++ b/tests/python/runner-service/runner_service/arguments.py
@@ -14,11 +14,6 @@ class GaiaIntegrationParser(ArgumentParser):
           "default": "desktop",
           "help": "The type of build to run gaia-integration tests on.",
         }],
-        [["--manifest"],
-        { "dest": "manifest",
-          "default": None,
-          "help": "Path to a test manifest to use."
-        }],
         [["--b2gpath"],
         { "dest": "b2g_home",
           "default": None,

--- a/tests/python/runner-service/runner_service/runintegration.py
+++ b/tests/python/runner-service/runner_service/runintegration.py
@@ -2,61 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
-import os
-import subprocess
 import sys
-import tempfile
-
-from manifestparser import TestManifest
 
 from .arguments import GaiaIntegrationParser
 from .handlers import runner_handlers
 from .listener import SocketListener
-
-here = os.path.abspath(os.path.dirname(__file__))
-gaia_dir = os.path.abspath(os.path.join(here, '../../../../'))
-
-class GaiaIntegrationRunner(object):
-
-    def __init__(self, manifest=None, buildapp=None):
-        self.manifest = manifest or os.path.join(gaia_dir, 'shared', 'test',
-                                                 'integration', 'manifest.ini')
-        if self.manifest.endswith('.ini'):
-            self.manifest = self.convert_ini_manifest_to_json(self.manifest)
-
-        self.buildapp = buildapp
-
-    def run_gi(self):
-        command = ['make', 'test-integration-test',
-                   'REPORTER=mocha-socket-reporter',
-                   'MARIONETTE_RUNNER_HOST=marionette-socket-host',
-                   'TEST_MANIFEST=%s' % self.manifest,
-                   'BUILDAPP=%s' % self.buildapp]
-        # TODO use mozprocess?
-        self.proc = subprocess.Popen(command, cwd=gaia_dir)
-
-    @classmethod
-    def convert_ini_manifest_to_json(cls, manifest_path):
-        manifest = TestManifest([manifest_path])
-
-        whitelist = [t['path'] for t in manifest.active_tests(disabled=False)]
-        blacklist = [t for t in manifest.paths() if t not in whitelist]
-
-        whitelist.insert(0, os.path.join(gaia_dir, 'shared', 'test', 'integration', 'setup.js'))
-
-        map(lambda l: [os.path.relpath(p, gaia_dir) for p in l] , (whitelist, blacklist))
-        contents = { 'whitelist': whitelist }
-
-        manifest_path = tempfile.NamedTemporaryFile(suffix='.json').name
-        with open(manifest_path, 'w') as f:
-            f.writelines(json.dumps(contents, indent=2))
-        return manifest_path
-
-    def cleanup(self):
-        if self.proc:
-            self.proc.kill()
-
 
 def cli(args=sys.argv[1:]):
     parser = GaiaIntegrationParser()
@@ -74,13 +24,9 @@ def cli(args=sys.argv[1:]):
     listener = SocketListener()
     listener.add_runner_handler(rhandler)
 
-    integration = GaiaIntegrationRunner(manifest=args.manifest, buildapp=args.buildapp)
-    integration.run_gi()
-
     try:
         listener.poll()
     finally:
-        integration.cleanup()
         listener.cleanup()
         #rhandler.cleanup()
 


### PR DESCRIPTION
Currently, we have to use runner_service to kick off gaia-integration tests on devices/emulator. This patch lets use use the 'make test-integration' target for gaia integration tests on any platform (desktop, device, emulator). By default, it assumes 'desktop'. 

If something other than desktop is used, then we change the default values of REPORTER and MARIONETTE_RUNNER_HOST to those needed by devices/emulators. bin/gaia-marionette has been updated to kick off the runner_service's listener process (a python script used to interface with devices/emulators) and will kill that process when any kill/interrupt signal is received or when the script is complete.

This also removes the gaia-marionette call from runner-service.

NOTE: if you Cmd+C or Ctrl+C during a device test, you'll see ^C in the stdout, and it may look like nothing is happening for a while, but that's because mocha has received your abort signal, and will only propagate it once its next event gets processed. This actually happens now with the desktop, but since desktop is faster, you don't really notice it as often. On device, aborting during some actions will take a while, like if you do this while the phone is rebooting, for example. In this case, it's easier to Cmd+Z/Ctrl+Z, which will kill everything quickly.
