### PR TITLE
Bug 1096572 - [Building Blocks] Update some RTL styles to match latest RTL spec

### DIFF
--- a/shared/style/buttons.css
+++ b/shared/style/buttons.css
@@ -399,12 +399,6 @@ html[dir="rtl"] li .button {
   text-align: right;
 }
 
-html[dir="rtl"] li button.icon,
-html[dir="rtl"] li .bb-button.icon,
-html[dir="rtl"] li .button.icon {
-  padding: 1rem 1.3rem 1rem 4rem;
-}
-
 html[dir="rtl"] button[data-icon]:before,
 html[dir="rtl"] .bb-button[data-icon]:before,
 html[dir="rtl"] .button[data-icon]:before {

--- a/shared/style/headers.css
+++ b/shared/style/headers.css
@@ -117,23 +117,6 @@ section[role="region"] header h2 {
   line-height: 1.8rem;
 }
 
-/* ----------------------------------
-  right-to-left
----------------------------------- */
-
-html[dir="rtl"] section[role="region"] > header:first-child menu {
-  float: left;
-}
-
-html[dir="rtl"] section[role="region"] > header:first-child button,
-html[dir="rtl"] section[role="region"] > header:first-child a {
-  float: right;
-}
-
-html[dir="rtl"] section[role="region"] > header:first-child .icon-back {
-  transform: rotate(180deg);
-}
-
 /* -----------------------------------------------------------------
   HEADER SKIN: default
   Default values in case we are not overriding them using

--- a/shared/style/tabs.css
+++ b/shared/style/tabs.css
@@ -25,6 +25,11 @@
   z-index: 0;
 }
 
+/* RTL support in gaia right now keeps buttons in same direction as LTR */
+html[dir="rtl"] .bb-tablist {
+  flex-direction: row-reverse;
+}
+
 .bb-tablist > li {
   -moz-box-sizing: content-box;
   margin: 0;


### PR DESCRIPTION
Changes, in keeping with the latest RTL spec, as of November 5:
- buttons.css: removes a padding that seems out of place with current design, does not have an equivalent style for LTR layouts.
- headers.css: keeps the header buttons and icon visuals in same layout as LTR.
- tabs.css: for bb-tablist: keeps the buttons laid out in same horizontal layout as LTR.
