### PR TITLE
Bug 1153065 - [Calendar] remove observeDateLocalization logic from app.js r=gaye

### DIFF
--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -2,7 +2,7 @@ define(function(require, exports, module) {
 'use strict';
 
 var Calc = require('calc');
-var DateL10n = require('date_l10n');
+var dateL10n = require('date_l10n');
 var Db = require('db');
 var ErrorController = require('controllers/error');
 var PendingManager = require('pending_manager');
@@ -102,36 +102,6 @@ module.exports = {
     if (navigator.mozAudioChannelManager) {
       navigator.mozAudioChannelManager.volumeControlChannel = 'notification';
     }
-  },
-
-  /**
-   * Observes localized events and localizes elements
-   * with data-l10n-date-format should be registered
-   * after the first localized event.
-   *
-   *
-   * Example:
-   *
-   *
-   *    <span
-   *      data-date="Wed Jan 09 2013 19:25:38 GMT+0100 (CET)"
-   *      data-l10n-date-format="%x">
-   *
-   *      2013/9/19
-   *
-   *    </span>
-   *
-   */
-  observeDateLocalization: function() {
-    window.addEventListener('localized', DateL10n.localizeElements);
-    window.addEventListener('timeformatchange', () => {
-      this.setCurrentTimeFormat();
-      DateL10n.changeElementsHourFormat();
-    });
-  },
-
-  setCurrentTimeFormat: function() {
-    document.body.dataset.timeFormat = navigator.mozHour12 ? '12' : '24';
   },
 
   /**
@@ -250,9 +220,8 @@ module.exports = {
       });
     });
 
-    this.setCurrentTimeFormat();
     // re-localize dates on screen
-    this.observeDateLocalization();
+    dateL10n.init();
 
     this.timeController.move(new Date());
 

--- a/apps/calendar/js/date_l10n.js
+++ b/apps/calendar/js/date_l10n.js
@@ -4,16 +4,48 @@ define(function(require, exports) {
 var dateFormat = require('date_format');
 
 /**
+ * Observes localized events and localizes elements
+ * with data-l10n-date-format should be registered
+ * after the first localized event.
+ *
+ *
+ * Example:
+ *
+ *
+ *    <span
+ *      data-date="Wed Jan 09 2013 19:25:38 GMT+0100 (CET)"
+ *      data-l10n-date-format="%x">
+ *
+ *      2013/9/19
+ *
+ *    </span>
+ *
+ */
+exports.init = function() {
+  exports._setCurrentTimeFormat();
+
+  window.addEventListener('localized', exports._localizeElements);
+  window.addEventListener('timeformatchange', () => {
+    exports._setCurrentTimeFormat();
+    exports._changeElementsHourFormat();
+  });
+};
+
+exports._setCurrentTimeFormat = function() {
+  document.body.dataset.timeFormat = navigator.mozHour12 ? '12' : '24';
+};
+
+/**
  * Localizes all elements with data-l10n-date-format.
  */
-exports.localizeElements = function() {
+exports._localizeElements = function() {
   var elements = document.querySelectorAll('[data-l10n-date-format]');
   for (var i = 0; i < elements.length; i++) {
-    exports.localizeElement(elements[i]);
+    exports._localizeElement(elements[i]);
   }
 };
 
-exports.changeElementsHourFormat = function() {
+exports._changeElementsHourFormat = function() {
   var isHour12 = navigator.mozHour12;
   var previousFormat = isHour12 ? 24 : 12;
   var currentFormat = isHour12 ? 12 : 24;
@@ -29,7 +61,7 @@ exports.changeElementsHourFormat = function() {
 
     element.dataset.l10nDateFormat = format;
     // Remove leading zero of hour items in day, week view sidebars.
-    exports.localizeElement(element, {
+    exports._localizeElement(element, {
       addAmPmClass: format === 'week-hour-format12',
       removeLeadingZero: format.contains('hour-format')
     });
@@ -44,7 +76,7 @@ exports.changeElementsHourFormat = function() {
  *   (Boolean) addAmPmClass
  *   (Boolean) removeLeadingZero
  */
-exports.localizeElement = function(element, options) {
+exports._localizeElement = function(element, options) {
   var date = element.dataset.date;
   if (!date) {
     return;


### PR DESCRIPTION
added an underscore at the beginning of the internal methods, logic is same as before but grouped everything into the same file (which makes way more sense IMO).
