### PR TITLE
Bug 1162274 - "Settings" in search suggestion dialog is not linked.

### DIFF
--- a/apps/search/index.html
+++ b/apps/search/index.html
@@ -95,7 +95,9 @@
         </h2>
 
         <div id="suggestions-notice-wrapper" hidden>
-          <p data-l10n-id="suggestions-settings-notice"></p>
+          <p data-l10n-id="suggestions-settings-notice">
+            <span id="settings-link"></span>
+          </p>
           <button id="suggestions-notice-confirm" data-l10n-id="ok"></button>
         </div>
 

--- a/apps/search/locales/search.en-US.properties
+++ b/apps/search/locales/search.en-US.properties
@@ -8,7 +8,7 @@ places.ariaLabel = Places
 apps.ariaLabel = Apps
 
 # LOCALIZATION NOTE Search and Settings are names of applications. In this case, there is a section titled 'Search' within the Settings application.
-suggestions-settings-notice.innerHTML = Search suggestions are enabled. The characters you type when entering a search are being sent to the search engine. You can disable search suggestions in the device <span id="settings-link">Settings</span>.
+suggestions-settings-notice = Search suggestions are enabled. The characters you type when entering a search are being sent to the search engine. You can disable search suggestions in the device <span>Settings</span>.
 ok = OK
 
 add-to-home-screen.label = Add to Home Screen


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1162274
