### PR TITLE
Bug 1132194 - [RTL][Contacts] Fix padding to leave room for Add icon.

### DIFF
--- a/apps/communications/contacts/style/contacts.css
+++ b/apps/communications/contacts/style/contacts.css
@@ -916,7 +916,7 @@ form[role="combobox"] span[data-field="type"] {
   color: #5f5f5f;
   height: 5rem;
   vertical-align: middle;
-  padding-left: 4rem;
+  -moz-padding-start: 4rem;
   margin: 0;
 }
 

--- a/shared/style/buttons.css
+++ b/shared/style/buttons.css
@@ -178,7 +178,7 @@ li .button[aria-disabled="true"] {
 li button.icon,
 li .bb-button.icon,
 li .button.icon {
-  padding-right: 4rem;
+  -moz-padding-end: 4rem;
 }
 
 li button.icon:before,
@@ -460,10 +460,4 @@ html[dir="rtl"] .button[data-icon] select {
   left: unset;
   right: 0.3rem; /* .3rem space because of italic */
   text-indent: 1rem;
-}
-
-html[dir="rtl"] li button.icon,
-html[dir="rtl"] li .bb-button.icon,
-html[dir="rtl"] li .button.icon {
-    padding-right: 1rem;
 }


### PR DESCRIPTION
Using -moz-padding-{start,end} instead of padding-left or padding-right
makes things automatically work for RTL, instead of needing separate
rules with a dir=RTL selector to override the original values.
