### PR TITLE
Bug 1146831 - Don't create text node if line is empty. r=jrburke

### DIFF
--- a/apps/email/js/cards/editor_mixins.js
+++ b/apps/email/js/cards/editor_mixins.js
@@ -17,7 +17,10 @@ define(function(require) {
         if (i) {
           frag.appendChild(document.createElement('br'));
         }
-        frag.appendChild(document.createTextNode(lines[i]));
+
+        if (lines[i]) {
+          frag.appendChild(document.createTextNode(lines[i]));
+        }
       }
       this._editorNode.appendChild(frag);
     },


### PR DESCRIPTION
If line is empty then a empty text node would be created. Then long tap would select from this empty text node to next <br> node. So we skip text node creation if text is empty.
