### PR TITLE
Bug 1139265 - Fix context menu test in Gaia JS integration test. r=alive (v1)

### DIFF
--- a/apps/system/test/marionette/context_menu_test.js
+++ b/apps/system/test/marionette/context_menu_test.js
@@ -12,10 +12,11 @@ marionette('Test Context Menu Events', function() {
     settings: {
       'ftu.manifestURL': null,
       'lockscreen.enabled': false
-    }
+    },
+    apps: {}
   };
 
-  opts.apps[APP_HOST] = __dirname + '/' + APP_NAME;
+  opts.apps[APP_HOST] = __dirname + '/../apps/' + APP_NAME;
 
   var client = marionette.client(opts);
   var actions;


### PR DESCRIPTION
Add the necessary property "apps" back. Fix the relative path setting for test app.
