### PR TITLE
Bug 1089349 - [sharedtest] /unit/l10n/lib/resolver/indexes_test.js and newer version chai

### DIFF
--- a/apps/sharedtest/test/unit/l10n/lib/resolver/indexes_test.js
+++ b/apps/sharedtest/test/unit/l10n/lib/resolver/indexes_test.js
@@ -37,7 +37,7 @@ describe('Index', function(){
     it('throws when the index is an uncalled macro (resolve)', function() {
       assert.throws(function() {
         Resolver.format(env.indexUncalledMacro, {n: 1});
-      }, 'Macro plural expects 1 argument(s), yet 0 given');
+      }, 'Macro [object Object] expects 1 argument(s), yet 0 given');
     });
     it('returns undefined when the index is an uncalled macro (toString)',
       function() {


### PR DESCRIPTION
used chai version not check throwing messages  
