### PR TITLE
Bug 1117473 - [E-Mail] Typos in manifest.webapp

### DIFF
--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -67,10 +67,10 @@
     "view": {
       "filters": {
         "type": "url",
-        "url": { "required":true, "pattern":"mailto:.{1,16384}" },
-        "disposition": "window",
-        "returnValue": true
-      }
+        "url": { "required":true, "pattern":"mailto:.{1,16384}" }
+      },
+      "disposition": "window",
+      "returnValue": true
     }
   },
   "redirects": [


### PR DESCRIPTION
Bug 1117473 - [E-Mail] Typos in manifest.webapp

Move "disposition" and "returnValue" to parent object.
