### PR TITLE
Bug 1128630 - Browser windows should show URL + SSL state in task manager/tab view

### DIFF
--- a/apps/system/js/app_chrome.js
+++ b/apps/system/js/app_chrome.js
@@ -241,7 +241,7 @@
         this.handleScrollAreaChanged(evt);
         break;
 
-      case 'mozbrowsersecuritychange':
+      case '_securitychange':
         this.handleSecurityChanged(evt);
         break;
 
@@ -371,7 +371,7 @@
     this.app.element.addEventListener('mozbrowsertitlechange', this);
     this.app.element.addEventListener('mozbrowsermetachange', this);
     this.app.element.addEventListener('mozbrowserscrollareachanged', this);
-    this.app.element.addEventListener('mozbrowsersecuritychange', this);
+    this.app.element.addEventListener('_securitychange', this);
     this.app.element.addEventListener('_loading', this);
     this.app.element.addEventListener('_loaded', this);
     this.app.element.addEventListener('_namechanged', this);
@@ -472,7 +472,7 @@
   };
 
   AppChrome.prototype.handleSecurityChanged = function(evt) {
-    this.title.dataset.ssl = evt.detail.state;
+    this.title.dataset.ssl = this.app.getSSLState();
   };
 
   AppChrome.prototype.handleTitleChanged = function(evt) {

--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -418,6 +418,7 @@
     this.browserContainer.removeChild(this.browser.element);
     this.browser = null;
     this.iframe = null;
+    this._sslState = '';
     this.publish('suspended');
   };
 
@@ -761,6 +762,7 @@
      'mozbrowserloadend', 'mozbrowseractivitydone', 'mozbrowserloadstart',
      'mozbrowsertitlechange', 'mozbrowserlocationchange',
      'mozbrowsermetachange', 'mozbrowsericonchange', 'mozbrowserasyncscroll',
+     'mozbrowsersecuritychange',
      '_localized', '_swipein', '_swipeout', '_kill_suspended',
      '_orientationchange', '_focus', '_blur',  '_hidewindow', '_sheetdisplayed',
      '_sheetsgestureend', '_cardviewbeforeshow', '_cardviewclosed',
@@ -2271,6 +2273,29 @@
     }
     this.setVisible(false);
   };
