### PR TITLE
Bug 1103964 - Disable test_everythingme_add_collection_save_bookmark.py test for starting to perma-fail +autoland

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/everythingme/manifest.ini
@@ -8,6 +8,7 @@ smoketest = true
 
 [test_everythingme_add_collection_save_bookmark.py]
 smoketest = true
+skip-if = device == "desktop"
 
 [test_everythingme_search.py]
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1103964
