### PR TITLE
Bug 1100822 - Implement mplement audio channel manager

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -370,6 +370,7 @@
     <link rel="stylesheet" type="text/css" href="style/app_titlebar.css">
     <script defer src="js/base_ui.js"></script>
     <script defer src="js/context_menu_view.js"></script>
+    <script defer src="js/audio_channel_controller.js"></script>
     <script defer src="js/browser_context_menu.js"></script>
     <script defer src="js/child_window_factory.js"></script>
     <script defer src="js/app_modal_dialog.js"></script>

--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -1,4 +1,5 @@
 /* global AppChrome */
+/* global AudioChannelController */
 /* global applications */
 /* global BrowserFrame */
 /* global layoutManager */
@@ -838,6 +839,17 @@
         }
       }
 
+      // Register audio channels.
+      this.audioChannels = new Map();
+      var audioChannels = this.browser.element.allowedAudioChannels;
+      audioChannels && audioChannels.forEach((audioChannel) => {
+        this.audioChannels.set(
+          audioChannel.name,
+          new AudioChannelController(this, audioChannel)
+        );
+        this.debug('Registered ' + audioChannel.name + ' audio channel');
+      });
+
       if (this.isInputMethod) {
         return;
       }
@@ -871,6 +883,8 @@
         }
         this[componentName] = null;
       }
