### PR TITLE
Bug 1161229 - Use CSS Scroll Snapping in card view

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -210,8 +210,9 @@
 
     // Label the card by title (for screen reader).
     elem.setAttribute('aria-labelledby', this.titleId);
-    // define role group for the card (for screen reader).
-    elem.setAttribute('role', 'group');
+    // define role presentation for the card (for screen reader) in order to not
+    // land on the card container.
+    elem.setAttribute('role', 'presentation');
     // Indicate security state where applicable & available
     if (this.sslState) {
       elem.dataset.ssl = this.sslState;

--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -151,7 +151,7 @@
     var cardStripWidth = (cardWidth * length) +
                          (this.CARD_GUTTER * (length - 1));
     var contentWidth = margins +
-                       Math.max(1 + cardWidth, cardStripWidth);
+                       Math.max(cardWidth, cardStripWidth);
     this.cardsList.style.width = contentWidth + 'px';
   };
 

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -4,16 +4,25 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  overflow-x: auto;
+  /* clip the horizontal scrollbar */
+  height: calc(100% + 1.5rem);
+  overflow-y: hidden;
   -moz-user-select: none;
-  overflow: hidden;
   background-color: rgb(51, 51, 51);
+  /* Specifies that each child element’s snap coordinate should
+     align with the x-axis center of the scroll container */
+  scroll-snap-destination: 50% 0;
+  /* Requires that scrolling always end at a snap point
+     when the operation completes (hard snap). */
+  scroll-snap-type: mandatory;
 }
 
 @media not all and (-moz-physical-home-button) {
   #screen:not(.software-button-disabled) #cards-view {
-    height: calc(100% - var(--software-home-button-height));
-    bottom: var(--software-home-button-height);
+    /* clip the horizontal scrollbar */
+    height: calc(1.5rem + 100% - var(--software-home-button-height));
+    bottom: calc(var(--software-home-button-height) - 1.5rem);
   }
 }
 
@@ -23,16 +32,18 @@
 }
 
 #screen.software-button-enabled #cards-view {
-  height: calc(100% - var(--software-home-button-height));
-  bottom: var(--software-home-button-height);
+  /* clip the horizontal scrollbar */
+  height: calc(1.5rem + 100% - var(--software-home-button-height));
+  bottom: calc(var(--software-home-button-height) - 1.5rem);
 }
 
 @media (orientation:landscape) {
+  /* not currently in use, see bug 1174325 */
   #screen.software-button-enabled #cards-view {
     height: 100%;
-    width: calc(100% - var(--software-home-button-height));
+    width: calc(1.5rem + 100% - var(--software-home-button-height));
     bottom: 0;
-    right: var(--software-home-button-height);
+    right: calc(var(--software-home-button-height) - 1.5rem);
   }
 }
 
@@ -61,12 +72,13 @@
   background-color: rgba(51, 51, 51, .85);
 }
 
-#cards-view ul {
+#cards-list {
   list-style: none;
+  position: absolute;
   margin: 0;
   padding: 0;
-  width: 100%;
-  height: 100%;
+  height: calc(100% - 1.5rem);
+  overflow: hidden;
   white-space: nowrap;
   text-align: center;
 }
@@ -75,23 +87,27 @@
 /* Cards */
 
 #cards-view .card {
+  display: block;
   position: absolute;
-  top: 26%;
-  left: 26%;
-  width: 48%;
-  height: 48%;
+  top: 25vh;
+  left: 25vw;
+  width: 50vw;
+  height: 50vh;
+  transform: translateY(0);
+  /* Defines the center of each card (column) as the
+     coordinate that should be used for snapping */
+  scroll-snap-coordinate: 50% 50%;
+}
 
-  margin: 0;
-  transition: transform;
-  will-change: transform;
+#cards-view .card.sliding {
+  transition: transform var(--transition-duration);
 }
 
 #cards-view .card > * {
   pointer-events: none;
 }
 
-
-/* Screenshoots */
+/* Screenshots */
 
 #cards-view .screenshotView {
   background-size: 100% calc(100% - 1.5rem), cover;
@@ -353,27 +369,6 @@ html[dir="rtl"] #cards-view .card.show-subtitle[data-ssl="secure"] p.subtitle {
 
 
 /* Animations */
