### PR TITLE
Bug 1145542 - [Calendar] The ellipsis is displayed on the wrong side for bidirectional title and location in Day, Week and Month views. r=gaye

### DIFF
--- a/apps/calendar/js/templates/month_day_agenda.js
+++ b/apps/calendar/js/templates/month_day_agenda.js
@@ -36,7 +36,7 @@ var MonthDayAgenda = create({
       <div class="gaia-icon icon-calendar-dot" style="color:${color}"
           aria-hidden="true"></div>
         <div class="event-time">${eventTime}</div>
-        <div class="event-details">${eventDetails}</div>
+        <div class="event-details" dir="auto">${eventDetails}</div>
         <div id="${busytimeId}-icon-calendar-alarm" aria-hidden="true"
           class="gaia-icon icon-calendar-alarm" style="color:${color}"
           data-l10n-id="icon-calendar-alarm"></div>

--- a/apps/calendar/js/views/single_day.js
+++ b/apps/calendar/js/views/single_day.js
@@ -173,7 +173,8 @@ SingleDay.prototype = {
 
     var labels = [];
 
-    var title = document.createElement('span');
+    // we use a <bdi> element because content might be bidirectional
+    var title = document.createElement('bdi');
     title.className = 'md__event-title';
     title.id = 'md__event-' + busytime._id + '-title-' + this._instanceID;
     labels.push(title.id);
@@ -182,7 +183,8 @@ SingleDay.prototype = {
     el.appendChild(title);
 
     if (remote.location) {
-      var location = document.createElement('span');
+      // we use a <bdi> element because content might be bidirectional
+      var location = document.createElement('bdi');
       location.className = 'md__event-location';
       location.id = 'md__event-' + busytime._id + '-location-' +
         this._instanceID;

--- a/apps/calendar/style/month.css
+++ b/apps/calendar/style/month.css
@@ -354,7 +354,12 @@ html[dir="rtl"] #month-day-agenda .event-time {
 html[dir="rtl"] #month-day-agenda .event-details {
   left: unset;
   right: 11.5rem;
+  width: 19rem;
   text-align: right;
+}
+
+html[dir="rtl"] #month-day-agenda .has-alarms .event-details {
+  width: 16rem;
 }
 
 html[dir="rtl"] #month-day-agenda .has-alarms .icon-calendar-alarm {

--- a/apps/calendar/style/multi_day.css
+++ b/apps/calendar/style/multi_day.css
@@ -204,8 +204,7 @@
   border-left-width: 0.4rem;
   width: 100%;
   overflow: hidden;
-  padding: 0.6rem;
-  -moz-padding-end: 0.3rem;
+  padding: 0.5rem;
 }
 
 .md__event:active,
@@ -215,9 +214,7 @@
 }
 
 .day-view .md__event {
-  padding: 0.8rem;
-  -moz-padding-start: 0.7rem;
-  -moz-padding-end: 0.3rem;
+  padding: 0.8rem 0.5rem;
 }
 
 .md__main .md__event {
@@ -280,7 +277,8 @@
 }
 
 .day-view .md__event-title,
-.md__event.is-partial .md__event-title {
+.md__event.is-partial .md__event-title,
+.md__event.is-partial .md__event-location {
   line-height: 1;
   white-space: nowrap;
 }
@@ -296,6 +294,12 @@
   color: #707070;
   font-size: 1.3rem;
   font-weight: 400;
+}
+
+.md__event.is-partial .md__event-location {
+  top: unset;
+  min-height: unset;
+  padding-top: unset;
 }
 
 .md__event.many-overlaps .md__event-title,
@@ -317,29 +321,27 @@
   align-items: center;
 }
 
