### PR TITLE
Bug 922722 - [email] notifications count will only list most recent sync count

### DIFF
--- a/apps/email/js/app_messages.js
+++ b/apps/email/js/app_messages.js
@@ -3,7 +3,6 @@
 define(function(require) {
   var appSelf = require('app_self'),
       evt = require('evt'),
-      queryString = require('query_string'),
       queryURI = require('query_uri');
 
   var pending = {};
@@ -96,8 +95,7 @@ define(function(require) {
         });
       }
 
-      // icon url parsing is a cray cray way to pass day day
-      var data = queryString.toObject((msg.imageURL || '').split('#')[1]);
+      var data = msg.data || {};
 
       if (document.hidden) {
         appSelf.latest('self', function(app) {


### PR DESCRIPTION
There was already commented out code for this in the current master, but I expanded the change to switch to using Notification.data to store the data for the notification. This removed the goofy \n work around the names in the notification. Hooray!

As for an upgrade plan, if the user installs this 2.2 email app when a notification for a pre-2.2 email app exists, and if they then tap on it: in this case the data object will not have any data in it (the data would have been in the iconURL fragment ID). I opted for just ignoring the data and going to the message list.

Mechanics of the upgrade path: mail_app was changed to default to message_list if no data.type. If no account, then uses currently viewed or default account for email app.

I tested the upgrade path by temporarily manually modifying app_messages onNotification to just set data to an empty object, and the notification tap worked as expected, going to the message list.

The biggest effect of this upgrade plan is on outbox error notifications -- the user is not taken to the outbox in that case. However, if the user is not able to manually navigate to the outbox to fix, the next time a sync happens, the user will get a notification that will go to the correct place, it is not an unrecoverable situation.

This upgrade plan was chosen since notifications are very ephemeral. The multiple email sync would go to message_list anyway, the single email notification tap will go to the right message_list in the majority case so the user will see the new email. Outbox may require a bit more manual work or at least waiting for next sync to get a direct link, but given the small likelihood of overlap on time of upgrade of email and an outbox failure, seemed like a reasonable tradeoff to avoid bloating the code long term for these small edge cases.
