### PR TITLE
Bug 1109315 - (workaround) [Email] Folder list will be shown when navigating through account settings

### DIFF
--- a/apps/email/style/common.css
+++ b/apps/email/style/common.css
@@ -178,7 +178,6 @@ body {
 .scrollregion-below-header {
   overflow-x: hidden;
   height: calc(100% - 5rem);
-  will-change: scroll-position;
 }
 
 .scrollregion-below-header.scrollregion-horizontal-too {


### PR DESCRIPTION
[Bug 945461](https://bugzilla.mozilla.org/show_bug.cgi?id=945461) originally introduced will-change to all .scrollregion-below-header elements to make sure the layer for the main scrolling area in each email card is one layer.

However, in bug 1109315, there is a platform issue that leads to the buggy animation described in the bug. Initial manual testing seems to indicate that scrolling on cards seems fine without it. The place where we likely really want it, scrolling email messages, will-change is already set on the .msg-list-scrollouter used for that scroll area.

It would be good to get a platform fix for bug 1109315, but if that is not possible, particularly in a branch, this could be used as a workaround until then.
