### PR TITLE
Bug 1150798 - Disable the alameda loading timeout in the production build r=eragonj

### DIFF
--- a/apps/settings/build/settings.build.jslike
+++ b/apps/settings/build/settings.build.jslike
@@ -69,6 +69,17 @@
     mangle: true
   },
 
+  // Rewrite the waitSeconds directive so that we never time out
+  // waiting for modules to load when DEBUG=1 is not set. See
+  // js/config/require.js for more details.
+  onBuildWrite: function(id, url, contents) {
+    if (id === 'config/require') {
+      return contents.replace(/waitSeconds:\s*\d+/, 'waitSeconds: 0');
+    } else {
+      return contents;
+    }
+  },
+
   fileExclusionRegExp: /^\.|^test$|^build$/,
 
   // Keeping build dir since Makefile cleans it up and

--- a/apps/settings/js/config/require.js
+++ b/apps/settings/js/config/require.js
@@ -5,6 +5,9 @@ require.config({
     'panels': 'panels',
     'shared': '../shared/js'
   },
+  // This is the default value of the loading timeout, we will disable the
+  // timeout in the production build
+  waitSeconds: 7,
   shim: {
     'settings': {
       exports: 'Settings'


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1150798
