### PR TITLE
Bug 1082759 - go_to_url(self, url) doesn't escape ~ to browse http://peo...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from marionette import Wait
 from marionette.by import By
 
 from gaiatest.apps.base import Base
@@ -53,7 +54,7 @@ class SearchPanel(Base):
 
         self.wait_for_condition(lambda m: self.keyboard.is_keyboard_displayed)
         self.keyboard.tap_enter()
-        self.wait_for_condition(lambda m: urllib.quote(url, safe=':/?=') in self.apps.displayed_app.name)
+        Wait(self.marionette).until(lambda m: urllib.quote(url, safe=':/?=&~') in self.apps.displayed_app.name)
 
         from gaiatest.apps.search.regions.browser import Browser
         return Browser(self.marionette)


### PR DESCRIPTION
...ple.mozilla.com/~login/
