### PR TITLE
Bug 1043643 - Use shared mock_l10n in all Settings test

### DIFF
--- a/apps/settings/test/unit/panels/root/bluetooth_item_test.js
+++ b/apps/settings/test/unit/panels/root/bluetooth_item_test.js
@@ -5,7 +5,7 @@ mocha.globals(['MockL10n']);
 suite('BluetoothItem', function() {
   var realL10n;
   var modules = [
-    'unit/mock_l10n',
+    'shared_mocks/mock_l10n',
     'panels/root/bluetooth_item'
   ];
   var map = {


### PR DESCRIPTION
This is a followup landing to https://github.com/mozilla-b2g/gaia/commit/a6c29cc2f048dc08a2f008322699368b7e5cd9b0.

https://bugzilla.mozilla.org/show_bug.cgi?id=1043643#c17