-
-.card.current .titles,
-.card.current .card-tray,
-.card.current.private .privateOverlay {
-  opacity: 0;
-}
-
-#screen.cards-view .card.current .titles,
-#screen.cards-view .card.current .card-tray,
-#screen.cards-view .card.current.private .privateOverlay {
-  opacity: 1;
-  transition: opacity 0.5s ease;
-}
-
-#screen.cards-view .card.current.select .titles,
-#screen.cards-view .card.current.select .card-tray,
-#screen.cards-view .card.current.private.select .privateOverlay {
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
 #cards-view.from-home {
   animation: cardview-from-home 0.3s forwards cubic-bezier(0.7, 0.0, 1.0, 1.0);
 }
@@ -392,4 +387,3 @@ html[dir="rtl"] #cards-view .card.show-subtitle[data-ssl="secure"] p.subtitle {
   0%   { opacity: 1; }
   100% { opacity: 0; }
 }
-

--- a/apps/system/style/cards_view/cards_view.css
+++ b/apps/system/style/cards_view/cards_view.css
@@ -5,8 +5,7 @@
   left: 0;
   width: 100%;
   overflow-x: auto;
-  /* clip the horizontal scrollbar */
-  height: calc(100% + 1.5rem);
+  height: 100%;
   overflow-y: hidden;
   -moz-user-select: none;
   background-color: rgb(51, 51, 51);
@@ -20,9 +19,8 @@
 
 @media not all and (-moz-physical-home-button) {
   #screen:not(.software-button-disabled) #cards-view {
-    /* clip the horizontal scrollbar */
-    height: calc(1.5rem + 100% - var(--software-home-button-height));
-    bottom: calc(var(--software-home-button-height) - 1.5rem);
+    height: calc(100% - var(--software-home-button-height));
+    bottom: var(--software-home-button-height);
   }
 }
 
@@ -33,17 +31,17 @@
 
 #screen.software-button-enabled #cards-view {
   /* clip the horizontal scrollbar */
-  height: calc(1.5rem + 100% - var(--software-home-button-height));
-  bottom: calc(var(--software-home-button-height) - 1.5rem);
+  height: calc(100% - var(--software-home-button-height));
+  bottom: var(--software-home-button-height);
 }
 
 @media (orientation:landscape) {
   /* not currently in use, see bug 1174325 */
   #screen.software-button-enabled #cards-view {
     height: 100%;
-    width: calc(1.5rem + 100% - var(--software-home-button-height));
+    width: calc(100% - var(--software-home-button-height));
     bottom: 0;
-    right: calc(var(--software-home-button-height) - 1.5rem);
+    right: var(--software-home-button-height);
   }
 }
 

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -94,7 +94,7 @@
 }
 
 @keyframes openAppFromCardView {
-  0%   { transform: scale(0.48); }
+  0%   { transform: scale(0.5); }
   100% { transform: scale(1.0); }
 }
 
