### PR TITLE
Bug 1091910 - [System]Pressing the "battery is low" notification will so...

### DIFF
--- a/apps/system/js/battery_overlay.js
+++ b/apps/system/js/battery_overlay.js
@@ -1,6 +1,7 @@
 'use strict';
 /* global PowerSave */
 /* global ScreenManager */
+/* global MozActivity */
 
 (function(exports) {
 
@@ -23,7 +24,7 @@
     getAllElements: function bm_getAllElements() {
       this.screen = document.getElementById('screen');
       this.overlay = document.getElementById('system-overlay');
-      this.notification = document.getElementById('battery');
+      this._notification = document.getElementById('battery');
     },
 
     checkBatteryDrainage: function bm_checkBatteryDrainage() {
@@ -53,6 +54,9 @@
 
       this._screenOn = true;
       this._wasEmptyBatteryNotificationDisplayed = false;
+
+      this._notification.addEventListener('click',
+        this.handleEvent.bind(this));
 
       this.displayIfNecessary();
     },
@@ -92,6 +96,22 @@
           } else {
             this.displayIfNecessary();
           }
+          break;
+        case 'click':
+          /* jshint nonew: false */
+          new MozActivity({
+            name: 'configure',
+            data: {
+              target: 'device',
+              section: 'battery'
+            }
+          });
+
+          if (this._toasterTimeout) {
+            clearTimeout(this._toasterTimeout);
+          }
+
+          this.hide();
           break;
       }
     },

--- a/apps/system/style/battery_overlay/battery_overlay.css
+++ b/apps/system/style/battery_overlay/battery_overlay.css
@@ -17,6 +17,7 @@
   font-size: 1.4rem;
   font-weight: 500;
   padding: 1rem 0;
+  pointer-events: auto;
 }
 
 .icon-battery {

--- a/apps/system/test/unit/battery_overlay_test.js
+++ b/apps/system/test/unit/battery_overlay_test.js
@@ -3,6 +3,7 @@
 /* global MocksHelper */
 /* global MockL10n */
 /* global MockNavigatorBattery */
+/* global MozActivity */
 
 requireApp('system/test/unit/mock_navigator_battery.js');
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
@@ -12,11 +13,13 @@ require('/shared/test/unit/mocks/mock_gesture_detector.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
 requireApp('system/js/power_save.js');
 requireApp('system/js/battery_overlay.js');
+require('/shared/test/unit/mocks/mock_moz_activity.js');
 
 var mocksForBatteryOverlay = new MocksHelper([
   'SettingsListener',
   'sleepMenu',
-  'GestureDetector'
+  'GestureDetector',
+  'MozActivity'
 ]).init();
 
 suite('battery manager >', function() {
@@ -130,6 +133,22 @@ suite('battery manager >', function() {
         sendLevelChange(0.00);
         sinon.assert.calledWithMatch(window.dispatchEvent,
                                      { type: 'batteryshutdown' });
+      });
+
+      suite('Battery notification', function() {
+        var params = {
+          name: 'configure',
+          data: {
+            target: 'device',
+            section: 'battery'
+          }
+        };
+
+        test('open settings when notification is clicked', function() {
+          notifNode.click();
+
+          assert.deepEqual(MozActivity.calls[0], params);
+        });
       });
     });
 


### PR DESCRIPTION
...metimes cause the rocket bar and keyboard to pop up, and will fail to bring up the battery section in the settings menu
