### PR TITLE
Bug 1156445 - Ensure the device display is turned on when running python marionette

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -883,6 +883,10 @@ class GaiaTestCase(MarionetteTestCase, B2GTestCaseMixin):
                     self.device.file_manager.remove('/'.join([path, item]))
 
     def cleanup_gaia(self, full_reset=True):
+
+        self.device.turn_screen_off()
+        self.device.turn_screen_on()
+        
         # kill the FTU and any open, user-killable apps
         self.apps.kill_all()
 


### PR DESCRIPTION
trying to see whether commented out changes caused gip failures
