### PR TITLE
Bug 1033223 - [Vertical homescreen] Intermittent MarionetteJS failure on Travis: 1) Vertical - Bookmark Uninstall removal of bookmark: NoSuchElement: (7) Unable to locate element: gaia-confirm[data-type=remove]

### DIFF
--- a/apps/verticalhome/test/marionette/bookmark_uninstall_test.js
+++ b/apps/verticalhome/test/marionette/bookmark_uninstall_test.js
@@ -10,13 +10,7 @@ var System = require('../../../../apps/system/test/marionette/lib/system');
 
 marionette('Vertical - Bookmark Uninstall', function() {
 
-  // Bug 1007352 - homescreen URL is hard-coded so we run this test with the
-  // old homescreen, then launch the new homescreen as an app. This is only
-  // needed because we lauch other applications.
-  var options = JSON.parse(JSON.stringify(Home2.clientOptions));
-  delete options.settings['homescreen.manifestURL'];
-
-  var client = marionette.client(options);
+  var client = marionette.client(Home2.clientOptions);
   var bookmark, home, server, system;
 
   suiteSetup(function(done) {
@@ -50,6 +44,7 @@ marionette('Vertical - Bookmark Uninstall', function() {
   test('removal of bookmark', function() {
     // select the icon in edit mode and click remove
     var icon = home.getIcon(url);
+    home.moveIconToIndex(icon, 0);
     var remove = icon.findElement('.remove');
     remove.tap();
     home.confirmDialog('remove');

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -33,7 +33,6 @@
     "apps/settings/test/marionette/tests/message_settings_test.js": "",
     "apps/system/test/marionette/app_usage_metrics_test.js": "Bug 1049137 - Intermittent failing test, TEST-UNEXPECTED-FAIL | App Usage Metrics > Uninstalled apps are counted",
     "apps/system/fxa/test/marionette/fxa_screen_flow_test.js": "Bug 1064305 - [Marionette] FxA tests - intermittent timeout failures on system/fxa/test/marionette/fxa_screen_flow_test.js",
-    "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
-    "apps/verticalhome/test/marionette/bookmark_uninstall_test.js": "Bug 1033223 - [Vertical homescreen] Intermittent MarionetteJS failure on Travis: 1) Vertical - Bookmark Uninstall removal of bookmark: NoSuchElement: (7) Unable to locate element: gaia-confirm[data-type=\"remove\"]"
+    "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon"
   }
 }

--- a/shared/test/integration/travis-manifest.json
+++ b/shared/test/integration/travis-manifest.json
@@ -35,7 +35,6 @@
     "apps/system/test/marionette/edges_gesture_test.js": "Bug 1045729 - Intermittent failing test, Edges gesture > before each hook",
     "apps/system/fxa/test/marionette/fxa_screen_flow_test.js": "Bug 1064305 - [Marionette] FxA tests - intermittent timeout failures on system/fxa/test/marionette/fxa_screen_flow_test.js",
     "apps/system/test/marionette/homescreen_navigation_test.js": "Bug 1043870 - TEST-UNEXPECTED-FAIL | Homescreen navigation > Going to the homescreen and back to a warm app",
-    "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
-    "apps/verticalhome/test/marionette/bookmark_uninstall_test.js": "Bug 1033223 - [Vertical homescreen] Intermittent MarionetteJS failure on Travis: 1) Vertical - Bookmark Uninstall removal of bookmark: NoSuchElement: (7) Unable to locate element: gaia-confirm[data-type=\"remove\"]"
+    "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon"
   }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1033223
