### PR TITLE
Bug 1162548 - [Calendar] edit and modify event views should not talk directly to stores r=gaye

### DIFF
--- a/apps/calendar/js/app.js
+++ b/apps/calendar/js/app.js
@@ -9,6 +9,7 @@ var ServiceController = require('controllers/service');
 var SyncController = require('controllers/sync');
 var TimeController = require('controllers/time');
 var asyncRequire = require('common/async_require');
+var bridge = require('bridge');
 var co = require('ext/co');
 var core = require('core');
 var dateL10n = require('date_l10n');
@@ -34,6 +35,7 @@ function setupCore(dbName) {
   if (core.db) {
     return;
   }
+  core.bridge = bridge;
   core.db = new Db(dbName || 'b2g-calendar');
   core.errorController = new ErrorController();
   core.notificationsController = notificationsController;

--- a/apps/calendar/js/bridge.js
+++ b/apps/calendar/js/bridge.js
@@ -1,0 +1,129 @@
+define(function(require, exports) {
+'use strict';
+
+var EventEmitter2 = require('ext/eventemitter2');
+var co = require('ext/co');
+var core = require('core');
+var dayObserver = require('day_observer');
+var nextTick = require('common/next_tick');
+var object = require('common/object');
+
+/**
+ * Fetch all the data needed to display the busytime information on the event
+ * views based on the busytimeId
+ */
+exports.fetchRecord = function(busytimeId) {
+  return co(function *() {
+    var record = yield dayObserver.findAssociated(busytimeId);
+    var eventStore = core.storeFactory.get('Event');
+    var owners = yield eventStore.ownersOf(record.event);
+    var provider = core.providerFactory.get(owners.account.providerType);
+    var capabilities = yield provider.eventCapabilities(record.event);
+
+    record.calendar = owners.calendar;
+    record.account = owners.account;
+    record.capabilities = capabilities;
+
+    return record;
+  });
+};
+
+/**
+ * Fetch all the calendars from database and emits a new event every time the
+ * values changes.
+ *
+ * @returns {ClientStream}
+ */
+exports.observeCalendars = function() {
+  // TODO: replace with real threads.client.stream when we get db into worker
+  var stream = new FakeClientStream();
+  var calendarStore = core.storeFactory.get('Calendar');
+
+  var getAllAndWrite = co.wrap(function *() {
+    // calendarStore.all() returns an object! we convert into an array since
+    // that is easier to render/manipulate
+    var calendars = yield calendarStore.all();
+    var data = yield object.map(calendars, co.wrap(function *(id, calendar) {
+      var provider = yield calendarStore.providerFor(calendar);
+      var caps = provider.calendarCapabilities(calendar);
+      return { calendar: calendar, capabilities: caps };
+    }));
+    stream.write(data);
+  });
+
+  calendarStore.on('add', getAllAndWrite);
+  calendarStore.on('remove', getAllAndWrite);
+  calendarStore.on('update', getAllAndWrite);
+
+  stream.cancel = function() {
+    calendarStore.off('add', getAllAndWrite);
+    calendarStore.off('remove', getAllAndWrite);
+    calendarStore.off('update', getAllAndWrite);
+    stream._emitter.removeAllListeners();
+  };
+
+  nextTick(getAllAndWrite);
+
+  return stream;
+};
+
+exports.createEvent = function(event) {
+  return persistEvent(event, 'create', 'canCreate');
+};
+
+exports.updateEvent = function(event) {
+  return persistEvent(event, 'update', 'canUpdate');
+};
+
+exports.deleteEvent = function(event) {
+  return persistEvent(event, 'delete', 'canDelete');
+};
+
+var persistEvent = co.wrap(function *(event, action, capability) {
+  event = event.data || event;
+  try {
+    var eventStore = core.storeFactory.get('Event');
+    var provider = yield eventStore.providerFor(event);
+    var caps = yield provider.eventCapabilities(event);
+    if (!caps[capability]) {
+      return Promise.reject(new Error(`Can't ${action} event`));
+    }
+    return provider[action + 'Event'](event);
+  } catch(err) {
+    console.error(
+      `${action} Error for event "${event._id}" ` +
+      `on calendar "${event.calendarId}"`
+    );
+    console.error(err);
+    return Promise.reject(err);
+  }
+});
+
+exports.getSetting = co.wrap(function *(id) {
+  var settingsStore = core.storeFactory.get('Setting');
+  return yield settingsStore.getValue(id);
+});
+
+/**
+ * FakeClientStream is used as a temporary solution while we move all the db
+ * calls into the worker. In the end all the methods inside this file will be
+ * transfered into the "backend/calendar_service.js" and we will simply call
+ * the `threads.client('calendar')` API
+ */
+function FakeClientStream() {
+  this._emitter = new EventEmitter2();
+}
+
+FakeClientStream.prototype.write = function(data) {
+  this._emitter.emit('data', data);
+};
+
+FakeClientStream.prototype.listen = function(callback) {
+  this._emitter.on('data', callback);
+};
+
+FakeClientStream.prototype.unlisten = function(callback) {
+  this._emitter.off('data', callback);
+};
+
+});

--- a/apps/calendar/test/unit/views/event_base_test.js
+++ b/apps/calendar/test/unit/views/event_base_test.js
@@ -94,7 +94,7 @@ suite('Views.EventBase', function() {
     assert.ok(subject.uiSelector);
   });
 
-  suite('#useModel', function() {
+  suite('#_useModel', function() {
     var callsUpdateUI;
     setup(function() {
       callsUpdateUI = false;
@@ -103,56 +103,33 @@ suite('Views.EventBase', function() {
       };
     });
 
-    test('multiple pending operations', function(done) {
-      function throwsError() {
-        done(new Error('incorrect callback fired...'));
-      }
+    test('readonly', function() {
+      var record = {
+        busytime: this.busytime,
+        event: this.event,
+        capabilities: { canUpdate: false }
+      };
 
-      subject.useModel(this.busytime, this.event, throwsError);
-      subject.useModel(this.busytime, this.event, throwsError);
-      subject.useModel(this.busytime, this.event, done);
+      subject._useModel(record);
+      assert.isTrue(hasClass(subject.READONLY), 'is readonly');
+      assert.isTrue(callsUpdateUI, 'updates ui');
     });
 
-    test('readonly', function(done) {
-      var provider = core.providerFactory.get('Mock');
+    test('normal', function() {
+      var record = {
+        busytime: this.busytime,
+        event: this.event,
+        calendar: { _id: this.event.calendarId },
+        capabilities: { canUpdate: true }
+      };
 
-      provider.stageEventCapabilities(this.event._id, null, {
-        canUpdate: false
-      });
-
-      subject.useModel(this.busytime, this.event, function() {
-        done(function() {
-          assert.isTrue(hasClass(subject.READONLY), 'is readonly');
-          assert.isTrue(callsUpdateUI, 'updates ui');
-        });
-      });
-    });
-
-    test('normal', function(done) {
-      var isDone = false;
-      subject.useModel(this.busytime, this.event, function() {
-        done(function() {
-          assert.ok(isDone, 'not async');
-          assert.ok(
-            !subject.element.classList.contains(subject.LOADING),
-            'is not loading'
-          );
-
-          assert.equal(
-            subject.originalCalendar._id,
-            this.event.calendarId
-          );
-
-          assert.isTrue(callsUpdateUI, 'updates ui');
-          assert.isFalse(hasClass(subject.READONLY), 'is readonly');
-        }.bind(this));
-      }.bind(this));
-
-      assert.ok(
-        subject.element.classList.contains(subject.LOADING),
-        'is loading'
+      subject._useModel(record);
+      assert.equal(
+        subject.originalCalendar._id,
+        record.event.calendarId
       );
-      isDone = true;
+      assert.isTrue(callsUpdateUI, 'updates ui');
+      assert.isFalse(hasClass(subject.READONLY), 'is readonly');
     });
   });
 

--- a/apps/calendar/test/unit/views/modify_event_test.js
+++ b/apps/calendar/test/unit/views/modify_event_test.js
@@ -966,7 +966,7 @@ suite('views/modify_event', function() {
       var allday = subject.getEl('allday');
       allday.checked = isAllDay;
       subject.event.isAllDay = isAllDay;
-      subject.updateAlarms(isAllDay, function() {
+      subject.updateAlarms(isAllDay).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 2);
 
@@ -992,7 +992,7 @@ suite('views/modify_event', function() {
 
     test('populated with no existing alarms', function(done) {
       subject.event.alarms = [];
-      subject.updateAlarms(true, function() {
+      subject.updateAlarms(true).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 2);
         assert.equal(allAlarms[0].value, defaultAllDayAlarm);
@@ -1005,7 +1005,7 @@ suite('views/modify_event', function() {
       subject.event.alarms = [
         {trigger: -300}
       ];
-      subject.updateAlarms(true, function() {
+      subject.updateAlarms(true).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 2);
         assert.equal(allAlarms[0].value, -300);
@@ -1019,7 +1019,7 @@ suite('views/modify_event', function() {
       subject.isSaved = function() {
         return true;
       };
-      subject.updateAlarms(true, function() {
+      subject.updateAlarms(true).then(() => {
         var allAlarms = subject.alarmList.querySelectorAll('select');
         assert.equal(allAlarms.length, 1);
         assert.equal(allAlarms[0].value, 'none');
@@ -1065,7 +1065,7 @@ suite('views/modify_event', function() {
           var allday = subject.getEl('allday');
           allday.checked = isAllDay;
           subject.event.isAllDay = isAllDay;
-          subject.updateAlarms(isAllDay, function() {
+          subject.updateAlarms(isAllDay).then(() => {
             var allAlarms = subject.alarmList.querySelectorAll('select');
             var firstSelect = allAlarms[0];
             assert.ok(firstSelect);


### PR DESCRIPTION
basically same thing as https://github.com/mozilla-b2g/gaia/pull/29978 but now user should be able to add events to a Google calendar..

was using the wrong calendar id.. `[value]` on the `<option>` was wrong, it was using the `calendar.remote.id` instead of `calendar._id` :/

to make it easier to debug similar errors I added a couple `console.error` calls on the bridge (with calendar id and event id)
