### PR TITLE
Bug 1087066 - Checkboxes should not overlap in message list

### DIFF
--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -722,10 +722,6 @@ html:-moz-dir(rtl) .msg-attachment-filesize {
   display: inline-block;
 }
 
-html:-moz-dir(rtl) .msg-messages-container.show-edit label.negative {
-  right: 2rem;
-}
-
 .msg-messages-container.show-edit .msg-header-unread-section {
   left: 3.9rem;
 }


### PR DESCRIPTION
I believe this was just leftover from a previous attempt at RTL before I settled on the final patch, and I forgot to go back and check the bulk edit in message list with the final change.
