### PR TITLE
Bug 1150831 - [Calendar] On Week view, it displays some codes in the time fields when changing back to "12-hour" from "24-hour" format.

### DIFF
--- a/apps/calendar/js/views/multi_day.js
+++ b/apps/calendar/js/views/multi_day.js
@@ -118,6 +118,7 @@ MultiDay.prototype = {
     // we keep the localized listener even when view is inactive to avoid
     // rebuilding the hours/dates every time we switch between views
     window.addEventListener('localized', this);
+    window.addEventListener('timeformatchange', this);
     // When screen reader is used, scrolling is done using wheel events.
     this.element.addEventListener('wheel', this);
   },
@@ -191,6 +192,7 @@ MultiDay.prototype = {
         this._onDayChange(e.data[0]);
         break;
       case 'localized':
+      case 'timeformatchange':
         this._localize();
         break;
       case 'wheel':

--- a/apps/calendar/test/unit/views/multi_day_test.js
+++ b/apps/calendar/test/unit/views/multi_day_test.js
@@ -58,35 +58,50 @@ suite('Views.MultiDay', function() {
     });
   });
 
-  test('localized', function() {
-    var sidebar = subject.sidebar;
-    subject._visibleRange = 123;
-    subject.handleEvent({type: 'localized'});
+  suite('localized and timeformatchange', function() {
+    var sidebar;
 
-    // make sure we rebuild all hours during localize
-    var i = -1, date = new Date(0), hour;
-    while (++i < 24) {
-      date.setHours(i, 0, 0, 0);
-      hour = sidebar.querySelector('.md__hour-' + i);
-      assert.equal(hour.textContent, i, 'display hour');
+    setup(function() {
+      sidebar = subject.sidebar;
+      subject._visibleRange = 123;
+    });
+
+    function assertTimeRefresh() {
+      // make sure we rebuild all hours during localize
+      var i = -1, date = new Date(0), hour;
+      while (++i < 24) {
+        date.setHours(i, 0, 0, 0);
+        hour = sidebar.querySelector('.md__hour-' + i);
+        assert.equal(hour.textContent, i, 'display hour');
+        assert.equal(
+          hour.querySelector('.md__display-hour').dataset.date,
+          date,
+          'date data'
+        );
+      }
+
+      // make sure we update the current time
+      assert.ok(
+        subject._currentTime.refresh.calledOnce,
+        'called refresh'
+      );
+
       assert.equal(
-        hour.querySelector('.md__display-hour').dataset.date,
-        date,
-        'date data'
+        subject._currentTime.timespan,
+        subject._visibleRange,
+        'current time timespan matches the _visibleRange'
       );
     }
 
-    // make sure we update the current time
-    assert.ok(
-      subject._currentTime.refresh.calledOnce,
-      'called refresh'
-    );
+    test('localized', function() {
+      subject.handleEvent({type: 'localized'});
+      assertTimeRefresh();
+    });
 
-    assert.equal(
-      subject._currentTime.timespan,
-      subject._visibleRange,
-      'current time timespan matches the _visibleRange'
-    );
+    test('timeformatchange', function() {
+      subject.handleEvent({type: 'timeformatchange'});
+      assertTimeRefresh();
+    });
   });
 
   test('#_updateBaseDateAfterScroll', function() {


### PR DESCRIPTION
make sure we refresh the sidebar and current time indicator during `timeformatchange`

this is needed because we have the special `<span class="ampm">%p</span>`
