### PR TITLE
Bug 1126953 - Autolander test bug, remove strings for quick settings dialog +autoland

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -1028,8 +1028,8 @@
           <p data-l10n-id="data-roaming-enabled-warning2"></p>
         </section>
         <menu>
-          <button type="button" class="quick-setting-data-cancel-btn recommend" data-l10n-id="notNow">Not now</button>
-          <button type="button" class="quick-setting-data-ok-btn" data-l10n-id="turnOn">Turn ON</button>
+          <button type="button" class="quick-setting-data-cancel-btn recommend" data-l10n-id="notNow"></button>
+          <button type="button" class="quick-setting-data-ok-btn" data-l10n-id="turnOn"></button>
         </menu>
       </form>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1126953
