### PR TITLE
Bug 1167507 - Wrap the input of the FDN Contact to MozIcc.updateContact() as a mozContact.

### DIFF
--- a/apps/settings/js/modules/fdn_context.js
+++ b/apps/settings/js/modules/fdn_context.js
@@ -83,7 +83,7 @@ define(function() {
      * @param {String} action
      * @param {Number} options.cardIndex
      * @param {Object} options.contact
-     * @return {Object}
+     * @return {mozContact}
      */
     createAction: function(action, options) {
       var simContact = {};
@@ -109,7 +109,13 @@ define(function() {
           simContact.tel[0].value = '';
           break;
       }
-      return simContact;
+
+      var result = new window.mozContact(simContact);
+      if ('id' in simContact) {
+        result.id = simContact.id;
+      }
+
+      return result;
     }
   };
 

--- a/tests/atoms/gaia_data_layer.js
+++ b/tests/atoms/gaia_data_layer.js
@@ -110,7 +110,12 @@ var GaiaDataLayer = {
     var iccId = window.navigator.mozIccManager.iccIds[0];
     var icc = window.navigator.mozIccManager.getIccById(iccId);
 
-    var req = icc.updateContact(aType, aContact);
+    var simContact = new window.mozContact(aContact);
+    if ('id' in aContact) {
+      simContact.id = aContact.id;
+    }
+
+    var req = icc.updateContact(aType, simContact);
     req.onsuccess = function() {
       console.log('success saving contact to SIM');
       marionetteScriptFinished(req.result);


### PR DESCRIPTION
This is to have explicit data type 'mozContact' in MozIcc.updateContact() instead of 'any'.
After review the implementation in Gaia, there are 2 modules infected
1. Contacts App for the ADN contacts in UICC.
2. Settings App for the FDN contacts in UICC.
However Contacts App already apply mozContact as the input of MozIcc.updateContact().
What we have to do is to have FDN contacts wrapped with mozContact.
