### PR TITLE
Bug 1160096 - Fix confirm button padding

### DIFF
--- a/shared/style/confirm.css
+++ b/shared/style/confirm.css
@@ -79,7 +79,7 @@ form[role="dialog"][data-type="confirm"] menu button {
   width: 100%;
   height: 4rem;
   margin: 0 0 1rem;
-  padding: 0 1.2rem;
+  padding: 0 0.2rem;
   -moz-box-sizing: border-box;
   display: inline-block;
   vertical-align: middle;


### PR DESCRIPTION
This restores the space effectively given for label in v2.1 (see bug https://bugzilla.mozilla.org/show_bug.cgi?id=1010675 ). As they are aligned center and width:100%, we shouldn't see any difference in buttons with shorter values. 
