### PR TITLE
Bug 1147790 - [Email]The signature can't be added to mail automatically ...

### DIFF
--- a/apps/email/js/activity_composer_data.js
+++ b/apps/email/js/activity_composer_data.js
@@ -38,7 +38,7 @@ define(function(require, exports, module) {
           composer.subject = attachData.subject;
         }
         if (attachData.body) {
-          composer.body = { text: attachData.body };
+          composer.body = { text: attachData.body + composer.body.text };
         }
         if (attachData.cc) {
           composer.cc = attachData.cc;


### PR DESCRIPTION
...when you share a URL to Email.
