### PR TITLE
Bug 1124098 - Hide the Get More Languages link in devices other than phones

### DIFF
--- a/apps/settings/elements/languages.html
+++ b/apps/settings/elements/languages.html
@@ -29,7 +29,7 @@
             </select>
           </span>
         </li>
-        <li>
+        <li hidden class="more-languages">
           <a class="menu-item menuItem-more-languages" href="#">
             <span data-l10n-id="more-languages"></span>
           </a>

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" type="text/css" href="style/icons.css">
     <link rel="stylesheet" type="text/css" href="style/settings.css">
     <link rel="stylesheet" type="text/css" href="style/settings_large.css" data-device-type="tablet">
+    <link rel="stylesheet" type="text/css" href="style/settings_phone.css" data-device-type="phone">
     <link rel="stylesheet" type="text/css" href="style/dialog.css">
     <!-- Panel Stylesheets
     <link rel="stylesheet" type="text/css" href="shared/style/action_menu.css"/>

--- a/apps/settings/js/panels/languages/languages.js
+++ b/apps/settings/js/panels/languages/languages.js
@@ -55,7 +55,12 @@ define(function(require) {
       this.panel = panel;
       this.elements = elements;
 
-      this.elements.moreLanguages.onclick = this.showMoreLanguages;
+      // Installing additional languages is only available on phones for now;
+      // see https://bugzil.la/1124098.  On other device types the link to the
+      // Marketpace is hidden.  Don't set the handler if it's display: none.
+      if (this.elements.moreLanguages.offsetParent) {
+        this.elements.moreLanguages.onclick = this.showMoreLanguages;
+      }
       this.elements.langSel.onblur = this.buildList.bind(this);
     },
     onLocalized: function() {

--- a/apps/settings/style/settings_phone.css
+++ b/apps/settings/style/settings_phone.css
@@ -1,0 +1,13 @@
+/**
+ * Settings style & layout for phone
+ */
+
+/******************************************************************************
+ * Languages
+ *
+ * On phones the Get More Languages link should be visible.
+ * See https://bugzil.la/1124098.
+ */
+#languages .more-languages[hidden] {
+  display: block;
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1124098
