### PR TITLE
Bug 1131827 - [RTL] icon overlaps text in action button

### DIFF
--- a/apps/system/style/action_menu/action_menu_extended.css
+++ b/apps/system/style/action_menu/action_menu_extended.css
@@ -27,7 +27,7 @@
 form[role="dialog"][data-type="action"] > menu > button.icon,
 form[role="dialog"][data-type="object"] > menu > button.icon {
   background-repeat: no-repeat;
-  padding-left: 4rem;
+  -moz-padding-start: 4rem;
   background-size: 3rem;
   background-position: 0.5rem center;
 }


### PR DESCRIPTION
The padding added to leave room for an icon needs to be direction-aware.
