### PR TITLE
Bug 1064712 - Dont removeCard twice. r=etienne

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -238,10 +238,12 @@
    */
   Card.prototype.destroy = function() {
     this.publish('willdestroy');
-    this._unregisterEvents();
     var element = this.element;
-    if (element && element.parentNode) {
-      element.parentNode.removeChild(element);
+    if (element) {
+      this._unregisterEvents();
+      if (element.parentNode) {
+        element.parentNode.removeChild(element);
+      }
     }
     this.element = this.manager = this.app = null;
     this.publish('destroyed');

--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -477,9 +477,10 @@
    */
   TaskManager.prototype.removeCard = function cs_removeCard(card,
                                                             removeImmediately) {
+
     var element = card.element;
     var position = element.dataset.position;
-    delete this.cardsByAppID[card.app.instanceID];
+    delete this.cardsByAppID[element.dataset.appInstanceId];
     card.destroy();
     element = null;
 
@@ -601,7 +602,6 @@
       AppWindowManager._updateActiveApp(homescreenLauncher
                                           .getHomescreen().instanceID);
     }
-    this.removeCard(card, removeImmediately);
   };
 
   /**

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -96,6 +96,16 @@ suite('system/TaskManager >', function() {
     window.dispatchEvent(evt);
   }
 
+  function sendAppTerminated(detail) {
+    detail = detail || {
+      manifestURL: 'http://sms.gaiamobile.org/manifest.webapp',
+      origin: 'http://sms.gaiamobile.org',
+      isHomescreen: false
+    };
+    var evt = new CustomEvent('appterminated', { detail: detail });
+    window.dispatchEvent(evt);
+  }
+
   var apps, home;
   var sms, game, game2, game3, game4;
   var taskManager;
@@ -984,6 +994,12 @@ suite('system/TaskManager >', function() {
         'http://sms.gaiamobile.org': apps['http://sms.gaiamobile.org'],
         'http://game.gaiamobile.org': apps['http://game.gaiamobile.org']
       };
+      sinon.stub(apps['http://sms.gaiamobile.org'], 'kill', function() {
+        sendAppTerminated(this);
+      });
+      sinon.stub(apps['http://game.gaiamobile.org'], 'kill', function() {
+        sendAppTerminated(this);
+      });
 
       assert.isFalse(taskManager.isShown(), 'taskManager isnt showing yet');
       waitForEvent(window, 'cardviewshown')
@@ -992,6 +1008,8 @@ suite('system/TaskManager >', function() {
       taskManager.show();
     });
     teardown(function() {
+      apps['http://sms.gaiamobile.org'].kill.restore();
+      apps['http://game.gaiamobile.org'].kill.restore();
       taskManager.hide(true);
       cardsList.innerHTML = '';
     });


### PR DESCRIPTION
'element is null' exception was being thrown as a result of the removeCard method being called twice when closing an app in the task manager.
