### PR TITLE
Bug 1130436 - Flip to mozL10n.get for gaia-menu shadow dom

### DIFF
--- a/shared/elements/gaia_menu/script.js
+++ b/shared/elements/gaia_menu/script.js
@@ -28,8 +28,9 @@ window.GaiaMenu = (function(win) {
   };
 
   proto.localize = function() {
-    this.shadowRoot.querySelector('button').setAttribute('data-l10n-id' ,
-      'gaia-menu-cancel');
+    navigator.mozL10n.formatValue('gaia-menu-cancel').then(value => {
+      this.shadowRoot.querySelector('button').textContent = value;
+    });
   };
 
   proto.show = function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1130436
