### PR TITLE
Bug 1168326 - Enable sandbox option for marionette.client.executeScript in jsmarionette.

### DIFF
--- a/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
@@ -1218,22 +1218,30 @@
      *
      * @method executeScript
      * @chainable
-     * @param {String} script script to run.
+     * @param {String} script to run.
      * @param {Array} [args] optional args for script.
      * @param {Function} callback will receive result of the return \
      *                            call in the script if there is one.
+     * @param {String} optional sandbox is a tag referring to the sandbox you
+     *                 wish to use; if you specify a new tag, a new sandbox
+     *                 will be created. If you use the special tag 'system',
+     *                 the sandbox will be created using the system principal
+     *                 which has elevated privileges.
      * @return {Object} self.
      */
-    executeScript: function executeScript(script, args, callback) {
+    executeScript: function executeScript(script, args, callback, sandbox) {
       if (typeof(args) === 'function') {
         callback = args;
         args = null;
       }
+      if (typeof(sandbox) === 'undefined')
+        sandbox = 'default';
       return this._executeScript({
         name: 'executeScript',
         parameters: {
           script: script,
-          args: args
+          args: args,
+          sandbox: sandbox
         }
       }, callback || this.defaultCallback);
     },
@@ -1480,6 +1488,7 @@
      * @param {String} options.type command type like 'executeScript'.
      * @param {String} options.value javascript string.
      * @param {String} options.args arguments for script.
+     * @param {String} options.sandbox sandbox you wish to use
      * @param {Boolean} options.timeout timeout only used in 'executeJSScript'.
      * @param {Function} callback executes when script finishes.
      * @return {Object} self.
@@ -1489,7 +1498,8 @@
         name: options.name,
         parameters: {
           script: this._convertFunction(options.parameters.script),
-          args: this._prepareArguments(options.parameters.args || [])
+          args: this._prepareArguments(options.parameters.args || []),
+          sandbox: options.parameters.sandbox
         }
       }, 'value', callback);
     }

--- a/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
@@ -880,7 +880,10 @@ suite('marionette/client', function() {
 
       test('should call _executeScript', function() {
         assert.deepEqual(calledWith, [
-          { name: 'executeScript', parameters: { script: script, args: null }},
+          {
+            name: 'executeScript',
+            parameters: { script: script, args: null, sandbox: 'default' }
+          },
           commandCallback
         ]);
       });
@@ -1110,6 +1113,7 @@ suite('marionette/client', function() {
   suite('._executeScript', function() {
       var cmd = 'return window.location',
           args = [{1: true}],
+          sandbox = 'default',
           type = 'executeScript';
 
     suite('with args', function() {
@@ -1117,7 +1121,8 @@ suite('marionette/client', function() {
         name: type,
         parameters: {
           script: cmd,
-          args: args
+          args: args,
+          sandbox: sandbox
         }
       };
 
@@ -1132,7 +1137,8 @@ suite('marionette/client', function() {
       var request = {
         name: type,
         parameters: {
-          script: cmd
+          script: cmd,
+          sandbox: sandbox
         }
       };
 
@@ -1142,7 +1148,8 @@ suite('marionette/client', function() {
           name: type,
           parameters: {
             script: cmd,
-            args: []
+            args: [],
+            sandbox: sandbox
           }
         }).
         serverResponds('getUrlResponse').


### PR DESCRIPTION
Enable parameter "sandbox" for executeScript(), which is already enabled in Marionette Python Client. The unit-test is also patched.
