### PR TITLE
Bug 1093516 - [System2] Migrate AppUpdate/InstallDialog to SystemDialog

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -258,6 +258,7 @@
 
     <!-- App Install -->
     <link rel="stylesheet" type="text/css" href="style/app_install_manager/app_install_manager.css">
+    <script defer src="js/app_install_dialog.js"></script>
 
     <!-- Cost Control -->
     <link rel="stylesheet" type="text/css" href="style/cost_control/cost_control.css">
@@ -881,27 +882,6 @@
 
       <div id="app-uninstall-dialog" data-z-index-level="app-uninstall-dialog">
       </div>
-
-      <form id="app-install-dialog" class="app-install-dialog generic-dialog"
-            data-type="confirm" role="dialog"
-            data-z-index-level="app-install-dialog">
-        <section>
-          <h1 id="app-install-message"></h1>
-          <dl>
-            <dt data-l10n-id="size">Size</dt>
-              <dd id="app-install-size"></dd>
-            <dt data-l10n-id="author">Author</dt>
-              <dd>
-                <span id="app-install-author-name"></span><br />
-                <span id="app-install-author-url"></span>
-              </dd>
-          </dl>
-        </section>
-        <menu data-items="2">
-          <button id="app-install-cancel-button" data-l10n-id="cancel">Cancel</button>
-          <button id="app-install-install-button" class="recommend" data-l10n-id="install">Install</button>
-        </menu>
-      </form>
 
       <form id="app-install-cancel-dialog" class="app-install-dialog generic-dialog"
             data-type="confirm" role="dialog"

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -414,6 +414,7 @@
     <script defer src="js/app_install_dialog.js"></script>
     <script defer src="js/app_install_cancel_dialog.js"></script>
     <script defer src="js/app_download_cancel_dialog.js"></script>
+    <script defer src="js/setup_installed_app_dialog.js"></script>
 
     <!-- Edge Gestures -->
     <script defer src="js/stack_manager.js"></script>
@@ -930,19 +931,6 @@
         <menu>
           <button id="updates-viaDataConnection-notnow-button" type="reset" data-l10n-id="notNow">Not Now</button>
           <button id="updates-viaDataConnection-download-button" class="recommend" type="submit" data-l10n-id="download">Download</button>
-        </menu>
-      </form>
-
-      <form id="setup-installed-app-dialog" class="setup-installed-app-dialog"
-            data-type="confirm" role="dialog"
-            data-z-index-level="setup-installed-app-dialog">
-        <section>
-          <h1 id="setup-app-name"></h1>
-          <p id="setup-app-description"></p>
-        </section>
-        <menu data-items="2">
-          <button id="setup-cancel-button" type="button" data-l10n-id="later">Later</button>
-          <button id="setup-confirm-button" class="recommend" type="button" data-l10n-id="setup">Setup</button>
         </menu>
       </form>
 

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -258,7 +258,6 @@
 
     <!-- App Install -->
     <link rel="stylesheet" type="text/css" href="style/app_install_manager/app_install_manager.css">
-    <script defer src="js/app_install_manager.js"></script>
 
     <!-- Cost Control -->
     <link rel="stylesheet" type="text/css" href="style/cost_control/cost_control.css">

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -412,6 +412,7 @@
     <!-- App Install -->
     <link rel="stylesheet" type="text/css" href="style/app_install_manager/app_install_manager.css">
     <script defer src="js/app_install_dialog.js"></script>
+    <script defer src="js/app_install_cancel_dialog.js"></script>
 
     <!-- Edge Gestures -->
     <script defer src="js/stack_manager.js"></script>
@@ -882,23 +883,6 @@
 
       <div id="app-uninstall-dialog" data-z-index-level="app-uninstall-dialog">
       </div>
-
-      <form id="app-install-cancel-dialog" class="app-install-dialog generic-dialog"
-            data-type="confirm" role="dialog"
-            data-z-index-level="app-install-dialog">
-        <section>
-          <h1 data-l10n-id="cancel-install">Cancel Install</h1>
-          <p>
-            <small data-l10n-id="cancelling-will-not-refund">Cancelling will not refund a purchase. Refunds for paid content are provided by the original seller.</small>
-            <small data-l10n-id="apps-can-be-installed-later">Apps can be installed later from the original installation source.</small>
-          </p>
-          <p data-l10n-id="are-you-sure-you-want-to-cancel">Are you sure you want to cancel this install?</p>
-        </section>
-        <menu data-items="2">
-          <button id="app-install-confirm-cancel-button" type="reset" data-l10n-id="cancel-install-button">Cancel Install</button>
-          <button id="app-install-resume-button" type="submit" data-l10n-id="resume">Resume</button>
-        </menu>
-      </form>
 
       <form id="app-download-cancel-dialog" class="app-install-dialog generic-dialog"
         data-type="confirm" role="dialog"

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -256,10 +256,6 @@
     <link rel="stylesheet" type="text/css" href="style/permission_manager/permission_manager.css">
     <script defer src="js/permission_manager.js"></script>
 
-    <!-- App Install -->
-    <link rel="stylesheet" type="text/css" href="style/app_install_manager/app_install_manager.css">
-    <script defer src="js/app_install_dialog.js"></script>
-
     <!-- Cost Control -->
     <link rel="stylesheet" type="text/css" href="style/cost_control/cost_control.css">
 
@@ -412,6 +408,10 @@
     <script defer src="js/layout_manager.js"></script>
     <script defer src="js/suspending_app_priority_manager.js"></script>
     <script defer src="js/input_window.js"></script>
+
+    <!-- App Install -->
+    <link rel="stylesheet" type="text/css" href="style/app_install_manager/app_install_manager.css">
+    <script defer src="js/app_install_dialog.js"></script>
 
     <!-- Edge Gestures -->
     <script defer src="js/stack_manager.js"></script>

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -415,6 +415,7 @@
     <script defer src="js/app_install_cancel_dialog.js"></script>
     <script defer src="js/app_download_cancel_dialog.js"></script>
     <script defer src="js/setup_installed_app_dialog.js"></script>
+    <script defer src="js/ime_layout_dialog.js"></script>
 
     <!-- Edge Gestures -->
     <script defer src="js/stack_manager.js"></script>
@@ -931,32 +932,6 @@
         <menu>
           <button id="updates-viaDataConnection-notnow-button" type="reset" data-l10n-id="notNow">Not Now</button>
           <button id="updates-viaDataConnection-download-button" class="recommend" type="submit" data-l10n-id="download">Download</button>
-        </menu>
-      </form>
-
-      <form id="ime-layout-dialog" class="ime-layout-dialog"
-            data-type="confirm" role="dialog"
-            data-z-index-level="ime-layout-dialog">
-        <section>
-          <h1 data-l10n-id="ime-addkeyboards">Add keyboards</h1>
-          <!-- template for selecting IME layout after 3rd-party keyboard installed -->
-          <div id="ime-list-template" hidden>
-            <!--
-            <li>
-              <a>${displayName}</a>
-              <label class="pack-checkbox ime">
-                <input type="checkbox" name="keyboards" value="${imeName}">
-                <span></span>
-              </label>
-            </li>
-            -->
-          </div>
-          <ul id="ime-list">
-          </ul>
-        </section>
-        <menu data-items="2">
-          <button id="ime-cancel-button" type="button" data-l10n-id="cancel">Cancel</button>
-          <button id="ime-confirm-button" class="recommend" type="button" data-l10n-id="confirm">Confirm</button>
         </menu>
       </form>
 

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -413,6 +413,7 @@
     <link rel="stylesheet" type="text/css" href="style/app_install_manager/app_install_manager.css">
     <script defer src="js/app_install_dialog.js"></script>
     <script defer src="js/app_install_cancel_dialog.js"></script>
+    <script defer src="js/app_download_cancel_dialog.js"></script>
 
     <!-- Edge Gestures -->
     <script defer src="js/stack_manager.js"></script>
@@ -883,20 +884,6 @@
 
       <div id="app-uninstall-dialog" data-z-index-level="app-uninstall-dialog">
       </div>
-
-      <form id="app-download-cancel-dialog" class="app-install-dialog generic-dialog"
-        data-type="confirm" role="dialog"
-        data-z-index-level="app-install-dialog">
-        <section>
-          <h1></h1>
-          <p data-l10n-id="app-download-can-be-restarted">The download can
-          be restarted later.</p>
-        </section>
-        <menu data-items="2">
-          <button id="app-download-stop-button" class="danger confirm" data-l10n-id="app-download-stop-button">Stop Download</button>
-          <button id="app-download-continue-button" class="cancel" type="reset" data-l10n-id="continue">Continue</button>
-        </menu>
-      </form>
 
       <form id="updates-download-dialog" data-type="confirm" role="dialog"
             data-z-index-level="updates-download-dialog" data-nowifi="false"

--- a/apps/system/js/app_download_cancel_dialog.js
+++ b/apps/system/js/app_download_cancel_dialog.js
@@ -1,0 +1,81 @@
+'use strict';
+
+(function(exports) {
+  var AppDownloadCancelDialog = function AppDownloadCancelDialog(options) {
+    this.options = options || {};
+    this.render();
+    this.publish('created');
+  };
+
+  AppDownloadCancelDialog.prototype = Object.create(window.SystemDialog.prototype);
+
+  AppDownloadCancelDialog.prototype.customID = 'app-download-cancel-dialog';
+
+  AppDownloadCancelDialog.prototype.DEBUG = false;
+
+  /**
+   * Used for element id access.
+   * e.g., 'authentication-dialog-alert-ok'
+   * @type {String}
+   * @memberof AppDownloadCancelDialog.prototype
+   */
+  AppDownloadCancelDialog.prototype.ELEMENT_PREFIX = 'app-download-';
+
+  /**
+   * Maps to DOM elements.
+   * @type {Object}
+   * @memberof AppDownloadCancelDialog.prototype
+   */
+  AppDownloadCancelDialog.prototype.elements = null;
+
+  AppDownloadCancelDialog.prototype._fetchElements =
+    function appid__fetchElements() {
+    this.element = document.getElementById(this.instanceID);
+    this.elements = {};
+
+    var toCamelCase = function toCamelCase(str) {
+      return str.replace(/\-(.)/g, function replacer(str, p1) {
+        return p1.toUpperCase();
+      });
+    };
+
+    this.elementIds = [
+      'stop-button', 'continue-button'
+    ];
+
+    this.elementIds.forEach(function createElementRef(id) {
+      this.elements[toCamelCase(id)] =
+        this.element.querySelector('#' + this.ELEMENT_PREFIX + id);
+    }, this);
+  };
+
+  AppDownloadCancelDialog.prototype.view = function appid_view() {
+    return `<form id="${this.instanceID}" class="generic-dialog"
+            data-type="confirm" role="dialog"
+            data-z-index-level="app-install-dialog" hidden>
+              <section>
+                <h1></h1>
+                <p data-l10n-id="app-download-can-be-restarted">
+                  The download can be restarted later.
+                </p>
+              </section>
+              <menu data-items="2">
+                <button id="app-download-stop-button" 
+                class="danger confirm" data-l10n-id="app-download-stop-button">
+                  Stop Download
+                </button>
+                <button id="app-download-continue-button" 
+                class="cancel" type="reset" data-l10n-id="continue">
+                  Continue
+                </button>
+              </menu>
+            </form>`;
+  };
+
+  AppDownloadCancelDialog.prototype.getView = function appid_getView() {
+    return document.getElementById(this.instanceID);
+  };
+
+  exports.AppDownloadCancelDialog = AppDownloadCancelDialog;
+
+}(window));

