### PR TITLE
Bug 1150961 - Use show-subtitle class to show lock/url in task manager

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -166,6 +166,7 @@
     }
     if (displayUrl) {
       this.subTitle = this.getDisplayURLString(displayUrl);
+      this.viewClassList.push('show-subtitle');
     }
 
     var topMostWindow = app.getTopMostWindow();

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -299,22 +299,17 @@
   font-weight: normal;
 }
 
+#cards-view .card.show-subtitle p.subtitle {
+  display: block;
+}
+
 #cards-view .card.browser p.subtitle {
   color: #e7e7e7;
   pointer-events: auto;
   font-style: italic;
 }
 
-#cards-view .card p.subtitle:not(:empty) {
-  display: block;
-}
-
 #cards-view.filtered .card p.subtitle {
-  display: none;
-}
-
-#cards-view.filtered .card p.subtitle:not(:empty) {
-  display: block;
   color: #858585;
 }
 
@@ -326,8 +321,8 @@
   text-overflow: ellipsis;
 }
 
-#cards-view .card[data-ssl="secure"] p.subtitle:not(:empty),
-#cards-view .card[data-ssl="broken"] p.subtitle:not(:empty) {
+#cards-view .card.show-subtitle[data-ssl="secure"] p.subtitle,
+#cards-view .card.show-subtitle[data-ssl="broken"] p.subtitle {
   -moz-padding-start: 2rem;
   -moz-padding-end: 1rem;
   min-height: 2rem;
@@ -336,22 +331,22 @@
   background-size: 3rem 3rem;
 }
 
-#cards-view .card[data-ssl="secure"] p.subtitle:not(:empty) {
+#cards-view .card.show-subtitle[data-ssl="secure"] p.subtitle {
   background-image: url("../chrome/images/dark/ssl.png");
 }
-#cards-view .card[data-ssl="broken"] p.subtitle:not(:empty) {
+#cards-view .card.show-subtitle[data-ssl="broken"] p.subtitle {
   background-image: url("../chrome/images/dark/ssl_broken.png");
 }
 
-#cards-view.filtered .card[data-ssl="secure"] p.subtitle:not(:empty) {
+#cards-view.filtered .card.show-subtitle[data-ssl="secure"] p.subtitle {
   background-image: url("../chrome/images/light/ssl.png");
 }
-#cards-view .card[data-ssl="broken"] p.subtitle:not(:empty) {
+#cards-view .card.show-subtitle[data-ssl="broken"] p.subtitle {
   background-image: url("../chrome/images/light/ssl_broken.png");
 }
 
-html[dir="rtl"] #cards-view .card[data-ssl="broken"] p.subtitle:not(:empty),
-html[dir="rtl"] #cards-view .card[data-ssl="secure"] p.subtitle:not(:empty) {
+html[dir="rtl"] #cards-view .card.show-subtitle[data-ssl="broken"] p.subtitle,
+html[dir="rtl"] #cards-view .card.show-subtitle[data-ssl="secure"] p.subtitle {
   background-position: right -0.5rem top -1rem;
 }
 

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -11,26 +11,23 @@ var mocksForCard = new MocksHelper([
 suite('system/Card', function() {
 
   function makeApp(config) {
-    return new AppWindow({
+    var appWindow = new AppWindow({
       launchTime: 4,
       name: config.name || 'dummyapp',
-      frame: document.createElement('div'),
-      iframe: document.createElement('iframe'),
       manifest: {
         orientation: config.orientation || 'portrait-primary'
       },
       rotatingDegree: config.rotatingDegree || 0,
-      requestScreenshotURL: function() {
-        return null;
-      },
       getScreenshot: function(callback) {
         callback();
       },
-      origin: config.origin || 'http://' +
+      origin: config.origin || 'app://' +
               (config.name || 'dummyapp') + '.gaiamobile.org',
       url: config.url,
       blur: function() {}
     });
+    appWindow.browser.element.src = appWindow.origin + '/index.html';
+    return appWindow;
   }
 
   mocksForCard.attachTestHelpers();
@@ -95,6 +92,8 @@ suite('system/Card', function() {
                 '.screenshotView');
       assert.ok(header, 'h1');
       assert.ok(header.id, 'h1.id');
+      assert.isFalse(card.element.classList.contains('show-subtitle'),
+                     'no show-subtitle by default');
     });
 
     test('has expected aria values', function(){
@@ -187,6 +186,8 @@ suite('system/Card', function() {
         return true;
       });
       browserCard.render();
+      assert.ok(browserCard.element.classList.contains('show-subtitle'),
+                'show-subtitle class added');
       assert.equal(browserCard.subTitle, 'someorigin.org/foo');
     });
     test('getDisplayURLString', function() {
@@ -216,6 +217,7 @@ suite('system/Card', function() {
       });
       appCard.render();
       assert.equal(appCard.subTitle, '');
+      assert.isFalse(appCard.element.classList.contains('show-subtitle'));
     });
   });
 


### PR DESCRIPTION
The :empty selectors match always when I added the subtitle-url. Changed it up to add a show-subtitle class on the card. The unit tests were all using a http:// url which is the one case where we _do_ want to show the url/subtitle which I think was not the intention for the non-browser case tests here, so I changed that to use app://. 
