### PR TITLE
Bug 1075970 - The reverse (TargetObj-to-DOMElement) map introduced in Bug 1044525 is now one-to-many mapping.

### DIFF
--- a/apps/keyboard/js/keyboard/alternatives_char_menu_manager.js
+++ b/apps/keyboard/js/keyboard/alternatives_char_menu_manager.js
@@ -38,7 +38,7 @@ AlternativesCharMenuManager.prototype.show = function(target) {
 
   // Get the targetRect before menu is shown.
   var targetRect =
-    IMERender.targetObjDomMap.get(target).getBoundingClientRect();
+    IMERender.getDomElemFromTargetObject(target).getBoundingClientRect();
 
   // XXX: Remove reference to IMERender in the global in the future.
   this._currentMenuView = IMERender.showAlternativesCharMenu(target,
@@ -120,7 +120,7 @@ AlternativesCharMenuManager.prototype.isMenuTarget = function(target) {
     return false;
   }
 
-  return (IMERender.targetObjDomMap.get(target).parentNode ===
+  return (IMERender.getDomElemFromTargetObject(target).parentNode ===
           this._currentMenuView.getMenuContainer());
 };
 

--- a/apps/keyboard/js/views/alternatives_char_menu.js
+++ b/apps/keyboard/js/views/alternatives_char_menu.js
@@ -30,7 +30,7 @@ AlternativesCharMenuView.prototype.MENU_LINE_HEIGHT = 6;   // in rem
 
 AlternativesCharMenuView.prototype.show = function(key) {
   var content = document.createDocumentFragment();
-  var keyElem = IMERender.targetObjDomMap.get(key);
+  var keyElem = IMERender.getDomElemFromTargetObject(key);
 
   // XXX: should not cause reflow by ref. innerWidth
   var cachedWindowWidth = window.innerWidth;

--- a/apps/keyboard/test/unit/keyboard/alternatives_char_menu_manager_test.js
+++ b/apps/keyboard/test/unit/keyboard/alternatives_char_menu_manager_test.js
@@ -68,7 +68,13 @@ suite('AlternativesCharMenuManager', function() {
         };
       },
       hideAlternativesCharMenu: this.sinon.stub(),
-      targetObjDomMap: new WeakMap()
+      targetObjDomMap: new WeakMap(),
+      setDomElemTargetObject: function(elem, obj){
+        this.targetObjDomMap.set(obj, elem);
+      },
+      getDomElemFromTargetObject: function(obj){
+        return this.targetObjDomMap.get(obj);
+      }
     };
     this.sinon.spy(window.IMERender, 'showAlternativesCharMenu');
 
@@ -106,7 +112,7 @@ suite('AlternativesCharMenuManager', function() {
       uppercaseValue: 'X'
     };
 
-    IMERender.targetObjDomMap.set(target, targetElem);
+    IMERender.setDomElemTargetObject(targetElem, target);
 
     // Show an alternatives chars menu
     manager = new AlternativesCharMenuManager(app);
@@ -212,7 +218,7 @@ suite('AlternativesCharMenuManager', function() {
       var stubMapGet;
 
       setup(function() {
-        stubMapGet = this.sinon.stub(IMERender.targetObjDomMap, 'get');
+        stubMapGet = this.sinon.stub(IMERender, 'getDomElemFromTargetObject');
       });
 
       test('true', function() {

--- a/apps/keyboard/test/unit/render_test.js
+++ b/apps/keyboard/test/unit/render_test.js
@@ -1,4 +1,5 @@
 /*global requireApp suite test assert setup teardown IMERender sinon */
+
 requireApp('keyboard/js/render.js');
 
 mocha.globals(['perfTimer']);
@@ -698,6 +699,131 @@ suite('Renderer', function() {
         assert.equal(comp.marginTop, '0px');
         assert.equal(comp.borderTopWidth, '1px');
         next();
+      });
+    });
+
+
+    suite('Switching to different inputTypes/showCandidatePanel/uppercase/' +
+          'supportsSwitching,and switching back,' +
+          'the target object mapping should work.', function() {
+      var layout = {
+        layoutName: 'some',
+        width: 2,
+        pageIndex: 0,
+        keys: [
+          [{ value: 'a' }, { value: 'b' }],
+          [{ value: 'c' }, { value: 'd' }],
+          [{ value: 'e' }, { value: 'f' }]
+        ]
+      };
+
+      var targetKey = layout.keys[0][0];
+      var oldMozInputMethod;
+      var defaultFlags;
+
+      setup(function() {
+        oldMozInputMethod = navigator.mozInputMethod;
+        navigator.mozInputMethod = {
+          mgmt: {
+            supportsSwitching: this.sinon.stub().returns(false)
+          }
+        };
+
+        defaultFlags = {
+          inputType: 'some-type',
+          showCandidatePanel: false,
+          uppercase: false
+        };
+      });
+
+      teardown(function() {
+        navigator.mozInputMethod = oldMozInputMethod;
+      });
+
+      test('input types', function() {
+        defaultFlags.inputType = 'some-type';
+        IMERender.draw(layout, defaultFlags);
+
+        defaultFlags.inputType = 'another-type';
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-a-f-f-false'),
+          'Should map into another-type\'s DOM element'
+        );
+
+        defaultFlags.inputType = 'some-type';
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-f-f-false'),
+          'Should map into one-type\'s DOM element'
+        );
+      });
+
+      test('showCandidatePanel', function() {
+        defaultFlags.showCandidatePanel = true;
+        IMERender.draw(layout, defaultFlags);
+
+        defaultFlags.showCandidatePanel = false;
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-f-f-false'),
+          'Should map into false-showCandidatePanel\'s DOM element'
+        );
+
+        defaultFlags.showCandidatePanel = true;
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-t-f-false'),
+          'Should map into true-showCandidatePanel\'s DOM element'
+        );
+      });
+
+      test('uppercase', function() {
+        defaultFlags.uppercase = true;
+        IMERender.draw(layout, defaultFlags);
+
+        defaultFlags.uppercase = false;
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-f-f-false'),
+          'Should map into false-uppercase\'s DOM element'
+        );
+
+        defaultFlags.uppercase = true;
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-f-t-false'),
+          'Should map into true-uppercase\'s DOM element'
+        );
+      });
+
+      test('supportsSwitching', function() {
+        navigator.mozInputMethod.mgmt.supportsSwitching.returns(true);
+        IMERender.draw(layout, defaultFlags);
+
+        navigator.mozInputMethod.mgmt.supportsSwitching.returns(false);
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-f-f-false'),
+          'Should map into false-supportsSwitching\'s DOM element'
+        );
+
+        navigator.mozInputMethod.mgmt.supportsSwitching.returns(true);
+        IMERender.draw(layout, defaultFlags);
+        assert.isTrue(
+          IMERender.getDomElemFromTargetObject(targetKey).parentNode.parentNode
+            .classList.contains('some-0-s-f-f-true'),
+          'Should map into true-supportsSwitching\'s DOM element'
+        );
+
+        navigator.mozInputMethod = oldMozInputMethod;
       });
     });
   });

