### PR TITLE
Bug 1086673 - Log console/warn/info/dir/error messages sent over the soc...

### DIFF
--- a/tests/python/gaia-unit-tests/gaia_unit_test/main.py
+++ b/tests/python/gaia-unit-tests/gaia_unit_test/main.py
@@ -112,8 +112,9 @@ class TestAgentServer(tornado.websocket.WebSocketHandler):
 
             # remove from pending and trigger test complete check.
             if (test_event == 'end'):
-                idx = self.pending_envs.index(test_env)
-                del self.pending_envs[idx]
+                if test_env in self.pending_envs:
+                    idx = self.pending_envs.index(test_env)
+                    del self.pending_envs[idx]
 
                 self.passes += self.envs[test_env].passes
                 self.failures += self.envs[test_env].failures

--- a/tests/python/gaia-unit-tests/gaia_unit_test/reporters/structuredlog.py
+++ b/tests/python/gaia-unit-tests/gaia_unit_test/reporters/structuredlog.py
@@ -1,9 +1,34 @@
 from base import Base
+import json
 
 class StructuredLogReporter(Base):
     def __init__(self, *args, **kwargs):
         self.logger = kwargs.pop('logger')
         Base.__init__(self, *args, **kwargs)
+
+    def log_message(self, log_type, data, testname):
+        message = []
+        for item in data.get('messages', []):
+            if isinstance(item, basestring):
+                message += [item]
+            else:
+                message += [json.dumps(item)]
+        self.logger.info('TEST-INFO | %s | %s: %s' % (testname, log_type, ' '.join(message)))
+
+    def on_log(self, data, testname):
+        self.log_message('log', data, testname)
+
+    def on_info(self, data, testname):
+        self.log_message('info', data, testname)
+
+    def on_warn(self, data, testname):
+        self.log_message('warn', data, testname)
+
+    def on_dir(self, data, testname):
+        self.log_message('dir', data, testname)
+
+    def on_error(self, data, testname):
+        self.log_message('error', data, testname)
 
     def on_pass(self, data, testname):
         self.logger.test_status(testname, data['fullTitle'], 'PASS')


### PR DESCRIPTION
...ket for Gu tests, r=julienw

This produces output like:

TEST-INFO | clock/test/unit/alarm_test.js | log: [Clock] mozAlarm API invariant failure?

This output was previously missing from Gu in TBPL.
