### PR TITLE
Bug 1118893 - [RTL][Email] Carats in list items

### DIFF
--- a/apps/email/style/setup_cards.css
+++ b/apps/email/style/setup_cards.css
@@ -145,8 +145,18 @@ cards-setup-done .sup-form-btn.recommend {
 }
 
 li button.signature-button.icon:before {
-  background-image: url('../shared/style/buttons/images/next.png');
+  top: calc(50% - 1.3rem);
   right: 0;
+  width: 2.6rem;
+  height: 2.6rem;
+  margin-top: 0;
+  background: url('../shared/style/buttons/images/forward-light.svg') no-repeat center / 2.6rem;
+  opacity: 0.7;
+}
+
+html:-moz-dir(rtl) li button.signature-button.icon:before  {
+  left: 0;
+  right: unset;
 }
 
 li button.signature-button.button.icon {
@@ -332,16 +342,17 @@ li.align-center {
 
 .item-with-children::after  {
   content: "";
-  width: 3rem;
-  height: 3rem;
+  width: 2.6rem;
+  height: 2.6rem;
   position: absolute;
-  top: calc(50% - 1.5rem);
-  right: 0;
-  background: url(/shared/style/buttons/images/next.png) no-repeat center / 3rem auto;
+  top: calc(50% - 1.3rem);
+  right: -0.5rem;
+  background: url('../shared/style/buttons/images/forward-light.svg') no-repeat center / 2.6rem;
+  opacity: 0.7;
 }
 
 html:-moz-dir(rtl) .item-with-children::after  {
-  left: 0;
+  left: -0.5rem;
   right: auto;
 }
 


### PR DESCRIPTION
This updates the carats used in the email app's list items that have sub-cards use the smaller, lighter carats. Note that only the ones used in plain list items are updated. The ones in select boxes are still the same as before.

Screenshot in LTR mode (Username and IMAP Settings items show the change):

![carat-ltr](https://cloud.githubusercontent.com/assets/73359/6011753/6647c3c2-aaf4-11e4-9e94-97cf2f423130.png)

Screenshot in RTL mode:

![carat-rtl](https://cloud.githubusercontent.com/assets/73359/6011760/6eff5318-aaf4-11e4-90b6-937b9d65f4e6.png)
