### PR TITLE
Bug 1149886 - using <bdi> to replace <span> at Music app results in unable to locate <span.list-song-index> error. r=jlorenzo

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/music/regions/sublist_view.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/music/regions/sublist_view.py
@@ -13,7 +13,7 @@ from gaiatest.apps.music.regions.player_view import PlayerView
 
 class SublistView(Base):
 
-    _song_number_locator = (By.CSS_SELECTOR, 'span.list-song-index')
+    _song_number_locator = (By.CSS_SELECTOR, 'bdi.list-song-index')
     _play_control_locator = (By.ID, 'views-sublist-controls-play')
 
     def __init__(self, marionette):


### PR DESCRIPTION
a simple fix for gaia-ui-test v2.2.

change <span> to <bdi>
