### PR TITLE
Bug 1142572 - Use ManifestHelper's displayName instead of short_name

### DIFF
--- a/apps/settings/js/panels/app_permissions_detail/app_permissions_detail.js
+++ b/apps/settings/js/panels/app_permissions_detail/app_permissions_detail.js
@@ -47,7 +47,7 @@ define(function(require) {
       var manifest = new ManifestHelper(app.manifest ?
         app.manifest : app.updateManifest);
       var developer = manifest.developer;
-      elements.detailTitle.textContent = manifest.short_name || manifest.name;
+      elements.detailTitle.textContent = manifest.displayName;
       elements.uninstallButton.disabled = !app.removable;
       if (!developer || !('name' in developer)) {
         elements.developerInfos.hidden = true;

--- a/apps/settings/js/panels/app_permissions_list/app_permissions_list.js
+++ b/apps/settings/js/panels/app_permissions_list/app_permissions_list.js
@@ -207,7 +207,7 @@ define(function(require) {
         var manifest = new ManifestHelper(app.manifest ?
             app.manifest : app.updateManifest);
         var li = this._genAppItemTemplate({
-          name: manifest.short_name || manifest.name,
+          name: manifest.displayName,
           index: index,
           iconSrc: this._getBestIconURL(app, manifest.icons)
         });

--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -131,13 +131,10 @@
     // Store initial configuration in this.config
     this.config = configuration;
 
-    if (this.manifest) {
-      this.shortName = new ManifestHelper(this.manifest).short_name;
-    }
     if (!this.manifest && this.config && this.config.title) {
       this.updateName(this.config.title);
     } else {
-      this.name = new ManifestHelper(this.manifest).name;
+      this.name = new ManifestHelper(this.manifest).displayName;
     }
 
     // Get icon splash
@@ -885,8 +882,7 @@
     if (!this.manifest) {
       return;
     }
-    this.name = new ManifestHelper(this.manifest).name;
-    this.shortName = new ManifestHelper(this.manifest).short_name;
+    this.name = new ManifestHelper(this.manifest).displayName;
 
     if (this.identificationTitle) {
       this.identificationTitle.textContent = this.name;

--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -127,8 +127,7 @@
    */
   Card.prototype._populateViewData = function() {
     var app = this.app;
-    this.title = (app.isBrowser() && app.title) ?
-                  app.title : app.shortName || app.name;
+    this.title = (app.isBrowser() && app.title) ? app.title : app.name;
     this.sslState = app.getSSLState();
     this.subTitle = '';
     this.iconValue = '';

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1952,6 +1952,7 @@ suite('system/AppWindow', function() {
       var spyManifestHelper = this.sinon.stub(window, 'ManifestHelper');
       spyManifestHelper.returns({
         name: 'Mon Application',
+        displayName: 'Bref',
         short_name: 'Bref'
       });
       var stubPublish = this.sinon.stub(app1, 'publish');
@@ -1963,8 +1964,8 @@ suite('system/AppWindow', function() {
       assert.isTrue(spyManifestHelper.calledWithNew());
       assert.isTrue(spyManifestHelper.calledWithExactly(app1.manifest));
       assert.isTrue(stubPublish.calledWithExactly('namechanged'));
-      assert.equal(app1.identificationTitle.textContent, 'Mon Application');
-      assert.equal(app1.shortName, 'Bref');
+      assert.equal(app1.identificationTitle.textContent, 'Bref');
+      assert.equal(app1.name, 'Bref');
     });
 
     test('focus event', function() {

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -14,7 +14,6 @@ suite('system/Card', function() {
     return new AppWindow({
       launchTime: 4,
       name: config.name || 'dummyapp',
-      shortName: config.shortName,
       frame: document.createElement('div'),
       iframe: document.createElement('iframe'),
       manifest: {
@@ -158,16 +157,6 @@ suite('system/Card', function() {
       assert.equal(appCard.titleNode.textContent, 'otherapp');
     });
 
-    test('app short name', function() {
-      var appCard = new Card({
-        app: makeApp({ name: 'shortname', shortName: 'short' }),
-        manager: mockManager
-      });
-      appCard.app.title = 'Some long title';
-      appCard.render();
-      assert.equal(appCard.titleNode.textContent, 'short');
-    });
-
     test('app security for browser windows', function() {
       var browserCard = new Card({
         app: makeApp({ name: 'browserwindow' }),
@@ -217,7 +206,6 @@ suite('system/Card', function() {
     test('subTitle when private browser splash', function() {
       var app = makeApp({
         name: 'shortname',
-        shortName: 'short',
         origin: 'app://system.gaiamobile.org',
         url: 'app://system.gaiamobile.org/private_browser.html'
       });

--- a/shared/test/unit/mocks/mock_manifest_helper.js
+++ b/shared/test/unit/mocks/mock_manifest_helper.js
@@ -9,6 +9,6 @@ function MockManifestHelper(manifest) {
 
 Object.defineProperty(MockManifestHelper.prototype, 'displayName', {
     get: function displayName() {
-      return this.name;
+      return this.short_name || this.name;
     }
 });


### PR DESCRIPTION
Revised patch from https://github.com/mozilla-b2g/gaia/pull/29023 to remove the changes to bookmark_editor.js and the unit test mock - I hadnt noticed that was WebManifestHelper vs. ManifestHelper. 
