### PR TITLE
Bug 1119673 - Treat .key value 'MozHomeScreen' as Home key also, r=timdream

### DIFF
--- a/apps/system/js/browser_key_event_manager.js
+++ b/apps/system/js/browser_key_event_manager.js
@@ -15,16 +15,24 @@
     SYSTEM_ONLY_KEYS: Object.freeze([
       'power',
       'home',
+      'mozhomescreen',
       'exit'
     ]),
     APP_CANCELLED_KEYS: Object.freeze([
       'volumeup',
       'volumedown'
     ]),
+    // Home key has different .key values on different devices.
+    HOME_KEY_ALIAS: Object.freeze([
+      'home',
+      'mozhomescreen',
+      'exit'
+    ]),
     TRANSLATION_TABLE: Object.freeze({
       'power': 'sleep-button',
       'exit': 'home-button',
       'home': 'home-button',
+      'mozhomescreen': 'home-button',
       'volumeup': 'volume-up-button',
       'volumedown': 'volume-down-button'
     }),
@@ -79,7 +87,7 @@
     },
     isHomeKey: function bkem_isHomeKey(event) {
       var key = this._getLowerCaseKeyName(event);
-      return key === 'exit' || key === 'home';
+      return (this.HOME_KEY_ALIAS.indexOf(key) > -1);
     },
     isHardwareKeyEvent: function bkem_isHardwareKeyEvent(type) {
       return (this.KEY_EVENTS.indexOf(type) > -1);

--- a/tv_apps/smart-system/js/browser_key_event_manager.js
+++ b/tv_apps/smart-system/js/browser_key_event_manager.js
@@ -15,16 +15,24 @@
     SYSTEM_ONLY_KEYS: Object.freeze([
       'power',
       'home',
+      'mozhomescreen',
       'exit'
     ]),
     APP_CANCELLED_KEYS: Object.freeze([
       'volumeup',
       'volumedown'
     ]),
+    // Home key has different .key values on different devices.
+    HOME_KEY_ALIAS: Object.freeze([
+      'home',
+      'mozhomescreen',
+      'exit'
+    ]),
     TRANSLATION_TABLE: Object.freeze({
       'power': 'sleep-button',
       'exit': 'home-button',
       'home': 'home-button',
+      'mozhomescreen': 'home-button',
       'volumeup': 'volume-up-button',
       'volumedown': 'volume-down-button'
     }),
@@ -79,7 +87,7 @@
     },
     isHomeKey: function bkem_isHomeKey(event) {
       var key = this._getLowerCaseKeyName(event);
-      return key === 'exit' || key === 'home';
+      return (this.HOME_KEY_ALIAS.indexOf(key) > -1);
     },
     isHardwareKeyEvent: function bkem_isHardwareKeyEvent(type) {
       return (this.KEY_EVENTS.indexOf(type) > -1);


### PR DESCRIPTION
According to bug 1116762, `KeyboardEvent.key` value of Home key is going to be `MozHomeScreen`. We add .key value mapping in browser_key_event_manager.js accordingly to prevent Home key malfunction.

https://bugzilla.mozilla.org/show_bug.cgi?id=1119673
