### PR TITLE
Bug 1157174 - Reduce end-padding for menu buttons

### DIFF
--- a/shared/style/action_menu.css
+++ b/shared/style/action_menu.css
@@ -228,6 +228,7 @@
   text-shadow: none;
   text-align: start;
   padding: 0 1.2rem;
+  -moz-padding-end: 0.2rem;
   margin: 0 1.5rem 1rem 1.5rem;
   background: rgba(87, 87, 87, 0.8);
   border: none;


### PR DESCRIPTION
Action menu buttons are start-aligned rather than centred, so this just puts the end-padding back to the effective value prior to Bug 1010675.
