### PR TITLE
Bug 1059213 - Use font feature settings to enable tabular numbers, r=mcav

### DIFF
--- a/apps/clock/style/stopwatch.css
+++ b/apps/clock/style/stopwatch.css
@@ -8,6 +8,7 @@
   color: #CFE2E6;
   font-weight: lighter;
   font-variant-numeric: tabular-nums;
+  -moz-font-feature-settings: "tnum";
   font-size: 8.6rem;
   letter-spacing: -0.5rem;
   pointer-events: none;
@@ -67,6 +68,7 @@
 .lap-duration {
   float: right;
   font-variant-numeric: tabular-nums;
+  -moz-font-feature-settings: "tnum";
   font-weight: lighter;
 }
 

--- a/apps/clock/style/timer.css
+++ b/apps/clock/style/timer.css
@@ -6,6 +6,7 @@
 #timer-time {
   letter-spacing: -0.5rem;
   font-variant-numeric: tabular-nums;
+  -moz-font-feature-settings: "tnum";
   font-weight: lighter;
   font-size: 8.6rem;
   color: #CFE2E6;


### PR DESCRIPTION
font-variant-numeric is not supported on Gecko 32.
