### PR TITLE
Bug 1104644 - Force disable updates and tiles when running integration tests r=...

### DIFF
--- a/shared/test/integration/profile.js
+++ b/shared/test/integration/profile.js
@@ -8,7 +8,13 @@ module.exports = {
     'search.marketplace.url': null
   },
   prefs: {
-    'geo.wifi.uri': 'http://localhost'
+    'geo.wifi.uri': 'http://localhost',
+    'app.update.enabled': false,
+    'app.update.url': '',
+    'app.update.url.override': '',
+    'browser.newtabpage.directory.source': '',
+    'browser.newtabpage.directory.ping': '',
+    'webapps.update.enabled': false
   }
   // apps: {}
 };


### PR DESCRIPTION
When we are running Gaia integration tests, non local network
connections are forbidden (bug 1030045). This is making Gaia integration
tests to fail when ran in Mulet, because of update checking and because
of tiles ping/listing. Gaia does a force check when FTU is completed, so
we need to disable update checking. We also disable tiles URLs to avoid
pinging and listing.
