### PR TITLE
Bug 1127760 - Fix FxA text-alignment for RTL, flip progress

### DIFF
--- a/apps/system/fxa/style/fxa.css
+++ b/apps/system/fxa/style/fxa.css
@@ -41,6 +41,9 @@ h3 {
   margin: 0 0 1rem;
   text-align: left;
 }
+h3:-moz-dir(rtl) {
+  text-align: right;
+}
 
 label {
   width:100%;
@@ -127,6 +130,11 @@ ul {
 .bb-steps {
   margin: 0.5rem 1.5rem;
 }
+/* Mirror progress bar in RTL */
+.bb-steps:-moz-dir(rtl) {
+  transform: scaleX(-1);
+}
+
 
 #step-container {
   height: calc(100% - 6.3rem - 5rem);
@@ -150,16 +158,17 @@ ul {
 }
 
 .screen p.fxa-intro {
-  text-align: left;
   line-height: 2.3rem;
   font-size: 1.7rem;
 }
-
 .screen p {
   text-align: left;
   line-height: 1.9rem;
   font-size: 1.5rem;
   margin: 0 0 1rem;
+}
+.screen p:-moz-dir(rtl) {
+  text-align: right;
 }
 
 .current {
@@ -222,6 +231,14 @@ ul.fxa-verification-wrapper li {
 
 #show-pw-wrapper > label {
   float: left;
+}
+
+#show-pw-wrapper p:-moz-dir(rtl) {
+  float: right;
+}
+
+#show-pw-wrapper > label:-moz-dir(rtl) {
+  float: right;
 }
 
 /* Animate next screen */


### PR DESCRIPTION
The text in the login screen was explicitly aligned left. This patch adds overrides for RTL. Also a cheeky fix for the progressbar - mirroring it for this use. 
