### PR TITLE
Bug 1139303 - Optimise home-screen edit mode. r=kgrandon

### DIFF
--- a/shared/elements/gaia_grid/js/grid_dragdrop.js
+++ b/shared/elements/gaia_grid/js/grid_dragdrop.js
@@ -13,7 +13,7 @@
    * and causes user confusion, but a short delay globally would cause too many
    * accidental triggers of edit mode.
    */
-  const EDIT_LONG_PRESS_DELAY = 100;
+  const EDIT_LONG_PRESS_DELAY = 200;
 
   /* The movement threshold to use for the above synthetic long-press. */
   const EDIT_LONG_PRESS_THRESHOLD = 4 * devicePixelRatio;
@@ -31,6 +31,16 @@
 
   /* This is the delay before calling finish when handling touchend. */
   const TOUCH_END_FINISH_DELAY = 20;
+
+  /* The maximum frequency with which the grid will be rearranged in response
+   * to the item position changing, in ms.
+   */
+  const REARRANGE_FREQUENCY = 100;
+
+  /* The amount of cool-down time after a rearrange animation. To avoid
+   * rearranging too frequently and causing jank and user confusion.
+   */
+  const REARRANGE_COOLDOWN = 750;
 
   const SCREEN_HEIGHT = window.innerHeight;
 
@@ -103,6 +113,16 @@
      * considered as obscuring the grid when in edit mode.
      */
     editHeaderElement: null,
+
+    /**
+     * The timeout used to rearrange the grid during dragging.
+     */
+    rearrangeGridTimeout: null,
+
+    /**
+     * The time of the last reposition call.
+     */
+    lastRepositionTime: 0,
 
     /**
      * Returns the maximum active scale value.
@@ -194,10 +214,18 @@
       }
 
       // Redraw the icon at the new position and scale
-      this.positionIcon();
+      this.updateIconPosition();
+
+      // Rearrange grid to highlight the group underneath the icon
+      this.rearrangeGrid();
     },
 
     finish: function() {
+      // Complete the repositioning timeout
+      if (this.rearrangeGridTimeout !== null) {
+        this.rearrangeGrid();
+      }
+
       // Remove the dragging property after the icon has transitioned into
       // place to avoid jank due to animations starting that are disabled
       // when dragging.
@@ -332,25 +360,16 @@
     },
 
     /**
-     * Scrolls the page if needed.
+     * Positions the dragged icon, rearranges the grid and scrolls the page if
+     * needed.
      * The page is scrolled via javascript if an icon is being moved,
      * and is within a percentage of a page edge.
-     * @param {Object} e A touch object from a touchmove event.
      */
