### PR TITLE
Bug 1120974 - Allow various proportions for card view screenshots

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -2153,7 +2153,15 @@
     this._dirtyStyleProperties = {};
     if (this.element && this.transitionController) {
       this.element.classList.add('in-task-manager');
-      this.close( this.isActive() ? 'to-cardview' : 'immediate' );
+      if (this.isActive()) {
+        this.element.style.transformOrigin =
+          'calc(' + window.innerWidth + 'px - 50%) ' +
+          'calc(' + window.innerHeight + 'px - 50%)';
+        this._dirtyStyleProperties.transformOrigin = true;
+        this.close( 'to-cardview' );
+      } else {
+        this.close( 'immediate' );
+      }
     }
   };
 

--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -93,8 +93,13 @@
      <p class="subtitle">${this.subTitle}</p>
     </div>
 
-    <div class="screenshotView bb-button" data-l10n-id="openCard"
-      role="link"></div>
+    <div class="appIconView" style="background-image:${this.iconValue}"></div>
+    <div class="appPreview bb-button" data-l10n-id="openCard"
+      role="link">
+      <div class="windowReflection"
+           style="background-image:-moz-element(#${this.app.instanceID})"></div>
+      <div class="windowScreenshot"></div>
+    </div>
     <div class="appIconView" style="background-image:${this.iconValue}"></div>
 
     <footer class="card-tray">
@@ -305,6 +310,7 @@
       elem.classList.add('browser');
     }
 
+    var previewContainer = this.previewContainer;
     var screenshotView = this.screenshotView;
     var isIconPreview = !this.getScreenshotPreviewsSetting();
     if (isIconPreview) {
@@ -325,7 +331,7 @@
     var isLandscape = (degree == 90 || degree == 270);
 
     // Rotate screenshotView if needed
-    screenshotView.classList.add('rotate-' + degree);
+    previewContainer.classList.add('rotate-' + degree);
 
     if (isIconPreview) {
       return;
@@ -335,33 +341,33 @@
       // We must exchange width and height if it's landscape mode
       var width = elem.clientHeight;
       var height = elem.clientWidth;
-      screenshotView.style.width = width + 'px';
-      screenshotView.style.height = height + 'px';
-      screenshotView.style.left = ((height - width) / 2) + 'px';
-      screenshotView.style.top = ((width - height) / 2) + 'px';
+      previewContainer.style.width = width + 'px';
+      previewContainer.style.height = height + 'px';
+      previewContainer.style.left = ((height - width) / 2) + 'px';
+      previewContainer.style.top = ((width - height) / 2) + 'px';
     }
 
     // If we have a cached screenshot, use that first
     var cachedLayer = app.requestScreenshotURL();
 
     if (cachedLayer && app.isActive()) {
-      screenshotView.classList.toggle('fullscreen',
+      previewContainer.classList.toggle('fullscreen',
                                       app.isFullScreen());
-      screenshotView.classList.toggle('maximized',
+      previewContainer.classList.toggle('maximized',
                                       app.appChrome.isMaximized());
       screenshotView.style.backgroundImage =
-        'url(' + cachedLayer + '),' +
-        '-moz-element(#' + this.app.instanceID + ')';
+        'url(' + cachedLayer + ')';
     } else {
       screenshotView.style.backgroundImage =
-        'url(none),' +
-        '-moz-element(#' + this.app.instanceID + ')';
+        'url(none)';
     }
 
   };
 
   Card.prototype._fetchElements = function c__fetchElements() {
-    this.screenshotView = this.element.querySelector('.screenshotView');
+    this.previewContainer = this.element.querySelector('.appPreview');
+    this.screenshotView = this.previewContainer
+                          .querySelector('.windowScreenshot');
     this.titleNode = this.element.querySelector('h1.title');
     this.iconButton = this.element.querySelector('.appIcon');
   };

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -92,32 +92,48 @@
 
 /* Screenshoots */
 
-#cards-view .screenshotView {
-  background-size: 100% calc(100% - 1.5rem), cover;
-  background-position: left bottom, left top;
-  background-repeat: no-repeat;
+#cards-view .appPreview {
   width: 100%;
   height: 100%;
   position: relative;
 }
 
-#cards-view .screenshotView.maximized {
-  background-position: left calc(100% + 2.3rem), left top;
+#cards-view .windowScreenshot {
+  background-size: 100% calc(100% - 1.5rem);
+  background-position: left bottom;
+  background-repeat: no-repeat;
+  position: absolute;
+  top: 0; left: 0;
 }
 
-#cards-view .screenshotView.fullscreen {
-  background-size: 100% 100%, cover;
+#cards-view .windowReflection {
+  background-size: contain;
+  background-position: left top;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0; left: 0;
 }
 
-#cards-view .screenshotView.rotate-90 {
+
+#cards-view .appPreview.maximized > .windowScreenshot {
+  background-position: left calc(100% + 2.3rem);
+}
+
+#cards-view .appPreview.fullscreen > .windowScreenshot {
+  background-size: 100% 100%;
+}
+
+#cards-view .appPreview.rotate-90 {
   transform: rotate(90deg);
 }
 
