### PR TITLE
Bug 1093093 - Try to provide better error reporting r=janx

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -244,8 +244,11 @@ screenshotSDCardLow   = Not enough space on memory card
 
 # logshake
 logsSaved = Logs saved to storage
-logsFailed = The logs could not be saved
-logsStart = Capturing logs ...
+logsSaveError = Error while saving logs
+logsSaving = Capturing logṣ̣…
+logsOperationFailed = Operation {{operation}} failed.
+logsGenericError = Unexpected error occurred.
+logsSDCardMaybeShared = Make sure your SD card is not shared with your computer.
 
 # lock screen
 emergency-call-button=Emergency Call

--- a/apps/system/test/unit/logshake_test.js
+++ b/apps/system/test/unit/logshake_test.js
@@ -1,11 +1,20 @@
 'use strict';
-/* global MockNavigatorGetDeviceStorage, LogShake, MockNotification, MockL10n */
+/* global LogShake,
+          MockDOMRequest,
+          MockModalDialog,
+          MockNavigatorGetDeviceStorage,
+          MockNotification,
+          MockL10n
+*/
 
 requireApp('system/js/devtools/logshake.js');
 
-require('/test/unit/mock_navigator_get_device_storage.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
 require('/shared/test/unit/mocks/mock_notification.js');
+requireApp('system/shared/test/unit/mocks/mock_event_target.js');
+requireApp('system/shared/test/unit/mocks/mock_dom_request.js');
+requireApp('system/test/unit/mock_navigator_get_device_storage.js');
+requireApp('system/test/unit/mock_modal_dialog.js');
 
 /**
  * Test shake-to-log functionality.
@@ -13,6 +22,8 @@ require('/shared/test/unit/mocks/mock_notification.js');
  */
 suite('system/LogShake', function() {
   var realL10n;
+  var realDOMRequest;
+  var realModalDialog;
   var realNavigatorGetDeviceStorage;
   var realNotification;
 
@@ -25,6 +36,12 @@ suite('system/LogShake', function() {
       window.logshake.stop();
       window.logshake = null;
     }
+
+    realDOMRequest = window.DOMRequest;
+    window.DOMRequest = MockDOMRequest;
+
+    realModalDialog = window.ModalDialog;
+    window.ModalDialog = MockModalDialog;
 
     realNavigatorGetDeviceStorage = navigator.getDeviceStorage;
     navigator.getDeviceStorage = MockNavigatorGetDeviceStorage;
@@ -41,6 +58,8 @@ suite('system/LogShake', function() {
 
   teardown(function() {
     logshake.stop();
+    window.DOMRequest = realDOMRequest;
+    window.ModalDialog = realModalDialog;
     navigator.getDeviceStorage = realNavigatorGetDeviceStorage;
     navigator.mozL10n = realL10n;
     window.Notification = realNotification;
@@ -48,53 +67,127 @@ suite('system/LogShake', function() {
     // XXX: Do not restore window's logshake, its time is over
   });
 
-  test('Create notification after capture-logs-success event', function() {
-    var notificationSpy = this.sinon.spy(window, 'Notification');
+  suite('Capture success handling', function() {
     var filename = 'logs/2014-06-03-00-00/log.log';
     var logPrefix = 'logs/2014-06-03-00-00/';
+    var notificationSpy;
 
-    window.dispatchEvent(new CustomEvent('capture-logs-success',
-      { detail: { logFilenames: [filename], logPrefix: logPrefix } }));
+    setup(function() {
+      notificationSpy = this.sinon.spy(window, 'Notification');
 
-    // LogShake should dispatch a notification of some kind
-    assert.isTrue(notificationSpy.calledOnce);
-    assert.isTrue(notificationSpy.calledWithNew());
-    assert.equal(notificationSpy.firstCall.args[0],
-      'logsSaved');
-    assert.equal(notificationSpy.firstCall.args[1].body,
-      logPrefix);
-    assert.equal(notificationSpy.firstCall.args[1].tag,
-      logTag);
-    /* XXX: Cannot test without firing click event on notification
-    var mockDeviceStorage = MockNavigatorGetDeviceStorage();
-    var deviceStorageSpy = this.sinon.spy(navigator, 'getDeviceStorage');
-    var getSpy = this.sinon.spy(mockDeviceStorage, 'get');
-    assert.isTrue(deviceStorageSpy.calledOnce,
-      'Clicking notification should cause getDeviceStorage to be called');
-    assert.isTrue(getSpy.calledOnce,
-      'Clicking notification should cause get to be called');
-    assert.equal(getSpy.firstCall.args[0], filename,
-      'get should have been called with filename from event');
-      */
+      window.dispatchEvent(new CustomEvent('capture-logs-success',
+        { detail: { logFilenames: [filename], logPrefix: logPrefix } }));
+    });
+
+    test('Notification sent', function() {
+      assert.isTrue(notificationSpy.calledOnce);
+      assert.isTrue(notificationSpy.calledWithNew());
+      assert.equal(notificationSpy.firstCall.args[0],
+        'logsSaved');
+      assert.equal(notificationSpy.firstCall.args[1].body,
+        logPrefix);
+      assert.equal(notificationSpy.firstCall.args[1].tag,
+        logTag);
+    });
+
+    test('Clicking notification', function() {
+      var mockDeviceStorage = MockNavigatorGetDeviceStorage();
+      var storageSpy = this.sinon.spy(navigator, 'getDeviceStorage');
+      var getSpy = this.sinon.spy(mockDeviceStorage, 'get');
+
+      var notification = notificationSpy.firstCall.thisValue;
+      notification.onclick();
+
+      assert.isTrue(storageSpy.calledOnce, 'getDeviceStorage should be called');
+      assert.isTrue(getSpy.calledOnce, '.get() should be called');
+      assert.equal(getSpy.firstCall.args[0], filename,
+        '.get() should have been called with filename from event');
+    });
   });
 
-  test('Create notification after capture-logs-error event', function() {
-    var notificationSpy = this.sinon.spy(window, 'Notification');
-    var errorMessage = 'error error error';
+  suite('Capture error handling', function() {
+    var notificationSpy, errorMessage,
+        errorUnixSharedSD, errorUnixGeneric,
+        errorUnixExpectedBody;
 
-    window.dispatchEvent(new CustomEvent('capture-logs-error',
-      { detail: { error: errorMessage } }));
+    function sendError(e) {
+      window.dispatchEvent(new CustomEvent('capture-logs-error',
+        { detail: { error: e } }));
+    }
 
-    // LogShake should dispatch a notification of some kind
-    assert.isTrue(notificationSpy.calledOnce, 'Notification should be called');
-    assert.isTrue(notificationSpy.calledWithNew(),
-      'Notification should be called with new');
-    assert.equal(notificationSpy.firstCall.args[0],
-      'logsFailed');
-    assert.equal(notificationSpy.firstCall.args[1].body,
-      errorMessage);
-    assert.equal(notificationSpy.firstCall.args[1].tag,
-      logTag);
+    function notificationAsserts(spy) {
+      assert.isTrue(spy.calledOnce, 'Notification should be called');
+      assert.isTrue(spy.calledWithNew(), 'Notification created with new');
+      assert.equal(spy.firstCall.args[0], 'logsSaveError');
+      assert.equal(spy.firstCall.args[1].tag, logTag);
+    }
+
+    function assertBody(expected) {
+      assert.equal(notificationSpy.firstCall.args[1].body, expected);
+    }
+
+    setup(function() {
+      notificationSpy = this.sinon.spy(window, 'Notification');
+      errorMessage = 'error error error';
+      errorUnixSharedSD = {
+        operation: 'makeDir',
+        unixErrno: 30 // EROFS
+      };
+      errorUnixGeneric = {
+        operation: 'makeDir',
+        unixErrno: 0
+      };
+      errorUnixExpectedBody = 'logsOperationFailed{"operation":"makeDir"}';
+    });
+
+    test('Handling capture-logs-error event with string error', function() {
+      sendError(errorMessage);
+      notificationAsserts(notificationSpy);
+      assertBody(errorMessage);
+    });
+
+    suite('Handling capture-logs-error event with errno', function() {
+      test('Handling known errno', function() {
+        sendError(errorUnixSharedSD);
+        notificationAsserts(notificationSpy);
+        assertBody(errorUnixExpectedBody);
+      });
+
+      test('Handling unknown errno', function() {
+        sendError(errorUnixGeneric);
+        notificationAsserts(notificationSpy);
+        assertBody(errorUnixExpectedBody);
+      });
+    });
+
+    suite('Clicking error notification', function() {
+      var notification;
+      function triggerClick() {
+        notification = notificationSpy.firstCall.thisValue;
+        notification.onclick();
+      }
+
+      var modalSpy;
+      setup(function() {
+        modalSpy = this.sinon.spy(MockModalDialog, 'alert');
+      });
+
+      test('Known errno', function() {
+        sendError(errorUnixSharedSD);
+        triggerClick();
+        assert.isTrue(modalSpy.calledWith('logsSaveError',
+                                          'logsSDCardMaybeShared',
+                                          { title: 'ok' }));
+      });
+
+      test('Unknown errno', function() {
+        sendError(errorUnixGeneric);
+        triggerClick();
+        assert.isTrue(modalSpy.calledWith('logsSaveError',
+                                          'logsGenericError',
+                                          { title: 'ok' }));
+      });
+    });
   });
 
   test('Create notification after capture-logs-start event', function() {
@@ -107,7 +200,7 @@ suite('system/LogShake', function() {
     assert.isTrue(notificationSpy.calledWithNew(),
       'Notification should be called with new');
     assert.equal(notificationSpy.firstCall.args[0],
-      'logsStart');
+      'logsSaving');
     assert.equal(notificationSpy.firstCall.args[1].tag,
       logTag);
   });


### PR DESCRIPTION
When the LogShake feature reports an error, we will try to do as much as
we can to handle it gracefully and give more feedback to the user. One
case that we start with is handling the errno 30 (ro-mounted filesystem)
that happens when the user try to dump while his device is hooked to a
computer and the SD card is shared via UMS. For now, this is the only
one that we handle, so we display a more generic error message for
others.
