### PR TITLE
Bug 1165218 - [Stingray][TVDeck] Only storing TV tuner ID in asyncSto…

### DIFF
--- a/tv_apps/tv-deck/js/tv_deck.js
+++ b/tv_apps/tv-deck/js/tv_deck.js
@@ -16,12 +16,10 @@
       if (evt.target && evt.target.result) {
         this.selfApp = evt.target.result;
         this._fetchElements();
-        this._init();
-        // Initialize TVDeck. Fetch initial (tuner, source, channel) values from
-        // either URL hash or asyncStorage, and then scan all available tuners,
-        // sources and channels.
-        var hash = window.location.hash;
-        this.channelManager.fetchSettingFromHash(hash).then(function() {
+        // XXX: Currently, we do not support tuner switching
+        asyncStorage.getItem('Last-Tuner-ID', function(tunerId) {
+          this._init(tunerId);
+          this.channelManager.fetchSettingFromHash(window.location.hash);
           this.channelManager.scanTuners();
         }.bind(this));
       }
@@ -30,11 +28,11 @@
 
   var proto = {};
 
-  proto._init = function td__init() {
+  proto._init = function td__init(tunerId) {
 
     // lastChannelId maintains number of channel-switching user did.
     this.lastChannelId = 0;
-    this.channelManager = new ChannelManager();
+    this.channelManager = new ChannelManager(tunerId);
     this.channelManager.on('scanned', this.setHash.bind(this));
     this.channelManager.on('error', this._showErrorState.bind(this));
 
@@ -118,47 +116,45 @@
       this.channelPanel.focus();
     }
 
-    this.channelManager.fetchSettingFromHash(hash).then(function() {
+    this.channelManager.fetchSettingFromHash(hash);
 
-      // Cancel onPanelTimeout function, otherwise, panels will be hidden
-      // after 3 seconds.
-      clearTimeout(this.panelTimeoutId);
-      if (!this.channelManager.getTuner()) {
-        this.channelManager.scanTuners();
-      } else if (!this.channelManager.getSource()) {
-        this.channelManager.scanSources();
-      } else if (!this.channelManager.getChannel()) {
-        this.channelManager.scanChannels();
-      } else {
-        this._rotateLoadingIcon();
-        this._updateChannelInfo();
-        this.channelManager.setPlayingSource(function() {
-          // When an user swiches back and forth very fast, we only have to
-          // handle the last hash. Since setPlayingSource is an async function,
-          // id is used to record the last change.
-          if (id === this.lastChannelId) {
-            this.buttonGroupPanel.classList.remove('hidden');
-            this.overlay.classList.remove('visible');
-            this.updatePinButton();
-            this.bubbleElement.play([this.pinButton, this.menuButton]);
-            this.simpleKeyNavigation.start(
-              [this.pinButton, this.menuButton],
-              SimpleKeyNavigation.DIRECTION.HORIZONTAL
-            );
+    // Cancel onPanelTimeout function, otherwise, panels will be hidden
+    // after 3 seconds.
+    clearTimeout(this.panelTimeoutId);
+    if (!this.channelManager.getTuner()) {
+      this.channelManager.scanTuners();
+    } else if (!this.channelManager.getSource()) {
+      this.channelManager.scanSources();
+    } else if (!this.channelManager.getChannel()) {
+      this.channelManager.scanChannels();
+    } else {
+      this._rotateLoadingIcon();
+      this._updateChannelInfo();
+      this.channelManager.setPlayingSource(function() {
+        // When an user swiches back and forth very fast, we only have to
+        // handle the last hash. Since setPlayingSource is an async function,
+        // id is used to record the last change.
+        if (id === this.lastChannelId) {
+          this.buttonGroupPanel.classList.remove('hidden');
+          this.overlay.classList.remove('visible');
+          this.updatePinButton();
+          this.bubbleElement.play([this.pinButton, this.menuButton]);
+          this.simpleKeyNavigation.start(
+            [this.pinButton, this.menuButton],
+            SimpleKeyNavigation.DIRECTION.HORIZONTAL
+          );
 
-            this.panelTimeoutId = setTimeout(this._onPanelTimeout.bind(this),
-                                             this.panelTimeoutDelay);
+          this.panelTimeoutId = setTimeout(this._onPanelTimeout.bind(this),
+                                           this.panelTimeoutDelay);
 
-            var newStream = this.channelManager.getTuner().tuner.stream;
-            if (this.tvStreamElement.src !== newStream) {
-              this.tvStreamElement.src = newStream;
-              this.tvStreamElement.play();
-            }
+          var newStream = this.channelManager.getTuner().tuner.stream;
+          if (this.tvStreamElement.src !== newStream) {
+            this.tvStreamElement.src = newStream;
+            this.tvStreamElement.play();
           }
-        }.bind(this));
-      }
-      asyncStorage.setItem('TV_Hash', window.location.hash);
-    }.bind(this));
+        }
+      }.bind(this));
+    }
   };
 
   proto._updateChannelInfo = function td__updateChannelInfo(title, number) {
@@ -174,10 +170,6 @@
     }
 
     if (this.channelManager.currentHash === window.location.hash) {
-      // When initizlizing TVDeck, if either URL hash or asyncStorage is not
-      // null, the URL will be set to the same value in _onScanningCompleted
-      // function. However, we still have to call onHashChange function in order
-      // to switch to the correct channel.
       this._onHashChange();
     }
     window.location.hash = this.channelManager.currentHash;

--- a/tv_apps/tv-deck/jsdoc.json
+++ b/tv_apps/tv-deck/jsdoc.json
@@ -1,5 +1,5 @@
 {
-  "smart-home": {
+  "tv-deck": {
     "src": [
       "tv_apps/tv-deck/js/**/*.js"
     ],

--- a/tv_apps/tv-deck/test/unit/mock_channel_manager.js
+++ b/tv_apps/tv-deck/test/unit/mock_channel_manager.js
@@ -3,7 +3,6 @@
 
   function MockChannelManager() {
     var handler = {};
-    var fetchCallback;
 
     this.isReady = true;
     this.playingState = {};
@@ -31,17 +30,6 @@
     };
 
     this.fetchSettingFromHash = function() {
-      return {
-        then: function(callback) {
-          fetchCallback = callback;
-        }
-      };
-    };
-
-    this.mTriggerFetch = function() {
-      if (fetchCallback) {
-        fetchCallback();
-      }
     };
 
     this.on = function(evt, fn) {

--- a/tv_apps/tv-deck/test/unit/tv_deck_test.js
+++ b/tv_apps/tv-deck/test/unit/tv_deck_test.js
@@ -1,9 +1,7 @@
 'use strict';
-/*jshint browser: true */
+/* jshint browser: true */
 /* global TVDeck, MocksHelper, MockTVManager, MockNavigatormozApps */
-/* global MockasyncStorage */
 
-require('/shared/test/unit/mocks/mock_async_storage.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_apps.js');
 require('/shared/test/unit/mocks/mock_key_navigation_adapter.js');
 require('/shared/test/unit/mocks/mock_simple_key_navigation.js');
@@ -14,6 +12,7 @@ require('/shared/test/unit/mocks/mock_tv_manager.js');
 require('/bower_components/smart-bubbles/script.js');
 require('/test/unit/mock_pin_card.js');
 require('/test/unit/mock_channel_manager.js');
+require('/js/tv_deck.js');
 
 var mocksHelper = new MocksHelper([
   'PinCard',
@@ -24,9 +23,10 @@ var mocksHelper = new MocksHelper([
 
 suite('tv-deck/tv_deck', function() {
 
+  var MockasyncStorage;
   var realMozApps;
-  var realasyncStorage;
   var realTVManager;
+  var realasyncStorage;
   var tvDeck;
 
   mocksHelper.attachTestHelpers();
@@ -53,19 +53,24 @@ suite('tv-deck/tv_deck', function() {
     createMockElement('bubble-animation', 'smart-bubbles');
   }
 
-  suiteSetup(function(done) {
+  suiteSetup(function() {
     createMockUI();
     sinon.stub(window, 'addEventListener');
-    require('/js/tv_deck.js', done);
+    MockasyncStorage = {
+      _value: {},
+      getItem: function(name, callback) {
+        callback(this._value[name]);
+      }
+    };
   });
 
   setup(function() {
     realTVManager = window.navigator.tv;
     realMozApps = window.navigator.mozApps;
     realasyncStorage = window.asyncStorage;
-    window.asyncStorage = MockasyncStorage;
     window.navigator.tv = new MockTVManager();
     window.navigator.mozApps = MockNavigatormozApps;
+    window.asyncStorage = MockasyncStorage;
 
     window.location.hash = '';
     window.localStorage.removeItem('TV_Hash');
@@ -107,17 +112,9 @@ suite('tv-deck/tv_deck', function() {
       assert.notEqual(id, tvDeck.lastChannelId);
     });
 
-    test('Set item in asyncStorage', function() {
-      var setItem = this.sinon.stub(window.asyncStorage, 'setItem');
-      tvDeck._onHashChange();
-      tvDeck.channelManager.mTriggerFetch();
-      assert.isTrue(setItem.called);
-    });
-
     test('Rescan tuners if playing tuner is not found', function() {
       var scanTuners = this.sinon.stub(tvDeck.channelManager, 'scanTuners');
       tvDeck._onHashChange();
-      tvDeck.channelManager.mTriggerFetch();
       assert.isTrue(scanTuners.called);
     });
 
@@ -125,7 +122,6 @@ suite('tv-deck/tv_deck', function() {
       var scanSources = this.sinon.stub(tvDeck.channelManager, 'scanSources');
       this.sinon.stub(tvDeck.channelManager, 'getTuner').returns({});
       tvDeck._onHashChange();
-      tvDeck.channelManager.mTriggerFetch();
       assert.isTrue(scanSources.called);
     });
 
@@ -134,7 +130,6 @@ suite('tv-deck/tv_deck', function() {
       this.sinon.stub(tvDeck.channelManager, 'getTuner').returns({});
       this.sinon.stub(tvDeck.channelManager, 'getSource').returns({});
       tvDeck._onHashChange();
-      tvDeck.channelManager.mTriggerFetch();
       assert.isTrue(scanChannels.called);
     });
 
@@ -159,30 +154,9 @@ suite('tv-deck/tv_deck', function() {
         channel: {}
       });
       tvDeck._onHashChange();
-      tvDeck.channelManager.mTriggerFetch();
 
       var newStream = 'app://tv-deck.gaiamobile.org/test/unit/newStream';
       assert.equal(tvDeck.tvStreamElement.src, newStream);
-    });
-
-    test('Video stream should be the same if id does not equal to ' +
-         'lastChannelId', function() {
-      this.sinon.stub(tvDeck.channelManager, 'getTuner').returns({
-        tuner: {
-          stream: 'newStream'
-        }
-      });
-      this.sinon.stub(tvDeck.channelManager, 'getSource').returns({});
-      this.sinon.stub(tvDeck.channelManager, 'getChannel').returns({
-        channel: {}
-      });
-      tvDeck.tvStreamElement.src = 'oldStream';
-      tvDeck._onHashChange();
-      tvDeck.lastChannelId = 100;
-      tvDeck.channelManager.mTriggerFetch();
-
-      var newStream = 'app://tv-deck.gaiamobile.org/test/unit/newStream';
-      assert.notEqual(tvDeck.tvStreamElement.src, newStream);
     });
   });
 


### PR DESCRIPTION
…rage is enough
- Remove storing 'TV_Hash' in async Storage, but storing 'Last-Tuner-ID' instead.
