### PR TITLE
Bug 1134642 - Remove workaround of bug 918288 r=kgrandon

### DIFF
--- a/shared/elements/gaia_confirm/script.js
+++ b/shared/elements/gaia_confirm/script.js
@@ -15,14 +15,6 @@ window.GaiaConfirm = (function(win) {
   var baseurl = window.GaiaConfirmBaseurl ||
     '/shared/elements/gaia_confirm/';
 
-  // Bug 918288 - APZ does not have proper hit detection.
-  // This workaround prevents APZ from scrolling under the confirm dialog.
-  var EATEN_EVENTS = [
-    // XXX: touchmove to work around apz bugs touchstart should not be blocked
-    //      because it is needed for pressed state.
-    'touchmove'
-  ];
-
   /**
   preventDefault and prevent other listeners from hearing abut changes to a
   particular event object.
@@ -53,12 +45,6 @@ window.GaiaConfirm = (function(win) {
     var allowedTargets = [confirm, cancel].filter(function(element) {
       return !!element;
     });
-
-    EATEN_EVENTS.forEach(function(type) {
-      this.addEventListener(type, (event) => {
-        eatEvent(allowedTargets, event);
-      });
-    }, this);
 
     if (confirm) {
       confirm.addEventListener('click', (e) => {


### PR DESCRIPTION
Eating the 'touchmove' event was a workaround for bug 918288. This one
has been fixed by the end of november 2014, so this workaround should
not be used anymore. Plus, this has been messing with Settings dialogs
on some devices, as documented in bug 1134642.
