### PR TITLE
Bug 1157741 - Filter transitionend calls within eventSafety library

### DIFF
--- a/apps/sharedtest/test/unit/event_safety_test.js
+++ b/apps/sharedtest/test/unit/event_safety_test.js
@@ -40,4 +40,23 @@ suite('eventSafety', function() {
     window.dispatchEvent(new CustomEvent('foobar'));
   });
 
+  test('filters mismatched elements for transitionend events', function() {
+    this.sinon.useFakeTimers();
+    var called = false;
+    var timeoutSpy = this.sinon.spy(window, 'setTimeout');
+    eventSafety(window, 'foobar', function() {
+      called = true;
+    }, 1000);
+
+    // Get the private callback and execute with arguments.
+    timeoutSpy.getCall(0).args[0]({
+      type: 'transitionend',
+      target: document.body // (Not what we called the eventSafety method with)
+    });
+
+    assert.equal(called, false, 'should not call the callback');
+    this.sinon.clock.tick(1000);
+    assert.equal(called, true, 'called after timeout');
+  });
+
 });

--- a/apps/system/js/app_chrome.js
+++ b/apps/system/js/app_chrome.js
@@ -738,14 +738,7 @@
     if (!callback) {
       return;
     }
-
-    var finish = function(evt) {
-      if (evt && evt.target !== element) {
-        return;
-      }
-      callback();
-    };
-    eventSafety(element, 'transitionend', finish, 250);
+    eventSafety(element, 'transitionend', callback, 250);
   };
 
   AppChrome.prototype.collapse = function ac_collapse() {

--- a/shared/js/event_safety.js
+++ b/shared/js/event_safety.js
@@ -15,7 +15,13 @@
 function eventSafety(obj, event, callback, timeout) {
   var finishTimeout;
 
-  function done() {
+  function done(e) {
+
+    // transitionend events bubble by default, so we filter them by element.
+    if (e && e.type === 'transitionend' && e.target !== obj) {
+      return;
+    }
+
     clearTimeout(finishTimeout);
     obj.removeEventListener(event, done);
     /*jshint validthis:true */


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1157741
