### PR TITLE
Bug 1129494 - Fix easing function for value picker control

### DIFF
--- a/shared/style/date_selector.css
+++ b/shared/style/date_selector.css
@@ -172,6 +172,7 @@
 [role="dialog"][data-type="date-selector"] .animation-on {
   transition-duration: 0.5s;
   transition-property: transform;
+  transition-timing-function: cubic-bezier(0, 0, 0.4, 1);
 }
 
 [role="dialog"][data-type="date-selector"]  .picker-unit {


### PR DESCRIPTION
Since bug 927349 landed we wait until animations are ready (e.g. layerization etc. is complete) before starting them. For the value picker control, it uses the default transition timing function which is 'ease'. That means it has a slightly ease-in effect. Previously, before bug 927349 landed, we would end up skipping the ease in part of the timing function and jumping to somewhere in the middle. Now that we play the whole timing function we see the ease-in component which makes the control appear to the laggy. This patch adjusts the timing function to have an ease-out effect only and ramps up the first part of the timing function (to make it a little more snappy than the standard 'ease-out' function). This gives me the same behavior as is observed in B2G 2.0.
