### PR TITLE
Bug 1128812 - [Statusbar][Bluetooth] dispatch proper bluetooth events

### DIFF
--- a/apps/bluetooth/js/settings.js
+++ b/apps/bluetooth/js/settings.js
@@ -891,12 +891,10 @@ navigator.mozL10n.once(function bluetoothSettings() {
     // enable UI toggle
     gBluetoothCheckBox.disabled = false;
     initialDefaultAdapter();
-    dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
   });
 
   bluetooth.addEventListener('disabled', function() {
     gBluetoothCheckBox.disabled = false;  // enable UI toggle
     defaultAdapter = null;  // clear defaultAdapter
-    dispatchEvent(new CustomEvent('bluetooth-disabled'));
   });
 });

--- a/apps/settings/js/bluetooth.js
+++ b/apps/settings/js/bluetooth.js
@@ -881,11 +881,9 @@ navigator.mozL10n.once(function bluetoothSettings() {
     // enable UI toggle
     gBluetoothCheckBox.disabled = false;
     initialDefaultAdapter();
-    dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
   });
   bluetooth.addEventListener('disabled', function() {
     gBluetoothCheckBox.disabled = false;  // enable UI toggle
     defaultAdapter = null;  // clear defaultAdapter
-    dispatchEvent(new CustomEvent('bluetooth-disabled'));
   });
 });

--- a/apps/system/js/airplane_mode.js
+++ b/apps/system/js/airplane_mode.js
@@ -46,7 +46,7 @@
         disabled: 'wifi-disabled'
       },
       bluetooth: {
-        enabled: 'bluetooth-adapter-added',
+        enabled: 'bluetooth-enabled',
         disabled: 'bluetooth-disabled'
       },
       radio: {

--- a/apps/system/js/bluetooth.js
+++ b/apps/system/js/bluetooth.js
@@ -30,18 +30,6 @@ var Bluetooth = {
     }
   },
 
-  getCurrentProfiles: function bt_getCurrentProfiles() {
-    var profiles = this.Profiles;
-    var connectedProfiles = [];
-    for (var name in profiles) {
-      var profile = profiles[name];
-      if (this.isProfileConnected(profile)) {
-        connectedProfiles.push(profile);
-      }
-    }
-    return connectedProfiles;
-  },
-
   /**
    * check if bluetooth profile is connected.
    *
@@ -88,27 +76,33 @@ var Bluetooth = {
         return;
       }
     });
+    // send default bluetooth state so quick settings
+    // could be get updated
+    var req = SettingsListener.getSettingsLock()
+      .get('bluetooth.enabled');
+    req.onsuccess = function get_onsuccess() {
+      if (req.result['bluetooth.enabled']) {
+        window.dispatchEvent(new CustomEvent('bluetooth-enabled'));
+      } else {
+        window.dispatchEvent(new CustomEvent('bluetooth-disabled'));
+      }
+    };
 
     // when bluetooth adapter is ready, a.k.a enabled,
     // emit event to notify QuickSettings and try to get
     // defaultAdapter at this moment
     bluetooth.onadapteradded = function bt_onAdapterAdded() {
-      var evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent('bluetooth-adapter-added',
-        /* canBubble */ true, /* cancelable */ false, null);
-      window.dispatchEvent(evt);
+      window.dispatchEvent(new CustomEvent('bluetooth-enabled'));
       self.initDefaultAdapter();
     };
-    // if bluetooth is enabled in booting time, try to get adapter now
-    this.initDefaultAdapter();
 
     // when bluetooth is really disabled, emit event to notify QuickSettings
-    bluetooth.ondisabled = function bt_onDisabled() {
-      var evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent('bluetooth-disabled',
-        /* canBubble */ true, /* cancelable */ false, null);
-      window.dispatchEvent(evt);
-    };
+    bluetooth.addEventListener('disabled', function bt_onDisabled() {
+      window.dispatchEvent(new CustomEvent('bluetooth-disabled'));
+    });
+
+    // if bluetooth is enabled in booting time, try to get adapter now
+    this.initDefaultAdapter();
 
     /* In file transfering case:
      * since System Message can't be listened in two js files within a app,

--- a/apps/system/js/bluetooth_core.js
+++ b/apps/system/js/bluetooth_core.js
@@ -1,5 +1,5 @@
 /* exported BluetoothCore */
-/* global BaseModule, Bluetooth, BluetoothTransfer */
+/* global BaseModule, LazyLoader, Bluetooth2 */
 'use strict';
 
 (function() {
@@ -20,8 +20,15 @@
       // init Bluetooth module
       if (typeof(window.navigator.mozBluetooth.onattributechanged) ===
         'undefined') { // APIv1
-          Bluetooth.init();
-          BluetoothTransfer.init();
+          window.Bluetooth.init();
+          window.BluetoothTransfer.init();
+      } else { // APIv2
+        // Now only make sure statusbar works
+        // BluetoothTransfer will be done in Bug 1088591
+        LazyLoader.load(['js/bluetooth_v2.js'], () => {
+          window.Bluetooth = new Bluetooth2();
+          window.Bluetooth.start();
+        });
       }
     }
   });

