### PR TITLE
Bug 1105078 - Remove strings from index.html for crash reporter dialog  +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -642,16 +642,16 @@
           <form role="dialog" class="generic-dialog" data-type="confirm">
             <section id="crash-dialog-contents">
               <h1 id="crash-dialog-title"></h1>
-              <p data-l10n-id="crash-dialog-message">Would you like to send Mozilla a report about the crash to help us fix the problem? (Reports are sent over Wi-Fi only)</p>
-              <p><a id="crash-info-link" data-l10n-id="crash-info-link">What's in a crash report?</a></p>
+              <p data-l10n-id="crash-dialog-message"></p>
+              <p><a id="crash-info-link" data-l10n-id="crash-info-link"></a></p>
               <p>
                 <input id="always-send" type="checkbox" checked="true"/>
-                <label for="always-send" data-l10n-id="crash-always-report">Always send Mozilla a report when a crash occurs.</label>
+                <label for="always-send" data-l10n-id="crash-always-report"></label>
               <p>
             </section>
             <menu data-items="2">
-              <button id="dont-send-report" disabled="true" data-l10n-id="crash-dont-send">Don't Send</button>
-              <button id="send-report" class="recommend" data-l10n-id="crash-end">Send Report</button>
+              <button id="dont-send-report" disabled="true" data-l10n-id="crash-dont-send"></button>
+              <button id="send-report" class="recommend" data-l10n-id="crash-end"></button>
             </menu>
           </form>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1105078
