### PR TITLE
Bug 1118849 - [Email] Email Addresses overlap carat in Mail Settings

### DIFF
--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -282,6 +282,7 @@ li.select-item {
   /* Explicit -left used since RTL cases always want right alignment, regardless
      of direction of user input string. See rtl style overrides below */
   padding-left: 1.5rem;
+  padding-right: 2.2rem;
   line-height: 5.5rem;
   font-size: 1.8rem;
   outline: 0 none;
@@ -289,6 +290,7 @@ li.select-item {
 }
 
 html:-moz-dir(rtl) .list-text {
+  padding-left: 2.2rem;
   padding-right: 1.5rem;
   text-align: right;
 }


### PR DESCRIPTION
Forgot to give the other side padding, to account for carats that are placed in an ::after selector
