### PR TITLE
Bug 1136041 - [Text Selection] The carets overlap with utility bubble when the selected text is closed to top of device

### DIFF
--- a/apps/system/js/text_selection_dialog.js
+++ b/apps/system/js/text_selection_dialog.js
@@ -57,7 +57,10 @@
   // caret tile height is controlled by gecko, we estimate the height as
   // 22px. So 22px plus 12px which defined in UI spec, we get 34px from
   // the bottom of selected area to utility menu.
-  TextSelectionDialog.prototype.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 34;
+  TextSelectionDialog.prototype.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 43;
+
+  // Minimum distance between bubble and boundary.
+  TextSelectionDialog.prototype.DISTANCE_FROM_BOUNDARY = 5;
 
   TextSelectionDialog.prototype.ID_NAME = 'TextSelectionDialog';
 
@@ -471,12 +474,14 @@
             selectDialogBottom) - selectOptionHeight) / 2;
       }
 
-      if (posLeft < 0) {
-        posLeft = 0;
+      if (posLeft < this.DISTANCE_FROM_BOUNDARY) {
+        posLeft = this.DISTANCE_FROM_BOUNDARY;
       }
 
-      if ((posLeft + numOfSelectOptions * selectOptionWidth) > frameWidth) {
-        posLeft = frameWidth - numOfSelectOptions * selectOptionWidth;
+      if ((posLeft + numOfSelectOptions * selectOptionWidth +
+           this.DISTANCE_FROM_BOUNDARY) > frameWidth) {
+        posLeft = frameWidth - numOfSelectOptions * selectOptionWidth -
+          this.DISTANCE_FROM_BOUNDARY;
       }
 
       return {

--- a/apps/system/test/marionette/text_selection_test.js
+++ b/apps/system/test/marionette/text_selection_test.js
@@ -128,7 +128,7 @@ marionette('Text selection >', function() {
           'dialog should be placed lower than the input field'
         );
         assert.equal(
-          textSelectionLocation.x, 0,
+          textSelectionLocation.x, 5,
           'dialog should be placed near left boundary'
         );
       });
@@ -145,7 +145,7 @@ marionette('Text selection >', function() {
         assert.equal(
           Math.ceil(textSelectionLocation.x +
             fakeTextselectionApp.textSelection.width),
-          fakeTextselectionApp.width,
+          fakeTextselectionApp.width - 5,
           'dialog should be placed near right boundary'
         );
       });
@@ -160,7 +160,7 @@ marionette('Text selection >', function() {
           'dialog should be placed higher than the input field'
         );
         assert.equal(
-          textSelectionLocation.x, 0,
+          textSelectionLocation.x, 5,
           'dialog should be placed near left boundary'
         );
       });
@@ -177,7 +177,7 @@ marionette('Text selection >', function() {
         assert.equal(
           Math.ceil(textSelectionLocation.x +
             fakeTextselectionApp.textSelection.width),
-          fakeTextselectionApp.width,
+          fakeTextselectionApp.width - 5,
           'dialog should be placed near right boundary'
         );
       });

--- a/apps/system/test/unit/text_selection_dialog_test.js
+++ b/apps/system/test/unit/text_selection_dialog_test.js
@@ -691,7 +691,8 @@ suite('system/TextSelectionDialog', function() {
       windowHeight = window.layoutManager.height;
       windowWidth = window.layoutManager.width;
       td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 12;
-      td.DISTANCE_FROM_MENUBOTTOM_TO_SELECTEDAREA = 34;
+      td.DISTANCE_FROM_MENUBOTTOM_TO_SELECTEDAREA = 43;
+      td.DISTANCE_FROM_BOUNDARY = 5;
       td.TEXTDIALOG_WIDTH = 52;
       td.TEXTDIALOG_HEIGHT = 48;
     });
@@ -776,7 +777,7 @@ suite('system/TextSelectionDialog', function() {
         assert.deepEqual(result, {
           top: posTop,
           left: windowWidth - td.numOfSelectOptions * td.TEXTDIALOG_WIDTH +
-            positionDetail.offsetX
+            positionDetail.offsetX - td.DISTANCE_FROM_BOUNDARY
         });
       });
 
@@ -799,7 +800,7 @@ suite('system/TextSelectionDialog', function() {
         assert.deepEqual(result, {
           top: positionDetail.rect.bottom * positionDetail.zoomFactor +
             td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP + positionDetail.offsetY,
-          left: positionDetail.offsetX
+          left: positionDetail.offsetX + td.DISTANCE_FROM_BOUNDARY
         });
       });
 
@@ -823,7 +824,8 @@ suite('system/TextSelectionDialog', function() {
           top: positionDetail.rect.bottom * positionDetail.zoomFactor +
             td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP + positionDetail.offsetY,
           left: windowWidth + positionDetail.offsetX -
-            td.numOfSelectOptions * td.TEXTDIALOG_WIDTH
+            td.numOfSelectOptions * td.TEXTDIALOG_WIDTH -
+            td.DISTANCE_FROM_BOUNDARY
         });
       });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1136041
