### PR TITLE
1114907 - By default, close NotificationHelper notifications on click

### DIFF
--- a/shared/js/notification_helper.js
+++ b/shared/js/notification_helper.js
@@ -41,6 +41,14 @@
           options.lang = navigator.mozL10n.language.code;
 
           var notification = new window.Notification(title, options);
+
+          if (options.closeOnClick !== false) {
+            notification.addEventListener('click', function nh_click() {
+              notification.removeEventListener('click', nh_click);
+              notification.close();
+            });
+          }
+
           resolve(notification);
         });
       });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1114907
