### PR TITLE
Bug 1116728 - [Flame][Email]When sending email to several recipients whose addresses are separated by semicolon, the email can’t be sent successfully. r=andris9

### DIFF
--- a/apps/email/js/ext/ext/addressparser.js
+++ b/apps/email/js/ext/ext/addressparser.js
@@ -237,7 +237,15 @@
         "(": ")",
         "<": ">",
         ",": "",
-        ":": ";"
+        // Groups are ended by semicolons
+        ":": ";",
+        // Semicolons are not a legal delimiter per the RFC2822 grammar other
+        // than for terminating a group, but they are also not valid for any
+        // other use in this context.  Given that some mail clients have
+        // historically allowed the semicolon as a delimiter equivalent to the
+        // comma in their UI, it makes sense to treat them the same as a comma
+        // when used outside of a group.
+        ";": ""
     };
 
     /**


### PR DESCRIPTION
land https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/359
