### PR TITLE
Bug 1136466 - [RTL] Media player controls progress bar should NOT be mirrored if the rest of controls are not.

### DIFF
--- a/apps/music/index.html
+++ b/apps/music/index.html
@@ -118,8 +118,8 @@
         </div>
         <div id="player-seek">
           <span id="player-seek-elapsed" dir="ltr">00:00</span>
-          <div id="player-seek-bar">
-            <progress id="player-seek-bar-progress" value="0"></progress>
+          <div id="player-seek-bar" dir="ltr">
+            <progress id="player-seek-bar-progress" value="0" dir="ltr"></progress>
             <div id="player-seek-bar-indicator"></div>
           </div>
           <span id="player-seek-remaining" dir="ltr">00:00</span>

--- a/apps/music/js/ui/views/player_view.js
+++ b/apps/music/js/ui/views/player_view.js
@@ -787,15 +787,7 @@ var PlayerView = {
     var x = (ratio * this.seekBar.offsetWidth -
       this.seekIndicator.offsetWidth / 2);
 
-    if (this.isLTR) {
-      x = x + 'px';
-    } else {
-      if (x < 0) {
-        x = Math.abs(x) + 'px';
-      } else {
-        x = '-' + x + 'px';
-      }
-    }
+    x = x + 'px';
 
     this.seekIndicator.style.transform = 'translateX(' + x + ')';
 
@@ -1012,11 +1004,8 @@ var PlayerView = {
             x = 1;
           }
 
-          if (this.isLTR) {
-            this.seekTime = x * this.seekBar.max;
-          } else {
-            this.seekTime = this.audio.duration - x * this.seekBar.max;
-          }
+          this.seekTime = x * this.seekBar.max;
+
           this.setSeekBar(this.audio.startTime,
             this.audio.duration, this.seekTime);
         }


### PR DESCRIPTION
- let  'progress' and 'indicator' dir="ltr" and remove 'rtl' condition from 'player_view.js'
