### PR TITLE
Bug 1139731 - Let dependence on evt.js managed by bower

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -49,6 +49,12 @@ apps/system/js/uuid.js
 apps/camera/bower_components/**
 apps/bluetooth/js/vendor/alameda.js
 apps/bluetooth/js/settings.js
+tv_apps/app-deck/bower_components/**
+tv_apps/fling-player/bower_components/**
+tv_apps/notification-sender/bower_components/**
+tv_apps/smart-home/bower_components/**
+tv_apps/smart-settings/bower_components/**
+tv_apps/smart-system/bower_components/**
 tests/atoms/remote_date.js
 tests/atoms/screenshot.js
 tests/performance/getappname_atom.js

--- a/tv_apps/app-deck/bower.json
+++ b/tv_apps/app-deck/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "app-deck",
+  "version": "0.0.0",
+  "homepage": "https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/app-deck",
+  "description": "Smart Screen Apps Deck",
+  "main": "index.html",
+  "license": "MPL",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "evt": "gaia-components/evt#~0.4.0"
+  }
+}

--- a/tv_apps/app-deck/bower_components/evt/.bower.json
+++ b/tv_apps/app-deck/bower_components/evt/.bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
+  "authors": [
+    "Wilson Page <wilsonpage@me.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "test",
+    "tests",
+    "README.md"
+  ],
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "3593dd6b4dd19f683d00fd0eaf2581c11a128da6"
+  },
+  "_source": "git://github.com/gaia-components/evt.git",
+  "_target": "~0.4.0",
+  "_originalSource": "gaia-components/evt"
+}

--- a/tv_apps/app-deck/bower_components/evt/bower.json
+++ b/tv_apps/app-deck/bower_components/evt/bower.json
@@ -1,16 +1,19 @@
 {
-  "name": "gaia-component",
-  "version": "0.3.4",
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-component.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
+    "package.json",
     "test",
-    "tests"
+    "tests",
+    "README.md"
   ]
 }

--- a/tv_apps/app-deck/bower_components/evt/index.js
+++ b/tv_apps/app-deck/bower_components/evt/index.js
@@ -1,6 +1,6 @@
-/* *NOTE*: This file is a copy from the camera app. */
+
 /**
- * Event
+ * Evt
  *
  * A super lightweight
  * event emitter library.
@@ -8,7 +8,6 @@
  * @version 0.3.3
  * @author Wilson Page <wilson.page@me.com>
  */
