### PR TITLE
Bug 1105519 - Remove strings from index.html for battery dialog +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1174,8 +1174,8 @@
         <div id="battery">
           <span class="icon-battery"></span>
           <div class="battery-notification">
-            <span data-l10n-id="battery-almost-empty3">Battery almost empty.</span>
-            <span data-l10n-id="plug-in-your-charger">Plug in your charger.</span>
+            <span data-l10n-id="battery-almost-empty3"></span>
+            <span data-l10n-id="plug-in-your-charger"></span>
           </div>
         </div>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1105519
