### PR TITLE
Bug 1055914 - Fix/update three links in contributing guide r=julien

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 Hello!
 Thank you for your interests on contributing to the Gaia repository.
 
-Before submitting a pull request on GitHub, please create a bug report on [Bugzilla](https://bugzilla.mozilla.org/) under the [Boot2Gecko > Gaia](https://bugzilla.mozilla.org/enter_bug.cgi?product=Boot2Gecko&component=Gaia) component.
+Before submitting a pull request on GitHub, please create a bug report on [Bugzilla](https://bugzilla.mozilla.org/) under the [Firefox OS > Gaia](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox OS&component=Gaia) component.
 You should select a more specific component of Boot2Gecko when appropriate (i.e. if your problem concerns a single application).
 
 Please note that we have rules in place to keep our coding style in sync and our commit history clean.
 Be sure that your commit complies with these guidelines, or your change may not be accepted.
-Please refer to [the Gaia/Hacking page on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Platform/Gaia/Hacking), specifically on the [Submitting a patch section](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Platform/Gaia/Hacking#Submitting_a_patch) for complete information.
+Please refer to [the Developing Gaia page on MDN](https://developer.mozilla.org/en-US/Firefox_OS/Developing_Gaia), specifically on the [Submitting a Gaia patch section](https://developer.mozilla.org/en-US/Firefox_OS/Developing_Gaia/Submitting_a_Gaia_patch) for complete information.


### PR DESCRIPTION
- the Boot2Gecko product is now called Firefox OS on bugzilla
- the Gaia/Hacking page is now called Developing Gaia on MDN
- the 'Submitting a patch'  link was not pointing to the right section
