### PR TITLE
Bug 1159991 - Include developer mode prefs in |DEVICE_DEBUG=1|

### DIFF
--- a/build/preferences.js
+++ b/build/preferences.js
@@ -249,6 +249,9 @@ PreferencesBuilder.prototype.setDebugPref = function() {
 };
 
 PreferencesBuilder.prototype.setDeviceDebugPref = function() {
+  this.userPrefs['dom.apps.developer_mode'] = true;
+  this.userPrefs['network.disable.ipc.security'] = true;
+  this.userPrefs['dom.webcomponents.enabled'] = true;
   this.userPrefs['devtools.debugger.prompt-connection'] = false;
   this.userPrefs['devtools.debugger.forbid-certified-apps'] = false;
   // Bug 1001348: This optimization prevents debugger to fetch script sources

--- a/build/test/unit/preference_test.js
+++ b/build/test/unit/preference_test.js
@@ -357,6 +357,9 @@ suite('preferences.js', function() {
         'devtools.debugger.prompt-connection': false,
         'devtools.debugger.forbid-certified-apps': false,
         'javascript.options.discardSystemSource': false,
+        'dom.apps.developer_mode': true,
+        'network.disable.ipc.security': true,
+        'dom.webcomponents.enabled': true,
         'b2g.adb.timeout': 0
       });
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1159991