-/* jshint ignore:start */
 
 ;(function() {
 
@@ -29,8 +28,8 @@ var slice = [].slice;
  * @return {Object}
  */
 function Events(obj) {
-  if (!(this instanceof Events)) { return new Events(obj); }
-  if (obj) { return mixin(obj, proto); }
+  if (!(this instanceof Events)) return new Events(obj);
+  if (obj) return mixin(obj, proto);
 }
 
 /**
@@ -47,6 +46,17 @@ proto.on = function(name, cb) {
   return this;
 };
 
+/**
+ * Attach a callback that once
+ * called, detaches itself.
+ *
+ * TODO: Implement `.off()` to work
+ * with `once()` callbacks.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @public
+ */
 proto.once = function(name, cb) {
   this.on(name, one);
   function one() {
@@ -125,7 +135,7 @@ proto.firer = function(name) {
  * @return {Object}
  */
 function mixin(a, b) {
-  for (var key in b) { a[key] = b[key]; }
+  for (var key in b) a[key] = b[key];
   return a;
 }
 
@@ -136,7 +146,7 @@ function mixin(a, b) {
 if (typeof exports === 'object') {
   module.exports = Events;
 } else if (typeof define === 'function' && define.amd) {
-  define(function() { return Events; });
+  define(function(){ return Events; });
 } else {
   window.evt = Events;
 }

--- a/tv_apps/app-deck/index.html
+++ b/tv_apps/app-deck/index.html
@@ -23,7 +23,7 @@
     <!-- Shared libraries -->
     <script src="shared/js/l10n.js"></script>
     <script src="shared/js/manifest_helper.js"></script>
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
+    <script defer src="bower_components/evt/index.js"></script>
     <script defer src="tv_shared/js/scrollable.js"></script>
     <script defer src="tv_shared/js/spatial_navigator.js"></script>
     <script defer src="tv_shared/js/key_navigation_adapter.js"></script>

--- a/tv_apps/fling-player/bower.json
+++ b/tv_apps/fling-player/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "fling-player",
+  "version": "0.0.0",
+  "homepage": "https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/fling-player",
+  "authors": [
+    "Tzu-Lin Huang <tzhuang@mozilla.com>"
+  ],
+  "description": "Smart Screen Fling Player",
+  "main": "index.html",
+  "license": "MPL",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "gaia-loading": "gaia-components/gaia-loading",
+    "gaia-theme": "gaia-components/gaia-theme#~0.4.5",
+    "evt": "gaia-components/evt#~0.4.0"
+  }
+}

--- a/tv_apps/fling-player/bower_components/evt/.bower.json
+++ b/tv_apps/fling-player/bower_components/evt/.bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
+  "authors": [
+    "Wilson Page <wilsonpage@me.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "test",
+    "tests",
+    "README.md"
+  ],
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "3593dd6b4dd19f683d00fd0eaf2581c11a128da6"
+  },
+  "_source": "git://github.com/gaia-components/evt.git",
+  "_target": "~0.4.0",
+  "_originalSource": "gaia-components/evt"
+}

--- a/tv_apps/fling-player/bower_components/evt/bower.json
+++ b/tv_apps/fling-player/bower_components/evt/bower.json
@@ -1,16 +1,19 @@
 {
-  "name": "gaia-component",
-  "version": "0.3.4",
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-component.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
+    "package.json",
     "test",
-    "tests"
+    "tests",
+    "README.md"
   ]
 }

--- a/tv_apps/fling-player/bower_components/evt/index.js
+++ b/tv_apps/fling-player/bower_components/evt/index.js
@@ -1,0 +1,154 @@
+
+/**
+ * Evt
+ *
+ * A super lightweight
+ * event emitter library.
+ *
+ * @version 0.3.3
+ * @author Wilson Page <wilson.page@me.com>
+ */
+
+;(function() {
+
+/**
+ * Locals
+ */
+
+var proto = Events.prototype;
+var slice = [].slice;
+
+/**
+ * Creates a new event emitter
+ * instance, or if passed an
+ * object, mixes the event logic
+ * into it.
+ *
+ * @param  {Object} obj
+ * @return {Object}
+ */
+function Events(obj) {
+  if (!(this instanceof Events)) return new Events(obj);
+  if (obj) return mixin(obj, proto);
+}
+
+/**
+ * Registers a callback
+ * with an event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.on = function(name, cb) {
+  this._cbs = this._cbs || {};
+  (this._cbs[name] || (this._cbs[name] = [])).push(cb);
+  return this;
+};
+
+/**
+ * Attach a callback that once
+ * called, detaches itself.
+ *
+ * TODO: Implement `.off()` to work
+ * with `once()` callbacks.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @public
+ */
+proto.once = function(name, cb) {
+  this.on(name, one);
+  function one() {
+    cb.apply(this, arguments);
+    this.off(name, one);
+  }
+};
+
+/**
+ * Removes a single callback,
+ * or all callbacks associated
+ * with the passed event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.off = function(name, cb) {
+  this._cbs = this._cbs || {};
+
+  if (!name) { this._cbs = {}; return; }
+  if (!cb) { return delete this._cbs[name]; }
+
+  var cbs = this._cbs[name] || [];
+  var i;
+
+  while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
+  return this;
+};
+
+/**
+ * Fires an event, triggering
+ * all callbacks registered on this
+ * event name.
+ *
+ * @param  {String} name
+ * @return {Event}
+ */
+proto.fire = proto.emit = function(options) {
+  var cbs = this._cbs = this._cbs || {};
+  var name = options.name || options;
+  var batch = (cbs[name] || []).concat(cbs['*'] || []);
+  var ctx = options.ctx || this;
+
+  if (batch.length) {
+    this._fireArgs = arguments;
+    var args = slice.call(arguments, 1);
+    while (batch.length) {
+      batch.shift().apply(ctx, args);
+    }
+  }
+
+  return this;
+};
+
+proto.firer = function(name) {
+  var self = this;
+  return function() {
+    var args = slice.call(arguments);
+    args.unshift(name);
+    self.fire.apply(self, args);
+  };
+};
+
+/**
+ * Util
+ */
+
+/**
+ * Mixes in the properties
+ * of the second object into
+ * the first.
+ *
+ * @param  {Object} a
+ * @param  {Object} b
+ * @return {Object}
+ */
+function mixin(a, b) {
+  for (var key in b) a[key] = b[key];
+  return a;
+}
+
+/**
+ * Expose 'Event' (UMD)
+ */
+
+if (typeof exports === 'object') {
+  module.exports = Events;
+} else if (typeof define === 'function' && define.amd) {
+  define(function(){ return Events; });
+} else {
+  window.evt = Events;
+}
+
+})();

--- a/tv_apps/fling-player/bower_components/gaia-component/.bower.json
+++ b/tv_apps/fling-player/bower_components/gaia-component/.bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-component",
-  "version": "0.2.1",
+  "version": "0.3.4",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
@@ -14,13 +14,13 @@
     "tests"
   ],
   "homepage": "https://github.com/gaia-components/gaia-component",
-  "_release": "0.2.1",
+  "_release": "0.3.4",
   "_resolution": {
     "type": "version",
-    "tag": "v0.2.1",
-    "commit": "bf9a25d6673e3481f2c5544d876dcf3e8ba86d40"
+    "tag": "v0.3.4",
+    "commit": "84f95014d48d88fa8df570dc4ede50dc5be318b6"
   },
   "_source": "git://github.com/gaia-components/gaia-component.git",
-  "_target": "~0.2.0",
+  "_target": "~0.3.0",
   "_originalSource": "gaia-components/gaia-component"
 }

--- a/tv_apps/fling-player/bower_components/gaia-component/gaia-component.js
+++ b/tv_apps/fling-player/bower_components/gaia-component/gaia-component.js
@@ -6,21 +6,10 @@
  */
 
 var textContent = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
-var removeAttribute = HTMLElement.prototype.removeAttribute;
-var setAttribute = HTMLElement.prototype.setAttribute;
+var innerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML');
+var removeAttribute = Element.prototype.removeAttribute;
+var setAttribute = Element.prototype.setAttribute;
 var noop  = function() {};
-
-/**
- * Detects presence of shadow-dom
- * CSS selectors.
- *
- * @return {Boolean}
- */
-var hasShadowCSS = (function() {
-  var div = document.createElement('div');
-  try { div.querySelector(':host'); return true; }
-  catch (e) { return false; }
-})();
 
 /**
  * Register a new component.
@@ -30,12 +19,10 @@ var hasShadowCSS = (function() {
  * @return {constructor}
  * @public
  */
