### PR TITLE
Bug 1069817 - [sms] localization missing for unknown contacts

### DIFF
--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -335,7 +335,7 @@
         ${photoHTML}
         <p class="name">${phoneDetailsHTML}</p>
         <p class="number">
-          <span data-l10n-id="${type}">Unknown Contact</span>
+          <span data-l10n-id="unknown-contact">Unknown</span>
         </p>
      </a>
     </li>


### PR DESCRIPTION
- Fixing for 2.1: Only reuse the original "unknown-contact" string instead of creating new string.
