### PR TITLE
Bug 1134910 - dialer are always LTR even if current language is RTL. So ...

### DIFF
--- a/apps/sharedtest/test/unit/dialer/font_size_manager_test.js
+++ b/apps/sharedtest/test/unit/dialer/font_size_manager_test.js
@@ -77,7 +77,7 @@ suite('font size manager', function() {
         var getExpectedEllipsizedText = function(side, direction) {
           // MockL10n does not invert text when in RTL mode, but FSM will
           // treat the left side as the end for the purpose of ellipses.
-          return side === 'end' ^ direction === 'ltr' ? '\u2026ar' : 'fo\u2026';
+          return side === 'end' ? 'fo\u2026' : '\u2026ar';
         };
 
         setup(function() {

--- a/shared/js/dialer/font_size_manager.js
+++ b/shared/js/dialer/font_size_manager.js
@@ -103,12 +103,7 @@ var FontSizeManager = (function fontSizeManager() {
 
   function _useEllipsis(view, overflowCount, ellipsisSide) {
     var side = ellipsisSide || 'begin';
-    var localizedSide;
-    if (navigator.mozL10n.language.direction === 'rtl') {
-      localizedSide = (side === 'begin' ? 'right' : 'left');
-    } else {
-      localizedSide = (side === 'begin' ? 'left' : 'right');
-    }
+    var localizedSide = (side === 'begin' ? 'left' : 'right');
 
     var value = view.value || view.textContent;
     if (localizedSide == 'left') {


### PR DESCRIPTION
...for ellipsis, the end is always to the right, and the beginning always to the left
