### PR TITLE
Bug 1157173 - Rejigger change button styles

### DIFF
--- a/apps/ftu/style/style.css
+++ b/apps/ftu/style/style.css
@@ -734,6 +734,13 @@ aside.connecting {
   font-size: 1.4rem;
   font-weight: 500;
   margin: auto;
+  box-sizing: content-box;
+  display: inline-block;
+  width: auto;
+  min-width: 4.5rem;
+  max-width: 40%;
+  padding: 0 0.8rem;
+  -moz-padding-end: 1.8rem;
 }
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1157173

Main change here is using content-box for box sizing, plus tweaks on the width/padding values. I've set max-width to 40% which is about as big as it can be without the layout breaking down. It shouldnt come to that but 'Change' does translate to a rather long string in some languages. I figure legibility trumps here and we would rather get a legible label in the extreme case.
