### PR TITLE
Bug 1092440 - Email should follow text selection pattern

### DIFF
--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -7,6 +7,20 @@
   visibility: hidden !important;
 }
 
+* {
+  /* By default do not allow any user text selection, only enable for certain
+     parts on a per-element/region area */
+  -moz-user-select: none;
+}
+
+/* Allow inputs to be selectable, and to allow cut/copy operations */
+input[type="email"],
+input[type="search"],
+input[type="text"],
+input[type="url"] {
+  -moz-user-select: text;
+}
+
 html {
   width: 100%;
   height: 100%;

--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -128,6 +128,7 @@ input.cmp-subject-text {
   outline: 0;
   white-space: pre-wrap;
   word-wrap: break-word;
+  -moz-user-select: text;
 }
 
 .cmp-body-html {

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -318,6 +318,7 @@ reflows. Foreground/background colors should be safe.
   font-weight: 500;
   color: #5f5f5f;
   word-wrap: break-word;
+  -moz-user-select: text;
 }
 
 .msg-body-container {
@@ -326,6 +327,12 @@ reflows. Foreground/background colors should be safe.
   line-height: 2rem;
   margin: 1rem 1.5rem;
   word-wrap: break-word;
+}
+
+/* Plain text emails with their structured DOM created for the reader should
+   all have selectable text. */
+.msg-body-container * {
+  -moz-user-select: text;
 }
 
 .msg-peep-bubble {

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -140,6 +140,7 @@ cards-setup-done .sup-form-btn.recommend {
   word-wrap: break-word;
   padding: 1rem 1.5rem 0;
   font-size: 1.6rem;
+  -moz-user-select: text;
 }
 
 .tng-list {


### PR DESCRIPTION
This pull request sets it up so that no elements are user selectable as a baseline, then selectively enables:
- The input text entries we have. I included "url" just in case we have one later.
- I enabled text selection in the text entries for the signature, and for the email body compose area. I did this to allow easy cut/paste capabilities while composing text in those fields.
- Plain text email bodies in the message_reader are selectable. I chose to use a \* selector to allow that structure to change. I originally had a -moz-user-select style on each of the selectors in the CSS for those sub-DOM elements, but it seemed fragile to change later. So I am trading future flexibility for a slower selector. I am fine taking the tradeoff the other way though. Do not see a perf hit at user scale.

I originally tried just selecting `-moz-user-select: none` on the body, hoping other elements would inherit it but that did not seem to work. So I went with the \* selectors.

I had a change to add  "copy" menu item to the peep bubble contact menu, and dispatched a [ClipboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent.ClipboardEvent) on `document` for a 'copy' with the peep.address, but that did not seem to lead to it showing up as an option for paste text. So I did not include that change here, may need some upgrades to the copy/paste plumbing.

I tested copying rich text HTML from a web page and pasting it in our compose or signature card areas, and luckily the paste is text only, no HTML tags. So woohoo for that, no changes needed there.
