### PR TITLE
Bug 1149936 - Add RTL rule for FB import icon. r=fcampo

### DIFF
--- a/apps/ftu/style/style.css
+++ b/apps/ftu/style/style.css
@@ -816,6 +816,10 @@ aside.connecting {
 #fb_after_import1 {
   background: url('images/import_fb.png') no-repeat center left / 3rem;
 }
+html[dir="rtl"] #fb_after_import1 {
+  background-position: right center;
+}
+
 
 #statusMsg.ftu {
   bottom: 6.5rem;


### PR DESCRIPTION
We missed this one - shift the 'imported' facebook icon to the right for RTL. 
