### PR TITLE
Bug 1119126 - [TextSelection] The paste icon overlaps keyboard if tapping caret quickly before keyboard shows up

### DIFF
--- a/apps/keyboard/test/marionette/lib/system.js
+++ b/apps/keyboard/test/marionette/lib/system.js
@@ -38,14 +38,14 @@ System.prototype = {
    * Wait for keyboard frame trasition end.
    */
   waitForKeyboardFrameDisplayed: function() {
-    client.waitFor(function() {
+    this.client.waitFor(function() {
       return this.keyboardFrameDisplayed();
     }.bind(this));
   },
 
   keyboardFrameDisplayed: function() {
     // Switch to System app.
-    client.switchToFrame();
+    this.client.switchToFrame();
 
     // Wait for the keyboard pop up and switch to it.
     // This is satisfied as long as one inputWindow pops up.
@@ -61,7 +61,7 @@ System.prototype = {
 
   keyboardFrameHidden: function() {
     // Switch to System app.
-    client.switchToFrame();
+    this.client.switchToFrame();
 
     // This is satisfied only when all inputWindows are regarded as
     // having slided to the bottom.

--- a/apps/system/test/marionette/faketextselectionapp/bug.html
+++ b/apps/system/test/marionette/faketextselectionapp/bug.html
@@ -7,12 +7,17 @@
       input {
         width: 6rem;
         height: 2rem;
+      }
+      #bug-buttom-input {
         position: absolute;
+        bottom: 0;
       }
     </style>
   </head>
   <body>
-    <h3>BUG 1110963, BUG 1115508</h3>
+    <h3>BUG 1110963, BUG 1115508, BUG 1119126</h3>
     <input id="bug-center-input" value="testcenterinput">
+    <div id="bug-normal-div">NORMALDIV</div>
+    <input id="bug-buttom-input">
   </body>
 </html>

--- a/apps/system/test/marionette/lib/faketextselectionapp.js
+++ b/apps/system/test/marionette/lib/faketextselectionapp.js
@@ -28,7 +28,9 @@ FakeTextSelectionApp.Selector = Object.freeze({
   NonEditableNormalDiv: '#noneditable',
   NonEditableNonSelectedDiv: '#noneditable-userselectnone',
   // bug.html
-  BugCenterInput: '#bug-center-input'
+  BugCenterInput: '#bug-center-input',
+  BugButtomInput: '#bug-buttom-input',
+  BugNormalDiv: '#bug-normal-div',
 });
 
 FakeTextSelectionApp.ORIGIN = 'app://faketextselectionapp.gaiamobile.org';
@@ -88,6 +90,14 @@ FakeTextSelectionApp.prototype = {
     return this._getElement('BugCenterInput');
   },
 
+  get BugButtomInput() {
+    return this._getElement('BugButtomInput');
+  },
+
+  get BugNormalDiv() {
+    return this._getElement('BugNormalDiv');
+  },
+
   _getElement: function(target) {
     var element = this.client.helper.waitForElement(
       FakeTextSelectionApp.Selector[target]);
@@ -108,20 +118,31 @@ FakeTextSelectionApp.prototype = {
     this.textSelection.longPress(dom);
   },
 
-  // Copy element from fromEle and paste it to toEle.
-  copyTo: function(fromEle, toEle) {
+  copy: function(fromEle) {
     this.longPress(fromEle);
     this.textSelection.pressCopy();
+  },
+
+  paste: function(toEle) {
     this.longPress(toEle);
     this.textSelection.pressPaste();
   },
 
-  // Cut element from fromEle and paste it to toEle.
-  cutTo: function(fromEle, toEle) {
+  cut: function(fromEle) {
     this.longPress(fromEle);
     this.textSelection.pressCut();
-    this.longPress(toEle);
-    this.textSelection.pressPaste();
+  },
+
+  // Copy element from fromEle and paste it to toEle.
+  copyTo: function(fromEle, toEle) {
+    this.copy(fromEle);
+    this.paste(toEle);
+  },
+
+  // Cut element from fromEle and paste it to toEle.
+  cutTo: function(fromEle, toEle) {
+    this.cut(fromEle);
+    this.paste(toEle);
   },
 
   // Select all of ele and cut it.
@@ -135,5 +156,9 @@ FakeTextSelectionApp.prototype = {
     this.client.executeScript(function(frameName) {
       window.wrappedJSObject.location.href = '/' + frameName + '.html';
     }, [frameName]);
+  },
+
+  switchToTestApp: function() {
+    this.textSelection.switchToCurrentApp();
   }
 };

--- a/apps/system/test/marionette/lib/text_selection.js
+++ b/apps/system/test/marionette/lib/text_selection.js
@@ -53,6 +53,10 @@ TextSelection.prototype = {
     return location;
   },
 
+  switchToCurrentApp: function() {
+    this.client.apps.switchToApp(this._getDisplayedAppInfo().origin);
+  },
+
   /**
    * Get appWindow's id and origin of displayed app.
    * XXXXX: Since gecko is not ready yet, we need to simulate gecko dispatching

--- a/apps/system/test/marionette/text_selection_test.js
+++ b/apps/system/test/marionette/text_selection_test.js
@@ -32,7 +32,7 @@ marionette('Text selection >', function() {
       setup(function() {
         fakeTextselectionApp.setTestFrame('functionality');
       });
-      test.skip('copy and paste', function() {
+      test('copy and paste', function() {
         fakeTextselectionApp.copyTo('FunctionalitySourceInput',
           'FunctionalityTargetInput');
         assert.equal(
@@ -172,9 +172,13 @@ marionette('Text selection >', function() {
     });
 
     suite('bugs', function() {
+      var KeyboardSystem =
+        require('../../../keyboard/test/marionette/lib/system.js');
+      var keyboardSystem;
       setup(function() {
         fakeTextselectionApp.setTestFrame('bug');
       });
+
       test('bug1110963 : Cut/Copy/Paste menu should dismiss ' +
            'when tapping the keyboard',
         function() {
@@ -191,6 +195,28 @@ marionette('Text selection >', function() {
           client.waitFor(function() {
             return !fakeTextselectionApp.bubbleVisiblity;
           });
+        });
+
+      test('bug1119126 : Shortcut bubble should hide when system is resized',
+        function() {
+          keyboardSystem = new KeyboardSystem(client);
+          fakeTextselectionApp.copy('BugCenterInput');
+          client.waitFor(function() {
+            return keyboardSystem.keyboardFrameDisplayed();
+          });
+          fakeTextselectionApp.switchToTestApp();
+          fakeTextselectionApp.BugNormalDiv.tap();
+          client.waitFor(function() {
+            return keyboardSystem.keyboardFrameHidden();
+          });
+          fakeTextselectionApp.switchToTestApp();
+          fakeTextselectionApp.BugButtomInput.tap();
+          client.waitFor(function() {
+            return keyboardSystem.keyboardFrameDisplayed();
+          });
+          fakeTextselectionApp.switchToTestApp();
+          assert.ok(!fakeTextselectionApp.bubbleVisiblity);
+
         });
     });
   });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1119126