+
+      this.audioChannels = null;
 
       if (this.appChrome) {
         this.appChrome.destroy();

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -537,8 +537,8 @@
 
         case 'appterminated':
           var app = evt.detail; // jshint ignore:line
-          var instanceID = evt.detail.instanceID;
-          if (activeApp && app.instanceID === activeApp.instanceID) {
+          var instanceID = app.instanceID;
+          if (activeApp && instanceID === activeApp.instanceID) {
             activeApp = null;
           }
           delete this._apps[instanceID];

--- a/apps/system/js/audio_channel_controller.js
+++ b/apps/system/js/audio_channel_controller.js
@@ -1,0 +1,239 @@
+/* global BaseUI */
+'use strict';
+
+(function(exports) {
+  var FADE_IN_VOLUME = 1;
+  var FADE_OUT_VOLUME = 0.2;
+  var VIBRATION_DURATION = 1000;
+
+  /**
+   * AudioChannelController controls the audio channel to
+   * play or pause.
+   */
+  var AudioChannelController = function(app, channel) {
+    this.app = app;
+    this.name = channel.name;
+    this._channel = channel;
+    this._states = {
+      active: false,
+      playing: false,
+      fadingOut: false,
+      vibrating: false
+    };
+    this._policy = {};
+    this._generateID();
+    channel.addEventListener('activestatechanged', this);
+    app.element.addEventListener('_destroyed', this);
+  };
+
+  AudioChannelController.prototype = Object.create(BaseUI.prototype); 
+
+  AudioChannelController.prototype.EVENT_PREFIX = 'audiochannel';
+
+  /**
+   * General event handler interface.
+   *
+   * @param {Event} evt The event to handle.
+   */
+  AudioChannelController.prototype.handleEvent = function(evt) {
+    switch (evt.type) {
+      case 'activestatechanged':
+        var channel = evt.target;
+        // TODO: We should get the `isActive` state from evt.isActive.
+        // Then we don't need to do `channel.isActive()` here.
+        channel.isActive().onsuccess = (evt) => {
+          this._states.active = evt.target.result;
+          this.publish('statechanged');
+        };
+        break;
+
+      case '_destroyed':
+        this.publish('destroyed');
+        break;
+    }
+  };  
+
+  /**
+   * Set the policy for handling this audio channel.
+   *
+   * @param {Object} policy Policy to handle this audio channel.
+   * @param {Boolean} [policy.isAllowedToPlay] Play or pause it.
+   * @param {Boolean} [policy.isNeededToFadeOut] Fade out or not.
+   * @param {Boolean} [policy.isNeededToVibrate] Vibrate or not.
+   * @param {Boolean} [policy.isNeededToResumeWhenOtherEnds]
+   * Resume when other audio channel ends if as true.
+   * @return {AudioChannelController}
+   */
+  AudioChannelController.prototype.setPolicy = function(policy) {
+    this._policy = policy || this._policy;
+    return this;
+  };
+
+  AudioChannelController.prototype.getPolicy = function() {
+    return this._policy;
+  };
+
+  /**
+   * Handle the audio channel with the policy.
+   *
+   * @return {AudioChannelController}
+   */
+  AudioChannelController.prototype.proceedPolicy = function() {
+    var policy = this._policy;
+    if (policy.isAllowedToPlay) {
+      this._play();
+    } else if (policy.isAllowedToPlay != null) {
+      this._pause();
+    }
+    if (policy.isNeededToFadeOut) {
+      this._fadeOut();
+    } else if (policy.isNeededToFadeOut != null) {
+      this._fadeIn();
+    }
+    if (policy.isNeededToVibrate) {
+      this._vibrate();
+    }
+    return this;
+  };
+
+  /**
+   * Get active state.
+   *
+   * @return {Boolean}
+   */
+  AudioChannelController.prototype.isActive = function() {
+    return this._states.active;
+  };
+
+  /**
+   * Get state of playing.
+   *
+   * @return {Boolean}
+   */
+  AudioChannelController.prototype.isPlaying = function() {
+    return this._states.playing;
+  };
+
+  /**
+   * Get state of fading out.
+   *
+   * @return {Boolean}
+   */
+  AudioChannelController.prototype.isFadingOut = function() {
+    return this._states.fadingOut;
+  };
+
+  /**
+   * Get state of vibrating.
+   *
+   * @return {Boolean}
+   */
+  AudioChannelController.prototype.isVibrating = function() {
+    return this._states.vibrating;
+  };
+
+  /**
+   * Play the audio channel.
+   */
+  AudioChannelController.prototype._play = function() {
+    this._states.playing = true;
+    var promise = new Promise((resolve) => {
+      var request = this._channel.setMuted(false);
+      request.onsuccess = () => {
+        resolve();
+      };
+      request.onerror = () => {
+        throw 'Cannot play the audio channel.';
+      };
+    });
+    promise.then(() => {
+      this.app.debug('Play the audio channel.');
+    }).catch(e => {
+      this.app.debug(e);
+    });
+  };
+
+  /**
+   * Fade in the audio channel.
+   */
+  AudioChannelController.prototype._fadeIn = function() {
+    this._setVolume(FADE_IN_VOLUME);
+    this._states.fadingOut = false;
+  },
+
+  /**
+   * Fade out the audio channel.
+   */
+  AudioChannelController.prototype._fadeOut = function() {
+    this._setVolume(FADE_OUT_VOLUME);
+    this._states.fadingOut = true;
+    !this._states.playing && this._play();
+  },
+
+  /**
+   * Pause the audio channel.
+   */
+  AudioChannelController.prototype._pause = function() {
+    this._states.playing = false;
+    var promise = new Promise((resolve) => {
+      var request = this._channel.setMuted(true);
+      request.onsuccess = () => {
+        resolve();
+      };
+      request.onerror = () => {
+        throw 'Cannot pause the audio channel.';
+      };
+    });
+    promise.then(() => {
+      this.app.debug('Pause the audio channel');
+    }).catch(e => {
+      this.app.debug(e);
+    });
+  };
+
+  /**
+   * Vibrate for one second
+   * and the vibration pattern is [200, 100, 200, 100, ...].
+   */
+  AudioChannelController.prototype._vibrate = function() {
+    var intervalId = setInterval(() => {
+      navigator.vibrate(200);
+    }, 300);
+    this._states.vibrating = true;
+    setTimeout(() => {
+      clearInterval(intervalId);
+      this._states.vibrating = false;
+    }, VIBRATION_DURATION);
+  };
+
+  /**
+   * Change volume of audio channels.
+   *
+   * @param {Number} volume 0 to 1.
+   */
+  AudioChannelController.prototype._setVolume = function(volume) {
+    var promise = new Promise((resolve) => {
+      var request = this._channel.setVolume(volume);
+      request.onsuccess = () => {
+        resolve();
+      };
+      request.onerror = () => {
+        throw 'Cannot set volume of the audio channel.';
+      };
+    });
+    promise.then(() => {
+      this.app.debug('Set volume: ' + volume);
+    }).catch(e => {
+      this.app.debug(e);
+    });   
+  };
+
+  /**
+   * Generate instance ID.
+   */
+  AudioChannelController.prototype._generateID = function() {
+    this.instanceID = this.app.instanceID + '_' + this.name;
+  };
+
+  exports.AudioChannelController = AudioChannelController;
+}(window));

--- a/apps/system/js/audio_channel_manager.js
+++ b/apps/system/js/audio_channel_manager.js
@@ -1,0 +1,217 @@
+/* global BaseModule */
+/* global Service */
+'use strict';
+
+(function() {
+  /**
+   * AudioChannelManager manages audio channels in apps.
+   * It could allow or deny a audio channel to play in some specific cases.
+   * For example, Music app would like to play when FM app is already playing.
+   * It will allow Music app to play, and pause FM app.
+   *
+   * @class AudioChannelManager
+   */
+  var AudioChannelManager = function() {};
+
+  AudioChannelManager.EVENTS = [
+    'audiochannelstatechanged',
+    'audiochanneldestroyed',
+    'hierarchytopmostwindowchanged'
+  ];
+
+  AudioChannelManager.SUB_MODULES = [
+    'AudioChannelPolicy'
+  ];
+
+  BaseModule.create(AudioChannelManager, {
+    name: 'AudioChannelManager',
+    DEBUG: false,
+    // A map contains playing audio channels.
+    _activeAudioChannels: null,
+    // An array contains audio channels could be resumed
+    // when any other audio channel ends.
+    _interruptedAudioChannels: null,
+    // The most top app window.
+    _topMostWindow: null,
+
+    /**
+     * Initial the module.
+     */
+    _start: function() {
+      this._activeAudioChannels = new Map();
+      this._interruptedAudioChannels = [];
+      this.debug('Start Audio Channel Manager');
+    },
+
+    /**
+     * Handle the audio chanel when it is active or in inactive.
+     *
+     * @param {Event} evt The event to handle.
+     */
+    _handle_audiochannelstatechanged: function(evt) {
+      var audioChannel = evt.detail;
+      this.debug('Audio channel state is ' + audioChannel.isActive());
+      this._manageAudioChannels(audioChannel);
+    },
+
+    /**
+     * Remove the window's audio channels from
+     * `_activeAudioChannels` and `_interruptedAudioChannels`
+     * when the window is terminated.
+     *
+     * @param {Event} evt The event to handle.
+     */
+    _handle_audiochanneldestroyed: function(evt) {
+      var audioChannel = evt.detail;
+      this._activeAudioChannels.delete(audioChannel.instanceID);
+      this._deleteAudioChannelFromInterruptedAudioChannels(audioChannel);
+      this._resumeAudioChannels();
+    },
+
+    /**
+     * Handle the audio chanel when the app is in foreground or background.
+     */
+    _handle_hierarchytopmostwindowchanged: function() {
+      if (this._topMostWindow && this._topMostWindow.audioChannels) {
+        // Normal channel could not play in background.
+        this.debug(this._topMostWindow.name + ' is closed');
+        var audioChannel = this._topMostWindow.audioChannels.get('normal');
+        if (audioChannel && audioChannel.isPlaying()) {
+          audioChannel.setPolicy({ isAllowedToPlay: false });
+          this._handleAudioChannel(audioChannel);
+        }
+      }
+      this._topMostWindow = Service.query('getTopMostWindow');
+      if (this._topMostWindow) {
+        this.debug(this._topMostWindow.name + ' is opened');
+        this._resumeAudioChannels(this._topMostWindow);
+      }
+    },
+
+    /**
+     * Play or pause the new audio channel and the active audio channels.
+     *
+     * @param {AudioChannelController} audioChannel The new audio channel.
+     */
+    _manageAudioChannels: function(audioChannel) {
+      if (audioChannel.isActive()) {
+        this.audioChannelPolicy.applyPolicy(
+          audioChannel,
+          this._activeAudioChannels,
+          {
+            isNewAudioChannelInBackground:
+              this._isAudioChannelInBackground(audioChannel)
+          }
+        );
+        this._activeAudioChannels.forEach((audioChannel) => {
+          this._handleAudioChannel(audioChannel);
+        });
+        this._handleAudioChannel(audioChannel);
+      } else {
+        this._resetAudioChannel(audioChannel);
+        this._resumeAudioChannels();
+      }
+    },
+
+    /**
+     * Set the audio channel as default state as muted,
+     * and fade in the faded out audio channels.
+     *
+     * @param {AudioChannelController} audioChannel The audio channel.
+     */
+    _resetAudioChannel: function(audioChannel) {
+      audioChannel.setPolicy({ isAllowedToPlay: false });
+      this._handleAudioChannel(audioChannel);
+      audioChannel.name === 'notification' &&
+        this._fadeInFadedOutAudioChannels();
+    },
+
+    /**
+     * Handle the audio channel
+     * and update `_activeAudioChannels` and `_interruptedAudioChannels`.
+     *
+     * @param {AudioChannelController} audioChannel The audio channel.
+     */
+    _handleAudioChannel: function(audioChannel) {
+      var policy = audioChannel.proceedPolicy().getPolicy();
+      if (policy.isAllowedToPlay) {
+        this._activeAudioChannels.set(
+          audioChannel.instanceID,
+          audioChannel
+        );
+        this.debug('Playing ' + audioChannel.instanceID);
+      } else {
+        this._activeAudioChannels.delete(audioChannel.instanceID);
+        if (policy.isNeededToResumeWhenOtherEnds) {
+          this._interruptedAudioChannels.push(audioChannel);
+          this.debug('Interrupted ' + audioChannel.instanceID);
+        }
+      }
+    },
+
+    /**
+     * Fade in all faded out audio channels.
+     */
+    _fadeInFadedOutAudioChannels: function() {
+      this._activeAudioChannels.forEach((audioChannel) => {
+        audioChannel.isFadingOut() && audioChannel
+          .setPolicy({ isNeededToFadeOut: false })
+          .proceedPolicy();
+      });
+    },
+
+    /**
+     * Resume interrupted audio channels.
+     *
+     * @param {AppWindow} [app] The app window in foreground.
+     */
+    _resumeAudioChannels: function(app) {
+      var audioChannel;
+      // Resume the app's audio channels.
+      app && app.audioChannels.forEach((audioChannel) => {
+        audioChannel.isActive() && this._manageAudioChannels(audioChannel);
+        if (audioChannel.isPlaying()) {
+          this._deleteAudioChannelFromInterruptedAudioChannels(audioChannel);
+        }
+      });
+      // Resume the latest interrupted audio channel.
+      var length = this._interruptedAudioChannels.length;
+      if (this._activeAudioChannels.size === 0 && length) {
+        audioChannel = this._interruptedAudioChannels[length - 1];
+        audioChannel.setPolicy({ isAllowedToPlay: true });
+        this._handleAudioChannel(audioChannel);
+        audioChannel.isPlaying() && this._interruptedAudioChannels.pop();
+      }
+    },
+
+    /**
+     * Delete the audio channel from `_interruptedAudioChannels` array.
+     *
+     * @param {AudioChannelController} audioChannel
+     * The audio channel want to delete.
+     */
+    _deleteAudioChannelFromInterruptedAudioChannels: function(audioChannel) {
+      var index = this._interruptedAudioChannels
+        .findIndex(function(interruptedAudioChannel) {
+          return interruptedAudioChannel.instanceID ===
+            audioChannel.instanceID;
+      });
+      index !== -1 && this._interruptedAudioChannels.splice(index, 1);
+    },
+
+    /**
+     * Check the audio channel is in background or not.
+     *
+     * @param {AudioChannelController} audioChannel The audio channel.
+     * @retrun {Boolean}
+     */
+    _isAudioChannelInBackground: function(audioChannel) {
+      var isAudioChannelInBackground = true;
+      if (this._topMostWindow &&
+          this._topMostWindow.instanceID === audioChannel.app.instanceID) {
+        isAudioChannelInBackground = false;
+      }
+      return isAudioChannelInBackground;
+    }
+  });
+}());

--- a/apps/system/js/audio_channel_policy.js
+++ b/apps/system/js/audio_channel_policy.js
@@ -1,0 +1,295 @@
+/* global BaseModule */
+'use strict';
+
+(function() {
+  // The results of audo channel competition.
+  var PLAY = true;
+  var PAUSE = false;
+  /**
+   * It is the table to get the result of
+   * the competition of audio channels.
+   *
+   * Get the result of the competition
+   * of normal and content audio channels with
+   * `AUDIO_CHANNEL_COMPETITION_RESULTS.normal.content`.
+   */
+  var AUDIO_CHANNEL_COMPETITION_RESULTS = {
+    normal: {
+      normal: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    content: {
+      normal: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      notification:  { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification:  { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    alarm: {
+      normal: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    system: {
+      normal: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    ringer: {
+      normal: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PAUSE, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    telephony: {
+      normal: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PLAY, newAudioChannel: PAUSE },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PLAY, newAudioChannel: PAUSE },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PAUSE },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    notification: {
+      normal: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    },
+    publicNotification: {
+      normal: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      content: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      alarm: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      system: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      ringer: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      telephony: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      notification: { activeAudioChannel: PLAY, newAudioChannel: PLAY },
+      publicNotification: { activeAudioChannel: PLAY, newAudioChannel: PLAY }
+    }
+  };
+
+  /**
+   * AudioChannelPolicy provides policies to handle audio channels.
+   */
+  var AudioChannelPolicy = function() {};
+
+  AudioChannelPolicy.SETTINGS = [
+    'vibration.enabled'
+  ];
+
+  BaseModule.create(AudioChannelPolicy, {
+    name: 'AudioChannelPolicy',
+    DEBUG: false,
+    // The value of the vibration.enabled settings.
+    _isVibrateEnabled: true,
+
+    /**
+     * Get the policies of 
+     * handling the new audio channel and active audio channels.
+     *
+     * @param {AudioChannelController} newAudioChannel
+     * A new audio channel you want to handle.
+     * @param {Map} activeAudioChannels
+     * Active audio channels playing noew.
+     * @param {Object} [options] Options.
+     * @param {Boolean} [options.isNewAudioChannelInBackground]
+     * Is the new audio channel in background.
+     */
+    applyPolicy: function(newAudioChannel, activeAudioChannels, options) {
+      var newAudioChannelName = newAudioChannel.name;
+      // Deconflict the conflicted policies for the new audio channel.
+      // For example, we have a new audio channel `alarm` and
+      // two active audio channels `system` and `telephony`.
+      // `AUDIO_CHANNEL_COMPETITION_RESULTS.system.alarm` is `true`,
+      // but `AUDIO_CHANNEL_COMPETITION_RESULTS.telephony.alarm`
+      // is `false`.
+      // And we get conflict policies for the `alarm` audio channel.
+      // Once we get conflcts, we will take higher priority policy.
+      // `PAUSE` is higher than `PLAY`,
+      // and doing fade out is higher than not doing fade out.
+      var isAllowedToPlayForNewAudioChannel = [true];
+      var isNeededToFadeOutForNewAudioChannel = [false];
+      // The new audio channel will be allowed to play,
+      // if any other audio channel belonged to its app is already playing.
+      var isNewAudioChannelsAppPlaying = false;
+      activeAudioChannels.forEach((audioChannel) => {
+        if (audioChannel.app.instanceID === newAudioChannel.app.instanceID) {
+          isNewAudioChannelsAppPlaying = true;
+        }
+      });
+      !isNewAudioChannelsAppPlaying &&
+        activeAudioChannels.forEach((audioChannel) => {
+        var activeAudioChannelName = audioChannel.name;
+        var results = AUDIO_CHANNEL_COMPETITION_RESULTS
+          [activeAudioChannelName][newAudioChannelName];
+        var policy = {
+          isAllowedToPlay: results.activeAudioChannel
+        };
+        if (results.activeAudioChannel) {
+          policy.isNeededToFadeOut =
+            this._isNeededToFadeOutForActiveAudioChannel(
+              activeAudioChannelName, newAudioChannelName
+            );
+        }
+        if (!results.activeAudioChannel) {
+          policy.isNeededToVibrate = this._isVibrateEnabled &&
+          this._isNeededToVibrateForActiveAudioChannel(
+            activeAudioChannelName, newAudioChannelName
+          );
+          policy.isNeededToResumeWhenOtherEnds =
+            this._isNeededToResumeWhenOtherEndsForActiveAudioChannel(
+              activeAudioChannelName, newAudioChannelName
+            );
+        }
+        audioChannel.setPolicy(policy);
+        this.debug('Policy for ' + audioChannel.instanceID +
+          ': ' + JSON.stringify(policy));
+        isAllowedToPlayForNewAudioChannel.push(results.newAudioChannel);
+        results.newAudioChannel && isNeededToFadeOutForNewAudioChannel.push(
+          this._isNeededToFadeOutForNewAudioChannel
+            (activeAudioChannelName, newAudioChannelName)
+        );
+      });
+      // Normal channel could not play in background.
+      if (newAudioChannelName === 'normal' &&
+          options && options.isNewAudioChannelInBackground) {
+        isAllowedToPlayForNewAudioChannel.push(false);
+      }
+      // Deconflict the policies.
+      isAllowedToPlayForNewAudioChannel =
+        isAllowedToPlayForNewAudioChannel.every(isAllowed => isAllowed);
+      isNeededToFadeOutForNewAudioChannel =
+        isNeededToFadeOutForNewAudioChannel.some(isNeeded => isNeeded);
+      var policy = {
+        isAllowedToPlay: isAllowedToPlayForNewAudioChannel
+      };
+      if (isAllowedToPlayForNewAudioChannel) {
+        policy.isNeededToFadeOut = isNeededToFadeOutForNewAudioChannel;
+      }
+      if (!isAllowedToPlayForNewAudioChannel) {
+        policy.isNeededToVibrate = this._isVibrateEnabled &&
+          !isAllowedToPlayForNewAudioChannel &&
+          // Don't vibrate for background normal audio channel.
+          newAudioChannelName !== 'normal';
+      }
+      newAudioChannel.setPolicy(policy);
+      this.debug('Policy for ' + newAudioChannel.instanceID +
+        ': ' + JSON.stringify(policy));
+    },
+
+    /**
+     * Observer the value of vibration.enabled settings.
+     *
+     * @param {Boolean} value The value of the settings.
+     */
+    '_observe_vibration.enabled': function(value) {
+      this._isVibrateEnabled = value;
+    },
+
+    /**
+     * Get the policy of fading out the new audio channel.
+     *
+     * @param {String} activeChannelName The active audio channel name.
+     * @param {String} newChannelName The new audio channel name.
+     * @return {Boolean}
+     */
+    _isNeededToFadeOutForNewAudioChannel:
+      function(activeChannelName, newChannelName) {
+      var isNeeded = false;
+      if ((activeChannelName === 'notification' ||
+           activeChannelName === 'publicNotification') &&
+          (newChannelName === 'normal' ||
+           newChannelName === 'content')
+         )
+      {
+        isNeeded = true;
+      }
+      return isNeeded;
+    },
+
+    /**
+     * Get the policy of fading out the active audio channel.
+     *
+     * @param {String} activeChannelName The active audio channel name.
+     * @param {String} newChannelName The new audio channel name.
+     * @return {Boolean}
+     */
+    _isNeededToFadeOutForActiveAudioChannel:
+      function(activeChannelName, newChannelName) {
+      var isNeeded = false;
+      if (((activeChannelName === 'normal' ||
+            activeChannelName === 'content') &&
+              (newChannelName === 'notification' ||
+               newChannelName === 'publicNotification')
+          ) ||
+          (activeChannelName === 'alarm' &&
+             (newChannelName === 'ringer' ||
+              newChannelName === 'telephony')
+          )
+         )
+      {
+        isNeeded = true;
+      }
+      return isNeeded;
+    },
+
+    /**
+     * Get the policy of vibrating for the active audio channel.
+     *
+     * @param {String} activeChannelName The active audio channel name.
+     * @param {String} newChannelName The new audio channel name.
+     * @return {Boolean}
+     */
+    _isNeededToVibrateForActiveAudioChannel:
+      function(activeChannelName, newChannelName) {
+      return activeChannelName === 'ringer' && newChannelName === 'ringer';
+    },
+
+    /**
+     * Get the policy of resuming the active audio channel
+     * when any other audio channel ends.
+     *
+     * @param {String} activeChannelName The active audio channel name.
+     * @param {String} newChannelName The new audio channel name.
+     * @return {Boolean}
+     */
+    _isNeededToResumeWhenOtherEndsForActiveAudioChannel:
+      function(activeChannelName, newChannelName) {
+      var isNeeded = true;
+      if (activeChannelName === 'normal' ||
+          (activeChannelName === 'content' && newChannelName === 'normal') ||
+          (activeChannelName === 'alarm' && newChannelName === 'alarm') ||
+          (activeChannelName === 'ringer' && newChannelName === 'ringer')) {
+        isNeeded = false;
+      }
+      return isNeeded;
+    }
+  });
+}());

--- a/apps/system/js/core.js
+++ b/apps/system/js/core.js
@@ -22,7 +22,8 @@
     'TetheringMonitor',
     'UsbCore',
     'CameraTrigger',
-    'FeatureDetector'
+    'FeatureDetector',
+    'AudioChannelManager'
   ];
 
   Core.SERVICES = [

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1,6 +1,7 @@
 /* global AppWindow, ScreenLayout, MockOrientationManager, MockService,
       LayoutManager, MocksHelper, MockContextMenu, layoutManager, Service,
-      MockAppTransitionController, MockPermissionSettings, DocumentFragment,
+      MockAppTransitionController, MockAudioChannelController,
+      MockPermissionSettings, DocumentFragment,
       AppChrome */
 'use strict';
 
@@ -14,6 +15,7 @@ requireApp('system/test/unit/mock_layout_manager.js');
 requireApp('system/test/unit/mock_app_chrome.js');
 requireApp('system/test/unit/mock_screen_layout.js');
 requireApp('system/test/unit/mock_app_transition_controller.js');
+requireApp('system/test/unit/mock_audio_channel_controller.js');
 requireApp('system/shared/test/unit/mocks/mock_service.js');
 requireApp('system/shared/test/unit/mocks/mock_permission_settings.js');
 
@@ -2519,6 +2521,33 @@ suite('system/AppWindow', function() {
 
     assert.ok(app1.reConfig.calledOnce);
     assert.ok(app1.element.classList.contains('browser'));
+  });
+
+  suite('Sub component', function() {
+    var app;
+    setup(function() {
+      window.AudioChannelController = MockAudioChannelController;
+      app = new AppWindow(fakeAppConfig1);
+      app.browser.element.allowedAudioChannels = [
+        { name: 'normal' }, { name: 'content' }
+      ];
+      app.installSubComponents();
+    });
+
+    teardown(function() {
+      delete window.AudioChannelController;
+    });
+
+    test('installSubComponents', function() {
+      assert.equal(app.audioChannels.size, 2);
+      assert.equal(app.audioChannels.get('normal').name, 'normal');
+      assert.equal(app.audioChannels.get('content').name, 'content');
+    });
+
+    test('uninstallSubComponents', function() {
+      app.uninstallSubComponents();
+      assert.deepEqual(app.audioChannels, null);
+    });
   });
 
   suite('fadeOut', function() {

--- a/apps/system/test/unit/audio_channel_controller_test.js
+++ b/apps/system/test/unit/audio_channel_controller_test.js
@@ -1,0 +1,220 @@
+/* global AudioChannelController */
+'use strict';
+
+requireApp('system/js/base_ui.js');
+requireApp('system/js/audio_channel_controller.js');
+
+suite('system/AudioChannelController', function() {
+  var subject;
+  var mockApp = {
+    instanceID: 'appID' ,
+    element: {}
+  };
+  var mockChannel = {
+    _domRequest: {},
+    name: 'channelName' ,
+    isActive: function() {
+      return mockChannel._domRequest;
+    },
+    setMuted: function() {
+      return mockChannel._domRequest;
+    },
+    setVolume: function() {
+      return mockChannel._domRequest;
+    },
+    _triggerDomRequestOnsuccess: function() {
+      mockChannel._domRequest.onsuccess({
+        target: { result: true }
+      });
+    }
+  };
+
+  setup(function() {
+    mockApp.element = sinon.extend(mockApp.element, sinon.EventTarget);
+    mockChannel = sinon.extend(mockChannel, sinon.EventTarget);
+    subject = new AudioChannelController(mockApp, mockChannel);
+  });
+
+  suite('Initialize the module', function() {
+    test('Audio channel is not active', function() {
+      assert.equal(subject.isActive(), false);
+    });
+
+    test('Audio channel is not playing', function() {
+      assert.equal(subject.isPlaying(), false);
+    });
+
+    test('Audio channel is not fading out', function() {
+      assert.equal(subject.isFadingOut(), false);
+    });
+
+    test('It is not vibrating', function() {
+      assert.equal(subject.isVibrating(), false);
+    });
+  });
+
+  suite('Event handlers', function() {
+    setup(function() {
+      this.sinon.spy(subject, 'publish');
+    });
+
+    test('Handle activestatechanged event', function() {
+      mockChannel.dispatchEvent(
+        new sinon.CustomEvent('activestatechanged', {}, mockChannel)
+      );
+      mockChannel._triggerDomRequestOnsuccess();
+      assert.ok(subject.publish.withArgs('statechanged').calledOnce);
+    });
+
+    test('Handle _destroyed event', function() {
+      mockApp.element.dispatchEvent(new CustomEvent('_destroyed'));
+      assert.ok(subject.publish.withArgs('destroyed').calledOnce);
+    });
+  });
+
+  suite('Deal with policies', function() {
+    setup(function() {
+      this.sinon.spy(subject, '_play');
+      this.sinon.spy(subject, '_pause');
+      this.sinon.spy(subject, '_fadeOut');
+      this.sinon.spy(subject, '_fadeIn');
+      this.sinon.spy(subject, '_vibrate');
+    });
+
+    test('Set policy', function() {
+      var policy = { isAllowedToPlay: true };
+      var audioChanel = subject.setPolicy(policy);
+      assert.deepEqual(subject._policy, policy);
+      assert.ok(audioChanel instanceof AudioChannelController);
+    });
+
+    test('Get policy', function() {
+      var expectedPolicy = { isAllowedToPlay: true };
+      var policy = subject.setPolicy(expectedPolicy)
+        .proceedPolicy()
+        .getPolicy();
+      assert.deepEqual(policy, expectedPolicy);
+    });
+
+    test('Play the audio channel', function() {
+      subject
+        .setPolicy({ isAllowedToPlay: true })
+        .proceedPolicy();
+      assert.ok(subject._play.calledOnce);
+      assert.ok(subject._pause.notCalled);
+      assert.ok(subject._fadeOut.notCalled);
+      assert.ok(subject._fadeIn.notCalled);
+      assert.ok(subject._vibrate.notCalled);
+    });
+
+    test('Pause the audio channel', function() {
+      subject
+        .setPolicy({ isAllowedToPlay: false })
+        .proceedPolicy();
+      assert.ok(subject._pause.calledOnce);
+      assert.ok(subject._play.notCalled);
+      assert.ok(subject._fadeOut.notCalled);
+      assert.ok(subject._fadeIn.notCalled);
+      assert.ok(subject._vibrate.notCalled);
+    });
+
+    test('Fade in the audio channel', function() {
+      subject
+        .setPolicy({ isNeededToFadeOut: false })
+        .proceedPolicy();
+      assert.ok(subject._fadeIn.calledOnce);
+      assert.ok(subject._play.notCalled);
+      assert.ok(subject._pause.notCalled);
+      assert.ok(subject._fadeOut.notCalled);
+      assert.ok(subject._vibrate.notCalled);
+    });
+
+    test('Fade out the audio channel', function() {
+      subject
+        .setPolicy({ isNeededToFadeOut: true })
+        .proceedPolicy();
+      assert.ok(subject._fadeOut.calledOnce);
+      assert.ok(subject._play.calledOnce);
+      assert.ok(subject._pause.notCalled);
+      assert.ok(subject._fadeIn.notCalled);
+      assert.ok(subject._vibrate.notCalled);
+    });
+
+    test('Vibrate for the audio channel', function() {
+      subject
+        .setPolicy({ isNeededToVibrate: true })
+        .proceedPolicy();
+      assert.ok(subject._vibrate.calledOnce);
+      assert.ok(subject._play.notCalled);
+      assert.ok(subject._pause.notCalled);
+      assert.ok(subject._fadeOut.notCalled);
+      assert.ok(subject._fadeIn.notCalled);
+    });
+
+    test('Do nothing', function() {
+      subject.setPolicy().proceedPolicy();
+      assert.ok(subject._play.notCalled);
+      assert.ok(subject._pause.notCalled);
+      assert.ok(subject._fadeOut.notCalled);
+      assert.ok(subject._fadeIn.notCalled);
+      assert.ok(subject._vibrate.notCalled);
+    });
+  });
+
+  suite('Handle audio channel', function() {
+    test('Play the audio channel', function() {
+      subject._play();
+      assert.equal(subject.isPlaying(), true);
+    });
+
+    test('Fade in the audio channel', function() {
+      this.sinon.spy(subject, '_setVolume');
+      var FADE_IN_VOLUME = 1;
+      subject._fadeIn();
+      assert.ok(subject._setVolume.withArgs(FADE_IN_VOLUME).calledOnce);
+      assert.equal(subject.isFadingOut(), false);
+    });
+
+    test('Fade out the audio channel', function() {
+      this.sinon.spy(subject, '_play');
+      this.sinon.spy(subject, '_setVolume');
+      var FADE_OUT_VOLUME = 0.2;
+      subject._fadeOut();
+      assert.ok(subject._play.calledOnce);
+      assert.ok(subject._setVolume.withArgs(FADE_OUT_VOLUME).calledOnce);
+      assert.equal(subject.isFadingOut(), true);
+    });
+
+    test('Pause the audio channel', function() {
+      subject._pause();
+      assert.equal(subject.isPlaying(), false);
+    });
+
+    suite('Vibrate for the audio channel', function() {
+      test('Start vibration', function() {
+        subject._vibrate();
+        assert.equal(subject.isVibrating(), true);
+      });
+
+      test('Stop vibration', function() {
+        var VIBRATION_DURATION = 1000;
+        var clock = this.sinon.useFakeTimers();
+        subject._vibrate();
+        clock.tick(VIBRATION_DURATION);
+        assert.equal(subject.isVibrating(), false);
+      });
+    });
+
+    test('Set the volume of audio channel', function() {
+      this.sinon.spy(mockChannel, 'setVolume');
+      subject._setVolume(1);
+      assert.ok(mockChannel.setVolume.withArgs(1).calledOnce);
+    });
+  });
+
+  test('Generate instance ID', function() {
+    var instanceID = mockApp.instanceID + '_' + mockChannel.name;
+    subject._generateID();
+    assert.equal(subject.instanceID, instanceID);
+  });
+});

--- a/apps/system/test/unit/audio_channel_manager_test.js
+++ b/apps/system/test/unit/audio_channel_manager_test.js
@@ -1,0 +1,302 @@
+/* global BaseModule */
+/* global MockAudioChannelController */
+'use strict';
+
+requireApp('system/test/unit/mock_audio_channel_controller.js');
+requireApp('system/js/base_module.js');
+requireApp('system/js/audio_channel_manager.js');
+
+suite('system/AudioChannelManager', function() {
+  var subject;
+
+  setup(function() {
+    subject = BaseModule.instantiate('AudioChannelManager');
+    subject.audioChannelPolicy = {
+      applyPolicy: function() {}
+    };
+    subject.start();
+  });
+
+  teardown(function() {
+    subject.stop();
+    subject.audioChannelPolicy = undefined;
+  });
+
+  test('Should initial the module correctly', function() {
+    assert.equal(subject._activeAudioChannels.size, 0);
+    assert.equal(subject._interruptedAudioChannels.length, 0);
+  });
+
+  test('Handle audiochannelstatechanged event', function() {
+    this.sinon.spy(subject, '_manageAudioChannels');
+    var audioChannel = new MockAudioChannelController(
+      { instanceID: 'appID' }, { name: 'content' }
+    );
+    var event = new CustomEvent('audiochannelstatechanged', {
+      detail: audioChannel
+    });
+    window.dispatchEvent(event);
+    assert.ok(subject._manageAudioChannels.calledOnce);
+  });
+
+  test('Handle audiochanneldestroyed event', function() {
+    this.sinon.spy(subject, '_deleteAudioChannelFromInterruptedAudioChannels');
+    this.sinon.spy(subject, '_resumeAudioChannels');
+    var instanceID = 'theAudioChannelID';
+    var audioChannel = { instanceID: instanceID };
+    var event = new CustomEvent('audiochanneldestroyed', {
+      detail: audioChannel
+    });
+    // The audio channel is playing.
+    subject._activeAudioChannels.set(instanceID, audioChannel);
+    window.dispatchEvent(event);
+    assert.ok(!subject._activeAudioChannels.has(instanceID));
+    assert.ok(subject._deleteAudioChannelFromInterruptedAudioChannels
+      .withArgs(audioChannel).calledOnce);
+    assert.ok(subject._resumeAudioChannels.calledOnce);
+  });
+
+  suite('Handle hierarchytopmostwindowchanged event', function() {
+    var app;
+    var event;
+
+    setup(function() {
+      event = new CustomEvent('hierarchytopmostwindowchanged');
+      app  = {
+        instanceID: 'appID',
+        audioChannels: new Map()
+      };
+      var audioChannel = new MockAudioChannelController(
+        app, { name: 'normal' }
+      );
+      this.sinon.stub(audioChannel, 'isPlaying', function() {
+        return true;
+      });
+      app.audioChannels.set('normal', audioChannel);
+      window.Service = {
+        query: function() {
+          return app;
+        }
+      };
+    });
+
+    teardown(function() {
+      delete window.Service;
+    });
+
+    test('Pause normal audio channel when it is in background', function() {
+      this.sinon.spy(subject, '_handleAudioChannel');
+      subject._topMostWindow = app;
+      window.dispatchEvent(event);
+      assert.deepEqual(
+        subject._topMostWindow.audioChannels.get('normal')._policy,
+        { isAllowedToPlay: false }
+      );
+    });
+
+    test('Resume all active audio channels in the app', function() {
+      this.sinon.spy(subject, '_resumeAudioChannels');
+      window.dispatchEvent(event);
+      assert.ok(subject._resumeAudioChannels.withArgs(app).calledOnce);
+    });
+  });
+
+  suite('Manage audio channels', function() {
+    var audioChannel;
+
+    setup(function() {
+      audioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'content' }
+      );
+    });
+
+    test('Handle new and active audio channels', function() {
+      var isActiveStub = this.sinon.stub(audioChannel, 'isActive', function() {
+        return true;
+      });
+      this.sinon.spy(subject.audioChannelPolicy, 'applyPolicy');
+      this.sinon.spy(subject, '_isAudioChannelInBackground');
+      this.sinon.spy(subject, '_handleAudioChannel');
+      subject._manageAudioChannels(audioChannel);
+      assert.ok(isActiveStub.calledOnce);
+      assert.ok(subject.audioChannelPolicy.applyPolicy.calledOnce);
+      assert.ok(subject._isAudioChannelInBackground
+        .withArgs(audioChannel).calledOnce);
+      assert.ok(subject._handleAudioChannel
+        .withArgs(audioChannel).calledOnce);  
+    });
+
+    test('Reset and resume audio channels', function() {
+      var isActiveStub = this.sinon.stub(audioChannel, 'isActive', function() {
+        return false;
+      });
+      this.sinon.spy(subject, '_resetAudioChannel');
+      this.sinon.spy(subject, '_resumeAudioChannels');
+      subject._manageAudioChannels(audioChannel);
+      assert.ok(isActiveStub.calledOnce);
+      assert.ok(subject._resetAudioChannel.withArgs(audioChannel).calledOnce);
+      assert.ok(subject._resumeAudioChannels.calledOnce);
+    });
+  });
+
+  suite('Reset the audio channel', function() {
+
+    setup(function() {
+      this.sinon.spy(subject, '_handleAudioChannel');
+    });
+
+    test('Set audio channel as default state as muted', function() {
+      var audioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'content' }
+      );
+      subject._resetAudioChannel(audioChannel);
+      assert.deepEqual(audioChannel._policy, { isAllowedToPlay: false });
+      assert.ok(subject._handleAudioChannel.withArgs(audioChannel).calledOnce);
+    });
+
+    test('Fade in audio channel', function() {
+      var audioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'notification' }
+      );
+      this.sinon.spy(subject, '_fadeInFadedOutAudioChannels');
+      subject._resetAudioChannel(audioChannel);
+      assert.ok(subject._fadeInFadedOutAudioChannels.calledOnce);
+    });
+  });
+
+  suite('Handle audio channel', function() {
+    var audioChannel;
+
+    setup(function() {
+      audioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'content' }
+      );
+    });
+
+    test('Play the audio channel', function() {
+      audioChannel.setPolicy({
+        isAllowedToPlay: true
+      });
+      subject._handleAudioChannel(audioChannel);
+      assert.ok(subject._activeAudioChannels.has(audioChannel.instanceID));
+    });
+
+    test('Pause the audio channel', function() {
+      subject._activeAudioChannels.set(audioChannel.instanceID, audioChannel);
+      audioChannel.setPolicy({
+        isAllowedToPlay: false
+      });
+      subject._handleAudioChannel(audioChannel);
+      assert.ok(!subject._activeAudioChannels.has(audioChannel.instanceID));
+    });
+
+    test('Resume the audio channel when other audio channel ends', function() {
+      audioChannel.setPolicy({
+        isAllowedToPlay: false,
+        isNeededToResumeWhenOtherEnds: true
+      });
+      subject._handleAudioChannel(audioChannel);
+      var interruptedAudioChannels = subject._interruptedAudioChannels;
+      assert.equal(interruptedAudioChannels.length, 1);
+      assert.deepEqual(interruptedAudioChannels.pop(), audioChannel);
+    });
+  });
+
+  test('Fade in audio channel', function() {
+    var audioChannel = new MockAudioChannelController(
+      { instanceID: 'appID' }, { name: 'content' }
+    );
+    this.sinon.stub(audioChannel, 'isFadingOut', function() {
+      return true;
+    });
+    subject._activeAudioChannels.set(audioChannel.instanceID, audioChannel);
+    subject._fadeInFadedOutAudioChannels();
+    assert.deepEqual(audioChannel._policy, { isNeededToFadeOut: false });
+  });
+
+  suite('Resume audio channels', function() {
+    var audioChannel;
+
+    setup(function() {
+      audioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'content' }
+      );
+      this.sinon.stub(audioChannel, 'isActive', function() {
+        return true;
+      });
+      this.sinon.stub(audioChannel, 'isPlaying', function() {
+        return true;
+      });
+      subject._interruptedAudioChannels.push(audioChannel);
+    });
+
+    test('Resume the audio channels belong to the foreground app', function() {
+      var app = {
+        audioChannels: [audioChannel]
+      };
+      this.sinon.spy(subject, '_manageAudioChannels');
+      subject._resumeAudioChannels(app);
+      assert.ok(subject._manageAudioChannels.withArgs(audioChannel).calledOnce);
+      assert.equal(subject._interruptedAudioChannels.length, 0);
+    });
+
+    test('Resume the interrupted audio channel', function() {
+      subject._resumeAudioChannels();
+      assert.equal(subject._interruptedAudioChannels.length, 0);
+    });
+  });
+
+  suite('Delete audio channel from _interruptedAudioChannels', function() {
+    var audioChannel;
+
+    setup(function() {
+      audioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'content' }
+      );
+      subject._interruptedAudioChannels.push(audioChannel);
+    });
+
+    test('Delete the audio channel', function() {
+      subject._deleteAudioChannelFromInterruptedAudioChannels(audioChannel);
+      assert.equal(subject._interruptedAudioChannels.length, 0);
+    });
+
+    test('Do not delete the audio channel', function() {
+      subject._deleteAudioChannelFromInterruptedAudioChannels(
+        new MockAudioChannelController(
+          { instanceID: 'appID' }, { name: 'normal' }
+        ) 
+      );
+      subject._deleteAudioChannelFromInterruptedAudioChannels(
+        new MockAudioChannelController(
+          { instanceID: 'app2ID' }, { name: 'normal' }
+        ) 
+      );
+      assert.deepEqual(subject._interruptedAudioChannels.pop(), audioChannel);
+    });
+  });
+
+  suite('App is in foreground or background', function() {
+    var audioChannel;
+
+    setup(function() {
+      audioChannel = new MockAudioChannelController(
+        { instanceID: 'app1ID' }, { name: 'content' }
+      );
+    });
+
+    test('In foreground', function() {
+      subject._topMostWindow = { instanceID: 'app1ID' };
+      assert.equal(subject._isAudioChannelInBackground(audioChannel), false);
+    });
+
+    test('In background', function() {
+      subject._topMostWindow = { instanceID: 'app2ID' };
+      assert.equal(subject._isAudioChannelInBackground(audioChannel), true);
+    });
+
+    test('Top most window is not changed', function() {
+      assert.equal(subject._isAudioChannelInBackground(audioChannel), true);
+    });
+  });
+});

