### PR TITLE
Bug 1152486 - [Calendar] split view selector logic into its own file r=gaye

### DIFF
--- a/apps/calendar/build/calendar.build.js
+++ b/apps/calendar/build/calendar.build.js
@@ -26,7 +26,8 @@
         'views/errors',
         'views/month',
         'views/month_day_agenda',
-        'views/time_header'
+        'views/time_header',
+        'views/view_selector'
       ]
     },
     {

--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -1,7 +1,6 @@
 define(function(require, exports, module) {
 'use strict';
 
-var Calc = require('calc');
 var dateL10n = require('date_l10n');
 var Db = require('db');
 var ErrorController = require('controllers/error');
@@ -189,43 +188,13 @@ module.exports = {
   },
 
   _initUI: function() {
-    // quick hack for today button
-    var tablist = document.querySelector('#view-selector');
-    var today = tablist.querySelector('.today a');
-    var tabs = tablist.querySelectorAll('[role="tab"]');
-
-    this._showTodayDate();
-    this._syncTodayDate();
-    today.addEventListener('click', (e) => {
-      var date = new Date();
-      this.timeController.move(date);
-      this.timeController.selectedDay = date;
-
-      e.preventDefault();
-    });
-
-    // Handle aria-selected attribute for tabs.
-    tablist.addEventListener('click', (event) => {
-      if (event.target === today) {
-        return;
-      }
-
-      Array.prototype.forEach.call(tabs, tab => {
-        if (tab !== event.target) {
-          tab.setAttribute('aria-selected', false);
-          return;
-        }
-
-        nextTick(() => tab.setAttribute('aria-selected', true));
-      });
-    });
-
     // re-localize dates on screen
     dateL10n.init();
 
     this.timeController.move(new Date());
 
     this.view('TimeHeader', (header) => header.render());
+    this.view('ViewSelector', (tabs) => tabs.render());
 
     document.body.classList.remove('loading');
 
@@ -246,38 +215,6 @@ module.exports = {
       debug('Noticed timezone change!');
       nextTick(this.forceRestart);
     });
-  },
-
-  _setPresentDate: function() {
-    var id = Calc.getDayId(new Date());
-    var presentDate = document.querySelector(
-      '#month-view [data-date="' + id + '"]'
-    );
-    var previousDate = document.querySelector('#month-view .present');
-
-    previousDate.classList.remove('present');
-    previousDate.classList.add('past');
-    presentDate.classList.add('present');
-  },
-
-  _showTodayDate: function() {
-    var element = document.querySelector('#today .icon-calendar-today');
-    element.innerHTML = new Date().getDate();
-  },
-
-  _syncTodayDate: function() {
-    var now = new Date();
-    var midnight = new Date(
-      now.getFullYear(), now.getMonth(), now.getDate() + 1,
-      0, 0, 0
-    );
-
-    var timeout = midnight.getTime() - now.getTime();
-    setTimeout(() => {
-      this._showTodayDate();
-      this._setPresentDate();
-      this._syncTodayDate();
-    }, timeout);
   },
 
   /**

--- a/apps/calendar/js/views/view_selector.js
+++ b/apps/calendar/js/views/view_selector.js
@@ -1,0 +1,95 @@
+define(function(require, exports, module) {
+'use strict';
+
+var Calc = require('calc');
+var View = require('view');
+var nextTick = require('next_tick');
+
+function ViewSelector(opts) {
+  View.call(this, opts);
+}
+module.exports = ViewSelector;
+
+ViewSelector.prototype = {
+  __proto__: View.prototype,
+
+  selectors: {
+    element: '#view-selector'
+  },
+
+  render: function() {
+    this._syncTodayDate();
+    this.delegate(this.element, 'click', 'a', this);
+  },
+
+  handleEvent: function(event, target) {
+    if (target.matches('[role="tab"]')) {
+      this._toggleActiveTabOnClick(event);
+    } else {
+      this._moveToTodayOnClick(event);
+    }
+  },
+
+  _moveToTodayOnClick: function(event) {
+    var date = new Date();
+    this.app.timeController.move(date);
+    this.app.timeController.selectedDay = date;
+
+    event.preventDefault();
+  },
+
+  // FIXME: this should be handled by the router (Bug 1021445)
+  // Handle aria-selected attribute for tabs.
+  _toggleActiveTabOnClick: function(event) {
+    var tabs = this.element.querySelectorAll('[role="tab"]');
+    Array.from(tabs).forEach(tab => {
+      if (tab !== event.target) {
+        tab.setAttribute('aria-selected', false);
+        return;
+      }
+      nextTick(() => tab.setAttribute('aria-selected', true));
+    });
+  },
+
+  _showTodayDate: function() {
+    var icon = this.element.querySelector('.icon-calendar-today');
+    icon.innerHTML = (new Date()).getDate();
+  },
+
+  // FIXME: this should be handled by month view after we fix Bug 1118850
+  _setPresentDate: function() {
+    var id = Calc.getDayId(new Date());
+    var presentDate = document.querySelector(
+      '#month-view [data-date="' + id + '"]'
+    );
+    var previousDate = document.querySelector('#month-view .present');
+
+    if (previousDate) {
+      previousDate.classList.remove('present');
+      previousDate.classList.add('past');
+    }
+    if (presentDate) {
+      presentDate.classList.add('present');
+    }
+  },
+
+  // FIXME: this should be replaced when we abstract the way we listen for
+  // date/time changes (Bug 1118850)
+  _syncTodayDate: function() {
+    this._showTodayDate();
+    this._setPresentDate();
+
+    var now = new Date();
+    var midnight = new Date(
+      now.getFullYear(), now.getMonth(), now.getDate() + 1,
+      0, 0, 0
+    );
+
+    var timeout = midnight.getTime() - now.getTime();
+    setTimeout(() => {
+      this._syncTodayDate();
+    }, timeout);
+  }
+};
+
+});


### PR DESCRIPTION
trying to break my app.js refactor into small commits/PRs that are easier to review and revert..
expect a bunch of these soon.

I did not add tests for the `ViewSelector` because marionette already tests it and the old logic didn't have tests anyway (and most of the logic will be replaced soon, so no point in testing it now).
