### PR TITLE
Bug 1093822 - Update notifications tutorial string. r=fcampo

### DIFF
--- a/apps/ftu/config/large.json
+++ b/apps/ftu/config/large.json
@@ -3,7 +3,7 @@
     "steps": [
       {
         "image": "/style/images/tutorial/1_large.png",
-        "l10nKey": "tutorial-step1-large-2"
+        "l10nKey": "tutorial-step1-large-3"
       },
       {
         "image": "/style/images/tutorial/2_large.png",

--- a/apps/ftu/config/tiny.json
+++ b/apps/ftu/config/tiny.json
@@ -7,7 +7,7 @@
       },
       {
         "video": "/style/images/tutorial/Notifications.mp4",
-        "l10nKey": "tutorial-notifications-tiny"
+        "l10nKey": "tutorial-notifications-v2-tiny"
       },
       {
         "video": "/style/images/tutorial/Sheets.mp4",

--- a/apps/ftu/locales/ftu.en-US.properties
+++ b/apps/ftu/locales/ftu.en-US.properties
@@ -302,13 +302,13 @@ tutorial-step4-tiny = Swipe down to access recent notifications, credit informat
 tutorial-step5-tiny = Tap and hold the home button to browse and close recent apps.
 tutorial-step6-tiny = Swipe from the side of the screen to move back and forth between recent apps.
 
-tutorial-step1-large-2 = Swipe down from top to access recent notifications, credit information and settings.
+tutorial-step1-large-3 = Swipe down to access recent notifications, usage information and settings.
 tutorial-step2-large-2 = Swipe left or right to discover new apps on home screen.
 tutorial-step3-large-2 = Tap and hold on an icon to delete or move it.
 tutorial-step4-large-2 = Two fingers swipe up from the bottom edge to trigger card view.
 
 tutorial-vertical-scroll-v2-tiny = Swipe up and down to browse your apps and bookmarks. Tap and hold an icon to delete, move, or edit it.
-tutorial-notifications-tiny = Swipe down to access recent notifications, credit information and settings.
+tutorial-notifications-v2-tiny = Swipe down to access recent notifications, usage information and settings.
 tutorial-sheets-tiny = Drag from the left edge of your screen to return to recently used apps.
 tutorial-rocketbar-tiny = Tap on the search box anytime to start a search or go to a website.
 tutorial-bookmarks-migration-tiny = Your bookmarks have been moved to the homescreen. When editing, tap a bookmark to edit or rename it.

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_with_tour.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/ftu/test_ftu_with_tour.py
@@ -28,7 +28,7 @@ class TestFtu(GaiaTestCase):
         # Walk through the tour
         self.assertEqual(self.ftu.step1_header_text, "Swipe up and down to browse your apps and bookmarks. Tap and hold an icon to delete, move, or edit it.")
         self.ftu.tap_tour_next()
-        self.assertEqual(self.ftu.step2_header_text, "Swipe down to access recent notifications, credit information and settings.")
+        self.assertEqual(self.ftu.step2_header_text, "Swipe down to access recent notifications, usage information and settings.")
         self.ftu.tap_tour_next()
         self.assertEqual(self.ftu.step3_header_text, "Drag from the left edge of your screen to return to recently used apps.")
         self.ftu.tap_tour_next()


### PR DESCRIPTION
Revised string, bump id in both phone and tablet usages (tutorial-notifications-v2-tiny and tutorial-step1-large-3 respectively) Note that tutorial-step1-tiny thru tutorial-step6-tiny are no longer in use and can get cleaned up in a follow-up
