### PR TITLE
Bug 1121978 - Test test_keyboard_predictive_key.py is failing intermitte...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/manifest.ini
@@ -10,6 +10,8 @@ skip-if = device == "desktop" && os == "linux" && debug
 [test_number_keyboard.py]
 
 [test_keyboard_predictive_key.py]
+# Bug 1008932 - On desktopb2g, mozOrientation reports landscape when Gaia is oriented in portrait
+fail-if = device == "desktop"
 
 [test_email_keyboard.py]
 

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/keyboard/test_keyboard_predictive_key.py
@@ -15,6 +15,9 @@ class TestKeyboardPredictiveKey(GaiaTestCase):
         self.data_layer.set_setting('keyboard.autocorrect', True)
 
     def test_keyboard_predictive_key(self):
+        # Check that the device is in portrait mode as the autocorrect words returned depend on the screen orientation
+        self.assertEqual('portrait-primary', self.device.screen_orientation)
+
         self.ui_tests = UiTests(self.marionette)
         self.ui_tests.launch()
 


### PR DESCRIPTION
...ntly, wrong predictive word is selected
