### PR TITLE
Bug 825318 - Handle downloads that have already succeeded at add-time. r...

### DIFF
--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -1013,7 +1013,8 @@ return [
         var activity = new MozActivity({
           name: 'pick',
           data: {
-            type: ['image/*', 'video/*', 'audio/*', 'application/*'],
+            type: ['image/*', 'video/*', 'audio/*', 'application/*',
+                   'text/vcard'],
             nocrop: true
           }
         });

--- a/apps/email/js/cards/message_reader.js
+++ b/apps/email/js/cards/message_reader.js
@@ -11,6 +11,8 @@ var MimeMapper,
     msgAttachmentItemNode = require('tmpl!./msg/attachment_item.html'),
     msgAttachmentDisabledConfirmNode =
                          require('tmpl!./msg/attachment_disabled_confirm.html'),
+    msgAttachmentDidNotOpenAlertNode =
+      require('tmpl!./msg/attachment_did_not_open_alert.html'),
     cards = require('cards'),
     ConfirmDialog = require('confirm_dialog'),
     date = require('date'),
@@ -49,6 +51,8 @@ var CONTENT_QUOTE_CLASS_NAMES = [
     'msg-body-q9'
   ];
 var MAX_QUOTE_CLASS_NAME = 'msg-body-qmax';
+
+var OCTET_STREAM_TYPE = 'application/octet-stream';
 
 // This function exists just to avoid lint errors around
 // "do not use 'new' for side effects.
@@ -615,17 +619,24 @@ return [
 
     onDownloadAttachmentClick: function(node, attachment) {
       node.setAttribute('state', 'downloading');
+      // We register all downloads with the download manager.  Previously we had
+      // thought about only registering non-media types because the media types
+      // were already covered by built-in apps.  But we didn't have a good
+      // reason for that; perhaps risk avoidance?  So everybody gets logged!
+      // Note that POP3 also does this, but that happens in pop3/sync.js in
+      // the back-end and the front-end has no control over that.
+      var registerWithDownloadManager = true;
       attachment.download(function downloaded() {
         if (!attachment._file) {
           return;
         }
 
         node.setAttribute('state', 'downloaded');
-      });
+      }, null, registerWithDownloadManager);
     },
 
     onViewAttachmentClick: function(node, attachment) {
-      console.log('trying to open', attachment._file, 'type:',
+      console.log('trying to open', attachment._file, 'known type:',
                   attachment.mimetype);
       if (!attachment._file) {
         return;
@@ -639,35 +650,99 @@ return [
               throw new Error('Blob does not exist');
             }
 
-            // To delegate a correct activity, we should try to avoid the unsure
-            // mimetype because types like "application/octet-stream" which told
-            // by the e-mail client are not supported.
-            // But it doesn't mean we really don't support that attachment
-            // what we can do here is:
-            // 1. Check blob.type, most of the time it will not be empty
-            //    because it's reported by deviceStorage, it should be a
-            //    correct mimetype, or
-            // 2. Use the original mimetype from the attachment,
-            //    but it's possibly an unsupported mimetype, like
-            //    "application/octet-stream" which cannot be used correctly, or
-            // 3. Use MimeMapper to help us, if it's still an unsure mimetype,
-            //    MimeMapper can guess the possible mimetype from extension,
-            //    then we can delegate a right activity.
-            var extension = attachment.filename.split('.').pop();
-            var originalType = blob.type || attachment.mimetype;
-            var mappedType = (MimeMapper.isSupportedType(originalType)) ?
-              originalType : MimeMapper.guessTypeFromExtension(extension);
+            // - Figure out the best MIME type
+            //
+            // We have three MIME type databases at our disposal:
+            //
+            // - mimetypes(.js): A reasonably comprehensive database but that's
+            //   not continually updated and potentially is out-of-date about
+            //   some audio and video types.
+            //
+            // - nsIMIMEService via DeviceStorage.  Anything that was stored
+            //   in DeviceStorage will have its MIME type looked-up using
+            //   nsIMIMEService which in turn checks a short hard-coded list
+            //   (mainly containing the core web video/audio/doc types),
+            //   preferences, the OS, extensions, plugins, category manager
+            //   stuff, and then a slightly longer list of hard-coded entries.
+            //
+            // - shared/js/mime_mapper.js: It knows about all of the media types
+            //   supported by Gecko and our media apps.  It at least has
+            //   historically been updated pretty promptly.
+            //
+            //
+            // For IMAP and POP3, we get the MIME type from the composer of the
+            // message.  They explicitly include a MIME type.  Assuming the
+            // author of the message also created the attachment, there's a very
+            // high probability they included a valid MIME type (based on a
+            // local file extension mapping).  If the author forwarded a message
+            // with the attachment maintained, there's also a good chance the
+            // MIME type was maintained.  If the author downloaded the
+            // attachment but lacked a mapping for the file extension, the
+            // reported MIME type is probably application/octet-stream.  As
+            // of writing this, our IMAP and POP3 implementations do not
+            // second-guess the reported MIME type if it is
+            // application/octet-stream.
+            //
+            // In the ActiveSync case, we are not given any MIME type
+            // information and our ActiveSync library uses mimetypes.js to
+            // map the extension type.  This may result in
+            // application/octet-stream being returned.
+            //
+            // Given all of this, our process for determining MIME types is to:
+            // - Trust the MIME type we have on file for the message if it's
+            //   anything other than application/octet-stream.
+            var useType = attachment.mimetype;
+            // - If it was octet-stream (or somehow missing), we check if
+            //   DeviceStorage has an opinion.  We use it if so.
+            if (!useType || useType === OCTET_STREAM_TYPE) {
+              useType = blob.type;
+            }
+            // - If we still think it's octet-stream (or falsey), we ask the
+            //   MimeMapper to map the file extension to a MIME type.
+            if (!useType || useType === OCTET_STREAM_TYPE) {
+              useType = MimeMapper.guessTypeFromFileProperties(
+                          attachment.filename, OCTET_STREAM_TYPE);
+            }
+            // - If it's falsey (MimeMapper returns an emptry string if it
+            //   can't map), we set the value to application/octet-stream.
+            if (!useType) {
+              useType = OCTET_STREAM_TYPE;
+            }
+            // - At this point, we're fine with application/octet-stream.
+            //   Although there are some file-types where we can just chuck
+            //   "application/" on the front, there aren't enough of them.
+            //   Apps can, however, use a regexp filter on the filename we
+            //   provide to capture extension types that way.
+            console.log('triggering open activity with MIME type:', useType);
 
             var activity = new MozActivity({
               name: 'open',
               data: {
-                type: mappedType,
+                type: useType,
                 filename: attachment.filename,
-                blob: blob
+                blob: blob,
+                // the PDF viewer really wants a "url".  download_helper.js
+                // provides the local filesystem path which is sketchy and
+                // non-sensical.  We just provide the filename again.
+                url: attachment.filename
               }
             });
             activity.onerror = function() {
               console.warn('Problem with "open" activity', activity.error.name);
+              // NO_PROVIDER is returned if there's nothing to service the
+              // activity.
+              if (activity.error.name === 'NO_PROVIDER') {
+                var dialog = msgAttachmentDidNotOpenAlertNode.cloneNode(true);
+                ConfirmDialog.show(dialog,
+                  {
+                    id: 'msg-attachment-did-not-open-ok',
+                    handler: null
+                  },
+                  {
+                    handler: null
+                  }
+                );
+              }
             };
             activity.onsuccess = function() {
               console.log('"open" activity allegedly succeeded');
@@ -1019,12 +1094,8 @@ return [
             } else if (attachment.sizeEstimateInBytes > MAX_ATTACHMENT_SIZE) {
               state = 'toolarge';
               attachmentDownloadable = false;
-            } else if (MimeMapper.isSupportedType(attachment.mimetype) ||
-                     MimeMapper.isSupportedExtension(extension)) {
-              state = 'downloadable';
             } else {
-              state = 'nodownload';
-              attachmentDownloadable = false;
+              state = 'downloadable';
             }
             attTemplate.setAttribute('state', state);
             filenameTemplate.textContent = attachment.filename;

--- a/apps/email/js/cards/msg/attachment_did_not_open_alert.html
+++ b/apps/email/js/cards/msg/attachment_did_not_open_alert.html
@@ -1,0 +1,9 @@
+<form role="dialog" class="msg-attachment-did-not-open" data-type="confirm">
+  <section>
+    <h1 data-l10n-id="message-attachment-did-not-open-label"></h1>
+    <p><span data-l10n-id="message-attachment-did-not-open-body"></span></p>
+  </section>
+  <menu>
+    <button id="msg-attachment-did-not-open-ok" data-l10n-id="dialog-button-ok"></button>
+  </menu>
+</form>

--- a/apps/email/js/ext/drafts/composer.js
+++ b/apps/email/js/ext/drafts/composer.js
@@ -155,8 +155,18 @@ function Composer(newRecords, account, identity) {
 
   body.attachments.forEach(function(attachment) {
     try {
-      var attachmentNode = new MimeNode(attachment.type,
-                                        { filename: attachment.name });
+      var attachmentNode = new MimeNode(
+        attachment.type,
+        {
+          // This implies Content-Disposition: attachment
+          filename: attachment.name
+        });
+      // Explicitly indicate that the attachment is base64 encoded.  mailbuild
+      // only picks base64 for non-text/* MIME parts, but our attachment logic
+      // encodes *all* attachments in base64, so base64 is the only correct
+      // answer.  (Also, failure to base64 encode our _uniqueBlobBoundary breaks
+      // the replace logic in withMessageBlob.  So base64 all the things!)
+      attachmentNode.setHeader('Content-Transfer-Encoding', 'base64');
       attachmentNode.setContent(this._uniqueBlobBoundary);
       root.appendChild(attachmentNode);
       this._blobReplacements.push(new Blob(attachment.file));

--- a/apps/email/js/ext/ext/rdcommon/testdriver.js
+++ b/apps/email/js/ext/ext/rdcommon/testdriver.js
@@ -443,7 +443,7 @@ TestDefinerRunner.prototype = {
       if (rval instanceof Error) {
         // in the event we threw during the case setup phase, it's a failure.
         if (self._superDebug)
-          self._superDebug(' :( setup func error thrown!');
+          self._superDebug(' :( setup func error thrown! ' + rval);
         defContext._log.result('fail');
         testCase.log.result('fail');
         reject(false);

--- a/apps/email/js/ext/jobmixins.js
+++ b/apps/email/js/ext/jobmixins.js
@@ -267,7 +267,8 @@ exports.do_download = function(op, callback) {
   // Now that we have the body, we can know the part numbers and eliminate /
   // filter out any redundant download requests.  Issue all the fetches at
   // once.
-  var partsToDownload = [], storePartsTo = [], header, bodyInfo, uid;
+  var partsToDownload = [], storePartsTo = [], registerDownload = [],
+      header, bodyInfo, uid;
   var gotHeader = function gotHeader(_headerInfo) {
     header = _headerInfo;
     uid = header.srvid;
@@ -282,6 +283,7 @@ exports.do_download = function(op, callback) {
         continue;
       partsToDownload.push(partInfo);
       storePartsTo.push('idb');
+      registerDownload.push(false);
     }
     for (i = 0; i < op.attachmentIndices.length; i++) {
       partInfo = bodyInfo.attachments[op.attachmentIndices[i]];
@@ -290,6 +292,7 @@ exports.do_download = function(op, callback) {
       partsToDownload.push(partInfo);
       // right now all attachments go in sdcard
       storePartsTo.push('sdcard');
+      registerDownload.push(op.registerAttachments[i]);
     }
 
     folderConn.downloadMessageAttachments(uid, partsToDownload, gotParts);
@@ -324,7 +327,8 @@ exports.do_download = function(op, callback) {
         } else {
           pendingCbs++;
           saveToDeviceStorage(
-              self._LOG, blob, storeTo, partInfo.name, partInfo, next);
+              self._LOG, blob, storeTo, registerDownload[i],
+              partInfo.name, partInfo, next);
         }
       }
     }
@@ -354,13 +358,14 @@ exports.do_download = function(op, callback) {
  * encounter a collision.
  */
 var saveToDeviceStorage = exports.saveToDeviceStorage =
-function(_LOG, blob, storeTo, filename, partInfo, cb, isRetry) {
+function(_LOG, blob, storeTo, registerDownload, filename, partInfo, cb,
+         isRetry) {
   var self = this;
-  var callback = function(success, error, savedFilename) {
+  var callback = function(success, error, savedFilename, registered) {
     if (success) {
       _LOG.savedAttachment(storeTo, blob.type, blob.size);
       console.log('saved attachment to', storeTo, savedFilename,
-                  'type:', blob.type);
+                  'type:', blob.type, 'registered:', registered);
       partInfo.file = [storeTo, savedFilename];
       cb();
     } else {
@@ -379,10 +384,11 @@ function(_LOG, blob, storeTo, filename, partInfo, cb, isRetry) {
         idxLastPeriod = filename.length;
       filename = filename.substring(0, idxLastPeriod) + '-' + $date.NOW() +
         filename.substring(idxLastPeriod);
-      saveToDeviceStorage(_LOG, blob, storeTo, filename, partInfo, cb, true);
+      saveToDeviceStorage(_LOG, blob, storeTo, registerDownload,
+                          filename, partInfo, cb, true);
     }
   };
-  sendMessage('save', [storeTo, blob, filename], callback);
+  sendMessage('save', [storeTo, blob, filename, registerDownload], callback);
 }
 
 exports.local_do_download = function(op, callback) {

--- a/apps/email/js/ext/mailapi.js
+++ b/apps/email/js/ext/mailapi.js
@@ -1314,7 +1314,7 @@ MailBody.prototype = {
         callWhenDone();
       return;
     }
-    this._api._downloadAttachments(this, relPartIndices, [],
+    this._api._downloadAttachments(this, relPartIndices, [], [],
                                    callWhenDone, callOnProgress);
   },
 
@@ -1447,13 +1447,28 @@ MailAttachment.prototype = {
     return this.mimetype !== 'application/x-gelam-no-download';
   },
 
-  download: function(callWhenDone, callOnProgress) {
+  /**
+   * Queue this attachment for downloading.
+   *
+   * @param {Function} callWhenDone
+   *     A callback to be invoked when the download completes.
+   * @param {Function} callOnProgress
+   *     A callback to be invoked as the download progresses.  NOT HOOKED UP!
+   * @param {Boolean} [registerWithDownloadManager]
+   *     Should we register the Blob with the mozDownloadManager (if it is
+   *     present)?  For the Gaia mail app this decision is based on the
+   *     capabilities of the default gaia apps, and not a decision easily made
+   *     by GELAM.
+   */
+  download: function(callWhenDone, callOnProgress,
+                     registerWithDownloadManager) {
     if (this.isDownloaded) {
       callWhenDone();
       return;
     }
     this._body._api._downloadAttachments(
       this._body, [], [this._body.attachments.indexOf(this)],
+      [registerWithDownloadManager || false],
       callWhenDone, callOnProgress);
   },
 };
@@ -2706,6 +2721,7 @@ MailAPI.prototype = {
   },
 
   _downloadAttachments: function(body, relPartIndices, attachmentIndices,
+                                 registerAttachments,
                                  callWhenDone, callOnProgress) {
     var handle = this._nextHandle++;
     this._pendingRequests[handle] = {
@@ -2722,7 +2738,8 @@ MailAPI.prototype = {
       suid: body.id,
       date: body._date,
       relPartIndices: relPartIndices,
-      attachmentIndices: attachmentIndices
+      attachmentIndices: attachmentIndices,
+      registerAttachments: registerAttachments
     });
   },
 

--- a/apps/email/js/ext/mailbridge.js
+++ b/apps/email/js/ext/mailbridge.js
@@ -817,6 +817,7 @@ MailBridge.prototype = {
     var self = this;
     this.universe.downloadMessageAttachments(
       msg.suid, msg.date, msg.relPartIndices, msg.attachmentIndices,
+      msg.registerAttachments,
       function(err) {
         self.__sendMessage({
           type: 'downloadedAttachments',

--- a/apps/email/js/ext/mailuniverse.js
+++ b/apps/email/js/ext/mailuniverse.js
@@ -1764,9 +1764,21 @@ MailUniverse.prototype = {
    *
    * This request is persistent although the callback will obviously be
    * discarded in the event the app is killed.
+   *
+   * @param {String[]} relPartIndices
+   *     The part identifiers of any related parts to be saved to IndexedDB.
+   * @param {String[]} attachmentIndices
+   *     The part identifiers of any attachment parts to be saved to
+   *     DeviceStorage.  For each entry in this array there should be a
+   *     corresponding boolean in registerWithDownloadManager.
+   * @param {Boolean[]} registerAttachments
+   *     An array of booleans corresponding to each entry in attachmentIndices
+   *     indicating whether the download should be registered with the download
+   *     manager.
    */
   downloadMessageAttachments: function(messageSuid, messageDate,
                                        relPartIndices, attachmentIndices,
+                                       registerAttachments,
                                        callback) {
     var account = this.getAccountForMessageSuid(messageSuid);
     var longtermId = this._queueAccountOp(
@@ -1782,7 +1794,8 @@ MailUniverse.prototype = {
         messageSuid: messageSuid,
         messageDate: messageDate,
         relPartIndices: relPartIndices,
-        attachmentIndices: attachmentIndices
+        attachmentIndices: attachmentIndices,
+        registerAttachments: registerAttachments
       },
       callback);
   },

--- a/apps/email/js/ext/pop3/sync.js
+++ b/apps/email/js/ext/pop3/sync.js
@@ -211,11 +211,16 @@ Pop3FolderSyncer.prototype = {
       var att = bodyInfo.attachments[i];
       if (att.file instanceof Blob) {
         // We want to save attachments to device storage (sdcard),
-        // rather than IndexedDB. NB: This will change when download
-        // manager comes.
+        // rather than IndexedDB, for now.  It's a v3 thing to use IndexedDB
+        // as a cache.
         console.log('Saving attachment', att.file);
+        // Always register all POP3 downloads with the download manager since
+        // the user didn't have to explicitly trigger download for each
+        // attachment.
+        var registerDownload = true;
         jobmixins.saveToDeviceStorage(
-          this._LOG, att.file, 'sdcard', att.name, att, latch.defer());
+          this._LOG, att.file, 'sdcard', registerDownload, att.name, att,
+          latch.defer());
         // When saveToDeviceStorage completes, att.file will
         // be a reference to the file on the sdcard.
       }

--- a/apps/email/js/ext/worker-support/devicestorage-main.js
+++ b/apps/email/js/ext/worker-support/devicestorage-main.js
@@ -6,18 +6,19 @@ define(function() {
   }
 
 
-  function save(uid, cmd, storage, blob, filename) {
+  function save(uid, cmd, storage, blob, filename, registerDownload) {
+    // For the download manager, we want to avoid the composite storage
     var deviceStorage = navigator.getDeviceStorage(storage);
 
     if (!deviceStorage) {
-      self.sendMessage(uid, cmd, [false, 'no-device-storage']);
+      self.sendMessage(uid, cmd, [false, 'no-device-storage', null, false]);
       return;
     }
 
     var req = deviceStorage.addNamed(blob, filename);
 
     req.onerror = function() {
-      self.sendMessage(uid, cmd, [false, req.error.name]);
+      self.sendMessage(uid, cmd, [false, req.error.name, null, false]);
     };
 
     req.onsuccess = function(e) {
@@ -27,8 +28,55 @@ define(function() {
         prefix = 'TEST_PREFIX/';
       }
 
+      var savedPath = prefix + e.target.result;
+
+      var registering = false;
+      if (registerDownload) {
+        var downloadManager = navigator.mozDownloadManager;
+        console.warn('have downloadManager?', !!downloadManager,
+                      'have adoptDownload?', downloadManager && !!downloadManager.adoptDownload);
+        if (downloadManager && downloadManager.adoptDownload) {
+          try {
+            var fullPath = e.target.result;
+            var firstSlash = fullPath.indexOf('/', 2); // ignore leading /
+            var storageName = fullPath.substring(1, firstSlash); // eat 1st /
+            var storagePath = fullPath.substring(firstSlash + 1);
+            console.log('adopting download', deviceStorage.storageName,
+                        e.target.result);
+            registering = true;
+            downloadManager.adoptDownload({
+              totalBytes: blob.size,
+              // There's no useful URL we can provide; anything would be an
+              // internal URI scheme that we can't service.
+              url: '',
+              storageName: storageName,
+              storagePath: storagePath,
+              contentType: blob.type,
+              // The time we started isn't inherently interesting given that the
+              // entirety of the file appears instantaneously to the download
+              // manager, now is good enough.
+              startTime: new Date(Date.now()),
+            }).then(function() {
+              console.log('registered download with download manager');
+              self.sendMessage(uid, cmd, [true, null, savedPath, true]);
+            }, function() {
+              console.warn('failed to register download with download manager');
+              self.sendMessage(uid, cmd, [true, null, savedPath, false]);
+            });
+          } catch (ex) {
+            console.error('Problem adopting download!:', ex, '\n', ex.stack);
+          }
+        } else {
+          console.log('download manager not available, not registering.');
+        }
+      } else {
+        console.log('do not want to register download');
+      }
+
       // Bool success, String err, String filename
-      self.sendMessage(uid, cmd, [true, null, prefix + e.target.result]);
+      if (!registering) {
+        self.sendMessage(uid, cmd, [true, null, savedPath, false]);
+      }
     };
   }
 
@@ -39,7 +87,7 @@ define(function() {
       debug('process ' + cmd);
       switch (cmd) {
         case 'save':
-          save(uid, cmd, args[0], args[1], args[2]);
+          save(uid, cmd, args[0], args[1], args[2], args[3]);
           break;
       }
     }

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -557,7 +557,20 @@ attachment-size-kib={{kilobytes}}K
 
 message-attachment-view=View
 
+# LOCALIZATION NOTE(message-attachment-did-not-open-label):
+# When a downloaded attachment cannot be opened because there is no app on the
+# device to handle its file type (as identified by MIME type), display a
+# confirmation dialog with this header.
+message-attachment-did-not-open-label=Unable to open
+# LOCALIZATION NOTE(message-attachment-did-not-open-label):
+# When a downloaded attachment cannot be opened because there is no app on the
+# device to handle its file type (as identified by MIME type), display a
+# confirmation dialog with this body.
+message-attachment-did-not-open-body=The device does not have an app that can open the attachment.
+
 message-attachment-too-large=This file is too large to download.
+
+
 
 message-no-subject=(no subject)
 

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -17,7 +17,7 @@
     "audio-channel-notification":{},
     "contacts":{ "access": "readcreate" },
     "desktop-notification":{},
-    "storage":{},
+    "downloads":{},
     "device-storage:sdcard":{ "access": "readcreate" },
     "systemXHR":{},
     "tcp-socket":{}

--- a/apps/email/test/unit/message_reader_card_test.js
+++ b/apps/email/test/unit/message_reader_card_test.js
@@ -139,6 +139,7 @@ suite('message_reader', function() {
     });
 
     test('disabled attachments accessibility', function(done) {
+      subject.body.attachments[0].isDownloadable = false;
       evt.once('metrics:contentDone', function() {
         assert.equal(subject.attachmentsContainer.children[0].getAttribute(
           'aria-disabled'), 'true');
@@ -148,6 +149,7 @@ suite('message_reader', function() {
     });
 
     test('attachments accessibility', function(done) {
+      subject.body.attachments[0].isDownloadable = true;
       subject.body.attachments[0].isDownloaded = true;
       evt.once('metrics:contentDone', function() {
         assert.equal(subject.attachmentsContainer.children[0].getAttribute(

--- a/apps/pdfjs/content/web/viewer.html
+++ b/apps/pdfjs/content/web/viewer.html
@@ -23,17 +23,17 @@ limitations under the License.
 
     <link rel="stylesheet" href="viewer.css"/>
     <link rel="resource" type="application/l10n" href="locale/locale.properties"/>
-    <script src="l10n.js"></script>
-    <script src="../build/pdf.js"></script>
-    <script src="/shared/js/async_storage.js"></script>
+    <script src="l10n.js" defer></script>
+    <script src="../build/pdf.js" defer></script>
+    <script src="/shared/js/async_storage.js" defer></script>
 
-    <script src="viewer.js"></script>
+    <script src="viewer.js" defer></script>
 
     <!-- Web Components -->
     <link rel="stylesheet" type="text/css" href="/shared/elements/gaia-theme/gaia-theme.css" />
     <!-- <link rel="stylesheet" type="text/css" href="/shared/elements/gaia-icons/gaia-icons.css" /> -->
-    <script type="text/javascript" src="/shared/elements/config.js"></script>
-    <script type="text/javascript" src="/shared/elements/gaia-header/dist/gaia-header.js"></script>
+    <script type="text/javascript" src="/shared/elements/config.js" defer></script>
+    <script type="text/javascript" src="/shared/elements/gaia-header/dist/gaia-header.js" defer></script>
   </head>
 
 

--- a/apps/system/js/download/download_notification.js
+++ b/apps/system/js/download/download_notification.js
@@ -13,11 +13,17 @@ function DownloadNotification(download) {
   this.state = 'started';
   this.id = DownloadFormatter.getUUID(download);
 
-  NotificationScreen.addNotification(this._getInfo());
-
   // We have to listen for state changes
   this.listener = this._update.bind(this);
   this.download.addEventListener('statechange', this.listener);
+
+  if (download.state === 'started') {
+    NotificationScreen.addNotification(this._getInfo());
+  } else {
+    // For adopted downloads, it is possible for the download to already be
+    // completed.
+    this._update();
+  }
 }
 
 DownloadNotification.prototype = {


### PR DESCRIPTION
...=jrburke, r=crdlc

(v2.2 merge of 6820bdc07e51ff0199f24bc20bdc1bdde022e383)

This patch consists of a few parts:
- Changes to download_notification.js (r=crdlc)

The new mozDownloadManager adoptDownload mechanism adds downloads with their
state already set to succeeded.  In that case we want to avoid the "started"
notification being displayed and instead jump directly towards displaying the
"succeeded"/completed notification.  Additionally, we want to process the
completion so the download is added to the data store.
- Changes to the email app (r=jrburke) (Now with test fixes!)

Improvements to MIME-type derivation logic.

Register all downloads with the download manager.  This requires the
"downloads" permission and a version of mozDownloadManager that implements
adoptDownload.

Display an error message if the user attempts to view/open a downloaded
attachment and there is no eligible activity.

NOTE: the gaia-email-libs-and-more parts of this patch are being layered on
top in a separate commit for ease of reviewing, etc.
- Make the PDF viewer not break itself it loses a race. (r=jrburke)

It's not okay to access the DOM before it has been populated, so we use defer.
And we use defer on all script nodes for consistency and to avoid any
unpleasant surprises from the webapp optimizer logic, should it start running
on the file.  (Currently pdfjs is blacklisted at an l10n level which also
defeats the other general _optimize steps.)

See https://bugzilla.mozilla.org/show_bug.cgi?id=1071449#c18 for more info.
