### PR TITLE
Bug 1144235 - Use more specific path for browser images in build test

### DIFF
--- a/build/test/integration/build_test.js
+++ b/build/test/integration/build_test.js
@@ -66,7 +66,10 @@ suite('Integration tests', function() {
       var fileInZip = zipEntries[f];
       var fileName = fileInZip.entryName;
       if (/\.(png|gif|jpg)$/.test(fileName)) {
-        if (reso !== 1 && fileName.indexOf('browser_') === -1) {
+        // Manually modify the pathname of the browser branding images as
+        // these are packaged differently than normal images.
+        if (reso !== 1 &&
+            fileName.indexOf('shared/resources/branding/browser_') === -1) {
           fileName = fileName.replace(
             /(.*)(\.(png|gif|jpg))$/, '$1@' + reso + 'x$2');
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1144235
