### PR TITLE
Bug 1100263 - [Flame][Homescreen]It will show a blank page and close icon can't work when you open two App folders quickly

### DIFF
--- a/apps/collection/js/view_collection.js
+++ b/apps/collection/js/view_collection.js
@@ -47,6 +47,7 @@
 
   navigator.mozSetMessageHandler('activity', function onActivity(activity) {
     if (activity.source.name === 'view-collection') {
+      navigator.mozSetMessageHandler('activity', null);
       HandleView(activity);
     }
   });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1100263
