### PR TITLE
Bug 1105648 - The `low-device-storage' l10n string ends with a '\n' character. r=ferjm

### DIFF
--- a/apps/system/locales/system.en-US.properties
+++ b/apps/system/locales/system.en-US.properties
@@ -488,7 +488,7 @@ notification-powersaving-mode-on-title=Power Saving Mode
 notification-powersaving-mode-on-description=Power saving mode is on.
 
 # Low device storage
-low-device-storage=Device space low.\n
+low-device-storage=Device space low.
 # LOCALIZATION NOTE {{value}} is the amount of remaining free space expressed
 # in the corresponding unit ({{unit}}), which is one of the byteUnit-* strings
 # of this same file.


### PR DESCRIPTION
...r
