### PR TITLE
Merge pull request #24454 from nullaus/bug1069452

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -218,6 +218,11 @@
   AppWindow.prototype._showFrame = function aw__showFrame() {
     this.debug('before showing frame');
 
+    // If we're already showing, do nothing!
+    if (!this.browser.element.classList.contains('hidden')) {
+      return;
+    }
+
     this.browser.element.classList.remove('hidden');
     this._setVisible(true);
 
@@ -238,8 +243,15 @@
    * So this shouldn't be invoked by others directly.
    */
   AppWindow.prototype._hideFrame = function aw__hideFrame() {
+    this.debug('before hiding frame');
+
+    // If we're already hidden, we have nothing to do!
+    if (this.browser.element.classList.contains('hidden')) {
+      return;
+    }
+
     this._setVisible(false);
-    this.iframe.classList.add('hidden');
+    this.browser.element.classList.add('hidden');
   };
 
   /**
@@ -1637,6 +1649,21 @@
   };
 
   AppWindow.prototype._handle__closed = function aw_closed() {
+    //
+    // Never take screenshots of the homescreen.
+    //
+    // We don't need the screenshot of homescreen because:
+    // 1. Homescreen background is transparent,
+    //    currently gecko only sends JPG to us.
+    //    See bug 878003.
+    // 2. Homescreen screenshot isn't required by card view.
+    //    Since getScreenshot takes additional memory usage,
+    //    let's early return here.
+    // 3. We want to remove this long term, see bug 1072781.
+    //
+    if (this.getBottomMostWindow().isHomescreen) {
+      return;
+    }
     // Update screenshot blob here to avoid slowing down closing transitions.
     this.getScreenshot();
   };

--- a/apps/system/js/browser_mixin.js
+++ b/apps/system/js/browser_mixin.js
@@ -69,13 +69,6 @@
         }
         return;
       }
-      // We don't need the screenshot of homescreen because:
-      // 1. Homescreen background is transparent,
-      //    currently gecko only sends JPG to us.
-      //    See bug 878003.
-      // 2. Homescreen screenshot isn't required by card view.
-      //    Since getScreenshot takes additional memory usage,
-      //    let's early return here.
       var self = this;
       var invoked = false;
       var timer;

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1014,6 +1014,21 @@ suite('system/AppWindow', function() {
       assert.isFalse(app1.screenshotOverlay.classList.contains('visible'));
       assert.isFalse(app2.screenshotOverlay.classList.contains('visible'));
     });
+
+    test('setVisible: called twice', function() {
+      var app1 = new AppWindow(fakeAppConfig1);
+      injectFakeMozBrowserAPI(app1.browser.element);
+      app1.browser.element.classList.add('hidden');
+      var stubMixinSetVisible = this.sinon.stub(app1, '_setVisible');
+
+      app1.setVisible(true);
+      assert.isTrue(stubMixinSetVisible.calledOnce,
+                    'should call _setVisible once!');
+
+      app1.setVisible(true);
+      assert.isTrue(stubMixinSetVisible.calledOnce,
+                    'calling setVisible again should *not* call _setVisible!');
+    });
   });
 
   suite('setVisibleForScreenReader', function() {
@@ -1255,6 +1270,29 @@ suite('system/AppWindow', function() {
       });
 
       assert.isTrue(stubKill.called);
+    });
+
+    test('Closed event', function() {
+      var app1 = new AppWindow(fakeAppConfig1);
+      app1.isHomescreen = true;
+      var app2 = new AppWindow(fakeAppConfig2);
+
+      injectFakeMozBrowserAPI(app1.browser.element);
+      injectFakeMozBrowserAPI(app2.browser.element);
+      var stubScreenshot = this.sinon.stub(app1.browser.element,
+        'getScreenshot');
+      var stubScreenshot2 = this.sinon.stub(app2.browser.element,
+        'getScreenshot');
+
+      app2.rearWindow = app1;
+      app2.handleEvent({
+        type: '_closed'
+      });
+
+      assert.isFalse(stubScreenshot.called,
+                     'should never take screenshot on _closed when homescreen');
+      assert.isFalse(stubScreenshot2.called,
+                     'should never take screenshot on _closed when homescreen');
     });
 
     test('Kill a child window.', function() {


### PR DESCRIPTION
bug 1069452 - Never take screenshot of closing AppWindow if part of home...
(cherry picked from commit 2834baf4c7e34fe6ef335f0469f6d0f593c5922b)

Conflicts:
    apps/system/test/unit/callscreen_window_test.js

Manually resolved, this test does not exist in 2.0 because the callscreen
does not have it's own window type.
