### PR TITLE
Bug 1121468 - Long-pressing a selection when the selection bubble isn't visible should show the selection bubble

### DIFF
--- a/apps/clock/style/alarm.css
+++ b/apps/clock/style/alarm.css
@@ -75,6 +75,10 @@ ul.compact li label:active {
   display: none;
 }
 
+#time-select {
+  text-indent: 1000rem;
+}
+
 /**
  * 1. COMPLEX: Scoped style-sheets within <gaia-header>
  * trump all other rules. !important is required


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1121468
