### PR TITLE
Bug 1094598 - [VerticalHome] Remove strings from home index.html +autoland

### DIFF
--- a/apps/verticalhome/index.html
+++ b/apps/verticalhome/index.html
@@ -79,8 +79,8 @@
 
     <section id="edit-header" role="region">
       <gaia-header>
-        <h1 data-l10n-id="edit-mode">Edit</h1>
-        <a href="#" data-l10n-id="edit-done" id="exit-edit-mode">Done</a>
+        <h1 data-l10n-id="edit-mode"></h1>
+        <a href="#" data-l10n-id="edit-done" id="exit-edit-mode"></a>
       </gaia-header>
     </section>
 
@@ -109,7 +109,7 @@
       <form>
         <p>
           <input type="text" id="edit-group-title" x-inputmode="latin-prose" dir="auto"></input>
-          <button id="edit-group-title-clear" type="reset">Clear</button>
+          <button id="edit-group-title-clear" type="reset"></button>
         </p>
       </form>
     </section>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1094598
