### PR TITLE
Bug 1118174 - [TextSelection] Copypaste bubble should not show on the front of utility_tray

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -85,8 +85,7 @@
   z-index: 65538;
 }
 
-#screen > [data-z-index-level="attention-indicator"],
-#screen > [data-z-index-level="text-selection-dialog"] {
+#screen > [data-z-index-level="attention-indicator"] {
   z-index: 32769;
 }
 
@@ -129,6 +128,9 @@
   z-index: 16384;
 }
 
+#screen > [data-z-index-level="text-selection-dialog"] {
+  z-index: 16383;
+}
 
 /* Level 4: Attention window */
 /*


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1118174
