### PR TITLE
Bug 1134009 - make space in header for SSL icon

### DIFF
--- a/apps/system/style/chrome/chrome.css
+++ b/apps/system/style/chrome/chrome.css
@@ -270,6 +270,11 @@
   background: url("images/light/ssl_broken.png") no-repeat 0.1rem center / 3rem 3rem;
 }
 
+.chrome.maximized .bar .title[data-ssl="secure"],
+.chrome.maximized .bar .title[data-ssl="broken"] {
+  text-indent: 2.5rem;
+}
+
 .appWindow.private > .chrome.maximized .title[data-ssl="broken"],
 .appWindow.private > .chrome.maximized .title[data-ssl="secure"] {
   -moz-padding-start: 6.5rem;
@@ -591,12 +596,12 @@ html[dir="rtl"] .light .controls .forward-button:active {
 
 html[dir="rtl"] .chrome.maximized .title[data-ssl="broken"],
 html[dir="rtl"] .chrome.maximized .title[data-ssl="secure"] {
-  background-position: calc(100% - 0.1rem) 0.1rem;
+  background-position: right 0.1rem top 50%;
 }
 
 html[dir="rtl"] .appWindow.private > .chrome.maximized .title[data-ssl="broken"],
 html[dir="rtl"] .appWindow.private > .chrome.maximized .title[data-ssl="secure"] {
-  background-position: calc(100% - 3.7rem) 0.1rem;
+  background-position: right 3.7rem top 50%;
 }
 
 /*

--- a/apps/system/test/apps/chromeheaderapp/index.html
+++ b/apps/system/test/apps/chromeheaderapp/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>App w/o Chrome</title>
+    <style>
+      button {
+        width: 100%;
+        height: 8rem;
+        display: block;
+        font-size: 300%;
+      }
+
+    </style>
+  </head>
+  <body>
+    <h1>Popup-launching fake app!</h1>
+    <button id="popup-button">launch popup</button>
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/apps/system/test/apps/chromeheaderapp/manifest.webapp
+++ b/apps/system/test/apps/chromeheaderapp/manifest.webapp
@@ -1,0 +1,13 @@
+{
+  "name": "Fake App Chrome",
+  "description": "A fake app with chrome bar",
+  "type": "certified",
+  "launch_path": "/index.html",
+  "developer": {
+    "name": "The Gaia Team",
+    "url": "https://github.com/mozilla-b2g/gaia"
+  },
+  "chrome": {
+    "navigation": false
+  }
+}

--- a/apps/system/test/apps/chromeheaderapp/popup.html
+++ b/apps/system/test/apps/chromeheaderapp/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Popup</title>
+    <style></style>
+  </head>
+  <body>
+    <h1>I am a popup in a fake app!</h1>
+  </body>
+</html>

--- a/apps/system/test/apps/chromeheaderapp/script.js
+++ b/apps/system/test/apps/chromeheaderapp/script.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var testApp = {
+  init: function() {
+    Array.from(document.querySelectorAll('button'))
+    .forEach(function(btn) {
+      btn.addEventListener('click', testApp);
+    });
+  },
+  handleEvent: function(evt) {
+    switch (evt.target.id) {
+      case 'popup-button':
+        window.open('/popup.html', '', 'dialog');
+        break;
+    }
+  }
+};
+
+testApp.init();

--- a/apps/system/test/marionette/app_chrome_ssl_header_test.js
+++ b/apps/system/test/marionette/app_chrome_ssl_header_test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+marionette('App Chrome - Lock Icon', function() {
+  var assert = require('assert');
+
+  var client = marionette.client({
+    prefs: {
+      'dom.w3c_touch_events.enabled': 1
+    },
+    settings: {
+      'ftu.manifestURL': null,
+      'lockscreen.enabled': false
+    },
+    apps: {
+      'chromeheaderapp.gaiamobile.org':
+        __dirname + '/../apps/chromeheaderapp'
+    }
+  });
+
+  function changeWindowState(appWindowId, state) {
+    client.executeScript(function(appWindowId, state) {
+      // Dispatch a mozsecuritychange event to the app element.
+      var win = window.wrappedJSObject;
+      var evt = new CustomEvent('mozbrowsersecuritychange',
+                                { detail: { 'state': state }});
+      var container = win.document.getElementById(appWindowId);
+      container.dispatchEvent(evt);
+    }, [appWindowId, state]);
+  }
+
+  function getTitleProperties(appElement) {
+    var header = appElement.findElement('gaia-header');
+    client.waitFor(function() {
+      return (
+        header.getAttribute('title-start') !== null &&
+        header.getAttribute('title-end') !== null
+      );
+    });
+    return {
+      start: parseInt(header.getAttribute('title-start')),
+      end: parseInt(header.getAttribute('title-end')),
+      fontSize: parseInt(header.findElement('h1').cssProperty('fontSize'))
+    };
+  }
+
+  var appElement, popupElement, popupHeader;
+  var TEST_APP = 'app://chromeheaderapp.gaiamobile.org';
+
+  setup(function() {
+    client.apps.launch(TEST_APP);
+    client.apps.switchToApp(TEST_APP);
+
+    client.findElement('#popup-button').click();
+    client.switchToFrame();
+
+    var appWindowId = client.executeScript(function() {
+      var app = window.wrappedJSObject.Service.currentApp;
+      return app.element.id;
+    });
+    appElement = client.findElement('#' + appWindowId);
+    popupElement = client.helper.waitForElement(
+      '#' + appWindowId + ' .popupWindow'
+    );
+    popupHeader = popupElement.findElement('gaia-header');
+  });
+
+  test('popup should show no icon', function() {
+    var selector = '.title:not([data-ssl="secure"])';
+    assert(popupHeader.findElement(selector).displayed(),
+           selector + ' is displayed');
+
+    var titleProps = getTitleProperties(popupElement);
+    console.log('titleProps: ' + JSON.stringify(titleProps));
+    // first 50px is for close button
+    assert(titleProps.start <= 50 && titleProps.end === 0,
+           'no space allowed for lock icon: ' + JSON.stringify(titleProps));
+    client.apps.close(TEST_APP);
+  });
+
+  test('secured popup should show secure icon', function() {
+    var selector = '.title[data-ssl="secure"]';
+    changeWindowState(popupElement.getAttribute('id'), 'secure');
+    client.waitFor(function() {
+      return popupHeader.findElement(selector);
+    });
+    assert(popupHeader.findElement(selector).displayed(),
+           selector + ' is displayed');
+
+    var titleProps = getTitleProperties(popupElement);
+    assert(titleProps.start > 50 && titleProps.end === 0,
+           'space allowed for lock icon: ' + JSON.stringify(titleProps));
+    client.apps.close(TEST_APP);
+  });
+
+  test('broken-ssl popup should show broken icon', function() {
+    var selector = '.title[data-ssl="broken"]';
+    changeWindowState(popupElement.getAttribute('id'), 'broken');
+    client.waitFor(function() {
+      return popupHeader.findElement(selector);
+    });
+    assert(popupHeader.findElement(selector).displayed(),
+           selector + ' is displayed');
+
+    var titleProps = getTitleProperties(popupElement);
+    assert(titleProps.start > 50 && titleProps.end === 0,
+           'space allowed for broken lock icon: ' + JSON.stringify(titleProps));
+    client.apps.close(TEST_APP);
+  });
+
+  test('lock icon placement with RTL language', function() {
+    client.settings.set('language.current', 'qps-plocm');
+    var documentElement = client.findElement('html');
+    // Localization can be async, wait for the content to update
+    client.waitFor(function() {
+      return documentElement.getAttribute('dir') == 'rtl';
+    });
+
+    var selector = '.title[data-ssl="secure"]';
+    changeWindowState(popupElement.getAttribute('id'), 'secure');
+    client.waitFor(function() {
+      return popupHeader.findElement(selector);
+    });
+    assert(popupHeader.findElement(selector).displayed(),
+           selector + ' is displayed');
+
+    var titleProps = getTitleProperties(popupElement);
+    assert(titleProps.start == 50 && titleProps.end >= 30,
+           'space allowed for lock icon: ' + JSON.stringify(titleProps));
+    client.apps.close(TEST_APP);
+
+  });
+});


### PR DESCRIPTION
Use gaia-header's title-start / title-end to leave space for the SSL secure/broken lock icon
