### PR TITLE
Bug 1118850 - abstract day and minute change into the TimeObserver module to make sure we display the proper date/time on all the views r=gaye

### DIFF
--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -18,6 +18,7 @@ var notificationsController = require('controllers/notifications');
 var performance = require('performance');
 var periodicSyncController = require('controllers/periodic_sync');
 var providerFactory = require('provider/provider_factory');
+var timeObserver = require('time_observer');
 var viewFactory = require('views/factory');
 
 var pendingClass = 'pending-operation';
@@ -188,6 +189,7 @@ module.exports = {
     // re-localize dates on screen
     dateL10n.init();
 
+    timeObserver.init();
     this.timeController.move(new Date());
 
     viewFactory.get('TimeHeader', header => header.render());
@@ -210,6 +212,8 @@ module.exports = {
     // the user has completed their selection.
     window.addEventListener('moztimechange', () => {
       debug('Noticed timezone change!');
+      // for info on why we need to restart the app when the time changes see:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1093016#c9
       nextTick(this.forceRestart);
     });
   },

--- a/apps/calendar/js/time_observer.js
+++ b/apps/calendar/js/time_observer.js
@@ -1,0 +1,108 @@
+define(function(require, exports, module) {
+'use strict';
+
+// this module abstracts minute and day changes, it should be used by all the
+// views that needs to listen for time changes (ie. update current time/date).
+// listeners are enabled/disabled when the document visibility changes,
+// reducing battery usage and making sure we always display the proper value.
+// ---
+// XXX: we don't listen to moztimechange here because the app forces a restart
+// when the time changes; even if the app did not restart we would still need
+// to trigger a refresh of most of the views (timezone affects the way we
+// busytimes are rendered in all the views, even the view/edit event views)
+// see: https://bugzilla.mozilla.org/show_bug.cgi?id=1093016#c9
+
+var EventEmitter2 = require('ext/eventemitter2');
+
+exports = module.exports = new EventEmitter2();
+
+exports.on = function() {
+  EventEmitter2.prototype.on.apply(this, arguments);
+  this._start();
+};
+
+exports.once = function() {
+  EventEmitter2.prototype.once.apply(this, arguments);
+  this._start();
+};
+
+exports.off = function() {
+  EventEmitter2.prototype.off.apply(this, arguments);
+  this._autoStop();
+};
+
+exports.removeAllListeners = function() {
+  EventEmitter2.prototype.removeAllListeners.apply(this, arguments);
+  this._autoStop();
+};
+
+exports._autoStop = function() {
+  if (!this._hasListeners()) {
+    this._stop();
+  }
+};
+
+exports._hasListeners = function() {
+  return this.listeners('day').length > 0 ||
+    this.listeners('minute').length > 0;
+};
+
+exports._timeout = null;
+exports._prevTick = null;
+
+exports._start = function() {
+  if (this._timeout || !this._hasListeners()) {
+    return;
+  }
+  this._prevTick = new Date();
+  this._timeout = setTimeout(this._tick, this._nextMinute());
+};
+
+exports._stop = function() {
+  if (this._timeout) {
+    window.clearTimeout(this._timeout);
+    this._timeout = null;
+  }
+};
+
+exports._tick = function() {
+  this._stop();
+  this._exec();
+  this._start();
+}.bind(exports);
+
+exports._nextMinute = function() {
+  var now = new Date();
+  return (60 - now.getSeconds()) * 1000;
+};
+
+exports._exec = function() {
+  var now = new Date();
+  var prev = this._prevTick;
+  if (prev.getMinutes() !== now.getMinutes()) {
+    this.emit('minute');
+  }
+  if (prev.getDate() !== now.getDate()) {
+    this.emit('day');
+  }
+};
+
+exports.init = function() {
+  document.addEventListener('visibilitychange', () => {
+    exports._toggleStatusOnVisibilityChange(document.hidden);
+  });
+  exports._start();
+};
+
+exports._toggleStatusOnVisibilityChange = function(hidden) {
+  // we trigger an update as soon as document is visible to avoid issues with
+  // timer not being fired (eg. timer was disabled and day/minute changed while
+  // app was hidden)
+  if (!hidden) {
+    exports._exec();
+  }
+  var method = hidden ? '_stop' : '_start';
+  exports[method]();
+};
+
+});

--- a/apps/calendar/js/views/current_time.js
+++ b/apps/calendar/js/views/current_time.js
@@ -5,6 +5,7 @@ var View = require('view');
 var createDay = require('calc').createDay;
 var dateFormat = require('date_format');
 var getTimeL10nLabel = require('calc').getTimeL10nLabel;
+var timeObserver = require('time_observer');
 
 var activeClass = View.ACTIVE;
 
@@ -13,6 +14,8 @@ function CurrentTime(options) {
   // timespan can be injected later! this is just a convenience
   this.timespan = options.timespan;
   this._sticky = options.sticky;
+  this.activate = this.activate.bind(this);
+  this._tick = this._tick.bind(this);
 }
 module.exports = CurrentTime;
 
@@ -60,7 +63,7 @@ CurrentTime.prototype = {
       // inside timespan (eg. current time is 2014-05-22T23:59:50 and user is
       // viewing 2014-05-23 until past midnight)
       this._clearInterval();
-      this._interval = setTimeout(this.activate.bind(this), diff);
+      timeObserver.once('day', this.activate);
     }
   },
 
