### PR TITLE
Lock orientation when task manager shows. r=etienne

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -1,5 +1,5 @@
 /* global Card, eventSafety, SettingsListener,
-          Service, homescreenLauncher, StackManager */
+          Service, homescreenLauncher, StackManager, OrientationManager */
 
 (function(exports) {
   'use strict';
@@ -152,6 +152,7 @@
 
     this.publish('cardviewbeforeshow');
 
+    screen.mozLockOrientation(OrientationManager.defaultOrientation);
     this._placeCards();
     this.setActive(true);
 

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -1,6 +1,6 @@
 /* global MockStackManager, MockNavigatorSettings, MockService,
           TaskManager, Card, AppWindow, HomescreenLauncher,
-          HomescreenWindow, MocksHelper, MockL10n */
+          HomescreenWindow, MocksHelper, MockL10n, MockOrientationManager */
 
 'use strict';
 
@@ -9,6 +9,7 @@ requireApp('system/test/unit/mock_homescreen_launcher.js');
 requireApp('system/test/unit/mock_homescreen_window.js');
 requireApp('system/test/unit/mock_stack_manager.js');
 requireApp('system/test/unit/mock_app_window.js');
+requireApp('system/test/unit/mock_orientation_manager.js');
 
 require('/shared/js/event_safety.js');
 require('/shared/js/tagged.js');
@@ -21,7 +22,8 @@ var mocksForTaskManager = new MocksHelper([
   'StackManager',
   'HomescreenWindow',
   'AppWindow',
-  'Service'
+  'Service',
+  'OrientationManager'
 ]).init();
 
 function waitForEvent(target, name, timeout) {
@@ -1260,7 +1262,26 @@ suite('system/TaskManager >', function() {
       MockStackManager.mStack.forEach(function(app) {
         sinon.assert.calledOnce(app.enterTaskManager);
       }, this);
+    })  ;
+
+  });
+
+  suite('orientation', function() {
+    var app;
+    setup(function() {
+      app = MockService.currentApp = apps['http://sms.gaiamobile.org'];
+      MockStackManager.mCurrent = 0;
+    });
+
+    test('lock orientation when showing', function() {
+      var orientation = MockOrientationManager.defaultOrientation || (
+        MockOrientationManager.defaultOrientation = 'portrait-primary'
+      );
+      this.sinon.stub(screen, 'mozLockOrientation');
+      showTaskManager(this.sinon.clock);
+      assert.isTrue(screen.mozLockOrientation.calledWith(orientation));
     });
 
   });
+
 });


### PR DESCRIPTION
Patch just calls lock/unlock orientation when showing/hiding task-manager, to ensure task-manager is always in default orientation. No luck with writing a marionette to test the expected behavior - I gather orientation support is a work-in-progress - so I've just asserted this the lock/unlock calls occur in a unit test.
