### PR TITLE
Bug 1098664 - fallback to manifest app type if metadata.json one is empty. r=gduan

### DIFF
--- a/build/utils-xpc.js
+++ b/build/utils-xpc.js
@@ -348,7 +348,11 @@ function getWebapp(app, domain, scheme, port, stageDir) {
   if (metaData.exists()) {
     webapp.pckManifest = readZipManifest(webapp.sourceDirectoryFile);
     webapp.metaData = getJSON(metaData);
-    webapp.appStatus = utils.getAppStatus(webapp.metaData.type || 'web');
+    webapp.appStatus = utils.getAppStatus(webapp.metaData.type ||
+                                          (webapp.pckManifest ?
+                                           webapp.pckManifest.type :
+                                           webapp.manifest.type) ||
+                                          'web');
   } else {
     webapp.appStatus = utils.getAppStatus(webapp.manifest.type);
   }

--- a/build/webapp-manifests.js
+++ b/build/webapp-manifests.js
@@ -66,14 +66,14 @@ ManifestBuilder.prototype.fillExternalAppManifest = function(webapp) {
   // and it has an origin in its manifest file it'll be able to specify a custom
   // folder name. Otherwise, generate an UUID to use as folder name.
 
-  var uuid = this.uuidMapping[webapp.sourceDirectoryName] ||
-    utils.generateUUID().toString();
-
-  var webappTargetDirName = uuid;
+  var webappTargetDirName;
   if (type === 2 && isPackaged && webapp.pckManifest.origin) {
     webappTargetDirName = utils.getNewURI(webapp.pckManifest.origin).host;
   } else {
     // uuid is used for webapp directory name, save it for further usage
+    var uuid = this.uuidMapping[webapp.sourceDirectoryName] ||
+      utils.generateUUID().toString();
+    webappTargetDirName = uuid;
     this.uuidMapping[webapp.sourceDirectoryName] = uuid;
   }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1098664
