### PR TITLE
Bug 1091910 - [System]Pressing the "battery is low" notification will so...

### DIFF
--- a/apps/system/style/battery_overlay/battery_overlay.css
+++ b/apps/system/style/battery_overlay/battery_overlay.css
@@ -17,6 +17,7 @@
   font-size: 1.4rem;
   font-weight: 500;
   padding: 1rem 0;
+  pointer-events: auto;
 }
 
 .icon-battery {

--- a/apps/system/style/sound_manager/sound_manager.css
+++ b/apps/system/style/sound_manager/sound_manager.css
@@ -6,9 +6,9 @@
   right: 0;
   height: 4rem;
   -moz-transition: opacity 0.5s ease;
-  pointer-events: none;
   display: none;
   background-image: url("images/header_bg.png");
+  pointer-events: auto;
 }
 
 #volume.visible {

--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -231,7 +231,6 @@ textarea,
   top: 0;
   left: 0;
   visibility: hidden;
-
   pointer-events: none;
 }
 


### PR DESCRIPTION
...metimes cause the rocket bar and keyboard to pop up, and will fail to bring up the battery section in the settings menu
