### PR TITLE
Bug 1152514 - Enable test_lockscreen_time_check.py

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/lockscreen/manifest.ini
@@ -31,5 +31,3 @@ carrier = true
 skip-if = device == "desktop"
 # Due to the Bug 1133803, test requires active sim with data connection
 carrier = true
-# Bug 1140027 - test_lockscreen_time_check.py intermittently fails checking the time at the lockscreen
-disabled = https://bugzilla.mozilla.org/show_bug.cgi?id=1140027


### PR DESCRIPTION
Enable back the test since the test is consistenly passing in adhoc runs
