### PR TITLE
Bug 1122451 - Enable test_lockscreen_unlock_to_camera_with_passcode.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
@@ -16,7 +16,6 @@ camera = true
 skip-if = device == "desktop"
 smoketest = true
 camera = true
-disabled = Bug 1078270 - Camera app dies/crashes after unlocking from lockscreen with passcode
 
 [test_lockscreen_unlock_to_homescreen_with_passcode.py]
 


### PR DESCRIPTION
Due to Bug 1078270 was fixed, so enable this test script.
