### PR TITLE
Bug 1128981 - Fix display of Cost Control widget text in RTL languages

### DIFF
--- a/apps/costcontrol/style/widget.css
+++ b/apps/costcontrol/style/widget.css
@@ -2,7 +2,7 @@
 * {
   margin: 0;
   padding: 0;
-  text-align: left;
+  text-align: start;
 }
 
 html {
@@ -28,7 +28,7 @@ button::-moz-focus-inner {
 }
 
 p.meta {
-  font: italic 1.2rem/1.2rem auto;
+  font: italic 1.2rem auto;
   color: #858585;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -60,7 +60,7 @@ p.meta {
 }
 
 #fte-view p.meta {
-  font: italic 1.2rem/1.2rem auto;
+  font: italic 1.2rem auto;
   color: #858585;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
This corrects the alignment of the widget text in RTL languages, and also avoids clipping the second line for languages (such as Arabic, but likely applies to at least some Indian scripts as well) where the glyphs have a larger vertical extent.
