### PR TITLE
Bug 1088408 - [Calendar] Allow opening settings tray when account is in error state

### DIFF
--- a/apps/calendar/js/views/settings.js
+++ b/apps/calendar/js/views/settings.js
@@ -253,7 +253,7 @@ Settings.prototype = {
 
       if (object.error) {
         console.error('Views.Settings error:', object.error);
-        var idx = this.calendars.children.length;
+        var idx = this.calendars.children.length - 1;
         var el = this.calendars.children[idx];
         el.classList.add('error');
       }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1088408
