### PR TITLE
Bug 1093084 - make system/js/bluetooth v2 +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -298,6 +298,8 @@
     <!-- Bluetooth -->
     <script defer src="js/bluetooth.js"></script>
     <script defer src="js/bluetooth_transfer.js"></script>
+    <script defer src="js/bluetooth_v2.js"></script>
+    <script defer src="js/bluetooth_transfer_v2.js"></script>
     <link rel="stylesheet" type="text/css" href="style/bluetooth_transfer/bluetooth_transfer.css">
 
     <!-- Wifi -->

--- a/apps/system/js/bluetooth.js
+++ b/apps/system/js/bluetooth.js
@@ -1,5 +1,6 @@
 /* global SettingsListener, Service */
 /* exported Bluetooth */
+(function(exports) {
 'use strict';
 
 var Bluetooth = {
@@ -218,3 +219,6 @@ var Bluetooth = {
     return window.navigator.mozBluetooth.enabled;
   }
 };
+
+  exports.Bluetooth1 = Bluetooth;
+})(window);

--- a/apps/system/js/bluetooth_core.js
+++ b/apps/system/js/bluetooth_core.js
@@ -1,5 +1,5 @@
 /* exported BluetoothCore */
-/* global BaseModule, Bluetooth, BluetoothTransfer */
+/* global BaseModule */
 'use strict';
 
 (function() {
@@ -20,8 +20,17 @@
       // init Bluetooth module
       if (typeof(window.navigator.mozBluetooth.onattributechanged) ===
         'undefined') { // APIv1
-          Bluetooth.init();
-          BluetoothTransfer.init();
+          window.Bluetooth = window.Bluetooth1;
+          window.BluetoothTransfer = window.BluetoothTransfer1;
+          window.Bluetooth.init();
+          window.BluetoothTransfer.init();
+      } else { // APIv2
+        window.Bluetooth = window.Bluetooth2;
+        window.BluetoothTransfer = window.BluetoothTransfer2;
+        // window.Bluetooth = new window.Bluetooth2();
+        // window.BluetoothTransfer = new BluetoothTransfer2();
+        window.Bluetooth.start();
+        window.BluetoothTransfer.start();
       }
     }
   });

