### PR TITLE
bug 1077595 - Use DataStoreChangeEvents to update Download API Manager c...

### DIFF
--- a/apps/settings/js/downloads/download_api_manager.js
+++ b/apps/settings/js/downloads/download_api_manager.js
@@ -6,6 +6,7 @@
 (function(exports) {
 
   var downloadsCache = {};
+  var downloadsListener = null;
 
   var COMPLETE_STATE = 'finalized';
   var SUCCEEDED_STATE = 'succeeded';
@@ -26,6 +27,48 @@
 
   function _resetDownloadsCache() {
     downloadsCache = {};
+  }
+
+  function _getTypeFromOperation(operation) {
+    var TYPES = { added: 'added' };
+    return TYPES[operation] || 'unknown';
+  }
+
+  function _updateDownloadsCacheWithDataStoreDownload(dsChange) {
+    var getReq = DownloadStore.get(dsChange.id);
+    getReq.onsuccess = function(event) {
+      var entries = Object.keys(downloadsCache);
+      var download = event.target.result;
+
+      var cachedDownload = null;
+      for (var i = 0; i < entries.length; i++) {
+        var downloadCacheEntry = downloadsCache[entries[i]];
+        if (downloadCacheEntry.storageName == download.storageName &&
+            downloadCacheEntry.storagePath == download.storagePath) {
+          cachedDownload = downloadCacheEntry;
+          break;
+        }
+      }
+
+      var changeEvent = {
+        type: _getTypeFromOperation(dsChange.operation),
+        download: download
+      };
+
+      if (cachedDownload) {
+        changeEvent.downloadApiId = cachedDownload.id;
+        _deleteFromDownloadsCache(cachedDownload.id);
+        _setDownload(download);
+      }
+
+      _callListener(changeEvent);
+    };
+    getReq.onerror = function(e) {
+      console.error('Failed to get download with id = ',
+                    dsChange.id,
+                    ' -- ',
+                    e);
+    };
   }
 
   function getDownloadId(download) {
@@ -73,7 +116,43 @@
     }
   }
 
+  function _dataStoreChangeHandler(dsChange) {
+    switch (dsChange.operation) {
+      case 'added':
+        // Update function will call the listener when appropriate.
+        window.setTimeout(function nextTickUpdated() {
+          _updateDownloadsCacheWithDataStoreDownload(dsChange);
+        }, 0);
+        break;
+    }
+  }
+
+  function _callListener(data) {
+    downloadsListener && downloadsListener(data);
+  }
+
   var DownloadApiManager = {
+    _initialized: false,
+
+    init: function() {
+      if (this._initialized) {
+        return;
+      }
+
+      // Add a listener to track when Download objects get added to the
+      // Download Store. This is when we'll update our Download Item to use
+      // the DataStore representation instead of the Download API DOM Download
+      // object.
+      var req = DownloadStore.addListener(_dataStoreChangeHandler);
+
+      req.onsuccess = (function() {
+        this._initialized = true;
+      }.bind(this));
+      req.onerror = (function(e) {
+        console.error('Failed to initialize DownloadApiManager properly.', e);
+      });
+    },
+
     getDownloads: function(onsuccess, onerror, oncomplete) {
       var promise = navigator.mozDownloadManager.getDownloads();
       promise.then(
@@ -172,6 +251,10 @@
 
     updateDownload: function(download) {
       _setDownload(download);
+    },
+
+    setListener: function(listener) {
+      downloadsListener = listener;
     }
   };
 

--- a/apps/settings/js/downloads/download_item.js
+++ b/apps/settings/js/downloads/download_item.js
@@ -154,10 +154,20 @@ var DownloadItem = (function DownloadItem() {
     return domNodes;
   };
 
-  // TODO: Keep this function until the api returns valid dom id
-  // values on the id field.
   var getDownloadId = function getDownloadId(download) {
+    // We need to use this to generate our id because datastore ids are not
+    // compatible with dom element ids.
     return DownloadFormatter.getUUID(download);
+  };
+
+  var updateDownloadId = function updateDownloadId(download,
+                                                   domElement) {
+    // Get our new element id.
+    var id = getDownloadId(download);
+    // Update all the relevant instances of the item id.
+    domElement.id = id;
+    domElement.dataset.id = id;
+    domElement.getElementsByTagName('input')[0].value = id;
   };
 
   var getDownloadState = function getDownloadState(download) {
@@ -178,7 +188,8 @@ var DownloadItem = (function DownloadItem() {
   return {
     'create': create,
     'refresh': update,
-    'getDownloadId': getDownloadId
+    'getDownloadId': getDownloadId,
+    'updateDownloadId': updateDownloadId
   };
 
 }());

--- a/apps/settings/js/downloads/downloads_list.js
+++ b/apps/settings/js/downloads/downloads_list.js
@@ -376,15 +376,39 @@
     numberOfCheckedDownloads = 0;
   }
 
+  function _downloadApiManagerListener(changeEvent) {
+    switch (changeEvent.type) {
+      case 'added':
+        // First we'll try and find an existing item with the download api id.
+        var element = null;
+        if (changeEvent.downloadApiId &&
+            (element = _getElementForId(changeEvent.downloadApiId))) {
+          // If we find one, we'll want to update it's id before updating the
+          // content.
+          DownloadItem.updateDownloadId(changeEvent.download, element);
+        }
+        else if ((element = _getElementForId(changeEvent.download.id))) {
+          // Secondly, try and find it by it's download id.
+          _update(changeEvent.download);
+        }
+        else {
+          // Lastly, if we didn't find it by downloadApiId or id, it's truly
+          // new to the user so we need to add it to the download list.
+          _newDownload(changeEvent.download);
+        }
+        break;
+    }
+  }
+
   var DownloadsList = {
     init: function(oncomplete) {
       var scripts = [
-        'js/downloads/download_api_manager.js',
-        'shared/js/download/download_store.js',
+        'shared/js/download/download_store.js', // Must be loaded first.
         'shared/js/download/download_ui.js',
         'shared/js/mime_mapper.js',
         'shared/js/download/download_helper.js',
         'shared/js/download/download_formatter.js',
+        'js/downloads/download_api_manager.js',
         'js/downloads/download_item.js'
       ];
 
@@ -413,6 +437,10 @@
         // Localization of the nodes for avoiding weird repaintings
         var noDownloadsTextEl = document.getElementById('dle-text');
         var editModeTitle = document.getElementById('downloads-title-edit');
+
+        // Initialize the Api Manager and set our listener.
+        DownloadApiManager.init();
+        DownloadApiManager.setListener(_downloadApiManagerListener.bind(this));
 
         // Render the entire list
         DownloadApiManager.getDownloads(

--- a/apps/settings/test/unit/download_api_manager_test.js
+++ b/apps/settings/test/unit/download_api_manager_test.js
@@ -19,6 +19,9 @@ if (!window.DownloadHelper) {
 }
 
 suite('DownloadApiManager', function() {
+  var clock;
+  var TICK = 1000;
+
   var mocksHelperForDownloadApi = new MocksHelper([
     'DownloadStore',
     'DownloadUI'
@@ -45,15 +48,23 @@ suite('DownloadApiManager', function() {
   suite(' > methods', function() {
     var downloadsMock;
     setup(function(done) {
+      clock = this.sinon.useFakeTimers();
+
+      DownloadApiManager.init();
+      clock.tick(TICK);
+
       DownloadApiManager.getDownloads(function(downloads) {
         downloadsMock = downloads;
         done();
       });
+      clock.tick(TICK);
     });
 
     teardown(function() {
       downloadsMock = null;
       MockDownloadStore.downloads = [];
+
+      clock.restore();
     });
 
     test(' > getDownloads with empty datastore', function() {
@@ -75,6 +86,7 @@ suite('DownloadApiManager', function() {
         assert.equal(downloads.length, MockMozDownloads.mockLength);
         done();
       });
+      clock.tick(TICK);
     });
 
     test(' > getDownloads sorted properly', function(done) {
@@ -95,6 +107,7 @@ suite('DownloadApiManager', function() {
         }
         done();
       });
+      clock.tick(TICK);
     });
 
     test(' > getDownload given an ID', function() {
@@ -104,6 +117,7 @@ suite('DownloadApiManager', function() {
 
     test(' > updateDownload', function() {
       var download = DownloadApiManager.getDownload(0);
+      clock.tick(TICK);
       // This one comes from datastore, so state is succeed.
       var previousState = download.state;
       download.state = 'downloading';
@@ -122,12 +136,14 @@ suite('DownloadApiManager', function() {
       DownloadApiManager.deleteDownloads([{id: 0}], function() {}, function() {
         // Once cancelled, we get the same object
         var download = DownloadApiManager.getDownload(0);
+        clock.tick(TICK);
         // and the object still exists
         assert.ok(download);
         assert.isFalse(DownloadHelper.remove.called);
         showStub.restore();
         done();
       });
+      clock.tick(TICK);
     });
 
     test(' > deleteDownload given an ID (user confirms)', function(done) {
@@ -136,6 +152,7 @@ suite('DownloadApiManager', function() {
       DownloadApiManager.deleteDownloads([{id: 0}], function() {
         // Once deleted, we try to get the same object
         var download = DownloadApiManager.getDownload(0);
+        clock.tick(TICK);
         // Now the object does not exist
         assert.ok(!download);
         sinon.assert.called(DownloadUI.show);
@@ -144,6 +161,7 @@ suite('DownloadApiManager', function() {
         DownloadUI.show.restore();
         done();
       });
+      clock.tick(TICK);
     });
 
     test(' > force deleteDownload given an ID', function(done) {
@@ -152,6 +170,8 @@ suite('DownloadApiManager', function() {
       DownloadApiManager.deleteDownloads([{id: 1, force: true}], function() {
         // Once deleted, we try to get the same object
         var download = DownloadApiManager.getDownload(1);
+        clock.tick(TICK);
+
         // Now the object does not exist
         assert.ok(!download);
         assert.ok(!DownloadUI.show.called);
@@ -160,6 +180,7 @@ suite('DownloadApiManager', function() {
         DownloadUI.show.restore();
         done();
       });
+      clock.tick(TICK);
     });
   });
 });

--- a/apps/settings/test/unit/download_helper_test.js
+++ b/apps/settings/test/unit/download_helper_test.js
@@ -38,6 +38,9 @@ suite('DownloadHelper', function() {
 
   mocksHelperForDownloadHelper.attachTestHelpers();
 
+  var clock;
+  var TICK = 1000;
+
   suiteSetup(function() {
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
@@ -70,19 +73,23 @@ suite('DownloadHelper', function() {
 
   setup(function() {
     download = new MockDownload();
+    clock = this.sinon.useFakeTimers();
   });
 
   teardown(function() {
     download = null;
+    clock.restore();
   });
 
   suite('Launch', function() {
     setup(function() {
       download = new MockDownload();
+      clock = this.sinon.useFakeTimers();
     });
 
     teardown(function() {
       download = null;
+      clock.restore();
     });
 
     function getStorage(state) {
@@ -90,7 +97,7 @@ suite('DownloadHelper', function() {
         'get' : function(path) {
           return {
             set onsuccess(cb) {},
-            set onerror(cb) {setTimeout(cb, 100)},
+            set onerror(cb) {setTimeout(cb, 0)},
             error: { 'name': 'custom error' }
           };
         },
@@ -117,6 +124,8 @@ suite('DownloadHelper', function() {
         assert.ok(false);
         done();
       };
+
+      clock.tick(TICK);
     }
 
     function assertIncompleteDownloadRemoved(state, done) {
@@ -154,6 +163,8 @@ suite('DownloadHelper', function() {
         stubGetDeviceStorages.restore();
         done();
       };
+
+      clock.tick(TICK);
     }
 
     test('Invalid state download', function(done) {
@@ -168,6 +179,8 @@ suite('DownloadHelper', function() {
         assert.equal(evt.target.error.code, DownloadHelper.CODE.INVALID_STATE);
         done();
       };
+
+      clock.tick(TICK);
     });
 
     test('Unknown download type', function(done) {
@@ -192,6 +205,8 @@ suite('DownloadHelper', function() {
                   'All content types should be openable via third party apps.');
         done();
       };
+
+      clock.tick(TICK);
     });
 
     test('Missing file', function(done) {

--- a/apps/settings/test/unit/downloads_list_test.js
+++ b/apps/settings/test/unit/downloads_list_test.js
@@ -45,6 +45,9 @@ suite('DownloadList', function() {
   var downloadsContainerDOM, editButton, deleteButton,
     selectAllButton, deselectAllButton, downloadsEditMenu;
 
+  var clock;
+  var TICK = 1000;
+
   suiteSetup(function() {
     // Mock l10n
     realL10n = navigator.mozL10n;
@@ -93,12 +96,15 @@ suite('DownloadList', function() {
       done();
     });
 
+    clock = this.sinon.useFakeTimers();
   });
 
   teardown(function() {
     document.body.innerHTML = '';
     MockDownloadStore.downloads = [];
     mocksHelperForDownloadList.teardown();
+
+    clock.restore();
   });
 
   suite(' > edit mode', function() {
@@ -136,6 +142,8 @@ suite('DownloadList', function() {
         // Delete all downloads
         deleteButton.click();
       });
+
+      clock.tick(TICK);
     });
 
     test(' > select all button enabled/disabled', function(done) {
@@ -152,6 +160,8 @@ suite('DownloadList', function() {
         assert.isFalse(selectAllButton.disabled);
         done();
       });
+
+      clock.tick(TICK);
     });
 
     test(' > select the first one download', function(done) {
@@ -171,6 +181,8 @@ suite('DownloadList', function() {
         assert.isFalse(selectAllButton.disabled);
         done();
       });
+
+      clock.tick(TICK);
     });
 
     test(' > deselect all button enabled/disabled', function(done) {
@@ -189,6 +201,8 @@ suite('DownloadList', function() {
         assert.ok(deselectAllButton.disabled);
         done();
       });
+
+      clock.tick(TICK);
     });
 
     test(' > Deletion', function(done) {
@@ -227,6 +241,8 @@ suite('DownloadList', function() {
         // Delete all downloads
         deleteButton.click();
       });
+
+      clock.tick(TICK);
     });
   });
 
@@ -242,6 +258,8 @@ suite('DownloadList', function() {
         assert.equal(downloadsContainerDOM.firstChild.tagName, 'LI');
         done();
       });
+
+      clock.tick(TICK);
     });
 
     test(' > check render with one item in datastore', function(done) {
@@ -257,6 +275,8 @@ suite('DownloadList', function() {
         assert.equal(downloadsContainerDOM.firstChild.tagName, 'LI');
         done();
       });
+
+      clock.tick(TICK);
     });
 
     // This takes into account the structure defined in the mock. In this case
@@ -277,6 +297,8 @@ suite('DownloadList', function() {
           container = document.querySelector('#downloadList ul');
           done();
         });
+
+        clock.tick(TICK);
       });
 
       teardown(function() {
@@ -315,6 +337,8 @@ suite('DownloadList', function() {
           DownloadsList.init(function() {
             done();
           });
+
+          clock.tick(TICK);
         });
 
         test(' > a finalized download, but not in datastore', function() {
@@ -342,8 +366,8 @@ suite('DownloadList', function() {
           container = document.querySelector('#downloadList ul');
           done();
         });
-
         emptyContainer = document.getElementById('download-list-empty');
+        clock.tick(TICK);
       });
 
       teardown(function() {
@@ -362,7 +386,7 @@ suite('DownloadList', function() {
         var launchStub = sinon.stub(DownloadHelper, 'open', function() {
           return {
             set onsuccess(cb) {},
-            set onerror(cb) {setTimeout(cb, 50);}
+            set onerror(cb) {setTimeout(cb, 0); clock.tick(TICK); }
           };
         });
 
@@ -381,6 +405,7 @@ suite('DownloadList', function() {
               assert.equal(0, emptyContainer.classList.length);
               done();
               setTimeout(cleanStubs, 0);
+              clock.tick(TICK);
             },
             set onerror(cb) {}
           };

--- a/apps/settings/test/unit/mock_download_store.js
+++ b/apps/settings/test/unit/mock_download_store.js
@@ -5,6 +5,7 @@
 var MockDownloadStore = {
   error: false,
   downloads: [],
+  listeners: [],
   getAll: function() {
     var request = {
       onsuccess: null
@@ -17,11 +18,32 @@ var MockDownloadStore = {
       };
       request.onsuccess(event);
 
-    }.bind(this), 1000);
+    }.bind(this), 0);
     return request;
   },
   add: function() {
   },
   remove: function() {
+  },
+  addListener: function(listener) {
+    var request = {
+      onsuccess: null
+    };
+
+    if (this.listeners.indexOf(listener) == -1) {
+      this.listeners.push(listener);
+    }
+    setTimeout(function() {
+      var event = { target: { result: {} }};
+      request.onsuccess(event);
+    }.bind(this), 0);
+
+    return request;
+  },
+  removeListener: function(listener) {
+    var index = this.listeners.indexOf(listener);
+    if (index > -1) {
+      this.listeners.splice(index, 1);
+    }
   }
 };

--- a/apps/system/js/download/download_manager.js
+++ b/apps/system/js/download/download_manager.js
@@ -24,8 +24,8 @@ var DownloadManager = (function() {
   var notifications = {};
   var started = false;
 
-  // Set our download start handler.
-  mozDownloadManager.ondownloadstart = function onDownloadStart(ev) {
+  // Define and set our download start handler.
+  function onDownloadStart(ev) {
     if (started) {
       createDownloadNotification(ev.download);
     } else {
@@ -39,7 +39,8 @@ var DownloadManager = (function() {
         window.addEventListener('notification-clicked', handleEvent);
       });
     }
-  };
+  }
+  mozDownloadManager.addEventListener('downloadstart', onDownloadStart);
 
   function createDownloadNotification(download) {
     var id = DownloadFormatter.getUUID(download);

--- a/apps/system/js/download/download_notification.js
+++ b/apps/system/js/download/download_notification.js
@@ -36,26 +36,9 @@ DownloadNotification.prototype = {
   },
 
   /**
-   * This method is in charge of incrementing/decrementing the system downloads
-   * according to previous and current states
-   */
-  _updateSystemDownloads: function dn_updateSystemDownloads() {
-    var prevState = this.state;
-    var newState = this.download.state;
-    if (prevState !== newState) {
-      if (newState === 'downloading') {
-        StatusBar.incSystemDownloads();
-      } else if (prevState === 'downloading') {
-        StatusBar.decSystemDownloads();
-      }
-    }
-  },
-
-  /**
    * It updates the notification when the download state changes.
    */
   _update: function dn_update() {
-    this._updateSystemDownloads();
     if (this.download.state === 'finalized') {
       // In theory we should never see this, but, we know that if we were
       // to see this we want to do nothing.

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -139,6 +139,7 @@ var StatusBar = {
    * it triggers the icon "systemDownloads"
    */
   systemDownloadsCount: 0,
+  systemDownloads: {},
 
   _minimizedStatusBarWidth: window.innerWidth,
 
@@ -302,6 +303,13 @@ var StatusBar = {
     window.addEventListener('homescreenopening', this);
     window.addEventListener('homescreenopened', this);
     window.addEventListener('stackchanged', this);
+
+    // Track Downloads via the Downloads API.
+    var mozDownloadManager = navigator.mozDownloadManager;
+    if (mozDownloadManager) {
+      mozDownloadManager.addEventListener('downloadstart',
+                                          this.handleEvent.bind(this));
+    }
 
     // We need to preventDefault on mouse events until
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1005815 lands
@@ -569,6 +577,44 @@ var StatusBar = {
         // the bottom window as it will *become* the shown window.
         this.setAppearance(evt.detail, true);
         this.element.classList.remove('hidden');
+        break;
+      case 'downloadstart':
+        // New download, track it so we can show or hide the active downloads
+        // indicator. If you think this logic needs to change, think really hard
+        // about it and then come and ask @nullaus
+        evt.download.onstatechange = function(downloadEvent) {
+          var download = downloadEvent.download;
+          switch(download.state) {
+            case 'downloading':
+              // If this download has not already been tracked as actively
+              // downloading we'll add it to our list and increment the
+              // downloads counter.
+              if (!this.systemDownloads[download.id]) {
+                this.incSystemDownloads();
+                this.systemDownloads[download.id] = true;
+              }
+              break;
+            // Once the download is finalized, and only then, is it safe to
+            // remove our state change listener. If we remove it before then
+            // we are likely to miss paused or errored downloads being restarted
+            case 'finalized':
+              download.onstatechange = null;
+              break;
+            // All other state changes indicate the download is no longer
+            // active, if we were previously tracking the download as active
+            // we'll decrement the counter now and remove it from active
+            // download status.
+            case 'stopped':
+            case 'succeeded':
+              if (this.systemDownloads[download.id]) {
+                this.decSystemDownloads();
+                delete this.systemDownloads[download.id];
+              }
+              break;
+            default:
+              console.warn('Unexpected download state = ', download.state);
+          }
+        }.bind(this);
         break;
     }
   },

--- a/apps/system/test/unit/download_notification_test.js
+++ b/apps/system/test/unit/download_notification_test.js
@@ -10,12 +10,10 @@ requireApp('system/test/unit/mock_download_helper.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
 requireApp('system/test/unit/mock_notification_screen.js');
 requireApp('system/test/unit/mock_activity.js');
-requireApp('system/test/unit/mock_statusbar.js');
 
 requireApp('system/js/download/download_notification.js');
 
 var mocksForDownloadNotification = new MocksHelper([
-  'StatusBar',
   'Download',
   'NotificationScreen',
   'L10n',
@@ -92,8 +90,6 @@ suite('system/DownloadNotification >', function() {
     test('Download notification has been created', function() {
       notification = new DownloadNotification(download);
       assert.isTrue(NotificationScreen.addNotification.called);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('The download starts', function() {
@@ -105,8 +101,6 @@ suite('system/DownloadNotification >', function() {
       sinon.assert.calledWithMatch(NotificationScreen.addNotification, {
         noNotify: true
       });
-      assert.ok(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('The notification was clicked while downloading > Show download list',
@@ -125,8 +119,6 @@ suite('system/DownloadNotification >', function() {
       };
       download.onstatechange();
       assertUpdatedNotification(download, 'failed');
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
       assert.equal(DownloadHelper.methodCalled, 'getFreeSpace');
       assert.isNull(DownloadUI.methodCalled);
     });
@@ -145,8 +137,6 @@ suite('system/DownloadNotification >', function() {
       sinon.assert.calledWithMatch(NotificationScreen.addNotification, {
         noNotify: true
       });
-      assert.ok(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('Download was stopped by the user', function() {
@@ -154,8 +144,6 @@ suite('system/DownloadNotification >', function() {
       download.state = 'stopped';
       download.onstatechange();
       assertUpdatedNotification(download);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('Stopped notification was clicked > Show confirmation', function() {
@@ -173,8 +161,6 @@ suite('system/DownloadNotification >', function() {
       sinon.assert.calledWithMatch(NotificationScreen.addNotification, {
         noNotify: true
       });
-      assert.ok(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('The download failed because the SD card is missing', function() {
@@ -187,8 +173,6 @@ suite('system/DownloadNotification >', function() {
       DownloadHelper.bytes = 0;
       download.onstatechange();
       assertUpdatedNotification(download, 'failed');
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
       assert.equal(DownloadUI.methodCalled, 'show');
 
       // pretend like the user fixed the issue and move onto the next failure.
@@ -207,8 +191,6 @@ suite('system/DownloadNotification >', function() {
       DownloadHelper.bytes = 0;
       download.onstatechange();
       assertUpdatedNotification(download, 'failed');
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
       assert.equal(DownloadUI.methodCalled, 'show');
 
       // pretend like the user fixed the issue and move onto the next failure.
@@ -227,8 +209,6 @@ suite('system/DownloadNotification >', function() {
       DownloadHelper.bytes = 0;
       download.onstatechange();
       assertUpdatedNotification(download, 'failed');
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
       assert.equal(DownloadUI.methodCalled, 'show');
     });
 
@@ -242,8 +222,6 @@ suite('system/DownloadNotification >', function() {
       sinon.assert.calledWithMatch(NotificationScreen.addNotification, {
         noNotify: true
       });
-      assert.ok(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('Download was stopped because the connectivity was lost', function() {
@@ -252,8 +230,6 @@ suite('system/DownloadNotification >', function() {
       navigator.onLine = false;
       download.onstatechange();
       assertUpdatedNotification(download, 'downloading');
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('Download finishes', function() {
@@ -262,8 +238,6 @@ suite('system/DownloadNotification >', function() {
       download.onstatechange();
       assertUpdatedNotification(download);
       assert.ok(DownloadStore.add.calledOnce);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.ok(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('Finished notification was clicked > Open file', function() {
@@ -286,8 +260,6 @@ suite('system/DownloadNotification >', function() {
     test('Download notification has been created ', function() {
       notification = new DownloadNotification(download);
       sinon.assert.called(NotificationScreen.addNotification);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['incSystemDownloads']);
-      assert.isUndefined(MockStatusBar.wasMethodCalled['decSystemDownloads']);
     });
 
     test('The download finalizes (download object is dead on the gecko side) ',

--- a/apps/system/test/unit/mock_navigator_moz_download_manager.js
+++ b/apps/system/test/unit/mock_navigator_moz_download_manager.js
@@ -6,6 +6,7 @@ var realMozDownloadManager = navigator.mozDownloadManager;
 navigator.mozDownloadManager = {
   // Should always be an array of DOM Download like objects.
   mDownloads: [],
+  mListeners: [],
 
   mSuiteTeardown: function mdm_mSuiteTeardown() {
     window.navigator.mozDownloadManager = realMozDownloadManager;
@@ -22,5 +23,16 @@ navigator.mozDownloadManager = {
 
   getDownloads: function() {
     return this.mDownloads;
+  },
+
+  addEventListener: function(type, listener) {
+    if (!this.ondownloadstart) {
+      this.ondownloadstart = listener;
+    }
+
+    var index = this.mListeners.indexOf(listener);
+    if (index == -1) {
+      this.mListeners.splice(index, 1);
+    }
   }
 };

--- a/shared/js/download/download_helper.js
+++ b/shared/js/download/download_helper.js
@@ -387,7 +387,7 @@ var DownloadHelper = (function() {
   }
 
   /*
-   * This method allows clients to remove a downlaod, from the
+   * This method allows clients to remove a download, from the
    * list and the phone.
    *
    * @param{Object} It represents a DOMDownload object
@@ -402,13 +402,27 @@ var DownloadHelper = (function() {
         if (!navigator.mozDownloadManager) {
           sendError(req, 'DownloadManager not present', CODE.INVALID_STATE);
         } else {
-          navigator.mozDownloadManager.remove(download).then(
-            function success() {
-              req.done(download);
+          // First we pause the download so that everyone knows it's being
+          // stopped. The Downloads API itself won't stop the download first,
+          // it will simply kill it.
+          // XXXAus: Remove when we fix bug #1090551
+          download.pause().then(
+            function() {
+              navigator.mozDownloadManager.remove(download).then(
+                function success() {
+                  req.done(download);
+                },
+                function error() {
+                  sendError(req,
+                            'DownloadManager doesnt know about this download',
+                            CODE.INVALID_STATE);
+                }
+              );
             },
-            function error() {
-              sendError(req, 'DownloadManager doesnt know about this download',
-                CODE.INVALID_STATE);
+            function() {
+              sendError(req,
+                        'Failed to pause download before removal',
+                        CODE.INVALID_STATE);
             }
           );
         }

--- a/shared/js/download/download_store.js
+++ b/shared/js/download/download_store.js
@@ -312,6 +312,21 @@ var DownloadStore = (function() {
     return req;
   }
 
+  function doGet(id, req) {
+    datastore.get(id).then(function(download) { req.done(download); },
+                           defaultError(req));
+  }
+
+  function get(id) {
+   var req = new Request();
+
+   window.setTimeout(function() {
+    init(doGet.bind(null, id, req), req.failed.bind(req));
+   });
+
+   return req;
+  }
+
   function doGetAll(req) {
     updateDownloadList().then(function() {
       datastore.get.apply(datastore, downloadList).then(defaultSuccess(req),
@@ -352,7 +367,40 @@ var DownloadStore = (function() {
     return req;
   }
 
+  function doAddListener(listener) {
+    datastore.addEventListener('change', listener);
+  }
+
+  function addListener(listener) {
+    var req = new Request();
+
+    window.setTimeout(function() {
+      init(doAddListener.bind(null, listener), req.failed.bind(req));
+    });
+
+    return req;
+  }
+
+  function doRemoveListener(listener) {
+    datastore.removeEventListener('change', listener);
+  }
+
+  function removeListener(listener) {
+    var req = new Request();
+
+    window.setTimeout(function() {
+      init(doRemoveListener.bind(null, listener), req.failed.bind(req));
+    });
+
+    return req;
+  }
+
   return {
+   /*
+    * This method returns the download with the specified id.
+    */
+   get: get,
+
    /*
     * This method returns an array of complete downloads
     */
@@ -373,6 +421,20 @@ var DownloadStore = (function() {
      * @param{Object} The download object to be removed from the datastore
      *
      */
-    remove: remove
+    remove: remove,
+
+    /*
+     * Add a listener that will receive datastore change events.
+     *
+     * @param{Function} The listener to be added.
+     */
+    addListener: addListener,
+
+    /*
+     * Remove a listener previously added via addListener.
+     *
+     * @param{Function} The listener to be removed.
+     */
+    removeListener: removeListener
   };
 }());

--- a/shared/test/unit/mocks/mock_download.js
+++ b/shared/test/unit/mocks/mock_download.js
@@ -25,17 +25,18 @@ function MockDownload(params) {
   this.contentType = params.contentType || DEFAULT_PARAMS.contentType;
   this.startTime = params.startTime || DEFAULT_PARAMS.startTime;
   this.error = params.error || DEFAULT_PARAMS.error;
+
 }
 
 MockDownload.prototype = {
   pause: function() {
     return {
-      then: function() {}
+      then: function(success, error) { setTimeout(success, 0); }
     };
   },
   resume: function() {
     return {
-      then: function() {}
+      then: function(success, error) { setTimeout(success, 0); }
     };
   }
 };


### PR DESCRIPTION
...ache up to date. Move tracking of active downloads into StatusBar instead of DownloadNotifications. r=crdlc,mhenretty
