### PR TITLE
Bug 1162548 - [Calendar] edit and modify event views should not talk directly to stores r=gaye

### DIFF
--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -9,6 +9,7 @@ var ServiceController = require('controllers/service');
 var SyncController = require('controllers/sync');
 var TimeController = require('controllers/time');
 var asyncRequire = require('common/async_require');
+var bridge = require('bridge');
 var co = require('ext/co');
 var core = require('core');
 var dateL10n = require('date_l10n');
@@ -34,6 +35,7 @@ function setupCore(dbName) {
   if (core.db) {
     return;
   }
+  core.bridge = bridge;
   core.db = new Db(dbName || 'b2g-calendar');
   core.errorController = new ErrorController();
   core.notificationsController = notificationsController;

--- a/apps/calendar/js/bridge.js
+++ b/apps/calendar/js/bridge.js
@@ -1,0 +1,121 @@
+define(function(require, exports) {
+'use strict';
+
+var EventEmitter2 = require('ext/eventemitter2');
+var co = require('ext/co');
+var core = require('core');
+var dayObserver = require('day_observer');
+var nextTick = require('common/next_tick');
+var object = require('common/object');
+
+/**
+ * Fetch all the data needed to display the busytime information on the event
+ * views based on the busytimeId
+ */
+exports.fetchRecord = function(busytimeId) {
+  return co(function *() {
+    var record = yield dayObserver.findAssociated(busytimeId);
+    var eventStore = core.storeFactory.get('Event');
+    var owners = yield eventStore.ownersOf(record.event);
+    var provider = core.providerFactory.get(owners.account.providerType);
+    var capabilities = yield provider.eventCapabilities(record.event);
+
+    record.calendar = owners.calendar;
+    record.account = owners.account;
+    record.capabilities = capabilities;
+
+    return record;
+  });
+};
+
+/**
+ * Fetch all the calendars from database and emits a new event every time the
+ * values changes.
+ *
+ * @returns {ClientStream}
+ */
+exports.observeCalendars = function() {
+  // TODO: replace with real threads.client.stream when we get db into worker
+  var stream = new FakeClientStream();
+  var calendarStore = core.storeFactory.get('Calendar');
+
+  var getAllAndWrite = co.wrap(function *() {
+    // calendarStore.all() returns an object! we convert into an array since
+    // that is easier to render/manipulate
+    var calendars = yield calendarStore.all();
+    var data = yield object.map(calendars, co.wrap(function *(id, calendar) {
+      var provider = yield calendarStore.providerFor(calendar);
+      var caps = provider.calendarCapabilities(calendar);
+      return { calendar: calendar, capabilities: caps };
+    }));
+    stream.write(data);
+  });
+
+  calendarStore.on('add', getAllAndWrite);
+  calendarStore.on('preRemove', getAllAndWrite);
+  calendarStore.on('remove', getAllAndWrite);
+  calendarStore.on('update', getAllAndWrite);
+
+  stream.cancel = function() {
+    calendarStore.off('add', getAllAndWrite);
+    calendarStore.off('preRemove', getAllAndWrite);
+    calendarStore.off('remove', getAllAndWrite);
+    calendarStore.off('update', getAllAndWrite);
+    stream._emitter.removeAllListeners();
+  };
+
+  nextTick(getAllAndWrite);
+
+  return stream;
+};
+
+exports.createEvent = function(event) {
+  return persistEvent(event, 'create', 'canCreate');
+};
+
+exports.updateEvent = function(event) {
+  return persistEvent(event, 'update', 'canUpdate');
+};
+
+exports.deleteEvent = function(event) {
+  return persistEvent(event, 'delete', 'canDelete');
+};
+
+var persistEvent = co.wrap(function *(event, action, capability) {
+  var eventStore = core.storeFactory.get('Event');
+  var provider = yield eventStore.providerFor(event);
+  var caps = yield provider.eventCapabilities(event);
+  if (!caps[capability]) {
+    return Promise.reject(new Error(`Can't ${action} event`));
+  }
+  return provider[action + 'Event'](event.data);
+});
+
+exports.getSetting = co.wrap(function *(id) {
+  var settingsStore = core.storeFactory.get('Setting');
+  return yield settingsStore.getValue(id);
+});
+
+/**
+ * FakeClientStream is used as a temporary solution while we move all the db
+ * calls into the worker. In the end all the methods inside this file will be
+ * transfered into the "backend/calendar_service.js" and we will simply call
+ * the `threads.client('calendar')` API
+ */
+function FakeClientStream() {
+  this._emitter = new EventEmitter2();
+}
+
+FakeClientStream.prototype.write = function(data) {
+  this._emitter.emit('data', data);
+};
+
+FakeClientStream.prototype.listen = function(callback) {
+  this._emitter.on('data', callback);
+};
+
+FakeClientStream.prototype.unlisten = function(callback) {
+  this._emitter.off('data', callback);
+};
+
+});

--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -6,10 +6,10 @@ var EventBase = require('./event_base');
 var InputParser = require('shared/input_parser');
 var Local = require('provider/local');
 var QueryString = require('querystring');
+var co = require('ext/co');
 var core = require('core');
 var dateFormat = require('date_format');
 var getTimeL10nLabel = require('common/calc').getTimeL10nLabel;
-var nextTick = require('common/next_tick');
 var router = require('router');
 var viewFactory = require('./factory');
 
@@ -54,13 +54,6 @@ ModifyEvent.prototype = {
 
   _initEvents: function() {
     EventBase.prototype._initEvents.apply(this, arguments);
-
-    var calendars = core.storeFactory.get('Calendar');
-
-    calendars.on('add', this._addCalendarId.bind(this));
-    calendars.on('preRemove', this._removeCalendarId.bind(this));
-    calendars.on('remove', this._removeCalendarId.bind(this));
-    calendars.on('update', this._updateCalendarId.bind(this));
 
     this.deleteButton.addEventListener('click', this.deleteRecord);
     this.form.addEventListener('click', this.focusHandler);
@@ -152,7 +145,7 @@ ModifyEvent.prototype = {
    * Check if current event has been stored in the database
    */
   isSaved: function() {
-      return !!this.provider;
+    return this.element.classList.contains(this.UPDATE);
   },
 
   /**
@@ -166,128 +159,33 @@ ModifyEvent.prototype = {
     // really rare occasions "onfirstseen" is called after the EventBase
     // removed the "loading" class from the root element (seen it happen less
     // than 1% of the time)
-    this.getEl('calendarId').classList.add(self.LOADING);
-
-    var calendarStore = core.storeFactory.get('Calendar');
-    calendarStore.all(function(err, calendars) {
-      if (err) {
-        return console.error('Could not build list of calendars');
-      }
-
-      var pending = 0;
-      var self = this;
-
-      function next() {
-        if (!--pending) {
-          self.getEl('calendarId').classList.remove(self.LOADING);
-
-          if (self.onafteronfirstseen) {
-            self.onafteronfirstseen();
-          }
-        }
-      }
-
-      for (var id in calendars) {
-        pending++;
-        this._addCalendarId(id, calendars[id], next);
-      }
-
-    }.bind(this));
+    this.getEl('calendarId').classList.add(this.LOADING);
   },
 
-  /**
-   * Updates a calendar id option.
-   *
-   * @param {String} id calendar id.
-   * @param {Calendar.Model.Calendar} calendar model.
-   */
-  _updateCalendarId: function(id, calendar) {
-    var element = this.getEl('calendarId');
-    var option = element.querySelector('[value="' + id + '"]');
-    var store = core.storeFactory.get('Calendar');
+  _renderCalendars: function(records) {
+    // remove old calendars (this will be called every time we have a change on
+    // any calendar)
+    var select = this.getEl('calendarId');
+    // remove all the options
+    select.options.length = 0;
+    select.classList.remove(this.LOADING);
 
-    store.providerFor(calendar, function(err, provider) {
-      var caps = provider.calendarCapabilities(
-        calendar
-      );
-
-      if (!caps.canCreateEvent) {
-        this._removeCalendarId(id);
-        return;
-      }
-
-      if (option) {
-        option.text = calendar.remote.name;
-      }
-
-
-      if (this.oncalendarupdate) {
-        this.oncalendarupdate(calendar);
-      }
-    }.bind(this));
-  },
-
-  /**
-   * Add a single calendar id.
-   *
-   * @param {String} id calendar id.
-   * @param {Calendar.Model.Calendar} calendar calendar to add.
-   */
-  _addCalendarId: function(id, calendar, callback) {
-    var store = core.storeFactory.get('Calendar');
-    store.providerFor(calendar, function(err, provider) {
-      var caps = provider.calendarCapabilities(
-        calendar
-      );
-
-      if (!caps.canCreateEvent) {
-        if (callback) {
-          nextTick(callback);
-        }
-        return;
-      }
-
-      var option;
-      var element = this.getEl('calendarId');
-
-      option = document.createElement('option');
+    records
+    .filter(r => r.capabilities.canCreateEvent)
+    .forEach(record => {
+      var {id, name} = record.calendar.remote;
+      var option = document.createElement('option');
 
       if (id === Local.calendarId) {
         option.text = navigator.mozL10n.get('calendar-local');
         option.setAttribute('data-l10n-id', 'calendar-local');
       } else {
-        option.text = calendar.remote.name;
+        option.text = name;
       }
 
       option.value = id;
-      element.add(option);
-
-      if (callback) {
-        nextTick(callback);
-      }
-
-      if (this.onaddcalendar) {
-        this.onaddcalendar(calendar);
-      }
-    }.bind(this));
-  },
-
-  /**
-   * Remove a single calendar id.
-   *
-   * @param {String} id to remove.
-   */
-  _removeCalendarId: function(id) {
-    var element = this.getEl('calendarId');
-
-    var option = element.querySelector('[value="' + id + '"]');
-    if (option) {
-      element.removeChild(option);
-    }
-
-    if (this.onremovecalendar) {
-      this.onremovecalendar(id);
-    }
+      select.add(option);
+    });
   },
 
   /**
@@ -339,7 +237,7 @@ ModifyEvent.prototype = {
    * For now both update & create share the same
    * behaviour (redirect) in the future we may change this.
    */
-  _persistEvent: function(method, capability) {
+  _persistEvent: co.wrap(function *(method) {
     // create model data
     var data = this.formData();
     var errors;
@@ -357,114 +255,71 @@ ModifyEvent.prototype = {
       return;
     }
 
-    var self = this;
-    var provider;
+    // mark view as 'in progress' so we can style
+    // it via css during that time period
+    this.element.classList.add(this.PROGRESS);
 
-    this.store.providerFor(this.event, fetchProvider);
-
-    function fetchProvider(err, result) {
-      provider = result;
-      provider.eventCapabilities(
-        self.event.data,
-        verifyCaps
-      );
+    try {
+      // need to store date before async operation (event might change)
+      var moveDate = this.event.startDate;
+      yield core.bridge[method](this.event);
+      // move the position in the calendar to the added/edited day
+      core.timeController.move(moveDate);
+      // order is important the above method triggers the building
+      // of the dom elements so selectedDay must come after.
+      core.timeController.selectedDay = moveDate;
+      this._navigateAfterPersist(method, moveDate);
+    } catch(err) {
+      this.showErrors(err);
     }
 
-    function verifyCaps(err, caps) {
-      if (err) {
-        return console.error('Error fetching capabilities for', self.event);
-      }
+    this.element.classList.remove(this.PROGRESS);
+  }),
 
-      // safe-guard but should not ever happen.
-      if (caps[capability]) {
-        persistEvent();
-      }
+  _navigateAfterPersist: function(method, moveDate) {
+    // we pass the date so we are able to scroll to the event on the
+    // day/week views
+    var state = {
+      eventStartHour: moveDate.getHours()
+    };
+
+    if (method === 'updateEvent') {
+      // If we edit a view our history stack looks like:
+      //   /week -> /event/view -> /event/save -> /event/view
+      // We need to return all the way to the top of the stack
+      // We can remove this once we have a history stack
+      viewFactory.get('ViewEvent', v => router.go(v.returnTop(), state));
+      return;
     }
 
-    function persistEvent() {
-      var list = self.element.classList;
-
-      // mark view as 'in progress' so we can style
-      // it via css during that time period
-      list.add(self.PROGRESS);
-
-      var moveDate = self.event.startDate;
-
-      provider[method](self.event.data, function(err) {
-        list.remove(self.PROGRESS);
-
-        if (err) {
-          self.showErrors(err);
-          return;
-        }
-
-        // move the position in the calendar to the added/edited day
-        core.timeController.move(moveDate);
-        // order is important the above method triggers the building
-        // of the dom elements so selectedDay must come after.
-        core.timeController.selectedDay = moveDate;
-
-        // we pass the date so we are able to scroll to the event on the
-        // day/week views
-        var state = {
-          eventStartHour: moveDate.getHours()
-        };
-
-        if (method === 'updateEvent') {
-          // If we edit a view our history stack looks like:
-          //   /week -> /event/view -> /event/save -> /event/view
-          // We need to return all the way to the top of the stack
-          // We can remove this once we have a history stack
-          viewFactory.get('ViewEvent', function(view) {
-            router.go(view.returnTop(), state);
-          });
-
-          return;
-        }
-
-        router.go(self.returnTo(), state);
-      });
-    }
+    router.go(this.returnTo(), state);
   },
 
   /**
    * Deletes current record if provider is present and has the capability.
    */
-  deleteRecord: function(event) {
+  deleteRecord: co.wrap(function *(event) {
     if (event) {
       event.preventDefault();
     }
 
-    if (this.isSaved()) {
-      var self = this;
-      var handleDelete = function me_handleDelete() {
-        self.provider.deleteEvent(self.event.data, function(err) {
-          if (err) {
-            self.showErrors(err);
-            return;
-          }
-
-          // If we edit a view our history stack looks like:
-          //   /week -> /event/view -> /event/save -> /event/view
-          // We need to return all the way to the top of the stack
-          // We can remove this once we have a history stack
-          viewFactory.get('ViewEvent', function(view) {
-            router.go(view.returnTop());
-          });
-        });
-      };
-
-      this.provider.eventCapabilities(this.event.data, function(err, caps) {
-        if (err) {
-          return console.error('Error fetching event capabilities', this.event);
-        }
-
-        if (caps.canDelete) {
-          handleDelete();
-        }
-      });
+    if (!this.isSaved()) {
+      return;
     }
-  },
+
+    try {
+      yield core.bridge.deleteEvent(this.event);
+      // If we edit a view our history stack looks like:
+      //   /week -> /event/view -> /event/save -> /event/view
+      // We need to return all the way to the top of the stack
+      // We can remove this once we have a history stack
+      viewFactory.get('ViewEvent', view => {
+        router.go(view.returnTop());
+      });
+    } catch(err) {
+      this.showErrors(err);
+    }
+  }),
 
   /**
    * Persist current model.
@@ -478,9 +333,9 @@ ModifyEvent.prototype = {
     this.disablePrimary();
 
     if (this.isSaved()) {
-      this._persistEvent('updateEvent', 'canUpdate');
+      this._persistEvent('updateEvent');
     } else {
-      this._persistEvent('createEvent', 'canCreate');
+      this._persistEvent('createEvent');
     }
   },
 
@@ -785,7 +640,7 @@ ModifyEvent.prototype = {
   /**
    * Called on render or when toggling an all-day event
    */
-  updateAlarms: function(isAllDay, callback) {
+  updateAlarms: co.wrap(function *(isAllDay) {
     var template = AlarmTemplate;
     var alarms = [];
 
@@ -801,35 +656,27 @@ ModifyEvent.prototype = {
       }
     }
 
-    var settings = core.storeFactory.get('Setting');
     var layout = isAllDay ? 'allday' : 'standard';
-    settings.getValue(layout + 'AlarmDefault', next.bind(this));
+    var value = yield core.bridge.getSetting(layout + 'AlarmDefault');
 
-    function next(err, value) {
-      //jshint -W040
-      if (!this.isSaved() && !alarmMap[value] && !this.event.alarms.length) {
-        alarms.push({
-          layout: layout,
-          trigger: value
-        });
-      }
-
-      // Bug_898242 to show an event when default is 'none',
-      // we check if the event is not saved, if so, we push
-      // the default alarm on to the list.
-      if ((value === 'none' && this.isSaved()) || value !== 'none') {
-        alarms.push({
-          layout: layout
-        });
-      }
-
-      this.alarmList.innerHTML = template.picker.renderEach(alarms).join('');
-
-      if (callback) {
-        callback();
-      }
+    if (!this.isSaved() && !alarmMap[value] && !this.event.alarms.length) {
+      alarms.push({
+        layout: layout,
+        trigger: value
+      });
     }
-  },
+
+    // Bug_898242 to show an event when default is 'none',
+    // we check if the event is not saved, if so, we push
+    // the default alarm on to the list.
+    if ((value === 'none' && this.isSaved()) || value !== 'none') {
+      alarms.push({
+        layout: layout
+      });
+    }
+
+    this.alarmList.innerHTML = template.picker.renderEach(alarms).join('');
+  }),
 
   reset: function() {
     var list = this.element.classList;
@@ -847,7 +694,6 @@ ModifyEvent.prototype = {
 
     this._returnTo = null;
     this._markReadonly(false);
-    this.provider = null;
     this.event = null;
     this.busytime = null;
 
@@ -856,9 +702,16 @@ ModifyEvent.prototype = {
     this.form.reset();
   },
 
+  onactive: function() {
+    EventBase.prototype.onactive.apply(this, arguments);
+    this.calendarStream = core.bridge.observeCalendars();
+    this.calendarStream.listen(this._renderCalendars.bind(this));
+  },
+
   oninactive: function() {
     EventBase.prototype.oninactive.apply(this, arguments);
     this.reset();
+    this.calendarStream && this.calendarStream.cancel();
   }
 };
 

--- a/apps/calendar/test/unit/views/event_base_test.js
+++ b/apps/calendar/test/unit/views/event_base_test.js
@@ -94,7 +94,7 @@ suite('Views.EventBase', function() {
     assert.ok(subject.uiSelector);
   });
 
-  suite('#useModel', function() {
+  suite('#_useModel', function() {
     var callsUpdateUI;
     setup(function() {
       callsUpdateUI = false;
@@ -103,56 +103,33 @@ suite('Views.EventBase', function() {
       };
     });
 
-    test('multiple pending operations', function(done) {
-      function throwsError() {
-        done(new Error('incorrect callback fired...'));
-      }
+    test('readonly', function() {
+      var record = {
+        busytime: this.busytime,
+        event: this.event,
+        capabilities: { canUpdate: false }
+      };
 
-      subject.useModel(this.busytime, this.event, throwsError);
-      subject.useModel(this.busytime, this.event, throwsError);
-      subject.useModel(this.busytime, this.event, done);
+      subject._useModel(record);
+      assert.isTrue(hasClass(subject.READONLY), 'is readonly');
+      assert.isTrue(callsUpdateUI, 'updates ui');
     });
 
-    test('readonly', function(done) {
-      var provider = core.providerFactory.get('Mock');
+    test('normal', function() {
+      var record = {
+        busytime: this.busytime,
+        event: this.event,
+        calendar: { _id: this.event.calendarId },
+        capabilities: { canUpdate: true }
+      };
 
-      provider.stageEventCapabilities(this.event._id, null, {
-        canUpdate: false
-      });
-
-      subject.useModel(this.busytime, this.event, function() {
-        done(function() {
-          assert.isTrue(hasClass(subject.READONLY), 'is readonly');
-          assert.isTrue(callsUpdateUI, 'updates ui');
-        });
-      });
-    });
-
-    test('normal', function(done) {
-      var isDone = false;
-      subject.useModel(this.busytime, this.event, function() {
-        done(function() {
-          assert.ok(isDone, 'not async');
-          assert.ok(
-            !subject.element.classList.contains(subject.LOADING),
-            'is not loading'
-          );
-
-          assert.equal(
-            subject.originalCalendar._id,
-            this.event.calendarId
-          );
-
-          assert.isTrue(callsUpdateUI, 'updates ui');
-          assert.isFalse(hasClass(subject.READONLY), 'is readonly');
-        }.bind(this));
-      }.bind(this));
-
-      assert.ok(
-        subject.element.classList.contains(subject.LOADING),
-        'is loading'
+      subject._useModel(record);
+      assert.equal(
+        subject.originalCalendar._id,
+        record.event.calendarId
       );
-      isDone = true;
+      assert.isTrue(callsUpdateUI, 'updates ui');
+      assert.isFalse(hasClass(subject.READONLY), 'is readonly');
     });
   });
 

--- a/apps/calendar/test/unit/views/modify_event_test.js
+++ b/apps/calendar/test/unit/views/modify_event_test.js
@@ -966,7 +966,7 @@ suite('views/modify_event', function() {
       var allday = subject.getEl('allday');
       allday.checked = isAllDay;
       subject.event.isAllDay = isAllDay;
-      subject.updateAlarms(isAllDay, function() {
+      subject.updateAlarms(isAllDay).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 2);
 
@@ -992,7 +992,7 @@ suite('views/modify_event', function() {
 
     test('populated with no existing alarms', function(done) {
       subject.event.alarms = [];
-      subject.updateAlarms(true, function() {
+      subject.updateAlarms(true).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 2);
         assert.equal(allAlarms[0].value, defaultAllDayAlarm);
@@ -1005,7 +1005,7 @@ suite('views/modify_event', function() {
       subject.event.alarms = [
         {trigger: -300}
       ];
-      subject.updateAlarms(true, function() {
+      subject.updateAlarms(true).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 2);
         assert.equal(allAlarms[0].value, -300);
@@ -1019,7 +1019,7 @@ suite('views/modify_event', function() {
       subject.isSaved = function() {
         return true;
       };
-      subject.updateAlarms(true, function() {
+      subject.updateAlarms(true).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 1);
         assert.equal(allAlarms[0].value, 'none');
@@ -1065,7 +1065,7 @@ suite('views/modify_event', function() {
           var allday = subject.getEl('allday');
           allday.checked = isAllDay;
           subject.event.isAllDay = isAllDay;
-          subject.updateAlarms(isAllDay, function() {
+          subject.updateAlarms(isAllDay).then(() => {
             var allAlarms = subject.alarmList.querySelectorAll('select');
             var firstSelect = allAlarms[0];
             assert.ok(firstSelect);


### PR DESCRIPTION
created a `bridge.js` that abstracts the store/provider logic into fewer calls as a temporary solution while we move all the db logic into the worker.

my goal is to later simply copy the code inside the `bridge` into the `backend/calendar_service` and use `threads.client('calendar')` to call the methods there.
## TODO:
- [x] remove the need of the `settingsStore`
- [x] update the unit tests
