### PR TITLE
Bug 1112020 - The build script of keyboard app would fail when copying the a

### DIFF
--- a/apps/keyboard/build/keyboard-config.js
+++ b/apps/keyboard/build/keyboard-config.js
@@ -27,12 +27,17 @@ function copyLayoutsAndResources(appDir, distDir, layoutNames) {
     layout.file.copyTo(layoutDest, layout.file.leafName);
 
     try {
-      if (layout.imEngineDir)
-        layout.imEngineDir.copyTo(imeDest, layout.imEngineDir.leafName);
+      if (layout.imEngineDir) {
+        var  imEngineDirDest = imeDest.clone();
+        imEngineDirDest.append(layout.imEngineDir.leafName);
+        if (!imEngineDirDest.exists()) {
+          layout.imEngineDir.copyTo(imeDest, layout.imEngineDir.leafName);
+        }
+      }
     }
     catch(e) {
       throw new Error('Unknown ime directory ' + layout.imEngineDir.path +
-                      ' for keyboard layout ' + layout.name);
+                      ' for keyboard layout ' + layout.name + ' error: ' + e);
 
     }
 


### PR DESCRIPTION
specific ime folder for the 3rd time.
- Stop copying the same ime folder when it already exists.
