### PR TITLE
Bug 1105639 - Release observers when SettingsHelper is done r=...

### DIFF
--- a/apps/system/js/findmydevice_launcher.js
+++ b/apps/system/js/findmydevice_launcher.js
@@ -29,76 +29,6 @@ var FMDOpenSettings = function() {
   };
 };
 
-navigator.mozSettings.addObserver('findmydevice.enabled', function(event) {
-  // make sure Find My Device is registered if it's enabled,
-  // and that it notifies the server if disabled
-  wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_ENABLED_CHANGED);
-});
-
-navigator.mozSettings.addObserver('findmydevice.retry-count', function(event) {
-  // Make sure a notification is displayed if the retry count is exceeded
-  if (event.settingValue >= FMD_MAX_REGISTRATION_RETRIES) {
-    SettingsHelper('findmydevice.enabled').set(false);
-
-    var _ = navigator.mozL10n.get;
-    var icon = 'style/find_my_device/images/findMyDevice.png';
-    var title = _('unable-to-connect');
-    var body = _('tap-to-check-settings');
-
-    var notification = new Notification(title,
-      {
-        body:body,
-        icon:icon,
-        tag: FMD_ENABLE_FAILURE_NOTIFICATION_TAG
-      });
-
-    notification.onclick = function(evt) {
-      FMDOpenSettings();
-      notification.close();
-    };
-  }
-});
-
-navigator.mozSettings.addObserver('geolocation.enabled', function(event) {
-  // invalidate registration so we can report to the server
-  // whether tracking is enabled or not, which depends on
-  // geolocation
-  wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_STALE_REGISTRATION);
-});
-
-window.addEventListener('lockscreen-request-unlock', function(event) {
-  if (event.detail && event.detail.activity &&
-      'record' === event.detail.activity.name) {
-    // Let's make sure we won't start FMD when user triggers Camera from
-    // the lockscreen.
-    return;
-  }
-
-  // clear the lockscreen lock message
-  var helper = SettingsHelper('lockscreen.lock-message');
-  helper.set('');
-
-  // stop the ringer if it's currently being rung
-  wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_LOCKSCREEN_CLOSED);
-});
-
-window.addEventListener('mozFxAccountsUnsolChromeEvent', function(event) {
-  if (!event || !event.detail) {
-    return;
-  }
-
-  var eventName = event.detail.eventName;
-  var loggedInHelper = SettingsHelper('findmydevice.logged-in');
-  DUMP('findmydevice received ' + eventName + ' FxA event in the System app');
-  if (eventName === 'onlogin' || eventName === 'onverified') {
-    loggedInHelper.set(true);
-    wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_LOGIN);
-  } else if (eventName === 'onlogout') {
-    loggedInHelper.set(false);
-    wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_LOGOUT);
-  }
-});
-
 // ensure resent notifications are closed properly
 var FMDCloseNotifications = function() {
   Notification.get().then(function(notifications) {
@@ -119,15 +49,94 @@ var FMDCloseNotifications = function() {
   });
 };
 
-// ensure resent notifications are handled correctly
-window.navigator.mozSetMessageHandler('notification', function(message) {
-  if (!message.clicked) {
-    return;
-  } else {
-    if (message.tag &&
-      message.tag.startsWith(FMD_ENABLE_FAILURE_NOTIFICATION_TAG)) {
-      FMDOpenSettings();
-      FMDCloseNotifications();
+function FMDInit() {
+  navigator.mozSettings.addObserver('findmydevice.enabled', function(event) {
+    // make sure Find My Device is registered if it's enabled,
+    // and that it notifies the server if disabled
+    wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_ENABLED_CHANGED);
+  });
+
+  var fmdEnabledHelper = SettingsHelper('findmydevice.enabled');
+  navigator.mozSettings.addObserver('findmydevice.retry-count',
+    function(event) {
+      // Make sure a notification is displayed if the retry count is exceeded
+      if (event.settingValue >= FMD_MAX_REGISTRATION_RETRIES) {
+        fmdEnabledHelper.set(false);
+
+        var _ = navigator.mozL10n.get;
+        var icon = 'style/find_my_device/images/findMyDevice.png';
+        var title = _('unable-to-connect');
+        var body = _('tap-to-check-settings');
+
+        var notification = new Notification(title,
+          {
+            body:body,
+            icon:icon,
+            tag: FMD_ENABLE_FAILURE_NOTIFICATION_TAG
+          });
+
+        notification.onclick = function(evt) {
+          FMDOpenSettings();
+          notification.close();
+        };
+      }
+    });
+
+  navigator.mozSettings.addObserver('geolocation.enabled', function(event) {
+    // invalidate registration so we can report to the server
+    // whether tracking is enabled or not, which depends on
+    // geolocation
+    wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_STALE_REGISTRATION);
+  });
+
+  var lockMessageHelper = SettingsHelper('lockscreen.lock-message');
+  window.addEventListener('lockscreen-request-unlock', function(event) {
+    if (event.detail && event.detail.activity &&
+        'record' === event.detail.activity.name) {
+      // Let's make sure we won't start FMD when user triggers Camera from
+      // the lockscreen.
+      return;
     }
-  }
+
+    // clear the lockscreen lock message
+    lockMessageHelper.set('');
+
+    // stop the ringer if it's currently being rung
+    wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_LOCKSCREEN_CLOSED);
+  });
+
+  var loggedInHelper = SettingsHelper('findmydevice.logged-in');
+  window.addEventListener('mozFxAccountsUnsolChromeEvent', function(event) {
+    if (!event || !event.detail) {
+      return;
+    }
+
+    var eventName = event.detail.eventName;
+    DUMP('findmydevice received ' + eventName + ' FxA event in the System app');
+    if (eventName === 'onlogin' || eventName === 'onverified') {
+      loggedInHelper.set(true);
+      wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_LOGIN);
+    } else if (eventName === 'onlogout') {
+      loggedInHelper.set(false);
+      wakeUpFindMyDevice(IAC_API_WAKEUP_REASON_LOGOUT);
+    }
+  });
+
+  // ensure resent notifications are handled correctly
+  window.navigator.mozSetMessageHandler('notification', function(message) {
+    if (!message.clicked) {
+      return;
+    } else {
+      if (message.tag &&
+        message.tag.startsWith(FMD_ENABLE_FAILURE_NOTIFICATION_TAG)) {
+        FMDOpenSettings();
+        FMDCloseNotifications();
+      }
+    }
+  });
+}
+
+window.addEventListener('load', function fmdlauncher_load() {
+  window.removeEventListener('load', fmdlauncher_load);
+  FMDInit();
 });

