### PR TITLE
Bug 1075970 - Ensure that the forward (DOMElem->TargetObj) and reverse (TargetObj->DOMElem) maps are one-to-one mapping

### DIFF
--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -912,8 +912,15 @@ var IMERender = (function() {
   // and renderer's reverse map.
   // ideally this should only be used with views (renderer & alt_char_menu.js).
   var setDomElemTargetObject = function setDomElemTargetObject(elem, obj) {
-    renderingManager.domObjectMap.set(elem, obj);
-    targetObjDomMap.set(obj, elem);
+    // since a target object of one layout may map to multiple rendered DOM
+    // layouts (by different |keyboardClass|'es above), we need to create a
+    // "reference stub" of the target object; each rendered DOM layout key
+    // has a reference stub unique from that key of another rendered DOM layout.
+    // So, a DOM element may forward map to a target object, and then reverse
+    // map back to the DOM element correctly.
+    var objRef = Object.freeze(Object.create(obj));
+    renderingManager.domObjectMap.set(elem, objRef);
+    targetObjDomMap.set(objRef, elem);
   };
 
   // Measure the width of the element, and return the scale that

--- a/apps/keyboard/test/unit/render_test.js
+++ b/apps/keyboard/test/unit/render_test.js
@@ -720,11 +720,16 @@ suite('Renderer', function() {
       dummy: 'dummy'
     };
 
+    setup(function() {
+      IMERender.init(fakeRenderingManager);
+    });
+
     test('Highlight a key with uppercase', function() {
       var keyElem = document.createElement('div');
 
       IMERender.setDomElemTargetObject(keyElem, dummyKey);
-      IMERender.highlightKey(dummyKey, { showUpperCase: true });
+      IMERender.highlightKey(fakeRenderingManager.getTargetObject(keyElem),
+                             { showUpperCase: true });
 
       assert.isTrue(keyElem.classList.contains('highlighted'));
       assert.isFalse(keyElem.classList.contains('lowercase'));
@@ -734,7 +739,8 @@ suite('Renderer', function() {
       var keyElem = document.createElement('div');
 
       IMERender.setDomElemTargetObject(keyElem, dummyKey);
-      IMERender.highlightKey(dummyKey, { showUpperCase: false });
+      IMERender.highlightKey(fakeRenderingManager.getTargetObject(keyElem),
+                             { showUpperCase: false });
 
       assert.isTrue(keyElem.classList.contains('highlighted'));
       assert.isTrue(keyElem.classList.contains('lowercase'));

--- a/apps/keyboard/test/unit/views/alternatives_char_menu_test.js
+++ b/apps/keyboard/test/unit/views/alternatives_char_menu_test.js
@@ -91,7 +91,7 @@ suite('Views > AlternativesCharMenuView', function() {
 
         IMERender.setDomElemTargetObject(child, childObj);
 
-        childObjs.push(childObj);
+        childObjs.push(fakeLayoutRenderingManager.getTargetObject(child));
       }
 
       rootElement.appendChild(fakeMenu);
@@ -170,7 +170,7 @@ suite('Views > AlternativesCharMenuView', function() {
 
         IMERender.setDomElemTargetObject(child, childObj);
 
-        childObjs.push(childObj);
+        childObjs.push(fakeLayoutRenderingManager.getTargetObject(child));
       }
 
       rootElement.appendChild(fakeMenu);
@@ -253,7 +253,7 @@ suite('Views > AlternativesCharMenuView', function() {
 
         IMERender.setDomElemTargetObject(child, childObj);
 
-        childObjs.push(childObj);
+        childObjs.push(fakeLayoutRenderingManager.getTargetObject(child));
       }
 
       rootElement.appendChild(fakeMenu);


### PR DESCRIPTION
Done by creating "reference stubs" to target objects when we're inserting things to the maps.
