### PR TITLE
Bug 1148632 - [Lockscreen] Tapping 'Open' on a lockscreen notification a...

### DIFF
--- a/apps/system/js/lockscreen.js
+++ b/apps/system/js/lockscreen.js
@@ -691,10 +691,16 @@
   function ls_handlePassCodeInput(key) {
     switch (key) {
       case 'e': // 'E'mergency Call
+        if (this._unlockingMessage.notificationId) {
+          delete this._unlockingMessage.notificationId;
+        }
         this.invokeSecureApp('emergency-call');
         break;
 
       case 'c': // 'C'ancel
+        if (this._unlockingMessage.notificationId) {
+          delete this._unlockingMessage.notificationId;
+        }
         // Delegate to LockScreenStateManager
         break;
 

--- a/apps/system/test/unit/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen_test.js
@@ -317,6 +317,21 @@ suite('system/LockScreen >', function() {
                   'ftuopen caused unlock to be called');
   });
 
+  test('When cancel or invoke emergency call, stop notification activation',
+  function() {
+    var mockThis = {
+      _unlockingMessage: {
+        notificationId: 'fakeid'
+      }
+    };
+    var method = subject.handlePassCodeInput;
+    method.call(mockThis, 'c');
+    assert.isUndefined(mockThis._unlockingMessage.notificationId);
+    mockThis._unlockingMessage.notificationId = 'fakeid';
+    method.call(mockThis, 'e');
+    assert.isUndefined(mockThis._unlockingMessage.notificationId);
+  });
+
   // XXX: Test 'Screen off: by proximity sensor'.
 
   teardown(function() {


### PR DESCRIPTION
...nd then canceling the passcode lock page will still queue up the open activity and open it after eventually accessing homescreen, even after lockscreen camera activity
