### PR TITLE
Bug 1073806 - In Gaia, bypass system-resize in LayoutManager in window resize event if Keyboard is showing and we've just changed orientation

### DIFF
--- a/apps/system/js/layout_manager.js
+++ b/apps/system/js/layout_manager.js
@@ -97,6 +97,13 @@
     keyboardEnabled: false,
 
     /**
+     * The orientation we keep each time we encounter resize event.
+     * @type {String}
+     * @memberOf LayoutManager
+     */
+    _lastOrientation: undefined,
+
+    /**
      * Startup. Adds all event listeners needed.
      * @return {LayoutManager} this object
      * @memberOf LayoutManager
@@ -111,6 +118,9 @@
       window.addEventListener('mozfullscreenchange', this);
       window.addEventListener('software-button-enabled', this);
       window.addEventListener('software-button-disabled', this);
+
+      this._lastOrientation = screen.mozOrientation;
+
       return this;
     },
 
@@ -129,8 +139,15 @@
           this.publish('system-resize');
           break;
         case 'resize':
-          this.publish('system-resize');
+          // bug 1073806: do not publish |system-resize| if keyboard is showing
+          // and we've just changed orientation: |keyboardchange| will trigger
+          // later and we'll resize then.
+          if (!(screen.mozOrientation !== this._lastOrientation &&
+                this.keyboardEnabled)) {
+            this.publish('system-resize');
+          }
           this.publish('orientationchange');
+          this._lastOrientation = screen.mozOrientation;
           break;
         default:
           if (evt.type === 'keyboardhide') {

--- a/apps/system/test/unit/layout_manager_test.js
+++ b/apps/system/test/unit/layout_manager_test.js
@@ -23,13 +23,94 @@ suite('system/LayoutManager >', function() {
   });
 
   suite('handle events', function() {
-    test('resize', function() {
-      var stubPublish = this.sinon.stub(layoutManager, 'publish');
-      layoutManager.handleEvent({
-        type: 'resize'
+    suite('resize', function() {
+      var oldMozOrientation;
+      var stubPublish;
+
+      setup(function() {
+        oldMozOrientation = screen.mozOrientation;
+        stubPublish = this.sinon.stub(layoutManager, 'publish');
       });
-      assert.isTrue(stubPublish.calledWith('system-resize'));
-      assert.isTrue(stubPublish.calledWith('orientationchange'));
+
+      teardown(function() {
+        Object.defineProperty(screen, 'mozOrientation', {
+          get: function(){
+            return oldMozOrientation;
+          }
+        });
+      });
+
+      var setMozOrientation = function (orientation) {
+        Object.defineProperty(screen, 'mozOrientation', {
+          get: function(){
+            return orientation;
+          },
+          configurable: true
+        });
+      };
+
+      test('Do not publish system-resize if keyboard is showing and' +
+           'orientation has changed', function() {
+        layoutManager.keyboardEnabled = true;
+        layoutManager._lastOrientation = 'portrait-secondary';
+
+        setMozOrientation('landscape-secondary');
+
+        layoutManager.handleEvent({
+          type: 'resize'
+        });
+        assert.isFalse(stubPublish.calledWith('system-resize'));
+        assert.isTrue(stubPublish.calledWith('orientationchange'));
+      });
+
+      test('Publish system-resize if keyboard is showing and' +
+           'orientation has not changed', function() {
+        layoutManager.keyboardEnabled = true;
+        layoutManager._lastOrientation = 'portrait-secondary';
+
+        setMozOrientation('portrait-secondary');
+
+        layoutManager.handleEvent({
+          type: 'resize'
+        });
+        assert.isTrue(stubPublish.calledWith('system-resize'));
+        assert.isTrue(stubPublish.calledWith('orientationchange'));
+      });
+
+      test('Publish system-resize if keyboard is not showing', function() {
+        layoutManager.keyboardEnabled = false;
+        layoutManager._lastOrientation = 'portrait-secondary';
+
+        setMozOrientation('landscape-secondary');
+
+        layoutManager.handleEvent({
+          type: 'resize'
+        });
+        assert.isTrue(stubPublish.calledWith('system-resize'));
+        assert.isTrue(stubPublish.calledWith('orientationchange'));
+
+        stubPublish.reset();
+
+        // this time orientation isn't changed; we send system-resize too.
+        layoutManager.handleEvent({
+          type: 'resize'
+        });
+        assert.isTrue(stubPublish.calledWith('system-resize'));
+        assert.isTrue(stubPublish.calledWith('orientationchange'));
+      });
+
+      test('_lastOrientation is correctly remembered', function() {
+        layoutManager.keyboardEnabled = false;
+        layoutManager._lastOrientation = 'portrait-secondary';
+
+        setMozOrientation('landscape-secondary');
+
+        layoutManager.handleEvent({
+          type: 'resize'
+        });
+
+        assert.equal(layoutManager._lastOrientation, 'landscape-secondary');
+      });
     });
 
     test('status-active', function() {


### PR DESCRIPTION
cherry-pick from master's patch:

Conflicts:
    apps/system/js/layout_manager.js
    apps/system/test/unit/layout_manager_test.js
