### PR TITLE
Bug 1100319 - [v2.2] Disable test_fmradio_find_stations.py due to Bug 10...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/fmradio/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/fmradio/manifest.ini
@@ -8,6 +8,7 @@ external = false
 skip-if = device == "desktop"
 
 [test_fmradio_find_stations.py]
+disabled = Bug 1000863 - Investigate test_fmradio_find_stations.py failure
 skip-if = device == "desktop"
 
 [test_fmradio_frequency_dialer.py]


### PR DESCRIPTION
...00863
