### PR TITLE
Bug 1083288 - Lag when typing on keyboard after press Next button during config

### DIFF
--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -370,6 +370,13 @@ li.sup-manual-account-type-container .button {
   text-align: center;
 }
 
+/* When card is not the center, but has a progress spinner, hide it, to avoid
+   the animation taking cycles away from activities like typing. Bug 1083288 */
+.before .sup-progress-container progress,
+.after .sup-progress-container progress {
+  display: none;
+}
+
 .card-setup-oauth2 .scrollregion-below-header {
   overflow: hidden;
   will-change: auto;


### PR DESCRIPTION
The comment in the file says most of the important information. The .before and .after are the class names the Cards object puts on cards that are not the current (".center") card, so only activates when not in the center.

Tested on device, style is fairly targeted given the .sup-progress-container qualifier, which is element that is used to center the progress spinner. Only matches this card setup case. The other cases of a progress element:
- message_reader: when loading the message contents. The progress element is removed when the content is loaded though.
- message_reader: for showing an attachment download. The default state for the wrapping div is display: none though, and is only shown if in the downloading state.

So this change should result in all the cases where progress spinners were interfering.
