### PR TITLE
Bug 1153769 - Bind the StackManager's "back home" support

### DIFF
--- a/apps/system/js/stack_manager.js
+++ b/apps/system/js/stack_manager.js
@@ -8,7 +8,7 @@ var StackManager = {
     window.addEventListener('appopening', this);
     window.addEventListener('appopened', this);
     window.addEventListener('appterminated', this);
-    window.addEventListener('home', this);
+    window.addEventListener('homescreenopened', this);
     window.addEventListener('cardviewclosed', this);
   },
 
@@ -209,7 +209,7 @@ var StackManager = {
           this._current = id;
         }
         break;
-      case 'home':
+      case 'homescreenopened':
         // only handle home events if task manager is not visible
         if (window.taskManager && window.taskManager.isShown()) {
           return;

--- a/apps/system/test/unit/stack_manager_test.js
+++ b/apps/system/test/unit/stack_manager_test.js
@@ -164,7 +164,7 @@ suite('system/StackManager >', function() {
   }
 
   function home() {
-    window.dispatchEvent(new Event('home'));
+    window.dispatchEvent(new Event('homescreenopened'));
   }
 
   function appOpening(app) {


### PR DESCRIPTION
on the |homescreenopened| event instead of |home|. r=alive
