### PR TITLE
Bug 1133338 - Use verticalhome for flatfish

### DIFF
--- a/build/config/tablet/apps-production.list
+++ b/build/config/tablet/apps-production.list
@@ -9,7 +9,6 @@ apps/email
 apps/fl
 apps/ftu
 apps/gallery
-apps/homescreen
 apps/keyboard
 apps/marketplace.firefox.com
 apps/music
@@ -19,6 +18,7 @@ apps/search
 apps/setringtone
 apps/settings
 apps/system
+apps/verticalhome
 apps/video
 apps/wallpaper
 outoftree_apps/*


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1133338
