### PR TITLE
Bug 1115649 - Differentiate concept of Panel and Dialog in Keyboard Settings

### DIFF
--- a/apps/keyboard/build/settings-config.js
+++ b/apps/keyboard/build/settings-config.js
@@ -61,7 +61,7 @@ function addSettings(appDirPath, distDirPath, enabledFeatures) {
   }
 
   if (enabledFeatures.userDict) {
-    insertScript('js/settings/user_dictionary_edit_panel.js');
+    insertScript('js/settings/user_dictionary_edit_dialog.js');
     insertScript('js/settings/user_dictionary_list_panel.js');
     insertScript('js/settings/user_dictionary.js');
     insertScript('js/settings/panel_controller.js');

--- a/apps/keyboard/js/settings/keyboard_settings_app.js
+++ b/apps/keyboard/js/settings/keyboard_settings_app.js
@@ -2,7 +2,8 @@
 
 /* global SettingsPromiseManager, CloseLockManager, UserDictionaryListPanel,
           GeneralSettingsGroupView, HandwritingSettingsGroupView,
-          MozActivity, PanelController, UserDictionaryEditPanel */
+          DialogController, MozActivity, PanelController,
+          UserDictionaryEditDialog */
 
 (function(exports) {
 
@@ -14,8 +15,9 @@ var KeyboardSettingsApp = function KeyboardSettingsApp() {
   // the existence of panelController is indicative of the suport for userdict.
   // let's keep the reference of panels here for now.
   this.panelController = null;
+  this.dialogController = null;
   this.userDictionaryListPanel = null;
-  this.userDictionaryEditPanel = null;
+  this.userDictionaryEditDialog = null;
 
   this._closeLock = null;
 };
@@ -43,7 +45,10 @@ KeyboardSettingsApp.prototype.start = function() {
     this.panelController = new PanelController(document.getElementById('root'));
     this.panelController.start();
 
-    this.userDictionaryEditPanel = new UserDictionaryEditPanel();
+    this.dialogController = new DialogController();
+    this.dialogController.start();
+
+    this.userDictionaryEditDialog = new UserDictionaryEditDialog();
 
     this.userDictionaryListPanel = new UserDictionaryListPanel(this);
 
@@ -74,11 +79,14 @@ KeyboardSettingsApp.prototype.stop = function() {
     this.panelController.stop();
     this.panelController = null;
 
+    this.dialogController.stop();
+    this.dialogController = null;
+
     this.userDictionaryListPanel.uninit();
     this.userDictionaryListPanel = null;
 
-    this.userDictionaryEditPanel.uninit();
-    this.userDictionaryEditPanel = null;
+    this.userDictionaryEditDialog.uninit();
+    this.userDictionaryEditDialog = null;
 
     document.getElementById('menu-userdict').removeEventListener('click', this);
   }

--- a/apps/keyboard/js/settings/panel_controller.js
+++ b/apps/keyboard/js/settings/panel_controller.js
@@ -3,47 +3,60 @@
 (function(exports) {
 
 /*
- * Controls transitioning of different panels. The concept is largely the same
- * with Settings app, but we're working under these bases here:
+ * Controls transitioning of different panels and dialogs. The concept is
+ * largely the same with Settings app, but we're working under these bases here:
  *
- * 1) we only have three panels (root, user-dictionary-word-list
- *    user-dictionary-edit).
+ * 1) we only have two panels (root and user-dictionary-word-list), and one
+ *    dialog (user-dictionary-edit).
  * 2) we either navigate to root from word list, or
  *    navigate from root to word list, or
- *    show the dict edit panel (in a dialog's sense) when we're at word list.
+ *    show the dict edit dialog when we're at word list.
  *
  * The transition between root and word list panels are written ad-hoc thereby.
  *
  * The architecture is like Settings app and we have a few exposed event hooks
- * required for each panel class, like:
- * - beforeShow(): when a panel is to be shown.
- * - show(): when a panel has fully transitioned in. Do event binding here
- * - beforeHide(): when a panel is to be hidden. Do event unbinding here
- * - hide(): when a panel has fully transitioned out.
+ * required for each panel/dialog class, like:
+ * - beforeShow(): when a panel/dialog is to be shown.
+ * - show(): when a panel/dialog has fully transitioned in.
+             Do event binding here.
+ * - beforeHide(): when a panel/dialog is to be hidden. Do event unbinding here.
+ * - hide(): when a panel/dialog has fully transitioned out.
  * Each event hook may optionally be asynchronous by returning a Promise.
  *
- * Additionally, each panel should initialize itself on first beforeShow() in
- * its object lifetime.
+ * Additionally, each panel/dialog should initialize itself on first
+ *  beforeShow() in its object lifetime.
  * 
  * The big exception is the root panel -- it's still taken care of by the old
  * codes; and it doesn't need to do any housekeeping job when we transition
  * back from word list.
  *
- * Similar to Settings app, a dialog panel has a onsubmit call back where it
- * passes the result of the dialog when it's done. It should be handled by
- * openDialog (for subsequent clean-up and transition-out) and the results will
- * propagate through openDialog's originally returned Promise to its caller.
+ * == Dialogs ==
+ *
+ * A dialog is of more limited use:
+ *
+ * Similr to Settings app, a dialog is always modal and may only be stacked on
+ * top of another panel or another dialog, and cannot freely transition to
+ * another panel.
+ *
+ * We should always open a dialog with DialogController -- we try to limit a
+ * dialog object's ability to reach other components, and we only provide it
+ * with DialogController such that it is able to open other dialogs only.
+ *
+ * A dialog has a onsubmit call back where it passes its result, which is
+ * processed by openDialog, for subsequent clean-up and transition-out, and for
+ * propogation the results through openDialog's originally returned Promise to
+ * its caller.
  */
+
+// in case transitionend event is interrupted due to whatever reason,
+// we use a timeout to make sure that the sequence is not uncontrollably
+// interruptted.
+const TRANSITION_TIMEOUT = 600;
 
 var PanelController = function(rootPanelElem) {
   this._rootPanelElem = rootPanelElem;
   this._currentPanel = null;
 };
-
-// in case transitionend event is interrupted due to whatever reason,
-// we use a timeout to make sure that the sequence is not uncontrollably
-// interruptted.
-PanelController.prototype.TRANSITION_TIMEOUT = 600;
 
 PanelController.prototype.start = function() {
 };
@@ -62,9 +75,9 @@ PanelController.prototype._createTransitionPromise = function(target) {
       resolve();
     };
 
-    var timeout = setTimeout(transitionEnd, this.TRANSITION_TIMEOUT);
+    var timeout = setTimeout(transitionEnd, TRANSITION_TIMEOUT);
     target.addEventListener('transitionend', transitionEnd);
-  }.bind(this));
+  });
 };
 
 PanelController.prototype.navigateToRoot = function() {
@@ -110,7 +123,23 @@ PanelController.prototype.navigateToPanel = function(panel, options) {
   .catch(e => e && console.error(e));
 };
 
-PanelController.prototype.openDialog = function(panel, options) {
+var DialogController = function() {
+};
+
+DialogController.prototype.start = function() {
+};
+
+DialogController.prototype.stop = function() {
+};
+
+DialogController.prototype._createTransitionPromise =
+  PanelController.prototype._createTransitionPromise;
+
+DialogController.prototype.openDialog = function(dialog, options) {
+  if (!('onsubmit' in dialog)) {
+    return Promise.reject('Dialog does not have a onsubmit callback');
+  }
+
   var resultPromiseResolve, resultPromiseReject;
 
   var resultPromise = new Promise(function(resolve, reject){
@@ -118,38 +147,42 @@ PanelController.prototype.openDialog = function(panel, options) {
     resultPromiseReject = reject;
   });
 
-  panel.onsubmit = results => {
+  dialog.onsubmit = results => {
     resultPromiseResolve(results);
 
-    Promise.resolve(panel.beforeHide())
+    Promise.resolve(dialog.beforeHide())
     .then(() => {
-      var transitionPromise = this._createTransitionPromise(panel._container);
+      var transitionPromise = this._createTransitionPromise(dialog._container);
 
-      panel._container.classList.remove('displayed');
+      dialog._container.classList.remove('displayed');
 
       return transitionPromise;
     })
     .then(() => {
-      panel.onsubmit = undefined;
-      return panel.hide();
+      dialog.onsubmit = undefined;
+      return dialog.hide();
     })
     .catch(e => e && console.log(e));
   };
 
-  Promise.resolve(panel.beforeShow(options))
-  .then(() => {
-    var transitionPromise = this._createTransitionPromise(panel._container);
+  options = options || {};
+  options.dialogController = this;
 
-    panel._container.classList.add('displayed');
+  Promise.resolve(dialog.beforeShow(options))
+  .then(() => {
+    var transitionPromise = this._createTransitionPromise(dialog._container);
+
+    dialog._container.classList.add('displayed');
 
     return transitionPromise;
   })
-  .then(panel.show.bind(panel))
+  .then(dialog.show.bind(dialog))
   .catch(e => resultPromiseReject(e));
 
   return resultPromise;
 };
 
 exports.PanelController = PanelController;
+exports.DialogController = DialogController;
 
 })(window);

--- a/apps/keyboard/js/settings/user_dictionary_edit_dialog.js
+++ b/apps/keyboard/js/settings/user_dictionary_edit_dialog.js
@@ -3,8 +3,6 @@
 /* global KeyEvent */
 
 /*
- * This panel should be used as a Dialog.
- *
  * We may be in two modes: "edit mode" or "add mode".
  *
  * Its onsubmit results may be:
@@ -20,7 +18,7 @@
 
 (function(exports) {
 
-var UserDictionaryEditPanel = function() {
+var UserDictionaryEditDialog = function() {
   this._initialized = false;
 
   this._container = null;
@@ -29,25 +27,25 @@ var UserDictionaryEditPanel = function() {
   this._oldWord = undefined;
 };
 
-UserDictionaryEditPanel.prototype.CONTAINER_ID = 'panel-ud-editword';
+UserDictionaryEditDialog.prototype.CONTAINER_ID = 'panel-ud-editword';
 
-UserDictionaryEditPanel.prototype.onsubmit = undefined;
+UserDictionaryEditDialog.prototype.onsubmit = undefined;
 
-UserDictionaryEditPanel.prototype.init = function(){
+UserDictionaryEditDialog.prototype.init = function(){
   this._initialized = true;
 
   this._container = document.getElementById(this.CONTAINER_ID);
   this._inputField = this._container.querySelector('#ud-editword-input');
 };
 
-UserDictionaryEditPanel.prototype.uninit = function(){
+UserDictionaryEditDialog.prototype.uninit = function(){
   this._initialized = false;
 
   this._container = null;
   this._inputField = null;
 };
 
-UserDictionaryEditPanel.prototype.beforeShow = function(options) {
+UserDictionaryEditDialog.prototype.beforeShow = function(options) {
   if (!this._initialized) {
     this.init();
   }
@@ -62,7 +60,7 @@ UserDictionaryEditPanel.prototype.beforeShow = function(options) {
   }
 };
 
-UserDictionaryEditPanel.prototype.show = function() {
+UserDictionaryEditDialog.prototype.show = function() {
   this._container.querySelector('#ud-editword-header')
     .addEventListener('action', this);
 
@@ -80,7 +78,7 @@ UserDictionaryEditPanel.prototype.show = function() {
   this._inputField.focus();
 };
 
-UserDictionaryEditPanel.prototype.beforeHide = function() {
+UserDictionaryEditDialog.prototype.beforeHide = function() {
   this._container.querySelector('#ud-editword-header')
     .removeEventListener('action', this);
 
@@ -96,12 +94,12 @@ UserDictionaryEditPanel.prototype.beforeHide = function() {
     .removeEventListener('click', this);
 };
 
-UserDictionaryEditPanel.prototype.hide = function() {
+UserDictionaryEditDialog.prototype.hide = function() {
   this._inputField.value = '';
   this._oldWord = undefined;
 };
 
-UserDictionaryEditPanel.prototype.handleEvent = function(evt) {
+UserDictionaryEditDialog.prototype.handleEvent = function(evt) {
   switch (evt.type) {
     case 'action':
       this._cancel();
@@ -142,18 +140,18 @@ UserDictionaryEditPanel.prototype.handleEvent = function(evt) {
 };
 
 
-UserDictionaryEditPanel.prototype._removeWord = function() {
+UserDictionaryEditDialog.prototype._removeWord = function() {
   this.onsubmit({action: 'remove'});
 };
 
-UserDictionaryEditPanel.prototype._commitWord = function() {
+UserDictionaryEditDialog.prototype._commitWord = function() {
   this.onsubmit({action: 'commit', word: this._inputField.value.trim()});
 };
 
-UserDictionaryEditPanel.prototype._cancel = function() {
+UserDictionaryEditDialog.prototype._cancel = function() {
   this.onsubmit({action: 'cancel'});
 };
 
-exports.UserDictionaryEditPanel = UserDictionaryEditPanel;
+exports.UserDictionaryEditDialog = UserDictionaryEditDialog;
 
 })(window);

--- a/apps/keyboard/js/settings/user_dictionary_list_panel.js
+++ b/apps/keyboard/js/settings/user_dictionary_list_panel.js
@@ -120,7 +120,7 @@ UserDictionaryListPanel.prototype._appendList = function(word) {
 };
 
 UserDictionaryListPanel.prototype._showAddDialog = function() {
-  this.app.panelController.openDialog(this.app.userDictionaryEditPanel)
+  this.app.dialogController.openDialog(this.app.userDictionaryEditDialog)
   .then(
     result => {
       if ('commit' === result.action) {
@@ -133,7 +133,7 @@ UserDictionaryListPanel.prototype._showAddDialog = function() {
 UserDictionaryListPanel.prototype._showEditDialog = function(wordElem) {
   var word = this._domWordMap.get(wordElem);
 
-  this.app.panelController.openDialog(this.app.userDictionaryEditPanel, {
+  this.app.dialogController.openDialog(this.app.userDictionaryEditDialog, {
     word: word
   })
   .then(

--- a/apps/keyboard/test/build/integration/keyboard_test.js
+++ b/apps/keyboard/test/build/integration/keyboard_test.js
@@ -389,8 +389,8 @@ suite('Keyboard settings building tests', function() {
         var settingsDOMDoc = getSettingsDomDoc();
 
         assert.isTrue(getScriptsFromDomDoc(settingsDOMDoc).every(function(elem){
-          return elem.src !== 'js/settings/user_dictionary_edit_panel.js';
-        }), 'No script should include user_dictionary_edit_panel.js');
+          return elem.src !== 'js/settings/user_dictionary_edit_dialog.js';
+        }), 'No script should include user_dictionary_edit_dialog.js');
 
         assert.isTrue(getScriptsFromDomDoc(settingsDOMDoc).every(function(elem){
           return elem.src !== 'js/settings/user_dictionary_list_panel.js';
@@ -420,8 +420,8 @@ suite('Keyboard settings building tests', function() {
         var settingsDOMDoc = getSettingsDomDoc();
 
         assert.isTrue(getScriptsFromDomDoc(settingsDOMDoc).some(function(elem){
-          return elem.src === 'js/settings/user_dictionary_edit_panel.js';
-        }), 'Some script should include user_dictionary_edit_panel.js');
+          return elem.src === 'js/settings/user_dictionary_edit_dialog.js';
+        }), 'Some script should include user_dictionary_edit_dialog.js');
 
         assert.isTrue(getScriptsFromDomDoc(settingsDOMDoc).some(function(elem){
           return elem.src === 'js/settings/user_dictionary_list_panel.js';

--- a/apps/keyboard/test/unit/settings/keyboard_settings_app_test.js
+++ b/apps/keyboard/test/unit/settings/keyboard_settings_app_test.js
@@ -2,13 +2,13 @@
 
 /* global GeneralSettingsGroupView, HandwritingSettingsGroupView,
           KeyboardSettingsApp, UserDictionaryListPanel, PanelController,
-          UserDictionaryEditPanel */
+          UserDictionaryEditDialog */
 
 require('/js/settings/close_locks.js');
 require('/js/settings/general_settings.js');
 require('/js/settings/handwriting_settings.js');
 require('/js/settings/panel_controller.js');
-require('/js/settings/user_dictionary_edit_panel.js');
+require('/js/settings/user_dictionary_edit_dialog.js');
 require('/js/settings/user_dictionary_list_panel.js');
 
 require('/js/settings/keyboard_settings_app.js');
@@ -26,7 +26,7 @@ suite('KeyboardSettingsApp', function() {
   var stubHandwritingSettingsGroupView;
   var stubPanelController;
   var stubUserDictionaryListPanel;
-  var stubUserDictionaryEditPanel;
+  var stubUserDictionaryEditDialog;
 
   var isHidden;
 
@@ -87,10 +87,10 @@ suite('KeyboardSettingsApp', function() {
     this.sinon.stub(window, 'UserDictionaryListPanel')
       .returns(stubUserDictionaryListPanel);
 
-    stubUserDictionaryEditPanel =
-      this.sinon.stub(Object.create(UserDictionaryEditPanel.prototype));
-    this.sinon.stub(window, 'UserDictionaryEditPanel')
-      .returns(stubUserDictionaryEditPanel);
+    stubUserDictionaryEditDialog =
+      this.sinon.stub(Object.create(UserDictionaryEditDialog.prototype));
+    this.sinon.stub(window, 'UserDictionaryEditDialog')
+      .returns(stubUserDictionaryEditDialog);
 
     stubGetElemById = this.sinon.stub(document, 'getElementById', function(id){
       switch (id) {
@@ -146,7 +146,7 @@ suite('KeyboardSettingsApp', function() {
       assert.isTrue(stubHandwritingSettingsGroupView.stop.calledOnce);
       assert.isTrue(stubPanelController.stop.calledOnce);
       assert.isTrue(stubUserDictionaryListPanel.uninit.calledOnce);
-      assert.isTrue(stubUserDictionaryEditPanel.uninit.calledOnce);
+      assert.isTrue(stubUserDictionaryEditDialog.uninit.calledOnce);
 
       assert.isTrue(menuUDStub.removeEventListener.calledWith('click', app));
       assert.isTrue(headerStub.removeEventListener.calledWith('action', app));

--- a/apps/keyboard/test/unit/settings/user_dictionary_edit_dialog_test.js
+++ b/apps/keyboard/test/unit/settings/user_dictionary_edit_dialog_test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-/* global UserDictionaryEditPanel, MockEventTarget, KeyEvent */
+/* global UserDictionaryEditDialog, MockEventTarget, KeyEvent */
 
 require('/shared/test/unit/mocks/mock_event_target.js');
 
-require('/js/settings/user_dictionary_edit_panel.js');
+require('/js/settings/user_dictionary_edit_dialog.js');
 
-suite('UserDictionary Edit Panel', function() {
-  var panel;
+suite('UserDictionary Edit Dialog', function() {
+  var dialog;
   var stubContainer;
   var stubGetElemById;
 
@@ -19,7 +19,7 @@ suite('UserDictionary Edit Panel', function() {
   var stubDialogDeleteBtn;
 
   setup(function() {
-    panel = new UserDictionaryEditPanel();
+    dialog = new UserDictionaryEditDialog();
 
     stubContainer = {
       querySelector:
@@ -53,84 +53,86 @@ suite('UserDictionary Edit Panel', function() {
     stubContainer.querySelector
       .withArgs('#ud-editword-dialog-delete-btn').returns(stubDialogDeleteBtn);
 
-    panel.init();
+    dialog.init();
 
     assert.isTrue(stubGetElemById.calledWith('panel-ud-editword'));
 
-    assert.equal(panel._inputField, stubInput);
+    assert.equal(dialog._inputField, stubInput);
   });
 
   teardown(function() {
-    panel.uninit();
+    dialog.uninit();
   });
 
   suite('Transition hooks', function() {
     suite('beforeShow', function() {
       test('call init if necessary', function() {
-        panel._initialized = false;
-        this.sinon.stub(panel, 'init');
+        dialog._initialized = false;
+        this.sinon.stub(dialog, 'init');
 
-        panel.beforeShow();
+        dialog.beforeShow();
 
-        assert.isTrue(panel.init.called);
+        assert.isTrue(dialog.init.called);
       });
 
       test('edit mode', function() {
-        panel.beforeShow({
+        dialog.beforeShow({
           word: 'star'
         });
 
         assert.isTrue(stubContainer.classList.remove.calledWith('add-mode'));
-        assert.equal(panel._inputField.value, 'star');
-        assert.equal(panel._oldWord, 'star');
+        assert.equal(dialog._inputField.value, 'star');
+        assert.equal(dialog._oldWord, 'star');
     });
 
       test('add mode', function() {
-        panel.beforeShow();
+        dialog.beforeShow();
 
         assert.isTrue(stubContainer.classList.add.calledWith('add-mode'));
-        assert.strictEqual(panel._oldWord, undefined);
+        assert.strictEqual(dialog._oldWord, undefined);
       });
     });
 
     test('show', function() {
       stubInput.focus = this.sinon.spy();
 
-      panel.show();
+      dialog.show();
 
-      assert.isTrue(stubHeader.addEventListener.calledWith('action', panel));
+      assert.isTrue(stubHeader.addEventListener.calledWith('action', dialog));
       assert.isTrue(
-        stubSaveWordBtn.addEventListener.calledWith('click', panel));
-      assert.isTrue(stubInput.addEventListener.calledWith('keydown', panel));
-      assert.isTrue(stubDeleteBtn.addEventListener.calledWith('click', panel));
+        stubSaveWordBtn.addEventListener.calledWith('click', dialog));
+      assert.isTrue(stubInput.addEventListener.calledWith('keydown', dialog));
+      assert.isTrue(stubDeleteBtn.addEventListener.calledWith('click', dialog));
       assert.isTrue(
-        stubDialogCancelBtn.addEventListener.calledWith('click', panel));
+        stubDialogCancelBtn.addEventListener.calledWith('click', dialog));
       assert.isTrue(
-        stubDialogDeleteBtn.addEventListener.calledWith('click', panel));
+        stubDialogDeleteBtn.addEventListener.calledWith('click', dialog));
 
       assert.isTrue(stubInput.focus.called);
     });
 
     test('beforeHide', function() {
-      panel.beforeHide();
+      dialog.beforeHide();
 
-      assert.isTrue(stubHeader.removeEventListener.calledWith('action', panel));
       assert.isTrue(
-        stubSaveWordBtn.removeEventListener.calledWith('click', panel));
-      assert.isTrue(stubInput.removeEventListener.calledWith('keydown', panel));
+        stubHeader.removeEventListener.calledWith('action', dialog));
       assert.isTrue(
-        stubDeleteBtn.removeEventListener.calledWith('click', panel));
+        stubSaveWordBtn.removeEventListener.calledWith('click', dialog));
       assert.isTrue(
-        stubDialogCancelBtn.removeEventListener.calledWith('click', panel));
+        stubInput.removeEventListener.calledWith('keydown', dialog));
       assert.isTrue(
-        stubDialogDeleteBtn.removeEventListener.calledWith('click', panel));
+        stubDeleteBtn.removeEventListener.calledWith('click', dialog));
+      assert.isTrue(
+        stubDialogCancelBtn.removeEventListener.calledWith('click', dialog));
+      assert.isTrue(
+        stubDialogDeleteBtn.removeEventListener.calledWith('click', dialog));
     });
 
     test('hide', function() {
-      panel.hide();
+      dialog.hide();
 
-      assert.strictEqual(panel._inputField.value, '');
-      assert.strictEqual(panel._oldWord, undefined);
+      assert.strictEqual(dialog._inputField.value, '');
+      assert.strictEqual(dialog._oldWord, undefined);
     });
   });
 
@@ -141,7 +143,7 @@ suite('UserDictionary Edit Panel', function() {
     var stubDeleteDialog;
 
     setup(function() {
-      panel.onsubmit = this.sinon.spy();
+      dialog.onsubmit = this.sinon.spy();
 
       stubDeleteDialog = {
         setAttribute: this.sinon.spy(),
@@ -153,31 +155,31 @@ suite('UserDictionary Edit Panel', function() {
     });
 
     test('action -> cancel', function() {
-      panel.handleEvent({type: 'action'});
+      dialog.handleEvent({type: 'action'});
 
-      assert.isTrue(panel.onsubmit.calledWith({action: 'cancel'}));
+      assert.isTrue(dialog.onsubmit.calledWith({action: 'cancel'}));
     });
 
     test('enter key -> submit', function() {
       stubInput.value = 'star';
       stubInput.blur = this.sinon.spy();
-      panel.handleEvent({type: 'keydown', keyCode: KeyEvent.DOM_VK_RETURN});
+      dialog.handleEvent({type: 'keydown', keyCode: KeyEvent.DOM_VK_RETURN});
 
       assert.isTrue(stubInput.blur.called);
       assert.isTrue(
-        panel.onsubmit.calledWith({action: 'commit', word: 'star'}));
+        dialog.onsubmit.calledWith({action: 'commit', word: 'star'}));
     });
 
     test('save button -> submit', function() {
       stubInput.value = 'star';
-      panel.handleEvent({type: 'click', target: {id: 'ud-saveword-btn'}});
+      dialog.handleEvent({type: 'click', target: {id: 'ud-saveword-btn'}});
 
       assert.isTrue(
-        panel.onsubmit.calledWith({action: 'commit', word: 'star'}));
+        dialog.onsubmit.calledWith({action: 'commit', word: 'star'}));
     });
 
     test('delete button -> show dialog', function() {
-      panel._oldWord = 'oldstar';
+      dialog._oldWord = 'oldstar';
 
       var oldMozL10n = navigator.mozL10n;
       navigator.mozL10n = {
@@ -187,7 +189,7 @@ suite('UserDictionary Edit Panel', function() {
       stubContainer.querySelector
         .withArgs('#ud-editword-delete-prompt').returns('dummy-delete');
 
-      panel.handleEvent({
+      dialog.handleEvent({
         type: 'click',
         target: {id: 'ud-editword-delete-btn'}
       });
@@ -204,25 +206,25 @@ suite('UserDictionary Edit Panel', function() {
     });
 
     test('dialog delete button -> delete & hide dialog', function() {
-      panel.handleEvent({
+      dialog.handleEvent({
         type: 'click',
         target: {id: 'ud-editword-dialog-delete-btn'}
       });
 
       assert.isTrue(
-        panel.onsubmit.calledWith({action: 'remove'}));
+        dialog.onsubmit.calledWith({action: 'remove'}));
 
       assert.isTrue(stubDeleteDialog.setAttribute.calledWith('hidden', true));
     });
 
     test('dialog cancel button -> hide dialog', function() {
-      panel.handleEvent({
+      dialog.handleEvent({
         type: 'click',
         target: {id: 'ud-editword-dialog-cancel-btn'}
       });
 
       assert.isFalse(
-        panel.onsubmit.calledWith({action: 'remove'}));
+        dialog.onsubmit.calledWith({action: 'remove'}));
 
       assert.isTrue(stubDeleteDialog.setAttribute.calledWith('hidden', true));
     });

--- a/apps/keyboard/test/unit/settings/user_dictionary_list_panel_test.js
+++ b/apps/keyboard/test/unit/settings/user_dictionary_list_panel_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* global UserDictionaryListPanel, MockEventTarget, CloseLockManager, CloseLock,
-          PanelController, UserDictionary, MockPromise */
+          PanelController, DialogController, UserDictionary, MockPromise */
 
 require('/shared/test/unit/mocks/mock_event_target.js');
 require('/shared/test/unit/mocks/mock_promise.js');
@@ -32,7 +32,8 @@ suite('UserDictionary List Panel', function() {
     app = {
       closeLockManager: this.sinon.stub(new CloseLockManager()),
       panelController: this.sinon.stub(new PanelController()),
-      userDictionaryEditPanel: 'dummyEditPanel'
+      dialogController: this.sinon.stub(new DialogController()),
+      userDictionaryEditDialog: 'dummyEditDialog'
     };
 
     panel = new UserDictionaryListPanel(app);
@@ -197,7 +198,7 @@ suite('UserDictionary List Panel', function() {
     setup(function() {
       pDialog = new MockPromise();
 
-      app.panelController.openDialog.returns(pDialog);
+      app.dialogController.openDialog.returns(pDialog);
     });
 
     test('canceled dialog', function() {
@@ -206,7 +207,8 @@ suite('UserDictionary List Panel', function() {
       panel._showAddDialog();
 
       assert.isTrue(
-        app.panelController.openDialog.calledWith(app.userDictionaryEditPanel));
+        app.dialogController.openDialog.calledWith(app.userDictionaryEditDialog)
+      );
 
       pDialog.mFulfillToValue({action: 'cancel'});
       assert.isFalse(stubAddWord.called);
@@ -276,15 +278,15 @@ suite('UserDictionary List Panel', function() {
       };
       panel._domWordMap.set(stubWordElem, 'star');
 
-      app.panelController.openDialog.returns(pDialog);
+      app.dialogController.openDialog.returns(pDialog);
     });
 
     test('word is correctly propogated to dialog', function() {
       panel._showEditDialog(stubWordElem);
 
       assert.isTrue(
-        app.panelController.openDialog.calledWith(app.userDictionaryEditPanel),
-        'star'
+        app.dialogController.openDialog.calledWith(app.userDictionaryEditDialog,
+        {word: 'star'})
       );
     });
 


### PR DESCRIPTION
- Dialogs are now such named, instead of named as panels.
- PanelController and DialogController is differentiated. DialogController checks the existence of onsubmit to make sure it's acting upon a dialog.
