### PR TITLE
Bug 1094601 - Remove strings from search html pages +autoland

### DIFF
--- a/apps/search/index.html
+++ b/apps/search/index.html
@@ -73,7 +73,7 @@
 
       <div id="offline-message">
         <span id="settings-connectivity"></span>
-        <span data-l10n-id="offline-message">No Internet Connection</span>
+        <span data-l10n-id="offline-message"></span>
       </div>
 
       <div id="suggestions-wrapper">
@@ -84,7 +84,7 @@
 
       <div id="suggestions-notice-wrapper" hidden>
         <p data-l10n-id="suggestions-settings-notice"></p>
-        <button id="suggestions-notice-confirm" data-l10n-id="ok">Ok</button>
+        <button id="suggestions-notice-confirm" data-l10n-id="ok"></button>
       </div>
 
       <section id="contacts" class="local" data-l10n-id="contacts"

--- a/apps/search/newtab.html
+++ b/apps/search/newtab.html
@@ -23,9 +23,9 @@
     <script defer src="js/providers/places.js"></script>
   </head>
   <body>
-      <h2 id="top-sites-header"><span data-l10n-id="top-sites">TOP SITES</span></h2>
+      <h2 id="top-sites-header"><span data-l10n-id="top-sites"></span></h2>
       <section id="top-sites" aria-labelledby="top-sites-header"></section>
-      <h2 id="history-header"><span data-l10n-id="history">HISTORY</span></h2>
+      <h2 id="history-header"><span data-l10n-id="history"></span></h2>
       <section id="history" class="local" aria-labelledby="history-header"></section>
   </body>
 </html>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1094601