-module.exports.register = function(name, props) {
+exports.register = function(name, props) {
+  var baseProto = getBaseProto(props.extends);
 
-  // Decide on a base protoype, create a handy
-  // reference to super (extended) class, then clean up.
-  var parent = props.extends ? props.extends.prototype : base;
-  props.super = parent;
+  // Clean up
   delete props.extends;
 
   // Pull out CSS that needs to be in the light-dom
@@ -57,137 +44,186 @@ module.exports.register = function(name, props) {
 
   // Merge base getter/setter attributes with the user's,
   // then define the property descriptors on the prototype.
-  var descriptors = Object.assign(props.attrs || {}, baseAttrs);
+  var descriptors = Object.assign(props.attrs || {}, base.descriptors);
 
   // Store the orginal descriptors somewhere
   // a little more private and delete the original
   props._attrs = props.attrs;
   delete props.attrs;
 
-  // Create the prototype, extended from the parent
-  var proto = Object.assign(Object.create(parent), props);
-
-  // Define the properties directly on the prototype
+  // Create the prototype, extended from base and
+  // define the descriptors directly on the prototype
+  var proto = createProto(baseProto, props);
   Object.defineProperties(proto, descriptors);
 
   // Register the custom-element and return the constructor
   return document.registerElement(name, { prototype: proto });
 };
 
-var base = Object.assign(Object.create(HTMLElement.prototype), {
-  attributeChanged: noop,
-  attached: noop,
-  detached: noop,
-  created: noop,
+var base = {
+  properties: {
+    GaiaComponent: true,
+    attributeChanged: noop,
+    attached: noop,
+    detached: noop,
+    created: noop,
 
-  createdCallback: function() {
-    injectLightCss(this);
-    this.created();
-  },
-
-  /**
-   * It is very common to want to keep object
-   * properties in-sync with attributes,
-   * for example:
-   *
-   *   el.value = 'foo';
-   *   el.setAttribute('value', 'foo');
-   *
-   * So we support an object on the prototype
-   * named 'attrs' to provide a consistent
-   * way for component authors to define
-   * these properties. When an attribute
-   * changes we keep the attr[name]
-   * up-to-date.
-   *
-   * @param  {String} name
-   * @param  {String||null} from
-   * @param  {String||null} to
-   */
-  attributeChangedCallback: function(name, from, to) {
-    var prop = toCamelCase(name);
-    if (this._attrs && this._attrs[prop]) { this[prop] = to; }
-    this.attributeChanged(name, from, to);
-  },
-
-  attachedCallback: function() { this.attached(); },
-  detachedCallback: function() { this.detached(); },
-
-  /**
-   * A convenient method for setting up
-   * a shadow-root using the defined template.
-   *
-   * @return {ShadowRoot}
-   */
-  setupShadowRoot: function() {
-    if (!this.template) { return; }
-    var node = document.importNode(this.template.content, true);
-    this.createShadowRoot().appendChild(node);
-    return this.shadowRoot;
-  },
-
-  /**
-   * Sets an attribute internally
-   * and externally. This is so that
-   * we can style internal shadow-dom
-   * content.
-   *
-   * @param {String} name
-   * @param {String} value
-   */
-  setAttr: function(name, value) {
-    var internal = this.shadowRoot.firstElementChild;
-    setAttribute.call(internal, name, value);
-    setAttribute.call(this, name, value);
-  },
-
-  /**
-   * Removes an attribute internally
-   * and externally. This is so that
-   * we can style internal shadow-dom
-   * content.
-   *
-   * @param {String} name
-   * @param {String} value
-   */
-  removeAttr: function(name) {
-    var internal = this.shadowRoot.firstElementChild;
-    removeAttribute.call(internal, name);
-    removeAttribute.call(this, name);
-  }
-});
-
-var baseAttrs = {
-  textContent: {
-    set: function(value) {
-      var node = firstChildTextNode(this);
-      if (node) { node.nodeValue = value; }
+    createdCallback: function() {
+      if (this.rtl) { addDirObserver(); }
+      injectLightCss(this);
+      this.created();
     },
 
-    get: function() {
-      var node = firstChildTextNode(this);
-      return node && node.nodeValue;
+    /**
+     * It is very common to want to keep object
+     * properties in-sync with attributes,
+     * for example:
+     *
+     *   el.value = 'foo';
+     *   el.setAttribute('value', 'foo');
+     *
+     * So we support an object on the prototype
+     * named 'attrs' to provide a consistent
+     * way for component authors to define
+     * these properties. When an attribute
+     * changes we keep the attr[name]
+     * up-to-date.
+     *
+     * @param  {String} name
+     * @param  {String||null} from
+     * @param  {String||null} to
+     */
+    attributeChangedCallback: function(name, from, to) {
+      var prop = toCamelCase(name);
+      if (this._attrs && this._attrs[prop]) { this[prop] = to; }
+      this.attributeChanged(name, from, to);
+    },
+
+    attachedCallback: function() { this.attached(); },
+    detachedCallback: function() { this.detached(); },
+
+    /**
+     * A convenient method for setting up
+     * a shadow-root using the defined template.
+     *
+     * @return {ShadowRoot}
+     */
+    setupShadowRoot: function() {
+      if (!this.template) { return; }
+      var node = document.importNode(this.template.content, true);
+      this.createShadowRoot().appendChild(node);
+      return this.shadowRoot;
+    },
+
+    /**
+     * Sets an attribute internally
+     * and externally. This is so that
+     * we can style internal shadow-dom
+     * content.
+     *
+     * @param {String} name
+     * @param {String} value
+     */
+    setAttr: function(name, value) {
+      var internal = this.shadowRoot.firstElementChild;
+      setAttribute.call(internal, name, value);
+      setAttribute.call(this, name, value);
+    },
+
+    /**
+     * Removes an attribute internally
+     * and externally. This is so that
+     * we can style internal shadow-dom
+     * content.
+     *
+     * @param {String} name
+     * @param {String} value
+     */
+    removeAttr: function(name) {
+      var internal = this.shadowRoot.firstElementChild;
+      removeAttribute.call(internal, name);
+      removeAttribute.call(this, name);
+    }
+  },
+
+  descriptors: {
+    textContent: {
+      set: function(value) {
+        textContent.set.call(this, value);
+        if (this.lightStyle) { this.appendChild(this.lightStyle); }
+      },
+
+      get: textContent.get
+    },
+
+    innerHTML: {
+      set: function(value) {
+        innerHTML.set.call(this, value);
+        if (this.lightStyle) { this.appendChild(this.lightStyle); }
+      },
+
+      get: innerHTML.get
     }
   }
 };
 
 /**
- * Return the first child textNode.
+ * The default base prototype to use
+ * when `extends` is undefined.
  *
- * @param  {Element} el
- * @return {TextNode}
+ * @type {Object}
  */
-function firstChildTextNode(el) {
-  for (var i = 0; i < el.childNodes.length; i++) {
-    var node = el.childNodes[i];
-    if (node && node.nodeType === 3) { return node; }
-  }
+var defaultPrototype = createProto(HTMLElement.prototype, base.properties);
+
+/**
+ * Returns a suitable prototype based
+ * on the object passed.
+ *
+ * @param  {HTMLElementPrototype|undefined} proto
+ * @return {HTMLElementPrototype}
+ * @private
+ */
+function getBaseProto(proto) {
+  if (!proto) { return defaultPrototype; }
+  proto = proto.prototype || proto;
+  return !proto.GaiaComponent
+    ? createProto(proto, base.properties)
+    : proto;
 }
 
+/**
+ * Extends the given proto and mixes
+ * in the given properties.
+ *
+ * @param  {Object} proto
+ * @param  {Object} props
+ * @return {Object}
+ */
+function createProto(proto, props) {
+  return Object.assign(Object.create(proto), props);
+}
+
+/**
+ * Detects presence of shadow-dom
+ * CSS selectors.
+ *
+ * @return {Boolean}
+ */
+var hasShadowCSS = (function() {
+  var div = document.createElement('div');
+  try { div.querySelector(':host'); return true; }
+  catch (e) { return false; }
+})();
+
+/**
+ * Regexs used to extract shadow-css
+ *
+ * @type {Object}
+ */
 var regex = {
   shadowCss: /(?:\:host|\:\:content)[^{]*\{[^}]*\}/g,
   ':host': /(?:\:host)/g,
-  ':host()': /\:host\((.+)\)/g,
+  ':host()': /\:host\((.+)\)(?: \:\:content)?/g,
   ':host-context': /\:host-context\((.+)\)([^{,]+)?/g,
   '::content': /(?:\:\:content)/g
 };
@@ -245,7 +281,25 @@ function injectGlobalCss(css) {
   if (!css) return;
   var style = document.createElement('style');
   style.innerHTML = css.trim();
-  document.head.appendChild(style);
+  headReady().then(() => {
+    document.head.appendChild(style)
+  });
+}
+
+
+/**
+ * Resolves a promise once document.head is ready.
+ *
+ * @private
+ */
+function headReady() {
+  return new Promise(resolve => {
+    if (document.head) { return resolve(); }
+    window.addEventListener('load', function fn() {
+      window.removeEventListener('load', fn);
+      resolve();
+    });
+  });
 }
 
 
@@ -286,6 +340,37 @@ function toCamelCase(string) {
   return string.replace(/-(.)/g, function replacer(string, p1) {
     return p1.toUpperCase();
   });
+}
+
+/**
+ * Observer (singleton)
+ *
+ * @type {MutationObserver|undefined}
+ */
+var dirObserver;
+
+/**
+ * Observes the document `dir` (direction)
+ * attribute and dispatches a global event
+ * when it changes.
+ *
+ * Components can listen to this event and
+ * make internal changes if need be.
+ *
+ * @private
+ */
+function addDirObserver() {
+  if (dirObserver) { return; }
+
+  dirObserver = new MutationObserver(onChanged);
+  dirObserver.observe(document.documentElement, {
+    attributeFilter: ['dir'],
+    attributes: true
+  });
+
+  function onChanged(mutations) {
+    document.dispatchEvent(new Event('dirchanged'));
+  }
 }
 
 });})(typeof define=='function'&&define.amd?define

--- a/tv_apps/fling-player/bower_components/gaia-loading/.bower.json
+++ b/tv_apps/fling-player/bower_components/gaia-loading/.bower.json
@@ -16,16 +16,15 @@
     "README.md"
   ],
   "dependencies": {
-    "gaia-component": "gaia-components/gaia-component#~0.2.0"
+    "gaia-component": "gaia-components/gaia-component#~0.3.0"
   },
-  "_release": "91142e18fc",
+  "_release": "84a8803886",
   "_resolution": {
     "type": "branch",
     "branch": "master",
-    "commit": "91142e18fc16905f0d5860d43de187e2e8827c63"
+    "commit": "84a880388686523e68172651fce2d570d4499daf"
   },
   "_source": "git://github.com/gaia-components/gaia-loading.git",
   "_target": "*",
-  "_originalSource": "gaia-components/gaia-loading",
-  "_direct": true
+  "_originalSource": "gaia-components/gaia-loading"
 }

--- a/tv_apps/fling-player/bower_components/gaia-loading/bower.json
+++ b/tv_apps/fling-player/bower_components/gaia-loading/bower.json
@@ -17,6 +17,6 @@
     "README.md"
   ],
   "dependencies": {
-    "gaia-component": "gaia-components/gaia-component#~0.2.0"
+    "gaia-component": "gaia-components/gaia-component#~0.3.0"
   }
 }

--- a/tv_apps/fling-player/bower_components/gaia-loading/gaia-loading.js
+++ b/tv_apps/fling-player/bower_components/gaia-loading/gaia-loading.js
@@ -29,9 +29,9 @@ module.exports = component.register('gaia-loading', {
     :host {
       position: relative;
       display: block;
-      width: 100%;
-      height: 100%;
-      margin: auto;
+      width: 40px;
+      height: 40px;
+      margin: var(--base-l, 24px) auto;
     }
 
     /** Circle
@@ -39,9 +39,9 @@ module.exports = component.register('gaia-loading', {
 
     .circle {
       position: absolute;
-      top: 25%; left: 25%;
-      width: 50%;
-      height: 50%;
+      top: 0; left: 0;
+      width: 100%;
+      height: 100%;
       border-radius: 50%;
 
       animation-name: gaia-loading-animation;

--- a/tv_apps/fling-player/bower_components/gaia-theme/.bower.json
+++ b/tv_apps/fling-player/bower_components/gaia-theme/.bower.json
@@ -31,6 +31,5 @@
   },
   "_source": "git://github.com/gaia-components/gaia-theme.git",
   "_target": "~0.4.5",
-  "_originalSource": "gaia-components/gaia-theme",
-  "_direct": true
+  "_originalSource": "gaia-components/gaia-theme"
 }

--- a/tv_apps/fling-player/index.html
+++ b/tv_apps/fling-player/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" type="text/css" href="style/fling_player.css">
 
     <!-- shared libraries -->
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
+    <script defer src="bower_components/evt/index.js"></script>
 
     <!-- building block -->
     <script defer src="bower_components/gaia-component/gaia-component.js"></script>

--- a/tv_apps/notification-sender/bower.json
+++ b/tv_apps/notification-sender/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "notification-sender",
+  "version": "0.0.0",
+  "homepage": "https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/notification-sender",
+  "description": "Notification Sender",
+  "main": "index.html",
+  "license": "MPL",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "evt": "gaia-components/evt#~0.4.0"
+  }
+}

--- a/tv_apps/notification-sender/bower_components/evt/.bower.json
+++ b/tv_apps/notification-sender/bower_components/evt/.bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
+  "authors": [
+    "Wilson Page <wilsonpage@me.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "test",
+    "tests",
+    "README.md"
+  ],
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "3593dd6b4dd19f683d00fd0eaf2581c11a128da6"
+  },
+  "_source": "git://github.com/gaia-components/evt.git",
+  "_target": "~0.4.0",
+  "_originalSource": "gaia-components/evt"
+}

--- a/tv_apps/notification-sender/bower_components/evt/bower.json
+++ b/tv_apps/notification-sender/bower_components/evt/bower.json
@@ -1,16 +1,19 @@
 {
-  "name": "gaia-component",
-  "version": "0.3.4",
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-component.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
+    "package.json",
     "test",
-    "tests"
+    "tests",
+    "README.md"
   ]
 }

--- a/tv_apps/notification-sender/bower_components/evt/index.js
+++ b/tv_apps/notification-sender/bower_components/evt/index.js
@@ -1,0 +1,154 @@
+
+/**
+ * Evt
+ *
+ * A super lightweight
+ * event emitter library.
+ *
+ * @version 0.3.3
+ * @author Wilson Page <wilson.page@me.com>
+ */
+
+;(function() {
+
+/**
+ * Locals
+ */
+
+var proto = Events.prototype;
+var slice = [].slice;
+
+/**
+ * Creates a new event emitter
+ * instance, or if passed an
+ * object, mixes the event logic
+ * into it.
+ *
+ * @param  {Object} obj
+ * @return {Object}
+ */
+function Events(obj) {
+  if (!(this instanceof Events)) return new Events(obj);
+  if (obj) return mixin(obj, proto);
+}
+
+/**
+ * Registers a callback
+ * with an event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.on = function(name, cb) {
+  this._cbs = this._cbs || {};
+  (this._cbs[name] || (this._cbs[name] = [])).push(cb);
+  return this;
+};
+
+/**
+ * Attach a callback that once
+ * called, detaches itself.
+ *
+ * TODO: Implement `.off()` to work
+ * with `once()` callbacks.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @public
+ */
+proto.once = function(name, cb) {
+  this.on(name, one);
+  function one() {
+    cb.apply(this, arguments);
+    this.off(name, one);
+  }
+};
+
+/**
+ * Removes a single callback,
+ * or all callbacks associated
+ * with the passed event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.off = function(name, cb) {
+  this._cbs = this._cbs || {};
+
+  if (!name) { this._cbs = {}; return; }
+  if (!cb) { return delete this._cbs[name]; }
+
+  var cbs = this._cbs[name] || [];
+  var i;
+
+  while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
+  return this;
+};
+
+/**
+ * Fires an event, triggering
+ * all callbacks registered on this
+ * event name.
+ *
+ * @param  {String} name
+ * @return {Event}
+ */
+proto.fire = proto.emit = function(options) {
+  var cbs = this._cbs = this._cbs || {};
+  var name = options.name || options;
+  var batch = (cbs[name] || []).concat(cbs['*'] || []);
+  var ctx = options.ctx || this;
+
+  if (batch.length) {
+    this._fireArgs = arguments;
+    var args = slice.call(arguments, 1);
+    while (batch.length) {
+      batch.shift().apply(ctx, args);
+    }
+  }
+
+  return this;
+};
+
+proto.firer = function(name) {
+  var self = this;
+  return function() {
+    var args = slice.call(arguments);
+    args.unshift(name);
+    self.fire.apply(self, args);
+  };
+};
+
+/**
+ * Util
+ */
+
+/**
+ * Mixes in the properties
+ * of the second object into
+ * the first.
+ *
+ * @param  {Object} a
+ * @param  {Object} b
+ * @return {Object}
+ */
+function mixin(a, b) {
+  for (var key in b) a[key] = b[key];
+  return a;
+}
+
+/**
+ * Expose 'Event' (UMD)
+ */
+
+if (typeof exports === 'object') {
+  module.exports = Events;
+} else if (typeof define === 'function' && define.amd) {
+  define(function(){ return Events; });
+} else {
+  window.evt = Events;
+}
+
+})();

--- a/tv_apps/notification-sender/index.html
+++ b/tv_apps/notification-sender/index.html
@@ -17,7 +17,7 @@
 
     <!-- Shared libraries -->
     <script src="shared/js/l10n.js"></script>
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
+    <script defer src="bower_components/evt/index.js"></script>
 
     <!-- Specific code -->
     <script defer src="js/notification_sender.js"></script>

--- a/tv_apps/smart-home/_test/unit/card_manager_test.js
+++ b/tv_apps/smart-home/_test/unit/card_manager_test.js
@@ -2,7 +2,7 @@
 /* global Application, CardManager, Deck, Folder, AsyncSemaphore,
           MockCardStore, MockPipedPromise, MockXMLHttpRequest */
 
-require('/tv_apps/tv_shared/js/vendor/evt.js');
+require('/bower_components/evt/index.js');
 require('/shared/js/uuid.js');
 require('/tv_apps/tv_shared/js/shared_utils.js');
 require('/tv_apps/tv_shared/test/unit/mocks/mock_piped_promise.js');

--- a/tv_apps/smart-home/_test/unit/folder_test.js
+++ b/tv_apps/smart-home/_test/unit/folder_test.js
@@ -2,11 +2,11 @@
 
 /* global Deck, Folder */
 
-require('/tv_apps/tv_shared/js/vendor/evt.js');
+require('/bower_components/evt/index.js');
 require('/shared/js/uuid.js');
 require('/tv_apps/tv_shared/js/cards/card.js');
-require('/tv_apps//tv_shared/js/cards/deck.js');
-require('/tv_apps//tv_shared/js/cards/folder.js');
+require('/tv_apps/tv_shared/js/cards/deck.js');
+require('/tv_apps/tv_shared/js/cards/folder.js');
 
 suite('tv_shared/Folder', function() {
   var folder;

--- a/tv_apps/smart-home/bower.json
+++ b/tv_apps/smart-home/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "smart-home",
+  "version": "0.0.0",
+  "homepage": "https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/smart-home",
+  "description": "Smart Screen Home App",
+  "main": "index.html",
+  "license": "MPL",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "evt": "gaia-components/evt#~0.4.0"
+  }
+}

--- a/tv_apps/smart-home/bower_components/evt/.bower.json
+++ b/tv_apps/smart-home/bower_components/evt/.bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
+  "authors": [
+    "Wilson Page <wilsonpage@me.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "test",
+    "tests",
+    "README.md"
+  ],
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "3593dd6b4dd19f683d00fd0eaf2581c11a128da6"
+  },
+  "_source": "git://github.com/gaia-components/evt.git",
+  "_target": "~0.4.0",
+  "_originalSource": "gaia-components/evt"
+}

--- a/tv_apps/smart-home/bower_components/evt/bower.json
+++ b/tv_apps/smart-home/bower_components/evt/bower.json
@@ -1,16 +1,19 @@
 {
-  "name": "gaia-component",
-  "version": "0.3.4",
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-component.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
+    "package.json",
     "test",
-    "tests"
+    "tests",
+    "README.md"
   ]
 }

