### PR TITLE
Bug 1142371 - [Bluetooth] Replace getAdapter with bluetooth-available ev...

### DIFF
--- a/apps/system/js/bluetooth_core.js
+++ b/apps/system/js/bluetooth_core.js
@@ -1,5 +1,6 @@
 /* exported BluetoothCore */
-/* global BaseModule, LazyLoader, Bluetooth1, Bluetooth2 */
+/* global BaseModule, LazyLoader, Bluetooth1, Bluetooth2,
+   BluetoothTransfer */
 'use strict';
 
 (function() {
@@ -17,21 +18,25 @@
     name: 'BluetoothCore',
 
     start: function() {
-      // init Bluetooth module
+      // Init Bluetooth module by version.
+      // Make sure BluetoothTranfer is start before Bluetooth to ensure
+      // bluetooth related events are properly catched.
+      // XXX: make BluetoothTranfer as submodule to access adapter
+      // via this.parent.adapter once APIv1 support can be removed.
       if (typeof(window.navigator.mozBluetooth.onattributechanged) ===
         'undefined') { // APIv1
-        LazyLoader.load(['js/bluetooth.js', 'js/bluetooth_transfer.js'],
+        LazyLoader.load(['js/bluetooth_transfer.js', 'js/bluetooth.js'],
           function() {
+            BluetoothTransfer.start();
             window.Bluetooth = Bluetooth1;
             window.Bluetooth.init();
-            window.BluetoothTransfer.init();
         });
       } else { // APIv2
-        // Now only make sure statusbar works
-        // BluetoothTransfer will be done in Bug 1093084
-        LazyLoader.load(['js/bluetooth_v2.js'], function() {
-          window.Bluetooth = new Bluetooth2();
-          window.Bluetooth.start();
+        LazyLoader.load(['js/bluetooth_transfer.js', 'js/bluetooth_v2.js'],
+          function() {
+            BluetoothTransfer.start();
+            window.Bluetooth = new Bluetooth2();
+            window.Bluetooth.start();
         });
       }
     }

--- a/apps/system/js/bluetooth_transfer.js
+++ b/apps/system/js/bluetooth_transfer.js
@@ -4,7 +4,7 @@
    stopSendingFile(in DOMString aDeviceAddress);
    confirmReceivingFile(in DOMString aDeviceAddress, in bool aConfirmation); */
 'use strict';
-/* global Bluetooth, CustomDialog, MimeMapper, Service,
+/* global CustomDialog, MimeMapper, Service,
           MozActivity, NotificationHelper, UtilityTray */
 /* exported BluetoothTransfer */
 (function(exports) {
@@ -17,9 +17,19 @@ var BluetoothTransfer = {
   /**
    * Debug message.
    *
+   * @private
    * @type {Boolean} turn on/off the console log
    */
   onDebug: false,
+
+  /**
+   * Store a reference of the default adapter.
+   * If the adapter is not availble, no bluetooth operation could be
+   * executed.
+   *
+   * @private
+   */
+  _adapter: null,
 
   get _deviceStorage() {
     return navigator.getDeviceStorage('sdcard');
@@ -33,7 +43,26 @@ var BluetoothTransfer = {
     return transferStatusList;
   },
 
-  init: function bt_init() {
+  /**
+   * Initialize BluetoothTransfer module.
+   *
+   * @public
+   */
+  start: function bt_start() {
+    window.addEventListener('bluetooth-available', function(evt) {
+      if (evt.detail && evt.detail.adapter) {
+        this.debug('got bluetooth adapter');
+        this._adapter = evt.detail.adapter;
+      } else {
+        this.debug('receive the wrong event format');
+      }
+    }.bind(this));
+
+    window.addEventListener('bluetooth-unavailable', function(evt) {
+      this.debug('clean the bluetooth adapter');
+      this._adapter = null;
+    }.bind(this));
+
     // Bind message handler for sending files from Bluetooth app
     window.addEventListener('iac-bluetoothTransfercomms',
       this._onFilesSending.bind(this)
@@ -62,19 +91,18 @@ var BluetoothTransfer = {
       this.sendFileViaHandover.bind(this));
 
     Service.registerState('isSendFileQueueEmpty', this);
+    Service.registerState('isFileTransferInProgress', this);
   },
 
   getDeviceName: function bt_getDeviceName(address) {
-    return new Promise(function(resolve) {
+    return new Promise((resolve) => {
       var _ = navigator.mozL10n.get;
-      var adapter = Bluetooth.getAdapter();
-      if (adapter == null) {
+      if (this._adapter === null) {
         var msg = 'Since cannot get Bluetooth adapter, ' +
                   'resolve with an unknown device.';
         this.debug(msg);
         resolve(_('unknown-device'));
       }
-      var self = this;
       // Service Class Name: OBEXObjectPush, UUID: 0x1105
       // Specification: Object Push Profile (OPP)
       //   NOTE: Used as both Service Class Identifier and Profile.
@@ -82,9 +110,10 @@ var BluetoothTransfer = {
       // https://www.bluetooth.org/en-us/specification/assigned-numbers/
       // service-discovery
       var serviceUuid = '0x1105';
-      var req = adapter.getConnectedDevices(serviceUuid);
-      req.onsuccess = function bt_gotConnectedDevices() {
+      var req = this._adapter.getConnectedDevices(serviceUuid);
+      req.onsuccess = () => {
         if (req.result) {
+          this.debug('got connectedList');
           var connectedList = req.result;
           var length = connectedList.length;
           for (var i = 0; i < length; i++) {
@@ -96,12 +125,12 @@ var BluetoothTransfer = {
           resolve(_('unknown-device'));
         }
       };
-      req.onerror = function() {
+      req.onerror = () => {
         var msg = 'Can not check is device connected from adapter.';
-        self.debug(msg);
+        this.debug(msg);
         resolve(_('unknown-device'));
       };
-    }.bind(this));
+    });
   },
 
   debug: function bt_debug(msg) {
@@ -161,11 +190,11 @@ var BluetoothTransfer = {
 
     // Prompt appears when a transfer request from a paired device is
     // received.
+    this.debug('show receive confirm dialog');
     var address = evt.address;
-    var self = this;
     var icon = 'style/bluetooth_transfer/images/icon_bluetooth.png';
 
-    this.getDeviceName(address).then(function(deviceName) {
+    this.getDeviceName(address).then((deviceName) => {
       var title = {
         id: 'transfer-confirmation-title',
         args: { deviceName: deviceName }
@@ -175,10 +204,10 @@ var BluetoothTransfer = {
       NotificationHelper.send(title, {
         'bodyL10n': body,
         'icon': icon
-      }).then(function(notification) {
-        notification.addEventListener('click', function() {
+      }).then((notification) => {
+        notification.addEventListener('click', () => {
           UtilityTray.hide();
-          self.showReceivePrompt(evt);
+          this.showReceivePrompt(evt);
         });
       });
     });
@@ -221,9 +250,8 @@ var BluetoothTransfer = {
 
   declineReceive: function bt_declineReceive(address) {
     CustomDialog.hide();
-    var adapter = Bluetooth.getAdapter();
-    if (adapter != null) {
-      adapter.confirmReceivingFile(address, false);
+    if (this._adapter != null) {
+      this._adapter.confirmReceivingFile(address, false);
     } else {
       var msg = 'Cannot get adapter from system Bluetooth monitor.';
       this.debug(msg);
@@ -231,26 +259,25 @@ var BluetoothTransfer = {
   },
 
   acceptReceive: function bt_acceptReceive(evt) {
+    this.debug('accepted the file transfer');
     CustomDialog.hide();
     // Check storage is available or not before confirm receiving file
     var address = evt.address;
     var fileSize = evt.fileLength;
-    var self = this;
     this.checkStorageSpace(fileSize,
       function checkStorageSpaceComplete(isStorageAvailable, errorMessage) {
-        var adapter = Bluetooth.getAdapter();
         var option = (isStorageAvailable) ? true : false;
-        if (adapter) {
-          adapter.confirmReceivingFile(address, option);
+        if (this._adapter) {
+          this._adapter.confirmReceivingFile(address, option);
         } else {
           var msg = 'Cannot get adapter from system Bluetooth monitor.';
-          self.debug(msg);
+          this.debug(msg);
         }
         // Storage is not available, then pop out a prompt with the reason
         if (!isStorageAvailable) {
-          self.showStorageUnavaliablePrompt(errorMessage);
+          this.showStorageUnavaliablePrompt(errorMessage);
         }
-    });
+    }.bind(this));
   },
 
   showStorageUnavaliablePrompt:
@@ -316,11 +343,15 @@ var BluetoothTransfer = {
     return this._sendingFilesQueue.length === 0;
   },
 
+  isFileTransferInProgress: function() {
+    var jobs = this.transferStatusList.querySelector('div');
+    return jobs != null;
+  },
+
   sendFileViaHandover: function bt_sendFileViaHandover(evt) {
     var mac = evt.detail.mac;
     var blob = evt.detail.blob;
-    var adapter = Bluetooth.getAdapter();
-    if (adapter != null) {
+    if (this._adapter !== null) {
       var sendingFilesSchedule = {
         viaHandover: true,
         numberOfFiles: 1,
@@ -333,8 +364,8 @@ var BluetoothTransfer = {
       // The paired device is ready to send file.
       // Since above issue is existed, we use a setTimeout with 3 secs delay
       var waitConnectionReadyTimeoutTime = 3000;
-      setTimeout(function() {
-        adapter.sendFile(mac, blob);
+      setTimeout(() => {
+        this._adapter.sendFile(mac, blob);
       }, waitConnectionReadyTimeoutTime);
     } else {
       var msg = 'Cannot get adapter from system Bluetooth monitor.';
@@ -455,9 +486,8 @@ var BluetoothTransfer = {
 
   cancelTransfer: function bt_cancelTransfer(address) {
     CustomDialog.hide();
-    var adapter = Bluetooth.getAdapter();
-    if (adapter != null) {
-      adapter.stopSendingFile(address);
+    if (this._adapter !== null) {
+      this._adapter.stopSendingFile(address);
     } else {
       var msg = 'Cannot get adapter from system Bluetooth monitor.';
       this.debug(msg);

--- a/apps/system/js/bluetooth_v2.js
+++ b/apps/system/js/bluetooth_v2.js
@@ -107,7 +107,8 @@ Bluetooth.prototype = {
             name: profile,
             connected: connected
           }
-        }));
+        }
+      ));
       if (profile === 'opp' && this.transferIcon) {
         this.transferIcon.update();
       }
@@ -321,7 +322,8 @@ Bluetooth.prototype = {
     window.dispatchEvent(new CustomEvent('bluetooth-opp-transfer-start',
       {
         detail: { transferInfo: transferInfo }
-      }));
+      }
+    ));
   },
 
   /*
@@ -337,7 +339,8 @@ Bluetooth.prototype = {
     window.dispatchEvent(new CustomEvent('bluetooth-opp-transfer-complete',
       {
         detail: { transferInfo: transferInfo }
-      }));
+      }
+    ));
   },
 
   /**
@@ -437,7 +440,10 @@ Bluetooth.prototype = {
   _dispatchAdapterState: function bt__dispatchAdapterState(state) {
     if (state) {
       window.dispatchEvent(new CustomEvent('bluetooth-available',
-        { detail: { adapter: this._adapter }}));
+        {
+          detail: { adapter: this._adapter }
+        }
+      ));
     } else {
       window.dispatchEvent(new CustomEvent('bluetooth-unavailable'));
     }

--- a/apps/system/test/unit/bluetooth_core_test.js
+++ b/apps/system/test/unit/bluetooth_core_test.js
@@ -24,10 +24,7 @@ suite('system/BluetoothCore', function() {
 
   setup(function(done) {
     MockLazyLoader.mLoadRightAway = true;
-    sinon.stub(MockLazyLoader, 'load', function() {
-      window.Bluetooth1 = { init: function() {} };
-      window.BluetoothTransfer = { init: function() {} };
-    }.bind(this));
+    sinon.stub(MockLazyLoader, 'load');
 
     realMozBluetooth = navigator.mozBluetooth;
     switchReadOnlyProperty(navigator, 'mozBluetooth', MockMozBluetooth);
@@ -52,7 +49,7 @@ suite('system/BluetoothCore', function() {
 
     test('read', function() {
       assert.isTrue(MockLazyLoader.load.calledWith(
-        ['js/bluetooth.js', 'js/bluetooth_transfer.js']
+        ['js/bluetooth_transfer.js', 'js/bluetooth.js']
       ));
     });
   });

--- a/apps/system/test/unit/bluetooth_core_v2_test.js
+++ b/apps/system/test/unit/bluetooth_core_v2_test.js
@@ -24,9 +24,7 @@ suite('system/BluetoothCore', function() {
 
   setup(function(done) {
     MockLazyLoader.mLoadRightAway = true;
-    sinon.stub(MockLazyLoader, 'load', function() {
-      window.Bluetooth2 = function() {};
-    });
+    sinon.stub(MockLazyLoader, 'load');
 
     realMozBluetooth = navigator.mozBluetooth;
     switchReadOnlyProperty(navigator, 'mozBluetooth', MockMozBluetooth);
@@ -51,7 +49,7 @@ suite('system/BluetoothCore', function() {
 
     test('read', function() {
       assert.isTrue(MockLazyLoader.load.calledWith(
-        ['js/bluetooth_v2.js']
+        ['js/bluetooth_transfer.js', 'js/bluetooth_v2.js']
       ));
     });
   });

--- a/apps/system/test/unit/mock_bluetooth.js
+++ b/apps/system/test/unit/mock_bluetooth.js
@@ -46,10 +46,6 @@ var MockBluetooth = {
     this.defaultAdapter = mockAdapater;
   },
 
-  getAdapter: function mbt_getAdapter() {
-    return this.defaultAdapter;
-  },
-
   getDefaultAdapter: function mbt_getDefaultAdapter() {
     return new MockDOMRequest();
   },

--- a/shared/test/unit/mocks/mock_navigator_moz_bluetooth.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_bluetooth.js
@@ -15,6 +15,9 @@
     setPairingConfirmation: function mba_setPairingConfirmation() {},
     setPinCode: function mba_setPinCode() {},
     setPasskey: function mba_setPasskey() {},
+    confirmReceivingFile: function mba_confirmReceivingFile() {},
+    sendFile: function mba_sendFile() {},
+    stopSendingFile: function mba_stopSendingFile() {},
 
     onscostatuschanged: null,
     ona2dpstatuschanged: null

--- a/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
+++ b/shared/test/unit/mocks/mock_navigator_moz_bluetooth_v2.js
@@ -37,7 +37,10 @@
     onhfpstatuschanged: null,
     ona2dpstatuschanged: null,
     addEventListener: mba_addEventListener,
-    removeEventListener: mba_removeEventListener
+    removeEventListener: mba_removeEventListener,
+    confirmReceivingFile: function mba_confirmReceivingFile() {},
+    sendFile: function mba_sendFile() {},
+    stopSendingFile: function mba_stopSendingFile() {}
   };
 
   var mManagerEventListeners = [];


### PR DESCRIPTION
...ent listener
- use `bluetooth-available` event to bring adapter to BluetoothTransfer module
- remove getAdapter interface
