### PR TITLE
Bug 1093268 added autostart for bn-Avro layout with bn-BD

### DIFF
--- a/build/config/keyboard-layouts.json
+++ b/build/config/keyboard-layouts.json
@@ -15,6 +15,7 @@
         {"layoutId": "en", "app": ["apps", "keyboard"]}
     ],
     "bn-BD": [
+        {"layoutId": "bn-Avro", "app": ["apps", "keyboard"]},
         {"layoutId": "en", "app": ["apps", "keyboard"]}
     ],
     "bs": [


### PR DESCRIPTION
This patch will fix Bug #1093268 and will auto-start bn-Avro when bn-BD locale is selected.
