### PR TITLE
Bug 1097497 - Make sure utility tray is open before flicking closed, r=k...

### DIFF
--- a/apps/system/test/marionette/utility_tray_gestures_test.js
+++ b/apps/system/test/marionette/utility_tray_gestures_test.js
@@ -79,10 +79,10 @@ marionette('Utility Tray - Gestures', function() {
   });
 
   test('Swiping up', function() {
-    var grippy = client.findElement(utilityTray.Selectors.grippy);
-
     utilityTray.open();
+    utilityTray.waitForOpened();
 
+    var grippy = client.findElement(utilityTray.Selectors.grippy);
     swipeUp(grippy);
     utilityTray.waitForClosed();
   });


### PR DESCRIPTION
...grandon, a=test-only
