### PR TITLE
Bug 1100305 - [browser_navigate_landing_page_test.js] Try re-enabling test by not sending keypress until after app window validation a=testonly +autoland

### DIFF
--- a/apps/system/test/marionette/browser_navigate_landing_page_test.js
+++ b/apps/system/test/marionette/browser_navigate_landing_page_test.js
@@ -51,15 +51,21 @@ marionette('Browser - Navigating from the landing page',
     client.apps.switchToApp(Search.URL);
     client.helper.waitForElement('body');
     client.switchToFrame();
-    system.appUrlbar.click();
-
     var nApps = system.getAppWindows().length;
     var nBrowsers = system.getBrowserWindows().length;
+
+    system.appUrlbar.click();
     var url = server.url('sample.html');
+    rocketbar.enterText(url);
+
+    // Wait for the search app to be open.
+    client.waitFor(function() {
+      return (nApps + 1) === system.getAppWindows().length;
+    });
     rocketbar.enterText(url + '\uE006');
 
-    // Opens the search window, so we should have 3 with the home screen.
-    // Wait for the expected number of app windows.
+    // Wait for the new browser window.
+    // It should override the search app.
     client.waitFor(function() {
       return (nApps + 1) === system.getAppWindows().length;
     });

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -38,7 +38,6 @@
     "apps/system/test/marionette/notification_test.js": "Bug 1091484 - TEST-UNEXPECTED-FAIL | null | notification tests swipe up should hide the toast",
     "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
     "apps/verticalhome/test/marionette/collection_pin_result_uninstall_test.js": "Bug 1098310 - TEST-UNEXPECTED-FAIL | Vertical - Collection uninstall pinned collection web result",
-    "apps/verticalhome/test/marionette/collection_rename_test.js": "Bug 1090756 - TEST-UNEXPECTED-FAIL | Vertical - Collection Rename rename collection",
-    "apps/system/test/marionette/browser_navigate_landing_page_test.js": "Bug 1100305 - TEST-UNEXPECTED-FAIL | apps/system/test/marionette/browser_navigate_landing_page_test.js"
+    "apps/verticalhome/test/marionette/collection_rename_test.js": "Bug 1090756 - TEST-UNEXPECTED-FAIL | Vertical - Collection Rename rename collection"
   }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1100305
