### PR TITLE
Bug 1157326 - test_lockscreen_unlock_to_homescreen_with_passcode.py in Imagecompare needs to be updated

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_lockscreen_unlock_to_homescreen_with_passcode.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_lockscreen_unlock_to_homescreen_with_passcode.py
@@ -40,6 +40,7 @@ class TestLockScreen(GaiaImageCompareTestCase):
 
         # 2nd try
         self.device.turn_screen_on()
+        lock_screen.switch_to_frame()
         passcode_pad = lock_screen.unlock_to_passcode_pad()
         homescreen = passcode_pad.type_passcode(self._input_passcode)
 


### PR DESCRIPTION
switching to root frame is required upon every screen wake
