### PR TITLE
Bug 1145097 - Clean up html syntax of ds-test/index.html R=michielbdejong

### DIFF
--- a/dev_apps/ds-test/index.html
+++ b/dev_apps/ds-test/index.html
@@ -1,15 +1,15 @@
-  <!DOCTYPE HTML>
+<!DOCTYPE html>
+<html lang="en">
   <head>
-      <meta charset="utf-8" />
-<html>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <title>Device Storage Test</title>
-    <link rel="stylesheet" type="text/css" href="shared/style/buttons.css" />
-    <link rel="stylesheet" type="text/css" href="shared/style/headers.css" />
-    <link rel="stylesheet" type="text/css" href="style/ds-test.css"/>
+    <link rel="stylesheet" type="text/css" href="shared/style/buttons.css">
+    <link rel="stylesheet" type="text/css" href="shared/style/headers.css">
+    <link rel="stylesheet" type="text/css" href="style/ds-test.css">
     <script src="js/ds-test.js"></script>
-</head>
-<body role="application">
+  </head>
+  <body role="application">
     <section role="region">
       <header>
         <h1 data-l10n-id="dstest-title">Device Storage Test</h1>
@@ -19,7 +19,7 @@
     <section role="region">
       <table>
         <tr>
-          <td align="right">Commad:</td>
+          <td align="right">Command:</td>
           <td>
             <select class="fake-select" id="ds.cmd" name="ds.cmd">
               <option value="getDeviceStorage">GetDeviceStorage</option>
@@ -73,6 +73,6 @@
         <span id="log"></span>
       </div>
     </section>
-</body>
+  </body>
 </html>
 


### PR DESCRIPTION
Move <html> tag into the right place. This was the reason to start this PR, I couldn't deploy to 5apps.com because of this.
But once I had the file open, I also made these changes:
- Fix indentation
- Lower-case 'html' in DOCTYPE
- Add missing lang="en" attribute
- Consistent empty tags. I had to look up which one is preferred, and it seems that the `< ... />` syntax was a thing only in XHTML; in html it [should now always just be `< ... >`](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Introduction#Tags).

UPDATE: also fixed typo "commad" -> "command"
