### PR TITLE
Bug 1113812 - Remove strings from index.html for cards view +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1086,7 +1086,7 @@
       <!-- cards view -->
       <div id="cards-view" data-z-index-level="cards-view">
         <ul id="cards-list"></ul>
-        <span id="cards-no-recent-windows" class="no-recent-apps" data-l10n-id="no-recent-app-windows">No recent windows</span>
+        <span id="cards-no-recent-windows" class="no-recent-apps" data-l10n-id="no-recent-app-windows"></span>
       </div>
 
       <!-- icc / stk -->


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1113812

Autolander testing bug.
