### PR TITLE
Bug 1071235 - Fix touching fullscreen video displaying controls

### DIFF
--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -299,6 +299,11 @@
   background-color: inherit;
 }
 
+/* Bug 1071235: Workaround for bug 1076783 */
+.browser-container:-moz-full-screen-ancestor > .screenshot-overlay {
+  visibility: hidden;
+}
+
 .appWindow.collapsible:not(.active) .screenshot-overlay {
   margin-top: 4.6rem;
 }


### PR DESCRIPTION
CSS background-color in ".appWindow.collapsible .screenshot-overlay"
makes the platform breaking tapping on a fullscreen video. Setting
'visiblity: hidden' when we are fullscreen does workaround the issue.