--- a/apps/keyboard/test/unit/views/alternatives_char_menu_test.js
+++ b/apps/keyboard/test/unit/views/alternatives_char_menu_test.js
@@ -40,7 +40,7 @@ suite('Views > AlternativesCharMenuView', function() {
     IMERender.init(fakeLayoutRenderingManager);
 
     var keyElem = document.createElement('button');
-    IMERender.targetObjDomMap.set(key, keyElem);
+    IMERender.setDomElemTargetObject(keyElem, key);
   });
 
   suite('basic show/hide testing', function() {
@@ -109,7 +109,7 @@ suite('Views > AlternativesCharMenuView', function() {
       menu.getLineHeight.returns(KEY_HEIGHT);
 
       var keyElem = document.createElement('button');
-      IMERender.targetObjDomMap.set(key, keyElem);
+      IMERender.setDomElemTargetObject(keyElem, key);
     });
 
     teardown(function() {
@@ -188,7 +188,7 @@ suite('Views > AlternativesCharMenuView', function() {
       menu.getLineHeight.returns(KEY_HEIGHT);
 
       var keyElem = document.createElement('button');
-      IMERender.targetObjDomMap.set(key, keyElem);
+      IMERender.setDomElemTargetObject(keyElem, key);
     });
 
     teardown(function() {
@@ -271,7 +271,7 @@ suite('Views > AlternativesCharMenuView', function() {
       menu.getLineHeight.returns(KEY_HEIGHT);
 
       var keyElem = document.createElement('button');
-      IMERender.targetObjDomMap.set(key, keyElem);
+      IMERender.setDomElemTargetObject(keyElem, key);
     });
 
     teardown(function() {


### PR DESCRIPTION
- Since a layout may be associated with more than one rendered layouts (according to different input types and other flags), a target obj must be able to reverse-mapped to multiple DOMElements.
- The 'value' of the reverse WeakMap() (key'ed by target obj) is now an object of keyboardClass-to-DOMElement; the keyboardClass is decided by render as different keyboardClass values map to different physical DOM keyboard layout.
