### PR TITLE
Bug 1125007 - [Text Selection] "Loading" during adding smart collection should not be selected 

### DIFF
--- a/apps/collection/style/css/base.css
+++ b/apps/collection/style/css/base.css
@@ -12,3 +12,7 @@ body {
 html[dir="rtl"] {
   direction: ltr;
 }
+
+section {
+  -moz-user-select: none;
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1125007
