### PR TITLE
Bug 1149448 - Cardview subtitles are always URLs and always LTR

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -90,7 +90,9 @@
     /* jshint -W033 */
     return Tagged.escapeHTML `<div class="titles">
      <h1 id="${this.titleId}" class="title">${this.title}</h1>
-     <p class="subtitle">${this.subTitle}</p>
+     <p class="subtitle">
+      <span class="subtitle-url">${this.subTitle}</span>
+     </p>
     </div>
 
     <div class="screenshotView bb-button" data-l10n-id="openCard"

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -294,7 +294,6 @@
   display: none;
   pointer-events: auto;
   overflow: hidden;
-  text-overflow: ellipsis;
   margin: 0;
   text-align: center;
   font-weight: normal;
@@ -306,6 +305,10 @@
   font-style: italic;
 }
 
+#cards-view .card p.subtitle:not(:empty) {
+  display: block;
+}
+
 #cards-view.filtered .card p.subtitle {
   display: none;
 }
@@ -315,8 +318,12 @@
   color: #858585;
 }
 
-#cards-view .card p.subtitle:not(:empty) {
-  display: block;
+#cards-view .titles .subtitle-url {
+  direction: ltr;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #cards-view .card[data-ssl="secure"] p.subtitle:not(:empty),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1149448

This patch seperates the URL text into a span inside the subtitle element. The subtitle gets the direction from the document, so the lock icon appears on the left in LTR, on the right in RTL. The URL is always LTR so the ellipsis and truncation will always be on the right. 
