### PR TITLE
Bug 1053641 - Remove newlines from localized strings describing call forwarding status r=drs

### DIFF
--- a/apps/communications/dialer/js/mmi.js
+++ b/apps/communications/dialer/js/mmi.js
@@ -89,8 +89,6 @@ var MmiManager = {
     // Helper function to compose an informative message about a successful
     // request to query the call forwarding status.
     var processCf = (function processCf(result) {
-      var msg = this._('cf-status');
-
       var voice, data, fax, sms, sync, async, packet, pad;
 
       for (var i = 0; i < result.length; i++) {
@@ -134,14 +132,21 @@ var MmiManager = {
         }
       }
 
-      msg += this._('cf-voice', {voice: voice || this._('cf-inactive')}) +
-             this._('cf-data', {data: data || this._('cf-inactive')}) +
-             this._('cf-fax', {fax: fax || this._('cf-inactive')}) +
-             this._('cf-sms', {sms: sms || this._('cf-inactive')}) +
-             this._('cf-sync', {sync: sync || this._('cf-inactive')}) +
-             this._('cf-async', {async: async || this._('cf-inactive')}) +
-             this._('cf-packet', {packet: packet || this._('cf-inactive')}) +
-             this._('cf-pad', {pad: pad || this._('cf-inactive')});
+      var inactive = this._('cf-inactive');
+      var msg = [
+        this._('cf-status'),
+        this._('cf-voice', { voice: voice || inactive }),
+        this._('cf-data', { data: data || inactive }),
+        this._('cf-fax', { fax: fax || inactive }),
+        this._('cf-sms', { sms: sms || inactive }),
+        this._('cf-sync', { sync: sync || inactive }),
+        this._('cf-async', { async: async || inactive }),
+        this._('cf-packet', { packet: packet || inactive }),
+        this._('cf-pad', { pad: pad || inactive })
+      ].map(function(str) {
+        return str.replace('\\n', '');
+      }).join('\n');
+
       return msg;
     }).bind(this);
 

--- a/apps/communications/dialer/test/unit/mmi_test.js
+++ b/apps/communications/dialer/test/unit/mmi_test.js
@@ -28,6 +28,7 @@ const MMI_MSG = 'mmi_msg';
 const MMI_CF_MSG_ACTIVE_VOICE = 'mmi_cf_active_voice';
 const MMI_CF_MSG_ACTIVE_DATA = 'mmi_cf_active_data';
 const MMI_CF_MSG_ACTIVE_FAX = 'mmi_cf_active_fax';
+const MMI_CF_MSG_ACTIVE_SMS = 'mmi_cf_active_sms';
 const MMI_CF_MSG_ACTIVE_DATA_SYNC = 'mmi_cf_active_data_sync';
 const MMI_CF_MSG_ACTIVE_DATA_ASYNC = 'mmi_cf_active_data_async';
 const MMI_CF_MSG_ACTIVE_PACKET = 'mmi_cf_active_package';
@@ -43,12 +44,11 @@ const MMI_CALL_WAITING_STATUS_DISABLED = 'mmi_call_waiting_status_disabled';
 const ICC_SERVICE_CLASS_VOICE = (1 << 0);
 const ICC_SERVICE_CLASS_DATA = (1 << 1);
 const ICC_SERVICE_CLASS_FAX = (1 << 2);
-// const ICC_SERVICE_CLASS_SMS = (1 << 3);
+const ICC_SERVICE_CLASS_SMS = (1 << 3);
 const ICC_SERVICE_CLASS_DATA_SYNC = (1 << 4);
 const ICC_SERVICE_CLASS_DATA_ASYNC = (1 << 5);
 const ICC_SERVICE_CLASS_PACKET = (1 << 6);
 const ICC_SERVICE_CLASS_PAD = (1 << 7);
-// const ICC_SERVICE_CLASS_MAX = (1 << 7);
 
 const EXPECTED_PHONE = '+34666222111';
 
@@ -109,6 +109,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ACTIVE_VOICE:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -119,6 +121,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ACTIVE_DATA:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -129,6 +133,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ACTIVE_FAX:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -137,8 +143,22 @@ suite('dialer/mmi', function() {
         };
         MmiManager.notifySuccess(evt);
         break;
+      case MMI_CF_MSG_ACTIVE_SMS:
+        evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
+          additionalInformation: [{
+            active: true,
+            number: EXPECTED_PHONE,
+            serviceClass: ICC_SERVICE_CLASS_SMS
+          }]
+        };
+        MmiManager.notifySuccess(evt);
+        break;
       case MMI_CF_MSG_ACTIVE_DATA_SYNC:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -149,6 +169,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ACTIVE_DATA_ASYNC:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -159,6 +181,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ACTIVE_PACKET:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -169,6 +193,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ACTIVE_PAD:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -179,6 +205,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_INVALID_SERVICE_CLASS:
         evt.target.result = [{
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           active: true,
           number: EXPECTED_PHONE,
           serviceClass: -1
@@ -187,6 +215,8 @@ suite('dialer/mmi', function() {
         break;
      case MMI_CF_MSG_TWO_RULES:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: true,
             number: EXPECTED_PHONE,
@@ -201,6 +231,8 @@ suite('dialer/mmi', function() {
         break;
       case MMI_CF_MSG_ALL_INACTIVE:
         evt.target.result = {
+          serviceCode: 'scCallForwarding',
+          statusMessage: 'smServiceInterrogated',
           additionalInformation: [{
             active: false
           }]
@@ -768,154 +800,166 @@ suite('dialer/mmi', function() {
     });
   });
 
-  /** Temporary disable CF tests until Bug 884343 (Use MMIResult for Call
-   *   Forwarding related functionality) is done.
+  suite('Call forwarding request via MMI.', function() {
+    var _spy;
 
-  suite('Call forwarding request via MMI. Active voice', function() {
-    test('Check call forwarding rules', function(done) {
+    setup(function() {
+      _spy = this.sinon.spy(MmiManager, '_');
+    });
+
+    test('Check call forwarding rules, active voice', function(done) {
       MmiManager.send(MMI_CF_MSG_ACTIVE_VOICE);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-data'].data, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Active data', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, active data', function(done) {
       MmiManager.send(MMI_CF_MSG_ACTIVE_DATA);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-data'].data, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Active data sync', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, active fax', function(done) {
+      MmiManager.send(MMI_CF_MSG_ACTIVE_FAX);
+      setTimeout(function() {
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
+        done();
+      }, TINY_TIMEOUT);
+    });
+
+    test('Check call forwarding rules, active SMS', function(done) {
+      MmiManager.send(MMI_CF_MSG_ACTIVE_SMS);
+      setTimeout(function() {
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
+        done();
+      }, TINY_TIMEOUT);
+    });
+
+    test('Check call forwarding rules, active data sync', function(done) {
       MmiManager.send(MMI_CF_MSG_ACTIVE_DATA_SYNC);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-data'].data, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Active data async', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, data async', function(done) {
       MmiManager.send(MMI_CF_MSG_ACTIVE_DATA_ASYNC);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-async'].async, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-data'].data, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Active package', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, active package', function(done) {
       MmiManager.send(MMI_CF_MSG_ACTIVE_PACKET);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-data'].data, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Active PAD', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, active PAD', function(done) {
       MmiManager.send(MMI_CF_MSG_ACTIVE_PAD);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-data'].data, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: EXPECTED_PHONE });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. All inactive', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, all inactive', function(done) {
       MmiManager.send(MMI_CF_MSG_ALL_INACTIVE);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-data'].data, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Two rules', function() {
-    test('Check call forwarding rules', function(done) {
+    test('Check call forwarding rules, two rules', function(done) {
       MmiManager.send(MMI_CF_MSG_TWO_RULES);
       setTimeout(function() {
-        assert.equal(MockLazyL10n.keys['cf-voice'].voice, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-data'].data, EXPECTED_PHONE);
-        assert.equal(MockLazyL10n.keys['cf-fax'].fax, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sms'].sms, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-sync'].sync, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-async'].async, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-packet'].packet, 'cf-inactive');
-        assert.equal(MockLazyL10n.keys['cf-pad'].pad, 'cf-inactive');
+        sinon.assert.calledWith(_spy, 'cf-voice', { voice: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-data', { data: EXPECTED_PHONE });
+        sinon.assert.calledWith(_spy, 'cf-fax', { fax: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sms', { sms: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-sync', { sync: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-async', { async: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-packet', { packet: 'cf-inactive' });
+        sinon.assert.calledWith(_spy, 'cf-pad', { pad: 'cf-inactive' });
         done();
       }, TINY_TIMEOUT);
     });
-  });
 
-  suite('Call forwarding request via MMI. Invalid', function() {
-    setup(function() {
+    test('Invalid request', function() {
       MmiManager.send(MMI_CF_MSG_INVALID_SERVICE_CLASS);
-    });
-
-    test('Check call forwarding rules', function() {
       assert.equal(MmiManager._ui._messageReceived, null);
     });
   });
-
-  */
 });

--- a/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js
@@ -64,6 +64,17 @@
     function mnmmc_cancelMMI() {}
 
     var _mock = {
+      // Constants
+      ICC_SERVICE_CLASS_VOICE: (1 << 0),
+      ICC_SERVICE_CLASS_DATA: (1 << 1),
+      ICC_SERVICE_CLASS_FAX: (1 << 2),
+      ICC_SERVICE_CLASS_SMS: (1 << 3),
+      ICC_SERVICE_CLASS_DATA_SYNC: (1 << 4),
+      ICC_SERVICE_CLASS_DATA_ASYNC: (1 << 5),
+      ICC_SERVICE_CLASS_PACKET: (1 << 6),
+      ICC_SERVICE_CLASS_PAD: (1 << 7),
+      ICC_SERVICE_CLASS_MAX: (1 << 7),
+      // Methods
       addEventListener: mnmmc_addEventListener,
       removeEventListener: mnmmc_removeEventListener,
       triggerEventListeners: mnmmc_triggerEventListeners,


### PR DESCRIPTION
(cherry picked from commit c451052868e71c932311dae95d99857c5b368f49)

Conflicts:
    apps/communications/dialer/locales/dialer.en-US.properties
