### PR TITLE
Bug 1155421 - Change 'Discard' string to 'Delete Draft' sms R=aron.bordin

### DIFF
--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -1208,7 +1208,7 @@ var ThreadUI = {
             }.bind(this)
           },
           {
-            l10nId: 'discard-message',
+            l10nId: 'delete-draft',
             method: function onDiscard() {
               this.discardDraft();
               resolve();

--- a/apps/sms/locales/sms.en-US.properties
+++ b/apps/sms/locales/sms.en-US.properties
@@ -132,7 +132,7 @@ thread-participant-separator = ,\u20
 # Modal Dialogs
 replace-draft               = Replace existing Draft
 save-as-draft               = Save as Draft
-discard-message             = Discard
+delete-draft                = Delete draft
 discard-sms                 = Are you sure you want to discard this message?
 discard-new-message         = Discard the message you’re composing and open the new message?
 resend-confirmation         = The message could not be sent. Try again?

--- a/apps/sms/test/marionette/conversion_banner_test.js
+++ b/apps/sms/test/marionette/conversion_banner_test.js
@@ -74,7 +74,7 @@ marionette('Message Type Conversion Banner', function() {
       // Force it to be MMS
       messagesApp.addRecipient('a@b.c');
       // Without waiting for the banner to disappear, return to thread list
-      exitThread('Discard');
+      exitThread('Delete Draft');
       // Create another new message
       threadList.navigateToComposer();
 

--- a/apps/sms/test/marionette/share_activity_test.js
+++ b/apps/sms/test/marionette/share_activity_test.js
@@ -47,7 +47,7 @@ marionette('Messages as share target', function() {
 
         // Exit from activity and verify that Messages is dismissed
         messagesApp.performHeaderAction();
-        messagesApp.selectAppMenuOption('Discard');
+        messagesApp.selectAppMenuOption('Delete Draft');
         messagesApp.waitForAppToDisappear();
       });
 

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -5737,7 +5737,7 @@ suite('thread_ui.js >', function() {
 
           // Assert the correct menu items were displayed
           assert.equal(items[0].l10nId, 'save-as-draft');
-          assert.equal(items[1].l10nId, 'discard-message');
+          assert.equal(items[1].l10nId, 'delete-draft');
           assert.equal(items[2].l10nId, 'cancel');
         }).then(done, done);
       });
@@ -5755,7 +5755,7 @@ suite('thread_ui.js >', function() {
 
           // Assert the correct menu items were displayed
           assert.equal(items[0].l10nId, 'save-as-draft');
-          assert.equal(items[1].l10nId, 'discard-message');
+          assert.equal(items[1].l10nId, 'delete-draft');
           assert.equal(items[2].l10nId, 'cancel');
         }).then(done, done);
       });
@@ -5772,7 +5772,7 @@ suite('thread_ui.js >', function() {
 
           // Assert the correct menu items were displayed
           assert.equal(items[0].l10nId, 'save-as-draft');
-          assert.equal(items[1].l10nId, 'discard-message');
+          assert.equal(items[1].l10nId, 'delete-draft');
           assert.equal(items[2].l10nId, 'cancel');
         }).then(done, done);
       });
@@ -5847,7 +5847,7 @@ suite('thread_ui.js >', function() {
 
               // Assert the correct menu items were displayed
               assert.equal(items[0].l10nId, 'replace-draft');
-              assert.equal(items[1].l10nId, 'discard-message');
+              assert.equal(items[1].l10nId, 'delete-draft');
               assert.equal(items[2].l10nId, 'cancel');
             }).then(done, done);
           });
@@ -5864,7 +5864,7 @@ suite('thread_ui.js >', function() {
 
               // Assert the correct menu items were displayed
               assert.equal(items[0].l10nId, 'replace-draft');
-              assert.equal(items[1].l10nId, 'discard-message');
+              assert.equal(items[1].l10nId, 'delete-draft');
               assert.equal(items[2].l10nId, 'cancel');
             }).then(done, done);
           });
@@ -5881,7 +5881,7 @@ suite('thread_ui.js >', function() {
 
               // Assert the correct menu items were displayed
               assert.equal(items[0].l10nId, 'replace-draft');
-              assert.equal(items[1].l10nId, 'discard-message');
+              assert.equal(items[1].l10nId, 'delete-draft');
               assert.equal(items[2].l10nId, 'cancel');
             }).then(done, done);
           });


### PR DESCRIPTION
Change the string 'Discard' -> 'Delete Draft' in the sms app.
![2015-04-22-20-45-10](https://cloud.githubusercontent.com/assets/4960137/7264879/cb326bc4-e867-11e4-94e6-04fef52d5bfe.png)
