### PR TITLE
Bug 1123262 - [Midori 2.0]WLAN:signal strenght levels are not supported ...

### DIFF
--- a/apps/system/js/statusbar.js
+++ b/apps/system/js/statusbar.js
@@ -912,7 +912,7 @@ var StatusBar = {
     if (active) {
       var wifiManager = window.navigator.mozWifiManager;
       if (wifiManager) {
-        wifiManager.connectionInfoUpdate = this.update.wifi.bind(this);
+        wifiManager.onconnectioninfoupdate = this.update.wifi.bind(this);
       }
 
       this.update.wifi.call(this);


### PR DESCRIPTION
...on notification bar
- Correct the wifi 'onconnectioninfoupdate' usage.
