### PR TITLE
Bug 1018833 - Calendar sync duplicates events r=gaye

### DIFF
--- a/apps/calendar/js/calendar.js
+++ b/apps/calendar/js/calendar.js
@@ -2,7 +2,7 @@
 'use strict';
 
 exports.ACTIVE = 'active';
-exports.DEBUG = 'debug';
+exports.DEBUG = false;
 exports.ERROR = 'error';
 
 }(this.Calendar = {}));

--- a/apps/calendar/test/unit/controllers/recurring_events_test.js
+++ b/apps/calendar/test/unit/controllers/recurring_events_test.js
@@ -198,11 +198,11 @@ suiteGroup('Controllers.RecurringEvents', function() {
       expectedDate.setDate(expectedDate.getDate() + subject.paddingInDays);
     });
 
-    function setupProvider(type) {
+    function setupProvider(type, id) {
       setup(function(done) {
         account = Factory('account', {
           providerType: type,
-          _id: type
+          _id: id || type
         });
 
         provider = app.provider(type);
@@ -227,7 +227,9 @@ suiteGroup('Controllers.RecurringEvents', function() {
     });
 
     suite('provider that can expand', function() {
-      setupProvider('Caldav');
+      // two caldav accounts to catch duplicate busytimes error (Bug 1018833)
+      setupProvider('Caldav', 1);
+      setupProvider('Caldav', 2);
 
       // custom helper to allow each test
       // to inject specific logic while sharing the


### PR DESCRIPTION
problem was caused because it was calling `ensureRecurrencesExpanded` on the caldav provider multiple times (once for each account) before it was able to update the `lastRecurrenceId`...

I'm still not sure if I changed the _best place_ in the source code, it felt like the proper place was on the `IcalComponent#ensureRecurrencesExpanded` or on the `CaldavProvider#ensureRecurrencesExpanded`, but all the things that I could think seemed like the solution would be way more complex... - let me know if you think of a better solution on one of these methods. Basically we need to make sure it doesn't expand the same date twice while it is still _pending_.. (but we should allow it to expand again after it's complete)

the changes that I did to the unit test should catch regressions.
