### PR TITLE
Bug 1095774 - [Text Selection] Choosing "select all" when only 1 word is displayed dismisses the keyboard but not the menu

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -85,7 +85,8 @@
   z-index: 65538;
 }
 
-#screen > [data-z-index-level="attention-indicator"] {
+#screen > [data-z-index-level="attention-indicator"],
+#screen > [data-z-index-level="text-selection-dialog"] {
   z-index: 32769;
 }
 
@@ -194,8 +195,7 @@
   z-index: 2046;
 }
 
-#screen > [data-z-index-level="system-dialog"],
-#screen > [data-z-index-level="text-selection-dialog"] {
+#screen > [data-z-index-level="system-dialog"] {
   z-index: 2045;
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1095774
