### PR TITLE
Update providers.json

### DIFF
--- a/apps/settings/resources/search/providers.json
+++ b/apps/settings/resources/search/providers.json
@@ -16,5 +16,10 @@
     "urlTemplate": "https://www.bing.com/search?q={searchTerms}",
     "suggestionsUrlTemplate": "http://api.bing.com/osjson.aspx?query={searchTerms}",
     "iconUrl": "bing.ico"
-  }
+  },
+  {
+    "title": "DuckDuckGo",
+    "urlTemplate": "https://duckduckgo.com/?q={searchTerms}",
+    "suggestionsUrlTemplate": "ac.duckduckgo.com/ac/?&q={searchTerms}",
+    "iconUrl": "ddg.ico"
 ]


### PR DESCRIPTION
I added DuckDuckGo (www.duckduckgo.com) as a search engine for the Firefox browser.
