### PR TITLE
gaia marionette retry exit 1 on failure

### DIFF
--- a/apps/bookmark/test/marionette/install_app_test.js
+++ b/apps/bookmark/test/marionette/install_app_test.js
@@ -27,6 +27,7 @@ marionette('Bookmark -', function() {
   });
 
   test('Install app from page', function() {
+    throw new Error('YOU HAZ ERROR');
 
     var url = server.url('app.html');
 

--- a/bin/gaia_marionette_retry.js
+++ b/bin/gaia_marionette_retry.js
@@ -64,6 +64,9 @@ function summarize(results) {
   console.log('passed: %d', results.pass);
   console.log('failed: %d', results.fail);
   console.log('todo: %d', results.pending);
+  if (results.fail > 0) {
+    process.exit(1);
+  }
 }
 
 /**


### PR DESCRIPTION
Testing for this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1147477
