### PR TITLE
Bug 1098664 - fallback to manifest app type if metadata.json one is empt...

### DIFF
--- a/build/utils-xpc.js
+++ b/build/utils-xpc.js
@@ -368,7 +368,11 @@ function getWebapp(app, config) {
   if (metaData.exists()) {
     webapp.pckManifest = readZipManifest(webapp.sourceDirectoryFile);
     webapp.metaData = getJSON(metaData);
-    webapp.appStatus = utils.getAppStatus(webapp.metaData.type || 'web');
+    webapp.appStatus = utils.getAppStatus(webapp.metaData.type ||
+                                          (webapp.pckManifest ?
+                                           webapp.pckManifest.type :
+                                           webapp.manifest.type) ||
+                                          'web');
   } else {
     webapp.appStatus = utils.getAppStatus(webapp.manifest.type);
   }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1098664
