### PR TITLE
Bug 1074446 - gaia-l10n builds for Portuguese locale (pt-PT)

### DIFF
--- a/locales/languages_all.json
+++ b/locales/languages_all.json
@@ -52,6 +52,7 @@
   "pa"        : "ਪੰਜਾਬੀ",
   "pl"        : "Polski",
   "pt-BR"     : "Português (do Brasil)",
+  "pt-PT"     : "Português (Europeu)",
   "ro"        : "Română",
   "ru"        : "Русский",
   "si"        : "සිංහල",


### PR DESCRIPTION
gaia-l10n builds for Portuguese locale (pt-PT):
https://bugzilla.mozilla.org/show_bug.cgi?id=1074446
