### PR TITLE
Bug 1157092 - Permaorange apps/system/test/marionette/text_selection_test.js | Text selection > without lockscreen check functionality copy and paste across all trees independent of merges

### DIFF
--- a/apps/system/test/apps/faketextselectionapp/functionality.html
+++ b/apps/system/test/apps/faketextselectionapp/functionality.html
@@ -21,7 +21,7 @@
     </style>
   </head>
   <body>
-    <input id="functionality-source" value="testvalue">
+    <input id="functionality-source" value="test">
     <input id="functionality-target" value="">
   </body>
 </html>

--- a/apps/system/test/marionette/text_selection_test.js
+++ b/apps/system/test/marionette/text_selection_test.js
@@ -70,9 +70,10 @@ marionette('Text selection >', function() {
         fakeTextselectionApp.longPress('FunctionalitySourceInput');
         fakeTextselectionApp.copyTo('FunctionalitySourceInput',
           'FunctionalityTargetInput');
+
         assert.equal(
           fakeTextselectionApp.FunctionalityTargetInput.getAttribute('value'),
-          'testvalue');
+          'test');
       });
 
       test('cut and paste', function() {
@@ -83,7 +84,7 @@ marionette('Text selection >', function() {
           '');
         assert.equal(
           fakeTextselectionApp.FunctionalityTargetInput.getAttribute('value'),
-          'testvalue');
+          'test');
       });
 
       test('select all and cut', function() {

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -35,7 +35,6 @@
     "apps/system/test/marionette/statusbar_icon_color_test.js": "Bug 1134018",
     "apps/system/fxa/test/marionette/fxa_screen_flow_test.js": "Bug 1064305 - [Marionette] FxA tests - intermittent timeout failures on system/fxa/test/marionette/fxa_screen_flow_test.js",
     "apps/system/test/marionette/global_overlay_window_test.js": "Bug 1117125 - Update b2g desktop in tbpl after bug 1101029 lands",
-    "apps/system/test/marionette/text_selection_test.js": "Bug 1157092 - Permaorange | Text selection > without lockscreen check functionality copy and paste across all trees independent of merges",
     "apps/system/test/marionette/statusbar_home_button_test.js": "Bug 1154405 - TEST-UNEXPECTED-FAIL | Closing statusbar via home button > Home screen keeps scroll position AssertionError: false == true",
     "apps/system/test/marionette/software_home_file_open_error_test.js": "Bug 1119079 - Intermittent software_home_file_open_error_test.js | Software Home Button - File Open Error Proper layout for file error dialog",
     "apps/verticalhome/test/marionette/app_hosted_use_cached_icon_test.js": "Bug 1037194 - TEST-UNEXPECTED-FAIL | Vertical Home - Hosted app cached icon fetch fallback to default icon",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1157092
