### PR TITLE
Bug 1073433 - [Flatfish][Settings][UI] The USB storage icon in left settings panel is out of alignment.

### DIFF
--- a/apps/settings/elements/root.html
+++ b/apps/settings/elements/root.html
@@ -183,7 +183,7 @@
             <input class="usb-switch" data-ignore type="checkbox">
             <span></span>
           </label>
-          <label id="menuItem-enableStorage" class="name">
+          <label id="menuItem-enableStorage" class="name pack-switch">
             <span class="menu-item" data-icon="usb" data-l10n-id="enableUSBStorage1">USB storage</span>
             <small class="usb-desc menu-item-desc">Disabled</small>
           </label>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1073433
