### PR TITLE
Bug 1061660 - Fix some missing show transitions on BaseUI elements. r=alive

### DIFF
--- a/apps/system/js/base_ui.js
+++ b/apps/system/js/base_ui.js
@@ -26,6 +26,11 @@
     this.containerElement.insertAdjacentHTML('afterbegin', this.view());
     this._fetchElements();
     this._registerEvents();
+    if (this.element) {
+      // Force a style flush so that if the UI is immediately shown, any
+      // transition associated with the visible class will play.
+      this.element.clientTop;
+    }
     this.publish('rendered');
   };
 


### PR DESCRIPTION
Flush the style after element creation so that animations associated with
the visible class play.
