### PR TITLE
Bug 1135860 - Change LogShake activity to share r=janx

### DIFF
--- a/apps/system/js/devtools/logshake.js
+++ b/apps/system/js/devtools/logshake.js
@@ -129,9 +129,8 @@
           });
           /* jshint nonew: false */
           new MozActivity({
-            name: 'new',
+            name: 'share',
             data: {
-              type: 'mail',
               blobs: logFiles,
               filenames: logNames
             }

--- a/apps/system/test/unit/logshake_test.js
+++ b/apps/system/test/unit/logshake_test.js
@@ -195,9 +195,8 @@ suite('system/LogShake', function() {
       };
 
       var expectedActivity = {
-        name: 'new',
+        name: 'share',
         data: {
-          type: 'mail',
           blobs: [ mockBlob ],
           filenames: [ filename ]
         }


### PR DESCRIPTION
To be able to handle sharing with a bugzilla client, we need to change
the activity triggered by LogShake, since name "new" and type "email" is
really intended to limit to the Email client. We make use of the "share"
activity.
