### PR TITLE
Bug 1114853 - [Text Selection] when calling input.focus(), the text selection bubble would show up randomly

### DIFF
--- a/apps/system/js/text_selection_dialog.js
+++ b/apps/system/js/text_selection_dialog.js
@@ -164,6 +164,10 @@
         commands.canSelectAll = false;
       }
 
+      if (!isTempShortcut && (isCollapsed || !this._isSelectionVisible)) {
+        this.close();
+        return;
+      }
       // If current element lost focus, we should hide the bubble.
       if (states.indexOf('blur') !== -1) {
         this.hide();
@@ -200,12 +204,6 @@
       if (states.indexOf('selectall') !== -1 ||
           states.indexOf('mouseup') !== -1 ||
           states.indexOf('updateposition') !== -1) {
-        if (!isTempShortcut && isCollapsed ||
-            !this._isSelectionVisible) {
-          this.close();
-          return;
-        }
-
         this.show(detail);
         if (isTempShortcut) {
           this._triggerShortcutTimeout();

--- a/apps/system/test/unit/text_selection_dialog_test.js
+++ b/apps/system/test/unit/text_selection_dialog_test.js
@@ -290,6 +290,8 @@ suite('system/TextSelectionDialog', function() {
 
     test('when the focus element is blurred', function() {
       testDetail.states = ['blur'];
+      testDetail.visible = true;
+      testDetail.isCollapsed = false;
       td._onSelectionStateChanged(fakeTextSelectInAppEvent);
       assert.isTrue(stubHide.calledOnce);
     });
@@ -297,6 +299,8 @@ suite('system/TextSelectionDialog', function() {
     test('should hide bubble if user call selection.collapseToEnd() by script',
       function() {
         testDetail.states = ['collapsetoend'];
+        testDetail.visible = true;
+        testDetail.isCollapsed = false;
         td._onSelectionStateChanged(fakeTextSelectInAppEvent);
         assert.isTrue(stubHide.calledOnce);
       });
@@ -305,6 +309,8 @@ suite('system/TextSelectionDialog', function() {
       // In editable div, we may receive this event while bubble is displaying
       // and tapping on other context.
       function() {
+        testDetail.visible = true;
+        testDetail.isCollapsed = false;
         testDetail.rect.top = testDetail.rect.bottom;
         testDetail.rect.left = testDetail.rect.right;
         td._onSelectionStateChanged(fakeTextSelectInAppEvent);
@@ -313,6 +319,8 @@ suite('system/TextSelectionDialog', function() {
 
     test('with no states', function() {
       testDetail.states = [];
+      testDetail.visible = true;
+      testDetail.isCollapsed = false;
       td._onSelectionStateChanged(fakeTextSelectInAppEvent);
       assert.isFalse(stubClose.calledOnce);
       assert.isFalse(stubHide.calledOnce);
@@ -323,6 +331,8 @@ suite('system/TextSelectionDialog', function() {
     test('should do nothing if rect has no size with no mouseup reason',
       function() {
         testDetail.states = ['mousedown'];
+        testDetail.visible = true;
+        testDetail.isCollapsed = false;
         testDetail.rect.top = testDetail.rect.bottom;
         testDetail.rect.left = testDetail.rect.right;
         td._onSelectionStateChanged(fakeTextSelectInAppEvent);
@@ -334,6 +344,8 @@ suite('system/TextSelectionDialog', function() {
 
     test('should do nothing if no commands', function() {
       testDetail.commands = {};
+      testDetail.visible = true;
+      testDetail.isCollapsed = false;
       td._onSelectionStateChanged(fakeTextSelectInAppEvent);
       assert.isFalse(stubClose.calledOnce);
       assert.isFalse(stubHide.calledOnce);
@@ -342,6 +354,8 @@ suite('system/TextSelectionDialog', function() {
     });
 
     test('should render when first show', function() {
+      testDetail.visible = true;
+      testDetail.isCollapsed = false;
       td._onSelectionStateChanged(fakeTextSelectInAppEvent);
       assert.isTrue(stubRender.calledOnce);
       assert.isTrue(td._injected);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1114853
