### PR TITLE
Bug 1091166 - Fix the color contrast value when enabling it

### DIFF
--- a/apps/system/js/accessibility.js
+++ b/apps/system/js/accessibility.js
@@ -144,7 +144,8 @@
                   'layers.effect.grayscale': aValue ?
                     this.settings['accessibility.colors.grayscale'] : false,
                   'layers.effect.contrast': aValue ?
-                    this.settings['accessibility.colors.contrast'] : '0.0'
+                    this.settings['accessibility.colors.contrast'] *
+                    this.CONTRAST_CAP : '0.0'
                 });
                 break;
 


### PR DESCRIPTION
The color contrast should also be multiplied by CONTRAST_CAP (0.6)
when enabling the color filter option.
