### PR TITLE
Bug 1120704 - No longer "freeze" the iframe sizing for background apps on orientation change. r=alive +autoland

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -857,13 +857,6 @@
       }
     }
 
-    // We don't want to resize/reflow all backgrounds app
-    // so we make sure the iframe doesn't get resized
-    if (this.browser) {
-      this.iframe.style.width = this.width + 'px';
-      this.iframe.style.height = this.height + 'px';
-    }
-
     var width = layoutManager.width;
     var height = layoutManager.getHeightFor(this);
     this.element.style.width = width + 'px';
@@ -1244,11 +1237,6 @@
    */
   AppWindow.prototype._hideScreenshotOverlay =
     function aw__hideScreenshotOverlay() {
-      // The iframe might be "freezed" to an old size
-      // making sure it's resized properly before dipslaying it
-      this.iframe.style.width = '';
-      this.iframe.style.height = '';
-
       if (!this.screenshotOverlay ||
           !this.screenshotOverlay.classList.contains('visible')) {
         return;

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -691,17 +691,6 @@ suite('system/AppWindow', function() {
       assert.isFalse(app1.element.classList.contains('overlay'));
     });
 
-    test('should reset the iframe inline size when hiding the overlay',
-    function() {
-      app1.iframe.style.width = '480px';
-      app1.iframe.style.height = '320px';
-
-      app1._hideScreenshotOverlay();
-
-      assert.equal(app1.iframe.style.width, '');
-      assert.equal(app1.iframe.style.height, '');
-    });
-
     test('hideScreenshotOverlay noop when the screenshot is not displayed',
     function() {
       app1._screenshotOverlayState = 'none';
@@ -1871,8 +1860,6 @@ suite('system/AppWindow', function() {
 
       assert.equal(app1.element.style.width, '480px');
       assert.equal(app1.element.style.height, '300px');
-      assert.equal(app1.iframe.style.width, '320px');
-      assert.equal(app1.iframe.style.height, '460px');
 
       assert.equal(app1.screenshotOverlay.style.visibility, 'hidden');
     });
@@ -1906,8 +1893,6 @@ suite('system/AppWindow', function() {
       assert.equal(app1.element.style.width, layoutManager.width + 'px');
       assert.equal(app1.element.style.height,
         (layoutManager.height - 100) + 'px');
-      assert.equal(app1.iframe.style.width, '');
-      assert.equal(app1.iframe.style.height, '');
     });
 
     test('Orientation change event on active but not top most app', function() {
@@ -1922,8 +1907,6 @@ suite('system/AppWindow', function() {
 
       assert.equal(app1.element.style.width, layoutManager.width + 'px');
       assert.equal(app1.element.style.height, layoutManager.height + 'px');
-      assert.equal(app1.iframe.style.width, '');
-      assert.equal(app1.iframe.style.height, '');
     });
 
     test('Orientation change event on active homescreen app', function() {
@@ -1947,8 +1930,6 @@ suite('system/AppWindow', function() {
         'prevent it is modified by other background app');
       assert.equal(app1.element.style.width, '460px');
       assert.equal(app1.element.style.height, '320px');
-      assert.equal(app1.iframe.style.width, '320px');
-      assert.equal(app1.iframe.style.height, '460px');
       MockService.currentApp = null;
     });
 
@@ -1967,8 +1948,6 @@ suite('system/AppWindow', function() {
 
       assert.equal(app1.element.style.width, '480px');
       assert.equal(app1.element.style.height, '320px');
-      assert.equal(app1.iframe.style.width, '320px');
-      assert.equal(app1.iframe.style.height, '480px');
 
       assert.equal(app1.screenshotOverlay.style.visibility, 'hidden');
     });


### PR DESCRIPTION
This was originally done to prevent reflows but it's not working. So the added complexity isn't worth it.
