### PR TITLE
Bug 1127559 - [Dialer] End call button gets wider when putting a call on hold

### DIFF
--- a/apps/callscreen/style/oncall.css
+++ b/apps/callscreen/style/oncall.css
@@ -334,7 +334,6 @@
   #callbar-hang-up > .callbar-inner-button {
     background: url('images/handled_call/actionicon_activecall_hangup.png') center / 4rem no-repeat,
                 #e00000;
-    -moz-margin-end: 1rem;
   }
 
   #callbar-hang-up:active > .callbar-inner-button {


### PR DESCRIPTION
Now the end call button not get wider after put a call on hold
