### PR TITLE
Bug 1117185 - [firefox os 2.2] [gaia] sms settings back button responding but not working

### DIFF
--- a/apps/settings/js/modules/settings_service.js
+++ b/apps/settings/js/modules/settings_service.js
@@ -79,7 +79,11 @@ define(function(require) {
       }
 
       if (!_currentNavigation) {
-        return false;
+        if (panelId === 'root') {
+          return true;
+        } else {
+          return false;
+        }
       }
 
       // Get the parent panel id of the current panel.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1117185
