### PR TITLE
Bug 1150495 - [GaiaGrid] Do not overwrite icons when we have a cached icon

### DIFF
--- a/shared/elements/gaia_grid/js/items/grid_item.js
+++ b/shared/elements/gaia_grid/js/items/grid_item.js
@@ -270,6 +270,14 @@
       };
       background.onerror = () => {
         URL.revokeObjectURL(background.src);
+
+        // If we already have a cached icon, do not overwrite it on error.
+        if (this.hasCachedIcon) {
+          this._stampElementWithIcon('blobcache');
+          this._displayDecoratedIcon(this.detail.decoratedIconBlob, true);
+          return;
+        }
+
         this.renderIconFromSrc(this.defaultIcon);
         this._stampElementWithIcon(this.defaultIcon);
       };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1150495
