### PR TITLE
Bug 1127898: Drop unnecessary 'height on .composer-button-container. r=a...

### DIFF
--- a/apps/sms/style/composer.css
+++ b/apps/sms/style/composer.css
@@ -240,7 +240,6 @@ form[role="search"] button[type="submit"]:after {
   align-content: space-between;
   flex-wrap: wrap;
 
-  height: 100%;
   width: 6rem;
 
   -moz-user-select: none; /* without this, tapping on the element selects its content */


### PR DESCRIPTION
...zasypkin

The .composer-button-container element will already stretch its height to match its parent, due to the (default) "align-self:stretch" behavior.
