### PR TITLE
Bug 1178248 - Use new syntax to define the hotspot settings module r=eragonj

### DIFF
--- a/apps/settings/js/panels/hotspot/hotspot_settings.js
+++ b/apps/settings/js/panels/hotspot/hotspot_settings.js
@@ -8,215 +8,237 @@ define(function(require) {
 
   var SettingsListener = require('shared/settings_listener');
   var SettingsCache = require('modules/settings_cache');
+  var Module = require('modules/base/module');
   var Observable = require('modules/mvvm/observable');
 
   /**
-   * @alias module:hotspot/hotspot_settings
    * @requires module:modules/mvvm/observable
    * @requires module:modules/settings_cache
-   * @returns {hotspotSettingsPrototype}
+   * @returns {HotspotSettings}
    */
-  var hotspotSettingsPrototype = {
-    /**
-     * Hotspot SSID.
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @type {String}
-     */
-    hotspotSSID: '',
+  var HotspotSettings = Module.create(function HotspotSettings() {
+    this.super(Observable).call(this);
+    this._init();
+  }).extend(Observable);
 
-    /**
-     * Hotspot security type
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @type {String}
-     */
-    hotspotSecurity: '',
-
-    /**
-     * Hotspot Password
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @type {String}
-     */
-    hotspotPassword: '',
-
-    /**
-     * Hotspot SSID setting key
-     *
-     * @access public
-     * @memberOf hotspotSettingsPrototype
-     * @type {String}
-     */
-    tetheringSSIDKey: 'tethering.wifi.ssid',
-
-    /**
-     * Hotspot security type setting key
-     *
-     * @access public
-     * @memberOf hotspotSettingsPrototype
-     * @type {String}
-     */
-    tetheringSecurityKey: 'tethering.wifi.security.type',
-
-    /**
-     * Hotspot password setting key
-     *
-     * @access public
-     * @memberOf hotspotSettingsPrototype
-     * @type {String}
-     */
-    tetheringPasswordKey: 'tethering.wifi.security.password',
-
-    /**
-     * Init module.
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     */
-    _init: function hs_init() {
-      this._settings = navigator.mozSettings;
-      this._bindEvents();
-      this._updatePasswordIfNeeded();
-    },
-
-    /**
-     * We will generate a random password for the hotspot
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     */
-    _generateHotspotPassword: function hs_generateHotspotPassword() {
-      var words = ['amsterdam', 'ankara', 'auckland',
-                 'belfast', 'berlin', 'boston',
-                 'calgary', 'caracas', 'chicago',
-                 'dakar', 'delhi', 'dubai',
-                 'dublin', 'houston', 'jakarta',
-                 'lagos', 'lima', 'madrid',
-                 'newyork', 'osaka', 'oslo',
-                 'porto', 'santiago', 'saopaulo',
-                 'seattle', 'stockholm', 'sydney',
-                 'taipei', 'tokyo', 'toronto'];
-      var password = words[Math.floor(Math.random() * words.length)];
-      for (var i = 0; i < 4; i++) {
-        password += Math.floor(Math.random() * 10);
-      }
-      return password;
-    },
-
-    /**
-     * We will update hotspot password if needed
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-    */
-    _updatePasswordIfNeeded: function hs_updatePasswordIfNeeded() {
-      var self = this;
-      SettingsCache.getSettings(function(results) {
-        if (!results[self.tetheringPasswordKey]) {
-          var pwd = self._generateHotspotPassword();
-          self.setHotspotPassword(pwd);
-        }
-      });
-    },
-
-    /**
-     * Sets the value to the tethering SSID setting
-     *
-     * @access public
-     * @memberOf hotspotSettingsPrototype
-     * @param {String} value
-     */
-    setHotspotSSID: function hs_setHotspotSSID(value) {
-      var cset = {};
-      cset[this.tetheringSSIDKey] = value;
-      this._settings.createLock().set(cset);
-    },
-
-    /**
-     * Sets the value to the tethering security type setting
-     *
-     * @access public
-     * @memberOf hotspotSettingsPrototype
-     * @param {String} value
-     */
-    setHotspotSecurity: function hs_setHotspotSecurity(value) {
-      var cset = {};
-      cset[this.tetheringSecurityKey] = value;
-      this._settings.createLock().set(cset);
-    },
-
-    /**
-     * Sets the value to the tethering password setting
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @param {String} value
-     */
-    setHotspotPassword: function hs_setHotspotPassword(value) {
-      var cset = {};
-      cset[this.tetheringPasswordKey] = value;
-      this._settings.createLock().set(cset);
-    },
-
-    /**
-     * Updates the current value of hotspot SSID
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @param {String} value
-     */
-    _onSSIDChange: function hs_onSSIDChange(value) {
-      this.hotspotSSID = value;
-    },
-
-    /**
-     * Updates the current value of hotspot security type
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @param {String} value
-     */
-    _onSecurityChange: function hs_onSecurityChange(value) {
-      this.hotspotSecurity = value;
-    },
-
-    /**
-     * Updates the current value of hotspot password
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     * @param {String} value
-     */
-    _onPasswordChange: function hs_onPasswordChange(value) {
-      this.hotspotPassword = value;
-    },
-
-    /**
-     * Listen to hotspot settings changes
-     *
-     * @access private
-     * @memberOf hotspotSettingsPrototype
-     */
-    _bindEvents: function hs_bindEvents() {
-      SettingsListener.observe(this.tetheringSSIDKey,
-        '', this._onSSIDChange.bind(this));
-
-      SettingsListener.observe(this.tetheringSecurityKey,
-        'wpa-psk', this._onSecurityChange.bind(this));
-
-      SettingsListener.observe(this.tetheringPasswordKey,
-        '', this._onPasswordChange.bind(this));
+  /**
+   * Hotspot SSID setting key
+   *
+   * @access public
+   * @memberOf HotspotSettings
+   * @type {String}
+   */
+  Object.defineProperty(HotspotSettings.prototype, 'tetheringSSIDKey', {
+    get: function() {
+      return 'tethering.wifi.ssid';
     }
+  });
+
+  /**
+   * Hotspot security type setting key
+   *
+   * @access public
+   * @memberOf HotspotSettings
+   * @type {String}
+   */
+  Object.defineProperty(HotspotSettings.prototype, 'tetheringSecurityKey', {
+    get: function() {
+      return 'tethering.wifi.security.type';
+    }
+  });
+
+  /**
+   * Hotspot password setting key
+   *
+   * @access public
+   * @memberOf HotspotSettings
+   * @type {String}
+   */
+  Object.defineProperty(HotspotSettings.prototype, 'tetheringPasswordKey', {
+    get: function() {
+      return 'tethering.wifi.security.password';
+    }
+  });
+
+  /**
+   * Hotspot SSID.
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @type {String}
+   */
+  Observable.defineObservableProperty(HotspotSettings.prototype,
+    'hotspotSSID', {
+      readonly: true,
+      value: ''
+  });
+
+  /**
+   * Hotspot security type
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @type {String}
+   */
+  Observable.defineObservableProperty(HotspotSettings.prototype,
+    'hotspotSecurity', {
+      readonly: true,
+      value: ''
+  });
+
+  /**
+   * Hotspot Password
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @type {String}
+   */
+  Observable.defineObservableProperty(HotspotSettings.prototype,
+    'hotspotPassword', {
+      readonly: true,
+      value: ''
+  });
+
+  /**
+   * Init module.
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   */
+  HotspotSettings.prototype._init = function() {
+    this._settings = navigator.mozSettings;
+    this._bindEvents();
+    this._updatePasswordIfNeeded();
   };
 
-  return function ctor_hotspotSettings() {
-    // Create the observable object using the prototype.
-    var hotspotSettings = Observable(hotspotSettingsPrototype);
-    hotspotSettings._init();
-    return hotspotSettings;
+  /**
+   * We will generate a random password for the hotspot
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   */
+  HotspotSettings.prototype._generateHotspotPassword = function() {
+    var words = ['amsterdam', 'ankara', 'auckland',
+               'belfast', 'berlin', 'boston',
+               'calgary', 'caracas', 'chicago',
+               'dakar', 'delhi', 'dubai',
+               'dublin', 'houston', 'jakarta',
+               'lagos', 'lima', 'madrid',
+               'newyork', 'osaka', 'oslo',
+               'porto', 'santiago', 'saopaulo',
+               'seattle', 'stockholm', 'sydney',
+               'taipei', 'tokyo', 'toronto'];
+    var password = words[Math.floor(Math.random() * words.length)];
+    for (var i = 0; i < 4; i++) {
+      password += Math.floor(Math.random() * 10);
+    }
+    return password;
   };
+
+  /**
+   * We will update hotspot password if needed
+   *
+   * @access private
+   * @memberOf HotspotSettings
+  */
+  HotspotSettings.prototype._updatePasswordIfNeeded = function() {
+    var self = this;
+    SettingsCache.getSettings(function(results) {
+      if (!results[self.tetheringPasswordKey]) {
+        var pwd = self._generateHotspotPassword();
+        self.setHotspotPassword(pwd);
+      }
+    });
+  };
+
+  /**
+   * Sets the value to the tethering SSID setting
+   *
+   * @access public
+   * @memberOf HotspotSettings
+   * @param {String} value
+   */
+  HotspotSettings.prototype.setHotspotSSID = function(value) {
+    var cset = {};
+    cset[this.tetheringSSIDKey] = value;
+    this._settings.createLock().set(cset);
+  };
+
+  /**
+   * Sets the value to the tethering security type setting
+   *
+   * @access public
+   * @memberOf HotspotSettings
+   * @param {String} value
+   */
+  HotspotSettings.prototype.setHotspotSecurity = function(value) {
+    var cset = {};
+    cset[this.tetheringSecurityKey] = value;
+    this._settings.createLock().set(cset);
+  };
+
+  /**
+   * Sets the value to the tethering password setting
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @param {String} value
+   */
+  HotspotSettings.prototype.setHotspotPassword = function(value) {
+    var cset = {};
+    cset[this.tetheringPasswordKey] = value;
+    this._settings.createLock().set(cset);
+  };
+
+  /**
+   * Updates the current value of hotspot SSID
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @param {String} value
+   */
+  HotspotSettings.prototype._onSSIDChange = function(value) {
+    this._hotspotSSID = value;
+  };
+
+  /**
+   * Updates the current value of hotspot security type
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @param {String} value
+   */
+  HotspotSettings.prototype._onSecurityChange = function(value) {
+    this._hotspotSecurity = value;
+  };
+
+  /**
+   * Updates the current value of hotspot password
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   * @param {String} value
+   */
+  HotspotSettings.prototype._onPasswordChange = function(value) {
+    this._hotspotPassword = value;
+  };
+
+  /**
+   * Listen to hotspot settings changes
+   *
+   * @access private
+   * @memberOf HotspotSettings
+   */
+  HotspotSettings.prototype._bindEvents = function() {
+    SettingsListener.observe(this.tetheringSSIDKey,
+      '', this._onSSIDChange.bind(this));
+
+    SettingsListener.observe(this.tetheringSecurityKey,
+      'wpa-psk', this._onSecurityChange.bind(this));
+
+    SettingsListener.observe(this.tetheringPasswordKey,
+      '', this._onPasswordChange.bind(this));
+  };
+
+  return HotspotSettings;
 });

--- a/apps/settings/test/unit/panels/hotspot/hotspot_settings_test.js
+++ b/apps/settings/test/unit/panels/hotspot/hotspot_settings_test.js
@@ -41,9 +41,9 @@ suite('Hotspot settings panel >', function() {
 
   suite('Update settings values', function() {
     setup(function() {
-        hotspotSettings.hotspotSSID = '';
-        hotspotSettings.hotspotSecurity = '';
-        hotspotSettings.hotspotPassword = '';
+        hotspotSettings._hotspotSSID = '';
+        hotspotSettings._hotspotSecurity = '';
+        hotspotSettings._hotspotPassword = '';
     });
 
     test('Should reflect the SSID setting change', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1178248
