### PR TITLE
Bug 1139238 - [FFOS2.0][Woodduck][Airplane mode]The airplane mode is invalid.

### DIFF
--- a/apps/system/js/quick_settings.js
+++ b/apps/system/js/quick_settings.js
@@ -236,7 +236,8 @@ var QuickSettings = {
 
           case this.bluetooth:
             // do nothing if bluetooth isn't ready
-            if (this.bluetooth.dataset.initializing)
+            if (this.bluetooth.dataset.initializing 
+                || this.airplaneMode.dataset.enabling)
               return;
 
             var enabled = !!this.bluetooth.dataset.enabled;


### PR DESCRIPTION
--  disable buletooth click handler when 'this.airplaneMode.dataset.enabling' is true.