--- a/apps/system/test/unit/audio_channel_policy_test.js
+++ b/apps/system/test/unit/audio_channel_policy_test.js
@@ -1,0 +1,461 @@
+/* global BaseModule */
+/* global MockAudioChannelController */
+'use strict';
+
+requireApp('system/test/unit/mock_audio_channel_controller.js');
+requireApp('system/js/base_module.js');
+requireApp('system/js/audio_channel_policy.js');
+
+suite('system/AudioChannelPolicy', function() {
+  var subject;
+
+  setup(function() {
+    subject = BaseModule.instantiate('AudioChannelPolicy');
+  });
+
+  test('Initialize the module', function() {
+    assert.ok(subject._isVibrateEnabled);
+  });
+
+  suite('Policies for handling audio channels', function() {
+    /**
+     * Check the policies.
+     *
+     * @param {Array|Object} audioChannels
+     * The audio channels for generating policies.
+     * @param {Object} expectedPolicy
+     * The policy for the audio channels.
+     * @param {Boolean} [isSameApp]
+     * If true, the audio channels belong to same app.
+     * Otherwise each audio channel belong to different app.
+     */
+    function checkPolicy(audioChannels, expectedPolicy, isSameApp) {
+      var appID = 0;
+      audioChannels = Array.isArray(audioChannels) ?
+        audioChannels : [audioChannels];
+      expectedPolicy.activeAudioChannels =
+        Array.isArray(expectedPolicy.activeAudioChannels) ?
+        expectedPolicy.activeAudioChannels :
+        [expectedPolicy.activeAudioChannels];
+      audioChannels.map(function(obj) {
+        var activeAudioChannels = new Map();
+        obj.activeAudioChannels = Array.isArray(obj.activeAudioChannels) ?
+          obj.activeAudioChannels : [obj.activeAudioChannels];
+        var newAudioChannel =
+          new MockAudioChannelController(
+            { instanceID: appID }, { name: obj.newAudioChannel }
+          );
+        // Array to map.
+        obj.activeAudioChannels.forEach(function(audioChannel, i) {
+          if (!isSameApp) {
+            appID++;
+          }
+          activeAudioChannels.set(i, 
+            new MockAudioChannelController(
+              { instanceID: appID }, { name: audioChannel }
+            )
+          );
+        });
+        return {
+          newAudioChannel: newAudioChannel,
+          activeAudioChannels: activeAudioChannels
+        };
+      }).forEach(function(obj) {
+        var newAudioChannel = obj.newAudioChannel;
+        var activeAudioChannels = obj.activeAudioChannels;
+        subject.applyPolicy(newAudioChannel, activeAudioChannels);
+        assert.deepEqual(newAudioChannel._policy,
+          expectedPolicy.newAudioChannel);
+        activeAudioChannels.forEach(function(audioChannel, i) {
+          assert.deepEqual(
+            audioChannel._policy,
+            expectedPolicy.activeAudioChannels[i]
+          );
+        });
+      });
+    }
+    
+    test('Play active and new audio channels', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'normal', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'normal', activeAudioChannels: 'system' },
+          { newAudioChannel: 'normal', activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'normal', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'content', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'content', activeAudioChannels: 'system' },
+          { newAudioChannel: 'content', activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'content', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'system' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'notification' },
+          { newAudioChannel: 'alarm',
+            activeAudioChannels: 'publicNotification' },
+          { newAudioChannel: 'system', activeAudioChannels: 'normal' },
+          { newAudioChannel: 'system', activeAudioChannels: 'content' },
+          { newAudioChannel: 'system', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'system', activeAudioChannels: 'system' },
+          { newAudioChannel: 'system', activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'system', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'system', activeAudioChannels: 'notification' },
+          { newAudioChannel: 'system',
+            activeAudioChannels: 'publicNotification' },
+          { newAudioChannel: 'ringer', activeAudioChannels: 'system' },
+          { newAudioChannel: 'ringer', activeAudioChannels: 'notification' },
+          { newAudioChannel: 'ringer',
+            activeAudioChannels: 'publicNotification' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'system' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'notification' },
+          { newAudioChannel: 'telephony',
+            activeAudioChannels: 'publicNotification' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'system' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'notification',
+            activeAudioChannels: 'notification' },
+          { newAudioChannel: 'notification',
+            activeAudioChannels: 'publicNotification' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'system' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'ringer' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'notification' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'publicNotification' },
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          }
+        }
+      );
+    });
+
+    test('Pause active audio channel and ' +
+         'play new audio channel', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'normal', activeAudioChannels: 'normal' },
+          { newAudioChannel: 'normal', activeAudioChannels: 'content' },
+          { newAudioChannel: 'content', activeAudioChannels: 'normal' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'normal' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'ringer', activeAudioChannels: 'normal' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'normal' },
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: false,
+            isNeededToVibrate: false,
+            isNeededToResumeWhenOtherEnds: false,
+          }
+        }
+      );
+    });
+
+    test('Pause active audio channel, ' +
+         'play new audio channel, ' +
+         'and resume the pause audio channel when other ends', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'content', activeAudioChannels: 'content' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'content' },
+          { newAudioChannel: 'ringer', activeAudioChannels: 'content' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'content' }
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: false,
+            isNeededToVibrate: false,
+            isNeededToResumeWhenOtherEnds: true,
+          }
+        }
+      );
+    });
+
+    test('Fade out active audio channel', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'ringer', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'alarm' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'normal' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'content' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'normal' },
+          { newAudioChannel: 'publicNotification',
+            activeAudioChannels: 'content' },  
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: true,
+          }
+        }
+      );
+    });
+
+    test('Fade out new audio channel', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'normal', activeAudioChannels: 'notification' },
+          { newAudioChannel: 'normal',
+            activeAudioChannels: 'publicNotification' },
+          { newAudioChannel: 'content', activeAudioChannels: 'notification' },
+          { newAudioChannel: 'content',
+            activeAudioChannels: 'publicNotification' }
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: true,
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          }
+        }
+      );
+    });
+
+    test('Vibrate for active audio channel', function(){
+      checkPolicy(
+        { newAudioChannel: 'ringer', activeAudioChannels: 'ringer' },
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: false,
+            isNeededToVibrate: true,
+            isNeededToResumeWhenOtherEnds: false
+          }
+        }
+      );
+    });
+
+    test('Vibrate for new audio channel', function(){
+      checkPolicy(
+        [
+          { newAudioChannel: 'ringer', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'telephony' },
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: false,
+            isNeededToVibrate: true
+          },
+          activeAudioChannels: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          }
+        }
+      );
+    });
+
+    test('Deconflict conflicted policy', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'alarm', activeAudioChannels:
+            ['system', 'telephony', 'publicNotification'] },
+          { newAudioChannel: 'ringer', activeAudioChannels:
+            ['system', 'telephony', 'publicNotification'] },
+          { newAudioChannel: 'notification', activeAudioChannels:
+            ['system', 'telephony', 'publicNotification'] },
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: false,
+            isNeededToVibrate: true
+          },
+          activeAudioChannels: [
+            {
+              isAllowedToPlay: true,
+              isNeededToFadeOut: false,
+            },
+            {
+              isAllowedToPlay: true,
+              isNeededToFadeOut: false,
+            },
+            {
+              isAllowedToPlay: true,
+              isNeededToFadeOut: false,
+            }
+          ]
+        }
+      );
+    });
+
+    test('All audio channels belong to same app', function() {
+      checkPolicy(
+        [
+          { newAudioChannel: 'normal', activeAudioChannels: 'content' },
+          { newAudioChannel: 'telephony', activeAudioChannels: 'content' },
+          { newAudioChannel: 'alarm', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'ringer', activeAudioChannels: 'telephony' },
+          { newAudioChannel: 'notification', activeAudioChannels: 'telephony' },
+        ],
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          // Do nothing for active audio channels.
+          activeAudioChannels: {}
+        },
+        // All audio channels belong to same app.
+        true
+      );
+
+      checkPolicy(
+        {
+          newAudioChannel: 'normal',
+          activeAudioChannels: [
+            'content', 'alarm', 'system', 'ringer', 'telephony',
+            'notification', 'publicNotification'
+          ]
+        },
+        {
+          newAudioChannel: {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false,
+          },
+          activeAudioChannels: [{}, {}, {}, {}, {}, {}, {}]
+        },
+        true
+      );
+    });
+
+    test('Normal audio channel cannot play in background', function() {
+      var newAudioChannel = new MockAudioChannelController(
+        { instanceID: 'appID' }, { name: 'normal' }
+      );
+      var activeAudioChannels = new Map();
+      subject.applyPolicy(newAudioChannel, activeAudioChannels,
+        { isNewAudioChannelInBackground: true });
+      assert.deepEqual(
+        newAudioChannel._policy,
+        {
+          isAllowedToPlay: false,
+          isNeededToVibrate: false
+        }
+      );
+    });
+
+    test('All audio channel except normal audio channel ' +
+         'can play in background', function() {
+      ['content', 'alarm', 'system', 'ringer', 'telephony',
+       'notification', 'publicNotification'].forEach(function(name) {
+        var newAudioChannel = new MockAudioChannelController(
+          { instanceID: 'appID' }, { name: name }
+        );
+        var activeAudioChannels = new Map();
+        subject.applyPolicy(newAudioChannel, activeAudioChannels,
+          { isNewAudioChannelInBackground: true });
+        assert.deepEqual(
+          newAudioChannel._policy,
+          {
+            isAllowedToPlay: true,
+            isNeededToFadeOut: false
+          }
+        );
+      });
+    });
+  });
+
+  suite('Observe vibration.enabled', function() {
+    test('Observed', function() {
+      var index = subject.constructor.SETTINGS.indexOf('vibration.enabled');
+      assert.ok(index !== -1);
+    });
+
+    test('Enabled', function() {
+      subject['_observe_vibration.enabled'](true);
+      assert.equal(subject._isVibrateEnabled, true);
+    });
+
+    test('Disabled', function() {
+      subject['_observe_vibration.enabled'](false);
+      assert.equal(subject._isVibrateEnabled, false);
+    });
+  });
+
+  test('Fade out new audio channel', function() {
+    var isNeeded = [
+      { activeChannelName: 'notification', newChannelName: 'normal' },
+      { activeChannelName: 'notification', newChannelName: 'content' },
+      { activeChannelName: 'publicNotification', newChannelName: 'normal' },
+      { activeChannelName: 'publicNotification', newChannelName: 'content' }
+    ].map(function(obj) {
+      return subject._isNeededToFadeOutForNewAudioChannel(
+        obj.activeChannelName, obj.newChannelName
+      );
+    }).every(elem => elem);
+    assert.equal(isNeeded, true);
+  });
+
+  test('Fade out active audio channel', function() {
+    var isNeeded = [
+      { activeChannelName: 'alarm', newChannelName: 'ringer' },
+      { activeChannelName: 'alarm', newChannelName: 'telephony' },
+      { activeChannelName: 'normal', newChannelName: 'notification' },
+      { activeChannelName: 'normal', newChannelName: 'publicNotification' },
+      { activeChannelName: 'content', newChannelName: 'notification' },
+      { activeChannelName: 'content', newChannelName: 'publicNotification' }
+    ].map(function(obj) {
+      return subject._isNeededToFadeOutForActiveAudioChannel(
+        obj.activeChannelName, obj.newChannelName
+      );
+    }).every(elem => elem);
+    assert.equal(isNeeded, true);
+  });
+
+  test('Vibrate for active audio channel', function() {
+    var isNeeded = [
+      { activeChannelName: 'ringer', newChannelName: 'ringer' }
+    ].map(function(obj) {
+      return subject._isNeededToVibrateForActiveAudioChannel(
+        obj.activeChannelName, obj.newChannelName
+      );
+    }).every(elem => elem);
+    assert.equal(isNeeded, true);
+  });
+
+  test('Resume active audio channel when other ends', function() {
+    var isNeeded = [
+      { activeChannelName: 'content', newChannelName: 'content' },
+      { activeChannelName: 'content', newChannelName: 'alarm' },
+      { activeChannelName: 'content', newChannelName: 'ringer' },
+      { activeChannelName: 'content', newChannelName: 'telephony' }
+    ].map(function(obj) {
+      return subject._isNeededToResumeWhenOtherEndsForActiveAudioChannel(
+        obj.activeChannelName, obj.newChannelName
+      );
+    }).every(elem => elem);
+    assert.equal(isNeeded, true);
+  });
+});

