### PR TITLE
Revert "Bug 1103910 - Xfail test_settings_bluetooth.py because of Bug 11...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -16,8 +16,6 @@ smoketest = true
 skip-if = device == "desktop"
 bluetooth = true
 sanity = true
-# Bug 1102885 - Bluetooth setting gets turned on at each reboot
-expected = fail
 
 [test_settings_wifi.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
...02885"

This reverts commit 23b9233724c0f9a29ca658f0f9462812dea5e4a6.
