### PR TITLE
Bug 1113441 - [Email] Top appears on the top left of the screen when scrolling down email search results

### DIFF
--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -51,6 +51,15 @@ section[role="region"] > header:first-child h1.msg-list-header-folder-label {
   font-style: italic;
 }
 
+/* The search header sets a z-index on its children so that the topbar goes
+   under it when not in use. Not needed for non-search since shared header
+   styles handle it. Specific selectors because some set explicit z-index and
+   setting z-index on just the msg-search-header is not enough. */
+cards-message-list-search .msg-search-header form,
+cards-message-list-search .msg-search-header .bb-tablist {
+  z-index: 10;
+}
+
 cards-message-list-search .msg-search-tease-bar {
   display: none;
 }


### PR DESCRIPTION
The non-search header already had a shared style that set the orange header to have a z-index, so the topbar would slide under it. The basic HTML order is:
- header
- scroll area
- topbar

The topbar is placed at the end so that it will naturally show over the scroll area. Placing the topbar above it or the header would hide it. However, with it at the bottom of the DOM order, it would by default overlap the header unless the header content had a z-order on it. This patch fixes that for the search mode.
