### PR TITLE
Bug 1078232 - Show empty group name edit hint text. r=crdlc

### DIFF
--- a/shared/elements/gaia_grid/js/items/group.js
+++ b/shared/elements/gaia_grid/js/items/group.js
@@ -117,9 +117,9 @@
       // Create the title span
       span = document.createElement('span');
       span.className = 'title';
-      span.textContent = this.name;
       this.headerSpanElement.appendChild(span);
       this.titleElement = span;
+      this.updateTitle();
 
       // Create the expand/collapse toggle
       span = document.createElement('span');
@@ -271,6 +271,25 @@
       // This needs to be called last, or the grid will skip rendering this
       // group and the collapse won't cause the icons below to shift position
       GaiaGrid.GridItem.prototype.setActive.call(this, active);
+    },
+
+    updateTitle: function() {
+      var titleElement = this.titleElement;
+      if (!titleElement) {
+        return;
+      }
+
+      if (this.name && this.name.trim() !== '') {
+        titleElement.classList.remove('empty');
+        titleElement.removeAttribute('data-l10n-id');
+        titleElement.textContent = this.name;
+        return;
+      }
+
+      titleElement.classList.add('empty');
+      titleElement.textContent = 'Enter a group name';
+      titleElement.setAttribute('data-l10n-id',
+                                     'gaia-grid-enter-group-name');
     },
 
     collapse: function() {

--- a/shared/elements/gaia_grid/locales/gaia_grid.en-US.properties
+++ b/shared/elements/gaia_grid/locales/gaia_grid.en-US.properties
@@ -9,3 +9,6 @@ gaia-grid-resume-download-body=Do you want to download {{name}}?
 gaia-grid-resume-download-action=Download
 
 gaia-grid-cancel=Cancel
+
+# Hint that appears in edit mode for groups with no title set.
+gaia-grid-enter-group-name=Enter a group name

--- a/shared/elements/gaia_grid/style.css
+++ b/shared/elements/gaia_grid/style.css
@@ -241,24 +241,35 @@
 }
 
 .group .header .title {
-  top: 0.9rem;
   left: 1.4rem;
   /* This is full width - gripper - toggle - padding */
   width: calc(100% - 2.7rem - 2.7rem - 2.8rem);
+  height: 4rem;
 
   text-align: left;
+  vertical-align: middle;
   color: white;
   font-size: 1.6rem;
   font-style: italic;
   font-weight: 300;
+  text-shadow: 0 0 0.6rem rgba(0, 0, 0, 0.45);
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
   pointer-events: none;
 }
 
+.group .header .title.empty {
+  opacity: 0;
+  color: #989898;
+}
+
 .edit-mode .header .title {
   transform: translate(3.3rem, 0);
+}
+
+.edit-mode .header .title.empty {
+  opacity: 1;
 }
 
 .group .header .toggle {


### PR DESCRIPTION
When a group is empty, show hint text in edit mode that you can enter a
name.
