### PR TITLE
Bug 1133327 - Increasing the maximum size for pictures r=wilsonpage,djf

### DIFF
--- a/apps/camera/js/config/config.js
+++ b/apps/camera/js/config/config.js
@@ -7,8 +7,8 @@ module.exports = {
   // shared/js/media/media_frame.js
   globals : {
     // The maximum picture size that camera is allowed to take
-    CONFIG_MAX_IMAGE_PIXEL_SIZE: 5242880, // 5MP
-    CONFIG_MAX_SNAPSHOT_PIXEL_SIZE: 5242880, // 5MP
+    CONFIG_MAX_IMAGE_PIXEL_SIZE: 24 * 1024 * 1024,
+    CONFIG_MAX_SNAPSHOT_PIXEL_SIZE: 24 * 1024 * 1024,
 
     // Size of the exif preview embeded in images taken by camera
     CONFIG_REQUIRED_EXIF_PREVIEW_WIDTH: 0,


### PR DESCRIPTION
In order to be able to make use of the full 21Mpx capacity of Camera on some
devices, we need to push this limit higher than the current 5Mpx.
