### PR TITLE
Bug 1168396 - Adjust Marionette JS client to protocol changes; r=gaye

### DIFF
--- a/tests/jsmarionette/client/marionette-client/lib/marionette/actions.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/actions.js
@@ -248,7 +248,7 @@
           nextId: this.currentId
         }
       };
-      this.currentId = this.client._sendCommand(cmd, 'value', callback);
+      this.currentId = this.client._sendCommand(cmd, callback, 'value');
       this.actionChain = [];
       return this;
     }

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
@@ -188,8 +188,23 @@
     _state: null,
 
     /**
-     * Actor id for instance
+     * The current Marionette protocol level.
      *
+     * When a new connection is established, the client will assume
+     * the protocol version that the passed driver connection got upon
+     * establishing a connection with the remote end.
+     *
+     * Defaults to protocol version 1.
+     *
+     * @property protocol
+     * @type Number
+     */
+    protocol: 1,
+
+    /**
+     * Actor ID for instance.
+     *
+     * @deprecated
      * @property actor
      * @type String
      */
@@ -198,10 +213,10 @@
     /**
      * Session id for instance.
      *
-     * @property session
+     * @property sessionId
      * @type String
      */
-    session: null,
+    sessionId: null,
 
     // _state getters
 
@@ -275,6 +290,9 @@
       for (var key in this._state) {
         this._scope[key] = this._state[key];
       }
+
+      // assume protocol level from driver, if set
+      this.protocol = this.driver.marionetteProtocol || this.protocol;
     },
 
     /**
@@ -422,10 +440,12 @@
     },
 
     /**
-     * Sends a command to the server.
-     * Adds additional information like actor and session
-     * to command if not present.
+     * Send given command to the server with optional callback fired
+     * on completion.
      *
+     * Adds additional information like actor and session ID to command
+     * if not present and using the deprecated version 1 of the Marionette
+     * protocol.
      *
      * @method send
      * @chainable
@@ -448,12 +468,13 @@
         this._bypassScopeChecks = false;
       }
 
-      if (!cmd.to) {
-        cmd.to = this.actor || 'root';
-      }
-
-      if (this.session) {
-        cmd.session = cmd.session || this.session;
+      if (this.protocol == 1) {
+        if (!cmd.to) {
+          cmd.to = this.actor || 'root';
+        }
+        if (this.sessionId) {
+          cmd.session = cmd.session || this.sessionId;
+        }
       }
 
       if (!cb && this.defaultCallback) {
@@ -477,7 +498,8 @@
         callback = this.defaultCallback;
       }
 
-      assert(typeof callback === 'function', 'you must use functions');
+      assert(typeof callback == 'function',
+          'expected function, got ' + callback);
 
       // Convert first argument to an error it is possible for this to already
       // be an exception so skip conversion if that is the case...
@@ -496,28 +518,37 @@
     /**
      * Sends request and formats response.
      *
-     *
      * @private
      * @method _sendCommand
      * @chainable
-     * @param {Object} command marionette command.
-     * @param {String} responseKey the part of the response to pass \
-     *                             unto the callback.
-     * @param {Object} callback wrapped callback.
+     * @param {Object} body The body of the Marionette command
+     * @param {Object} cb wrapped callback
+     * @param {String} key optional key in the response to pass
+     *     unto the callback, will return the full object if undefined
      */
