### PR TITLE
Bug 1151105 - [Settings]Attempting to enter Call Settings will prevent entering all Settings sub menus

### DIFF
--- a/apps/settings/js/call.js
+++ b/apps/settings/js/call.js
@@ -17,7 +17,7 @@ require([
   /**
    * Singleton object that handles some call settings.
    */
-  var CallSettings = (function(window, document, undefined) {
+  var CallSettings = (function() {
     var _settings = window.navigator.mozSettings;
     var _mobileConnections = window.navigator.mozMobileConnections;
     var _voiceTypes = Array.prototype.map.call(_mobileConnections,
@@ -1130,7 +1130,7 @@ require([
     return {
       init: cs_init
     };
-  })(this, document);
+  })();
 
   /**
    * Startup.

--- a/apps/settings/js/carrier.js
+++ b/apps/settings/js/carrier.js
@@ -6,7 +6,7 @@
 /**
  * Singleton object that handles some cell and data settings.
  */
-var CarrierSettings = (function(window, document, undefined) {
+var CarrierSettings = (function() {
   var DATA_KEY = 'ril.data.enabled';
   var DATA_ROAMING_KEY = 'ril.data.roaming_enabled';
   var NETWORK_TYPE_SETTING = 'operatorResources.data.icon';
@@ -887,6 +887,6 @@ var CarrierSettings = (function(window, document, undefined) {
   return {
     init: cs_init
   };
-})(this, document);
+})();
 
 CarrierSettings.init();

--- a/apps/settings/js/carrier_iccs.js
+++ b/apps/settings/js/carrier_iccs.js
@@ -7,7 +7,7 @@
  * Singleton object that helps to populate and manage the 'Select a SIM card'
  * panel in the cell and data settings panel.
  */
-var IccHandlerForCarrierSettings = (function(window, document, undefined) {
+var IccHandlerForCarrierSettings = (function() {
   /** Card state mapping const. */
   var CARDSTATE_MAPPING = {
    'pinRequired' : 'simCardLockedMsg',
@@ -260,4 +260,4 @@ var IccHandlerForCarrierSettings = (function(window, document, undefined) {
   return {
     init: ihfcs_init
   };
-})(this, document);
+})();

--- a/apps/settings/js/dsds_settings.js
+++ b/apps/settings/js/dsds_settings.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-var DsdsSettings = (function(window, document, undefined) {
+var DsdsSettings = (function() {
   var _settings = window.navigator.mozSettings;
   var _mobileConnections = null;
   if (window.navigator.mozMobileConnections) {
@@ -111,4 +111,4 @@ var DsdsSettings = (function(window, document, undefined) {
     setIccCardIndexForCellAndDataSettings:
       ds_setIccCardIndexForCellAndDataSettings
   };
-})(this, document);
+})();

--- a/apps/settings/js/panels/call_iccs/call_icc_handler.js
+++ b/apps/settings/js/panels/call_iccs/call_icc_handler.js
@@ -7,7 +7,7 @@ define(function(require) {
    * Singleton object that helps to populate and manage the 'Select a SIM card'
    * panel in the call settings panel.
    */
-  var CallIccHandler = (function(window, document) {
+  var CallIccHandler = (function() {
 
     /** Card state mapping const. */
     var CARDSTATE_MAPPING = {
@@ -271,7 +271,7 @@ define(function(require) {
     return {
       init: ihfcs_init
     };
-  })(this, document);
+  })();
 
   return CallIccHandler;
 });

--- a/apps/settings/js/telephony_items_handler.js
+++ b/apps/settings/js/telephony_items_handler.js
@@ -7,7 +7,7 @@
  * Singleton object that helps to enable/disable and to show card state
  * information for telephony-related items from the root in the setting app.
  */
-var TelephonyItemsHandler = (function(window, document, undefined) {
+var TelephonyItemsHandler = (function() {
   var DATA_TYPE_SETTING = 'operatorResources.data.icon';
 
   var dataTypeMapping = {
@@ -215,4 +215,4 @@ var TelephonyItemsHandler = (function(window, document, undefined) {
       });
     }
   };
-})(this, document);
+})();

--- a/apps/settings/js/telephony_settings.js
+++ b/apps/settings/js/telephony_settings.js
@@ -7,7 +7,7 @@
  * Singleton object (base object) that handle listener and events on mozIcc
  * objects in order to handle telephony-related menu items in the root panel.
  */
-var TelephonySettingHelper = (function(window, document, undefined) {
+var TelephonySettingHelper = (function() {
   var _iccManager;
   var _mobileConnections;
 
@@ -86,4 +86,4 @@ var TelephonySettingHelper = (function(window, document, undefined) {
   return {
     init: tsh_init
   };
-})(this, document);
+})();


### PR DESCRIPTION
With the change in bug 1087811, "use strict" inside functions are correctly kept after a build.

call_icc_handler.js was running into problems with "use strict" rules because the `(function(window, document) { })(this, document);` wrapper under "use strict" inside a function mean that "this" is set to `undefined` for functions that are not called as part of an object method invocation. More details in the second paragraph here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#.22Securing.22_JavaScript

The function passing in those global values was not really doing much, just might help with slightly smaller minification for those variables. However, it does not help with protection from globals (we explicitly want those globals), and it does lead to this use strict hazard.

While call_icc_handler.js is the source of this bug, I went ahead and changed other files that were using this idiom, as they have the potential to be a hazard if they do become wrapped in an outer function with 'use strict' set inside it (the r.js build tool still strips top level "use strict" calls since mixing non-strict and strict code can lead to bugs, but now keeps 'use strict' indented inside function wrappers).

So the end result is by fixing a correctness issue with the build, it triggered this use strict behavior -- if the file was run in source mode in the browser, it would have failed this way too.
