### PR TITLE
Merge pull request #22254 from

### DIFF
--- a/apps/keyboard/js/imes/latin/latin.js
+++ b/apps/keyboard/js/imes/latin/latin.js
@@ -893,21 +893,15 @@
     //
     // 1) If the cursor is at the start of the field: uppercase
     //
-    // 2) If there are two uppercase chars before the cursor: uppercase
-    //
-    // 3) If there is a non space character immediately before the cursor:
+    // 2) If there is a non space character immediately before the cursor:
     //    lowercase
     //
-    // 4) If the first non-space character before the cursor is . ? or !:
+    // 3) If the first non-space character before the cursor is . ? or !:
     //    uppercase
     //
-    // 5) Otherwise: lowercase
+    // 4) Otherwise: lowercase
     //
     if (cursor === 0) {
-      keyboard.setUpperCase(true);
-    }
-    else if (cursor >= 2 &&
-             isUpperCase(inputText.substring(cursor - 2, cursor))) {
       keyboard.setUpperCase(true);
     }
     else if (!isWhiteSpace(inputText.substring(cursor - 1, cursor))) {

--- a/apps/keyboard/test/unit/latin_test.js
+++ b/apps/keyboard/test/unit/latin_test.js
@@ -229,10 +229,6 @@ suite('latin input method capitalization and punctuation', function() {
     if (cursor === 0)
       return capitalize(input);
 
-    // If inserting in an all caps word, use uppercase
-    if (cursor >= 2 && isUppercase(value.substring(cursor - 2, cursor)))
-      return input.toUpperCase();
-
     // if the character before the cursor is not a space, don't capitalize
     if (!/\s/.test(value[cursor - 1]))
       return input;
@@ -535,8 +531,9 @@ suite('latin input method capitalization and punctuation', function() {
           im.deactivate();
           assert.equal(output, expected,
                        'expected "' + expected + '" for input "' + input + '"');
-          next();
-        });
+        }, function() {
+          assert.ok(false, 'should not reject');
+        }).then(next, next);
       } else {
         // Send the input one character at a time, converting
         // the input to uppercase if the IM has set uppercase


### PR DESCRIPTION
RudyLu/keyboard/Bug1031561-no_auto_capitalize_acronym

Bug 1031561 - don't auto-capitalize when there are 2 uppercase letters in 
r=djf
(cherry picked from commit 80a452a2615446839482ee98a0744285d723f531)

Conflicts:
apps/keyboard/js/imes/latin/latin.js
