### PR TITLE
Bug 1073356 - [Calendar] Wobbly Refresh Icon Animation

### DIFF
--- a/apps/calendar/style/settings.css
+++ b/apps/calendar/style/settings.css
@@ -179,14 +179,21 @@ not actually shown since the top header should be transparent.
   left: 0;
   width: 100%;
   height: 4.5rem;
+}
+
+#settings [role="toolbar"] .sync .icon {
+  display: block;
+  width: 3rem;
+  height: 3rem;
+  margin: 0 auto;
   background: url("icons/refresh.png") no-repeat 50% 50% / 3rem auto;
 }
 
-#settings [role="toolbar"] .sync:active:after {
+#settings [role="toolbar"] .sync:active .icon {
   background-image: url("icons/refresh_press.png");
 }
 
-.pending-operation #settings [role="toolbar"] .sync:after {
+.pending-operation #settings [role="toolbar"] .sync .icon {
   animation: 0.9s msg-refresh-rotate infinite steps(30);
 }
 


### PR DESCRIPTION
Use the span element inside the button to give it a fixed size that matches the background size, and rely on the auto centering that was already possible within the container and by margin: 0 auto.
