### PR TITLE
Bug 1152591 - [Shared] Add variables.css to contain gaia-wide CSS definitions

### DIFF
--- a/shared/style/variables.css
+++ b/shared/style/variables.css
@@ -1,0 +1,6 @@
+/*csslint empty-rules: false*/
+/*See bug 1053721*/
+:root {
+  /* The default transition time for gaia animations. */
+  --transition-time: 0.2s;
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1152591
