### PR TITLE
Bug 1119960 - Download app should have basic l10n metadata

### DIFF
--- a/apps/download/pick.html
+++ b/apps/download/pick.html
@@ -6,6 +6,8 @@
     <title>Download Picker</title>
 
     <!-- Localization -->
+    <meta name="defaultLanguage" content="en-US">
+    <meta name="availableLanguages" content="en-US">
     <link rel="localization" href="shared/locales/date/date.{locale}.properties">
     <link rel="localization" href="shared/locales/download/download.{locale}.properties">
     <link rel="localization" href="locales/download.{locale}.properties">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1119960