@@ -83,26 +86,19 @@ CurrentTime.prototype = {
   },
 
   _clearInterval: function() {
-    if (this._interval) {
-      clearTimeout(this._interval);
-      this._interval = null;
-    }
+    timeObserver.off('day', this.activate);
+    timeObserver.off('minute', this._tick);
   },
 
   _tick: function() {
     this._clearInterval();
-    var now = new Date();
-
-    if (!this.timespan.contains(now)) {
+    if (!this.timespan.contains(new Date())) {
       this.deactivate();
       this._unmarkCurrentDay();
       return;
     }
     this._render();
-
-    // will call tick once per minute
-    var nextTick = (60 - now.getSeconds()) * 1000;
-    this._interval = setTimeout(this._tick.bind(this), nextTick);
+    timeObserver.once('minute', this._tick);
   },
 
   _render: function() {

--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -9,6 +9,7 @@ var dateFromId = Calc.dateFromId;
 var monthStart = Calc.monthStart;
 var performance = require('performance');
 var router = require('router');
+var timeObserver = require('time_observer');
 
 // minimum difference between X and Y axis to be considered an horizontal swipe
 var XSWIPE_OFFSET = window.innerWidth / 10;
@@ -17,6 +18,7 @@ function Month() {
   View.apply(this, arguments);
   this.frames = new Map();
   window.addEventListener('localized', this);
+  this._setPresentDate = this._setPresentDate.bind(this);
 }
 module.exports = Month;
 
@@ -93,6 +95,8 @@ Month.prototype = {
     this.controller.on('monthChange', this);
     this.delegate(this.element, 'click', '[data-date]', this);
     this.delegate(this.element, 'dbltap', '[data-date]', this);
+
+    timeObserver.on('day', this._setPresentDate);
 
     this.gd = new GestureDetector(this.element);
     this.gd.startDetecting();
@@ -187,6 +191,20 @@ Month.prototype = {
     Array.from(this.frames.keys())
     .sort((a, b) => a - b)
     .forEach(key => this.frames.get(key).append());
+  },
+
+  _setPresentDate: function() {
+    var id = Calc.getDayId(new Date());
+    var presentDate = this.element.querySelector('[data-date="' + id + '"]');
+    var previousDate = this.element.querySelector('.present');
+
+    if (previousDate) {
+      previousDate.classList.remove('present');
+      previousDate.classList.add('past');
+    }
+    if (presentDate) {
+      presentDate.classList.add('present');
+    }
   },
 
   oninactive: function() {

--- a/apps/calendar/js/views/view_selector.js
+++ b/apps/calendar/js/views/view_selector.js
@@ -1,12 +1,13 @@
 define(function(require, exports, module) {
 'use strict';
 
-var Calc = require('calc');
 var View = require('view');
 var nextTick = require('next_tick');
+var timeObserver = require('time_observer');
 
 function ViewSelector(opts) {
   View.call(this, opts);
+  this._showTodayDate = this._showTodayDate.bind(this);
 }
 module.exports = ViewSelector;
 
@@ -18,8 +19,9 @@ ViewSelector.prototype = {
   },
 
   render: function() {
-    this._syncTodayDate();
+    this._showTodayDate();
     this.delegate(this.element, 'click', 'a', this);
+    timeObserver.on('day', this._showTodayDate);
   },
 
   handleEvent: function(event, target) {
@@ -54,41 +56,6 @@ ViewSelector.prototype = {
   _showTodayDate: function() {
     var icon = this.element.querySelector('.icon-calendar-today');
     icon.innerHTML = (new Date()).getDate();
-  },
-
-  // FIXME: this should be handled by month view after we fix Bug 1118850
-  _setPresentDate: function() {
-    var id = Calc.getDayId(new Date());
-    var presentDate = document.querySelector(
-      '#month-view [data-date="' + id + '"]'
-    );
-    var previousDate = document.querySelector('#month-view .present');
-
-    if (previousDate) {
-      previousDate.classList.remove('present');
-      previousDate.classList.add('past');
-    }
-    if (presentDate) {
-      presentDate.classList.add('present');
-    }
-  },
-
-  // FIXME: this should be replaced when we abstract the way we listen for
-  // date/time changes (Bug 1118850)
-  _syncTodayDate: function() {
-    this._showTodayDate();
-    this._setPresentDate();
-
-    var now = new Date();
-    var midnight = new Date(
-      now.getFullYear(), now.getMonth(), now.getDate() + 1,
-      0, 0, 0
-    );
-
-    var timeout = midnight.getTime() - now.getTime();
-    setTimeout(() => {
-      this._syncTodayDate();
-    }, timeout);
   }
 };
 

--- a/apps/calendar/test/unit/time_observer_test.js
+++ b/apps/calendar/test/unit/time_observer_test.js
@@ -1,0 +1,149 @@
+define(function(require) {
+'use strict';
+
+var timeObserver = require('time_observer');
+
+suite('time_observer', function() {
+  var subject;
+  var MINUTE = 60 * 1000;
+  var DAY = 24 * 60 * MINUTE;
+
+  suiteSetup(function() {
+    subject = timeObserver;
+  });
+
+  suite('minuteChange', function() {
+    var clock;
+
+    setup(function() {
+      clock = sinon.useFakeTimers((new Date(2015, 3, 15)).getTime());
+    });
+
+    teardown(function() {
+      subject._stop();
+      subject.removeAllListeners();
+      clock.restore();
+    });
+
+    test('#add', function() {
+      var prev = (new Date()).getMinutes();
+      var count = 0;
+      subject.on('minute', function() {
+        count += 1;
+        var cur = (new Date()).getMinutes();
+        assert.notEqual(prev, cur);
+        prev = cur;
+      });
+      // need to make sure that callback is only triggered when minute changes
+      clock.tick(MINUTE);
+      clock.tick(1000);
+      clock.tick(MINUTE);
+      clock.tick(20 * 1000);
+      clock.tick(MINUTE);
+      assert.equal(count, 3);
+    });
+
+    test('#once', function() {
+      var count = 0;
+      subject.once('minute', function() {
+        count += 1;
+      });
+      clock.tick(MINUTE);
+      clock.tick(MINUTE);
+      clock.tick(MINUTE);
+      assert.equal(count, 1);
+    });
+
+    test('#remove', function(done) {
+      var cb = function() {
+        assert.fail('should not be called');
+      };
+      subject.on('minute', cb);
+      subject.off('minute', cb);
+      clock.tick(MINUTE);
+      done();
+    });
+  });
+
+  suite('dayChange', function() {
+    var clock;
+
+    setup(function() {
+      clock = sinon.useFakeTimers((new Date(2015, 3, 15)).getTime());
+    });
+
+    teardown(function() {
+      subject._stop();
+      subject.removeAllListeners();
+      clock.restore();
+    });
+
+    test('#add', function() {
+      var prev = (new Date()).getDate();
+      var count = 0;
+      subject.on('day', function() {
+        count += 1;
+        var cur = (new Date()).getDate();
+        assert.notEqual(prev, cur);
+        prev = cur;
+      });
+      // need to make sure that callback is only triggered when day changes
+      clock.tick(MINUTE);
+      clock.tick(DAY);
+      clock.tick(MINUTE);
+      clock.tick(MINUTE);
+      clock.tick(DAY);
+      clock.tick(DAY);
+      assert.equal(count, 3);
+    });
+
+    test('#once', function() {
+      var count = 0;
+      subject.once('day', function() {
+        count += 1;
+      });
+      clock.tick(DAY);
+      clock.tick(DAY);
+      clock.tick(DAY);
+      assert.equal(count, 1);
+    });
+
+    test('#remove', function(done) {
+      var cb = function() {
+        assert.fail('should not be called');
+      };
+      subject.on('day', cb);
+      subject.off('day', cb);
+      clock.tick(DAY);
+      done();
+    });
+  });
+
+  suite('_toggleStatusOnVisibilityChange', function() {
+    var mock;
+    setup(function() {
+      mock = sinon.mock(subject);
+    });
+    teardown(function() {
+      mock.restore();
+    });
+
+    test('hidden', function() {
+      mock.expects('_stop').once();
+      mock.expects('_start').never();
+      mock.expects('_exec').never();
+      subject._toggleStatusOnVisibilityChange(true);
+      mock.verify();
+    });
+
+    test('visible', function() {
+      mock.expects('_stop').never();
+      mock.expects('_start').once();
+      mock.expects('_exec').once();
+      subject._toggleStatusOnVisibilityChange(false);
+      mock.verify();
+    });
+  });
+
+});
+});

--- a/apps/calendar/test/unit/views/current_time_test.js
+++ b/apps/calendar/test/unit/views/current_time_test.js
@@ -118,7 +118,7 @@ suite('Views.CurrentTime', function() {
   suite('#_maybeActivateInTheFuture', function() {
     var clock;
     var start;
-    var offset = 123456;
+    var offset = 24 * 60 * 60 * 1000;
 
     setup(function() {
       clock = sinon.useFakeTimers();


### PR DESCRIPTION
I could not reproduce any bug related to current day and current time after applying this patch.. I think the `visibilitychange` listener was the missing piece.

now it also executes the day check once per minute, before it was trying to do it once per day but I couldn't find what is the maximum value we can use on `setTimeout` and decided that doing a simple check once per minute wasn't too bad and would probably avoid headaches..

it increased the amount of code drastically, but a good part of it is just the new test logic and keeping the methods on the `TimeObserver` with a single purpose.
