### PR TITLE
Bug 1083571 - Start removing exposedProps from mozMobileMessage mock

### DIFF
--- a/apps/sms/test/marionette/mocks/mock_navigator_moz_mobile_message.js
+++ b/apps/sms/test/marionette/mocks/mock_navigator_moz_mobile_message.js
@@ -1,7 +1,8 @@
 /* global Components, Services */
 'use strict';
 
-Components.utils.import('resource://gre/modules/Services.jsm');
+var Cu = Components.utils;
+Cu.import('resource://gre/modules/Services.jsm');
 
 Services.obs.addObserver(function(document) {
   if (!document || !document.location) {
@@ -272,6 +273,9 @@ Services.obs.addObserver(function(document) {
   };
 
   window.navigator.__defineGetter__('mozMobileMessage', function() {
-    return exposeObject(MobileMessage);
+    return Cu.cloneInto(
+      MobileMessage,
+      window,
+      {cloneFunctions: true});
   });
 }, 'document-element-inserted', false);


### PR DESCRIPTION
Unfortunately I did not get to finish this tonight. Someone please steal it from me.

https://bugzilla.mozilla.org/show_bug.cgi?id=1083571
