### PR TITLE
Bug 1170834 - Show No SIM card message, when no SIM card in the device.

### DIFF
--- a/apps/settings/js/panels/root/sim_security_item.js
+++ b/apps/settings/js/panels/root/sim_security_item.js
@@ -40,12 +40,17 @@ define(function(require) {
      */
     set enabled(enabled) {
       // 1. SimSecurityItem only shows up on Single SIM devices
-      // 2. If there is no activeSlot, it means we don't have to do anything
+      // 2. If there is no activeSlot, we show No SIM card
       // 3. If internal variable is enabled and we still want to enable,
       // we don't have to do anything and vice versa.
       if (SIMSlotManager.isMultiSIM() ||
-        !this._activeSlot || enabled === this._itemEnabled) {
+         enabled === this._itemEnabled) {
           return;
+      }
+
+      if (!this._activeSlot) {
+        this._element.setAttribute('data-l10n-id', 'noSimCard');
+        return;
       }
 
       this._itemEnabled = enabled;


### PR DESCRIPTION
Add "No SIM card" in the list item status, when there is no SIM Card in the device.