@@ -197,7 +197,7 @@
 
 @keyframes closeAppTowardsCardView {
   0%   { transform: scale(1.0); }
-  100% { transform: scale(0.48); }
+  100% { transform: scale(0.5); }
 }
 
 .appWindow.home-from-cardview {

--- a/apps/system/test/unit/card_test.js
+++ b/apps/system/test/unit/card_test.js
@@ -112,7 +112,7 @@ suite('system/Card', function() {
       var card = this.card;
 
       assert.equal(card.screenshotView.getAttribute('role'), 'link');
-      assert.equal(card.element.getAttribute('role'), 'group');
+      assert.equal(card.element.getAttribute('role'), 'presentation');
       assert.strictEqual(card.iconButton.getAttribute('aria-hidden'), 'true');
     });
 

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -49,22 +49,14 @@ function failOnReject(err) {
 }
 
 suite('system/TaskManager >', function() {
-  var fakeInnerHeight = 200;
+  var fakeInnerWidth = 360;
+  var fakeInnerHeight = 640;
 
   var screenNode, realMozSettings, realSettingsListener, realL10n;
   var cardsView, cardsList, noRecentWindowsNode;
-  var ihDescriptor;
-
-  function createTouchEvent(type, target, x, y) {
-    var touch = document.createTouch(window, target, 1, x, y, x, y);
-    var touchList = document.createTouchList(touch);
-
-    var evt = document.createEvent('TouchEvent');
-    evt.initTouchEvent(type, true, true, window,
-                       0, false, false, false, false,
-                       touchList, touchList, touchList);
-    return evt;
-  }
+  var innerHeightDescriptor, innerWidthDescriptor,
+      scrollLeftDescriptor, scrollTopDescriptor,
+      scrollToDescriptor;
 
   function sendHoldhome() {
     var evt = new CustomEvent('holdhome', { });
@@ -112,9 +104,11 @@ suite('system/TaskManager >', function() {
   var apps, home;
   var sms, game, game2;
   var taskManager;
+  var scrollProperties = {};
 
   mocksForTaskManager.attachTestHelpers();
   suiteSetup(function cv_suiteSetup(done) {
+
     apps = {
       'http://sms.gaiamobile.org': new AppWindow({
         launchTime: 5,
@@ -273,10 +267,49 @@ suite('system/TaskManager >', function() {
       blur: function() {}
     });
 
-    ihDescriptor = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    innerHeightDescriptor = Object
+                              .getOwnPropertyDescriptor(window, 'innerHeight');
     Object.defineProperty(window, 'innerHeight', {
       value: fakeInnerHeight,
       configurable: true
+    });
+    innerWidthDescriptor = Object
+                            .getOwnPropertyDescriptor(window, 'innerWidth');
+    Object.defineProperty(window, 'innerWidth', {
+      value: fakeInnerWidth,
+      configurable: true
+    });
+
+    scrollLeftDescriptor = Object.getOwnPropertyDescriptor(Element.prototype,
+                            'scrollLeft');
+    scrollTopDescriptor = Object.getOwnPropertyDescriptor(Element.prototype,
+                            'scrollTop');
+    scrollToDescriptor = Object.getOwnPropertyDescriptor(Element.prototype,
+                            'scrollTo');
+    Object.defineProperty(Element.prototype, 'scrollLeft', {
+      configurable: true,
+      get: function() { return scrollProperties[this.id].scrollLeft || 0; },
+      set: function(x) { return (scrollProperties[this.id].scrollLeft = x); }
+    });
+
+    Object.defineProperty(Element.prototype, 'scrollTop', {
+      configurable: true,
+      get: function() { return scrollProperties[this.id].scrollTop || 0; },
+      set: function(y) { return (scrollProperties[this.id].scrollTop = y); }
+    });
+
+    Object.defineProperty(Element.prototype, 'scrollTo', {
+      configurable: true,
+      get: function() {
+        return function scrollTo(x, y) {
+          if ('object' == typeof x) {
+            y = x.top;
+            x = x.left;
+          }
+          this.scrollLeft = (isNaN(x) || !x) ? 0 : x;
+          this.scrollTop = (isNaN(y) || !y) ? 0 : y;
+        };
+      }
     });
 
     screenNode = document.createElement('div');
@@ -328,6 +361,7 @@ suite('system/TaskManager >', function() {
     requireApp('system/js/base_ui.js');
     requireApp('system/js/card.js');
 
+
     requireApp('system/js/task_manager.js', function() {
       // normally done by bootstrap
       taskManager = new TaskManager();
@@ -338,7 +372,15 @@ suite('system/TaskManager >', function() {
   });
 
   suiteTeardown(function() {
-    Object.defineProperty(window, 'innerHeight', ihDescriptor);
+    Object.defineProperty(window, 'innerHeight', innerHeightDescriptor);
+    Object.defineProperty(window, 'innerWidth', innerWidthDescriptor);
+    Object.defineProperty(Element.prototype, 'scrollTop',
+                          scrollTopDescriptor);
+    Object.defineProperty(Element.prototype, 'scrollLeft',
+                          scrollLeftDescriptor);
+    Object.defineProperty(Element.prototype, 'scrollTo',
+                          scrollToDescriptor);
+
     screenNode.parentNode.removeChild(screenNode);
     navigator.mozSettings = realMozSettings;
     window.SettingsListener = realSettingsListener;
@@ -352,6 +394,10 @@ suite('system/TaskManager >', function() {
     MockService.mockQueryWith('fetchCurrentOrientation', 'portrait-primary');
     MockService.mockQueryWith('defaultOrientation', 'portrait-primary');
     this.sinon.useFakeTimers();
+
+    scrollProperties['cards-view'] = {
+      scrollLeft: 0, scrollTop: 0
+    };
   });
 
   // We make sure to end each test with a hidden cardview
@@ -491,16 +537,12 @@ suite('system/TaskManager >', function() {
         MockStackManager.mStack.push(apps[app]);
       }
       apps.home = home;
-      MockStackManager.mCurrent = 0;
-
-      MockService.mockQueryWith('getTopMostWindow',
-        apps['http://sms.gaiamobile.org']);
     });
 
     suite('display cardsview >', function() {
       setup(function() {
-        MockService.mockQueryWith('getTopMostWindow',
-          apps['http://sms.gaiamobile.org']);
+        MockService.mockQueryWith('getTopMostWindow', apps.search);
+        MockStackManager.mCurrent = MockStackManager.mStack.length -1;
         showTaskManager(this.sinon.clock);
       });
 
@@ -545,63 +587,47 @@ suite('system/TaskManager >', function() {
       });
 
       test('initial state', function() {
-        assert.equal(taskManager.position, 0,
-                    'initial position should be 0');
         assert.ok(taskManager.currentCard,
                   'has a truthy currentCard property');
+
+        var numCards = taskManager.cardsList.children.length;
+        assert.equal(MockStackManager.snapshot().length, numCards,
+                     'has correct number of list items');
+
+        // not sure we want to expose _stackIndex,
+        // but we'll sanity-check check it anyway
+        var currentIndex = MockStackManager.mCurrent;
+        assert.equal(currentIndex, taskManager._stackIndex);
+        assert.equal(taskManager.currentCard.position, currentIndex);
       });
 
-      function undefinedProps(value) {
-        for (var key in value) {
-          if (typeof value[key] === 'undefined') {
-            return true;
-          }
+      test('placement', function() {
+        var numCards = taskManager.cardsList.children.length;
+        var margins = taskManager.windowWidth - taskManager.cardWidth;
+        var expectedWidth = numCards * taskManager.cardWidth +
+                           (numCards - 1) * taskManager.CARD_GUTTER +
+                           margins;
+        assert.equal(taskManager.cardsList.style.width, expectedWidth +'px');
+
+        function checkCardPlacement(element, position) {
+          var expectedLeft = margins / 2 +
+                             position * (taskManager.cardWidth +
+                                             taskManager.CARD_GUTTER);
+          assert.equal(element.style.left,
+                       expectedLeft+'px');
         }
-        return false;
-      }
 
-      test('applyStyle is called by swiping', function(done) {
-        var card = taskManager.getCardAtIndex(0);
-        var element = card.element;
-        var applyStyleSpy = this.sinon.spy(card, 'applyStyle');
-
-        waitForEvent(element, 'touchend').then(function() {
-          var callCount = applyStyleSpy.callCount;
-          assert.isTrue(callCount > 0,
-                        'card.applyStyle was called at least once');
-          assert.isFalse(applyStyleSpy.calledWith(sinon.match(undefinedProps)),
-            'card.applyStyle was not called with undefined properties');
-
-        }, failOnReject).then(function() { done(); }, done);
-
-        // Simulate a drag up that doesn't remove the card
-        element.dispatchEvent(createTouchEvent('touchstart', element, 0, 500));
-        element.dispatchEvent(createTouchEvent('touchmove', element, 0, 250));
-        element.dispatchEvent(createTouchEvent('touchend', element, 0, 450));
-      });
-
-      test('cards should be hidden for better performance', function() {
-        var card = taskManager.getCardAtIndex(0);
-        assert.equal(card.element.style.visibility, '');
-
-        var farAway = taskManager.getCardAtIndex(3);
-        assert.equal(farAway.element.style.visibility, 'hidden');
-      });
-
-      test('and shown when needed', function() {
-        taskManager.position = 3;
-        taskManager.alignCurrentCard();
-        var card = taskManager.getCardAtIndex(0);
-        assert.equal(card.element.style.visibility, 'hidden');
-
-        var farAway = taskManager.getCardAtIndex(3);
-        assert.equal(farAway.element.style.visibility, '');
+        for(var idx=0; idx < taskManager.cardsList.children; idx++) {
+          checkCardPlacement(cardsList.children[idx], idx);
+        }
       });
 
       test('wheel up event', function() {
-        var card = taskManager.getCardAtIndex(0);
+        var card = taskManager.currentCard;
         var killAppStub = this.sinon.stub(card, 'killApp');
-
+        this.sinon.stub(taskManager.currentCard.app, 'killable', function() {
+          return true;
+        });
         taskManager.handleEvent({
           type: 'wheel',
           deltaMode: 2,
@@ -612,67 +638,19 @@ suite('system/TaskManager >', function() {
       });
 
       test('wheel left/right event', function() {
-        var alignCurrentCardSpy = this.sinon.spy(taskManager,
-          'alignCurrentCard');
+        var card = taskManager.currentCard;
+        this.sinon.spy(card, 'setVisibleForScreenReader');
 
-        assert.equal(taskManager.position, 0);
         taskManager.handleEvent({
           type: 'wheel',
           deltaMode: 2,
           DOM_DELTA_PAGE: 2,
           deltaX: 1
         });
-        assert.equal(taskManager.position, 1);
-
-        taskManager.handleEvent({
-          type: 'wheel',
-          deltaMode: 2,
-          DOM_DELTA_PAGE: 2,
-          deltaX: -1
-        });
-        assert.equal(taskManager.position, 0);
-
-        assert.equal(alignCurrentCardSpy.callCount, 2);
+        assert.ok(card.setVisibleForScreenReader.calledOnce);
       });
-
-      test('transitions are removed correctly after swiping', function(done) {
-        var card = taskManager.getCardAtIndex(0);
-        var applyStyleSpy = this.sinon.spy(card, 'applyStyle');
-        var element = card.element;
-
-        // Simulate a swipe to the side
-        waitForEvent(element, 'touchend').then(function() {
-          assert.isTrue(applyStyleSpy.callCount > 0,
-                        'card.applyStyle was called');
-          assert.isFalse(applyStyleSpy.calledWith(sinon.match(undefinedProps)),
-            'card.applyStyle was not called with undefined properties');
-        }, failOnReject).then(function() { done(); }, done);
-
-        element.dispatchEvent(createTouchEvent('touchstart', element, 0, 500));
-        element.dispatchEvent(createTouchEvent('touchmove', element, 100, 500));
-        element.dispatchEvent(createTouchEvent('touchend', element, 100, 500));
-      });
-
-      test('user can change swipe direction', function() {
-        var currentCard = taskManager.currentCard;
-
-        // Simulate a swipe that goes to one side, then back again
-        var el = currentCard.element;
-        el.dispatchEvent(createTouchEvent('touchstart', el, 200, 500));
-        this.sinon.clock.tick(300);
-        el.dispatchEvent(createTouchEvent('touchmove', el, 0, 500));
-        this.sinon.clock.tick(300);
-        el.dispatchEvent(createTouchEvent('touchmove', el, 380, 500));
-        this.sinon.clock.tick(300);
-        el.dispatchEvent(createTouchEvent('touchmove', el, 190, 500));
-        this.sinon.clock.tick(300);
-        el.dispatchEvent(createTouchEvent('touchend', el, 180, 500));
-
-        assert.isTrue(currentCard == taskManager.currentCard,
-                      'current card remains unchanged');
-      });
-
     });
+
     suite('when the currently displayed app is out of the stack',
     function() {
       setup(function() {
@@ -682,7 +660,7 @@ suite('system/TaskManager >', function() {
           apps['http://game.gaiamobile.org'],
           apps['http://game2.gaiamobile.org']
         ];
-        MockStackManager.mCurrent = 1;
+        MockStackManager.mCurrent = MockStackManager.mStack.length -1;
         taskManager.show();
       });
 
@@ -690,9 +668,11 @@ suite('system/TaskManager >', function() {
         MockStackManager.mOutOfStack = false;
       });
 
-      test('position should be the last position in the stack',
+      test('currentCard should be the last in the stack',
       function() {
-        assert.equal(taskManager.position, 2);
+        var currentApp = taskManager.currentCard.app;
+        var expectedPosition = MockStackManager.mStack.indexOf(currentApp);
+        assert.equal(expectedPosition, MockStackManager.mCurrent);
       });
 
       test('exitToApp handles out-of-stack app',
@@ -783,9 +763,10 @@ suite('system/TaskManager >', function() {
                     'cardviewshown event raised when shown with empty stack');
         assert.isTrue(cardsView.classList.contains('active'));
         assert.isTrue(taskManager.isShown());
+      }).then(function() {
         done();
       }, failOnReject);
-      // Pre-Haida/Cardsview mode: taskManager shows empty message
+
       showTaskManager(this.sinon.clock);
     });
 
@@ -794,7 +775,7 @@ suite('system/TaskManager >', function() {
         showTaskManager(this.sinon.clock);
       });
 
-      test('on touchstart, empty cardsview is closed and back to home screen',
+      test('on click, empty cardsview is closed and back to home screen',
       function(done) {
         var events = [];
         assert.isTrue(cardsView.classList.contains('empty'));
@@ -813,8 +794,9 @@ suite('system/TaskManager >', function() {
         }, failOnReject)
         .then(done, done);
 
-        cardsView.dispatchEvent(
-          createTouchEvent('touchstart', cardsView, 100, 100));
+        taskManager.handleEvent({target: taskManager.element,
+                              type: 'click',
+                              preventDefault: function(){} });
         this.sinon.clock.tick(501);
       });
     });
@@ -942,18 +924,6 @@ suite('system/TaskManager >', function() {
       MockStackManager.mStack = [apps['http://sms.gaiamobile.org']];
       MockStackManager.mCurrent = 0;
       showTaskManager(this.sinon.clock);
-    });
-
-    test('Prevent reflowing during swipe to remove', function() {
-      var card = cardsView.querySelector('.card');
-
-      var touchstart = createTouchEvent('touchstart', card, 0, 500);
-      var touchmove = createTouchEvent('touchmove', card, 0, 200);
-      var touchend = createTouchEvent('touchend', card, 0, 200);
-
-      assert.isFalse(card.dispatchEvent(touchstart));
-      assert.isFalse(card.dispatchEvent(touchmove));
-      assert.isFalse(card.dispatchEvent(touchend));
     });
   });
 
@@ -1228,7 +1198,9 @@ suite('system/TaskManager >', function() {
     });
     test('filter for browsers', function() {
       assert.equal(taskManager.stack.length, 2);
-      assert.equal(taskManager.position, 1);
+      // ensure sms app is filtered out, so browser1 should be first
+      var currentCard = taskManager.currentCard;
+      assert.equal(currentCard.app, apps.browser1);
     });
     test('exitToApp sets newStackPosition correctly using a filtered stack',
     function(done) {
@@ -1274,7 +1246,7 @@ suite('system/TaskManager >', function() {
     });
     test('filter includes search app', function() {
       assert.equal(taskManager.stack.length, 2);
-      assert.equal(taskManager.position, 1);
+      assert.ok(taskManager.cardsByAppID[apps.search.instanceID]);
     });
   });
 

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -49,6 +49,7 @@ apps/sms/views/shared/style/common.css 0 1
 apps/sms/views/shared/style/sms.css 0 2
 apps/sms/views/inbox/style/inbox.css 0 2
 apps/system/mobile_id/style/mobile_id.css 0 16
+apps/system/style/cards_view/cards_view.css 3 0
 apps/system/style/modal_dialog/modal_dialog.css 0 1
 apps/system/style/net_error.css 1 0
 apps/system/style/sound_manager/sound_manager.css 1 3

--- a/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/cards_view.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/system/regions/cards_view.py
@@ -41,10 +41,17 @@ class CardsView(Base):
         return self.accessibility.is_hidden(self.marionette.find_element(
             *self._cards_view_locator))
 
+    def _card_is_centered(self, card):
+        screen_width = int(self.marionette.execute_script('return window.innerWidth'))
+        left = card.location['x']
+        width = card.size['width']
+        # center of card should be within 1px of viewport center
+        return 1 >= abs(screen_width / 2 - (left + width / 2))
+
     def wait_for_card_ready(self, app):
-        cards = self.marionette.find_element(*self._cards_view_locator)
         card = self.marionette.find_element(*self._app_card_locator(app))
-        Wait(self.marionette).until(lambda m: cards.size['width'] - card.size['width'] == 2 * card.location['x'])
+        Wait(self.marionette).until(lambda m: self._card_is_centered(card))
+
         # TODO: Remove sleep when we find a better wait
         time.sleep(0.2)
 


### PR DESCRIPTION
Re-applies origin commit (2be1637848116b56a293eed1b305766661333fa7) with horizontal scrollbar clipping removed, and over-width (force scrolling/enable overscroll) for single card removed. I've left these changes in their own commit for easier re-review. 

The other changes are as before:  
    \* Add CSS scroll-snapping to card view (etienne, jetvillegas)
      https://github.com/jetvillegas/gaia/tree/APZC-card-view
    \* Restore support for vertical swiping to kill apps.
    \* Unknown scroll-snap properties added to csslint's xfail list
    \* Move width/height/margin card props to CSS
    \* Move cross-slide via translateY to Card
    \* Maintain _stackIndex as default pointer into stack to return to
    \* Slide to fill gap from right, fix initial/return-to position
    \* Re-enable wheel event handling, update a11y attributes on each wheel DOM_D
    \* Update Card and TaskManager unit tests
    \* Update wait_for_card_ready in python CardView class
