### PR TITLE
Bug 1107139 - Show id-overlay when there's no screenshot. r=etienne

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -800,7 +800,7 @@
      '_localized', '_swipein', '_swipeout', '_kill_suspended',
      '_orientationchange', '_focus', '_blur',  '_hidewindow', '_sheetdisplayed',
      '_sheetsgestureend', '_cardviewbeforeshow', '_cardviewclosed',
-     '_closed', '_shrinkingstart', '_shrinkingstop'];
+     '_cardviewshown', '_closed', '_shrinkingstart', '_shrinkingstop'];
 
   AppWindow.SUB_COMPONENTS = {
     'transitionController': window.AppTransitionController,
@@ -1263,6 +1263,7 @@
         return this.frontWindow.requestScreenshotURL();
       }
       if (!this._screenshotBlob) {
+        this.debug('requestScreenshotURL, no _screenshotBlob');
         return null;
       }
       var screenshotURL = URL.createObjectURL(this._screenshotBlob);
@@ -1289,16 +1290,17 @@
           this.screenshotOverlay.classList.contains('visible')) {
         return;
       }
-
       if (this.identificationOverlay) {
         this.element.classList.add('overlay');
       }
 
       this.screenshotOverlay.classList.add('visible');
 
+      // will be null if there is no blob
       var screenshotURL = this.requestScreenshotURL();
-      this.screenshotOverlay.style.backgroundImage =
-        'url(' + screenshotURL + ')';
+      this.screenshotOverlay.style.backgroundImage = screenshotURL ?
+          'url(' + screenshotURL + ')' : 'none';
+      this.element.classList.toggle('no-screenshot', !screenshotURL);
     };
 
   /**
@@ -1317,6 +1319,7 @@
 
       this.screenshotOverlay.classList.remove('visible');
       this.screenshotOverlay.style.backgroundImage = '';
+      this.element.classList.remove('no-screenshot');
 
       if (this.identificationOverlay) {
         var element = this.element;
@@ -1983,13 +1986,21 @@
     this._showScreenshotOverlay();
   };
 
+  AppWindow.prototype._handle__cardviewshown = function aw_cvshown() {
+    if (this.element && this.element.classList.contains('no-screenshot') &&
+        this._screenshotBlob) {
+      this.element.classList.remove('no-screenshot');
+    }
+  };
+
   AppWindow.prototype._handle__cardviewclosed = function aw_cvclosed() {
     this.debug('hiding screenshot after cardsview closed.');
     this._hideScreenshotOverlay();
   };
 
   AppWindow.prototype._handle__closed = function aw_closed() {
-    if (Service.isBusyLoading() && this.getBottomMostWindow().isHomescreen) {
+    if (!this.loaded ||
+        (Service.isBusyLoading() && this.getBottomMostWindow().isHomescreen)) {
       // We will eventually get screenshot when being requested from
       // task manager.
       return;

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -313,6 +313,7 @@
         this.element.classList.remove('slow-transition');
       }
       window.addEventListener('cardviewbeforeshow', this);
+      window.addEventListener('cardviewshown', this);
       window.addEventListener('cardviewclosed', this);
       window.addEventListener('launchapp', this);
       window.addEventListener('appcreated', this);
@@ -394,6 +395,7 @@
      */
     stop: function awm_stop() {
       window.removeEventListener('cardviewbeforeshow', this);
+      window.removeEventListener('cardviewshown', this);
       window.removeEventListener('cardviewclosed', this);
       window.removeEventListener('launchapp', this);
       window.removeEventListener('appcreated', this);
@@ -647,6 +649,10 @@
             this._activeApp.getTopMostWindow().blur();
           }
           this.broadcastMessage('cardviewbeforeshow');
+          break;
+
+        case 'cardviewshown':
+          this.broadcastMessage('cardviewshown');
           break;
 
         case 'cardviewclosed':

--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -332,22 +332,19 @@
     }
 
     // If we have a cached screenshot, use that first
+    // will be null or blob url
     var cachedLayer = app.requestScreenshotURL();
