### PR TITLE
Bug 1083729 - Avoid callscreen window leakage r=etienne_s

### DIFF
--- a/apps/callscreen/js/index.js
+++ b/apps/callscreen/js/index.js
@@ -11,6 +11,9 @@ window.addEventListener('load', function callSetup(evt) {
   KeypadManager.init(true);
 });
 
+// Bug 1083729: add an empty unload event listener to circumvent bug 1078448.
+window.addEventListener('unload', function unloadCallScreen(evt) { });
+
 // Don't keep an audio channel open when the callscreen is not displayed
 document.addEventListener('visibilitychange', function visibilitychanged() {
   if (document.hidden) {


### PR DESCRIPTION
Because of a platform bug, the callscreen window gets leaked in bfcache,
as documented on bug 1078448 and stated in comment 8. Adding an empty
'unload' event listener allows us to avoid the leakage.
