### PR TITLE
Bug 1114524 - [Flame][Email]The email address with extra special character"<" will be added to compose mail view if you tap the fromAddress in replied email. r=asuth

### DIFF
--- a/apps/email/js/ext/mailapi.js
+++ b/apps/email/js/ext/mailapi.js
@@ -2130,7 +2130,7 @@ var RE_HTTP = /^https?:/i;
 //                       Otherwise we use the same base regexp from our URL
 //                       logic.
 var RE_MAIL =
-  /(^|[\s(,;])([^(,;@\s]+@[a-z0-9.\-]{2,250}[.][a-z0-9\-]{2,32})/im;
+  /(^|[\s(,;<>])([^(,;<>@\s]+@[a-z0-9.\-]{2,250}[.][a-z0-9\-]{2,32})/im;
 var RE_MAILTO = /^mailto:/i;
 
 var MailUtils = {


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/356
