### PR TITLE
Bug 1122298 - Lockscreen will not show accurate time after receiving RPP Lock command

### DIFF
--- a/apps/system/lockscreen/js/lockscreen.js
+++ b/apps/system/lockscreen/js/lockscreen.js
@@ -443,19 +443,7 @@
       this.setLockMessage(value);
     }).bind(this));
 
-
-    // FIXME(ggp) this is currently used by Find My Device
-    // to force locking. Should be replaced by a proper IAC API in
-    // bug 992277. We don't need to use SettingsListener because
-    // we're only interested in changes to the setting, and don't
-    // keep track of its value.
-    navigator.mozSettings.addObserver('lockscreen.lock-immediately',
-      (function(event) {
-      if (event.settingValue === true) {
-        this.lockIfEnabled(true);
-      }
-    }).bind(this));
-
+    this.setupRemoteLock();
     this.notificationsContainer.addEventListener('scroll', this);
 
     navigator.mozL10n.ready(this.l10nInit.bind(this));
@@ -1109,6 +1097,22 @@
       this.kPassCodeErrorTimeout = 500;
       this.kPassCodeErrorCounter = 0;
       // delegate the unlocking function call to panel state.
+    };
+
+  LockScreen.prototype.setupRemoteLock =
+    function() {
+      // FIXME(ggp) this is currently used by Find My Device
+      // to force locking. Should be replaced by a proper IAC API in
+      // bug 992277. We don't need to use SettingsListener because
+      // we're only interested in changes to the setting, and don't
+      // keep track of its value.
+      navigator.mozSettings.addObserver('lockscreen.lock-immediately',
+        (function(event) {
+        if (event.settingValue === true) {
+          this.lockIfEnabled(true);
+          this.refreshClock(new Date());
+        }
+      }).bind(this));
     };
 
   /** @exports LockScreen */

--- a/apps/system/test/unit/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen_test.js
@@ -433,10 +433,31 @@ suite('system/LockScreen >', function() {
   });
 
   test('Lock when asked via lock-immediately setting', function() {
-    window.MockNavigatorSettings.mTriggerObservers(
-      'lockscreen.lock-immediately', {settingValue: true});
-    assert.isTrue(subject.locked,
+    var listener;
+    var stubLockIfEnabled = this.sinon.stub(subject, 'lockIfEnabled');
+    this.sinon.stub(subject, 'refreshClock');
+    this.sinon.stub(navigator.mozSettings, 'addObserver', function(type, cb) {
+      listener = cb;
+    });
+    subject.setupRemoteLock();
+    // So we now 'triggers' it.
+    listener({ settingValue: true });
+    assert.isTrue(stubLockIfEnabled.calledWith(true),
       'it didn\'t lock after the lock-immediately setting got changed');
+  });
+
+  test('Refresh clock when locked via lock-immediately setting', function() {
+    var listener;
+    this.sinon.stub(subject, 'lockIfEnabled');
+    var stubRefreshClock = this.sinon.stub(subject, 'refreshClock');
+    this.sinon.stub(navigator.mozSettings, 'addObserver', function(type, cb) {
+      listener = cb;
+    });
+    subject.setupRemoteLock();
+    // So we now 'triggers' it.
+    listener({ settingValue: true });
+    assert.isTrue(stubRefreshClock.called,
+      'it didn\'t refresh the clock after the lock-immediately event');
   });
 
   // XXX: Test 'Screen off: by proximity sensor'.


### PR DESCRIPTION
1. refresh the clock while it's invoked
2. re-arrange the code in lockscreen.js to make test works (it's already broken: always reports false positive result)