--- a/apps/system/js/bluetooth_v2.js
+++ b/apps/system/js/bluetooth_v2.js
@@ -1,0 +1,438 @@
+'use strict';
+/**
+ * Bluetooth2 is compatible with Bluetooth APIv2 and used to enable/
+ * disable bluetooth hardware, get bluetooth adapter, and check target
+ * bluetooth profile is connected.
+ *
+ * Bluetooth api v2 is the two level structure.
+ * We use _bluetoothManagerHandler to handle BluetoothManager defaultAdapter
+ * change event and _bluetoothAdapterHandler to handle status change event.
+ *
+ */
+/* global SettingsListener, Service */
+/* exported Bluetooth2 */
+(function(exports) {
+
+var Bluetooth = function() {};
+
+Bluetooth.prototype = {
+  name: 'Bluetooth',
+  /**
+   * Keep a global connected property.
+   *
+   * @public
+   */
+  connected: false,
+
+  /**
+   * Debug message.
+   *
+   * @type {Boolean} turn on/off the console log
+   */
+  onDebug: false,
+
+  /**
+   * Store a reference of the default adapter.
+   *
+   * @private
+   */
+  _adapter: null,
+
+  /**
+   * Hold instance of bluetooth attribute change handler.
+   *
+   * @private
+   */
+  _defaultAdapterChangeHandler: null,
+
+  /**
+   * Hold instance of bluetooth adapter state change handler.
+   *
+   * @private
+   */
+  _stateChangeHandler: null,
+
+  /**
+   * Hold instance of bluetooth attribute change handler in
+   * getAdapter when the default adapter is not available.
+   *
+   * @private
+   */
+  _promiseAdapterChangeHandler: null,
+
+  /**
+   * Hold instance of the getAdapter promise
+   * when the default adapter is not available.
+   */
+  _cacheGetAdapterPromise: null,
+
+  /**
+   * Store a reference of the Bluetooth API.
+   *
+   * @private
+   */
+  _bluetooth: null,
+
+  /**
+   * Store a reference of the Bluetooth API.
+   *
+   * @private
+   */
+  _isEnabled: false,
+
+  /**
+   * Build-in Bluetooth profiles
+   *
+   * @public
+   */
+  get Profiles() {
+    return {
+      HFP: 'hfp',   // Hands-Free Profile
+      OPP: 'opp',   // Object Push Profile
+      A2DP: 'a2dp', // A2DP status
+      SCO: 'sco'    // Synchronous Connection-Oriented
+    };
+  },
+
+  /**
+   * Set profile connect state.
+   *
+   * @public
+   * @param {String} profile profile id
+   * @param {Boolean} connected connect status
+   */
+  _setProfileConnected: function bt_setProfileConnected(profile, connected) {
+    var value = this['_' + profile + 'Connected'];
+    if (value !== connected) {
+      this['_' + profile + 'Connected'] = connected;
+
+      // Raise an event for the profile connection changes.
+      window.dispatchEvent(new CustomEvent('bluetoothprofileconnectionchange',
+      {
+        name: profile,
+        connected: connected
+      }));
+      // if (profile === 'opp' && this.transferIcon) {
+      //   this.transferIcon.update();
+      // }
+      // if (profile === 'a2dp' && this.headphoneIcon) {
+      //   this.headphoneIcon.update();
+      // }
+    }
+  },
+
+  /**
+   * Check if bluetooth profile is connected.
+   *
+   * @public
+   * @param {String} profile profile name
+   * @return {Boolean} connected state
+   */
+  isProfileConnected: function bt_isProfileConnected(profile) {
+    var isConnected = this['_' + profile + 'Connected'];
+    if (isConnected === undefined) {
+      return false;
+    } else {
+      return isConnected;
+    }
+  },
+
+  /**
+   * Initialize bluetooth module.
+   *
+   * @public
+   */
+  start: function bt_start() {
+    if (!window.navigator.mozSettings || !window.navigator.mozBluetooth) {
+      return;
+    }
+
+    this._bluetooth = window.navigator.mozBluetooth;
+    SettingsListener.observe('bluetooth.enabled', true, (value) => {
+      if (!this._bluetooth) {
+        // roll back the setting value to notify the UIs
+        // that Bluetooth interface is not available
+        if (value) {
+          navigator.mozSettings.createLock()
+            .set({'bluetooth.enabled': false});
+        }
+        return;
+      }
+    });
+
+    this._defaultAdapterChangeHandler =
+      this._bluetoothManagerHandler.bind(this, null);
+    this._bluetooth.addEventListener('attributechanged',
+      this._defaultAdapterChangeHandler);
+
+    // clear defaultAdapter and listener once adapter is removed
+    this._bluetooth.addEventListener('adapterremoved',
+      this._removeEventListeners.bind(this));
+
+    // if bluetooth is enabled in booting time, try to get adapter now
+    this._debug('init bluetooth adapter');
+    this._adapter = this._bluetooth.defaultAdapter;
+    if (this._adapter) {
+      this._debug('bluetooth state:' + this._adapter.state);
+      this._isEnabled = (this._adapter.state === 'enabled');
+      // send default bluetooth state so quick settings
+      // could be get updated
+      if (this._isEnabled) {
+        window.dispatchEvent(new CustomEvent('bluetooth-enabled'));
+      } else {
+        window.dispatchEvent(new CustomEvent('bluetooth-disabled'));
+      }
+
+      this._stateChangeHandler =
+        this._bluetoothAdapterHandler.bind(this);
+      this._adapter.addEventListener('attributechanged',
+        this._stateChangeHandler);
+    }
+
+    /*
+     * In file transfering case:
+     * since System Message can't be listened in two js files within a app,
+     * so we listen here but dispatch events to bluetooth_transfer.js
+     * while getting bluetooth file transfer start/complete system messages
+     */
+    navigator.mozSetMessageHandler('bluetooth-opp-transfer-start',
+      (transferInfo) => {
+        this._setProfileConnected(this.Profiles.OPP, true);
+        window.dispatchEvent(new CustomEvent('bluetooth-opp-transfer-start',
+          {transferInfo: transferInfo}));
+      }
+    );
+
+    navigator.mozSetMessageHandler('bluetooth-opp-transfer-complete',
+      (transferInfo) => {
+        this._setProfileConnected(this.Profiles.OPP, false);
+        window.dispatchEvent(new CustomEvent('bluetooth-opp-transfer-complete',
+          {transferInfo: transferInfo}));
+      }
+    );
+
+    // decouple bluetooth enable/disable function from other system part
+    window.addEventListener('request-enable-bluetooth',
+      this._enableHandler.bind(this));
+    window.addEventListener('request-disable-bluetooth',
+      this._disableHandler.bind(this));
+
+    Service.registerState('isEnabled', this);
+    // LazyLoader.load(['js/bluetooth_icon.js',
+    //                  'js/bluetooth_transfer_icon.js',
+    //                  'js/bluetooth_headphone_icon.js'], function() {
+    //   this.icon = new BluetoothIcon(this);
+    //   this.icon.start();
+    //   this.transferIcon = new BluetoothTransferIcon(this);
+    //   this.transferIcon.start();
+    //   this.headphoneIcon = new BluetoothHeadphoneIcon(this);
+    //   this.headphoneIcon.start();
+    // }.bind(this)).catch(function(err) {
+    //   console.error(err);
+    // });
+  },
+
+  /**
+   * Remove all EventListeners and adapters when default adapter
+   * is changed.
+   */
+  _removeEventListeners() {
+    this._bluetooth.removeEventListener('attributechanged',
+      this._defaultAdapterChangeHandler);
+    this._adapter.removeEventListener('attributechanged',
+      this._stateChangeHandler);
+    // remove getAdapter cached promise
+    if (this._cacheGetAdapterPromise) {
+      this._bluetooth.removeEventListener('attributechanged',
+        this._promiseAdapterChangeHandler);
+      this._cacheGetAdapterPromise = null;
+    }
+    this._adapter = null;
+  },
+
+  /**
+   * update settings value and enable bluetooth hardware
+   *
+   * @private
+   */
+  _enableHandler: function bt__enableHandler() {
+    this._debug('enabling bluetooth');
+    this.getAdapter().then((adapter) => {
+      adapter.enable().then(() => { //resolve
+        this._debug('bluetooth enabled');
+        this._updateProfileState(adapter);
+      }, () => { //reject
+        this._debug('can not get bluetooth adapter');
+      });
+    });
+  },
+
+  /**
+   * update settings value and disable bluetooth hardware
+   *
+   * @private
+   */
+  _disableHandler: function bt__disableHandler() {
+    this._debug('disabling bluetooth');
+    this.getAdapter().then((adapter) => {
+      adapter.disable().then(() => { //resolve
+        this._debug('bluetooth disabled');
+      }, () => { //reject
+        this._debug('can not get bluetooth adapter');
+      });
+    });
+  },
+
+  /**
+   * Maintain connect stat of supported profiles.
+   *
+   * @private
+   * @param  {Object} adapter bluetooth adapter
+   */
+  _updateProfileState: function bt__updateProfileState(adapter) {
+    /* for v1, we only support two use cases for bluetooth connection:
+     *   1. connecting with a headset
+     *   2. transfering a file to/from another device
+     * So we need to listen to corresponding events to know we are (aren't)
+     * connected, then summarize to an event and dispatch to StatusBar
+     */
+    // In headset connected case:
+    adapter.addEventListener('hfpstatuschanged', (evt) => {
+      this._setProfileConnected(this.Profiles.HFP, evt.status);
+    });
+
+    adapter.addEventListener('a2dpstatuschanged', (evt) => {
+      this._setProfileConnected(this.Profiles.A2DP, evt.status);
+    });
+
+    adapter.addEventListener('scostatuschanged', (evt) => {
+      this._setProfileConnected(this.Profiles.SCO, evt.status);
+    });
+  },
+
+  /**
+   * BT APIv2: Watch 'onattributechanged' event from
+   * mozBluetooth.defaultAdapter for updating state information.
+   *
+   * @private
+   * @param  {Object} evt event object
+   */
+  _bluetoothAdapterHandler:
+    function bt__bluetoothAdapterHandler(evt) {
+      for (var i in evt.attrs) {
+        switch (evt.attrs[i]) {
+          case 'state':
+            if (this._adapter.state === 'enabled') {
+              this._isEnabled = true;
+              navigator.mozSettings.createLock()
+                .set({'bluetooth.enabled': true});
+              window.dispatchEvent(new CustomEvent('bluetooth-enabled'));
+              // this.icon && this.icon.update();
+            } else if (this._adapter.state === 'disabled') {
+              this._isEnabled = false;
+              navigator.mozSettings.createLock()
+                .set({'bluetooth.enabled': false});
+              window.dispatchEvent(new CustomEvent('bluetooth-disabled'));
+              // this.icon && this.icon.update();
+            }
+            break;
+          default:
+            break;
+        }
+      }
+  },
+
+  /**
+   * Watch 'onattributechanged' event from mozBluetooth for updating default
+   * adapter information.
+   *
+   * 'onattributechanged' event description:
+   * A handler to trigger when bluetooth manager's only property
+   * defaultAdapter has changed.
+   *
+   * @private
+   * @param  {Object} evt event object
+   */
+  _bluetoothManagerHandler:
+    function bt__bluetoothManagerHandler(resolve, evt) {
+      for (var i in evt.attrs) {
+        switch (evt.attrs[i]) {
+          case 'defaultAdapter':
+            this._debug('defaultAdapter changed.');
+            if (this._bluetooth.defaultAdapter) {
+              // Default adapter attribute change.
+              // Usually, it means that we reach new default adapter.
+              this._adapter = this._bluetooth.defaultAdapter;
+              this._isEnabled = (this._adapter.state === 'enabled');
+              this._stateChangeHandler =
+                this._bluetoothAdapterHandler.bind(this);
+              this._adapter.addEventListener('attributechanged',
+                this._stateChangeHandler);
+              this._updateProfileState(this._adapter);
+              if (typeof resolve === 'function') {
+                resolve(this._adapter);
+              }
+            }
+            break;
+          default:
+            break;
+        }
+      }
+  },
+
+  /**
+   * Called by external for re-use adapter.
+   * For defaultAdapter not ready case, we cached the Promise object
+   * therefore all caller would get the same Promise object.
+   *
+   * @public
+   */
+  getAdapter: function bt_getAdapter() {
+    if (this._adapter) {
+      return new Promise((resolve) => {
+        this._debug('return cached adapter');
+        resolve(this._adapter);
+      });
+    } else {
+      // return cached promise to caller if the promise is exist
+      if (this._cacheGetAdapterPromise) {
+        return this._cacheGetAdapterPromise;
+      } else {
+        this._debug('try to get adapter');
+        // cache the promise which listen to defaultAdapter change
+        this._cacheGetAdapterPromise = new Promise((resolve) => {
+          this._promiseAdapterChangeHandler =
+            this._bluetoothManagerHandler.bind(this, resolve);
+          this._bluetooth.addEventListener('attributechanged',
+            this._promiseAdapterChangeHandler);
+        });
+        return this._cacheGetAdapterPromise;
+      }
+    }
+  },
+
+  /**
+   * Maintain bluetooth enable/disable stat.
+   *
+   * @public
+   */
+  get isEnabled() {
+    return this._isEnabled;
+  },
+
+  /**
+   * Console log.
+   *
+   * @param  {[type]} msg debug message
+   */
+  _debug: function bt__debug(msg) {
+    if (!this.onDebug) {
+      return;
+    }
+
+    console.log('[System Bluetooth]: ' + msg);
+  }
+};
+
+  exports.Bluetooth2 = Bluetooth;
+})(window);

