### PR TITLE
Bug 1132672 - [RTL] [FTE] The icons found on the import contacts page ar...

### DIFF
--- a/apps/ftu/style/style.css
+++ b/apps/ftu/style/style.css
@@ -1242,8 +1242,3 @@ html[dir="rtl"] #configure_network_params .pack-checkbox {
   left: unset;
   right: auto;
 }
-
-html[dir="rtl"] #import_contacts li button.icon {
-    -moz-padding-start: unset;
-    -moz-padding-end: 4rem;
-}


### PR DESCRIPTION
...e overlapping the text next to them
