### PR TITLE
Bug 1114509 - [Flame][Homescreen] The text edit botton is still displayed in homescreen after exiting homescreen edit mode.

### DIFF
--- a/shared/elements/gaia-header/dist/gaia-header.js
+++ b/shared/elements/gaia-header/dist/gaia-header.js
@@ -576,6 +576,7 @@ module.exports = Component.register('gaia-header', {
 
   ::content a,
   ::content button {
+    -moz-user-select: none;
     box-sizing: border-box;
     display: flex;
     border: none;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1114509
