### PR TITLE
Bug 1117450 - Add mozSettings and CalledNumber cache to optimize the updateCallNumber process

### DIFF
--- a/apps/callscreen/index.html
+++ b/apps/callscreen/index.html
@@ -36,6 +36,7 @@
     <script defer type="application/javascript" src="/shared/js/date_time_helper.js"></script>
 
     <script defer type="application/javascript" src="/shared/js/simple_phone_matcher.js"></script>
+    <script defer type="application/javascript" src="/shared/js/dialer/settings_cache.js"></script>
     <script defer type="application/javascript" src="/shared/js/dialer/contacts.js"></script>
     <script defer type="application/javascript" src="/shared/js/dialer/tone_player.js"></script>
     <script defer type="application/javascript" src="/shared/js/dialer/keypad.js"></script>

--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -37,6 +37,7 @@
     <script defer src="/shared/js/lazy_l10n.js"></script>
     <script defer src="/dialer/js/index.js"></script>
 
+    <script defer src="/shared/js/dialer/settings_cache.js"></script>
     <script defer src="/shared/js/dialer/utils.js"></script>
     <script defer src="/shared/js/dialer/tone_player.js"></script>
     <script defer src="/shared/js/dialer/keypad.js"></script>

--- a/shared/js/dialer/contacts.js
+++ b/shared/js/dialer/contacts.js
@@ -11,6 +11,153 @@ var Contacts = {
     '/shared/js/fb/fb_reader_utils.js'
   ],
 
+  _calledNumberCache: [],
+
+  _CACHE_SIZE: 10,
+
+  init: function init() {
+    var self = this;
+    var mozContacts = window.navigator.mozContacts;
+
+    asyncStorage.getItem('contactsCache', function (value) {
+      if(value) {
+        self._calledNumberCache = JSON.parse(value);
+      }
+    });
+
+    if (mozContacts) {
+      LazyLoader.load(self._FB_FILES, function() {
+        mozContacts.oncontactchange = self._oncontactchange.bind(self);
+      });
+    }
+  },
+
+  _calledNumberCachePush: function (number, contact, matchingTel) {
+    if (this._calledNumberCache.length > this._CACHE_SIZE) {
+      this._calledNumberCache.shift();
+    }
+
+    this._calledNumberCache.push({
+      id: (contact ? contact.id : null),
+      number: number,
+      contact: contact,
+      matchingTel: matchingTel
+    });
+
+    var self = this;
+    setTimeout(function () {
+      asyncStorage.setItem('contactsCache', JSON.stringify(self._calledNumberCache));
+    },0);
+  },
+
+  _calledNumberCacheGet: function (number) {
+    for (var i = 0; i < this._CACHE_SIZE; i++) {
+      if (this._calledNumberCache[i]) {
+        if (number === this._calledNumberCache[i].number) {
+        return this._calledNumberCache[i];
+        }
+      }
+    }
+    return null;
+  },
+
+  _oncontactchange: function _oncontactchange(event) {
+    var self = this;
+    var reason = event.reason;
+    var contactID = event.contactID;
+    // Mark if the local cache has been modified on the event or not
+    var isCacheUpdated = false;
+    // To store the cache index should be deleted on the event and then remove
+    // it from cache after the traversal finished.
+    var tempDeletedIndex = null;
+
+    function calledNumberCacheUpdate(contact, reason) {
+      self._calledNumberCache.forEach(function(cachedContact, index) {
+        var isMatched = false;
+
+        // Update the cache if all of the following conditions satisfied:
+        // 1) reason is 'create' or 'update'
+        // 2) cached number equals to the contact's
+        // 3) cached id is null or cached id equals to the contact's
+        if (contact && contact.tel &&
+            (reason === 'create' || reason === 'update')) {
+          isMatched = contact.tel.some(function(tel) {
+            if (tel.value === cachedContact.number &&
+                (!cachedContact.id || cachedContact.id === contactID)) {
+              cachedContact.id = contactID;
+              cachedContact.contact = contact;
+              cachedContact.matchingTel = tel;
+              return true;
+            }
+            return false;
+          });
+        }
+
+        // Delete from cache after the traversal if either satisfied:
+        // 1) reason is 'remove' and cached id equals to the contact's
+        // 2) reason is 'update' and its number's been changed for the same id
+        if (!isMatched && cachedContact.id === contactID) {
+          isMatched = true;
+          tempDeletedIndex = index;
+          cachedContact.contact = null;
+          cachedContact.matchingTel = null;
+        }
+
+        // Only modify as true when matched between cache and the contact
+        isCacheUpdated = isMatched || isCacheUpdated;
+      });
+
+      if (tempDeletedIndex !== null) {
+        self._calledNumberCache.splice(tempDeletedIndex, 1);
+        tempDeletedIndex = null;
+      }
+
+      if (isCacheUpdated) {
+        setTimeout(function () {
+          asyncStorage.setItem('contactsCache', JSON.stringify(self._calledNumberCache));
+        },0);
+      }
+    }
+
+    if (reason === 'remove') {
+      calledNumberCacheUpdate(null, 'remove');
+      return;
+    }
+
+    var options = {
+      filterBy: ['id'],
+      filterOp: 'equals',
+      filterValue: contactID
+    };
+
+    var request = navigator.mozContacts.find(options);
+    request.onsuccess = function contactRetrieved(e) {
+      if (!e.target.result || e.target.result.length === 0) {
+        console.warn('sharedContacts: No Contact Found: ', contactID);
+        return;
+      }
+
+      var contact = e.target.result[0];
+      if (!fb.isFbContact(contact)) {
+         calledNumberCacheUpdate(contact, reason);
+         return;
+      }
+
+      var fbReq = fb.getData(contact);
+      fbReq.onsuccess = function fbContactSuccess() {
+        calledNumberCacheUpdate(fbReq.result, reason);
+      };
+      fbReq.onerror = function fbContactError() {
+        console.error('sharedContacts: Query FB error:', fbReq.error.name);
+        calledNumberCacheUpdate(contact, reason);
+      };
+    };
+
+    request.onerror = function errorHandler(e) {
+      console.error('sharedContacts: request error by ID:' + contactID);
+    };
+  },
+
   // The mozContact API stores a revision of its database that allow us to know
   // if we have a proper and updated contact cache.
   getRevision: function getRevision(callback) {
@@ -41,8 +188,15 @@ var Contacts = {
       return;
     }
 
+    var cachedContact = this._calledNumberCacheGet(number);
+    if (cachedContact) {
+      callback(cachedContact.contact, cachedContact.matchingTel);
+      return ;
+    }
+
     var options;
     var variants;
+    var self = this;
 
     // Based on E.164 (http://en.wikipedia.org/wiki/E.164)
     // if length < 7 we're dealing with a short number
@@ -88,6 +242,8 @@ var Contacts = {
               carrier: null
             };
           }
