### PR TITLE
Bug 1155907 - Remove listeners immediately in exitToApp r=etienne

### DIFF
--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -978,11 +978,10 @@ suite('system/TaskManager >', function() {
 
     test('displays the new app before dismissing the task manager',
     function(done) {
-     waitForEvent(window, 'cardviewclosed').then(function(evt) {
+      waitForEvent(window, 'cardviewclosed').then(function(evt) {
         assert.ok(evt.detail && !isNaN(evt.detail.newStackPosition),
                   'cardviewclosed evt has new position detail');
-        done();
-      }, failOnReject);
+      }, failOnReject).then(function() { done(); }, done);
 
       var app = MockStackManager.mStack[0];
       this.sinon.stub(app, 'open', function() {
@@ -1121,6 +1120,21 @@ suite('system/TaskManager >', function() {
         .then(function() { done(); }, done);
 
         taskManager.exitToApp(targetApp);
+        fakeFinish(this.sinon.clock, targetApp);
+      });
+
+      test('no touch input handled while opening selected app', function(done) {
+        var targetApp = apps['http://game.gaiamobile.org'];
+        this.sinon.spy(taskManager, 'handleEvent');
+
+        waitForEvent(window, 'cardviewclosed').then(function() {
+          assert.isFalse(taskManager.handleEvent.called,
+                         'handleEvent not called');
+        }).then(function() { done(); }, done);
+
+        taskManager.exitToApp(targetApp);
+        var touchEvent = new CustomEvent('touchstart');
+        taskManager.element.dispatchEvent(touchEvent);
         fakeFinish(this.sinon.clock, targetApp);
       });
 


### PR DESCRIPTION
The setTimeout in exitToApp was leaving a window in which you could still interact with the card view while it transitioned to open the selected app. This patch rearranges things just a little to close up that window by immediately detaching the "showing" listeners 