--- a/tv_apps/smart-home/bower_components/evt/index.js
+++ b/tv_apps/smart-home/bower_components/evt/index.js
@@ -1,0 +1,154 @@
+
+/**
+ * Evt
+ *
+ * A super lightweight
+ * event emitter library.
+ *
+ * @version 0.3.3
+ * @author Wilson Page <wilson.page@me.com>
+ */
+
+;(function() {
+
+/**
+ * Locals
+ */
+
+var proto = Events.prototype;
+var slice = [].slice;
+
+/**
+ * Creates a new event emitter
+ * instance, or if passed an
+ * object, mixes the event logic
+ * into it.
+ *
+ * @param  {Object} obj
+ * @return {Object}
+ */
+function Events(obj) {
+  if (!(this instanceof Events)) return new Events(obj);
+  if (obj) return mixin(obj, proto);
+}
+
+/**
+ * Registers a callback
+ * with an event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.on = function(name, cb) {
+  this._cbs = this._cbs || {};
+  (this._cbs[name] || (this._cbs[name] = [])).push(cb);
+  return this;
+};
+
+/**
+ * Attach a callback that once
+ * called, detaches itself.
+ *
+ * TODO: Implement `.off()` to work
+ * with `once()` callbacks.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @public
+ */
+proto.once = function(name, cb) {
+  this.on(name, one);
+  function one() {
+    cb.apply(this, arguments);
+    this.off(name, one);
+  }
+};
+
+/**
+ * Removes a single callback,
+ * or all callbacks associated
+ * with the passed event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.off = function(name, cb) {
+  this._cbs = this._cbs || {};
+
+  if (!name) { this._cbs = {}; return; }
+  if (!cb) { return delete this._cbs[name]; }
+
+  var cbs = this._cbs[name] || [];
+  var i;
+
+  while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
+  return this;
+};
+
+/**
+ * Fires an event, triggering
+ * all callbacks registered on this
+ * event name.
+ *
+ * @param  {String} name
+ * @return {Event}
+ */
+proto.fire = proto.emit = function(options) {
+  var cbs = this._cbs = this._cbs || {};
+  var name = options.name || options;
+  var batch = (cbs[name] || []).concat(cbs['*'] || []);
+  var ctx = options.ctx || this;
+
+  if (batch.length) {
+    this._fireArgs = arguments;
+    var args = slice.call(arguments, 1);
+    while (batch.length) {
+      batch.shift().apply(ctx, args);
+    }
+  }
+
+  return this;
+};
+
+proto.firer = function(name) {
+  var self = this;
+  return function() {
+    var args = slice.call(arguments);
+    args.unshift(name);
+    self.fire.apply(self, args);
+  };
+};
+
+/**
+ * Util
+ */
+
+/**
+ * Mixes in the properties
+ * of the second object into
+ * the first.
+ *
+ * @param  {Object} a
+ * @param  {Object} b
+ * @return {Object}
+ */
+function mixin(a, b) {
+  for (var key in b) a[key] = b[key];
+  return a;
+}
+
+/**
+ * Expose 'Event' (UMD)
+ */
+
+if (typeof exports === 'object') {
+  module.exports = Events;
+} else if (typeof define === 'function' && define.amd) {
+  define(function(){ return Events; });
+} else {
+  window.evt = Events;
+}
+
+})();

