### PR TITLE
Bug 1153445 - Icon labels shouls be dir=auto. r=kgrandon

### DIFF
--- a/shared/elements/gaia_grid/js/items/grid_item.js
+++ b/shared/elements/gaia_grid/js/items/grid_item.js
@@ -549,6 +549,7 @@
 
         var nameEl = document.createElement('span');
         nameEl.className = 'title';
+        nameEl.setAttribute('dir', 'auto');
 
         nameContainerEl.appendChild(nameEl);
 


### PR DESCRIPTION
We were picking up direction: ltr from https://github.com/mozilla-b2g/gaia/blob/master/shared/elements/gaia_grid/style/external.css#L22, adding dir=auto onto the label itself seems like the right fix here.
