### PR TITLE
Bug 951312 - [email/backend] check_syncFolderList's doneCallback('idempotent') should be doneCallback(null, 'coherent-notyet') so we retry synchronizing the folder list. r=jrburke

### DIFF
--- a/apps/email/js/ext/activesync/jobs.js
+++ b/apps/email/js/ext/activesync/jobs.js
@@ -385,7 +385,7 @@ ActiveSyncJobDriver.prototype = {
   }, 'aborted-retry'),
 
   check_syncFolderList: function(op, doneCallback) {
-    doneCallback('idempotent');
+    doneCallback(null, 'coherent-notyet');
   },
 
   local_undo_syncFolderList: function(op, doneCallback) {

--- a/apps/email/js/ext/imap/jobs.js
+++ b/apps/email/js/ext/imap/jobs.js
@@ -886,7 +886,7 @@ ImapJobDriver.prototype = {
   },
 
   check_syncFolderList: function(op, doneCallback) {
-    doneCallback('idempotent');
+    doneCallback(null, 'coherent-notyet');
   },
 
   local_undo_syncFolderList: function(op, doneCallback) {


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/350

In bug 951076 we saw a syncFolderList failure from ActiveSync.
ActiveSync triggers an 'aborted-retry' which has us run a check
operation. The check operation intends to have us retry by returning
'idempotent', but screws up and returns it as an error code instead of
the return value.

Also, idempotent is semantically the wrong thing for us to be returning.
'coherent-notyet' is better.
