### PR TITLE
Bug 1162276 - Display the current timezone information when auto time zone is enabled r=eragonj

### DIFF
--- a/apps/settings/elements/date_time.html
+++ b/apps/settings/elements/date_time.html
@@ -10,51 +10,50 @@
         <li>
           <label class="pack-switch">
             <input type="checkbox" name="time.clock.automatic-update.enabled" class="uninit">
-            <span data-l10n-id="setTimeAutomatically">Set Automatically</span>
+            <span data-l10n-id="setTimeAutomatically"></span>
           </label>
         </li>
       </ul>
       <ul class="time-manual">
         <li>
-          <label>
-            <input type="date" class="date-picker" min="1970-1-1" max="2037-12-31"/>
-          </label>
-          <p data-l10n-id="dateMessage">Date</p>
+          <input type="date" class="date-picker" min="1970-1-1" max="2035-12-31"/>
+          <p data-l10n-id="dateMessage"></p>
           <span class="clock-date button icon icon-dialog"></span>
         </li>
         <li>
-          <label>
-            <input type="time" class="time-picker" />
-          </label>
-          <p data-l10n-id="timeMessage">Time</p>
+          <input type="time" class="time-picker"/>
+          <p data-l10n-id="timeMessage"></p>
           <span class="clock-time button icon icon-dialog"></span>
         </li>
       </ul>
 
       <header>
-        <h2 data-l10n-id="timezoneMessage">Time Zone</h2>
+        <h2 data-l10n-id="timezoneMessage"></h2>
       </header>
       <ul class="timezone">
-        <li>
-          <p data-l10n-id="tz-region">Region</p>
+        <li class="timezone-picker">
+          <p data-l10n-id="tz-region"></p>
           <span class="button icon icon-dialog">
             <select class="timezone-region"></select>
           </span>
         </li>
-        <li>
-          <p data-l10n-id="tz-city">City</p>
+        <li class="timezone-picker">
+          <p data-l10n-id="tz-city"></p>
           <span class="button icon icon-dialog">
             <select class="timezone-city"></select>
           </span>
         </li>
+        <li class="timezone-info" hidden>
+          <span class="timezone-info-text"></span>
+        </li>
       </ul>
 
       <header>
-        <h2 data-l10n-id="time-format">Format</h2>
+        <h2 data-l10n-id="time-format"></h2>
       </header>
       <ul class="timeformat">
         <li>
-          <p data-l10n-id="time-format-time">Time Format</p>
+          <p data-l10n-id="time-format-time"></p>
           <span class="button icon icon-dialog">
             <select class="time-format-time"></select>
           </span>

