### PR TITLE
Bug 944662 - Set one of the Bulgarian Input Method as default keyboard

### DIFF
--- a/build/config/keyboard-layouts.json
+++ b/build/config/keyboard-layouts.json
@@ -12,8 +12,7 @@
     ],
     "bg": [
         {"layoutId": "bg-BDS", "app": ["apps", "keyboard"]},
-        {"layoutId": "bg-Pho-Ban", "app": ["apps", "keyboard"]},
-        {"layoutId": "bg-Pho-Trad", "app": ["apps", "keyboard"]}
+        {"layoutId": "en", "app": ["apps", "keyboard"]}
     ],
     "bn-BD": [
         {"layoutId": "en", "app": ["apps", "keyboard"]}


### PR DESCRIPTION
for Bulgarian language.
