### PR TITLE
Fix: Bug 1069599

### DIFF
--- a/apps/costcontrol/settings.html
+++ b/apps/costcontrol/settings.html
@@ -68,7 +68,7 @@
           </ul>
 
           <!-- Phone activity -->
-          <gaia-subheader id="phone-activity-settings" aria-hidden="true" skin="organic">
+          <gaia-subheader id="phone-activity-settings" aria-hidden="true" aria-level="2" role="heading" skin="organic">
             <span data-l10n-id="phone-activity">Phone Activity</span>
           </gaia-subheader>
           <ul class="settings" aria-hidden="true">
@@ -82,7 +82,7 @@
           </ul>
 
           <!-- Balance alerts -->
-          <gaia-subheader id="balance-settings" aria-hidden="true" skin="organic">
+          <gaia-subheader id="balance-settings" aria-hidden="true" aria-level="2" role="heading" skin="organic">
             <span data-l10n-id="balance">balance</span>
           </gaia-subheader>
           <ul class="settings" aria-hidden="true">
@@ -106,7 +106,7 @@
           </ul>
 
           <!-- Data usage limits -->
-          <gaia-subheader id="data-usage-settings" skin="organic">
+          <gaia-subheader id="data-usage-settings" aria-level="2" role="heading" skin="organic">
             <span data-l10n-id="data-usage">Data Usage</span>
           </gaia-subheader>
           <ul class="settings">
@@ -135,7 +135,7 @@
           </ul>
 
           <!-- Tracking period -->
-          <gaia-subheader id="phone-internet-settings" aria-hidden="true" skin="organic">
+          <gaia-subheader id="phone-internet-settings" aria-hidden="true" aria-level="2" role="heading" skin="organic">
             <span data-l10n-id="internet-data-report">Internet data report</span>
           </gaia-subheader>
           <ul class="settings">


### PR DESCRIPTION
Changed all gaia-subheaders in costcontrol to aria-level 2 with role="heading".

Bug can be found at https://bugzilla.mozilla.org/show_bug.cgi?id=1069599

@lodr I was asked to have you review this PR.
