### PR TITLE
Bug 1155543 - Toggle "mms.debugging.enabled" from developer menu

### DIFF
--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -214,6 +214,12 @@
         </li>
         <li>
           <label class="pack-checkbox">
+            <input type="checkbox" name="mms.debugging.enabled">
+            <span data-l10n-id="mms-debugging"></span>
+          </label>
+        </li>
+        <li>
+          <label class="pack-checkbox">
             <input type="checkbox" name="debug.console.enabled">
             <span data-l10n-id="console-enabled"></span>
           </label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -1228,6 +1228,7 @@ bluetooth-snoop-debugging=Bluetooth HCI Sniffing Logs to SD Card
 nfc-debugging=NFC Output in ADB
 ril-debugging=RIL Output in ADB
 network-debugging=Network Output in ADB
+mms-debugging=MMS Output in ADB
 console-enabled=Console Enabled
 cards-view-screenshots=Cards View: Screenshots
 geolocation-debugging-enabled=Geolocation Output in ADB

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -121,6 +121,7 @@
    "lockscreen.unlock-sound.enabled": false,
    "message.sent-sound.enabled": true,
    "moz.b2g.version": "3.0",
+   "mms.debugging.enabled": false,
    "network.debugging.enabled": false,
    "nfc.enabled": false,
    "nfc.suspended": false,


### PR DESCRIPTION
Adding a checkbox to allow enabling / disabling "mms.debugging.enabled" from developer menu.