+
+          self._calledNumberCachePush(number, finalContact, objMatching);
           callback(finalContact, objMatching);
         }, function fb_err(err) {
           callback(null);
@@ -116,14 +272,17 @@ var Contacts = {
         // Merge with the FB data
         var req = fb.getData(contact);
         req.onsuccess = function() {
+          self._calledNumberCachePush(number, req.result, matchingTel);
           callback(req.result, matchingTel, contactsWithSameNumber);
         };
         req.onerror = function() {
           window.console.error('Error while getting FB Data');
+          self._calledNumberCachePush(number, contact, matchingTel);
           callback(contact, matchingTel, contactsWithSameNumber);
         };
       }
       else {
+        self._calledNumberCachePush(number, contact, matchingTel);
         callback(contact, matchingTel, contactsWithSameNumber);
       }
     };
@@ -233,3 +392,12 @@ var Contacts = {
     }
   }
 };
+
+window.addEventListener('load', function onLoad(event) {
+  window.removeEventListener('load', onLoad);
+  Contacts.init();
+
+  window.LazyL10n.get(function loadLazyFilesSet() {
+    console.log('moz1117450 --- LazyL10n is loaded.');
+  });
+});

--- a/shared/js/dialer/settings_cache.js
+++ b/shared/js/dialer/settings_cache.js
@@ -1,0 +1,154 @@
+/**
+ * SettingsCache is a singleton that caches mozSettings values for fast
+ * access.
+ *
+ * @module SettingsCache
+ */
+(function() {
+  'use strict';
+  var _settings = window.navigator.mozSettings;
+
+  // Cache of all current settings values.  There's some large stuff
+  // in here, but not much useful can be done with the settings app
+  // without these, so we keep this around most of the time.
+  var _settingsCache = null;
+
+  // True when a request has already been made to fill the settings
+  // cache.  When this is true, no further get("*") requests should be
+  // made; instead, pending callbacks should be added to
+  // _pendingSettingsCallbacks.
+  var _settingsCacheRequestSent = null;
+
+  // There can be race conditions in which we need settings values,
+  // but haven't filled the cache yet.  This array tracks those
+  // listeners.
+  var _pendingSettingsCallbacks = [];
+
+  var _callbacks = [];
+  var _keyCallbacks = {};
+
+  var _onSettingsChange = function sc_onSettingsChange(event) {
+    var key = event.settingName;
+    var value = event.settingValue;
+
+    // Always update the cache if it's present, even if the DOM
+    // isn't loaded yet.
+    if (_settingsCache) {
+      _settingsCache[key] = value;
+    }
+
+    _callbacks.forEach(function(callback) {
+      callback(event);
+    });
+
+    if (_keyCallbacks[key]) {
+      _keyCallbacks[key].forEach(function(callback) {
+        callback(value);
+      });
+    }
+  };
+
+  if (_settings) {
+    _settings.onsettingchange = _onSettingsChange;
+  }
+
+  /**
+   * Event reporting that a setting value is changed.
+   *
+   * @event module:SettingsCache#settingsChange
+   * @property {MozSettingsEvent} event
+   */
+  var SettingsCache = {
+
+    init: function sc_init() {
+      // Make a request for settings to warm the cache, since we need it
+      // very soon in startup after the DOM is available.
+      this.getSettings();
+    },
+
+    // the reset function is for unit tests
+    reset: function sc_reset() {
+      _settings = window.navigator.mozSettings;
+      if (_settings) {
+        _settings.onsettingchange = _onSettingsChange;
+      }
+      _settingsCache = null;
+      _settingsCacheRequestSent = null;
+      _pendingSettingsCallbacks = [];
+      _callbacks = [];
+    },
+
+    get cache() {
+      return _settingsCache;
+    },
+
+    /**
+     * Where callback is a function to be called with a request object for a
+     * successful fetch of settings values, when those values are ready.
+     *
+     * @alias module:SettingsCache#getSettings
+     * @param {Function} callback
+     */
+    getSettings: function sc_getSettings(callback) {
+      if (!_settings) {
+        return;
+      }
+
+      if (_settingsCache && callback) {
+        // Fast-path that we hope to always hit: our settings cache is
+        // already available, so invoke the callback now.
+        callback(_settingsCache);
+        return;
+      }
+
+      if (!_settingsCacheRequestSent && !_settingsCache) {
+        _settingsCacheRequestSent = true;
+        var lock = _settings.createLock();
+        var request = lock.get('ril.iccInfo.mbdn');
+        request.onsuccess = function(e) {
+          var result = request.result;
+          var cachedResult = {};
+          for (var attr in result) {
+            cachedResult[attr] = result[attr];
+          }
+          _settingsCache = cachedResult;
+          var cbk;
+          while ((cbk = _pendingSettingsCallbacks.pop())) {
+            cbk(result);
+          }
+        };
+      }
+      if (callback) {
+        _pendingSettingsCallbacks.push(callback);
+      }
+    },
+
+    observe: function sc_observe(name, defaultValue, callback) {
+      if (!callback) {
+        return;
+      }
+      this.getSettings(function(cache) {
+        if (callback) {
+          callback((typeof cache[name]) === 'undefined' ?
+                   defaultValue : cache[name]);
+        }
+      });
+
+      if (!_keyCallbacks[name]) {
+        _keyCallbacks[name] = [];
+      }
+      _keyCallbacks[name].push(function(v) {
+        callback((typeof v) === 'undefined' ? defaultValue : v);
+      });
+    },
+
+    get: function sc_get(name, callback) {
+      this.getSettings(function(cache) {
+        callback(cache[name]);
+      });
+    }
+  };
+
+  SettingsCache.init();
+  window.SettingsCache = SettingsCache;
+})();