--- a/apps/system/test/unit/mock_audio_channel_controller.js
+++ b/apps/system/test/unit/mock_audio_channel_controller.js
@@ -1,0 +1,28 @@
+'use strict';
+
+(function(exports) {
+  function MockAudioChannelController(app, audioChannel) {
+    this.app = app;
+    this.name = audioChannel.name;
+    this.instanceID = this.app.instanceID + '_' + this.name;
+    this._policy = {};
+  }
+
+  MockAudioChannelController.prototype = {
+    isActive: function() {},
+    isPlaying: function() {},
+    isFadingOut: function() {},
+    setPolicy: function(policy) {
+      this._policy = policy;
+      return this;
+    },
+    getPolicy: function() {
+      return this._policy;
+    },
+    proceedPolicy: function() {
+      return this;
+    }
+  };
+
+  exports.MockAudioChannelController = MockAudioChannelController;
+}(window));


### PR DESCRIPTION
The below is the API interface of BrowserElementAudioChannel[1](https://bug1113086.bugzilla.mozilla.org/attachment.cgi?id=8553107).

```
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+[Pref="dom.mozBrowserFramesEnabled",
+ CheckPermissions="browser"]
+interface BrowserElementAudioChannel : EventTarget {
+  readonly attribute AudioChannel name;
+
+  // This event is dispatched when this audiochannel is actually in used by the
+  // app or one of the sub-iframes.
+  attribute EventHandler onactivestatechanged;
+
+  [Throws]
+  DOMRequest getVolume();
+
+  [Throws]
+  DOMRequest setVolume(float aVolume);
+
+  [Throws]
+  DOMRequest getMuted();
+
+  [Throws]
+  DOMRequest setMuted(boolean aMuted);
+
+  [Throws]
+  DOMRequest isActive();
+};
```

And you could see the UX spec in [2](https://bug961967.bugzilla.mozilla.org/attachment.cgi?id=8541542).
