### PR TITLE
Bug 1103559 - Voicemail, Captive Portal and Roaming notifications should not be resent r=mherentty

### DIFF
--- a/apps/system/js/captive_portal.js
+++ b/apps/system/js/captive_portal.js
@@ -58,7 +58,10 @@ var CaptivePortal = {
     var options = {
       body: message,
       icon: icon,
-      tag: this.notificationPrefix + networkName
+      tag: this.notificationPrefix + networkName,
+      mozbehavior: {
+        showOnlyOnce: true
+      }
     };
 
     this.notification = new Notification('', options);

--- a/apps/system/js/eu_roaming_manager.js
+++ b/apps/system/js/eu_roaming_manager.js
@@ -267,7 +267,10 @@
       var options = {
         body: _('euRoamingNotificationMsg'),
         icon: iconUrl,
-        tag: this.TAG_PREFIX + serviceId
+        tag: this.TAG_PREFIX + serviceId,
+        mozbehavior: {
+          showOnlyOnce: true
+        }
       };
       var notification =
         new Notification(_('euRoamingNotificationTitle'), options);

--- a/apps/system/js/voicemail.js
+++ b/apps/system/js/voicemail.js
@@ -93,7 +93,10 @@ var Voicemail = {
     var notifOptions = {
       body: text,
       icon: this.icon,
-      tag: this.tagPrefix + serviceId
+      tag: this.tagPrefix + serviceId,
+      mozbehavior: {
+        showOnlyOnce: true
+      }
     };
 
     var notification = new Notification(title, notifOptions);

--- a/apps/system/test/marionette/notification_resend_block_test.js
+++ b/apps/system/test/marionette/notification_resend_block_test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/* globals Notification */
+
+var assert = require('assert');
+
+var CALENDAR_APP = 'app://calendar.gaiamobile.org';
+
+marionette('mozChromeNotifications:', function() {
+
+  var client = marionette.client({
+    settings: {
+      'ftu.manifestURL': null,
+      'lockscreen.enabled': false
+    }
+  });
+
+  test('Sending one notification, resends none', function(done) {
+    var notificationTitle = 'Title:' + Date.now();
+
+    // switch to calendar app and send notification
+    client.apps.launch(CALENDAR_APP);
+    client.apps.switchToApp(CALENDAR_APP);
+    var error = client.executeAsyncScript(function(title) {
+      var options = {
+        mozbehavior: {
+          showOnlyOnce: true
+        }
+      };
+      var notification = new Notification(title, options);
+      notification.addEventListener('show', function() {
+        marionetteScriptFinished(false);
+      });
+    }, [notificationTitle]);
+    assert.equal(error, false, 'Error on sending notification: ' + error);
+
+    // switch to system app and trigger resending
+    client.switchToFrame();
+    error = client.executeAsyncScript(function() {
+      var resendCb = (function(number) {
+        if (number !== 0) {
+          marionetteScriptFinished(
+            'Unexpected number of resent notifications: ' + number +
+            ' instead of 0.');
+        }
+
+        marionetteScriptFinished(false);
+      }).bind(this);
+      navigator.mozChromeNotifications.mozResendAllNotifications(resendCb);
+    });
+    assert.equal(error, false, 'Error on one resend: ' + error);
+    done();
+  });
+
+});

--- a/apps/system/test/unit/captive_portal_test.js
+++ b/apps/system/test/unit/captive_portal_test.js
@@ -20,7 +20,6 @@ requireApp('system/test/unit/mocks_helper.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
 requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
-requireApp('system/shared/test/unit/mocks/mock_notification.js');
 requireApp('system/test/unit/mock_wifi_manager.js');
 requireApp('system/test/unit/mock_activity.js');
 requireApp('system/test/unit/mock_app_window_manager.js');
@@ -32,7 +31,6 @@ requireApp('system/js/ftu_launcher.js');
 
 var mocksForCaptivePortal = new MocksHelper([
   'SettingsListener',
-  'Notification',
   'AppWindowManager'
 ]).init();
 
@@ -126,12 +124,16 @@ suite('captive portal > ', function() {
   });
 
   test('system/captive portal login', function() {
-    var sendSpy = this.sinon.spy(window, 'Notification');
+    var sendSpy = this.sinon.stub(window, 'Notification').returns({
+      addEventListener: function() {},
+      close: function() {}
+    });
     CaptivePortal.handleEvent(event);
     sinon.assert.called(sendSpy);
-    var notification = sendSpy.firstCall.thisValue;
+    var notification = sendSpy.firstCall.args[1];
     assert.equal(notification.body, expectedBody);
     assert.equal(notification.tag, expectedTag);
+    assert.equal(notification.mozbehavior.showOnlyOnce, true);
   });
 
   test('system/captive portal open activity url', function() {
@@ -153,12 +155,16 @@ suite('captive portal > ', function() {
   });
 
   test('system/captive portal login again', function() {
-    var sendSpy = this.sinon.spy(window, 'Notification');
+    var sendSpy = this.sinon.stub(window, 'Notification').returns({
+      addEventListener: function() {},
+      close: function() {}
+    });
     CaptivePortal.handleEvent(event);
     sinon.assert.called(sendSpy);
-    var notification = sendSpy.firstCall.thisValue;
+    var notification = sendSpy.firstCall.args[1];
     assert.equal(notification.body, expectedBody);
     assert.equal(notification.tag, expectedTag);
+    assert.equal(notification.mozbehavior.showOnlyOnce, true);
   });
 
   test('system/captive portal login abort', function() {

--- a/apps/system/test/unit/eu_roaming_manager_test.js
+++ b/apps/system/test/unit/eu_roaming_manager_test.js
@@ -546,6 +546,7 @@ suite('system/EuRoamingManager', function() {
         this.euRoamingManager.TAG_PREFIX + this.targetIndex);
       assert.equal(notificationOption.body,
         'euRoamingNotificationMsg');
+      assert.equal(notificationOption.mozbehavior.showOnlyOnce, true);
     });
 
     test('should trigger settings activity when clicking on it', function() {

--- a/apps/system/test/unit/voicemail_test.js
+++ b/apps/system/test/unit/voicemail_test.js
@@ -1,6 +1,4 @@
-'use strict';
-/* global
-   MocksHelper,
+/* global MocksHelper,
    MockL10n,
    MockMozActivity,
    MockNavigatorMozTelephony,
@@ -10,10 +8,11 @@
    MockSIMSlotManager,
    ModalDialog,
    Notification,
-   SettingsHelper,
    SIMSlotManager,
    Voicemail
 */
+
+'use strict';
 
 requireApp('system/js/voicemail.js');
 requireApp('system/shared/js/settings_helper.js');
@@ -58,8 +57,8 @@ suite('voicemail notification', function() {
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
 
-    realSettingsHelper = SettingsHelper;
-    SettingsHelper = MockSettingsHelper;
+    realSettingsHelper = window.SettingsHelper;
+    window.SettingsHelper = MockSettingsHelper;
 
     realMozTelephony = navigator.mozTelephony;
     navigator.mozTelephony = MockNavigatorMozTelephony;
@@ -84,7 +83,7 @@ suite('voicemail notification', function() {
     navigator.mozSettings = realMozSettings;
     navigator.mozL10n = realL10n;
     window.SIMSlotManager = realSIMSlotManager;
-    SettingsHelper = realSettingsHelper;
+    window.SettingsHelper = realSettingsHelper;
     navigator.mozTelephony = realMozTelephony;
     window.MozActivity = realMozActivity;
   });
@@ -323,6 +322,9 @@ suite('voicemail notification', function() {
               assert.equal(notificationSpy.firstCall.args[1].body, 'bbbb');
               assert.equal(notificationSpy.firstCall.args[1].tag,
                            'voicemailNotification:' + serviceId);
+              assert.equal(
+                notificationSpy.firstCall.args[1].mozbehavior.showOnlyOnce,
+                true);
 
               if (this.isMultiSIM) {
                 assert.equal(

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -338,7 +338,6 @@ apps/system/test/unit/storage_watcher_test.js
 apps/system/test/unit/updatable_test.js
 apps/system/test/unit/update_manager_test.js
 apps/system/test/unit/utility_tray_test.js
-apps/system/test/unit/voicemail_test.js
 apps/system/test/unit/wifi_test.js
 apps/system/test/unit/wrapper_factory_test.js
 apps/video/js/db.js


### PR DESCRIPTION
We do not want those notifications to be resent, since they depend on
external conditions:
- Voicemail will be anyway retriggered by RIL code when connecting to
  network,
- Captive Portal will be redetected when reconnecting to the network,
  which may have changed in-between,
- Roaming status will also be redetected when rebooting
  Gecko offers a mozbehavior object which can contain a noresend property.
  We set this for all those notifications. We need, however, to keep the
  cleanup code for migration/upgrade usecase: pre-existing sent
  notification will still need to be cleanup if we don't want them to be
  resent.
