### PR TITLE
Bug 1110040 - [Text Selection] bubble broken when selection area is too narrow

### DIFF
--- a/apps/system/js/text_selection_dialog.js
+++ b/apps/system/js/text_selection_dialog.js
@@ -32,7 +32,7 @@
 
   TextSelectionDialog.prototype.TEXTDIALOG_HEIGHT = 52;
 
-  TextSelectionDialog.prototype.TEXTDIALOG_WIDTH = 52;
+  TextSelectionDialog.prototype.TEXTDIALOG_WIDTH = 54;
 
   // Based on UX spec, there would be a temporary shortcut and only appears
   // after the action 'copy/cut'. In this use case, the utility bubble will be


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1110040
