### PR TITLE
Bug 1105079 - Remove strings from index.html for crash info page  +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -658,15 +658,14 @@
           <!-- "Crash Reports" information page -->
           <section role="region">
             <gaia-header id="crash-reports-header" action="close">
-              <h1 data-l10n-id="crashReports">Crash Reports</h1>
+              <h1 data-l10n-id="crashReports"></h1>
             </gaia-header>
             <div>
               <ul>
-                <li class="description" data-l10n-id="crash-reports-description-1">
-                A crash report contains some details about the crash and your device, as well as a snapshot of the state of your device when it crashed.</li>
-                <li class="description" data-l10n-id="crash-reports-description-2">This may include things like open pages and apps, text typed into forms and the content of open messages, recent browsing history, or geolocation used by an open app.</li>
+                <li class="description" data-l10n-id="crash-reports-description-1"></li>
+                <li class="description" data-l10n-id="crash-reports-description-2"></li>
                 <li class="description">
-                  <span data-l10n-id="crash-reports-description-3-start">We use crash reports to try to fix problems and improve our products. We handle your information as we describe in our </span><span data-l10n-id="crash-reports-description-3-privacy">privacy policy</span><span data-l10n-id="crash-reports-description-3-end">.</span>
+                  <span data-l10n-id="crash-reports-description-3-start"></span><span data-l10n-id="crash-reports-description-3-privacy"></span><span data-l10n-id="crash-reports-description-3-end"></span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1105079
