### PR TITLE
Bug 1168326 - Replace SpecialPowers in selection_helper.js

### DIFF
--- a/apps/system/test/marionette/lib/selection_helper.js
+++ b/apps/system/test/marionette/lib/selection_helper.js
@@ -23,13 +23,12 @@ SelectionHelper.prototype = {
 
   get selectedContent() {
     return this.client.executeScript(this.getSelectionCmd() +
-      'return sel.toString();', [this.element]);
+      'return sel.toString();', [this.element], null, 'system');
   },
 
   getSelectionCmd: function() {
     if (this.isInputOrTextarea) {
-      return 'var sel = SpecialPowers.wrap(arguments[0]).editor.selection;' +
-             'sel = SpecialPowers.unwrap(sel);';
+      return 'var sel = arguments[0].editor.selection;';
     } else {
       return 'var sel = window.getSelection();';
     }
@@ -38,12 +37,12 @@ SelectionHelper.prototype = {
   selectionRectList: function(idx) {
     var cmd = this.getSelectionCmd() + 'return sel.getRangeAt(' + idx + ')' +
       '.getClientRects();';
-    return this.client.executeScript(cmd, [this.element]);
+    return this.client.executeScript(cmd, [this.element], null, 'system');
   },
 
   rangeCount: function() {
     var cmd = this.getSelectionCmd() + 'return sel.rangeCount;';
-    return this.client.executeScript(cmd, [this.element]);
+    return this.client.executeScript(cmd, [this.element], null, 'system');
   },
 
   /**

--- a/apps/system/test/marionette/text_selection_test.js
+++ b/apps/system/test/marionette/text_selection_test.js
@@ -35,9 +35,9 @@ marionette('Text selection >', function() {
         fakeTextselectionApp.setTestFrame('functionality');
       });
 
-      // XXX: bug 1168326 .
-      test.skip('short cut test', function(done) {
+      test('short cut test', function(done) {
         fakeTextselectionApp.longPress('FunctionalitySourceInput');
+
         // store caret position
         var caretPositionOfSourceInput =
           fakeTextselectionApp.FunctionalitySourceInput
@@ -291,7 +291,7 @@ marionette('Text selection >', function() {
     });
 
     // XXX: bug 1168326 .
-    suite.skip('selection carets bug', function() {
+    suite('selection carets bug', function() {
       setup(function() {
         fakeTextselectionApp.setTestFrame('bug1120358');
       });

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
@@ -1224,16 +1224,19 @@
      *                            call in the script if there is one.
      * @return {Object} self.
      */
-    executeScript: function executeScript(script, args, callback) {
+    executeScript: function executeScript(script, args, callback, sandbox) {
       if (typeof(args) === 'function') {
         callback = args;
         args = null;
       }
+      if (typeof(sandbox) === 'undefined')
+        sandbox = 'default';
       return this._executeScript({
         name: 'executeScript',
         parameters: {
           script: script,
-          args: args
+          args: args,
+          sandbox: sandbox
         }
       }, callback || this.defaultCallback);
     },
@@ -1489,7 +1492,8 @@
         name: options.name,
         parameters: {
           script: this._convertFunction(options.parameters.script),
-          args: this._prepareArguments(options.parameters.args || [])
+          args: this._prepareArguments(options.parameters.args || []),
+          sandbox: options.parameters.sandbox
         }
       }, 'value', callback);
     }

--- a/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
@@ -880,7 +880,10 @@ suite('marionette/client', function() {
 
       test('should call _executeScript', function() {
         assert.deepEqual(calledWith, [
-          { name: 'executeScript', parameters: { script: script, args: null }},
+          {
+            name: 'executeScript',
+            parameters: { script: script, args: null, sandbox: 'default' }
+          },
           commandCallback
         ]);
       });
@@ -1110,6 +1113,7 @@ suite('marionette/client', function() {
   suite('._executeScript', function() {
       var cmd = 'return window.location',
           args = [{1: true}],
+          sandbox = 'default',
           type = 'executeScript';
 
     suite('with args', function() {
@@ -1117,7 +1121,8 @@ suite('marionette/client', function() {
         name: type,
         parameters: {
           script: cmd,
-          args: args
+          args: args,
+          sandbox: sandbox
         }
       };
 
@@ -1132,7 +1137,8 @@ suite('marionette/client', function() {
       var request = {
         name: type,
         parameters: {
-          script: cmd
+          script: cmd,
+          sandbox: sandbox
         }
       };
 
@@ -1142,7 +1148,8 @@ suite('marionette/client', function() {
           name: type,
           parameters: {
             script: cmd,
-            args: []
+            args: [],
+            sandbox: sandbox
           }
         }).
         serverResponds('getUrlResponse').


### PR DESCRIPTION
SpecialPowers has been removed from marionette in bug 1149618, but somehow SpecialPowers was not removed in selection_helper.js yet. To remove that, we could enable parameter "sandbox" for executeScript(), which is already enabled in Marionette Python Client. In my first commit, I enable parameter "sandbox" for executeScript() and fix the unit-test. In my second commit, I use the newly supported executeScript() to remove the use of SpecialPowers.
