### PR TITLE
Bug 1112596 - Fix loading indicator not showing on load. r=alive

### DIFF
--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1,6 +1,7 @@
 /* global AppWindow, ScreenLayout, MockOrientationManager, MockService,
       LayoutManager, MocksHelper, MockContextMenu, layoutManager, Service,
-      MockAppTransitionController, MockPermissionSettings, DocumentFragment */
+      MockAppTransitionController, MockPermissionSettings, DocumentFragment,
+      AppChrome */
 'use strict';
 
 requireApp('system/test/unit/mock_orientation_manager.js');
@@ -1626,6 +1627,22 @@ suite('system/AppWindow', function() {
 
       assert.isTrue(app1.loaded);
       assert.isFalse(app1.loading);
+    });
+
+    test('Load event before _opened', function() {
+      var spy = this.sinon.spy(window, 'AppChrome');
+      var app1 = new AppWindow(fakeChromeConfigWithNavigationBar);
+      app1.handleEvent({
+        type: 'mozbrowserloadstart'
+      });
+      assert.isFalse(spy.calledWithNew());
+
+      var chromeEventSpy = this.sinon.stub(AppChrome.prototype, 'handleEvent');
+
+      app1.element.dispatchEvent(new CustomEvent('_opened'));
+
+      sinon.assert.calledWith(chromeEventSpy, {type: 'mozbrowserloadstart'});
+      sinon.assert.calledWith(chromeEventSpy, {type: '_loading'});
     });
 
     test('Locationchange event', function() {

--- a/apps/system/test/unit/mock_app_chrome.js
+++ b/apps/system/test/unit/mock_app_chrome.js
@@ -4,5 +4,6 @@
 
   var MockAppChrome = function AppChrome(app) {};
   MockAppChrome.prototype.destroy = function() {};
+  MockAppChrome.prototype.handleEvent = function(evt) {};
   exports.MockAppChrome = MockAppChrome;
 })(window);


### PR DESCRIPTION
If a page triggers a loadstart before the app chrome loads, the app chrome
will not show the loading state.
