### PR TITLE
Bug 1117463 - [Browser]User can't slide down to view tabs after adding s...

### DIFF
--- a/apps/browser/js/browser.js
+++ b/apps/browser/js/browser.js
@@ -1592,7 +1592,6 @@ var Browser = {
     containerWidth: null,
 
     touchstart: function tabSwipe_touchstart(e) {
-      e.preventDefault();
 
       this.isCloseButton = e.target.nodeName === 'BUTTON';
       this.tab = this.isCloseButton ? e.target.parentNode : e.target;


### PR DESCRIPTION
...ome tabs in Browser.
- Remove 'preventDefault' in the tabsSwipeMngr touchstart event which  disables scrolling in tabs view.
