### PR TITLE
Bug 1118648 - MockHelper:  the original property before overwriting it w...

### DIFF
--- a/apps/keyboard/test/unit/mock_indexeddb.js
+++ b/apps/keyboard/test/unit/mock_indexeddb.js
@@ -206,13 +206,6 @@ MockIDBFactory.attachToWindow = function(instance) {
   if (!instance) {
     instance = new this();
   }
-
-  window.indexedDB._open = window.indexedDB.open;
-  window.indexedDB.open = instance.open.bind(instance);
-  window.indexedDB._cmp = window.indexedDB.cmp;
-  window.indexedDB.cmp = instance.cmp.bind(instance);
-  window.indexedDB._deleteDatabase = window.indexedDB.deleteDatabase;
-  window.indexedDB.deleteDatabase = instance.deleteDatabase.bind(instance);
 };
 
 MockIDBFactory.restore = function() {


### PR DESCRIPTION
...ith mock and remove IndexedDB mock workaround
