### PR TITLE
Bug 1155075 - discovery devices automatically while share files via bluetooth, r=arthur

### DIFF
--- a/apps/bluetooth/js/modules/bluetooth/bluetooth_context.js
+++ b/apps/bluetooth/js/modules/bluetooth/bluetooth_context.js
@@ -469,7 +469,27 @@ define(function(require) {
         enabled = false;
       }
 
+      // Update state
+      this.state = state;
+      Debug('_updateStatus(): set state = ' + state);
+
+      // Update enabled
+      this.enabled = enabled;
+      Debug('_updateStatus(): set enabled = ' + enabled);
+
       // Sync with settings key
+      this._syncWithSettingsKey(enabled);
+    },
+
+    /**
+     * The function provides to set booleans to update the 'bluetooth.enabled'
+     * settings key if the value is not sync.
+     *
+     * @access private
+     * @memberOf BluetoothContext
+     * @param {Boolean} enabled
+     */
+    _syncWithSettingsKey: function btc__syncWithSettingsKey(enabled) {
       var req = settings.createLock().get('bluetooth.enabled');
       req.onsuccess = function bt_onGetBTEnabledSuccess() {
         if (req.result) {
@@ -477,16 +497,8 @@ define(function(require) {
           if (btEnabled !== enabled) {
             settings.createLock().set({'bluetooth.enabled': enabled});
           }
-
-          // Update state
-          this.state = state;
-          Debug('_updateStatus(): set state = ' + state);
-
-          // Update enabled
-          this.enabled = enabled;
-          Debug('_updateStatus(): set enabled = ' + enabled);  
         }
-      }.bind(this);
+      };
     },
 
     /**

--- a/apps/bluetooth/js/views/device_picker_panel.js
+++ b/apps/bluetooth/js/views/device_picker_panel.js
@@ -134,6 +134,14 @@ define(function(require) {
 
       // Init items state.
       this._initItemsState();
+
+      // search devices automatically while the panel is inited.
+      BtContext.startDiscovery().then(() => {
+        Debug('_init(): startDiscovery successfully');
+      }, (reason) => {
+        Debug('_init(): startDiscovery failed, ' +
+              'reason = ' + reason);
+      });
     },
 
     /**

--- a/apps/bluetooth/test/unit/modules/bluetooth/bluetooth_context_test.js
+++ b/apps/bluetooth/test/unit/modules/bluetooth/bluetooth_context_test.js
@@ -549,73 +549,130 @@ suite('BluetoothContext', function() {
   suite('_updateStatus > ', function() {
     suite('enabled = false, state = "disabled", ' +
       '_updateStatus with "enabled" ', function() {
-      var fakeTimer;
       setup(function() {
         btContext.enabled = false;
         btContext.state = 'disabled';
-        navigator.mozSettings.mSettings['bluetooth.enabled'] = false;
-        fakeTimer = this.sinon.useFakeTimers();
+        this.sinon.stub(btContext, '_syncWithSettingsKey');
       });
 
       test('new state will be enabled = true, state = "enabled" ', function() {
         btContext._updateStatus('enabled');
-        fakeTimer.tick();
         assert.equal(btContext.state, 'enabled');
         assert.isTrue(btContext.enabled);
+        assert.isTrue(btContext._syncWithSettingsKey.calledWith(
+          btContext.enabled));
       });
     });
 
     suite('enabled = false, state = "disabled", ' +
       '_updateStatus with "enabling" ', function() {
-      var fakeTimer;
       setup(function() {
         btContext.enabled = false;
         btContext.state = 'disabled';
-        navigator.mozSettings.mSettings['bluetooth.enabled'] = false;
-        fakeTimer = this.sinon.useFakeTimers();
+        this.sinon.stub(btContext, '_syncWithSettingsKey');
       });
 
       test('new state will be enabled = false, state = "enabling"', function() {
         btContext._updateStatus('enabling');
-        fakeTimer.tick();
         assert.equal(btContext.state, 'enabling');
         assert.isFalse(btContext.enabled);
+        assert.isTrue(btContext._syncWithSettingsKey.calledWith(
+          btContext.enabled));
       });
     });
 
     suite('enabled = true, state = "enabled", ' +
       '_updateStatus with "disabled" ', function() {
-      var fakeTimer;
       setup(function() {
         btContext.enabled = true;
         btContext.state = 'enabled';
-        navigator.mozSettings.mSettings['bluetooth.enabled'] = true;
-        fakeTimer = this.sinon.useFakeTimers();
+        this.sinon.stub(btContext, '_syncWithSettingsKey');
       });
 
       test('new state will be enabled = false, state = "disabled"', function() {
         btContext._updateStatus('disabled');
-        fakeTimer.tick();
         assert.equal(btContext.state, 'disabled');
         assert.isFalse(btContext.enabled);
+        assert.isTrue(btContext._syncWithSettingsKey.calledWith(
+          btContext.enabled));
       });
     });
 
     suite('enabled = true, state = "enabled", ' +
       '_updateStatus with "disabling" ', function() {
-      var fakeTimer;
       setup(function() {
         btContext.enabled = true;
         btContext.state = 'enabled';
-        navigator.mozSettings.mSettings['bluetooth.enabled'] = true;
-        fakeTimer = this.sinon.useFakeTimers();
+        this.sinon.stub(btContext, '_syncWithSettingsKey');
       });
 
       test('new state will be enabled = false, state = "disabled"', function() {
         btContext._updateStatus('disabling');
-        fakeTimer.tick();
         assert.equal(btContext.state, 'disabling');
         assert.isTrue(btContext.enabled);
+        assert.isTrue(btContext._syncWithSettingsKey.calledWith(
+          btContext.enabled));
+      });
+    });
+  });
+
+  suite('_syncWithSettingsKey > ', function() {
+    var reqStub, settingsSetSpy, mockEnabled;
+    suite('set with different state ', function() {
+      setup(function() {
+        mockEnabled = true;
+        reqStub = {
+          onsuccess: null,
+          result: {
+            'bluetooth.enabled': !mockEnabled
+          }
+        };
+        settingsSetSpy = this.sinon.spy();
+        var newCreateLock = function() {
+          return {
+            get: function() {
+              return reqStub;
+            },
+            set: settingsSetSpy
+          };
+        };
+        this.sinon.stub(navigator.mozSettings, 'createLock', newCreateLock);
+      });
+
+      test('"bluetooth.enabled" settings key should be set with new state ',
+      function() {
+        btContext._syncWithSettingsKey(mockEnabled);
+        reqStub.onsuccess();
+        assert.isTrue(settingsSetSpy.calledWith(
+          {'bluetooth.enabled': mockEnabled}));
+      });
+    });
+    
+    suite('set with same state ', function() {
+      setup(function() {
+        mockEnabled = true;
+        reqStub = {
+          onsuccess: null,
+          result: {
+            'bluetooth.enabled': mockEnabled
+          }
+        };
+        settingsSetSpy = this.sinon.spy();
+        var newCreateLock = function() {
+          return {
+            get: function() {
+              return reqStub;
+            },
+            set: settingsSetSpy
+          };
+        };
+        this.sinon.stub(navigator.mozSettings, 'createLock', newCreateLock);
+      });
+
+      test('"bluetooth.enabled" settings key should not be set ', function() {
+        btContext._syncWithSettingsKey(mockEnabled);
+        reqStub.onsuccess();
+        assert.isFalse(settingsSetSpy.called);
       });
     });
   });

--- a/apps/bluetooth/test/unit/views/device_picker_panel_test.js
+++ b/apps/bluetooth/test/unit/views/device_picker_panel_test.js
@@ -44,7 +44,7 @@ suite('DevicePickerPanel', function() {
       hasPairedDevice: false,
       state: 'disabled',
       discovering: false,
-      startDiscovery: function() {},
+      startDiscovery: function() {return Promise.resolve();},
       pair: function() {}
     };
 
@@ -79,12 +79,14 @@ suite('DevicePickerPanel', function() {
       devicePickerPanel._pairedDevicesListView = null;
       devicePickerPanel._foundDevicesListView = null;
       this.sinon.stub(devicePickerPanel, '_initItemsState');
+      this.sinon.stub(btContext, 'startDiscovery').returns(Promise.resolve());
     });
 
     test('The close button of header should be regedit action callback, ' +
          'search button should be regedit onclick callback, ' +
          'paired/found list view should be defined, ' +
-         '_initItemsState() should be called ', function() {
+         '_initItemsState() should be called ' +
+         'BtContext.startDiscovery() should be called ', function() {
       devicePickerPanel._init();
       // close button
       assert.equal(
@@ -104,6 +106,7 @@ suite('DevicePickerPanel', function() {
       assert.isDefined(devicePickerPanel._pairedDevicesListView);
       assert.isDefined(devicePickerPanel._foundDevicesListView);
       assert.isTrue(devicePickerPanel._initItemsState.called);
+      assert.isTrue(btContext.startDiscovery.called);
     });
   });
 

--- a/apps/settings/js/modules/bluetooth/bluetooth_context.js
+++ b/apps/settings/js/modules/bluetooth/bluetooth_context.js
@@ -470,20 +470,32 @@ define(function(require) {
         enabled = false;
       }
 
+      // Update state
+      this.state = state;
+      Debug('_updateStatus(): set state = ' + state);
+
+      // Update enabled
+      this.enabled = enabled;
+      Debug('_updateStatus(): set enabled = ' + enabled);
+
       // Sync with settings key
+      this._syncWithSettingsKey(enabled);
+    },
+
+    /**
+     * The function provides to set booleans to update the 'bluetooth.enabled'
+     * settings key if the value is not sync.
+     *
+     * @access private
+     * @memberOf BluetoothContext
+     * @param {Boolean} enabled
+     */
+    _syncWithSettingsKey: function btc__syncWithSettingsKey(enabled) {
       SettingsCache.getSettings((results) => {
         var btEnabled = results['bluetooth.enabled'];
         if (btEnabled !== enabled) {
           settings.createLock().set({'bluetooth.enabled': enabled});
         }
-
-        // Update state
-        this.state = state;
-        Debug('_updateStatus(): set state = ' + state);
-
-        // Update enabled
-        this.enabled = enabled;
-        Debug('_updateStatus(): set enabled = ' + enabled);
       });
     },
 


### PR DESCRIPTION
- To discovery devices actively while `device_picker_panel` init.
- Update the `state`, `enabled` properties in `BluetoothContext` module immediately while `adapter.state` is changed.
- Create  `_syncWithSettingsKey` function to do this thing only.
