### PR TITLE
Bug 1145875 - Guard against falsy this.element in show/hideScreenshotOverlay

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -1286,7 +1286,7 @@
         this.frontWindow._showScreenshotOverlay();
         return;
       }
-      if (!this.screenshotOverlay ||
+      if (!this.element || !this.screenshotOverlay ||
           this.screenshotOverlay.classList.contains('visible')) {
         return;
       }
@@ -1312,7 +1312,7 @@
       if (this.frontWindow && this.frontWindow.isActive()) {
         this.frontWindow._hideScreenshotOverlay();
       }
-      if (!this.screenshotOverlay ||
+      if (!this.element || !this.screenshotOverlay ||
           !this.screenshotOverlay.classList.contains('visible')) {
         return;
       }
@@ -1326,7 +1326,7 @@
         // A white flash can occur when removing the screenshot
         // so we trigger this transition after a tick to hide it.
         setTimeout(function nextTick() {
-          element.classList.remove('overlay');
+          element && element.classList.remove('overlay');
         });
       }
     };


### PR DESCRIPTION
Speculative patch, just guarding against a null/undefined this.element in the _showScreenshotOverlay and _hideScreenshotOverlay methods which were modified in bug 1107139
