### PR TITLE
Bug 1126080 - Intermittent test_music_change_rating.py TestSetMusicRating.test_music_change_rating | TimeoutException: TimeoutException: Timed out after 10.1 seconds

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/music/test_music_change_rating.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/music/test_music_change_rating.py
@@ -43,8 +43,10 @@ class TestSetMusicRating(GaiaTestCase):
 
         # give rating of 4
         player_view.tap_star(4)
+        player_view.tap_cover_in_player_view() # tap again in case the overlay disappears due to timeout
         Wait(self.marionette).until(lambda m: player_view.star_rating == 4)
 
         #change the rating to 1
         player_view.tap_star(1)
+        player_view.tap_cover_in_player_view() # tap again in case the overlay disappears due to timeout
         Wait(self.marionette).until(lambda m: player_view.star_rating == 1)


### PR DESCRIPTION
The overlay could be disappearing at odd time intervals, so tap the screen right before checking for the star
