### PR TITLE
Bug 1074499 - Check setCallingLineIdRestriction directly instead of using hasOwnProperty r=alive

### DIFF
--- a/apps/system/js/telephony_settings.js
+++ b/apps/system/js/telephony_settings.js
@@ -151,7 +151,7 @@
     },
 
     _setCallerIdPreference: function(conn, callerIdPreference, callback) {
-      if (!conn.hasOwnProperty('setCallingLineIdRestriction')) {
+      if (!conn.setCallingLineIdRestriction) {
         if (callback) {
           callback();
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1074499
