### PR TITLE
Bug 819304 - Add hit state to clear all notifications button

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -168,6 +168,10 @@
   font: italic normal 1.3rem/1.3rem auto;
 }
 
+#notification-bar button:active {
+  opacity: 0.5;
+}
+
 #notification-bar button[disabled] {
   color: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
Text of the button now turns to orange on click to show that the Clear all button has been hitted.
