### PR TITLE
Bug 1113792 - Remove strings from index.html for permission screen +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -842,8 +842,8 @@
             <h1 id="permission-title"></h1>
             <h2 id="permission-message"></h2>
             <div id="permission-more-info" class="hidden">
-              <a id="permission-more-info-link" data-l10n-id="more-info" href="#">More Info…</a>
-              <a id="permission-hide-info-link" data-l10n-id="hide-info" href="#" class="hidden">Hide Info</a>
+              <a id="permission-more-info-link" data-l10n-id="more-info" href="#"></a>
+              <a id="permission-hide-info-link" data-l10n-id="hide-info" href="#" class="hidden"></a>
               <div id="permission-more-info-box" class="hidden"> </div>
             </div>
             <div id="permission-remember-section">
@@ -851,7 +851,7 @@
                 <input type="checkbox" id="permission-remember-checkbox" />
                 <span></span>
               </label>
-              <a data-l10n-id="remember-my-choice" id="permission-remember-label">Remember my choice</a>
+              <a data-l10n-id="remember-my-choice" id="permission-remember-label"></a>
             </div>
             <div id="permission-device-selector"></div>
             <ul id="permission-devices">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1113792
