### PR TITLE
Bug 1102220 - Always place apps in the last group when installing. r=kgrandon,crdlc

### DIFF
--- a/apps/sharedtest/test/unit/elements/gaia_grid/gaia_grid_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/gaia_grid_test.js
@@ -147,7 +147,7 @@ suite('GaiaGrid', function() {
       assert.equal(items[items.length - 1], divider);
     });
 
-    test('appendItemToExpandedGroup adds after collapsed divider', function() {
+    test('appendItemToExpandedGroup expands collapsed divider', function() {
       element.clear();
 
       var divider = new GaiaGrid.Divider();
@@ -160,7 +160,7 @@ suite('GaiaGrid', function() {
 
       var items = element.getItems();
       assert.ok(items.length > itemLength);
-      assert.equal(items[itemLength], fakeBookmarkItem2);
+      assert.notEqual(divider.detail.collapsed, true);
     });
 
     test('clear will dereference item elements', function() {

--- a/shared/elements/gaia_grid/script.js
+++ b/shared/elements/gaia_grid/script.js
@@ -133,8 +133,8 @@ window.GaiaGrid = (function(win) {
   };
 
   /**
-   * If the last item is a collapsed divider, appends the item after said
-   * divider. Otherwise falls back to appendItem().
+   * If the last item is a collapsed divider, expand that divider before
+   * appending the item.
    */
   proto.appendItemToExpandedGroup = function(item) {
     var items = this._grid.items;
@@ -142,10 +142,10 @@ window.GaiaGrid = (function(win) {
 
     if (items[lastIndex].detail.type === 'divider' &&
         items[lastIndex].detail.collapsed) {
-      this.add(item);
-    } else {
-      this.appendItem(item);
+      items[lastIndex].expand();
     }
+
+    this.appendItem(item);
   };
 
   /**


### PR DESCRIPTION
If the last group is collapsed, instead of placing newly installed apps
into a new group, expand that group and place it there as normal.
