### PR TITLE
Bug 1103697: Revert line that shouldn't have changed in bug 1093862's 2....

### DIFF
--- a/apps/callscreen/js/calls_handler.js
+++ b/apps/callscreen/js/calls_handler.js
@@ -314,7 +314,7 @@ var CallsHandler = (function callsHandler() {
         } else {
           document.body.classList.toggle('no-handled-calls', false);
         }
-      }, timeout);
+      }, CallScreen.callEndPromptTime);
     }
   }
 


### PR DESCRIPTION
...1 merge, to hopefully restore callscreen functionality. r=drs

This commit reverts a line of context that was accidentally (I assume) changed in a merge, introducing an undeclared variable.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1103697#c2 (and subsequent bug-comment) for more info/analysis.  I suspect this will fix bug 1103697 (but we should fix it regardless).
