### PR TITLE
Bug 1125753 - Fix Gaia Keyboard Build Integration Tests by fixing "expected" data

### DIFF
--- a/apps/keyboard/test/build/integration/keyboard_test.js
+++ b/apps/keyboard/test/build/integration/keyboard_test.js
@@ -81,9 +81,7 @@ suite('Keyboard layouts building tests', function() {
   });
 
   // Build with all layouts and dictionaries
-  // XXX: bug 1125703: disable this test until bug 1119731's
-  //      false-negative is resolved.
-  test.skip('APP=keyboard GAIA_KEYBOARD_LAYOUTS=* ' +
+  test('APP=keyboard GAIA_KEYBOARD_LAYOUTS=* ' +
     'GAIA_KEYBOARD_PRELOAD_DICT_LAYOUTS=* make', function(done) {
     var cmd = 'APP=keyboard GAIA_KEYBOARD_LAYOUTS=* ' +
     'GAIA_KEYBOARD_PRELOAD_DICT_LAYOUTS=* make';
@@ -186,9 +184,7 @@ suite('Keyboard layouts building tests', function() {
   });
 
   // Build with all layouts with no dictionaries
-  // XXX: bug 1125703: disable this test until bug 1119731's
-  //      false-negative is resolved.
-  test.skip('APP=keyboard GAIA_KEYBOARD_LAYOUTS=noPreloadDictRequired ' +
+  test('APP=keyboard GAIA_KEYBOARD_LAYOUTS=noPreloadDictRequired ' +
     'GAIA_KEYBOARD_PRELOAD_DICT_LAYOUTS="" make',
   function(done) {
     var cmd = 'APP=keyboard GAIA_KEYBOARD_LAYOUTS=noPreloadDictRequired ' +

--- a/apps/keyboard/test/build/integration/resources/all-layout-make-dictionaries.json
+++ b/apps/keyboard/test/build/integration/resources/all-layout-make-dictionaries.json
@@ -56,6 +56,7 @@
     "label": "English (UK)",
     "id": "latin::en_gb",
     "inputIds": [
+      "en-Africa",
       "en-GB"
     ],
     "preload": true,
@@ -356,6 +357,14 @@
     "dictFilePath": "dictionaries/tr.dict"
   },
   {
+    "label": "Wolof",
+    "id": "wo",
+    "inputIds": [
+      "wo"
+    ],
+    "preload": true
+  },
+  {
     "label": "Česká",
     "id": "latin::cs",
     "inputIds": [
@@ -459,6 +468,14 @@
     "id": "te",
     "inputIds": [
       "te"
+    ],
+    "preload": true
+  },
+  {
+    "label": "ไทย",
+    "id": "th",
+    "inputIds": [
+      "th"
     ],
     "preload": true
   },

--- a/apps/keyboard/test/build/integration/resources/no-preload-dict-required-make-dictionaries.json
+++ b/apps/keyboard/test/build/integration/resources/no-preload-dict-required-make-dictionaries.json
@@ -56,6 +56,7 @@
     "label": "English (UK)",
     "id": "latin::en_gb",
     "inputIds": [
+      "en-Africa",
       "en-GB"
     ],
     "preload": false,
@@ -348,6 +349,14 @@
     "dictFilePath": "dictionaries/tr.dict"
   },
   {
+    "label": "Wolof",
+    "id": "wo",
+    "inputIds": [
+      "wo"
+    ],
+    "preload": true
+  },
+  {
     "label": "Česká",
     "id": "latin::cs",
     "inputIds": [
@@ -451,6 +460,14 @@
     "id": "te",
     "inputIds": [
       "te"
+    ],
+    "preload": true
+  },
+  {
+    "label": "ไทย",
+    "id": "th",
+    "inputIds": [
+      "th"
     ],
     "preload": true
   },


### PR DESCRIPTION
- Fix "expected" dictionaries.json by amending en-Africa, wo, th layout information into the data structure.
