### PR TITLE
Bug 1124081 - Warning about configuring email without SSL has not enough space for localization

### DIFF
--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -455,3 +455,28 @@ cards-settings-debug button {
   margin: 1.5rem auto;
   width: calc(100% - 3rem);
 }
+
+/* Shared style overrides for the "are you sure" unencrypted connection
+   confirmation. Since the button text is longer than the typical yes/no, give
+   each button full width, with them stacked on top of each other. Also remove
+   extraneous p border. */
+form.tng-plain-socket-confirm[role="dialog"][data-type="confirm"] {
+   padding-bottom: 13rem;
+}
+
+form.tng-plain-socket-confirm[role="dialog"][data-type="confirm"] menu {
+  display: block;
+  white-space: unset;
+}
+
+form.tng-plain-socket-confirm[role="dialog"][data-type="confirm"] menu button {
+  margin: 0.5rem 0;
+}
+
+form.tng-plain-socket-confirm[role="dialog"][data-type="confirm"] p {
+  border-top: 0;
+}
+
+form.tng-plain-socket-confirm[role="dialog"][data-type="confirm"] p:first-of-type {
+  border-top: 0.1rem solid #686868;
+}


### PR DESCRIPTION
Overrides some shared styles for confirm dialogs:
- Buttons are vertically stacked, so that "Learn More" is on the top, and buttons take full width of screen.
- The existing padding-bottom in the shared styles for the form is increased to account for the use of vertical space of the buttons.
- Paragraph border is only applied to the first paragraph.

The paragraph area is scrollable, so if the localization needs more space, the user will be able to scroll to see the rest of the text.

Picture of how it looks now on a flame device:

![2015-01-21-12-18-49](https://cloud.githubusercontent.com/assets/73359/5844478/07468a00-a169-11e4-8f87-d23e80aca9df.png)
