### PR TITLE
Add a clear all notifications effect

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -287,6 +287,7 @@
 }
 
 #notifications-container .notification.disappearing,
+#notifications-container .notification.disappearing-via-clear-all,
 .notification-toaster.disappearing {
   transition: transform 0.2s linear;
   transform: translateX(100%);

--- a/apps/system/test/marionette/notification_behavior_test.js
+++ b/apps/system/test/marionette/notification_behavior_test.js
@@ -87,12 +87,18 @@ marionette('notification behavior tests', function() {
     notificationList.refresh();
     assert.equal(notificationList.notifications.length, 2,
                  'unexpected number of notifications');
-
-    client.executeScript(function() {
+    // Adding a new notification (to be sure it's the last one),
+    // once is shown triggers a `click` event on the `Clear all` button
+    // which starts the closing animation.
+    // The animation finish when the last `close` event is fired.
+    client.executeAsyncScript(function() {
       var clearAll = document.getElementById('notification-clear');
       var event = document.createEvent('CustomEvent');
       event.initCustomEvent('click', true, true, {});
-      clearAll.dispatchEvent(event);
+      var notification;
+      notification = new Notification('title 3');
+      notification.onclose = function(){ marionetteScriptFinished(true); };
+      notification.onshow = function(){ clearAll.dispatchEvent(event); };
     });
 
     notificationList.refresh();
@@ -169,4 +175,3 @@ marionette('notification behavior tests', function() {
     done();
   });
 });
-


### PR DESCRIPTION
bugzilla bug 
https://bugzilla.mozilla.org/show_bug.cgi?id=1092536 

I implement a simple slide to right animation,
I changed the ns_closeNotification in a backward compatible way, so that when no delay are passed it will just work as before (if you try to swipe for example the new effect doesn't collide).
On the other hand you can now pass a delay and a waitBeforeClosing parameter, and if you do, there will be a percentual TranslateX applied to each notification.

The waitBeforeClosing is needed to avoid the animation that will trigger when a single notification get removed.
Another solution would have been to start from the bottom, but that's just does not feel natural.