--- a/tv_apps/smart-home/index.html
+++ b/tv_apps/smart-home/index.html
@@ -32,7 +32,7 @@
     <script defer src="shared/js/iac_handler.js"></script>
 
     <!-- Helper libraries -->
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
+    <script defer src="bower_components/evt/index.js"></script>
     <script defer src="tv_shared/js/shared_utils.js"></script>
     <script defer src="tv_shared/js/clock.js"></script>
     <script defer src="tv_shared/js/piped_promise.js"></script>

--- a/tv_apps/smart-settings/bower.json
+++ b/tv_apps/smart-settings/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "smart-settings",
+  "version": "0.0.0",
+  "homepage": "https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/smart-settings",
+  "description": "Smart Screen Settings App",
+  "main": "index.html",
+  "license": "MPL",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "evt": "gaia-components/evt#~0.4.0"
+  }
+}

--- a/tv_apps/smart-settings/bower_components/evt/.bower.json
+++ b/tv_apps/smart-settings/bower_components/evt/.bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
+  "authors": [
+    "Wilson Page <wilsonpage@me.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "test",
+    "tests",
+    "README.md"
+  ],
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "3593dd6b4dd19f683d00fd0eaf2581c11a128da6"
+  },
+  "_source": "git://github.com/gaia-components/evt.git",
+  "_target": "~0.4.0",
+  "_originalSource": "gaia-components/evt"
+}

