### PR TITLE
Bug 1155131 - add wrapping & unwrapping to tagged.js.

### DIFF
--- a/apps/sharedtest/test/unit/tagged_test.js
+++ b/apps/sharedtest/test/unit/tagged_test.js
@@ -11,4 +11,26 @@ suite('tagged template helper', function() {
     var generated = Tagged.escapeHTML `${myVal} world`;
     assert.equal(generated, '&lt;b&gt;hello&lt;&#x2F;b&gt; world');
   });
+
+  test('#createSafeHTML', function() {
+    var title = 'Click me';
+    var url = '" ><script>alert(1)</script>';
+    var s;
+    s = Tagged.createSafeHTML`<a href="${url}" title="${title}">${title}</a>`;
+
+    var expectedDocs = 'https://developer.mozilla.org/en-US/Firefox_OS/'+
+                        'Security/Security_Automation';
+    assert.equal(s.__html,
+                 '<a href="&quot; &gt;&lt;script&gt;alert(1)&lt;&#x2F;script'+
+                  '&gt;" title="Click me">Click me</a>');
+    assert.ok(s.info.indexOf(expectedDocs) !== -1);
+  });
+
+  test('#unwrapSafeHTML', function() {
+    var escapeMe = '<s>hax</s>';
+    var obj = Tagged.createSafeHTML`<b>${escapeMe}</b>`;
+    var unwrapped = Tagged.unwrapSafeHTML(obj);
+    assert.equal(unwrapped, '<b>&lt;s&gt;hax&lt;&#x2F;s&gt;</b>');
+  });
+
 });

--- a/shared/js/tagged.js
+++ b/shared/js/tagged.js
@@ -1,8 +1,17 @@
 'use strict';
-
 /**
- * tagged.js is a simple library to help you manage tagged template strings.
+ * tagged.js is a simple library to help you escape HTML using template strings
+ *
+ * It's the counterpart to our eslint "no-unsafe-innerhtml" plugin that helps us
+ * avoid unsafe coding practices.
+ * A full write-up of the Hows and Whys are documented
+ * for developers at
+ *  https://developer.mozilla.org/en-US/Firefox_OS/Security/Security_Automation
+ * with additional background information and design docs at
+ *  https://wiki.mozilla.org/User:Fbraun/Gaia/SafeinnerHTMLRoadmap
+ *
  */
+
 var Tagged = {
 
   _entity: /[&<>"'/]/g,
@@ -34,5 +43,26 @@ var Tagged = {
     }
 
     return result;
+  },
+  /**
+   * Escapes HTML and returns a wrapped object to be used during DOM insertion
+   */
+  createSafeHTML: function(strings, ...values) {
+    var escaped = Tagged.escapeHTML(strings, ...values);
+    return {
+      __html: escaped,
+      toString: function() {
+        return '[object WrappedHTMLObject]';
+      },
+      info: 'This is a wrapped HTML object. See https://developer.mozilla.or'+
+        'g/en-US/Firefox_OS/Security/Security_Automation for more.'
+    };
+  },
+  /**
+   * Unwrap safe HTML created by createSafeHTML or a custom replacement that
+   * underwent security review.
+   */
+  unwrapSafeHTML: function(htmlObject) {
+    return htmlObject.__html;
   }
 };

--- a/shared/js/tagged.js
+++ b/shared/js/tagged.js
@@ -1,4 +1,5 @@
-'use strict';
+/* globals define, module */
+
 /**
  * tagged.js is a simple library to help you escape HTML using template strings
  *
@@ -11,58 +12,72 @@
  *  https://wiki.mozilla.org/User:Fbraun/Gaia/SafeinnerHTMLRoadmap
  *
  */
-
-var Tagged = {
-
-  _entity: /[&<>"'/]/g,
-
-  _entities: {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    '\'': '&apos;',
-    '/': '&#x2F;'
-  },
-
-  getEntity: function(s) {
-    return Tagged._entities[s];
-  },
-
-  /**
-   * Escapes HTML for all values in a tagged template string.
-   */
-  escapeHTML: function(strings, ...values) {
-    var result = '';
-
-    for (var i = 0; i < strings.length; i++) {
-      result += strings[i];
-      if (i < values.length) {
-        result += String(values[i]).replace(Tagged._entity, Tagged.getEntity);
-      }
-    }
-
-    return result;
-  },
-  /**
-   * Escapes HTML and returns a wrapped object to be used during DOM insertion
-   */
-  createSafeHTML: function(strings, ...values) {
-    var escaped = Tagged.escapeHTML(strings, ...values);
-    return {
-      __html: escaped,
-      toString: function() {
-        return '[object WrappedHTMLObject]';
-      },
-      info: 'This is a wrapped HTML object. See https://developer.mozilla.or'+
-        'g/en-US/Firefox_OS/Security/Security_Automation for more.'
-    };
-  },
-  /**
-   * Unwrap safe HTML created by createSafeHTML or a custom replacement that
-   * underwent security review.
-   */
-  unwrapSafeHTML: function(htmlObject) {
-    return htmlObject.__html;
+(function (root, factory) {
+  'use strict';
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.Tagged = factory();
   }
-};
+}(this, function () {
+  'use strict';
+
+  var Tagged = {
+    _entity: /[&<>"'/]/g,
+
+    _entities: {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      '\'': '&apos;',
+      '/': '&#x2F;'
+    },
+
+    getEntity: function (s) {
+      return Tagged._entities[s];
+    },
+
+    /**
+     * Escapes HTML for all values in a tagged template string.
+     */
+    escapeHTML: function (strings, ...values) {
+      var result = '';
+
+      for (var i = 0; i < strings.length; i++) {
+        result += strings[i];
+        if (i < values.length) {
+          result += String(values[i]).replace(Tagged._entity, Tagged.getEntity);
+        }
+      }
+
+      return result;
+    },
+    /**
+     * Escapes HTML and returns a wrapped object to be used during DOM insertion
+     */
+    createSafeHTML: function (strings, ...values) {
+      var escaped = Tagged.escapeHTML(strings, ...values);
+      return {
+        __html: escaped,
+        toString: function () {
+          return '[object WrappedHTMLObject]';
+        },
+        info: 'This is a wrapped HTML object. See https://developer.mozilla.or'+
+          'g/en-US/Firefox_OS/Security/Security_Automation for more.'
+      };
+    },
+    /**
+     * Unwrap safe HTML created by createSafeHTML or a custom replacement that
+     * underwent security review.
+     */
+    unwrapSafeHTML: function (htmlObject) {
+      return htmlObject.__html;
+    }
+  };
+
+  return Tagged;
+
+}));


### PR DESCRIPTION
This is the first part of the patch, adding the new wrapper & unwrapper functions.

I was going to use the UMD pattern as suggested, but I have multiple questions about that.

a) jshint complains about a possible strict mode violation in [line 32](https://github.com/umdjs/umd/blob/master/returnExportsGlobal.js#L32), which looks like a false positive to me. I could fix this by either not using strict mode (meh) or telling jshint to ignore the line (doublemeh: Then jshint will shout syntax error, because the code does not make any sense when ignoring this line :))

b) I'm not sure where I'd actually define my `Tagged` object within a file organized like this. Here it seems to require something just to export it again. Instead, would I just define "var Tagged...`in between line 17 and 18 and reuse the variable instead of a`require(b)`? How would I make sure how it's thrown onto the scope with the name "Tagged" though? I really don't understand module loading.
