### PR TITLE
Bug 1105077 - Remove strings from index.html for rocketbar and utility tray +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -474,8 +474,7 @@
               placeholder="Search or enter address" data-l10n-id="search-or-enter-address" value="">
             </input>
             <button type="button" id="rocketbar-clear" data-l10n-id="clear" aria-label="Clear"></button>
-            <button type="button" id="rocketbar-cancel"
-                    data-l10n-id="close">Close</button>
+            <button type="button" id="rocketbar-cancel" data-l10n-id="close"></button>
           </form>
         </div>
         <!-- Statusbar icons -->
@@ -539,7 +538,7 @@
               <div data-icon="notifications"></div>
               <div class="title-container">
                 <div id="notification-some" class="title" data-l10n-id="statusbarNotifications" data-l10n-args='{"n": "0"}'></div>
-                <button id="notification-clear" data-l10n-id="clear-all" disabled>Clear all</button>
+                <button id="notification-clear" data-l10n-id="clear-all" disabled></button>
               </div>
             </div>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1105077
