### PR TITLE
Bug 1121880 - Add missing facebook-import-msg strings to FTU

### DIFF
--- a/apps/ftu/locales/ftu.en-US.properties
+++ b/apps/ftu/locales/ftu.en-US.properties
@@ -198,6 +198,13 @@ fb-checking     = … checking
 notImportedYet  = Not imported yet
 otherAccount    = Other accounts
 afterFbImport   = You can import and edit Facebook friends anytime in Contacts settings
+facebook-import-msg               = {[ plural(imported) ]}
+facebook-import-msg[zero]         = No friends imported (out of {{total}})
+facebook-import-msg[one]          = One friend imported (out of {{total}})
+facebook-import-msg[two]          = {{imported}}/{{total}} friends imported
+facebook-import-msg[few]          = {{imported}}/{{total}} friends imported
+facebook-import-msg[many]         = {{imported}}/{{total}} friends imported
+facebook-import-msg[other]        = {{imported}}/{{total}} friends imported
 
 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#
 # Fxa Intro


### PR DESCRIPTION
The facebook-import-msg string(s) is referenced in the FTU when you import contacts. I've copy/pasted the content from where the same string gets used in communications/contacts
