### PR TITLE
Bug 1152917 - [Followup][Permission Manager] Geolocation permission prom...

### DIFF
--- a/apps/system/js/permission_manager.js
+++ b/apps/system/js/permission_manager.js
@@ -338,6 +338,7 @@
     handlePermissionPrompt: function pm_handlePermissionPrompt(detail) {
       // Clean dialog if was rendered before
       this.cleanDialog();
+      this.isFullscreenRequest = false;
       this.currentOrigin = detail.origin;
       this.currentRequestId = detail.id;
 


### PR DESCRIPTION
...pts display inaccurate '{{ origin }} is now fullscreen.' text after a fullscreen prompt is encountered. r=alive
