### PR TITLE
Bug 1097450 - Save (to settings) the activeLayout of groups supported by one layout, when we change to that layout

### DIFF
--- a/apps/system/test/unit/keyboard_helper_test.js
+++ b/apps/system/test/unit/keyboard_helper_test.js
@@ -15,7 +15,6 @@ suite('KeyboardHelper', function() {
   var appEvents = ['applicationinstallsuccess'];
   var DEFAULT_KEY = 'keyboard.default-layouts';
   var ENABLED_KEY = 'keyboard.enabled-layouts';
-  var CURRENT_ACTIVE = 'keyboard.current-active-layouts';
   var THIRD_PARTY_APP_ENABLED_KEY = 'keyboard.3rd-party-app.enabled';
   var keyboardAppOrigin = 'app://keyboard.gaiamobile.org';
   var keyboardAppManifestURL =
@@ -153,14 +152,13 @@ suite('KeyboardHelper', function() {
 
   test('requests initial settings', function() {
     var requests = MockNavigatorSettings.mRequests;
-    assert.equal(requests.length, 26);
+    assert.equal(requests.length, 25);
     assert.ok(DEFAULT_KEY in requests[0].result, 'requested defaults');
     assert.ok(ENABLED_KEY in requests[1].result, 'requested enabled');
-    assert.ok(CURRENT_ACTIVE in requests[2].result, 'active enabled');
 
     var i = 0;
     for (var key in DEPRECATE_KEYBOARD_SETTINGS) {
-      assert.ok(DEPRECATE_KEYBOARD_SETTINGS[key] in requests[3 + i].result,
+      assert.ok(DEPRECATE_KEYBOARD_SETTINGS[key] in requests[2 + i].result,
                 'requested deprecated settings - ' +
                 DEPRECATE_KEYBOARD_SETTINGS[key]);
       i++;
@@ -668,9 +666,9 @@ suite('KeyboardHelper', function() {
     suite('old settings: cs enabled', function() {
       setup(function() {
         this.sinon.stub(KeyboardHelper, 'saveToSettings');
-        MockNavigatorSettings.mRequests[3].
+        MockNavigatorSettings.mRequests[2].
           result[DEPRECATE_KEYBOARD_SETTINGS.en] = false;
-        MockNavigatorSettings.mRequests[5].
+        MockNavigatorSettings.mRequests[4].
           result[DEPRECATE_KEYBOARD_SETTINGS.cs] = true;
         MockNavigatorSettings.mReplyToRequests();
       });
@@ -691,9 +689,9 @@ suite('KeyboardHelper', function() {
     suite('old settings: serbian enabled', function() {
       setup(function() {
         this.sinon.stub(KeyboardHelper, 'saveToSettings');
-        MockNavigatorSettings.mRequests[3].
+        MockNavigatorSettings.mRequests[2].
           result[DEPRECATE_KEYBOARD_SETTINGS.en] = false;
-        MockNavigatorSettings.mRequests[23].
+        MockNavigatorSettings.mRequests[22].
           result[DEPRECATE_KEYBOARD_SETTINGS.sr] = true;
         MockNavigatorSettings.mReplyToRequests();
       });
@@ -804,15 +802,6 @@ suite('KeyboardHelper', function() {
 
       assert.deepEqual(KeyboardHelper.settings.enabled,
                        expectedSettings.enabled);
-    });
-  });
-
-  suite('Active layouts', function() {
-    test('save layout stores in settings', function() {
-      KeyboardHelper.saveCurrentActiveLayout('yolo', 'en', 'app://something');
-
-      assert.deepEqual(KeyboardHelper.settings.active,
-        { 'yolo': { id: 'en', manifestURL: 'app://something' } });
     });
   });
 });

--- a/shared/test/unit/mocks/mock_keyboard_helper.js
+++ b/shared/test/unit/mocks/mock_keyboard_helper.js
@@ -136,9 +136,7 @@ var MockKeyboardHelper = {
   isKeyboardType: function() {
     return true;
   },
-  changeDefaultLayouts: function() {},
-  getCurrentActiveLayout: function() {},
-  saveCurrentActiveLayout: function() {}
+  changeDefaultLayouts: function() {}
 };
 
 MockKeyboardHelper.mSuiteSetup = MockKeyboardHelper.mSetup;

--- a/tv_apps/smart-system/js/input_layouts.js
+++ b/tv_apps/smart-system/js/input_layouts.js
@@ -1,4 +1,4 @@
-/* global KeyboardHelper */
+/* global KeyboardHelper, SettingsCache */
 
 'use strict';
 
@@ -56,15 +56,22 @@
       this._groupToTypeTable[group] = this._groupToTypeTable[group] || [];
       this._groupToTypeTable[group].push(type);
     }, this);
+
+    this._currentActiveLayouts = {};
+
+    this._promise = null;
   };
 
   InputLayouts.prototype.start = function il_start() {
-
+    this._getSettings();
   };
 
   InputLayouts.prototype.stop = function il_stop() {
-
+    this._promise = null;
   };
+
+  InputLayouts.prototype.SETTINGS_KEY_CURRENT_ACTIVE =
+    'keyboard.current-active-layouts';
 
   InputLayouts.prototype._transformLayout =
     function il_transformLayout(layout) {
@@ -163,14 +170,6 @@
     });
   };
 
-  InputLayouts.prototype.setGroupsActiveLayout =
-    function il_setGroupsActiveLayout(layout) {
-    this._layoutToGroupMapping[layout.manifestURL + '/' + layout.id].forEach(
-      groupInfo => {
-        this.layouts[groupInfo.group].activeLayout = groupInfo.index;
-      });
-  };
-
   InputLayouts.prototype.processLayouts =
     function il_processLayouts(appLayouts) {
     this.layouts = {};
@@ -183,12 +182,95 @@
 
     // some initialization
     for (var group in this.layouts) {
-      this.layouts[group].activeLayout = 0;
+      this.layouts[group].activeLayout = undefined;
     }
 
     this._emitLayoutsCount();
 
     return this._enabledApps;
+  };
+
+  // We only care about currentActiveLayout for now
+  InputLayouts.prototype._getSettings = function il_getSettings() {
+    if (!navigator.mozSettings) {
+      throw 'InputLayouts: No mozSettings?';
+    }
+
+    if (!this._promise) {
+      this._promise = new Promise((resolve, reject) => {
+        try{
+          SettingsCache.get(this.SETTINGS_KEY_CURRENT_ACTIVE, value => {
+            if (value) {
+              this._currentActiveLayouts = value;
+            }
+
+            resolve(this._currentActiveLayouts);
+          });
+        } catch (e) {
+          this._promise = null;
+          reject(e);
+        }
+      });
+    }
+
+    return this._promise;
+  };
+
+  // Return the Promise that would resolve to the active layout index of the
+  // group, as indicated by settings
+  InputLayouts.prototype.getGroupCurrentActiveLayoutIndexAsync =
+  function il_getGroupCurrentActiveLayoutIndexAsync(group) {
+    return this._getSettings().then(currentActiveLayouts => {
+      var currentActiveLayout = currentActiveLayouts[group];
+      var currentActiveLayoutIdx;
+
+      if (currentActiveLayout && this.layouts[group]) {
+        this.layouts[group].every((layout, index) => {
+          if (layout.manifestURL === currentActiveLayout.manifestURL &&
+              layout.id === currentActiveLayout.id) {
+            // If so, default to that, saving the users choice
+            currentActiveLayoutIdx = index;
+            return false;
+          }
+          return true;
+        });
+      }
+
+      return currentActiveLayoutIdx;
+    });
+  };
+
+  // Set the active layout index for the groups supported by the layout,
+  // to the bookkeeping variables and into the settings
+  InputLayouts.prototype.saveGroupsCurrentActiveLayout =
+  function il_saveGroupsCurrentActiveLayout(layout) {
+    var supportedGroups = [];
+
+    this._layoutToGroupMapping[layout.manifestURL + '/' + layout.id].forEach(
+      groupInfo => {
+        this.layouts[groupInfo.group].activeLayout = groupInfo.index;
+
+        supportedGroups.push(groupInfo.group);
+      });
+
+    supportedGroups.forEach(group => {
+      var curr = this._currentActiveLayouts[group];
+      if (curr && curr.id === layout.id &&
+          curr.manifestURL === layout.manifestURL) {
+        return;
+      }
+
+      this._currentActiveLayouts[group] = {
+        id: layout.id,
+        manifestURL: layout.manifestURL
+      };
+    });
+
+    var toSet = {};
+    toSet[this.SETTINGS_KEY_CURRENT_ACTIVE] = this._currentActiveLayouts;
+    var req = navigator.mozSettings.createLock().set(toSet);
+    req.onerror =
+      () => console.error('Error while saving currentActiveLayout', req.error);
   };
 
   exports.InputLayouts = InputLayouts;

--- a/tv_apps/smart-system/js/keyboard_manager.js
+++ b/tv_apps/smart-system/js/keyboard_manager.js
@@ -202,35 +202,38 @@ var KeyboardManager = {
       group = 'text';
     }
 
-      var previousLayout = this._showingLayoutInfo.layout;
+    var previousLayout = this._showingLayoutInfo.layout;
 
-      // Get the last keyboard the user used for this group
-      var currentActiveLayout = KeyboardHelper.getCurrentActiveLayout(group);
-      var currentActiveLayoutIdx;
-      if (currentActiveLayout && this.inputLayouts.layouts[group]) {
-        for (var i = 0; i < this.inputLayouts.layouts[group].length; i++) {
-          // See if we still have that keyboard in our current layouts
-          var layout = this.inputLayouts.layouts[group][i];
-          if (layout.manifestURL === currentActiveLayout.manifestURL &&
-              layout.id === currentActiveLayout.id) {
-            // If so, default to that, saving the users choice
-            currentActiveLayoutIdx = i;
-            break;
-          }
-        }
+    var resetPreviousFrame = function() {
+      // We need to reset the previous frame only when we switch to a new frame
+      // this "frame" is decided by layout properties
+      if (previousLayout &&
+          (previousLayout.manifestURL !==
+           this._showingLayoutInfo.layout.manifestURL ||
+           previousLayout.id !== this._showingLayoutInfo.layout.id)
+         ) {
+        this._debug('reset previousFrame.');
+        this.inputFrameManager.resetFrame(previousLayout);
       }
+    }.bind(this);
 
-      this._setKeyboardToShow(group, currentActiveLayoutIdx);
 
-    // We need to reset the previous frame only when we switch to a new frame
-    // this "frame" is decided by layout properties
-    if (previousLayout &&
-        (previousLayout.manifestURL !==
-         this._showingLayoutInfo.layout.manifestURL ||
-         previousLayout.id !== this._showingLayoutInfo.layout.id)
-       ) {
-      this._debug('reset previousFrame.');
-      this.inputFrameManager.resetFrame(previousLayout);
+    if (this.inputLayouts.layouts[group].activeLayout !== undefined) {
+      this._setKeyboardToShow(group);
+      resetPreviousFrame();
+    } else {
+      this.inputLayouts.getGroupCurrentActiveLayoutIndexAsync(group)
+        .then(currentActiveLayoutIdx => {
+          this._setKeyboardToShow(group, currentActiveLayoutIdx);
+          resetPreviousFrame();
+        })
+        .catch(e => {
+          console.error(`KeyboardManager: failed to retrieve
+                         currentActiveLayoutIdx`, e);
+          // launch keyboard anyway, just don't assign a default layout
+          this._setKeyboardToShow(group);
+          resetPreviousFrame();
+        });
     }
   },
 
@@ -340,14 +343,12 @@ var KeyboardManager = {
       return;
     }
     if (undefined === index) {
-      index = this.inputLayouts.layouts[group].activeLayout;
+      index = this.inputLayouts.layouts[group].activeLayout || 0;
     }
     this._debug('set layout to display: group=' + group + ' index=' + index);
     var layout = this.inputLayouts.layouts[group][index];
     this.inputFrameManager.launchFrame(layout, launchOnly);
     this._setShowingLayoutInfo(group, index, layout);
-
-    this.inputLayouts.setGroupsActiveLayout(layout);
 
     // By setting launchOnly to true, we load the keyboard frame w/o bringing it
     // to the backgorund; this is convenient to call
@@ -357,9 +358,7 @@ var KeyboardManager = {
       return;
     }
 
-    this.inputLayouts.layouts[group].activeLayout = index;
-    KeyboardHelper.saveCurrentActiveLayout(group,
-      layout.id, layout.manifestURL);
+    this.inputLayouts.saveGroupsCurrentActiveLayout(layout);
 
     // Make sure we are not in the transition out state
     // while user foucus quickly again.


### PR DESCRIPTION
- Also, properly define the undefiness of activeLayout in InputLayout's layouts.
