### PR TITLE
Bug 1072191, 1074613 - Layout normalization follow-ups

### DIFF
--- a/apps/keyboard/js/keyboard/layout_loader.js
+++ b/apps/keyboard/js/keyboard/layout_loader.js
@@ -145,7 +145,6 @@ Keyboards.telLayout = {
 
 var LayoutLoader = function(app) {
   this.app = app;
-  this._normalizer = null;
 };
 
 LayoutLoader.prototype.SOURCE_DIR = './js/layouts/';
@@ -153,7 +152,6 @@ LayoutLoader.prototype.SOURCE_DIR = './js/layouts/';
 LayoutLoader.prototype.start = function() {
   this._initializedLayouts = {};
   this._layoutsPromises = {};
-  this._normalizer = new LayoutNormalizer();
   this.initLayouts();
 };
 
@@ -167,8 +165,10 @@ LayoutLoader.prototype.initLayouts = function() {
     if (this._initializedLayouts[layoutName]) {
       console.warn('LayoutLoader: ' + layoutName + ' is overwritten.');
     }
-    this._initializedLayouts[layoutName] = Keyboards[layoutName];
-    this._normalizeLayout(layoutName);
+
+    var layoutNormalizer = new LayoutNormalizer(Keyboards[layoutName]);
+    layoutNormalizer.normalize();
+    this._initializedLayouts[layoutName] = layoutNormalizer.normalizedLayout;
 
     // Create a promise so that these panels can be loaded async
     // even if they are not loaded with file of their name.
@@ -177,111 +177,6 @@ LayoutLoader.prototype.initLayouts = function() {
         Promise.resolve(this._initializedLayouts[layoutName]);
     }
   }
-};
-
-// In order to keep the commit log sane, some amendments of the
-// layout JS structure are fix here in runtime instead of hardcoded.
-// TODO: normalize the layout files and maybe remove this function.
-LayoutLoader.prototype._normalizeLayout = function(layoutName) {
-  var layout = this.getLayout(layoutName);
-
-  var pages;
-  if ('pages' in layout) {
-    pages = layout.pages;
-  } else {
-    pages = layout.pages = [];
-  }
-
-  if (!pages[0]) {
-    pages[0] = {};
-
-    // These are properties of the basic page that previously put in the layout
-    // itself. We should move them to the page object and remove them from
-    // the layout object.
-    ['alt', 'keys', 'upperCase', 'width', 'keyClassName',
-      'typeInsensitive', 'textLayoutOverwrite',
-      'needsCommaKey', 'secondLayout', 'specificCssRule'
-    ].forEach(function(prop) {
-      if (layout[prop]) {
-        pages[0][prop] = layout[prop];
-        delete layout[prop];
-      }
-    });
-  }
-
-  // Normalize key properties such that other modules can deal with them easily
-  // Also, go through each pages and inspect it's "alt" property;
-  // we want to normalize our existing mixed notations into arrays.
-  pages.forEach(function(page) {
-    this._normalizer.normalizePageKeys(page, layout);
-
-    // XXX: move alt char normalization to the normalizer
-    var alt = page.alt = page.alt || {};
-    var upperCase = page.upperCase = page.upperCase || {};
-    var altKeys = Object.keys(alt);
-    altKeys.forEach(function(key) {
-      var alternatives = alt[key];
-
-      // Split alternatives
-      // If the alternatives are delimited by spaces, it means that one or more
-      // of them is more than a single character long.
-      if (!Array.isArray(alternatives)) {
-        if (alternatives.indexOf(' ') !== -1) {
-          alternatives = alternatives.split(' ');
-
-          // If there is just a single multi-character alternative, it will have
-          // trailing whitespace which we have to discard here.
-          if (alternatives.length === 2 && alternatives[1] === '') {
-            alternatives.pop();
-          }
-        } else {
-          // No spaces, so all of the alternatives are single characters
-          alternatives = alternatives.split('');
-        }
-      }
-
-      alt[key] = alternatives;
-
-      var upperCaseKey = upperCase[key] || key.toUpperCase();
-      if (!alt[upperCaseKey]) {
-        var needDifferentUpperCaseLockedAlternatives = false;
-        // Creating an array for upper case too.
-        // XXX: The original code does not respect page.upperCase here.
-        alt[upperCaseKey] = alternatives.map(function(key) {
-          if (key.length === 1) {
-            return key.toUpperCase();
-          }
-
-          // The 'l·l' key in the Catalan layout needs to be
-          // 'L·l' in upper case mode and 'L·L' in upper case locked mode.
-          // (see http://bugzil.la/896363#c19)
-          // If that happens we will create a different array for
-          // upper case locked mode.
-
-          // Last chance for figuring out if we need a different list of
-          // alternatives; if key.substr(1) has no upper case form,
-          // (e.g. R$ key) we should be able to skip this.
-          needDifferentUpperCaseLockedAlternatives =
-            needDifferentUpperCaseLockedAlternatives ||
-            (key.substr(1).toUpperCase() !== key.substr(1));
-
-          // We only capitalize the first character of the key in
-          // the normalization here.
-          return key[0].toUpperCase() + key.substr(1);
-        });
-
-        // If we really need an special upper case locked alternatives,
-        // do it here and attach that as a property of the
-        // alt[upperCaseKey] array/object. Noted that this property of the array
-        // can't be represented in JSON so it's not visible in JSON.stringify().
-        if (needDifferentUpperCaseLockedAlternatives) {
-          alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
-            return key.toUpperCase();
-          });
-        }
-      }
-    }, this);
-  }, this);
 };
 
 LayoutLoader.prototype.getLayout = function(layoutName) {

--- a/apps/keyboard/js/keyboard/layout_manager.js
+++ b/apps/keyboard/js/keyboard/layout_manager.js
@@ -246,7 +246,6 @@ LayoutManager.prototype._updateCurrentPage = function() {
     var imeSwitchKey = {
       value: '&#x1f310;', // U+1F310 GLOBE WITH MERIDIANS
       uppercaseValue: '&#x1f310;',
-      ratio: 1,
       keyCode: this.KEYCODE_SWITCH_KEYBOARD,
       className: 'switch-key',
       isSpecialKey: true
@@ -287,7 +286,6 @@ LayoutManager.prototype._updateCurrentPage = function() {
   if (!page.typeInsensitive) {
     var periodKey = {
       value: '.',
-      ratio: 1,
       keyCode: 46,
       keyCodeUpper: 46,
       lowercaseValue: '.',
@@ -297,6 +295,7 @@ LayoutManager.prototype._updateCurrentPage = function() {
     if (page.alt && page.alt['.']) {
       periodKey.className = 'alternate-indicator';
     }
+
 
 
     var modifyType = 'default';
@@ -333,7 +332,6 @@ LayoutManager.prototype._updateCurrentPage = function() {
         // Add '/' key when we are at the default page
         spaceKeyRow.splice(spaceKeyCount, 0, {
           value: '/',
-          ratio: 1,
           keyCode: 47,
           keyCodeUpper: 47,
           lowercaseValue: '/',
@@ -352,7 +350,6 @@ LayoutManager.prototype._updateCurrentPage = function() {
         // Add '@' key when we are at the default page
         spaceKeyRow.splice(spaceKeyCount, 0, {
           value: '@',
-          ratio: 1,
           keyCode: 64,
           keyCodeUpper: 64,
           lowercaseValue: '@',
@@ -381,22 +378,20 @@ LayoutManager.prototype._updateCurrentPage = function() {
         // set explicitly.
         if (overwrites[','] !== false &&
             (!needsSwitchingKey || page.needsCommaKey)) {
-          var commaKey = {
-            value: ',',
-            ratio: 1,
-            keyCode: 44,
-            keyCodeUpper: 44,
-            lowercaseValue: ',',
-            uppercaseValue: ',',
-            isSpecialKey: false
-          };
+
+          var commaKey;
 
           if (overwrites[',']) {
-            commaKey.value = overwrites[','];
-            commaKey.keyCode = overwrites[','].charCodeAt(0);
-            commaKey.keyCodeUpper = overwrites[','].charCodeAt(0);
-            commaKey.lowercaseValue = overwrites[','];
-            commaKey.uppercaseValue = overwrites[','];
+            commaKey = overwrites[','];
+          } else {
+            commaKey = {
+              value: ',',
+              keyCode: 44,
+              keyCodeUpper: 44,
+              lowercaseValue: ',',
+              uppercaseValue: ',',
+              isSpecialKey: false
+            };
           }
 
           spaceKeyObject.ratio -= 1;
@@ -407,11 +402,7 @@ LayoutManager.prototype._updateCurrentPage = function() {
         // Only add peroid key if we are asked to.
         if (overwrites['.'] !== false) {
           if (overwrites['.']) {
-            periodKey.value = overwrites['.'];
-            periodKey.keyCode = overwrites['.'].charCodeAt(0);
-            periodKey.keyCodeUpper = overwrites['.'].charCodeAt(0);
-            periodKey.lowercaseValue = overwrites['.'];
-            periodKey.uppercaseValue = overwrites['.'];
+            periodKey = overwrites['.'];
           }
 
           spaceKeyObject.ratio -= 1;

--- a/apps/keyboard/js/keyboard/layout_normalizer.js
+++ b/apps/keyboard/js/keyboard/layout_normalizer.js
@@ -8,9 +8,11 @@
  * LayoutNormalizer normalizes a layout's key objects such that
  * Dealing business logics with them will be less painful.
  * @class
- * @param {Object} app the keyboard app instance
+ * @param {Object} layout the layout we're going to normalize
  */
-var LayoutNormalizer = function() {
+var LayoutNormalizer = function(layout) {
+  this._layout = layout;
+  this._normalizedLayout = null;
 };
 
 LayoutNormalizer.prototype._isSpecialKey = function(key) {
@@ -26,21 +28,21 @@ LayoutNormalizer.prototype._isSpecialKey = function(key) {
   return hasSpecialCode || key.keyCode <= 0;
 };
 
-LayoutNormalizer.prototype._getUpperCaseValue = function(key, layout) {
+LayoutNormalizer.prototype._getUpperCaseValue = function(key) {
   if (KeyEvent.DOM_VK_SPACE === key.keyCode ||
       this._isSpecialKey(key) ||
       key.compositeKey) {
     return key.value;
   }
 
-  var upperCase = layout.upperCase || {};
+  var upperCase = this._layout.upperCase || {};
   return upperCase[key.value] || key.value.toUpperCase();
 };
 
 // normalize one key of the layout
-LayoutNormalizer.prototype._normalizeKey = function(key, layout) {
+LayoutNormalizer.prototype._normalizeKey = function(key) {
   var keyChar = key.value;
-  var upperCaseKeyChar = this._getUpperCaseValue(key, layout);
+  var upperCaseKeyChar = this._getUpperCaseValue(key);
 
   var code = key.keyCode || keyChar.charCodeAt(0);
   var upperCode = key.keyCode || upperCaseKeyChar.charCodeAt(0);
@@ -60,24 +62,157 @@ LayoutNormalizer.prototype._normalizeKey = function(key, layout) {
   }
 
   if (key.supportsSwitching) {
-    this._normalizeKey(key.supportsSwitching, layout);
+    this._normalizeKey(key.supportsSwitching);
   }
 
   if (KeyboardEvent.DOM_VK_ALT === code && !('targetPage' in key)) {
     console.error('LayoutNormalizer: no targetPage for switching key.');
   }
+
+  return key;
 };
 
 // normalize all keys in the page of the layout
-LayoutNormalizer.prototype.normalizePageKeys = function(page, layout) {
+LayoutNormalizer.prototype._normalizePageKeys = function(page) {
   var keyRows = page.keys || [];
 
-  keyRows.forEach(function(keyRow) {
-    keyRow.forEach(function(key) {
-      this._normalizeKey(key, layout);
+  page.keys = keyRows.map(function(keyRow) {
+    return keyRow.map(function(key) {
+      return this._normalizeKey(key);
     }, this);
   }, this);
+
+  var overwrites = page.textLayoutOverwrite || {};
+
+  page.textLayoutOverwrite =
+    Object.keys(overwrites).reduce(function(result, overwrittenKey){
+      if (false === overwrites[overwrittenKey]) {
+        result[overwrittenKey] = false;
+      } else {
+        result[overwrittenKey] =
+          this._normalizeKey({value: overwrites[overwrittenKey]});
+      }
+      return result;
+    }.bind(this), {});
 };
+
+// normalize alt keys in the page of the layout
+LayoutNormalizer.prototype._normalizePageAltKeys = function(page) {
+  var alt = page.alt = page.alt || {};
+  var upperCase = page.upperCase = page.upperCase || {};
+  var altKeys = Object.keys(alt);
+  altKeys.forEach(function(key) {
+    var alternatives = alt[key];
+
+    // Split alternatives
+    // If the alternatives are delimited by spaces, it means that one or more
+    // of them is more than a single character long.
+    if (!Array.isArray(alternatives)) {
+      if (alternatives.indexOf(' ') !== -1) {
+        alternatives = alternatives.split(' ');
+
+        // If there is just a single multi-character alternative, it will have
+        // trailing whitespace which we have to discard here.
+        if (alternatives.length === 2 && alternatives[1] === '') {
+          alternatives.pop();
+        }
+      } else {
+        // No spaces, so all of the alternatives are single characters
+        alternatives = alternatives.split('');
+      }
+    }
+
+    alt[key] = alternatives;
+
+    var upperCaseKey = upperCase[key] || key.toUpperCase();
+    if (!alt[upperCaseKey]) {
+      var needDifferentUpperCaseLockedAlternatives = false;
+      // Creating an array for upper case too.
+      // XXX: The original code does not respect page.upperCase here.
+      alt[upperCaseKey] = alternatives.map(function(key) {
+        if (key.length === 1) {
+          return key.toUpperCase();
+        }
+
+        // The 'l·l' key in the Catalan layout needs to be
+        // 'L·l' in upper case mode and 'L·L' in upper case locked mode.
+        // (see http://bugzil.la/896363#c19)
+        // If that happens we will create a different array for
+        // upper case locked mode.
+
+        // Last chance for figuring out if we need a different list of
+        // alternatives; if key.substr(1) has no upper case form,
+        // (e.g. R$ key) we should be able to skip this.
+        needDifferentUpperCaseLockedAlternatives =
+          needDifferentUpperCaseLockedAlternatives ||
+          (key.substr(1).toUpperCase() !== key.substr(1));
+
+        // We only capitalize the first character of the key in
+        // the normalization here.
+        return key[0].toUpperCase() + key.substr(1);
+      });
+
+      // If we really need an special upper case locked alternatives,
+      // do it here and attach that as a property of the
+      // alt[upperCaseKey] array/object. Noted that this property of the array
+      // can't be represented in JSON so it's not visible in JSON.stringify().
+      if (needDifferentUpperCaseLockedAlternatives) {
+        alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
+          return key.toUpperCase();
+        });
+      }
+    }
+  }, this);
+};
+
+// In order to keep the commit log sane, some amendments of the
+// layout JS structure are fixed here in runtime instead of hardcoded.
+LayoutNormalizer.prototype.normalize = function() {
+  var pages;
+  if ('pages' in this._layout) {
+    pages = this._layout.pages;
+  } else {
+    pages = this._layout.pages = [];
+  }
+
+  if (!pages[0]) {
+    pages[0] = {};
+
+    // These are properties of the basic page that previously put in the layout
+    // itself. We should move them to the page object and remove them from
+    // the layout object.
+    // TODO: normalize the layout files themselves and maybe remove this part.
+    ['alt', 'keys', 'upperCase', 'width', 'keyClassName',
+      'typeInsensitive', 'textLayoutOverwrite',
+      'needsCommaKey', 'secondLayout', 'specificCssRule'
+    ].forEach(function(prop) {
+      if (this._layout[prop]) {
+        pages[0][prop] = this._layout[prop];
+        delete this._layout[prop];
+      }
+    }, this);
+  }
+
+  // Normalize key properties such that other modules can deal with them easily
+  // Also, go through each pages and inspect it's "alt" property;
+  // we want to normalize our existing mixed notations into arrays.
+  pages.forEach(function(page) {
+    this._normalizePageKeys(page);
+    this._normalizePageAltKeys(page);
+  }, this);
+
+  this._normalizedLayout = this._layout;
+};
+
+Object.defineProperty(LayoutNormalizer.prototype, 'normalizedLayout', {
+  configurable: true,
+  get: function ln_getNormalizedLayout() {
+    if (!this._normalizedLayout) {
+      throw Error('Tried to get normalized layout before calling normalize()');
+    }
+    return this._normalizedLayout;
+  }
+});
 
 exports.LayoutNormalizer = LayoutNormalizer;
 

--- a/apps/keyboard/test/unit/keyboard/layout_loader_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_loader_test.js
@@ -2,64 +2,41 @@
 
 /* global LayoutLoader, LayoutNormalizer */
 
-require('/js/keyboard/layout_normalizer.js');
 require('/js/keyboard/layout_loader.js');
+require('/js/keyboard/layout_normalizer.js');
 
 suite('LayoutLoader', function() {
   var realKeyboards;
 
   var expectedFooLayout = {
-    pages: [
-      {
-        keys: [
-          [
-            { value: 'foo' }
-          ]
-        ],
-        alt: {},
-        upperCase: {}
-      }
+    keys: [
+      [
+        { value: 'foo' }
+      ]
     ]
   };
 
   var expectedFoo2Layout = {
-    pages: [
-      {
-        keys: [
-          [
-            { value: 'foo2' }
-          ]
-        ],
-        alt: {},
-        upperCase: {}
-      }
+    keys: [
+      [
+        { value: 'foo2' }
+      ]
     ]
   };
 
   var expectedFoo3Layout = {
-    pages: [
-      {
-        keys: [
-          [
-            { value: 'foo3' }
-          ]
-        ],
-        alt: {},
-        upperCase: {}
-      }
+    keys: [
+      [
+        { value: 'foo3' }
+      ]
     ]
   };
 
-  // because LayoutLoader.start calls LayoutLoader.initLayouts which uses its
-  // instantiated _normalizer, we can't stub the instance after we call start().
-  var stubLayoutNormalizer;
-  setup(function() {
-    stubLayoutNormalizer = this.sinon.stub(LayoutNormalizer.prototype);
-    this.sinon.stub(window, 'LayoutNormalizer').returns(stubLayoutNormalizer);
-  });
-
   suiteSetup(function() {
     realKeyboards = window.Keyboards;
+    sinon.stub(LayoutNormalizer.prototype, 'normalize', function(){
+      this._normalizedLayout = this._layout;
+    });
   });
 
   suiteTeardown(function() {
@@ -86,34 +63,20 @@ suite('LayoutLoader', function() {
     var p = loader.getLayoutAsync('preloaded');
     p.then(function(layout) {
       assert.isTrue(true, 'loaded');
+      // the loader instantiates normalizer by using its getLayout
+      // so testing this would test getLayout at the same time
+      // (same for following tests)
       assert.deepEqual(
-        stubLayoutNormalizer.normalizePageKeys.getCall(0).args[0],
+        loader._initializedLayouts.preloaded,
         {
           keys: [
             [
-              { value: 'preloaded' }
+             { value: 'preloaded' }
             ]
-          ],
-          alt: {},
-          upperCase: {}
+          ]
         },
-        'normalizer argument "page" incorrect'
-      );
-      assert.equal(
-        stubLayoutNormalizer.normalizePageKeys.getCall(0).args[1].pages.length,
-        1,
         'normalizer argument "layout" incorrect'
       );
-      assert.deepEqual(loader.getLayout('preloaded'), { pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {},
-        upperCase: {}
-      } ] }, 'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
     }, function(e) {
       if (e) {
         throw (e);
@@ -132,26 +95,11 @@ suite('LayoutLoader', function() {
     var p = loader.getLayoutAsync('foo');
     p.then(function(layout) {
       assert.deepEqual(
-        stubLayoutNormalizer.normalizePageKeys.getCall(0).args[0],
-        {
-          keys: [
-            [
-              { value: 'foo' }
-            ]
-          ],
-          alt: {},
-          upperCase: {}
-        },
-        'normalizer argument "page" incorrect'
-      );
-      assert.equal(
-        stubLayoutNormalizer.normalizePageKeys.getCall(0).args[1].pages.length,
-        1,
+        loader._initializedLayouts.foo,
+        expectedFooLayout,
         'normalizer argument "layout" incorrect'
       );
       assert.isTrue(true, 'loaded');
-      assert.deepEqual(
-        loader.getLayout('foo'), expectedFooLayout, 'foo loaded');
       assert.equal(layout, loader.getLayout('foo'));
     }, function(e) {
       if (e) {
@@ -172,48 +120,17 @@ suite('LayoutLoader', function() {
     p.then(function(layout) {
       assert.isTrue(true, 'loaded');
       assert.deepEqual(
-        stubLayoutNormalizer.normalizePageKeys.getCall(0).args[0],
-        {
-          keys: [
-            [
-              { value: 'foo2' }
-            ]
-          ],
-          alt: {},
-          upperCase: {}
-        },
-        'normalizer argument "page" incorrect'
-      );
-      assert.equal(
-        stubLayoutNormalizer.normalizePageKeys.getCall(0).args[1].pages.length,
-        1,
+        loader._initializedLayouts.foo2,
+        expectedFoo2Layout,
         'normalizer argument "layout" incorrect'
       );
       assert.deepEqual(
-        stubLayoutNormalizer.normalizePageKeys.getCall(1).args[0],
-        {
-          keys: [
-            [
-              { value: 'foo3' }
-            ]
-          ],
-          alt: {},
-          upperCase: {}
-        },
-        'normalizer argument "page" incorrect'
-      );
-      assert.equal(
-        stubLayoutNormalizer.normalizePageKeys.getCall(1).args[1].pages.length,
-        1,
+        loader._initializedLayouts.foo3,
+        expectedFoo3Layout,
         'normalizer argument "layout" incorrect'
       );
-      assert.deepEqual(
-        loader.getLayout('foo2'), expectedFoo2Layout, 'foo2 loaded');
-      assert.equal(layout, loader.getLayout('foo2'));
       assert.deepEqual(window.Keyboards, {});
 
-      assert.deepEqual(
-        loader.getLayout('foo3'), expectedFoo3Layout, 'foo3 loaded');
       var p2 = loader.getLayoutAsync('foo3');
 
       return p2;
@@ -290,284 +207,6 @@ suite('LayoutLoader', function() {
       assert.isTrue(true, 'loaded');
       assert.deepEqual(
         loader.getLayout('foo'), expectedFooLayout, 'foo loaded');
-    }, function(e) {
-      if (e) {
-        throw (e);
-      }
-      assert.isTrue(false, 'should not reject');
-    }).then(done, done);
-  });
-
-  test('normalize alt menu (single char keys)', function(done) {
-    window.Keyboards = {
-      'preloaded': {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {
-          'a': 'áàâäåãāæ'
-        }
-      }
-    };
-
-    var loader = new LayoutLoader();
-    loader.start();
-
-    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
-    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
-
-    var p = loader.getLayoutAsync('preloaded');
-    p.then(function(layout) {
-      assert.isTrue(true, 'loaded');
-      assert.deepEqual(loader.getLayout('preloaded'), { pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: { 'a': [ 'á', 'à', 'â', 'ä', 'å', 'ã', 'ā', 'æ' ],
-               'A': [ 'Á', 'À', 'Â', 'Ä', 'Å', 'Ã', 'Ā', 'Æ' ] },
-        upperCase: {}
-      } ] }, 'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
-    }, function(e) {
-      if (e) {
-        throw (e);
-      }
-      assert.isTrue(false, 'should not reject');
-    }).then(done, done);
-  });
-
-  test('normalize alt menu of multiple pages', function(done) {
-    window.Keyboards = {
-      'preloaded': {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        pages: [ undefined, {
-          keys: [
-            [
-              { value: 'preloaded-alternateLayout' }
-            ]
-          ],
-          alt: {
-            'a': 'áàâäåãāæ'
-          }
-        } ]
-      }
-    };
-
-    var loader = new LayoutLoader();
-    loader.start();
-
-    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
-    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
-
-    var p = loader.getLayoutAsync('preloaded');
-    p.then(function(layout) {
-      assert.isTrue(true, 'loaded');
-      assert.deepEqual(loader.getLayout('preloaded'), { pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {},
-        upperCase: {}
-      }, {
-        keys: [
-          [
-            { value: 'preloaded-alternateLayout' }
-          ]
-        ],
-        alt: { 'a': [ 'á', 'à', 'â', 'ä', 'å', 'ã', 'ā', 'æ' ],
-               'A': [ 'Á', 'À', 'Â', 'Ä', 'Å', 'Ã', 'Ā', 'Æ' ] },
-        upperCase: {}
-      } ] }, 'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
-    }, function(e) {
-      if (e) {
-        throw (e);
-      }
-      assert.isTrue(false, 'should not reject');
-    }).then(done, done);
-  });
-
-  test('normalize alt menu (with multi-char keys)', function(done) {
-    window.Keyboards = {
-      'preloaded': {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {
-          'a': 'á à â A$'
-        }
-      }
-    };
-
-    var loader = new LayoutLoader();
-    loader.start();
-
-    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
-    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
-
-    var p = loader.getLayoutAsync('preloaded');
-    p.then(function(layout) {
-      assert.isTrue(true, 'loaded');
-      assert.deepEqual(loader.getLayout('preloaded'), { pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: { 'a': [ 'á', 'à', 'â', 'A$' ],
-               'A': [ 'Á', 'À', 'Â', 'A$' ] },
-        upperCase: {}
-      } ] }, 'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
-    }, function(e) {
-      if (e) {
-        throw (e);
-      }
-      assert.isTrue(false, 'should not reject');
-    }).then(done, done);
-  });
-
-  test('normalize alt menu (with one multi-char keys)', function(done) {
-    window.Keyboards = {
-      'preloaded': {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {
-          'a': 'A$ '
-        }
-      }
-    };
-
-    var loader = new LayoutLoader();
-    loader.start();
-
-    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
-    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
-
-    var p = loader.getLayoutAsync('preloaded');
-    p.then(function(layout) {
-      assert.isTrue(true, 'loaded');
-      assert.deepEqual(loader.getLayout('preloaded'), { pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: { 'a': [ 'A$' ],
-               'A': [ 'A$' ] },
-        upperCase: {}
-      } ] }, 'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
-    }, function(e) {
-      if (e) {
-        throw (e);
-      }
-      assert.isTrue(false, 'should not reject');
-    }).then(done, done);
-  });
-
-  test('normalize alt menu (with Turkish \'i\' key)', function(done) {
-    window.Keyboards = {
-      'preloaded': {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {
-          'i': 'ß'
-        },
-        upperCase: {
-          'i': 'İ'
-        }
-      }
-    };
-
-    var loader = new LayoutLoader();
-    loader.start();
-
-    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
-    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
-
-    var p = loader.getLayoutAsync('preloaded');
-    p.then(function(layout) {
-      assert.isTrue(true, 'loaded');
-      assert.deepEqual(loader.getLayout('preloaded'), { pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: { 'i': [ 'ß' ],
-               'İ': [ 'ß' ] },
-        upperCase: {
-          'i': 'İ'
-        }
-      } ] }, 'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
-    }, function(e) {
-      if (e) {
-        throw (e);
-      }
-      assert.isTrue(false, 'should not reject');
-    }).then(done, done);
-  });
-
-  test('normalize alt menu (with Catalan \'l·l\' key)', function(done) {
-    window.Keyboards = {
-      'preloaded': {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: {
-          'l': 'l·l ł £'
-        }
-      }
-    };
-
-    var loader = new LayoutLoader();
-    loader.start();
-
-    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
-    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
-
-    var expectedLayout = {
-      pages: [ {
-        keys: [
-          [
-            { value: 'preloaded' }
-          ]
-        ],
-        alt: { 'l': [ 'l·l', 'ł', '£' ],
-               'L': [ 'L·l', 'Ł', '£' ] },
-        upperCase: {}
-      } ]
-    };
-    expectedLayout.pages[0].alt.L.upperCaseLocked = [ 'L·L', 'Ł', '£' ];
-
-    var p = loader.getLayoutAsync('preloaded');
-    p.then(function(layout) {
-      assert.isTrue(true, 'loaded');
-      assert.deepEqual(loader.getLayout('preloaded'), expectedLayout,
-        'preloaded loaded');
-      assert.equal(layout, loader.getLayout('preloaded'));
     }, function(e) {
       if (e) {
         throw (e);

--- a/apps/keyboard/test/unit/keyboard/layout_manager_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_manager_test.js
@@ -16,27 +16,20 @@ suite('LayoutManager', function() {
           [
             { value: 'foo' }
           ]
-        ],
-        alt: {},
-        upperCase: {}
+        ]
       }
     ]
   };
 
   suiteSetup(function() {
     realKeyboards = window.Keyboards;
+    // for skae of simplicity, we bypass these two normalizations
+    sinon.stub(LayoutNormalizer.prototype, '_normalizePageKeys');
+    sinon.stub(LayoutNormalizer.prototype, '_normalizePageAltKeys');
   });
 
   suiteTeardown(function() {
     window.Keyboards = realKeyboards;
-  });
-
-  // because LayoutLoader.start calls LayoutLoader.initLayouts which uses its
-  // instantiated _normalizer, we can't stub the instance after we call
-  // LayoutManager.start() (which directly calls LayoutLoader.start()).
-  setup(function() {
-    var stubLayoutNormalizer = this.sinon.stub(LayoutNormalizer.prototype);
-    this.sinon.stub(window, 'LayoutNormalizer').returns(stubLayoutNormalizer);
   });
 
   // since bug 1035619, enter key's layout properties will always come
@@ -1128,9 +1121,7 @@ suite('LayoutManager', function() {
                       ariaLabel: 'alternateLayoutKey',
                       className: 'page-switch-key',
                       targetPage: 1 },
-                    { value: '!', ratio: 1, keyCode: 33, keyCodeUpper: 33,
-                      lowercaseValue: '!', uppercaseValue: '!',
-                      isSpecialKey: false },
+                    '!',
                     { value: '&nbsp', ratio: 4, keyCode: 32 },
                     { value: '.', ratio: 1, keyCode: 46, keyCodeUpper: 46,
                       lowercaseValue: '.', uppercaseValue: '.',
@@ -1257,9 +1248,7 @@ suite('LayoutManager', function() {
                       lowercaseValue: ',', uppercaseValue: ',',
                       isSpecialKey: false },
                     { value: '&nbsp', ratio: 4, keyCode: 32 },
-                    { value: '*', ratio: 1, keyCode: 42, keyCodeUpper: 42,
-                      lowercaseValue: '*', uppercaseValue: '*',
-                      isSpecialKey: false },
+                    '*',
                     { value: 'ENTER', ratio: 2.0,
                       keyCode: KeyboardEvent.DOM_VK_RETURN } ] ] };
 
@@ -1393,14 +1382,6 @@ suite('LayoutManager', function() {
         assert.equal(manager.currentPage.__proto__,
           supportsSwitchingLayout.pages[0],
           'proto is set correctly for layout.');
-
-        assert.equal(manager.currentPage.keys[0][0].__proto__,
-          supportsSwitchingLayout.pages[0].keys[0][0].supportsSwitching,
-          'proto is set correctly for supportsSwitching key.');
-
-        assert.equal(manager.currentPage.keys[0][1].__proto__,
-          supportsSwitchingLayout.pages[0].keys[0][1].supportsSwitching,
-          'proto is set correctly for supportsSwitching key.');
 
         assert.equal(manager.currentPage.keys[1][2].__proto__,
           supportsSwitchingLayout.pages[0].keys[1][0],

--- a/apps/keyboard/test/unit/keyboard/layout_normalizer_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_normalizer_test.js
@@ -30,14 +30,10 @@ suite('LayoutNormalizer', function() {
     'VK_VK_ALT': KeyEvent.DOM_VK_ALT
   };
 
-  var normalizer;
-
-  setup(function (){
-    normalizer = new LayoutNormalizer();
-  });
-
   suite('isSpecialKey', function() {
     test('keyCode is in special codes', function(){
+      var normalizer = new LayoutNormalizer();
+
       Object.keys(SPECIAL_CODES_MAP).forEach(keyCodeName => {
         var key = {
           keyCode: SPECIAL_CODES_MAP[keyCodeName]
@@ -48,6 +44,8 @@ suite('LayoutNormalizer', function() {
     });
 
     test('keyCode is <= 0', function(){
+      var normalizer = new LayoutNormalizer();
+
       // for the sake of this test, we only test 0 to -128
       range(-128, 1).forEach(keyCode => {
         var key = {
@@ -59,6 +57,8 @@ suite('LayoutNormalizer', function() {
     });
 
     test('keyCode is > 0 and is not in special codes', function(){
+      var normalizer = new LayoutNormalizer();
+
       // for the sake of this test, we only test 1 to 255
       var keyCodeName;    // linter needs this definition
       var specialKeyCodes = [for (keyCodeName of Object.keys(SPECIAL_CODES_MAP))
@@ -83,6 +83,8 @@ suite('LayoutNormalizer', function() {
     // is definitely wrong.
 
     test('Space key', function(){
+      var normalizer = new LayoutNormalizer();
+
       var key = {
         keyCode: KeyEvent.DOM_VK_SPACE,
         value: 'space'
@@ -91,6 +93,8 @@ suite('LayoutNormalizer', function() {
     });
 
     test('Special keys', function(){
+      var normalizer = new LayoutNormalizer();
+
       Object.keys(SPECIAL_CODES_MAP).forEach(keyCodeName => {
         var key = {
           keyCode: SPECIAL_CODES_MAP[keyCodeName],
@@ -101,6 +105,8 @@ suite('LayoutNormalizer', function() {
     });
 
     test('Composite keys', function(){
+      var normalizer = new LayoutNormalizer();
+
       var key = {
         keyCode: 'C'.charCodeAt(0),
         value: 'Com',
@@ -110,72 +116,73 @@ suite('LayoutNormalizer', function() {
     });
 
     test('Use uppercase from layout', function(){
-      var layout = {
+      var normalizer = new LayoutNormalizer({
         upperCase: {
           'a': 'E'
         }
-      };
+      });
+
       var key = {
         keyCode: 'a'.charCodeAt(0),
         value: 'a'
       };
-      assert.equal(normalizer._getUpperCaseValue(key, layout), 'E',
+      assert.equal(normalizer._getUpperCaseValue(key), 'E',
                    'upperCase of "a" should be "E" in this crafted test');
     });
 
     test('Use key.value.toUpperCase()', function(){
+      var normalizer = new LayoutNormalizer({});
       var key = {
         keyCode: 'a'.charCodeAt(0),
         value: 'a'
       };
-      assert.equal(normalizer._getUpperCaseValue(key, {}), 'A');
+      assert.equal(normalizer._getUpperCaseValue(key), 'A');
     });
   });
 
   suite('normalizeKey', function() {
-    var stubGetUpperCaseValue;
-
-    setup(function(){
-      stubGetUpperCaseValue = this.sinon.stub(normalizer, '_getUpperCaseValue');
-    });
-
-
     test('Calling getUpperCaseValue', function(){
+      var normalizer = new LayoutNormalizer({});
+
       var key = {
         value: 'a'
       };
 
-      stubGetUpperCaseValue.returns('A');
+      var stubGetUpperCaseValue =
+        this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
-      assert.isTrue(stubGetUpperCaseValue.calledWith(key, {}));
-
+      assert.isTrue(stubGetUpperCaseValue.calledWith(key));
     });
 
     test('keyCode is not present: value should derive into keyCode and ' +
          'keyCodeUpper', function(){
+      var normalizer = new LayoutNormalizer({});
+
       var key = {
         value: 'a'
       };
 
-      stubGetUpperCaseValue.returns('A');
+      this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.keyCode, 'a'.charCodeAt(0));
       assert.equal(key.keyCodeUpper, 'A'.charCodeAt(0));
     });
 
     test('keyCode is present: should derive into keyCodeUpper', function(){
+      var normalizer = new LayoutNormalizer({});
+
       var key = {
         value: 'a',
         keyCode: 'e'.charCodeAt(0)
       };
 
-      stubGetUpperCaseValue.returns('A');
+      this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.keyCodeUpper, 'e'.charCodeAt(0),
                    'keyCodeUpper should be keyCode of "e" ' +
@@ -183,20 +190,23 @@ suite('LayoutNormalizer', function() {
     });
 
     test('value should derive into lowercaseValue and uppercaseValue',
-      function(){
+    function(){
+      var normalizer = new LayoutNormalizer({});
+
       var key = {
         value: 'a'
       };
 
-      stubGetUpperCaseValue.returns('A');
+      this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.lowercaseValue, 'a');
       assert.equal(key.uppercaseValue, 'A');
     });
 
     test('isSpecialKey', function(){
+      var normalizer = new LayoutNormalizer({});
       var stubIsSpecialKey = this.sinon.stub(normalizer, '_isSpecialKey');
 
       stubIsSpecialKey.returns(true);
@@ -205,9 +215,9 @@ suite('LayoutNormalizer', function() {
         value: 'a'
       };
 
-      stubGetUpperCaseValue.returns('A');
+      this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.isTrue(key.isSpecialKey);
 
@@ -217,38 +227,39 @@ suite('LayoutNormalizer', function() {
         value: 'a'
       };
 
-      stubGetUpperCaseValue.returns('A');
-
-      normalizer._normalizeKey(key2, {});
+      normalizer._normalizeKey(key2);
 
       assert.isFalse(key2.isSpecialKey);
     });
 
     test('longPressKeyCode is not present: should derive from longPressValue',
-      function(){
+    function(){
+      var normalizer = new LayoutNormalizer({});
       var key = {
         value: 'a',
         longPressValue: 'a'
       };
 
-      stubGetUpperCaseValue.returns('A');
+      this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.longPressKeyCode, 'a'.charCodeAt(0));
     });
 
     test('longPressKeyCode is present: should not derive from longPressValue',
-      function(){
+    function(){
+      var normalizer = new LayoutNormalizer({});
+
       var key = {
         value: 'a',
         longPressValue: 'a',
         longPressKeyCode: 'b'.charCodeAt(0)
       };
 
-      stubGetUpperCaseValue.returns('A');      
+      this.sinon.stub(normalizer, '_getUpperCaseValue').returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.longPressKeyCode, 'b'.charCodeAt(0),
                    'longPressKeyCode should be keyCode of "b" ' +
@@ -256,6 +267,8 @@ suite('LayoutNormalizer', function() {
     });
 
     test('supprtsSwitching key should be normalized too', function(){
+      var normalizer = new LayoutNormalizer({});
+
       var key = {
         value: 'c',
         supportsSwitching: {
@@ -263,32 +276,278 @@ suite('LayoutNormalizer', function() {
         }
       };
 
-      stubGetUpperCaseValue.onFirstCall().returns('C');
-      stubGetUpperCaseValue.onSecondCall().returns('A');
+      this.sinon.stub(normalizer, '_getUpperCaseValue')
+                .onFirstCall().returns('C')
+                .onSecondCall().returns('A');
 
-      normalizer._normalizeKey(key, {});
+      normalizer._normalizeKey(key);
 
       assert.equal(key.supportsSwitching.keyCodeUpper, 'A'.charCodeAt(0));
     });
   });
 
-  test('normalizePageKeys', function() {
-    var page = {
-      keys: [
-        [ {value: 'a'}, {value: 'b'} ],
-        [ {value: 'c'}, {value: 'd'}, {value: 'e'} ]
-      ]
-    };
-    var layout = {};
+  suite('normalizePageKeys', function() {
+    test('keys', function() {
+      var normalizer = new LayoutNormalizer({});
 
-    var stubNormalizeKey = this.sinon.stub(normalizer, '_normalizeKey');
+      var page = {
+        keys: [
+          [ {value: 'a'}, {value: 'b'} ],
+          [ {value: 'c'}, {value: 'd'}, {value: 'e'} ]
+        ]
+      };
 
-    normalizer.normalizePageKeys(page, layout);
+      var stubNormalizeKey = this.sinon.stub(normalizer, '_normalizeKey');
 
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'a'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'b'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'c'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'd'}, layout));
-    assert.isTrue(stubNormalizeKey.calledWith({value: 'e'}, layout));
+      normalizer._normalizePageKeys(page);
+
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'a'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'b'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'c'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'd'}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'e'}));
+    });
+
+    test('textLayoutOverwrite', function() {
+      var normalizer = new LayoutNormalizer({});
+
+      var page = {
+        textLayoutOverwrite: {
+          'a': false,
+          'b': 'B'
+        }
+      };
+
+      var stubNormalizeKey = this.sinon.stub(normalizer, '_normalizeKey');
+      stubNormalizeKey.returns('C');
+
+      normalizer._normalizePageKeys(page);
+
+      assert.isFalse(stubNormalizeKey.calledWith({value: false}));
+      assert.isTrue(stubNormalizeKey.calledWith({value: 'B'}));
+
+      assert.deepEqual(page.textLayoutOverwrite, {
+        'a': false,
+        'b': 'C'
+      });
+    });
+  });
+
+  suite('normalizePageAltKeys', function() {
+    test('normalize alt menu (single char keys)', function() {
+      var normalizer = new LayoutNormalizer({});
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'a': 'áàâäåãāæ'
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'a': [ 'á', 'à', 'â', 'ä', 'å', 'ã', 'ā', 'æ' ],
+               'A': [ 'Á', 'À', 'Â', 'Ä', 'Å', 'Ã', 'Ā', 'Æ' ] },
+        upperCase: {}
+      });
+    });
+
+    test('normalize alt menu (with multi-char keys)', function() {
+      var normalizer = new LayoutNormalizer({});
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'a': 'á à â A$'
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'a': [ 'á', 'à', 'â', 'A$' ],
+               'A': [ 'Á', 'À', 'Â', 'A$' ] },
+        upperCase: {}
+      });
+    });
+
+    test('normalize alt menu (with one multi-char keys)', function() {
+      var normalizer = new LayoutNormalizer({});
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'a': 'A$ '
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'a': [ 'A$' ],
+               'A': [ 'A$' ] },
+        upperCase: {}
+      });
+    });
+
+    test('normalize alt menu (with Turkish \'i\' key)', function() {
+      var normalizer = new LayoutNormalizer({});
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'i': 'ß'
+        },
+        upperCase: {
+          'i': 'İ'
+        }
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      assert.deepEqual(page, {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'i': [ 'ß' ],
+               'İ': [ 'ß' ] },
+        upperCase: {
+          'i': 'İ'
+        }
+      });
+    });
+
+    test('normalize alt menu (with Catalan \'l·l\' key)', function() {
+      var normalizer = new LayoutNormalizer({});
+      var page = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: {
+          'l': 'l·l ł £'
+        },
+        upperCase: {}
+      };
+
+      normalizer._normalizePageAltKeys(page);
+
+      var expectedPage = {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alt: { 'l': [ 'l·l', 'ł', '£' ],
+               'L': [ 'L·l', 'Ł', '£' ] },
+        upperCase: {}
+      };
+      expectedPage.alt.L.upperCaseLocked = [ 'L·L', 'Ł', '£' ];
+
+      assert.deepEqual(page, expectedPage);
+    });
+  });
+
+  suite('normalize', function() {
+    test('generation of page 0', function(){
+      var normalizer = new LayoutNormalizer({
+        alt: {'alt': [1]},
+        keys: [2],
+        upperCase: {'a': 'A'},
+        width: 3,
+        keyClassName: 'C',
+        typeInsensitive: true,
+        textLayoutOverwrite: {',': 'comma'},
+        needsCommaKey: true,
+        secondLayout: true,
+        specificCssRule: true
+      });
+
+      this.sinon.stub(normalizer, '_normalizePageKeys');
+      this.sinon.stub(normalizer, '_normalizePageAltKeys');
+
+      normalizer.normalize();
+
+      assert.deepEqual(normalizer._layout, {
+        pages: [
+          {
+            alt: {'alt': [1]},
+            keys: [2],
+            upperCase: {'a': 'A'},
+            width: 3,
+            keyClassName: 'C',
+            typeInsensitive: true,
+            textLayoutOverwrite: {',': 'comma'},
+            needsCommaKey: true,
+            secondLayout: true,
+            specificCssRule: true
+          }
+        ]
+      }, 'page 0 of layout was not generated from layout top-most attributes');
+    });
+
+    test('each page gets normalized', function(){
+      var layout = {
+        pages: []
+      };
+
+      range(4).forEach( index => {
+        layout.pages.push({index: index});
+      });
+
+      var normalizer = new LayoutNormalizer(layout);
+
+      var stubNormalizePageKeys =
+        this.sinon.stub(normalizer, '_normalizePageKeys');
+      var stubNormalizePageAltKeys =
+        this.sinon.stub(normalizer, '_normalizePageAltKeys');
+
+      normalizer.normalize();
+
+      range(4).forEach( index => {
+        assert.isTrue(
+          stubNormalizePageKeys.calledWith({index: index}),
+          'normalizePageKeys was not called for index = ' + index
+        );
+        assert.isTrue(
+          stubNormalizePageAltKeys.calledWith({index: index}),
+          'normalizePageAltKeys was not called for index = ' + index
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
- |LayoutLoader._normalizeLayout| is now delegated onto LayoutNormalizer
  -- Alternativs chars normalization codes are moved to LayoutNormalizer
- LayoutNormalizer is no longer a singleton (better pattern since it's only used locally)
- textLayoutOverwrites is now normalized