-    scrollIfNeeded: function() {
+    positionAndScrollIfNeeded: function() {
       var touch = this.currentTouch;
-      if (!touch) {
+      if (!touch || !this.inDragAction) {
         this.isScrolling = false;
         return;
-      }
-
-      function doScroll(amount) {
-        /* jshint validthis:true */
-        this.isScrolling = true;
-        this.scrollable.scrollTop += amount;
-        exports.requestAnimationFrame(this.scrollIfNeeded.bind(this));
-        touch.pageY += amount;
-        this.positionIcon();
       }
 
       var scrollStep;
@@ -358,29 +377,37 @@
       var distanceFromTop = Math.abs(touch.pageY - docScroll);
       var distanceFromHeader = distanceFromTop -
         (this.editHeaderElement ? this.editHeaderElement.clientHeight : 0);
+      this.isScrolling = true;
+
       if (distanceFromTop > SCREEN_HEIGHT - EDGE_PAGE_THRESHOLD) {
         var maxY = this.maxScroll;
         scrollStep = this.getScrollStep(SCREEN_HEIGHT - distanceFromTop);
         // We cannot exceed the maximum scroll value
         if (touch.pageY >= maxY || maxY - touch.pageY < scrollStep) {
           this.isScrolling = false;
-          return;
         }
-
-        doScroll.call(this, scrollStep);
       } else if (touch.pageY > 0 && distanceFromHeader < EDGE_PAGE_THRESHOLD) {
         // We cannot go below the minimum scroll value
-        scrollStep = this.getScrollStep(distanceFromHeader);
-        scrollStep = Math.min(scrollStep, this.scrollable.scrollTop);
-        if (scrollStep <= 0) {
+        scrollStep = -this.getScrollStep(distanceFromHeader);
+        scrollStep = Math.max(scrollStep, -this.scrollable.scrollTop);
+        if (scrollStep >= 0) {
           this.isScrolling = false;
-          return;
         }
-
-        doScroll.call(this, -scrollStep);
       } else {
         this.isScrolling = false;
       }
+
+      if (!this.isScrolling) {
+        this.updateIconPosition();
+        this.deferredRearrangeGrid();
+        return;
+      }
+
+      this.updateIconPosition();
+      this.scrollable.scrollTop += scrollStep;
+      touch.pageY += scrollStep;
+
+      exports.requestAnimationFrame(this.positionAndScrollIfNeeded.bind(this));
     },
 
     /**
@@ -417,27 +444,63 @@
     /**
      * Positions an icon on the grid using the current touch coordinates.
      */
-    positionIcon: function() {
-      var iconIsDivider = this.icon.detail.type === 'divider';
-
-      var pageX = this.currentTouch.pageX - (this.initialPageX - this.icon.x);
-      var pageY = this.currentTouch.pageY - (this.initialPageY - this.icon.y);
-
+    updateIconPosition: function() {
       var oldX = this.icon.x;
       var oldY = this.icon.y;
+      var newX = this.currentTouch.pageX - (this.initialPageX - this.icon.x);
+      var newY = this.currentTouch.pageY - (this.initialPageY - this.icon.y);
+
       // Adjust new icon coordinates for the slightly inflated scale so that
-      // it appears centered around the touch point.
-      var newX = pageX;
-      var newY = pageY;
-      if (!iconIsDivider) {
-        newX = pageX - ((this.icon.scale * this.gridView.layout.gridItemWidth) -
-                        this.gridView.layout.gridItemWidth) / 2;
-        newY = pageY - ((this.icon.scale * this.icon.pixelHeight) -
-                        this.icon.pixelHeight) / 2;
+      // it appears centered around the touch point. Dividers aren't scaled
+      // during dragging.
+      if (this.icon.detail.type !== 'divider') {
+        newX = newX - ((this.icon.scale * this.gridView.layout.gridItemWidth) -
+                       this.gridView.layout.gridItemWidth) / 2;
+        newY = newY - ((this.icon.scale * this.icon.pixelHeight) -
+                       this.icon.pixelHeight) / 2;
       }
+
       this.icon.setCoordinates(newX, newY);
       this.icon.render();
       this.icon.setCoordinates(oldX, oldY);
+    },
+
+    /**
+     * Will call rearrangeGrid after a short period, calculated based on how
+     * recently the grid was last rearranged.
+     */
+    deferredRearrangeGrid: function() {
+      if (this.rearrangeGridTimeout !== null) {
+        return;
+      }
+
+      var delay = Math.max(
+        REARRANGE_FREQUENCY, REARRANGE_COOLDOWN -
+          Math.max(0, Date.now() - this.lastRepositionTime));
+      this.rearrangeGridTimeout = setTimeout(() => {
+        this.rearrangeGridTimeout = null;
+        this.rearrangeGrid();
+      }, delay);
+    },
+
+    /**
+     * Rearranges the grid icons and groups based on the current position of
+     * the dragged icon.
+     */
+    rearrangeGrid: function() {
+      if (this.rearrangeGridTimeout !== null) {
+        clearTimeout(this.rearrangeGridTimeout);
+        this.rearrangeGridTimeout = null;
+      }
+
+      if (this.isScrolling) {
+        // We don't want the grid to shift while we're auto-scrolling
+        return;
+      }
+
+      var iconIsDivider = this.icon.detail.type === 'divider';
+      var pageX = this.currentTouch.pageX - (this.initialPageX - this.icon.x);
+      var pageY = this.currentTouch.pageY - (this.initialPageY - this.icon.y);
 
       // Reposition in the icons array if necessary.
       // Find the icon with the closest X/Y position of the move,
@@ -673,6 +736,8 @@
       // after rearranging.
       this.initialPageX -= oldX - this.icon.x;
       this.initialPageY -= oldY - this.icon.y;
+
+      this.lastRepositionTime = Date.now();
     },
 
     enterEditMode: function() {
@@ -805,10 +870,8 @@
                 pageY: touch.pageY
               };
 
-              this.positionIcon();
-
               if (!this.isScrolling) {
-                this.scrollIfNeeded();
+                this.positionAndScrollIfNeeded();
               }
             } else if (this.longPressTimeout !== null &&
                        !this.inLongPressThreshold(touch.screenX,

--- a/shared/elements/gaia_grid/js/grid_view.js
+++ b/shared/elements/gaia_grid/js/grid_view.js
@@ -399,6 +399,9 @@
           // We must de-reference element explicitly so we can re-use item
           // objects the next time we call render.
           item.element = null;
+          item.lastX = null;
+          item.lastY = null;
+          item.lastScale = null;
         }
       }
       this.items = [];

--- a/shared/elements/gaia_grid/js/items/grid_item.js
+++ b/shared/elements/gaia_grid/js/items/grid_item.js
@@ -78,6 +78,14 @@
     persistToDB: true,
 
     /**
+     * Cached values of the last transform of the element, to avoid redundant
+     * style changes.
+     */
+    lastX: null,
+    lastY: null,
+    lastScale: null,
+
+    /**
      * Whether or not this item has a cached icon or not.
      */
     get hasCachedIcon() {
@@ -553,7 +561,17 @@
      */
     transform: function(x, y, scale, element) {
       scale = scale || 1;
-      element = element || this.element;
+
+      if (!element) {
+        if (x === this.lastX && y === this.lastY && scale === this.lastScale) {
+          return;
+        }
+        element = this.element;
+        this.lastX = x;
+        this.lastY = y;
+        this.lastScale = scale;
+      }
+
       element.style.transform =
         'translate(' + x + 'px,' + y + 'px) scale(' + scale + ')';
     },

--- a/shared/elements/gaia_grid/js/items/group.js
+++ b/shared/elements/gaia_grid/js/items/group.js
@@ -62,6 +62,7 @@
      * Height in pixels of the background of the group.
      */
     backgroundHeight: 0,
+    lastBackgroundHeight: null,
 
     /**
      * Height in pixels of the separator at the bottom of the group.
@@ -146,6 +147,7 @@
 
       this.grid.element.appendChild(group);
       this.separatorHeight = this.dividerSpanElement.clientHeight;
+      this.lastBackgroundHeight = null;
     },
 
     /**
@@ -235,9 +237,11 @@
       // icons, but we want it to display above.
       var y = this.getRealYPosition(nApps);
 
-      // Place the header span
-      this.headerSpanElement.style.transform =
-        'translate(0px, ' + y + 'px)';
+      if (y !== this.lastY) {
+        // Place the header span
+        this.headerSpanElement.style.transform =
+          'translate(0px, ' + y + 'px)';
+      }
 
       if (this.toggleElement) {
         var toggleLabel = this.detail.collapsed ? 'collapsed' : 'expanded';
@@ -254,18 +258,25 @@
       }
       this.backgroundHeight += this.headerHeight;
 
-      // Place and size the background span element
-      this.backgroundSpanElement.style.transform =
-        'translate(0px, ' + y + 'px) scale(1, ' + this.backgroundHeight + ')';
+      if (y != this.lastY ||
+          this.backgroundHeight !== this.lastBackgroundHeight) {
+        // Place and size the background span element
+        this.backgroundSpanElement.style.transform =
+          'translate(0px, ' + y + 'px) scale(1, ' + this.backgroundHeight + ')';
 
-      // Place and size the shadow span element
-      this.shadowSpanElement.style.transform =
-        'translateY(' + y + 'px)';
-      this.shadowSpanElement.style.height = this.backgroundHeight + 'px';
+        // Place and size the shadow span element
+        this.shadowSpanElement.style.transform =
+          'translateY(' + y + 'px)';
+        this.shadowSpanElement.style.height = this.backgroundHeight + 'px';
 
-      // Place the divider after this point
-      this.dividerSpanElement.style.transform =
-        'translate(0px, ' + (y + this.backgroundHeight) + 'px)';
+        // Place the divider after this point
+        this.dividerSpanElement.style.transform =
+          'translate(0px, ' + (y + this.backgroundHeight) + 'px)';
+      }
+
+      // Update the cached size values
+      this.lastBackgroundHeight = this.backgroundHeight;
+      this.lastY = y;
 
       // Now include the separator in the background height
       this.backgroundHeight += this.separatorHeight;
@@ -349,7 +360,7 @@
         if (dragging) {
           // If we're dragging, make sure to reposition the icon in the correct
           // place, as the render call won't redraw us
-          this.grid.dragdrop.positionIcon();
+          this.grid.dragdrop.updateIconPosition();
         } else {
           // If we're not dragging, save the collapsed state
           window.dispatchEvent(new CustomEvent('gaiagrid-saveitems'));

--- a/shared/elements/gaia_grid/style.css
+++ b/shared/elements/gaia_grid/style.css
@@ -47,10 +47,6 @@
   z-index: 3;
 }
 
-.dragging .icon {
-  will-change: transform;
-}
-
 .icon.launching {
   opacity: .65;
 }
@@ -147,6 +143,10 @@
   transition: transform 0.5s, opacity 0.5s;
 }
 
+.icon.active {
+  will-change: transform;
+}
+
 .edit-mode .icon .remove {
   display: block;
   position: absolute;
@@ -208,12 +208,12 @@ instead of the context menu.
   transition: background-color 0.5s, opacity 0.5s;
 }
 
-.dragging .group > span {
-  will-change: transform;
-}
-
 .group:not(.active):not(.newly-created) > span {
   transition: background-color 0.5s, opacity 0.5s, transform 0.5s;
+}
+
+.group.active > span {
+  will-change: transform;
 }
 
 .group .header {
@@ -390,7 +390,6 @@ instead of the context menu.
  * creation hint.
  */
 .edit-mode {
-  will-change: transform;
   transition: transform 0.25s;
 }
 


### PR DESCRIPTION
This makes a number of small optimisations/changes:
- Don't set will-change on everything in edit mode.
- Cache item positions to avoid redundant style changes.
- Throttle grid rearrangement.
- More aggressively throttle successive grid rearrangements.
- (Mostly) fix jank while auto-scrolling on homescreen edit.
- Increase long-press delay in edit mode.

Collectively, these changes improve responsiveness of the homescreen
edit mode.
