### PR TITLE
Bug 1100860 - [email/UI] message_reader should filter move targets

### DIFF
--- a/apps/email/js/cards/message_reader.js
+++ b/apps/email/js/cards/message_reader.js
@@ -388,7 +388,9 @@ return [
         var op = this.header.moveMessage(folder);
         cards.removeCardAndSuccessors(this, 'animate');
         toaster.toastOperation(op);
-      }.bind(this));
+      }.bind(this), function(folder) {
+        return folder.isValidMoveTarget;
+      });
     },
 
     /**


### PR DESCRIPTION
The message_list card already does this.  Without this fix it's possible
to break the back-end, at least for ActiveSync.  Spinning off a separate
bug to harden the back-end, specifically ActiveSync.
