### PR TITLE
Bug 1116087 - Safely clone elements for HTML cookie cache

### DIFF
--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -1084,7 +1084,10 @@ return [
         return;
       }
 
-      var cacheNode = this.cloneNode(true);
+      // Safely clone the node so we can mutate the tree to cut out the parts
+      // we do not want/need.
+      var cacheNode =
+            htmlCache.cloneAsInertNodeAvoidingCustomElementHorrors(this);
       cacheNode.dataset.cached = 'cached';
 
       // Make sure toolbar is visible, could be hidden by drawer

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -161,7 +161,9 @@ function getStartCardArgs(id) {
       'setup_account_info', 'immediate',
       {
         onPushed: function(cardNode) {
-          var cachedNode = cardNode.cloneNode(true);
+          var cachedNode =
+                htmlCache.cloneAsInertNodeAvoidingCustomElementHorrors(
+                  cardNode);
           cachedNode.dataset.cached = 'cached';
           htmlCache.delayedSaveFromNode(cachedNode);
         }


### PR DESCRIPTION
Bug 1081039 fixed the platform to call the custom element callback
appropriately when cloning / importing nodes.  A document context
with a fresh registry is required to do this (actually) correctly.

Without this fix the email app's HTML cookie cache would end up
with a corrupted cookie cache state and potentially other app
problems since the rest of the card infrastructure really was not
expecting this type of thing to happen.
