### PR TITLE
Bug 1138402 - Bump marionette_client dependency to 0.9

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/edit_picture_base.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/edit_picture_base.py
@@ -5,7 +5,7 @@
 import time
 
 from marionette_driver import By
-from marionette.marionette import Actions
+from marionette_driver.marionette import Actions
 
 from gaiatest.apps.gallery.app import Gallery
 from gaiatest.gaia_graphics_test import GaiaImageCompareTestCase


### PR DESCRIPTION
This patch updates the import statement on one of the imagecompare tests 
