### PR TITLE
Bug 1172013 - [Calendar] views should not depend directly on day observer r=gaye

### DIFF
--- a/apps/calendar/js/bridge.js
+++ b/apps/calendar/js/bridge.js
@@ -169,6 +169,24 @@ exports.observeAccounts = function() {
   return stream;
 };
 
+exports.observeDay = function(date) {
+  var stream = new FakeClientStream();
+  var emit = stream.write.bind(stream);
+
+  stream.cancel = function() {
+    dayObserver.off(date, emit);
+    stream._cancel();
+  };
+
+  // FIXME: nextTick only really needed because dayObserver dispatches the
+  // first callback synchronously, easier to solve it here than to change
+  // dayObserver; we can remove this nextTick call after moving to threads.js
+  // (since it will always be async)
+  nextTick(() => dayObserver.on(date, emit));
+
+  return stream;
+};
+
 /**
  * FakeClientStream is used as a temporary solution while we move all the db
  * calls into the worker. In the end all the methods inside this file will be

--- a/apps/calendar/js/views/month_day.js
+++ b/apps/calendar/js/views/month_day.js
@@ -2,7 +2,7 @@ define(function(require, exports, module) {
 'use strict';
 
 var Calc = require('common/calc');
-var dayObserver = require('day_observer');
+var core = require('core');
 
 // MonthDay represents a single day inside the Month view grid.
 function MonthDay(options) {
@@ -19,6 +19,7 @@ MonthDay.prototype = {
   date: null,
   element: null,
   month: null,
+  _observer: null,
 
   create: function() {
     var dayId = Calc.getDayId(this.date);
@@ -57,11 +58,12 @@ MonthDay.prototype = {
   },
 
   activate: function() {
-    dayObserver.on(this.date, this._updateBusyCount);
+    this._observer = core.bridge.observeDay(this.date);
+    this._observer.listen(this._updateBusyCount);
   },
 
   deactivate: function() {
-    dayObserver.off(this.date, this._updateBusyCount);
+    this._observer && this._observer.cancel();
   },
 
   destroy: function() {

--- a/apps/calendar/js/views/single_day.js
+++ b/apps/calendar/js/views/single_day.js
@@ -3,7 +3,7 @@ define(function(require, exports, module) {
 
 var Overlap = require('utils/overlap');
 var buildElement = require('utils/dom').buildElement;
-var dayObserver = require('day_observer');
+var core = require('core');
 var isSameDate = require('common/calc').isSameDate;
 var localeFormat = require('date_format').localeFormat;
 var relativeDuration = require('common/calc').relativeDuration;
@@ -31,6 +31,7 @@ SingleDay.prototype = {
   _isActive: false,
   _borderWidth: 0.1,
   _attached: false,
+  _observer: null,
 
   setup: function() {
     this.day = buildElement(template.day.render({
@@ -76,7 +77,8 @@ SingleDay.prototype = {
     if (this._isActive) {
       return;
     }
-    dayObserver.on(this.date, this._render);
+    this._observer = core.bridge.observeDay(this.date);
+    this._observer.listen(this._render);
     window.addEventListener('localized', this);
     this._isActive = true;
   },
@@ -189,7 +191,7 @@ SingleDay.prototype = {
     if (!this._isActive) {
       return;
     }
-    dayObserver.off(this.date, this._render);
+    this._observer.cancel();
     window.removeEventListener('localized', this);
     this._isActive = false;
   },

--- a/apps/calendar/test/unit/views/single_day_test.js
+++ b/apps/calendar/test/unit/views/single_day_test.js
@@ -4,7 +4,6 @@ define(function(require) {
 var Calc = require('common/calc');
 var SingleDay = require('views/single_day');
 var core = require('core');
-var dayObserver = require('day_observer');
 
 suite('Views.SingleDay', function() {
   var alldaysHolder;
@@ -35,8 +34,7 @@ suite('Views.SingleDay', function() {
       oneDayLabelFormat: 'event-one-day-duration'
     });
 
-    this.sinon.spy(dayObserver, 'on');
-    this.sinon.spy(dayObserver, 'off');
+    this.sinon.spy(core.bridge, 'observeDay');
     this.sinon.spy(window, 'addEventListener');
     this.sinon.spy(window, 'removeEventListener');
     this.sinon.spy(subject, 'onactive');
@@ -45,8 +43,7 @@ suite('Views.SingleDay', function() {
   });
 
   teardown(function() {
-    dayObserver.on.restore();
-    dayObserver.off.restore();
+    core.bridge.observeDay.restore();
     window.addEventListener.restore();
     window.removeEventListener.restore();
     subject.onactive.restore();
@@ -68,11 +65,11 @@ suite('Views.SingleDay', function() {
     subject.onactive();
     subject.onactive();
     assert.ok(
-      dayObserver.on.calledOnce,
+      core.bridge.observeDay.calledOnce,
       'should add listener only once'
     );
     assert.ok(
-      dayObserver.on.calledWithExactly(date, subject._render),
+      core.bridge.observeDay.calledWithExactly(date),
       'observing day events'
     );
     assert.ok(
@@ -81,60 +78,69 @@ suite('Views.SingleDay', function() {
     );
   });
 
-  test('#oninactive > when inactive', function() {
-    subject.oninactive();
-    subject.oninactive();
-    assert.ok(
-      !dayObserver.off.called,
-      'should not execute if not active'
-    );
-    assert.ok(
-      !window.removeEventListener.called,
-      'localized'
-    );
+  suite('#oninactive', function() {
+    var observer;
+
+    setup(function() {
+      subject._observer = observer = { cancel: sinon.spy() };
+    });
+
+    test('> when inactive', function() {
+      subject.oninactive();
+      subject.oninactive();
+      assert.ok(
+        !observer.cancel.called,
+        'should not execute if not active'
+      );
+      assert.ok(
+        !window.removeEventListener.called,
+        'localized'
+      );
+    });
+
+    test('> when active', function() {
+      subject._isActive = true;
+      subject.oninactive();
+      subject.oninactive();
+      assert.ok(
+        observer.cancel.calledOnce,
+        'should stop listening for date'
+      );
+      assert.ok(
+        window.removeEventListener.calledWithExactly('localized', subject),
+        'localized'
+      );
+    });
   });
 
-  test('#oninactive > after onactive', function() {
-    subject.setup();
-    subject.onactive();
-    subject.oninactive();
-    subject.oninactive();
-    assert.ok(
-      dayObserver.off.calledOnce,
-      'should stop listening for date'
-    );
-    assert.ok(
-      dayObserver.off.calledWithExactly(date, subject._render),
-      'wont render anymore'
-    );
-    assert.ok(
-      window.removeEventListener.calledWithExactly('localized', subject),
-      'localized'
-    );
-  });
+  suite('#append', function() {
+    setup(function(done) {
+      subject.setup();
+      subject.append();
+      // render is async!
+      setTimeout(done);
+    });
 
-  test('#append', function() {
-    subject.setup();
-    subject.append();
+    test('> should render', function() {
+      var d = date.toString();
 
-    var d = date.toString();
+      assert.equal(
+        daysHolder.innerHTML,
+        `<div class="md__day" data-date="${d}"></div>`,
+        'should add day node'
+      );
 
-    assert.equal(
-      daysHolder.innerHTML,
-      `<div class="md__day" data-date="${d}"></div>`,
-      'should add day node'
-    );
-
-    assert.equal(
-      sanitize(alldaysHolder.innerHTML),
-      sanitize(`<div class="md__allday" data-date="${d}">
-        <h1 class="md__day-name" aria-level="2"
-          id="md__day-name-${subject._instanceID}">Wed 23</h1>
-        <div aria-describedby="md__day-name-4"
-          data-l10n-id="create-all-day-event" role="button"
-          class="md__allday-events"></div>
-      </div>`)
-    );
+      assert.equal(
+        sanitize(alldaysHolder.innerHTML),
+        sanitize(`<div class="md__allday" data-date="${d}">
+          <h1 class="md__day-name" aria-level="2"
+            id="md__day-name-${subject._instanceID}">Wed 23</h1>
+          <div aria-describedby="md__day-name-${subject._instanceID}"
+            data-l10n-id="create-all-day-event" role="button"
+            class="md__allday-events"></div>
+        </div>`)
+      );
+    });
   });
 
   test('#handleEvent', function() {
@@ -157,290 +163,302 @@ suite('Views.SingleDay', function() {
   });
 
   test('#_render', function() {
-    subject.setup();
-    subject.append();
-
-    var data = {
-      amount: 3,
-      basic: [
-        makeRecord('Dolor Amet', '4:00', '6:00', 1),
-        makeRecord('Lorem Ipsum', '5:00', '6:00')
-      ],
-      allday: [
-        makeAlldayRecord('Curabitur')
-      ]
-    };
-    var makeFirstEventID = makeID.bind(this, subject, data.basic[0]);
-    var makeSecondEventID = makeID.bind(this, subject, data.basic[1]);
-    var makeAllDayEventID = makeID.bind(this, subject, data.allday[0]);
-
-    // notice that we are testing the method indirectly (the important thing to
-    // check is if the view updates when the dayObserver emits events)
-    dayObserver.emitter.emit(dayId, data);
-
-    assert.lengthOf(daysHolder.querySelectorAll('.md__event'), 2, '0: events');
-    assert.lengthOf(alldaysHolder.querySelectorAll('.md__event'), 1, '0: all');
-
-    // testing the whole markup is enough to check if position and overlaps are
-    // handled properly and also makes sure all the data is passed to the
-    // templates, a drawback is that if we change the markup we need to update
-    // the tests (might catch differences that are not regressions)
-
-    var days = daysHolder.querySelectorAll('.md__day');
-    assert.lengthOf(days, 1, 'single day');
-    assert.equal(days[0].dataset.date, date.toString(), '[data-date]');
-
-    var busytimes = days[0].querySelectorAll('.md__event');
-    assert.lengthOf(busytimes, 2, 'busytimes');
-
-    // busytime #1
-    var busy = busytimes[0];
-
-    // position/size is enough to test overlaps
-    assert.equal(busy.style.height, '99.9px', '1: height');
-    assert.equal(busy.style.top, '200px', '1: top');
-    assert.equal(busy.style.width, '50%', '1: width');
-    assert.equal(busy.style.left, '50%', '1: left');
-    assert.include(
-      busy.href, '/event/show/' + data.basic[0].busytime._id, '1: href');
-
-    var labels = busy.getAttribute('aria-labelledby');
-    assert.include(labels, makeFirstEventID('title'), '1: label title');
-    assert.include(labels, makeFirstEventID('location'), '1: label location');
-    assert.include(labels, makeFirstEventID('icon'), '1: label icon');
-    assert.include(labels, makeFirstEventID('description'), '1: label desc');
-
-    assert.include(busy.className, 'has-alarms', '1: class');
-    assert.include(busy.className, 'has-overlaps', '1: class');
-
-    var remote = data.basic[0].event.remote;
-
-    var title = busy.querySelector('#' + makeFirstEventID('title'));
-    assert.equal(title.textContent.trim(), remote.title, '1: title');
-
-    var location = busy.querySelector('#' + makeFirstEventID('location'));
-    assert.equal(location.textContent.trim(), remote.location, '1: location');
-
-    var icon = busy.querySelector('#' + makeFirstEventID('icon'));
-    assert.include(icon.className, 'icon-calendar-alarm', '1: icon');
-    assert.equal(icon.getAttribute('aria-hidden'), 'true', '1: icon hidden');
-
-    var description = busy.querySelector('#' + makeFirstEventID('description'));
-    assert.equal(
-      description.getAttribute('aria-hidden'), 'true', '1: desc hidden');
-    assert.equal(
-      description.dataset.l10nId, 'event-one-day-duration', '1: desc l10nId'
-    );
-    assert.equal(
-      description.dataset.l10nArgs,
-      '{"startDate":"Wednesday, July 23, 2014","startTime":"04:00",' +
-      '"endDate":"Wednesday, July 23, 2014","endTime":"06:00"}',
-      '1: desc l10nArgs'
-    );
-
-    // busytime #2
-    busy = busytimes[1];
-
-    // position/size is enough to test overlaps
-    assert.equal(busy.style.height, '49.9px', '2: height');
-    assert.equal(busy.style.top, '250px', '2: top');
-    assert.equal(busy.style.width, '50%', '2: width');
-    assert.equal(busy.style.left, '0%', '2: left');
-    assert.include(
-      busy.href, '/event/show/' + data.basic[1].busytime._id, '2: href');
-
-    labels = busy.getAttribute('aria-labelledby');
-    assert.include(labels, makeSecondEventID('title'), '2: label title');
-    assert.include(labels, makeSecondEventID('location'), '2: label location');
-    assert.include(labels, makeSecondEventID('description'), '2: label desc');
-
-    assert.include(busy.className, 'has-overlaps', '2: class');
-
-    remote = data.basic[1].event.remote;
-
-    title = busy.querySelector('#' + makeSecondEventID('title'));
-    assert.equal(title.textContent.trim(), remote.title, '2: title');
-
-    location = busy.querySelector('#' + makeSecondEventID('location'));
-    assert.equal(location.textContent.trim(), remote.location, '2: location');
-
-    icon = busy.querySelector('#' + makeSecondEventID('icon'));
-    assert.isNull(icon, '2: icon');
-
-    description = busy.querySelector('#' + makeSecondEventID('description'));
-    assert.equal(
-      description.getAttribute('aria-hidden'), 'true', '2: desc hidden');
-    assert.equal(
-      description.dataset.l10nId, 'event-one-day-duration', '2: desc l10nId'
-    );
-    assert.equal(
-      description.dataset.l10nArgs,
-      '{"startDate":"Wednesday, July 23, 2014","startTime":"05:00",' +
-      '"endDate":"Wednesday, July 23, 2014","endTime":"06:00"}',
-      '2: desc l10nArgs'
-    );
-
-    var id = subject._instanceID;
-
-    var dayName = alldaysHolder.querySelector('.md__day-name');
-    assert.equal(dayName.getAttribute('aria-level'), '2', '3: day level');
-    assert.equal(dayName.id, `md__day-name-${id}`, '3: day id');
-    assert.equal(dayName.textContent.trim(), 'Wed 23', '3: day');
-
-    var wrapper = alldaysHolder.querySelector('.md__allday-events');
-    assert.equal(
-      wrapper.getAttribute('aria-labelledby'),
-      `all-day-icon md__day-name-${id}`,
-      '3: wrapper aria-labelledby'
-    );
-    assert.equal(
-      wrapper.getAttribute('aria-describedby'),
-      `md__day-name-${id}`,
-      '3: wrapper aria-describedby'
-    );
-    assert.equal(
-      wrapper.dataset.l10nId,
-      'create-all-day-event',
-      '3: wrapper data-l10n-id'
-    );
-    assert.equal(wrapper.getAttribute('role'), 'listbox', '3: wrapper role');
-    assert.equal(wrapper.childNodes.length, 1, '3: wrapper childNodes');
-
-    busy = wrapper.firstChild;
-    assert.equal(busy.getAttribute('role'), 'option', '4: busy role');
-    assert.include(busy.className, 'md__event', '4: busy md__event');
-    assert.include(busy.className, 'is-allday', '4: busy is-allday');
-    assert.equal(
-      busy.style.borderColor,
-      'rgb(0, 255, 204)',
-      '4: busy border color'
-    );
-    assert.equal(
-      busy.style.backgroundColor,
-     'rgba(0, 255, 204, 0.2)',
-     '4: busy background color'
-    );
-    assert.include(
-      busy.getAttribute('aria-labelledby'),
-      makeAllDayEventID('location'),
-      '4: busy location label'
-    );
-    assert.include(
-      busy.getAttribute('aria-labelledby'),
-      makeAllDayEventID('title'),
-      '4: busy title label'
-    );
-    assert.include(
-      busy.getAttribute('aria-labelledby'),
-      makeAllDayEventID('description'),
-      '4: busy description label'
-    );
-
-    remote = data.allday[0].event.remote;
-
-    title = busy.querySelector('.md__event-title');
-    assert.equal(
-      title.textContent.trim(),
-      remote.title,
-      '4: title'
-    );
-    assert.equal(
-      title.id,
-      makeAllDayEventID('title'),
-      '4: title id'
-    );
-
-    location = busy.querySelector('.md__event-location');
-    assert.equal(
-      location.textContent.trim(),
-      remote.location,
-      '4: location'
-    );
-    assert.equal(
-      location.id,
-      makeAllDayEventID('location'),
-      '4: location id'
-    );
-
-    description = busy.querySelector('#' + makeAllDayEventID('description'));
-    assert.equal(
-      description.getAttribute('aria-hidden'),
-      'true',
-      '4: description aria-hidden'
-    );
-    assert.equal(
-      description.getAttribute('data-l10n-id'),
-      'event-multiple-day-duration',
-      '4: description data-l10n-id'
-    );
-    assert.equal(
-      description.dataset.l10nArgs,
-      '{"startDate":"Wednesday, July 23, 2014","startTime":"00:00",' +
-        '"endDate":"Thursday, July 24, 2014","endTime":"00:00"}',
-      '4: description data-l10n-id'
-    );
-
-    data = {
-      amount: 2,
-      basic: [
-        makeRecord('Lorem Ipsum', '5:00', '6:00'),
-        makeRecord('Maecennas', '6:00', '17:00', 1)
-      ],
-      allday: []
-    };
-    // we always send all the events for that day and redraw whole view
-    dayObserver.emitter.emit(dayId, data);
-
-    // it's enough to check only the new event and the amount of busytimes
-    // inside each holder (just to ensure we are removing old elements)
-    busytimes = daysHolder.querySelectorAll('.md__event');
-    assert.lengthOf(busytimes, 2, '5: events');
-    assert.lengthOf(alldaysHolder.querySelectorAll('.md__event'), 0, '5: all');
-    assert.equal(
-      busytimes[1].querySelector('.md__event-title').textContent.trim(),
-      data.basic[1].event.remote.title,
-      '5: event title'
-    );
-  });
-
-  test('#_render > partial hour', function() {
-    subject.setup();
-    subject.append();
-
-    dayObserver.emitter.emit(dayId, {
-      amount: 4,
-      basic: [
-        makeRecord('Lorem Ipsum', '5:00', '5:15'),
-        makeRecord('Maecennas', '6:00', '6:25'),
-        makeRecord('Dolor', '6:30', '7:00'),
-        makeRecord('Amet', '7:00', '7:50')
-      ],
-      allday: []
+    setup(function(done) {
+      subject.setup();
+      subject.append();
+      setTimeout(done);
     });
 
-    assert.include(
-      daysHolder.innerHTML,
-      'is-partial is-partial-micro',
-      'smaller than 18min'
-    );
+    test('> should render', function() {
+      var data = {
+        amount: 3,
+        basic: [
+          makeRecord('Dolor Amet', '4:00', '6:00', 1),
+          makeRecord('Lorem Ipsum', '5:00', '6:00')
+        ],
+        allday: [
+          makeAlldayRecord('Curabitur')
+        ]
+      };
+      var makeFirstEventID = makeID.bind(this, subject, data.basic[0]);
+      var makeSecondEventID = makeID.bind(this, subject, data.basic[1]);
+      var makeAllDayEventID = makeID.bind(this, subject, data.allday[0]);
 
-    assert.include(
-      daysHolder.innerHTML,
-      'is-partial is-partial-tiny',
-      'between 18-30min'
-    );
+      // notice that we are testing the method indirectly (the important thing
+      // to check is if the view updates when we receive new data)
+      subject._observer.write(data);
 
-    assert.include(
-      daysHolder.innerHTML,
-      'is-partial is-partial-small',
-      'between 30-45min'
-    );
+      assert.lengthOf(
+        daysHolder.querySelectorAll('.md__event'), 2, '0: events'
+      );
+      assert.lengthOf(
+        alldaysHolder.querySelectorAll('.md__event'), 1, '0: all'
+      );
 
-    assert.include(
-      daysHolder.innerHTML,
-      'is-partial"',
-      'longer than 45min'
-    );
+      // testing the whole markup is enough to check if position and overlaps
+      // are handled properly and also makes sure all the data is passed to the
+      // templates, a drawback is that if we change the markup we need to update
+      // the tests (might catch differences that are not regressions)
+
+      var days = daysHolder.querySelectorAll('.md__day');
+      assert.lengthOf(days, 1, 'single day');
+      assert.equal(days[0].dataset.date, date.toString(), '[data-date]');
+
+      var busytimes = days[0].querySelectorAll('.md__event');
+      assert.lengthOf(busytimes, 2, 'busytimes');
+
+      // busytime #1
+      var busy = busytimes[0];
+
+      // position/size is enough to test overlaps
+      assert.equal(busy.style.height, '99.9px', '1: height');
+      assert.equal(busy.style.top, '200px', '1: top');
+      assert.equal(busy.style.width, '50%', '1: width');
+      assert.equal(busy.style.left, '50%', '1: left');
+      assert.include(
+        busy.href, '/event/show/' + data.basic[0].busytime._id, '1: href');
+
+      var labels = busy.getAttribute('aria-labelledby');
+      assert.include(labels, makeFirstEventID('title'), '1: label title');
+      assert.include(labels, makeFirstEventID('location'), '1: label location');
+      assert.include(labels, makeFirstEventID('icon'), '1: label icon');
+      assert.include(labels, makeFirstEventID('description'), '1: label desc');
+
+      assert.include(busy.className, 'has-alarms', '1: class');
+      assert.include(busy.className, 'has-overlaps', '1: class');
+
+      var remote = data.basic[0].event.remote;
+
+      var title = busy.querySelector('#' + makeFirstEventID('title'));
+      assert.equal(title.textContent.trim(), remote.title, '1: title');
+
+      var location = busy.querySelector('#' + makeFirstEventID('location'));
+      assert.equal(location.textContent.trim(), remote.location, '1: location');
+
+      var icon = busy.querySelector('#' + makeFirstEventID('icon'));
+      assert.include(icon.className, 'icon-calendar-alarm', '1: icon');
+      assert.equal(icon.getAttribute('aria-hidden'), 'true', '1: icon hidden');
+
+      var description = busy.querySelector(
+        '#' + makeFirstEventID('description')
+      );
+      assert.equal(
+        description.getAttribute('aria-hidden'), 'true', '1: desc hidden');
+      assert.equal(
+        description.dataset.l10nId, 'event-one-day-duration', '1: desc l10nId'
+      );
+      assert.equal(
+        description.dataset.l10nArgs,
+        '{"startDate":"Wednesday, July 23, 2014","startTime":"04:00",' +
+        '"endDate":"Wednesday, July 23, 2014","endTime":"06:00"}',
+        '1: desc l10nArgs'
+      );
+
+      // busytime #2
+      busy = busytimes[1];
+
+      // position/size is enough to test overlaps
+      assert.equal(busy.style.height, '49.9px', '2: height');
+      assert.equal(busy.style.top, '250px', '2: top');
+      assert.equal(busy.style.width, '50%', '2: width');
+      assert.equal(busy.style.left, '0%', '2: left');
+      assert.include(
+        busy.href, '/event/show/' + data.basic[1].busytime._id, '2: href');
+
+      labels = busy.getAttribute('aria-labelledby');
+      assert.include(labels, makeSecondEventID('title'), '2: label title');
+      assert.include(
+        labels, makeSecondEventID('location'), '2: label location'
+      );
+      assert.include(labels, makeSecondEventID('description'), '2: label desc');
+
+      assert.include(busy.className, 'has-overlaps', '2: class');
+
+      remote = data.basic[1].event.remote;
+
+      title = busy.querySelector('#' + makeSecondEventID('title'));
+      assert.equal(title.textContent.trim(), remote.title, '2: title');
+
+      location = busy.querySelector('#' + makeSecondEventID('location'));
+      assert.equal(location.textContent.trim(), remote.location, '2: location');
+
+      icon = busy.querySelector('#' + makeSecondEventID('icon'));
+      assert.isNull(icon, '2: icon');
+
+      description = busy.querySelector('#' + makeSecondEventID('description'));
+      assert.equal(
+        description.getAttribute('aria-hidden'), 'true', '2: desc hidden');
+      assert.equal(
+        description.dataset.l10nId, 'event-one-day-duration', '2: desc l10nId'
+      );
+      assert.equal(
+        description.dataset.l10nArgs,
+        '{"startDate":"Wednesday, July 23, 2014","startTime":"05:00",' +
+        '"endDate":"Wednesday, July 23, 2014","endTime":"06:00"}',
+        '2: desc l10nArgs'
+      );
+
+      var id = subject._instanceID;
+
+      var dayName = alldaysHolder.querySelector('.md__day-name');
+      assert.equal(dayName.getAttribute('aria-level'), '2', '3: day level');
+      assert.equal(dayName.id, `md__day-name-${id}`, '3: day id');
+      assert.equal(dayName.textContent.trim(), 'Wed 23', '3: day');
+
+      var wrapper = alldaysHolder.querySelector('.md__allday-events');
+      assert.equal(
+        wrapper.getAttribute('aria-labelledby'),
+        `all-day-icon md__day-name-${id}`,
+        '3: wrapper aria-labelledby'
+      );
+      assert.equal(
+        wrapper.getAttribute('aria-describedby'),
+        `md__day-name-${id}`,
+        '3: wrapper aria-describedby'
+      );
+      assert.equal(
+        wrapper.dataset.l10nId,
+        'create-all-day-event',
+        '3: wrapper data-l10n-id'
+      );
+      assert.equal(wrapper.getAttribute('role'), 'listbox', '3: wrapper role');
+      assert.equal(wrapper.childNodes.length, 1, '3: wrapper childNodes');
+
+      busy = wrapper.firstChild;
+      assert.equal(busy.getAttribute('role'), 'option', '4: busy role');
+      assert.include(busy.className, 'md__event', '4: busy md__event');
+      assert.include(busy.className, 'is-allday', '4: busy is-allday');
+      assert.equal(
+        busy.style.borderColor,
+        'rgb(0, 255, 204)',
+        '4: busy border color'
+      );
+      assert.equal(
+        busy.style.backgroundColor,
+       'rgba(0, 255, 204, 0.2)',
+       '4: busy background color'
+      );
+      assert.include(
+        busy.getAttribute('aria-labelledby'),
+        makeAllDayEventID('location'),
+        '4: busy location label'
+      );
+      assert.include(
+        busy.getAttribute('aria-labelledby'),
+        makeAllDayEventID('title'),
+        '4: busy title label'
+      );
+      assert.include(
+        busy.getAttribute('aria-labelledby'),
+        makeAllDayEventID('description'),
+        '4: busy description label'
+      );
+
+      remote = data.allday[0].event.remote;
+
+      title = busy.querySelector('.md__event-title');
+      assert.equal(
+        title.textContent.trim(),
+        remote.title,
+        '4: title'
+      );
+      assert.equal(
+        title.id,
+        makeAllDayEventID('title'),
+        '4: title id'
+      );
+
+      location = busy.querySelector('.md__event-location');
+      assert.equal(
+        location.textContent.trim(),
+        remote.location,
+        '4: location'
+      );
+      assert.equal(
+        location.id,
+        makeAllDayEventID('location'),
+        '4: location id'
+      );
+
+      description = busy.querySelector('#' + makeAllDayEventID('description'));
+      assert.equal(
+        description.getAttribute('aria-hidden'),
+        'true',
+        '4: description aria-hidden'
+      );
+      assert.equal(
+        description.getAttribute('data-l10n-id'),
+        'event-multiple-day-duration',
+        '4: description data-l10n-id'
+      );
+      assert.equal(
+        description.dataset.l10nArgs,
+        '{"startDate":"Wednesday, July 23, 2014","startTime":"00:00",' +
+          '"endDate":"Thursday, July 24, 2014","endTime":"00:00"}',
+        '4: description data-l10n-id'
+      );
+
+      data = {
+        amount: 2,
+        basic: [
+          makeRecord('Lorem Ipsum', '5:00', '6:00'),
+          makeRecord('Maecennas', '6:00', '17:00', 1)
+        ],
+        allday: []
+      };
+      // we always send all the events for that day and redraw whole view
+      subject._observer.write(data);
+
+      // it's enough to check only the new event and the amount of busytimes
+      // inside each holder (just to ensure we are removing old elements)
+      busytimes = daysHolder.querySelectorAll('.md__event');
+      assert.lengthOf(busytimes, 2, '5: events');
+      assert.lengthOf(
+        alldaysHolder.querySelectorAll('.md__event'), 0, '5: all'
+      );
+      assert.equal(
+        busytimes[1].querySelector('.md__event-title').textContent.trim(),
+        data.basic[1].event.remote.title,
+        '5: event title'
+      );
+    });
+
+    test('> partial hour', function() {
+      subject._observer.write({
+        amount: 4,
+        basic: [
+          makeRecord('Lorem Ipsum', '5:00', '5:15'),
+          makeRecord('Maecennas', '6:00', '6:25'),
+          makeRecord('Dolor', '6:30', '7:00'),
+          makeRecord('Amet', '7:00', '7:50')
+        ],
+        allday: []
+      });
+
+      assert.include(
+        daysHolder.innerHTML,
+        'is-partial is-partial-micro',
+        'smaller than 18min'
+      );
+
+      assert.include(
+        daysHolder.innerHTML,
+        'is-partial is-partial-tiny',
+        'between 18-30min'
+      );
+
+      assert.include(
+        daysHolder.innerHTML,
+        'is-partial is-partial-small',
+        'between 30-45min'
+      );
+
+      assert.include(
+        daysHolder.innerHTML,
+        'is-partial"',
+        'longer than 45min'
+      );
+    });
   });
 
   function makeID(subject, event, postfix) {


### PR DESCRIPTION
just so we can move most of the day observer logic into the worker.

I'll probably provide another pull request with a temporary implementation of the day observer inside the backend folder (keeping all the DB actions but skipping the "controllers" logic)
