### PR TITLE
Bug 1136170 - [Messages] Adjust the read ahead number to be the same or higher than what the max number of threads on Flame r=azasypkin, schung

### DIFF
--- a/apps/sms/js/settings.js
+++ b/apps/sms/js/settings.js
@@ -15,6 +15,8 @@ var Settings = {
     smsServiceId: 'ril.sms.defaultServiceId'
   },
 
+  READ_AHEAD_THREADS_KEY: 'ril.sms.maxReadAheadEntries',
+
   // we evaluate to 5KB the size overhead of wrapping a payload in a MMS
   MMS_SIZE_OVERHEAD: 5 * 1024,
 
@@ -194,5 +196,15 @@ var Settings = {
 
     var conn = navigator.mozMobileConnections[index];
     return MobileOperator.userFacingInfo(conn).operator;
+  },
+
+  setReadAheadThreadRetrieval: function(value) {
+    if (!navigator.mozSettings) {
+      return;
+    }
+
+    var setting = {};
+    setting[this.READ_AHEAD_THREADS_KEY] = value;
+    navigator.mozSettings.createLock().set(setting);
   }
 };

--- a/apps/sms/test/unit/mock_settings.js
+++ b/apps/sms/test/unit/mock_settings.js
@@ -17,6 +17,7 @@ var MockSettings = {
   getServiceIdByIccId: function() { return null; },
   getSimNameByIccId: function(id) { return 'sim-name-' + id; },
   getOperatorByIccId: function(id) { return 'sim-operator-' + id; },
+  setReadAheadThreadRetrieval: function() {},
 
   mSetup: function() {
     MockSettings.mmsSizeLimitation = 295 * 1024;

--- a/apps/sms/test/unit/settings_test.js
+++ b/apps/sms/test/unit/settings_test.js
@@ -87,6 +87,12 @@ suite('Settings >', function() {
     test('getServiceIdByIccId returns null', function() {
       assert.isNull(Settings.getServiceIdByIccId('anything'));
     });
+
+    test('setReadAheadThreadRetrieval does nothing', function() {
+      assert.doesNotThrow(() => {
+        Settings.setReadAheadThreadRetrieval(9);
+      });
+    });
   });
 
   suite('With mozSettings', function() {
@@ -141,6 +147,7 @@ suite('Settings >', function() {
           set: function() {}
         };
         sinon.spy(api, 'get');
+        sinon.spy(api, 'set');
         return api;
       });
     });
@@ -384,8 +391,17 @@ suite('Settings >', function() {
 
         conn.data.state = 'registered';
         listenerSpy.yield();
- 
+
       });
+    });
+
+    test('setReadAheadThreadRetrieval()', function() {
+      Settings.setReadAheadThreadRetrieval(9);
+
+      sinon.assert.calledWithMatch(
+        navigator.mozSettings.createLock.lastCall.returnValue.set,
+        { 'ril.sms.maxReadAheadEntries' : 9 }
+      );
     });
   });
 });

--- a/apps/sms/test/unit/thread_list_ui_test.js
+++ b/apps/sms/test/unit/thread_list_ui_test.js
@@ -2,7 +2,7 @@
          MessageManager, WaitingScreen, Threads, Template, MockMessages,
          MockThreadList, MockTimeHeaders, Draft, Drafts, Thread, ThreadUI,
          MockOptionMenu, Utils, Contacts, MockContact, Navigation,
-         MockSettings,
+         MockSettings, Settings,
          InterInstanceEventDispatcher,
          MockStickyHeader,
          StickyHeader
@@ -53,7 +53,8 @@ var mocksHelperForThreadListUI = new MocksHelper([
   'Navigation',
   'InterInstanceEventDispatcher',
   'SelectionHandler',
-  'LazyLoader'
+  'LazyLoader',
+  'Settings'
 ]).init();
 
 suite('thread_list_ui', function() {
@@ -1289,6 +1290,9 @@ suite('thread_list_ui', function() {
       this.sinon.spy(ThreadListUI, 'renderDrafts');
       this.sinon.spy(MockStickyHeader.prototype, 'refresh');
       this.sinon.spy(window, 'StickyHeader');
+
+      this.sinon.stub(Settings, 'setReadAheadThreadRetrieval');
+
       firstViewDone = sinon.stub();
       panel = document.getElementById('thread-list');
 
@@ -1366,6 +1370,11 @@ suite('thread_list_ui', function() {
           // Check that all threads have been properly inserted in the list
           assert.equal(mmsThreads.length, 2);
           assert.equal(smsThreads.length, 8);
+
+          sinon.assert.calledWith(
+            Settings.setReadAheadThreadRetrieval,
+            ThreadListUI.FIRST_PANEL_THREAD_COUNT
+          );
         });
       });
     });


### PR DESCRIPTION
Bug 1136170 - [Messages] Adjust the read ahead number to be the same or higher than what the max number of threads on Flame r=azasypkin, schung
