### PR TITLE
Bug 1162440 - Adjust confirm button padding

### DIFF
--- a/apps/camera/style/confirm.css
+++ b/apps/camera/style/confirm.css
@@ -57,8 +57,10 @@
 }
 
 .confirm-controls > button {
-   height: 3.8rem;
+  height: 3.8rem;
   -moz-margin-end: 1rem;
+  /* override shared/style/buttons.css, until strings can be shortened */
+  padding: 0 0.2rem;
 }
 
 .confirm-controls > button:last-child {


### PR DESCRIPTION
These labels never fit, but used to overflow into the padding. Since that was fixed in bug 1010675, we need to reduce padding to the equivalent value to avoid truncation and regression in legibility I picked the more conservative place to fix this, rather than the global buttons.css
