### PR TITLE
Bug 1157610 - Bidi entry sheet titles

### DIFF
--- a/apps/system/fxa/js/fxam_errors.js
+++ b/apps/system/fxa/js/fxam_errors.js
@@ -91,7 +91,10 @@
 
         this.entrySheet = new EntrySheet(
           window.top.document.getElementById('screen'),
-          coppaUrl,
+          // Prefix url with LRM character
+          // This ensures truncation occurs correctly in an RTL document
+          // We can remove this when bug 1154438 is fixed.
+          '\u200E URL:' + coppaUrl,
           new BrowserFrame({
             url: coppaUrl,
             oop: true

--- a/apps/system/fxa/js/screens/fxam_enter_email.js
+++ b/apps/system/fxa/js/screens/fxam_enter_email.js
@@ -121,7 +121,10 @@ var FxaModuleEnterEmail = (function() {
       }
       this.entrySheet = new EntrySheet(
         window.top.document.getElementById('screen'),
-        url,
+        // Prefix url with LRM character
+        // This ensures truncation occurs correctly in an RTL document
+        // We can remove this when bug 1154438 is fixed.
+        '\u200E' + url,
         new BrowserFrame({
           url: url,
           oop: true

--- a/apps/system/js/captive_portal.js
+++ b/apps/system/js/captive_portal.js
@@ -33,10 +33,14 @@ var CaptivePortal = {
 
     if (FtuLauncher.isFtuRunning()) {
       settings.createLock().set({'wifi.connect_via_settings': false});
-
-      this.entrySheet = new EntrySheet(document.getElementById('screen'),
-                                      url,
-                                      new BrowserFrame({url: url}));
+      this.entrySheet = new EntrySheet(
+        document.getElementById('screen'),
+        // Prefix url with LRM character
+        // This ensures truncation occurs correctly in an RTL document
+        // We can remove this when bug 1154438 is fixed.
+        '\u200E' + url,
+        new BrowserFrame({url: url})
+      );
       this.entrySheet.open();
       return;
     }

--- a/apps/system/js/entry_sheet.js
+++ b/apps/system/js/entry_sheet.js
@@ -45,7 +45,9 @@ var EntrySheet = (function invocation() {
     return `<div class="${EntrySheet.className}">
       <section role="region" class="skin-organic header">
         <gaia-header action="close">
-          <h1 class="title"></h1>
+          <h1 class="title">
+            <bdi class="${EntrySheet.className}-title"></bdi>
+          </h1>
         </gaia-header>
         <div class="throbber"></div>
       </section>
@@ -62,7 +64,7 @@ var EntrySheet = (function invocation() {
     this.header =
       this.container.querySelector('.' + EntrySheet.className + ' gaia-header');
     this.titleElement =
-      this.container.querySelector('.' + EntrySheet.className + ' .title');
+      this.container.querySelector('.' + EntrySheet.className + '-title');
     this.throbberElement =
       this.container.querySelector('.' + EntrySheet.className + ' .throbber');
     this.content =

--- a/apps/system/style/entry_sheet/entry_sheet.css
+++ b/apps/system/style/entry_sheet/entry_sheet.css
@@ -46,6 +46,19 @@
   position: absolute;
 }
 
+/*
+ * We need to style the title placed in the entrySheet's gaia-header
+ * To ensure it overflows and truncates for the correct direction
+ * for the content placed in there
+ */
+gaia-header h1 > bdi.entrySheet-title {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  unicode-bidi: -moz-plaintext;
+}
+
+
 .entrySheet .content {
   position: absolute;
   top: 5rem;


### PR DESCRIPTION
Fix Firefox Accounts and Captive Portal EntrySheet usage to allow correct bidi handling of titles in the header, and specifically LTR display and truncation of URLs as titles when using a RTL language. 
