### PR TITLE
Bug 1170963: Remove not used functions from l10n_date

### DIFF
--- a/shared/js/l10n_date.js
+++ b/shared/js/l10n_date.js
@@ -163,15 +163,6 @@ navigator.mozL10n.DateTimeFormat = function(locales, options) {
 
   // API
   return {
-    localeDateString: function localeDateString(d) {
-      return localeFormat(d, '%x');
-    },
-    localeTimeString: function localeTimeString(d) {
-      return localeFormat(d, '%X');
-    },
-    localeString: function localeString(d) {
-      return localeFormat(d, '%c');
-    },
     localeFormat: localeFormat,
     fromNow: prettyDate,
     relativeParts: relativeParts

--- a/shared/test/unit/mocks/mock_l10n.js
+++ b/shared/test/unit/mocks/mock_l10n.js
@@ -80,9 +80,6 @@
 
   // Defining methods on the prototype allows to spy on them in tests
   exports.MockL10n.DateTimeFormat.prototype = {
-    localeDateString: stringify,
-    localeTimeString: stringify,
-    localeString: stringify,
     localeFormat: stringify,
     fromNow: stringify,
     relativeParts: stringify


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1170963
