### PR TITLE
Bug 1101158 - Use shared tagged template library for escaping card content

### DIFF
--- a/apps/sharedtest/test/unit/tagged_test.js
+++ b/apps/sharedtest/test/unit/tagged_test.js
@@ -1,0 +1,18 @@
+/* global Tagged */
+
+'use strict';
+
+require('/shared/js/tagged.js');
+
+suite('tagged template helper', function() {
+
+  test('#escapeHTML', function() {
+    var myVal = '<b>hello</b>';
+    // fix a jshint issue with tagged template strings
+    // https://github.com/jshint/jshint/issues/2000
+    /* jshint -W033 */
+    var generated = Tagged.escapeHTML `${myVal} world`;
+    /* jshint +W033 */
+    assert.equal(generated, '&lt;b&gt;hello&lt;&#x2F;b&gt; world');
+  });
+});

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -32,6 +32,7 @@
     <script defer src="shared/js/screen_layout.js"></script>
     <script defer src="shared/js/iac_handler.js"></script>
     <script defer src="shared/js/apn_helper.js"></script>
+    <script defer src="shared/js/tagged.js"></script>
     <script defer src="shared/js/utilities.js"></script>
     <script defer src="js/touch_forwarder.js"></script>
     <script defer src="shared/js/version_helper.js"></script>

--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -1,4 +1,4 @@
-/* globals BaseUI, CardsHelper, TrustedUIManager */
+/* globals BaseUI, CardsHelper, Tagged, TrustedUIManager */
 
 /* exported Card */
 
@@ -97,25 +97,27 @@
    * Template string representing the innerHTML of the instance's element
    * @memberOf Card.prototype
    */
-  Card.prototype._template =
-    '<div data-l10n-id="closeCard" class="close-card" role="button" ' +
-      'style="visibility: {closeButtonVisibility}"></div>' +
-    '<div class="screenshotView" data-l10n-id="openCard" role="button"></div>' +
-    '<div class="appIconView" style="background-image:{iconValue}"></div>' +
-    '<div class="titles">' +
-    '<h1 id="{titleId}" class="title">{title}</h1>' +
-    '<p class="subtitle">{subTitle}</p>' +
-    '</div>';
+  Card.prototype.template = function() {
+    // fix a jshint issue with tagged template strings
+    // https://github.com/jshint/jshint/issues/2000
+    /* jshint -W033 */
+    return Tagged.escapeHTML `<div data-l10n-id="closeCard" class="close-card"
+     role="button" style="visibility: ${this.closeButtonVisibility}"></div>
+    <div class="screenshotView" data-l10n-id="openCard" role="button"></div>
+    <div class="appIconView" style="background-image:${this.iconValue}"></div>
+    <div class="titles">
+    <h1 id="${this.titleId}" class="title">${this.title}</h1>
+    <p class="subtitle">${this.subTitle}</p>
+    </div>`;
+    /* jshint +W033 */
+  };
 
   /**
    * Card html view - builds the innerHTML for a card element
    * @memberOf Card.prototype
    */
   Card.prototype.view = function c_view() {
-    var viewData = this;
-    return this._template.replace(/\{([^\}]+)\}/g, function(m, key) {
-        return viewData[key];
-    });
+    return this.template();
   };
 
   /**

--- a/apps/system/js/task_card.js
+++ b/apps/system/js/task_card.js
@@ -1,4 +1,4 @@
-/* globals Card */
+/* globals Card, Tagged */
 
 /* exported TaskCard */
 
@@ -56,23 +56,29 @@
     this.favoriteButtonVisibility = 'visible';
   };
 
-  TaskCard.prototype._template = '<section class="card-inner">' +
-    '<header class="card-header"><h1 class="title">{title}</h1>' +
-    '<p class="subtitle">{subTitle}</p></header>' +
-    '<div class="appPreview"></div>' +
-    '<footer class="card-tray">'+
-      '<button class="appIcon" data-button-action="select" ' +
-      '   style="background-image:{iconValue}">' +
-      '</button>' +
-      '<menu class="buttonbar">' +
-        '<button class="close-button" data-button-action="close" ' +
-        '   role="button" ' +
-        '   style="visibility: {closeButtonVisibility}"></button>' +
-        '<button class="favorite-button" data-button-action="favorite" ' +
-        '   role="button" ' +
-        '   style="visibility: {favoriteButtonVisibility}"></button>' +
-    '</menu></footer>' +
-  '</section>';
+  TaskCard.prototype.template = function() {
+    // fix a jshint issue with tagged template strings
+    // https://github.com/jshint/jshint/issues/2000
+    /* jshint -W033 */
+    return Tagged.escapeHTML `<section class="card-inner">
+      <header class="card-header"><h1 class="title">${this.title}</h1>
+      <p class="subtitle">${this.subTitle}</p></header>
+      <div class="appPreview"></div>
+      <footer class="card-tray">
+        <button class="appIcon" data-button-action="select"
+           style="background-image:${this.iconValue}">
+        </button>
+        <menu class="buttonbar">
+          <button class="close-button" data-button-action="close"
+             role="button"
+             style="visibility: ${this.closeButtonVisibility}"></button>
+          <button class="favorite-button" data-button-action="favorite"
+             role="button"
+             style="visibility: ${this.favoriteButtonVisibility}"></button>
+      </menu></footer>
+    </section>`;
+    /* jshint +W033 */
+  };
 
   /**
    * Build a card representation of an app window.

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -1,6 +1,7 @@
 /* global AppWindow, Card, MocksHelper, CardsHelper */
 'use strict';
 
+require('/shared/js/tagged.js');
 requireApp('system/test/unit/mock_app_window.js');
 requireApp('system/test/unit/mock_trusted_ui_manager.js');
 

--- a/apps/system/test/unit/task_card_test.js
+++ b/apps/system/test/unit/task_card_test.js
@@ -1,6 +1,7 @@
 /* global AppWindow, MocksHelper, TaskCard */
 'use strict';
 
+require('/shared/js/tagged.js');
 requireApp('system/test/unit/mock_app_window.js');
 requireApp('system/test/unit/mock_trusted_ui_manager.js');
 

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -19,7 +19,7 @@ requireApp('system/test/unit/mock_rocketbar.js');
 requireApp('system/test/unit/mock_sleep_menu.js');
 requireApp('system/test/unit/mock_stack_manager.js');
 requireApp('system/test/unit/mock_app_window.js');
-
+require('/shared/js/tagged.js');
 
 var mocksForTaskManager = new MocksHelper([
   'GestureDetector',

--- a/shared/js/tagged.js
+++ b/shared/js/tagged.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * tagged.js is a simple library to help you manage tagged template strings.
+ */
+var Tagged = {
+
+  _entity: /[&<>"'/]/g,
+
+  _entities: {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '\'': '&apos;',
+    '/': '&#x2F;'
+  },
+
+  getEntity: function(s) {
+    return Tagged._entities[s];
+  },
+
+  /**
+   * Escapes HTML for all values in a tagged template string.
+   */
+  escapeHTML: function(strings, ...values) {
+    var result = '';
+
+    for (var i = 0; i < strings.length; i++) {
+      result += strings[i];
+      if (i < values.length) {
+        result += String(values[i]).replace(Tagged._entity, Tagged.getEntity);
+      }
+    }
+
+    return result;
+  }
+};


### PR DESCRIPTION
Conflicts:
    apps/system/js/card.js
    apps/system/test/unit/task_manager_test.js

https://bugzilla.mozilla.org/show_bug.cgi?id=1101158
