### PR TITLE
Bug 1070883 - In SimPin Dialog, use touchend event instead of click event to handle skip/OK clicks.

### DIFF
--- a/apps/system/js/simcard_dialog.js
+++ b/apps/system/js/simcard_dialog.js
@@ -367,8 +367,8 @@ var SimPinDialog = {
 
     this.initElements();
 
-    this.dialogDone.onclick = this.verify.bind(this);
-    this.dialogSkip.onclick = this.skip.bind(this);
+    this.dialogDone.ontouchend = this.verify.bind(this);
+    this.dialogSkip.ontouchend = this.skip.bind(this);
     this.header.addEventListener('action', this.back.bind(this));
     this.pinInput = this.getNumberPasswordInputField('simpin');
     this.pukInput = this.getNumberPasswordInputField('simpuk');


### PR DESCRIPTION
This changes the old, buggy flow: [user touches skip button -> input focus blurred -> keyboard hidden -> simpin dialog resized -> "skip" button repositioned -> click on the skip button would not be trigerred] to [user touches skip button -> input focus blurred -> keyboard hidden -> simpin dialog resized -> "skip" button repositioned -> touch end would still be trigerred on skip button], thus fixes the bug.
