### PR TITLE
Bug 1115180 - Get test_cost_control_data_alert_mobile.py re-enabled

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/cost_control/manifest.ini
@@ -15,7 +15,6 @@ wifi = false
 skip-if = device == "desktop"
 smoketest = true
 wifi = false
-disabled = Bug 1115180 for getting it re-enabled
 
 [test_cost_control_reset_wifi.py]
 skip-if = device == "desktop"


### PR DESCRIPTION
Bug 1115180 - Get test_cost_control_data_alert_mobile.py re-enabled
