### PR TITLE
Bug 1094000 - [SMS] Caret position becomes out of message body box

### DIFF
--- a/apps/sms/js/compose.js
+++ b/apps/sms/js/compose.js
@@ -120,6 +120,9 @@ var Compose = (function() {
       // firefox will keep an extra <br> in there
       if (brs.length > 1) {
         isEmptyMessage = false;
+      } else if (brs.length === 0) {
+        // <br> element is gone away, but we require it
+        dom.message.innerHTML = '<br>';
       }
     }
 

--- a/apps/sms/test/unit/compose_test.js
+++ b/apps/sms/test/unit/compose_test.js
@@ -386,6 +386,19 @@ suite('compose_test.js', function() {
         assert.deepEqual(final, original);
       });
 
+      test('Compose empty at force', function(done) {
+        Compose.clear();
+        var message = document.getElementById('messages-input');
+
+        message.innerHTML = '';
+        message.dispatchEvent(new InputEvent('input'));
+        waitForComposeEvent('segmentinfochange').then(function() {
+          assert.equal(message.innerHTML, '<br>');
+        }).then(done, done);
+
+        clock.tick(UPDATE_DELAY);
+      });
+
       teardown(function() {
         Compose.clear();
       });


### PR DESCRIPTION
When using text input, it cannot remove <br> element into message body. But, text selection can remove <br> element into message body, So this issue occurs.  I think that message body becomes real empty, we shoulld set <br> element.
