### PR TITLE
Bug 1155299 - Update manifest file for imagecompare (i.e. defined smoke tests) 

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/manifest.ini
@@ -39,7 +39,6 @@ smoketest=true
 [test_cards_view_with_two_apps.py]
 
 [test_calendar_new_event_appears_on_all_calendar_views.py]
-smoketest=true
 
 [test_calendar_flick.py]
 smoketest=true
@@ -49,7 +48,6 @@ smoketest=true
 carrier=true
 
 [test_lockscreen_unlock_to_homescreen_with_passcode.py]
-smoketest=true
 carrier=true
 
 [test_music_album_mp3.py]
@@ -57,7 +55,6 @@ smoketest=true
 sdcard=true
 
 [test_music_empty.py]
-smoketest=true
 
 [test_music_songs_3gp.py]
 smoketest=true


### PR DESCRIPTION
Remove tests that are redundant
