### PR TITLE
Bug 1152439 - Use the same AudioContext for preventing the growth of memory.

### DIFF
--- a/apps/ringtones/js/tone_player.js
+++ b/apps/ringtones/js/tone_player.js
@@ -147,12 +147,6 @@ TonePlayer.prototype = {
         this._source = this._context.createMediaElementSource(this._player);
         this._source.connect(this._context.destination);
       }
-    } else {
-      if (this._source) {
-        this._source.disconnect();
-        this._context = null;
-        this._source = null;
-      }
     }
   }
 };


### PR DESCRIPTION
per https://bugzilla.mozilla.org/show_bug.cgi?id=1152439#c36 and https://bugzilla.mozilla.org/show_bug.cgi?id=1152439#c39, remove the code.
