### PR TITLE
Bug 1093537 - Move input app window management-related responsibility from KeyboardManager to InputWindowManager

### DIFF
--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -2,7 +2,7 @@
 /* global ConfirmDialogHelper */
 /* global FtuLauncher */
 /* global KeyboardHelper */
-/* global KeyboardManager */
+/* global inputWindowManager */
 /* global LazyLoader */
 /* global ManifestHelper */
 /* global ModalDialog */
@@ -14,18 +14,6 @@
 /* global applications */
 
 'use strict';
-/* global ModalDialog */
-/* global SystemBanner */
-/* global StatusBar */
-/* global KeyboardManager */
-/* global LazyLoader */
-/* global ManifestHelper */
-/* global FtuLauncher */
-/* global Template */
-/* global NotificationScreen */
-/* global KeyboardHelper */
-/* global UtilityTray */
-/* global applications */
 
 var AppInstallManager = {
   mapDownloadErrorsToMessage: {
@@ -300,7 +288,7 @@ var AppInstallManager = {
 
     // We must stop 3rd-party keyboard app from being installed
     // if the feature is not enabled.
-    if (role === 'input' && !KeyboardManager.isOutOfProcessEnabled) {
+    if (role === 'input' && !inputWindowManager.isOutOfProcessEnabled) {
       navigator.mozApps.mgmt.uninstall(app);
 
       return;

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -1,4 +1,4 @@
-/* global SettingsListener, homescreenWindowManager, KeyboardManager,
+/* global SettingsListener, homescreenWindowManager, inputWindowManager,
           layoutManager, Service, NfcHandler, rocketbar, ShrinkingUI */
 'use strict';
 
@@ -204,10 +204,10 @@
 
         if (this.continuousTransition) {
           // Do keyboard transition.
-          KeyboardManager.hideKeyboard();
+          inputWindowManager.hideInputWindow();
         } else {
           // Hide keyboard immediately.
-          KeyboardManager.hideKeyboardImmediately();
+          inputWindowManager.hideInputWindowImmediately();
         }
       } else if (rocketbar.active) {
         // Wait for the rocketbar to close

--- a/apps/system/js/bootstrap.js
+++ b/apps/system/js/bootstrap.js
@@ -44,6 +44,10 @@ window.addEventListener('load', function startup() {
     window.appWindowManager = new AppWindowManager();
 
     /** @global */
+    window.inputWindowManager = new window.InputWindowManager();
+    window.inputWindowManager.start();
+
+    /** @global */
     window.activityWindowManager = new ActivityWindowManager();
     window.activityWindowManager.start();
 

--- a/apps/system/js/icc.js
+++ b/apps/system/js/icc.js
@@ -1,6 +1,6 @@
 /* -*- Mode: js; js-indent-level: 2; indent-tabs-mode: nil -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
-/* global LazyLoader, DUMP */
+/* global LazyLoader, DUMP, inputWindowManager */
 'use strict';
 
 var icc = {
@@ -266,7 +266,7 @@ var icc = {
   keyboardChangedEvent: function(viewId, hidden) {
     var keyboardHeight = 0;
     if (!hidden) {
-      keyboardHeight = KeyboardManager.getHeight() || 0;
+      keyboardHeight = inputWindowManager.getHeight();
     }
     var form = viewId.getElementsByTagName('form');
     var height = (window.innerHeight - keyboardHeight - StatusBar.height);

--- a/apps/system/js/input_window.js
+++ b/apps/system/js/input_window.js
@@ -171,7 +171,7 @@
       this.browser.element.removeEventListener('mozbrowserresize', this, true);
       this.element.classList.remove('top-most');
 
-      this.height = undefined;
+      this.height = 0;
     }
   };
 

--- a/apps/system/js/layout_manager.js
+++ b/apps/system/js/layout_manager.js
@@ -1,4 +1,4 @@
-/* global KeyboardManager, softwareButtonManager, Service */
+/* global inputWindowManager, softwareButtonManager, Service */
 'use strict';
 
 (function(exports) {
@@ -21,7 +21,6 @@
    * ![resize layout flow](http://i.imgur.com/bUMm4VM.png)
    *
    * @class LayoutManager
-   * @requires KeyboardManager
    * @requires SoftwareButtonManager
    * @requires StatusBar
    * @requires Service
@@ -53,7 +52,7 @@
       var softwareButtonHeight = Service.locked || isFullScreenLayout ?
         0 : softwareButtonManager.height;
       var keyboardHeight = this.keyboardEnabled ?
-        KeyboardManager.getHeight() : 0;
+        inputWindowManager.getHeight() : 0;
       var height = window.innerHeight - keyboardHeight - softwareButtonHeight;
 
       // Normalizing the height so that it always translates to an integral

--- a/apps/system/js/trusted_ui.js
+++ b/apps/system/js/trusted_ui.js
@@ -1,6 +1,8 @@
 /* -*- Mode: js2; js2-basic-offset: 2; indent-tabs-mode: nil -*- */
 /* vim: set ft=javascript sw=2 ts=2 autoindent cindent expandtab: */
 
+/* global inputWindowManager */
+
 'use strict';
 
 var TrustedUIManager = {
@@ -433,7 +435,7 @@ var TrustedUIManager = {
         this._hide();
         break;
       case 'keyboardchange':
-        var keyboardHeight = KeyboardManager.getHeight();
+        var keyboardHeight = inputWindowManager.getHeight();
         this._setHeight(window.innerHeight - StatusBar.height - keyboardHeight);
         break;
       case 'keyboardhide':

--- a/apps/system/test/marionette/rocketbar_activity_layout_test.js
+++ b/apps/system/test/marionette/rocketbar_activity_layout_test.js
@@ -69,7 +69,7 @@ marionette('Rocketbar - Opened Activity From Search', function() {
       var matches = newHeight === lastHeight;
       lastHeight = newHeight;
       var keyboardHeight = client.executeScript(function() {
-        return window.wrappedJSObject.KeyboardManager.getHeight();
+        return window.wrappedJSObject.inputWindowManager.getHeight();
       });
       var frameRect = bookmark.currentTabFrame.scriptWith(function(el) {
         return el.getBoundingClientRect();

--- a/apps/system/test/unit/app_install_manager_test.js
+++ b/apps/system/test/unit/app_install_manager_test.js
@@ -1,3 +1,5 @@
+/* global InputWindowManager, inputWindowManager */
+
 'use strict';
 
 requireApp('system/test/unit/mock_app.js');
@@ -10,7 +12,7 @@ requireApp('system/test/unit/mock_utility_tray.js');
 requireApp('system/test/unit/mock_modal_dialog.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
 requireApp('system/test/unit/mock_ftu_launcher.js');
-requireApp('system/test/unit/mock_keyboard_manager.js');
+require('/js/input_window_manager.js');
 
 require('/shared/js/template.js');
 require('/shared/test/unit/mocks/mock_lazy_loader.js');
@@ -20,6 +22,7 @@ require('/shared/test/unit/mocks/mock_navigator_moz_apps.js');
 require('/shared/test/unit/mocks/mock_keyboard_helper.js');
 
 requireApp('system/js/app_install_manager.js');
+
 var mocksForAppInstallManager = new MocksHelper([
   'StatusBar',
   'SystemBanner',
@@ -30,7 +33,6 @@ var mocksForAppInstallManager = new MocksHelper([
   'ManifestHelper',
   'LazyLoader',
   'FtuLauncher',
-  'KeyboardManager',
   'KeyboardHelper'
 ]).init();
 
@@ -218,6 +220,9 @@ suite('system/AppInstallManager >', function() {
     document.body.appendChild(fakeSetupDialog);
     document.body.appendChild(fakeImeListDialog);
     document.body.appendChild(fakeImeListTemplate);
+
+    window.inputWindowManager =
+      this.sinon.stub(Object.create(InputWindowManager.prototype));
 
     AppInstallManager.init();
   });
@@ -1354,7 +1359,7 @@ suite('system/AppInstallManager >', function() {
     var mockApp, mockAppTwo, mockAppName, mockAppTwoName;
     setup(function() {
       AppInstallManager.init();
-      KeyboardManager.isOutOfProcessEnabled = true;
+      inputWindowManager.isOutOfProcessEnabled = true;
 
       navigator.mozL10n = MockL10n;
       mockAppName = 'Fake keyboard app';
@@ -1423,8 +1428,8 @@ suite('system/AppInstallManager >', function() {
 
     test('should be uninstalled if disabled', function() {
       // Disabling keyboard app installation.
-      // Set MockKeyboardManager.isOutOfProcessEnabled to false
-      KeyboardManager.isOutOfProcessEnabled = false;
+      // Set stubbed inputWindowManager.isOutOfProcessEnabled to false
+      inputWindowManager.isOutOfProcessEnabled = false;
 
       this.sinon.spy(navigator.mozApps.mgmt, 'uninstall');
       AppInstallManager.handleInstallSuccess(mockApp);

--- a/apps/system/test/unit/bootstrap_test.js
+++ b/apps/system/test/unit/bootstrap_test.js
@@ -41,6 +41,7 @@ requireApp('system/js/rocketbar.js');
 requireApp('system/js/home_gesture.js');
 requireApp('system/js/homescreen_launcher.js');
 requireApp('system/js/internet_sharing.js');
+requireApp('system/js/input_window_manager.js');
 requireApp('system/js/layout_manager.js');
 requireApp('system/js/lockscreen_agent.js');
 requireApp('system/js/lockscreen_window_manager.js');

--- a/apps/system/test/unit/icc_test.js
+++ b/apps/system/test/unit/icc_test.js
@@ -1,4 +1,4 @@
-/* global MocksHelper, MockNavigatorMozIccManager, icc,
+/* global MocksHelper, MockNavigatorMozIccManager, icc, InputWindowManager,
           MockNavigatorMozMobileConnections, MockNavigatormozSetMessageHandler,
           MockL10n, MockFtuLauncher, MockNavigatorSettings, KeyboardEvent */
 'use strict';
@@ -7,7 +7,6 @@ require('/shared/test/unit/mocks/mock_l10n.js');
 requireApp('system/test/unit/mock_system_icc_worker.js');
 requireApp('system/test/unit/mock_ftu_launcher.js');
 requireApp('system/test/unit/mock_statusbar.js');
-requireApp('system/test/unit/mock_keyboard_manager.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_icc_manager.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_set_message_handler.js');
@@ -15,13 +14,13 @@ require('/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js');
 require('/shared/test/unit/mocks/mock_dump.js');
 require('/shared/test/unit/load_body_html_helper.js');
 require('/shared/js/lazy_loader.js');
+require('/js/input_window_manager.js');
 
 var mocksForIcc = new MocksHelper([
   'Dump',
   'FtuLauncher',
   'SystemICCWorker',
-  'StatusBar',
-  'KeyboardManager'
+  'StatusBar'
 ]).init();
 
 suite('STK (icc) >', function() {
@@ -140,6 +139,9 @@ suite('STK (icc) >', function() {
     xhrFake.onCreate = function (xhr) {
       xhrRequests.push(xhr);
     };
+
+    window.inputWindowManager =
+      this.sinon.stub(Object.create(InputWindowManager.prototype));
 
     requireApp('system/js/icc.js', done);
   });

--- a/apps/system/test/unit/input_window_test.js
+++ b/apps/system/test/unit/input_window_test.js
@@ -234,7 +234,7 @@ suite('system/InputWindow', function() {
         stubRemoveEventListener.calledWith('mozbrowserresize', app, true)
       );
 
-      assert.strictEqual(app.height, undefined);
+      assert.strictEqual(app.height, 0);
     });
   });
 

--- a/apps/system/test/unit/layout_manager_test.js
+++ b/apps/system/test/unit/layout_manager_test.js
@@ -1,16 +1,15 @@
-/* global MocksHelper, LayoutManager, MockKeyboardManager,
+/* global MocksHelper, LayoutManager, InputWindowManager,
           MocksoftwareButtonManager, MockLockScreen,
-          MockService */
+          MockService, inputWindowManager */
 'use strict';
 
 require('/shared/test/unit/mocks/mock_service.js');
 requireApp('system/js/layout_manager.js');
 requireApp('system/test/unit/mock_lock_screen.js');
-requireApp('system/test/unit/mock_keyboard_manager.js');
 requireApp('system/test/unit/mock_software_button_manager.js');
+require('/js/input_window_manager.js');
 
 var mocksForLayoutManager = new MocksHelper([
-  'KeyboardManager',
   'softwareButtonManager',
   'LockScreen',
   'Service'
@@ -27,6 +26,8 @@ suite('system/LayoutManager >', function() {
       }
     };
     window.lockScreen = MockLockScreen;
+    window.inputWindowManager =
+      this.sinon.stub(Object.create(InputWindowManager.prototype));
     layoutManager = new LayoutManager();
     layoutManager.start();
   });
@@ -215,7 +216,7 @@ suite('system/LayoutManager >', function() {
     test('should take into account keyboard and home button',
     function() {
       var _w = document.documentElement.clientWidth;
-      MockKeyboardManager.mHeight = 100;
+      inputWindowManager.getHeight.returns(100);
       MocksoftwareButtonManager.height = 50;
       layoutManager.keyboardEnabled = true;
       assert.equal(layoutManager.height, H - 100 - 50);
@@ -230,7 +231,7 @@ suite('system/LayoutManager >', function() {
         this.sinon.stub(MockService.currentApp, 'isFullScreenLayout')
           .returns(true);
         var _w = document.documentElement.clientWidth;
-        MockKeyboardManager.mHeight = 100;
+        inputWindowManager.getHeight.returns(100);
         MocksoftwareButtonManager.height = 50;
         layoutManager.keyboardEnabled = true;
         assert.equal(layoutManager.height, H - 100);
@@ -245,7 +246,7 @@ suite('system/LayoutManager >', function() {
         this.sinon.stub(MockService.currentApp, 'isFullScreenLayout')
           .returns(true);
         var _w = document.documentElement.clientWidth;
-        MockKeyboardManager.mHeight = 100;
+        inputWindowManager.getHeight.returns(100);
         MocksoftwareButtonManager.height = 50;
         layoutManager.keyboardEnabled = true;
         assert.equal(layoutManager.height, H - 100);
@@ -260,7 +261,7 @@ suite('system/LayoutManager >', function() {
         MockService.locked = true;
         this.sinon.stub(MockService.currentApp, 'isFullScreenLayout')
           .returns(true);
-        MockKeyboardManager.mHeight = 100;
+        inputWindowManager.getHeight.returns(100);
         MocksoftwareButtonManager.height = 50;
         layoutManager.keyboardEnabled = true;
         // Even though the software home button is enabled and reports a height
@@ -280,7 +281,7 @@ suite('system/LayoutManager >', function() {
       H = window.innerHeight;
       W = window.innerWidth;
       _w = document.documentElement.clientWidth;
-      MockKeyboardManager.mHeight = 100;
+      inputWindowManager.getHeight.returns(100);
       MocksoftwareButtonManager.height = 50;
       MocksoftwareButtonManager.width = 50;
     });

--- a/apps/system/test/unit/mock_keyboard_manager.js
+++ b/apps/system/test/unit/mock_keyboard_manager.js
@@ -1,16 +1,10 @@
 MockKeyboardManager = {
   mHeight: 0,
   init: function() {},
-  removeKeyboard: function() {},
-  hideKeyboard: function() {},
-  getHeight: function() {
-    return this.mHeight;
-  },
   mTeardown: function() {
     this.mHeight = 0;
   },
   _onKeyboardReady: function() {},
-  inputTypeTable: {},
-  isOutOfProcessEnabled: false,
-  totalMemory: 0
+  _onKeyboardKilled: function() {},
+  inputTypeTable: {}
 };


### PR DESCRIPTION
- A lot of events that only affects inputWindow showing/hiding goes to InputWindowManager instead of KeyboardManager now.
- "RemoveKeyboard" concept is now separated:
  -- "keyboardlayoutsremoved" is used to signify that some keyboard layouts have been removed (disabled from system settings, or uninstalled keyboard app); or loaded In
  -- "keyboardkilled" is used to signify that a loaded and currently showing out-of-process keyboard has been OOM'killed. This event only goes from InputWindowManager t
- A closed InputWindow now has height 0 instead of undefined.
- Please use inputWindowManager.hideInputWindow()/.hideInputWindowImmediately()/.getHeight() in place of KeyboardManager.hideKeyboard()/.hideKeyboardImmediately/.getHe
- inputWindowManager is a singleton and accessible in the window scope.
