### PR TITLE
Bug 1143781 - Override "position:relative" on .icon-calendar-today span, to avoid hitting bug 1144259.

### DIFF
--- a/apps/calendar/style/ui.css
+++ b/apps/calendar/style/ui.css
@@ -41,6 +41,8 @@ ol.link-list li:only-child a {
 
 #today .icon-calendar-today {
   font-size: 1.4rem;
+  position: static;  /* Override 'position: relative' from .gaia-icon
+                        class, so that we don't hit bug 1144259. */
 }
 
 #today .icon-calendar-today:before {


### PR DESCRIPTION
...to avoid hitting bug 1144259.

See description of bug in https://bugzilla.mozilla.org/show_bug.cgi?id=1143781#c8 (and more details on the long-standing layout bug in https://bugzilla.mozilla.org/show_bug.cgi?id=1144259 )

Brief description of fix in https://bugzilla.mozilla.org/show_bug.cgi?id=1143781#c10 .
