### PR TITLE
Bug 1165758 - Increase timeout for linter task, code base size now re…

### DIFF
--- a/tests/taskcluster/tasks/linters.yml
+++ b/tests/taskcluster/tasks/linters.yml
@@ -9,6 +9,7 @@ task:
     - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
+    maxRunTime: 600
     image: quay.io/mozilla/gaia-taskenv:0.8.9
     command:
       - entrypoint


### PR DESCRIPTION
…quires longer timeout. a=testonly
