### PR TITLE
Bug 1127953 - [Lockscreen] [text selection] The text selection options (select all, cut, copy, paste) can appear on the lockscreen if they are present prior to quickly turning your screen off and back on.

### DIFF
--- a/apps/system/js/text_selection_dialog.js
+++ b/apps/system/js/text_selection_dialog.js
@@ -1,4 +1,4 @@
-/* global layoutManager, SettingsListener */
+/* global layoutManager, SettingsListener, Service */
 'use strict';
 (function(exports) {
   var DEBUG = false;
@@ -69,6 +69,7 @@
     this._enabled = true;
     window.addEventListener('hierachychanged', this);
     window.addEventListener('activeappchanged', this);
+    window.addEventListener('screenchange', this);
     window.addEventListener('home', this);
     window.addEventListener('mozChromeEvent', this);
     window.addEventListener('value-selector-shown', this);
@@ -83,6 +84,7 @@
     this._enabled = false;
     window.removeEventListener('hierachychanged', this);
     window.removeEventListener('activeappchanged', this);
+    window.removeEventListener('screenchange', this);
     window.removeEventListener('home', this);
     window.removeEventListener('mozChromeEvent', this);
     window.removeEventListener('value-selector-shown', this);
@@ -105,6 +107,11 @@
         if (this._shortcutTimeout) {
           this._resetShortcutTimeout();
           this.hide();
+        }
+        break;
+      case 'screenchange':
+        if (!evt.detail.screenEnabled && Service.locked) {
+          this.close();
         }
         break;
       case 'home':


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1127953
