### PR TITLE
Bug 1141958 - Refine the change event handler to prevent some unexpected reasons

### DIFF
--- a/apps/camera/js/lib/storage.js
+++ b/apps/camera/js/lib/storage.js
@@ -163,13 +163,18 @@ Storage.prototype.onStorageChange = function(e) {
   debug('state change: %s', e.reason);
   var value = e.reason;
 
-  // Emit an `itemdeleted` event to
-  // allow parts of the UI to update.
-  if (value === 'deleted') {
-    var filepath = this.checkFilepath(e.path);
-    this.emit('itemdeleted', { path: filepath });
-  } else {
-    this.setState(value);
+  switch (value) {
+    case 'deleted':
+      // Emit an `itemdeleted` event to
+      // allow parts of the UI to update.
+      var filepath = this.checkFilepath(e.path);
+      this.emit('itemdeleted', { path: filepath });
+      break;
+    case 'available':
+    case 'shared':
+    case 'unavailable':
+      this.setState(value);
+      break;
   }
 
   // Check storage

--- a/apps/camera/test/unit/lib/storage_test.js
+++ b/apps/camera/test/unit/lib/storage_test.js
@@ -72,6 +72,46 @@ suite('lib/storage', function() {
       assert.isTrue(this.picture.addEventListener.calledWith('change'));
       assert.isTrue(navigator.mozSettings.addObserver.called);
     });
+
+    test('Should set state when receiving change events with available reason', function() {
+      this.sandbox.stub(this.storage, 'setState');
+      this.sandbox.stub(this.storage, 'check');
+      this.storage.onStorageChange({
+        reason: 'available'
+      });
+      assert.isTrue(this.storage.setState.called);
+      assert.isTrue(this.storage.check.called);
+    });
+
+    test('Should set state when receiving change events with unavailable reason', function() {
+      this.sandbox.stub(this.storage, 'setState');
+      this.sandbox.stub(this.storage, 'check');
+      this.storage.onStorageChange({
+        reason: 'unavailable'
+      });
+      assert.isTrue(this.storage.setState.called);
+      assert.isTrue(this.storage.check.called);
+    });
+
+    test('Should set state when receiving change events with shared reason', function() {
+      this.sandbox.stub(this.storage, 'setState');
+      this.sandbox.stub(this.storage, 'check');
+      this.storage.onStorageChange({
+        reason: 'shared'
+      });
+      assert.isTrue(this.storage.setState.called);
+      assert.isTrue(this.storage.check.called);
+    });
+
+    test('Should not set state when receiving change events with unexpected reason', function() {
+      this.sandbox.stub(this.storage, 'setState');
+      this.sandbox.stub(this.storage, 'check');
+      this.storage.onStorageChange({
+        reason: 'foo'
+      });
+      assert.isFalse(this.storage.setState.called);
+      assert.isTrue(this.storage.check.called);
+    });
   });
 
   suite('Storage#addPicture()', function() {


### PR DESCRIPTION
For the state of device storage, camera app only need to take care about "available", "unavailable", "shared".
By doing this, the state of device storage will be fine if there is a new added reason for change event.
