### PR TITLE
Bug 1064463 - Do not set caller id explicitly when users preference is not available r=alive

### DIFF
--- a/apps/system/js/telephony_settings.js
+++ b/apps/system/js/telephony_settings.js
@@ -86,20 +86,22 @@
      * CLIR_SUPPRESSION: 2
      */
     initCallerIdPreference: function() {
-      var defaultCallerIdPreferences =
-        this.connections.map(function() { return 0; });
-      var callerIdPreferenceHelper =
-        SettingsHelper('ril.clirMode', defaultCallerIdPreferences);
+      var callerIdPreferenceHelper = SettingsHelper('ril.clirMode', null);
       var that = this;
 
       callerIdPreferenceHelper.get(function got_cid(values) {
         that.connections.forEach(function cid_iterator(conn, index) {
-          that._setCallerIdPreference(conn, values[index], function() {
-            that._syncCallerIdPreferenceWithCarrier(conn, index,
-              callerIdPreferenceHelper);
+          if (values && values[index] !== null) {
+            that._setCallerIdPreference(conn, values[index], function() {
+              that._syncCallerIdPreferenceWithCarrier(conn, index,
+                callerIdPreferenceHelper);
+              that._registerListenerForCallerIdPreference(conn, index,
+                callerIdPreferenceHelper);
+            });
+          } else {
             that._registerListenerForCallerIdPreference(conn, index,
               callerIdPreferenceHelper);
-          });
+          }
         });
       });
     },

--- a/apps/system/test/unit/telephony_settings_test.js
+++ b/apps/system/test/unit/telephony_settings_test.js
@@ -155,6 +155,9 @@ suite('system/TelephonySettings', function() {
         'getCallingLineIdRestriction').returns(reqResponse);
       setStub = this.sinon.stub(fakeConnections[0],
         'setCallingLineIdRestriction').returns(reqResponse);
+      MockSettingsHelper.instances['ril.clirMode'] = {
+        value: ['custom-value-clir']
+      };
 
       subject = new TelephonySettings();
       stubFunctions(subject, 'initCallerIdPreference');
@@ -166,11 +169,6 @@ suite('system/TelephonySettings', function() {
       setStub.restore();
     });
 
-    test('setCallingLineIdRestriction default value', function() {
-      subject.start();
-      assert.ok(setStub.calledWith(0));
-    });
-
     test('_registerListenerForCallerIdPreference is called when init',
       function() {
         subject.start();
@@ -180,10 +178,17 @@ suite('system/TelephonySettings', function() {
     });
 
     test('setCallingLineIdRestriction from settings', function() {
-      MockSettingsHelper.instances['ril.clirMode'] =
-        {value: ['custom-value-clir']};
       subject.start();
       assert.ok(setStub.calledWith('custom-value-clir'));
+    });
+
+    test('setCallingLineIdRestriction should not be called when user ' +
+      'preference is not available', function() {
+        MockSettingsHelper.instances['ril.clirMode'] = {
+          value: null
+        };
+        subject.start();
+        assert.ok(setStub.notCalled);
     });
   });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1064463
