### PR TITLE
Bug 1095369 - [FFOS2.0][Woodduck][Browser]Wallpaper will display when ed...

### DIFF
--- a/apps/system/js/layout_manager.js
+++ b/apps/system/js/layout_manager.js
@@ -128,6 +128,7 @@
           this.publish('system-resize');
           break;
         case 'resize':
+          this.keyboardEnabled = false;
           this.publish('system-resize');
           this.publish('orientationchange');
           break;

--- a/apps/system/test/unit/layout_manager_test.js
+++ b/apps/system/test/unit/layout_manager_test.js
@@ -37,6 +37,7 @@ suite('system/LayoutManager >', function() {
       layoutManager.handleEvent({
         type: 'resize'
       });
+      assert.isFalse(layoutManager.keyboardEnabled);
       assert.isTrue(stubPublish.calledWith('system-resize'));
       assert.isTrue(stubPublish.calledWith('orientationchange'));
     });


### PR DESCRIPTION
...it bookmark

When changing orientation from portrait to landscape and resizing with keyboard on, the layout manager in the system app will resize the height of the active app first with the keyboard height in portrait (line 55 in layout_manager.js). When the height of the keyboard in portrait mode is bigger than the height in landscape mode, the calculated height of the active app will be smaller than it should've been. The system wallpaper is visible at the mean time. Subsequent resize events later will immediately correct the active app height using the correct landscape keyboard height.

The resizing event sequence is 'resize' --> 'keyboardchange' --> 'keyboardchange'. This patch disables the keyboard height check in the 'resize' event since it'd be incorrect during orientation change, which would display part of the system wallpaper in a flash.
