### PR TITLE
Bug 1083841 - [System] Don't need to check 'success' when handing cfstatechange event

### DIFF
--- a/apps/system/js/call_forwarding.js
+++ b/apps/system/js/call_forwarding.js
@@ -124,7 +124,7 @@
      * @memberof CallForwarding.prototype
      */
     _updateCallForwardingIconState: function(slot, event) {
-      if (!event || !event.success ||
+      if (!event ||
           (event.reason != _cfReason.CALL_FORWARD_REASON_UNCONDITIONAL &&
            event.reason != _cfReason.CALL_FORWARD_REASON_ALL_CALL_FORWARDING)) {
         return;

--- a/apps/system/test/unit/call_forwarding_test.js
+++ b/apps/system/test/unit/call_forwarding_test.js
@@ -260,8 +260,7 @@ suite('system/callForwarding >', function() {
           setup(function() {
             this.event = {
               reason: reason,
-              action: cfAction.CALL_FORWARD_ACTION_ENABLE,
-              success: true
+              action: cfAction.CALL_FORWARD_ACTION_ENABLE
             };
 
             this.callForwarding.start();
@@ -282,22 +281,6 @@ suite('system/callForwarding >', function() {
                 this.event);
               sinon.assert.notCalled(
                 this.callForwarding._callForwardingHelper.get);
-          });
-
-          test('the icon state should remains unchanged when unsuccess',
-            function(done) {
-              var originalValue =
-                MockSettingsHelper.instances['ril.cf.enabled'].value[0];
-              this.event.success = false;
-              this.callForwarding._updateCallForwardingIconState(this.slots[0],
-                this.event);
-              setTimeout(function() {
-                assert.equal(
-                  MockSettingsHelper.instances['ril.cf.enabled'].value[0],
-                  originalValue
-                );
-                done();
-              });
           });
 
           test('should set the icon state to false when erase the setting ' +
@@ -343,18 +326,6 @@ suite('system/callForwarding >', function() {
                 this.event);
               assert.isTrue(
                 MockasyncStorage.mItems['ril.cf.enabled.' + this.iccid]);
-            });
-
-            test('when unsuccess', function() {
-              var originalValue =
-                MockSettingsHelper.instances['ril.cf.enabled.' + this.iccid];
-              this.event.success = false;
-              this.callForwarding._updateCallForwardingIconState(this.slots[0],
-                this.event);
-              assert.equal(
-                MockasyncStorage.mItems['ril.cf.enabled.' + this.iccid],
-                originalValue
-              );
             });
           });
         });


### PR DESCRIPTION
Please see [bug 1083841](https://bugzilla.mozilla.org/show_bug.cgi?id=1083841).

Now gecko will only send `cfstatechange` event when `success` is true, so gaia won't need to check `success` when handing the event.
