### PR TITLE
Bug 1150317 - Move gaia-grid RTL css into external.css

### DIFF
--- a/shared/elements/gaia_grid/style.css
+++ b/shared/elements/gaia_grid/style.css
@@ -401,8 +401,3 @@ instead of the context menu.
   left: 0;
   right: unset;
 }
-
-/* RTL fixes being tracked in bug 1008013 */
-:-moz-dir(rtl) gaia-grid {
-  direction: ltr;
-}

--- a/shared/elements/gaia_grid/style/external.css
+++ b/shared/elements/gaia_grid/style/external.css
@@ -18,3 +18,7 @@ Bug 1018269 - we need to specify the keyframe outside
     transform: rotate(360deg)
   }
 }
+
+:-moz-dir(rtl) gaia-grid {
+  direction: ltr;
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1150317
