### PR TITLE
Bug 1059650 - [Browser]Back button stops working after clicking '+' icon...

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1620,10 +1620,16 @@ var Browser = {
       this.tab.style.left = e.detail.absolute.dx + 'px';
     },
 
-    tap: function tabSwipe_tap() {
+    tap: function tabSwipe_tap(e) {
       if (this.browser.inTransition) {
         return;
       }
+
+      this.isCloseButton = e.target.nodeName === 'BUTTON';
+      this.tab = this.isCloseButton ? e.target.parentNode : e.target;
+      this.id = this.tab.getAttribute('data-id');
+      this.containerWidth = this.tab.parentNode.clientWidth;
+
       if (this.isCloseButton) {
         this.tab.style.left = '0px';
         this.deleteTab(100, this.containerWidth);


### PR DESCRIPTION
... multiple times
- Doesn't rely on 'mousedown' event to get the tab ID, use 'tap' event to select tab ID directly
