### PR TITLE
Bug 1129580 - [RTL][Gallery][Video] The Date Taken information is not displayed in proper RTL format (Year/Month/Day) when viewing the meta-data for pictures and videos.

### DIFF
--- a/shared/locales/date/date.ar.properties
+++ b/shared/locales/date/date.ar.properties
@@ -195,7 +195,7 @@ incorrectDate = (تاريخ غير صحيح)
 # see http://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html
 
 dateTimeFormat_%c = %a %e %b %Y %I:%M:%S %p
-dateTimeFormat_%x = %d/%m/%Y
+dateTimeFormat_%x = %Y/%m/%d
 dateTimeFormat_%X = %I:%M:%S %p
 
 shortTimeFormat = %I:%M %p


### PR DESCRIPTION
Change format Date 
![screendate](https://cloud.githubusercontent.com/assets/1905513/8015734/6bc46326-0bdb-11e5-917c-ef3ddb76b79b.png)