-#cards-view .screenshotView.rotate-270 {
+#cards-view .appPreview.rotate-270 {
   transform: rotate(270deg);
 }
 
-#cards-view .screenshotView.rotate-180 {
+#cards-view .appPreview.rotate-180 {
   transform: rotate(180deg);
   transform-origin: 50% 50%;
 }
@@ -162,7 +178,7 @@
   background-color: rgba(255, 255, 255, 1);
 }
 
-#cards-view.filtered .card .screenshotView {
+#cards-view.filtered .card .appPreview {
   outline: solid 1px rgba(133, 133, 133, 0.8);
 }
 

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -138,7 +138,7 @@
   transform-origin: 50% 50%;
 }
 
-#cards-view .card.private .screenshotView::after {
+#cards-view .card.private .appPreview::after {
   width: 100%;
   height: 100%;
   content: "";

--- a/apps/system/test/marionette/lib/task_manager.js
+++ b/apps/system/test/marionette/lib/task_manager.js
@@ -9,7 +9,8 @@
     selectors: {
       element: '#cards-view',
       cards: '#cards-view li',
-      screenshot: '.screenshotView'
+      screenshot: '.windowScreenshot',
+      reflection: '.windowReflection'
     },
     get element() {
       return this.client.helper.waitForElement(this.selectors.element);

--- a/apps/system/test/marionette/task_manager_test.js
+++ b/apps/system/test/marionette/task_manager_test.js
@@ -66,13 +66,13 @@ marionette('Task Manager', function() {
       taskManager.show();
     });
 
-    test('should display moz-element screenshots for all apps',
+    test('should display moz-element preview for all apps',
     function() {
       var cards = taskManager.cards;
       cards.forEach(function(card) {
-        var screenshot = card.findElement(taskManager.selectors.screenshot);
+        var reflection = card.findElement(taskManager.selectors.reflection);
         client.waitFor(function() {
-          return screenshot.scriptWith(function(div) {
+          return reflection.scriptWith(function(div) {
             return div.style.backgroundImage.contains('-moz-element');
           });
         });
@@ -110,7 +110,7 @@ marionette('Task Manager', function() {
       var otherScreenshot = app.findElement(taskManager.selectors.screenshot);
       client.waitFor(function() {
         return otherScreenshot.scriptWith(function(div) {
-          return div.style.backgroundImage.contains('-moz-element');
+          return !div.style.backgroundImage.contains('blob');
         });
       });
     });

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -79,6 +79,8 @@ suite('system/Card', function() {
       assert.ok(card.element, 'element node');
       assert.equal(card.element.tagName, 'LI');
       assert.ok(card.screenshotView, 'screenshotView node');
+      assert.ok(card.previewContainer, 'previewContainer node');
+
       assert.ok(card.titleNode, 'title node');
       assert.ok(card.titleId, 'title id');
       assert.ok(card.iconButton, 'iconButton');
@@ -91,8 +93,8 @@ suite('system/Card', function() {
       assert.isFalse(card.element.classList.contains('browser'),
                      'no browser class for non-browser windows');
       assert.ok(card.element.querySelector('.close-button'), '.close-button');
-      assert.ok(card.element.querySelector('.screenshotView'),
-                '.screenshotView');
+      assert.ok(card.element.querySelector('.appPreview'),
+                '.appPreview');
       assert.ok(header, 'h1');
       assert.ok(header.id, 'h1.id');
     });
@@ -100,7 +102,7 @@ suite('system/Card', function() {
     test('has expected aria values', function(){
       var card = this.card;
 
-      assert.equal(card.screenshotView.getAttribute('role'), 'link');
+      assert.equal(card.previewContainer.getAttribute('role'), 'link');
       assert.strictEqual(card.iconButton.getAttribute('aria-hidden'), 'true');
     });
 
@@ -292,7 +294,7 @@ suite('system/Card', function() {
       return function() {
         var card = cards[orientation];
         card.render();
-        var orientationNode = card.screenshotView;
+        var orientationNode = card.previewContainer;
 
         card.element.dispatchEvent(new CustomEvent('onviewport'));
         assert.isTrue(

--- a/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/cards_view.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/cards_view.py
@@ -108,7 +108,7 @@ class CardsView(Base):
 
 class Card(PageRegion):
     _close_button_locator = (By.CLASS_NAME, 'close-button')
-    _screenshot_view_locator = (By.CLASS_NAME, 'screenshotView')
+    _screenshot_view_locator = (By.CLASS_NAME, 'appPreview')
     _app_icon_locator = (By.CLASS_NAME, 'appIcon')
 
     def a11y_click_close_button(self):


### PR DESCRIPTION
There are a few scenarios in which the aspect ratio of the screenshot and app-window (via -moz-element) arent aligned with the current window size which gives us the card size. The previous solution of doubling up the backgrounds on the screenshot element didnt give us any way to allow for that - all we can do is offset and size (scale) the backgrounds. This patch creates seperate elements for the -moz-element (I called it reflection, maybe projection is better? I dunno) and the actual screenshot blob. This allows finer control over sizing and seems-to-work-for-me (tm).
