### PR TITLE
Bug 1062728 - [email/pop3] POP3 sync breaks on messages that lack a Date header. v2.0-specific uplift. r=mcav

### DIFF
--- a/apps/email/js/ext/mailapi/composite/configurator.js
+++ b/apps/email/js/ext/mailapi/composite/configurator.js
@@ -6909,11 +6909,11 @@ return {
 
 define('pop3/pop3',['module', 'exports', 'rdcommon/log', 'net', 'crypto',
         './transport', 'mailparser/mailparser', '../mailapi/imap/imapchew',
-        '../mailapi/syncbase',
+        '../mailapi/syncbase', '../mailapi/date',
         './mime_mapper', '../mailapi/allback'],
 function(module, exports, log, net, crypto,
          transport, mailparser, imapchew,
-         syncbase, mimeMapper, allback) {
+         syncbase, dateMod, mimeMapper, allback) {
 
   /**
    * The Pop3Client modules and classes are organized according to
@@ -7709,11 +7709,16 @@ function(module, exports, log, net, crypto,
     var estSize = number && this.idToSize[number] || mimeContent.length;
     var content;
 
+    var date = rootNode.meta.date && rootNode.meta.date.valueOf();
+    if (!date) {
+      date = dateMod.NOW();
+    }
+
     var partMap = {}; // partId -> content
     var msg = {
       id: number && this.idToUidl[number], // the server-given ID
       msg: rootNode,
-      date: rootNode.meta.date && rootNode.meta.date.valueOf(),
+      date: date,
       flags: [],
       structure: mimeTreeToStructure(rootNode, '1', partMap, partialNode),
     };

--- a/apps/email/js/ext/mailapi/pop3/probe.js
+++ b/apps/email/js/ext/mailapi/pop3/probe.js
@@ -1142,11 +1142,11 @@ return {
 
 define('pop3/pop3',['module', 'exports', 'rdcommon/log', 'net', 'crypto',
         './transport', 'mailparser/mailparser', '../mailapi/imap/imapchew',
-        '../mailapi/syncbase',
+        '../mailapi/syncbase', '../mailapi/date',
         './mime_mapper', '../mailapi/allback'],
 function(module, exports, log, net, crypto,
          transport, mailparser, imapchew,
-         syncbase, mimeMapper, allback) {
+         syncbase, dateMod, mimeMapper, allback) {
 
   /**
    * The Pop3Client modules and classes are organized according to
@@ -1942,11 +1942,16 @@ function(module, exports, log, net, crypto,
     var estSize = number && this.idToSize[number] || mimeContent.length;
     var content;
 
+    var date = rootNode.meta.date && rootNode.meta.date.valueOf();
+    if (!date) {
+      date = dateMod.NOW();
+    }
+
     var partMap = {}; // partId -> content
     var msg = {
       id: number && this.idToUidl[number], // the server-given ID
       msg: rootNode,
-      date: rootNode.meta.date && rootNode.meta.date.valueOf(),
+      date: date,
       flags: [],
       structure: mimeTreeToStructure(rootNode, '1', partMap, partialNode),
     };

--- a/apps/email/js/ext/pop3/pop3.js
+++ b/apps/email/js/ext/pop3/pop3.js
@@ -2872,11 +2872,11 @@ return {
 
 define('pop3/pop3',['module', 'exports', 'rdcommon/log', 'net', 'crypto',
         './transport', 'mailparser/mailparser', '../mailapi/imap/imapchew',
-        '../mailapi/syncbase',
+        '../mailapi/syncbase', '../mailapi/date',
         './mime_mapper', '../mailapi/allback'],
 function(module, exports, log, net, crypto,
          transport, mailparser, imapchew,
-         syncbase, mimeMapper, allback) {
+         syncbase, dateMod, mimeMapper, allback) {
 
   /**
    * The Pop3Client modules and classes are organized according to
@@ -3672,11 +3672,16 @@ function(module, exports, log, net, crypto,
     var estSize = number && this.idToSize[number] || mimeContent.length;
     var content;
 
+    var date = rootNode.meta.date && rootNode.meta.date.valueOf();
+    if (!date) {
+      date = dateMod.NOW();
+    }
+
     var partMap = {}; // partId -> content
     var msg = {
       id: number && this.idToUidl[number], // the server-given ID
       msg: rootNode,
-      date: rootNode.meta.date && rootNode.meta.date.valueOf(),
+      date: date,
       flags: [],
       structure: mimeTreeToStructure(rootNode, '1', partMap, partialNode),
     };


### PR DESCRIPTION
This is a minimal v2.0 specific uplift of the trunk fix for bug 1062728.  It
only includes the date logic to fix the specific error.