-
-    if (cachedLayer && app.isActive()) {
+    if (app.isActive()) {
       screenshotView.classList.toggle('fullscreen',
                                       app.isFullScreen());
-      screenshotView.classList.toggle('maximized',
+      if (app.appChrome) {
+        screenshotView.classList.toggle('maximized',
                                       app.appChrome.isMaximized());
-      screenshotView.style.backgroundImage =
-        'url(' + cachedLayer + '),' +
-        '-moz-element(#' + this.app.instanceID + ')';
-    } else {
-      screenshotView.style.backgroundImage =
-        'url(none),' +
-        '-moz-element(#' + this.app.instanceID + ')';
+      }
     }
-
+    screenshotView.style.backgroundImage =
+      (cachedLayer ? 'url(' + cachedLayer + ')' : 'none' ) + ',' +
+      '-moz-element(#' + this.app.instanceID + ')';
   };
 
   Card.prototype._fetchElements = function c__fetchElements() {

--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -552,7 +552,7 @@
       if (app && !app.isHomescreen) {
         app.getScreenshot(function onGettingRealtimeScreenshot() {
           this.show(filter);
-        }.bind(this), 0, 0, 400);
+        }.bind(this), 0, 0, 300);
       } else {
         this.show(filter);
       }

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -337,11 +337,23 @@
   opacity: 1;
 }
 
+.appWindow.in-task-manager.overlay.no-screenshot > .identification-overlay {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.2s ease-in, visibility 0.2s;
+}
+.appWindow.overlay.no-screenshot.from-cardview.overlay > .identification-overlay {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.2s ease-in, visibility 0.2s;
+}
+
+
 /* we don't want to show the overlay at all during the opening
    transition (from the homescreen and from the cardview) */
-#screen .appWindow.in-task-manager.overlay > .identification-overlay,
+#screen .appWindow.in-task-manager:not(.no-screenshot).overlay > .identification-overlay,
 .appWindow.enlarge.overlay > .identification-overlay,