--- a/tv_apps/smart-settings/bower_components/evt/bower.json
+++ b/tv_apps/smart-settings/bower_components/evt/bower.json
@@ -1,16 +1,19 @@
 {
-  "name": "gaia-component",
-  "version": "0.3.4",
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-component.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
+    "package.json",
     "test",
-    "tests"
+    "tests",
+    "README.md"
   ]
 }

--- a/tv_apps/smart-settings/bower_components/evt/index.js
+++ b/tv_apps/smart-settings/bower_components/evt/index.js
@@ -1,0 +1,154 @@
+
+/**
+ * Evt
+ *
+ * A super lightweight
+ * event emitter library.
+ *
+ * @version 0.3.3
+ * @author Wilson Page <wilson.page@me.com>
+ */
+
+;(function() {
+
+/**
+ * Locals
+ */
+
+var proto = Events.prototype;
+var slice = [].slice;
+
+/**
+ * Creates a new event emitter
+ * instance, or if passed an
+ * object, mixes the event logic
+ * into it.
+ *
+ * @param  {Object} obj
+ * @return {Object}
+ */
+function Events(obj) {
+  if (!(this instanceof Events)) return new Events(obj);
+  if (obj) return mixin(obj, proto);
+}
+
+/**
+ * Registers a callback
+ * with an event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.on = function(name, cb) {
+  this._cbs = this._cbs || {};
+  (this._cbs[name] || (this._cbs[name] = [])).push(cb);
+  return this;
+};
+
+/**
+ * Attach a callback that once
+ * called, detaches itself.
+ *
+ * TODO: Implement `.off()` to work
+ * with `once()` callbacks.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @public
+ */
+proto.once = function(name, cb) {
+  this.on(name, one);
+  function one() {
+    cb.apply(this, arguments);
+    this.off(name, one);
+  }
+};
+
+/**
+ * Removes a single callback,
+ * or all callbacks associated
+ * with the passed event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.off = function(name, cb) {
+  this._cbs = this._cbs || {};
+
+  if (!name) { this._cbs = {}; return; }
+  if (!cb) { return delete this._cbs[name]; }
+
+  var cbs = this._cbs[name] || [];
+  var i;
+
+  while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
+  return this;
+};
+
+/**
+ * Fires an event, triggering
+ * all callbacks registered on this
+ * event name.
+ *
+ * @param  {String} name
+ * @return {Event}
+ */
+proto.fire = proto.emit = function(options) {
+  var cbs = this._cbs = this._cbs || {};
+  var name = options.name || options;
+  var batch = (cbs[name] || []).concat(cbs['*'] || []);
+  var ctx = options.ctx || this;
+
+  if (batch.length) {
+    this._fireArgs = arguments;
+    var args = slice.call(arguments, 1);
+    while (batch.length) {
+      batch.shift().apply(ctx, args);
+    }
+  }
+
+  return this;
+};
+
+proto.firer = function(name) {
+  var self = this;
+  return function() {
+    var args = slice.call(arguments);
+    args.unshift(name);
+    self.fire.apply(self, args);
+  };
+};
+
+/**
+ * Util
+ */
+
+/**
+ * Mixes in the properties
+ * of the second object into
+ * the first.
+ *
+ * @param  {Object} a
+ * @param  {Object} b
+ * @return {Object}
+ */
+function mixin(a, b) {
+  for (var key in b) a[key] = b[key];
+  return a;
+}
+
+/**
+ * Expose 'Event' (UMD)
+ */
+
+if (typeof exports === 'object') {
+  module.exports = Events;
+} else if (typeof define === 'function' && define.amd) {
+  define(function(){ return Events; });
+} else {
+  window.evt = Events;
+}
+
+})();

