### PR TITLE
Bug 1162276 - Display the current timezone information when auto time zone is enabled r=eragonj

### DIFF
--- a/apps/settings/elements/date_time.html
+++ b/apps/settings/elements/date_time.html
@@ -10,51 +10,50 @@
         <li>
           <label class="pack-switch">
             <input type="checkbox" name="time.clock.automatic-update.enabled" class="uninit">
-            <span data-l10n-id="setTimeAutomatically">Set Automatically</span>
+            <span data-l10n-id="setTimeAutomatically"></span>
           </label>
         </li>
       </ul>
       <ul class="time-manual">
         <li>
-          <label>
-            <input type="date" class="date-picker" min="1970-1-1" max="2035-12-31"/>
-          </label>
-          <p data-l10n-id="dateMessage">Date</p>
+          <input type="date" class="date-picker" min="1970-1-1" max="2035-12-31"/>
+          <p data-l10n-id="dateMessage"></p>
           <span class="clock-date button icon icon-dialog"></span>
         </li>
         <li>
-          <label>
-            <input type="time" class="time-picker" />
-          </label>
-          <p data-l10n-id="timeMessage">Time</p>
+          <input type="time" class="time-picker"/>
+          <p data-l10n-id="timeMessage"></p>
           <span class="clock-time button icon icon-dialog"></span>
         </li>
       </ul>
 
       <header>
-        <h2 data-l10n-id="timezoneMessage">Time Zone</h2>
+        <h2 data-l10n-id="timezoneMessage"></h2>
       </header>
       <ul class="timezone">
-        <li>
-          <p data-l10n-id="tz-region">Region</p>
+        <li class="timezone-picker">
+          <p data-l10n-id="tz-region"></p>
           <span class="button icon icon-dialog">
             <select class="timezone-region"></select>
           </span>
         </li>
-        <li>
-          <p data-l10n-id="tz-city">City</p>
+        <li class="timezone-picker">
+          <p data-l10n-id="tz-city"></p>
           <span class="button icon icon-dialog">
             <select class="timezone-city"></select>
           </span>
         </li>
+        <li class="timezone-info" hidden>
+          <span class="timezone-info-text"></span>
+        </li>
       </ul>
 
       <header>
-        <h2 data-l10n-id="time-format">Format</h2>
+        <h2 data-l10n-id="time-format"></h2>
       </header>
       <ul class="timeformat">
         <li>
-          <p data-l10n-id="time-format-time">Time Format</p>
+          <p data-l10n-id="time-format-time"></p>
           <span class="button icon icon-dialog">
             <select class="time-format-time"></select>
           </span>

