### PR TITLE
Bug 1040651 - Map a preference to a Gaia setting to enable Layerscope r=arthurcc

### DIFF
--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -104,6 +104,12 @@
         </li>
         <li>
           <label class="pack-checkbox">
+            <input type="checkbox" name="gfx.layerscope.enabled">
+            <span data-l10n-id="dumps-layerscope"></span>
+          </label>
+        </li>
+        <li>
+          <label class="pack-checkbox">
             <input type="checkbox" name="app.cards_view.screenshots.enabled">
             <span data-l10n-id="cards-view-screenshots">Cards View: Screenshots</span>
           </label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -1058,6 +1058,7 @@ graphics=Graphics
 hardware-composer=Hardware composer
 paint-flashing=Flash repainted area
 dumps-layers=Dump layers tree
+dumps-layerscope=Dump layerscope
 apz=Async Pan/Zoom
 apz-overscroll=Overscrolling
 tiling=Tiling

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -72,6 +72,7 @@
    "geolocation.debugging.gps-locations-ignored": false,
    "geolocation.enabled": true,
    "geolocation.suspended": false,
+   "gfx.layerscope.enabled": false,
    "hud.logging": true,
    "hud.warnings": true,
    "hud.errors": true,


### PR DESCRIPTION
Add a new option, "LayerScope", in "Settings -> Developer", so we can
enable this perference dynamically, instead of enabling it manually by
edit-prefs.sh.
