### PR TITLE
Bug 1089951 - [Midori 2.0][Homescreen]The main interface menus overlap when MS quits games

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -1,4 +1,4 @@
-/* global SettingsListener, OrientationManager, StatusBar */
+/* global SettingsListener, OrientationManager, StatusBar, AppWindowManager */
 'use strict';
 
 (function(exports) {
@@ -713,10 +713,14 @@
 
   AppWindow.prototype._handle__orientationchange = function() {
     if (this.isActive()) {
-      // Will be resized by the AppWindowManager
-      return;
+      if (!this.isHomescreen) {
+        return;
+      // XXX: Preventing orientaiton of homescreen app is changed by background
+      //      app. It's a workaround for bug 1089951.
+      } else if (AppWindowManager && AppWindowManager.getActiveApp() === this) {
+        this.lockOrientation();
+      }
     }
-
     // Resize only the overlays not the app
     var width = self.layoutManager.width;
     var height = self.layoutManager.height + this.calibratedHeight();
@@ -1315,6 +1319,7 @@
                       OrientationManager.globalOrientation;
     if (orientation) {
       var rv = screen.mozLockOrientation(orientation);
+
       if (rv === false) {
         console.warn('screen.mozLockOrientation() returned false for',
                      this.origin, 'orientation', orientation);

--- a/apps/system/js/layout_manager.js
+++ b/apps/system/js/layout_manager.js
@@ -111,6 +111,7 @@
       window.addEventListener('mozfullscreenchange', this);
       window.addEventListener('software-button-enabled', this);
       window.addEventListener('software-button-disabled', this);
+      this._lastOrientation = screen.mozOrientation;
       return this;
     },
 
@@ -129,8 +130,11 @@
           this.publish('system-resize');
           break;
         case 'resize':
-          this.publish('system-resize');
+          if (screen.mozOrientation === this._lastOrientation) {
+            this.publish('system-resize');
+          }
           this.publish('orientationchange');
+          this._lastOrientation = screen.mozOrientation;
           break;
         default:
           if (evt.type === 'keyboardhide') {

--- a/apps/system/test/unit/layout_manager_test.js
+++ b/apps/system/test/unit/layout_manager_test.js
@@ -23,12 +23,33 @@ suite('system/LayoutManager >', function() {
   });
 
   suite('handle events', function() {
+    var setMozOrientation = function (orientation) {
+      Object.defineProperty(screen, 'mozOrientation', {
+        get: function(){
+          return orientation;
+        },
+        configurable: true
+      });
+    };
+
     test('resize', function() {
       var stubPublish = this.sinon.stub(layoutManager, 'publish');
       layoutManager.handleEvent({
         type: 'resize'
       });
       assert.isTrue(stubPublish.calledWith('system-resize'));
+      assert.isTrue(stubPublish.calledWith('orientationchange'));
+    });
+
+    test('Do not publish system-resize if orientation has changed', function() {
+      var stubPublish = this.sinon.stub(layoutManager, 'publish');
+      layoutManager._lastOrientation = 'portrait-secondary';
+      setMozOrientation('landscape-secondary');
+
+      layoutManager.handleEvent({
+        type: 'resize'
+      });
+      assert.isFalse(stubPublish.calledWith('system-resize'));
       assert.isTrue(stubPublish.calledWith('orientationchange'));
     });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1089951
