### PR TITLE
Bug 1107139 - Raising and handling appscreenshotupdate for task-manager....

### DIFF
--- a/apps/system/js/browser_mixin.js
+++ b/apps/system/js/browser_mixin.js
@@ -131,6 +131,7 @@
         if (!width) {
           // Refresh _screenshotBlob when no width/height is specified.
           self._screenshotBlob = result;
+          self.publish && self.publish('screenshotupdate');
         }
 
         self.debug('getScreenshot succeed!');

--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -81,6 +81,12 @@
 
 
   /**
+   * Is card waiting/in need of screenshot to display
+   * @memberOf Card.prototype
+   */
+  Card.prototype.needsScreenshot = false;
+
+  /**
    * Template string representing the innerHTML of the instance's element
    * @memberOf Card.prototype
    */
@@ -350,20 +356,22 @@
     // If we have a cached screenshot, use that first
     var cachedLayer = app.requestScreenshotURL();
 
-    if (cachedLayer && app.isActive()) {
+    if (app.isActive()) {
       screenshotView.classList.toggle('fullscreen',
                                       app.isFullScreen());
-      screenshotView.classList.toggle('maximized',
-                                      app.appChrome.isMaximized());
-      screenshotView.style.backgroundImage =
-        'url(' + cachedLayer + '),' +
-        '-moz-element(#' + this.app.instanceID + ')';
+      if (app.appChrome) {
+        screenshotView.classList.toggle('maximized',
+                                        app.appChrome.isMaximized());
+      }
+      this.needsScreenshot = true;
+    }
+    if (cachedLayer && this.needsScreenshot) {
+      this.updateScreenshot(cachedLayer);
     } else {
       screenshotView.style.backgroundImage =
-        'url(none),' +
+        'none,' +
         '-moz-element(#' + this.app.instanceID + ')';
     }
-
   };
 
   Card.prototype._fetchElements = function c__fetchElements() {
@@ -383,6 +391,24 @@
     }
     var displayString = url.substring(url.indexOf(anURL.host));
     return displayString;
+  };
+
+  Card.prototype.updateScreenshot = function(imageUrl) {
+    // ignore before render is complete
+    if (!this.screenshotView) {
+      return;
+    }
+    if (!imageUrl) {
+      imageUrl = this.app.requestScreenshotURL();
+    }
+    console.log(this.toString() +
+                ', handling updateScreenshot with image: ' + imageUrl);
+    if (imageUrl) {
+      this.screenshotView.style.backgroundImage =
+          'url(' + imageUrl + '),' +
+          '-moz-element(#' + this.app.instanceID + ')';
+      this.needsScreenshot = false;
+    }
   };
 
   return (exports.Card = Card);

--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -207,6 +207,7 @@
     window.addEventListener('appterminated', this);
     window.addEventListener('wheel', this);
     window.addEventListener('resize', this);
+    window.addEventListener('appscreenshotupdate', this);
 
     this.element.addEventListener('touchstart', this);
     this.element.addEventListener('touchmove', this);
@@ -220,6 +221,7 @@
     window.removeEventListener('appterminated', this);
     window.removeEventListener('wheel', this);
     window.removeEventListener('resize', this);
+    window.removeEventListener('appscreenshotupdate', this);
 
     this.element.removeEventListener('touchstart', this);
     this.element.removeEventListener('touchmove', this);
@@ -589,7 +591,7 @@
    * @param  {DOMEvent} evt The event.
    */
   TaskManager.prototype.handleEvent = function cv_handleEvent(evt) {
-    var app;
+    var app, card;
     switch (evt.type) {
       case 'touchstart':
         this.onTouchStart(evt);
@@ -634,9 +636,18 @@
 
       case 'appterminated':
         app = evt.detail;
-        var card = app && this.cardsByAppID[app.instanceID];
+        card = app && this.cardsByAppID[app.instanceID];
         if (card && card.app && app.instanceID === card.app.instanceID) {
           this.removeCard(card);
+        }
+        break;
+
+      case 'appscreenshotupdate':
+        console.log('appscreenshotupdate event: ', evt);
+        app = evt.detail;
+        card = app && this.cardsByAppID[app.instanceID];
+        if (card.needsScreenshot) {
+          card.updateScreenshot();
         }
         break;
     }

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -21,9 +21,6 @@ suite('system/Card', function() {
         orientation: config.orientation || 'portrait-primary'
       },
       rotatingDegree: config.rotatingDegree || 0,
-      requestScreenshotURL: function() {
-        return null;
-      },
       getScreenshot: function(callback) {
         callback();
       },
@@ -376,6 +373,51 @@ suite('system/Card', function() {
       var iconView = card.element.querySelector('.appIconView');
       assert.ok(iconView.style.backgroundImage.indexOf('url') > -1,
                 '.appIconView element has backgroundImage value');
+    });
+  });
+
+  suite('screenshot updates', function() {
+    var imageUrl = 'data:image/gif;base64,' +
+                   'R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+    setup(function() {
+      this.card = new Card({
+        app: makeApp({ name: 'dummyapp' }),
+        manager: mockManager
+      });
+      this.card.render();
+    });
+
+    test('needsScreenshot', function() {
+      // is initially false
+      assert.isFalse(this.card.needsScreenshot);
+    });
+
+    test('updateScreenshot with image', function() {
+      var card = this.card;
+      card.needsScreenshot = true;
+      this.sinon.stub(card.app, 'requestScreenshotURL');
+
+      card.updateScreenshot(imageUrl);
+      var background = card.screenshotView.style.backgroundImage;
+
+      assert.isFalse(card.app.requestScreenshotURL.called);
+      assert.isFalse(card.needsScreenshot);
+      assert.isTrue(background.indexOf(imageUrl) > -1);
+    });
+
+    test('updateScreenshot without image', function() {
+      var card = this.card;
+      card.needsScreenshot = true;
+      this.sinon.stub(card.app, 'requestScreenshotURL', function() {
+        return imageUrl;
+      });
+
+      card.updateScreenshot();
+      var background = card.screenshotView.style.backgroundImage;
+
+      assert.isTrue(card.app.requestScreenshotURL.calledOnce);
+      assert.isFalse(card.needsScreenshot);
+      assert.isTrue(background.indexOf(imageUrl) > -1);
     });
   });
 

--- a/apps/system/test/unit/mock_app_window.js
+++ b/apps/system/test/unit/mock_app_window.js
@@ -89,6 +89,7 @@
     queueShow: function() {},
     cancelQueuedShow: function() {},
     queueHide: function() {},
+    requestScreenshotURL: function() {},
     setOrientation: function() {},
     focus: function() {},
     debug: function() {},


### PR DESCRIPTION
Adds a screenshotupdate event which gets published by app windows when getScreenshot results in a new screenshot blob. This is used in the task-manager to update (once) the screenshot of the active app - in cases where the card was rendered before that screenshot was available. 
