### PR TITLE
Bug 1161456 - Handle bidi wifi ids

### DIFF
--- a/apps/ftu/js/wifi.js
+++ b/apps/ftu/js/wifi.js
@@ -349,6 +349,7 @@ var WifiUI = {
           var li = document.createElement('li');
           var icon = document.createElement('aside');
           var ssidp = document.createElement('p');
+          ssidp.setAttribute('dir', 'auto');
           var small = document.createElement('p');
 
           small.dataset.securityLevel = true;

--- a/apps/ftu/style/style.css
+++ b/apps/ftu/style/style.css
@@ -367,9 +367,17 @@ gaia-buttons.forward-only .icon-previous {
 
 #wifi [data-type="list"] li > p {
   pointer-events: none;
-  -moz-padding-end: 6.2rem;
   line-height: 1.33;
 }
+#wifi:-moz-dir(ltr) [data-type="list"] li > p {
+  /* using padding-right/left on purpose as strings may be bidi,
+     which can change the meaning of -moz-padding-end */
+  padding-right: 6.2rem;
+}
+#wifi:-moz-dir(rtl) [data-type="list"] li > p {
+  padding-left: 6.2rem;
+}
+
 
 #wifi li {
   padding: 0 1.5rem 0.5rem 1.5rem;


### PR DESCRIPTION
I'm using -moz-dir(ltr) and (rtl) to get around the ambiguity of the HTML dir attribute  - which may or may not be present. If I'm not explicit here, there's a risk both rules will apply and we end up with left AND right padding. 
