### PR TITLE
Bug 967516 - Enable DEVICE_DEBUG by default for non production builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,16 +114,6 @@ REMOTE_DEBUGGER?=0
 # Debug mode for build process
 BUILD_DEBUG?=0
 
-ifeq ($(DEVICE_DEBUG),1)
-REMOTE_DEBUGGER=1
-NO_LOCK_SCREEN=1
-SCREEN_TIMEOUT=300
-endif
-
-ifeq ($(SIMULATOR),1)
-SCREEN_TIMEOUT=0
-endif
-
 # We also disable FTU when running in Firefox or in debug mode
 ifeq ($(DEBUG),1)
 NOFTU=1
@@ -195,6 +185,19 @@ endif
 ifeq ($(PRODUCTION), 1)
 GAIA_OPTIMIZE=1
 GAIA_APP_TARGET=production
+else ifneq ($(DEBUG),1)
+# Enable DEVICE_DEBUG for non-production, non-debug builds.
+DEVICE_DEBUG=1
+endif
+
+ifeq ($(DEVICE_DEBUG),1)
+REMOTE_DEBUGGER=1
+SCREEN_TIMEOUT=300
+endif
+
+ifeq ($(SIMULATOR),1)
+SCREEN_TIMEOUT=0
+NO_LOCK_SCREEN=1
 endif
 
 ifeq ($(DOGFOOD), 1)

--- a/build/test/integration/build.test.js
+++ b/build/test/integration/build.test.js
@@ -363,7 +363,8 @@ suite('Build Integration tests', function() {
       var ignoreSettings = [
         'apz.force-enable',
         'debug.console.enabled',
-        'developer.menu.enabled'
+        'developer.menu.enabled',
+        'screen.timeout'
       ];
       ignoreSettings.forEach(function(key) {
         if (commonSettings[key] !== undefined) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=967516

Try run: https://tbpl.mozilla.org/?tree=Try&rev=ae4f013b9e98
