### PR TITLE
Bug 1148632 - [Lockscreen] Tapping 'Open' on a lockscreen notification a...

### DIFF
--- a/apps/system/lockscreen/js/lockscreen_inputpad.js
+++ b/apps/system/lockscreen/js/lockscreen_inputpad.js
@@ -191,10 +191,18 @@
   function(key) {
     switch (key) {
       case 'e': // 'E'mergency Call
+        // Cancel the notification clicked to activate.
+        if (this.lockScreen._unlockingMessage.notificationId) {
+          delete this.lockScreen._unlockingMessage.notificationId;
+        }
         this.lockScreen.invokeSecureApp('emergency-call');
         break;
 
       case 'c': // 'C'ancel
+        // Cancel the notification clicked to activate.
+        if (this.lockScreen._unlockingMessage.notificationId) {
+          delete this.lockScreen._unlockingMessage.notificationId;
+        }
         this.dispatchEvent(new window.CustomEvent(
           'lockscreen-keypad-input', { detail: {
             key: key

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -259,6 +259,25 @@ suite('LockScreenInputpad', function() {
         method.call(mockThis, '4');
         assert.isTrue(stubVibrate.called);
       });
+      test('it would clear notification opening ID', function() {
+        var method = subject.handlePassCodeInput;
+        var mockThis = {
+          lockScreen: {
+            invokeSecureApp: function() {},
+            _unlockingMessage: {
+              notificationId: 'fakeid'
+            }
+          },
+          dispatchEvent: function() {}
+        };
+        method.call(mockThis, 'e');
+        assert.isUndefined(
+          mockThis.lockScreen._unlockingMessage.notificationId);
+        mockThis.lockScreen._unlockingMessage.notificationId = 'fakeid';
+        method.call(mockThis, 'c');
+        assert.isUndefined(
+          mockThis.lockScreen._unlockingMessage.notificationId);
+      });
     });
   });
 });


### PR DESCRIPTION
...nd then canceling the passcode lock page will still queue up the open activity and open it after eventually accessing homescreen, even after lockscreen camera activity
