### PR TITLE
Bug 1141699 - Update package.json mail-fakeservers to 0.0.36 r=asuth

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "istanbul": "^0.3.2",
     "jshint": "2.6.0",
     "load-grunt-tasks": "0.4.0",
-    "mail-fakeservers": "0.0.24",
+    "mail-fakeservers": "0.0.36",
     "marionette-apps": "0.3.12",
     "marionette-client": "1.5.8",
     "marionette-content-script": "0.0.4",


### PR DESCRIPTION
The previous node modules commit to gaia_node_modules.revision for bug 1129445 already included the actual modules.tar of the 0.0.36 mail-fakeservers package, so just the gaia package.json needs to synchronized.