--- a/apps/system/test/unit/battery_overlay_test.js
+++ b/apps/system/test/unit/battery_overlay_test.js
@@ -3,9 +3,11 @@
 /* global MocksHelper */
 /* global MockL10n */
 /* global MockNavigatorBattery */
+/* global MockNavigatorSettings */
 
 requireApp('system/test/unit/mock_navigator_battery.js');
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('system/test/unit/mock_sleep_menu.js');
 requireApp('system/test/unit/mock_screen_manager.js');
 require('/shared/test/unit/mocks/mock_gesture_detector.js');
@@ -24,6 +26,7 @@ suite('battery manager >', function() {
   var screenNode, notifNode, overlayNode;
   var tinyTimeout = 10;
 
+  var realMozSettings;
   var realL10n;
   var subject;
 
@@ -32,6 +35,9 @@ suite('battery manager >', function() {
     subject = window.batteryOverlay = new BatteryOverlay();
     realBattery = subject._battery;
     subject._battery = MockNavigatorBattery;
+
+    realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
 
     // must be big enough, otherwise the BatteryOverlay timeout occurs
     // before the different suites execute.
@@ -44,6 +50,7 @@ suite('battery manager >', function() {
   suiteTeardown(function() {
     subject._battery = realBattery;
     realBattery = null;
+    navigator.mozSettings = realMozSettings;
 
     navigator.mozL10n = realL10n;
   });

--- a/apps/system/test/unit/findmydevice_launcher_test.js
+++ b/apps/system/test/unit/findmydevice_launcher_test.js
@@ -3,7 +3,7 @@
    IAC_API_WAKEUP_REASON_LOGIN, IAC_API_WAKEUP_REASON_LOGOUT,
    IAC_API_WAKEUP_REASON_STALE_REGISTRATION,
    IAC_API_WAKEUP_REASON_ENABLED_CHANGED,
-   IAC_API_WAKEUP_REASON_LOCKSCREEN_CLOSED
+   IAC_API_WAKEUP_REASON_LOCKSCREEN_CLOSED, FMDInit
 */
 
 'use strict';
@@ -17,6 +17,7 @@ require('/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_set_message_handler.js');
 require('/shared/test/unit/mocks/mock_notification.js');
 require('/shared/js/findmydevice_iac_api.js');
+require('/js/findmydevice_launcher.js');
 
 const FMD_RETRIES = 5;
 
@@ -24,20 +25,19 @@ var mocksForFindMyDevice = new MocksHelper([
   'Dump', 'Notification', 'SettingsHelper', 'MozActivity'
 ]).init();
 
-suite('FindMyDevice Launcher >', function(done) {
+suite('FindMyDevice Launcher >', function() {
   var realMozSettings;
   var realMozL10n;
   var realMozSetMessageHandler;
 
   mocksForFindMyDevice.attachTestHelpers();
 
-  suiteSetup(function(done) {
+  suiteSetup(function() {
     realMozSettings = navigator.mozSettings;
     realMozL10n = navigator.mozL10n;
     realMozSetMessageHandler = navigator.mozSetMessageHandler;
 
     navigator.mozSettings = MockNavigatorSettings;
-    MockNavigatorSettings.mSetup();
 
     MockMozActivity.mSetup();
 
@@ -45,11 +45,6 @@ suite('FindMyDevice Launcher >', function(done) {
     MockNavigatormozSetMessageHandler.mSetup();
 
     navigator.mozL10n = MockL10n;
-
-    // We need to load this after setting up MockNavigatorSettings
-    require('/js/findmydevice_launcher.js', function() {
-      done();
-    });
   });
 
   suiteTeardown(function() {
@@ -61,7 +56,13 @@ suite('FindMyDevice Launcher >', function(done) {
   });
 
   setup(function() {
+    MockNavigatorSettings.mSetup();
+    FMDInit();
     this.sinon.stub(window, 'wakeUpFindMyDevice');
+  });
+
+  teardown(function() {
+    MockNavigatorSettings.mTeardown();
   });
 
   test('send ENABLED_CHANGED wakeup message when enabled', function() {

--- a/apps/system/test/unit/power_save_test.js
+++ b/apps/system/test/unit/power_save_test.js
@@ -1,45 +1,69 @@
 'use strict';
-/* global MocksHelper, MockNavigatorSettings, MockSettingsListener,
-   PowerSave, MockBluetooth */
+/* global BatteryOverlay,
+          MockBluetooth,
+          MockNavigatorBattery,
+          MockNavigatorSettings,
+          MockSettingsListener,
+          MocksHelper,
+          PowerSave
+*/
 
 requireApp('system/test/unit/mock_navigator_battery.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
+requireApp('system/shared/test/unit/mocks/mock_notification_helper.js');
 requireApp('system/test/unit/mock_bluetooth.js');
 requireApp('system/js/power_save.js');
+requireApp('system/js/battery_overlay.js');
 
 var mocksForPowerSave = new MocksHelper([
-  'SettingsListener'
+  'SettingsListener', 'NotificationHelper'
 ]).init();
 
 suite('power save >', function() {
 
   var realBluetooth;
+  var realMozSettings;
   var subject;
+  var realBattery, battery;
 
   mocksForPowerSave.attachTestHelpers();
   suiteSetup(function() {
     realBluetooth = window.Bluetooth;
     window.Bluetooth = MockBluetooth;
 
+    realMozSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+
     subject = new PowerSave();
+
+    realBattery = subject._battery;
+    window.batteryOverlay = new BatteryOverlay();
+    window.batteryOverlay._battery = MockNavigatorBattery;
+    battery = window.batteryOverlay._battery;
   });
 
   suiteTeardown(function() {
+    subject = null;
+
+    battery = null;
+    window.batteryOverlay._battery = realBattery;
+    window.batteryOverlay = null;
+
+    navigator.mozSettings = realMozSettings;
     window.Bluetooth = realBluetooth;
   });
 
   suite('restores state >', function() {
+    var dispatchSpy, enablePowerSpy, disablePowerSpy,
+        doCheckThresholdSpy, checkThresholdSpy;
     setup(function(){
-      sinon.spy(window, 'dispatchEvent');
+      dispatchSpy = this.sinon.spy(window, 'dispatchEvent');
       subject.start();
-      sinon.spy(subject, 'enablePowerSave');
-      sinon.spy(subject, 'disablePowerSave');
-    });
-
-    teardown(function() {
-      window.dispatchEvent.restore();
-      subject.enablePowerSave.restore();
-      subject.disablePowerSave.restore();
+      enablePowerSpy  = this.sinon.spy(subject, 'enablePowerSave');
+      disablePowerSpy = this.sinon.spy(subject, 'disablePowerSave');
+      checkThresholdSpy = this.sinon.spy(subject, 'checkThreshold');
+      doCheckThresholdSpy = this.sinon.spy(subject, 'doCheckThreshold');
     });
 
     test('restores all states', function() {
@@ -48,9 +72,9 @@ suite('power save >', function() {
         MockSettingsListener.mCallbacks[state](true);
       }
       MockSettingsListener.mCallbacks['powersave.enabled'](true);
-      assert.ok(subject.enablePowerSave.called);
-      assert.isFalse(subject.disablePowerSave.called);
-      assert.ok(window.dispatchEvent.calledOnce);
+      sinon.assert.called(enablePowerSpy);
+      sinon.assert.notCalled(disablePowerSpy);
+      sinon.assert.calledOnce(dispatchSpy);
       // States should be false now.
       for (state in subject._states) {
         if ('bluetooth.enabled' !== state) {
@@ -62,9 +86,9 @@ suite('power save >', function() {
         MockSettingsListener.mCallbacks[state](false);
       }
       MockSettingsListener.mCallbacks['powersave.enabled'](false);
-      assert.ok(subject.disablePowerSave.called);
+      sinon.assert.called(disablePowerSpy);
 
-      assert.ok(window.dispatchEvent.calledTwice);
+      sinon.assert.calledTwice(dispatchSpy);
       // States should be restored.
       for (state in subject._states) {
         if ('bluetooth.enabled' !== state) {
@@ -81,15 +105,121 @@ suite('power save >', function() {
         }
         subject._powerSaveResume['bluetooth.enabled'] = false;
         MockSettingsListener.mCallbacks['powersave.enabled'](false);
-        assert.ok(subject.disablePowerSave.called);
+        sinon.assert.called(disablePowerSpy);
 
-        assert.ok(!window.dispatchEvent.called);
+        sinon.assert.notCalled(dispatchSpy);
         // States should be restored.
         for (state in subject._states) {
           if ('bluetooth.enabled' !== state) {
             assert.equal(true, MockNavigatorSettings.mSettings[state]);
           }
         }
+    });
+
+    test('change to powersave.threshold calls doCheckThreshold', function() {
+      MockSettingsListener.mCallbacks['powersave.threshold'](0.1);
+      sinon.assert.notCalled(checkThresholdSpy);
+      sinon.assert.calledOnce(doCheckThresholdSpy);
+      sinon.assert.calledWith(doCheckThresholdSpy, 0.1);
+    });
+  });
+
+  suite('battery change >', function() {
+    suite('onBatteryChange behavior >', function() {
+      var checkSpy, setSpy;
+      setup(function() {
+        checkSpy = this.sinon.spy(subject, 'checkThreshold');
+        setSpy = this.sinon.spy(subject, 'setMozSettings');
+      });
+
+      test('no checkThreshold call when charging', function() {
+        battery.charging = true;
+        subject.onBatteryChange();
+        sinon.assert.notCalled(checkSpy);
+      });
+
+      test('checkThreshold called when not charging', function() {
+        battery.charging = false;
+        subject.onBatteryChange();
+        sinon.assert.calledOnce(checkSpy);
+      });
+
+      test('charging with powersave enabled sets setting to false', function() {
+        battery.charging = true;
+        subject._powerSaveEnabled = true;
+        subject.onBatteryChange();
+        sinon.assert.calledOnce(setSpy);
+        sinon.assert.calledWith(setSpy, { 'powersave.enabled': false });
+      });
+
+      test('charging with powersave disables does nothing', function() {
+        battery.charging = true;
+        subject._powerSaveEnabled = false;
+        subject.onBatteryChange();
+        sinon.assert.notCalled(setSpy);
+      });
+    });
+
+    suite('checkThreshold behavior', function() {
+      var setSpy;
+      setup(function() {
+        MockNavigatorSettings.mSetup();
+        MockNavigatorSettings.mSyncRepliesOnly = true;
+        setSpy = this.sinon.spy(subject, 'setMozSettings');
+        battery.level = 0.15;
+      });
+
+      teardown(function() {
+        MockNavigatorSettings.mTeardown();
+      });
+
+      test('powersave.threshold -1 does nothing', function() {
+        MockNavigatorSettings.createLock().set({'powersave.threshold': -1});
+        subject.checkThreshold();
+        MockNavigatorSettings.mReplyToRequests();
+        sinon.assert.notCalled(setSpy);
+      });
+
+      function trigger(threshold, value) {
+        MockNavigatorSettings.createLock().set({
+          'powersave.threshold': threshold
+        });
+        subject._powerSaveEnabled = value;
+        subject.checkThreshold();
+        MockNavigatorSettings.mReplyToRequests();
+      }
+
+      suite('level under threshold', function() {
+        test('enable power save if not already enabled', function() {
+          trigger(0.25, false);
+          sinon.assert.calledOnce(setSpy);
+          sinon.assert.calledWith(setSpy, { 'powersave.enabled': true });
+        });
+
+        test('keep power save enabled', function() {
+          MockNavigatorSettings.createLock().set({'powersave.enabled': true});
+          trigger(0.25, true);
+          sinon.assert.notCalled(setSpy);
+          assert.equal(true,
+            MockNavigatorSettings.mSettings['powersave.enabled']);
+        });
+      });
+
+      suite('level above threshold', function() {
+        test('disable power save if it was enabled', function() {
+          trigger(0.05, true);
+          sinon.assert.calledOnce(setSpy);
+          sinon.assert.calledWith(setSpy, { 'powersave.enabled': false });
+        });
+
+        test('keep power save disabled', function() {
+          MockNavigatorSettings.createLock().set({'powersave.enabled': false});
+          trigger(0.05, false);
+          sinon.assert.notCalled(setSpy);
+          assert.equal(false,
+            MockNavigatorSettings.mSettings['powersave.enabled']);
+        });
+      });
     });
   });
 });

--- a/shared/js/settings_helper.js
+++ b/shared/js/settings_helper.js
@@ -69,15 +69,17 @@
       };
     };
 
+    var _valuechanged = function sh_valuehanged(e) {
+      _value = e.settingValue;
+    };
+
     var _init = function sh_init(callback) {
       _getValue(function(value) {
         _value = value ? value : _defaultValue;
         _return(callback);
       });
 
-      _settings.addObserver(SETTINGS_KEY, function valuehanged(e) {
-        _value = e.settingValue;
-      });
+      _settings.addObserver(SETTINGS_KEY, _valuechanged);
     };
 
     _init(function() {
@@ -109,6 +111,12 @@
         _ready(function() {
           _setValue(value, _return.bind(null, callback));
         });
+      },
+      /**
+       * Cleanup ressources, specifically observers.
+       */
+      uninit: function() {
+        _settings.removeObserver(SETTINGS_KEY, _valuechanged);
       }
     };
   };

--- a/shared/test/unit/mocks/mock_settings_helper.js
+++ b/shared/test/unit/mocks/mock_settings_helper.js
@@ -20,7 +20,8 @@ function MockSettingsHelper(aSetting, defaultValue) {
     set: function (value, callback) {
       MockSettingsHelper.instances[setting].value = value;
       callback && callback();
-    }
+    },
+    uninit: function() { }
   };
 }
 


### PR DESCRIPTION
SettingsHelper's init() method does add an observer on the setting
value. To avoid leaking, we have to make sure we call removeObserver()
once we are done with the request.
