### PR TITLE
Bug 1102185 - [FFOS2.0][Woodduck][STK]There has no terminal response when execute "setup call ->cancel".

### DIFF
--- a/apps/settings/manifest.webapp
+++ b/apps/settings/manifest.webapp
@@ -52,6 +52,12 @@
       "disposition": "window"
     }
   },
+  "connections": {
+    "settingsstk": {
+      "description": "Communicate between Settings app and System app for SIM Toolkit.",
+      "rules": {}
+    }
+  },
   "locales": {
     "ar": {
       "name": "الضبط",

--- a/apps/system/js/icc.js
+++ b/apps/system/js/icc.js
@@ -78,6 +78,14 @@ var icc = {
         self._toneDefaultTimeout = e.settingValue;
       }
     );
+
+    window.addEventListener('iac-settingsstk', function(evt) {
+      var message = evt.detail;
+      DUMP('STK_System IAC!!!!');
+      if (message === 'StkMenuHidden') {
+        window.dispatchEvent(new CustomEvent('stkMenuHidden'));
+      }
+    });
   },
 
   getIccInfo: function icc_getIccInfo() {
@@ -178,6 +186,7 @@ var icc = {
    * Response ICC Command
    */
   responseSTKCommand: function icc_responseSTKCommand(message, response) {
+    DUMP('sendStkResponse to message: ', message);
     DUMP('STK sendStkResponse -- # response = ', response);
     var _icc = icc.getIcc(message.iccId);
     _icc && _icc.sendStkResponse(message.command, response);
@@ -425,11 +434,21 @@ var icc = {
     );
 
     var self = this;
+
+    function stkMenuHiddenHandler(event) {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
+      self.hideViews();
+      callback(false);
+    }
+    window.addEventListener('stkMenuHidden', stkMenuHiddenHandler);
+
     this.icc_asyncconfirm_btn_no.onclick = function rejectConfirm() {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
       self.hideViews();
       callback(false);
     };
     this.icc_asyncconfirm_btn_yes.onclick = function acceptConfirm() {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
       self.hideViews();
       callback(true);
     };
@@ -508,11 +527,19 @@ var icc = {
         timeoutId = null;
       }
     }
+    function stkMenuHiddenHandler(event) {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
+      clearInputTimeout();
+      self.hideViews();
+      self.terminateResponse(stkMessage);
+      callback(null);
+    }
     function setInputTimeout() {
       DUMP('setting new STK INPUT timeout to - ', timeout);
       if (timeout) {
         clearInputTimeout();
         timeoutId = setTimeout(function() {
+          window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
           self.hideViews();
           callback(false);
         }, timeout);
@@ -583,6 +610,7 @@ var icc = {
           options.maxLength);
       };
       this.icc_input_btn.onclick = function() {
+        window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
         clearInputTimeout();
         self.hideViews();
         callback(true, self.icc_input_box.value);
@@ -592,11 +620,13 @@ var icc = {
       this.icc_input.classList.add('yesnomode');
       this.icc_input_box.type = 'hidden';
       this.icc_input_btn_yes.onclick = function(event) {
+        window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
         clearInputTimeout();
         self.hideViews();
         callback(true, true);
       };
       this.icc_input_btn_no.onclick = function(event) {
+        window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
         clearInputTimeout();
         self.hideViews();
         callback(true, false);
@@ -611,18 +641,24 @@ var icc = {
 
     // STK Default response (BACK, CLOSE and HELP)
     this.icc_input_header.addEventListener('action', function() {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
       clearInputTimeout();
       self.hideViews();
       self.backResponse(stkMessage);
       callback(null);
     });
+
+    window.addEventListener('stkMenuHidden', stkMenuHiddenHandler);
+
     this.icc_input_btn_close.onclick = function() {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
       clearInputTimeout();
       self.hideViews();
       self.terminateResponse(stkMessage);
       callback(null);
     };
     this.icc_input_btn_help.onclick = function() {
+      window.removeEventListener('stkMenuHidden', stkMenuHiddenHandler);
       clearInputTimeout();
       self.hideViews();
       self.responseSTKCommand(stkMessage, {

--- a/apps/system/js/icc_worker.js
+++ b/apps/system/js/icc_worker.js
@@ -299,17 +299,6 @@ var icc_worker = {
 
     DUMP('STK Input title: ' + options.text);
 
-    document.addEventListener('visibilitychange',
-      function stkInputNoAttended() {
-        document.removeEventListener('visibilitychange', stkInputNoAttended,
-          true);
-        icc.responseSTKCommand(message, {
-          resultCode:
-            icc._iccManager.STK_RESULT_UICC_SESSION_TERM_BY_USER
-        });
-        icc.hideViews();
-      }, true);
-
     var duration = options.duration;
     var timeout = (duration &&
       icc.calculateDurationInMS(duration.timeUnit, duration.timeInterval)) ||

--- a/apps/system/manifest.webapp
+++ b/apps/system/manifest.webapp
@@ -118,6 +118,10 @@
       "description": "Communication with bluetooth apps for sending files info",
       "rules": {}
     },
+    "settingsstk": {
+      "description": "Communicate between Settings app and System app for SIM Toolkit.",
+      "rules": {}
+    },
     "fxa-mgmt": {
       "description": "Firefox Accounts management API",
       "rules": {

--- a/apps/system/test/unit/icc_test.js
+++ b/apps/system/test/unit/icc_test.js
@@ -124,6 +124,19 @@ suite('STK (icc) >', function() {
         }
       },
 
+      STK_CMD_SET_UP_CALL: {
+        iccId: '1010011010',
+        command: {
+          commandNumber: 1,
+          typeOfCommand: navigator.mozIccManager.STK_CMD_SET_UP_CALL,
+          commandQualifier: 0,
+          options: {
+            confirmMessage: 'STK_CMD_SET_UP_IDLE_MODE_TEXT Unit Test',
+            address: '990022'
+          }
+        }
+      },
+
       STK_CMD_REFRESH: {
         iccId: '1010011010',
         command: {
@@ -433,4 +446,26 @@ suite('STK (icc) >', function() {
     };
     launchStkCommand(stkTestCommands.STK_CMD_REFRESH);
   });
+
+  test('settings visibilitychange - STK_CMD_GET_INPUT', function(done) {
+    var testCmd = stkTestCommands.STK_CMD_GET_INPUT;
+    window.icc.input(testCmd, testCmd.command.options.text, 40000,
+      stkTestCommands.STK_CMD_GET_INPUT.command.options,
+      function(resultObject) {
+        assert.equal(resultObject, null);
+        done();
+    });
+    window.dispatchEvent(new CustomEvent('stkMenuHidden'));
+  });
+
+  test('settings visibilitychange - STK_CMD_SET_UP_CALL', function(done) {
+    var testCmd = stkTestCommands.STK_CMD_SET_UP_CALL;
+    window.icc.asyncConfirm(testCmd, testCmd.command.options.confirmMessage,
+      function(resultBoolean) {
+        assert.equal(resultBoolean, false);
+        done();
+    });
+    window.dispatchEvent(new CustomEvent('stkMenuHidden'));
+  });
+
 });

--- a/apps/system/test/unit/icc_worker_test.js
+++ b/apps/system/test/unit/icc_worker_test.js
@@ -207,14 +207,4 @@ suite('STK (icc_worker) >', function() {
     launchStkCommand(stkTestCommands.STK_CMD_PLAY_TONE);
   });
 
-  test('visibilitychange => STK_RESULT_UICC_SESSION_TERM_BY_USER',
-    function(done) {
-      window.icc.onresponse = function(message, response) {
-        window.icc.onresponse = function() {};  // Avoid multiple calls
-        assert.equal(response.resultCode,
-          navigator.mozIccManager.STK_RESULT_UICC_SESSION_TERM_BY_USER);
-        done();
-      };
-      document.dispatchEvent(new CustomEvent('visibilitychange'));
-    });
 });


### PR DESCRIPTION
PR for bug 1102185 
- Clear the event of onVisibilityChange when any option is clicked.
- Redirect visibilityChange of Settings to System app. System app handles the event is a better strategy.
- Add test case to handle on visibility change event from Settings app.