--- a/apps/system/js/app_install_cancel_dialog.js
+++ b/apps/system/js/app_install_cancel_dialog.js
@@ -1,0 +1,90 @@
+'use strict';
+
+(function(exports) {
+  var AppInstallCancelDialog = function AppInstallDialog(options) {
+    this.options = options || {};
+    this.render();
+    this.publish('created');
+  };
+
+  AppInstallCancelDialog.prototype =
+    Object.create(window.SystemDialog.prototype);
+
+  AppInstallCancelDialog.prototype.customID = 'app-install-cancel-dialog';
+
+  AppInstallCancelDialog.prototype.DEBUG = false;
+
+  /**
+   * Used for element id access.
+   * e.g., 'authentication-dialog-alert-ok'
+   * @type {String}
+   * @memberof AppInstallCancelDialog.prototype
+   */
+  AppInstallCancelDialog.prototype.ELEMENT_PREFIX = 'app-install-cancel-';
+
+  /**
+   * Maps to DOM elements.
+   * @type {Object}
+   * @memberof AppInstallCancelDialog.prototype
+   */
+  AppInstallCancelDialog.prototype.elements = null;
+
+  AppInstallCancelDialog.prototype._fetchElements =
+    function appid__fetchElements() {
+    this.element = document.getElementById(this.instanceID);
+    this.elements = {};
+
+    var toCamelCase = function toCamelCase(str) {
+      return str.replace(/\-(.)/g, function replacer(str, p1) {
+        return p1.toUpperCase();
+      });
+    };
+
+    this.elementIds = [
+      'confirm-cancel-button', 'resume-button'
+    ];
+
+    this.elementIds.forEach(function createElementRef(id) {
+      this.elements[toCamelCase(id)] =
+        this.element.querySelector('#' + this.ELEMENT_PREFIX + id);
+    }, this);
+  };
+
+  AppInstallCancelDialog.prototype.view = function appid_view() {
+    return `<form id="${this.instanceID}" class="generic-dialog"
+            data-type="confirm" role="dialog"
+            data-z-index-level="app-install-dialog" hidden>
+              <section>
+                <h1 data-l10n-id="cancel-install">Cancel Install</h1>
+                <p>
+                  <small data-l10n-id="cancelling-will-not-refund">
+                    Cancelling will not refund a purchase. Refunds 
+                    for paid content are provided by the original seller.
+                  </small>
+                  <small data-l10n-id="apps-can-be-installed-later">
+                    Apps can be installed later 
+                    from the original installation source.
+                  </small>
+                </p>
+                <p data-l10n-id="are-you-sure-you-want-to-cancel">
+                  Are you sure you want to cancel this install?
+                </p>
+              </section>
+              <menu data-items="2">
+                <button id="app-install-cancel-confirm-cancel-button" 
+                type="reset" data-l10n-id="cancel-install-button">
+                  Cancel Install
+                </button>
+                <button id="app-install-cancel-resume-button" type="submit" 
+                  data-l10n-id="resume">Resume</button>
+              </menu>
+            </form>`;
+  };
+
+  AppInstallCancelDialog.prototype.getView = function appid_getView() {
+    return document.getElementById(this.instanceID);
+  };
+
+  exports.AppInstallCancelDialog = AppInstallCancelDialog;
+
+}(window));

--- a/apps/system/js/app_install_dialog.js
+++ b/apps/system/js/app_install_dialog.js
@@ -55,7 +55,7 @@
     return `<form id="${this.instanceID}"
             class="generic-dialog"
             data-type="confirm" role="dialog"
-            data-z-index-level="app-install-dialog">
+            data-z-index-level="app-install-dialog" hidden>
               <section>
                 <h1 id="app-install-message"></h1>
                 <dl>

--- a/apps/system/js/app_install_dialog.js
+++ b/apps/system/js/app_install_dialog.js
@@ -1,7 +1,8 @@
 'use strict';
 
 (function(exports) {
-  var AppInstallDialog = function AppInstallDialog() {
+  var AppInstallDialog = function AppInstallDialog(options) {
+    this.options = options || {};
     this.render();
     this.publish('created');
   };
@@ -52,7 +53,7 @@
 
   AppInstallDialog.prototype.view = function appid_view() {
     return `<form id="${this.instanceID}"
-            class="app-install-dialog generic-dialog"
+            class="generic-dialog"
             data-type="confirm" role="dialog"
             data-z-index-level="app-install-dialog">
               <section>

--- a/apps/system/js/app_install_dialog.js
+++ b/apps/system/js/app_install_dialog.js
@@ -1,0 +1,85 @@
+'use strict';
+
+(function(exports) {
+  var AppInstallDialog = function AppInstallDialog() {
+    this.render();
+    this.publish('created');
+  };
+
+  AppInstallDialog.prototype = Object.create(window.SystemDialog.prototype);
+
+  AppInstallDialog.prototype.customID = 'app-install-dialog';
+
+  AppInstallDialog.prototype.DEBUG = false;
+
+  /**
+   * Used for element id access.
+   * e.g., 'authentication-dialog-alert-ok'
+   * @type {String}
+   * @memberof AppInstallDialog.prototype
+   */
+  AppInstallDialog.prototype.ELEMENT_PREFIX = 'app-install-';
+
+  /**
+   * Maps to DOM elements.
+   * @type {Object}
+   * @memberof AppInstallDialog.prototype
+   */
+  AppInstallDialog.prototype.elements = null;
+
+  AppInstallDialog.prototype._fetchElements =
+    function appid__fetchElements() {
+    this.element = document.getElementById(this.instanceID);
+    this.elements = {};
+
+    var toCamelCase = function toCamelCase(str) {
+      return str.replace(/\-(.)/g, function replacer(str, p1) {
+        return p1.toUpperCase();
+      });
+    };
+
+    this.elementIds = [
+      'message', 'size',
+      'author-name', 'author-url',
+      'install-button', 'cancel-button'
+    ];
+
+    this.elementIds.forEach(function createElementRef(id) {
+      this.elements[toCamelCase(id)] =
+        this.element.querySelector('#' + this.ELEMENT_PREFIX + id);
+    }, this);
+  };
+
+  AppInstallDialog.prototype.view = function appid_view() {
+    return `<form id="${this.instanceID}"
+            class="app-install-dialog generic-dialog"
+            data-type="confirm" role="dialog"
+            data-z-index-level="app-install-dialog">
+              <section>
+                <h1 id="app-install-message"></h1>
+                <dl>
+                  <dt data-l10n-id="size">Size</dt>
+                  <dd id="app-install-size"></dd>
+                  <dt data-l10n-id="author">Author</dt>
+                  <dd>
+                    <span id="app-install-author-name"></span><br />
+                    <span id="app-install-author-url"></span>
+                  </dd>
+                </dl>
+              </section>
+              <menu data-items="2">
+                <button id="app-install-cancel-button"
+                 data-l10n-id="cancel">Cancel</button>
+                <button id="app-install-install-button"
+                 class="recommend" data-l10n-id="install">Install</button>
+              </menu>
+            </form>`;
+  };
+
+  AppInstallDialog.prototype.getView = function appid_getView() {
+    return document.getElementById(this.instanceID);
+  };
+
+  exports.AppInstallDialog = AppInstallDialog;
+
+}(window));

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -1,9 +1,9 @@
 /* jshint moz:true */
+/* global BaseModule */
 /* global ConfirmDialogHelper */
 /* global FtuLauncher */
 /* global KeyboardHelper */
 /* global inputWindowManager */
-/* global LazyLoader */
 /* global ManifestHelper */
 /* global ModalDialog */
 /* global NotificationScreen */
@@ -15,700 +15,716 @@
 
 'use strict';
 
