### PR TITLE
Bug 1071775  - avoid reset orientation when new app is attentionWindow or callscreenWindow

### DIFF
--- a/apps/system/js/app_transition_controller.js
+++ b/apps/system/js/app_transition_controller.js
@@ -216,8 +216,7 @@
 
       this.resetTransition();
       /* The AttentionToaster will take care of that for AttentionWindows */
-      if (this.app.CLASS_NAME !== 'AttentionWindow' &&
-          this.app.CLASS_NAME !== 'CallscreenWindow') {
+      if (!this.app.isAttentionWindow && !this.app.isCallscreenWindow) {
         this.app.setVisible(false);
       }
 
@@ -267,7 +266,9 @@
 
       // TODO:
       // May have orientation manager to deal with lock orientation request.
-      this.app.setOrientation();
+      if (!this.app.isAttentionWindow && !this.app.isCallscreenWindow) {
+        this.app.setOrientation();
+      }
       this.focusApp();
     };
 

--- a/apps/system/js/attention_window.js
+++ b/apps/system/js/attention_window.js
@@ -56,6 +56,7 @@
    * @event AttentionWindow#attentionrendered
    */
   var AttentionWindow = function AttentionWindow(config) {
+    this.isAttentionWindow = true;
     this.reConfig(config);
     this.render();
     if (this._DEBUG) {

--- a/apps/system/js/callscreen_window.js
+++ b/apps/system/js/callscreen_window.js
@@ -53,6 +53,7 @@
       url: CSORIGIN + 'index.html',
       origin: CSORIGIN
     };
+    this.isCallscreenWindow = true;
     this.reConfig(this.config);
     this.render();
     if (this._DEBUG) {

--- a/apps/system/test/unit/app_transition_controller_test.js
+++ b/apps/system/test/unit/app_transition_controller_test.js
@@ -245,16 +245,37 @@ suite('system/AppTransitionController', function() {
   });
 
   suite('Opened', function() {
+    var app1, acn1, stubRequestForeground, stubSetOrientation, stubShow;
+    setup(function() {
+      app1 = new MockAppWindow(fakeAppConfig1);
+      acn1 = new AppTransitionController(app1);
+      stubRequestForeground = this.sinon.stub(app1, 'requestForeground');
+      stubSetOrientation = this.sinon.stub(app1, 'setOrientation');
+      stubShow = this.sinon.stub(app1, 'show');
+    });
     test('Handle opened', function() {
-      var app1 = new MockAppWindow(fakeAppConfig1);
-      var acn1 = new AppTransitionController(app1);
-      var stubRequestForeground = this.sinon.stub(app1, 'requestForeground');
-      var stubSetOrientation = this.sinon.stub(app1, 'setOrientation');
-      var stubShow = this.sinon.stub(app1, 'show');
       acn1.handle_opened();
       assert.isTrue(stubRequestForeground.calledOnce);
       assert.isTrue(stubShow.called);
       assert.isTrue(stubSetOrientation.called);
+    });
+
+    test('Handle opened if the new window is attentionWindow', function() {
+      app1.isAttentionWindow = true;
+      acn1.handle_opened();
+      assert.isTrue(stubRequestForeground.calledOnce);
+      assert.isTrue(stubShow.called);
+      assert.isFalse(stubSetOrientation.called);
+      app1.element.classList.remove('attentionWindow');
+    });
+
+    test('Handle opened if the new window is callscreenWindow', function() {
+      app1.isCallscreenWindow = true;
+      acn1.handle_opened();
+      assert.isTrue(stubRequestForeground.calledOnce);
+      assert.isTrue(stubShow.called);
+      assert.isFalse(stubSetOrientation.called);
+      app1.element.classList.remove('callscreenWindow');
     });
   });
 
@@ -275,7 +296,7 @@ suite('system/AppTransitionController', function() {
   test('Do not send to background in closed handler for attention windows',
     function() {
       var app1 = new MockAppWindow(fakeAppConfig1);
-      app1.CLASS_NAME = 'AttentionWindow';
+      app1.isAttentionWindow = true;
       var acn1 = new AppTransitionController(app1);
       var stubSetVisible = this.sinon.stub(app1, 'setVisible');
       acn1.handle_closed();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1071775
