### PR TITLE
Bug 1069380 - Use link role instead of button for open action in cards view

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -71,7 +71,7 @@
    */
   Card.prototype._template =
     '<div class="screenshotView bb-button" data-l10n-id="openCard" ' +
-    '  role="button"></div>' +
+    '  role="link"></div>' +
     '<div class="appIconView" style="background-image:{iconValue}"></div>' +
     '' +
     '<div class="titles">' +
@@ -81,7 +81,7 @@
     '' +
     '<footer class="card-tray">'+
     ' <button class="appIcon" data-l10n-id="openCard" ' +
-    '   data-button-action="select"></button>' +
+    '   data-button-action="select" aria-hidden="true"></button>' +
     ' <menu class="buttonbar">' +
     '   <button class="close-button bb-button" data-l10n-id="closeCard" ' +
     '     data-button-action="close" role="button" ' +
@@ -335,4 +335,3 @@
   return (exports.Card = Card);
 
 })(window);
-

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -83,6 +83,13 @@ suite('system/Card', function() {
       assert.ok(header.id, 'h1.id');
     });
 
+    test('has expected aria values', function(){
+      var card = this.card;
+
+      assert.equal(card.screenshotView.getAttribute('role'), 'link');
+      assert.strictEqual(card.iconButton.getAttribute('aria-hidden'), 'true');
+    });
+
     test('adds browser class for browser windows', function(){
       var app = makeApp({ name: 'browserwindow' });
       this.sinon.stub(app, 'isBrowser', function() {


### PR DESCRIPTION
Changes the button role on the screenshotView to link, and adds the aria-hidden=true attribute to the iconButton to hide it from AT's. Added tests to ensure the aria properties in the cards view.

https://bugzilla.mozilla.org/show_bug.cgi?id=1069380

Replaces https://github.com/mozilla-b2g/gaia/pull/24785
