### PR TITLE
Bug 1119130 - Clock tabs should not be selectable. +autoland

### DIFF
--- a/apps/clock/style/clock.css
+++ b/apps/clock/style/clock.css
@@ -13,6 +13,11 @@ html, body {
   -moz-user-select: none;
 }
 
+/* Absolutely-positioned elements don't inherit -moz-user-select. */
+#clock-tabs {
+  -moz-user-select: none;
+}
+
 #clock-view {
   width: 100%;
   height: calc(100% - 0.13rem);


### PR DESCRIPTION
Turns out, -moz-user-select doesn't apply to absolutely-positioned
elements. Only in Firefox.
