### PR TITLE
Bug 1084252 - Add TODO comment about removing duplicated style. r=steveck

### DIFF
--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -10,7 +10,9 @@ html, body {
 
 
 /* Style for the attachment options menu, mimics style for shared
- * options dialog element.
+ * options menu element.
+ * TODO: We should remove this once we used the shared options menu for the
+ *       attachment menu.
  */
 #attachment-options {
   visibility: hidden;


### PR DESCRIPTION
Once the attachment menu uses the shared options menu element, we want to
remove the duplicated style rules in sms.css.
