### PR TITLE
Bug 1061390 - Re-enable the language test in the root panel r=eragonj

### DIFF
--- a/apps/settings/test/marionette/app/regions/root.js
+++ b/apps/settings/test/marionette/app/regions/root.js
@@ -134,8 +134,12 @@ RootPanel.prototype = {
       return false;
     }
 
-    var expected = LanguagePanel.prototype._languageMap[languageKey].desc;
-    return this.languageDesc === expected;
+    var expected;
+    this.client.waitFor(function() {
+      expected = LanguagePanel.prototype._languageMap[languageKey].desc;
+      return this.languageDesc === expected;
+    }.bind(this));
+    return true;
   },
 
   get languageDesc() {

--- a/apps/settings/test/marionette/tests/root_settings_test.js
+++ b/apps/settings/test/marionette/tests/root_settings_test.js
@@ -61,8 +61,7 @@ marionette('check root panel settings', function() {
       });
     });
 
-    // XXX Disabled in https://bugzil.la/1061390
-    test.skip('language description on the root panel is translated',
+    test('language description on the root panel is translated',
       function() {
       settingsApp.currentLanguage = 'accented';
       assert.ok(


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1061390