-var AppInstallManager = {
-  mapDownloadErrorsToMessage: {
-    'NETWORK_ERROR': 'download-failed',
-    'DOWNLOAD_ERROR': 'download-failed',
-    'MISSING_MANIFEST': 'install-failed',
-    'INVALID_MANIFEST': 'install-failed',
-    'INSTALL_FROM_DENIED': 'install-failed',
-    'INVALID_SECURITY_LEVEL': 'install-failed',
-    'INVALID_PACKAGE': 'install-failed',
-    'APP_CACHE_DOWNLOAD_ERROR': 'download-failed'
-  },
+(function() {
+  var AppInstallManager = function() {
+  };
 
-  init: function ai_init() {
-    this.systemBanner = new SystemBanner();
-    this.dialog = document.getElementById('app-install-dialog');
-    this.msg = document.getElementById('app-install-message');
-    this.size = document.getElementById('app-install-size');
-    this.authorName = document.getElementById('app-install-author-name');
-    this.authorUrl = document.getElementById('app-install-author-url');
-    this.installButton = document.getElementById('app-install-install-button');
-    this.cancelButton = document.getElementById('app-install-cancel-button');
-    this.imeLayoutDialog = document.getElementById('ime-layout-dialog');
-    this.imeListTemplate = document.getElementById('ime-list-template');
-    this.imeList = document.getElementById('ime-list');
-    this.imeCancelButton = document.getElementById('ime-cancel-button');
-    this.imeConfirmButton = document.getElementById('ime-confirm-button');
-    this.setupCancelButton =
-      document.getElementById('setup-cancel-button');
-    this.setupConfirmButton =
-      document.getElementById('setup-confirm-button');
+  AppInstallManager.IMPORTS = [
+    'shared/js/template.js',
+    'shared/js/homescreens/confirm_dialog_helper.js'
+  ];
 
-    this.installCancelDialog =
-      document.getElementById('app-install-cancel-dialog');
-    this.downloadCancelDialog =
-      document.getElementById('app-download-cancel-dialog');
-    this.setupInstalledAppDialog =
-      document.getElementById('setup-installed-app-dialog');
-    this.confirmCancelButton =
-      document.getElementById('app-install-confirm-cancel-button');
-    this.setupAppName = document.getElementById('setup-app-name');
-    this.setupAppDescription = document.getElementById('setup-app-description');
+  BaseModule.create(AppInstallManager, {
+    name: 'AppInstallManager',
 
-    this.resumeButton = document.getElementById('app-install-resume-button');
+    mapDownloadErrorsToMessage: {
+      'NETWORK_ERROR': 'download-failed',
+      'DOWNLOAD_ERROR': 'download-failed',
+      'MISSING_MANIFEST': 'install-failed',
+      'INVALID_MANIFEST': 'install-failed',
+      'INSTALL_FROM_DENIED': 'install-failed',
+      'INVALID_SECURITY_LEVEL': 'install-failed',
+      'INVALID_PACKAGE': 'install-failed',
+      'APP_CACHE_DOWNLOAD_ERROR': 'download-failed'
+    },
 
-    this.notifContainer =
-            document.getElementById('install-manager-notification-container');
-    this.appInfos = {};
-    this.setupQueue = [];
-    this.isSetupInProgress = false;
-    window.addEventListener('mozChromeEvent',
-      (function ai_handleChromeEvent(e) {
-      if (e.detail.type == 'webapps-ask-install') {
-        this.handleAppInstallPrompt(e.detail);
-      }
-      if (e.detail.type == 'webapps-ask-uninstall') {
-        this.handleAppUninstallPrompt(e.detail);
-      }
-    }).bind(this));
+    _start: function() {
+      this.systemBanner = new SystemBanner();
+      this.dialog = document.getElementById('app-install-dialog');
+      this.msg = document.getElementById('app-install-message');
+      this.size = document.getElementById('app-install-size');
+      this.authorName = document.getElementById('app-install-author-name');
+      this.authorUrl =
+        document.getElementById('app-install-author-url');
+      this.installButton =
+        document.getElementById('app-install-install-button');
+      this.cancelButton = document.getElementById('app-install-cancel-button');
+      this.imeLayoutDialog = document.getElementById('ime-layout-dialog');
+      this.imeListTemplate = document.getElementById('ime-list-template');
+      this.imeList = document.getElementById('ime-list');
+      this.imeCancelButton = document.getElementById('ime-cancel-button');
+      this.imeConfirmButton = document.getElementById('ime-confirm-button');
+      this.setupCancelButton =
+        document.getElementById('setup-cancel-button');
+      this.setupConfirmButton =
+        document.getElementById('setup-confirm-button');
 
-    window.addEventListener('applicationinstall',
-      this.handleApplicationInstall.bind(this));
+      this.installCancelDialog =
+        document.getElementById('app-install-cancel-dialog');
+      this.downloadCancelDialog =
+        document.getElementById('app-download-cancel-dialog');
+      this.setupInstalledAppDialog =
+        document.getElementById('setup-installed-app-dialog');
+      this.confirmCancelButton =
+        document.getElementById('app-install-confirm-cancel-button');
+      this.setupAppName = document.getElementById('setup-app-name');
+      this.setupAppDescription =
+        document.getElementById('setup-app-description');
 
-    window.addEventListener('applicationuninstall',
-      this.handleApplicationUninstall.bind(this));
+      this.resumeButton = document.getElementById('app-install-resume-button');
 
-    this.installButton.onclick = this.handleInstall.bind(this);
-    this.cancelButton.onclick = this.showInstallCancelDialog.bind(this);
-    this.confirmCancelButton.onclick = this.handleInstallCancel.bind(this);
-    this.resumeButton.onclick = this.hideInstallCancelDialog.bind(this);
-    this.notifContainer.onclick = this.showDownloadCancelDialog.bind(this);
-
-    this.downloadCancelDialog.querySelector('.confirm').onclick =
-      this.handleConfirmDownloadCancel.bind(this);
-    this.downloadCancelDialog.querySelector('.cancel').onclick =
-      this.handleCancelDownloadCancel.bind(this);
-
-    this.setupCancelButton.onclick = this.handleSetupCancelAction.bind(this);
-    this.setupConfirmButton.onclick =
-                             this.handleSetupConfirmAction.bind(this);
-    this.imeCancelButton.onclick = this.hideIMEList.bind(this);
-    this.imeConfirmButton.onclick = this.handleImeConfirmAction.bind(this);
-    LazyLoader.load(['shared/js/template.js',
-                     'shared/js/homescreens/confirm_dialog_helper.js']);
-
-    // bind these handlers so that we can have only one instance and check
-    // them later on
-    ['handleDownloadSuccess',
-     'handleDownloadError',
-     'handleProgress',
-     'handleApplicationReady'
-    ].forEach(function(name) {
-      this[name] = this[name].bind(this);
-    }, this);
-
-    window.addEventListener('applicationready',
-        this.handleApplicationReady);
-
-    window.addEventListener('home', this.handleHomeButtonPressed.bind(this));
-  },
-
-  handleHomeButtonPressed: function ai_handleHomeButtonPressed(e) {
-    this.dialog.classList.remove('visible');
-    this.handleInstallCancel();
-
-    // hide IME setup dialog if presented
-    if (this.setupInstalledAppDialog.classList.contains('visible') ) {
-      this.handleSetupCancelAction();
-    }
-
-    // hide IME layout list if presented
-    if (this.imeLayoutDialog.classList.contains('visible')) {
-      this.hideIMEList();
-    }
-  },
-
-  handleApplicationReady: function ai_handleApplicationReady(e) {
-    window.removeEventListener('applicationready',
-        this.handleApplicationReady);
-
-    var apps = e.detail.applications;
-
-    Object.keys(apps)
-      .filter(function(key) { return apps[key].installState === 'pending'; })
-      .map(function(key) { return apps[key]; })
-      .forEach(this.prepareForDownload, this);
-  },
-
-  handleApplicationInstall: function ai_handleApplicationInstallEvent(e) {
-    var app = e.detail.application;
-
-    if (app.installState === 'installed') {
-      this.handleInstallSuccess(app);
-      return;
-    }
-
-    this.prepareForDownload(app);
-  },
-
-  handleApplicationUninstall: function ai_handleApplicationUninstall(e) {
-    var app = e.detail.application;
-
-    this.onDownloadStop(app);
-    this.onDownloadFinish(app);
-  },
-
-  handleAppInstallPrompt: function ai_handleInstallPrompt(detail) {
-    var _ = navigator.mozL10n.get;
-    var app = detail.app;
-    // updateManifest is used by packaged apps until they are installed
-    var manifest = app.manifest ? app.manifest : app.updateManifest;
-
-    if (!manifest) {
-      return;
-    }
-
-    this.dialog.classList.add('visible');
-
-    var id = detail.id;
-
-    if (manifest.size) {
-      this.size.textContent = this.humanizeSize(manifest.size);
-    } else {
-      this.size.textContent = _('size-unknown');
-    }
-
-    // Wrap manifest to get localized properties
-    manifest = new ManifestHelper(manifest);
-    var msg = _('install-app', {'name': manifest.name});
-    this.msg.textContent = msg;
-
-    if (manifest.developer) {
-      this.authorName.textContent = manifest.developer.name ||
-        _('author-unknown');
-      this.authorUrl.textContent = manifest.developer.url || '';
-    } else {
-      this.authorName.textContent = _('author-unknown');
-      this.authorUrl.textContent = '';
-    }
-
-    this.installCallback = (function ai_installCallback() {
-      this.dispatchResponse(id, 'webapps-install-granted');
-    }).bind(this);
-
-    this.installCancelCallback = (function ai_cancelCallback() {
-      this.dispatchResponse(id, 'webapps-install-denied');
-    }).bind(this);
-
-  },
-
-  handleInstall: function ai_handleInstall(evt) {
-    if (evt) {
-      evt.preventDefault();
-    }
-    if (this.installCallback) {
-      this.installCallback();
-    }
-    this.installCallback = null;
-    this.dialog.classList.remove('visible');
-  },
-
-  handleAppUninstallPrompt: function ai_handleUninstallPrompt(detail) {
-    var app = detail.app;
-    var id = detail.id;
-
-    // updateManifest is used by packaged apps until they are installed
-    var manifest = app.manifest ? app.manifest : app.updateManifest;
-    if (!manifest) {
-      return;
-    }
-
-    // Wrap manifest to get localized properties
-    manifest = new ManifestHelper(manifest);
-
-    var unrecoverable = app.installState === 'pending' &&
-                        !app.downloadAvailable &&
-                        !app.readyToApplyDownload;
-
-    var dialogConfig;
-
-    if (unrecoverable) {
-      dialogConfig = {
-        type: 'unrecoverable',
-        title: 'unrecoverable-error-title',
-        body: 'unrecoverable-error-body',
-        confirm: {
-          title: 'unrecoverable-error-action',
-          cb: () => { this.dispatchResponse(id, 'webapps-uninstall-granted'); }
+      this.notifContainer =
+              document.getElementById('install-manager-notification-container');
+      this.appInfos = {};
+      this.setupQueue = [];
+      this.isSetupInProgress = false;
+      window.addEventListener('mozChromeEvent',
+        (function ai_handleChromeEvent(e) {
+        if (e.detail.type == 'webapps-ask-install') {
+          this.handleAppInstallPrompt(e.detail);
         }
-      };
-    } else {
-      var nameObj = { name: manifest.name };
-      dialogConfig = {
-        type: 'remove',
-        title: {id: 'delete-title', args: nameObj},
-        body: {id: 'delete-body', args: nameObj},
-        cancel: {
-          title: 'cancel',
-          cb: () => { this.dispatchResponse(id, 'webapps-uninstall-denied'); }
-        },
-        confirm: {
-          title: 'delete',
-          type: 'danger',
-          cb: () => { this.dispatchResponse(id, 'webapps-uninstall-granted'); }
+        if (e.detail.type == 'webapps-ask-uninstall') {
+          this.handleAppUninstallPrompt(e.detail);
         }
-      };
-    }
+      }).bind(this));
 
-    var dialog = new ConfirmDialogHelper(dialogConfig);
-    dialog.show(document.getElementById('app-uninstall-dialog'));
-  },
+      window.addEventListener('applicationinstall',
+        this.handleApplicationInstall.bind(this));
 
-  prepareForDownload: function ai_prepareForDownload(app) {
-    var manifestURL = app.manifestURL;
-    this.appInfos[manifestURL] = {};
+      window.addEventListener('applicationuninstall',
+        this.handleApplicationUninstall.bind(this));
 
-    // these methods are already bound to |this|
-    app.ondownloadsuccess = this.handleDownloadSuccess;
-    app.ondownloaderror = this.handleDownloadError;
-    app.onprogress = this.handleProgress;
-  },
+      this.installButton.onclick = this.handleInstall.bind(this);
+      this.cancelButton.onclick = this.showInstallCancelDialog.bind(this);
+      this.confirmCancelButton.onclick = this.handleInstallCancel.bind(this);
+      this.resumeButton.onclick = this.hideInstallCancelDialog.bind(this);
+      this.notifContainer.onclick = this.showDownloadCancelDialog.bind(this);
 
-  configurations: {
-    'input': {
-      fnName: 'showIMEList'
-    }
-  },
+      this.downloadCancelDialog.querySelector('.confirm').onclick =
+        this.handleConfirmDownloadCancel.bind(this);
+      this.downloadCancelDialog.querySelector('.cancel').onclick =
+        this.handleCancelDownloadCancel.bind(this);
 
-  handleInstallSuccess: function ai_handleInstallSuccess(app) {
-    var manifest = app.manifest || app.updateManifest;
-    var role = manifest.role;
+      this.setupCancelButton.onclick = this.handleSetupCancelAction.bind(this);
+      this.setupConfirmButton.onclick =
+                               this.handleSetupConfirmAction.bind(this);
+      this.imeCancelButton.onclick = this.hideIMEList.bind(this);
+      this.imeConfirmButton.onclick = this.handleImeConfirmAction.bind(this);
 
-    // We must stop 3rd-party keyboard app from being installed
-    // if the feature is not enabled.
-    if (role === 'input' && !inputWindowManager.isOutOfProcessEnabled) {
-      navigator.mozApps.mgmt.uninstall(app);
+      // bind these handlers so that we can have only one instance and check
+      // them later on
+      ['handleDownloadSuccess',
+       'handleDownloadError',
+       'handleProgress',
+       'handleApplicationReady'
+      ].forEach(function(name) {
+        this[name] = this[name].bind(this);
+      }, this);
 
-      return;
-    }
+      window.addEventListener('applicationready',
+          this.handleApplicationReady);
 
-    if (this.configurations[role]) {
-      this.setupQueue.push(app);
+      window.addEventListener('home', this.handleHomeButtonPressed.bind(this));
+    },
+
+    handleHomeButtonPressed: function ai_handleHomeButtonPressed(e) {
+      this.dialog.classList.remove('visible');
+      this.handleInstallCancel();
+
+      // hide IME setup dialog if presented
+      if (this.setupInstalledAppDialog.classList.contains('visible') ) {
+        this.handleSetupCancelAction();
+      }
+
+      // hide IME layout list if presented
+      if (this.imeLayoutDialog.classList.contains('visible')) {
+        this.hideIMEList();
+      }
+    },
+
+    handleApplicationReady: function ai_handleApplicationReady(e) {
+      window.removeEventListener('applicationready',
+          this.handleApplicationReady);
+
+      var apps = e.detail.applications;
+
+      Object.keys(apps)
+        .filter(function(key) { return apps[key].installState === 'pending'; })
+        .map(function(key) { return apps[key]; })
+        .forEach(this.prepareForDownload, this);
+    },
+
+    handleApplicationInstall: function ai_handleApplicationInstallEvent(e) {
+      var app = e.detail.application;
+
+      if (app.installState === 'installed') {
+        this.handleInstallSuccess(app);
+        return;
+      }
+
+      this.prepareForDownload(app);
+    },
+
+    handleApplicationUninstall: function ai_handleApplicationUninstall(e) {
+      var app = e.detail.application;
+
+      this.onDownloadStop(app);
+      this.onDownloadFinish(app);
+    },
+
+    handleAppInstallPrompt: function ai_handleInstallPrompt(detail) {
+      var _ = navigator.mozL10n.get;
+      var app = detail.app;
+      // updateManifest is used by packaged apps until they are installed
+      var manifest = app.manifest ? app.manifest : app.updateManifest;
+
+      if (!manifest) {
+        return;
+      }
+
+      this.dialog.classList.add('visible');
+
+      var id = detail.id;
+
+      if (manifest.size) {
+        this.size.textContent = this.humanizeSize(manifest.size);
+      } else {
+        this.size.textContent = _('size-unknown');
+      }
+
+      // Wrap manifest to get localized properties
+      manifest = new ManifestHelper(manifest);
+      var msg = _('install-app', {'name': manifest.name});
+      this.msg.textContent = msg;
+
+      if (manifest.developer) {
+        this.authorName.textContent = manifest.developer.name ||
+          _('author-unknown');
+        this.authorUrl.textContent = manifest.developer.url || '';
+      } else {
+        this.authorName.textContent = _('author-unknown');
+        this.authorUrl.textContent = '';
+      }
+
+      this.installCallback = (function ai_installCallback() {
+        this.dispatchResponse(id, 'webapps-install-granted');
+      }).bind(this);
+
+      this.installCancelCallback = (function ai_cancelCallback() {
+        this.dispatchResponse(id, 'webapps-install-denied');
+      }).bind(this);
+
+    },
+
+    handleInstall: function ai_handleInstall(evt) {
+      if (evt) {
+        evt.preventDefault();
+      }
+      if (this.installCallback) {
+        this.installCallback();
+      }
+      this.installCallback = null;
+      this.dialog.classList.remove('visible');
+    },
+
+    handleAppUninstallPrompt: function ai_handleUninstallPrompt(detail) {
+      var app = detail.app;
+      var id = detail.id;
+
+      // updateManifest is used by packaged apps until they are installed
+      var manifest = app.manifest ? app.manifest : app.updateManifest;
+      if (!manifest) {
+        return;
+      }
+
+      // Wrap manifest to get localized properties
+      manifest = new ManifestHelper(manifest);
+
+      var unrecoverable = app.installState === 'pending' &&
+                          !app.downloadAvailable &&
+                          !app.readyToApplyDownload;
+
+      var dialogConfig;
+
+      if (unrecoverable) {
+        dialogConfig = {
+          type: 'unrecoverable',
+          title: 'unrecoverable-error-title',
+          body: 'unrecoverable-error-body',
+          confirm: {
+            title: 'unrecoverable-error-action',
+            cb: () => {
+              this.dispatchResponse(id,'webapps-uninstall-granted'); 
+            }
+          }
+        };
+      } else {
+        var nameObj = { name: manifest.name };
+        dialogConfig = {
+          type: 'remove',
+          title: {id: 'delete-title', args: nameObj},
+          body: {id: 'delete-body', args: nameObj},
+          cancel: {
+            title: 'cancel',
+            cb: () => { this.dispatchResponse(id, 'webapps-uninstall-denied'); }
+          },
+          confirm: {
+            title: 'delete',
+            type: 'danger',
+            cb: () => {
+              this.dispatchResponse(id, 'webapps-uninstall-granted'); 
+            }
+          }
+        };
+      }
+
+      var dialog = new ConfirmDialogHelper(dialogConfig);
+      dialog.show(document.getElementById('app-uninstall-dialog'));
+    },
+
+    prepareForDownload: function ai_prepareForDownload(app) {
+      var manifestURL = app.manifestURL;
+      this.appInfos[manifestURL] = {};
+
+      // these methods are already bound to |this|
+      app.ondownloadsuccess = this.handleDownloadSuccess;
+      app.ondownloaderror = this.handleDownloadError;
+      app.onprogress = this.handleProgress;
+    },
+
+    configurations: {
+      'input': {
+        fnName: 'showIMEList'
+      }
+    },
+
+    handleInstallSuccess: function ai_handleInstallSuccess(app) {
+      var manifest = app.manifest || app.updateManifest;
+      var role = manifest.role;
+
+      // We must stop 3rd-party keyboard app from being installed
+      // if the feature is not enabled.
+      if (role === 'input' && !inputWindowManager.isOutOfProcessEnabled) {
+        navigator.mozApps.mgmt.uninstall(app);
+
+        return;
+      }
+
+      if (this.configurations[role]) {
+        this.setupQueue.push(app);
+        this.checkSetupQueue();
+      } else {
+        this.showInstallSuccess(app);
+      }
+      // send event
+      var evt = new CustomEvent('applicationinstallsuccess',
+                             { detail: { application: app } });
+      window.dispatchEvent(evt);
+    },
+
+    showInstallSuccess: function ai_showInstallSuccess(app) {
+      if (FtuLauncher.isFtuRunning()) {
+        return;
+      }
+      var manifest = app.manifest || app.updateManifest;
+      var appManifest = new ManifestHelper(manifest);
+      var name = appManifest.name;
+      var l10nId = appManifest.role === 'langpack' ?
+        'langpack-install-success' : 'app-install-success';
+      this.systemBanner.show(
+        navigator.mozL10n.get(l10nId, { appName: name }));
+    },
+
+    checkSetupQueue: function ai_checkSetupQueue() {
+      if (this.setupQueue.length && !(this.isSetupInProgress)) {
+        this.isSetupInProgress = true;
+        this.showSetupDialog();
+      }
+    },
+
+    completedSetupTask: function ai_completedSetupTask() {
+      // clean completed app
+      this.setupQueue.shift();
+      this.isSetupInProgress = false;
       this.checkSetupQueue();
-    } else {
-      this.showInstallSuccess(app);
-    }
-    // send event
-    var evt = new CustomEvent('applicationinstallsuccess',
-                           { detail: { application: app } });
-    window.dispatchEvent(evt);
-  },
+    },
 
-  showInstallSuccess: function ai_showInstallSuccess(app) {
-    if (FtuLauncher.isFtuRunning()) {
-      return;
-    }
-    var manifest = app.manifest || app.updateManifest;
-    var appManifest = new ManifestHelper(manifest);
-    var name = appManifest.name;
-    var l10nId = appManifest.role === 'langpack' ?
-      'langpack-install-success' : 'app-install-success';
-    this.systemBanner.show(
-      navigator.mozL10n.get(l10nId, { appName: name }));
-  },
+    hideSetupDialog: function ai_hideSetupDialog() {
+      this.setupAppName.textContent = '';
+      this.setupAppDescription.textContent = '';
+      this.setupInstalledAppDialog.classList.remove('visible');
+    },
 
-  checkSetupQueue: function ai_checkSetupQueue() {
-    if (this.setupQueue.length && !(this.isSetupInProgress)) {
-      this.isSetupInProgress = true;
-      this.showSetupDialog();
-    }
-  },
+    showSetupDialog: function ai_showSetupDialog() {
+      var app = this.setupQueue[0];
+      var manifest = app.manifest;
+      var appManifest = new ManifestHelper(manifest);
+      var appName = appManifest.name;
+      var appDescription = appManifest.description;
+      this.setupAppDescription.textContent = appDescription;
+      navigator.mozL10n.setAttributes(this.setupAppName,
+                                      'app-install-success',
+                                      { appName: appName });
+      this.setupInstalledAppDialog.classList.add('visible');
+      window.dispatchEvent(new CustomEvent('applicationsetupdialogshow'));
+    },
 
-  completedSetupTask: function ai_completedSetupTask() {
-    // clean completed app
-    this.setupQueue.shift();
-    this.isSetupInProgress = false;
-    this.checkSetupQueue();
-  },
-
-  hideSetupDialog: function ai_hideSetupDialog() {
-    this.setupAppName.textContent = '';
-    this.setupAppDescription.textContent = '';
-    this.setupInstalledAppDialog.classList.remove('visible');
-  },
-
-  showSetupDialog: function ai_showSetupDialog() {
-    var app = this.setupQueue[0];
-    var manifest = app.manifest;
-    var appManifest = new ManifestHelper(manifest);
-    var appName = appManifest.name;
-    var appDescription = appManifest.description;
-    this.setupAppDescription.textContent = appDescription;
-    navigator.mozL10n.setAttributes(this.setupAppName,
-                                    'app-install-success',
-                                    { appName: appName });
-    this.setupInstalledAppDialog.classList.add('visible');
-    window.dispatchEvent(new CustomEvent('applicationsetupdialogshow'));
-  },
-
-  handleSetupCancelAction: function ai_handleSetupCancelAction() {
-    this.hideSetupDialog();
-    this.completedSetupTask();
-  },
-
-  handleSetupConfirmAction: function ai_handleSetupConfirmAction() {
-    var fnName = this.configurations[this.setupQueue[0].manifest.role].fnName;
-    this[fnName].call(this);
-    this.hideSetupDialog();
-  },
-
-  showIMEList: function ai_showIMEList() {
-    var app = this.setupQueue[0];
-    var inputs = app.manifest.inputs;
-    if (typeof inputs !== 'object') {
-      console.error('inputs must be an object for ' +
-                    'third-party keyboard layouts');
+    handleSetupCancelAction: function ai_handleSetupCancelAction() {
+      this.hideSetupDialog();
       this.completedSetupTask();
-      return;
-    }
+    },
 
-    // Check permission level is correct
-    var hasInputPermission = (app.manifest.type === 'certified' ||
-                              app.manifest.type === 'privileged') &&
-                             (app.manifest.permissions &&
-                              'input' in app.manifest.permissions);
-    if (!hasInputPermission) {
-      console.error('third-party IME does not have correct input permission');
-      this.completedSetupTask();
-      return;
-    }
+    handleSetupConfirmAction: function ai_handleSetupConfirmAction() {
+      var fnName = this.configurations[this.setupQueue[0].manifest.role].fnName;
+      this[fnName].call(this);
+      this.hideSetupDialog();
+    },
 
-    // build the list of keyboard layouts
-    var listHtml = '';
-    var imeListWrap = Template(this.imeListTemplate);
-    for (var name in inputs) {
-      var displayIMEName = new ManifestHelper(inputs[name]).name;
-      listHtml += imeListWrap.interpolate({
-        imeName: name,
-        displayName: displayIMEName
-      });
-    }
-    // keeping li template
-    this.imeList.innerHTML = listHtml;
-    this.imeLayoutDialog.classList.add('visible');
-  },
-
-  hideIMEList: function ai_hideIMEList() {
-    this.imeLayoutDialog.classList.remove('visible');
-    this.imeList.innerHTML = '';
-    this.completedSetupTask();
-  },
-
-  handleImeConfirmAction: function ai_handleImeConfirmAction() {
-    var manifestURL = this.setupQueue[0].manifestURL;
-    var keyboards = this.imeList.getElementsByTagName('input');
-    for (var i = 0, l = keyboards.length; i < l; i++) {
-      var keyboardIME = keyboards[i];
-      if (keyboardIME.checked) {
-        KeyboardHelper.setLayoutEnabled(manifestURL, keyboardIME.value, true);
-        KeyboardHelper.saveToSettings();
+    showIMEList: function ai_showIMEList() {
+      var app = this.setupQueue[0];
+      var inputs = app.manifest.inputs;
+      if (typeof inputs !== 'object') {
+        console.error('inputs must be an object for ' +
+                      'third-party keyboard layouts');
+        this.completedSetupTask();
+        return;
       }
-    }
-    this.hideIMEList();
-  },
 
-  handleDownloadSuccess: function ai_handleDownloadSuccess(evt) {
-    var app = evt.application;
-    this.handleInstallSuccess(app);
-    this.onDownloadStop(app);
-    this.onDownloadFinish(app);
-  },
+      // Check permission level is correct
+      var hasInputPermission = (app.manifest.type === 'certified' ||
+                                app.manifest.type === 'privileged') &&
+                               (app.manifest.permissions &&
+                                'input' in app.manifest.permissions);
+      if (!hasInputPermission) {
+        console.error('third-party IME does not have correct input permission');
+        this.completedSetupTask();
+        return;
+      }
 
-  handleDownloadError: function ai_handleDownloadError(evt) {
-    var app = evt.application;
-    var _ = navigator.mozL10n.get;
-    var manifest = app.manifest || app.updateManifest;
-    var name = new ManifestHelper(manifest).name;
+      // build the list of keyboard layouts
+      var listHtml = '';
+      var imeListWrap = Template(this.imeListTemplate);
+      for (var name in inputs) {
+        var displayIMEName = new ManifestHelper(inputs[name]).name;
+        listHtml += imeListWrap.interpolate({
+          imeName: name,
+          displayName: displayIMEName
+        });
+      }
+      // keeping li template
+      this.imeList.innerHTML = listHtml;
+      this.imeLayoutDialog.classList.add('visible');
+    },
 
-    var errorName = app.downloadError.name;
+    hideIMEList: function ai_hideIMEList() {
+      this.imeLayoutDialog.classList.remove('visible');
+      this.imeList.innerHTML = '';
+      this.completedSetupTask();
+    },
 
-    switch (errorName) {
-      case 'INSUFFICIENT_STORAGE':
-        var title = 'not-enough-space',
-            buttonText = 'ok',
-            message = 'not-enough-space-message';
-
-        ModalDialog.alert(title, message, {title: buttonText});
-        break;
-      default:
-        // showing the real error to a potential developer
-        console.info('downloadError event, error code is', errorName);
-
-        var key = this.mapDownloadErrorsToMessage[errorName] || 'generic-error';
-        var msg = _('app-install-' + key, { appName: name });
-        this.systemBanner.show(msg);
-    }
-
-    this.onDownloadStop(app);
-  },
-
-  onDownloadStart: function ai_onDownloadStart(app) {
-    if (! this.hasNotification(app)) {
-      StatusBar.incSystemDownloads();
-      this.addNotification(app);
-      this.requestWifiLock(app);
-    }
-  },
-
-  onDownloadStop: function ai_onDownloadStop(app) {
-    if (this.hasNotification(app)) {
-      StatusBar.decSystemDownloads();
-      this.removeNotification(app);
-      this.releaseWifiLock(app);
-    }
-  },
-
-  hasNotification: function ai_hasNotification(app) {
-    var appInfo = this.appInfos[app.manifestURL];
-    return appInfo && !!appInfo.installNotification;
-  },
-
-  onDownloadFinish: function ai_onDownloadFinish(app) {
-    delete this.appInfos[app.manifestURL];
-
-    // check if these are our handlers before removing them
-    if (app.ondownloadsuccess === this.handleDownloadSuccess) {
-      app.ondownloadsuccess = null;
-    }
-
-    if (app.ondownloaderror === this.handleDownloadError) {
-      app.ondownloaderror = null;
-    }
-
-    if (app.onprogress === this.handleProgress) {
-      app.onprogress = null;
-    }
-  },
-
-  addNotification: function ai_addNotification(app) {
-    // should be unique (this is used already in applications.js)
-    var manifestURL = app.manifestURL,
-        appInfo = this.appInfos[manifestURL];
-
-    if (appInfo.installNotification) {
-      return;
-    }
-
-    var newNotif =
-      `<div class="fake-notification" role="link">
-        <div data-icon="rocket" class="alert"></div>
-        <div class="title-container"></div>
-        <progress></progress>
-      </div>`;
-
-    this.notifContainer.insertAdjacentHTML('afterbegin', newNotif);
-
-    var newNode = this.notifContainer.firstElementChild;
-    newNode.dataset.manifest = manifestURL;
-
-    var manifest = app.manifest || app.updateManifest;
-
-    navigator.mozL10n.setAttributes(
-      newNode.querySelector('.title-container'),
-      'downloadingAppMessage',
-      { appName: new ManifestHelper(manifest).name }
-    );
-
-    var progressNode = newNode.querySelector('progress');
-    if (app.updateManifest && app.updateManifest.size) {
-      progressNode.max = app.updateManifest.size;
-      appInfo.hasMax = true;
-    }
-
-    appInfo.installNotification = newNode;
-    NotificationScreen.addUnreadNotification(manifestURL);
-  },
-
-  getNotificationProgressNode: function ai_getNotificationProgressNode(app) {
-    var appInfo = this.appInfos[app.manifestURL];
-    var progressNode = appInfo &&
-      appInfo.installNotification &&
-      appInfo.installNotification.querySelector('progress');
-    return progressNode || null;
-  },
-
-  handleProgress: function ai_handleProgress(evt) {
-    var app = evt.application,
-        appInfo = this.appInfos[app.manifestURL];
-
-    this.onDownloadStart(app);
-
-
-    var progressNode = this.getNotificationProgressNode(app);
-    var message;
-
-    if (isNaN(app.progress) || app.progress == null) {
-      // now we get NaN if there is no progress information but let's
-      // handle the null and undefined cases as well
-      message = {
-        id: 'downloadingAppProgressIndeterminate',
-        args: null
-      };
-      progressNode.removeAttribute('value'); // switch to indeterminate state
-    } else if (appInfo.hasMax) {
-      message = {
-        id: 'downloadingAppProgress',
-        args: {
-          progress: this.humanizeSize(app.progress),
-          max: this.humanizeSize(progressNode.max)
+    handleImeConfirmAction: function ai_handleImeConfirmAction() {
+      var manifestURL = this.setupQueue[0].manifestURL;
+      var keyboards = this.imeList.getElementsByTagName('input');
+      for (var i = 0, l = keyboards.length; i < l; i++) {
+        var keyboardIME = keyboards[i];
+        if (keyboardIME.checked) {
+          KeyboardHelper.setLayoutEnabled(manifestURL, keyboardIME.value, true);
+          KeyboardHelper.saveToSettings();
         }
-      };
-      progressNode.value = app.progress;
-    } else {
-      message = {
-        id: 'downloadingAppProgressNoMax',
-        args: { progress: this.humanizeSize(app.progress) }
-      };
-    }
-    navigator.mozL10n.setAttributes(
-      progressNode,
-      message.id,
-      message.args);
-  },
+      }
+      this.hideIMEList();
+    },
 
-  removeNotification: function ai_removeNotification(app) {
-    var manifestURL = app.manifestURL,
-        appInfo = this.appInfos[manifestURL],
-        node = appInfo.installNotification;
+    handleDownloadSuccess: function ai_handleDownloadSuccess(evt) {
+      var app = evt.application;
+      this.handleInstallSuccess(app);
+      this.onDownloadStop(app);
+      this.onDownloadFinish(app);
+    },
 
-    if (!node) {
-      return;
-    }
+    handleDownloadError: function ai_handleDownloadError(evt) {
+      var app = evt.application;
+      var _ = navigator.mozL10n.get;
+      var manifest = app.manifest || app.updateManifest;
+      var name = new ManifestHelper(manifest).name;
 
-    node.parentNode.removeChild(node);
-    delete appInfo.installNotification;
-    NotificationScreen.removeUnreadNotification(manifestURL);
-  },
+      var errorName = app.downloadError.name;
 
-  requestWifiLock: function ai_requestWifiLock(app) {
-    var appInfo = this.appInfos[app.manifestURL];
-    if (! appInfo.wifiLock) {
-      // we don't want 2 locks for the same app
-      appInfo.wifiLock = navigator.requestWakeLock('wifi');
-    }
-  },
+      switch (errorName) {
+        case 'INSUFFICIENT_STORAGE':
+          var title = 'not-enough-space',
+              buttonText = 'ok',
+              message = 'not-enough-space-message';
 
-  releaseWifiLock: function ai_releaseWifiLock(app) {
-    var appInfo = this.appInfos[app.manifestURL];
+          ModalDialog.alert(title, message, {title: buttonText});
+          break;
+        default:
+          // showing the real error to a potential developer
+          console.info('downloadError event, error code is', errorName);
 
-    if (appInfo.wifiLock) {
-      try {
-        appInfo.wifiLock.unlock();
-      } catch (e) {
-        // this can happen if the lock is already unlocked
-        console.error('error during unlock', e);
+          var key = this.mapDownloadErrorsToMessage[errorName] ||
+            'generic-error';
+          var msg = _('app-install-' + key, { appName: name });
+          this.systemBanner.show(msg);
       }
 
-      delete appInfo.wifiLock;
+      this.onDownloadStop(app);
+    },
+
+    onDownloadStart: function ai_onDownloadStart(app) {
+      if (! this.hasNotification(app)) {
+        StatusBar.incSystemDownloads();
+        this.addNotification(app);
+        this.requestWifiLock(app);
+      }
+    },
+
+    onDownloadStop: function ai_onDownloadStop(app) {
+      if (this.hasNotification(app)) {
+        StatusBar.decSystemDownloads();
+        this.removeNotification(app);
+        this.releaseWifiLock(app);
+      }
+    },
+
+    hasNotification: function ai_hasNotification(app) {
+      var appInfo = this.appInfos[app.manifestURL];
+      return appInfo && !!appInfo.installNotification;
+    },
+
+    onDownloadFinish: function ai_onDownloadFinish(app) {
+      delete this.appInfos[app.manifestURL];
+
+      // check if these are our handlers before removing them
+      if (app.ondownloadsuccess === this.handleDownloadSuccess) {
+        app.ondownloadsuccess = null;
+      }
+
+      if (app.ondownloaderror === this.handleDownloadError) {
+        app.ondownloaderror = null;
+      }
+
+      if (app.onprogress === this.handleProgress) {
+        app.onprogress = null;
+      }
+    },
+
+    addNotification: function ai_addNotification(app) {
+      // should be unique (this is used already in applications.js)
+      var manifestURL = app.manifestURL,
+          appInfo = this.appInfos[manifestURL];
+
+      if (appInfo.installNotification) {
+        return;
+      }
+
+      var newNotif =
+        `<div class="fake-notification" role="link">
+          <div data-icon="rocket" class="alert"></div>
+          <div class="title-container"></div>
+          <progress></progress>
+        </div>`;
+
+      this.notifContainer.insertAdjacentHTML('afterbegin', newNotif);
+
+      var newNode = this.notifContainer.firstElementChild;
+      newNode.dataset.manifest = manifestURL;
+
+      var manifest = app.manifest || app.updateManifest;
+
+      navigator.mozL10n.setAttributes(
+        newNode.querySelector('.title-container'),
+        'downloadingAppMessage',
+        { appName: new ManifestHelper(manifest).name }
+      );
+
+      var progressNode = newNode.querySelector('progress');
+      if (app.updateManifest && app.updateManifest.size) {
+        progressNode.max = app.updateManifest.size;
+        appInfo.hasMax = true;
+      }
+
+      appInfo.installNotification = newNode;
+      NotificationScreen.addUnreadNotification(manifestURL);
+    },
+
+    getNotificationProgressNode: function ai_getNotificationProgressNode(app) {
+      var appInfo = this.appInfos[app.manifestURL];
+      var progressNode = appInfo &&
+        appInfo.installNotification &&
+        appInfo.installNotification.querySelector('progress');
+      return progressNode || null;
+    },
+
+    handleProgress: function ai_handleProgress(evt) {
+      var app = evt.application,
+          appInfo = this.appInfos[app.manifestURL];
+
+      this.onDownloadStart(app);
+
+
+      var progressNode = this.getNotificationProgressNode(app);
+      var message;
+
+      if (isNaN(app.progress) || app.progress == null) {
+        // now we get NaN if there is no progress information but let's
+        // handle the null and undefined cases as well
+        message = {
+          id: 'downloadingAppProgressIndeterminate',
+          args: null
+        };
+        progressNode.removeAttribute('value'); // switch to indeterminate state
+      } else if (appInfo.hasMax) {
+        message = {
+          id: 'downloadingAppProgress',
+          args: {
+            progress: this.humanizeSize(app.progress),
+            max: this.humanizeSize(progressNode.max)
+          }
+        };
+        progressNode.value = app.progress;
+      } else {
+        message = {
+          id: 'downloadingAppProgressNoMax',
+          args: { progress: this.humanizeSize(app.progress) }
+        };
+      }
+      navigator.mozL10n.setAttributes(
+        progressNode,
+        message.id,
+        message.args);
+    },
+
+    removeNotification: function ai_removeNotification(app) {
+      var manifestURL = app.manifestURL,
+          appInfo = this.appInfos[manifestURL],
+          node = appInfo.installNotification;
+
+      if (!node) {
+        return;
+      }
+
+      node.parentNode.removeChild(node);
+      delete appInfo.installNotification;
+      NotificationScreen.removeUnreadNotification(manifestURL);
+    },
+
+    requestWifiLock: function ai_requestWifiLock(app) {
+      var appInfo = this.appInfos[app.manifestURL];
+      if (! appInfo.wifiLock) {
+        // we don't want 2 locks for the same app
+        appInfo.wifiLock = navigator.requestWakeLock('wifi');
+      }
+    },
+
+    releaseWifiLock: function ai_releaseWifiLock(app) {
+      var appInfo = this.appInfos[app.manifestURL];
+
+      if (appInfo.wifiLock) {
+        try {
+          appInfo.wifiLock.unlock();
+        } catch (e) {
+          // this can happen if the lock is already unlocked
+          console.error('error during unlock', e);
+        }
+
+        delete appInfo.wifiLock;
+      }
+    },
+
+    dispatchResponse: function ai_dispatchResponse(id, type) {
+      var event = document.createEvent('CustomEvent');
+
+      event.initCustomEvent('mozContentEvent', true, true, {
+        id: id,
+        type: type
+      });
+
+      window.dispatchEvent(event);
+    },
+
+    humanizeSize: function ai_humanizeSize(bytes) {
+      var _ = navigator.mozL10n.get;
+      var units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
+
+      if (!bytes) {
+        return '0.00 ' + _(units[0]);
+      }
+
+      var e = Math.floor(Math.log(bytes) / Math.log(1024));
+      return (bytes / Math.pow(1024, Math.floor(e))).toFixed(2) + ' ' +
+        _(units[e]);
+    },
+
+    showInstallCancelDialog: function ai_showInstallCancelDialog(evt) {
+      if (evt) {
+        evt.preventDefault();
+      }
+      this.installCancelDialog.classList.add('visible');
+      this.dialog.classList.remove('visible');
+    },
+
+    hideInstallCancelDialog: function ai_hideInstallCancelDialog(evt) {
+      if (evt) {
+        evt.preventDefault();
+      }
+      this.dialog.classList.add('visible');
+      this.installCancelDialog.classList.remove('visible');
+    },
+
+    showDownloadCancelDialog: function ai_showDownloadCancelDialog(e) {
+      var currentNode = e.target;
+
+      if (!currentNode.classList.contains('fake-notification')) {
+        // tapped outside of a notification
+        return;
+      }
+
+      var manifestURL = currentNode.dataset.manifest,
+          app = applications.getByManifestURL(manifestURL),
+          manifest = app.manifest || app.updateManifest,
+          dialog = this.downloadCancelDialog;
+
+      var title = dialog.querySelector('h1');
+
+      navigator.mozL10n.setAttributes(title, 'stopDownloading', {
+        app: new ManifestHelper(manifest).name
+      });
+
+      dialog.classList.add('visible');
+      dialog.dataset.manifest = manifestURL;
+      UtilityTray.hide();
+    },
+
+    handleInstallCancel: function ai_handleInstallCancel() {
+      if (this.installCancelCallback) {
+        this.installCancelCallback();
+      }
+      this.installCancelCallback = null;
+      this.installCancelDialog.classList.remove('visible');
+    },
+
+    handleConfirmDownloadCancel: function ai_handleConfirmDownloadCancel(e) {
+      e && e.preventDefault();
+      var dialog = this.downloadCancelDialog,
+          manifestURL = dialog.dataset.manifest;
+      if (manifestURL) {
+        var app = applications.getByManifestURL(manifestURL);
+        app && app.cancelDownload();
+      }
+
+      this.hideDownloadCancelDialog();
+    },
+
+    handleCancelDownloadCancel: function ai_handleCancelDownloadCancel(e) {
+      e && e.preventDefault();
+      this.hideDownloadCancelDialog();
+    },
+
+    hideDownloadCancelDialog: function() {
+      var dialog = this.downloadCancelDialog;
+      dialog.classList.remove('visible');
+      delete dialog.dataset.manifest;
     }
-  },
-
-  dispatchResponse: function ai_dispatchResponse(id, type) {
-    var event = document.createEvent('CustomEvent');
-
-    event.initCustomEvent('mozContentEvent', true, true, {
-      id: id,
-      type: type
-    });
-
-    window.dispatchEvent(event);
-  },
-
-  humanizeSize: function ai_humanizeSize(bytes) {
-    var _ = navigator.mozL10n.get;
-    var units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
-
-    if (!bytes) {
-      return '0.00 ' + _(units[0]);
-    }
-
-    var e = Math.floor(Math.log(bytes) / Math.log(1024));
-    return (bytes / Math.pow(1024, Math.floor(e))).toFixed(2) + ' ' +
-      _(units[e]);
-  },
-
-  showInstallCancelDialog: function ai_showInstallCancelDialog(evt) {
-    if (evt) {
-      evt.preventDefault();
-    }
-    this.installCancelDialog.classList.add('visible');
-    this.dialog.classList.remove('visible');
-  },
-
-  hideInstallCancelDialog: function ai_hideInstallCancelDialog(evt) {
-    if (evt) {
-      evt.preventDefault();
-    }
-    this.dialog.classList.add('visible');
-    this.installCancelDialog.classList.remove('visible');
-  },
-
-  showDownloadCancelDialog: function ai_showDownloadCancelDialog(e) {
-    var currentNode = e.target;
-
-    if (!currentNode.classList.contains('fake-notification')) {
-      // tapped outside of a notification
-      return;
-    }
-
-    var manifestURL = currentNode.dataset.manifest,
-        app = applications.getByManifestURL(manifestURL),
-        manifest = app.manifest || app.updateManifest,
-        dialog = this.downloadCancelDialog;
-
-    var title = dialog.querySelector('h1');
-
-    navigator.mozL10n.setAttributes(title, 'stopDownloading', {
-      app: new ManifestHelper(manifest).name
-    });
-
-    dialog.classList.add('visible');
-    dialog.dataset.manifest = manifestURL;
-    UtilityTray.hide();
-  },
-
-  handleInstallCancel: function ai_handleInstallCancel() {
-    if (this.installCancelCallback) {
-      this.installCancelCallback();
-    }
-    this.installCancelCallback = null;
-    this.installCancelDialog.classList.remove('visible');
-  },
-
-  handleConfirmDownloadCancel: function ai_handleConfirmDownloadCancel(e) {
-    e && e.preventDefault();
-    var dialog = this.downloadCancelDialog,
-        manifestURL = dialog.dataset.manifest;
-    if (manifestURL) {
-      var app = applications.getByManifestURL(manifestURL);
-      app && app.cancelDownload();
-    }
-
-    this.hideDownloadCancelDialog();
-  },
-
-  handleCancelDownloadCancel: function ai_handleCancelDownloadCancel(e) {
-    e && e.preventDefault();
-    this.hideDownloadCancelDialog();
-  },
-
-  hideDownloadCancelDialog: function() {
-    var dialog = this.downloadCancelDialog;
-    dialog.classList.remove('visible');
-    delete dialog.dataset.manifest;
-  }
-};
-
-AppInstallManager.init();
+  });
+}());

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -1,6 +1,7 @@
 /* jshint moz:true */
 /* global BaseModule */
 /* global AppInstallDialog */
+/* global AppInstallCancelDialog */
 /* global ConfirmDialogHelper */
 /* global FtuLauncher */
 /* global KeyboardHelper */
@@ -43,6 +44,8 @@
       this.systemBanner = new SystemBanner();
 
       this.dialog = new AppInstallDialog();
+      this.installCancelDialog = new AppInstallCancelDialog();
+
       this.imeLayoutDialog = document.getElementById('ime-layout-dialog');
       this.imeListTemplate = document.getElementById('ime-list-template');
       this.imeList = document.getElementById('ime-list');
@@ -54,19 +57,14 @@
       this.setupConfirmButton =
         document.getElementById('setup-confirm-button');
 
-      this.installCancelDialog =
-        document.getElementById('app-install-cancel-dialog');
       this.downloadCancelDialog =
         document.getElementById('app-download-cancel-dialog');
       this.setupInstalledAppDialog =
         document.getElementById('setup-installed-app-dialog');
-      this.confirmCancelButton =
-        document.getElementById('app-install-confirm-cancel-button');
+
       this.setupAppName = document.getElementById('setup-app-name');
       this.setupAppDescription =
-        document.getElementById('setup-app-description');
-
-      this.resumeButton = document.getElementById('app-install-resume-button');
+        document.getElementById('setup-app-description');      
 
       this.notifContainer =
               document.getElementById('install-manager-notification-container');
@@ -93,8 +91,11 @@
         this.handleInstall.bind(this);
       this.dialog.elements.cancelButton.onclick =
         this.showInstallCancelDialog.bind(this);
-      this.confirmCancelButton.onclick = this.handleInstallCancel.bind(this);
-      this.resumeButton.onclick = this.hideInstallCancelDialog.bind(this);
+      this.installCancelDialog.elements.confirmCancelButton.onclick =
+        this.handleInstallCancel.bind(this);
+      this.installCancelDialog.elements.resumeButton.onclick =
+        this.hideInstallCancelDialog.bind(this);
+
       this.notifContainer.onclick = this.showDownloadCancelDialog.bind(this);
 
       this.downloadCancelDialog.querySelector('.confirm').onclick =
@@ -659,7 +660,7 @@
       if (evt) {
         evt.preventDefault();
       }
-      this.installCancelDialog.classList.add('visible');
+      this.installCancelDialog.show();
       this.dialog.hide();
     },
 
@@ -668,7 +669,7 @@
         evt.preventDefault();
       }
       this.dialog.show();
-      this.installCancelDialog.classList.remove('visible');
+      this.installCancelDialog.hide();
     },
 
     showDownloadCancelDialog: function ai_showDownloadCancelDialog(e) {
@@ -701,7 +702,7 @@
         this.installCancelCallback();
       }
       this.installCancelCallback = null;
-      this.installCancelDialog.classList.remove('visible');
+      this.installCancelDialog.hide();
     },
 
     handleConfirmDownloadCancel: function ai_handleConfirmDownloadCancel(e) {

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -1,5 +1,6 @@
 /* jshint moz:true */
 /* global BaseModule */
+/* global AppInstallDialog */
 /* global ConfirmDialogHelper */
 /* global FtuLauncher */
 /* global KeyboardHelper */
@@ -40,20 +41,14 @@
 
     _start: function() {
       this.systemBanner = new SystemBanner();
-      this.dialog = document.getElementById('app-install-dialog');
-      this.msg = document.getElementById('app-install-message');
-      this.size = document.getElementById('app-install-size');
-      this.authorName = document.getElementById('app-install-author-name');
-      this.authorUrl =
-        document.getElementById('app-install-author-url');
-      this.installButton =
-        document.getElementById('app-install-install-button');
-      this.cancelButton = document.getElementById('app-install-cancel-button');
+
+      this.dialog = new AppInstallDialog();
       this.imeLayoutDialog = document.getElementById('ime-layout-dialog');
       this.imeListTemplate = document.getElementById('ime-list-template');
       this.imeList = document.getElementById('ime-list');
       this.imeCancelButton = document.getElementById('ime-cancel-button');
       this.imeConfirmButton = document.getElementById('ime-confirm-button');
+
       this.setupCancelButton =
         document.getElementById('setup-cancel-button');
       this.setupConfirmButton =
@@ -94,8 +89,10 @@
       window.addEventListener('applicationuninstall',
         this.handleApplicationUninstall.bind(this));
 
-      this.installButton.onclick = this.handleInstall.bind(this);
-      this.cancelButton.onclick = this.showInstallCancelDialog.bind(this);
+      this.dialog.elements.installButton.onclick =
+        this.handleInstall.bind(this);
+      this.dialog.elements.cancelButton.onclick =
+        this.showInstallCancelDialog.bind(this);
       this.confirmCancelButton.onclick = this.handleInstallCancel.bind(this);
       this.resumeButton.onclick = this.hideInstallCancelDialog.bind(this);
       this.notifContainer.onclick = this.showDownloadCancelDialog.bind(this);
@@ -128,7 +125,7 @@
     },
 
     handleHomeButtonPressed: function ai_handleHomeButtonPressed(e) {
-      this.dialog.classList.remove('visible');
+      this.dialog.element.classList.remove('visible');
       this.handleInstallCancel();
 
       // hide IME setup dialog if presented
@@ -182,28 +179,30 @@
         return;
       }
 
-      this.dialog.classList.add('visible');
+      this.dialog.element.classList.add('visible');
 
       var id = detail.id;
 
       if (manifest.size) {
-        this.size.textContent = this.humanizeSize(manifest.size);
+        this.dialog.elements.size.textContent =
+          this.humanizeSize(manifest.size);
       } else {
-        this.size.textContent = _('size-unknown');
+        this.dialog.elements.size.textContent = _('size-unknown');
       }
 
       // Wrap manifest to get localized properties
       manifest = new ManifestHelper(manifest);
       var msg = _('install-app', {'name': manifest.name});
-      this.msg.textContent = msg;
+      this.dialog.elements.msg.textContent = msg;
 
       if (manifest.developer) {
-        this.authorName.textContent = manifest.developer.name ||
+        this.dialog.elements.authorName.textContent = manifest.developer.name ||
           _('author-unknown');
-        this.authorUrl.textContent = manifest.developer.url || '';
+        this.dialog.elements.authorUrl.textContent =
+          manifest.developer.url || '';
       } else {
-        this.authorName.textContent = _('author-unknown');
-        this.authorUrl.textContent = '';
+        this.dialog.elements.authorName.textContent = _('author-unknown');
+        this.dialog.elements.authorUrl.textContent = '';
       }
 
       this.installCallback = (function ai_installCallback() {
@@ -224,7 +223,7 @@
         this.installCallback();
       }
       this.installCallback = null;
-      this.dialog.classList.remove('visible');
+      this.dialog.element.classList.remove('visible');
     },
 
     handleAppUninstallPrompt: function ai_handleUninstallPrompt(detail) {
@@ -661,14 +660,14 @@
         evt.preventDefault();
       }
       this.installCancelDialog.classList.add('visible');
-      this.dialog.classList.remove('visible');
+      this.dialog.element.classList.remove('visible');
     },
 
     hideInstallCancelDialog: function ai_hideInstallCancelDialog(evt) {
       if (evt) {
         evt.preventDefault();
       }
-      this.dialog.classList.add('visible');
+      this.dialog.element.classList.add('visible');
       this.installCancelDialog.classList.remove('visible');
     },
 

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -46,24 +46,13 @@
       this.dialog = new AppInstallDialog();
       this.installCancelDialog = new AppInstallCancelDialog();
       this.downloadCancelDialog = new AppDownloadCancelDialog();
+      this.setupInstalledAppDialog = new SetupInstalledAppDialog();
 
       this.imeLayoutDialog = document.getElementById('ime-layout-dialog');
       this.imeListTemplate = document.getElementById('ime-list-template');
       this.imeList = document.getElementById('ime-list');
       this.imeCancelButton = document.getElementById('ime-cancel-button');
-      this.imeConfirmButton = document.getElementById('ime-confirm-button');
-
-      this.setupCancelButton =
-        document.getElementById('setup-cancel-button');
-      this.setupConfirmButton =
-        document.getElementById('setup-confirm-button');
-
-      this.setupInstalledAppDialog =
-        document.getElementById('setup-installed-app-dialog');
-
-      this.setupAppName = document.getElementById('setup-app-name');
-      this.setupAppDescription =
-        document.getElementById('setup-app-description');      
+      this.imeConfirmButton = document.getElementById('ime-confirm-button');     
 
       this.notifContainer =
               document.getElementById('install-manager-notification-container');
@@ -102,9 +91,11 @@
       this.downloadCancelDialog.elements.continueButton.onclick =
         this.handleCancelDownloadCancel.bind(this);
 
-      this.setupCancelButton.onclick = this.handleSetupCancelAction.bind(this);
-      this.setupConfirmButton.onclick =
-                               this.handleSetupConfirmAction.bind(this);
+      this.setupInstalledAppDialog.elements.cancelButton.onclick =
+        this.handleSetupCancelAction.bind(this);
+      this.setupInstalledAppDialog.elements.confirmButton.onclick =
+        this.handleSetupConfirmAction.bind(this);
+
       this.imeCancelButton.onclick = this.hideIMEList.bind(this);
       this.imeConfirmButton.onclick = this.handleImeConfirmAction.bind(this);
 
@@ -129,7 +120,7 @@
       this.handleInstallCancel();
 
       // hide IME setup dialog if presented
-      if (this.setupInstalledAppDialog.classList.contains('visible') ) {
+      if (!this.setupInstalledAppDialog.element.hidden) {
         this.handleSetupCancelAction();
       }
 
@@ -349,9 +340,10 @@
     },
 
     hideSetupDialog: function ai_hideSetupDialog() {
-      this.setupAppName.textContent = '';
-      this.setupAppDescription.textContent = '';
-      this.setupInstalledAppDialog.classList.remove('visible');
+      var setupInstalledAppDialog = this.setupInstalledAppDialog.elements;
+      setupInstalledAppDialog.appName.textContent = '';
+      setupInstalledAppDialog.appDescription.textContent = '';
+      this.setupInstalledAppDialog.hide();
     },
 
     showSetupDialog: function ai_showSetupDialog() {
@@ -360,11 +352,14 @@
       var appManifest = new ManifestHelper(manifest);
       var appName = appManifest.name;
       var appDescription = appManifest.description;
-      this.setupAppDescription.textContent = appDescription;
-      navigator.mozL10n.setAttributes(this.setupAppName,
-                                      'app-install-success',
-                                      { appName: appName });
-      this.setupInstalledAppDialog.classList.add('visible');
+      var setupInstalledAppDialog = this.setupInstalledAppDialog.elements;
+      setupInstalledAppDialog.appDescription.textContent = appDescription;
+      navigator.mozL10n.setAttributes(
+        setupInstalledAppDialog.appName,
+        'app-install-success',
+        { appName: appName }
+      );
+      this.setupInstalledAppDialog.show();
       window.dispatchEvent(new CustomEvent('applicationsetupdialogshow'));
     },
 

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -125,7 +125,7 @@
     },
 
     handleHomeButtonPressed: function ai_handleHomeButtonPressed(e) {
-      this.dialog.element.classList.remove('visible');
+      this.dialog.hide();
       this.handleInstallCancel();
 
       // hide IME setup dialog if presented
@@ -179,7 +179,7 @@
         return;
       }
 
-      this.dialog.element.classList.add('visible');
+      this.dialog.show();
 
       var id = detail.id;
 
@@ -193,7 +193,7 @@
       // Wrap manifest to get localized properties
       manifest = new ManifestHelper(manifest);
       var msg = _('install-app', {'name': manifest.name});
-      this.dialog.elements.msg.textContent = msg;
+      this.dialog.elements.message.textContent = msg;
 
       if (manifest.developer) {
         this.dialog.elements.authorName.textContent = manifest.developer.name ||
@@ -223,7 +223,7 @@
         this.installCallback();
       }
       this.installCallback = null;
-      this.dialog.element.classList.remove('visible');
+      this.dialog.hide();
     },
 
     handleAppUninstallPrompt: function ai_handleUninstallPrompt(detail) {
@@ -660,14 +660,14 @@
         evt.preventDefault();
       }
       this.installCancelDialog.classList.add('visible');
