### PR TITLE
1092573: include Latvian (lv) in FxOS builds

### DIFF
--- a/build/config/keyboard-layouts.json
+++ b/build/config/keyboard-layouts.json
@@ -115,6 +115,9 @@
     "lij": [
         {"layoutId": "en", "app": ["apps", "keyboard"]}
     ],
+     "lv": [
+        {"layoutId": "en", "app": ["apps", "keyboard"]}
+    ],
     "mk": [
         {"layoutId": "mk", "app": ["apps", "keyboard"]}
     ],

--- a/locales/languages_all.json
+++ b/locales/languages_all.json
@@ -41,6 +41,7 @@
   "ko"        : "한국어",
   "lij"       : "Ligure",
   "lt"        : "Lietuvių",
+  "lv"        : "Latviešu valoda",
   "mai"       : "मैथिली",
   "mk"        : "Македонски",
   "ml"        : "മലയാളം",


### PR DESCRIPTION
related to https://bugzilla.mozilla.org/show_bug.cgi?id=1092573
