### PR TITLE
Bug 1150755 - Convert gaiatest to not use SpecialPowers, r=davehunt

### DIFF
--- a/tests/atoms/accessibility.js
+++ b/tests/atoms/accessibility.js
@@ -3,14 +3,15 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
-/* globals SpecialPowers, marionetteScriptFinished */
+
+/* globals Components, marionetteScriptFinished */
 /* exported Accessibility */
 
 var Accessibility = {
 
-  _accRetrieval: SpecialPowers.Cc[
+  _accRetrieval: Components.classes[
     '@mozilla.org/accessibleRetrieval;1'].getService(
-      SpecialPowers.Ci.nsIAccessibleRetrieval),
+      Components.interfaces.nsIAccessibleRetrieval),
 
   _getAccessible:
     function Accessibility__getAccessible(element, callback, once) {
@@ -35,8 +36,7 @@ var Accessibility = {
   },
 
   _matchState: function Accessibility__matchState(acc, stateName) {
-    let stateToMatch = SpecialPowers.wrap(
-      SpecialPowers.Components).interfaces.nsIAccessibleStates[stateName];
+    let stateToMatch = Components.interfaces.nsIAccessibleStates[stateName];
     let state = {};
     let extState = {};
     acc.getState(state, extState);

--- a/tests/atoms/gaia_data_layer.js
+++ b/tests/atoms/gaia_data_layer.js
@@ -4,7 +4,7 @@
 
 'use strict';
 /* global marionetteScriptFinished, pair, device:true, mozContact, i */
-/* global waitFor, SpecialPowers, adapter:true, aContacts */
+/* global waitFor, adapter:true, aContacts */
 /* exported pair, discovery, GaiaDataLayer */
 /* jshint -W083 */
 
@@ -86,22 +86,20 @@ var GaiaDataLayer = {
   },
 
   insertContact: function(aContact) {
+    // requires the 'contacts-create' permission
     if (aContact.photo) {
       var blob = GaiaDataLayer.base64ToBlob(aContact.photo, 'image/jpg');
       aContact.photo = [blob];
     }
 
-    SpecialPowers.addPermission('contacts-create', true, document);
     var contact = new mozContact(aContact);
     var req = window.navigator.mozContacts.save(contact);
     req.onsuccess = function() {
       console.log('success saving contact');
-      SpecialPowers.removePermission('contacts-create', document);
       marionetteScriptFinished(true);
     };
     req.onerror = function() {
       console.error('error saving contact', req.error.name);
-      SpecialPowers.removePermission('contacts-create', document);
       marionetteScriptFinished(false);
     };
   },
@@ -146,17 +144,15 @@ var GaiaDataLayer = {
 
 
   getAllContacts: function(aCallback) {
+    // requires 'contacts-read' permission
     var callback = aCallback || marionetteScriptFinished;
-    SpecialPowers.addPermission('contacts-read', true, document);
     var req = window.navigator.mozContacts.find({});
     req.onsuccess = function() {
       console.log('success finding contacts');
-      SpecialPowers.removePermission('contacts-read', document);
       callback(req.result);
     };
     req.onerror = function() {
       console.error('error finding contacts ' + req.error.name);
-      SpecialPowers.removePermission('contacts-read', document);
       callback([]);
     };
   },
@@ -175,12 +171,10 @@ var GaiaDataLayer = {
     var req = icc.readContacts(type);
     req.onsuccess = function() {
       console.log('success finding ' + type + ' contacts');
-      SpecialPowers.removePermission('contacts-read', document);
       callback(req.result);
     };
     req.onerror = function() {
       console.error('error finding ' + type + ' contacts ' + req.error.name);
-      SpecialPowers.removePermission('contacts-read', document);
       callback([]);
     };
   },
@@ -207,27 +201,24 @@ var GaiaDataLayer = {
   },
 
   removeContact: function(aContact, aCallback) {
+    // requires the 'contacts-write' persmission
     var callback = aCallback || marionetteScriptFinished;
-    SpecialPowers.addPermission('contacts-write', true, document);
     console.log('removing contact with id \'' + aContact.id + '\'');
     var req = window.navigator.mozContacts.remove(aContact);
     req.onsuccess = function() {
       console.log('success removing contact with id \'' + aContact.id + '\'');
-      SpecialPowers.removePermission('contacts-write', document);
       callback(true);
     };
     req.onerror = function() {
       console.error('error removing contact with id \'' +
                       aContacts[i].id + '\'');
-      SpecialPowers.removePermission('contacts-write', document);
       callback(false);
     };
   },
 
   getSetting: function(aName, aCallback) {
+    // requires the 'settings-read' and 'settings-api-read' permissions
     var callback = aCallback || marionetteScriptFinished;
-    SpecialPowers.addPermission('settings-read', true, document);
-    SpecialPowers.addPermission('settings-api-read', true, document);
     var req = window.navigator.mozSettings.createLock().get(aName);
     req.onsuccess = function() {
       console.log('setting retrieved');
@@ -240,8 +231,7 @@ var GaiaDataLayer = {
   },
 
   setSetting: function(aName, aValue, aReturnOnSuccess) {
-    SpecialPowers.addPermission('settings-write', true, document);
-    SpecialPowers.addPermission('settings-api-write', true, document);
+    // requires the 'settings-write' and 'settings-api-write' permissions
     var returnOnSuccess = aReturnOnSuccess || aReturnOnSuccess === undefined;
     var setting = {};
     setting[aName] = aValue;
@@ -506,19 +496,15 @@ var GaiaDataLayer = {
   },
 
   sendSMS: function(recipient, content, aCallback) {
+    // requires the 'sms' permission and the 'dom.sms.enabled' pref
     var callback = aCallback || marionetteScriptFinished;
     console.log('sending sms message to number: ' + recipient);
-
-    SpecialPowers.addPermission('sms', true, document);
-    SpecialPowers.setBoolPref('dom.sms.enabled', true);
 
     let messageManager = window.navigator.mozMobileMessage;
     let request = messageManager.send(recipient, content);
 
     request.onsuccess = function(event) {
       var sms = event.target.result;
-      SpecialPowers.removePermission('sms', document);
-      SpecialPowers.clearUserPref('dom.sms.enabled');
 
       waitFor(
         function() { callback(true); },
@@ -531,18 +517,15 @@ var GaiaDataLayer = {
 
     request.onerror = function() {
       console.log('sms message not sent');
-      SpecialPowers.removePermission('sms', document);
-      SpecialPowers.clearUserPref('dom.sms.enabled');
       callback(false);
     };
   },
 
   getAllSms: function(aCallback) {
+    // requires the 'sms' permission and the 'dom.sms.enabled' pref
     var callback = aCallback || marionetteScriptFinished;
     console.log('searching for sms messages');
 
-    SpecialPowers.addPermission('sms', true, document);
-    SpecialPowers.setBoolPref('dom.sms.enabled', true);
     let sms = window.navigator.mozMobileMessage;
 
     let msgList = [];
@@ -555,7 +538,6 @@ var GaiaDataLayer = {
         // Now get the next in the list
         cursor.continue();
       }else{
-        disableSms();
         // Send back the list
         callback(msgList);
       }
@@ -563,22 +545,15 @@ var GaiaDataLayer = {
 
     cursor.onerror = function(event) {
       console.log('sms.getMessages error: ' + event.target.error.name);
-      disableSms();
       callback(false);
     };
-
-    function disableSms() {
-      SpecialPowers.removePermission('sms', document);
-      SpecialPowers.clearUserPref('dom.sms.enabled');
-    }
   },
 
   deleteAllSms: function(aCallback) {
+    // requires the 'sms' permission and the 'dom.sms.enabled' pref
     var callback = aCallback || marionetteScriptFinished;
     console.log('searching for sms messages');
 
-    SpecialPowers.addPermission('sms', true, document);
-    SpecialPowers.setBoolPref('dom.sms.enabled', true);
     let sms = window.navigator.mozMobileMessage;
 
     let msgList = [];
@@ -597,7 +572,6 @@ var GaiaDataLayer = {
           deleteSmsMsgs(msgList);
         } else {
           console.log('zero sms messages found');
-          disableSms();
           callback(true);
         }
       }
@@ -605,7 +579,6 @@ var GaiaDataLayer = {
 
     cursor.onerror = function(event) {
       console.log('sms.getMessages error: ' + event.target.error.name);
-      disableSms();
       callback(false);
     };
 
@@ -622,12 +595,10 @@ var GaiaDataLayer = {
           } else {
             // All messages deleted
             console.log('finished deleting all sms messages');
-            disableSms();
             callback(true);
           }
         } else {
           console.log('sms delete failed');
-          disableSms();
           callback(false);
         }
       };
@@ -635,14 +606,8 @@ var GaiaDataLayer = {
       request.onerror = function(event) {
         console.log('sms.delete request returned unexpected error: ' +
                     event.target.error.name);
-        disableSms();
         callback(false);
       };
-    }
-
-    function disableSms() {
-      SpecialPowers.removePermission('sms', document);
-      SpecialPowers.clearUserPref('dom.sms.enabled');
     }
   },
 

--- a/tests/python/gaia-ui-tests/gaiatest/apps/calendar/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/calendar/app.py
@@ -196,9 +196,9 @@ class Calendar(Base):
             return previous
 
     def a11y_click_header(self, header, selector):
-        self.marionette.execute_async_script(
+        self.accessibility.execute_async_script(
             "Accessibility.click(arguments[0].shadowRoot.querySelector('%s'));" % selector,
-            [header], special_powers=True)
+            [header])
 
     def wait_fot_settings_drawer_animation(self):
         el = self.marionette.find_element(*self.settings._settings_drawer_locator)

--- a/tests/python/gaia-ui-tests/gaiatest/apps/calendar/regions/event.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/calendar/regions/event.py
@@ -46,9 +46,9 @@ class NewEvent(Calendar):
         self.keyboard.dismiss()
 
     def a11y_click_close_button(self):
-        self.marionette.execute_async_script(
+        self.accessibility.execute_async_script(
             "Accessibility.click(arguments[0].shadowRoot.querySelector('button.action-button'));",
-            [self.marionette.find_element(*self._modify_event_header_locator)], special_powers=True)
+            [self.marionette.find_element(*self._modify_event_header_locator)])
 
     def a11y_click_save_event(self):
         event_start_time = self.marionette.find_element(*self._event_start_time_value_locator).text

--- a/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/contact_import_picker.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/contacts/regions/contact_import_picker.py
@@ -21,7 +21,7 @@ class ContactImportPicker(Base):
         self.marionette.switch_to_frame(select_contacts)
 
     def tap_import_button(self, wait_for_import = True):
-        self.marionette.execute_script('window.wrappedJSObject.importer.ui.importAll();', special_powers=True)
+        self.marionette.execute_script('window.wrappedJSObject.importer.ui.importAll();')
         # TODO uncomment this when Bug 932804 is resolved
         # self.marionette.find_element(*self._import_button_locator).tap()
         self.apps.switch_to_displayed_app()
@@ -35,12 +35,12 @@ class ContactImportPicker(Base):
         self.marionette.execute_script("""
             window.wrappedJSObject.document.getElementById("friends-list")
                   .getElementsByTagName("a")[1].click()
-        """, special_powers=True)
+        """)
         self.wait_for_element_not_displayed(*self._friends_list_locator)
         self.apps.switch_to_displayed_app()
 
     def tap_select_all(self):
         # TODO replace this with proper tap when Bug 932804 is resolved
-        self.marionette.execute_script('window.wrappedJSObject.importer.ui.selectAll();', special_powers=True)
+        self.marionette.execute_script('window.wrappedJSObject.importer.ui.selectAll();')
         el = self.marionette.find_element(*self._import_button_locator)
         Wait(self.marionette).until(expected.element_enabled(el))

--- a/tests/python/gaia-ui-tests/gaiatest/apps/email/regions/setup.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/email/regions/setup.py
@@ -180,10 +180,12 @@ class ManualSetupEmail(Base):
         # rather than the default value of 100 seconds
         # The UI data layer of the UI is changed, because the minimum check mail time value is 5 min,
         # which is far too long to check for in a test. This allows us to check earlier
+        with self.marionette.using_context('chrome'):
+            self.marionette.execute_script(
+                "Services.prefs.setIntPref('dom.requestSync.minInterval', 1);")
         self.marionette.execute_script("""
-            SpecialPowers.setIntPref('dom.requestSync.minInterval', 1);
             document.querySelector("[data-l10n-id = settings-check-every-5min]").value = '%s';
-        """ % value, special_powers=True)
+        """ % value)
         self.marionette.find_element(*self._check_for_new_messages_locator).tap()
         self.select('Every 5 minutes')
 

--- a/tests/python/gaia-ui-tests/gaiatest/apps/search/regions/html5_player.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/search/regions/html5_player.py
@@ -60,18 +60,18 @@ class HTML5Player(PageRegion):
     def show_controls(self):
         Wait(self.marionette).until(lambda m: not self.controls_visible)
         self.marionette.execute_script("""
-           var a = SpecialPowers.Cc["@mozilla.org/inspector/dom-utils;1"]
-               .getService(SpecialPowers.Ci.inIDOMUtils)
+           var a = Components.classes["@mozilla.org/inspector/dom-utils;1"]
+               .getService(Components.interfaces.inIDOMUtils)
                .getChildrenForNode(document.getElementsByTagName('video')[0], true);
            var x = a[1].ownerDocument.getAnonymousElementByAttribute(a[1],'class', 'controlBar');
            x.removeAttribute('hidden');
-         """)
+         """, sandbox='system')
         Wait(self.marionette).until(lambda m: self.controls_visible)
 
     def get_location(self, class_name):
         return self.marionette.execute_script("""
-           var a = SpecialPowers.Cc["@mozilla.org/inspector/dom-utils;1"]
-               .getService(SpecialPowers.Ci.inIDOMUtils)
+           var a = Components.classes["@mozilla.org/inspector/dom-utils;1"]
+               .getService(Components.interfaces.inIDOMUtils)
                .getChildrenForNode(document.getElementsByTagName('video')[0], true);
            var x1 = document.getElementsByTagName('video')[0].getBoundingClientRect().left;
            var x2 = a[1].ownerDocument
@@ -82,7 +82,7 @@ class HTML5Player(PageRegion):
            var y2 = a[1].ownerDocument.getAnonymousElementByAttribute(a[1],'class', '%s')
                         .getBoundingClientRect().top;
            return (Math.floor(x2-x1) + ',' + Math.floor(y2-y1));
-         """ % (class_name, class_name)).split(',')
+         """ % (class_name, class_name), sandbox='system').split(',')
 
     def tap_video_control(self, class_name):
         location = self.get_location(class_name)

--- a/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_test.py
@@ -89,7 +89,9 @@ class GaiaApps(object):
                                                           % (manifest_url, json.dumps(entry_point)), script_timeout=launch_timeout)
             assert result, "Failed to launch app with manifest_url '%s'" % manifest_url
         else:
-            result = self.marionette.execute_async_script("GaiaApps.launchWithName('%s')" % name, script_timeout=launch_timeout)
+            result = self.marionette.execute_async_script(
+                "GaiaApps.launchWithName('%s')" % name,
+                script_timeout=launch_timeout)
             assert result, "Failed to launch app with name '%s'" % name
         app = GaiaApp(frame=result.get('frame'),
                       src=result.get('src'),
@@ -192,68 +194,88 @@ class GaiaData(object):
     @property
     def all_contacts(self):
         # TODO Bug 1049489 - In future, simplify executing scripts from the chrome context
+        self.marionette.push_permission('contacts-read', True)
         self.marionette.set_context(self.marionette.CONTEXT_CHROME)
-        result = self.marionette.execute_async_script('return GaiaDataLayer.getAllContacts();', special_powers=True)
+        result = self.marionette.execute_async_script('return GaiaDataLayer.getAllContacts();')
         self.marionette.set_context(self.marionette.CONTEXT_CONTENT)
+        self.marionette.push_permission('contacts-read', False)
         return result
 
     @property
     def sim_contacts(self):
         self.marionette.switch_to_frame()
-        adn_contacts = self.marionette.execute_async_script('return GaiaDataLayer.getSIMContacts("adn");', special_powers=True)
-        sdn_contacts = self.marionette.execute_async_script('return GaiaDataLayer.getSIMContacts("sdn");', special_powers=True)
+        adn_contacts = self.marionette.execute_async_script('return GaiaDataLayer.getSIMContacts("adn");')
+        sdn_contacts = self.marionette.execute_async_script('return GaiaDataLayer.getSIMContacts("sdn");')
         return adn_contacts + sdn_contacts
 
     def insert_contact(self, contact):
         # TODO Bug 1049489 - In future, simplify executing scripts from the chrome context
+        self.marionette.push_permission('contacts-create', True)
         self.marionette.set_context(self.marionette.CONTEXT_CHROME)
         mozcontact = contact.create_mozcontact()
-        result = self.marionette.execute_async_script('return GaiaDataLayer.insertContact(%s);' % json.dumps(mozcontact), special_powers=True)
+        result = self.marionette.execute_async_script('return GaiaDataLayer.insertContact(%s);' % json.dumps(mozcontact))
         assert result, 'Unable to insert contact %s' % contact
         self.marionette.set_context(self.marionette.CONTEXT_CONTENT)
+        self.marionette.push_permission('contacts-create', False)
 
     def insert_sim_contact(self, contact, contact_type='adn'):
         mozcontact = contact.create_mozcontact()
         result = self.marionette.execute_async_script('return GaiaDataLayer.insertSIMContact("%s", %s);'
-                                                      % (contact_type, json.dumps(mozcontact)), special_powers=True)
+                                                      % (contact_type, json.dumps(mozcontact)))
         assert result, 'Unable to insert SIM contact %s' % contact
         return result
 
     def delete_sim_contact(self, moz_contact_id, contact_type='adn'):
         result = self.marionette.execute_async_script('return GaiaDataLayer.deleteSIMContact("%s", "%s");'
-                                                      % (contact_type, moz_contact_id), special_powers=True)
+                                                      % (contact_type, moz_contact_id))
         assert result, 'Unable to insert SIM contact %s' % moz_contact_id
 
     def remove_all_contacts(self):
         # TODO Bug 1049489 - In future, simplify executing scripts from the chrome context
+        self.marionette.push_permission('contacts-write', True)
         self.marionette.set_context(self.marionette.CONTEXT_CHROME)
         timeout = max(self.marionette.timeout or 60000, 1000 * len(self.all_contacts))
-        result = self.marionette.execute_async_script('return GaiaDataLayer.removeAllContacts();', special_powers=True, script_timeout=timeout)
+        self.marionette.push_permission('contacts-read', True)
+        result = self.marionette.execute_async_script('return GaiaDataLayer.removeAllContacts();', script_timeout=timeout)
         assert result, 'Unable to remove all contacts'
         self.marionette.set_context(self.marionette.CONTEXT_CONTENT)
 
     def get_setting(self, name):
-        return self.marionette.execute_async_script('return GaiaDataLayer.getSetting("%s")' % name, special_powers=True)
+        self.marionette.push_permission('settings-read', True)
+        self.marionette.push_permission('settings-api-read', True)
+        return self.marionette.execute_async_script(
+            'return GaiaDataLayer.getSetting("%s")' % name)
 
     @property
     def all_settings(self):
         return self.get_setting('*')
 
     def set_setting(self, name, value):
+        self.marionette.push_permission('settings-write', True)
+        self.marionette.push_permission('settings-api-write', True)
         import json
         value = json.dumps(value)
-        result = self.marionette.execute_async_script('return GaiaDataLayer.setSetting("%s", %s)' % (name, value), special_powers=True)
+        result = self.marionette.execute_async_script('return GaiaDataLayer.setSetting("%s", %s)' % (name, value))
         assert result, "Unable to change setting with name '%s' to '%s'" % (name, value)
 
     def _get_pref(self, datatype, name):
         self.marionette.switch_to_frame()
-        pref = self.marionette.execute_script("return SpecialPowers.get%sPref('%s');" % (datatype, name), special_powers=True)
+        with self.marionette.using_context('chrome'):
+            pref = self.marionette.execute_script("return Services.prefs.get%sPref('%s');" % (datatype, name))
         return pref
 
     def _set_pref(self, datatype, name, value):
         value = json.dumps(value)
         self.marionette.switch_to_frame()
-        self.marionette.execute_script("SpecialPowers.set%sPref('%s', %s);" % (datatype, name, value), special_powers=True)
+        with self.marionette.using_context('chrome'):
+            self.marionette.execute_script(
+                "Services.prefs.set%sPref('%s', %s);" % (datatype, name, value))
+
+    def clear_user_pref(self, name):
+        self.marionette.switch_to_frame()
+        with self.marionette.using_context('chrome'):
+            self.marionette.execute_script(
+                "Services.prefs.clearUserPref('%s');" % name)
 
     def get_bool_pref(self, name):
         """Returns the value of a Gecko boolean pref, which is different from a Gaia setting."""
@@ -312,12 +334,12 @@ class GaiaData(object):
 
     def connect_to_cell_data(self):
         self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script("return GaiaDataLayer.connectToCellData()", special_powers=True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.connectToCellData()")
         assert result, 'Unable to connect to cell data'
 
     def disable_cell_data(self):
         self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script("return GaiaDataLayer.disableCellData()", special_powers=True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.disableCellData()")
         assert result, 'Unable to disable cell data'
 
     @property
@@ -338,12 +360,12 @@ class GaiaData(object):
 
     def enable_wifi(self):
         self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script("return GaiaDataLayer.enableWiFi()", special_powers=True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.enableWiFi()")
         assert result, 'Unable to enable WiFi'
 
     def disable_wifi(self):
         self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script("return GaiaDataLayer.disableWiFi()", special_powers=True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.disableWiFi()")
         assert result, 'Unable to disable WiFi'
 
     def connect_to_wifi(self, network=None):
@@ -397,11 +419,21 @@ class GaiaData(object):
 
     def delete_all_sms(self):
         self.marionette.switch_to_frame()
-        return self.marionette.execute_async_script("return GaiaDataLayer.deleteAllSms();", special_powers=True)
+        self.marionette.push_permission('sms', True)
+        self.set_bool_pref('dom.sms.enabled', True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.deleteAllSms();")
+        self.marionette.push_permission('sms', False)
+        self.clear_user_pref('dom.sms.enabled')
+        return result
 
     def get_all_sms(self):
         self.marionette.switch_to_frame()
-        return self.marionette.execute_async_script("return GaiaDataLayer.getAllSms();", special_powers=True)
+        self.marionette.push_permission('sms', True)
+        self.set_bool_pref('dom.sms.enabled', True)
+        result = self.marionette.execute_async_script("return GaiaDataLayer.getAllSms();")
+        self.marionette.push_permission('sms', False)
+        self.clear_user_pref('dom.sms.enabled')
+        return result
 
     def delete_all_call_log_entries(self):
         """The call log needs to be open and focused in order for this to work."""
@@ -455,7 +487,13 @@ class GaiaData(object):
         import json
         number = json.dumps(number)
         message = json.dumps(message)
-        result = self.marionette.execute_async_script('return GaiaDataLayer.sendSMS(%s, %s)' % (number, message), special_powers=True)
+
+        self.marionette.push_permission('sms', True)
+        self.set_bool_pref('dom.sms.enabled', True)
+        result = self.marionette.execute_async_script('return GaiaDataLayer.sendSMS(%s, %s)' % (number, message))
+        self.marionette.push_permission('sms', False)
+        self.clear_user_pref('dom.sms.enabled')
+
         assert result, 'Unable to send SMS to recipient %s with text %s' % (number, message)
 
     def add_notification(self, title, options=None):
@@ -474,9 +512,6 @@ class Accessibility(object):
 
     def __init__(self, marionette):
         self.marionette = marionette
-        js = os.path.abspath(os.path.join(__file__, os.path.pardir,
-                                          'atoms', "accessibility.js"))
-        self.marionette.import_script(js)
 
     def is_hidden(self, element):
         return self._run_async_script('isHidden', [element])
@@ -491,8 +526,20 @@ class Accessibility(object):
         self._run_async_script('click', [element])
 
     def wheel(self, element, direction):
-        self.marionette.execute_script('Accessibility.wheel.apply(Accessibility, arguments)', [
-            element, direction])
+        self.marionette.execute_script("""
+        let element = arguments[0];
+        let direction = arguments[1];
+        let horizontal = direction === 'left' || direction === 'right';
+        let page = (direction === 'left' || direction === 'up') ? 1 : -1;
+        let event = new window.wrappedJSObject.WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          deltaX: horizontal ? page : 0,
+          deltaY: horizontal ? 0 : page,
+          deltaMode: window.wrappedJSObject.WheelEvent.DOM_DELTA_PAGE,
+        });
+        element.wrappedJSObject.dispatchEvent(event);
+        """, [element, direction], sandbox='default')
 
     def get_name(self, element):
         return self._run_async_script('getName', [element])
@@ -503,12 +550,17 @@ class Accessibility(object):
     def dispatchEvent(self):
         self.marionette.switch_to_frame()
         self.marionette.execute_script(
-            "window.wrappedJSObject.dispatchEvent(new CustomEvent('accessibility-action'));")
+            "window.dispatchEvent(new CustomEvent('accessibility-action'));")
 
-    def _run_async_script(self, func, args):
+    def execute_async_script(self, script, args, **kwargs):
+        js = os.path.abspath(os.path.join(__file__, os.path.pardir,
+                                          'atoms', "accessibility.js"))
+        with open(js, 'r') as f:
+            content = f.read()
+
+        kwargs['sandbox'] = 'system'
         result = self.marionette.execute_async_script(
-            'return Accessibility.%s.apply(Accessibility, arguments)' % func,
-            args, special_powers=True)
+            '%s\n%s' % (content, script), args, **kwargs)
 
         if not result:
             return
@@ -518,6 +570,11 @@ class Accessibility(object):
             raise Exception(message)
 
         return result.get('result', None)
+
+    def _run_async_script(self, func, args):
+        return self.execute_async_script(
+            'return Accessibility.%s.apply(Accessibility, arguments)' % func,
+            args)
 
 
 class FakeUpdateChecker(object):
@@ -739,11 +796,12 @@ class GaiaDevice(object):
         Wait(self.marionette).until(lambda m: m.find_element(By.CSS_SELECTOR, 'div.lockScreenWindow.active'))
 
     def unlock(self):
-        self.marionette.import_script(self.lockscreen_atom)
-        self.marionette.switch_to_frame()
-        result = self.marionette.execute_async_script('GaiaLockScreen.unlock()')
-        GaiaData(self.marionette).set_setting('lockscreen.enabled', False)
-        assert result, 'Unable to unlock screen'
+        if self.is_locked:
+            self.marionette.import_script(self.lockscreen_atom)
+            self.marionette.switch_to_frame()
+            result = self.marionette.execute_async_script("GaiaLockScreen.unlock();", sandbox='default')
+            GaiaData(self.marionette).set_setting('lockscreen.enabled', False)
+            assert result, 'Unable to unlock screen'
 
     def change_orientation(self, orientation):
         """  There are 4 orientation states which the phone can be passed in:

--- a/tests/python/gaia-ui-tests/gaiatest/runtests.py
+++ b/tests/python/gaia-ui-tests/gaiatest/runtests.py
@@ -68,16 +68,13 @@ class GaiaTestRunner(BaseMarionetteTestRunner, GaiaTestRunnerMixin,
             if marionette.session is not None:
                 try:
                     marionette.switch_to_frame()
+                    marionette.push_permission('settings-read', True)
+                    marionette.push_permission('settings-api-read', True)
                     rv['settings'] = json.dumps(marionette.execute_async_script("""
-SpecialPowers.pushPermissions([
-  {type: 'settings-read', allow: true, context: document},
-  {type: 'settings-api-read', allow: true, context: document},
-], function() {
   var req = window.navigator.mozSettings.createLock().get('*');
   req.onsuccess = function() {
     marionetteScriptFinished(req.result);
-  }
-});""", special_powers=True), sort_keys=True, indent=4, separators=(',', ': '))
+  }""", sandbox='system'), sort_keys=True, indent=4, separators=(',', ': '))
                 except:
                     logger = mozlog.structured.get_default_logger()
                     if not logger:

--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/email/test_IMAP_email_notification.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/email/test_IMAP_email_notification.py
@@ -88,7 +88,5 @@ class TestEmailNotification(GaiaTestCase):
                          '"%s".' % (mock_email['message'], email.body))
 
     def tearDown(self):
-        self.marionette.execute_script("SpecialPowers.setIntPref('dom.requestSync.minInterval', 100);",
-                                        special_powers=True)
-
+        self.data_layer.set_int_pref('dom.requestSync.minInterval', 100)
         GaiaTestCase.tearDown(self)

--- a/tests/python/gaia-ui-tests/requirements.txt
+++ b/tests/python/gaia-ui-tests/requirements.txt
@@ -1,6 +1,6 @@
 boto>=2.32.1
-marionette_driver==0.5
-marionette_client==0.12
+marionette_driver==0.7
+marionette_client==0.13
 mozdevice>=0.34
 moztest>=0.6
 requests


### PR DESCRIPTION
This patch makes gaiatest not depend on SpecialPowers.  It does depend on a new 'sandbox' feature introduced (but not quite landed yet) in bug 1149618.

try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=300a308db174
