### PR TITLE
Bug 1158519 - Remove inexistent file from jshint xfail.list

### DIFF
--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -61,7 +61,6 @@ apps/keyboard/js/settings/settings.js
 apps/keyboard/test/unit/imes/jspinyin/jspinyin_test.js
 apps/keyboard/test/unit/imes/latin/worker_test.js
 apps/keyboard/test/unit/setup_engine.js
-apps/music/js/metadata.js
 apps/system/js/browser_mixin.js
 apps/system/js/icc.js
 apps/system/js/init_logo_handler.js


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1158519
