### PR TITLE
Bug 1175831 - make privacy panel use new-style passcodes

### DIFF
--- a/apps/privacy-panel/js/app.js
+++ b/apps/privacy-panel/js/app.js
@@ -23,6 +23,9 @@ require.config({
     },
     'shared/manifest_helper': {
       exports: 'ManifestHelper'
+    },
+    'shared/passcode_helper': {
+      exports: 'PasscodeHelper'
     }
   }
 });

--- a/apps/privacy-panel/js/sms/commands.js
+++ b/apps/privacy-panel/js/sms/commands.js
@@ -7,10 +7,11 @@
 define([
   'shared/settings_listener',
   'shared/settings_helper',
-  'shared/settings_url'
+  'shared/settings_url',
+  'shared/passcode_helper'
 ],
 
-function(SettingsListener, SettingsHelper, SettingsURL) {
+function(SettingsListener, SettingsHelper, SettingsURL, PasscodeHelper) {
   'use strict';
 
   var Commands = {
@@ -98,13 +99,17 @@ function(SettingsListener, SettingsHelper, SettingsURL) {
           settings['lockscreen.lock-message'] = message;
         }
 
-        if (!this.deviceHasPasscode() && passcode) {
-          settings['lockscreen.passcode-lock.code'] = passcode;
-        }
-
         var request = SettingsListener.getSettingsLock().set(settings);
         request.onsuccess = function() {
-          reply(true);
+          if (!this.deviceHasPasscode() && passcode) {
+            PasscodeHelper.set(passcode).then(() => {
+              reply(true);
+            }).catch(() => {
+              reply(false);
+            });
+          } else {
+            reply(true);
+          }
         };
 
         request.onerror = function() {


### PR DESCRIPTION
All operations on the lockscreen Passcode now go through the PasscodeHelper, which returns a promise.
- I have rewritten few functions that relied on a synchronous flow so that they support this asynchronous style.
- I have removed observers for the passcode value and replaced them with a call to check().
- Checks on the passcode now only return true or false, so the error granularity in verifyPasscode (auth.js line 348) has become a bit smaller.

I have not run any tests yet, as I am still trying to figure out how to enable this app for my build environment. Hopefully, Marta can help.
