### PR TITLE
Bug 1091295 - [email] normalize newlines in composer. r=jrburke

### DIFF
--- a/apps/email/js/ext/smtp/client.js
+++ b/apps/email/js/ext/smtp/client.js
@@ -288,6 +288,7 @@ define(function(require, exports) {
       normalizedError: normalizedError,
       errorName: err.name,
       errorMessage: err.message,
+      errorData: err.data,
       wasSending: wasSending
     });
 


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/352

Failure to normalize newlines in composed messages. May cause some SMTP servers
(ex: qmail) to refuse to send mail with a 451 error.
