### PR TITLE
Bug 1118854 - Follow up. Never let appclosed listener laying around once...

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -178,15 +178,12 @@
    */
   TaskManager.prototype.hide = function cs_hideCardSwitcher() {
     if (!this.isActive()) {
-      // To avoid wrong behaviour when the app is closed
-      // by a second home button event
-      window.removeEventListener('appclosed', this._appClosedHandler);
-      this.screenElement.classList.remove('cards-view');
       return;
     }
     this._unregisterShowingEvents();
     this._removeCards();
     this.setActive(false);
+    window.removeEventListener('appclosed', this._appClosedHandler);
     this.screenElement.classList.remove('cards-view');
 
     var detail;


### PR DESCRIPTION
... the .cards-view class is removed from the screenElement r=sfoster
