### PR TITLE
Bug 1092048 - [WIFI]The long name of Wi-Fi and the singal strength icon ...

### DIFF
--- a/apps/settings/elements/wifi_manage_networks.html
+++ b/apps/settings/elements/wifi_manage_networks.html
@@ -18,7 +18,7 @@
       <header>
         <h2 data-l10n-id="knownNetworks"></h2>
       </header>
-      <ul class="wifi-knownNetworks">
+      <ul class="wifi-knownNetworks" data-state="ready">
       </ul>
 
       <header>


### PR DESCRIPTION
...are overlapping in 'Manage Networks'
