### PR TITLE
Bug 1129844 - Keyboard UserDictionary displays word list as sorted alphabetically

### DIFF
--- a/apps/keyboard/style/settings.css
+++ b/apps/keyboard/style/settings.css
@@ -241,6 +241,10 @@ input:focus {
   display: none;
 }
 
+#ud-wordlist-list a {
+  pointer-events: none;
+}
+
 #panel-ud-editword #ud-editword-add-header {
   display: none;
 }

--- a/apps/keyboard/test/unit/settings/user_dictionary_test.js
+++ b/apps/keyboard/test/unit/settings/user_dictionary_test.js
@@ -142,6 +142,8 @@ suite('UserDictionary', function() {
 
       var pRet = model.updateWord('oldstar', 'oldstar');
 
+      assert.isTrue(Promise.resolve.calledWith(['oldstar']),
+        'resolve() should be called with wordlist as parameter');
       assert.equal(pRet, pRes);
     });
     test('new word is trimmed correctly', function(){
@@ -264,6 +266,21 @@ suite('UserDictionary', function() {
           wordlist: [],
           dictblob: undefined
         }));
+
+        done();
+      }, done);
+    });
+
+    test('Word list is returned and sorted', function(done) {
+      model._wordSet = new Set(['apply', 'Banana', 'Apple']);
+
+      pSave1 = model._saveDict();
+
+      rSaveQueue();
+      rDB1();
+
+      pSave1.then(wordList => {
+        assert.deepEqual(wordList, ['Apple', 'apply', 'Banana']);
 
         done();
       }, done);


### PR DESCRIPTION
- Only the UserDictionary model does the sorting. It returns a full list on each list modification call .
- The view maintains an extra word-to-domElem mapping and can re-order the domElems on retrieving the full list from model.
- A new UDListView.rearrangeList function replaces .appendList function, which is used to re-order domElems, and generate new domEleme for words that haven't bee displayed (such as initialization, add, and replace).
