### PR TITLE
Bug 1116162 - Expose console.log|warn|info|error when loading l10n.js at buildtime.

### DIFF
--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -758,7 +758,12 @@ function execute(options) {
     },
     CustomEvent: function() {},
     dispatchEvent: function() {},
-    console: {}
+    console: {
+      log: utils.log,
+      warn: utils.log,
+      error: utils.log,
+      info: utils.log
+    }
   };
 
   // Load window object from build/l10n.js and shared/js/l10n.js into win;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1116162
