### PR TITLE
Bug 1109089 - Make sure `cardviewclosed` is broadcasted properly to app windows +autoland

### DIFF
--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -308,6 +308,7 @@
         this.element.classList.remove('slow-transition');
       }
       window.addEventListener('cardviewbeforeshow', this);
+      window.addEventListener('cardviewclosed', this);
       window.addEventListener('launchapp', this);
       window.addEventListener('appcreated', this);
       window.addEventListener('appterminated', this);
@@ -400,6 +401,8 @@
      * @memberOf module:AppWindowManager
      */
     stop: function awm_stop() {
+      window.removeEventListener('cardviewbeforeshow', this);
+      window.removeEventListener('cardviewclosed', this);
       window.removeEventListener('launchapp', this);
       window.removeEventListener('appcreated', this);
       window.removeEventListener('appterminated', this);

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -274,6 +274,17 @@ suite('system/AppWindowManager', function() {
       assert.isTrue(stubBlur.called);
     });
 
+    test('Should broadcast cardview events to apps', function() {
+      var stubBroadcastMessage =
+        this.sinon.stub(appWindowManager, 'broadcastMessage');
+
+      appWindowManager.handleEvent({ type: 'cardviewbeforeshow' });
+      assert.isTrue(stubBroadcastMessage.calledWith('cardviewbeforeshow'));
+
+      appWindowManager.handleEvent({ type: 'cardviewclosed' });
+      assert.isTrue(stubBroadcastMessage.calledWith('cardviewclosed'));
+    });
+
     test('Home Gesture enabled', function() {
       var stubBroadcastMessage =
         this.sinon.stub(appWindowManager, 'broadcastMessage');


### PR DESCRIPTION
So that the screenshots are properly unloaded.
