### PR TITLE
Bug 1122327 - rename Bluetooth.js/BluetoothTransfer.js to Bluetooth1.js/BluetoothTransfer1.js +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -298,8 +298,8 @@
     <script defer src="js/task_manager.js"></script>
 
     <!-- Bluetooth -->
-    <script defer src="js/bluetooth.js"></script>
-    <script defer src="js/bluetooth_transfer.js"></script>
+    <script defer src="js/bluetooth1.js"></script>
+    <script defer src="js/bluetooth_transfer1.js"></script>
     <link rel="stylesheet" type="text/css" href="style/bluetooth_transfer/bluetooth_transfer.css">
 
     <!-- Wifi -->

--- a/apps/system/js/bluetooth1.js
+++ b/apps/system/js/bluetooth1.js
@@ -1,5 +1,6 @@
 /* global SettingsListener, Service */
-/* exported Bluetooth */
+/* exported Bluetooth1 */
+(function(exports) {
 'use strict';
 
 var Bluetooth = {
@@ -242,3 +243,6 @@ var Bluetooth = {
     return window.navigator.mozBluetooth.enabled;
   }
 };
+
+  exports.Bluetooth1 = Bluetooth;
+})(window);

--- a/apps/system/js/bluetooth_core.js
+++ b/apps/system/js/bluetooth_core.js
@@ -1,5 +1,5 @@
 /* exported BluetoothCore */
-/* global BaseModule, Bluetooth, BluetoothTransfer, NfcHandoverManager */
+/* global BaseModule */
 'use strict';
 
 (function() {
@@ -20,9 +20,11 @@
       // init Bluetooth module
       if (typeof(window.navigator.mozBluetooth.onattributechanged) ===
         'undefined') { // APIv1
-          Bluetooth.init();
-          BluetoothTransfer.init();
-          NfcHandoverManager.init();
+          window.Bluetooth = window.Bluetooth1;
+          window.BluetoothTransfer = window.BluetoothTransfer1;
+          window.Bluetooth.init();
+          window.BluetoothTransfer.init();
+          window.NfcHandoverManager.init();
       }
     }
   });

--- a/apps/system/js/bluetooth_transfer1.js
+++ b/apps/system/js/bluetooth_transfer1.js
@@ -3,10 +3,11 @@
 /* API Summary:
    stopSendingFile(in DOMString aDeviceAddress);
    confirmReceivingFile(in DOMString aDeviceAddress, in bool aConfirmation); */
+(function(exports) {
 'use strict';
 /* global Bluetooth, CustomDialog, NfcHandoverManager, MimeMapper,
           MozActivity, NotificationHelper, UtilityTray, NfcHandoverManager*/
-/* exported BluetoothTransfer */
+/* exported BluetoothTransfer1 */
 
 var BluetoothTransfer = {
   // The first-in-first-out queue maintain each scheduled sending task.
@@ -637,3 +638,6 @@ var BluetoothTransfer = {
   }
 
 };
+
+  exports.BluetoothTransfer1 = BluetoothTransfer;
+})(window);

--- a/apps/system/js/nfc_handover_manager.js
+++ b/apps/system/js/nfc_handover_manager.js
@@ -6,6 +6,7 @@
 /* globals BluetoothTransfer, NDEFUtils, NfcConnectSystemDialog,
            NDEF, NfcUtils, NotificationHelper, SettingsListener */
 /* exported NfcHandoverManager */
