### PR TITLE
Bug 796486 - basicLayoutKey for nonabc languages fixed for some r=timdream

### DIFF
--- a/apps/keyboard/js/layouts/bg-BDS.js
+++ b/apps/keyboard/js/layouts/bg-BDS.js
@@ -5,6 +5,7 @@ Keyboards['bg-BDS'] = {
   types: ['text', 'url', 'email'],
   imEngine: 'latin',
   autoCorrectLanguage: 'bg',
+  basicLayoutKey: 'AБB',
   width: 11,
   alt: {
     'и': 'ѝ'

--- a/apps/keyboard/js/layouts/bg-Pho-Ban.js
+++ b/apps/keyboard/js/layouts/bg-Pho-Ban.js
@@ -5,6 +5,7 @@ Keyboards['bg-Pho-Ban'] = {
   types: ['text', 'url', 'email', 'password'],
   imEngine: 'latin',
   autoCorrectLanguage: 'bg',
+  basicLayoutKey: 'AБB',
   width: 11,
   alt: {
     'и': 'ѝ'

--- a/apps/keyboard/js/layouts/bg-Pho-Trad.js
+++ b/apps/keyboard/js/layouts/bg-Pho-Trad.js
@@ -5,6 +5,7 @@ Keyboards['bg-Pho-Trad'] = {
   types: ['text', 'url', 'email', 'password'],
   imEngine: 'latin',
   autoCorrectLanguage: 'bg',
+  basicLayoutKey: 'AБB',
   width: 11,
   alt: {
     'и': 'ѝ'

--- a/apps/keyboard/js/layouts/el.js
+++ b/apps/keyboard/js/layouts/el.js
@@ -4,6 +4,7 @@ Keyboards.el = {
   menuLabel: 'Ελληνικό',
   imEngine: 'latin',
   types: ['text', 'url', 'email', 'password'],
+  basicLayoutKey: 'ABΓ',
   autoCorrectLanguage: 'el',
   upperCase: {
     'ς': 'ς'

--- a/apps/keyboard/js/layouts/he.js
+++ b/apps/keyboard/js/layouts/he.js
@@ -3,6 +3,7 @@ Keyboards.he = {
   shortLabel: 'He',
   types: ['text', 'url', 'email'],
   menuLabel: 'עִבְרִית',
+  basicLayoutKey: 'אבג',
   alt: {
     // incomplete
   },

--- a/apps/keyboard/js/layouts/ko.js
+++ b/apps/keyboard/js/layouts/ko.js
@@ -2,6 +2,7 @@ Keyboards.ko = {
   label: 'Korean',
   shortLabel: 'Ko',
   secondLayout: true,
+  basicLayoutKey: 'ㄱㄴㄷ',
   imEngine: 'jshangul',
   types: ['text', 'url', 'email'],
   menuLabel: '한국어',

--- a/apps/keyboard/js/layouts/mk.js
+++ b/apps/keyboard/js/layouts/mk.js
@@ -4,6 +4,7 @@ Keyboards.mk = {
   menuLabel: 'Македонски',
   imEngine: 'latin',
   types: ['text', 'url', 'email', 'password'],
+  basicLayoutKey: 'АБВ',
   alt: {
     'е': 'ѐ',
     'и': 'ѝ'

--- a/apps/keyboard/js/layouts/ru.js
+++ b/apps/keyboard/js/layouts/ru.js
@@ -5,6 +5,7 @@ Keyboards.ru = {
   imEngine: 'latin',
   types: ['text', 'url', 'email', 'password'],
   autoCorrectLanguage: 'ru',
+  basicLayoutKey: 'АБВ',
   alt: {
     е: 'ё',
     ь: 'ъ'

--- a/apps/keyboard/js/layouts/sr-Cyrl.js
+++ b/apps/keyboard/js/layouts/sr-Cyrl.js
@@ -5,6 +5,7 @@ Keyboards['sr-Cyrl'] = {
   imEngine: 'latin',
   types: ['text', 'url', 'email', 'password'],
   autoCorrectLanguage: 'sr-Cyrl',
+  basicLayoutKey: 'АБВ',
   alt: {
     // incomplete
   },


### PR DESCRIPTION
Fixed the basicLayoutKey button label for most of the nonabc languages except Japanese-Kanji , Pulaar-Fulfulde and Wolof.
