### PR TITLE
Bug 1096057 - Added cs-qwerty layout

### DIFF
--- a/apps/keyboard/js/layouts/cs-qwerty.js
+++ b/apps/keyboard/js/layouts/cs-qwerty.js
@@ -1,0 +1,43 @@
+Keyboards.cs = {
+  label: 'Czech (QWERTY)',
+  shortLabel: 'Cs',
+  menuLabel: 'Česká (QWERTY)',
+  imEngine: 'latin',
+  types: ['text', 'url', 'email', 'password'],
+  autoCorrectLanguage: 'cs',
+  alt: {
+    a: 'á',
+    c: 'č',
+    d: 'ď',
+    e: 'éě',
+    i: 'í',
+    n: 'ň',
+    o: 'ó',
+    r: 'ř',
+    s: 'š',
+    t: 'ť',
+    u: 'úů',
+    y: 'ý',
+    z: 'ž',
+    '.': ',?!;:…'
+  },
+  keys: [
+    [
+      { value: 'q' }, { value: 'w' }, { value: 'e' }, { value: 'r' },
+      { value: 't' }, { value: 'y' }, { value: 'u' } , { value: 'i' },
+      { value: 'o' }, { value: 'p' }
+    ], [
+      { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
+      { value: 'g' }, { value: 'h' }, { value: 'j' }, { value: 'k' },
+      { value: 'l' }
+    ], [
+      { value: '&#8682;', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+      { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
+      { value: 'b' }, { value: 'n' }, { value: 'm' },
+      { value: '&#9003;', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+    ], [
+      { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '&#8629;', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+    ]
+  ]
+};


### PR DESCRIPTION
The only difference from cs.js is that it is QWERTY, not QWERTZ.

Although, this is not an official layout according to the Czech
technical norms, it is very widely used “in the wild”.
