### PR TITLE
Bug 1105521 - Remove strings from index.html for sleep menu +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1158,14 +1158,14 @@
       <div id="sleep-menu" data-z-index-level="sleep-menu">
         <div id="sleep-menu-container" role="dialog" data-type="object">
           <header>
-            <h1 data-l10n-id="deviceMenu">Device menu</h1>
+            <h1 data-l10n-id="deviceMenu"></h1>
           </header>
           <section>
             <ul role="menu">
             </ul>
           </section>
           <gaia-buttons skin="dark">
-            <button data-l10n-id="cancel">Cancel</button>
+            <button data-l10n-id="cancel"></button>
           </gaia-buttons>
         </div>
       </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1105521
