### PR TITLE
Bug 1110532 - [Email][Search] Inputting then quickly deleting characters in the Email Search field causes text overlap with erroneous search results

### DIFF
--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -692,11 +692,6 @@ return [
       this.curPhrase = phrase;
       this.curFilter = filter;
 
-      if (phrase.length < 1) {
-        this.showEmptyLayout();
-        return false;
-      }
-
       // We are creating a new slice, so any pending snippet requests are moot.
       this._snippetRequestPending = false;
       // Don't bother the new slice with requests until we hears it completion


### PR DESCRIPTION
Brings over the gelam change from https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/364 and removes the phrase.length short circuit in message_list.js to allow the empty search to complete on its own.
