### PR TITLE
Bug 1053709 - Make SMS messages content UI RTL-friendly

### DIFF
--- a/apps/sms/js/desktop-only/navigator_moz_mobilemessage.js
+++ b/apps/sms/js/desktop-only/navigator_moz_mobilemessage.js
@@ -867,11 +867,66 @@
     receiver: '+197121111111',
     read: true,
     body: 'مرحبا!',
+    id: messagesDb.id++,
     delivery: 'sent',
     deliveryStatus: 'success',
     deliveryTimestamp: now - (60000000 * 20),
     type: 'sms',
     timestamp: now - (60000000 * 20)
+  }, {
+    threadId: 13,
+    sender: '+197121111111',
+    receiver: null,
+    read: true,
+    subject: 'Subject field',
+    smil: '<smil><body><par><text src="text1"/></par></body></smil>',
+    attachments: [{
+      location: 'text1',
+      content: new Blob(
+        ['هذا هو الاختبار باللغة العربية\n' +
+         'This is the Arabic bidi message content test\n'],
+        { type: 'text/plain' }
+      )
+    }],
+    id: messagesDb.id++,
+    delivery: 'received',
+    deliveryInfo: [{deliveryStatus: 'success'}],
+    deliveryTimestamp: now - (60000000 * 15),
+    type: 'mms',
+    timestamp: now - (60000000 * 15)
+  }, {
+    threadId: 13,
+    sender: '+197121111111',
+    receiver: null,
+    read: true,
+    body: 'هذا هو رقم هاتفي: 1234-5678\n' +
+      'your email?',
+    id: messagesDb.id++,
+    delivery: 'received',
+    deliveryStatus: 'success',
+    deliveryTimestamp: now - (60000000 * 10),
+    type: 'sms',
+    timestamp: now - (60000000 * 10)
+  }, {
+    threadId: 13,
+    sender: null,
+    receiver: '+197121111111',
+    read: true,
+    subject: 'رئيسية',
+    smil: '<smil><body><par><text src="text1"/></par></body></smil>',
+    attachments: [{
+      location: 'text1',
+      content: new Blob(
+        ['ok\n' + 'abc@mail.com\n' + 'see you! ' + 'أراك!'],
+        { type: 'text/plain' }
+      )
+    }],
+    id: messagesDb.id++,
+    delivery: 'sent',
+    deliveryInfo: [{deliveryStatus: 'success'}],
+    deliveryTimestamp: now - (60000000 * 5),
+    type: 'mms',
+    timestamp: now - (60000000 * 5)
   });
 
   messagesDb.messages.push({
@@ -892,7 +947,6 @@
     type: 'mms',
     timestamp: now - (60000000 * 20)
   });
-
 
   // Internal publisher/subscriber implementation
   var allHandlers = {};

--- a/apps/sms/style/attachment.css
+++ b/apps/sms/style/attachment.css
@@ -37,8 +37,8 @@
 }
 
 .article-list[data-type="list"] .message.outgoing .attachment-container {
-  margin-left: auto;
-  margin-right: 0;
+  -moz-margin-start: auto;
+  -moz-margin-end: 0;
 }
 
 /**
@@ -125,6 +125,8 @@
 
 .nopreview .file-name {
   display: block;
+
+  unicode-bidi: -moz-plaintext;
 }
 
 .thumbnail {

--- a/apps/sms/style/message.css
+++ b/apps/sms/style/message.css
@@ -1,11 +1,11 @@
 .message.incoming {
-  padding-left: 1.5rem;
-  padding-right: 4rem;
+  -moz-padding-start: 1.5rem;
+  -moz-padding-end: 4rem;
 }
 
 .message.outgoing {
-  padding-left: 4rem;
-  padding-right: 1.5rem;
+  -moz-padding-start: 4rem;
+  -moz-padding-end: 1.5rem;
 }
 
 .message .bubble {
@@ -90,6 +90,8 @@
   font-size: 1.4rem;
   font-style: italic;
   line-height: 1.7rem;
+
+  unicode-bidi: -moz-plaintext;
 }
 
 .message.has-subject .message-subject {
@@ -100,6 +102,10 @@
 .message-content a {
   color: #004eff;
   text-decoration: underline;
+}
+
+.message-content > p {
+  unicode-bidi: -moz-plaintext;
 }
 
 .message-details {
@@ -197,4 +203,17 @@
 .message.pending .download {
   border-color: transparent;
   opacity: 0.8;
+}
+
+/* RTL for message bubble float direction and border-radius*/
+.message.outgoing .bubble:-moz-dir(rtl) {
+  float: left;
+
+  border-radius: 0 1.5rem 1.5rem 1.5rem;
+}
+
+.message.incoming .bubble:-moz-dir(rtl) {
+  float: right;
+
+  border-radius: 1.5rem 0 1.5rem 1.5rem;
 }

--- a/apps/sms/style/sms.css
+++ b/apps/sms/style/sms.css
@@ -966,11 +966,11 @@ html[dir="rtl"] .edit #threads-container[data-type="list"] aside.pack-end span {
 
 /* RTL for thread view */
 
-html[dir="rtl"] .edit .message.incoming .bubble {
+html[dir="rtl"] .edit .message.outgoing .bubble {
   transform: translateX(0);
 }
 
-html[dir="rtl"] .edit .message.outgoing .bubble {
+html[dir="rtl"] .edit .message.incoming .bubble {
   transform: translateX(-2.5rem);
 }
 


### PR DESCRIPTION
- Mirror the incoming/outgoing message bubble layout
- Use  unicode-bidi: -moz-plaintext to display the content properly
