### PR TITLE
Bug 1162592 - [Calendar] views should not depend on providers r=gaye

### DIFF
--- a/apps/calendar/js/backend/db.js
+++ b/apps/calendar/js/backend/db.js
@@ -3,12 +3,13 @@ define(function(require, exports, module) {
 'use strict';
 
 var Account = require('models/account');
-var Presets = require('common/presets');
 var Local = require('provider/local');
+var Presets = require('common/presets');
 var Responder = require('common/responder');
 var core = require('core');
 var debug = require('common/debug')('db');
 var denodeifyAll = require('common/promise').denodeifyAll;
+var localCalendarId = require('common/constants').localCalendarId;
 var nextTick = require('common/next_tick');
 var probablyParseInt = require('common/probably_parse_int');
 var uuid = require('ext/uuid');
@@ -426,7 +427,7 @@ Db.prototype = {
     account._id = uuid();
 
     var calendar = {
-      _id: Local.calendarId,
+      _id: localCalendarId,
       accountId: account._id,
       remote: Local.defaultCalendar()
     };

--- a/apps/calendar/js/backend/provider/local.js
+++ b/apps/calendar/js/backend/provider/local.js
@@ -3,10 +3,9 @@ define(function(require, exports, module) {
 
 var Abstract = require('./abstract');
 var core = require('core');
+var localCalendarId = require('common/constants').localCalendarId;
 var mutations = require('event_mutations');
 var uuid = require('ext/uuid');
-
-var LOCAL_CALENDAR_ID = 'local-first';
 
 function Local() {
   Abstract.apply(this, arguments);
@@ -17,8 +16,6 @@ function Local() {
   this.alarms = storeFactory.get('Alarm');
 }
 module.exports = Local;
-
-Local.calendarId = LOCAL_CALENDAR_ID;
 
 /**
  * Returns the details for the default calendars.
@@ -45,7 +42,7 @@ Local.defaultCalendar = function() {
   return {
     // XXX localize this name somewhere
     name: name,
-    id: LOCAL_CALENDAR_ID,
+    id: localCalendarId,
     color: Local.prototype.defaultColor
   };
 
@@ -62,7 +59,7 @@ Local.prototype = {
 
   findCalendars: function(account, callback) {
     var list = {};
-    list[LOCAL_CALENDAR_ID] = Local.defaultCalendar();
+    list[localCalendarId] = Local.defaultCalendar();
     callback(null, list);
   },
 

--- a/apps/calendar/js/backend/store/calendar.js
+++ b/apps/calendar/js/backend/store/calendar.js
@@ -3,9 +3,9 @@ define(function(require, exports, module) {
 
 var Abstract = require('./abstract');
 var CalendarModel = require('models/calendar');
-var Local = require('provider/local');
 var core = require('core');
 var denodeifyAll = require('common/promise').denodeifyAll;
+var localCalendarId = require('common/constants').localCalendarId;
 var probablyParseInt = require('common/probably_parse_int');
 
 function Store() {
@@ -161,7 +161,7 @@ Store.prototype = {
 
   _setCalendarColor: function(calendar) {
     // local calendar should always use the same color
-    if (calendar._id === Local.calendarId) {
+    if (calendar._id === localCalendarId) {
       calendar.color = Store.LOCAL_COLOR;
       return;
     }

--- a/apps/calendar/js/common/constants.js
+++ b/apps/calendar/js/common/constants.js
@@ -1,0 +1,6 @@
+define(function(require, exports) {
+'use strict';
+
+exports.localCalendarId = 'local-first';
+
+});

--- a/apps/calendar/js/db.js
+++ b/apps/calendar/js/db.js
@@ -10,6 +10,7 @@ var core = require('core');
 var debug = require('common/debug')('db');
 var denodeifyAll = require('common/promise').denodeifyAll;
 var nextTick = require('common/next_tick');
+var localCalendarId = require('common/constants').localCalendarId;
 var probablyParseInt = require('common/probably_parse_int');
 var uuid = require('ext/uuid');
 
@@ -426,7 +427,7 @@ Db.prototype = {
     account._id = uuid();
 
     var calendar = {
-      _id: Local.calendarId,
+      _id: localCalendarId,
       accountId: account._id,
       remote: Local.defaultCalendar()
     };

--- a/apps/calendar/js/provider/local.js
+++ b/apps/calendar/js/provider/local.js
@@ -3,10 +3,9 @@ define(function(require, exports, module) {
 
 var Abstract = require('./abstract');
 var core = require('core');
+var localCalendarId = require('common/constants').localCalendarId;
 var mutations = require('event_mutations');
 var uuid = require('ext/uuid');
-
-var LOCAL_CALENDAR_ID = 'local-first';
 
 function Local() {
   Abstract.apply(this, arguments);
@@ -17,8 +16,6 @@ function Local() {
   this.alarms = storeFactory.get('Alarm');
 }
 module.exports = Local;
-
-Local.calendarId = LOCAL_CALENDAR_ID;
 
 /**
  * Returns the details for the default calendars.
@@ -42,7 +39,7 @@ Local.defaultCalendar = function() {
   return {
     // XXX localize this name somewhere
     name: name,
-    id: LOCAL_CALENDAR_ID,
+    id: localCalendarId,
     color: Local.prototype.defaultColor
   };
 
@@ -59,7 +56,7 @@ Local.prototype = {
 
   findCalendars: function(account, callback) {
     var list = {};
-    list[LOCAL_CALENDAR_ID] = Local.defaultCalendar();
+    list[localCalendarId] = Local.defaultCalendar();
     callback(null, list);
   },
 

--- a/apps/calendar/js/store/calendar.js
+++ b/apps/calendar/js/store/calendar.js
@@ -3,9 +3,9 @@ define(function(require, exports, module) {
 
 var Abstract = require('./abstract');
 var CalendarModel = require('models/calendar');
-var Local = require('provider/local');
 var core = require('core');
 var denodeifyAll = require('common/promise').denodeifyAll;
+var localCalendarId = require('common/constants').localCalendarId;
 var probablyParseInt = require('common/probably_parse_int');
 
 function Store() {
@@ -166,7 +166,7 @@ Store.prototype = {
 
   _setCalendarColor: function(calendar) {
     // local calendar should always use the same color
-    if (calendar._id === Local.calendarId) {
+    if (calendar._id === localCalendarId) {
       calendar.color = Store.LOCAL_COLOR;
       return;
     }

--- a/apps/calendar/js/templates/calendar.js
+++ b/apps/calendar/js/templates/calendar.js
@@ -1,8 +1,8 @@
 define(function(require, exports, module) {
 'use strict';
 
-var Local = require('provider/local');
 var create = require('template').create;
+var localCalendarId = require('common/constants').localCalendarId;
 
 module.exports = create({
   item: function() {
@@ -13,7 +13,7 @@ module.exports = create({
 
     // localize only the default calendar; there is no need to set the name
     // the [data-l10n-id] will take care of setting the proper value
-    if (id && Local.calendarId === id) {
+    if (id && localCalendarId === id) {
       // localize the default calendar name
       l10n = 'data-l10n-id="calendar-local"';
     } else {

--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -4,12 +4,12 @@ define(function(require, exports, module) {
 var AlarmTemplate = require('templates/alarm');
 var EventBase = require('./event_base');
 var InputParser = require('shared/input_parser');
-var Local = require('provider/local');
 var QueryString = require('querystring');
 var co = require('ext/co');
 var core = require('core');
 var dateFormat = require('date_format');
 var getTimeL10nLabel = require('common/calc').getTimeL10nLabel;
+var localCalendarId = require('common/constants').localCalendarId;
 var router = require('router');
 var viewFactory = require('./factory');
 
@@ -177,7 +177,7 @@ ModifyEvent.prototype = {
       var {name} = record.calendar.remote;
       var option = document.createElement('option');
 
-      if (id === Local.calendarId) {
+      if (id === localCalendarId) {
         option.text = navigator.mozL10n.get('calendar-local');
         option.setAttribute('data-l10n-id', 'calendar-local');
       } else {

--- a/apps/calendar/js/views/view_event.js
+++ b/apps/calendar/js/views/view_event.js
@@ -3,8 +3,8 @@ define(function(require, exports, module) {
 
 var DurationTime = require('templates/duration_time');
 var EventBase = require('./event_base');
-var Local = require('provider/local');
 var alarmTemplate = require('templates/alarm');
+var localCalendarId = require('common/constants').localCalendarId;
 var router = require('router');
 
 require('dom!event-view');
@@ -87,7 +87,7 @@ ViewEvent.prototype = {
         this.originalCalendar.color;
 
       var calendarId = this.originalCalendar.remote.id;
-      var isLocalCalendar = calendarId === Local.calendarId;
+      var isLocalCalendar = calendarId === localCalendarId;
       var calendarName = isLocalCalendar ?
         navigator.mozL10n.get('calendar-local') :
         this.originalCalendar.remote.name;

--- a/apps/calendar/test/unit/store/calendar_test.js
+++ b/apps/calendar/test/unit/store/calendar_test.js
@@ -7,8 +7,8 @@ var CalendarError = require('common/error');
 var CalendarModel = require('models/calendar');
 var CalendarStore = require('store/calendar');
 var Factory = require('test/support/factory');
-var Local = require('provider/local');
 var core = require('core');
+var localCalendarId = require('common/constants').localCalendarId;
 
 suite('store/calendar', function() {
   var subject;
@@ -329,7 +329,7 @@ suite('store/calendar', function() {
     test('> local calendar', function() {
       var calendar = Factory('calendar', {
         color: '#BADA55',
-        _id: Local.calendarId
+        _id: localCalendarId
       });
       subject._updateCalendarColor(calendar);
       assert.equal(

--- a/apps/calendar/test/unit/templates/calendar_test.js
+++ b/apps/calendar/test/unit/templates/calendar_test.js
@@ -2,7 +2,7 @@ define(function(require) {
 'use strict';
 
 var Calendar = require('templates/calendar');
-var Local = require('provider/local');
+var localCalendarId = require('common/constants').localCalendarId;
 
 suite('Templates.Calendar', function() {
   var subject;
@@ -18,7 +18,7 @@ suite('Templates.Calendar', function() {
   test('#item with local id', function() {
     var model = {
       localDisplayed: true,
-      _id: Local.calendarId,
+      _id: localCalendarId,
       name: 'foo',
       color: '#BADA55'
     };
@@ -36,7 +36,7 @@ suite('Templates.Calendar', function() {
   test('#item not local displayed', function() {
     var model = {
       localDisplayed: false,
-      _id: Local.calendarId,
+      _id: localCalendarId,
       name: 'foo'
     };
 


### PR DESCRIPTION
kinda ugly solution (constants file) but there are a few places where we actually need to use the string value so a helper method wouldn't improve things that much... I just hope the constants file doesn't grow exponentially over time.
