### PR TITLE
Bug 1146078 - Include fb_resolver.js to avoid races with imgLoader being undefined

### DIFF
--- a/apps/communications/contacts/test/unit/search_test.js
+++ b/apps/communications/contacts/test/unit/search_test.js
@@ -10,6 +10,7 @@ require('/shared/js/lazy_loader.js');
 require('/shared/js/contacts/utilities/dom.js');
 require('/shared/js/utilities.js');
 require('/shared/js/contacts/search.js');
+require('/contacts/js/fb_resolver.js');
 
 suite('Search mode', function() {
   var searchBox, searchList, noResults;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1146078

On tc: https://treeherder.mozilla.org/#/jobs?repo=gaia&revision=38ea6c3860922a0f3dec4c7694b4189fbeb058b3
