### PR TITLE
Bug 1147315 - No resize for 180 orientation changes. r=etienne

### DIFF
--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -542,9 +542,9 @@
       filter = (evt.detail && evt.detail.filter) || null;
     }
 
-
-    var shouldResize = (OrientationManager.defaultOrientation !=
-                        OrientationManager.fetchCurrentOrientation());
+    var currOrientation = OrientationManager.fetchCurrentOrientation();
+    var shouldResize = (OrientationManager.defaultOrientation.split('-')[0] !=
+                        currOrientation.split('-')[0]);
     var shouldHideKeyboard = layoutManager.keyboardEnabled;
 
     this.publish('cardviewbeforeshow'); // Will hide the keyboard if needed
@@ -561,6 +561,7 @@
 
       screen.mozLockOrientation(OrientationManager.defaultOrientation);
       if (shouldResize) {
+        // aspect ratio change will produce resize event
         window.addEventListener('resize', function resized() {
           window.removeEventListener('resize', resized);
           shouldResize = false;

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -1346,6 +1346,17 @@ suite('system/TaskManager >', function() {
         assert.isTrue(taskManager.isShown());
       });
     });
+
+    suite('when the orientation flips', function() {
+      setup(function() {
+        MockOrientationManager.mCurrentOrientation = 'portrait-secondary';
+      });
+
+      test('should just show', function() {
+        showTaskManager(this.sinon.clock);
+        assert.isTrue(taskManager.isShown());
+      });
+    });
   });
 
 });


### PR DESCRIPTION
We don't get a resize event for 180 degree orientation changes, so bad things were happening. Forgive my ignorance,  but I'm not sure what event if any to listen for in this case, in this context. I opted for the setTimeout with 250ms constant per the setTimeout delay in https://dxr.mozilla.org/mozilla-central/source/b2g/components/OrientationChangeHandler.jsm#51