-      this.dialog.element.classList.remove('visible');
+      this.dialog.hide();
     },
 
     hideInstallCancelDialog: function ai_hideInstallCancelDialog(evt) {
       if (evt) {
         evt.preventDefault();
       }
-      this.dialog.element.classList.add('visible');
+      this.dialog.show();
       this.installCancelDialog.classList.remove('visible');
     },
 

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -693,6 +693,7 @@
       dialog.classList.add('visible');
       dialog.dataset.manifest = manifestURL;
       UtilityTray.hide();
+      // => Service.request('hide');
     },
 
     handleInstallCancel: function ai_handleInstallCancel() {

--- a/apps/system/js/app_install_manager.js
+++ b/apps/system/js/app_install_manager.js
@@ -45,6 +45,7 @@
 
       this.dialog = new AppInstallDialog();
       this.installCancelDialog = new AppInstallCancelDialog();
+      this.downloadCancelDialog = new AppDownloadCancelDialog();
 
       this.imeLayoutDialog = document.getElementById('ime-layout-dialog');
       this.imeListTemplate = document.getElementById('ime-list-template');
@@ -57,8 +58,6 @@
       this.setupConfirmButton =
         document.getElementById('setup-confirm-button');
 
-      this.downloadCancelDialog =
-        document.getElementById('app-download-cancel-dialog');
       this.setupInstalledAppDialog =
         document.getElementById('setup-installed-app-dialog');
 
@@ -98,9 +97,9 @@
 
       this.notifContainer.onclick = this.showDownloadCancelDialog.bind(this);
 
-      this.downloadCancelDialog.querySelector('.confirm').onclick =
+      this.downloadCancelDialog.elements.stopButton.onclick =
         this.handleConfirmDownloadCancel.bind(this);
-      this.downloadCancelDialog.querySelector('.cancel').onclick =
+      this.downloadCancelDialog.elements.continueButton.onclick =
         this.handleCancelDownloadCancel.bind(this);
 
       this.setupCancelButton.onclick = this.handleSetupCancelAction.bind(this);
@@ -685,14 +684,14 @@
           manifest = app.manifest || app.updateManifest,
           dialog = this.downloadCancelDialog;
 
-      var title = dialog.querySelector('h1');
+      var title = dialog.element.querySelector('h1');
 
       navigator.mozL10n.setAttributes(title, 'stopDownloading', {
         app: new ManifestHelper(manifest).name
       });
 
-      dialog.classList.add('visible');
-      dialog.dataset.manifest = manifestURL;
+      dialog.show();
+      dialog.element.dataset.manifest = manifestURL;
       UtilityTray.hide();
       // => Service.request('hide');
     },
