### PR TITLE
Bug 1067649 - v2.1 exit to app or homescreen

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -584,18 +584,19 @@
   TaskManager.prototype.exitToApp = function(app,
                                              openAnimation) {
     // Tell all applications we're about to leave task manager.
-    this.unfilteredStack.forEach(function(app) {
+    this.unfilteredStack && this.unfilteredStack.forEach(function(app) {
       app.leaveTaskManager();
     });
 
     if (!app) {
-      // return if possible to previous app.
-      // else homescreen
-      app = StackManager.getCurrent() ||
-            homescreenLauncher.getHomescreen(true);
+      // bug 1071852
+      app = homescreenLauncher.getHomescreen(true);
     }
+
+    // to know if position has changed we need index into original stack,
     var position = this.unfilteredStack ? this.unfilteredStack.indexOf(app) :
-                                          StackManager.position;
+                                          -1;
+
     if (position !== StackManager.position) {
       this.newStackPosition = position;
     }
@@ -612,14 +613,7 @@
    */
   TaskManager.prototype.closeApp = function cs_closeApp(card,
                                                         removeImmediately) {
-    var wasActive = AppWindowManager.getActiveApp() === card.app;
     card.killApp();
-
-    // if we killed the active app, make homescreen active
-    if (wasActive) {
-      AppWindowManager._updateActiveApp(homescreenLauncher
-                                          .getHomescreen().instanceID);
-    }
   };
 
   /**

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -1151,11 +1151,11 @@ suite('system/TaskManager >', function() {
     });
 
     test('when exitToApp is passed no app', function(done) {
-      var activeApp = MockAppWindowManager.mActiveApp;
-      var stub = this.sinon.stub(activeApp, 'open');
+      // See bug 1071852, in v2.1 'home' button should always open homescreen
+      var stub = this.sinon.stub(apps.home, 'open');
 
       waitForEvent(window, 'cardviewclosed').then(function() {
-        assert.isTrue(stub.calledOnce, 'active app open method was called');
+        assert.isTrue(stub.calledOnce, 'homescreen open method was called');
       }, failOnReject)
       .then(function() { done(); }, done);
 

--- a/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/cards_view.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/cards_view.py
@@ -29,11 +29,12 @@ class CardsView(Base):
         return self.is_element_displayed(*self._cards_view_locator)
 
     def wait_for_card_ready(self, app):
-        current_frame = self.apps.displayed_app.frame
-        card = self.marionette.find_element(*self._app_card_locator(app))
-        self.wait_for_condition(lambda m: current_frame.size['width'] - card.size['width'] == 2 * card.location['x'])
+        self.wait_for_condition(lambda m: self.is_closebutton_displayed(app))
         # TODO: Remove sleep when we find a better wait
         time.sleep(0.2)
+
+    def is_closebutton_displayed(self, app):
+        return self.is_element_displayed(*self._close_button_locator(app))
 
     def is_app_displayed(self, app):
         return self.is_element_displayed(*self._app_card_locator(app))

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/test_cards_view_kill_apps_with_two_apps.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cards_view/test_cards_view_kill_apps_with_two_apps.py
@@ -34,11 +34,17 @@ class TestCardsViewTwoApps(GaiaTestCase):
 
         # Close the current apps from the cards view
         self.cards_view.close_app(self._test_apps[1])
-        self.cards_view.close_app(self._test_apps[0])
 
-        # If successfully killed, the apps should no longer appear in the cards view and the "No recent apps" message should be displayed
+        # If successfully killed, the app should no longer appear in the cards view
         self.assertFalse(self.cards_view.is_app_present(self._test_apps[1]),
                          "Killed app not expected to appear in cards view")
+
+        self.assertTrue(self.cards_view.is_app_present(self._test_apps[0]),
+                         "2nd card remains after first is killed")
+
+        # If the last app is successfully killed, the cards view should hide
+        self.cards_view.close_app(self._test_apps[0])
+        self.cards_view.wait_for_cards_view_not_displayed()
 
         self.assertFalse(self.cards_view.is_app_present(self._test_apps[0]),
                          "Killed app not expected to appear in cards view")


### PR DESCRIPTION
Since bug 1071852, this logic can be simplified greatly. The patch avoids the trap where StackManager's getCurrent calls back to AppWindowManager's activeApp - which is not yet updated and points to the app we just killed.  
