### PR TITLE
Bug 1132801 - L10nError: "ime-settings" not found in en-US in

### DIFF
--- a/apps/system/js/ime_menu.js
+++ b/apps/system/js/ime_menu.js
@@ -36,8 +36,7 @@
 
       dummy.innerHTML = Template('ime-menu-template').interpolate({
         title: this.title,
-        cancelLabel: _('cancel'),
-        settingsLabel: _('ime-settings')
+        cancelLabel: _('cancel')
       });
       this.container = dummy.firstElementChild;
 


### PR DESCRIPTION
app://system.gaiamobile.org/index.html.  - Remove the unused l10n id for IME
settings button.
