### PR TITLE
Bug 1116986 - Quick fix for FxA failing test by hard-coding additional years

### DIFF
--- a/apps/system/fxa/elements/fxa-coppa.html
+++ b/apps/system/fxa/elements/fxa-coppa.html
@@ -34,6 +34,10 @@
               <option value="2012">2012</option>
               <option value="2013">2013</option>
               <option value="2014">2014</option>
+              <option value="2015">2015</option>
+              <option value="2016">2016</option>
+              <option value="2017">2017</option>
+              <option value="2018">2018</option>
             </select>
           </span>
         </li>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1116986
