### PR TITLE
Bug 1090799 - make nfc_handover reuse system bluetooth adapter

### DIFF
--- a/apps/system/js/bluetooth.js
+++ b/apps/system/js/bluetooth.js
@@ -1,6 +1,4 @@
-/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
-/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-
+/* global SettingsListener */
 'use strict';
 
 var Bluetooth = {
@@ -42,6 +40,13 @@ var Bluetooth = {
     return connectedProfiles;
   },
 
+  /**
+   * check if bluetooth profile is connected.
+   *
+   * @public
+   * @param {String} profile profile name
+   * @return {Boolean} connected state
+   */
   isProfileConnected: function bt_isProfileConnected(profile) {
     var isConnected = this['_' + profile + 'Connected'];
     if (isConnected === undefined) {
@@ -54,19 +59,19 @@ var Bluetooth = {
   /* this property store a reference of the default adapter */
   defaultAdapter: null,
 
-  /* keep a global connected property here */
+  /**
+   * keep a global connected property.
+   *
+   * @public
+   */
   connected: false,
 
   init: function bt_init() {
-    if (!window.navigator.mozSettings)
+    if (!window.navigator.mozSettings || !window.navigator.mozBluetooth) {
       return;
+    }
 
-    if (!window.navigator.mozBluetooth)
-      return;
-
-    var telephony = window.navigator.mozTelephony;
     var bluetooth = window.navigator.mozBluetooth;
-    var settings = window.navigator.mozSettings;
     var self = this;
 
     SettingsListener.observe('bluetooth.enabled', true, function(value) {
@@ -82,8 +87,9 @@ var Bluetooth = {
       }
     });
 
-    // when bluetooth adapter is ready, emit event to notify QuickSettings
-    // and try to get defaultAdapter at this moment
+    // when bluetooth adapter is ready, a.k.a enabled,
+    // emit event to notify QuickSettings and try to get
+    // defaultAdapter at this moment
     bluetooth.onadapteradded = function bt_onAdapterAdded() {
       var evt = document.createEvent('CustomEvent');
       evt.initCustomEvent('bluetooth-adapter-added',
@@ -138,8 +144,9 @@ var Bluetooth = {
     var self = this;
 
     if (!bluetooth || !bluetooth.enabled ||
-        !('getDefaultAdapter' in bluetooth))
+        !('getDefaultAdapter' in bluetooth)) {
       return;
+    }
 
     var req = bluetooth.getDefaultAdapter();
     req.onsuccess = function bt_gotDefaultAdapter(evt) {
@@ -176,8 +183,9 @@ var Bluetooth = {
   updateConnected: function bt_updateConnected() {
     var bluetooth = window.navigator.mozBluetooth;
 
-    if (!bluetooth || !('isConnected' in bluetooth))
+    if (!bluetooth || !('isConnected' in bluetooth)) {
       return;
+    }
 
     var wasConnected = this.connected;
     this.connected = this.isProfileConnected(this.Profiles.HFP) ||
@@ -193,9 +201,25 @@ var Bluetooth = {
     }
   },
 
-  // This function is called by external (BluetoothTransfer) for re-use adapter
+  /**
+   * called by external for re-use adapter.
+   *
+   * @public
+   */
   getAdapter: function bt_getAdapter() {
     return this.defaultAdapter;
+  },
+
+  enable: function bt_enable() {
+    SettingsListener.getSettingsLock().set({
+      'bluetooth.enabled': true
+    });
+  },
+
+  disable: function bt_disable() {
+    SettingsListener.getSettingsLock().set({
+      'bluetooth.enabled': false
+    });
   }
 };
 

--- a/apps/system/test/unit/mock_bluetooth.js
+++ b/apps/system/test/unit/mock_bluetooth.js
@@ -60,6 +60,14 @@ var MockBluetooth = {
 
   isProfileConnected: function mbt_isProfileConnected(profile) {
     return this.mExpectedProfile === profile;
+  },
+
+  enable: function mbt_enable() {
+    this.enabled = true;
+  },
+
+  disable: function mbt_disable() {
+    this.enabled = false;
   }
 };
 

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -280,7 +280,6 @@ apps/sharedtest/test/unit/wifi_helper_test.js
 apps/system/js/airplane_mode.js
 apps/system/js/app_modal_dialog.js
 apps/system/js/base_ui.js
-apps/system/js/bluetooth.js
 apps/system/js/bluetooth_transfer.js
 apps/system/js/browser_config_helper.js
 apps/system/js/browser_frame.js


### PR DESCRIPTION
- fix jshint of system/js/bluetooth
- add annotation of system/js/bluetooth public API
- make nfc_handover reuse system bluetooth adapter
- use 'bluetooth-adapter-added'/'bluetooth-disabled' system event to maintain bluetoothIsEnabled stat
- use bluetooth enable/disable to set settings value so we could decouple `bluetooth.enable` setting
- fix unit tests
