### PR TITLE
Bug 1142798 - Autolander test, remove unused mock

### DIFF
--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -210,7 +210,6 @@ apps/system/test/unit/mock_sheets_transition.js
 apps/system/test/unit/mock_stack_manager.js
 apps/system/test/unit/mock_statusbar.js
 apps/system/test/unit/mock_template.js
-apps/system/test/unit/mock_trusted_ui_manager.js
 apps/system/test/unit/operator_variant_helper_test.js
 apps/system/test/unit/orientation_manager_test.js
 apps/system/test/unit/settings_helper_test.js


### PR DESCRIPTION
Autolander test bug for autolander deploy changes.

https://bugzilla.mozilla.org/show_bug.cgi?id=1142798