+
+
+  /**
+   *  Track current SSL state of the browser.
+   */
+  AppWindow.prototype._sslState = '';
+
+  /**
+   * Handle mozbrowsersecuritychange events from the browser
+   */
+  AppWindow.prototype._handle_mozbrowsersecuritychange =
+    function aw__handle_mozbrowsersecuritychange(evt) {
+      var state = this._sslState = evt.detail.state;
+      this.publish('securitychange', state);
+    };
+
+  /**
+   * Get the current SSL state for the browser
+   */
+  AppWindow.prototype.getSSLState = function() {
+    return this._sslState;
+  };
+
 
   /**
    * Statusbar will bypass touch event to us via this method

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -232,8 +232,8 @@
 
 #cards-view .card .title {
   width: 100%;
-  height: 3rem;
-  line-height: 3rem;
+  height: 2rem;
+  line-height: 2rem;
 
   overflow-x: hidden;
   margin: 0;
@@ -251,15 +251,48 @@
 #cards-view .card p.subtitle {
   display: none;
   pointer-events: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+  text-align: center;
+  font-weight: normal;
 }
 
-#cards-view.filtered .card .titles p.subtitle {
-  display: none;
+#cards-view .card.browser p.subtitle {
+  color: #858585;
   pointer-events: auto;
+}
+
+#cards-view.filtered .card p.subtitle {
+  display: none;
+}
+
+#cards-view .card p.subtitle:not(:empty),
+#cards-view.filtered .card p.subtitle:not(:empty) {
+  display: block;
+}
+
+#cards-view .card p.subtitle:not(:empty) {
+  display: block;
+}
+
+#cards-view .card[data-ssl="secure"] p.subtitle:not(:empty) {
+  -moz-padding-start: 2rem;
+  background: url("../chrome/images/light/ssl.png") no-repeat 0.1rem center / 2rem 2rem;
+}
+
+#cards-view .card[data-ssl="broken"] p.subtitle:not(:empty) {
+  -moz-padding-start: 3rem;
+  background: url("../chrome/images/light/ssl_broken.png") no-repeat 0.1rem center / 2rem 2rem;
 }
 
 #cards-view.filtered .card .titles h1 {
   color: #4d4d4d;
+}
+
+html[dir="rtl"] #cards-view .card[data-ssl="broken"] p.subtitle:not(:empty),
+html[dir="rtl"] #cards-view .card[data-ssl="secure"] p.subtitle:not(:empty) {
+  background-position: calc(100% - 0.1rem) center
 }
 
 

--- a/apps/system/test/unit/app_chrome_test.js
+++ b/apps/system/test/unit/app_chrome_test.js
@@ -132,6 +132,18 @@ suite('system/AppChrome', function() {
       assert.isTrue(stubSelectOne.called);
     });
 
+    test('app ssl state is changed', function() {
+      var app = new AppWindow(fakeWebSite);
+      this.sinon.stub(app, 'getSSLState', function() {
+        return 'broken';
+      });
+      var chrome = new AppChrome(app);
+      var stubHandleSecurityChanged =
+        this.sinon.spy(chrome, 'handleSecurityChanged');
+      chrome.handleEvent({ type: '_securitychange' });
+      assert.isTrue(stubHandleSecurityChanged.called);
+      assert.equal(chrome.title.dataset.ssl, 'broken');
+    });
   });
 
   suite('Views', function() {

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -2078,6 +2078,27 @@ suite('system/AppWindow', function() {
       assert.isTrue(stubSetVisible.calledWith(true), 'setVisible');
       assert.isTrue(stubBroadcast.calledWith('focus'));
     });
+
+    test('browsersecuritychange event', function() {
+      var app1 = new AppWindow(fakeAppConfig1);
+      // expect indeterminate state before first event
+      var publishStub = this.sinon.stub(app1, 'publish');
+      assert.equal(app1.getSSLState(), '',
+                  'SSL state is empty before the first security change');
+
+
+      ['broken', 'secure', 'insecure'].forEach(function(state, i) {
+        app1.handleEvent({
+          type: 'mozbrowsersecuritychange',
+          detail: {
+            'state': state
+          }
+        });
+        assert.equal(app1.getSSLState(), state);
+        assert.equal(publishStub.getCall(i).args[0], 'securitychange');
+        assert.equal(publishStub.getCall(i).args[1], state);
+      });
+    });
   });
 
   test('Change URL at run time', function() {
@@ -2121,6 +2142,7 @@ suite('system/AppWindow', function() {
     assert.isNull(app1.iframe);
     assert.isTrue(app1.suspended);
     assert.isTrue(stubPublish.calledWith('suspended'));
+    assert.equal(app1._sslState, '');
   });
 
   test('set child window', function() {

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -66,6 +66,7 @@ suite('system/Card', function() {
       assert.isDefined(this.card.title);
       assert.isDefined(this.card.subTitle);
       assert.isDefined(this.card.iconValue);
+      assert.isDefined(this.card.sslState);
       assert.isDefined(this.card.viewClassList);
       assert.isDefined(this.card.titleId);
       assert.isDefined(this.card.closeButtonVisibility);
@@ -142,6 +143,51 @@ suite('system/Card', function() {
       assert.equal(appCard.titleNode.textContent, 'otherapp');
     });
 
+    test('app security for browser windows', function() {
+      var browserCard = new Card({
+        app: makeApp({ name: 'browserwindow' }),
+        manager: mockManager
+      });
+      browserCard.app.title = 'Page title';
+      this.sinon.stub(browserCard.app, 'isBrowser', function() {
+        return true;
+      });
+      this.sinon.stub(browserCard.app, 'getSSLState', function() {
+        return 'broken';
+      });
+      browserCard.render();
+      assert.isTrue(browserCard.app.getSSLState.calledOnce);
+      assert.equal(browserCard.sslState, 'broken');
+      assert.equal(browserCard.element.dataset.ssl, 'broken');
+    });
+    test('browser windows display URL in their subTitle', function() {
+      var browserCard = new Card({
+        app: makeApp({ name: 'browserwindow' }),
+        manager: mockManager
+      });
+      browserCard.app.config.url = 'https://someorigin.org/foo';
+      this.sinon.stub(browserCard, 'getDisplayURLString', function() {
+        return 'someorigin.org/foo';
+      });
+      this.sinon.stub(browserCard.app, 'isBrowser', function() {
+        return true;
+      });
+      browserCard.render();
+      assert.equal(browserCard.subTitle, 'someorigin.org/foo');
+    });
+    test('getDisplayURLString', function() {
+      var browserCard = new Card({
+        app: makeApp({ name: 'browserwindow' }),
+        manager: mockManager
+      });
+      assert.equal(browserCard.getDisplayURLString('foo'), 'foo');
+      assert.equal(browserCard.getDisplayURLString('about:blank'),
+                   'about:blank');
+      assert.equal(
+        browserCard.getDisplayURLString('http://foo.com:8080/bar?bazz#boss'),
+        'foo.com:8080/bar?bazz#boss'
+      );
+    });
   });
 
   suite('destroy', function() {

--- a/apps/system/test/unit/mock_app_window.js
+++ b/apps/system/test/unit/mock_app_window.js
@@ -13,7 +13,7 @@
         try {
           this[key] = config[key];
         } catch (e) {
-          
+
         }
       }
       this.config = config;
@@ -146,7 +146,8 @@
     setVisibileForScreenReader: function() {},
     handleStatusbarTouch: function() {},
     setNFCFocus: function() {},
-    setActive: function() {}
+    setActive: function() {},
+    getSSLState: function() { return ''; }
   };
   MockAppWindow.mTeardown = function() {
     MockAppWindowHelper.mInstances = [];


### PR DESCRIPTION
Populates the card's subTitle with a prettified url (just removes scheme currently) for browser windows. 
To get the SSL state icon in there I had to refactor AppChrome a little to get its SSL state from AppWindow, from a new getSecurity method. 
