### PR TITLE
Bug 1068116 - [email/POP3] email.js POP3 attachment regressions: binary attachments are corrupted on download and partially downloaded attachments are saved to disk. r=mcav

### DIFF
--- a/apps/email/js/ext/imap/folder.js
+++ b/apps/email/js/ext/imap/folder.js
@@ -882,11 +882,6 @@ console.log('BISECT CASE', serverUIDs.length, 'curDaysDelta', curDaysDelta);
 
             var node = parser.node;
 
-            console.error('imap:built-attachment-part', JSON.stringify({
-              contentType: node.contentType.value,
-              length: node.content.length
-            }));
-
             bodies[index] = new Blob([node.content], {
               type: node.contentType.value
             });

--- a/apps/email/js/ext/jobmixins.js
+++ b/apps/email/js/ext/jobmixins.js
@@ -362,7 +362,7 @@ function(_LOG, blob, storeTo, filename, partInfo, cb, isRetry) {
       var idxLastPeriod = filename.lastIndexOf('.');
       if (idxLastPeriod === -1)
         idxLastPeriod = filename.length;
-      filename = filename.substring(0, idxLastPeriod) + '-' + Date.now() +
+      filename = filename.substring(0, idxLastPeriod) + '-' + $date.NOW() +
         filename.substring(idxLastPeriod);
       saveToDeviceStorage(_LOG, blob, storeTo, filename, partInfo, cb, true);
     }
@@ -466,7 +466,7 @@ exports.do_downloadBodyReps = function(op, callback) {
     // many times body change notifications will be fired.
     folderStorage.getMessageBody(header.suid, header.date,
                                          function(body) {
-      if (!body.bodyReps.every(function(rep) { return rep.isDownloaded; })) {
+      if (!folderStorage.messageBodyRepsDownloaded(body)) {
         folderConn.downloadBodyReps(header, onDownloadReps);
       } else {
         // passing flushed = true because we don't need to save anything


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/342 in gaia
