### PR TITLE
Bug 1119294 - Add logshake ID to keep multiple notifications around r=janx

### DIFF
--- a/apps/system/js/devtools/logshake.js
+++ b/apps/system/js/devtools/logshake.js
@@ -79,8 +79,10 @@
       }
     },
 
+    _shakeId: null,
     handleCaptureLogsStart: function(event) {
       debug('handling capture-logs-start');
+      this._shakeId = Date.now();
       this._notify('logsSaving', '');
     },
 
@@ -95,6 +97,7 @@
       this._notify('logsSaved', event.detail.logPrefix,
                    this.triggerShareLogs.bind(this, event.detail.logFilenames),
                    event.detail);
+      this._shakeId = null;
     },
 
     handleCaptureLogsError: function(event) {
@@ -104,6 +107,7 @@
       this._notify('logsSaveError', errorMsg,
                    this.showErrorMessage.bind(this, error),
                    event.detail);
+      this._shakeId = null;
     },
 
     triggerShareLogs: function(logFilenames, notif) {
@@ -206,7 +210,7 @@
       var title = navigator.mozL10n.get(titleId) || titleId;
       var payload = {
         body: body,
-        tag: 'logshake',
+        tag: 'logshake:' + this._shakeId,
         data: {
           systemMessageTarget: 'logshake',
           logshakePayload: dataPayload || undefined


### PR DESCRIPTION
Users may want to keep multiple logshake notifications around, so lets
generate a tag that is dependant on the timestamp to provide this. We
use the current time when receiving the capture start event, and keep it
until we receive either a success or a failure event, at which point we
reset it to null.
