### PR TITLE
Bug 1087813 - Fix the unable to entry Settings app menus on Flatfish

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -110,7 +110,7 @@ var Settings = {
       // WifiHelper is guaranteed to be loaded in main.js before calling to
       // this line.
       if (this.isTabletAndLandscape()) {
-        self.currentPanel = self.initialPanelForTablet;
+        this.currentPanel = this.initialPanelForTablet;
       }
 
       window.addEventListener('keydown', this.handleSpecialKeys);


### PR DESCRIPTION
The self pointing to window, we should not use it.
