### PR TITLE
Bug 1092965 - Disable text selection for non-editables. +autoland

### DIFF
--- a/apps/ftu/style/style.css
+++ b/apps/ftu/style/style.css
@@ -1,3 +1,7 @@
+* {
+  -moz-user-select: none;
+}
+
 html, body {
   width: 100%;
   height: 100%;
@@ -6,7 +10,12 @@ html, body {
   overflow: hidden !important;
   font-size: 10px;
   font-weight: 400;
-  -moz-user-select: none;
+}
+
+input,
+textarea,
+[contenteditable="true"] {
+  -moz-user-select: text;
 }
 
 a {


### PR DESCRIPTION
Following system app's lead, disable text selection for all but the explicitly editable elements 
