### PR TITLE
Bug 1112416 - Fix racing of InputMgmt/KBApp when switching from RocketBar to other app

### DIFF
--- a/apps/system/js/app_transition_controller.js
+++ b/apps/system/js/app_transition_controller.js
@@ -216,7 +216,9 @@
 
       this.resetTransition();
       /* The AttentionToaster will take care of that for AttentionWindows */
-      if (!this.app.isAttentionWindow && !this.app.isCallscreenWindow) {
+      /* InputWindow & InputWindowManager will take care of visibility of IM */
+      if (!this.app.isAttentionWindow && !this.app.isCallscreenWindow &&
+          !this.app.isInputMethod) {
         this.app.setVisible(false);
       }
 

--- a/apps/system/js/input_window.js
+++ b/apps/system/js/input_window.js
@@ -22,6 +22,9 @@
 
     this.splashed = true;
 
+    // we're waiting for _ready to fire to do something further
+    this._pendingReady = false;
+
     AppWindow.call(this, configs);
 
     // input keyboard transition was not supposed to have a timeout before,
@@ -118,6 +121,7 @@
   InputWindow.prototype._handle__ready =
   function iw_handle__ready(evt) {
     this.element.removeEventListener('_ready', this);
+    this._pendingReady = false;
 
     this._setHeight(evt.detail.height);
 
@@ -227,6 +231,7 @@
     this.immediateOpen = configs.immediateOpen;
 
     this.element.addEventListener('_ready', this);
+    this._pendingReady = true;
 
     this._setAsActiveInput(true);
 

--- a/apps/system/js/input_window_manager.js
+++ b/apps/system/js/input_window_manager.js
@@ -159,6 +159,7 @@
     if (evt.type.startsWith('input-app')) {
       inputWindow = evt.detail;
     }
+    this._debug('handleEvent: ' + evt.type);
     switch (evt.type) {
       case 'input-appopened':
       case 'input-appheightchanged':
@@ -189,6 +190,18 @@
         }
         break;
       case 'input-appclosed':
+        // bug 1112416: when blur and focus successively fire, there is a racing
+        // where we may close an inputWindow while its input app is still busy
+        // to become ready. If we were to set that inputWindow as inactive
+        // input, it would abort that input app's becoming-ready progress and
+        // we'll get stuck. Thus, do not really set the inactiveness when we
+        // know the inputWindow is waiting to be ready.
+        this._debug('inputWindow pendingReady: ' + inputWindow._pendingReady);
+
+        if (inputWindow._pendingReady) {
+          return;
+        }
+
         inputWindow._setAsActiveInput(false);
         if (!this._currentWindow) {
           this._kbPublish('keyboardhidden', undefined);

--- a/apps/system/test/unit/input_window_manager_test.js
+++ b/apps/system/test/unit/input_window_manager_test.js
@@ -207,26 +207,43 @@ suite('InputWindowManager', function() {
         };
       });
 
-      test('Send keyboardhidden if there is no currentWindow', function() {
+      suite('inputWindow._pendingReady = false', function() {
+        setup(function() {
+          evt.detail._pendingReady = false;
+        });
+        test('Send keyboardhidden if there is no currentWindow', function() {
+          manager._currentWindow = undefined;
+
+          manager.handleEvent(evt);
+
+          assert.isTrue(stubKBPublish.calledWith('keyboardhidden', undefined));
+        });
+
+        test('Do not send keyboardhidden if there is currentWindow',
+        function() {
+          manager._currentWindow = new InputWindow();
+
+          manager.handleEvent(evt);
+
+          assert.isFalse(stubKBPublish.called);
+        });
+
+        test('Source InputWindow is deactivated', function() {
+          manager.handleEvent(evt);
+
+          assert.isTrue(evt.detail._setAsActiveInput.calledWith(false));
+        });
+      });
+
+      test('inputWindow._pendingReady = true -- should not do anything',
+      function() {
+        evt.detail._pendingReady = true;
         manager._currentWindow = undefined;
 
         manager.handleEvent(evt);
 
-        assert.isTrue(stubKBPublish.calledWith('keyboardhidden', undefined));
-      });
-
-      test('Do not send keyboardhidden if there is currentWindow', function() {
-        manager._currentWindow = new InputWindow();
-
-        manager.handleEvent(evt);
-
+        assert.isFalse(evt.detail._setAsActiveInput.called);
         assert.isFalse(stubKBPublish.called);
-      });
-
-      test('Source InputWindow is deactivated', function() {
-        manager.handleEvent(evt);
-
-        assert.isTrue(evt.detail._setAsActiveInput.calledWith(false));
       });
     });
 

--- a/apps/system/test/unit/input_window_test.js
+++ b/apps/system/test/unit/input_window_test.js
@@ -123,6 +123,7 @@ suite('system/InputWindow', function() {
       setup(function(){
         app.element.addEventListener('_ready', app);
         app.height = 300;
+        app._pendingReady = true;
 
         stubSetHeight = this.sinon.stub(app, '_setHeight');
         stubOpen = this.sinon.stub(AppWindow.prototype, 'open');
@@ -134,6 +135,7 @@ suite('system/InputWindow', function() {
         assert.isTrue(stubSetHeight.calledWith(300));
         assert.isTrue(stubOpen.calledOn(app),
                       'should call superclass open');
+        assert.isFalse(app._pendingReady, 'should reset _pendingReady');
       });
 
       test('immediateOpen = true', function() {
@@ -278,6 +280,17 @@ suite('system/InputWindow', function() {
     setup(function() {
       app.hash = '#ime1';
       app.pathInitial = '/index.html';
+    });
+
+    test('should set _pendingReady', function() {
+      app._pendingReady = false;
+
+      app.open({
+        hash: '#ime1',
+        immediateOpen: false
+      });
+
+      assert.isTrue(app._pendingReady);
     });
 
     test('hash changed', function() {


### PR DESCRIPTION
- Through a flag in InputWindow, do not really set the iW as inactive during iW's input-appclosed event if we know it will become ready soon.