--- a/apps/settings/js/panels/date_time/panel.js
+++ b/apps/settings/js/panels/date_time/panel.js
@@ -23,39 +23,46 @@ define(function(require) {
           clockTime: panel.querySelector('.clock-time'),
           timeManual: panel.querySelector('.time-manual'),
           timezone: panel.querySelector('.timezone'),
+          timezonePickers: [].slice.apply(
+            panel.querySelectorAll('.timezone-picker')),
+          timezoneInfo: panel.querySelector('.timezone-info'),
+          timezoneInfoText: panel.querySelector('.timezone-info-text'),
           timeFormat: panel.querySelector('.time-format-time')
         };
 
         // update date/clock periodically
-        this._boundSetDate = function() {
+        this._boundSetDate = () => {
           this._elements.clockDate.textContent = DateTime.date;
-        }.bind(this);
+        };
 
-        this._boundSetTime = function() {
+        this._boundSetTime = () => {
           this._elements.clockTime.textContent = DateTime.time;
-        }.bind(this);
+        };
+
+        this._boundSetTimezoneInfo = () => {
+          // Only display the timezone info when auto time is enabled.
+          var info = DateTime.clockAutoEnabled ? DateTime.timezone : '';
+          this._elements.timezoneInfoText.textContent = info;
+        };
 
         // Reset the timezone to the previous user selected value
-        this._boundSetSelectedTimeZone = function(selected) {
+        this._boundSetSelectedTimeZone = (selected) => {
           DateTime.setUserSelectedTimezone(selected);
-        }.bind(this);
+        };
 
         this._boundUpdateUI = this._updateUI.bind(this);
+        this._boundDatePickerChange = this._datePickerChange.bind(this);
+        this._boundTimePickerChange = this._timePickerChange.bind(this);
 
-        this._boundDatePickerChange =
-          this._datePickerChange.bind(this);
-
-        this._boundTimePickerChange =
-          this._timePickerChange.bind(this);
-
-        this._boundTimeFormatChange = function() {
+        this._boundTimeFormatChange = () => {
           var value = (this._elements.timeFormat.value === HOUR_12);
           DateTime.setCurrentHour12(value);
-        }.bind(this);
+        };
       },
       onBeforeShow: function() {
         DateTime.observe('date', this._boundSetDate);
         DateTime.observe('time', this._boundSetTime);
+        DateTime.observe('timezone', this._boundSetTimezoneInfo);
         DateTime.observe('clockAutoEnabled', this._boundUpdateUI);
         DateTime.observe('clockAutoAvailable', this._boundUpdateUI);
         DateTime.observe('timezoneAutoAvailable', this._boundUpdateUI);
@@ -72,6 +79,7 @@ define(function(require) {
         this._renderTimeZone();
         this._boundSetDate();
         this._boundSetTime();
+        this._boundSetTimezoneInfo();
         if (DateTime.userSelectedTimezone && !DateTime.clockAutoEnabled) {
           this._boundSetSelectedTimeZone(DateTime.userSelectedTimezone);
         }
@@ -84,6 +92,7 @@ define(function(require) {
       onHide: function() {
         DateTime.unobserve('date', this._boundSetDate);
         DateTime.unobserve('time', this._boundSetTime);
+        DateTime.unobserve('timezone', this._boundSetTimezoneInfo);
         DateTime.unobserve('clockAutoEnabled', this._boundUpdateUI);
         DateTime.unobserve('clockAutoAvailable', this._boundUpdateUI);
         DateTime.unobserve('timezoneAutoAvailable', this._boundUpdateUI);
@@ -144,6 +153,7 @@ define(function(require) {
         this._elements.timeAutoSwitch.dataset.state =
             DateTime.clockAutoEnabled ? 'auto' : 'manual';
         this._elements.timeAutoSwitch.hidden =
+          this._elements.timezoneInfo.hidden =
             !(DateTime.clockAutoAvailable || DateTime.timezoneAutoAvailable);
 
         this._elements.datePicker.disabled = DateTime.clockAutoEnabled &&
@@ -155,15 +165,28 @@ define(function(require) {
         this._elements.timezoneCity.disabled =
           (DateTime.timezoneAutoAvailable && DateTime.clockAutoEnabled);
 
+        // XXX: Force to trigger the selector change so that tz_select is able
+        //      to write the previous user-selected value back to time.timezone.
+        if (!DateTime.clockAutoEnabled) {
+          this._elements.timezoneRegion.dispatchEvent(new Event('change'));
+          this._elements.timezoneCity.dispatchEvent(new Event('change'));
+        }
+
         if (DateTime.clockAutoEnabled &&
           !this._elements.timeAutoSwitch.hidden) {
           this._elements.timeManual.classList.add('disabled');
           if (DateTime.timezoneAutoAvailable) {
-            this._elements.timezone.classList.add('disabled');
+            this._elements.timezonePickers.forEach((picker) => {
+              picker.hidden = true;
+            });
+            this._elements.timezoneInfo.hidden = false;
           }
         } else {
           this._elements.timeManual.classList.remove('disabled');
-          this._elements.timezone.classList.remove('disabled');
+          this._elements.timezonePickers.forEach((picker) => {
+            picker.hidden = false;
+          });
+          this._elements.timezoneInfo.hidden = true;
         }
       },
 

--- a/apps/settings/test/marionette/app/regions/date_time.js
+++ b/apps/settings/test/marionette/app/regions/date_time.js
@@ -16,7 +16,8 @@ function DateTimePanel(client) {
 module.exports = DateTimePanel;
 
 DateTimePanel.Selectors = {
-  'timezoneRegion': '#dateTime .timezone-region'
+  'timezoneRegion': '#dateTime .timezone-region',
+  'timezoneInfoText': '#dateTime .timezone-info-text'
 };
 
 DateTimePanel.prototype = {
@@ -25,6 +26,10 @@ DateTimePanel.prototype = {
 
   selectRegion: function(value) {
     this.tapSelectOption('timezoneRegion', value);
+  },
+
+  get timezoneInfoText() {
+    return this.waitForElement('timezoneInfoText').text();
   }
 
 };

--- a/apps/settings/test/marionette/tests/date_time_settings_test.js
+++ b/apps/settings/test/marionette/tests/date_time_settings_test.js
@@ -13,9 +13,11 @@ marionette('manipulate date time settings', function() {
   });
 
   test('manipulate region', function() {
-    // Simply change the value in the timezone region to
+    // Simply check the value in the timezone region to
     // ensure the menu is is populated.
-    dateTimePanel.selectRegion('Europe');
+    client.waitFor(function() {
+      return dateTimePanel.timezoneInfoText !== '';
+    });
   });
 
 });

--- a/apps/settings/test/unit/_date_time.html
+++ b/apps/settings/test/unit/_date_time.html
@@ -15,15 +15,18 @@
     </li>
   </ul>
   <ul class="timezone">
-    <li>
+    <li class="timezone-picker">
       <span class="button icon icon-dialog">
         <select class="timezone-region"></select>
       </span>
     </li>
-    <li>
+    <li class="timezone-picker">
       <span class="button icon icon-dialog">
         <select class="timezone-city"></select>
       </span>
+    </li>
+    <li class="timezone-info" hidden>
+      <span class="timezone-info-text"></span>
     </li>
   </ul>
   <ul class="timeformat">

--- a/apps/settings/test/unit/panels/date_time/panel_test.js
+++ b/apps/settings/test/unit/panels/date_time/panel_test.js
@@ -77,39 +77,26 @@ suite('Date & Time panel > ', function() {
       this.sinon.stub(this.MockDateTime, 'observe');
       this.sinon.stub(this.MockDateTime, 'setTimezoneAutoEnabled');
       this.panel.beforeShow();
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('date')));
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('clock')));
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('clockAutoEnabled')));
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('clockAutoAvailable')));
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('timezoneAutoAvailable')));
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('timezone')));
-      assert.ok(this.MockDateTime.observe.calledWith(
-        sinon.match('userSelectedTimezone')));
+      assert.ok(this.MockDateTime.observe.calledWith('time'));
+      assert.ok(this.MockDateTime.observe.calledWith('date'));
+      assert.ok(this.MockDateTime.observe.calledWith('timezone'));
+      assert.ok(this.MockDateTime.observe.calledWith('clockAutoEnabled'));
+      assert.ok(this.MockDateTime.observe.calledWith('clockAutoAvailable'));
+      assert.ok(this.MockDateTime.observe.calledWith('timezoneAutoAvailable'));
+      assert.ok(this.MockDateTime.observe.calledWith('userSelectedTimezone'));
     });
 
     test('unobserve DateTime when onHide', function() {
       this.sinon.stub(this.MockDateTime, 'unobserve');
       this.panel.hide();
+      assert.ok(this.MockDateTime.unobserve.calledWith('date'));
+      assert.ok(this.MockDateTime.unobserve.calledWith('time'));
+      assert.ok(this.MockDateTime.unobserve.calledWith('timezone'));
+      assert.ok(this.MockDateTime.unobserve.calledWith('clockAutoEnabled'));
+      assert.ok(this.MockDateTime.unobserve.calledWith('clockAutoAvailable'));
       assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('date')));
-      assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('clock')));
-      assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('clockAutoEnabled')));
-      assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('clockAutoAvailable')));
-      assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('timezoneAutoAvailable')));
-      assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('timezone')));
-      assert.ok(this.MockDateTime.unobserve.calledWith(
-        sinon.match('userSelectedTimezone')));
+        'timezoneAutoAvailable'));
+      assert.ok(this.MockDateTime.unobserve.calledWith('userSelectedTimezone'));
     });
   });
 });


### PR DESCRIPTION
When auto timezone is enabled, we are not able to tell the region and city from the timzone information. In this case we show the information itself and hide the selectors for choosing region and city.
