### PR TITLE
Bug 1098289 - Migrate Email to use navigator.sync (RequestSync) API (Phase1)

### DIFF
--- a/apps/email/js/app_messages.js
+++ b/apps/email/js/app_messages.js
@@ -115,8 +115,8 @@ define(function(require) {
     evt.on(
         'notification', appMessages.onNotification.bind(appMessages));
 
-    // Do not listen for navigator.mozSetMessageHandler('alarm') type, that is
-    // only done in the back end's cronsync for now.
+    // Do not listen for navigator.mozSetMessageHandler('request-sync')
+    // type, that is only done in the back end's cronsync for now.
   } else {
     console.warn('Activity support disabled!');
   }

--- a/apps/email/js/cards/settings_debug.html
+++ b/apps/email/js/cards/settings_debug.html
@@ -63,5 +63,9 @@
     <button data-event="click:fastSync"
             href="#"
             class="tng-dbg-fastsync">Enable faster sync options</button>
+
+    <button data-event="click:showSyncs" href="#">Show sync tasks
+    in logcat</button>
+
   </section>
 </section>

--- a/apps/email/js/cards/settings_debug.js
+++ b/apps/email/js/cards/settings_debug.js
@@ -41,7 +41,32 @@ return [
     },
 
     fastSync: function() {
-      _secretDebug.fastSync = [20000, 60000];
+      _secretDebug.fastSync = [100000, 200000];
+    },
+
+    showSyncs: function() {
+      var navSync = navigator.sync;
+      if (!navSync) {
+        console.error('navigator.sync not available');
+        return;
+      }
+
+      navSync.registrations().then(function(regs) {
+        console.log('navigator.sync registrations count: ', regs.length);
+        regs.forEach(function(reg) {
+          console.log('Registered task: ' + reg.task);
+          Object.keys(reg).forEach(function(key) {
+            if (key === 'data') {
+              console.log(key + ': ' + JSON.stringify(reg[key]));
+            } else {
+              console.log(key + ': ' + reg[key]);
+            }
+          });
+          console.log('-----------');
+        });
+      }, function(err) {
+        console.error('navigator.sync.registrations failed: ', err);
+      });
     },
 
     die: function() {

--- a/apps/email/js/ext/main-frame-setup.js
+++ b/apps/email/js/ext/main-frame-setup.js
@@ -5,7 +5,7 @@
  * Main: Spawns worker
  * Worker: Loads core JS
  * Worker: 'hello' => main
- * Main: 'hello' => worker with online status and mozAlarms status
+ * Main: 'hello' => worker with online status and navigator.sync status
  * Worker: Creates MailUniverse
  * Worker 'mailbridge'.'hello' => main
  * Main: Creates MailAPI, sends event to UI

--- a/apps/email/js/ext/worker-support/cronsync-main.js
+++ b/apps/email/js/ext/worker-support/cronsync-main.js
@@ -9,15 +9,6 @@ define(function(require) {
     console.log('cronsync-main: ' + str);
   }
 
-  function makeData(accountIds, interval, date) {
-    return {
-      type: 'sync',
-      accountIds: accountIds,
-      interval: interval,
-      timestamp: date.getTime()
-    };
-  }
-
   // Creates a string key from an array of string IDs. Uses a space
   // separator since that cannot show up in an ID.
   function makeAccountKey(accountIds) {
@@ -33,8 +24,9 @@ define(function(require) {
 
   // Makes sure two arrays have the same values, account IDs.
   function hasSameValues(ary1, ary2) {
-    if (ary1.length !== ary2.length)
+    if (ary1.length !== ary2.length) {
       return false;
+    }
 
     var hasMismatch = ary1.some(function(item, i) {
       return item !== ary2[i];
@@ -44,13 +36,10 @@ define(function(require) {
   }
 
   if (navigator.mozSetMessageHandler) {
-    navigator.mozSetMessageHandler('alarm', function onAlarm(alarm) {
-      // Do not bother with alarms that are not sync alarms.
-      var data = alarm.data;
-      if (!data || data.type !== 'sync')
-        return;
-
-      // Need to acquire the wake locks during this alarm notification
+    navigator.mozSetMessageHandler('request-sync',
+    function onRequestSync(e) {
+      var data = e.data;
+      // Need to acquire the wake locks during this notification
       // turn of the event loop -- later turns are not guaranteed to
       // be up and running. However, knowing when to release the locks
       // is only known to the front end, so publish event about it.
@@ -72,7 +61,10 @@ define(function(require) {
                              makeAccountKey(data.accountIds), locks);
       }
 
-      dispatcher._sendMessage('alarm', [data.accountIds, data.interval]);
+      debug('request-sync started at ' + (new Date()));
+
+      dispatcher._sendMessage('requestSync',
+                              [data.accountIds, data.interval]);
     });
   }
 
@@ -103,161 +95,157 @@ define(function(require) {
     },
 
     /**
-     * Clears all sync-based alarms. Normally not called, except perhaps for
+     * Clears all sync-based tasks. Normally not called, except perhaps for
      * tests or debugging.
      */
     clearAll: function() {
-      var mozAlarms = navigator.mozAlarms;
-      if (!mozAlarms)
+      var navSync = navigator.sync;
+      if (!navSync) {
         return;
+      }
 
-      var r = mozAlarms.getAll();
-
-      r.onsuccess = function(event) {
-        var alarms = event.target.result;
-        if (!alarms)
+      navSync.registrations().then(function(registrations) {
+        if (!registrations.length) {
           return;
+        }
 
-        alarms.forEach(function(alarm) {
-          if (alarm.data && alarm.data.type === 'sync')
-            mozAlarms.remove(alarm.id);
+        registrations.forEach(function(registeredTask) {
+          navSync.unregister(registeredTask.task);
         });
-      }.bind(this);
-      r.onerror = function(err) {
-        console.error('cronsync-main clearAll mozAlarms.getAll: error: ' +
-                      err);
-      }.bind(this);
+      }.bind(this),
+      function(err) {
+        console.error('cronsync-main clearAll navigator.sync.registrations ' +
+                      'error: ' + err);
+      }.bind(this));
     },
 
     /**
-     * Makes sure there is an alarm set for every account in
+     * Makes sure there is an sync task set for every account in
      * the list.
      * @param  {Object} syncData. An object with keys that are
      * 'interval' + intervalInMilliseconds, and values are arrays
      * of account IDs that should be synced at that interval.
      */
     ensureSync: function (syncData) {
-      var mozAlarms = navigator.mozAlarms;
-      if (!mozAlarms) {
-        console.warn('no mozAlarms support!');
+      var navSync = navigator.sync;
+      if (!navSync) {
+        console.warn('no navigator.sync support!');
+        // Let backend know work has finished, even though it was a no-op.
+        this._sendMessage('syncEnsured');
         return;
       }
 
       debug('ensureSync called');
 
-      var request = mozAlarms.getAll();
-
-      request.onsuccess = function(event) {
+      navSync.registrations().then(function(registrations) {
         debug('success!');
 
-        var alarms = event.target.result;
-        // If there are no alarms a falsey value may be returned.  We want
-        // to not die and also make sure to signal we completed, so just make
-        // an empty list.
-        if (!alarms) {
-          alarms = [];
-        }
+        // Find all IDs being tracked by sync tasks
+        var expiredTasks = [],
+            okTaskIntervals = {},
+            uniqueTasks = {};
 
-        // Find all IDs being tracked by alarms
-        var expiredAlarmIds = [],
-            okAlarmIntervals = {},
-            uniqueAlarms = {};
-
-        alarms.forEach(function(alarm) {
-          // Only care about sync alarms.
-          if (!alarm.data || !alarm.data.type || alarm.data.type !== 'sync')
-            return;
-
-          var intervalKey = 'interval' + alarm.data.interval,
+        registrations.forEach(function(task) {
+          // minInterval in seconds, but use milliseconds for sync values
+          // internally.
+          var intervalKey = 'interval' + (task.minInterval * 1000),
               wantedAccountIds = syncData[intervalKey];
 
           if (!wantedAccountIds || !hasSameValues(wantedAccountIds,
-                                                  alarm.data.accountIds)) {
-            debug('account array mismatch, canceling existing alarm');
-            expiredAlarmIds.push(alarm.id);
+                                                  task.data.accountIds)) {
+            debug('account array mismatch, canceling existing sync task');
+            expiredTasks.push(task);
           } else {
-            // Confirm the existing alarm is still good.
+            // Confirm the existing sync task is still good.
             var interval = toInterval(intervalKey),
-                now = Date.now(),
-                alarmTime = alarm.data.timestamp,
                 accountKey = makeAccountKey(wantedAccountIds);
 
-            // If the interval is nonzero, and there is no other alarm found
+            // If the interval is nonzero, and there is no other task found
             // for that account combo, and if it is not in the past and if it
             // is not too far in the future, it is OK to keep.
-            if (interval && !uniqueAlarms.hasOwnProperty(accountKey) &&
-                alarmTime > now && alarmTime < now + interval) {
-              debug('existing alarm is OK');
-              uniqueAlarms[accountKey] = true;
-              okAlarmIntervals[intervalKey] = true;
+            if (interval && !uniqueTasks.hasOwnProperty(accountKey)) {
+              debug('existing sync task is OK: ' + interval);
+              uniqueTasks[accountKey] = true;
+              okTaskIntervals[intervalKey] = true;
             } else {
-              debug('existing alarm is out of interval range, canceling');
-              expiredAlarmIds.push(alarm.id);
+              debug('existing sync task is out of interval range, canceling');
+              expiredTasks.push(task);
             }
           }
         });
 
-        expiredAlarmIds.forEach(function(alarmId) {
-          mozAlarms.remove(alarmId);
+        expiredTasks.forEach(function(expiredTask) {
+          navSync.unregister(expiredTask.task);
         });
 
-        var alarmMax = 0,
-            alarmCount = 0,
+        var taskMax = 0,
+            taskCount = 0,
             self = this;
 
-        // Called when alarms are confirmed to be set.
+        // Called when sync tasks are confirmed to be set.
         function done() {
-          alarmCount += 1;
-          if (alarmCount < alarmMax)
+          taskCount += 1;
+          if (taskCount < taskMax) {
             return;
+          }
 
           debug('ensureSync completed');
           // Indicate ensureSync has completed because the
-          // back end is waiting to hear alarm was set before
-          // triggering sync complete.
+          // back end is waiting to hear sync task was set
+          // before triggering sync complete.
           self._sendMessage('syncEnsured');
         }
 
         Object.keys(syncData).forEach(function(intervalKey) {
-          // Skip if the existing alarm is already good.
-          if (okAlarmIntervals.hasOwnProperty(intervalKey))
+          // Skip if the existing sync task is already good.
+          if (okTaskIntervals.hasOwnProperty(intervalKey)) {
             return;
+          }
 
           var interval = toInterval(intervalKey),
-              accountIds = syncData[intervalKey],
-              date = new Date(Date.now() + interval);
+              accountIds = syncData[intervalKey];
 
           // Do not set an timer for a 0 interval, bad things happen.
-          if (!interval)
+          if (!interval) {
             return;
+          }
 
-          alarmMax += 1;
+          taskMax += 1;
 
-          var alarmRequest = mozAlarms.add(date, 'ignoreTimezone',
-                                       makeData(accountIds, interval, date));
-
-          alarmRequest.onsuccess = function() {
-            debug('success: mozAlarms.add for ' + 'IDs: ' + accountIds +
+          navSync.register('interval' + interval, {
+            // minInterval is in seconds.
+            minInterval: interval / 1000,
+            oneShot: false,
+            data: {
+              accountIds: accountIds,
+              interval: interval
+            },
+            wifiOnly: false,
+            // TODO: allow this to be more generic, getting this passed in
+            // from the page using this module. This assumes the current page
+            // without query strings or fragment IDs is the desired entry point.
+            wakeUpPage: location.href.split('?')[0].split('#')[0] })
+          .then(function() {
+            debug('success: navigator.sync.register for ' + 'IDs: ' +
+                  accountIds +
                   ' at ' + interval + 'ms');
             done();
-          };
-
-          alarmRequest.onerror = function(err) {
-            console.error('cronsync-main mozAlarms.add for IDs: ' +
+          }, function(err) {
+            console.error('cronsync-main navigator.sync.register for IDs: ' +
                           accountIds +
                           ' failed: ' + err);
-          };
+          });
         });
 
-        // If no alarms were added, indicate ensureSync is done.
-        if (!alarmMax)
+        // If no sync tasks were added, indicate ensureSync is done.
+        if (!taskMax) {
           done();
-      }.bind(this);
-
-      request.onerror = function(err) {
-        console.error('cronsync-main ensureSync mozAlarms.getAll: error: ' +
-                      err);
-      };
+        }
+      }.bind(this),
+      function(err) {
+        console.error('cronsync-main ensureSync navigator.sync.register: ' +
+                      'error: ' + err);
+      });
     }
   };
 

--- a/apps/email/js/html_cache_restore.js
+++ b/apps/email/js/html_cache_restore.js
@@ -285,8 +285,8 @@ window.htmlCacheRestorePendingMessage = [];
     if (navigator.mozHasPendingMessage('activity')) {
       window.htmlCacheRestorePendingMessage.push('activity');
     }
-    if (navigator.mozHasPendingMessage('alarm')) {
-      window.htmlCacheRestorePendingMessage.push('alarm');
+    if (navigator.mozHasPendingMessage('request-sync')) {
+      window.htmlCacheRestorePendingMessage.push('request-sync');
     }
     if (navigator.mozHasPendingMessage('notification')) {
       window.htmlCacheRestorePendingMessage.push('notification');

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -204,9 +204,9 @@ if (appMessages.hasPending('activity') ||
   console.log('email waitForAppMessage');
 }
 
-if (appMessages.hasPending('alarm')) {
-  // There is an alarm, do not use the cache node, start fresh,
-  // as we were woken up just for the alarm.
+if (appMessages.hasPending('request-sync')) {
+  // There is an sync task, do not use the cache node, start fresh,
+  // as we were woken up just for the sync task.
   cachedNode = null;
   startedInBackground = true;
   console.log('email startedInBackground');

--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -1,9 +1,10 @@
 /*jshint browser: true */
-/*global define, console, plog, Notification */
+/*global define, console, Notification */
 'use strict';
 define(function(require) {
 
-  var appSelf = require('app_self'),
+  var cronSyncStartTime,
+      appSelf = require('app_self'),
       evt = require('evt'),
       model = require('model'),
       mozL10n = require('l10n!'),
@@ -96,6 +97,7 @@ define(function(require) {
 
     api.oncronsyncstart = function(accountIds) {
       console.log('email oncronsyncstart: ' + accountIds);
+      cronSyncStartTime = Date.now();
       var accountKey = makeAccountKey(accountIds);
       waitingOnCron[accountKey] = true;
     };
@@ -229,13 +231,9 @@ define(function(require) {
         });
 
         if (!hasBeenVisible && !stillWaiting) {
-          var msg = 'mail sync complete, closing mail app';
-          if (typeof plog === 'function') {
-            plog(msg);
-          } else {
-            console.log(msg);
-          }
-
+          console.log('sync completed in ' +
+                     ((Date.now() - cronSyncStartTime) / 1000) +
+                     ' seconds, closing mail app');
           window.close();
         }
       }

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -8,12 +8,11 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "messages": [
-    { "alarm": "/index.html" },
-    { "notification": "/index.html" }
+    { "notification": "/index.html" },
+    { "request-sync": "/index.html" }
   ],
   "permissions": {
     "themeable":{},
-    "alarms":{},
     "browser": {},
     "audio-channel-notification":{},
     "contacts":{ "access": "readcreate" },

--- a/apps/email/test/marionette/lib/email_sync.js
+++ b/apps/email/test/marionette/lib/email_sync.js
@@ -19,23 +19,20 @@ EmailSync.prototype = {
 
   /**
    * Does the work to trigger a sync using helpers in
-   * mock_navigator_mozalarms.js. Assumes the mock
-   * mock_navigator_mozalarms.js was already injected.
+   * mock_navigator_moz_set_message_handler.js.
    */
   triggerSync: function() {
     // trigger sync in Email App
     this.client.executeScript(function() {
       var interval = 1000;
       var date = new Date(Date.now() + interval).getTime();
-      var alarm = {
+      var task = {
         data: {
-          type: 'sync',
           accountIds: ['0', '1'],
-          interval: interval,
-          timestamp: date
+          interval: interval
         }
       };
-      return window.wrappedJSObject.fireMessageHandler(alarm);
+      return window.wrappedJSObject.fireMessageHandler(task, 'request-sync');
     });
   }
 };

--- a/apps/email/test/marionette/notification_set_interval_test.js
+++ b/apps/email/test/marionette/notification_set_interval_test.js
@@ -18,23 +18,20 @@ marionette('email notifications, set interval', function() {
                   }
                 }, this);
 
-  function getAlarms(client) {
-    var alarms;
+  function getSynRegistrations(client) {
+    var regs;
     client.waitFor(function() {
-      alarms = client.executeScript(function() {
-        var alarms = window.wrappedJSObject.navigator.__mozFakeAlarms;
-        if (alarms && alarms.length) {
-            return alarms;
-        }
+      regs = client.executeScript(function() {
+        var nav = window.wrappedJSObject.navigator;
+        return nav.__mozFakeSyncRegistrations;
        });
-      return alarms;
+      return regs;
     });
-    return alarms;
+    return regs;
   }
 
   setup(function() {
     app = new Email(client);
-    client.contentScript.inject(SHARED_PATH + '/mock_navigator_mozalarms.js');
     app.launch();
   });
 
@@ -52,12 +49,6 @@ marionette('email notifications, set interval', function() {
     // change.
     var emailData = new EmailData(client);
     emailData.waitForCurrentAccountUpdate('syncInterval', 3600000);
-
-    // Make sure an alarm was set.
-    var alarms = getAlarms(client);
-    assert(alarms.length === 1, 'have one alarm');
-    var alarm = alarms[0];
-    assert(alarm.interval === 3600000, 'has correct interval value');
 
     // Close the app, relaunch and make sure syncInterval was
     // persisted correctly

--- a/shared/test/integration/mock_navigator_moz_set_message_handler.js
+++ b/shared/test/integration/mock_navigator_moz_set_message_handler.js
@@ -16,18 +16,21 @@ Services.obs.addObserver(function(document) {
   }
 
   var window = document.defaultView.wrappedJSObject;
-  var messageHandler;
+  var messageHandlers = {};
 
   window.navigator.__defineGetter__('mozSetMessageHandler', function() {
     return function(type, callback) {
-      if (type === 'alarm') {
-        messageHandler = callback;
-      }
+      messageHandlers[type] = callback;
     };
   });
 
   window.__defineGetter__('fireMessageHandler', function() {
-    return function(data) {
+    return function(data, type) {
+      // For historical purposes, this only supported alarm callbacks. To avoid
+      // force updating code that still assumes that, still assume that as a
+      // default.
+      type = type || 'alarm';
+      var messageHandler = messageHandlers[type];
       if (messageHandler && typeof(messageHandler) === 'function') {
         messageHandler(data);
         return true;


### PR DESCRIPTION
Move from mozAlarms to navigator.sync API. The bulk of the changes were just name swaps:
- mozSetMessageHandler: from 'alarm' to 'request-sync'.
- mozAlarm and its DOMRequest style API to navigator.sync's promise API.
- naming local variables with 'alarm' to 'registrations' or a 'sync task', or 'task' in the name.

See the [gelam pull request](https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/368) for the email/js/ext and upgrade notes. For files tracked only in gaia:
# js/cards/settings_debug.js

It now has an option to print the sync tasks in the logcat. There is also the [requestsyncmanager](https://github.com/jrburke/requestsyncmanager) app that can be used to look at all sync tasks on the device. Hopefully it will be possible to use it to adjust the minInterval from a lower value than 100 second minimum that is enforced by default. See bug referenced in that project's README. The "fastSync" options are now 100 and 200 seconds because of the minimum in the request-sync code. I expect over time the requestsyncmanager would be used to shift syncs down to faster times for dev debugging.

https://mxr.mozilla.org/mozilla-central/source/dom/requestsync/ has the backing code for navigator.sync.
## js/sync.js

The change here was mostly to print out a number that was more useful than the plog timing, which was not really insightful. Now it shows how long the sync took once we started up the app.
## test/marionette/notification_set_interval_test.js

I simplified the test to avoid needing to mock the navigator.sync API. I took a pass at it, but it started to feel complicated with the promises .then returning other promises that all needed **exposedProps** to work, and in the end, I think the most value in the test is confirming that a UI change for the interval is properly persisted.
## shared/test/integration/mock_navigator_moz_set_message_handler.js

Expanded to allow 'request-sync' to work with this mock. Preserves the default of 'alarm' so other people's code does not have to change, but now allows request-sync to also work.
