### PR TITLE
Bug 1072500 - Do not launch FindMyDevice when user triggers Camera from LockScreen

### DIFF
--- a/apps/system/js/findmydevice_launcher.js
+++ b/apps/system/js/findmydevice_launcher.js
@@ -66,7 +66,14 @@ navigator.mozSettings.addObserver('geolocation.enabled', function(event) {
   wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_STALE_REGISTRATION);
 });
 
-window.addEventListener('lockscreen-appclosing', function(event) {
+window.addEventListener('lockscreen-request-unlock', function(event) {
+  if (event.detail && event.detail.activity &&
+      'record' === event.detail.activity.name) {
+    // Let's make sure we won't start FMD when user triggers Camera from
+    // the lockscreen.
+    return;
+  }
+
   // clear the lockscreen lock message
   var helper = SettingsHelper('lockscreen.lock-message');
   helper.set('');

--- a/apps/system/test/unit/findmydevice_launcher_test.js
+++ b/apps/system/test/unit/findmydevice_launcher_test.js
@@ -147,16 +147,26 @@ suite('FindMyDevice Launcher >', function(done) {
   });
 
   test('clear lockscreen message when the lockscreen unlocks', function() {
-    window.dispatchEvent(new CustomEvent('lockscreen-appclosing'));
+    window.dispatchEvent(new CustomEvent('lockscreen-request-unlock'));
     assert.equal(
       MockSettingsHelper.instances['lockscreen.lock-message'].value, '');
   });
 
   test('fmd is awoken with LOCKSCREEN_CLOSED on lockscreen unlock', function() {
-    window.dispatchEvent(new CustomEvent('lockscreen-appclosing'));
+    window.dispatchEvent(new CustomEvent('lockscreen-request-unlock'));
     sinon.assert.calledWith(window.wakeUpFindMyDevice,
       IAC_API_WAKEUP_REASON_LOCKSCREEN_CLOSED);
   });
+
+  test('fmd is not awoken with LOCKSCREEN_CLOSED on lockscreen camera launch',
+    function() {
+      window.dispatchEvent(
+        new CustomEvent('lockscreen-request-unlock',
+        {detail: {activity: {name: 'record'}}}));
+      sinon.assert.notCalled(window.wakeUpFindMyDevice,
+        IAC_API_WAKEUP_REASON_LOCKSCREEN_CLOSED);
+    }
+  );
 
   test('send LOGIN wakeup message on FxA login', function() {
     window.dispatchEvent(


### PR DESCRIPTION
When the user triggers Camera from the LockScreen, FMD will catch the
event and wake up. This consumes a preallocated process at least.
Figures shows that we double the launch time from the Camera app point
of view.
