### PR TITLE
Bug 1124426 - [email/UI] The cookie cache may permanently screw up if we ever have more than 40 cookies worth of cache

### DIFF
--- a/apps/email/js/html_cache.js
+++ b/apps/email/js/html_cache.js
@@ -1,5 +1,5 @@
-// HTML_COOKIE_CACHE_VERSION is set in html_cache_restore as a global.
-/*global HTML_COOKIE_CACHE_VERSION */
+// These vars are set in html_cache_restore as a globals.
+/*global HTML_COOKIE_CACHE_VERSION, HTML_COOKIE_CACHE_MAX_SEGMENTS */
 'use strict';
 define(function(require, exports) {
 
@@ -62,8 +62,14 @@ exports.save = function htmlCacheSave(html) {
       endPoint = length;
     }
 
-    document.cookie = 'htmlc' + index + '=' + html.substring(i, endPoint) +
-                      '; expires=' + expiry;
+    // Do not write cookie values past the max. Preferring this approach to
+    // doing two loops, one to generate segments strings, then another to
+    // set document.cookie for each segment. For the usual good case, the
+    // cache fits within the max segments.
+    if (index < HTML_COOKIE_CACHE_MAX_SEGMENTS) {
+      document.cookie = 'htmlc' + index + '=' + html.substring(i, endPoint) +
+                        '; expires=' + expiry;
+    }
   }
 
   // If previous cookie was bigger, clear out the other values,
@@ -71,12 +77,11 @@ exports.save = function htmlCacheSave(html) {
   // reassembling. If the cache saved is too big, just clear it as
   // there will likely be cache corruption/partial, bad HTML saved
   // otherwise.
-  var maxSegment = 40;
-  if (index > 39) {
+  if (index > HTML_COOKIE_CACHE_MAX_SEGMENTS - 1) {
     index = 0;
     console.log('htmlCache.save TOO BIG. Removing all of it.');
   }
-  for (i = index; i < maxSegment; i++) {
+  for (i = index; i < HTML_COOKIE_CACHE_MAX_SEGMENTS; i++) {
     document.cookie = 'htmlc' + i + '=; expires=' + expiry;
   }
 

--- a/apps/email/js/html_cache_restore.js
+++ b/apps/email/js/html_cache_restore.js
@@ -23,6 +23,12 @@ var startupCacheEventsSent = false;
  */
 var HTML_COOKIE_CACHE_VERSION = '2';
 
+/**
+ * Max size of cookie cache segments. Set as a global because it is also used by
+ * html_cache.js.
+ */
+var HTML_COOKIE_CACHE_MAX_SEGMENTS = 40;
+
 // Use a global to work around issue with
 // navigator.mozHasPendingMessage only returning
 // true to the first call made to it.
@@ -210,6 +216,17 @@ window.htmlCacheRestorePendingMessage = [];
 
     while ((match = pairRegExp.exec(value))) {
       segments[parseInt(match[1], 10)] = match[2] || '';
+    }
+
+    if (segments.length > HTML_COOKIE_CACHE_MAX_SEGMENTS) {
+      // Somehow, garbage got in the a higher segment level than the one used by
+      // html_cache, which makes sure the spaced up to the max is well gardened.
+      // So it is safe to just use the max segment size vs just dumping the
+      // whole cache.
+      console.warn('Trimming cache segments of ' + segments.length +
+                   ' to well kept limit of ' + HTML_COOKIE_CACHE_MAX_SEGMENTS);
+      segments.splice(HTML_COOKIE_CACHE_MAX_SEGMENTS,
+                      segments.length - HTML_COOKIE_CACHE_MAX_SEGMENTS);
     }
 
     value = decodeURIComponent(segments.join(''));


### PR DESCRIPTION
Max segments now in a global HTML_COOKIE_CACHE_MAX_SEGMENTS, and html_cache.js does not write past that now for cookies, and html_cache_restore.js will not use values past that value.

Since html_cache.js has always kept that 40 segment area clean, this should be enough to ignore any cases where we get garbage above the 40 segment max.
