### PR TITLE
Bug 1127160 - [text selection]No new line copied after copying multiple lines from email compose view

### DIFF
--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -138,6 +138,10 @@ input.cmp-subject-text {
   -moz-user-select: text;
 }
 
+.cmp-body-text * {
+  -moz-user-select: text;
+}
+
 .cmp-body-html {
   margin: 0 1.5rem;
 }


### PR DESCRIPTION
This rule enables the <br> tags to participate in the entirety of the text selection in the compose. Before this change, they were inheriting the "none" for the text selection that is set globally.
