### PR TITLE
Bug 1120947: settings mock now  properly then-able

### DIFF
--- a/shared/test/unit/mocks/mock_navigator_moz_settings.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_settings.js
@@ -64,6 +64,11 @@
     var req = {
       addEventListener: function(name, cb) {
         req['on' + name] = cb;
+      },
+      then: function(cb, eb) {
+        // error-handler `eb`is never used, since the mock never fails.
+        return Promise.resolve(0).then(cb); // set resolve to 0.
+
       }
     };
 
@@ -114,6 +119,10 @@
       result: resultObj,
       addEventListener: function(name, cb) {
         settingsRequest['on' + name] = cb;
+      },
+      then: function(cb, eb) {
+        // error-handler `eb`is never used, since the mock never fails.
+        return Promise.resolve(resultObj).then(cb);
       }
     };
     if (!_mSyncRepliesOnly) {


### PR DESCRIPTION
This is a less invasive patch for the same bug.
