### PR TITLE
Bug 1130865 - [Calendar] Try using center coordinates of current day

### DIFF
--- a/apps/calendar/test/marionette/month_view_test.js
+++ b/apps/calendar/test/marionette/month_view_test.js
@@ -182,7 +182,7 @@ marionette('month view', function() {
 
   test('double tap', function() {
     var month = app.month;
-    month.actions.doubleTap(month.currentDay, 8, 8).perform();
+    month.actions.doubleTap(month.currentDay).perform();
 
     var editEvent = app.editEvent;
     editEvent.waitForDisplay();

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -3,7 +3,6 @@
     "apps/calendar/test/marionette/alarm_test.js": "Bug 994976 - Perma-red TBPL test, alarm > without alarm mocks create two events with simultaneous reminders",
     "apps/calendar/test/marionette/caldav_test.js": "Bug 972631 - CalDAV setup causing tbpl timeouts",
     "apps/calendar/test/marionette/day_view_test.js": "Bug 1076716 - TEST-UNEXPECTED-FAIL | day view before each hook",
-    "apps/calendar/test/marionette/month_view_test.js": "Bug 1130865 - Permaorange on Sunday | month view double tap",
     "apps/calendar/test/marionette/server_test.js": "",
     "apps/calendar/test/marionette/week_view_test.js": "Bug 1060447 - Re-enable week_view_test.js",
     "apps/calendar/test/marionette/toggle_calendar_test.js": "Bug 1007519 - Perma failing test, toggle calendar > regular event disable calendar day view",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1130865
