### PR TITLE
Bug 1151067 - Alignment & direction for search/history results

### DIFF
--- a/apps/search/js/providers/places.js
+++ b/apps/search/js/providers/places.js
@@ -255,7 +255,13 @@
   function formatTopResult(result) {
     var div = document.createElement('div');
     var span = document.createElement('span');
-    span.textContent = result.title || result.url;
+    if (result.title) {
+      span.setAttribute('dir', 'auto');
+      span.textContent = result.title;
+    } else {
+      span.setAttribute('dir', 'ltr');
+      span.textContent = result.url;
+    }
     div.dataset.url = result.url;
     div.classList.add('top-site');
     div.appendChild(span);

--- a/apps/search/js/providers/provider.js
+++ b/apps/search/js/providers/provider.js
@@ -114,7 +114,14 @@ Provider.prototype = {
         result.dataset[i] = config.dataset[i];
       }
 
-      title.textContent = config.title || config.url;
+      if (config.title) {
+        title.setAttribute('dir', 'auto');
+        title.textContent = config.title;
+      } else {
+        title.setAttribute('dir', 'ltr');
+        title.textContent = config.url;
+      }
+
       if (config.meta) {
         meta.textContent = config.meta;
         // Expose meta infrormation as a helpful description for each result.
@@ -142,9 +149,9 @@ Provider.prototype = {
       result.appendChild(iconWrapper);
       result.appendChild(description);
       frag.appendChild(result);
-      
+
       if (!config.icon) {
-        this.updateIcon(config, iconWrapper); 
+        this.updateIcon(config, iconWrapper);
       }
     }, this);
     return frag;

--- a/apps/search/style/newtab.css
+++ b/apps/search/style/newtab.css
@@ -95,7 +95,7 @@ h2 span,
 }
 
 #history .result .description {
-  width: calc(100% - 1.6rem);
+  width: calc(100% - 1.8rem);
 }
 
 #history .icon {
@@ -146,7 +146,10 @@ html[dir="rtl"] .top-site {
   float: right;
 }
 
+html[dir="rtl"] #history .description {
+  text-align: right;
+}
+
 html[dir="rtl"] #history .meta {
   direction: ltr;
-  float: right;
 }

--- a/apps/search/style/search.css
+++ b/apps/search/style/search.css
@@ -312,7 +312,10 @@ html[dir="rtl"] #suggestions-provider-dropdown {
   transform: scaleX(-1);
 }
 
+html[dir="rtl"] #places .description {
+  text-align: right;
+}
+
 html[dir="rtl"] #places .meta {
   direction: ltr;
-  float: right;
 }


### PR DESCRIPTION
Fix up the handling of rtl/bidi content in rocketbar results and new tab page. 
Along the way I noticed width miscalculation which was causing the history results to bleed into the margins slightly - that's the  width: calc(100% - 1.8rem) change. 
