### PR TITLE
Bug 1110932 - Add default button visibility props to Card.prototype. +autoland

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -48,6 +48,20 @@
   Card.prototype.element = null;
 
   /**
+   * CSS visibility value to show/hide close button for this app
+   * @type {String}
+   * @memberof Card.prototype
+   */
+  Card.prototype.closeButtonVisibility = 'hidden';
+
+  /**
+   * CSS visibility value to show/hide favorite button for this app
+   * @type {String}
+   * @memberof Card.prototype
+   */
+  Card.prototype.favoriteButtonVisibility = 'hidden';
+
+  /**
    * Debugging helper to output a useful string representation of an instance.
    * @memberOf Card.prototype
   */
@@ -64,6 +78,7 @@
   Card.prototype.getScreenshotPreviewsSetting = function() {
     return this.manager.useAppScreenshotPreviews;
   };
+
 
   /**
    * Template string representing the innerHTML of the instance's element

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -61,6 +61,19 @@ suite('system/Card', function() {
       this.card.render();
     });
 
+    test('card instance properties', function() {
+      // sanity check properties expected to be exposed on the instance
+      assert.isDefined(this.card.app);
+      assert.isDefined(this.card.instanceID);
+      assert.isDefined(this.card.title);
+      assert.isDefined(this.card.subTitle);
+      assert.isDefined(this.card.iconValue);
+      assert.isDefined(this.card.viewClassList);
+      assert.isDefined(this.card.titleId);
+      assert.isDefined(this.card.closeButtonVisibility);
+      assert.isDefined(this.card.favoriteButtonVisibility);
+    });
+
     test('exposes expected element properties', function(){
       var card = this.card;
       assert.ok(card.element, 'element node');


### PR DESCRIPTION
The card view template expects closeButtonVisibility and favoriteButtonVisibility properties, but neither were on the Card prototype. This patch adds default values for those and a little unit test to sanity check instance properties
