### PR TITLE
Issue 1089511

### DIFF
--- a/apps/system/js/bluetooth.js
+++ b/apps/system/js/bluetooth.js
@@ -1,202 +1,226 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
-/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-
+/* global SettingsListener */
 'use strict';
 
-var Bluetooth = {
-  get Profiles() {
-    return {
-      HFP: 'hfp',   // Hands-Free Profile
-      OPP: 'opp',   // Object Push Profile
-      A2DP: 'a2dp', // A2DP status
-      SCO: 'sco'    // Synchronous Connection-Oriented
-    };
-  },
+(function(exports) {
+  var Bluetooth = function() {
+    /* this property store a reference of the default adapter */
+    this._adapter = null;
 
-  _setProfileConnected: function bt_setProfileConnected(profile, connected) {
-    var value = this['_' + profile + 'Connected'];
-    if (value != connected) {
-      this['_' + profile + 'Connected'] = connected;
+    /**
+     * keep a global connected property.
+     *
+     * @public
+     */
+    this.connected = false;
+  };
 
-      // Raise an event for the profile connection changes.
-      var evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent('bluetoothprofileconnectionchange',
-        /* canBubble */ true, /* cancelable */ false,
-        {
-          name: profile,
-          connected: connected
-        });
-      window.dispatchEvent(evt);
-    }
-  },
+  Bluetooth.prototype = {
+    get Profiles() {
+      return {
+        HFP: 'hfp',   // Hands-Free Profile
+        OPP: 'opp',   // Object Push Profile
+        A2DP: 'a2dp', // A2DP status
+        SCO: 'sco'    // Synchronous Connection-Oriented
+      };
+    },
 
-  getCurrentProfiles: function bt_getCurrentProfiles() {
-    var profiles = this.Profiles;
-    var connectedProfiles = [];
-    for (var name in profiles) {
-      var profile = profiles[name];
-      if (this.isProfileConnected(profile)) {
-        connectedProfiles.push(profile);
-      }
-    }
-    return connectedProfiles;
-  },
+    _setProfileConnected: function bt_setProfileConnected(profile, connected) {
+      var value = this['_' + profile + 'Connected'];
+      if (value != connected) {
+        this['_' + profile + 'Connected'] = connected;
 
-  isProfileConnected: function bt_isProfileConnected(profile) {
-    var isConnected = this['_' + profile + 'Connected'];
-    if (isConnected === undefined) {
-      return false;
-    } else {
-      return isConnected;
-    }
-  },
-
-  /* this property store a reference of the default adapter */
-  defaultAdapter: null,
-
-  /* keep a global connected property here */
-  connected: false,
-
-  init: function bt_init() {
-    if (!window.navigator.mozSettings)
-      return;
-
-    if (!window.navigator.mozBluetooth)
-      return;
-
-    var telephony = window.navigator.mozTelephony;
-    var bluetooth = window.navigator.mozBluetooth;
-    var settings = window.navigator.mozSettings;
-    var self = this;
-
-    SettingsListener.observe('bluetooth.enabled', true, function(value) {
-      if (!bluetooth) {
-        // roll back the setting value to notify the UIs
-        // that Bluetooth interface is not available
-        if (value) {
-          SettingsListener.getSettingsLock().set({
-            'bluetooth.enabled': false
+        // Raise an event for the profile connection changes.
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent('bluetoothprofileconnectionchange',
+          /* canBubble */ true, /* cancelable */ false,
+          {
+            name: profile,
+            connected: connected
           });
+        window.dispatchEvent(evt);
+      }
+    },
+
+    getCurrentProfiles: function bt_getCurrentProfiles() {
+      var profiles = this.Profiles;
+      var connectedProfiles = [];
+      for (var name in profiles) {
+        var profile = profiles[name];
+        if (this.isProfileConnected(profile)) {
+          connectedProfiles.push(profile);
         }
+      }
+      return connectedProfiles;
+    },
+
+    /**
+     * check if bluetooth profile is connected.
+     *
+     * @public
+     * @param  {[type]}  profile profile name
+     * @return {Boolean} connected state
+     */
+    isProfileConnected: function bt_isProfileConnected(profile) {
+      var isConnected = this['_' + profile + 'Connected'];
+      if (isConnected === undefined) {
+        return false;
+      } else {
+        return isConnected;
+      }
+    },
+
+    /**
+     * bootstrap bluetooth.
+     *
+     * @public
+     */
+    start: function bt_init() {
+      if (!window.navigator.mozSettings || !window.navigator.mozBluetooth) {
         return;
       }
-    });
 
-    // when bluetooth adapter is ready, emit event to notify QuickSettings
-    // and try to get defaultAdapter at this moment
-    bluetooth.onadapteradded = function bt_onAdapterAdded() {
-      var evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent('bluetooth-adapter-added',
-        /* canBubble */ true, /* cancelable */ false, null);
-      window.dispatchEvent(evt);
-      self.initDefaultAdapter();
-    };
-    // if bluetooth is enabled in booting time, try to get adapter now
-    this.initDefaultAdapter();
+      var bluetooth = window.navigator.mozBluetooth;
+      var self = this;
 
-    // when bluetooth is really disabled, emit event to notify QuickSettings
-    bluetooth.ondisabled = function bt_onDisabled() {
-      var evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent('bluetooth-disabled',
-        /* canBubble */ true, /* cancelable */ false, null);
-      window.dispatchEvent(evt);
-    };
+      SettingsListener.observe('bluetooth.enabled', true, function(value) {
+        if (!bluetooth) {
+          // roll back the setting value to notify the UIs
+          // that Bluetooth interface is not available
+          if (value) {
+            SettingsListener.getSettingsLock().set({
+              'bluetooth.enabled': false
+            });
+          }
+          return;
+        }
+      });
 
-    /* In file transfering case:
-     * since System Message can't be listened in two js files within a app,
-     * so we listen here but dispatch events to bluetooth_transfer.js
-     * when getting bluetooth file transfer start/complete system messages
-     */
-    navigator.mozSetMessageHandler('bluetooth-opp-transfer-start',
-      function bt_fileTransferUpdate(transferInfo) {
-        self._setProfileConnected(self.Profiles.OPP, true);
-        self.updateConnected();
+      // when bluetooth adapter is ready, emit event to notify QuickSettings
+      // and try to get defaultAdapter at this moment
+      bluetooth.onadapteradded = function bt_onAdapterAdded() {
         var evt = document.createEvent('CustomEvent');
-        evt.initCustomEvent('bluetooth-opp-transfer-start',
-          /* canBubble */ true, /* cancelable */ false,
-          {transferInfo: transferInfo});
+        evt.initCustomEvent('bluetooth-adapter-added',
+          /* canBubble */ true, /* cancelable */ false, null);
         window.dispatchEvent(evt);
-      }
-    );
+        self._initDefaultAdapter();
+      };
 
-    navigator.mozSetMessageHandler('bluetooth-opp-transfer-complete',
-      function bt_fileTransferUpdate(transferInfo) {
-        self._setProfileConnected(self.Profiles.OPP, false);
-        self.updateConnected();
+      // if bluetooth is enabled in booting time, try to get adapter now
+      this._initDefaultAdapter();
+
+      // when bluetooth is really disabled, emit event to notify QuickSettings
+      bluetooth.ondisabled = function bt_onDisabled() {
         var evt = document.createEvent('CustomEvent');
-        evt.initCustomEvent('bluetooth-opp-transfer-complete',
-          /* canBubble */ true, /* cancelable */ false,
-          {transferInfo: transferInfo});
+        evt.initCustomEvent('bluetooth-disabled',
+          /* canBubble */ true, /* cancelable */ false, null);
         window.dispatchEvent(evt);
-      }
-    );
-  },
+      };
 
-  // Get adapter for BluetoothTransfer when everytime bluetooth is enabled
-  initDefaultAdapter: function bt_initDefaultAdapter() {
-    var bluetooth = window.navigator.mozBluetooth;
-    var self = this;
+      /* In file transfering case:
+       * since System Message can't be listened in two js files within a app,
+       * so we listen here but dispatch events to bluetooth_transfer.js
+       * when getting bluetooth file transfer start/complete system messages
+       */
+      navigator.mozSetMessageHandler('bluetooth-opp-transfer-start',
+        this._fileTransferUpdate.bind(this));
 
-    if (!bluetooth || !bluetooth.enabled ||
-        !('getDefaultAdapter' in bluetooth))
-      return;
+      navigator.mozSetMessageHandler('bluetooth-opp-transfer-complete',
+        this._onTransferComplete.bind(this));
+    },
 
-    var req = bluetooth.getDefaultAdapter();
-    req.onsuccess = function bt_gotDefaultAdapter(evt) {
-      self.defaultAdapter = req.result;
-      self.initWithAdapter(self.defaultAdapter);
-    };
-  },
-
-  initWithAdapter: function bt_initWithAdapter(adapter) {
-    /* for v1, we only support two use cases for bluetooth connection:
-     *   1. connecting with a headset
-     *   2. transfering a file to/from another device
-     * So we need to listen to corresponding events to know we are (aren't)
-     * connected, then summarize to an event and dispatch to StatusBar
-     */
-
-    // In headset connected case:
-    var self = this;
-    adapter.onhfpstatuschanged = function bt_hfpStatusChanged(evt) {
-      self._setProfileConnected(self.Profiles.HFP, evt.status);
-      self.updateConnected();
-    };
-
-    adapter.ona2dpstatuschanged = function bt_a2dpStatusChanged(evt) {
-      self._setProfileConnected(self.Profiles.A2DP, evt.status);
-      self.updateConnected();
-    };
-
-    adapter.onscostatuschanged = function bt_scoStatusChanged(evt) {
-      self._setProfileConnected(self.Profiles.SCO, evt.status);
-    };
-  },
-
-  updateConnected: function bt_updateConnected() {
-    var bluetooth = window.navigator.mozBluetooth;
-
-    if (!bluetooth || !('isConnected' in bluetooth))
-      return;
-
-    var wasConnected = this.connected;
-    this.connected = this.isProfileConnected(this.Profiles.HFP) ||
-                     this.isProfileConnected(this.Profiles.A2DP) ||
-                     this.isProfileConnected(this.Profiles.OPP);
-
-    if (wasConnected !== this.connected) {
+    _fileTransferUpdate: function bt_fileTransferUpdate(transferInfo) {
+      this._setProfileConnected(this.Profiles.OPP, true);
+      this._updateConnected();
       var evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent('bluetoothconnectionchange',
+      evt.initCustomEvent('bluetooth-opp-transfer-start',
         /* canBubble */ true, /* cancelable */ false,
-        {deviceConnected: this.connected});
+        {transferInfo: transferInfo});
       window.dispatchEvent(evt);
+    },
+
+    _onTransferComplete: function bt_onTransferComplete(transferInfo) {
+      this._setProfileConnected(this.Profiles.OPP, false);
+      this._updateConnected();
+      var evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent('bluetooth-opp-transfer-complete',
+        /* canBubble */ true, /* cancelable */ false,
+        {transferInfo: transferInfo});
+      window.dispatchEvent(evt);
+    },
+
+    // Get adapter for BluetoothTransfer when everytime bluetooth is enabled
+    _initDefaultAdapter: function bt_initDefaultAdapter() {
+      var bluetooth = window.navigator.mozBluetooth;
+      var self = this;
+
+      if (!bluetooth || !bluetooth.enabled ||
+          !('getDefaultAdapter' in bluetooth)) {
+        return;
+      }
+
+      var req = bluetooth.getDefaultAdapter();
+      req.onsuccess = function bt_gotDefaultAdapter(evt) {
+        self._adapter = req.result;
+        self._initWithAdapter(self._adapter);
+      };
+    },
+
+    _initWithAdapter: function bt_initWithAdapter(adapter) {
+      /* for v1, we only support two use cases for bluetooth connection:
+       *   1. connecting with a headset
+       *   2. transfering a file to/from another device
+       * So we need to listen to corresponding events to know we are (aren't)
+       * connected, then summarize to an event and dispatch to StatusBar
+       */
+
+      // In headset connected case:
+      var self = this;
+      adapter.onhfpstatuschanged = function bt_hfpStatusChanged(evt) {
+        self._setProfileConnected(self.Profiles.HFP, evt.status);
+        self._updateConnected();
+      };
+
+      adapter.ona2dpstatuschanged = function bt_a2dpStatusChanged(evt) {
+        self._setProfileConnected(self.Profiles.A2DP, evt.status);
+        self._updateConnected();
+      };
+
+      adapter.onscostatuschanged = function bt_scoStatusChanged(evt) {
+        self._setProfileConnected(self.Profiles.SCO, evt.status);
+      };
+    },
+
+    _updateConnected: function bt_updateConnected() {
+      var bluetooth = window.navigator.mozBluetooth;
+
+      if (!bluetooth || !('isConnected' in bluetooth)) {
+        return;
+      }
+
+      var wasConnected = this.connected;
+      this.connected = this.isProfileConnected(this.Profiles.HFP) ||
+                       this.isProfileConnected(this.Profiles.A2DP) ||
+                       this.isProfileConnected(this.Profiles.OPP);
+
+      if (wasConnected !== this.connected) {
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent('bluetoothconnectionchange',
+          /* canBubble */ true, /* cancelable */ false,
+          {deviceConnected: this.connected});
+        window.dispatchEvent(evt);
+      }
+    },
+
+    /**
+     * Called by external (BluetoothTransfer) for re-use adapter.
+     *
+     * @public
+     * @return {Object} default adapter
+     */
+    getAdapter: function bt_getAdapter() {
+      return this._adapter;
     }
-  },
+  };
 
-  // This function is called by external (BluetoothTransfer) for re-use adapter
-  getAdapter: function bt_getAdapter() {
-    return this.defaultAdapter;
-  }
-};
-
-Bluetooth.init();
+  exports.Bluetooth = Bluetooth;
+}(window));

--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -1,614 +1,663 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
-/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 /* API Summary:
    stopSendingFile(in DOMString aDeviceAddress);
    confirmReceivingFile(in DOMString aDeviceAddress, in bool aConfirmation); */
+/* global bluetooth, NotificationHelper, UtilityTray, NfcHandoverManager,
+   CustomDialog, MimeMapper, MozActivity */
 'use strict';
 
-var BluetoothTransfer = {
-  pairList: {
-    index: []
-  },
-  // The first-in-first-out queue maintain each scheduled sending task.
-  // Each element is a object for scheduled sending tasks.
-  _sendingFilesQueue: [],
-  _deviceStorage: navigator.getDeviceStorage('sdcard'),
-  _debug: false,
+(function(exports) {
+  var BluetoothTransfer = function() {
+    /**
+     * Bluetooth pair list
+     *
+     * @public
+     * @type {Object} pair list
+     */
+    this.pairList = {
+      index: []
+    };
+    // The first-in-first-out queue maintain each scheduled sending task.
+    // Each element is a object for scheduled sending tasks.
+    this._sendingFilesQueue = [];
+    this._deviceStorage = navigator.getDeviceStorage('sdcard');
+    this._debug = true;
+    this._elements = null;
+  };
 
-  get transferStatusList() {
-    delete this.transferStatusList;
-    return this.transferStatusList =
-      document.getElementById('bluetooth-transfer-status-list');
-  },
+  BluetoothTransfer.prototype = {
+    get _transferStatusList() {
+      delete this._elements.transferStatusList;
+      this._elements.transferStatusList =
+        document.getElementById('bluetooth-transfer-status-list');
+      return this._elements.transferStatusList;
+    },
 
-  init: function bt_init() {
-    // Bind message handler for sending files from Bluetooth app
-    window.addEventListener('iac-bluetoothTransfercomms',
-      this.onFilesSending.bind(this)
-    );
+    /**
+     * Initialization
+     */
+    start: function bt_init() {
+      this._elements = {
+        screen: document.getElementById('screen'),
+        transferStatusList:
+          document.getElementById('bluetooth-transfer-status-list')
+      };
 
-    // Bind message handler for transferring file callback
-    navigator.mozSetMessageHandler('bluetooth-opp-receiving-file-confirmation',
-      this.onReceivingFileConfirmation.bind(this)
-    );
+      // Bind message handler for sending files from Bluetooth app
+      window.addEventListener('iac-bluetoothTransfercomms', this);
+      // Listen to 'bluetooth-opp-transfer-start' from bluetooth.js
+      window.addEventListener('bluetooth-opp-transfer-start', this);
+      // Listen to 'bluetooth-opp-transfer-complete' from bluetooth.js
+      window.addEventListener('bluetooth-opp-transfer-complete', this);
 
-    // Listen to 'bluetooth-opp-transfer-start' from bluetooth.js
-    window.addEventListener('bluetooth-opp-transfer-start',
-      this.onUpdateProgress.bind(this, 'start')
-    );
+      // Bind message handler for transferring file callback
+      navigator.mozSetMessageHandler(
+        'bluetooth-opp-receiving-file-confirmation',
+        this._onReceivingFileConfirmation.bind(this)
+      );
 
-    navigator.mozSetMessageHandler('bluetooth-opp-update-progress',
-      this.onUpdateProgress.bind(this, 'progress')
-    );
+      navigator.mozSetMessageHandler('bluetooth-opp-update-progress',
+        this._onUpdateProgress.bind(this, 'progress')
+      );
+    },
 
-    // Listen to 'bluetooth-opp-transfer-complete' from bluetooth.js
-    window.addEventListener('bluetooth-opp-transfer-complete',
-      this.onTransferComplete.bind(this)
-    );
-  },
+    handleEvent: function bt_handleEvent(evt) {
+      switch (evt.type) {
+        case 'iac-bluetoothTransfercomms':
+          this._onFilesSending();
+          break;
+        case 'bluetooth-opp-transfer-start':
+          this._onUpdateProgress('start');
+          break;
+        case 'bluetooth-opp-transfer-complete':
+          this._onTransferComplete();
+          break;
+      }
+    },
 
-  getDeviceName: function bt_getDeviceName(address) {
-    var _ = navigator.mozL10n.get;
-    var length = this.pairList.index.length;
-    for (var i = 0; i < length; i++) {
-      if (this.pairList.index[i].address == address)
-        return this.pairList.index[i].name;
-    }
-    return _('unknown-device');
-  },
+    _getDeviceName: function bt_getDeviceName(address) {
+      var _ = navigator.mozL10n.get;
+      var length = this.pairList.index.length;
+      for (var i = 0; i < length; i++) {
+        if (this.pairList.index[i].address === address) {
+          return this.pairList.index[i].name;
+        }
+      }
+      return _('unknown-device');
+    },
 
-  getPairedDevice: function bt_getPairedDevice(callback) {
-    var adapter = Bluetooth.getAdapter();
-    if (adapter == null) {
-      var msg = 'Cannot get Bluetooth adapter.';
-      this.debug(msg);
-      return;
-    }
-    var self = this;
-    var req = adapter.getPairedDevices();
-    req.onsuccess = function bt_getPairedSuccess() {
-      self.pairList.index = req.result;
-      var length = self.pairList.index.length;
-      if (length == 0) {
-        var msg =
-          'There is no paired device! Please pair your bluetooth device first.';
-        self.debug(msg);
+    _getPairedDevice: function bt_getPairedDevice(callback) {
+      var _adapter = bluetooth.getAdapter();
+      if (_adapter == null) {
+        var msg = 'Cannot get Bluetooth adapter.';
+        this.debug(msg);
         return;
       }
-      if (callback) {
-        callback();
+      var self = this;
+      var req = _adapter.getPairedDevices();
+      req.onsuccess = function bt_getPairedSuccess() {
+        self.pairList.index = req.result;
+        var length = self.pairList.index.length;
+        if (length === 0) {
+          var msg = 'There is no paired device! ' +
+            'Please pair your bluetooth device first.';
+          self.debug(msg);
+          return;
+        }
+        if (callback) {
+          callback();
+        }
+      };
+      req.onerror = function() {
+        var msg = 'Can not get paired devices from adapter.';
+        self.debug(msg);
+      };
+    },
+
+    debug: function bt_debug(msg) {
+      if (!this._debug) {
+        return;
       }
-    };
-    req.onerror = function() {
-      var msg = 'Can not get paired devices from adapter.';
-      self.debug(msg);
-    };
-  },
 
-  debug: function bt_debug(msg) {
-    if (!this._debug)
-      return;
+      console.log('[System Bluetooth Transfer]: ' + msg);
+    },
 
-    console.log('[System Bluetooth Transfer]: ' + msg);
-  },
+    _humanizeSize: function bt_humanizeSize(bytes) {
+      var _ = navigator.mozL10n.get;
+      var units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+      var size, e;
+      if (bytes) {
+        e = Math.floor(Math.log(bytes) / Math.log(1024));
+        size = (bytes / Math.pow(1024, e)).toFixed(2);
+      } else {
+        e = 0;
+        size = '0.00';
+      }
+      return _('fileSize', {
+        size: size,
+        unit: _('byteUnit-' + units[e])
+      });
+    },
 
-  humanizeSize: function bt_humanizeSize(bytes) {
-    var _ = navigator.mozL10n.get;
-    var units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-    var size, e;
-    if (bytes) {
-      e = Math.floor(Math.log(bytes) / Math.log(1024));
-      size = (bytes / Math.pow(1024, e)).toFixed(2);
-    } else {
-      e = 0;
-      size = '0.00';
-    }
-    return _('fileSize', {
-      size: size,
-      unit: _('byteUnit-' + units[e])
-    });
-  },
+    _onFilesSending: function bt_onFilesSending(evt) {
+      var _ = navigator.mozL10n.get;
 
-  onFilesSending: function bt_onFilesSending(evt) {
-    var _ = navigator.mozL10n.get;
+      // Notify user that we are sending files
+      var icon = 'style/bluetooth_transfer/images/transfer.png';
+      NotificationHelper.send(_('transfer-has-started-title'),
+        _('transfer-has-started-description'),
+        icon,
+        function() {
+          UtilityTray.show();
+        });
 
-    // Notify user that we are sending files
-    var icon = 'style/bluetooth_transfer/images/transfer.png';
-    NotificationHelper.send(_('transfer-has-started-title'),
-                            _('transfer-has-started-description'),
-                            icon,
-                            function() {
-                              UtilityTray.show();
-                            });
+      // Push sending files request in queue
+      this._sendingFilesQueue.push(evt.detail);
+      var msg = 'push sending files request in queue, queued length = ' +
+        this._sendingFilesQueue.length;
+      this.debug(msg);
+    },
 
-    // Push sending files request in queue
-    var sendingFilesSchedule = evt.detail;
-    this._sendingFilesQueue.push(sendingFilesSchedule);
-    var msg = 'push sending files request in queue, queued length = ' +
-              this._sendingFilesQueue.length;
-    this.debug(msg);
-  },
+    _onReceivingFileConfirmation:
+      function bt_onReceivingFileConfirmation(evt) {
+        if (NfcHandoverManager.isHandoverInProgress()) {
+          // Bypassing confirm dialog while incoming file
+          // transfer via NFC Handover
+          this.debug('Incoming file via NFC Handover. ' +
+            'Bypassing confirm dialog');
+          NfcHandoverManager.transferStarted();
+          this._acceptReceive(evt);
+          return;
+        }
 
-  onReceivingFileConfirmation: function bt_onReceivingFileConfirmation(evt) {
-    if (NfcHandoverManager.isHandoverInProgress()) {
-      // Bypassing confirm dialog while incoming file transfer via NFC Handover
-      this.debug('Incoming file via NFC Handover. Bypassing confirm dialog');
-      NfcHandoverManager.transferStarted();
-      this.acceptReceive(evt);
-      return;
-    }
+        // Prompt appears when a transfer request from a
+        // paired device is received.
+        var _ = navigator.mozL10n.get;
 
-    // Prompt appears when a transfer request from a paired device is received.
-    var _ = navigator.mozL10n.get;
+        var address = evt.address;
+        var self = this;
+        var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
 
-    var address = evt.address;
-    var fileSize = evt.fileLength;
-    var self = this;
-    var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
+        this._getPairedDevice(function getPairedDeviceComplete() {
+          var deviceName = self._getDeviceName(address);
+          NotificationHelper.send(_('transfer-confirmation-title',
+            { deviceName: deviceName }),
+            _('transfer-confirmation-description'),
+            icon,
+            function() {
+              UtilityTray.hide();
+              self._showReceivePrompt(evt);
+            });
+        });
+    },
 
-    this.getPairedDevice(function getPairedDeviceComplete() {
-      var deviceName = self.getDeviceName(address);
-      NotificationHelper.send(_('transfer-confirmation-title',
-                              { deviceName: deviceName }),
-                              _('transfer-confirmation-description'),
-                              icon,
-                              function() {
-                                UtilityTray.hide();
-                                self.showReceivePrompt(evt);
-                              });
-    });
-  },
+    _showReceivePrompt: function bt_showReceivePrompt(evt) {
 
-  showReceivePrompt: function bt_showReceivePrompt(evt) {
+      var address = evt.address;
+      var fileName = evt.fileName;
+      var fileSize = this._humanizeSize(evt.fileLength);
+      var cancel = {
+        title: 'deny',
+        callback: this._declineReceive.bind(this, address)
+      };
 
-    var address = evt.address;
-    var fileName = evt.fileName;
-    var fileSize = this.humanizeSize(evt.fileLength);
-    var cancel = {
-      title: 'deny',
-      callback: this.declineReceive.bind(this, address)
-    };
+      var confirm = {
+        title: 'transfer',
+        callback: this._acceptReceive.bind(this, evt),
+        recommend: true
+      };
 
-    var confirm = {
-      title: 'transfer',
-      callback: this.acceptReceive.bind(this, evt),
-      recommend: true
-    };
+      var deviceName = '';
+      var screen = this._elements.screen;
+      this._getPairedDevice(function getPairedDeviceComplete() {
+        deviceName = this._getDeviceName(address);
+        CustomDialog.show(
+          'acceptFileTransfer',
+          {
+            id: 'wantToReceiveFile',
+            args: {
+              deviceName: deviceName,
+              fileName: fileName,
+              fileSize: fileSize
+            }
+          },
+          cancel,
+          confirm,
+          screen
+        )
+        .setAttribute('data-z-index-level', 'system-dialog');
+      }.bind(this));
+    },
 
-    var deviceName = '';
-    var screen = document.getElementById('screen');
-    this.getPairedDevice(function getPairedDeviceComplete() {
-      deviceName = this.getDeviceName(address);
-      CustomDialog.show(
-        'acceptFileTransfer',
-        {
-          id: 'wantToReceiveFile',
-          args: {
-            deviceName: deviceName,
-            fileName: fileName,
-            fileSize: fileSize
+    _declineReceive: function bt_declineReceive(address) {
+      CustomDialog.hide();
+      var _adapter = bluetooth.getAdapter();
+      if (_adapter != null) {
+        _adapter.confirmReceivingFile(address, false);
+      } else {
+        var msg = 'Cannot get adapter from system Bluetooth monitor.';
+        this.debug(msg);
+      }
+    },
+
+    _acceptReceive: function bt_acceptReceive(evt) {
+      CustomDialog.hide();
+      // Check storage is available or not before confirm receiving file
+      var address = evt.address;
+      var fileSize = evt.fileLength;
+      var self = this;
+      this._checkStorageSpace(fileSize,
+        function checkStorageSpaceComplete(isStorageAvailable, errorMessage) {
+          var _adapter = bluetooth.getAdapter();
+          var option = (isStorageAvailable) ? true : false;
+          if (_adapter) {
+            _adapter.confirmReceivingFile(address, option);
+          } else {
+            var msg = 'Cannot get adapter from system Bluetooth monitor.';
+            self.debug(msg);
           }
-        },
+          // Storage is not available, then pop out a prompt with the reason
+          if (!isStorageAvailable) {
+            self._showStorageUnavaliablePrompt(errorMessage);
+          }
+      });
+    },
+
+    _showStorageUnavaliablePrompt:
+      function bt_showStorageUnavaliablePrompt(msg) {
+        var confirm = {
+          title: 'confirm',
+          callback: function() {
+            CustomDialog.hide();
+          }
+        };
+
+        var body = msg;
+        var screen = this._elements.screen;
+        CustomDialog.show('cannotReceiveFile', body, confirm, null, screen)
+          .setAttribute('data-z-index-level', 'system-dialog');
+    },
+
+    _checkStorageSpace: function bt_checkStorageSpace(fileSize, callback) {
+      if (!callback) {
+        return;
+      }
+
+      var storage = this._deviceStorage;
+
+      var availreq = storage.available();
+      availreq.onsuccess = function(e) {
+        switch (availreq.result) {
+        case 'available':
+          // skip down to the code below
+          break;
+        case 'unavailable':
+          callback(false, 'sdcard-not-exist2');
+          return;
+        case 'shared':
+          callback(false, 'sdcard-in-use');
+          return;
+        default:
+          callback(false, 'unknown-error');
+          return;
+        }
+
+        // If we get here, then the sdcard is available, so we need to find out
+        // if there is enough free space on it
+        var freereq = storage.freeSpace();
+        freereq.onsuccess = function() {
+          if (freereq.result >= fileSize) {
+            callback(true, '');
+          } else {
+            callback(false, 'sdcard-no-space2');
+          }
+        };
+        freereq.onerror = function() {
+          callback(false, 'cannotGetStorageState');
+        };
+      };
+
+      availreq.onerror = function(e) {
+        callback(false, 'cannotGetStorageState');
+      };
+    },
+
+    /**
+     * Check if SendFile queue is empty.
+     *
+     * @public
+     */
+    get isSendFileQueueEmpty() {
+      return this._sendingFilesQueue.length === 0;
+    },
+
+    /**
+     * Send file via nfc handover.
+     *
+     * @public
+     * @param  {String} mac mac address
+     * @param  {Blob} blob blob file
+     */
+    sendFileViaHandover: function bt_sendFileViaHandover(mac, blob) {
+      var _adapter = bluetooth.getAdapter();
+      if (_adapter != null) {
+        var sendingFilesSchedule = {
+          viaHandover: true,
+          numberOfFiles: 1,
+          numSuccessful: 0,
+          numUnsuccessful: 0
+        };
+        this._onFilesSending({detail: sendingFilesSchedule});
+        // XXX: Bug 915602 - [Bluetooth] Call sendFile api will crash
+        // the system while device is just paired.
+        // The paired device is ready to send file.
+        // Since above issue is existed, we use a setTimeout with 3 secs delay
+        var waitConnectionReadyTimeoutTime = 3000;
+        setTimeout(function() {
+          _adapter.sendFile(mac, blob);
+        }, waitConnectionReadyTimeoutTime);
+      } else {
+        var msg = 'Cannot get adapter from system Bluetooth monitor.';
+        this.debug(msg);
+      }
+    },
+
+    _onUpdateProgress: function bt_onUpdateProgress(mode, evt) {
+      switch (mode) {
+        case 'start':
+          var transferInfo = evt.detail.transferInfo;
+          this._initProgress(transferInfo);
+          break;
+
+        case 'progress':
+          var processedLength = evt.processedLength;
+          var fileLength = evt.fileLength;
+          var progress = 0;
+          if (fileLength === 0) {
+            //XXX: May need to handle unknow progress
+          } else if (processedLength > fileLength) {
+            // According Bluetooth spec.,
+            // the processed length is a referenced value only.
+            // XXX: If processed length is bigger than file length,
+            //      show an unknown progress
+          } else {
+            progress = processedLength / fileLength;
+          }
+          this._updateProgress(progress, evt);
+          break;
+      }
+    },
+
+    _initProgress: function bt_initProgress(evt) {
+      var _ = navigator.mozL10n.get;
+      // Create progress dynamically in notification center
+      var address = evt.address;
+      var transferMode = (evt.received === true) ?
+        _('bluetooth-receiving-progress') : _('bluetooth-sending-progress');
+      var content =
+        '<div data-icon="bluetooth-transfer-circle"></div>' +
+        '<div class="title-container">' + transferMode + '</div>' +
+        // XXX: Bug 804533 - [Bluetooth]
+        // Need sending/receiving icon for Bluetooth file transfer
+        '<progress value="0" max="1"></progress>';
+
+      var transferTask = document.createElement('div');
+      transferTask.id = 'bluetooth-transfer-status';
+      transferTask.className = 'fake-notification';
+      transferTask.setAttribute('data-id', address);
+      transferTask.setAttribute('role', 'link');
+      transferTask.innerHTML = content;
+      transferTask.addEventListener('click',
+        this._onCancelTransferTask.bind(this));
+      this._elements.transferStatusList.appendChild(transferTask);
+    },
+
+    _updateProgress: function bt_updateProgress(value, evt) {
+      var address = evt.address;
+      var id = 'div[data-id="' + address + '"] progress';
+      var progressEl = this._elements.transferStatusList.querySelector(id);
+      progressEl.value = value;
+    },
+
+    _removeProgress: function bt_removeProgress(evt) {
+      var address = evt.address;
+      var id = 'div[data-id="' + address + '"]';
+      var finishedTask = this._elements.transferStatusList.querySelector(id);
+      // If we decline receiving file, Bluetooth won't callback
+      // 'bluetooth-opp-transfer-start',
+      // 'bluetooth-opp-update-progress' event.
+      // So that there is no progress element which was
+      // created on notification.
+      // There is only 'bluetooth-opp-transfer-complete' event to
+      // notify Gaia the transferring request in failed case.
+      if (finishedTask == null) {
+        return;
+      }
+
+      finishedTask.removeEventListener('click',
+        this._onCancelTransferTask.bind(this));
+      this._elements.transferStatusList.removeChild(finishedTask);
+    },
+
+    _onCancelTransferTask: function bt_onCancelTransferTask(evt) {
+      var id = evt.target.dataset.id;
+      // Show confirm dialog for user to cancel transferring task
+      UtilityTray.hide();
+      this._showCancelTransferPrompt(id);
+    },
+
+    _showCancelTransferPrompt: function bt_showCancelTransferPrompt(address) {
+      var cancel = {
+        title: 'continueFileTransfer',
+        callback: this._continueTransfer.bind(this)
+      };
+
+      var confirm = {
+        title: 'cancel',
+        callback: this._cancelTransfer.bind(this, address)
+      };
+
+      var screen = this._elements.screen;
+      CustomDialog.show(
+        'cancelFileTransfer',
+        'cancelFileTransfer',
         cancel,
         confirm,
         screen
       )
       .setAttribute('data-z-index-level', 'system-dialog');
-    }.bind(this));
-  },
+    },
 
-  declineReceive: function bt_declineReceive(address) {
-    CustomDialog.hide();
-    var adapter = Bluetooth.getAdapter();
-    if (adapter != null) {
-      adapter.confirmReceivingFile(address, false);
-    } else {
-      var msg = 'Cannot get adapter from system Bluetooth monitor.';
-      this.debug(msg);
-    }
-  },
+    _continueTransfer: function bt_continueTransfer() {
+      CustomDialog.hide();
+    },
 
-  acceptReceive: function bt_acceptReceive(evt) {
-    CustomDialog.hide();
-    // Check storage is available or not before confirm receiving file
-    var address = evt.address;
-    var fileSize = evt.fileLength;
-    var self = this;
-    this.checkStorageSpace(fileSize,
-      function checkStorageSpaceComplete(isStorageAvailable, errorMessage) {
-        var adapter = Bluetooth.getAdapter();
-        var option = (isStorageAvailable) ? true : false;
-        if (adapter) {
-          adapter.confirmReceivingFile(address, option);
-        } else {
-          var msg = 'Cannot get adapter from system Bluetooth monitor.';
-          self.debug(msg);
-        }
-        // Storage is not available, then pop out a prompt with the reason
-        if (!isStorageAvailable) {
-          self.showStorageUnavaliablePrompt(errorMessage);
-        }
-    });
-  },
-
-  showStorageUnavaliablePrompt: function bt_showStorageUnavaliablePrompt(msg) {
-    var confirm = {
-      title: 'confirm',
-      callback: function() {
-        CustomDialog.hide();
-      }
-    };
-
-    var body = msg;
-    var screen = document.getElementById('screen');
-    CustomDialog.show('cannotReceiveFile', body, confirm, null, screen)
-    .setAttribute('data-z-index-level', 'system-dialog');
-  },
-
-  checkStorageSpace: function bt_checkStorageSpace(fileSize, callback) {
-    if (!callback)
-      return;
-
-    var _ = navigator.mozL10n.get;
-    var storage = this._deviceStorage;
-
-    var availreq = storage.available();
-    availreq.onsuccess = function(e) {
-      switch (availreq.result) {
-      case 'available':
-        // skip down to the code below
-        break;
-      case 'unavailable':
-        callback(false, 'sdcard-not-exist2');
-        return;
-      case 'shared':
-        callback(false, 'sdcard-in-use');
-        return;
-      default:
-        callback(false, 'unknown-error');
-        return;
-      }
-
-      // If we get here, then the sdcard is available, so we need to find out
-      // if there is enough free space on it
-      var freereq = storage.freeSpace();
-      freereq.onsuccess = function() {
-        if (freereq.result >= fileSize)
-          callback(true, '');
-        else
-          callback(false, 'sdcard-no-space2');
-      };
-      freereq.onerror = function() {
-        callback(false, 'cannotGetStorageState');
-      };
-    };
-
-    availreq.onerror = function(e) {
-      callback(false, 'cannotGetStorageState');
-    };
-  },
-
-  get isSendFileQueueEmpty() {
-    return this._sendingFilesQueue.length === 0;
-  },
-
-  sendFileViaHandover: function bt_sendFileViaHandover(mac, blob) {
-    var adapter = Bluetooth.getAdapter();
-    if (adapter != null) {
-      var sendingFilesSchedule = {
-        viaHandover: true,
-        numberOfFiles: 1,
-        numSuccessful: 0,
-        numUnsuccessful: 0
-      };
-      this.onFilesSending({detail: sendingFilesSchedule});
-      // XXX: Bug 915602 - [Bluetooth] Call sendFile api will crash
-      // the system while device is just paired.
-      // The paired device is ready to send file.
-      // Since above issue is existed, we use a setTimeout with 3 secs delay
-      var waitConnectionReadyTimeoutTime = 3000;
-      setTimeout(function() {
-        adapter.sendFile(mac, blob);
-      }, waitConnectionReadyTimeoutTime);
-    } else {
-      var msg = 'Cannot get adapter from system Bluetooth monitor.';
-      this.debug(msg);
-    }
-  },
-
-  onUpdateProgress: function bt_onUpdateProgress(mode, evt) {
-    switch (mode) {
-      case 'start':
-        var transferInfo = evt.detail.transferInfo;
-        this.initProgress(transferInfo);
-        break;
-
-      case 'progress':
-        var address = evt.address;
-        var processedLength = evt.processedLength;
-        var fileLength = evt.fileLength;
-        var progress = 0;
-        if (fileLength == 0) {
-          //XXX: May need to handle unknow progress
-        } else if (processedLength > fileLength) {
-          // According Bluetooth spec.,
-          // the processed length is a referenced value only.
-          // XXX: If processed length is bigger than file length,
-          //      show an unknown progress
-        } else {
-          progress = processedLength / fileLength;
-        }
-        this.updateProgress(progress, evt);
-        break;
-    }
-  },
-
-  initProgress: function bt_initProgress(evt) {
-    var _ = navigator.mozL10n.get;
-    // Create progress dynamically in notification center
-    var address = evt.address;
-    var transferMode =
-      (evt.received == true) ?
-      _('bluetooth-receiving-progress') : _('bluetooth-sending-progress');
-    var content =
-      '<div data-icon="bluetooth-transfer-circle"></div>' +
-      '<div class="title-container">' + transferMode + '</div>' +
-      // XXX: Bug 804533 - [Bluetooth]
-      // Need sending/receiving icon for Bluetooth file transfer
-      '<progress value="0" max="1"></progress>';
-
-    var transferTask = document.createElement('div');
-    transferTask.id = 'bluetooth-transfer-status';
-    transferTask.className = 'fake-notification';
-    transferTask.setAttribute('data-id', address);
-    transferTask.setAttribute('role', 'link');
-    transferTask.innerHTML = content;
-    transferTask.addEventListener('click',
-                                  this.onCancelTransferTask.bind(this));
-    this.transferStatusList.appendChild(transferTask);
-  },
-
-  updateProgress: function bt_updateProgress(value, evt) {
-    var address = evt.address;
-    var id = 'div[data-id="' + address + '"] progress';
-    var progressEl = this.transferStatusList.querySelector(id);
-    progressEl.value = value;
-  },
-
-  removeProgress: function bt_removeProgress(evt) {
-    var address = evt.address;
-    var id = 'div[data-id="' + address + '"]';
-    var finishedTask = this.transferStatusList.querySelector(id);
-    // If we decline receiving file, Bluetooth won't callback
-    // 'bluetooth-opp-transfer-start', 'bluetooth-opp-update-progress' event.
-    // So that there is no progress element which was created on notification.
-    // There is only 'bluetooth-opp-transfer-complete' event to notify Gaia the
-    // transferring request in failed case.
-    if (finishedTask == null)
-      return;
-
-    finishedTask.removeEventListener('click',
-                                     this.onCancelTransferTask.bind(this));
-    this.transferStatusList.removeChild(finishedTask);
-  },
-
-  onCancelTransferTask: function bt_onCancelTransferTask(evt) {
-    var id = evt.target.dataset.id;
-    // Show confirm dialog for user to cancel transferring task
-    UtilityTray.hide();
-    this.showCancelTransferPrompt(id);
-  },
-
-  showCancelTransferPrompt: function bt_showCancelTransferPrompt(address) {
-    var _ = navigator.mozL10n.get;
-
-    var cancel = {
-      title: 'continueFileTransfer',
-      callback: this.continueTransfer.bind(this)
-    };
-
-    var confirm = {
-      title: 'cancel',
-      callback: this.cancelTransfer.bind(this, address)
-    };
-
-    var screen = document.getElementById('screen');
-
-    CustomDialog.show(
-      'cancelFileTransfer',
-      'cancelFileTransfer',
-      cancel,
-      confirm,
-      screen
-    )
-    .setAttribute('data-z-index-level', 'system-dialog');
-  },
-
-  continueTransfer: function bt_continueTransfer() {
-    CustomDialog.hide();
-  },
-
-  cancelTransfer: function bt_cancelTransfer(address) {
-    CustomDialog.hide();
-    var adapter = Bluetooth.getAdapter();
-    if (adapter != null) {
-      adapter.stopSendingFile(address);
-    } else {
-      var msg = 'Cannot get adapter from system Bluetooth monitor.';
-      this.debug(msg);
-    }
-  },
-
-  onTransferComplete: function bt_onTransferComplete(evt) {
-    var transferInfo = evt.detail.transferInfo;
-    var _ = navigator.mozL10n.get;
-    // Remove transferring progress
-    this.removeProgress(transferInfo);
-    var fileName =
-      (transferInfo.fileName) ? transferInfo.fileName : _('unknown-file');
-    var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
-    // Show notification
-    if (transferInfo.success == true) {
-      if (transferInfo.received) {
-        // Received file can be opened only
-        NotificationHelper.send(_('transferFinished-receivedSuccessful-title'),
-                                fileName,
-                                icon,
-                                this.openReceivedFile.bind(this, transferInfo));
+    _cancelTransfer: function bt_cancelTransfer(address) {
+      CustomDialog.hide();
+      var _adapter = bluetooth.getAdapter();
+      if (_adapter != null) {
+        _adapter.stopSendingFile(address);
       } else {
-        NotificationHelper.send(_('transferFinished-sentSuccessful-title'),
-                                fileName,
-                                icon);
-      }
-    } else {
-      if (transferInfo.received) {
-        NotificationHelper.send(_('transferFinished-receivedFailed-title'),
-                                fileName,
-                                icon);
-      } else {
-        NotificationHelper.send(_('transferFinished-sentFailed-title'),
-                                fileName,
-                                icon);
-      }
-    }
-
-    var viaHandover = false;
-    if (this._sendingFilesQueue.length > 0) {
-      viaHandover = this._sendingFilesQueue[0].viaHandover || false;
-    }
-
-    // Have a report notification for sending multiple files.
-    this.summarizeSentFilesReport(transferInfo);
-
-    // Inform NfcHandoverManager that the transfer completed
-    var details = {received: transferInfo.received,
-                   success: transferInfo.success,
-                   viaHandover: viaHandover};
-    NfcHandoverManager.transferComplete(details);
-  },
-
-  summarizeSentFilesReport: function bt_summarizeSentFilesReport(transferInfo) {
-    var _ = navigator.mozL10n.get;
-
-    // Ignore received files
-    if (transferInfo.received)
-      return;
-
-    // Consumer: System app consume each sending file request from Bluetooth app
-    var msg = 'remove the finished sending task from queue, queue length = ';
-    var successful = transferInfo.success;
-    var sendingFilesSchedule = this._sendingFilesQueue[0];
-    var numberOfFiles = sendingFilesSchedule.numberOfFiles;
-    if (numberOfFiles == 1) { // The scheduled task is for sent one file only.
-      // We don't need to summarize a report for sent one file only.
-      // Remove the finished sending task from the queue
-      this._sendingFilesQueue.shift();
-      msg += this._sendingFilesQueue.length;
-      this.debug(msg);
-    } else { // The scheduled task is for sent multiple files.
-      // Create a report in notification.
-      // Record each transferring report.
-      if (successful) {
-        this._sendingFilesQueue[0].numSuccessful++;
-      } else {
-        this._sendingFilesQueue[0].numUnsuccessful++;
-      }
-
-      var numSuccessful = this._sendingFilesQueue[0].numSuccessful;
-      var numUnsuccessful = this._sendingFilesQueue[0].numUnsuccessful;
-      if ((numSuccessful + numUnsuccessful) == numberOfFiles) {
-        // In this item of queue, all files were sent completely.
-        var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
-        NotificationHelper.send(_('transferReport-title'),
-                                _('transferReport-description',
-                                { numSuccessful: numSuccessful,
-                                  numUnsuccessful: numUnsuccessful }),
-                                icon);
-
-        // Remove the finished sending task from the queue
-        this._sendingFilesQueue.shift();
-        msg += this._sendingFilesQueue.length;
+        var msg = 'Cannot get adapter from system Bluetooth monitor.';
         this.debug(msg);
       }
-    }
-  },
+    },
 
-  openReceivedFile: function bt_openReceivedFile(evt) {
-    // Launch the gallery with an open activity to view this specific photo
-    // XXX: Bug 897434 - Save received/downloaded files in one specific folder
-    // with meaningful path and filename
-    var filePath = 'Download/Bluetooth/' + evt.fileName;
-    var contentType = evt.contentType;
-    var storageType = 'sdcard';
-    var self = this;
-    var storage = navigator.getDeviceStorage(storageType);
-    var getreq = storage.get(filePath);
-
-    getreq.onerror = function() {
-      var msg = 'failed to get file:' +
-                filePath + getreq.error.name +
-                getreq.error.name;
-      self.debug(msg);
-    };
-
-    getreq.onsuccess = function() {
-      var file = getreq.result;
-      // When we got the file by storage type of "sdcard"
-      // use the file.type to replace the empty fileType which is given by API
-      var fileName = file.name;
-      var extension = fileName.split('.').pop();
-      var originalType = file.type || contentType;
-      var mappedType = (MimeMapper.isSupportedType(originalType)) ?
-        originalType : MimeMapper.guessTypeFromExtension(extension);
-
-      var a = new MozActivity({
-        name: mappedType == 'text/vcard' ? 'import' : 'open',
-        data: {
-          type: mappedType,
-          blob: file,
-          // XXX: https://bugzilla.mozilla.org/show_bug.cgi?id=812098
-          // Pass the file name for Music APP since it can not open blob
-          filename: fileName
+    _onTransferComplete: function bt_onTransferComplete(evt) {
+      var transferInfo = evt.detail.transferInfo;
+      var _ = navigator.mozL10n.get;
+      // Remove transferring progress
+      this._removeProgress(transferInfo);
+      var fileName =
+        (transferInfo.fileName) ? transferInfo.fileName : _('unknown-file');
+      var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
+      // Show notification
+      if (transferInfo.success === true) {
+        if (transferInfo.received) {
+          // Received file can be opened only
+          NotificationHelper.send(
+            _('transferFinished-receivedSuccessful-title'),
+            fileName, icon,
+            this._openReceivedFile.bind(this, transferInfo));
+        } else {
+          NotificationHelper.send(
+            _('transferFinished-sentSuccessful-title'),
+            fileName, icon);
         }
-      });
-
-      a.onerror = function(e) {
-        var msg = 'open activity error:' + a.error.name;
-        self.debug(msg);
-        switch (a.error.name) {
-        case 'NO_PROVIDER':
-          UtilityTray.hide();
-          // Cannot identify MIMETYPE
-          // So, show cannot open file dialog with unknow media type
-          self.showUnknownMediaPrompt(fileName);
-          return;
-        case 'ActivityCanceled':
-        case 'USER_ABORT':
-        default:
-          return;
+      } else {
+        if (transferInfo.received) {
+          NotificationHelper.send(
+            _('transferFinished-receivedFailed-title'),
+            fileName, icon);
+        } else {
+          NotificationHelper.send(
+            _('transferFinished-sentFailed-title'),
+            fileName, icon);
         }
-      };
-      a.onsuccess = function(e) {
-        var msg = 'open activity onsuccess';
-        self.debug(msg);
-      };
-    };
-  },
-
-  showUnknownMediaPrompt: function bt_showUnknownMediaPrompt(fileName) {
-    var confirm = {
-      title: 'confirm',
-      callback: function() {
-        CustomDialog.hide();
       }
-    };
 
-    var screen = document.getElementById('screen');
-    var body = {id: 'unknownMediaTypeToOpenFile', args: {fileName: fileName}};
-    CustomDialog.show('cannotOpenFile', body, confirm, null, screen)
-    .setAttribute('data-z-index-level', 'system-dialog');
-  }
+      var viaHandover = false;
+      if (this._sendingFilesQueue.length > 0) {
+        viaHandover = this._sendingFilesQueue[0].viaHandover || false;
+      }
 
-};
+      // Have a report notification for sending multiple files.
+      this._summarizeSentFilesReport(transferInfo);
 
-BluetoothTransfer.init();
+      // Inform NfcHandoverManager that the transfer completed
+      var details = {received: transferInfo.received,
+                     success: transferInfo.success,
+                     viaHandover: viaHandover};
+      NfcHandoverManager.transferComplete(details);
+    },
+
+    _summarizeSentFilesReport:
+      function bt_summarizeSentFilesReport(transferInfo) {
+        var _ = navigator.mozL10n.get;
+
+        // Ignore received files
+        if (transferInfo.received) {
+          return;
+        }
+
+        // Consumer: System app consume each sending file request
+        // from Bluetooth app
+        var msg = 'remove the finished sending task from queue, ' +
+          'queue length = ';
+        var successful = transferInfo.success;
+        var sendingFilesSchedule = this._sendingFilesQueue[0];
+        var numberOfFiles = sendingFilesSchedule.numberOfFiles;
+        // The scheduled task is for sent one file only.
+        if (numberOfFiles == 1) {
+          // We don't need to summarize a report for sent one file only.
+          // Remove the finished sending task from the queue
+          this._sendingFilesQueue.shift();
+          msg += this._sendingFilesQueue.length;
+          this.debug(msg);
+        } else { // The scheduled task is for sent multiple files.
+          // Create a report in notification.
+          // Record each transferring report.
+          if (successful) {
+            this._sendingFilesQueue[0].numSuccessful++;
+          } else {
+            this._sendingFilesQueue[0].numUnsuccessful++;
+          }
+
+          var numSuccessful = this._sendingFilesQueue[0].numSuccessful;
+          var numUnsuccessful = this._sendingFilesQueue[0].numUnsuccessful;
+          if ((numSuccessful + numUnsuccessful) == numberOfFiles) {
+            // In this item of queue, all files were sent completely.
+            var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
+            NotificationHelper.send(_('transferReport-title'),
+                                    _('transferReport-description',
+                                    { numSuccessful: numSuccessful,
+                                      numUnsuccessful: numUnsuccessful }),
+                                    icon);
+
+            // Remove the finished sending task from the queue
+            this._sendingFilesQueue.shift();
+            msg += this._sendingFilesQueue.length;
+            this.debug(msg);
+          }
+        }
+    },
+
+    _openReceivedFile: function bt_openReceivedFile(evt) {
+      // Launch the gallery with an open activity to view this specific photo
+      // XXX: Bug 897434 - Save received/downloaded files in one specific folder
+      // with meaningful path and filename
+      var filePath = 'Download/Bluetooth/' + evt.fileName;
+      var contentType = evt.contentType;
+      var storageType = 'sdcard';
+      var self = this;
+      var storage = navigator.getDeviceStorage(storageType);
+      var getreq = storage.get(filePath);
+
+      getreq.onerror = function() {
+        var msg = 'failed to get file:' +
+                  filePath + getreq.error.name +
+                  getreq.error.name;
+        self.debug(msg);
+      };
+
+      getreq.onsuccess = function() {
+        var file = getreq.result;
+        // When we got the file by storage type of "sdcard"
+        // use the file.type to replace the empty fileType which is given by API
+        var fileName = file.name;
+        var extension = fileName.split('.').pop();
+        var originalType = file.type || contentType;
+        var mappedType = (MimeMapper.isSupportedType(originalType)) ?
+          originalType : MimeMapper.guessTypeFromExtension(extension);
+
+        var a = new MozActivity({
+          name: mappedType == 'text/vcard' ? 'import' : 'open',
+          data: {
+            type: mappedType,
+            blob: file,
+            // XXX: https://bugzilla.mozilla.org/show_bug.cgi?id=812098
+            // Pass the file name for Music APP since it can not open blob
+            filename: fileName
+          }
+        });
+
+        a.onerror = function(e) {
+          var msg = 'open activity error:' + a.error.name;
+          self.debug(msg);
+          switch (a.error.name) {
+          case 'NO_PROVIDER':
+            UtilityTray.hide();
+            // Cannot identify MIMETYPE
+            // So, show cannot open file dialog with unknow media type
+            self._showUnknownMediaPrompt(fileName);
+            return;
+          case 'ActivityCanceled':
+          case 'USER_ABORT':
+            /* falls through */
+          default:
+            return;
+          }
+        };
+        a.onsuccess = function(e) {
+          var msg = 'open activity onsuccess';
+          self.debug(msg);
+        };
+      };
+    },
+
+    _showUnknownMediaPrompt: function bt_showUnknownMediaPrompt(fileName) {
+      var confirm = {
+        title: 'confirm',
+        callback: function() {
+          CustomDialog.hide();
+        }
+      };
+
+      var screen = this._elements.screen;
+      var body = {id: 'unknownMediaTypeToOpenFile', args: {fileName: fileName}};
+      CustomDialog.show('cannotOpenFile', body, confirm, null, screen)
+        .setAttribute('data-z-index-level', 'system-dialog');
+    }
+  };
+
+  exports.BluetoothTransfer = BluetoothTransfer;
+}(window));

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -119,6 +119,10 @@ window.addEventListener('load', function startup() {
   window.addEventListener('ftuskip', doneWithFTU);
 
   Shortcuts.init();
+
+  // To make sure ScreenManager can get bluetooth object
+  window.bluetooth = new Bluetooth();
+  window.bluetooth.start();
   ScreenManager.turnScreenOn();
 
   // To make sure homescreen window manager can intercept webapps-launch event,
@@ -136,17 +140,18 @@ window.addEventListener('load', function startup() {
   window.appUsageMetrics.start();
   window.appWindowFactory = new AppWindowFactory();
   window.appWindowFactory.start();
+  window.attentionWindowManager = new window.AttentionWindowManager();
+  window.attentionWindowManager.start();
   window.batteryOverlay = new BatteryOverlay();
   window.batteryOverlay.start();
+  window.bluetoothTransfer = new BluetoothTransfer();
+  window.bluetoothTransfer.start();
   window.cellBroadcastSystem = new CellBroadcastSystem();
   window.cellBroadcastSystem.start();
   window.cpuManager = new CpuManager();
   window.cpuManager.start();
   window.developerHUD = new DeveloperHUD();
   window.developerHUD.start();
-  /** @global */
-  window.attentionWindowManager = new window.AttentionWindowManager();
-  window.attentionWindowManager.start();
   window.dialerAgent = new DialerAgent();
   window.dialerAgent.start();
   window.edgeSwipeDetector = new EdgeSwipeDetector();
@@ -187,10 +192,6 @@ window.addEventListener('load', function startup() {
   window.sourceView = new SourceView();
   window.taskManager = new TaskManager();
   window.taskManager.start();
-  window.bluetooth = new Bluetooth();
-  window.bluetooth.start();
-  window.bluetoothTransfer = new BluetoothTransfer();
-  window.bluetoothTransfer.start();
   window.telephonySettings = new TelephonySettings();
   window.telephonySettings.start();
   window.ttlView = new TTLView();

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -15,7 +15,8 @@
          ExternalStorageMonitor,
          BrowserSettings, AppMigrator, SettingsMigrator, EuRoamingManager,
          CpuManager, CellBroadcastSystem, EdgeSwipeDetector, QuickSettings,
-         BatteryOverlay, BaseModule, AppWindowManager */
+         BatteryOverlay, BaseModule, AppWindowManager, Bluetooth,
+         BluetoothTransfer */
 'use strict';
 
 
@@ -186,6 +187,10 @@ window.addEventListener('load', function startup() {
   window.sourceView = new SourceView();
   window.taskManager = new TaskManager();
   window.taskManager.start();
+  window.bluetooth = new Bluetooth();
+  window.bluetooth.start();
+  window.bluetoothTransfer = new BluetoothTransfer();
+  window.bluetoothTransfer.start();
   window.telephonySettings = new TelephonySettings();
   window.telephonySettings.start();
   window.ttlView = new TTLView();

--- a/apps/system/js/media_playback.js
+++ b/apps/system/js/media_playback.js
@@ -1,4 +1,4 @@
-/* global Bluetooth, IACHandler, appWindowManager */
+/* global bluetooth, IACHandler, appWindowManager */
 
 'use strict';
 
@@ -76,7 +76,7 @@ MediaPlaybackWidget.prototype = {
     var name = event.detail.name;
     var connected = event.detail.connected;
 
-    if (name === Bluetooth.Profiles.SCO) {
+    if (name === bluetooth.Profiles.SCO) {
       this.container.classList.toggle('disabled', connected);
     }
   },

--- a/apps/system/js/screen_manager.js
+++ b/apps/system/js/screen_manager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* globals SettingsListener, Bluetooth, StatusBar, System,
+/* globals SettingsListener, bluetooth, StatusBar, System,
            ScreenBrightnessTransition, ScreenWakeLockManager */
 
 var ScreenManager = {
@@ -260,7 +260,7 @@ var ScreenManager = {
         break;
 
       case 'userproximity':
-        if (Bluetooth.isProfileConnected(Bluetooth.Profiles.SCO) ||
+        if (bluetooth.isProfileConnected(bluetooth.Profiles.SCO) ||
             telephony.speakerEnabled ||
             StatusBar.headphonesActive) {
             // XXX: Remove this hack in Bug 868348

--- a/apps/system/js/sound_manager.js
+++ b/apps/system/js/sound_manager.js
@@ -1,7 +1,7 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-/* global AsyncSemaphore, Bluetooth, CustomDialog, FtuLauncher, ScreenManager,
+/* global AsyncSemaphore, bluetooth, CustomDialog, FtuLauncher, ScreenManager,
           SettingsListener, System */
 
 (function(exports) {
@@ -345,7 +345,7 @@
       return;
     }
 
-    if (Bluetooth.isProfileConnected(Bluetooth.Profiles.SCO) &&
+    if (bluetooth.isProfileConnected(bluetooth.Profiles.SCO) &&
         this.isOnCall()) {
       this.changeVolume(offset, 'bt_sco');
     } else if (this.isHeadsetConnected && offset > 0) {

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -15,7 +15,7 @@
 */
 
 /*global Clock, SettingsListener, TouchForwarder, FtuLauncher, MobileOperator,
-         SIMSlotManager, System, Bluetooth, UtilityTray, nfcManager,
+         SIMSlotManager, System, bluetooth, UtilityTray, nfcManager,
          layoutManager */
 
 'use strict';
@@ -1339,7 +1339,7 @@ var StatusBar = {
       var icon = this.icons.bluetooth;
 
       icon.hidden = !this.settingValues['bluetooth.enabled'];
-      icon.dataset.active = Bluetooth.connected;
+      icon.dataset.active = bluetooth.connected;
       this.updateIconLabel(icon, 'bluetooth', icon.dataset.active);
 
       this._updateIconVisibility();
@@ -1350,10 +1350,10 @@ var StatusBar = {
       var bluetoothTransferringIcon = this.icons.bluetoothTransferring;
 
       bluetoothHeadphoneIcon.hidden =
-        !Bluetooth.isProfileConnected(Bluetooth.Profiles.A2DP);
+        !bluetooth.isProfileConnected(bluetooth.Profiles.A2DP);
 
       bluetoothTransferringIcon.hidden =
-        !Bluetooth.isProfileConnected(Bluetooth.Profiles.OPP);
+        !bluetooth.isProfileConnected(bluetooth.Profiles.OPP);
 
       this._updateIconVisibility();
     },

--- a/apps/system/test/unit/bootstrap_test.js
+++ b/apps/system/test/unit/bootstrap_test.js
@@ -61,6 +61,8 @@ requireApp('system/js/software_button_manager.js');
 requireApp('system/js/source_view.js');
 requireApp('system/js/usb_storage.js');
 requireApp('system/js/system_dialog_manager.js');
+requireApp('system/js/bluetooth.js');
+requireApp('system/js/bluetooth_transfer.js');
 requireApp('system/js/telephony_settings.js');
 requireApp('system/js/base_ui.js');
 requireApp('system/js/text_selection_dialog.js');

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -281,8 +281,6 @@ apps/sharedtest/test/unit/wifi_helper_test.js
 apps/system/js/airplane_mode.js
 apps/system/js/app_modal_dialog.js
 apps/system/js/base_ui.js
-apps/system/js/bluetooth.js
-apps/system/js/bluetooth_transfer.js
 apps/system/js/browser_config_helper.js
 apps/system/js/browser_frame.js
 apps/system/js/browser_mixin.js
@@ -320,7 +318,6 @@ apps/system/test/marionette/net_error_test.js
 apps/system/test/marionette/notification_launch_app_test.js
 apps/system/test/marionette/notification_test.js
 apps/system/test/unit/app_install_manager_test.js
-apps/system/test/unit/bluetooth_transfer_test.js
 apps/system/test/unit/download_manager_test.js
 apps/system/test/unit/download_notification_test.js
 apps/system/test/unit/entery_sheet_test.js


### PR DESCRIPTION
- wrap `Bluetooth` & `BluetoothTransfer` to new-able format
- rename private methods with `_` prefix
- rename `init` to `start` method to align other bootstrapers
- add jsdoc
- fix jshint
