### PR TITLE
Bug 1153071 - [Calendar] remove view factory logic from app.js r=gaye

### DIFF
--- a/apps/calendar/js/router.js
+++ b/apps/calendar/js/router.js
@@ -5,6 +5,7 @@ define(function(require, exports, module) {
 var COPY_METHODS = ['start', 'stop', 'show'];
 
 var page = require('ext/page');
+var viewFactory = require('views/factory');
 
 function Router() {
   var i = 0;
@@ -113,7 +114,7 @@ Router.prototype = {
 
       /*jshint loopfunc: true */
       for (i = 0; i < numViews; i++) {
-        self.app.view(views[i], function(view) {
+        viewFactory.get(views[i], function(view) {
           viewObjs.push(view);
           len--;
 

--- a/apps/calendar/js/views/factory.js
+++ b/apps/calendar/js/views/factory.js
@@ -1,0 +1,81 @@
+define(function(require, exports, module) {
+'use strict';
+
+var debug = require('debug')('viewFactory');
+var nextTick = require('next_tick');
+var snakeCase = require('snake_case');
+
+// FIXME: app is injected later, we can only remove this after Bug 1154988
+exports.app = null;
+exports._instances = Object.create(null);
+
+/**
+ * Initializes a view and stores
+ * a internal reference so when
+ * view is called a second
+ * time the same view is used.
+ *
+ * Makes an asynchronous call to
+ * load the script if we do not
+ * have the view cached.
+ *
+ *    // for example if you have
+ *    // a calendar view Foo
+ *
+ *    viewFactory.get('Foo', function(view) {
+ *      (view instanceof require('views/foo')) === true
+ *    });
+ *
+ * @param {String} name view name.
+ * @param {Function} view loaded callback.
+ */
+exports.get = function(name, cb) {
+  if (this._registered(name)) {
+    debug(`Found view named ${name}`);
+    this._get(name, cb);
+    return;
+  }
+
+  var path = `views/${snakeCase(name)}`;
+
+  try {
+    // we try sync require first since it should be faster (skip an extra
+    // "tick"); our modules are bundled into few files during build time, so
+    // sync require should work in almost all the calls (will only fail if
+    // module was not defined/loaded before)
+    var Ctor = require(path);
+    debug(`Initializing view ${name} registered as ${path}`);
+    this._initView(name, Ctor, cb);
+  } catch(e) {
+    debug(`Will try to load view ${name} at ${path}`);
+    // we need to grab the global `require` because the async require is not
+    // part of the AMD spec and is not implemented by all loaders
+    window.require([path], Ctor => {
+      debug(`Loaded view ${name}`);
+      this._initView(name, Ctor, cb);
+    });
+  }
+},
+
+exports._registered = function(name) {
+  return name in this._instances;
+};
+
+exports._get = function(name, cb) {
+  var view = this._instances[name];
+  cb && nextTick(() => cb.call(null, view));
+};
+
+exports._initView = function(name, Ctor, cb) {
+  if (this._registered(name)) {
+    // need to safeguard in case async load is triggered multiple times before
+    // we can save a reference to the Constructor and/or view instance (would
+    // trigger the window.require callback multiple times)
+    return;
+  }
+  var view = new Ctor({ app: exports.app });
+  this._instances[name] = view;
+  this._get(name, cb);
+};
+
+});

--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -10,6 +10,7 @@ var dateFormat = require('date_format');
 var getTimeL10nLabel = require('calc').getTimeL10nLabel;
 var nextTick = require('next_tick');
 var router = require('router');
+var viewFactory = require('./factory');
 
 require('dom!modify-event-view');
 
@@ -413,7 +414,7 @@ ModifyEvent.prototype = {
           //   /week -> /event/view -> /event/save -> /event/view
           // We need to return all the way to the top of the stack
           // We can remove this once we have a history stack
-          self.app.view('ViewEvent', function(view) {
+          viewFactory.get('ViewEvent', function(view) {
             router.go(view.returnTop(), state);
           });
 
@@ -446,7 +447,7 @@ ModifyEvent.prototype = {
           //   /week -> /event/view -> /event/save -> /event/view
           // We need to return all the way to the top of the stack
           // We can remove this once we have a history stack
-          self.app.view('ViewEvent', function(view) {
+          viewFactory.get('ViewEvent', function(view) {
             router.go(view.returnTop());
           });
         });


### PR DESCRIPTION
one step closer to killing the `app` namespace!
