### PR TITLE
Bug 1111575 - Conditionally set mainTitle on mozL10N.ready. r=fcampo

### DIFF
--- a/apps/ftu/js/app.js
+++ b/apps/ftu/js/app.js
@@ -104,8 +104,9 @@ navigator.mozL10n.ready(function showBody() {
       AppManager.init(versionInfo);
     } else {
       UIManager.initTZ();
-      UIManager.mainTitle.setAttribute('data-l10n-id', 'language');
+      if (!UIManager.mainTitle.hasAttribute('data-l10n-id')) {
+        UIManager.mainTitle.setAttribute('data-l10n-id', 'language');
+      }
     }
-
   });
 });


### PR DESCRIPTION
The patch ensures we only add a data-l10n-id on #main-title if one has not yet been added. We use navigator.mozL10n.ready as the entry point to start the FTU, but when you select a different language mozL10n.ready fires again. Previously we had a race condition that allowed the #main-title to get set to Language even if the user was no longer on that screen. 
