### PR TITLE
Bug 1143795 - Reduce font-weight of identification overlay

### DIFF
--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -405,6 +405,7 @@
   font-size: 1.6rem;
   font-style: italic;
   line-height: 1.8rem;
+  font-weight: 400;
   text-overflow: ellipsis;
   white-space: nowrap;
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1143795

Old browser overlay:
![2015-03-27-17-47-34](https://cloud.githubusercontent.com/assets/122602/6876705/78b5d67c-d487-11e4-960e-f108c9450cdc.png)

Old private browser overlay:
![2015-03-27-17-47-06](https://cloud.githubusercontent.com/assets/122602/6876709/80b12eda-d487-11e4-9fad-bb51786fb6cb.png)

New browser overlay:
![2015-03-27-17-47-27](https://cloud.githubusercontent.com/assets/122602/6876716/917828ae-d487-11e4-864c-acb1077b24c2.png)

New private browser overlay:
![2015-03-27-17-47-13](https://cloud.githubusercontent.com/assets/122602/6876718/96d8c95c-d487-11e4-85f5-ee874458eb55.png)
