### PR TITLE
Bug 1079211 - [v2.2] Disable test_unlock_to_camera_with_passcode because...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
@@ -17,6 +17,7 @@ camera = true
 skip-if = device == "desktop"
 smoketest = true
 camera = true
+disabled = Bug 1078270 - Camera app dies/crashes after unlocking from lockscreen with passcode
 
 [test_lockscreen_unlock_to_homescreen_with_passcode.py]
 


### PR DESCRIPTION
... of Bug 1078270
