### PR TITLE
Bug 1141958 - Refine the change event handler to prevent some unexpected reasons. f=justindarc,mikeh

### DIFF
--- a/apps/camera/js/lib/storage.js
+++ b/apps/camera/js/lib/storage.js
@@ -163,13 +163,18 @@ Storage.prototype.onStorageChange = function(e) {
   debug('state change: %s', e.reason);
   var value = e.reason;
 
-  // Emit an `itemdeleted` event to
-  // allow parts of the UI to update.
-  if (value === 'deleted') {
-    var filepath = this.checkFilepath(e.path);
-    this.emit('itemdeleted', { path: filepath });
-  } else {
-    this.setState(value);
+  switch (value) {
+    case 'deleted':
+      // Emit an `itemdeleted` event to
+      // allow parts of the UI to update.
+      var filepath = this.checkFilepath(e.path);
+      this.emit('itemdeleted', { path: filepath });
+      break;
+    case 'available':
+    case 'shared':
+    case 'unavailable':
+      this.setState(value);
+      break;
   }
 
   // Check storage


### PR DESCRIPTION
For the state of device storage, camera app only need to take care about "available", "unavailable", "shared".
By doing this, the state of device storage will be fine if there is a new added reason for change event.