--- a/apps/settings/js/panels/date_time/panel.js
+++ b/apps/settings/js/panels/date_time/panel.js
@@ -23,39 +23,46 @@ define(function(require) {
           clockTime: panel.querySelector('.clock-time'),
           timeManual: panel.querySelector('.time-manual'),
           timezone: panel.querySelector('.timezone'),
+          timezonePickers: [].slice.apply(
+            panel.querySelectorAll('.timezone-picker')),
+          timezoneInfo: panel.querySelector('.timezone-info'),
+          timezoneInfoText: panel.querySelector('.timezone-info-text'),
           timeFormat: panel.querySelector('.time-format-time')
         };
 
         // update date/clock periodically
-        this._boundSetDate = function() {
+        this._boundSetDate = () => {
           this._elements.clockDate.textContent = DateTime.date;
-        }.bind(this);
+        };
 
-        this._boundSetTime = function() {
+        this._boundSetTime = () => {
           this._elements.clockTime.textContent = DateTime.time;
-        }.bind(this);
+        };
+
+        this._boundSetTimezoneInfo = () => {
+          // Only display the timezone info when auto time is enabled.
+          var info = DateTime.clockAutoEnabled ? DateTime.timezone : '';
+          this._elements.timezoneInfoText.textContent = info;
+        };
 
         // Reset the timezone to the previous user selected value
-        this._boundSetSelectedTimeZone = function(selected) {
+        this._boundSetSelectedTimeZone = (selected) => {
           DateTime.setUserSelectedTimezone(selected);
-        }.bind(this);
+        };
 
         this._boundUpdateUI = this._updateUI.bind(this);
+        this._boundDatePickerChange = this._datePickerChange.bind(this);
+        this._boundTimePickerChange = this._timePickerChange.bind(this);
 
-        this._boundDatePickerChange =
-          this._datePickerChange.bind(this);
-
-        this._boundTimePickerChange =
-          this._timePickerChange.bind(this);
-
-        this._boundTimeFormatChange = function() {
+        this._boundTimeFormatChange = () => {
           var value = (this._elements.timeFormat.value === HOUR_12);
           DateTime.setCurrentHour12(value);
-        }.bind(this);
+        };
       },
       onBeforeShow: function() {
         DateTime.observe('date', this._boundSetDate);
         DateTime.observe('time', this._boundSetTime);
+        DateTime.observe('timezone', this._boundSetTimezoneInfo);
         DateTime.observe('clockAutoEnabled', this._boundUpdateUI);
         DateTime.observe('clockAutoAvailable', this._boundUpdateUI);
         DateTime.observe('timezoneAutoAvailable', this._boundUpdateUI);
@@ -72,6 +79,7 @@ define(function(require) {
         this._renderTimeZone();
         this._boundSetDate();
         this._boundSetTime();
+        this._boundSetTimezoneInfo();
         if (DateTime.userSelectedTimezone && !DateTime.clockAutoEnabled) {
           this._boundSetSelectedTimeZone(DateTime.userSelectedTimezone);
         }
@@ -84,6 +92,7 @@ define(function(require) {
       onHide: function() {
         DateTime.unobserve('date', this._boundSetDate);
         DateTime.unobserve('time', this._boundSetTime);
+        DateTime.unobserve('timezone', this._boundSetTimezoneInfo);
         DateTime.unobserve('clockAutoEnabled', this._boundUpdateUI);
         DateTime.unobserve('clockAutoAvailable', this._boundUpdateUI);
         DateTime.unobserve('timezoneAutoAvailable', this._boundUpdateUI);
@@ -143,27 +152,49 @@ define(function(require) {
       _updateUI: function dt_updateUI() {
         this._elements.timeAutoSwitch.dataset.state =
             DateTime.clockAutoEnabled ? 'auto' : 'manual';
-        this._elements.timeAutoSwitch.hidden =
-            !(DateTime.clockAutoAvailable || DateTime.timezoneAutoAvailable);
+        // There are three possible combinations:
+        // - clockAutoAvailable is true, timezoneAutoAvailable is true
+        // - clockAutoAvailable is false, timezoneAutoAvailable is false
+        // - clockAutoAvailable is true, timezoneAutoAvailable is false
+        // We show the auto time switch only when clockAutoAvailable is true.
+        this._elements.timeAutoSwitch.hidden = !DateTime.clockAutoAvailable;
 
-        this._elements.datePicker.disabled = DateTime.clockAutoEnabled &&
-          !this._elements.timeAutoSwitch.hidden;
-        this._elements.timePicker.disabled = DateTime.clockAutoEnabled &&
-          !this._elements.timeAutoSwitch.hidden;
+        // DataTime.clockAutoEnabled is a user preference and in some cases it
+        // can be true while DateTime.clockAutoAvailable is false. The reason is
+        // the device may not connect to the network to retrieve the correct
+        // time automatically after startup. That being said, we should always
+        // check both `DateTime.clockAutoEnabled` and
+        // `DateTime.clockAutoAvailable` to determine whether the device is in
+        // the auto time mode.
+        var autoTimeMode =
+          DateTime.clockAutoEnabled && DateTime.clockAutoAvailable;
+
+        this._elements.datePicker.disabled = autoTimeMode;
+        this._elements.timePicker.disabled = autoTimeMode;
         this._elements.timezoneRegion.disabled =
-          (DateTime.timezoneAutoAvailable && DateTime.clockAutoEnabled);
+          DateTime.timezoneAutoAvailable && autoTimeMode;
         this._elements.timezoneCity.disabled =
-          (DateTime.timezoneAutoAvailable && DateTime.clockAutoEnabled);
+          DateTime.timezoneAutoAvailable && autoTimeMode;
 
-        if (DateTime.clockAutoEnabled &&
-          !this._elements.timeAutoSwitch.hidden) {
+        // XXX: Force to trigger the selector change so that tz_select is able
+        //      to write the previous user-selected value back to time.timezone.
+        if (!DateTime.clockAutoEnabled) {
+          this._elements.timezoneRegion.dispatchEvent(new Event('change'));
+          this._elements.timezoneCity.dispatchEvent(new Event('change'));
+        }
+
+        if (autoTimeMode) {
           this._elements.timeManual.classList.add('disabled');
-          if (DateTime.timezoneAutoAvailable) {
-            this._elements.timezone.classList.add('disabled');
-          }
+          this._elements.timezonePickers.forEach((picker) => {
+            picker.hidden = DateTime.timezoneAutoAvailable;
+          });
+          this._elements.timezoneInfo.hidden = !DateTime.timezoneAutoAvailable;
         } else {
           this._elements.timeManual.classList.remove('disabled');
-          this._elements.timezone.classList.remove('disabled');
+          this._elements.timezonePickers.forEach((picker) => {
+            picker.hidden = false;
+          });
+          this._elements.timezoneInfo.hidden = true;
         }
       },
 

--- a/apps/settings/test/marionette/app/regions/date_time.js
+++ b/apps/settings/test/marionette/app/regions/date_time.js
@@ -16,7 +16,9 @@ function DateTimePanel(client) {
 module.exports = DateTimePanel;
 
 DateTimePanel.Selectors = {
-  'timezoneRegion': '#dateTime .timezone-region'
+  'timezoneRegion': '#dateTime .timezone-region',
+  'timezoneInfoText': '#dateTime .timezone-info-text',
+  'timeFormatSelect': '#dateTime .time-format-time'
 };
 
 DateTimePanel.prototype = {
@@ -25,6 +27,14 @@ DateTimePanel.prototype = {
 
   selectRegion: function(value) {
     this.tapSelectOption('timezoneRegion', value);
+  },
+
+  selectTimeFormat: function(value) {
+    this.tapSelectOption('timeFormatSelect', value);
+  },
+
+  get timezoneInfoText() {
+    return this.waitForElement('timezoneInfoText').text();
   }
 
 };

--- a/apps/settings/test/marionette/tests/date_time_settings_test.js
+++ b/apps/settings/test/marionette/tests/date_time_settings_test.js
@@ -17,10 +17,10 @@ marionette('manipulate date time settings', function() {
     dateTimePanel = settingsApp.dateTimePanel;
   });
 
-  test('manipulate region', function() {
-    // Simply change the value in the timezone region to
+  test('manipulate time format', function() {
+    // Simply select the value in the time format to
     // ensure the menu is is populated.
-    dateTimePanel.selectRegion('Europe');
+    dateTimePanel.selectTimeFormat('12-hour');
   });
 
 });

--- a/apps/settings/test/unit/_date_time.html
+++ b/apps/settings/test/unit/_date_time.html
@@ -15,15 +15,18 @@
     </li>
   </ul>
   <ul class="timezone">
-    <li>
+    <li class="timezone-picker">
       <span class="button icon icon-dialog">
         <select class="timezone-region"></select>
       </span>
     </li>
-    <li>
+    <li class="timezone-picker">
       <span class="button icon icon-dialog">
         <select class="timezone-city"></select>
       </span>
+    </li>
+    <li class="timezone-info" hidden>
+      <span class="timezone-info-text"></span>
     </li>
   </ul>
   <ul class="timeformat">


### PR DESCRIPTION
When auto timezone is enabled, we are not able to tell the region and city from the timzone information. In this case we show the information itself and hide the selectors for choosing region and city.
