### PR TITLE
Bug 966228 - Email notification with no subject displays subject as 'nul...

### DIFF
--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -75,6 +75,8 @@ define(function(require) {
           });
         }
 
+        title = title || mozL10n.get('notification-no-subject');
+
         var notification = new Notification(title, notificationOptions);
 
         // If the app is open, but in the background, when the notification

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -800,6 +800,10 @@ new-messages[few]={{ n }} New Messages
 new-messages[many]={{ n }} New Messages
 new-messages[other]={{ n }} New Messages
 
+# LOCALIZATION NOTE(notification-no-subject): is used for notifications 
+# if the new email doesn't have a subject
+notification-no-subject=(no subject)
+
 # new-emails-notify-one-account is used when a system notification is generated during
 # a periodic background sync with the server. Since this goes to the system's
 # notification area, and user has only one account configured with the email App.


### PR DESCRIPTION
...l'
