### PR TITLE
Bug 1135324 - Reduce one more jshint xfail file on apps/sharedtest +autoland

### DIFF
--- a/apps/sharedtest/test/unit/.jshintrc
+++ b/apps/sharedtest/test/unit/.jshintrc
@@ -2,16 +2,9 @@
   "extends": "../../../../.jshintrc",
   "predef": [
     "assert",
-    "suite",
-    "test",
-    "setup",
-    "teardown",
-    "suiteSetup",
-    "suiteTeardown",
     "require",
     "requireApp",
-    "sinon",
-    "mocha",
-    "loadBodyHTML"
-  ]
+    "sinon"
+  ],
+  "mocha": true
 }

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -211,7 +211,6 @@ apps/sharedtest/test/unit/device_storage_test.js
 apps/sharedtest/test/unit/gesture_detector_test.js
 apps/sharedtest/test/unit/mediadb_test.js
 apps/sharedtest/test/unit/tag_visibility_monitor_test.js
-apps/sharedtest/test/unit/template_test.js
 apps/system/js/airplane_mode.js
 apps/system/js/base_ui.js
 apps/system/js/browser_config_helper.js


### PR DESCRIPTION
- template_test.js now passes `make hint` since jshint 2.6.0 supports `DocumentFragment`
- Use `mocha` for .jshintrc
