### PR TITLE
Bug 1160363 - [Calendar][Week Bar] Tapping on the bar at the top with the initials of the days of the week will bring the user to the 1st day of the month r=gaye

### DIFF
--- a/apps/calendar/js/views/month.js
+++ b/apps/calendar/js/views/month.js
@@ -93,8 +93,8 @@ Month.prototype = {
     this.element.addEventListener('swipe', this);
     this.element.addEventListener('wheel', this);
     this.controller.on('monthChange', this);
-    this.delegate(this.element, 'click', '[data-date]', this);
-    this.delegate(this.element, 'dbltap', '[data-date]', this);
+    this.delegate(this.element, 'click', '.month-day', this);
+    this.delegate(this.element, 'dbltap', '.month-day', this);
 
     timeObserver.on('day', this._setPresentDate);
 

--- a/apps/calendar/js/views/month_day.js
+++ b/apps/calendar/js/views/month_day.js
@@ -45,6 +45,7 @@ MonthDay.prototype = {
     );
     el.dataset.date = dayId;
     el.className = state;
+    el.classList.add('month-day');
     el.innerHTML = `<span class="day" role="button">${date}</span>
       <div id="${id}-busy-indicator" class="busy-indicator"
         aria-hidden="true"></div>

--- a/apps/calendar/test/unit/views/month_test.js
+++ b/apps/calendar/test/unit/views/month_test.js
@@ -59,14 +59,8 @@ suite('Views.Month', function() {
     test('dom: click', function() {
       subject.onfirstseen();
 
-      // find something with [data-date];
-      var el = subject.element.querySelector(
-        '[data-date]'
-      );
-
-      var date = Calc.dateFromId(
-        el.dataset.date
-      );
+      var el = subject.element.querySelector('.month-day');
+      var date = Calc.dateFromId(el.dataset.date);
 
       triggerEvent(el, 'click');
       assert.deepEqual(


### PR DESCRIPTION
the `.month` wrapper also have `[data-date]`, so the delegated event was being triggered with the wrong element.

found it easier to add a new new class name instead of removing the `[data-date]` from the `.month` (less changes to the tests and less likely to re-introduce the same bug in the future)
