### PR TITLE
Bug 1075273 - Remove mozL10n.translate

### DIFF
--- a/shared/js/l10n.js
+++ b/shared/js/l10n.js
@@ -1362,9 +1362,6 @@
     localize: function localize(element, id, args) {
       return localizeElement.call(navigator.mozL10n, element, id, args);
     },
-    translate: function () {
-      // XXX: Remove after removing obsolete calls. Bugs 992473 and 1020136
-    },
     translateFragment: function (fragment) {
       return translateFragment.call(navigator.mozL10n, fragment);
     },

--- a/shared/test/unit/mocks/mock_l10n.js
+++ b/shared/test/unit/mocks/mock_l10n.js
@@ -7,9 +7,6 @@
 
     get: stringify,
 
-    // XXX Remove in https://bugzil.la/1020136
-    translate: function() {},
-
     translateFragment: function() {},
 
     // XXX Remove in https://bugzil.la/1020137


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1075273
