### PR TITLE
Bug 1072191, 1074613, 1072186 - Layout normalization follow-ups

### DIFF
--- a/apps/keyboard/js/keyboard/layout_loader.js
+++ b/apps/keyboard/js/keyboard/layout_loader.js
@@ -145,7 +145,6 @@ Keyboards.telLayout = {
 
 var LayoutLoader = function(app) {
   this.app = app;
-  this._normalizer = null;
 };
 
 LayoutLoader.prototype.SOURCE_DIR = './js/layouts/';
@@ -153,7 +152,6 @@ LayoutLoader.prototype.SOURCE_DIR = './js/layouts/';
 LayoutLoader.prototype.start = function() {
   this._initializedLayouts = {};
   this._layoutsPromises = {};
-  this._normalizer = new LayoutNormalizer();
   this.initLayouts();
 };
 
@@ -168,7 +166,9 @@ LayoutLoader.prototype.initLayouts = function() {
       console.warn('LayoutLoader: ' + layoutName + ' is overwritten.');
     }
     this._initializedLayouts[layoutName] = Keyboards[layoutName];
-    this._normalizeLayout(layoutName);
+
+    var layoutNormalizer = new LayoutNormalizer(this.getLayout(layoutName));
+    layoutNormalizer.normalize();
 
     // Create a promise so that these panels can be loaded async
     // even if they are not loaded with file of their name.
@@ -177,111 +177,6 @@ LayoutLoader.prototype.initLayouts = function() {
         Promise.resolve(this._initializedLayouts[layoutName]);
     }
   }
