### PR TITLE
Bug 1026967 - [email] Change Discard Draft string to Delete the Draft

### DIFF
--- a/apps/email/js/cards/cmp/draft_menu.html
+++ b/apps/email/js/cards/cmp/draft_menu.html
@@ -1,7 +1,7 @@
 <form role="dialog" class="cmp-draft-menu" data-type="action">
   <menu>
     <button id="cmp-draft-save" data-l10n-id="compose-draft-save"></button>
-    <button id="cmp-draft-discard" class="danger" data-l10n-id="compose-discard-confirm"></button>
+    <button id="cmp-draft-discard" class="danger" data-l10n-id="compose-delete-confirm"></button>
     <button id="cmp-draft-cancel" data-l10n-id="message-multiedit-cancel"></button>
   </menu>
 </form>

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -543,7 +543,12 @@ compose-attachment-still-working=One moment, still working on the previous attac
 
 compose-subject=Subject
 compose-draft-save=Save to Local Drafts
-compose-discard-confirm=Discard
+
+# LOCALIZATION NOTE(compose-delete-confirm): Wheh leaving the Compose card, the
+# user is prompted to save the draft or delete it. This is the delete button
+# text.
+compose-delete-confirm=Delete the draft
+
 compose-send-message-failed=Sending email failed
 composer-attachment-large=Attachment too large
 composer-attachments-large=Attachments too large


### PR DESCRIPTION
To clarify that the draft will be deleted rather than just changes since last explicit save discarded
