### PR TITLE
Bug 1130632 - Add FirefoxOS version information to gaia build

### DIFF
--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -119,6 +119,7 @@
    "lockscreen.locked": true,
    "lockscreen.unlock-sound.enabled": false,
    "message.sent-sound.enabled": true,
+   "moz.b2g.version": "3.0",
    "nfc.enabled": false,
    "nfc.suspended": false,
    "nfc.debugging.enabled": false,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1130632