-};
-
-// In order to keep the commit log sane, some amendments of the
-// layout JS structure are fix here in runtime instead of hardcoded.
-// TODO: normalize the layout files and maybe remove this function.
-LayoutLoader.prototype._normalizeLayout = function(layoutName) {
-  var layout = this.getLayout(layoutName);
-
-  var pages;
-  if ('pages' in layout) {
-    pages = layout.pages;
-  } else {
-    pages = layout.pages = [];
-  }
-
-  if (!pages[0]) {
-    pages[0] = {};
-
-    // These are properties of the basic page that previously put in the layout
-    // itself. We should move them to the page object and remove them from
-    // the layout object.
-    ['alt', 'keys', 'upperCase', 'width', 'keyClassName',
-      'typeInsensitive', 'textLayoutOverwrite',
-      'needsCommaKey', 'secondLayout', 'specificCssRule'
-    ].forEach(function(prop) {
-      if (layout[prop]) {
-        pages[0][prop] = layout[prop];
-        delete layout[prop];
-      }
-    });
-  }
-
-  // Normalize key properties such that other modules can deal with them easily
-  // Also, go through each pages and inspect it's "alt" property;
-  // we want to normalize our existing mixed notations into arrays.
-  pages.forEach(function(page) {
-    this._normalizer.normalizePageKeys(page, layout);
-
-    // XXX: move alt char normalization to the normalizer
-    var alt = page.alt = page.alt || {};
-    var upperCase = page.upperCase = page.upperCase || {};
-    var altKeys = Object.keys(alt);
-    altKeys.forEach(function(key) {
-      var alternatives = alt[key];
-
-      // Split alternatives
-      // If the alternatives are delimited by spaces, it means that one or more
-      // of them is more than a single character long.
-      if (!Array.isArray(alternatives)) {
-        if (alternatives.indexOf(' ') !== -1) {
-          alternatives = alternatives.split(' ');
-
-          // If there is just a single multi-character alternative, it will have
-          // trailing whitespace which we have to discard here.
-          if (alternatives.length === 2 && alternatives[1] === '') {
-            alternatives.pop();
-          }
-        } else {
-          // No spaces, so all of the alternatives are single characters
-          alternatives = alternatives.split('');
-        }
-      }
-
-      alt[key] = alternatives;
-
-      var upperCaseKey = upperCase[key] || key.toUpperCase();
-      if (!alt[upperCaseKey]) {
-        var needDifferentUpperCaseLockedAlternatives = false;
-        // Creating an array for upper case too.
-        // XXX: The original code does not respect page.upperCase here.
-        alt[upperCaseKey] = alternatives.map(function(key) {
-          if (key.length === 1) {
-            return key.toUpperCase();
-          }
-
-          // The 'l·l' key in the Catalan layout needs to be
-          // 'L·l' in upper case mode and 'L·L' in upper case locked mode.
-          // (see http://bugzil.la/896363#c19)
-          // If that happens we will create a different array for
-          // upper case locked mode.
-
-          // Last chance for figuring out if we need a different list of
-          // alternatives; if key.substr(1) has no upper case form,
-          // (e.g. R$ key) we should be able to skip this.
-          needDifferentUpperCaseLockedAlternatives =
-            needDifferentUpperCaseLockedAlternatives ||
-            (key.substr(1).toUpperCase() !== key.substr(1));
-
-          // We only capitalize the first character of the key in
-          // the normalization here.
-          return key[0].toUpperCase() + key.substr(1);
-        });
-
-        // If we really need an special upper case locked alternatives,
-        // do it here and attach that as a property of the
-        // alt[upperCaseKey] array/object. Noted that this property of the array
-        // can't be represented in JSON so it's not visible in JSON.stringify().
-        if (needDifferentUpperCaseLockedAlternatives) {
-          alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
-            return key.toUpperCase();
-          });
-        }
-      }
-    }, this);
-  }, this);
 };
 
 LayoutLoader.prototype.getLayout = function(layoutName) {

--- a/apps/keyboard/js/keyboard/layout_normalizer.js
+++ b/apps/keyboard/js/keyboard/layout_normalizer.js
@@ -8,9 +8,10 @@
  * LayoutNormalizer normalizes a layout's key objects such that
  * Dealing business logics with them will be less painful.
  * @class
- * @param {Object} app the keyboard app instance
+ * @param {Object} layout the layout we're going to normalize
  */
-var LayoutNormalizer = function() {
+var LayoutNormalizer = function(layout) {
+  this._layout = layout;
 };
 
 LayoutNormalizer.prototype._isSpecialKey = function(key) {
@@ -26,21 +27,21 @@ LayoutNormalizer.prototype._isSpecialKey = function(key) {
   return hasSpecialCode || key.keyCode <= 0;
 };
 
-LayoutNormalizer.prototype._getUpperCaseValue = function(key, layout) {
+LayoutNormalizer.prototype._getUpperCaseValue = function(key) {
   if (KeyEvent.DOM_VK_SPACE === key.keyCode ||
       this._isSpecialKey(key) ||
       key.compositeKey) {
     return key.value;
   }
 
-  var upperCase = layout.upperCase || {};
+  var upperCase = this._layout.upperCase || {};
   return upperCase[key.value] || key.value.toUpperCase();
 };
 
 // normalize one key of the layout
-LayoutNormalizer.prototype._normalizeKey = function(key, layout) {
+LayoutNormalizer.prototype._normalizeKey = function(key) {
   var keyChar = key.value;
-  var upperCaseKeyChar = this._getUpperCaseValue(key, layout);
+  var upperCaseKeyChar = this._getUpperCaseValue(key);
 
   var code = key.keyCode || keyChar.charCodeAt(0);
   var upperCode = key.keyCode || upperCaseKeyChar.charCodeAt(0);
@@ -60,22 +61,151 @@ LayoutNormalizer.prototype._normalizeKey = function(key, layout) {
   }
 
   if (key.supportsSwitching) {
-    this._normalizeKey(key.supportsSwitching, layout);
+    this._normalizeKey(key.supportsSwitching);
   }
 
   if (KeyboardEvent.DOM_VK_ALT === code && !('targetPage' in key)) {
     console.error('LayoutNormalizer: no targetPage for switching key.');
   }
+
+  // XXX: we modify space key and enter key in layout_manager
+  //      so we can't freeze them
+  if(key.keyCode !== KeyboardEvent.DOM_VK_SPACE &&
+     key.keyCode !== KeyboardEvent.DOM_VK_RETURN) {
+    return Object.freeze(key);
+  }else{
+    return key;
+  }
 };
 
 // normalize all keys in the page of the layout
-LayoutNormalizer.prototype.normalizePageKeys = function(page, layout) {
+LayoutNormalizer.prototype._normalizePageKeys = function(page) {
   var keyRows = page.keys || [];
 
-  keyRows.forEach(function(keyRow) {
-    keyRow.forEach(function(key) {
-      this._normalizeKey(key, layout);
+  page.keys = keyRows.map(function(keyRow) {
+    return keyRow.map(function(key) {
+      return this._normalizeKey(key);
     }, this);
+  }, this);
+
+  var overwrites = page.textLayoutOverwrite || {};
+
+  page.textLayoutOverwrite =
+    Object.keys(overwrites).reduce(function(result, overwrittenKey){
+    if (false === overwrites[overwrittenKey]) {
+      result[overwrittenKey] = false;
+    } else {
+      result[overwrittenKey] =
+        this._normalizeKey({value: overwrites[overwrittenKey]});
+    }
+    return result;
+  }.bind(this), {});
+};
+
+// normalize alt keys in the page of the layout
+LayoutNormalizer.prototype._normalizePageAltKeys = function(page) {
+  // XXX: move alt char normalization to the normalizer
+  var alt = page.alt = page.alt || {};
+  var upperCase = page.upperCase = page.upperCase || {};
+  var altKeys = Object.keys(alt);
+  altKeys.forEach(function(key) {
+    var alternatives = alt[key];
+
+    // Split alternatives
+    // If the alternatives are delimited by spaces, it means that one or more
+    // of them is more than a single character long.
+    if (!Array.isArray(alternatives)) {
+      if (alternatives.indexOf(' ') !== -1) {
+        alternatives = alternatives.split(' ');
+
+        // If there is just a single multi-character alternative, it will have
+        // trailing whitespace which we have to discard here.
+        if (alternatives.length === 2 && alternatives[1] === '') {
+          alternatives.pop();
+        }
+      } else {
+        // No spaces, so all of the alternatives are single characters
+        alternatives = alternatives.split('');
+      }
+    }
+
+    alt[key] = alternatives;
+
+    var upperCaseKey = upperCase[key] || key.toUpperCase();
+    if (!alt[upperCaseKey]) {
+      var needDifferentUpperCaseLockedAlternatives = false;
+      // Creating an array for upper case too.
+      // XXX: The original code does not respect page.upperCase here.
+      alt[upperCaseKey] = alternatives.map(function(key) {
+        if (key.length === 1) {
+          return key.toUpperCase();
+        }
+
+        // The 'l·l' key in the Catalan layout needs to be
+        // 'L·l' in upper case mode and 'L·L' in upper case locked mode.
+        // (see http://bugzil.la/896363#c19)
+        // If that happens we will create a different array for
+        // upper case locked mode.
+
+        // Last chance for figuring out if we need a different list of
+        // alternatives; if key.substr(1) has no upper case form,
+        // (e.g. R$ key) we should be able to skip this.
+        needDifferentUpperCaseLockedAlternatives =
+          needDifferentUpperCaseLockedAlternatives ||
+          (key.substr(1).toUpperCase() !== key.substr(1));
+
+        // We only capitalize the first character of the key in
+        // the normalization here.
+        return key[0].toUpperCase() + key.substr(1);
+      });
+
+      // If we really need an special upper case locked alternatives,
+      // do it here and attach that as a property of the
+      // alt[upperCaseKey] array/object. Noted that this property of the array
+      // can't be represented in JSON so it's not visible in JSON.stringify().
+      if (needDifferentUpperCaseLockedAlternatives) {
+        alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
+          return key.toUpperCase();
+        });
+      }
+    }
+  }, this);
+};
+
+// In order to keep the commit log sane, some amendments of the
+// layout JS structure are fix here in runtime instead of hardcoded.
+// TODO: normalize the layout files and maybe remove this function.
+LayoutNormalizer.prototype.normalize = function() {
+  var pages;
+  if ('pages' in this._layout) {
+    pages = this._layout.pages;
+  } else {
+    pages = this._layout.pages = [];
+  }
+
+  if (!pages[0]) {
+    pages[0] = {};
+
+    // These are properties of the basic page that previously put in the layout
+    // itself. We should move them to the page object and remove them from
+    // the layout object.
+    ['alt', 'keys', 'upperCase', 'width', 'keyClassName',
+      'typeInsensitive', 'textLayoutOverwrite',
+      'needsCommaKey', 'secondLayout', 'specificCssRule'
+    ].forEach(function(prop) {
+      if (this._layout[prop]) {
+        pages[0][prop] = this._layout[prop];
+        delete this._layout[prop];
+      }
+    }, this);
+  }
+
+  // Normalize key properties such that other modules can deal with them easily
+  // Also, go through each pages and inspect it's "alt" property;
+  // we want to normalize our existing mixed notations into arrays.
+  pages.forEach(function(page) {
+    this._normalizePageKeys(page);
+    this._normalizePageAltKeys(page);
   }, this);
 };
 

--- a/apps/keyboard/test/unit/keyboard/layout_manager_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_manager_test.js
@@ -16,27 +16,20 @@ suite('LayoutManager', function() {
           [
             { value: 'foo' }
           ]
-        ],
-        alt: {},
-        upperCase: {}
+        ]
       }
     ]
   };
 
   suiteSetup(function() {
     realKeyboards = window.Keyboards;
+    // for skae of simplicity, we by pass these two normalizations
+    LayoutNormalizer.prototype._normalizePageKeys = function() {};
+    LayoutNormalizer.prototype._normalizePageAltKeys = function() {};
   });
 
   suiteTeardown(function() {
     window.Keyboards = realKeyboards;
-  });
-
-  // because LayoutLoader.start calls LayoutLoader.initLayouts which uses its
-  // instantiated _normalizer, we can't stub the instance after we call
-  // LayoutManager.start() (which directly calls LayoutLoader.start()).
-  setup(function() {
-    var stubLayoutNormalizer = this.sinon.stub(LayoutNormalizer.prototype);
-    this.sinon.stub(window, 'LayoutNormalizer').returns(stubLayoutNormalizer);
   });
 
   // since bug 1035619, enter key's layout properties will always come
@@ -1128,9 +1121,7 @@ suite('LayoutManager', function() {
                       ariaLabel: 'alternateLayoutKey',
                       className: 'page-switch-key',
                       targetPage: 1 },
-                    { value: '!', ratio: 1, keyCode: 33, keyCodeUpper: 33,
-                      lowercaseValue: '!', uppercaseValue: '!',
-                      isSpecialKey: false },
+                    '!',
                     { value: '&nbsp', ratio: 4, keyCode: 32 },
                     { value: '.', ratio: 1, keyCode: 46, keyCodeUpper: 46,
                       lowercaseValue: '.', uppercaseValue: '.',
@@ -1393,14 +1384,6 @@ suite('LayoutManager', function() {
         assert.equal(manager.currentPage.__proto__,
           supportsSwitchingLayout.pages[0],
           'proto is set correctly for layout.');
-
-        assert.equal(manager.currentPage.keys[0][0].__proto__,
-          supportsSwitchingLayout.pages[0].keys[0][0].supportsSwitching,
-          'proto is set correctly for supportsSwitching key.');
-
-        assert.equal(manager.currentPage.keys[0][1].__proto__,
-          supportsSwitchingLayout.pages[0].keys[0][1].supportsSwitching,
-          'proto is set correctly for supportsSwitching key.');
 
         assert.equal(manager.currentPage.keys[1][2].__proto__,
           supportsSwitchingLayout.pages[0].keys[1][0],

--- a/apps/keyboard/test/unit/keyboard/layout_normalizer_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_normalizer_test.js
@@ -110,7 +110,7 @@ suite('LayoutNormalizer', function() {
     });
 
     test('Use uppercase from layout', function(){
-      var layout = {
+      normalizer._layout = {
         upperCase: {
           'a': 'E'
         }
@@ -119,16 +119,17 @@ suite('LayoutNormalizer', function() {
         keyCode: 'a'.charCodeAt(0),
         value: 'a'
       };
-      assert.equal(normalizer._getUpperCaseValue(key, layout), 'E',
+      assert.equal(normalizer._getUpperCaseValue(key), 'E',
                    'upperCase of "a" should be "E" in this crafted test');
     });
 
     test('Use key.value.toUpperCase()', function(){
+      normalizer._layout = {};
       var key = {
         keyCode: 'a'.charCodeAt(0),
         value: 'a'
       };
-      assert.equal(normalizer._getUpperCaseValue(key, {}), 'A');
+      assert.equal(normalizer._getUpperCaseValue(key), 'A');
     });
   });
 
@@ -141,33 +142,39 @@ suite('LayoutNormalizer', function() {
 
 
     test('Calling getUpperCaseValue', function(){
+      normalizer._layout = {};
+
       var key = {
         value: 'a'
       };
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
-      assert.isTrue(stubGetUpperCaseValue.calledWith(key, {}));
+      assert.isTrue(stubGetUpperCaseValue.calledWith(key));
 
     });
 
     test('keyCode is not present: value should derive into keyCode and ' +
          'keyCodeUpper', function(){
+      normalizer._layout = {};
+
       var key = {
         value: 'a'
       };
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.keyCode, 'a'.charCodeAt(0));
       assert.equal(key.keyCodeUpper, 'A'.charCodeAt(0));
     });
 
     test('keyCode is present: should derive into keyCodeUpper', function(){
+      normalizer._layout = {};
+
       var key = {
         value: 'a',
         keyCode: 'e'.charCodeAt(0)
@@ -175,7 +182,7 @@ suite('LayoutNormalizer', function() {
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.keyCodeUpper, 'e'.charCodeAt(0),
                    'keyCodeUpper should be keyCode of "e" ' +
@@ -184,13 +191,15 @@ suite('LayoutNormalizer', function() {
 
     test('value should derive into lowercaseValue and uppercaseValue',
       function(){
+      normalizer._layout = {};
+
       var key = {
         value: 'a'
       };
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.lowercaseValue, 'a');
       assert.equal(key.uppercaseValue, 'A');
@@ -201,13 +210,15 @@ suite('LayoutNormalizer', function() {
 
       stubIsSpecialKey.returns(true);
 
+      normalizer._layout = {};
+
       var key = {
         value: 'a'
       };
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.isTrue(key.isSpecialKey);
 
@@ -219,13 +230,14 @@ suite('LayoutNormalizer', function() {
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key2, {});
+      normalizer._normalizeKey(key2);
 
       assert.isFalse(key2.isSpecialKey);
     });
 
     test('longPressKeyCode is not present: should derive from longPressValue',
       function(){
+      normalizer._layout = {};
       var key = {
         value: 'a',
         longPressValue: 'a'
@@ -233,13 +245,15 @@ suite('LayoutNormalizer', function() {
 
       stubGetUpperCaseValue.returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.longPressKeyCode, 'a'.charCodeAt(0));
     });
 
     test('longPressKeyCode is present: should not derive from longPressValue',
       function(){
+      normalizer._layout = {};
+
       var key = {
         value: 'a',
         longPressValue: 'a',
@@ -248,7 +262,7 @@ suite('LayoutNormalizer', function() {
 
       stubGetUpperCaseValue.returns('A');      
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.longPressKeyCode, 'b'.charCodeAt(0),
                    'longPressKeyCode should be keyCode of "b" ' +
@@ -256,6 +270,8 @@ suite('LayoutNormalizer', function() {
     });
 
     test('supprtsSwitching key should be normalized too', function(){
+      normalizer._layout = {};
+
       var key = {
         value: 'c',
         supportsSwitching: {
@@ -266,29 +282,268 @@ suite('LayoutNormalizer', function() {
       stubGetUpperCaseValue.onFirstCall().returns('C');
       stubGetUpperCaseValue.onSecondCall().returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.supportsSwitching.keyCodeUpper, 'A'.charCodeAt(0));
     });
   });
 
-  test('normalizePageKeys', function() {
-    var page = {
-      keys: [
-        [ {value: 'a'}, {value: 'b'} ],
-        [ {value: 'c'}, {value: 'd'}, {value: 'e'} ]
-      ]
-    };
-    var layout = {};
+  suite('normalizePageKeys', function() {
+    test('keys', function() {
+      normalizer._layout = {};
 
-    var stubNormalizeKey = this.sinon.stub(normalizer, '_normalizeKey');
+      var page = {
+        keys: [
+          [ {value: 'a'}, {value: 'b'} ],
+          [ {value: 'c'}, {value: 'd'}, {value: 'e'} ]
+        ]
+      };
 
-    normalizer.normalizePageKeys(page, layout);
+      var stubNormalizeKey = this.sinon.stub(normalizer, '_normalizeKey');
 
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'a'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'b'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'c'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'd'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'e'}, layout));
+      normalizer._normalizePageKeys(page);
+
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'a'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'b'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'c'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'd'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'e'}));
+    });
+
+    text('textLayoutOverwrite', function() {
+      normalizer._layout = {};
+
+      var page = {
+        textLayoutOverwrite: {
+          'a': false,
+          'b': 'B'
+        }
+      };
+
+      var stubNormalizeKey = this.sinon.stub(normalizer, '_normalizeKey');
+      stubNormalizeKey.returns('C');
+
+      normalizer._normalizePageKeys(page);
+
+      assert.isFalse(stubNormalizeKey.calledWith({value: 'a'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'b'}));
+
+      assert.deepEqual(page.textLayoutOverwrite, {
+        'a': false,
+        'b': 'C'
+      });
+    });
+  });
+
+  suite('normalizePageAltKeys', function() {
+    test('normalize alt menu (single char keys)', function() {
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'a': 'áàâäåãāæ'
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'a': [ 'á', 'à', 'â', 'ä', 'å', 'ã', 'ā', 'æ' ],
+               'A': [ 'Á', 'À', 'Â', 'Ä', 'Å', 'Ã', 'Ā', 'Æ' ] },
+        upperCase: {}
+      });
+    });
+
+    test('normalize alt menu (with multi-char keys)', function() {
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'a': 'á à â A$'
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'a': [ 'á', 'à', 'â', 'A$' ],
+               'A': [ 'Á', 'À', 'Â', 'A$' ] },
+        upperCase: {}
+      });
+    });
+
+    test('normalize alt menu (with one multi-char keys)', function() {
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'a': 'A$ '
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'a': [ 'A$' ],
+               'A': [ 'A$' ] },
+        upperCase: {}
+      });
+    });
+
+    test('normalize alt menu (with Turkish \'i\' key)', function() {
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'i': 'ß'
+        },
+        upperCase: {
+          'i': 'İ'
+        }
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'i': [ 'ß' ],
+               'İ': [ 'ß' ] },
+        upperCase: {
+          'i': 'İ'
+        }
+      });
+    });
+
+    test('normalize alt menu (with Catalan \'l·l\' key)', function() {
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'l': 'l·l ł £'
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      var expectedPage = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'l': [ 'l·l', 'ł', '£' ],
+               'L': [ 'L·l', 'Ł', '£' ] },
+        upperCase: {}
+      };
+      expectedPage.alt.L.upperCaseLocked = [ 'L·L', 'Ł', '£' ];
+
+      assert.deepEqual(page, expectedPage);
+    });
+  });
+
+  suite('normalize', function() {
+    var stubNormalizePageKeys;
+    var stubNormalizePageAltKeys;
+
+    setup(function(){
+      stubNormalizePageKeys = this.sinon.stub(normalizer, '_normalizePageKeys');
+      stubNormalizePageAltKeys =
+        this.sinon.stub(normalizer, '_normalizePageAltKeys');
+    });
+
+    test('generation of page 0', function(){
+      normalizer._layout = {
+        alt: {'alt': [1]},
+        keys: [2],
+        upperCase: {'a': 'A'},
+        width: 3,
+        keyClassName: 'C',
+        typeInsensitive: true,
+        textLayoutOverwrite: {',': 'comma'},
+        needsCommaKey: true,
+        secondLayout: true,
+        specificCssRule: true
+      };
+
+      normalizer.normalize();
+
+      assert.deepEqual(normalizer._layout, {
+        pages: [
+          {
+            alt: {'alt': [1]},
+            keys: [2],
+            upperCase: {'a': 'A'},
+            width: 3,
+            keyClassName: 'C',
+            typeInsensitive: true,
+            textLayoutOverwrite: {',': 'comma'},
+            needsCommaKey: true,
+            secondLayout: true,
+            specificCssRule: true
+          }
+        ]
+      }, 'page 0 of layout was not generated from layout top-most attributes');
+    });
+
+    test('each page gets normalized', function(){
+      normalizer._layout = {
+        pages: []
+      };
+
+      range(4).forEach( index => {
+        normalizer._layout.pages.push({index: index});
+      });
+
+      normalizer.normalize();
+
+      range(4).forEach( index => {
+        assert.isTrue(
+          stubNormalizePageKeys.calledWith({index: index}),
+          'normalizePageKeys was not called for index = ' + index
+        );
+        assert.isTrue(
+          stubNormalizePageAltKeys.calledWith({index: index}),
+          'normalizePageAltKeys was not called for index = ' + index
+        );
+      });
+    });
   });
 });

--- a/apps/keyboard/test/unit/keyboard/mocks/mock_layout_normalizer.js
+++ b/apps/keyboard/test/unit/keyboard/mocks/mock_layout_normalizer.js
@@ -1,0 +1,25 @@
+'use strict';
+
+(function(exports) {
+  var MockLayoutNormalizer = function(layout) {
+    this._layout = layout;
+
+    MockLayoutNormalizer.instances.push(this);
+  };
+
+  MockLayoutNormalizer.instances = [];
+
+  MockLayoutNormalizer.teardown = function() {
+    MockLayoutNormalizer.instances = [];
+  };
+
+  MockLayoutNormalizer.setup = function() {
+    MockLayoutNormalizer.instances = [];
+  };
+
+  MockLayoutNormalizer.prototype = {
+    normalize: sinon.stub()
+  };
+
+  exports.MockLayoutNormalizer = MockLayoutNormalizer;
+}(window));

--- a/apps/keyboard/test/unit/setup.js
+++ b/apps/keyboard/test/unit/setup.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('/shared/test/unit/mocks/mocks_helper.js');


### PR DESCRIPTION
- |LayoutLoader._normalizeLayout| is now delegated onto LayoutNormalizer
  -- Alternativs chars normalization codes are moved to LayoutNormalizer
- LayoutNormalizer is no longer a singleton (better pattern since it's only used locally)
- textLayoutOverwrites is now normalized
- Layout keys are frozen after normalization (in normalizer) or creation (in LayoutManager)