-    _sendCommand: function(command, responseKey, callback) {
-      var self = this;
-
+    _sendCommand: function(body, cb, key) {
       try {
-        return this.send(command, function(data) {
-          var value;
-          try {
-            value = self._transformResultValue(data[responseKey]);
-          } catch (e) {
-            console.log('Error: unable to transform marionette response', data);
+        return this.send(body, function(data) {
+          var res, err;
+
+          if ('error' in data) {
+            if (this.protocol == 1) {
+              err = data.error;
+            } else {
+              err = data;
+            }
+          } else if (key) {
+            res = data[key];
+          } else {
+            res = data;
           }
-          return self._handleCallback(callback, data.error, value);
-        });
+
+          if (res) {
+            res = this._unmarshalWebElement(res);
+          }
+
+          return this._handleCallback(cb, err, res);
+        }.bind(this));
       } catch (e) {
         // Attach current client to any host related errors too...
         e.client = this;
@@ -528,43 +559,48 @@
     /**
      * Finds the actor for this instance.
      *
+     * @deprecated
      * @private
      * @method _getActorId
-     * @param {Function} callback executed when response is sent.
+     * @param {Function} callback executed when response is sent
      */
-    _getActorId: function _getActorId(callback) {
-      var self = this, cmd;
-
-      cmd = { name: 'getMarionetteID' };
-
-      return this._sendCommand(cmd, 'id', function(err, actor) {
-        self.actor = actor;
-        if (callback) {
-          callback(err, actor);
+    _getActorId: function(cb) {
+      var body = {name: 'getMarionetteID'};
+      return this._sendCommand(body, function(err, actor) {
+        this.actor = actor;
+        if (cb) {
+          cb(err, actor);
         }
-      });
+      }.bind(this), 'id');
     },
 
     /**
-     * Starts a remote session.
+     * Starts a new remote session with the old Marionette protocol.
      *
+     * @deprecated
      * @private
      * @method _newSession
-     * @param {Function} callback optional.
+     * @param {Function} optional callback
      * @param {Object} desired capabilities
      */
-    _newSession: function _newSession(callback, desiredCapabilities) {
-      var self = this;
-
-      function newSession(data) {
-        self.session = data.value;
-        return self._handleCallback(callback, data.error, data);
-      }
-
-      return this.send({
+    _newSession: function(callback, desiredCapabilities) {
+      var newSession = function(data) {
+        this.sessionId = data.value;
+        var err;
+        if ('error' in data) {
+          if (typeof data.error == 'object') {
+            err = data.error;
+          } else {
+            err = data;
+          }
+        }
+        return this._handleCallback(callback, err, data);
+      }.bind(this);
+      var body = {
         name: 'newSession',
-        parameters: { capabilities: desiredCapabilities }
-      }, newSession);
+        parameters: {capabilities: desiredCapabilities},
+      };
+      return this.send(body, newSession);
     },
 
     /**
@@ -680,23 +716,22 @@
      */
     waitForSync: function(test, callback, interval, timeout) {
       var err, result;
-
-      function done(_err, _result) {
+      var testFunc = function(_err, _result) {
         err = _err;
         result = _result;
-      }
-
-      function sleep(waitMillis) {
-        setTimeout(marionetteScriptFinished, waitMillis);
-      }
+      };
+      var wait = function(ms) {
+        setTimeout(marionetteScriptFinished, ms);
+      };
 
       while (Date.now() < timeout) {
         if (err || result) {
           return callback(err);
         }
 
-        test(done);
-        this.executeAsyncScript(sleep, [interval]);
+        test(testFunc);
+
+        this.executeAsyncScript(wait, [interval]);
       }
 
       this.onScriptTimeout && this.onScriptTimeout();
@@ -736,32 +771,49 @@
     },
 
     /**
-     * Finds actor and creates connection to marionette.
-     * This is a combination of calling getMarionetteId and then newSession.
+     * Starts a new session with Marionette.
      *
      * @method startSession
      * @param {Function} callback executed when session is started.
      * @param {Object} desired capabilities
      */
     startSession: function startSession(callback, desiredCapabilities) {
-      var self = this;
       callback = callback || this.defaultCallback;
       desiredCapabilities = desiredCapabilities || {};
 
-      function runHook(err) {
-        if (err) return callback(err);
-        self.runHook('startSession', callback);
-      }
+      if (this.protocol == 1) {
+        var runHook = function(err) {
+          if (err) {
+            return callback(err);
+          }
+          this.runHook('startSession', callback);
+        };
 
-      return this._getActorId(function() {
-        //actor will not be set if we send the command then
-        self._newSession(runHook, desiredCapabilities);
-      });
+        return this._getActorId(function() {
+          // actor will not be set if we send the command then
+          this._newSession(runHook, desiredCapabilities);
+        }.bind(this));
+      } else {
+        var newSession = function(err, res) {
+          if (err) {
+            callback(err);
+          } else {
+            this.sessionId = res.sessionId;
+            this.capabilities = res.capabilities;
+            this.runHook('startSession', function() { callback(err, res); });
+          }
+        }.bind(this);
+  
+        var body = {
+          name: 'newSession',
+          parameters: {capabilities: desiredCapabilities},
+        };
+        return this._sendCommand(body, newSession);
+      }
     },
 
     /**
      * Destroys current session.
-     *
      *
      * @chainable
      * @method deleteSession
@@ -771,13 +823,14 @@
       var cmd = { name: 'deleteSession' };
 
       var closeDriver = function closeDriver() {
-        this._sendCommand(cmd, 'ok', function(err, value) {
+        this._sendCommand(cmd, function(err) {
           // clear state of the past session
-          this.session = null;
+          this.sessionId = null;
+          this.capabilities = null;
           this.actor = null;
 
           this.driver.close();
-          this._handleCallback(callback, err, value);
+          this._handleCallback(callback, err);
         }.bind(this));
       }.bind(this);
 
@@ -795,8 +848,9 @@
      * @return {Object} A JSON representing capabilities.
      */
      sessionCapabilities: function sessionCapabilities(callback) {
-       var cmd = { name: 'getSessionCapabilities' };
-       return this._sendCommand(cmd, 'value', callback);
+       var cmd = {name: 'getSessionCapabilities'};
+       return this._sendCommand(
+           cmd, callback, this.protocol == 1 ? 'value' : 'capabilities');
      },
 
     /**
@@ -808,8 +862,8 @@
      * @return {Object} self.
      */
     getWindow: function getWindow(callback) {
-      var cmd = { name: 'getWindow' };
-      return this._sendCommand(cmd, 'value', callback);
+      var cmd = {name: 'getWindow'};
+      return this._sendCommand(cmd, callback, 'value');
     },
 
     /**
@@ -820,8 +874,9 @@
      * @param {Function} [callback] executes with an array of ids.
      */
     getWindows: function getWindows(callback) {
-      var cmd = { name: 'getWindows' };
-      return this._sendCommand(cmd, 'value', callback);
+      var cmd = {name: 'getWindows'};
+      return this._sendCommand(
+          cmd, callback, this.protocol == 1 ? 'value' : undefined);
     },
 
     /**
@@ -834,8 +889,8 @@
      * @param {Function} callback called with boolean.
      */
     switchToWindow: function switchToWindow(id, callback) {
-      var cmd = { name: 'switchToWindow', parameters: {value: id }};
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'switchToWindow', parameters: {value: id}};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -846,8 +901,8 @@
      * @return {Object} self.
      */
      getWindowType: function getWindowType(callback) {
-       var cmd = { name: 'getWindowType' };
-       return this._sendCommand(cmd, 'value', callback);
+       var cmd = {name: 'getWindowType'};
+       return this._sendCommand(cmd, callback, 'value');
      },
 
     /**
@@ -862,8 +917,8 @@
      * @param {Function} callback called with boolean.
      */
     importScript: function(script, callback) {
-      var cmd = { name: 'importScript', parameters: {script: script }};
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'importScript', parameters: {script: script}};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -910,7 +965,7 @@
         }
       }
 
-      return this._sendCommand(cmd, 'ok', callback);
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -938,8 +993,8 @@
       }
 
       setState(this, 'context', context);
-      var cmd = { name: 'setContext', parameters: { value: context }};
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'setContext', parameters: {value: context}};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -952,10 +1007,10 @@
      * @return {Object} self.
      */
     setScriptTimeout: function setScriptTimeout(timeout, callback) {
-      var cmd = { name: 'setScriptTimeout', parameters: {ms: timeout} };
+      var cmd = {name: 'setScriptTimeout', parameters: {ms: timeout}};
       setState(this, 'scriptTimeout', timeout);
       this.driver.setScriptTimeout(timeout);
-      return this._sendCommand(cmd, 'ok', callback);
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -978,7 +1033,7 @@
     setSearchTimeout: function setSearchTimeout(timeout, callback) {
       var cmd = { name: 'setSearchTimeout', parameters:{ ms: timeout }};
       setState(this, 'searchTimeout', timeout);
-      return this._sendCommand(cmd, 'ok', callback);
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -989,8 +1044,8 @@
      * @return {Object} self.
      */
      title: function title(callback) {
-       var cmd = { name: 'getTitle' };
-       return this._sendCommand(cmd, 'value', callback);
+       var cmd = {name: 'getTitle'};
+       return this._sendCommand(cmd, callback, 'value');
      },
 
     /**
@@ -1001,8 +1056,8 @@
      * @param {Function} callback receives url.
      */
     getUrl: function getUrl(callback) {
-      var cmd = { name: 'getUrl' };
-      return this._sendCommand(cmd, 'value', callback);
+      var cmd = {name: 'getUrl'};
+      return this._sendCommand(cmd, callback, 'value');
     },
 
     /**
@@ -1013,8 +1068,8 @@
      * @return {Object} self.
      */
     refresh: function refresh(callback) {
-      var cmd = { name: 'refresh' };
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'refresh'};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -1026,8 +1081,8 @@
      * @param {Function} callback executes when finished driving browser to url.
      */
     goUrl: function goUrl(url, callback) {
-      var cmd = { name: 'goUrl', parameters: { url: url }};
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'goUrl', parameters: {url: url}};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -1039,8 +1094,8 @@
      * @param {Function} callback receives boolean.
      */
     goForward: function goForward(callback) {
-      var cmd = { name: 'goForward' };
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'goForward'};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -1051,8 +1106,8 @@
      * @param {Function} callback receives boolean.
      */
     goBack: function goBack(callback) {
-      var cmd = { name: 'goBack' };
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'goBack'};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -1067,8 +1122,8 @@
      * @return {Object} self.
      */
     log: function log(msg, level, callback) {
-      var cmd = { name: 'log', parameters:{level: level, value: msg }};
-      return this._sendCommand(cmd, 'ok', callback);
+      var cmd = {name: 'log', parameters: {level: level, value: msg}};
+      return this._sendCommand(cmd, callback);
     },
 
     /**
@@ -1091,8 +1146,9 @@
      * @param {Function} callback receive an array of logs.
      */
     getLogs: function getLogs(callback) {
-      var cmd = { name: 'getLogs' };
-      return this._sendCommand(cmd, 'value', callback);
+      var cmd = {name: 'getLogs'};
+      return this._sendCommand(
+          cmd, callback, this.protocol == 1 ? 'value' : undefined);
     },
 
     /**
@@ -1103,8 +1159,8 @@
      * @return {Object} self.
      */
      pageSource: function pageSource(callback) {
-       var cmd = { name: 'getPageSource' };
-       return this._sendCommand(cmd, 'value', callback);
+       var cmd = {name: 'getPageSource'};
+       return this._sendCommand(cmd, callback, 'value');
      },
 
     /**
@@ -1145,7 +1201,7 @@
         }
       }
 
-      return this._sendCommand(cmd, 'value', callback);
+      return this._sendCommand(cmd, callback, 'value');
     },
 
     /**
@@ -1299,8 +1355,6 @@
      * @param {Function} callback executes with element uuid(s).
      */
     _findElement: function _findElement(type, query, method, id, callback) {
-      var cmd, self = this;
-
       if (isFunction(id)) {
         callback = id;
         id = undefined;
@@ -1313,7 +1367,7 @@
 
       callback = callback || this.defaultCallback;
 
-      cmd = {
+      var cmd = {
         name: type || 'findElement',
         parameters: {
           value: query,
@@ -1321,40 +1375,39 @@
         }
       };
 
-      // only pass element when id is given.
-      if (id) cmd.parameters.element = id;
+      // only pass element when id is given
+      if (id) {
+        cmd.parameters.element = id;
+      }
 
-      if (this.searchMethods.indexOf(cmd.parameters.using) === -1) {
+      if (this.searchMethods.indexOf(cmd.parameters.using) < 0) {
         throw new Error(
-          'invalid option for using: \'' +
-          cmd.parameters.using +
-          '\' use one of : ' +
-          this.searchMethods.join(', ')
+          'invalid option for using: \'' + cmd.parameters.using + '\' ' +
+          'use one of : ' + this.searchMethods.join(', ')
         );
       }
 
-      //proably should extract this function into a private
-      return this._sendCommand(cmd, 'value',
-                               function processElements(err, result) {
+      var processElements = function(err, res) {
+        var rv;
+        if (res instanceof Array) {
+           rv = [];
+           res.forEach(function(el) {
+             rv.push(this._unmarshalWebElement(el));
+           }, this);
+         } else {
+           rv = this._unmarshalWebElement(res);
+         }
+         return this._handleCallback(callback, err, rv);
+      }.bind(this);
 
-       if (result instanceof this.Element) {
-         return self._handleCallback(callback, err, result);
-       }
+      // always look for "value" key for protocol 1,
+      // but only for single element searches under protocol 2
+      var extract;
+      if (this.protocol == 1 || type == 'findElement') {
+        extract = 'value';
+      }
 
-       var element;
-       if (result instanceof Array) {
-          element = [];
-          result.forEach(function(el) {
-            if (typeof el === 'object' && el.ELEMENT) {
-              el = el.ELEMENT;
-            }
-            element.push(new this.Element(el, self));
-          }, this);
-        } else {
-          element = new this.Element(result, self);
-        }
-        return self._handleCallback(callback, err, element);
-      });
+      return this._sendCommand(cmd, processElements, extract);
     },
 
     /**
@@ -1374,8 +1427,6 @@
      *
      *        });
      *     });
-     *
-     *
      *
      * @method findElement
      * @chainable
@@ -1415,7 +1466,6 @@
       return this._findElement.apply(this, args);
     },
 
-
     /**
      * Converts an function into a string
      * that can be sent to marionette.
@@ -1434,19 +1484,21 @@
     },
 
     /**
-     * Processes result of command
-     * if an {'ELEMENT': 'uuid'} combination
-     * is returned a Marionette.Element
-     * instance will be created and returned.
+     * Unmarshals a web element object if provided input holds a web
+     * element reference and returns a Marionette.Element object, or the
+     * original input if not.
      *
+     * A web element represents a DOM element through a
+     * {"ELEMENT": <UUID>} JSON object.
      *
      * @private
-     * @method _transformResultValue
-     * @param {Object} value original result from server.
-     * @return {Object|Marionette.Element} processed result.
+     * @method _unmarshalWebElement
+     * @param {Object} value result body from server.
+     * @return {Object|Marionette.Element} unmarshaled element, or the
+     *     original input.
      */
-    _transformResultValue: function _transformResultValue(value) {
-      if (value && typeof(value.ELEMENT) === 'string') {
+    _unmarshalWebElement: function(value) {
+      if (typeof value == 'object' && 'ELEMENT' in value) {
         return new this.Element(value.ELEMENT, this);
       }
       return value;
@@ -1501,10 +1553,9 @@
           args: this._prepareArguments(options.parameters.args || []),
           sandbox: options.parameters.sandbox
         }
-      }, 'value', callback);
+      }, callback, 'value');
     }
   };
-
 
   //gjslint: ignore
   var proto = Client.prototype;

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/abstract.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/abstract.js
@@ -96,10 +96,10 @@
      * Requires a _connect function to be defined.
      *
      *     MyClass.prototype._connect = function _connect(){
-     *       //open a socket to marrionete accept response
-     *       //you *must* call _onDeviceResponse with the first
-     *       //response from marionette it looks like this:
-     *       //{ from: 'root', applicationType: 'gecko', traits: [] }
+     *       // open a socket to marrionete accept response
+     *       // you *must* call _onDeviceResponse with the first
+     *       // response from Marionette it looks like this:
+     *       // {applicationType: "gecko", marionetteProtocol: 2}
      *       this.connectionId = result.id;
      *     }
      *
@@ -110,8 +110,19 @@
     connect: function connect(callback) {
       this.ready = true;
       this._responseQueue.push(function(data) {
+        // determine protocol version
+        if ('marionetteProtocol' in data) {
+          this.marionetteProtocol = data.marionetteProtocol;
+        } else {
+          this.marionetteProtocol = 1;
+        }
+
+        // protocol specific properties to populate
+        if (this.marionetteProtocol == 1) {
+          this.traits = data.traits;
+        }
         this.applicationType = data.applicationType;
-        this.traits = data.traits;
+
         callback();
       }.bind(this));
       this._connect();

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/tcp-sync.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/tcp-sync.js
@@ -128,7 +128,10 @@ TcpSync.prototype.connect = function(callback) {
       debug('socket connected');
       delete this._beginConnect;
 
-      this._readResponse();
+      var resp = this._readResponse();
+      this.marionetteProtocol = resp.marionetteProtocol || 1;
+      this.traits = resp.traits;
+      this.applicationType = resp.applicationType;
 
       callback();
     }.bind(this));

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/element.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/element.js
@@ -33,23 +33,22 @@
      * @chainable
      * @private
      * @param {Object} command marionette request.
-     * @param {String} responseKey key in the response to pass to callback.
      * @param {Function} callback callback function receives the result of
-     *                            response[responseKey] as its first argument.
+     *                            response[key] as its first argument.
+     * @param {String} key key in the response to pass to callback.
      *
      * @return {Object} self.
      */
-    _sendCommand: function(command, responseKey, callback) {
+    _sendCommand: function(command, callback, key) {
       if (!command.parameters) {
         command.parameters = {};
       }
-      if (typeof(command.parameters.id) === 'undefined') {
+      if (typeof command.parameters.id == 'undefined') {
         command.parameters.id = this.id;
       }
 
       var isSync = this.client.isSync;
-      var result =
-        this.client._sendCommand(command, responseKey, callback);
+      var result = this.client._sendCommand(command, callback, key);
 
       if (isSync)
         return result;
@@ -133,14 +132,14 @@
      * @return {String} the value of the Attribute.
      */
     getAttribute: function getAttribute(attr, callback) {
-      var cmd = {
+      var body = {
         name: 'getElementAttribute',
         parameters: {
-          name: attr
-        }
+          name: attr,
+        },
       };
 
-      return this._sendCommand(cmd, 'value', callback);
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
@@ -156,13 +155,13 @@
       if (!Array.isArray(input)) {
         input = [input];
       }
-      var cmd = {
+      var body = {
         name: 'sendKeysToElement',
         parameters: {
-          value: input
-        }
+          value: input,
+        },
       };
-      return this._sendCommand(cmd, 'ok', callback);
+      return this._sendCommand(body, callback);
     },
 
     /**
@@ -173,10 +172,8 @@
      * @return {Object} self.
      */
     click: function click(callback) {
-      var cmd = {
-        name: 'clickElement'
-      };
-      return this._sendCommand(cmd, 'ok', callback);
+      var body = {name: 'clickElement'};
+      return this._sendCommand(body, callback);
     },
 
     /**
@@ -187,10 +184,8 @@
      * @return {String} text of element.
      */
     text: function text(callback) {
-      var cmd = {
-        name: 'getElementText'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'getElementText'};
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
@@ -201,10 +196,8 @@
      * @return {String} tag name of element.
      */
     tagName: function tagName(callback) {
-      var cmd = {
-        name: 'getElementTagName'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'getElementTagName'};
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
@@ -218,20 +211,20 @@
      * @return {object} self
      */
     tap: function(x, y, callback) {
-      var cmd = {
+      var body = {
         name: 'singleTap',
-        parameters: {}
+        parameters: {},
       };
 
-      if (typeof(x) === 'number') {
-        cmd.parameters.x = x;
+      if (typeof x == 'number') {
+        body.parameters.x = x;
       }
 
-      if (typeof(y) === 'number') {
-        cmd.parameters.y = y;
+      if (typeof y == 'number') {
+        body.parameters.y = y;
       }
 
-      return this._sendCommand(cmd, 'value', callback);
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
@@ -242,25 +235,20 @@
      * @return {Object} self.
      */
     clear: function clear(callback) {
-      var cmd = {
-        name: 'clearElement'
-      };
-      return this._sendCommand(cmd, 'ok', callback);
+      var body = {name: 'clearElement'};
+      return this._sendCommand(body, callback);
     },
 
     /**
      * Checks if element is selected.
-     *
      *
      * @method selected
      * @param {Function} callback boolean argument.
      * @return {Object} self.
      */
     selected: function selected(callback) {
-      var cmd = {
-        name: 'isElementSelected'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'isElementSelected'};
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
@@ -271,25 +259,20 @@
      * @return {Object} self.
      */
     enabled: function enabled(callback) {
-      var cmd = {
-        name: 'isElementEnabled'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'isElementEnabled'};
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
      * Checks if element is displayed.
-     *
      *
      * @method displayed
      * @param {Function} callback boolean argument.
      * @return {Object} self.
      */
     displayed: function displayed(callback) {
-      var cmd = {
-        name: 'isElementDisplayed'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'isElementDisplayed'};
+      return this._sendCommand(body, callback, 'value');
     },
 
     /**
@@ -308,10 +291,9 @@
      * @return {Object} self.
      */
     size: function size(callback) {
-      var cmd = {
-        name: 'getElementRect'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'getElementRect'};
+      return this._sendCommand(
+          body, callback, this.client.protocol == 1 ? 'value' : undefined);
     },
 
     /**
@@ -330,25 +312,24 @@
      * @return {Object} self.
      */
     location: function location(callback) {
-      var cmd = {
-        name: 'getElementRect'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'getElementRect'};
+      return this._sendCommand(
+          body, callback, this.client.protocol == 1 ? 'value' : undefined);
     },
 
     /**
      * Returns the object with:
      *   x and y location of the element
      *   height and width of the element
+     *
      * @method rect
      * @param  {Function} callback [Error err, Object rect]
      * @return {Object} self.
      */
     rect: function rect (callback) {
-      var cmd = {
-        name: 'getElementRect'
-      };
-      return this._sendCommand(cmd, 'value', callback);
+      var body = {name: 'getElementRect'};
+      return this._sendCommand(
+          body, callback, this.client.protocol == 1 ? 'value' : undefined);
     },
 
     /**
@@ -360,13 +341,13 @@
      * @return {Object} self.
      */
      cssProperty: function cssProperty(property, callback) {
-       var cmd = {
+       var body = {
          name: 'getElementValueOfCssProperty',
          parameters: {
-           propertyName: property
-         }
+           propertyName: property,
+         },
        };
-       return this._sendCommand(cmd, 'value', callback);
+       return this._sendCommand(body, callback, 'value');
      }
   };
 

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/error.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/error.js
@@ -3,60 +3,58 @@
 (function(module, ns) {
   'use strict';
 
-  var STATUSES = Object.freeze({
+  var ERRORS = Object.freeze({
+    'element not accessible': 'ElementNotAccessibleError',
+    'element not selectable': 'ElementIsNotSelectable',
+    'element not visible': 'ElementNotVisible',
+    'invalid cookie domain': 'InvalidCookieDomain',
+    'invalid element coordinates': 'InvalidElementCoordinates',
+    'invalid element state': 'InvalidElementState',
+    'invalid selector': 'InvalidSelector',
+    'invalid xpath selector': 'XPathLookupError',
+    'javascript error': 'JavaScriptError',
+    'no such alert': 'NoAlertOpenError',
     'no such element': 'NoSuchElement',
     'no such frame': 'NoSuchFrame',
-    'unknown command': 'UnknownCommand',
-    'stale element reference': 'StaleElementReference',
-    'element not visible': 'ElementNotVisible',
-    'invalid element state': 'InvalidElementState',
-    'unknown error': 'UnknownError',
-    'element not selectable': 'ElementIsNotSelectable',
-    'javascript error': 'JavaScriptError',
-    'invalid xpath selector': 'XPathLookupError',
-    'timeout': 'Timeout',
     'no such window': 'NoSuchWindow',
-    'invalid cookie domain': 'InvalidCookieDomain',
+    'script timeout': 'ScriptTimeout',
+    'stale element reference': 'StaleElementReference',
+    'timeout': 'Timeout',
     'unable to set cookie': 'UnableToSetCookie',
     'unexpected alert open': 'UnexpectedAlertOpen',
-    'no such alert': 'NoAlertOpenError',
-    'script timeout': 'ScriptTimeout',
-    'invalid element coordinates': 'InvalidElementCoordinates',
-    'invalid selector': 'InvalidSelector',
+    'unknown command': 'UnknownCommand',
+    'unknown error': 'UnknownError',
     'webdriver error': 'GenericError',
-    'element not accessible': 'ElementNotAccessibleError'
   });
 
   var CODES = Object.freeze({
-    7: STATUSES['no such element'],
-    8: STATUSES['no such frame'],
-    9: STATUSES['unknown command'],
-    10: STATUSES['stale element reference'],
-    11: STATUSES['element not visible'],
-    12: STATUSES['invalid element state'],
-    13: STATUSES['unknown error'],
-    15: STATUSES['element not selectable'],
-    17: STATUSES['javascript error'],
-    19: STATUSES['invalid xpath selector'],
-    21: STATUSES['timeout'],
-    23: STATUSES['no such window'],
-    24: STATUSES['invalid cookie domain'],
-    25: STATUSES['unable to set cookie'],
-    26: STATUSES['unexpected alert open'],
-    27: STATUSES['no such alert'],
-    28: STATUSES['script timeout'],
-    29: STATUSES['invalid element coordinates'],
-    32: STATUSES['invalid selector'],
-    56: STATUSES['element not accessible'],
-    500: STATUSES['webdriver error']
+    7: ERRORS['no such element'],
+    8: ERRORS['no such frame'],
+    9: ERRORS['unknown command'],
+    10: ERRORS['stale element reference'],
+    11: ERRORS['element not visible'],
+    12: ERRORS['invalid element state'],
+    13: ERRORS['unknown error'],
+    15: ERRORS['element not selectable'],
+    17: ERRORS['javascript error'],
+    19: ERRORS['invalid xpath selector'],
+    21: ERRORS['timeout'],
+    23: ERRORS['no such window'],
+    24: ERRORS['invalid cookie domain'],
+    25: ERRORS['unable to set cookie'],
+    26: ERRORS['unexpected alert open'],
+    27: ERRORS['no such alert'],
+    28: ERRORS['script timeout'],
+    29: ERRORS['invalid element coordinates'],
+    32: ERRORS['invalid selector'],
+    56: ERRORS['element not accessible'],
+    500: ERRORS['webdriver error']
   });
 
-  var DEFAULT_STATUS = STATUSES['webdriver error'];
+  var DEFAULT_ERROR = ERRORS['webdriver error'];
 
   /**
-   * Returns an error object given
-   * a error object from the marionette client.
-   * Expected input follows this format:
+   * Returns an error object given an error object from the Marionette client.
    *
    * Codes are from:
    * http://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_Codes
@@ -64,24 +62,37 @@
    * Status strings are from:
    * https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors
    *
-   *    {
-   *      message: "Something",
-   *      stacktrace: "wentwrong@line",
-   *      status: "javascript error"
-   *    }
+   * The expected input for protocol version 2 and higher:
+   *
+   *     {
+   *       error: "javascript error",
+   *       message: "Something",
+   *       stacktrace: "wentwrong@line",
+   *     }
+   *
+   * The expected input for protocol version 1:
+   *
+   *     {
+   *       message: "Something",
+   *       stacktrace: "wentwrong@line",
+   *       status: "javascript error",
+   *     }
    *
    * @param {Client} client which the error originates from.
    * @param {Object} options for error (see above).
    */
   function MarionetteError(client, options) {
-    var status = DEFAULT_STATUS;
-    if (options.status in CODES)
-      status = CODES[options.status];
-    else if (options.status in STATUSES)
-      status = STATUSES[options.status];
+    var error = DEFAULT_ERROR;
+    if (options.status in CODES) {
+      error = CODES[options.status];
+    } else if (options.status in ERRORS) {
+      error = ERRORS[options.status];
+    } else if (options.error in ERRORS) {
+      error = ERRORS[options.error];
+    }
 
     this.client = client;
-    this.type = status;
+    this.type = error;
     this.name = this.type;
 
     this.message = this.name;
@@ -108,7 +119,7 @@
     }
   });
 
-  MarionetteError.STATUSES = STATUSES;
+  MarionetteError.ERRORS = ERRORS;
   MarionetteError.CODES = CODES;
   module.exports = MarionetteError;
 

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/example-commands.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/example-commands.js
@@ -2,19 +2,25 @@
 (function(module, ns) {
   'use strict';
 
-  function merge() {
-    var args = Array.prototype.slice.call(arguments),
-        result = {};
-
-    args.forEach(function(object) {
-      var key;
-      for (key in object) {
-        if (object.hasOwnProperty(key)) {
-          result[key] = object[key];
+  function deepmerge(d) {
+    for (var i = 1; i < arguments.length; ++i) {
+      var o = arguments[i];
+      for (var k in o) {
+        var v = o[k];
+        if (typeof v == 'object') {
+          d[k] = deepmerge(d[k], v);
+        } else {
+          if (Array.isArray(d)) {
+            if (d.indexOf(v) < 0) {
+              d.push(v);
+            }
+          } else {
+            d[k] = v;
+          }
         }
       }
-    });
-    return result;
+    }
+    return d;
   }
 
   function cmd(defaults) {
@@ -22,113 +28,96 @@
       if (typeof(override) === 'undefined') {
         override = {};
       }
-      return merge(defaults, override);
+      return deepmerge(defaults, override);
     };
   }
 
   module.exports = {
-    connect: cmd(
-      { from: 'root', applicationType: 'gecko', traits: [] }
-    ),
+    connectProto1: cmd({from: 'root', applicationType: 'gecko', traits: []}),
+    connectProto2: cmd({applicationType: 'gecko', marionetteProtocol: 2}),
 
-    getMarionetteID: cmd(
-      { type: 'getMarionetteID' }
-    ),
+    getMarionetteID: cmd({type: 'getMarionetteID'}),
+    getMarionetteIDResponse: cmd({from: 'root', id: 'con1'}),
 
-    getMarionetteIDResponse: cmd(
-      { from: 'root', id: 'con1' }
-    ),
+    newSession: cmd({type: 'newSession'}),
+    newSessionResponseProto1: cmd({
+      from: 'actor',
+      value: 'b2g-7',
+    }),
+    newSessionResponseProto2: cmd({
+      sessionId: '{2dddca75-7f78-415f-a7de-63eb2bc9412b}',
+      capabilities: {browserName: 'firefox'},
+    }),
 
-    newSession: cmd(
-      { type: 'newSession' }
-    ),
+    getWindow: cmd({name: 'getWindow'}),
+    getWindowResponse: cmd({value: '3-b2g'}),
 
-    newSessionResponse: cmd(
-      { from: 'actor', value: 'b2g-7' }
-    ),
+    getWindows: cmd({name: 'getWindows'}),
+    getWindowsResponseProto1: cmd({from: 'actor', value: ['1-b2g', '2-b2g']}),
+    getWindowsResponseProto2: cmd(['1-b2g', '2-b2g']),
 
-    getWindow: cmd(
-      { type: 'getWindow' }
-    ),
+    getUrl: cmd({name: 'getUrl'}),
+    getUrlResponse: cmd({value: 'http://localhost/'}),
 
-    getWindows: cmd(
-      { type: 'getWindows' }
-    ),
+    getLogsResponseProto1: cmd({
+      from: 'actor',
+      value: [
+        ['debug', 'wow', 'Fri Apr 27 2012 11:00:32 GMT-0700 (PDT)'],
+      ],
+    }),
+    getLogsResponseProto2: cmd([
+      ['debug', 'wow', 'Fri Apr 27 2012 11:00:32 GMT-0700 (PDT)'],
+    ]),
 
-    getWindowsResponse: cmd(
-      { from: 'actor', value: ['1-b2g', '2-b2g'] }
-    ),
+    screenshotResponse: cmd({
+      value: 'data:image/png;base64,iVBOgoAAAANSUhEUgAAAUAAAAHMCAYAAACk4nEJA',
+    }),
 
-    getWindowResponse: cmd(
-      { from: 'actor', value: '3-b2g' }
-    ),
-
-    getUrl: cmd(
-      { type: 'getUrl' }
-    ),
-
-    getUrlResponse: cmd(
-      { from: 'actor', value: 'http://localhost/' }
-    ),
-
-    getLogsResponse: cmd(
-      {
-        from: 'actor',
-        value: [
-          //log, level, time
-          ['debug', 'wow', 'Fri Apr 27 2012 11:00:32 GMT-0700 (PDT)']
-        ]
-      }
-    ),
-
-    screenshotResponse: cmd(
-      {
-        from: 'actor',
-        value: 'data:image/png;base64,iVBOgoAAAANSUhEUgAAAUAAAAHMCAYAAACk4nEJA'
-      }
-    ),
-
-    elementEqualsResponse: cmd(
-      { from: 'actor', value: false }
-    ),
+    elementEqualsResponse: cmd({value: false}),
 
     findElementResponse: cmd(
-      { from: 'actor', value: '{some-uuid}' }
-    ),
+        {value: {ELEMENT: '{8056e6f7-2213-41d4-9db6-ad77ac7a96d3}'}}),
+    findElementsResponseProto1: cmd({
+      from: 'actor',
+      value: [
+        {ELEMENT: '{46982c9e-bb0c-486e-a514-d1cf20b42641}'},
+        {ELEMENT: '{585e70ee-e088-43cc-9b07-a4b078c1b8db}'},
+      ],
+    }),
+    findElementsResponseProto2: cmd([
+      {ELEMENT: '{46982c9e-bb0c-486e-a514-d1cf20b42641}'},
+      {ELEMENT: '{585e70ee-e088-43cc-9b07-a4b078c1b8db}'},
+    ]),
 
-    findElementsResponse: cmd(
-      { from: 'actor', value: ['{some-uuid}', '{some-other-uuid}'] }
-    ),
+    numberError: cmd({
+      from: 'actor',
+      error: {
+        message: 'you fail',
+        status: 7,
+        stacktrace: 'fail@url\nother:300',
+      },
+    }),
+    stringError: cmd({
+      from: 'actor',
+      error: {
+        message: 'you fail',
+        status: 'no such element',
+        stacktrace: 'fail@url\nother:300',
+      },
+    }),
+    modernError: cmd({
+      error: 'no such element',
+      message: 'you fail',
+      stacktrace: 'fail@url\nother:300',
+    }),
 
-    numberError: cmd(
-      {
-        from: 'actor',
-        error: {
-          message: 'you fail',
-          status: 7,
-          stacktrace: 'fail@url\nother:300'
-        }
-      }
-    ),
+    //valueProto1: cmd({from: 'actor', value: 'zomg'}),
+    value: cmd({value: 'zomg'}),
 
-    stringError: cmd(
-      {
-        from: 'actor',
-        error: {
-          message: 'you fail',
-          status: 'no such element',
-          stacktrace: 'fail@url\nother:300'
-        }
-      }
-    ),
+    capabilities: cmd({capabilities: {browserName: 'firefox'}}),
 
-    value: cmd(
-      { from: 'actor', value: 'zomg' }
-    ),
-
-    ok: cmd(
-      { from: 'actor', ok: true }
-    )
+    //okProto1: cmd({from: 'actor', ok: true}),
+    ok: cmd({}),
   };
 
 }.apply(

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/multi-actions.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/multi-actions.js
@@ -48,7 +48,7 @@
         max_length: this.maxLength
       };
 
-      this.client._sendCommand(cmd, 'ok', callback);
+      this.client._sendCommand(cmd, callback);
       this.multiActions = [];
       return this;
     }

--- a/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
@@ -21,8 +21,9 @@ suite('marionette/client', function() {
     return subject;
   });
 
-  function commandCallback(data) {
-    commandCallback.value = data;
+  function commandCallback(error, value) {
+    commandCallback.error = error;
+    commandCallback.value = value;
   }
 
   setup(function() {
@@ -247,7 +248,7 @@ suite('marionette/client', function() {
         };
 
         var err = {
-          status: 'script timeout',
+          error: 'script timeout',
           message: 'foo',
           stacktrace: 'bar'
         };
@@ -285,60 +286,75 @@ suite('marionette/client', function() {
     });
   });
 
-  suite('.send', function() {
-
+  suite('protocol 1 .send', function() {
     suite('when session: is present', function() {
       var result;
+      
       setup(function() {
-        subject.session = 'session';
+        subject.sessionId = 'session';
         subject.actor = 'actor';
-        result = subject.send({ name: 'newSession' });
+        result = subject.send({name: 'newSession'});
       });
-
+      
       test('should be chainable', function() {
         assert.strictEqual(result, subject);
       });
-
+      
       test('should add session to cmd', function() {
         assert.deepEqual(driver.sent[0], {
           to: subject.actor,
-          session: subject.session,
-          name: 'newSession'
+          session: subject.sessionId,
+          name: 'newSession',
         });
       });
     });
-
+    
     suite('when to: is not given', function() {
-
       suite('with an actor', function() {
         setup(function() {
           subject.actor = 'foo';
-          subject.send({ name: '_getActorId' }, cb);
+          subject.send({name: '_getActorId'}, cb);
         });
-
+        
         test('should add to:', function() {
           assert.deepEqual(driver.sent[0], {
             to: 'foo',
-            name: '_getActorId'
+            name: '_getActorId',
           });
         });
-
       });
-
+      
       suite('without an actor', function() {
         setup(function() {
-          subject.send({ name: '_getActorId' }, cb);
+          subject.send({name: '_getActorId'}, cb);
         });
-
-        test('should add to:', function() {
+        
+        test('should add to', function() {
           assert.deepEqual(driver.sent[0], {
             to: 'root',
-            name: '_getActorId'
+            name: '_getActorId',
           });
         });
-
       });
+    });
+  });
 
+  suite('protocol 2 .send', function() {
+    var result;
+    setup(function() {
+      subject.protocol = 2;
+      result = subject.send({name: 'get', parameters: {'url': 'about:blank'}});
+    });
+
+    test('should be chainable', function() {
+      assert.strictEqual(result, subject);
+    });
+
+    test('sends exact packet', function() {
+      assert.deepEqual(driver.sent[0], {
+        name: 'get',
+        parameters: {'url': 'about:blank'},
+      });
     });
   });
 
@@ -366,8 +382,8 @@ suite('marionette/client', function() {
         });
       });
 
-      test('should update the ._scope' +
-           'when state changes in scoped', function() {
+      test('should update the ._scope when state changes in scoped',
+          function() {
         scope.setScriptTimeout(250);
         assert.strictEqual(scope._scope.scriptTimeout, 250);
       });
@@ -382,63 +398,126 @@ suite('marionette/client', function() {
     });
   });
 
-  suite('.startSession', function() {
+  suite('.startSession protocol version 1', function() {
     var result;
-    var desiredCapabilities = { desiredCapability: true };
-
+    var desiredCapabilities = {desiredCapability: true};
+    
     setup(function(done) {
       var firesHook = false;
-
+      
       subject.addHook('startSession', function(complete) {
         firesHook = true;
         complete();
       });
-
+      
       result = subject.startSession(function() {
         assert.ok(firesHook);
         done();
       }, desiredCapabilities);
+      
+      device.shouldSend({parameters: {capabilities: desiredCapabilities}});
+      
+      driver.respond(exampleCmds.getMarionetteIDResponse());
+      driver.respond(exampleCmds.newSessionResponseProto1());
+    });
+    
+    test('should be chainable', function() {
+      assert.strictEqual(result, subject);
+    });
+    
+    test('should have an actor property', function() {
+      assert.property(subject, 'actor');
+      assert.isNotNull(subject.actor);
+    });
+    
+    test('should have a sessionId property', function() {
+      assert.property(subject, 'sessionId');
+      assert.isNotNull(subject.sessionId);
+    });
 
-      device.shouldSend({
-        parameters: { capabiltiies: desiredCapabilities }
+    test('should have protocol version 1', function() {
+      assert.property(subject, 'protocol');
+      assert.strictEqual(subject.protocol, 1);
+    });
+  });
+
+  suite('.startSession protocol version 2', function() {
+    var result;
+    var response = exampleCmds.newSessionResponseProto2();
+    var desiredCapabilities = {desiredCapability: true};
+
+    setup(function(done) {
+      subject.protocol = 2;
+
+      var hookFired = false;
+      subject.addHook('startSession', function(done) {
+        hookFired = true;
+        done();
       });
 
-      driver.respond(exampleCmds.getMarionetteIDResponse());
-      driver.respond(exampleCmds.newSessionResponse());
+      result = subject.startSession(function() {
+        cbResponse = arguments;
+        assert.ok(hookFired);
+        done();
+      }, desiredCapabilities);
+
+      device.
+        withProtocol(2).
+        shouldSend({
+        parameters: {capabilities: desiredCapabilities}
+      });
+
+      driver.respond(response);
     });
 
     test('should be chainable', function() {
       assert.strictEqual(result, subject);
     });
 
-    test('should have actor', function() {
-      assert.ok(subject.actor);
+    test('should have an empty actor property', function() {
+      assert.isNull(subject.actor);
     });
 
-    test('should have a session', function() {
-      assert.ok(subject.session);
+    test('should have sessionId property', function() {
+      assert.property(subject, 'sessionId');
+      assert.strictEqual(subject.sessionId, response.sessionId);
+    });
+
+    test('should have a capabilities property', function() {
+      assert.property(subject, 'capabilities');
+      assert.strictEqual(subject.capabilities, response.capabilities);
+    });
+
+    test('should send newSession', function() {
+      assert.strictEqual(driver.sent[0].name, 'newSession');
+    });
+
+    test('should send callback response', function() {
+      assert.deepEqual(cbResponse[1], response);
+    });
+
+    test('should have protocol version 2', function() {
+      assert.property(subject, 'protocol');
+      assert.strictEqual(subject.protocol, 2);
     });
   });
 
   suite('._getActorId', function() {
-    device.
-      issues('_getActorId').
-      shouldSend({ name: 'getMarionetteID' }).
-      serverResponds('getMarionetteIDResponse').
-      callbackReceives('id');
-
-    test('should save actor id', function() {
-      assert.strictEqual(
-        subject.actor,
-        exampleCmds.getMarionetteIDResponse().id
-      );
+    device
+      .issues('_getActorId')
+      .shouldSend({name: 'getMarionetteID'})
+      .serverResponds('getMarionetteIDResponse')
+      .callbackReceives('id');
+    
+    test('should save actor ID', function() {
+      var resp = exampleCmds.getMarionetteIDResponse();
+      assert.strictEqual(subject.actor, resp.id);
     });
-
   });
 
   suite('._sendCommand', function() {
     var cmd, response,
-        calledTransform, result,
+        calledUnmarshal, result,
         calledWith;
 
     suite('on success', function() {
@@ -447,14 +526,14 @@ suite('marionette/client', function() {
         cmd = exampleCmds.getUrl();
         response = exampleCmds.getUrlResponse();
 
-        calledTransform = false;
-        subject._transformResultValue = function(value) {
-          calledTransform = true;
-          assert.strictEqual(value, response.value);
+        calledUnmarshal = false;
+        subject._unmarshalWebElement = function(value) {
+          calledUnmarshal = true;
+          assert.strictEqual(value, response);
           return 'foo';
         };
 
-        result = subject._sendCommand(cmd, 'value', function() {
+        result = subject._sendCommand(cmd, function() {
           calledWith = arguments;
           done();
         });
@@ -466,25 +545,23 @@ suite('marionette/client', function() {
         assert.strictEqual(result, subject);
       });
 
-      test('should send command through _transformResultValue', function() {
-        assert.strictEqual(calledTransform, true);
+      test('should send command through _unmarshalWebElement', function() {
+        assert.strictEqual(calledUnmarshal, true);
         assert.strictEqual(calledWith[1], 'foo');
       });
 
     });
 
-    suite('on number error', function() {
-
+    suite('on number error from protocol 1', function() {
       setup(function(done) {
         calledWith = null;
         cmd = exampleCmds.getUrl();
         response = exampleCmds.numberError();
 
-        subject._sendCommand(cmd, 'value', function(err, data) {
+        subject._sendCommand(cmd, function(err, data) {
           calledWith = arguments;
           done();
-        });
-
+        }, 'value');
         driver.respond(response);
       });
 
@@ -492,20 +569,37 @@ suite('marionette/client', function() {
         assert.ok(calledWith[0]);
         assert.notOk(calledWith[1]);
       });
-
     });
 
-    suite('on string error', function() {
-
+    suite('on string error from protocol 1', function() {
       setup(function(done) {
         calledWith = null;
         cmd = exampleCmds.getUrl();
         response = exampleCmds.stringError();
 
-        subject._sendCommand(cmd, 'value', function(err, data) {
+        subject._sendCommand(cmd, function(err, data) {
           calledWith = arguments;
           done();
-        });
+        }, 'value');
+        driver.respond(response);
+      });
+
+      test('should pass error to callback', function() {
+        assert.ok(calledWith[0]);
+        assert.notOk(calledWith[1]);
+      });
+    });
+
+    suite('on modern error from protocol 2', function() {
+      setup(function(done) {
+        calledWith = null;
+        cmd = exampleCmds.getUrl();
+        response = exampleCmds.modernError();
+
+        subject._sendCommand(cmd, function(err, data) {
+          calledWith = arguments;
+          done();
+        }, 'value');
 
         driver.respond(response);
       });
@@ -514,9 +608,7 @@ suite('marionette/client', function() {
         assert.ok(calledWith[0]);
         assert.notOk(calledWith[1]);
       });
-
     });
-
   });
 
   suite('.deleteSession', function() {
@@ -528,7 +620,8 @@ suite('marionette/client', function() {
       var callsHook = false;
 
       subject.actor = '1';
-      subject.session = 'sess';
+      subject.sessionId = 'session id';
+      subject.capabilities = {capability: true};
 
       subject.driver.close = function() {
         assert.strictEqual(callsHook, true);
@@ -546,12 +639,16 @@ suite('marionette/client', function() {
       result = subject.deleteSession(done);
     });
 
-    test('should clear session', function() {
-      assert.notOk(subject.session);
+    test('should set actorId to null', function() {
+      assert.isNull(subject.actor);
     });
 
-    test('should set actor to null', function() {
-      assert.notOk(subject.actor);
+    test('should set sessionId to null', function() {
+      assert.isNull(subject.sessionId);
+    });
+
+    test('should set capabilities to null', function() {
+      assert.isNull(subject.capabilities);
     });
 
     test('should be chainable', function() {
@@ -567,7 +664,8 @@ suite('marionette/client', function() {
     test('should have default .searchTimeout', function() {
       assert.ok(subject.searchTimeout);
     });
-    suite('after setting', function() {
+
+    suite('after setting with protocol 1', function() {
       device.
         issues('setSearchTimeout', 50).
         shouldSend({
@@ -577,7 +675,25 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
+
+      test('should set timeout', function() {
+        assert.strictEqual(subject.searchTimeout, 50);
+      });
+    });
+
+    suite('after setting with protocol 2', function() {
+      device.
+        withProtocol(2).
+        issues('setSearchTimeout', 50).
+        shouldSend({
+          name: 'setSearchTimeout',
+          parameters: {
+            ms: 50
+          }
+        }).
+        serverResponds('ok').
+        callbackReceives();
 
       test('should set timeout', function() {
         assert.strictEqual(subject.searchTimeout, 50);
@@ -585,14 +701,26 @@ suite('marionette/client', function() {
     });
   });
 
-  suite('.sessionCapabilities', function() {
+  suite('.sessionCapabilities with protocol 1', function() {
     device.
+      withProtocol(1).
       issues('sessionCapabilities').
       shouldSend({
         name: 'getSessionCapabilities'
       }).
       serverResponds('value').
       callbackReceives('value');
+  });
+
+  suite('.sessionCapabilities with protocol 2', function() {
+    device.
+      withProtocol(2).
+      issues('sessionCapabilities').
+      shouldSend({
+        name: 'getSessionCapabilities'
+      }).
+      serverResponds('capabilities').
+      callbackReceives('capabilities');
   });
 
   suite('.getWindow', function() {
@@ -605,7 +733,7 @@ suite('marionette/client', function() {
       callbackReceives('value');
   });
 
-  suite('.setContext', function() {
+  suite('.setContext with protocol 1', function() {
     test('should have a default context', function() {
       assert.strictEqual(subject.context, 'content');
     });
@@ -620,7 +748,7 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
 
       test('should remember context', function() {
         assert.strictEqual(subject.context, 'chrome');
@@ -628,17 +756,53 @@ suite('marionette/client', function() {
     });
   });
 
-  suite('.getWindows', function() {
+  suite('.setContext with protocol 2', function() {
+    test('should have a default context', function() {
+      assert.strictEqual(subject.context, 'content');
+    });
+
+    suite('after setting context', function() {
+      device.
+        withProtocol(2).
+        issues('setContext', 'chrome').
+        shouldSend({
+          name: 'setContext',
+          parameters: {
+            value: 'chrome'
+          }
+        }).
+        serverResponds('ok').
+        callbackReceives();
+
+      test('should remember context', function() {
+        assert.strictEqual(subject.context, 'chrome');
+      });
+    });
+  });
+
+  suite('.getWindows with protocol 1', function() {
     device.
+      withProtocol(1).
       issues('getWindows').
       shouldSend({
         name: 'getWindows'
       }).
-      serverResponds('getWindowsResponse').
+      serverResponds('getWindowsResponseProto1').
       callbackReceives('value');
   });
 
-  suite('.switchToWindow', function() {
+  suite('.getWindows with protocol 2', function() {
+    device.
+      withProtocol(2).
+      issues('getWindows').
+      shouldSend({
+        name: 'getWindows'
+      }).
+      serverResponds('getWindowsResponseProto2').
+      callbackReceives();
+  });
+
+  suite('.switchToWindow with protocol 1', function() {
     device.
       issues('switchToWindow', '1-b2g').
       shouldSend({
@@ -648,7 +812,21 @@ suite('marionette/client', function() {
         }
       }).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
+  });
+
+  suite('.switchToWindow with protocol 2', function() {
+    device.
+      withProtocol(2).
+      issues('switchToWindow', '1-b2g').
+      shouldSend({
+        name: 'switchToWindow',
+        parameters: {
+          value: '1-b2g'
+        }
+      }).
+      serverResponds('ok').
+      callbackReceives();
   });
 
   suite('.getWindowType', function() {
@@ -667,7 +845,7 @@ suite('marionette/client', function() {
         issues('switchToFrame').
         shouldSend({ name: 'switchToFrame' }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
 
     suite('when given a callback', function() {
@@ -680,7 +858,7 @@ suite('marionette/client', function() {
           name: 'switchToFrame'
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
 
     suite('when given an element', function() {
@@ -699,7 +877,7 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
 
     suite('when given an object with ELEMENT', function() {
@@ -718,15 +896,15 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
 
     suite('when switch to a frame with options', function() {
-      var el;
+      var el, options;
 
       setup(function() {
         el = { ELEMENT: 'foo' };
-        var options = { focus: true };
+        options = { focus: true };
         subject.switchToFrame(el, options, commandCallback);
       });
 
@@ -739,15 +917,15 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
 
     suite('when switch to a frame with multiple options', function() {
-      var el;
+      var el, options;
 
       setup(function() {
-        el = { ELEMENT: 'foo' };
-        var options = {
+        el = {ELEMENT: 'foo'};
+        options = {
           focus: true,
           testOption: 'hi'
         };
@@ -764,7 +942,7 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
   });
 
@@ -778,7 +956,7 @@ suite('marionette/client', function() {
         }
       }).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
   });
 
   suite('.setScriptTimeout', function() {
@@ -796,7 +974,7 @@ suite('marionette/client', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
 
       test('should update .scriptTimeout', function() {
         assert.strictEqual(subject.scriptTimeout, 100);
@@ -829,7 +1007,7 @@ suite('marionette/client', function() {
         }
       }).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
   });
 
   suite('.getUrl', function() {
@@ -849,7 +1027,7 @@ suite('marionette/client', function() {
         name: 'goForward'
       }).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
   });
 
   suite('.goBack', function() {
@@ -859,12 +1037,12 @@ suite('marionette/client', function() {
         name: 'goBack'
       }).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
   });
 
   suite('script executing commands', function() {
-    var calledWith;
-    var script = 'return null;';
+    var calledWith,
+        script = 'return null;';
 
     setup(function() {
       calledWith = null;
@@ -895,13 +1073,10 @@ suite('marionette/client', function() {
       });
 
       test('should call _executeScript', function() {
-        assert.deepEqual(calledWith, [
-          {
-            name: 'executeJSScript',
-            parameters: {script: script, timeout: true, args: null }
-          },
-          commandCallback
-        ]);
+        assert.deepEqual(calledWith, [{
+          name: 'executeJSScript',
+          parameters: {script: script, timeout: true, args: null}
+        }, commandCallback]);
       });
     });
 
@@ -914,7 +1089,7 @@ suite('marionette/client', function() {
         assert.deepEqual(calledWith, [
           {
             name: 'executeAsyncScript',
-            parameters: {script: script, args: null }
+            parameters: {script: script, args: null}
           },
           commandCallback
         ]);
@@ -927,7 +1102,7 @@ suite('marionette/client', function() {
       issues('refresh').
       serverResponds('ok').
       shouldSend({ name: 'refresh' }).
-      callbackReceives('ok');
+      callbackReceives();
   });
 
   suite('.log', function() {
@@ -935,18 +1110,27 @@ suite('marionette/client', function() {
       issues('log', 'wow', 'info').
       shouldSend({ name: 'log', parameters: {value: 'wow', level: 'info' }}).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
   });
 
-  suite('.getLogs', function() {
+  suite('.getLogs with protocol 1', function() {
     device.
       issues('getLogs').
-      shouldSend({ name: 'getLogs' }).
-      serverResponds('getLogsResponse').
+      shouldSend({name: 'getLogs'}).
+      serverResponds('getLogsResponseProto1').
       callbackReceives('value');
   });
 
-  suite('.pageSouce', function() {
+  suite('.getLogs with protocol 2', function() {
+    device.
+      withProtocol(2).
+      issues('getLogs').
+      shouldSend({name: 'getLogs'}).
+      serverResponds('getLogsResponseProto2').
+      callbackReceives();
+  });
+
+  suite('.pageSource', function() {
     device.
       issues('pageSource').
       shouldSend({ name: 'getPageSource' }).
@@ -986,22 +1170,24 @@ suite('marionette/client', function() {
   suite('._findElement', function() {
 
     function receivesElement() {
-      var value;
+      var els;
 
       suite('callback argument', function() {
         setup(function() {
-          value = device.commandCallback.value;
-          if (!(value instanceof Element) && !(value instanceof Array)) {
-            throw new Error('result is not an array or an Element instance');
-          }
+          var value = device.commandCallback.value;
 
-          if (!(value instanceof Array)) {
-            value = [value];
-          }
+          if (!(value instanceof Element) && !(value instanceof Array))
+            throw new Error(
+                'Result is not an array or an Element instance: ' + value);
+
+          if (value instanceof Array)
+            els = value;
+          else
+            els = [value];
         });
 
         test('should be an instance of Marionette.Element', function() {
-          value.forEach(function(el) {
+          els.forEach(function(el) {
             assert.instanceOf(el, Element);
             assert.strictEqual(el.client, subject);
             assert.include(el.id, '{');
@@ -1034,8 +1220,8 @@ suite('marionette/client', function() {
         serverResponds('findElementResponse');
 
       test('should return an instance of MyElement', function() {
-        var value = device.commandCallback.value;
-        assert.instanceOf(value, MyElement);
+        var el = device.commandCallback.value;
+        assert.instanceOf(el, MyElement);
       });
     });
 
@@ -1158,20 +1344,16 @@ suite('marionette/client', function() {
   });
 
   suite('._newSession', function() {
-    var response;
-    var desiredCapabilities = { desiredCapability: true };
+    var desiredCapabilities = {desiredCapability: true};
+    var response = exampleCmds.newSessionResponseProto1();
 
     setup(function(done) {
-      response = exampleCmds.newSessionResponse();
       subject._newSession(function() {
         cbResponse = arguments;
         done();
       }, desiredCapabilities);
 
-      device.shouldSend({
-        parameters: { capabiltiies: desiredCapabilities }
-      });
-
+      device.shouldSend({parameters: {capabilities: desiredCapabilities}});
       driver.respond(response);
     });
 
@@ -1179,14 +1361,13 @@ suite('marionette/client', function() {
       assert.strictEqual(driver.sent[0].name, 'newSession');
     });
 
-    test('should save session id', function() {
-      assert.strictEqual(subject.session, response.value);
+    test('should save session ID', function() {
+      assert.strictEqual(subject.sessionId, response.value);
     });
 
     test('should send callback response', function() {
       assert.deepEqual(cbResponse[1], response);
     });
-
   });
 
   suite('._convertFunction', function() {
@@ -1211,27 +1392,24 @@ suite('marionette/client', function() {
 
   });
 
-  suite('._transformResultValue', function() {
+  suite('._unmarshalWebElement', function() {
     var result;
     suite('when it is an element', function() {
       setup(function() {
-        result = subject._transformResultValue({
-          'ELEMENT': 'foo'
-        });
+        result = subject._unmarshalWebElement({'ELEMENT': 'foo'});
       });
 
       test('should return an instance of element', function() {
         assert.instanceOf(result, Element);
         assert.strictEqual(result.id, 'foo');
       });
-
     });
 
     suite('when it is not an element', function() {
       var obj = {'foo': true};
 
       setup(function() {
-        result = subject._transformResultValue(obj);
+        result = subject._unmarshalWebElement(obj);
       });
 
       test('should return same object', function() {
@@ -1239,7 +1417,6 @@ suite('marionette/client', function() {
       });
     });
   });
-
 
   suite('._prepareArguments', function() {
     var args, result;

--- a/tests/jsmarionette/client/marionette-client/test/marionette/drivers/abstract-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/drivers/abstract-test.js
@@ -137,11 +137,11 @@ suite('marionette/drivers/abstract', function() {
 
   });
 
-  suite('.connect', function() {
+  suite('.connect with protocol 1', function() {
     var cmd, calledChild;
 
     setup(function(done) {
-      cmd = exampleCmds.connect();
+      cmd = exampleCmds.connectProto1();
       calledChild = false;
 
       subject._connect = function() {
@@ -161,11 +161,65 @@ suite('marionette/drivers/abstract', function() {
       });
     });
 
-    test('should set .traits', function() {
-      assert.deepEqual(subject.traits, []);
+    test('should set .marionetteProtocol', function() {
+      assert.property(subject, 'marionetteProtocol');
+      assert.strictEqual(subject.marionetteProtocol, 1 /* fallback */);
     });
 
     test('should set .applicationType', function() {
+      assert.property(subject, 'applicationType');
+      assert.strictEqual(subject.applicationType, cmd.applicationType);
+    });
+
+    test('should set .traits', function() {
+      assert.property(subject, 'traits');
+      assert.strictEqual(subject.traits, cmd.traits);
+    });
+
+    test('should call _connect', function() {
+      assert.strictEqual(calledChild, true);
+    });
+
+    test('should not be waiting', function() {
+      assert.strictEqual(subject._waiting, false);
+    });
+
+    test('should be ready', function() {
+      assert.strictEqual(subject.ready, true);
+    });
+  });
+
+  suite('.connect with protocol 2', function() {
+    var cmd, calledChild;
+
+    setup(function(done) {
+      cmd = exampleCmds.connectProto2();
+      calledChild = false;
+
+      subject._connect = function() {
+        subject.connectionId = 10;
+        calledChild = true;
+        //this will cause connect to callback to fire
+        subject._onDeviceResponse({
+          id: 10,
+          response: cmd
+        });
+      };
+
+      assert.strictEqual(subject._waiting, true);
+
+      subject.connect(function() {
+        done();
+      });
+    });
+
+    test('should set .marionetteProtocol', function() {
+      assert.property(subject, 'marionetteProtocol');
+      assert.strictEqual(subject.marionetteProtocol, cmd.marionetteProtocol);
+    });
+
+    test('should set .applicationType', function() {
+      assert.property(subject, 'applicationType');
       assert.strictEqual(subject.applicationType, cmd.applicationType);
     });
 
@@ -180,7 +234,6 @@ suite('marionette/drivers/abstract', function() {
     test('should be ready', function() {
       assert.strictEqual(subject.ready, true);
     });
-
   });
 
   suite('._nextCommand', function() {
@@ -245,7 +298,6 @@ suite('marionette/drivers/abstract', function() {
     });
 
     suite('when device is not ready', function() {
-
       test('should throw an error', function() {
         assert.throws(function() {
           subject.send({ type: 'newSession' });
@@ -304,4 +356,3 @@ suite('marionette/drivers/abstract', function() {
 
 
 });
-

--- a/tests/jsmarionette/client/marionette-client/test/marionette/drivers/tcp-sync-test-server.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/drivers/tcp-sync-test-server.js
@@ -2,7 +2,7 @@
 var debug = require('debug')('marionette:tcp-sync-test-server');
 var net = require('net');
 
-var response = '53:{"from":"root","applicationType":"gecko","traits":[]}';
+var response = '54:{"applicationType": "gecko", "marionetteProtocol": 2}';
 
 var server = net.createServer(function(connection) { //'connection' listener
   debug('server connected');

--- a/tests/jsmarionette/client/marionette-client/test/marionette/element-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/element-test.js
@@ -16,7 +16,7 @@ suite('marionette/element', function() {
 
   id = '{fake-uuid-root}';
 
-  function simpleCommand(method, type, responseKey) {
+  function simpleCommand(method, type, response, key) {
     suite('.' + method, function() {
       device.
         issues(method).
@@ -26,8 +26,8 @@ suite('marionette/element', function() {
             id: id
           }
         }).
-        serverResponds(responseKey).
-        callbackReceives(responseKey);
+        serverResponds(response).
+        callbackReceives(key);
     });
   }
 
@@ -53,10 +53,10 @@ suite('marionette/element', function() {
 
   suite('._sendCommand', function() {
     device.
-      issues('_sendCommand', { name: 'test' }, 'ok').
-      shouldSend({ name: 'test', parameters:{ id: id}}).
-      serverResponds('ok').
-      callbackReceives('ok');
+      issues('_sendCommand', {name: 'test'}).
+      shouldSend({name: 'test', parameters: {id: id}}).
+      serverResponds('value').
+      callbackReceives('value');
   });
 
   suite('.findElement', function() {
@@ -73,8 +73,8 @@ suite('marionette/element', function() {
       serverResponds('findElementResponse');
 
     test('should send callback a single element', function() {
-      var value = device.commandCallback.value,
-          resultId = exampleCmds.findElementResponse().value;
+      var value = device.commandCallback.value;
+      var resultId = exampleCmds.findElementResponse().value;
       assert.instanceOf(value, Element);
       assert.strictEqual(value.id, resultId);
     });
@@ -194,7 +194,7 @@ suite('marionette/element', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
 
     suite('when given a string', function() {
@@ -209,7 +209,7 @@ suite('marionette/element', function() {
           }
         }).
         serverResponds('ok').
-        callbackReceives('ok');
+        callbackReceives();
     });
   });
 
@@ -269,15 +269,15 @@ suite('marionette/element', function() {
     });
   });
 
-  simpleCommand('tagName', 'getElementTagName', 'value');
+  simpleCommand('tagName', 'getElementTagName', 'value', 'value');
   simpleCommand('click', 'clickElement', 'ok');
-  simpleCommand('text', 'getElementText', 'value');
+  simpleCommand('text', 'getElementText', 'value', 'value');
   simpleCommand('clear', 'clearElement', 'ok');
-  simpleCommand('selected', 'isElementSelected', 'value');
-  simpleCommand('enabled', 'isElementEnabled', 'value');
-  simpleCommand('displayed', 'isElementDisplayed', 'value');
-  simpleCommand('size', 'getElementRect', 'value');
-  simpleCommand('location', 'getElementRect', 'value');
-  simpleCommand('rect', 'getElementRect', 'value');
+  simpleCommand('selected', 'isElementSelected', 'value', 'value');
+  simpleCommand('enabled', 'isElementEnabled', 'value', 'value');
+  simpleCommand('displayed', 'isElementDisplayed', 'value', 'value');
+  simpleCommand('size', 'getElementRect', 'value', 'value');
+  simpleCommand('location', 'getElementRect', 'value', 'value');
+  simpleCommand('rect', 'getElementRect', 'value', 'value');
 
 });

--- a/tests/jsmarionette/client/marionette-client/test/marionette/error-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/error-test.js
@@ -8,12 +8,8 @@ suite('marionette/error', function() {
     MarionetteError = obj;
   });
 
-  test('should expose .CODES', function() {
-    assert.operator(Object.keys(MarionetteError.CODES).length, '>', 0);
-  });
-
-  test('should expose .STATUSES', function() {
-    assert.operator(Object.keys(MarionetteError.STATUSES).length, '>', 0);
+  test('should expose .ERRORS', function() {
+    assert.property(MarionetteError, 'ERRORS');
   });
 
   suite('#error', function() {
@@ -36,44 +32,23 @@ suite('marionette/error', function() {
       assert.property(err, 'type');
     });
 
-    test('should recognise known number', function() {
-      var err = new MarionetteError({}, {status: 7});
+    test('should recognise known error code', function() {
+      var err = new MarionetteError({}, {error: 'no such element'});
       assert.property(err, 'type');
       assert.equal(err.type, 'NoSuchElement');
     });
 
-    test('should recognise known string', function() {
-      var err = new MarionetteError({}, {status: 'no such element'});
-      assert.property(err, 'type');
-      assert.equal(err.type, 'NoSuchElement');
-    });
-
-    test('should fall back to GenericError for unknown number', function() {
-      var err = new MarionetteError({}, {status: 666});
+    test('should fall back to GenericError for unknown error code', function() {
+      var err = new MarionetteError({}, {error: 'brunost'});
       assert.property(err, 'type');
       assert.equal(err.type, 'GenericError');
     });
 
-    test('should fall back to GenericError for unknown string', function() {
-      var err = new MarionetteError({}, {status: 'brunost'});
-      assert.property(err, 'type');
-      assert.equal(err.type, 'GenericError');
-    });
-
-    test('should support all error number codes', function() {
-      for (var n in MarionetteError.CODES) {
-        var err = new MarionetteError({}, {status: n});
-        assert.strictEqual(err.type, MarionetteError.CODES[n]);
-        assert.include(err.message, MarionetteError.CODES[n]);
-        assert.instanceOf(err, Error);
-      }
-    });
-
-    test('should support all error status strings', function() {
-      for (var s in MarionetteError.STATUSES) {
-        var err = new MarionetteError({}, {status: s});
-        assert.strictEqual(err.type, MarionetteError.STATUSES[s]);
-        assert.include(err.message, MarionetteError.STATUSES[s]);
+    test('should support all errors', function() {
+      for (var s in MarionetteError.ERRORS) {
+        var err = new MarionetteError({}, {error: s});
+        assert.strictEqual(err.type, MarionetteError.ERRORS[s]);
+        assert.include(err.message, MarionetteError.ERRORS[s]);
         assert.instanceOf(err, Error);
       }
     });
@@ -89,23 +64,15 @@ suite('marionette/error', function() {
       assert.equal(result.client, client);
       assert.strictEqual(
         result.name,
-        MarionetteError.STATUSES['webdriver error']
+        MarionetteError.ERRORS['webdriver error']
       );
     });
 
-    test('should use GenericError when unknown error code', function() {
-      var result = new MarionetteError({}, {status: 7777});
+    test('should use GenericError error when unknown error code', function() {
+      var result = new MarionetteError({}, {error: 'cheese'});
       assert.strictEqual(
         result.name,
-        MarionetteError.STATUSES['webdriver error']
-      );
-    });
-
-    test('should use GenericError error when unknown error status', function() {
-      var result = new MarionetteError({}, {status: 'cheese'});
-      assert.strictEqual(
-        result.name,
-        MarionetteError.STATUSES['webdriver error']
+        MarionetteError.ERRORS['webdriver error']
       );
     });
   });

--- a/tests/jsmarionette/client/marionette-client/test/marionette/multi-actions-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/multi-actions-test.js
@@ -52,6 +52,6 @@ suite('marionette/multi-actions', function() {
         max_length: 0
       }).
       serverResponds('ok').
-      callbackReceives('ok');
+      callbackReceives();
   });
 });

--- a/tests/jsmarionette/plugins/marionette-plugin-forms/lib/index.js
+++ b/tests/jsmarionette/plugins/marionette-plugin-forms/lib/index.js
@@ -15,7 +15,6 @@ function Forms(client) {
  *                       (when setting multiple values)
  */
 Forms.prototype.fill = function(elem, value, done) {
-
   elem.tagName(function(err, tagName) {
     if (tagName === 'form') {
       setValues(elem, value, done);
@@ -51,15 +50,18 @@ function setValue(elem, value, done) {
 function setValues(form, values, done) {
   var keys = Object.keys(values);
   var setCount = keys.length;
-  function setKey() {
+  var setKey = function() {
     setCount--;
     if (setCount === 0) {
       done && done();
     }
-  }
+  };
 
   keys.forEach(function(key) {
     form.findElement('[name="' + key + '"]', function(err, elem) {
+      if (err) {
+        return;
+      }
       setValue(elem, values[key], setKey);
     });
   });


### PR DESCRIPTION
Bug 1153822 to Gecko reduces the amount of data sent will make requests
faster. Aligning the protocol closer to what WebDriver expects, will
reduce the amount of post-processing required in the httpd.

The Marionette protocol version 1 value response looked like this:

```
    {"from":"0","value":null,"status":0,"sessionId":"{6b6d68d2-4ac9-4308-9f07-d2e72519c407}"}
```

And this for ok responses:

```
    {"from":"0","ok":true}
```

And this for errors:

```
    {"from":"0","status":21,"sessionId":"{6b6d68d2-4ac9-4308-9f07-d2e72519c407}","error":{"message":"Error loading page, timed out (onDOMContentLoaded)","stacktrace":null,"status":21}}
```

Bug 1153822 (protocol 2) drops the "from" and "sessionId" fields and
"status" field from non-error responses. It also drops the "ok" field
in non-value responses and flattes the error response.

This patch adds support for protocol version 2 with backwards
compatibility for protocol 1.
