### PR TITLE
Bug 1147650 - Have the touch forwarder forward all move events instead o...

### DIFF
--- a/apps/system/js/touch_forwarder.js
+++ b/apps/system/js/touch_forwarder.js
@@ -37,13 +37,7 @@
         break;
 
       case 'touchmove':
-        // We only forward one touchmove for APZ enabled iframes
-        // the potention subsequent ones are ignored.
-        if (!this._firstMoveForwarded) {
-          sendTouchEvent(iframe, e);
-          this._firstMoveForwarded = true;
-        }
-
+        sendTouchEvent(iframe, e);
         touch = e.touches[0];
         this._updateShouldTap(touch);
         break;
@@ -67,7 +61,6 @@
     this._startX = null;
     this._startY = null;
     this._shouldTap = false;
-    this._firstMoveForwarded = false;
   };
 
   TouchForwarder.prototype._updateShouldTap = function(touch) {

--- a/apps/system/test/unit/touch_forwarder_test.js
+++ b/apps/system/test/unit/touch_forwarder_test.js
@@ -73,11 +73,9 @@ suite('system/TouchForwarder >', function() {
       subject.forward(forgeTouch('touchstart', 3, 20));
     });
 
-    test('it should only forward the first touchmove event', function() {
+    test('it should forward touchmove events', function() {
       var sendTouchSpy = this.sinon.spy(iframe, 'sendTouchEvent');
       subject.forward(forgeTouch('touchmove', 3, 27));
-      subject.forward(forgeTouch('touchmove', 3, 37));
-      subject.forward(forgeTouch('touchmove', 3, 57));
 
       assert.isTrue(sendTouchSpy.calledOnce);
 


### PR DESCRIPTION
...f just the first one. r=etienne
