### PR TITLE
Bug 1159644 - Reduce padding on buttons to account for fixed overflow/tr...

### DIFF
--- a/shared/style/edit_mode.css
+++ b/shared/style/edit_mode.css
@@ -53,7 +53,7 @@
   height: 4rem;
   margin: 0;
   -moz-margin-start: 1rem;
-  padding: 0 1.2rem;
+  padding: 0 0.2rem;
   -moz-box-sizing: border-box;
   display: block;
   text-overflow: ellipsis;


### PR DESCRIPTION
...uncation behavior

The fix in bug 1010675 changed the way these labels overflow, with the result that they will ellipsize sooner. This change restores the space previously allowed in practice for the button label strings. 
