### PR TITLE
Bug 1162516 - Remove FrameSendFailureError symbol; r=davehunt

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/camera/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/camera/app.py
@@ -6,7 +6,7 @@ import time
 
 from marionette_driver import expected, By, Wait
 from marionette_driver.marionette import Actions
-from marionette_driver.errors import FrameSendFailureError, NoSuchWindowException
+from marionette_driver.errors import NoSuchWindowException
 
 from gaiatest.apps.base import Base
 
@@ -96,7 +96,7 @@ class Camera(Base):
 
         try:
             select.tap()
-        except (FrameSendFailureError, NoSuchWindowException):
+        except NoSuchWindowException:
             # The frame may close for Marionette but that's expected so we can continue - Bug 1065933
             pass
 

--- a/tests/python/gaia-ui-tests/gaiatest/apps/clock/regions/alarm_alert.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/clock/regions/alarm_alert.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette_driver import expected, By, Wait
-from marionette_driver.errors import FrameSendFailureError, NoSuchWindowException
+from marionette_driver.errors import NoSuchWindowException
 
 from gaiatest.apps.base import Base
 
@@ -25,7 +25,7 @@ class AlarmAlertScreen(Base):
         Wait(self.marionette).until(expected.element_displayed(stop_alarm_button))
         try:
             stop_alarm_button.tap()
-        except (FrameSendFailureError, NoSuchWindowException):
+        except NoSuchWindowException:
             # The frame may close for Marionette but that's expected so we can continue - Bug 1065933
             pass
 

--- a/tests/python/gaia-ui-tests/gaiatest/apps/ftu/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/ftu/app.py
@@ -6,7 +6,7 @@ import re
 import time
 
 from marionette_driver import expected, By, Wait
-from marionette_driver.errors import FrameSendFailureError, NoSuchWindowException
+from marionette_driver.errors import NoSuchWindowException
 
 from gaiatest.apps.base import Base
 
@@ -369,7 +369,7 @@ class Ftu(Base):
     def tap_skip_tour(self):
         try:
             self.marionette.find_element(*self._skip_tour_button_locator).tap()
-        except (FrameSendFailureError, NoSuchWindowException):
+        except NoSuchWindowException:
             # The frame may close for Marionette but that's expected so we can continue - Bug 1065933
             pass
 
@@ -456,6 +456,6 @@ class Ftu(Base):
     def tap_lets_go_button(self):
         try:
             self.marionette.find_element(*self._lets_go_button_locator).tap()
-        except (FrameSendFailureError, NoSuchWindowException):
+        except NoSuchWindowException:
             # The frame may close for Marionette but that's expected so we can continue - Bug 1065933
             pass

--- a/tests/python/gaia-ui-tests/gaiatest/apps/gallery/regions/crop_view.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/gallery/regions/crop_view.py
@@ -5,7 +5,7 @@
 import time
 
 from marionette_driver import expected, By, Wait
-from marionette_driver.errors import FrameSendFailureError, NoSuchWindowException
+from marionette_driver.errors import NoSuchWindowException
 
 from gaiatest.apps.base import Base
 


### PR DESCRIPTION
Depends on bug 1155703 to land in Gecko, and blocks bug 1162515 to remove
these symbols from the Python client.
