### PR TITLE
Bug 1089615 - Add filtered class soonest to avoid black-white flash

### DIFF
--- a/apps/system/js/homescreen_launcher.js
+++ b/apps/system/js/homescreen_launcher.js
@@ -207,10 +207,14 @@
         case 'cardviewbeforeshow':
           // Fade out the homescreen before showing the cards view to avoid
           // having it bleed through during the transition animation.
+          if (evt.detail && evt.detail === 'browser-only') {
+            this.getHomescreen().element.classList.add('light');
+          }
           this.getHomescreen().fadeOut();
           break;
         case 'cardviewbeforeclose':
           // Fade homescreen back in before the cards view closes.
+          this.getHomescreen().element.classList.remove('light');
           this.getHomescreen().fadeIn();
           break;
         case 'shrinking-start':

--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -363,10 +363,7 @@
     this.initialTouchPosition = null;
 
     // Apply the filter. Noop if no filterName.
-    if (this.filter(filterName)) {
-      // Update visual style to indicate we're filtered.
-      this.element.classList.add('filtered');
-    }
+    this.filter(filterName);
 
     // Short-hand, but we need to get reference to it here as filter can
     // change the stack that will be used.
@@ -404,7 +401,7 @@
 
     // We're committed to showing the card switcher.
     // Homescreen fades (shows its fade-overlay) on cardviewbeforeshow events
-    this.fireCardViewBeforeShow();
+    this.fireCardViewBeforeShow({ detail: filterName });
 
     var activeApp = AppWindowManager.getActiveApp();
 
@@ -851,6 +848,9 @@
         var filter = null;
         if (evt.detail && evt.detail.filter) {
           filter = evt.detail.filter;
+          this.element.classList.add('filtered');
+        } else {
+          this.element.classList.remove('filtered');
         }
         this.show(filter);
         break;
@@ -910,8 +910,8 @@
   /**
    * @memberOf TaskManager.prototype
    */
-  TaskManager.prototype.fireCardViewBeforeShow = function() {
-    window.dispatchEvent(new CustomEvent('cardviewbeforeshow'));
+  TaskManager.prototype.fireCardViewBeforeShow = function(props) {
+    window.dispatchEvent(new CustomEvent('cardviewbeforeshow', props));
   };
 
   /**

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -217,6 +217,10 @@
   opacity: 0.8;
 }
 
+.appWindow.light > .fade-overlay {
+  background-color: white;
+}
+
 .appWindow.homescreen.fadeout .fade-overlay.hidden {
   visibility: hidden;
 }

--- a/apps/system/test/unit/homescreen_launcher_test.js
+++ b/apps/system/test/unit/homescreen_launcher_test.js
@@ -187,6 +187,28 @@ suite('system/HomescreenLauncher', function() {
       stubFadeIn.restore();
     });
 
+    test('light cardview', function() {
+      MockSettingsListener.mCallbacks['homescreen.manifestURL']('first.home');
+      var hasTrustedUI = this.sinon.stub(MockTrustedUIManager, 'hasTrustedUI');
+      hasTrustedUI.returns(false);
+      homescreen = window.homescreenLauncher.getHomescreen();
+      this.sinon.stub(homescreen, 'fadeOut');
+
+      window.homescreenLauncher.handleEvent({
+        type: 'cardviewbeforeshow',
+        detail: 'browser-only'
+      });
+      assert.isTrue(homescreen.element.classList.contains('light'),
+                    'light class added');
+
+      window.homescreenLauncher.handleEvent({
+        type: 'cardviewbeforeclose'
+      });
+      assert.isFalse(homescreen.element.classList.contains('light'),
+                     'light class removed');
+
+    });
+
     test('shrinking UI start; hide homescreen fade-overlay', function() {
       var isSuccessCalled = false;
       var stubGetHomescreen = this.sinon.stub(window.homescreenLauncher,


### PR DESCRIPTION
I cant think of a meaningful test for this. We could assert the class is there before showing the task manager, but that's not really the point - the outcome we want to assert on is that it doesnt flash black then white. 
