### PR TITLE
Bug 1137766 - test_settings_change_language.py error; exception "Element...

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/settings/manifest.ini
@@ -13,6 +13,8 @@ skip-if = device == "desktop" && os == "linux" && debug
 [test_settings_change_language_rtl.py]
 # Bug 1103106 - Assertion failure: !mWillChangeBudgetCalculated
 skip-if = device == "desktop" && os == "linux" && debug
+# Bug 1137766 - test_settings_change_language.py error; exception "Element '%s' could not be foundin select wrapper"
+expected = fail
 
 [test_settings_gps.py]
 


### PR DESCRIPTION
... '%s' could not be foundin select wrapper"
