### PR TITLE
Bug 1173530 - Remove unused _timer property from settings_listener.js

### DIFF
--- a/shared/js/settings_listener.js
+++ b/shared/js/settings_listener.js
@@ -2,9 +2,6 @@
 'use strict';
 
 var SettingsListener = {
-  /* Timer to remove the lock. */
-  _timer: null,
-
   /* lock stores here */
   _lock: null,
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1173530
