### PR TITLE
Bug 1124105 - [RTL][Camera]"More info..." is covered by underline in App Permission view after launching camera in RTL language.

### DIFF
--- a/apps/system/style/permission_manager/permission_manager.css
+++ b/apps/system/style/permission_manager/permission_manager.css
@@ -72,6 +72,11 @@
   font-size: 1.8rem;
 }
 
+html[dir="rtl"] #permission-more-info-link,
+html[dir="rtl"] #permission-hide-info-link {
+  text-decoration: none;
+}
+
 #permission-more-info.hidden {
   display: none;
 }


### PR DESCRIPTION
-- add RTL rule for 'more info...'
