### PR TITLE
Bug 1057795 (Fix) - Clean up MozL10n API use in Cost Control (Correction) R=gauravmittal1995

### DIFF
--- a/apps/costcontrol/test/unit/balance_view_test.js
+++ b/apps/costcontrol/test/unit/balance_view_test.js
@@ -84,8 +84,8 @@ suite(
         var isUpdating = true;
         balanceResult.timestamp = now;
         balanceView.update(balanceResult, isUpdating);
-        assert.equal(timestampLabel.setAttribute('data-l10n-id',
-          'updating-ellipsis'));
+        assert.equal(timestampLabel.getAttribute('data-l10n-id'),
+          'updating-ellipsis');
       }
     );
 
@@ -93,8 +93,8 @@ suite(
       'Balance not available',
       function() {
         balanceView.update(undefined);
-        assert.equal(balanceLabel.setAttribute('data-l10n-id',
-          'not-available'));
+        assert.equal(balanceLabel.getAttribute('data-l10n-id'),
+          'not-available');
         assert.equal(timestampLabel.innerHTML, '');
       }
     );


### PR DESCRIPTION
Fix in the previous patch ( https://github.com/mozilla-b2g/gaia/pull/24060 )
