### PR TITLE
Bug 1093951 - Entering wifi power save mode when screen off.

### DIFF
--- a/apps/system/js/wifi.js
+++ b/apps/system/js/wifi.js
@@ -171,6 +171,13 @@ var Wifi = {
     // But if wifi wake lock is held, turn wifi into power save mode instead of
     // turning wifi off.
     if (!ScreenManager.screenEnabled && !battery.charging) {
+      // When the screen is off and the phone is not charging,
+      // go to power save mode. It will be restored when screen
+      // is turned on or the phone is charging.
+      if (this.wifiEnabled) {
+        wifiManager.setPowerSavingMode(true);
+      }
+
       // Wifi wake lock is held while screen and wifi are off, turn on wifi and
       // get into power save mode.
       if (!this.wifiEnabled && this.wifiWakeLocked) {
@@ -214,6 +221,12 @@ var Wifi = {
       if (this._alarmId) {
         navigator.mozAlarms.remove(this._alarmId);
         this._alarmId = null;
+      }
+
+      if (this.wifiEnabled) {
+        // Restore from power save mode before the possible scan request if
+        // wifi is already enabled.
+        wifiManager.setPowerSavingMode(false);
       }
 
       // If wifi is enabled but disconnected.

--- a/apps/system/test/unit/wifi_test.js
+++ b/apps/system/test/unit/wifi_test.js
@@ -239,6 +239,37 @@ suite('WiFi > ', function() {
       stubMozWifiManager.restore();
     });
 
+    test('Test setPowerSavingMode should be called when screen off ' +
+         'and not charging', function() {
+      SettingsListener.mCallbacks['wifi.screen_off_timeout'](100);
+
+      ScreenManager.screenEnabled = false;
+      Wifi.wifiDisabledByWakelock = true;
+      Wifi.wifiWakeLocked = false;
+      Wifi.wifiEnabled = true;
+
+      var isPowerSavingModeEnabled;
+      var stubMozWifiManager = this.sinon.stub(navigator,
+        'mozWifiManager', {
+          setPowerSavingMode: function(enabled) {
+            isPowerSavingModeEnabled = enabled;
+          }
+        });
+
+      var stubMozAlarms = this.sinon.stub(navigator,
+        'mozAlarms', MockMozAlarms);
+
+      navigator.battery = { charging: false };
+
+      Wifi.maybeToggleWifi();
+
+      assert.equal(isPowerSavingModeEnabled, true);
+
+      navigator.battery = realBattery;
+      stubMozAlarms.restore();
+      stubMozWifiManager.restore();
+    });
+
     test('Test sleep should be called when mozAlarms doesnt exist', function() {
       SettingsListener.mCallbacks['wifi.screen_off_timeout'](100);
 
@@ -251,6 +282,14 @@ suite('WiFi > ', function() {
       var stubSleep = this.sinon.stub(Wifi, 'sleep', function() {
         isSleepCalled = true;
       });
+
+      // We will test if setPowerSavingMode gets called in other test case.
+      // Simply provide
+      var stubMozWifiManager = this.sinon.stub(navigator,
+        'mozWifiManager', {
+          setPowerSavingMode: function(enabled) {}
+        });
+
       var stubMozAlarms = this.sinon.stub(navigator,
         'mozAlarms', null);
       navigator.battery = { charging: false };
@@ -262,6 +301,7 @@ suite('WiFi > ', function() {
       navigator.battery = realBattery;
       stubMozAlarms.restore();
       stubSleep.restore();
+      stubMozWifiManager.restore();
     });
 
     test('Test starting with a timer', function() {
@@ -281,6 +321,11 @@ suite('WiFi > ', function() {
         });
       navigator.battery = { charging: false };
 
+      var stubMozWifiManager = this.sinon.stub(navigator,
+        'mozWifiManager', {
+          setPowerSavingMode: function(enabled) {}
+        });
+
       Wifi.maybeToggleWifi();
 
       assert.equal(isSetSystemMessageHandlerCalled, true);
@@ -290,6 +335,7 @@ suite('WiFi > ', function() {
       navigator.battery = realBattery;
       stubMozAlarms.restore();
       stubSetSystemMessageHandler.restore();
+      stubMozWifiManager.restore();
     });
   });
 


### PR DESCRIPTION
While screen is off, wifi would go to power save mode only
when wifi lock is held. If wifi lock is not held, wifi would
stay on and be turned off after |wifi.screen_off_timeout|.
We can more aggressively request the wifi driver to enter
power save mode before timed out. This is what the patch
intends to do.