--- a/tv_apps/smart-settings/index.html
+++ b/tv_apps/smart-settings/index.html
@@ -16,7 +16,7 @@
     <script defer src="shared/js/manifest_helper.js"></script>
 
     <!-- Helper libraries -->
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
+    <script defer src="bower_components/evt/index.js"></script>
     <script defer src="tv_shared/js/selection_border.js"></script>
     <script defer src="tv_shared/js/spatial_navigator.js"></script>
     <script defer src="tv_shared/js/applications.js"></script>

--- a/tv_apps/smart-system/bower.json
+++ b/tv_apps/smart-system/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "smart-system",
+  "version": "0.0.0",
+  "homepage": "https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/smart-system",
+  "description": "Main System",
+  "main": "index.html",
+  "license": "MPL",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "evt": "gaia-components/evt#~0.4.0"
+  }
+}

--- a/tv_apps/smart-system/bower_components/evt/.bower.json
+++ b/tv_apps/smart-system/bower_components/evt/.bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
+  "authors": [
+    "Wilson Page <wilsonpage@me.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "test",
+    "tests",
+    "README.md"
+  ],
+  "_release": "0.4.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v0.4.0",
+    "commit": "3593dd6b4dd19f683d00fd0eaf2581c11a128da6"
+  },
+  "_source": "git://github.com/gaia-components/evt.git",
+  "_target": "~0.4.0",
+  "_originalSource": "gaia-components/evt"
+}

