### PR TITLE
Bug 1126566 - [email] Account settings layout regression

### DIFF
--- a/apps/email/js/cards/settings_account.html
+++ b/apps/email/js/cards/settings_account.html
@@ -124,10 +124,10 @@
     </header>
     <ul data-prop="serversContainer" data-l10n-id="settings-server-group"
         class="tng-list tng-account-server-container">
-      <li>
+      <li class="item-with-children">
         <a href="#" data-prop="accountCredNode"
                     data-event="click:onClickCredentials"
-          class="tng-account-credentials list-text item-with-children"></a>
+          class="tng-account-credentials list-text"></a>
       </li>
       <li class="list-text-pair">
         <span data-l10n-id="settings-account-type" role="presentation"

--- a/apps/email/js/cards/tng/account_item.html
+++ b/apps/email/js/cards/tng/account_item.html
@@ -1,5 +1,5 @@
-<li class="tng-account-item" role="option">
+<li class="tng-account-item item-with-children" role="option">
   <a href="#" dir="auto"
-     class="tng-account-item-label list-text item-with-children"></a>
+     class="tng-account-item-label list-text"></a>
   <!-- we may want to expose some other info in this row -->
 </li>

--- a/apps/email/js/cards/tng/account_settings_server.html
+++ b/apps/email/js/cards/tng/account_settings_server.html
@@ -1,3 +1,3 @@
-<li class="tng-account-settings-server">
-  <a href="#" class="tng-account-server-label list-text item-with-children"></a>
+<li class="tng-account-settings-server item-with-children">
+  <a href="#" class="tng-account-server-label list-text"></a>
 </li>

--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -255,7 +255,7 @@ label.list-pack-checkbox, .settings-input-list .list-pack-switch {
 .list-pack-switch .list-pack-switch-text,
 .list-pack-checkbox .list-pack-checkbox-text {
   flex-grow: 2;
-  -moz-margin-end: 9.5rem;
+  -moz-margin-end: 7.5rem;
   line-height: inherit;
 }
 
@@ -295,6 +295,13 @@ html:-moz-dir(rtl) .list-text {
   text-align: right;
 }
 
+/* Select items with list text do not need the after spacing for the submenu
+   chevrons, as the select that is on a line below the text will have the
+   chevron if it is needed, so give more space for the text. */
+li.select-item .list-text {
+  padding: 0 1.5rem;
+}
+
 .list-sub-text {
   text-decoration: none;
   overflow: hidden;
@@ -315,6 +322,12 @@ html:-moz-dir(rtl) .list-sub-text {
 
 li.align-center {
   text-align: center;
+}
+
+.item-with-children .list-text {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  line-height: inherit;
 }
 
 .item-with-children::after  {


### PR DESCRIPTION
Three main changes:
- Reduced the .list-pack-switch and .list-pack-checkbox margin-end spacing to 7.5rem, it was set much larger than it needed to be. I believe this was just a holdout from the older non-flexbox design, and it wasn't really seen given that for shorter translations it did not make a difference.
- For .list-text inside a  .select-item, it had a bigger right padding to account for a chevron, but since it is in a .select-item, not an item-with-children (which gets the chevron), it did not need to reserve that space.
- The .item-with-children makes more sense to apply as an li style instead of a child of that li (the chevron logically belongs to the li) and by doing so allowed targeted style targets for .list-text children inside of .item-with-children. This helped fixed crazy line-heights for items with chevrons, there we large gaps between the text (only visible in non-en-US locales with longer text).

Tested with French and RTL locale to confirm changes look good. Here is a screenshot of the French one now:

![a-top](https://cloud.githubusercontent.com/assets/73359/5932460/fcabc714-a662-11e4-82e9-15daa3b90457.png)

![a-bottom](https://cloud.githubusercontent.com/assets/73359/5932462/020c95a8-a663-11e4-8ac4-69024b36db08.png)
