### PR TITLE
Bug 1071348 - Observe setting in FTU UI. r=fcampo

### DIFF
--- a/apps/ftu/index.html
+++ b/apps/ftu/index.html
@@ -50,6 +50,7 @@
   <script defer src="/shared/js/input_mgmt/input_app_list.js"></script>
   <script defer src="/shared/js/keyboard_helper.js"></script>
   <script defer src="/shared/js/language_list.js"></script>
+  <script defer src="/shared/js/settings_listener.js"></script>
   <script defer src="/shared/js/version_helper.js"></script>
 
   <!-- Import contacts help files -->

--- a/apps/ftu/test/unit/ui_manager_test.js
+++ b/apps/ftu/test/unit/ui_manager_test.js
@@ -1,9 +1,11 @@
 /* global MockFxAccountsIACHelper, MocksHelper, MockL10n, MockMozApps,
-          MockTzSelect, Navigation, UIManager, WifiManager, WifiUI */
+          MockTzSelect, Navigation, UIManager, WifiManager, WifiUI,
+          MockSettingsListener, MockNavigatorSettings */
 'use strict';
 
 require('/shared/test/unit/load_body_html_helper.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
+require('/shared/test/unit/mocks/mock_settings_listener.js');
 
 requireApp('ftu/js/ui.js');
 requireApp('ftu/js/external_links.js');
@@ -26,7 +28,8 @@ var mocksHelperForUI = new MocksHelper([
   'WifiManager',
   'OperatorVariant',
   'utils',
-  'DataMobile'
+  'DataMobile',
+  'SettingsListener'
 ]).init();
 
 if (!window.tzSelect) {
@@ -37,7 +40,9 @@ suite('UI Manager > ', function() {
   var realL10n,
       realMozApps,
       realFxAccountsIACHelper,
-      realTzSelect;
+      realTzSelect,
+      realSettings,
+      realSettingsListener;
   var mocksHelper = mocksHelperForUI;
 
   suiteSetup(function() {
@@ -52,6 +57,13 @@ suite('UI Manager > ', function() {
 
     realFxAccountsIACHelper = window.FxAccountsIACHelper;
     window.FxAccountsIACHelper = MockFxAccountsIACHelper;
+
+    realSettings = navigator.mozSettings;
+    navigator.mozSettings = window.MockNavigatorSettings;
+    navigator.mozSettings.mSettings['geolocation.enabled'] = true;
+
+    realSettingsListener = window.SettingsListener;
+    window.SettingsListener = MockSettingsListener;
 
     mocksHelper.suiteSetup();
     loadBodyHTML('/index.html');
@@ -77,6 +89,9 @@ suite('UI Manager > ', function() {
 
     window.FxAccountsIACHelper = realFxAccountsIACHelper;
     realFxAccountsIACHelper = null;
+
+    navigator.mozSettings = realSettings;
+    window.SettingsListener = realSettingsListener;
   });
 
   suite('Date & Time >', function() {
@@ -151,6 +166,31 @@ suite('UI Manager > ', function() {
         assert.isTrue(localeFormatSpy.called);
       });
     });
+  });
+
+  suite('Geolocation section', function() {
+
+    setup(function() {
+      Navigation.currentStep = 5;
+      Navigation.manageStep();
+    });
+
+    suiteTeardown(function() {
+      Navigation.currentStep = 1;
+      Navigation.manageStep();
+    });
+
+    test('initial value', function() {
+      assert.isTrue(MockNavigatorSettings.mSettings['geolocation.enabled']);
+      // we set initial value at suite startup
+      assert.isTrue(UIManager.geolocationCheckbox.checked);
+    });
+
+    test('setting observer updates checked value', function() {
+      MockSettingsListener.mTriggerCallback('geolocation.enabled', false);
+      assert.isFalse(UIManager.geolocationCheckbox.checked);
+    });
+
   });
 
   suite('Firefox Accounts section', function() {

--- a/apps/ftu/test/unit/wifi_test.js
+++ b/apps/ftu/test/unit/wifi_test.js
@@ -13,10 +13,12 @@ requireApp('ftu/test/unit/mock_fx_accounts_iac_helper.js');
 requireApp('ftu/js/wifi.js');
 requireApp('ftu/js/ui.js');
 require('/shared/js/wifi_helper.js');
+require('/shared/test/unit/mocks/mock_settings_listener.js');
 
 var mocksHelperForWifi = new MocksHelper([
   'utils',
-  'MozWifiNetwork'
+  'MozWifiNetwork',
+  'SettingsListener'
 ]).init();
 
 suite('wifi > ', function() {


### PR DESCRIPTION
Adopting SettingsListener and  observer/update pattern from system app's AppWindowManager. The idea is to roll through each of the settings we represent in the UI and make sure they always represent the value in the settings db. This patch just hits geolocation.enabled. 
