### PR TITLE
Bug 1033917 - [Rocketbar][RTL] Vertical Homescreen E.me search input should be right aligned in RTL locales +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -470,7 +470,7 @@
         <!-- Rocketbar-->
         <div id="rocketbar">
           <form id="rocketbar-form" class="hidden">
-            <input id="rocketbar-input" type="search" x-inputmode="verbatim" dir="auto"
+            <input id="rocketbar-input" type="search" x-inputmode="verbatim"
               placeholder="Search or enter address" data-l10n-id="search-or-enter-address" value="" />
             <button type="button" id="rocketbar-clear" data-l10n-id="clear" aria-label="Clear"></button>
             <button type="button" id="rocketbar-cancel" data-l10n-id="close"></button>

--- a/apps/system/js/utility_tray.js
+++ b/apps/system/js/utility_tray.js
@@ -390,9 +390,18 @@ window.UtilityTray = {
       shouldOpen ? this.show() : this.hide();
     }
 
-    // Trigger search from the left half of the screen
-    var corner = touch && (touch.target === this.topPanel) &&
+    /*
+     * Trigger search from the left half of the screen if we're LTR
+     * And trigger from the right half if we're RTL.
+     */
+    var corner;
+    if (document.documentElement.dir  == 'rtl') {
+      corner = touch && (touch.target === this.topPanel) &&
+                 (touch.pageX > (window.innerWidth / 2));
+    } else {
+      corner = touch && (touch.target === this.topPanel) &&
                  (touch.pageX < (window.innerWidth / 2));
+    }
     if (this.isTap && corner) {
       if (this.shown) {
         this.hide();

--- a/apps/system/style/chrome/chrome.css
+++ b/apps/system/style/chrome/chrome.css
@@ -293,7 +293,7 @@
   right: 0.2rem;
   display: block;
   height: 2.4rem;
-  border-left: 1px solid rgba(0,0,0,0.05);
+  border-left: .1rem solid rgba(0,0,0,0.05);
 }
 
 /* Vertically align butons outside of urlbar. */
@@ -490,9 +490,83 @@ html[dir="rtl"] .chrome .controls .urlbar {
 html[dir="rtl"] .search-app .chrome.maximized .controls .urlbar:after {
   left: 0.8rem;
   right: unset;
-  background-position: center left;
 }
 
 html[dir="rtl"] .controls .urlbar {
   transform-origin: top right;
+  
+}
+
+html[dir="rtl"] .appWindow.fullscreen-app .chrome:not(.maximized) .controls .urlbar {
+  transform-origin: bottom right;
+}
+
+html[dir="rtl"] .controls button {
+  float: right;
+}
+
+html[dir="rtl"] .controls .reload-button,
+html[dir="rtl"] .controls .stop-button {
+  left: 0;
+  right: unset;
+}
+
+html[dir="rtl"] .controls .reload-button::before,
+html[dir="rtl"] .controls .stop-button::before {
+  left: 0.2rem;
+  right: unset;
+  border-left: none;
+  border-right: .1rem solid rgba(0,0,0,0.05);
+}
+
+html[dir="rtl"] .controls .back-button {
+  background-image: url("images/dark/forward.png");
+}
+
+html[dir="rtl"] .controls .back-button:active {
+  background-image: url("images/dark/forward_active.png");
+}
+
+html[dir="rtl"] .controls .forward-button {
+  background-image: url("images/dark/back.png");
+}
+
+html[dir="rtl"] .controls .forward-button:active {
+  background-image: url("images/dark/back_active.png");
+}
+
+html[dir="rtl"] .light .controls .back-button {
+  background-image: url("images/light/forward.png");
+}
+
+html[dir="rtl"] .light .controls .back-button:active {
+  background-image: url("images/light/forward_active.png");
+}
+
+html[dir="rtl"] .light .controls .forward-button {
+  background-image: url("images/light/back.png");
+}
+
+html[dir="rtl"] .light .controls .forward-button:active {
+  background-image: url("images/light/back_active.png");
+}
+
+html[dir="rtl"] .chrome.maximized .title[data-ssl="broken"],
+html[dir="rtl"] .chrome.maximized .title[data-ssl="secure"] {
+  background-position: calc(100% - 0.1rem) center
+}
+
+/*
+ * This is for translating the minimized titlebar 12rem to the right,
+ * which is what we need. And it's the direct opposite of -12rem in the
+ * original selector which moves it 12rem to the left.
+ */
+
+html[dir="rtl"] .collapsible .chrome:not(.maximized) .back-button:not([disabled]) + .forward-button:not([disabled]) + .urlbar {
+  transform: scaleX(var(--rocketbar-scale)) translateX(12rem);
+}
+
+html[dir="rtl"] .collapsible .chrome:not(.maximized) .back-button:not([disabled]) + .forward-button[disabled] + .urlbar,
+html[dir="rtl"] .collapsible .chrome:not(.maximized) .forward-button:not([disabled]) + .urlbar {
+  transform: scaleX(var(--rocketbar-scale)) translateX(5.5rem);
 }

--- a/apps/system/style/rocketbar/rocketbar.css
+++ b/apps/system/style/rocketbar/rocketbar.css
@@ -11,11 +11,6 @@
   transition: opacity 0.25s linear;
 }
 
-/* RTL fixes being tracked in bug 1008013 */
-*[dir=rtl] #rocketbar {
-  direction: ltr;
-}
-
 #rocketbar.active {
   opacity: 1;
   pointer-events: auto;
@@ -46,7 +41,8 @@
   width: 100%;
   height: 2rem;
   color: #e7e7e7;
-  padding: 0 0 0 0.5rem;
+  padding: 0;
+  -moz-padding-start: 0.5rem;
   text-overflow: ellipsis;
 }
 
@@ -98,7 +94,7 @@
   font-size: 1.4rem;
   font-style: italic;
   line-height: 1.8rem;
-  padding: 0 .7rem 0 1.4rem;
+  padding: 0 0.7rem 0 1.4rem;
 }
 
 #rocketbar-cancel::before {
@@ -161,4 +157,10 @@
     height: calc(100% - 7rem);
     width: calc(100% - var(--software-home-button-height));
   }
+}
+
+/* RTL View */
+html[dir="rtl"] #rocketbar-cancel::before {
+  left: unset;
+  right: 0;
 }

--- a/apps/verticalhome/style/css/search.css
+++ b/apps/verticalhome/style/css/search.css
@@ -22,7 +22,7 @@
 #search-input {
   margin: 0;
   padding: 0;
-  margin-left: 1.5rem;
+  -moz-margin-start: 1.5rem;
   background: none;
   font-size: 1.8rem;
   border: none;
@@ -49,4 +49,16 @@
   background-repeat: no-repeat;
   background-size: 2rem;
   background-position: center right;
+}
+
+/* RTL View */
+html[dir="rtl"] #search-input {
+  text-align: right;
+  padding-right: .1rem;
+}
+
+html[dir="rtl"] #search-form::after {
+  left: unset;
+  right: 0;
+  background-position: center left;
 }


### PR DESCRIPTION
This patch:
Fixes Homescreen rochetbar search RTL layout.
Fixes Rocketbar clicked state of the search RTL layout.
Fixes browser chrome controls.
Fixes Rocketbar problem of being initiated from the left corner of the status bar even when in RTL.
