### PR TITLE
Bug 1134321 - Settings app does not fire moz-app-loaded or mark fullyLoaded. r = arthur.chen.

### DIFF
--- a/apps/settings/js/panels/root/root.js
+++ b/apps/settings/js/panels/root/root.js
@@ -27,7 +27,6 @@ define(function(require) {
        */
       LazyLoader.load([
         'js/firefox_accounts/menu_loader.js',
-        'js/dsds_settings.js',
         'js/telephony_settings.js',
         'js/telephony_items_handler.js'
       ], function() {


### PR DESCRIPTION
  --  remove redundant 'dsds_settings.js'  from lazyloder in root.js.
