### PR TITLE
Bug 1156445 - Add check to see the device display is turned on

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -885,6 +885,11 @@ class GaiaTestCase(MarionetteTestCase, B2GTestCaseMixin):
         # kill the FTU and any open, user-killable apps
         self.apps.kill_all()
 
+        # Per bug 1156445, ensure the screen is on prior to running the test.
+        # When the bootup takes long time, the screen times out when homescreen is opened.
+        self.device.turn_screen_off()
+        self.device.turn_screen_on()
+
         # unlock
         if self.data_layer.get_setting('lockscreen.enabled'):
             self.device.unlock()


### PR DESCRIPTION
add check in gaiatest.py setup() method so it checks for screen status when the setup is completed.