+(function(exports) {
 'use strict';
 
 /**
@@ -700,3 +701,5 @@ var NfcHandoverManager = {
   }
 };
 
+  exports.NfcHandoverManager = NfcHandoverManager;
+})(window);

--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -1304,7 +1304,8 @@ var StatusBar = {
       var icon = this.icons.bluetooth;
 
       icon.hidden = !this.settingValues['bluetooth.enabled'];
-      icon.dataset.active = Bluetooth.connected;
+      // make sure window.Bluetooth is assigned
+      icon.dataset.active = Bluetooth ? Bluetooth.connected : false;
       this.updateIconLabel(icon, 'bluetooth', icon.dataset.active);
 
       this._updateIconVisibility();

--- a/apps/system/test/unit/bluetooth_core_test.js
+++ b/apps/system/test/unit/bluetooth_core_test.js
@@ -1,5 +1,4 @@
-/* global MockMozBluetooth, Bluetooth, BluetoothTransfer,
-   NfcHandoverManager, BaseModule */
+/* global MockMozBluetooth, BaseModule */
 'use strict';
 
 require('/shared/test/unit/mocks/mock_navigator_moz_bluetooth.js');
@@ -21,8 +20,8 @@ suite('system/BluetoothCore', function() {
     realMozBluetooth = navigator.mozBluetooth;
     switchReadOnlyProperty(navigator, 'mozBluetooth', MockMozBluetooth);
 
-    window.Bluetooth = { init: function() {} };
-    window.BluetoothTransfer = { init: function() {} };
+    window.Bluetooth1 = { init: function() {} };
+    window.BluetoothTransfer1 = { init: function() {} };
     window.NfcHandoverManager = { init: function() {} };
 
     requireApp('system/js/service.js');
@@ -36,9 +35,9 @@ suite('system/BluetoothCore', function() {
   suite('BluetoothCore API', function() {
     var subject;
     setup(function() {
-      this.sinon.stub(Bluetooth, 'init');
-      this.sinon.stub(BluetoothTransfer, 'init');
-      this.sinon.stub(NfcHandoverManager, 'init');
+      this.sinon.stub(window.Bluetooth1, 'init');
+      this.sinon.stub(window.BluetoothTransfer1, 'init');
+      this.sinon.stub(window.NfcHandoverManager, 'init');
       subject = BaseModule.instantiate('BluetoothCore');
       subject.start();
     });
@@ -48,9 +47,9 @@ suite('system/BluetoothCore', function() {
     });
 
     test('read', function() {
-      assert.ok(Bluetooth.init.called);
-      assert.ok(BluetoothTransfer.init.called);
-      assert.ok(NfcHandoverManager.init.called);
+      assert.ok(window.Bluetooth1.init.called);
+      assert.ok(window.BluetoothTransfer1.init.called);
+      assert.ok(window.NfcHandoverManager.init.called);
     });
   });
 });

--- a/apps/system/test/unit/bluetooth_transfer1_test.js
+++ b/apps/system/test/unit/bluetooth_transfer1_test.js
@@ -1,3 +1,7 @@
+/* global MocksHelper, MockNavigatormozSetMessageHandler,
+   MockNavigatorGetDeviceStorage, MockL10n, MockBluetooth, BluetoothTransfer,
+   MockNotificationHelper, MockNfcHandoverManager, MockUtilityTray,
+   NotificationHelper, MockCustomDialog, MimeMapper, mockMozActivityInstance*/
 'use strict';
 
 require('/shared/test/unit/mocks/mock_navigator_moz_set_message_handler.js');
@@ -12,8 +16,6 @@ require('/shared/js/mime_mapper.js');
 require('/test/unit/mock_utility_tray.js');
 require('/test/unit/mock_nfc_handover_manager.js');
 require('/test/unit/mock_activity.js');
-
-var realCustomDialog = require('/shared/js/custom_dialog.js');
 
 var mocksForBluetoothTransfer = new MocksHelper([
   'Bluetooth',
@@ -30,10 +32,8 @@ suite('system/bluetooth_transfer', function() {
   var realSetMessageHandler;
   var realNavigatorGetDeviceStorage;
   var realL10n;
-  var realPairList;
   var real_sendingFilesQueue;
 
-  var fakePairList;
   var fake_sendingFilesQueue;
 
   suiteSetup(function(done) {
@@ -48,7 +48,7 @@ suite('system/bluetooth_transfer', function() {
 
     MockNavigatormozSetMessageHandler.mSetup();
 
-    requireApp('system/js/bluetooth_transfer.js', done);
+    requireApp('system/js/bluetooth_transfer1.js', done);
   });
 
   suiteTeardown(function() {
@@ -59,6 +59,10 @@ suite('system/bluetooth_transfer', function() {
   });
 
   suite('UI', function() {
+    setup(function() {
+      window.BluetoothTransfer = window.BluetoothTransfer1;
+    });
+
     suite('getDeviceName', function() {
       var address = 'AA:BB:CC:00:11:22';
       var spyGetConnectedDevices;
@@ -72,10 +76,8 @@ suite('system/bluetooth_transfer', function() {
       });
 
       suite('cannot get adapter ', function() {
-        var stubGetAdapater;
         setup(function() {
-          stubGetAdapater =
-            this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
+          this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
         });
 
         test('should return unknown device name ', function(done) {
@@ -309,8 +311,7 @@ suite('system/bluetooth_transfer', function() {
 
         spyConfirmReceivingFile.reset();
 
-        var stubGetAdapater =
-          this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
+        this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
 
         BluetoothTransfer.declineReceive('AA:BB:CC:00:22:33');
         assert.isFalse(spyConfirmReceivingFile.called);
@@ -348,8 +349,7 @@ suite('system/bluetooth_transfer', function() {
         assert.isTrue(stubShowStorageUnavailablePrompt.calledWith('somemsg2'));
 
         spyConfirmReceivingFile.reset();
-        var stubGetAdapater =
-          this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
+        this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
         stubCheckStorageSpace.getCall(0).args[1](false, 'somemsg3');
         assert.isFalse(spyConfirmReceivingFile.called);
 
@@ -481,10 +481,8 @@ suite('system/bluetooth_transfer', function() {
         var spyGet = this.sinon.spy(mockDeviceStorage, 'get');
         BluetoothTransfer.openReceivedFile(evt);
 
-        var stubMimeIsSupportedType =
-          this.sinon.stub(MimeMapper, 'isSupportedType').returns(false);
-        var stubMimeGuessTypeFromExtension =
-          this.sinon.stub(MimeMapper, 'guessTypeFromExtension')
+        this.sinon.stub(MimeMapper, 'isSupportedType').returns(false);
+        this.sinon.stub(MimeMapper, 'guessTypeFromExtension')
           .returns('text/plain');
 
         var req = spyGet.getCall(0).returnValue;
@@ -544,7 +542,6 @@ suite('system/bluetooth_transfer', function() {
 
         BluetoothTransfer.openReceivedFile(evt);
 
-        var stubMimeIsSupportedType =
         this.sinon.stub(MimeMapper, 'isSupportedType').returns(true);
 
         var req = spyGet.getCall(0).returnValue;
@@ -623,8 +620,7 @@ suite('system/bluetooth_transfer', function() {
           .calledWith('AA:BB:CC:00:11:55', 'blahblahblah\0xa0\0xa0blahblahblah')
         );
 
-        var stubGetAdapater =
-          this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
+        this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
         BluetoothTransfer.sendFileViaHandover(
           'AA:BB:CC:00:11:66',
           'blahblahblah\0xa0\0xa0blahblahblahblah'
@@ -740,8 +736,7 @@ suite('system/bluetooth_transfer', function() {
         assert.isFalse(MockCustomDialog.mShown);
         assert.isTrue(spyStopSendingFile.calledWith('CC:DD:00:AA:22:44'));
 
-        var stubGetAdapater =
-          this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
+        this.sinon.stub(MockBluetooth, 'getAdapter').returns(null);
 
         spyStopSendingFile.reset();
 

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -256,7 +256,6 @@ apps/system/test/marionette/net_error_test.js
 apps/system/test/marionette/notification_launch_app_test.js
 apps/system/test/marionette/notification_test.js
 apps/system/test/unit/app_install_manager_test.js
-apps/system/test/unit/bluetooth_transfer_test.js
 apps/system/test/unit/download_manager_test.js
 apps/system/test/unit/download_notification_test.js
 apps/system/test/unit/entery_sheet_test.js


### PR DESCRIPTION
- rename module to fit the naming convention in Settings/Bluetooth
- fix lint error of Bluetooth Transfer test
