### PR TITLE
Bug 1104194 - Add 2.0..2.2 upgrade configs, remove <2.0

### DIFF
--- a/apps/ftu/config/tiny.json
+++ b/apps/ftu/config/tiny.json
@@ -19,7 +19,7 @@
       }
     ]
   },
-  "2.0..2.1": {
+  "2.0..2.2": {
     "steps": [
       {
         "video": "/style/images/tutorial/VerticalScroll.mp4",
@@ -31,31 +31,11 @@
       }
     ]
   },
-  "1.4..2.1": {
+  "2.1..2.2": {
     "steps": [
       {
         "video": "/style/images/tutorial/VerticalScroll.mp4",
-        "l10nKey": "tutorial-vertical-scroll-v2-tiny"
-      },
-      {
-        "video": "/style/images/tutorial/Sheets.mp4",
-        "l10nKey": "tutorial-sheets-tiny"
-      },
-      {
-        "video": "/style/images/tutorial/Rocketbar.mp4",
-        "l10nKey": "tutorial-rocketbar-tiny"
-      }
-    ]
-  },
-  "1.3..2.1": {
-    "steps": [
-      {
-        "video": "/style/images/tutorial/VerticalScroll.mp4",
-        "l10nKey": "tutorial-vertical-scroll-v2-tiny"
-      },
-      {
-        "video": "/style/images/tutorial/Sheets.mp4",
-        "l10nKey": "tutorial-sheets-tiny"
+        "l10nKey": "tutorial-bookmarks-migration-tiny"
       },
       {
         "video": "/style/images/tutorial/Rocketbar.mp4",


### PR DESCRIPTION
First step to update tutorial config for 2.2: remove pre-2.0 (we only support updates 2 minor versions back, so e.g 1.3 update will go to 2.0 then 2.2) and add 2.0 to 2.2 steps. The 2.1 to 2.2 steps are placeholder, this has not yet been spec'd and will get fixed in https://bugzilla.mozilla.org/show_bug.cgi?id=1111139
