### PR TITLE
Bug 1176502 - Failure in test_homescreen_column_layout.py on the Flam…

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/manifest.ini
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/functional/homescreen/manifest.ini
@@ -4,6 +4,8 @@
 external = false
 
 [test_homescreen_column_layout.py]
+# Bug 1176502 - Failure in test_homescreen_column_layout.py on the Flame device, because Settings app gets killed
+skip-if = device == "flame"
 
 [test_homescreen_change_wallpaper.py]
 sdcard = true


### PR DESCRIPTION
…e device, because Settings app gets killed
