### PR TITLE
Bug 1120513 - Replace task-manager color (not tab view) r=etienne

### DIFF
--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -7,7 +7,7 @@
   height: 100%;
   -moz-user-select: none;
   overflow: hidden;
-  background-color: black;
+  background-color: rgb(51, 51, 51);
 }
 
 @media not all and (-moz-physical-home-button) {
@@ -58,7 +58,7 @@
 }
 
 #cards-view.empty {
-  background-color: rgba(0, 0, 0, .8);
+  background-color: rgba(51, 51, 51, .85);
 }
 
 #cards-view ul {


### PR DESCRIPTION
Just swaps out the background color for the (apps-mode) task manager. Empty state and filtered/tab view is unchanged. 