-.appWindow.from-cardview.overlay > .identification-overlay {
+.appWindow:not(.no-screenshot).from-cardview.overlay > .identification-overlay {
   opacity: 0 !important;
   transition: none !important;
 }

--- a/apps/system/test/apps/fakecamera/js/fakecamera.js
+++ b/apps/system/test/apps/fakecamera/js/fakecamera.js
@@ -1,5 +1,7 @@
 'use strict';
 
+document.querySelector('body').classList.add('loaded');
+
 document.getElementById('snapshot').addEventListener('click', function() {
   document.getElementById('result').classList.add('done');
   document.getElementById('result').textContent = 'done';

--- a/apps/system/test/marionette/task_manager_test.js
+++ b/apps/system/test/marionette/task_manager_test.js
@@ -7,11 +7,14 @@ var ReflowHelper =
     require('../../../../tests/js-marionette/reflow_helper.js');
 
 marionette('Task Manager', function() {
-  var firstAppOrigin = 'fakeapp.gaiamobile.org';
+  var firstAppOrigin  = 'fakeapp.gaiamobile.org';
   var secondAppOrigin = 'fakegreenapp.gaiamobile.org';
+  var slowAppOrigin   = 'fakecamera.gaiamobile.org';
   var apps = {};
-  apps[firstAppOrigin] = __dirname + '/../apps/fakeapp';
+  apps[firstAppOrigin]  = __dirname + '/../apps/fakeapp';
   apps[secondAppOrigin] = __dirname + '/../apps/fakegreenapp';
+  apps[slowAppOrigin]   = __dirname + '/../apps/fakecamera';
+
 
   var client = marionette.client({
     prefs: {
@@ -122,6 +125,57 @@ marionette('Task Manager', function() {
         return client.findElement(system.Selector.activeHomescreenFrame)
           .displayed();
       });
+    });
+  });
+
+  suite('when launched while an app is still initializing', function() {
+    var slowApp;
+    setup(function() {
+      // launch a 3rd app which we can mock easily
+      slowApp = new FakeApp(client, 'app://' + slowAppOrigin);
+      slowApp.launch();
+
+      var iframeId = slowApp.iframe.getAttribute('id');
+      // mock iframe.getScreenshot so the screenshot never appears
+      client.executeScript(function(iframeId) {
+        var win = window.wrappedJSObject;
+        win.document.getElementById(iframeId).getScreenshot = function() {
+          var reqReject;
+          var req = {
+            then: function(cb, eb) {
+              return new window.Promise(function(resolve, reject) {
+                reqReject = reject;
+              });
+            }
+          };
+          setTimeout(function() {
+            req.error = new Error('mocked');
+            reqReject(req.error);
+          });
+          return req;
+        };
+        // reset screenshotBlob state
+        var app = win.Service.currentApp;
+        app._screenshotBlob = null;
+      }, [iframeId]);
+
+      taskManager.show();
+    });
+
+    test('should display identification overlay when theres no blob screenshot',
+    function() {
+      var card = taskManager.cards[taskManager.cards.length -1];
+      var screenshot = client.helper
+                       .waitForChild(card, taskManager.selectors.screenshot);
+      var backgroundImage = screenshot.cssProperty('background-image');
+      assert(backgroundImage.indexOf('blob') == -1);
+
+      var instanceId = card.getAttribute('data-app-instance-id');
+      var idOverlay =  client.findElement(
+        '#'+ instanceId +
+        '.appWindow.in-task-manager.overlay.no-screenshot ' +
+        '> .identification-overlay');
+      assert(idOverlay);
     });
   });
 

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -324,6 +324,9 @@ suite('system/AppWindowManager', function() {
       appWindowManager.handleEvent({ type: 'cardviewbeforeshow' });
       assert.isTrue(stubBroadcastMessage.calledWith('cardviewbeforeshow'));
 
+      appWindowManager.handleEvent({ type: 'cardviewshown' });
+      assert.isTrue(stubBroadcastMessage.calledWith('cardviewshown'));
+
       appWindowManager.handleEvent({ type: 'cardviewclosed' });
       assert.isTrue(stubBroadcastMessage.calledWith('cardviewclosed'));
     });
@@ -706,7 +709,7 @@ suite('system/AppWindowManager', function() {
       assert.isTrue(stubKill.called);
     });
   });
- 
+
   suite('updateActiveApp()', function() {
     test('update', function() {
       var spyPublish= this.sinon.spy(appWindowManager, 'publish');

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -700,13 +700,35 @@ suite('system/AppWindow', function() {
     });
 
     test('when cards view is shown and hidden', function() {
+      var fakeScreenshotBlob = 'blob:d3958f5c-0777-0845-9dcf-2cb28783acaf';
+      this.sinon.stub(app1, 'requestScreenshotURL', function() {
+        return fakeScreenshotBlob;
+      });
+
       app1.element.dispatchEvent(new CustomEvent('_cardviewbeforeshow'));
       assert.isTrue(app1.screenshotOverlay.classList.contains('visible'),
                     'Overlay should be visible after beforeshow is received');
+      assert.isFalse(app1.element.classList.contains('no-screenshot'),
+                    'Shouldnt have no-screenshot class when there is one');
 
       app1.element.dispatchEvent(new CustomEvent('_cardviewclosed'));
       assert.isFalse(app1.screenshotOverlay.classList.contains('visible'),
                      'Overlay should be hidden after closed is received');
+    });
+
+    test('when cards view is shown and theres no screenshot', function() {
+      this.sinon.stub(app1, 'requestScreenshotURL', function() {
+        return null;
+      });
+      app1.element.dispatchEvent(new CustomEvent('_cardviewbeforeshow'));
+      assert.isTrue(app1.element.classList.contains('no-screenshot'),
+                    'has no-screenshot class ' +
+                    'when requestScreenshotURL returns falsey');
+
+      app1.element.dispatchEvent(new CustomEvent('_cardviewshown'));
+      app1.element.dispatchEvent(new CustomEvent('_cardviewclosed'));
+      assert.isFalse(app1.element.classList.contains('no-screenshot'),
+                    'removes no-screenshot class');
     });
 
     test('show overlay when revealed by an edge swipe', function() {

--- a/apps/system/test/unit/mock_app_window.js
+++ b/apps/system/test/unit/mock_app_window.js
@@ -147,7 +147,9 @@
     handleStatusbarTouch: function() {},
     setNFCFocus: function() {},
     setActive: function() {},
-    getSSLState: function() { return ''; }
+    getSSLState: function() { return ''; },
+    getCachedScreenshotBlob: function() {},
+    requestScreenshotURL: function() {}
   };
   MockAppWindow.mTeardown = function() {
     MockAppWindowHelper.mInstances = [];


### PR DESCRIPTION
Same as https://github.com/sfoster/gaia/commit/b59f8b014e2d3c1abfe3b3911d2b468cbd75dc05, but using selector to assert on identification-overlay visibility.  
