### PR TITLE
Bug 1134680 - Use short_name where available in app permission panels

### DIFF
--- a/apps/settings/js/panels/app_permissions_detail/app_permissions_detail.js
+++ b/apps/settings/js/panels/app_permissions_detail/app_permissions_detail.js
@@ -47,7 +47,7 @@ define(function(require) {
       var manifest = new ManifestHelper(app.manifest ?
         app.manifest : app.updateManifest);
       var developer = manifest.developer;
-      elements.detailTitle.textContent = manifest.name;
+      elements.detailTitle.textContent = manifest.short_name || manifest.name;
       elements.uninstallButton.disabled = !app.removable;
       if (!developer || !('name' in developer)) {
         elements.developerInfos.hidden = true;

--- a/apps/settings/js/panels/app_permissions_list/app_permissions_list.js
+++ b/apps/settings/js/panels/app_permissions_list/app_permissions_list.js
@@ -207,7 +207,7 @@ define(function(require) {
         var manifest = new ManifestHelper(app.manifest ?
             app.manifest : app.updateManifest);
         var li = this._genAppItemTemplate({
-          name: manifest.name,
+          name: manifest.short_name || manifest.name,
           index: index,
           iconSrc: this._getBestIconURL(app, manifest.icons)
         });


### PR DESCRIPTION
Prefer using the manifest short_name property when available for the app permissions list and detail panels.
