### PR TITLE
Bug 1099374 - Add the target attribute to links r=eragonj

### DIFF
--- a/apps/settings/resources/open_source_license.html
+++ b/apps/settings/resources/open_source_license.html
@@ -31,12 +31,12 @@
 <body>
 <h1>Open Source Licensing Information</h1>
 
-<p> The <a href="http://www.opensource.org/docs/definition.php">open source</a> and
-<a href="http://www.gnu.org/philosophy/free-sw.html">free software</a> in
+<p> The <a href="http://www.opensource.org/docs/definition.php" target="_blank">open source</a> and
+<a href="http://www.gnu.org/philosophy/free-sw.html" target="_blank">free software</a> in
 this product is available under one of the following licenses. These licenses
 give you the freedom to run the software, study it, change it to meet your
 needs, and share your changes with others. You can
-<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Boot_to_Gecko/Building_and_installing_Firefox_OS">download the source code</a>
+<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Boot_to_Gecko/Building_and_installing_Firefox_OS" target="_blank">download the source code</a>
 from Mozilla. Please consult the source to see which license applies to which
 parts of the code.
 </p>
@@ -347,14 +347,14 @@ liability.</p>
         <p>This product contains code from the following LGPLed libraries:</p>
 
 <ul>
-<li>Headers from <a href="http://www.yaffs.net/">yaffs2</a>
-<li><a href="http://developer.gnome.org/glib/">glib</a>
-<li><a href="http://www.bluez.org/">bluez</a>
-<li><a href="http://www.surina.net/soundtouch/">libsoundtouch</a></li>
-<li><a href="http://e2fsprogs.sourceforge.net/">e2fsprogs</a></li>
-<li><a href="https://git.gnome.org/browse/atk">ATK</a></li>
-<li><a href="https://libav.org/">libav</a></li>
-<li><a href="http://qjson.sourceforge.net/">QJson</a></li>
+<li>Headers from <a href="http://www.yaffs.net/" target="_blank">yaffs2</a>
+<li><a href="http://developer.gnome.org/glib/" target="_blank">glib</a>
+<li><a href="http://www.bluez.org/" target="_blank">bluez</a>
+<li><a href="http://www.surina.net/soundtouch/" target="_blank">libsoundtouch</a></li>
+<li><a href="http://e2fsprogs.sourceforge.net/" target="_blank">e2fsprogs</a></li>
+<li><a href="https://git.gnome.org/browse/atk" target="_blank">ATK</a></li>
+<li><a href="https://libav.org/" target="_blank">libav</a></li>
+<li><a href="http://qjson.sourceforge.net/" target="_blank">QJson</a></li>
 <li>and various bits of the Linux kernel</li>
 </ul>
 
@@ -5508,7 +5508,7 @@ THE SOFTWARE.        </pre>
                             <li>Copyright © 2004 Imendio HB</li>
                         </ul>
                 
-        <pre>This software contains dbus, which is licensed under the <a href="http://spdx.org/licenses/AFL-2.1">Academic Free License version 2.1</a>. See the links at the top of the page for details of how to download the source code.        </pre>
+        <pre>This software contains dbus, which is licensed under the <a href="http://spdx.org/licenses/AFL-2.1" target="_blank">Academic Free License version 2.1</a>. See the links at the top of the page for details of how to download the source code.        </pre>
                                                                                                          
             <hr>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1099374
