### PR TITLE
Bug 1126709 - Should use the URL() object instead of string concatenation to resolve icon urls for Homescreen application.

### DIFF
--- a/apps/sharedtest/test/unit/elements/gaia_grid/items/grid_item_test.js
+++ b/apps/sharedtest/test/unit/elements/gaia_grid/items/grid_item_test.js
@@ -37,13 +37,14 @@ suite('GridItem', function() {
   test('basic auth in icon urls', function() {
     var subject = new GaiaGrid.GridItem();
     subject.app = {
-      origin: 'some:user@mozilla.org'
+      origin: 'app://user.mozilla.org',
+      manifestURL: 'app://user.mozilla.org/manifest.webapp'
     };
 
     var result = subject.closestIconFromList({
       100: '/icon.png'
     });
-    assert.equal(result, 'some:user@mozilla.org/icon.png');
+    assert.equal(result, 'app://user.mozilla.org/icon.png');
   });
 
 });

--- a/shared/elements/gaia_grid/js/items/grid_item.js
+++ b/shared/elements/gaia_grid/js/items/grid_item.js
@@ -204,7 +204,7 @@
 
       // Handle relative URLs
       if (!UrlHelper.hasScheme(icon)) {
-        icon = this.app.origin + icon;
+        icon = (new URL(icon, this.app.manifestURL)).href;
       }
 
       return icon;

--- a/shared/js/url_helper.js
+++ b/shared/js/url_helper.js
@@ -4,13 +4,8 @@ var rscheme = /^(?:[a-z\u00a1-\uffff0-9-+]+)(?::(?:\/\/)?)/i;
 
 var UrlHelper = {
 
-  // Placeholder anchor tag to format URLs.
-  a: null,
-
   getUrlFromInput: function urlHelper_getUrlFromInput(input) {
-    this.a = this.a || document.createElement('a');
-    this.a.href = input;
-    return this.a.href;
+    return new URL(input, document.location).href;
   },
 
   _getScheme: function(input) {


### PR DESCRIPTION
2nd PR with manifestURL
