### PR TITLE
Bug 941993 - Change a debug-only pluralized number of seconds string.

### DIFF
--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -272,12 +272,15 @@ settings-check-every-30min=Every 30 minutes
 settings-check-every-60min=Every hour
 settings-check-every-manual=Manually
 
-# Dynamically added sync interval checks. These are only added via special
-# debug/development tools, and are always in seconds. Otherwise, just
-# the settings-check-every-* options are visible.
+# LOCALIZATION NOTE(settings-check-dynamic):
+# DEBUG ONLY Dynamically added sync interval checks. These are only added via
+# special debug/development tools, and are always in seconds. Otherwise, just
+# the settings-check-every-* options are visible.  The zero case is impossible
+# (a separate string is used) and 20 seconds is the currently lowest possible
+# value.
 settings-check-dynamic={[ plural(n) ]}
-settings-check-dynamic[zero]  = seconds
-settings-check-dynamic[one]   = {{ n }} seconds
+settings-check-dynamic[zero]  = disabled
+settings-check-dynamic[one]   = {{ n }} second
 settings-check-dynamic[two]   = {{ n }} seconds
 settings-check-dynamic[few]   = {{ n }} seconds
 settings-check-dynamic[many]  = {{ n }} seconds


### PR DESCRIPTION
It was raised in bug 941993 that we would display "1 seconds" if a value of 1
was used.  This wouldn't happen, but I left the bug open because it's arguably
silly to have the incorrect value.

I am not updating the l10n string since this is a debug only pluralized string.
No user will ever see this string unless they use the secret debug menu to set
their periodic sync value to a ridiculously short value (20 seconds or 60
seconds.)  And in that case the existing localized strings are already correct.

I'm just doing this to close out the bug.
