### PR TITLE
Bug 1173706 - Let system bootup and fake app launch use the same marionette client.

### DIFF
--- a/apps/system/test/marionette/text_selection_test.js
+++ b/apps/system/test/marionette/text_selection_test.js
@@ -11,20 +11,6 @@ marionette('Text selection >', function() {
   apps[FakeTextSelectionApp.ORIGIN] =
     __dirname + '/../apps/faketextselectionapp';
 
-  var client = marionette.client({
-    apps: apps,
-    prefs: {
-      'dom.w3c_touch_events.enabled': 1,
-      'docshell.device_size_is_page_size': true,
-      'dom.mozInputMethod.enabled': false
-    }
-  });
-
-  setup(function() {
-    system = client.loader.getAppClass('system');
-    system.waitForFullyLoaded();
-  });
-
   suite('without lockscreen', function() {
     var fakeTextselectionApp;
     var client = marionette.client({
@@ -38,6 +24,8 @@ marionette('Text selection >', function() {
     });
 
     setup(function() {
+      system = client.loader.getAppClass('system');
+      system.waitForFullyLoaded();
       fakeTextselectionApp = new FakeTextSelectionApp(client);
       action = new Actions(client);
     });
@@ -371,8 +359,9 @@ marionette('Text selection >', function() {
           fakeTextselectionApp.selectAll('BugTextarea');
           assert.ok(fakeTextselectionApp.bubbleVisiblity,
             'bubble should show since we press selectall');
-        });
+      });
     });
+  });
 
   suite('with lockscreen enabled', function() {
     var fakeTextselectionAppWithLockscreen;
@@ -390,6 +379,8 @@ marionette('Text selection >', function() {
     });
 
     setup(function() {
+      system = clientWithLockscreen.loader.getAppClass('system');
+      system.waitForFullyLoaded();
       fakeTextselectionAppWithLockscreen =
         new FakeTextSelectionApp(clientWithLockscreen);
       fakeTextselectionAppWithLockscreen.setTestFrame('bug');
@@ -423,7 +414,6 @@ marionette('Text selection >', function() {
         clientWithLockscreen.waitFor(function() {
           return !fakeTextselectionAppWithLockscreen.bubbleVisiblity;
         });
-      });
     });
   });
 });


### PR DESCRIPTION
Not sure why system bootup was moved outside the test suite with an independent client in Bug 1094759. This causes that two B2G clients are created for each test when running Gij with text_selection_test.js. In this patch, system bootup is moved back to where it should be, inside the test suite and using the same client with that of fake app launch.

I also move 'with lockscreen enabled' suite outside from 'without lockscreen' suite. I think this is more reasonable.
