### PR TITLE
Bug 1169397 - Use hub.docker.com as our default for gaia-taskenv, npm…

### DIFF
--- a/build/docker/gaia-taskenv/DOCKER_TAG
+++ b/build/docker/gaia-taskenv/DOCKER_TAG
@@ -1,1 +1,1 @@
-quay.io/mozilla/gaia-taskenv
+taskcluster/gaia-taskenv

--- a/taskgraph.json
+++ b/taskgraph.json
@@ -17,8 +17,6 @@
         "scopes": [
           "docker-worker:cache:tc-vcs",
           "docker-worker:cache:gaia-misc-caches",
-          "docker-worker:image:quay.io/mozilla/gaia-taskenv:*",
-          "docker-worker:image:quay.io/mozilla/npm-cache:*",
           "docker-worker:image:quay.io/mozilla/raptor-tester:latest",
           "queue:define-task:aws-provisioner/gaia",
           "queue:create-task:aws-provisioner/gaia"
@@ -27,7 +25,7 @@
           "cache": {
             "gaia-misc-caches": "/home/tester/caches/"
           },
-          "image": "quay.io/mozilla/gaia-taskenv:0.8.11",
+          "image": "taskcluster/gaia-taskenv:0.8.11",
           "command": [
             "entrypoint",
             "echo 'what' && node tests/taskcluster/bin/graph > /graph.json && cat /graph.json"

--- a/tests/taskcluster/bootstrap.yml
+++ b/tests/taskcluster/bootstrap.yml
@@ -10,12 +10,11 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/npm-cache:*
     - index:insert-task:gaia.npm_cache.*
     - queue:create-artifact:public/node_modules.tar.gz
 
   payload:
-    image: quay.io/mozilla/npm-cache:0.1.10
+    image: taskcluster/npm-cache:0.1.10
 
     cache:
       gaia-misc-caches: /home/tester/caches/

--- a/tests/taskcluster/tasks/build_integration.yml
+++ b/tests/taskcluster/tasks/build_integration.yml
@@ -10,12 +10,11 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     cache:
       gaia-misc-caches: /home/tester/caches/
+
     env:
       REPORTER: 'mocha-tbpl-reporter'
       THIS_CHUNK: '{{chunk}}'

--- a/tests/taskcluster/tasks/build_unit.yml
+++ b/tests/taskcluster/tasks/build_unit.yml
@@ -10,10 +10,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     cache:
       gaia-misc-caches: /home/tester/caches/
 

--- a/tests/taskcluster/tasks/csslint.yml
+++ b/tests/taskcluster/tasks/csslint.yml
@@ -9,10 +9,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     env:
       NODE_MODULES_SRC: npm-cache
 

--- a/tests/taskcluster/tasks/gaia_ui_tests.yml
+++ b/tests/taskcluster/tasks/gaia_ui_tests.yml
@@ -12,10 +12,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     cache:
       gaia-misc-caches: /home/tester/caches/
     # See: ci/gaia_ui_tests/script for how this ties into the built in

--- a/tests/taskcluster/tasks/gjslint.yml
+++ b/tests/taskcluster/tasks/gjslint.yml
@@ -9,10 +9,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     env:
       NODE_MODULES_SRC: npm-cache
     cache:

--- a/tests/taskcluster/tasks/jshint.yml
+++ b/tests/taskcluster/tasks/jshint.yml
@@ -9,10 +9,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     env:
       NODE_MODULES_SRC: npm-cache
     cache:

--- a/tests/taskcluster/tasks/jsmarionette_unit_tests.yml
+++ b/tests/taskcluster/tasks/jsmarionette_unit_tests.yml
@@ -10,10 +10,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     cache:
       gaia-misc-caches: /home/tester/caches/
 

--- a/tests/taskcluster/tasks/linters.yml
+++ b/tests/taskcluster/tasks/linters.yml
@@ -5,12 +5,9 @@ task:
 
   workerType: '{{workerType}}'
   provisionerId: '{{provisionerId}}'
-  scopes:
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
     maxRunTime: 600
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     command:
       - entrypoint
       - ./bin/ci run linters

--- a/tests/taskcluster/tasks/marionette_js_tests.yml
+++ b/tests/taskcluster/tasks/marionette_js_tests.yml
@@ -12,10 +12,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     maxRunTime: 7200
     cache:
       gaia-misc-caches: /home/tester/caches/

--- a/tests/taskcluster/tasks/marionette_js_tv_tests.yml
+++ b/tests/taskcluster/tasks/marionette_js_tv_tests.yml
@@ -12,10 +12,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     maxRunTime: 7200
     cache:
       gaia-misc-caches: /home/tester/caches/

--- a/tests/taskcluster/tasks/raptor_decision.yml
+++ b/tests/taskcluster/tasks/raptor_decision.yml
@@ -10,11 +10,9 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:tc-vcs
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
     maxRunTime:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     cache:
       tc-vcs: /home/worker/.tc-vcs
     command:

--- a/tests/taskcluster/tasks/unit_tests_b2g.yml
+++ b/tests/taskcluster/tasks/unit_tests_b2g.yml
@@ -10,10 +10,8 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
-    image: quay.io/mozilla/gaia-taskenv:0.8.11
     cache:
       gaia-misc-caches: /home/tester/caches/
 


### PR DESCRIPTION
…-cache worker images. r=jonasfj
