### PR TITLE
Bug 1083633 - Remove x-inputmode="verbatim" on homescreen

### DIFF
--- a/apps/homescreen/elements/search_page.html
+++ b/apps/homescreen/elements/search_page.html
@@ -52,7 +52,7 @@
           <form action="/#!/search" id="search-rapper">
             <fieldset>
               <div id="search-q-bg">
-                <input type="text" id="search-q" name="search-q" maxlength="128" autocorrect="off" x-inputmode="verbatim"
+                <input type="text" id="search-q" name="search-q" maxlength="128" autocorrect="off"
                 data-l10n-id="evme-searchbar-default2" aria-describedby="helper-label" dir="auto"/>
               </div>
               <div id="helper-tip"><b></b></div>

--- a/apps/homescreen/everything.me/js/everything.me.js
+++ b/apps/homescreen/everything.me/js/everything.me.js
@@ -29,7 +29,7 @@ var EverythingME = {
     activationIcon.setAttribute('aria-haspopup', 'true');
     activationIcon.innerHTML =
       '<input id="evme-activation-icon-input" type="text" role="presentation"' +
-      ' x-inputmode="verbatim" data-l10n-id="evme-searchbar-default2"/>';
+      ' data-l10n-id="evme-searchbar-default2"/>';
 
     // insert into first page
     gridPage.insertBefore(activationIcon, gridPage.firstChild);

--- a/apps/homescreen/everything.me/modules/Collection/Collection.js
+++ b/apps/homescreen/everything.me/modules/Collection/Collection.js
@@ -81,8 +81,7 @@ void function() {
 
         elTitle.setAttribute('role', 'presentation');
         elTitle.innerHTML = '<input type="text" ' +
-                                    'autocorrect="off" ' +
-                                    'x-inputmode="verbatim" />' +
+                                    'autocorrect="off" />' +
                             '<button class="done" data-l10n-id="evme-done">' +
                             '</button>';
 

--- a/apps/verticalhome/index.html
+++ b/apps/verticalhome/index.html
@@ -86,7 +86,7 @@
 
     <div id="search" role="button" aria-labelledby="search-input" aria-haspopup="true">
       <form id="search-form">
-        <input id="search-input" type="text" x-inputmode="verbatim" role="presentation"
+        <input id="search-input" type="text" role="presentation"
           placeholder="Search or enter address" data-l10n-id="search-or-enter-address" value="" dir="auto">
         </input>
       </form>


### PR DESCRIPTION
The search box on homescreen should allow non-latin string.  If IME looks x-inputmode correctly, it can input latin character only is x-inputmode="verbatim".  (built-in keyboard doesn't check it correctly.)
