### PR TITLE
Bug 1135660 - Add transitions to gaia-confirm. r=kgrandon

### DIFF
--- a/shared/elements/gaia_confirm/style.css
+++ b/shared/elements/gaia_confirm/style.css
@@ -20,6 +20,7 @@ gaia-confirm {
   align-items: stretch;
   flex-direction: column;
   justify-content: center;
+  transition: transform ease-in-out 0.3s, visibility 0.3s;
   /**
   magic number ideally to place confirm dialogs on top.
   */
@@ -35,7 +36,9 @@ html[dir="rtl"] gaia-confirm {
 }
 
 gaia-confirm[hidden] {
-  display: none;
+  transform: translateY(100%);
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .confirm section {


### PR DESCRIPTION
Add transitions to gaia-confirm and make sure they don't get overridden
by ConfirmDialogHelper.
