### PR TITLE
Bug 1166966 - [Calendar] move logic from bridge.js into backend/calendar_service.js r=gaye

### DIFF
--- a/apps/calendar/js/backend/calendar_service.js
+++ b/apps/calendar/js/backend/calendar_service.js
@@ -2,9 +2,13 @@ define(function(require, exports) {
 'use strict';
 
 var Db = require('db');
+var accounts = require('services/accounts');
+var busytimes = require('services/busytimes');
+var calendars = require('services/calendars');
 var co = require('ext/co');
 var core = require('core');
-//var object = require('common/object');
+var events = require('services/events');
+var settings = require('services/settings');
 var threads = require('ext/threads');
 
 var service = threads.service('calendar');
@@ -45,150 +49,27 @@ function echo() {
   return Array.slice(arguments);
 }
 
-/**
- * This will not work until the sync controller
- * (1) is not a class anymore
- * (2) doesn't need the app ns/object
- */
-function saveAccount(details) {
-  return co(function *() {
-    var store = core.storeFactory.get('Account');
-    var account;
-    try {
-      account = yield store.verifyAndPersist(details);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-
-    yield syncAccount(account);
-    return account;
-  });
-}
-
-function removeAccount(id) {
-  return co(function *() {
-    var store = core.storeFactory.get('Account');
-    yield store.remove(id);
-  });
-}
-
-/**
- * This will not work until the sync controller
- * (1) is not a class anymore
- * (2) doesn't need the app ns/object
- */
-function syncAccount(account) {
-  console.log('syncAccount', account);
-  /*
-  return co(function *() {
-    var store = core.storeFactory.get('Calendar');
-    var calendars;
-    try {
-      calendars = yield store.remotesByAccount(account._id);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-
-    var syncCalendar = syncController.calendar.bind(null, account);
-    yield Promise.all(object.map(calendars, syncCalendar));
-  });
-  */
-}
-
-function saveEvent(exists, event) {
-  return co(function *() {
-    var store = core.storeFactory.get('Event');
-    var provider = yield store.providerFor(event);
-    var capabilities;
-    try {
-      capabilities = yield provider.eventCapabilities(event.data);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-
-    var capability = exists ? 'canUpdate' : 'canCreate';
-    if (!capabilities[capability]) {
-      return Promise.reject(new Error('User not allowed to perform operation'));
-    }
-
-    var method = exists ? 'updateEvent' : 'createEvent';
-    try {
-      yield provider[method](event.data);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  });
-}
-
-function removeEvent(event) {
-  return co(function *() {
-    var store = core.storeFactory.get('Event');
-    var provider = yield store.providerFor(event);
-    var capabilities;
-    try {
-      yield provider.eventCapabilities(event.data);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-
-    if (!capabilities.canDelete) {
-      return Promise.reject(new Error('User not allowed to perform operation'));
-    }
-
-    yield provider.deleteEvent(event.data);
-  });
-}
-
-function setSetting(key, value) {
-  var store = core.storeFactory.get('Setting');
-  return store.set(key, value);
-}
-
-function listAccounts(stream) {
-  // TODO
-  console.log('accounts/list', stream);
-}
-
-function getAccount(stream, id) {
-  // TODO
-  console.log('accounts/get', stream, id);
-}
-
-function listCalendars(stream) {
-  // TODO
-  console.log('calendars/list', stream);
-}
-
-function getEvent(stream, id) {
-  // TODO
-  console.log('events/get', stream, id);
-}
-
-function listBusytimes(stream, day) {
-  // TODO
-  console.log('busytimes/list', stream, day);
-}
-
-function getSetting(stream, key) {
-  // TODO
-  console.log('settings/set', stream, key);
-}
-
 method('echo', echo);
-method('accounts/create', saveAccount);
-method('accounts/update', saveAccount);
-method('accounts/remove', removeAccount);
-method('accounts/sync', syncAccount);
-method('events/create', saveEvent.bind(null, true));
-method('events/update', saveEvent.bind(null, true));
-method('events/remove', removeEvent);
-method('settings/set', setSetting);
-stream('accounts/list', listAccounts);
-stream('accounts/get', getAccount);
-stream('calendars/list', listCalendars);
-stream('events/get', getEvent);
-stream('busytimes/list', listBusytimes);
-stream('settings/get', getSetting);
+
+method('accounts/get', accounts.get);
+method('accounts/create', accounts.persist);
+method('accounts/remove', accounts.remove);
+method('accounts/presets', accounts.availablePresets);
+stream('accounts/observe', accounts.observe);
+
+method('events/create', events.create);
+method('events/update', events.update);
+method('events/remove', events.remove);
+
+method('records/get', busytimes.fetchRecord);
+stream('days/observe', busytimes.observeDay);
+
+method('settings/get', settings.get);
+method('settings/set', settings.set);
+stream('settings/observe', settings.observe);
+
+method('calendars/update', calendars.update);
+stream('calendars/observe', calendars.observe);
 
 exports.start = start;
 

--- a/apps/calendar/js/backend/services/accounts.js
+++ b/apps/calendar/js/backend/services/accounts.js
@@ -1,0 +1,90 @@
+define(function(require, exports) {
+'use strict';
+
+var co = require('ext/co');
+var core = require('core');
+var nextTick = require('common/next_tick');
+var object = require('common/object');
+
+exports.persist = co.wrap(function *(model) {
+  var storeFactory = core.storeFactory;
+  var accountStore = storeFactory.get('Account');
+  var calendarStore = storeFactory.get('Calendar');
+
+  // begin by persisting the account
+  var [, result] = yield accountStore.verifyAndPersist(model);
+
+  // finally sync the account so when
+  // we exit the request the user actually
+  // has some calendars. This should not take
+  // too long (compared to event sync).
+  yield accountStore.sync(result);
+
+  // begin sync of calendars
+  var calendars = yield calendarStore.remotesByAccount(result._id);
+
+  // note we don't wait for any of this to complete
+  // we just begin the sync and let the event handlers
+  // on the sync controller do the work.
+  for (var key in calendars) {
+    core.syncController.calendar(
+      result,
+      calendars[key]
+    );
+  }
+
+  return result;
+});
+
+exports.get = function(id) {
+  var accountStore = core.storeFactory.get('Account');
+  return accountStore.get(id);
+};
+
+exports.remove = function(id) {
+  var accountStore = core.storeFactory.get('Account');
+  return accountStore.remove(id);
+};
+
+exports.observe = function(stream) {
+  var accountStore = core.storeFactory.get('Account');
+
+  var getAllAndWrite = co.wrap(function *() {
+    try {
+      var accounts = yield accountStore.all();
+      var data = object.map(accounts, (id, account) => {
+        return {
+          account: account,
+          provider: core.providerFactory.get(account.providerType)
+        };
+      });
+      stream.write(data);
+    } catch(err) {
+      console.error(`Error fetching accounts: ${err.message}`);
+    }
+  });
+
+  accountStore.on('add', getAllAndWrite);
+  accountStore.on('remove', getAllAndWrite);
+  accountStore.on('update', getAllAndWrite);
+
+  stream.cancel = function() {
+    accountStore.off('add', getAllAndWrite);
+    accountStore.off('remove', getAllAndWrite);
+    accountStore.off('update', getAllAndWrite);
+  };
+
+  nextTick(getAllAndWrite);
+};
+
+/**
+ * Returns a list of available presets filtered by
+ * the currently used presets in the database.
+ * (can't create multiple local calendars)
+ */
+exports.availablePresets = function(presetList) {
+  var accountStore = core.storeFactory.get('Account');
+  return accountStore.availablePresets(presetList);
+};
+
+});

--- a/apps/calendar/js/backend/services/busytimes.js
+++ b/apps/calendar/js/backend/services/busytimes.js
@@ -1,0 +1,38 @@
+define(function(require, exports) {
+'use strict';
+
+var co = require('ext/co');
+var core = require('core');
+var dayObserver = require('day_observer');
+
+/**
+ * Fetch all the data needed to display the busytime information on the event
+ * views based on the busytimeId
+ */
+exports.fetchRecord = function(busytimeId) {
+  return co(function *() {
+    var record = yield dayObserver.findAssociated(busytimeId);
+    var eventStore = core.storeFactory.get('Event');
+    var owners = yield eventStore.ownersOf(record.event);
+    var provider = core.providerFactory.get(owners.account.providerType);
+    var capabilities = yield provider.eventCapabilities(record.event);
+
+    record.calendar = owners.calendar;
+    record.account = owners.account;
+    record.capabilities = capabilities;
+
+    return record;
+  });
+};
+
+exports.observeDay = function(stream, date) {
+  var emit = stream.write.bind(stream);
+
+  stream.cancel = function() {
+    dayObserver.off(date, emit);
+  };
+
+  dayObserver.on(date, emit);
+};
+
+});

--- a/apps/calendar/js/backend/services/calendars.js
+++ b/apps/calendar/js/backend/services/calendars.js
@@ -1,0 +1,48 @@
+define(function(require, exports) {
+'use strict';
+
+var co = require('ext/co');
+var core = require('core');
+var nextTick = require('common/next_tick');
+var object = require('common/object');
+
+/**
+ * Fetch all the calendars from database and emits a new event every time the
+ * values changes.
+ *
+ * @returns {ClientStream}
+ */
+exports.observe = function(stream) {
+  var calendarStore = core.storeFactory.get('Calendar');
+
+  var getAllAndWrite = co.wrap(function *() {
+    // calendarStore.all() returns an object! we convert into an array since
+    // that is easier to render/manipulate
+    var calendars = yield calendarStore.all();
+    var data = yield object.map(calendars, co.wrap(function *(id, calendar) {
+      var provider = yield calendarStore.providerFor(calendar);
+      var caps = provider.calendarCapabilities(calendar);
+      return { calendar: calendar, capabilities: caps };
+    }));
+    stream.write(data);
+  });
+
+  calendarStore.on('add', getAllAndWrite);
+  calendarStore.on('remove', getAllAndWrite);
+  calendarStore.on('update', getAllAndWrite);
+
+  stream.cancel = function() {
+    calendarStore.off('add', getAllAndWrite);
+    calendarStore.off('remove', getAllAndWrite);
+    calendarStore.off('update', getAllAndWrite);
+  };
+
+  nextTick(getAllAndWrite);
+};
+
+exports.update = function(calendar) {
+  var calendarStore = core.storeFactory.get('Calendar');
+  return calendarStore.persist(calendar);
+};
+
+});

--- a/apps/calendar/js/backend/services/events.js
+++ b/apps/calendar/js/backend/services/events.js
@@ -1,0 +1,39 @@
+define(function(require, exports) {
+'use strict';
+
+var co = require('ext/co');
+var core = require('core');
+
+exports.create = function(event) {
+  return persistEvent(event, 'create', 'canCreate');
+};
+
+exports.update = function(event) {
+  return persistEvent(event, 'update', 'canUpdate');
+};
+
+exports.remove = function(event) {
+  return persistEvent(event, 'delete', 'canDelete');
+};
+
+var persistEvent = co.wrap(function *(event, action, capability) {
+  event = event.data || event;
+  try {
+    var eventStore = core.storeFactory.get('Event');
+    var provider = yield eventStore.providerFor(event);
+    var caps = yield provider.eventCapabilities(event);
+    if (!caps[capability]) {
+      return Promise.reject(new Error(`Can't ${action} event`));
+    }
+    return provider[action + 'Event'](event);
+  } catch(err) {
+    console.error(
+      `${action} Error for event "${event._id}" ` +
+      `on calendar "${event.calendarId}"`
+    );
+    console.error(err);
+    return Promise.reject(err);
+  }
+});
+
+});

--- a/apps/calendar/js/backend/services/settings.js
+++ b/apps/calendar/js/backend/services/settings.js
@@ -1,0 +1,32 @@
+define(function(require, exports) {
+'use strict';
+
+var core = require('core');
+
+exports.get = function(id) {
+  var settingStore = core.storeFactory.get('Setting');
+  return settingStore.getValue(id);
+};
+
+exports.set = function(id, value) {
+  var settingStore = core.storeFactory.get('Setting');
+  return settingStore.set(id, value);
+};
+
+exports.observe = function(stream, id) {
+  var settingStore = core.storeFactory.get('Setting');
+
+  var writeOnChange = function(value) {
+    stream.write(value);
+  };
+
+  settingStore.on(`${id}Change`, writeOnChange);
+
+  stream.cancel = function() {
+    settingStore.off(`${id}Change`, writeOnChange);
+  };
+
+  exports.get(id).then(writeOnChange);
+};
+
+});


### PR DESCRIPTION
still no tests for the backend but copied all the methods that are used by frontend into the calendar_service to get the work started. decided to split into separate files to keep it organized.
