### PR TITLE
Bug 1079218 - Warning not required when device has 2G connection and "ap...

### DIFF
--- a/apps/system/js/update_manager.js
+++ b/apps/system/js/update_manager.js
@@ -240,11 +240,7 @@ var UpdateManager = {
 
       //2G connection
       if (self.connection2G) {
-        if (prioritized) {
-          self.showPromptWifiPrioritized(self.showForbiddenDownload);
-        } else {
-          self.showForbiddenDownload();
-        }
+        self.showForbiddenDownload();
         return;
       }
 

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -1505,7 +1505,7 @@ suite('system/UpdateManager', function() {
         ],
         update2g: false,
         wifiPrioritized: true,
-        testResult: 'wifiPrioritizedAndForbidden'
+        testResult: 'forbidden'
       },
       {
         title: 'Not WIFI, 2G, no Setting update2G, wifi not prioritized' +
@@ -1582,14 +1582,6 @@ suite('system/UpdateManager', function() {
               checkUpdate2gEnabled.lastCall.returnValue]).then(function() {
               assert.ok(showPromptWifiPrioritizedSpy.calledWith(),
                 'wifi prioritized dialog is shown to the user');
-            }).then(done, done);
-            break;
-          case 'wifiPrioritizedAndForbidden':
-            Promise.all([checkWifiPrioritizedSpy.lastCall.returnValue,
-              checkUpdate2gEnabled.lastCall.returnValue]).then(function() {
-              assert.ok(showPromptWifiPrioritizedSpy.calledWith(
-                UpdateManager.showForbiddenDownload),
-                'wifi prioritized dialog called with a callback');
             }).then(done, done);
             break;
           case 'forbidden':


### PR DESCRIPTION
...p.update.2g.enabled" = false and "app.update.wifi-prioritized" = true