@@ -707,8 +706,7 @@
 
     handleConfirmDownloadCancel: function ai_handleConfirmDownloadCancel(e) {
       e && e.preventDefault();
-      var dialog = this.downloadCancelDialog,
-          manifestURL = dialog.dataset.manifest;
+      var manifestURL = this.downloadCancelDialog.element.dataset.manifest;
       if (manifestURL) {
         var app = applications.getByManifestURL(manifestURL);
         app && app.cancelDownload();
@@ -724,8 +722,8 @@
 
     hideDownloadCancelDialog: function() {
       var dialog = this.downloadCancelDialog;
-      dialog.classList.remove('visible');
-      delete dialog.dataset.manifest;
+      dialog.hide();
+      delete dialog.element.dataset.manifest;
     }
   });
 }());

--- a/apps/system/js/core.js
+++ b/apps/system/js/core.js
@@ -12,7 +12,8 @@
 
   Core.SUB_MODULES = [
     'HierarchyManager',
-    'AirplaneMode'
+    'AirplaneMode',
+    'AppInstallManager'
   ];
 
   Core.SERVICES = [

--- a/apps/system/js/ime_layout_dialog.js
+++ b/apps/system/js/ime_layout_dialog.js
@@ -1,0 +1,98 @@
+/* global displayName */
+/* global imeName */
+
+'use strict';
+
+(function(exports) {
+  var ImeLayoutDialog = function AppInstallDialog(options) {
+    this.options = options || {};
+    this.render();
+    this.publish('created');
+  };
+
+  ImeLayoutDialog.prototype =
+    Object.create(window.SystemDialog.prototype);
+
+  ImeLayoutDialog.prototype.customID = 'ime-layout-dialog';
+
+  ImeLayoutDialog.prototype.DEBUG = false;
+
+  /**
+   * Used for element id access.
+   * e.g., 'authentication-dialog-alert-ok'
+   * @type {String}
+   * @memberof ImeLayoutDialog.prototype
+   */
+  ImeLayoutDialog.prototype.ELEMENT_PREFIX = 'ime-';
+
+  /**
+   * Maps to DOM elements.
+   * @type {Object}
+   * @memberof ImeLayoutDialog.prototype
+   */
+  ImeLayoutDialog.prototype.elements = null;
+
+  ImeLayoutDialog.prototype._fetchElements =
+    function appid__fetchElements() {
+    this.element = document.getElementById(this.instanceID);
+    this.elements = {};
+
+    var toCamelCase = function toCamelCase(str) {
+      return str.replace(/\-(.)/g, function replacer(str, p1) {
+        return p1.toUpperCase();
+      });
+    };
+
+    this.elementIds = [
+      'list-template', 'list',
+      'cancel-button', 'confirm-button'
+    ];
+
+    this.elementIds.forEach(function createElementRef(id) {
+      this.elements[toCamelCase(id)] =
+        this.element.querySelector('#' + this.ELEMENT_PREFIX + id);
+    }, this);
+  };
+
+  ImeLayoutDialog.prototype.view = function appid_view() {
+    return `<form id="${this.instanceID}"
+            data-type="confirm" role="dialog"
+            data-z-index-level="ime-layout-dialog" hidden>
+              <section>
+                <h1 data-l10n-id="ime-addkeyboards">Add keyboards</h1>
+                <!-- template for selecting IME layout
+                after 3rd-party keyboard installed -->
+                <div id="ime-list-template" hidden>
+                  <!--
+                  <li>
+                    <a>${displayName}</a>
+                    <label class="pack-checkbox ime">
+                      <input type="checkbox" name="keyboards"
+                      value="${imeName}">
+                      <span></span>
+                    </label>
+                  </li>
+                  -->
+                </div>
+                <ul id="ime-list"></ul>
+              </section>
+              <menu data-items="2">
+                <button id="ime-cancel-button" type="button" 
+                data-l10n-id="cancel">
+                  Cancel
+                </button>
+                <button id="ime-confirm-button" class="recommend" 
+                type="button" data-l10n-id="confirm">
+                  Confirm
+                </button>
+              </menu>
+            </form>`;
+  };
+
+  ImeLayoutDialog.prototype.getView = function appid_getView() {
+    return document.getElementById(this.instanceID);
+  };
+
+  exports.ImeLayoutDialog = ImeLayoutDialog;
+
+}(window));

--- a/apps/system/js/ime_layout_dialog.js
+++ b/apps/system/js/ime_layout_dialog.js
@@ -4,7 +4,7 @@
 'use strict';
 
 (function(exports) {
-  var ImeLayoutDialog = function AppInstallDialog(options) {
+  var ImeLayoutDialog = function ImeLayoutDialog(options) {
     this.options = options || {};
     this.render();
     this.publish('created');
@@ -44,8 +44,7 @@
     };
 
     this.elementIds = [
-      'list-template', 'list',
-      'cancel-button', 'confirm-button'
+      'list', 'cancel-button', 'confirm-button'
     ];
 
     this.elementIds.forEach(function createElementRef(id) {
@@ -55,25 +54,13 @@
   };
 
   ImeLayoutDialog.prototype.view = function appid_view() {
-    return `<form id="${this.instanceID}"
+    return `<form id="${this.instanceID}" class="generic-dialog" 
             data-type="confirm" role="dialog"
             data-z-index-level="ime-layout-dialog" hidden>
               <section>
                 <h1 data-l10n-id="ime-addkeyboards">Add keyboards</h1>
                 <!-- template for selecting IME layout
                 after 3rd-party keyboard installed -->
-                <div id="ime-list-template" hidden>
-                  <!--
-                  <li>
-                    <a>${displayName}</a>
-                    <label class="pack-checkbox ime">
-                      <input type="checkbox" name="keyboards"
-                      value="${imeName}">
-                      <span></span>
-                    </label>
-                  </li>
-                  -->
-                </div>
                 <ul id="ime-list"></ul>
               </section>
               <menu data-items="2">
@@ -87,6 +74,22 @@
                 </button>
               </menu>
             </form>`;
+  };
+
+  ImeLayoutDialog.prototype.renderList = function appid_renderList(names) {
+    // build the list of keyboard layouts
+    var listHtml = '';
+    var imeLayoutDialog = this.imeLayoutDialog;
+    names.forEach(function(name) {
+      listHtml += `<li>
+                     <a>${name.displayName}</a>
+                     <label class="pack-checkbox ime">
+                       <input type="checkbox" name="keyboards" value="${name.name}">
+                       <span></span>
+                     </label>
+                   </li>`;
+    });
+    this.elements.list.innerHTML = listHtml;
   };
 
   ImeLayoutDialog.prototype.getView = function appid_getView() {

--- a/apps/system/js/setup_installed_app_dialog.js
+++ b/apps/system/js/setup_installed_app_dialog.js
@@ -1,0 +1,80 @@
+'use strict';
+
+(function(exports) {
+  var SetupInstalledAppDialog = function SetupInstalledAppDialog(options) {
+    this.options = options || {};
+    this.render();
+    this.publish('created');
+  };
+
+  SetupInstalledAppDialog.prototype = Object.create(window.SystemDialog.prototype);
+
+  SetupInstalledAppDialog.prototype.customID = 'setup-installed-app-dialog';
+
+  SetupInstalledAppDialog.prototype.DEBUG = false;
+
+  /**
+   * Used for element id access.
+   * e.g., 'authentication-dialog-alert-ok'
+   * @type {String}
+   * @memberof SetupInstalledAppDialog.prototype
+   */
+  SetupInstalledAppDialog.prototype.ELEMENT_PREFIX = 'setup-';
+
+  /**
+   * Maps to DOM elements.
+   * @type {Object}
+   * @memberof SetupInstalledAppDialog.prototype
+   */
+  SetupInstalledAppDialog.prototype.elements = null;
+
+  SetupInstalledAppDialog.prototype._fetchElements =
+    function appid__fetchElements() {
+    this.element = document.getElementById(this.instanceID);
+    this.elements = {};
+
+    var toCamelCase = function toCamelCase(str) {
+      return str.replace(/\-(.)/g, function replacer(str, p1) {
+        return p1.toUpperCase();
+      });
+    };
+
+    this.elementIds = [
+      'app-name', 'app-description',
+      'cancel-button', 'confirm-button'
+    ];
+
+    this.elementIds.forEach(function createElementRef(id) {
+      this.elements[toCamelCase(id)] =
+        this.element.querySelector('#' + this.ELEMENT_PREFIX + id);
+    }, this);
+  };
+
+  SetupInstalledAppDialog.prototype.view = function appid_view() {
+    return `<form id="${this.instanceID}" class="generic-dialog"
+            data-type="confirm" role="dialog"
+            data-z-index-level="setup-installed-app-dialog" hidden>
+              <section>
+                <h1 id="setup-app-name"></h1>
+                <p id="setup-app-description"></p>
+              </section>
+              <menu data-items="2">
+                <button id="setup-cancel-button" type="button" 
+                data-l10n-id="later">
+                  Later
+                </button>
+                <button id="setup-confirm-button" 
+                class="recommend" type="button" data-l10n-id="setup">
+                  Setup
+                </button>
+              </menu>
+            </form>`;
+  };
+
+  SetupInstalledAppDialog.prototype.getView = function appid_getView() {
+    return document.getElementById(this.instanceID);
+  };
+
+  exports.SetupInstalledAppDialog = SetupInstalledAppDialog;
+
+}(window));

--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -1,41 +1,7 @@
-/* dialog */
-/* FIXME we have to see why we need such specific style here and why
- * the general style in confirm.css isn't sufficient */
-#ime-layout-dialog {
-  display: none;
-  top: 3rem;
-  pointer-events: none;
-}
 
-/* Shift the bottom of the prompt to account for the height of the
-   software home button */
-#screen.software-button-enabled #ime-layout-dialog {
-  bottom: var(--software-home-button-height);
-}
-
-@media (orientation: landscape) {
-  #screen.software-button-enabled #ime-layout-dialog {
-    bottom: 0;
-    right: var(--software-home-button-height);
-  }
-}
-
-#ime-layout-dialog.visible {
-  display: inline-block;
-  pointer-events: auto;
-}
 
 #app-uninstall-dialog {
   position: absolute;
-}
-
-#ime-layout-dialog section section {
-  height: auto;
-}
-
-#ime-layout-dialog h1 {
-  border-bottom: none;
-  background: none;
 }
 
 /* ... end of dialog */

--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -3,7 +3,6 @@
  * the general style in confirm.css isn't sufficient */
 #setup-installed-app-dialog,
 #ime-layout-dialog,
-#app-install-cancel-dialog,
 #app-download-cancel-dialog {
   display: none;
   top: 3rem;
@@ -14,7 +13,6 @@
    software home button */
 #screen.software-button-enabled #setup-installed-app-dialog,
 #screen.software-button-enabled #ime-layout-dialog,
-#screen.software-button-enabled #app-install-cancel-dialog,
 #screen.software-button-enabled #app-download-cancel-dialog {
   bottom: var(--software-home-button-height);
 }
@@ -22,7 +20,6 @@
 @media (orientation: landscape) {
   #screen.software-button-enabled #setup-installed-app-dialog,
   #screen.software-button-enabled #ime-layout-dialog,
-  #screen.software-button-enabled #app-install-cancel-dialog,
   #screen.software-button-enabled #app-download-cancel-dialog {
     bottom: 0;
     right: var(--software-home-button-height);
@@ -31,7 +28,6 @@
 
 #setup-installed-app-dialog.visible,
 #ime-layout-dialog.visible,
-#app-install-cancel-dialog.visible,
 #app-download-cancel-dialog.visible {
   display: inline-block;
   pointer-events: auto;
@@ -43,14 +39,12 @@
 
 #setup-installed-app-dialog section,
 #ime-layout-dialog section,
-#app-install-cancel-dialog section,
 #app-download-cancel-dialog section {
   height: auto;
 }
 
 #setup-installed-app-dialog h1,
 #ime-layout-dialog h1,
-#app-install-cancel-dialog h1,
 #app-download-cancel-dialog h1 {
   border-bottom: none;
   background: none;

--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -3,7 +3,6 @@
  * the general style in confirm.css isn't sufficient */
 #setup-installed-app-dialog,
 #ime-layout-dialog,
-#app-install-dialog,
 #app-install-cancel-dialog,
 #app-download-cancel-dialog {
   display: none;
@@ -15,7 +14,6 @@
    software home button */
 #screen.software-button-enabled #setup-installed-app-dialog,
 #screen.software-button-enabled #ime-layout-dialog,
-#screen.software-button-enabled #app-install-dialog,
 #screen.software-button-enabled #app-install-cancel-dialog,
 #screen.software-button-enabled #app-download-cancel-dialog {
   bottom: var(--software-home-button-height);
@@ -24,7 +22,6 @@
 @media (orientation: landscape) {
   #screen.software-button-enabled #setup-installed-app-dialog,
   #screen.software-button-enabled #ime-layout-dialog,
-  #screen.software-button-enabled #app-install-dialog,
   #screen.software-button-enabled #app-install-cancel-dialog,
   #screen.software-button-enabled #app-download-cancel-dialog {
     bottom: 0;
@@ -34,7 +31,6 @@
 
 #setup-installed-app-dialog.visible,
 #ime-layout-dialog.visible,
-#app-install-dialog.visible,
 #app-install-cancel-dialog.visible,
 #app-download-cancel-dialog.visible {
   display: inline-block;
@@ -47,7 +43,6 @@
 
 #setup-installed-app-dialog section,
 #ime-layout-dialog section,
-#app-install-dialog section,
 #app-install-cancel-dialog section,
 #app-download-cancel-dialog section {
   height: auto;
@@ -55,18 +50,10 @@
 
 #setup-installed-app-dialog h1,
 #ime-layout-dialog h1,
-#app-install-dialog h1,
 #app-install-cancel-dialog h1,
 #app-download-cancel-dialog h1 {
   border-bottom: none;
   background: none;
-}
-
-#app-install-dialog dl > dt {
-  width: 8rem;
-  margin-right: 1rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 #app-install-cancel-dialog small:first-child {

--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -2,8 +2,7 @@
 /* FIXME we have to see why we need such specific style here and why
  * the general style in confirm.css isn't sufficient */
 #setup-installed-app-dialog,
-#ime-layout-dialog,
-#app-download-cancel-dialog {
+#ime-layout-dialog {
   display: none;
   top: 3rem;
   pointer-events: none;
@@ -12,23 +11,20 @@
 /* Shift the bottom of the prompt to account for the height of the
    software home button */
 #screen.software-button-enabled #setup-installed-app-dialog,
-#screen.software-button-enabled #ime-layout-dialog,
-#screen.software-button-enabled #app-download-cancel-dialog {
+#screen.software-button-enabled #ime-layout-dialog {
   bottom: var(--software-home-button-height);
 }
 
 @media (orientation: landscape) {
   #screen.software-button-enabled #setup-installed-app-dialog,
-  #screen.software-button-enabled #ime-layout-dialog,
-  #screen.software-button-enabled #app-download-cancel-dialog {
+  #screen.software-button-enabled #ime-layout-dialog {
     bottom: 0;
     right: var(--software-home-button-height);
   }
 }
 
 #setup-installed-app-dialog.visible,
-#ime-layout-dialog.visible,
-#app-download-cancel-dialog.visible {
+#ime-layout-dialog.visible {
   display: inline-block;
   pointer-events: auto;
 }
@@ -38,14 +34,12 @@
 }
 
 #setup-installed-app-dialog section,
-#ime-layout-dialog section,
-#app-download-cancel-dialog section {
+#ime-layout-dialog section section {
   height: auto;
 }
 
 #setup-installed-app-dialog h1,
-#ime-layout-dialog h1,
-#app-download-cancel-dialog h1 {
+#ime-layout-dialog h1 {
   border-bottom: none;
   background: none;
 }

--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -1,7 +1,6 @@
 /* dialog */
 /* FIXME we have to see why we need such specific style here and why
  * the general style in confirm.css isn't sufficient */
-#setup-installed-app-dialog,
 #ime-layout-dialog {
   display: none;
   top: 3rem;
@@ -10,20 +9,17 @@
 
 /* Shift the bottom of the prompt to account for the height of the
    software home button */
-#screen.software-button-enabled #setup-installed-app-dialog,
 #screen.software-button-enabled #ime-layout-dialog {
   bottom: var(--software-home-button-height);
 }
 
 @media (orientation: landscape) {
-  #screen.software-button-enabled #setup-installed-app-dialog,
   #screen.software-button-enabled #ime-layout-dialog {
     bottom: 0;
     right: var(--software-home-button-height);
   }
 }
 
-#setup-installed-app-dialog.visible,
 #ime-layout-dialog.visible {
   display: inline-block;
   pointer-events: auto;
@@ -33,19 +29,13 @@
   position: absolute;
 }
 
-#setup-installed-app-dialog section,
 #ime-layout-dialog section section {
   height: auto;
 }
 
-#setup-installed-app-dialog h1,
 #ime-layout-dialog h1 {
   border-bottom: none;
   background: none;
-}
-
-#app-install-cancel-dialog small:first-child {
-  margin-bottom: 1rem;
 }
 
 /* ... end of dialog */


### PR DESCRIPTION
Currently, I created `AppInstallManager` module with `BaseModule`, and I used system dialog module for `AppInstallDialog`, `AppInstallCancelDialog`, `AppDownloadCancelDialog`, `SetupInstalledAppDialog`, and `ImeLayoutDialog` dialogs.

That is our phase one for the refactor work.
In the phase two, I will use `Service.request()` to remove the global object in the top of `app_install_manager.js`.
