### PR TITLE
Revert "Bug 1179993 - debug.peformancedata.shared should be debug.per...", because it caused a test failure in make_test.js

### DIFF
--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -62,7 +62,7 @@
    "debug.ttl.enabled": false,
    "debug.log-animations.enabled": false,
    "debug.paint-flashing.enabled": false,
-   "debug.performance_data.shared": false,
+   "debug.peformancedata.shared": false,
    "debug.gaia.enabled": false,
    "deviceinfo.build_number": "",
    "deviceinfo.firmware_revision": "",


### PR DESCRIPTION
Reverts mozilla-b2g/gaia#30841