--- a/apps/system/js/nfc_handover_manager.js
+++ b/apps/system/js/nfc_handover_manager.js
@@ -26,7 +26,7 @@
   ];
 
   NfcHandoverManager.EVENTS = [
-    'bluetooth-adapter-added',
+    'bluetooth-enabled',
     'bluetooth-disabled',
     'nfc-transfer-started',
     'nfc-transfer-completed'
@@ -161,6 +161,11 @@
       this.bluetoothStatusSaved = false;
       this.bluetoothAutoEnabled = false;
 
+      if (typeof(window.navigator.mozBluetooth.onattributechanged) !==
+        'undefined') {
+        this._debug('Bluetooth APIv2 does not support NFC yet');
+        return;
+      }
       if (this.bluetooth.enabled) {
         this._debug('Bluetooth already enabled on boot');
         var req = this.bluetooth.getDefaultAdapter();
@@ -195,9 +200,14 @@
       this._clearBluetoothStatus();
     },
 
-    '_handle_bluetooth-adapter-added': function() {
+    '_handle_bluetooth-enabled': function() {
+      if (typeof(window.navigator.mozBluetooth.onattributechanged) !==
+        'undefined') {
+        this._debug('Bluetooth APIv2 does not support NFC yet');
+        return;
+      }
       var self = this;
-      self._debug('bluetooth-adapter-added');
+      self._debug('bluetooth-enabled');
       var req = self.bluetooth.getDefaultAdapter();
       req.onsuccess = function bt_getAdapterSuccess() {
         self.settingsNotified = false;

--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -170,32 +170,8 @@
      * @memberof QuickSettings.prototype
      */
     monitorBluetoothChange: function() {
-      var self = this;
-      var btFirstSet = true;
-      SettingsListener.observe('bluetooth.enabled', true, function(value) {
-        // check self.bluetooth.dataset.enabled and value are identical
-        if ((self.bluetooth.dataset.enabled && value) ||
-          (self.bluetooth.dataset.enabled === undefined && !value)) {
-          return;
-        }
-
-        if (value) {
-          self.bluetooth.dataset.enabled = 'true';
-        } else {
-          delete self.bluetooth.dataset.enabled;
-        }
-
-        // Set to the initializing state to block user interaction until the
-        // operation completes. (unless we are being called for the first time,
-        // where Bluetooth is already initialize
-        if (!btFirstSet) {
-          self.bluetooth.dataset.initializing = 'true';
-        }
-        btFirstSet = false;
-
-        self.setAccessibilityAttributes(self.bluetooth, 'bluetoothButton');
-      });
-      window.addEventListener('bluetooth-adapter-added', this);
+      // Bluetooth module is loaded after quicksettings.
+      window.addEventListener('bluetooth-enabled', this);
       window.addEventListener('bluetooth-disabled', this);
     },
 
@@ -336,6 +312,7 @@
                 window.dispatchEvent(
                   new CustomEvent('request-enable-bluetooth'));
               }
+              this.bluetooth.dataset.initializing = 'true';
               break;
 
             case this.airplaneMode:
@@ -362,8 +339,13 @@
           break;
 
           // unlock bluetooth toggle
-        case 'bluetooth-adapter-added':
+        case 'bluetooth-enabled':
+          this.bluetooth.dataset.enabled = 'true';
+          delete this.bluetooth.dataset.initializing;
+          this.setAccessibilityAttributes(this.bluetooth, 'bluetoothButton');
+          break;
         case 'bluetooth-disabled':
+          delete this.bluetooth.dataset.enabled;
           delete this.bluetooth.dataset.initializing;
           this.setAccessibilityAttributes(this.bluetooth, 'bluetoothButton');
           break;

--- a/apps/system/test/unit/airplane_mode_test.js
+++ b/apps/system/test/unit/airplane_mode_test.js
@@ -164,7 +164,7 @@ suite('system/airplane_mode.js', function() {
       test('we will leave airplane mode', function() {
         emitEvent('radiostatechange', 'enabled');
         emitEvent('wifi-enabled');
-        emitEvent('bluetooth-adapter-added');
+        emitEvent('bluetooth-enabled');
         emitEvent('radio-enabled');
 
         assert.isTrue(subject.enabled);

--- a/apps/system/test/unit/bluetooth_v2_test.js
+++ b/apps/system/test/unit/bluetooth_v2_test.js
@@ -244,7 +244,7 @@ suite('system/bluetooth_v2', function() {
     });
 
     test('removeEventListener is called', function() {
-      Bluetooth._removeEventListeners();
+      Bluetooth._cleanupListenerAndAdapters();
       assert.ok(Bluetooth._bluetooth.removeEventListener
         .calledWith('attributechanged'));
       assert.equal(Bluetooth._adapter, null);
@@ -254,7 +254,7 @@ suite('system/bluetooth_v2', function() {
       Bluetooth._cacheGetAdapterPromise = new Promise(function(resolve) {
         resolve();
       });
-      Bluetooth._removeEventListeners();
+      Bluetooth._cleanupListenerAndAdapters();
       assert.ok(Bluetooth._bluetooth.removeEventListener
         .calledWith('attributechanged'));
       assert.equal(Bluetooth._cacheGetAdapterPromise, null);
@@ -264,8 +264,8 @@ suite('system/bluetooth_v2', function() {
 
   suite('handle Bluetooth states', function() {
     setup(function() {
-      this.sinon.spy(Bluetooth, '_enableHandler');
-      this.sinon.spy(Bluetooth, '_disableHandler');
+      this.sinon.spy(Bluetooth, '_requestEnableHandler');
+      this.sinon.spy(Bluetooth, '_requestDisableHandler');
       this.sinon.spy(Bluetooth, '_updateProfileState');
       this.sinon.stub(Bluetooth, 'getAdapter', function() {
         return { then: function(resolve) { resolve(MockBTAdapter); } };
@@ -281,14 +281,14 @@ suite('system/bluetooth_v2', function() {
 
     test('request-enable-bluetooth is called', function() {
       window.dispatchEvent(new CustomEvent('request-enable-bluetooth'));
-      assert.ok(Bluetooth._enableHandler.called);
+      assert.ok(Bluetooth._requestEnableHandler.called);
       assert.ok(MockBTAdapter.enable.called);
       assert.ok(Bluetooth._updateProfileState.called);
     });
 
     test('request-disable-bluetooth is called', function() {
       window.dispatchEvent(new CustomEvent('request-disable-bluetooth'));
-      assert.ok(Bluetooth._disableHandler.called);
+      assert.ok(Bluetooth._requestDisableHandler.called);
       assert.ok(MockBTAdapter.disable.called);
     });
   });

--- a/apps/system/test/unit/bluetooth_v2_test.js
+++ b/apps/system/test/unit/bluetooth_v2_test.js
@@ -1,0 +1,435 @@
+/* global Bluetooth, MockSettingsListener, Service,
+   MockNavigatorSettings, MockNavigatormozSetMessageHandler,
+   MockMozBluetooth, MockBTAdapter, MocksHelper, MockLazyLoader */
+'use strict';
+
+require('/shared/test/unit/mocks/mock_navigator_moz_set_message_handler.js');
+requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
+requireApp('system/shared/test/unit/mocks/mock_navigator_moz_settings.js');
+require('/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js');
+require('/shared/test/unit/mocks/mock_lazy_loader.js');
+requireApp('system/js/service.js');
+requireApp('system/js/base_module.js');
+requireApp('system/js/base_ui.js');
+requireApp('system/js/base_icon.js');
+requireApp('system/js/bluetooth_icon.js');
+requireApp('system/js/bluetooth_transfer_icon.js');
+requireApp('system/js/bluetooth_headphone_icon.js');
+
+function switchReadOnlyProperty(originObject, propName, targetObj) {
+  Object.defineProperty(originObject, propName, {
+    configurable: true,
+    get: function() { return targetObj; }
+  });
+}
+
+var mocksForBluetooth = new MocksHelper([
+  'SettingsListener',
+  'LazyLoader'
+]).init();
+
+suite('system/bluetooth_v2', function() {
+  var realSetMessageHandler;
+  var realSettings;
+  var realSettingsListener;
+  var realMozBluetooth;
+  mocksForBluetooth.attachTestHelpers();
+
+  suiteSetup(function(done) {
+    sinon.spy(MockLazyLoader, 'load');
+    MockLazyLoader.mLoadRightAway = true;
+
+    realSetMessageHandler = navigator.mozSetMessageHandler;
+    navigator.mozSetMessageHandler = MockNavigatormozSetMessageHandler;
+    MockNavigatormozSetMessageHandler.mSetup();
+
+    realSettings = navigator.mozSettings;
+    navigator.mozSettings = MockNavigatorSettings;
+
+    realSettingsListener = window.SettingsListener;
+    window.SettingsListener = MockSettingsListener;
+
+    realMozBluetooth = navigator.mozBluetooth;
+    switchReadOnlyProperty(navigator, 'mozBluetooth', MockMozBluetooth);
+
+    requireApp('system/js/bluetooth_v2.js', done);
+  });
+
+  suiteTeardown(function() {
+    MockNavigatormozSetMessageHandler.mTeardown();
+    navigator.mozSetMessageHandler = realSetMessageHandler;
+    window.SettingsListener = realSettingsListener;
+    switchReadOnlyProperty(navigator, 'mozBluetooth', realMozBluetooth);
+  });
+
+  setup(function() {
+    // instanciate bluetooth module
+    window.Bluetooth = new window.Bluetooth2();
+  });
+
+  suite('default variables', function() {
+    test('profiles', function() {
+      assert.equal(Bluetooth.Profiles.HFP, 'hfp');
+      assert.equal(Bluetooth.Profiles.OPP, 'opp');
+      assert.equal(Bluetooth.Profiles.A2DP, 'a2dp');
+      assert.equal(Bluetooth.Profiles.SCO, 'sco');
+    });
+  });
+
+  suite('setProfileConnected', function() {
+    var profiles = ['hfp', 'opp', 'a2dp', 'sco'];
+    setup(function() {
+      this.sinon.stub(window, 'dispatchEvent');
+    });
+
+    test('nothing is called when wasConnected', function() {
+      profiles.forEach(function(profile){
+        Bluetooth['_' + profile + 'Connected'] = true;
+        Bluetooth._setProfileConnected(profile, true);
+        assert.isFalse(window.dispatchEvent.called);
+      });
+    });
+
+    test('event is dispatched when disconnected', function() {
+      profiles.forEach(function(profile){
+        Bluetooth['_' + profile + 'Connected'] = true;
+        Bluetooth._setProfileConnected(profile, false);
+        assert.ok(window.dispatchEvent.called);
+      });
+    });
+
+    test('event is dispatched when first connect', function() {
+      profiles.forEach(function(profile){
+        Bluetooth['_' + profile + 'Connected'] = false;
+        Bluetooth._setProfileConnected(profile, true);
+        assert.ok(window.dispatchEvent.called);
+      });
+    });
+  });
+
+  suite('isProfileConnected', function() {
+    var profiles = ['hfp', 'opp', 'a2dp', 'sco'];
+
+    test('return true when profile is connected', function() {
+      profiles.forEach(function(profile) {
+        Bluetooth['_' + profile + 'Connected'] = false;
+      });
+      profiles.forEach(function(profile) {
+        assert.isFalse(Bluetooth.isProfileConnected(profile));
+      });
+    });
+
+    test('return true when profile is connected', function() {
+      profiles.forEach(function(profile) {
+        Bluetooth['_' + profile + 'Connected'] = true;
+      });
+      profiles.forEach(function(profile) {
+        assert.ok(Bluetooth.isProfileConnected(profile));
+      });
+    });
+  });
+
+  suite('updateProfileState', function() {
+    setup(function() {
+      this.sinon.stub(MockBTAdapter, 'addEventListener');
+      Bluetooth._updateProfileState(MockBTAdapter);
+    });
+
+    test('return true when profile is connected', function() {
+      assert.ok(MockBTAdapter.addEventListener.calledWith('hfpstatuschanged'));
+      assert.ok(MockBTAdapter.addEventListener.calledWith('a2dpstatuschanged'));
+      assert.ok(MockBTAdapter.addEventListener.calledWith('scostatuschanged'));
+    });
+  });
+
+  suite('Initialize', function() {
+    setup(function() {
+      this.sinon.spy(navigator.mozBluetooth, 'addEventListener');
+      this.sinon.stub(Bluetooth, '_setProfileConnected');
+      this.sinon.spy(window, 'addEventListener');
+      this.sinon.spy(window, 'dispatchEvent');
+      this.sinon.stub(Service, 'registerState');
+      Bluetooth.start();
+    });
+
+    test('defaultAdapter is called', function() {
+      assert.equal(Bluetooth._adapter, navigator.mozBluetooth.defaultAdapter);
+    });
+
+    test('listener called', function() {
+      assert.equal(MockSettingsListener.mName, 'bluetooth.enabled');
+      assert.ok(window.navigator.mozBluetooth
+        .addEventListener.calledWith('adapterremoved'));
+      assert.ok(window.addEventListener
+        .calledWith('request-enable-bluetooth'));
+      assert.ok(window.addEventListener
+        .calledWith('request-disable-bluetooth'));
+    });
+
+    test('MessageHandler bluetooth-opp-transfer-start is called',
+      function() {
+        MockNavigatormozSetMessageHandler.mTrigger(
+          'bluetooth-opp-transfer-start', {
+            source: {
+              data: {}
+            }
+        });
+
+        assert.ok(Bluetooth._setProfileConnected.called);
+        assert.ok(window.dispatchEvent.called);
+    });
+
+    test('MessageHandler bluetooth-opp-transfer-complete is called',
+      function() {
+        MockNavigatormozSetMessageHandler.mTrigger(
+          'bluetooth-opp-transfer-complete', {
+            source: {
+              data: {}
+            }
+        });
+
+        assert.ok(Bluetooth._setProfileConnected.called);
+        assert.ok(window.dispatchEvent.called);
+    });
+
+    test('register state', function() {
+      assert.ok(Service.registerState.calledWith('isEnabled'));
+    });
+
+    // test('Should lazy load icons', function() {
+    //   assert.isTrue(MockLazyLoader.load.calledWith(
+    //     ['js/bluetooth_icon.js',
+    //     'js/bluetooth_transfer_icon.js',
+    //     'js/bluetooth_headphone_icon.js']
+    //   ));
+    // });
+
+    // test('Update bluetooth icon when bluetooth is enabled', function() {
+    //   this.sinon.stub(Bluetooth.icon, 'update');
+    //   MockMozBluetooth.triggerEventListeners('enabled');
+    //   assert.isTrue(Bluetooth.icon.update.called);
+    // });
+
+    // test('Update bluetooth icon when bluetooth is disabled', function() {
+    //   this.sinon.stub(Bluetooth.icon, 'update');
+    //   MockMozBluetooth.triggerEventListeners('disabled');
+    //   assert.isTrue(Bluetooth.icon.update.called);
+    // });
+
+    // test('Update transfer icon on system message', function() {
+    //   this.sinon.stub(Bluetooth.transferIcon, 'update');
+    //   MockNavigatormozSetMessageHandler.mTrigger(
+    //     'bluetooth-opp-transfer-start', {});
+    //   assert.isTrue(Bluetooth.transferIcon.update.called);
+    //   MockNavigatormozSetMessageHandler.mTrigger(
+    //     'bluetooth-opp-transfer-complete', {});
+    //   assert.isTrue(Bluetooth.transferIcon.update.calledTwice);
+    // });
+
+    // test('Update headset icon on adapter notifying', function() {
+    //   this.sinon.stub(Bluetooth.headphoneIcon, 'update');
+    //   MockMozBluetooth.triggerOnGetAdapterSuccess();
+    //   MockBTAdapter.ona2dpstatuschanged({status: true});
+    //   assert.isTrue(Bluetooth.headphoneIcon.update.called);
+    //   MockBTAdapter.ona2dpstatuschanged({status: false});
+    //   assert.isTrue(Bluetooth.headphoneIcon.update.calledTwice);
+    // });
+  });
+
+  suite('handle Bluetooth states', function() {
+    setup(function() {
+      Bluetooth._bluetooth = MockMozBluetooth;
+      this.sinon.stub(Bluetooth._bluetooth, 'removeEventListener');
+      Bluetooth._adapter = MockBTAdapter;
+    });
+
+    test('removeEventListener is called', function() {
+      Bluetooth._removeEventListeners();
+      assert.ok(Bluetooth._bluetooth.removeEventListener
+        .calledWith('attributechanged'));
+      assert.equal(Bluetooth._adapter, null);
+    });
+
+    test('cached promise is cleaned', function() {
+      Bluetooth._cacheGetAdapterPromise = new Promise(function(resolve) {
+        resolve();
+      });
+      Bluetooth._removeEventListeners();
+      assert.ok(Bluetooth._bluetooth.removeEventListener
+        .calledWith('attributechanged'));
+      assert.equal(Bluetooth._cacheGetAdapterPromise, null);
+      assert.equal(Bluetooth._adapter, null);
+    });
+  });
+
+  suite('handle Bluetooth states', function() {
+    setup(function() {
+      this.sinon.spy(Bluetooth, '_enableHandler');
+      this.sinon.spy(Bluetooth, '_disableHandler');
+      this.sinon.spy(Bluetooth, '_updateProfileState');
+      this.sinon.stub(Bluetooth, 'getAdapter', function() {
+        return { then: function(resolve) { resolve(MockBTAdapter); } };
+      });
+      this.sinon.stub(MockBTAdapter, 'enable', function() {
+        return { then: function(resolve) { resolve(); } };
+      });
+      this.sinon.stub(MockBTAdapter, 'disable', function() {
+        return { then: function(resolve) { resolve(); } };
+      });
+      Bluetooth.start();
+    });
+
+    test('request-enable-bluetooth is called', function() {
+      window.dispatchEvent(new CustomEvent('request-enable-bluetooth'));
+      assert.ok(Bluetooth._enableHandler.called);
+      assert.ok(MockBTAdapter.enable.called);
+      assert.ok(Bluetooth._updateProfileState.called);
+    });
+
+    test('request-disable-bluetooth is called', function() {
+      window.dispatchEvent(new CustomEvent('request-disable-bluetooth'));
+      assert.ok(Bluetooth._disableHandler.called);
+      assert.ok(MockBTAdapter.disable.called);
+    });
+  });
+
+  suite('bluetoothAdapterHandler', function() {
+    setup(function() {
+      this.sinon.spy(MockNavigatorSettings, 'createLock');
+      this.sinon.stub(window, 'dispatchEvent');
+      Bluetooth._adapter = MockBTAdapter;
+    });
+
+    teardown(function() {
+      Bluetooth._adapter = null;
+    });
+
+    test('bluetooth state is enabled', function() {
+      Bluetooth._adapter.state = 'enabled';
+      Bluetooth._bluetoothAdapterHandler({attrs: ['state']});
+      assert.isTrue(Bluetooth._isEnabled);
+      assert.ok(window.dispatchEvent.called);
+    });
+
+    test('bluetooth state is disabled', function() {
+      Bluetooth._adapter.state = 'disabled';
+      Bluetooth._bluetoothAdapterHandler({attrs: ['state']});
+      assert.isFalse(Bluetooth._isEnabled);
+      assert.ok(window.dispatchEvent.called);
+    });
+  });
+
+  suite('getAdapter', function() {
+    setup(function() {
+      this.sinon.spy(MockMozBluetooth, 'addEventListener');
+      this.sinon.stub(Bluetooth, '_bluetoothManagerHandler');
+      Bluetooth._bluetooth = window.navigator.mozBluetooth;
+    });
+
+    teardown(function() {
+      Bluetooth._adapter = null;
+      Bluetooth._cacheGetAdapterPromise = null;
+    });
+
+    // normal path
+    test('addEventListener is not called when adapter is ready', function() {
+      Bluetooth._adapter = MockBTAdapter;
+      Bluetooth.getAdapter();
+
+      assert.ok(!MockMozBluetooth.addEventListener.called);
+      assert.equal(Bluetooth._adapter, MockBTAdapter);
+      // should not have _cacheGetAdapterPromise
+      assert.equal(Bluetooth._cacheGetAdapterPromise, null);
+    });
+
+    // first time path
+    test('addEventListener is called when adapter is not ready', function() {
+      Bluetooth.getAdapter();
+
+      assert.ok(MockMozBluetooth.addEventListener.called);
+      assert.equal(Bluetooth._adapter, null);
+      assert.equal(typeof Bluetooth._cacheGetAdapterPromise, 'object');
+    });
+
+    // multiple time path
+    test('make sure promise is only called once when multiple getAdapter' +
+      'is called', function() {
+        var promise = new Promise(function(resolve) {
+          resolve();
+        });
+        this.sinon.stub(window, 'Promise', function() {
+          return promise;
+        });
+        Bluetooth.getAdapter();
+        Bluetooth.getAdapter();
+        Bluetooth.getAdapter();
+        Bluetooth.getAdapter();
+
+        assert.ok(!MockMozBluetooth.addEventListener.called);
+        assert.equal(Bluetooth._adapter, null);
+        assert.deepEqual(Bluetooth._cacheGetAdapterPromise, promise);
+        // the promise only called once
+        assert.ok(window.Promise.calledOnce);
+    });
+
+    // cached path
+    test('return cached Promise when adapter is not ready but' +
+      'getAdapter has been called', function() {
+        var promise = new Promise(function(resolve) {
+          resolve();
+        });
+        Bluetooth._cacheGetAdapterPromise = promise;
+        Bluetooth.getAdapter();
+
+        assert.ok(!MockMozBluetooth.addEventListener.called);
+        assert.equal(Bluetooth._adapter, null);
+        assert.deepEqual(Bluetooth._cacheGetAdapterPromise, promise);   
+    });
+  });
+
+  suite('_bluetoothManagerHandler', function() {
+    setup(function() {
+      this.sinon.stub(Bluetooth, '_updateProfileState');
+      this.sinon.spy(Promise, 'resolve');
+      Bluetooth._bluetooth = window.navigator.mozBluetooth;
+    });
+
+    teardown(function() {
+      Bluetooth._adapter = null;
+    });
+
+    test('updateProfileState is called when defaultAdapter is matched',
+      function() {
+        var evt = {
+          attrs: ['defaultAdapter']
+        };
+        MockMozBluetooth.defaultAdapter = MockBTAdapter;
+        Bluetooth._bluetoothManagerHandler(null, evt);
+        assert.equal(Bluetooth._adapter, MockBTAdapter);
+        assert.ok(Bluetooth._updateProfileState.called);
+    });
+
+    test('updateProfileState is not called when no matched attribute',
+      function() {
+        var evt = {
+          attrs: []
+        };
+        MockMozBluetooth.defaultAdapter = null;
+        Bluetooth._bluetoothManagerHandler(null, evt);
+        assert.equal(Bluetooth._adapter, null);
+        assert.isFalse(Bluetooth._updateProfileState.called);
+    });
+
+    test('resolve is called when pass with resolve function',
+      function() {
+        var evt = {
+          attrs: ['defaultAdapter']
+        };
+        MockMozBluetooth.defaultAdapter = MockBTAdapter;
+        Bluetooth._bluetoothManagerHandler(Promise.resolve, evt);
+        assert.equal(Bluetooth._adapter, MockBTAdapter);
+        assert.ok(Bluetooth._updateProfileState.called);
+        assert.ok(Promise.resolve.called);
+    });
+  });
+});

--- a/apps/system/test/unit/nfc_handover_manager_test.js
+++ b/apps/system/test/unit/nfc_handover_manager_test.js
@@ -402,7 +402,7 @@ suite('Nfc Handover Manager Functions', function() {
 
       nfcHandoverManager._doAction(action);
 
-      window.dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
+      window.dispatchEvent(new CustomEvent('bluetooth-enabled'));
       invokeBluetoothGetDefaultAdapter();
 
       assert.isTrue(action.callback.calledOnce);
@@ -440,7 +440,7 @@ suite('Nfc Handover Manager Functions', function() {
 
     var initiateFileTransfer = function() {
       spySendNDEF = sinon.spy(MockMozNfc.MockNFCPeer, 'sendNDEF');
-      window.dispatchEvent(new CustomEvent('bluetooth-adapter-added'));
+      window.dispatchEvent(new CustomEvent('bluetooth-enabled'));
       invokeBluetoothGetDefaultAdapter();
       nfcHandoverManager.handleFileTransfer(mockFileRequest.peer,
                                             mockFileRequest.blob,

--- a/apps/system/test/unit/quick_settings_test.js
+++ b/apps/system/test/unit/quick_settings_test.js
@@ -1,12 +1,7 @@
 'use strict';
-/* global MockL10n */
-/* global MockNavigatorMozMobileConnections */
-/* global MockNavigatorSettings */
-/* global MocksHelper */
-/* global MockSettingsListener */
-/* global MockWifiManager */
-/* global QuickSettings */
-
+/* global MockL10n, MockNavigatorMozMobileConnections,
+   MockNavigatorSettings, MocksHelper, MockSettingsListener,
+   MockWifiManager, QuickSettings */
 
 require('/test/unit/mock_activity.js');
 require('/shared/test/unit/mocks/mock_l10n.js');

--- a/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
@@ -4,6 +4,23 @@
 
 (function(window) {
 
+  var mAdapterEventListeners = [];
+
+  function mba_addEventListener(type, callback) {
+    mAdapterEventListeners.push({
+      type: type,
+      callback: callback
+    });
+  }
+
+  function mba_removeEventListener(type, callback) {
+    mAdapterEventListeners.forEach(function(item, idx) {
+      if (item.type === type && Object.is(item, callback)) {
+        mAdapterEventListeners.slice(idx, 1);
+      }
+    });
+  }
+
   // refer to http://dxr.mozilla.org/mozilla-central/source/
   // dom/webidl/BluetoothAdapter2.webidl
   var MockBTAdapter = {
@@ -16,24 +33,36 @@
     enable: function mba_enable() {},
     disable: function mba_disable() {},
 
-    onscostatuschanged: null
+    onscostatuschanged: null,
+    onhfpstatuschanged: null,
+    ona2dpstatuschanged: null,
+    addEventListener: mba_addEventListener,
+    removeEventListener: mba_removeEventListener
   };
 
-  var mEventListeners = [];
+  var mManagerEventListeners = [];
 
   function mmb_defaultAdapter() {
     return MockBTAdapter;
   }
 
   function mmb_addEventListener(type, callback) {
-    mEventListeners.push({
+    mManagerEventListeners.push({
       type: type,
       callback: callback
     });
   }
 
+  function mmb_removeEventListener(type, callback) {
+    mManagerEventListeners.forEach(function(item, idx) {
+      if (item.type === type && Object.is(item, callback)) {
+        mManagerEventListeners.slice(idx, 1);
+      }
+    });
+  }
+
   function mmb_triggerEventListeners(type) {
-    mEventListeners.forEach(function(eventListener) {
+    mManagerEventListeners.forEach(function(eventListener) {
       if (eventListener.type === type) {
         eventListener.callback();
       }
@@ -45,6 +74,7 @@
   window.MockMozBluetooth = {
     defaultAdapter: mmb_defaultAdapter(),
     addEventListener: mmb_addEventListener,
+    removeEventListener: mmb_removeEventListener,
     triggerEventListeners: mmb_triggerEventListeners,
     onattributechanged: function mmb_onattributechanged() {},
     getAdapters: function mmb_getAdapters() {}

--- a/tv_apps/smart-system/js/bluetooth.js
+++ b/tv_apps/smart-system/js/bluetooth.js
@@ -31,18 +31,6 @@ var Bluetooth = {
     }
   },
 
-  getCurrentProfiles: function bt_getCurrentProfiles() {
-    var profiles = this.Profiles;
-    var connectedProfiles = [];
-    for (var name in profiles) {
-      var profile = profiles[name];
-      if (this.isProfileConnected(profile)) {
-        connectedProfiles.push(profile);
-      }
-    }
-    return connectedProfiles;
-  },
-
   isProfileConnected: function bt_isProfileConnected(profile) {
     var isConnected = this['_' + profile + 'Connected'];
     if (isConnected === undefined) {


### PR DESCRIPTION
- rename `bluetooth-adapter-added` to `bluetooth-enabled` to denote proper event naming
- update settings value and enable bluetooth hardware with new bluetooth v2 module
- add debug flag in Bluetooth2 to print console log
- listen Bluetooth adapterremoved event instead of disable event ( disable event is removed in BTv2)
- Lazyload  and make Bluetooth instanciable
- unit test with 79% coverage
- quick settings interoperation with settings works
- add test cases for cached promise
- avoid multi resolve in defaultAdapter call
