### PR TITLE
Bug 1140275 - Allow required system messages for mochitest.

### DIFF
--- a/dev_apps/mochitest/manifest.webapp
+++ b/dev_apps/mochitest/manifest.webapp
@@ -38,6 +38,11 @@
     "foo" : { "readonly": false },
     "bar" : { "readonly": false }
   },
-  "default_locale": "en-US"
+  "default_locale": "en-US",
+  "messages": [
+    { "alarm": "/tests/dom/alarm/test/test_bug1037079.html" },
+    { "alarm": "/tests/dom/alarm/test/test_bug1090896.html" },
+    { "alarm": "/tests/dom/messages/test/test_bug_993732.html" }
+  ]
 }
 


### PR DESCRIPTION
Bug 1140275 - Allow required system messages for mochitest.
