### PR TITLE
Bug 960800 - [B2G][SMS][RTSP] RTSP link doesn't appear as hyperlink when SMS is received

### DIFF
--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -56,7 +56,7 @@
       "filters": {
         "type": "url",
         "url": {
-          "required":true, "pattern":"https?:.{1,16384}", "patternFlags":"i"
+          "required":true, "pattern":"(https?:|rtsp:).{1,16384}", "patternFlags":"i"
         }
       }
     },

--- a/apps/sms/js/link_helper.js
+++ b/apps/sms/js/link_helper.js
@@ -111,8 +111,8 @@ var LINK_TYPES = {
   url: {
     regexp: new RegExp([
       // must begin at start of string, after whitespace,
-      // {1} match the protocol https?:// (optional)
-      '(https?://)?',
+      // {1} match the protocol https?:// or rtsp:// (optional)
+      '(https?://|rtsp://)?',
       // {2} match "server name": . must be followed by at least one letter
       '((?:\\.?[-\\w]){1,256})',
       // {3} match a . followed by one or more domain valid chars
@@ -141,7 +141,7 @@ var LINK_TYPES = {
 
       // For Cases where:
       //
-      //  1. There was no scheme (eg, "http", "https")
+      //  1. There was no scheme (eg, "http", "https", "rtsp")
       //  2. The matched tld is not a number
       //  3. The matched tld is not a known tld
       //

--- a/apps/sms/test/unit/link_helper_test.js
+++ b/apps/sms/test/unit/link_helper_test.js
@@ -86,6 +86,9 @@ suite('link_helper_test.js', function() {
       test('Simple URL with IPv4 with zero', function() {
         testURLOK('http://8.0.8.8/');
       });
+      test('Simple URL rtsp', function() {
+        testURLOK('rtsp://www.mozilla.org/video.mov');
+      });
       test('<br>prefix', function() {
         testURLMatch('<br>mozilla.org', 'mozilla.org', true);
       });


### PR DESCRIPTION
- add hyperlink support to rtsp protocol

cherry-picked from f7f71723f11ef0b69c883f3ab503283293a3108e
