### PR TITLE
Bug 1127559 - [Dialer] End call button gets wider when putting a call on hold r=gsvelto

### DIFF
--- a/apps/callscreen/style/oncall.css
+++ b/apps/callscreen/style/oncall.css
@@ -942,7 +942,8 @@
   }
 
   #call-screen[data-layout="dialing"] #callbar-hang-up > .callbar-inner-button,
-  #call-screen[data-layout="connected"] #callbar-hang-up > .callbar-inner-button {
+  #call-screen[data-layout="connected"] #callbar-hang-up > .callbar-inner-button,
+  #call-screen[data-layout="connected-hold"] #callbar-hang-up > .callbar-inner-button {
     margin: 1rem 1.5rem 1rem 1.5rem;
   }
 


### PR DESCRIPTION
Now the End call button doesn't get wider after putting a call on hold
