### PR TITLE
Bug 1126247 - Hide the Get More Languages link until Marketplace supports langpacks

### DIFF
--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" type="text/css" href="style/icons.css">
     <link rel="stylesheet" type="text/css" href="style/settings.css">
     <link rel="stylesheet" type="text/css" href="style/settings_large.css" data-device-type="tablet">
-    <link rel="stylesheet" type="text/css" href="style/settings_phone.css" data-device-type="phone">
+    <link rel="stylesheet" type="text/css" href="style/settings_phone.css" data-device-type="none">
     <link rel="stylesheet" type="text/css" href="style/dialog.css">
     <!-- Panel Stylesheets
     <link rel="stylesheet" type="text/css" href="shared/style/action_menu.css"/>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1126247