--- a/tv_apps/smart-system/bower_components/evt/bower.json
+++ b/tv_apps/smart-system/bower_components/evt/bower.json
@@ -1,16 +1,19 @@
 {
-  "name": "gaia-component",
-  "version": "0.3.4",
+  "name": "evt",
+  "main": "index.js",
+  "version": "0.4.0",
+  "homepage": "https://github.com/wilsonpage/evt",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-component.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
+    "package.json",
     "test",
-    "tests"
+    "tests",
+    "README.md"
   ]
 }

--- a/tv_apps/smart-system/bower_components/evt/index.js
+++ b/tv_apps/smart-system/bower_components/evt/index.js
@@ -1,0 +1,154 @@
+
+/**
+ * Evt
+ *
+ * A super lightweight
+ * event emitter library.
+ *
+ * @version 0.3.3
+ * @author Wilson Page <wilson.page@me.com>
+ */
+
+;(function() {
+
+/**
+ * Locals
+ */
+
+var proto = Events.prototype;
+var slice = [].slice;
+
+/**
+ * Creates a new event emitter
+ * instance, or if passed an
+ * object, mixes the event logic
+ * into it.
+ *
+ * @param  {Object} obj
+ * @return {Object}
+ */
+function Events(obj) {
+  if (!(this instanceof Events)) return new Events(obj);
+  if (obj) return mixin(obj, proto);
+}
+
+/**
+ * Registers a callback
+ * with an event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.on = function(name, cb) {
+  this._cbs = this._cbs || {};
+  (this._cbs[name] || (this._cbs[name] = [])).push(cb);
+  return this;
+};
+
+/**
+ * Attach a callback that once
+ * called, detaches itself.
+ *
+ * TODO: Implement `.off()` to work
+ * with `once()` callbacks.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @public
+ */
+proto.once = function(name, cb) {
+  this.on(name, one);
+  function one() {
+    cb.apply(this, arguments);
+    this.off(name, one);
+  }
+};
+
+/**
+ * Removes a single callback,
+ * or all callbacks associated
+ * with the passed event name.
+ *
+ * @param  {String}   name
+ * @param  {Function} cb
+ * @return {Event}
+ */
+proto.off = function(name, cb) {
+  this._cbs = this._cbs || {};
+
+  if (!name) { this._cbs = {}; return; }
+  if (!cb) { return delete this._cbs[name]; }
+
+  var cbs = this._cbs[name] || [];
+  var i;
+
+  while (cbs && ~(i = cbs.indexOf(cb))) { cbs.splice(i, 1); }
+  return this;
+};
+
+/**
+ * Fires an event, triggering
+ * all callbacks registered on this
+ * event name.
+ *
+ * @param  {String} name
+ * @return {Event}
+ */
+proto.fire = proto.emit = function(options) {
+  var cbs = this._cbs = this._cbs || {};
+  var name = options.name || options;
+  var batch = (cbs[name] || []).concat(cbs['*'] || []);
+  var ctx = options.ctx || this;
+
+  if (batch.length) {
+    this._fireArgs = arguments;
+    var args = slice.call(arguments, 1);
+    while (batch.length) {
+      batch.shift().apply(ctx, args);
+    }
+  }
+
+  return this;
+};
+
+proto.firer = function(name) {
+  var self = this;
+  return function() {
+    var args = slice.call(arguments);
+    args.unshift(name);
+    self.fire.apply(self, args);
+  };
+};
+
+/**
+ * Util
+ */
+
+/**
+ * Mixes in the properties
+ * of the second object into
+ * the first.
+ *
+ * @param  {Object} a
+ * @param  {Object} b
+ * @return {Object}
+ */
+function mixin(a, b) {
+  for (var key in b) a[key] = b[key];
+  return a;
+}
+
+/**
+ * Expose 'Event' (UMD)
+ */
+
+if (typeof exports === 'object') {
+  module.exports = Events;
+} else if (typeof define === 'function' && define.amd) {
+  define(function(){ return Events; });
+} else {
+  window.evt = Events;
+}
+
+})();

--- a/tv_apps/smart-system/index.html
+++ b/tv_apps/smart-system/index.html
@@ -23,7 +23,7 @@
     <script src="tv_shared/js/settings_cache.js"></script>
     <script src="tv_shared/js/animations.js"></script>
     <script defer src="tv_shared/js/shared_utils.js"></script>
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
+    <script defer src="bower_components/evt/index.js"></script>
     <script defer src="shared/js/manifest_helper.js"></script>
     <script defer src="shared/js/mime_mapper.js"></script>
     <script defer src="shared/js/settings_url.js"></script>
@@ -266,7 +266,6 @@
     <link rel="stylesheet" type="text/css" href="style/app_titlebar.css">
     <link rel="stylesheet" type="text/css" href="style/browser_context_menu/browser_context_menu.css">
     <script defer src="js/base_ui.js"></script>
-    <script defer src="tv_shared/js/vendor/evt.js"></script>
     <script defer src="tv_shared/js/scrollable.js"></script>
     <script defer src="js/browser_context_menu.js"></script>
     <script defer src="js/child_window_factory.js"></script>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1139731
This patch did the following things:
1. Add bower.json in `app-deck`, `fling-player`, `notification-sender`, `smart-home`, `smart-settings`, `smart-system`, and point dependency of evt.js to `gaia-components/evt#~0.4.0`
2. Remove `tv_shared/js/vendor/evt.js`
3. Change script inclusion of evt.js from

``` html
<script defer src="tv_shared/js/vendor/evt.js"></script> 
```

to 

``` html
<script defer src="bower_components/evt/index.js"></script>
```
