### PR TITLE
Bug 1068695 - added collapsed/expanded semantics to button to bring up f...

### DIFF
--- a/apps/email/js/cards/folder_picker.html
+++ b/apps/email/js/cards/folder_picker.html
@@ -3,7 +3,12 @@
      and fld-header-back which is a transparent button that overlays the menu
      button. -->
 <div class="fld-header-placeholder" data-statuscolor="default">
-  <button data-l10n-id="drawer-back"
+  <!-- Unlike a generic back button that navigates to a different screen, folder
+       picker header button triggers the folders and settings overlay closure.
+       Thus the screen reader user requires more context as to what activating
+       the button would do. -->
+  <button aria-expanded="true" aria-controls="cards-folder-picker"
+          data-l10n-id="message-list-menu"
           data-event="click:_closeCard"
           class="fld-header-back">BacK</button>
 </div>

--- a/apps/email/js/cards/message_list.html
+++ b/apps/email/js/cards/message_list.html
@@ -4,7 +4,13 @@
          data-statuscolor="default"
          role="region">
   <header>
-    <a href="#" class="msg-folder-list-btn" data-event="click:onShowFolders">
+    <!-- Unlike a generic back button that navigates to a different screen,
+       folder list header button triggers the folders and settings overlay. Thus
+       the screen reader user requires more context as to what activating the
+       button would do. -->
+    <a href="#" class="msg-folder-list-btn" data-event="click:onShowFolders"
+       aria-expanded="false" aria-controls="cards-folder-picker"
+       role="button" data-l10n-id="message-list-menu">
       <span class="icon icon-menu">menu</span>
     </a>
     <menu data-prop="headerMenuNode" type="toolbar" class="anim-opacity">

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -549,6 +549,12 @@ folder-last-synced-label=Last sync:
 # to the user, it is provided for accessibility.
 message-list-top-action=Top
 
+# LOCALIZATION NOTE(message-list-menu): For the message-list and folder picker,
+# a label for a header icon button that brings up or hides the folder picker and
+# settings menu. The following string is spoken by screen readers and not shown
+# on the screen.
+message-list-menu.ariaLabel=Folders and settings
+
 toaster-undo=Undo
 toaster-message-star={[ plural(n) ]}
 toaster-message-star[one]=1 message flag set


### PR DESCRIPTION
...older picker.

In here changing message-list's links semantics to button since it makes more sense for collapsed and expanded state and for consistency with the folder-picker card.
