### PR TITLE
Bug 1169972 - [System] Remove unused css rules inside of app_install_manager.css

### DIFF
--- a/apps/system/style/app_install_manager/app_install_manager.css
+++ b/apps/system/style/app_install_manager/app_install_manager.css
@@ -157,8 +157,4 @@ ul#ime-list > li > label.pack-checkbox.ime ~ a {
   padding-right: 6.1rem;
 }
 
-ul#ime-list > li > label.pack-switch ~ a {
-  padding-right: 9rem;
-}
-
 /* ... end of keyboard layout */

--- a/tv_apps/smart-system/style/app_install_manager/app_install_manager.css
+++ b/tv_apps/smart-system/style/app_install_manager/app_install_manager.css
@@ -134,8 +134,4 @@ ul#ime-list > li > label.pack-checkbox.ime ~ a {
   padding-right: 6.1rem;
 }
 
-ul#ime-list > li > label.pack-switch ~ a {
-  padding-right: 9rem;
-}
-
 /* ... end of keyboard layout */


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1169972
