### PR TITLE
Bug 1095187 - Software Home Button - File Open Error Proper layout for file error dialog - Wait for download success +autoland

### DIFF
--- a/apps/system/test/marionette/software_home_file_open_error_test.js
+++ b/apps/system/test/marionette/software_home_file_open_error_test.js
@@ -61,9 +61,13 @@ marionette('Software Home Button - File Open Error', function() {
 
     // Tap on the toaster to open the download.
     // We could also open this from settings or the utility tray if needed.
-    var toasterDetail = client.helper.waitForElement(
-      '#notification-toaster.displayed .toaster-detail');
-    toasterDetail.tap();
+    var toasterTitle;
+    client.waitFor(function() {
+      toasterTitle = client.helper.waitForElement(
+        '#notification-toaster.displayed .toaster-title');
+      return toasterTitle.text().indexOf('Download complete') !== -1;
+    });
+    toasterTitle.tap();
 
     function rect(el) {
       return el.getBoundingClientRect();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1095187
