### PR TITLE
Bug 1095080 - Fix browser endurance tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/homescreen/regions/search_panel.py
@@ -44,6 +44,9 @@ class SearchPanel(Base):
         self._switch_to_search_results_frame()
 
     def go_to_url(self, url):
+        # If a URL exists already, clear the field
+        self.marionette.find_element(*self._rocketbar_input_locator).clear()
+
         self.keyboard.send(url)
 
         #TODO Remove hack once Bug 1062309 is fixed

--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -963,19 +963,18 @@ class GaiaEnduranceTestCase(GaiaTestCase, EnduranceTestCaseMixin, MemoryEnduranc
         kwargs.pop('checkpoint_interval', None)
 
     def close_app(self):
-        # Close the current app (self.app) by using the home button
-        self.device.touch_home_button()
+        from gaiatest.apps.system.regions.cards_view import CardsView
+        self.cards_view = CardsView(self.marionette)
 
-        # Bring up the cards view
-        _cards_view_locator = ('id', 'cards-view')
+        # Pull up the cards view
         self.device.hold_home_button()
-        self.wait_for_element_displayed(*_cards_view_locator)
+        self.cards_view.wait_for_cards_view()
+
+        # Wait for first app ready
+        self.cards_view.wait_for_card_ready(self.app_under_test.lower())
+
+        # Close the current apps from the cards view
+        self.cards_view.close_app("search")
 
         # Sleep a bit
         time.sleep(5)
-
-        # Tap the close icon for the current app
-        locator_part_two = '#cards-view li.card[data-origin*="%s"] .close-card' % self.app_under_test.lower()
-        _close_button_locator = ('css selector', locator_part_two)
-        close_card_app_button = self.marionette.find_element(*_close_button_locator)
-        close_card_app_button.tap()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_browser_cell.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_browser_cell.py
@@ -7,7 +7,7 @@
 import time
 
 from gaiatest import GaiaEnduranceTestCase
-from gaiatest.apps.browser.app import Browser
+from gaiatest.apps.search.app import Search
 
 
 class TestEnduranceBrowserCell(GaiaEnduranceTestCase):
@@ -16,6 +16,7 @@ class TestEnduranceBrowserCell(GaiaEnduranceTestCase):
 
     def setUp(self):
         GaiaEnduranceTestCase.setUp(self)
+        self.apps.set_permission_by_url(Search.manifest_url, 'geolocation', 'deny')
 
         # Want cell network only
         self.data_layer.disable_wifi()
@@ -26,11 +27,12 @@ class TestEnduranceBrowserCell(GaiaEnduranceTestCase):
 
     def browser_cell(self):
         # Start browser and load page and verify, code taken from test_browser_cell_data.py
-        browser = Browser(self.marionette)
-        browser.launch()
+        search = Search(self.marionette)
+        search.launch()
 
-        browser.go_to_url('http://mozqa.com/data/firefox/layout/mozilla.html', timeout=120)
+        browser = search.go_to_url('http://mozqa.com/data/firefox/layout/mozilla.html')
 
+        browser.wait_for_page_to_load(120)
         browser.switch_to_content()
 
         self.wait_for_element_present(*self._page_title_locator, timeout=120)
@@ -40,9 +42,10 @@ class TestEnduranceBrowserCell(GaiaEnduranceTestCase):
         # Wait a couple of seconds with page displayed
         time.sleep(2)
 
-        # Close the browser using home button
-        self.app = browser
+        # Close browser via cards view
+        self.app_under_test = "search"
         self.close_app()
+        self.app_under_test = "browser"
 
         # Sleep between iterations
         time.sleep(10)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_browser_wifi.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/endurance/test_endurance_browser_wifi.py
@@ -7,7 +7,8 @@
 import time
 
 from gaiatest import GaiaEnduranceTestCase
-from gaiatest.apps.browser.app import Browser
+from gaiatest.apps.search.app import Search
+
 
 class TestEnduranceBrowserWifi(GaiaEnduranceTestCase):
 
@@ -15,6 +16,7 @@ class TestEnduranceBrowserWifi(GaiaEnduranceTestCase):
 
     def setUp(self):
         GaiaEnduranceTestCase.setUp(self)
+        self.apps.set_permission_by_url(Search.manifest_url, 'geolocation', 'deny')
 
         # Want wifi only
         self.data_layer.disable_cell_data()
@@ -26,11 +28,12 @@ class TestEnduranceBrowserWifi(GaiaEnduranceTestCase):
 
     def browser_wifi(self):
         # Start browser and load page and verify, code taken from test_browser_cell_data.py
-        browser = Browser(self.marionette)
-        browser.launch()
+        search = Search(self.marionette)
+        search.launch()
 
-        browser.go_to_url('http://mozqa.com/data/firefox/layout/mozilla.html')
+        browser = search.go_to_url('http://mozqa.com/data/firefox/layout/mozilla.html')
 
+        browser.wait_for_page_to_load(120)
         browser.switch_to_content()
 
         self.wait_for_element_present(*self._page_title_locator, timeout=120)
@@ -40,9 +43,10 @@ class TestEnduranceBrowserWifi(GaiaEnduranceTestCase):
         # Wait a couple of seconds with page displayed
         time.sleep(2)
 
-        # Close the browser using home button
-        self.app = browser
+        # Close browser via cards view
+        self.app_under_test = "search"
         self.close_app()
+        self.app_under_test = "browser"
 
         # Sleep between iterations
         time.sleep(10)


### PR DESCRIPTION
Switch from browser to search app. Clear the rocketbar URL before typing new URL. Update endurance test close_app() method. Mostly cobbled together from existing functional tests.
