### PR TITLE
Bug 1079567 - [NFC][Shrinking UI] App is rendered as a black screen if the recipient device is pulled away before the user finishes the transfer gesture.

### DIFF
--- a/apps/system/js/shrinking_ui.js
+++ b/apps/system/js/shrinking_ui.js
@@ -187,6 +187,15 @@
               window.System.manifestURL);
           }
           break;
+        case 'touchstart':
+          this._handleSendingStart(evt);
+          break;
+        case 'touchmove':
+          this._handleSendingSlide(evt);
+          break;
+        case 'touchend':
+          this._handleSendingOut(evt);
+          break;
       }
     };
 
@@ -408,9 +417,9 @@
       cover.style.height = '100%';
       cover.style.position = 'relative';
       cover.style.zIndex = '2';
-      cover.addEventListener('touchstart', this._handleSendingStart.bind(this));
-      cover.addEventListener('touchmove', this._handleSendingSlide.bind(this));
-      cover.addEventListener('touchend', this._handleSendingOut.bind(this));
+      cover.addEventListener('touchstart', this);
+      cover.addEventListener('touchmove', this);
+      cover.addEventListener('touchend', this);
       return cover;
     };
 
@@ -438,32 +447,11 @@
    * @return {DOMElement}
    * @this {ShrinkingUI}
    */
-  ShrinkingUI.prototype._enableSlidingCover =
-    function su_enableSlidingCover() {
-      this.cover.addEventListener('touchstart',
-        this._handleSendingStart.bind(this));
-      this.cover.addEventListener('touchmove',
-        this._handleSendingSlide.bind(this));
-      this.cover.addEventListener('touchend',
-        this._handleSendingOut.bind(this));
-      return this.cover;
-    };
-
-  /**
-   * Will return the disabled element to let caller manupulate it.
-   *
-   * @return {DOMElement}
-   * @this {ShrinkingUI}
-   */
   ShrinkingUI.prototype._disableSlidingCover =
     function su_disableSlidingCover() {
-      this.cover.removeEventListener('touchstart',
-        this._handleSendingStart);
-      this.cover.removeEventListener('touchmove',
-        this._handleSendingSlide);
-      this.cover.removeEventListener('touchend',
-        this._handleSendingOut);
-      return this.cover;
+      this.cover.removeEventListener('touchstart', this);
+      this.cover.removeEventListener('touchmove', this);
+      this.cover.removeEventListener('touchend', this);
     };
 
   /**
@@ -665,6 +653,7 @@
     var wrapper = this.wrapper;
     return new Promise((resolve, rejected) => {
       this.debug('_cleanEffects(): ', this._state());
+      this._disableSlidingCover();
       element.style.transition = '';
       element.style.transform = '';
       element.style.transformOrigin = '50% 50% 0';
@@ -675,8 +664,7 @@
       this._updateSlideTransition(null);
 
       wrapper.classList.remove('shrinking-wrapper');
-      this._disableSlidingCover().remove();
-
+      this.cover.remove();
       this.cover = null;
       resolve();
     });

--- a/apps/system/test/unit/shrinking_ui_test.js
+++ b/apps/system/test/unit/shrinking_ui_test.js
@@ -689,31 +689,6 @@ suite('system/shrinkingUI', function() {
     }
   });
 
-  test('Shrinking UI EnableSlidingCover', function() {
-    var oldCover = shrinkingUI.cover;
-
-    var stubHandleSendingStart =
-      this.sinon.stub(shrinkingUI, '_handleSendingStart');
-    var stubHandleSendingSlide =
-      this.sinon.stub(shrinkingUI, '_handleSendingSlide');
-    var stubHandleSendingOut =
-      this.sinon.stub(shrinkingUI, '_handleSendingOut');
-
-    shrinkingUI.cover = document.createElement('div');
-
-    var cover = shrinkingUI._enableSlidingCover();
-
-    cover.dispatchEvent(createTouchEvent('touchstart'));
-    cover.dispatchEvent(createTouchEvent('touchmove'));
-    cover.dispatchEvent(createTouchEvent('touchend'));
-
-    assert.isTrue(stubHandleSendingStart.called);
-    assert.isTrue(stubHandleSendingSlide.called);
-    assert.isTrue(stubHandleSendingOut.called);
-
-    shrinkingUI.cover = oldCover;
-  });
-
   test('Shrinking UI DisableSlidingCover', function() {
     var oldCover = shrinkingUI.cover;
 
@@ -728,22 +703,22 @@ suite('system/shrinkingUI', function() {
 
     shrinkingUI.cover.addEventListener(
       'touchstart',
-      shrinkingUI._handleSendingStart
+      shrinkingUI
     );
     shrinkingUI.cover.addEventListener(
       'touchmove',
-      shrinkingUI._handleSendingSlide
+      shrinkingUI
     );
     shrinkingUI.cover.addEventListener(
       'touchend',
-      shrinkingUI._handleSendingOut
+      shrinkingUI
     );
 
-    var cover = shrinkingUI._disableSlidingCover();
+    shrinkingUI._disableSlidingCover();
 
-    cover.dispatchEvent(createTouchEvent('touchstart'));
-    cover.dispatchEvent(createTouchEvent('touchmove'));
-    cover.dispatchEvent(createTouchEvent('touchend'));
+    shrinkingUI.cover.dispatchEvent(createTouchEvent('touchstart'));
+    shrinkingUI.cover.dispatchEvent(createTouchEvent('touchmove'));
+    shrinkingUI.cover.dispatchEvent(createTouchEvent('touchend'));
 
     assert.isFalse(stubHandleSendingStart.called);
     assert.isFalse(stubHandleSendingSlide.called);
@@ -1258,11 +1233,12 @@ suite('system/shrinkingUI', function() {
       this.sinon.stub(shrinkingUI, '_updateTiltTransition');
     var stubUpdateSlideTransition =
       this.sinon.stub(shrinkingUI, '_updateSlideTransition');
-    var spySlidingCoverRemove = this.sinon.spy();
     var stubDisableSlidingCover =
-      this.sinon.stub(shrinkingUI, '_disableSlidingCover').returns(
-        {remove: spySlidingCoverRemove}
-      );
+      this.sinon.stub(shrinkingUI, '_disableSlidingCover');
+    shrinkingUI.cover = {
+      remove: function() {}
+    };
+    var spySlidingCoverRemove = this.sinon.stub(shrinkingUI.cover, 'remove');
 
     fakeApp._element = document.createElement('div');
     var fakeParent = document.createElement('div');
@@ -1274,6 +1250,7 @@ suite('system/shrinkingUI', function() {
     shrinkingUI._cleanEffects();
     assert.isTrue(stubDebug.called);
     assert.isTrue(stubState.called);
+    assert.isTrue(spySlidingCoverRemove.called);
     assert.equal(fakeApp._element.style.transition, '');
     assert.equal(fakeApp._element.style.transform, '');
     assert.equal(fakeApp._element.style.transformOrigin, '50% 50% 0px');
@@ -1281,8 +1258,6 @@ suite('system/shrinkingUI', function() {
     assert.isTrue(stubUpdateTiltTransition.calledWith(null));
     assert.isTrue(stubUpdateSlideTransition.calledWith(null));
     assert.isTrue(fakeParent.classList.remove.calledWith('shrinking-wrapper'));
-    assert.isTrue(spySlidingCoverRemove.called);
-
     assert.isNull(shrinkingUI.cover);
 
     stubDebug.restore();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1079567
