### PR TITLE
Bug 1117710 - [FFOS2.0][Woodduck][WIFI]WIFI signal strength icon does no...

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -1386,8 +1386,8 @@ var StatusBar = {
           if (icon.dataset.connecting) {
             delete icon.dataset.connecting;
           }
-          var level = Math.floor(
-            wifiManager.connectionInformation.relSignalStrength / 25);
+          var level = Math.min(Math.floor(
+            wifiManager.connectionInformation.relSignalStrength / 20), 4);
           icon.dataset.level = level;
           icon.setAttribute('aria-label', navigator.mozL10n.get(
             'statusbarWiFiConnected', {level: level}));


### PR DESCRIPTION
...t matched with the strength shown on status bar.
- Apply the calculation of wifi signal strength in the settings app to the system app.
