### PR TITLE
Bug 1102348 - Call log checkboxes and direction indicators are too bunched up in edit mode +autoland

### DIFF
--- a/apps/communications/dialer/style/call_log.css
+++ b/apps/communications/dialer/style/call_log.css
@@ -282,7 +282,7 @@ html[dir="rtl"] .icon-container {
 }
 
 html[dir="rtl"] .recents-edit .pack-checkbox.call-log-selection {
-  transform: translateX(-5rem);
+  transform: translateX(-4rem);
 }
 
 html[dir="rtl"] .recents-edit .log-item a {


### PR DESCRIPTION
...
