### PR TITLE
Bug 1135976 - [RTL][Privacy Controls] Overlapping text in Transparency Control Permissions page.

### DIFF
--- a/apps/privacy-panel/style/menu.css
+++ b/apps/privacy-panel/style/menu.css
@@ -5,7 +5,7 @@
 
 .menu-item {
   position: static;
-  padding-left: 5.5rem;
+  -moz-padding-start: 5.5rem;
   background-repeat: no-repeat;
   background-position: 1.4rem center;
   background-size: 3rem 3rem;
@@ -49,11 +49,6 @@ label > .menu-item + small {
 /******************************************************************************
  * Right-To-Left layout
  */
-html[dir="rtl"] .menu-item {
-  padding-left: 0;
-  padding-right: 5.5rem;
-}
-
 html[dir="rtl"] a.menu-item::after  {
   right: auto;
   left: -0.5rem;


### PR DESCRIPTION
   -- use '-moz-padding-start' instead of 'padding-left' for fixing RTL
