### PR TITLE
Bug 1096603 - (reopened) Fix blank FxA screen by loading renamed service.js file r=gduan

### DIFF
--- a/apps/system/fxa/fxa_module.html
+++ b/apps/system/fxa/fxa_module.html
@@ -26,7 +26,7 @@
     <link rel="import" href="elements/fxa-refresh-auth.html">
     <link rel="import" href="elements/fxa-coppa.html">
 
-    <script defer src="../js/system.js"></script>
+    <script defer src="../js/service.js"></script>
     <script defer src="../js/ftu_launcher.js"></script>
     <script defer src="../js/browser_frame.js"></script>
     <script defer src="../js/entry_sheet.js"></script>


### PR DESCRIPTION
See Bugzilla for discussion.
