### PR TITLE
[System]Pressing the "battery is low" notification will sometimes cause ...

### DIFF
--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -221,8 +221,6 @@ body {
   top: 0;
   left: 0;
   visibility: hidden;
-
-  pointer-events: none;
 }
 
 #system-overlay.volume {


### PR DESCRIPTION
...the rocket bar and keyboard to pop up, and will fail to bring up the battery section in the settings menu