-.md__event.is-partial-micro,
-.md__event.is-partial-tiny {
-  /* since alarm icon is hidden we remove the padding right */
-  -moz-padding-end: 0.7rem;
-}
-
-.md__event.is-partial .md__event-location {
-  padding-top: 0.2rem;
-}
-
-.md__event.is-partial-tiny .md__event-title,
-.md__event.is-partial-tiny .md__event-location,
-.md__event.is-partial-small .md__event-title,
-.md__event.is-partial-small .md__event-location {
+/* location is never displayed on week view */
+.day_view .md__event.is-partial-tiny .md__event-title,
+.day_view .md__event.is-partial-tiny .md__event-location,
+.day_view .md__event.is-partial-small .md__event-title,
+.day_view .md__event.is-partial-small .md__event-location {
   display: inline-block;
   line-height: 1.6rem;
   min-height: 0;
   padding: 0;
 }
 
-.md__event.is-partial-tiny .md__event-title,
-.md__event.is-partial-small .md__event-title {
-  -moz-margin-end: 0.85rem;
+/* location and title are displayed on same line but because of bidirectional
+ * content we can't use -moz-margin-end */
+.md__event.is-partial-tiny .md__event-title + .md__event-location,
+.md__event.is-partial-small .md__event-title + .md__event-location {
+  margin-left: 0.85rem;
+}
+
+html[dir="rtl"] .md__event.is-partial-tiny .md__event-title + .md__event-location,
+html[dir="rtl"] .md__event.is-partial-small .md__event-title + .md__event-location {
+  margin-right: 0.85rem;
 }
 
 .md__event.is-partial-micro .md__event-title,
@@ -356,7 +358,7 @@
 
 .day-view .md__event.has-alarms {
   /* avoid text overlap with alarm icon */
-  -moz-padding-end: 1rem;
+  -moz-padding-end: 2.6rem;
 }
 
 .day-view .md__event.is-partial-tiny,

--- a/apps/calendar/test/unit/views/single_day_test.js
+++ b/apps/calendar/test/unit/views/single_day_test.js
@@ -291,10 +291,10 @@ suite('Views.SingleDay', function() {
         'rgba(0, 255, 204, 0.2);" ' +
           'class="md__event is-allday" ' +
           'href="/event/show/Curabitur-0-00-0-00">' +
-        '<span id="' + makeAllDayEventID('title') + '" ' +
-          'class="md__event-title">Curabitur</span>' +
-        '<span id="' + makeAllDayEventID('location') + '" ' +
-          'class="md__event-location">Mars</span>' +
+        '<bdi id="' + makeAllDayEventID('title') + '" ' +
+          'class="md__event-title">Curabitur</bdi>' +
+        '<bdi id="' + makeAllDayEventID('location') + '" ' +
+          'class="md__event-location">Mars</bdi>' +
         '</a></div></div>',
       'alldays: first render'
     );
@@ -321,10 +321,10 @@ suite('Views.SingleDay', function() {
         'style="border-color: rgb(0, 255, 204); background-color: ' +
         'rgba(0, 255, 204, 0.2); height: 49.9px; top: 250px;" ' +
         'class="md__event" href="/event/show/Lorem-Ipsum-5-00-6-00">' +
-        '<span id="' + makeFirstEventID('title') + '" ' +
-          'class="md__event-title">Lorem Ipsum</span>' +
-        '<span id="' + makeFirstEventID('location') + '" ' +
-          'class="md__event-location">Mars</span>' +
+        '<bdi id="' + makeFirstEventID('title') + '" ' +
+          'class="md__event-title">Lorem Ipsum</bdi>' +
+        '<bdi id="' + makeFirstEventID('location') + '" ' +
+          'class="md__event-location">Mars</bdi>' +
         '<span data-l10n-args="{&quot;startDate&quot;:&quot;Wednesday, July ' +
           '23, 2014&quot;,&quot;startTime&quot;:&quot;05:00&quot;,&quot;' +
           'endDate&quot;:&quot;Wednesday, July 23, 2014&quot;,&quot;endTime' +
@@ -340,10 +340,10 @@ suite('Views.SingleDay', function() {
         'rgba(0, 255, 204, 0.2); height: 549.9px; top: 300px;" ' +
         'class="md__event has-alarms" ' +
         'href="/event/show/Maecennas-6-00-17-00">' +
-        '<span id="' + makeSecondEventID('title') + '" ' +
-          'class="md__event-title">Maecennas</span>' +
-        '<span id="' + makeSecondEventID('location') + '" ' +
-          'class="md__event-location">Mars</span>' +
+        '<bdi id="' + makeSecondEventID('title') + '" ' +
+          'class="md__event-title">Maecennas</bdi>' +
+        '<bdi id="' + makeSecondEventID('location') + '" ' +
+          'class="md__event-location">Mars</bdi>' +
         '<i data-l10n-id="icon-calendar-alarm" id="' +
           makeSecondEventID('icon') + '" aria-hidden="true" ' +
           'style="color: rgb(0, 255, 204);" ' +


### PR DESCRIPTION
ended up simplifying the way we set the padding/margin inside the busytimes to use the same logic on RTL/LTR, specially because of bidirectional content (which breaks `-moz-margin-start`, `-moz-margin-end` since they change based on the text direction).

this means that the layout will be a few pixels different than before (nobody should really notice it) but it will be consistent no matter what is the text direction, which I think will be better and avoids all sorts of errors... (I tried to keep the same values as before but it was simply too hard)

I also used the opportunity to fix the text overlaps on RTL (alarm icon was covering text in some cases)
