### PR TITLE
Bug 1069367 - "Header" should be below in card in markup

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -70,14 +70,14 @@
    * @memberOf Card.prototype
    */
   Card.prototype._template =
-    '<div class="screenshotView bb-button" data-l10n-id="openCard" ' +
-    '  role="link"></div>' +
-    '<div class="appIconView" style="background-image:{iconValue}"></div>' +
-    '' +
     '<div class="titles">' +
     ' <h1 id="{titleId}" class="title">{title}</h1>' +
     ' <p class="subtitle">{subTitle}</p>' +
     '</div>' +
+    '' +
+    '<div class="screenshotView bb-button" data-l10n-id="openCard" ' +
+    '  role="link"></div>' +
+    '<div class="appIconView" style="background-image:{iconValue}"></div>' +
     '' +
     '<footer class="card-tray">'+
     ' <button class="appIcon" data-l10n-id="openCard" ' +


### PR DESCRIPTION
Moved the markup for the header to come before the screenshot. While this had been done with styling, it is more semantic it this way in the markup as well.

https://bugzilla.mozilla.org/show_bug.cgi?id=1069367
