### PR TITLE
Bug 1106229 - Remove strings from index.html for modal dialogs +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -711,7 +711,7 @@
               </p>
             </div>
             <menu>
-              <button id="modal-dialog-alert-ok" data-l10n-id="ok" class="affirmative">OK</button>
+              <button id="modal-dialog-alert-ok" data-l10n-id="ok" class="affirmative"></button>
             </menu>
           </div>
 
@@ -724,7 +724,7 @@
             </div>
             <menu data-items="2">
               <button id="modal-dialog-confirm-cancel" data-l10n-id="cancel">Cancel</button>
-              <button id="modal-dialog-confirm-ok" data-l10n-id="ok" class="affirmative">OK</button>
+              <button id="modal-dialog-confirm-ok" data-l10n-id="ok" class="affirmative"></button>
             </menu>
           </div>
 
@@ -738,7 +738,7 @@
             </div>
             <menu data-items="2">
               <button id="modal-dialog-prompt-cancel" data-l10n-id="cancel">Cancel</button>
-              <button id="modal-dialog-prompt-ok" data-l10n-id="ok" class="affirmative">OK</button>
+              <button id="modal-dialog-prompt-ok" data-l10n-id="ok" class="affirmative"></button>
             </menu>
           </div>
 


### PR DESCRIPTION
Testing autolander..

https://bugzilla.mozilla.org/show_bug.cgi?id=1106229
