### PR TITLE
Bug 1095805 - Update modal dialog height on resize event and not visible +autoland

### DIFF
--- a/apps/system/js/modal_dialog.js
+++ b/apps/system/js/modal_dialog.js
@@ -153,10 +153,8 @@ var ModalDialog = {
   },
 
   updateHeight: function sd_updateHeight() {
-    if (this.isVisible()) {
-      var height = window.layoutManager.height - StatusBar.height;
-      this.overlay.style.height = height + 'px';
-    }
+    var height = window.layoutManager.height - StatusBar.height;
+    this.overlay.style.height = height + 'px';
   },
 
   // Show relative dialog and set message/input value well

--- a/apps/system/test/unit/modal_dialog_test.js
+++ b/apps/system/test/unit/modal_dialog_test.js
@@ -222,5 +222,12 @@ suite('system/ModalDialog >', function() {
 
       ModalDialogCleanUp();
     });
+
+    test('updateHeight on resize event and not visible', function() {
+      ModalDialog.overlay.style.height = '';
+      this.sinon.stub(ModalDialog, 'isVisible').returns(false);
+      window.dispatchEvent(new CustomEvent('resize'));
+      assert.ok(parseInt(ModalDialog.overlay.style.height, 10) > 0);
+    });
   });
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1095805
