### PR TITLE
Bug 1126677 - [FFOS2.0][Woodduck]No IMSI detach prodecure when power off

### DIFF
--- a/apps/system/js/sleep_menu.js
+++ b/apps/system/js/sleep_menu.js
@@ -429,7 +429,9 @@
      */
     _actualPowerOff: function sm_actualPowerOff(isReboot) {
       var power = navigator.mozPower;
-
+      if (window.Radio) {
+        window.Radio.enabled = false;
+      }
       if (isReboot) {
         power.reboot();
       } else {


### PR DESCRIPTION
- turn off radio before reboot of poweroff
