### PR TITLE
Bug 1133452 - Python Gaia UI test: Account for software buttons container height when calculating keyboard target position.

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/keyboard/app.py
@@ -15,6 +15,7 @@ except:
     from marionette_driver.marionette import Actions
 
 from gaiatest.apps.base import Base
+from gaiatest.apps.system.app import System
 
 
 class Keyboard(Base):
@@ -164,8 +165,12 @@ class Keyboard(Base):
     def switch_to_keyboard(self, focus=False):
         self.marionette.switch_to_frame()
         input_window = self.marionette.find_element(*self._input_window_locator)
+
+        # if we have software buttons, keyboar's y will not be 0 but the minus height of the button container.
+        expected_y = -System(self.marionette).software_buttons_height
+
         Wait(self.marionette).until(
-            lambda m: 'active' in input_window.get_attribute('class') and input_window.location['y'] == 0,
+            lambda m: 'active' in input_window.get_attribute('class') and input_window.location['y'] == expected_y,
             message='Keyboard inputWindow not interpreted as displayed. Debug is_displayed(): %s, class: %s.'
             % (input_window.is_displayed(), input_window.get_attribute('class')))
 
@@ -339,10 +344,14 @@ class Keyboard(Base):
 var keyboard = navigator.mozKeyboard || navigator.mozInputMethod;
 keyboard.removeFocus();""")
         input_window = self.marionette.find_element(*self._input_window_locator)
+
+        # if we have software buttons, keyboar's y will not be 0 but the minus height of the button container.
+        expected_y = int(input_window.size['height']) - System(self.marionette).software_buttons_height
+
         Wait(self.marionette).until(
             lambda m: 'active' not in input_window.get_attribute('class') and
             not input_window.is_displayed() and
-            (int(input_window.location['y']) == int(input_window.size['height'])),
+            (int(input_window.location['y']) == expected_y),
             message="Keyboard was not dismissed. Debug is_displayed(): %s, class: %s."
                     %(input_window.is_displayed(), input_window.get_attribute('class')))
         self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/apps/system/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/system/app.py
@@ -30,6 +30,9 @@ class System(Base):
 
     _software_home_button_locator = (By.ID, 'software-home-button')
 
+    _software_buttons_locator = (By.ID, 'software-buttons')
+    _screen_locator = (By.ID, 'screen')
+
     @property
     def status_bar(self):
         self.marionette.switch_to_frame()
@@ -89,3 +92,14 @@ class System(Base):
 
     def wait_for_airplane_mode_icon_displayed(self):
         Wait(self.marionette).until(expected.element_displayed(*self._airplane_mode_statusbar_locator))
+
+    @property
+    def software_buttons_height(self):
+        """
+        Gets the height of the software buttons container on the screen.
+        Always returns 0 if software buttons are not displayed.
+        """
+        if 'software-button-enabled' in self.marionette.find_element(*self._screen_locator).get_attribute('class'):
+            return self.marionette.find_element(*self._software_buttons_locator).size['height']
+        else:
+            return 0


### PR DESCRIPTION
- The y-position value according to which keyboard is thought to be ready/dismissed by test script needs to be subtracted with software button container height if such container is present and visible.
- Python test infrastructure: System compoenent now exposes sw_buttons_height property which returns such container height if it's present and visible (relying on a class on #screen exposed by Gaia System app).
