### PR TITLE
Bug 1158665 - [Stingray][Home] After a card is added into a folder, align the folder list to the folder card

### DIFF
--- a/tv_apps/smart-home/js/home.js
+++ b/tv_apps/smart-home/js/home.js
@@ -73,7 +73,8 @@
                 listElem: 'folder-list',
                 itemClassName: 'app-button',
                 leftMargin: CARDLIST_LEFT_MARGIN,
-                scale: 0.68});
+                scale: 0.68,
+                referenceElement: that.cardScrollable});
 
         that.navigableScrollable = [that.cardScrollable, that.folderScrollable];
         var collection = that.getNavigateElements();
@@ -678,6 +679,7 @@
       this.folderScrollable.clean();
       this._folderCard = undefined;
       this.edit.isFolderReady = false;
+      this.cardScrollable.setColspanOnFocus(0);
     },
 
     handleCardUnfocus: function(scrollable, itemElem, nodeElem) {
@@ -721,38 +723,39 @@
       this._folderCard = card;
       var folderList = this._folderCard.getCardList();
 
-      // Build folder list
-      if (folderList.length > 0) {
-        folderList.forEach(function(card) {
-          this.folderScrollable.addNode(this._createCardNode(card));
-        }, this);
-
-        var step = 0;
-        var initFolderAnimation = function() {
-          if (step === 0) {
-            ++step;
-            // At first frame, we call setReferenceElement to move folder list
-            // right under folder card. Transition should be replaced by 'none'
-            // since we don't need to show this process as animation to user.
-            this.folderListElem.style.transition = 'none';
-            this.folderScrollable.setReferenceElement(target);
-            this.skipFolderBubble = Animations.doBubbleAnimation(
-                          this.folderListElem, '.app-button', 100, function() {
-                this.spatialNavigator.add(this.folderScrollable);
-                this.edit.isFolderReady = true;
-                this.skipFolderBubble = undefined;
-              }.bind(this));
-
-            window.requestAnimationFrame(initFolderAnimation);
-          } else {
-            // 2nd frame, recover original transition.
-            this.folderListElem.style.transition = '';
-          }
-        }.bind(this);
-        window.requestAnimationFrame(initFolderAnimation);
-      } else {
+      if (folderList.length === 0) {
         this.edit.isFolderReady = true;
+        return;
       }
+
+      // Build folder list
+      folderList.forEach(function(card) {
+        this.folderScrollable.addNode(this._createCardNode(card));
+      }, this);
+
+      var step = 0;
+      var initFolderAnimation = function() {
+        if (step === 0) {
+          ++step;
+          // At first frame, we call setReferenceElement to move folder list
+          // right under folder card. Transition should be replaced by 'none'
+          // since we don't need to show this process as animation to user.
+          this.folderListElem.style.transition = 'none';
+          this.folderScrollable.realignToReferenceElement();
+          this.skipFolderBubble = Animations.doBubbleAnimation(
+                        this.folderListElem, '.app-button', 100, function() {
+              this.spatialNavigator.add(this.folderScrollable);
+              this.edit.isFolderReady = true;
+              this.skipFolderBubble = undefined;
+            }.bind(this));
+
+          window.requestAnimationFrame(initFolderAnimation);
+        } else {
+          // 2nd frame, recover original transition.
+          this.folderListElem.style.transition = '';
+        }
+      }.bind(this);
+      window.requestAnimationFrame(initFolderAnimation);
     },
 
     openSettings: function() {

--- a/tv_apps/smart-home/style/home.css
+++ b/tv_apps/smart-home/style/home.css
@@ -56,7 +56,7 @@ section {
   position: relative;
   width: 100%;
   height: 100%;
-  transition: transform 0.2s ease;
+  transition: transform 0.4s cubic-bezier(0.25, 0, 0, 1);
   transform-origin: 0 50%;
 }
 
@@ -104,15 +104,19 @@ section {
   transform: translateY(-44rem);
 }
 
-#folder-list .card smart-button[type="app-button"].new-card-transition,
-#card-list .card smart-button[type="app-button"].new-card-transition.hover {
-  transition: transform 0.4s cubic-bezier(0.25, 0, 0, 1),
-              opacity 0.4s cubic-bezier(0.25, 0, 0, 1);
+/* XXX: This is an animation hack for dropping card to folder in reversed list.
+        When the list is shown revesed, the card would be initially inserted at
+        the end of folderList which is one unit exceed the right position
+        while the folderList scrolling back for one unit.
+        As a result we need to put its starting point one unit back to make it
+        looks like "moving straight down"　*/
+#folder-list.reversed .card:not([data-idx="0"]) smart-button[type="app-button"].new-card {
+  transform: translate(-34.6rem, -44rem);
 }
 
-#card-list .card smart-button[type="app-button"].new-card.hover {
-  opacity: 1;
-  transform: translateY(44rem) scale(1.72);
+#folder-list .card smart-button[type="app-button"].new-card-transition {
+  transition: transform 0.4s cubic-bezier(0.25, 0, 0, 1),
+              opacity 0.4s cubic-bezier(0.25, 0, 0, 1);
 }
 
 .card-panel {
@@ -183,7 +187,7 @@ section {
   position: relative;
   width: 100%;
   height: 100%;
-  transition: transform 0.2s ease;
+  transition: transform 0.4s cubic-bezier(0.25, 0, 0, 1);
   transform-origin: 0 50%;
 }
 


### PR DESCRIPTION
This bug mainly do:
- Let scrollable accept another scrollable as reference element. Its position of focused element is used as the reference point.
- calling `scrollable.realignToReferenceElement()` scrolls it with respect to the new position of reference element. This function is called when needed to achieve the goal of this bug.
- Add `colspanOnFocus` property to scrollable. It allows scrollable to expand the space occupied by focus elelment; and it would be set whenever it needs. (mainly on folder expanding). Calling `setColspanOnFocus()` triggers repainting with respect to new `colspanOnFocus` value.
- `scrollable._setNodePosition` is now able to calculate correct position of hovering elements. Thus calling `_setNodesPosition` keeps position of `hovering`/`hovered` element right.

Miscellaneous changes 
- Rename `edit.deleteCard` to `edit.openDeleteCardDialog`; `edit._onCardDeleted` to `edit.deleteCard`.
- Animation hack for inserting card into reversed-expanding `folderList`.