--- a/apps/system/js/bluetooth_v2.js
+++ b/apps/system/js/bluetooth_v2.js
@@ -301,15 +301,25 @@ var Bluetooth = {
         function onAttributeChanged(evt) {
           for (var i in evt.attrs) {
             switch (evt.attrs[i]) {
-              case 'address':
-                this.debug('defaultAdapter changed. address:',
-                  this._bluetooth.defaultAdapter.address);
+              case 'defaultAdapter':
+                this.debug('defaultAdapter changed.');
                 this._adapter = this._bluetooth.defaultAdapter;
+                this._adapter.onattributechanged = function onAttributeChanged(evt) {
+                  for (var i in evt.attrs) {
+                    switch (evt.attrs[i]) {
+                      case 'address':
+                        this.debug('defaultAdapter changed. address:',
+                          this._bluetooth.defaultAdapter.address);
+                        break;
+                      case 'stat':
+                        this._isEnabled = this._bluetooth.defaultAdapter.state;
+                        break;
+                      default:
+                        break;
+                    }
+                  }
+                }
                 resolve(this._adapter);
-                break;
-              case 'stat':
-                this._isEnabled = this._bluetooth.defaultAdapter.state;
-                break;
               default:
                 break;
             }

--- a/apps/system/js/bluetooth_v2.js
+++ b/apps/system/js/bluetooth_v2.js
@@ -183,27 +183,27 @@ var Bluetooth = {
     switch (evt.type) {
       // enable bluetooth hardware and update settings value
       case 'request-enable-bluetooth':
-        this.getAdapter().then(function(adapter) {
-          adapter.enable().then(function onResolve() {
+        this.getAdapter().then((adapter) => {
+          adapter.enable().then(() => { //resolve
             SettingsListener.getSettingsLock().set({
               'bluetooth.enabled': true
             });
-          }, function onReject() {
+          }, () => { //reject
             this.debug('can not get bluetooth adapter');
-          }.bind(this));
-        }.bind(this));
+          });
+        });
         break;
       // disable bluetooth hardware and update settings value
       case 'request-disable-bluetooth':
-        this.getAdapter().then(function(adapter) {
-          adapter.disable().then(function onResolve() {
+        this.getAdapter().then((adapter) => {
+          adapter.disable().then(() => { //resolve
             SettingsListener.getSettingsLock().set({
               'bluetooth.enabled': false
             });
-          }, function onReject() {
+          }, () => { //reject
             this.debug('can not get bluetooth adapter');
-          }.bind(this));
-        }.bind(this));
+          });
+        });
         break;
     }
   },
@@ -254,9 +254,9 @@ var Bluetooth = {
    * @private
    */
   _initDefaultAdapter: function bt_initDefaultAdapter() {
-    this.getAdapter().then(function(adapter) {
+    this.getAdapter().then((adapter) => {
       this._updateProfileStat(adapter);
-    }.bind(this));
+    });
   },
 
   /**
@@ -273,20 +273,17 @@ var Bluetooth = {
      * connected, then summarize to an event and dispatch to StatusBar
      */
     // In headset connected case:
-    adapter.addEventListener('hfpstatuschanged',
-      function bt_hfpStatusChanged(evt) {
+    adapter.addEventListener('hfpstatuschanged', (evt) => {
         this._setProfileConnected(this.Profiles.HFP, evt.status);
-    }.bind(this));
+    });
 
-    adapter.addEventListener('a2dpstatuschanged',
-      function bt_a2dpStatusChanged(evt) {
-        this._setProfileConnected(this.Profiles.A2DP, evt.status);
-    }.bind(this));
+    adapter.addEventListener('a2dpstatuschanged', (evt) => {
+      this._setProfileConnected(this.Profiles.A2DP, evt.status);
+    });
 
-    adapter.addEventListener('scostatuschanged',
-      function bt_scoStatusChanged(evt) {
-        this._setProfileConnected(this.Profiles.SCO, evt.status);
-    }.bind(this));
+    adapter.addEventListener('scostatuschanged', (evt) => {
+      this._setProfileConnected(this.Profiles.SCO, evt.status);
+    });
   },
 
   /**

--- a/apps/system/js/bluetooth_v2.js
+++ b/apps/system/js/bluetooth_v2.js
@@ -1,0 +1,350 @@
+/**
+ * Bluetooth2 is compatible with Bluetooth APIv2 and used to enable/
+ * diable bluetooth hardware, get bluetooth Adapter, and check target
+ * bluetooth profile is connected.
+ */
+/* global SettingsListener, Service */
+/* exported Bluetooth2 */
+(function(exports) {
+'use strict';
+
+// var Bluetooth = function() {};
+
+// Bluetooth.prototype = {
+var Bluetooth = {
+  /**
+   * keep a global connected property.
+   *
+   * @public
+   */
+  connected: false,
+
+  /**
+   * Debug message
+   *
+   * @type {Boolean} turn on/off the console log
+   */
+  _debug: true,
+
+  /**
+   * store a reference of the default adapter.
+   *
+   * @private
+   */
+  _adapter: null,
+
+  /**
+   * store a reference of the Bluetooth API.
+   *
+   * @private
+   */
+  _bluetooth: null,
+
+  /**
+   * store a reference of the Bluetooth API.
+   *
+   * @private
+   */
+  _isEnabled: false,
+
+  /**
+   * Build-in Bluetooth profiles
+   *
+   * @public
+   */
+  get Profiles() {
+    return {
+      HFP: 'hfp',   // Hands-Free Profile
+      OPP: 'opp',   // Object Push Profile
+      A2DP: 'a2dp', // A2DP status
+      SCO: 'sco'    // Synchronous Connection-Oriented
+    };
+  },
+
+  /**
+   * Set profile connect stat.
+   *
+   * @public
+   * @param {String} profile   profile id
+   * @param {Boolean} connected connect status
+   */
+  _setProfileConnected: function bt_setProfileConnected(profile, connected) {
+    var value = this['_' + profile + 'Connected'];
+    if (value !== connected) {
+      this['_' + profile + 'Connected'] = connected;
+
+      // Raise an event for the profile connection changes.
+      var evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent('bluetoothprofileconnectionchange',
+        /* canBubble */ true, /* cancelable */ false,
+        {
+          name: profile,
+          connected: connected
+        });
+      window.dispatchEvent(evt);
+    }
+  },
+
+  getCurrentProfiles: function bt_getCurrentProfiles() {
+    var profiles = this.Profiles;
+    var connectedProfiles = [];
+    for (var name in profiles) {
+      var profile = profiles[name];
+      if (this.isProfileConnected(profile)) {
+        connectedProfiles.push(profile);
+      }
+    }
+    return connectedProfiles;
+  },
+
+  /**
+   * check if bluetooth profile is connected.
+   *
+   * @public
+   * @param {String} profile profile name
+   * @return {Boolean} connected state
+   */
+  isProfileConnected: function bt_isProfileConnected(profile) {
+    var isConnected = this['_' + profile + 'Connected'];
+    if (isConnected === undefined) {
+      return false;
+    } else {
+      return isConnected;
+    }
+  },
+
+  /**
+   * initialize bluetooth module
+   *
+   * @public
+   */
+  start: function bt_start() {
+    if (!window.navigator.mozSettings || !window.navigator.mozBluetooth) {
+      return;
+    }
+
+    this._bluetooth = window.navigator.mozBluetooth;
+    SettingsListener.observe('bluetooth.enabled', true, function(value) {
+      if (!this._bluetooth) {
+        // roll back the setting value to notify the UIs
+        // that Bluetooth interface is not available
+        if (value) {
+          SettingsListener.getSettingsLock().set({
+            'bluetooth.enabled': false
+          });
+        }
+        return;
+      }
+    }.bind(this));
+
+    // when bluetooth adapter is ready, a.k.a enabled,
+    // emit event to notify QuickSettings and try to get
+    // defaultAdapter at this moment
+    this._bluetooth.addEventListener('adapteradded',
+      this._adapterAddedHandler.bind(this)
+    );
+
+    // when bluetooth is really disabled, emit event to notify QuickSettings
+    this._bluetooth.addEventListener('adapterremoved',
+      this._adapterRemovedhandler.bind(this)
+    );
+
+    // if bluetooth is enabled in booting time, try to get adapter now
+    this._initDefaultAdapter();
+
+    /* In file transfering case:
+     * since System Message can't be listened in two js files within a app,
+     * so we listen here but dispatch events to bluetooth_transfer.js
+     * while getting bluetooth file transfer start/complete system messages
+     */
+    navigator.mozSetMessageHandler('bluetooth-opp-transfer-start',
+      this._relayMessageEvent.bind(this, 'bluetooth-opp-transfer-start')
+    );
+
+    navigator.mozSetMessageHandler('bluetooth-opp-transfer-complete',
+      this._relayMessageEvent.bind(this, 'bluetooth-opp-transfer-complete')
+    );
+
+    // decouple bluetooth enable/disable function from other system part
+    window.addEventListener('request-enable-bluetooth', this);
+    window.addEventListener('request-disable-bluetooth', this);
+
+    Service.registerState('isEnabled', this);
+  },
+
+  /**
+   * handle bluetooth system events
+   *
+   * @public
+   * @param  {Object} evt event object
+   */
+  handleEvent: function bt_handleEvent(evt) {
+    switch (evt.type) {
+      // enable bluetooth hardware and update settings value
+      case 'request-enable-bluetooth':
+        this.getAdapter().then(function(adapter) {
+          adapter.enable().then(function onResolve() {
+            SettingsListener.getSettingsLock().set({
+              'bluetooth.enabled': true
+            });
+          }, function onReject() {
+            this.debug('can not get bluetooth adapter');
+          }.bind(this));
+        }.bind(this));
+        break;
+      // disable bluetooth hardware and update settings value
+      case 'request-disable-bluetooth':
+        this.getAdapter().then(function(adapter) {
+          adapter.disable().then(function onResolve() {
+            SettingsListener.getSettingsLock().set({
+              'bluetooth.enabled': false
+            });
+          }, function onReject() {
+            this.debug('can not get bluetooth adapter');
+          }.bind(this));
+        }.bind(this));
+        break;
+    }
+  },
+
+  /**
+   * Get adapter when bluetooth adapter is added.
+   *
+   * @private
+   */
+  _adapterAddedHandler: function bt__adapterAddedHandler() {
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent('bluetooth-adapter-added',
+      /* canBubble */ true, /* cancelable */ false, null);
+    window.dispatchEvent(evt);
+    this.initDefaultAdapter();
+  },
+
+  /**
+   * Send event when bluetooth adapter is removed.
+   *
+   * @private
+   */
+  _adapterRemovedhandler: function bt__adapterRemovedhandler() {
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent('bluetooth-disabled',
+      /* canBubble */ true, /* cancelable */ false, null);
+    window.dispatchEvent(evt);
+  },
+
+  /**
+   * dispatch events to bluetooth_transfer.js
+   * while getting bluetooth file transfer start/complete system messages
+   *
+   * @private
+   */
+  _relayMessageEvent: function bt__relayMessageEvent(msg, transferInfo) {
+    this._setProfileConnected(this.Profiles.OPP, true);
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent(msg,
+      /* canBubble */ true, /* cancelable */ false,
+      {transferInfo: transferInfo});
+    window.dispatchEvent(evt);
+  },
+
+  /**
+   * Get adapter for BluetoothTransfer when everytime bluetooth is enabled.
+   *
+   * @private
+   */
+  _initDefaultAdapter: function bt_initDefaultAdapter() {
+    this.getAdapter().then(function(adapter) {
+      this._updateProfileStat(adapter);
+    }.bind(this));
+  },
+
+  /**
+   * Maintain connect stat of supported profiles.
+   *
+   * @private
+   * @param  {Object} adapter bluetooth adapter
+   */
+  _updateProfileStat: function bt_updateProfileStat(adapter) {
+    /* for v1, we only support two use cases for bluetooth connection:
+     *   1. connecting with a headset
+     *   2. transfering a file to/from another device
+     * So we need to listen to corresponding events to know we are (aren't)
+     * connected, then summarize to an event and dispatch to StatusBar
+     */
+
+    // In headset connected case:
+    adapter.addEventListener('hfpstatuschanged',
+      function bt_hfpStatusChanged(evt) {
+        this._setProfileConnected(this.Profiles.HFP, evt.status);
+    }.bind(this));
+
+    adapter.addEventListener('a2dpstatuschanged',
+      function bt_a2dpStatusChanged(evt) {
+        this._setProfileConnected(this.Profiles.A2DP, evt.status);
+    }.bind(this));
+
+    adapter.addEventListener('scostatuschanged',
+      function bt_scoStatusChanged(evt) {
+        this._setProfileConnected(this.Profiles.SCO, evt.status);
+    }.bind(this));
+  },
+
+  /**
+   * called by external for re-use adapter.
+   *
+   * @public
+   */
+  getAdapter: function bt_getAdapter() {
+    return new Promise(function(resolve, reject) {
+      // need time to get bluetooth adapter at first run
+      this._bluetooth.onattributechanged =
+        function onAttributeChanged(evt) {
+          for (var i in evt.attrs) {
+            switch (evt.attrs[i]) {
+              case 'address':
+                this.debug('defaultAdapter changed. address:',
+                  this._bluetooth.defaultAdapter.address);
+                this._adapter = this._bluetooth.defaultAdapter;
+                resolve(this._adapter);
+                break;
+              case 'stat':
+                this._isEnabled = this._bluetooth.defaultAdapter.state;
+                break;
+              default:
+                break;
+            }
+          }
+      }.bind(this);
+
+      this._adapter = this._bluetooth.defaultAdapter;
+      if (this._adapter) {
+        resolve(this._adapter);
+      }
+    }.bind(this));
+  },
+
+  /**
+   * maintain bluetooth enable/disable stat.
+   *
+   * @public
+   */
+  get isEnabled() {
+    return this._isEnabled;
+  },
+
+  /**
+   * console log
+   *
+   * @param  {[type]} msg debug message
+   */
+  debug: function bt_debug(msg) {
+    if (!this._debug) {
+      return;
+    }
+
+    console.log('[System Bluetooth Transfer]: ' + msg);
+  }
+};
+
+  exports.Bluetooth2 = Bluetooth;
+})(window);

--- a/apps/system/js/bluetooth_v2.js
+++ b/apps/system/js/bluetooth_v2.js
@@ -12,6 +12,7 @@
 
 // Bluetooth.prototype = {
 var Bluetooth = {
+  name: 'Bluetooth',
   /**
    * keep a global connected property.
    *

--- a/apps/system/test/unit/bluetooth_v2_test.js
+++ b/apps/system/test/unit/bluetooth_v2_test.js
@@ -165,26 +165,23 @@ suite('system/bluetooth_transfer_v2', function() {
 
   suite('handleEvent', function() {
     setup(function() {
-      this.sinon.spy(navigator.mozBluetooth, 'addEventListener');
-      this.sinon.spy(window, 'addEventListener');
-      this.sinon.spy(window, 'dispatchEvent');
-      this.sinon.stub(Bluetooth, '_initDefaultAdapter');
-      this.sinon.stub(Bluetooth, '_setProfileConnected');
-      this.sinon.stub(MockBTAdapter, 'enable', function() {
-        return new Promise(function(resolve) {
-          resolve();
-        });
-      });
-      this.sinon.stub(Bluetooth, 'getAdapter', function() {
-        return new Promise(function(resolve) {
-          resolve(MockBTAdapter);
-        });
-      });
-      Bluetooth.start();
+      // this.sinon.stub(MockBTAdapter, 'enable', function() {
+      //   return new Promise(function(resolve) {console.log('PPPP');
+      //     resolve();
+      //   });
+      // });
+      // this.sinon.stub(Bluetooth, 'getAdapter', function() {
+      //   return new Promise(function(resolve) {
+      //     resolve(MockBTAdapter);
+      //   });
+      // });
+      this.sinon.spy(Bluetooth, 'getAdapter');
+      this.sinon.spy(MockBTAdapter, 'enable');
+      this.sinon.spy(MockBTAdapter, 'disable');
     });
 
     test('request-enable-bluetooth is called', function() {
-      window.dispatchEvent(new CustomEvent('request-enable-bluetooth'));
+      Bluetooth.handleEvent({type: 'request-enable-bluetooth'});
       assert.ok(Bluetooth.getAdapter.called);
       // this.sinon.clock.tick();
       // assert.ok(MockBTAdapter.enable.called);
@@ -193,8 +190,10 @@ suite('system/bluetooth_transfer_v2', function() {
     });
 
     test('request-disable-bluetooth is called', function() {
-      window.dispatchEvent(new CustomEvent('request-disable-bluetooth'));
+      Bluetooth.handleEvent({type: 'request-disable-bluetooth'});
+      // window.dispatchEvent(new CustomEvent('request-disable-bluetooth'));
       assert.ok(Bluetooth.getAdapter.called);
+      // assert.ok(MockBTAdapter.disable.called);
     //   // this.sinon.clock.tick();
     //   assert.equal(MockNavigatorSettings.mSettings['bluetooth.enabled'],
     //     false);

--- a/apps/system/test/unit/bluetooth_v2_test.js
+++ b/apps/system/test/unit/bluetooth_v2_test.js
@@ -1,0 +1,246 @@
+/* global Bluetooth, Bluetooth2, MockSettingsListener,
+   MockNavigatorSettings, MockNavigatormozSetMessageHandler,
+   MockMozBluetooth, MockBTAdapter */
+'use strict';
+
+require('/shared/test/unit/mocks/mock_navigator_moz_set_message_handler.js');
+requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js');
+requireApp('system/js/service.js');
+
+suite('system/bluetooth_transfer_v2', function() {
+  var realSetMessageHandler;
+  var realSettings;
+  var realSettingsListener;
+  var realMozBluetooth;
+
+  suiteSetup(function(done) {
+    realSetMessageHandler = navigator.mozSetMessageHandler;
+    navigator.mozSetMessageHandler = MockNavigatormozSetMessageHandler;
+
+    realSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+
+    realSettingsListener = window.SettingsListener;
+    window.SettingsListener = MockSettingsListener;
+
+    Object.defineProperty(navigator, 'mozBluetooth', {
+      configurable: true,
+      get: function() {
+        return MockMozBluetooth;
+      }
+    });
+
+    MockNavigatormozSetMessageHandler.mSetup();
+    requireApp('system/js/bluetooth_v2.js', done);
+  });
+
+  suiteTeardown(function() {
+    MockNavigatormozSetMessageHandler.mTeardown();
+    navigator.mozSetMessageHandler = realSetMessageHandler;
+    window.SettingsListener = realSettingsListener;
+    Object.defineProperty(navigator, 'mozBluetooth', {
+      configurable: true,
+      get: function() {
+        return realMozBluetooth;
+      }
+    });
+  });
+
+  setup(function() {
+    window.Bluetooth = window.Bluetooth2;
+    // this.sinon.useFakeTimers();
+  });
+
+  // teardown(function() {
+  //   this.sinon.clock.restore();
+  // });
+
+  suite('default variables', function() {
+    test('profiles', function() {
+      assert.equal(Bluetooth.Profiles.HFP, 'hfp');
+      assert.equal(Bluetooth.Profiles.OPP, 'opp');
+      assert.equal(Bluetooth.Profiles.A2DP, 'a2dp');
+      assert.equal(Bluetooth.Profiles.SCO, 'sco');
+    });
+  });
+
+  suite('setProfileConnected', function() {
+    var profiles = ['hfp', 'opp', 'a2dp', 'sco'];
+    setup(function() {
+      this.sinon.stub(window, 'dispatchEvent');
+      // this.sinon.stub(navigator.mozBluetooth, 'onattributechanged');
+      // this.sinon.stub(Bluetooth2, 'isProfileConnected', function() {
+      //   return true;
+      // });
+      // var adapter = Bluetooth2.getAdapter();
+    });
+
+    test('nothing is called when wasConnected', function() {
+      profiles.forEach(function(profile){
+        Bluetooth['_' + profile + 'Connected'] = true;
+        Bluetooth._setProfileConnected(profile, true);
+        assert.isFalse(window.dispatchEvent.called);
+      });
+    });
+
+    test('event is dispatched when disconnected', function() {
+      profiles.forEach(function(profile){
+        Bluetooth['_' + profile + 'Connected'] = true;
+        Bluetooth._setProfileConnected(profile, false);
+        assert.ok(window.dispatchEvent.called);
+      });
+    });
+
+    test('event is dispatched when first connect', function() {
+      profiles.forEach(function(profile){
+        Bluetooth['_' + profile + 'Connected'] = false;
+        Bluetooth._setProfileConnected(profile, true);
+        assert.ok(window.dispatchEvent.called);
+      });
+    });
+  });
+
+  suite('Initialize', function() {
+    setup(function() {
+      this.sinon.spy(navigator.mozBluetooth, 'addEventListener');
+      this.sinon.stub(Bluetooth, '_initDefaultAdapter');
+      this.sinon.stub(Bluetooth, '_setProfileConnected');
+      this.sinon.spy(window, 'addEventListener');
+      this.sinon.stub(window, 'dispatchEvent');
+      // this.sinon.stub(Bluetooth, '_adapterAddedHandler');
+      Bluetooth.start();
+    });
+
+    test('listener called', function() {
+      assert.equal(MockSettingsListener.mName, 'bluetooth.enabled');
+      assert.ok(window.navigator.mozBluetooth
+        .addEventListener.calledWith('adapteradded'));
+      assert.ok(window.navigator.mozBluetooth
+        .addEventListener.calledWith('adapterremoved'));
+      assert.ok(window.addEventListener
+        .calledWith('request-enable-bluetooth'));
+      assert.ok(window.addEventListener
+        .calledWith('request-disable-bluetooth'));
+    });
+
+    // test ('adapterAddedHandler is called when bluetooth adapter is added',
+    //   function() {
+    //     window.navigator.mozBluetooth.dispatchEvent(
+    //       new CustomEvent('adapteradded'));
+    //     assert.ok(Bluetooth._adapterAddedHandler.isCalled);
+    // });
+
+    test('MessageHandler bluetooth-opp-transfer-start is called',
+      function() {
+        MockNavigatormozSetMessageHandler.mTrigger(
+          'bluetooth-opp-transfer-start', {
+            source: {
+              data: {}
+            }
+        });
+
+        assert.ok(Bluetooth._setProfileConnected.called);
+        assert.ok(window.dispatchEvent.called);
+    });
+
+    test('MessageHandler bluetooth-opp-transfer-complete is called',
+      function() {
+        MockNavigatormozSetMessageHandler.mTrigger(
+          'bluetooth-opp-transfer-complete', {
+            source: {
+              data: {}
+            }
+        });
+
+        assert.ok(Bluetooth._setProfileConnected.called);
+        assert.ok(window.dispatchEvent.called);
+    });
+
+    test('function called', function() {
+      assert.ok(Bluetooth._initDefaultAdapter.called);
+    });
+  });
+
+  suite('handleEvent', function() {
+    setup(function() {
+      this.sinon.spy(navigator.mozBluetooth, 'addEventListener');
+      this.sinon.spy(window, 'addEventListener');
+      this.sinon.spy(window, 'dispatchEvent');
+      this.sinon.stub(Bluetooth, '_initDefaultAdapter');
+      this.sinon.stub(Bluetooth, '_setProfileConnected');
+      this.sinon.stub(MockBTAdapter, 'enable', function() {
+        return new Promise(function(resolve) {
+          resolve();
+        });
+      });
+      this.sinon.stub(Bluetooth, 'getAdapter', function() {
+        return new Promise(function(resolve) {
+          resolve(MockBTAdapter);
+        });
+      });
+      Bluetooth.start();
+    });
+
+    test('request-enable-bluetooth is called', function() {
+      window.dispatchEvent(new CustomEvent('request-enable-bluetooth'));
+      assert.ok(Bluetooth.getAdapter.called);
+      // this.sinon.clock.tick();
+      // assert.ok(MockBTAdapter.enable.called);
+      // assert.equal(MockNavigatorSettings.mSettings['bluetooth.enabled'],
+      //   true);
+    });
+
+    test('request-disable-bluetooth is called', function() {
+      window.dispatchEvent(new CustomEvent('request-disable-bluetooth'));
+      assert.ok(Bluetooth.getAdapter.called);
+    //   // this.sinon.clock.tick();
+    //   assert.equal(MockNavigatorSettings.mSettings['bluetooth.enabled'],
+    //     false);
+    });
+  });
+
+  suite('initDefaultAdapter', function() {
+    setup(function() {
+      this.sinon.stub(Bluetooth, '_updateProfileStat');
+      this.sinon.stub(Bluetooth, 'getAdapter', function() {
+        return new Promise(function(resolve) {
+          resolve(MockBTAdapter);
+        });
+      });
+      Bluetooth2._initDefaultAdapter();
+    });
+
+    test('getAdapter is called', function() {
+      assert.ok(Bluetooth.getAdapter.called);
+    });
+
+    // test('_updateProfileStat is called', function() {
+    //   assert.ok(Bluetooth._updateProfileStat.called);
+    // });
+  });
+
+  suite('getAdapter', function() {
+    setup(function() {
+      // this.sinon.stub(Bluetooth, '_updateProfileStat');
+      // this.sinon.stub(Bluetooth, 'getAdapter', function() {
+      //   return new Promise(function(resolve) {
+      //     resolve(MockBTAdapter);
+      //   });
+      // });
+      // this.sinon.stub(MockBTAdapter, 'onhfpstatuschanged');
+      // this.sinon.stub(MockBTAdapter, 'ona2dpstatuschanged');
+      // this.sinon.stub(MockBTAdapter, 'onscostatuschanged');
+      // this.sinon.stub(Bluetooth, '_setProfileConnected');
+      // Bluetooth2._updateProfileStat(MockBTAdapter);
+    });
+
+    test('statuschanged is called', function() {
+      // window.dispatchEvent(new CustomEvent(''));
+      // assert.ok(MockBTAdapter.onhfpstatuschanged.called);
+      // assert.ok(MockBTAdapter.ona2dpstatuschanged.called);
+      // assert.ok(MockBTAdapter.onscostatuschanged.called);
+    });
+  });
+});

--- a/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
@@ -27,7 +27,8 @@
 
     onscostatuschanged: null,
     onhfpstatuschanged: null,
-    ona2dpstatuschanged: null
+    ona2dpstatuschanged: null,
+    addEventListener: mmb_addEventListener
   };
 
   var mEventListeners = [];

--- a/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
@@ -1,3 +1,4 @@
+/* globals Promise */
 /* exported MockMozBluetooth, MockBTAdapter */
 
 'use strict';
@@ -13,10 +14,20 @@
     getConnectedDevices: function mba_getConnectedDevices() {},
     connectSco: function mba_connectSco() {},
     disconnectSco: function mba_disconnectSco() {},
-    enable: function mba_enable() {},
-    disable: function mba_disable() {},
+    enable: function mba_enable() {
+      return new Promise(function(resolve) {
+        resolve();
+      });
+    },
+    disable: function mba_disable() {
+      return new Promise(function(resolve) {
+        resolve();
+      });
+    },
 
-    onscostatuschanged: null
+    onscostatuschanged: null,
+    onhfpstatuschanged: null,
+    ona2dpstatuschanged: null
   };
 
   var mEventListeners = [];


### PR DESCRIPTION
- test BTv2 receive from android device
- BluetoothTransfer2 remove the NfcHandoverManager dependency parts.
- add `debug` flag in Bluetooth2 to print console log
- listen Bluetooth `adapterremoved` event instead of `disable` event ( `disable` event is removed in BTv2)
- refactor system message->window event relay to `relayMessageEvent`
- use promised adapter.enable/.disable to handle bt enable/disable message
