### PR TITLE
Bug 1118366 - Keep the direction of the carats in RTL mode r=eragonj

### DIFF
--- a/apps/settings/style/icons.css
+++ b/apps/settings/style/icons.css
@@ -291,7 +291,6 @@ aside.connecting {
 html[dir="rtl"] a.menu-item:after {
   left: 0.3rem;
   right: unset;
-  transform: scaleX(-1);
 }
 
 html[dir="rtl"] .menu-item::before {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1118366
