### PR TITLE
Bug 1074800 - NfcHandler starts to listen for peerready only when NFC is enabled, r=alive

### DIFF
--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -99,6 +99,14 @@
     _settingsObserveHandler: null,
 
     /**
+     * Handles system browser URL sharing via NFC. Starts listening for
+     * peerready events once NFC is enabled in settings
+     * @type {Object}
+     * @memberOf module:AppWindowManager
+     */
+    _nfcHandler: null,
+
+    /**
      * Switch to a different app
      * @param {AppWindow} newApp The new app window instance.
      * @param {String} [openAnimation] The open animation for opening app.
@@ -247,9 +255,6 @@
      * @memberOf module:AppWindowManager
      */
     init: function awm_init() {
-      var nfcHandler = new NfcHandler(this);
-      nfcHandler.start();
-
       if (System.slowTransition) {
         this.element.classList.add('slow-transition');
       } else {
@@ -316,6 +321,21 @@
               this.broadcastMessage('kill_suspended');
             }
           }.bind(this)
+        },
+
+        'nfc.enabled': {
+          defaultValue: false,
+          callback: (value) => {
+            if (!this._nfcHandler) {
+              this._nfcHandler = new NfcHandler(this);
+            }
+
+            if (value) {
+              this._nfcHandler.start();
+            } else {
+              this._nfcHandler.stop();
+            }
+          }
         }
       };
 

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -866,6 +866,27 @@ suite('system/AppWindowManager', function() {
       MockSettingsListener.mCallbacks['continuous-transition.enabled'](true);
       assert.isTrue(AppWindowManager.continuousTransition);
     });
+
+    test('nfc.enabled', function() {
+      assert.isNull(AppWindowManager._nfcHandler,
+                    '_nfcHandler should be null when NFC disabled');
+
+      // enable NFC to instantiate _nfcHandler before stubbing its methods
+      MockSettingsListener.mCallbacks['nfc.enabled'](true);
+      assert.isTrue(AppWindowManager._nfcHandler !== null,
+                    '_nfcHandler should not be null after enabling NFC');
+
+      var stubNfcStart = this.sinon.stub(AppWindowManager._nfcHandler, 'start');
+      var stubNfcStop = this.sinon.stub(AppWindowManager._nfcHandler, 'stop');
+
+      MockSettingsListener.mCallbacks['nfc.enabled'](false);
+      assert.isTrue(stubNfcStop.calledOnce,
+                    '_nfcHandler.stop() should be called');
+
+      MockSettingsListener.mCallbacks['nfc.enabled'](true);
+      assert.isTrue(stubNfcStart.calledOnce,
+                    '_nfcHandler.start() should be called');
+    });
   });
 
   suite('linkWindowActivity', function() {

--- a/apps/system/test/unit/mock_nfc_handler.js
+++ b/apps/system/test/unit/mock_nfc_handler.js
@@ -5,3 +5,4 @@
 function MockNfcHandler() {}
 
 MockNfcHandler.prototype.start = function() {};
+MockNfcHandler.prototype.stop = function() {};


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1074800
