### PR TITLE
Bug 1168326 - Remove SpecialPowers in selection_helper.js

### DIFF
--- a/apps/system/test/marionette/lib/selection_helper.js
+++ b/apps/system/test/marionette/lib/selection_helper.js
@@ -23,13 +23,12 @@ SelectionHelper.prototype = {
 
   get selectedContent() {
     return this.client.executeScript(this.getSelectionCmd() +
-      'return sel.toString();', [this.element]);
+      'return sel.toString();', [this.element], null, 'system');
   },
 
   getSelectionCmd: function() {
     if (this.isInputOrTextarea) {
-      return 'var sel = SpecialPowers.wrap(arguments[0]).editor.selection;' +
-             'sel = SpecialPowers.unwrap(sel);';
+      return 'var sel = arguments[0].editor.selection;';
     } else {
       return 'var sel = window.getSelection();';
     }
@@ -38,12 +37,12 @@ SelectionHelper.prototype = {
   selectionRectList: function(idx) {
     var cmd = this.getSelectionCmd() + 'return sel.getRangeAt(' + idx + ')' +
       '.getClientRects();';
-    return this.client.executeScript(cmd, [this.element]);
+    return this.client.executeScript(cmd, [this.element], null, 'system');
   },
 
   rangeCount: function() {
     var cmd = this.getSelectionCmd() + 'return sel.rangeCount;';
-    return this.client.executeScript(cmd, [this.element]);
+    return this.client.executeScript(cmd, [this.element], null, 'system');
   },
 
   /**

--- a/apps/system/test/marionette/text_selection_test.js
+++ b/apps/system/test/marionette/text_selection_test.js
@@ -47,9 +47,9 @@ marionette('Text selection >', function() {
         fakeTextselectionApp.setTestFrame('functionality');
       });
 
-      // XXX: bug 1168326 .
-      test.skip('short cut test', function(done) {
+      test('short cut test', function(done) {
         fakeTextselectionApp.longPress('FunctionalitySourceInput');
+
         // store caret position
         var caretPositionOfSourceInput =
           fakeTextselectionApp.FunctionalitySourceInput
@@ -302,8 +302,7 @@ marionette('Text selection >', function() {
         });
     });
 
-    // XXX: bug 1168326 .
-    suite.skip('selection carets bug', function() {
+    suite('selection carets bug', function() {
       setup(function() {
         fakeTextselectionApp.setTestFrame('bug1120358');
       });


### PR DESCRIPTION
SpecialPowers has been removed from marionette in bug 1149618, but somehow SpecialPowers was not removed in selection_helper.js yet. To remove that, we could use parameter "sandbox" for executeScript(), which is already enabled in Marionette Python Client.
