### PR TITLE
Bug 1096603 - [Flatfish] [FxA] [FTE] Register/ Log in screen during setup is blank 

### DIFF
--- a/apps/system/fxa/fxa_module.html
+++ b/apps/system/fxa/fxa_module.html
@@ -26,6 +26,7 @@
     <link rel="import" href="elements/fxa-refresh-auth.html">
     <link rel="import" href="elements/fxa-coppa.html">
 
+    <script defer src="../js/system.js"></script>
     <script defer src="../js/ftu_launcher.js"></script>
     <script defer src="../js/browser_frame.js"></script>
     <script defer src="../js/entry_sheet.js"></script>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1096603
