### PR TITLE
Bug 1119697 - return to homescreen on home event. r=etienne

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -506,6 +506,7 @@
 
   TaskManager.prototype._handle_home = function() {
     if (this.isActive()) {
+      this._shouldGoBackHome = true;
       this.exitToApp();
       return false;
     }

--- a/apps/system/test/marionette/task_manager_test.js
+++ b/apps/system/test/marionette/task_manager_test.js
@@ -115,14 +115,16 @@ marionette('Task Manager', function() {
       });
     });
 
-    test('pressing home should launch the centered app', function() {
+    test('pressing home should still take you back to the homescreen',
+    function() {
       actions.flick(taskManager.element, 30, halfHeight,
                     halfWidth, halfHeight).perform();
 
       taskManager.hide();
 
-      client.waitFor(function() {
-        return !firstApp.iframe.displayed() && secondApp.iframe.displayed();
+      client.waitFor(function(){
+        return client.findElement(system.Selector.activeHomescreenFrame)
+          .displayed();
       });
     });
   });

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -1050,7 +1050,7 @@ suite('system/TaskManager >', function() {
 
       window.dispatchEvent(new CustomEvent('lockscreen-appopened'));
       waitForEvent(window, 'cardviewclosed').then(function() {
-        sinon.assert.calledOrder([taskManager.exitToApp, taskManager.hide]);
+        sinon.assert.callOrder(taskManager.exitToApp, taskManager.hide);
       }, failOnReject);
     });
 
@@ -1061,7 +1061,7 @@ suite('system/TaskManager >', function() {
 
       window.dispatchEvent(new CustomEvent('attentionopened'));
       waitForEvent(window, 'cardviewclosed').then(function() {
-        sinon.assert.calledOrder([taskManager.exitToApp, taskManager.hide]);
+        sinon.assert.callOrder(taskManager.exitToApp, taskManager.hide);
       }, failOnReject);
     });
 
@@ -1132,18 +1132,17 @@ suite('system/TaskManager >', function() {
         fakeFinish(this.sinon.clock, activeApp);
       });
 
-      test('active app is opened on home event', function(done) {
-        var activeApp = MockService.currentApp;
-        var stub = this.sinon.stub(activeApp, 'open');
+      test('home should go back home', function(done) {
+        var stub = this.sinon.stub(home, 'open');
 
         waitForEvent(window, 'cardviewclosed').then(function() {
-          assert.isTrue(stub.calledOnce, 'active app open method was called');
+          assert.isTrue(stub.calledOnce, 'home was opened');
         }, failOnReject)
         .then(function() { done(); }, done);
 
         var event = new CustomEvent('home');
         taskManager.respondToHierarchyEvent(event);
-        fakeFinish(this.sinon.clock, activeApp);
+        fakeFinish(this.sinon.clock, home);
       });
 
       test('newStackPosition is defined when app is selected', function(done) {


### PR DESCRIPTION
Make 'home' behavior consistent in task manager so we always go back to homescreen. Update unit test for this and fix some calledOrder -> callOrder exceptions I was seeing
