### PR TITLE
Bug 1071919 - [Calendar] Settings drawer can become stuck open requiring app to be force closed r=gaye

### DIFF
--- a/apps/calendar/js/views/settings.js
+++ b/apps/calendar/js/views/settings.js
@@ -31,6 +31,11 @@
     _localUpdate: false,
 
     /**
+     * used to signal if transitionEnd was triggered by a "hide" action
+     */
+    _hiding: false,
+
+    /**
      * Name of the class that will be applied to the
      * body element when sync is in progress.
      */
@@ -312,7 +317,7 @@
 
     _onDrawerTransitionEnd: function(e) {
       this._updateDrawerAnimState('done');
-      if (!document.body.classList.contains('settings-drawer-visible')) {
+      if (this._hiding) {
         this.app.resetState();
       }
     },
@@ -325,11 +330,13 @@
     },
 
     _hideSettings: function() {
+      this._hiding = true;
       this._updateDrawerAnimState('animating');
       document.body.classList.remove('settings-drawer-visible');
     },
 
     _animateDrawer: function() {
+      this._hiding = false;
       // Wait for both _rendered and _activated before triggering
       // the animation, so that it is smooth, without jank due to
       // changes in style/layout from activating or rendering.
@@ -349,7 +356,7 @@
       // onactive can be called more times than oninactive, since
       // settings can overlay over and not trigger an inactive state,
       // so only bind these listeners and do the drawer animation once.
-      if (!document.body.classList.contains('settings-drawer-visible')) {
+      if (!this._activated) {
         this._activated = true;
         this._animateDrawer();
 


### PR DESCRIPTION
bug caused by race condition, that's why it's intermittent and not so easy to reproduce...

I was not able to write a marionette test to catch this regression (bug did not reproduce on marionette tests), so I think we will need to land it without tests.

code is basically triggering `_onDrawerTransitionEnd` before the class was added to the body, so it was behaving as if the user was closing the drawer, which made the view to get into a bad state (after opening the drawer again it did not have the click events).
