### PR TITLE
Bug 1173444 - [NFC] Adding utilities.js as a dependecy in NfcCore, r=alive

### DIFF
--- a/apps/system/js/nfc_core.js
+++ b/apps/system/js/nfc_core.js
@@ -8,6 +8,7 @@
   };
 
   NfcCore.IMPORTS = [
+    'shared/js/utilities.js',
     'shared/js/nfc_utils.js'
   ];
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1173444
