### PR TITLE
Bug 1138450 - Add version fields to built manifest.webapp files

### DIFF
--- a/build/post-manifest.js
+++ b/build/post-manifest.js
@@ -19,6 +19,14 @@ function execute(options) {
   // the app, with the same origin.
   manifest.origin = webapp.url;
 
+  // Get the Gaia version and set it as an app version in manifest.webapp.
+  // It's used by Langpack API
+  var settingsFile = utils.getFile(options.GAIA_DIR, 'build', 'config',
+      'common-settings.json');
+  var settings = utils.getJSON(settingsFile);
+
+  manifest.version = settings['moz.b2g.version'];
+
   utils.writeContent(buildManifestFile, JSON.stringify(manifest));
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1138450
