### PR TITLE
Bug 1106420 - Add try/catch to guard against unload error

### DIFF
--- a/apps/system/test/marionette/lib/lockscreen_media_playback_actions.js
+++ b/apps/system/test/marionette/lib/lockscreen_media_playback_actions.js
@@ -78,8 +78,10 @@
 
   LockScreenMediaPlaybackActions.prototype.killMusicApp =
   function() {
-    this.ensure()
-      .close(this.musicAppInfo.origin);
+    try {
+      this.ensure()
+        .close(this.musicAppInfo.origin);
+    } catch(e) {}
     return this;
   };
 

--- a/apps/system/test/marionette/lib/media_playback_actions.js
+++ b/apps/system/test/marionette/lib/media_playback_actions.js
@@ -118,8 +118,10 @@
 
   MediaPlaybackActions.prototype.killMusicApp =
   function() {
-    this.ensure()
-      .close(this.musicAppInfo.origin);
+    try {
+      this.ensure()
+        .close(this.musicAppInfo.origin);
+    } catch(e) {}
     return this;
   };
 

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -38,7 +38,6 @@
     "apps/system/fxa/test/marionette/fxa_screen_flow_test.js": "Bug 1064305 - [Marionette] FxA tests - intermittent timeout failures on system/fxa/test/marionette/fxa_screen_flow_test.js",
     "apps/system/test/marionette/browser_fullscreen_navigation_chrome_test.js": "Bug 1092022 - Intermittent failing test, TEST-UNEXPECTED-FAIL | Browser - App /w Fullscreen Navigation Chrome test progressbar",
     "apps/system/test/marionette/global_overlay_window_test.js": "Bug 1117125 - Update b2g desktop in tbpl after bug 1101029 lands",
-    "apps/system/test/marionette/media_playback_test.js": "Bug 1106420 - Intermittent test | media playback tests should hide now playing info by exiting",
     "apps/system/test/marionette/software_home_file_open_error_test.js": "Bug 1119079 - Intermittent software_home_file_open_error_test.js | Software Home Button - File Open Error Proper layout for file error dialog",
     "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",
     "apps/verticalhome/test/marionette/collection_pin_result_uninstall_test.js": "Bug 1098310 - TEST-UNEXPECTED-FAIL | Vertical - Collection uninstall pinned collection web result",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1106420
