### PR TITLE
Bug 1160649 - Force to use wrapping in the feedback textarea r=evelyn

### DIFF
--- a/apps/settings/style/settings.css
+++ b/apps/settings/style/settings.css
@@ -911,6 +911,7 @@ ul li > label.range-icons.volume input {
   height: 10rem;
   padding: 1rem 1rem 1.2rem;
   resize: none;
+  white-space: normal;
 }
 
 #sendFeedback .pack-checkbox span {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1160649