--- a/shared/js/dialer/voicemail.js
+++ b/shared/js/dialer/voicemail.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global Promise */
+/* global Promise, SettingsCache */
 
 (function(exports) {
   /**
@@ -45,11 +45,9 @@
 
         // check the voicemail number with the mozSetting value
         // based on /shared/resources/apn.json
-        var settings = navigator.mozSettings;
-        var req = settings.createLock().get('ril.iccInfo.mbdn');
-        req.onsuccess = function getVoicemailNumber() {
+        function getVoicemailNumber(value) {
           var isVoicemailNumber = false;
-          var voicemailNumbers = req.result['ril.iccInfo.mbdn'];
+          var voicemailNumbers = value;
           var voicemailNumber;
 
           if (typeof voicemailNumbers === 'string') {
@@ -61,11 +59,8 @@
             isVoicemailNumber = true;
           }
           resolve(isVoicemailNumber);
-        };
-
-        req.onerror = function getVoicemailNumberError() {
-          resolve(false);
-        };
+        }
+        SettingsCache.get('ril.iccInfo.mbdn', getVoicemailNumber);
       });
     }
   };


### PR DESCRIPTION
As the time spent on displaying callscreen is much longer after the dial button clicked, we should do something to optimize the scenario:
1) To preload and observe the property 'ril.iccInfo.mbdn' via SettingsCache so that we'll no longer need to make request for every updateCallNumber;
2) Create a local buffer to store the contacts info of the latest TEN[1] dialing numbers and then the cached data can be used directly instead of calling mozContacts.find any more. Of course, we also implement the function to listen the change of mozContact and check to update the cache if needed. Besides, the local cache will always be pushed into the asyncStorage once updated occurred and we can get the cached data from asyncStorage easily when the device booted up next time.

With the above actions, we can solve the bottle-neck under the scenario most of the time. 

[1] TEN is a constant, which can be adjusted dynamically as needed,  stands for the cache size.
