### PR TITLE
Bug 1180819 - Add features in imagecompare to help automating RTL acceptance tests

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/app.py
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 from marionette_driver import expected, By, Wait
 
@@ -10,6 +10,12 @@ from gaiatest.apps.base import Base
 class Settings(Base):
 
     name = 'Settings'
+
+    _bluetooth_l10n_locator = (By.CSS_SELECTOR, '[data-l10n-id="bt-status-turnoff"]')
+
+    _header_locator = (By.CSS_SELECTOR, '.current gaia-header')
+    _non_gaia_header_locator = (By.CSS_SELECTOR, '.current header')
+    _page_locator = (By.ID, 'root')
 
     _header_text_locator = (By.CSS_SELECTOR, '#root > gaia-header > h1')
     _data_text_locator = (By.ID, 'data-desc')
@@ -30,29 +36,57 @@ class Settings(Base):
     _usb_storage_confirm_button_locator = (By.CSS_SELECTOR, "button.ums-confirm-option")
     _gps_enabled_locator = (By.XPATH, "//input[@name='geolocation.enabled']")
     _gps_switch_locator = (By.XPATH, "//input[@name='geolocation.enabled']/..")
-    _accessibility_menu_item_locator = (By.ID, 'menuItem-accessibility')
+
+    # Following menu item list matches the menu item order in the settings app
+    _wifi_menu_item_locator = (By.ID, 'menuItem-wifi')
+    _sim_manager_menu_item_locator = (By.ID, 'menuItem-simManager')
+    _call_settings_menu_item_locator = (By.ID, 'menuItem-callSettings')
+    _message_settings_menu_item_locator = (By.ID, 'menuItem-messagingSettings')
     _cell_data_menu_item_locator = (By.ID, 'menuItem-cellularAndData')
     _bluetooth_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-bluetooth')
+    _internet_sharing_menu_item_locator = (By.ID, 'menuItem-internetSharing')
+
     _sound_menu_item_locator = (By.ID, 'menuItem-sound')
-    _keyboard_menu_item_locator = (By.ID, "menuItem-keyboard")
-    _language_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-languageAndRegion')
-    _do_not_track_menu_item_locator = (By.ID, 'menuItem-doNotTrack')
-    _media_storage_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-mediaStorage')
-    _screen_lock_menu_item_locator = (By.ID, 'menuItem-screenLock')
     _display_menu_item_locator = (By.ID, 'menuItem-display')
-    _wifi_menu_item_locator = (By.ID, 'menuItem-wifi')
-    _device_info_menu_item_locator = (By.ID, 'menuItem-deviceInfo')
-    _battery_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-battery')
-    _sim_manager_menu_item_locator = (By.ID, 'menuItem-simManager')
-    _date_and_time_menu_item_locator = (By.ID, 'menuItem-dateAndTime')
     _homescreen_menu_item_locator = (By.ID, 'menuItem-homescreen')
-    _browsing_privacy_item_locator = (By.ID, 'menuItem-browsingPrivacy')
+    _search_menu_item_locator = (By.ID, 'menuItem-search')
+    _navigation_menu_item_locator = (By.ID, 'menuItem-navigation')
+    _notification_menu_item_locator = (By.ID, 'menuItem-notifications')
+    _date_and_time_menu_item_locator = (By.ID, 'menuItem-dateAndTime')
+    _language_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-languageAndRegion')
+    _keyboard_menu_item_locator = (By.ID, "menuItem-keyboard")
+    _theme_menu_item_locator = (By.ID, "menuItem-themes")
+    _addon_menu_item_locator = (By.ID, "menuItem-addons")
+    _achievements_menu_item_locator = (By.ID, "achievements-section")
+
+    _firefox_accounts_menu_item_locator = (By.ID, "menuItem-fxa")
     _findmydevice_locator = (By.ID, 'menuItem-findmydevice')
+
+    _screen_lock_menu_item_locator = (By.ID, 'menuItem-screenLock')
+    _app_permission_menu_item_locator = (By.ID, 'menuItem-appPermissions')
+    _do_not_track_menu_item_locator = (By.ID, 'menuItem-doNotTrack')
+    _browsing_privacy_item_locator = (By.ID, 'menuItem-browsingPrivacy')
+    _media_storage_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-mediaStorage')
+    _application_storage_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-applicationStorage')
+
+    _device_info_menu_item_locator = (By.ID, 'menuItem-deviceInfo')
+    _downloads_menu_item_locator = (By.ID, 'menuItem-downloads')
+    _battery_menu_item_locator = (By.CSS_SELECTOR, '.menuItem-battery')
+    _accessibility_menu_item_locator = (By.ID, 'menuItem-accessibility')
+    _developer_menu_item_locator = (By.ID, 'menuItem-developer')
+    _improve_menu_item_locator = (By.ID, 'menuItem-improveBrowserOS')
+    _help_menu_item_locator = (By.ID, 'menuItem-help')
+
+    _main_title_locator = (By.ID, 'main-list-title')
 
     def launch(self):
         Base.launch(self)
         Wait(self.marionette).until(
             expected.element_present(*self._app_loaded_locator))
+
+        # this is located at the end of the page.  If this is shown, everything is rendered.
+        Wait(self.marionette).until(
+            expected.element_present(*self._bluetooth_l10n_locator))
 
     def switch_to_settings_app(self):
         Wait(self.marionette).until(
@@ -144,97 +178,131 @@ class Settings(Base):
     def bluetooth_menu_item_description(self):
         return self.marionette.find_element(*self._bluetooth_text_locator).text
 
-    def a11y_open_accessibility_settings(self):
-        from gaiatest.apps.settings.regions.accessibility import Accessibility
-        self._a11y_click_menu_item(self._accessibility_menu_item_locator)
-        return Accessibility(self.marionette)
+    @property
+    def screen_element(self):
+        return self.marionette.find_element(*self._page_locator)
 
-    def open_cell_and_data_settings(self):
-        from gaiatest.apps.settings.regions.cell_data import CellData
-        self._tap_menu_item(self._cell_data_menu_item_locator)
-        return CellData(self.marionette)
+    @property
+    def title(self):
+        return self.marionette.find_element(*self._main_title_locator)
 
-    def open_bluetooth_settings(self):
-        from gaiatest.apps.settings.regions.bluetooth import Bluetooth
-        self._tap_menu_item(self._bluetooth_menu_item_locator)
-        return Bluetooth(self.marionette)
+    def open_wifi(self):
+        return self._open_subpage(self._wifi_menu_item_locator, 'wifi', 'Wifi')
 
-    def open_sound_settings(self):
-        from gaiatest.apps.settings.regions.sound import Sound
-        self._tap_menu_item(self._sound_menu_item_locator)
-        return Sound(self.marionette)
+    def open_sim_manager(self):
+        return self._open_subpage(self._sim_manager_menu_item_locator, 'sim_manager', 'SimManager')
 
-    def open_keyboard_settings(self):
-        from gaiatest.apps.settings.regions.keyboard import Keyboard
-        self._tap_menu_item(self._keyboard_menu_item_locator)
-        return Keyboard(self.marionette)
+    def open_call(self):
+        return self._open_subpage(self._call_settings_menu_item_locator)
 
-    def open_language_settings(self):
-        from gaiatest.apps.settings.regions.language import Language
-        self._tap_menu_item(self._language_menu_item_locator)
-        language_menu = Language(self.marionette)
+    def open_message(self):
+        return self._open_subpage(self._message_settings_menu_item_locator)
+
+    def open_cell_and_data(self):
+        return self._open_subpage(self._cell_data_menu_item_locator, 'cell_data', 'CellData')
+
+    def open_bluetooth(self):
+        return self._open_subpage(self._bluetooth_menu_item_locator, 'bluetooth', 'Bluetooth')
+
+    def open_internet_sharing(self):
+        return self._open_subpage(self._internet_sharing_menu_item_locator)
+
+    def open_sound(self):
+        return self._open_subpage(self._sound_menu_item_locator, 'sound', 'Sound')
+
+    def open_display(self):
+        return self._open_subpage(self._display_menu_item_locator, 'display', 'Display')
+
+    def open_homescreen(self):
+        return self._open_subpage(self._homescreen_menu_item_locator, 'homescreen_settings',
+                                           'HomescreenSettings')
+
+    def open_search(self):
+        return self._open_subpage(self._search_menu_item_locator)
+
+    def open_navigation(self):
+        return self._open_subpage(self._navigation_menu_item_locator)
+
+    def open_notification(self):
+        return self._open_subpage(self._notification_menu_item_locator)
+
+    def open_date_and_time(self):
+        return self._open_subpage(self._date_and_time_menu_item_locator, 'date_and_time', 'DateAndTime')
+
+    def open_language(self):
+        language_menu = self._open_subpage(self._language_menu_item_locator, 'language', 'Language')
         language_menu.wait_for_languages_to_load()
         return language_menu
 
-    def open_do_not_track_settings(self):
-        from gaiatest.apps.settings.regions.do_not_track import DoNotTrack
-        self._tap_menu_item(self._do_not_track_menu_item_locator)
-        return DoNotTrack(self.marionette)
+    def open_keyboard(self):
+        return self._open_subpage(self._keyboard_menu_item_locator, 'keyboard', 'Keyboard')
 
-    def open_media_storage_settings(self):
-        from gaiatest.apps.settings.regions.media_storage import MediaStorage
-        self._tap_menu_item(self._media_storage_menu_item_locator)
-        return MediaStorage(self.marionette)
+    def open_themes(self):
+        return self._open_subpage(self._theme_menu_item_locator)
 
-    def open_screen_lock_settings(self):
-        from gaiatest.apps.settings.regions.screen_lock import ScreenLock
-        self._tap_menu_item(self._screen_lock_menu_item_locator)
-        return ScreenLock(self.marionette)
+    def open_addons(self):
+        return self._open_subpage(self._addon_menu_item_locator)
 
-    def open_display_settings(self):
-        from gaiatest.apps.settings.regions.display import Display
-        self._tap_menu_item(self._display_menu_item_locator)
-        return Display(self.marionette)
+    def open_achievements(self):
+        return self._open_subpage(self._achievements_menu_item_locator)
 
-    def open_wifi_settings(self):
-        from gaiatest.apps.settings.regions.wifi import Wifi
-        self._tap_menu_item(self._wifi_menu_item_locator)
-        return Wifi(self.marionette)
-
-    def open_date_and_time_settings(self):
-        from gaiatest.apps.settings.regions.date_and_time import DateAndTime
-        self._tap_menu_item(self._date_and_time_menu_item_locator)
-        return DateAndTime(self.marionette)
+    def open_firefox_accounts(self):
+        return self._open_subpage(self._firefox_accounts_menu_item_locator)
 
     def open_findmydevice(self):
-        from gaiatest.apps.settings.regions.findmydevice import FindMyDevice
-        self._tap_menu_item(self._findmydevice_locator)
-        return FindMyDevice(self.marionette)
+        return self._open_subpage(self._findmydevice_locator, 'findmydevice', 'FindMyDevice')
 
-    def open_device_info_settings(self):
-        from gaiatest.apps.settings.regions.device_info import DeviceInfo
-        self._tap_menu_item(self._device_info_menu_item_locator)
-        return DeviceInfo(self.marionette)
+    def open_screen_lock(self):
+        return self._open_subpage(self._screen_lock_menu_item_locator, 'screen_lock', 'ScreenLock')
 
-    def open_battery_settings(self):
-        from gaiatest.apps.settings.regions.battery import Battery
-        self._tap_menu_item(self._battery_menu_item_locator)
-        return Battery(self.marionette)
+    def open_app_permissions(self):
+        return self._open_subpage(self._app_permission_menu_item_locator)
 
-    def open_sim_manager_settings(self):
-        from gaiatest.apps.settings.regions.sim_manager import SimManager
-        self._tap_menu_item(self._sim_manager_menu_item_locator)
-        return SimManager(self.marionette)
+    def open_do_not_track(self):
+        return self._open_subpage(self._do_not_track_menu_item_locator, 'do_not_track', 'DoNotTrack')
 
-    def open_homescreen_settings(self):
-        from gaiatest.apps.settings.regions.homescreen_settings import HomescreenSettings
-        self._tap_menu_item(self._homescreen_menu_item_locator)
-        return HomescreenSettings(self.marionette)
+    def open_browsing_privacy(self):
+        return self._open_subpage(self._browsing_privacy_item_locator, 'browsing_privacy', 'BrowsingPrivacy')
 
-    def open_browsing_privacy_settings(self):
-        from gaiatest.apps.settings.regions.browsing_privacy import BrowsingPrivacy
-        self._tap_menu_item(self._browsing_privacy_item_locator)
-        return BrowsingPrivacy(self.marionette)
+    def open_media_storage(self):
+        return self._open_subpage(self._media_storage_menu_item_locator, 'media_storage', 'MediaStorage')
+
+    def open_application_storage(self):
+        return self._open_subpage(self._application_storage_menu_item_locator)
+
+    def open_device_info(self):
+        return self._open_subpage(self._device_info_menu_item_locator, 'device_info', 'DeviceInfo')
+
+    def open_downloads(self):
+        return self._open_subpage(self._downloads_menu_item_locator)
+
+    def open_battery(self):
+        return self._open_subpage(self._battery_menu_item_locator, 'battery', 'Battery')
+
+    def open_accessibility(self):
+        return self._open_subpage(self._accessibility_menu_item_locator, 'accessibility', 'Accessibility')
+
+    def open_developer(self):
+        return self._open_subpage(self._developer_menu_item_locator)
+
+    def open_improve(self):
+        return self._open_subpage(self._improve_menu_item_locator)
+
+    def open_help(self):
+        return self._open_subpage(self._help_menu_item_locator)
+
+    def _open_subpage(self, locator, file_name=None, class_name=None):
+        self._tap_menu_item(locator)
+        class_object = self._get_class_by_name(file_name, class_name)
+        if class_object is not None:
+            return class_object(self.marionette)
+
+    def _get_class_by_name(self, file_name=None, class_name=None):
+        if file_name is not None:
+            package_path = 'gaiatest.apps.settings.regions.{}'.format(file_name.lower())
+            mod = __import__(package_path, fromlist=[class_name])
+            class_defn = getattr(mod, class_name)
+            return class_defn
 
     @property
     def is_airplane_mode_visible(self):
@@ -276,3 +344,13 @@ class Settings(Base):
     def _wait_for_toggle_ready(self, by, locator):
         checkbox = self.marionette.find_element(by, locator)
         Wait(self.marionette).until(expected.element_enabled(checkbox))
+
+    # this method is a copy of go_back() method in regions/keyboard.py
+    def return_to_prev_menu(self, parent_view, gaia_header=True):
+
+        # TODO: remove tap with coordinates after Bug 1061698 is fixed
+        if gaia_header:
+            self.marionette.find_element(*self._header_locator).tap(25, 25)
+        else:
+            self.marionette.find_element(*self._non_gaia_header_locator).tap(25, 25)
+        Wait(self.marionette).until(expected.element_displayed(parent_view))

--- a/tests/python/gaia-ui-tests/gaiatest/gaia_graphics_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_graphics_test.py
@@ -17,6 +17,7 @@ from mozlog.structured import get_default_logger
 
 from gaiatest import GaiaTestCase
 from gaiatest.apps.system.app import System
+from gaiatest import DEFAULT_SETTINGS
 
 
 class GaiaImageCompareTestCase(GaiaTestCase):
@@ -27,6 +28,8 @@ class GaiaImageCompareTestCase(GaiaTestCase):
         self.fuzz_factor = kwargs.pop('fuzz_factor')
         self.reference_path = kwargs.pop('reference_path')
         self.screenshots_path = kwargs.pop('screenshots_path')
+        self.mismatch_path = os.path.join(self.screenshots_path, 'mismatches')
+        self.locale = kwargs.pop('locale')
 
         self.logger = get_default_logger()
         self.picture_index = 0
@@ -48,17 +51,24 @@ class GaiaImageCompareTestCase(GaiaTestCase):
         """At the end of test execution, it checks for the errors"""
         self.assertTrue(self.test_passed, msg=self.failcomment)
 
-    def take_screenshot(self):
-        """invokes screen capture event, crops the status bar, and saves to the file"""
+    # marionette hook to override default locale setting
+    def modify_settings(self, settings):
 
-        time.sleep(2)  # compensate for the time taken for actual action on previous step
+        if self.locale != 'undefined':
+            settings['language.current'] = self.locale
+        return settings
+
+    def take_screenshot(self,page_name = None):
+        """
+        invokes screen capture event, crops the status bar, and saves to the file
+        page_name: a (optional) name that is given to the screenshot image file
+        """
 
         # if the status bar is visible, crop it off
         current_frame = self.marionette.get_active_frame()
         self.marionette.switch_to_frame()
 
         _statusbar_locator = (By.ID, 'statusbar')
-        #if self.is_element_displayed(*System._status_bar_locator):
         if self.is_element_displayed(*_statusbar_locator):
         # get the size of the status bar to crop off
             status_bar = self.marionette.find_element(*System._status_bar_locator)
@@ -74,17 +84,23 @@ class GaiaImageCompareTestCase(GaiaTestCase):
         screenshot = self.marionette.screenshot(format="binary")
         self.marionette.set_context(self.marionette.CONTEXT_CONTENT)
 
-        # obtain reference filename
-        reference_filename = os.path.join(self.reference_path, '%s_%s_%s.png' % (
-            self.methodName, self.device_name, self.picture_index))
+        # Format: test_name.page_name(parameter).locale.device_name.index.png
+        reference_filename = os.path.join(self.reference_path, '%s_%s_%s_%s_%s.png' % (
+            self.methodName, page_name, self.device_name,
+            self.data_layer.get_setting('language.current'),
+            self.picture_index))
 
         # determine the image file name (path included)
         if self.store_reference_image:
             filename = reference_filename
         else:
+            # obtain screenshot filename
+            # Format: test_name.page_name(parameter).locale.device_name.index.timestamp.png
             timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
-            filename = os.path.join(self.screenshots_path, '%s_%s_%s+%s.png' % (
-                self.methodName, self.device_name, self.picture_index, timestamp))
+            filename = os.path.join(self.screenshots_path, '%s_%s_%s_%s_%s+%s.png' % (
+                self.methodName, page_name, self.device_name,
+                self.data_layer.get_setting('language.current'),
+                self.picture_index, timestamp))
 
         # save the image after cropping it
         im = Image.open(StringIO(screenshot))
@@ -109,30 +125,40 @@ class GaiaImageCompareTestCase(GaiaTestCase):
             else:
                 error_msg = "Ref file not found for: " + filename + '\n'
             if error_msg != "":
-                self.logger.critical(error_msg)
+                #self.logger.critical(error_msg)  uncomment for debugging
                 self.failcomment += error_msg
                 self.test_passed = False
 
         self.picture_index += 1
 
-    def image_compare(self, target_img, ref_img, diff_img, fuzz_value):
+    def image_compare(self, target, ref, diff, fuzz_value):
         """do single image compare using the convert console command of ImageMagick"""
 
         message = ""
 
         p = subprocess.Popen(
-            ["compare", "-fuzz", str(fuzz_value) + "%", "-metric", "AE", target_img, ref_img, diff_img],
+            ["compare", "-fuzz", str(fuzz_value) + "%", "-metric", "AE", target, ref, diff],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         p.wait()
 
         if not (err == '0\n' or err == '0'):
             err = err.replace('\n', '')
-            message = 'WARNING: ' + err + ' pixels mismatched between ' + target_img + ' and ' + ref_img + '\n'
+            message = 'WARNING: ' + err + ' pixels mismatched between ' + target + ' and ' + ref + '\n'
+
+            # move the diff image and the target image to a separate folder
+            if not os.path.exists(self.mismatch_path):
+                os.makedirs(self.mismatch_path)
+            target_image_name = target[target.rfind("/")+1:]
+            diff_image_name = diff[diff.rfind("/") + 1:]
+            os.rename(target, os.path.join(self.mismatch_path, target_image_name))
+            os.rename(diff, os.path.join(self.mismatch_path, diff_image_name))
 
         return message
 
-    def edge_scroll(self, frame, direction, dist, release=True):
+    # Make UI action related methods static, so they can be used outside the GaiaImageCompareTestCase object as well.
+    @staticmethod
+    def edge_scroll(marionette, frame, direction, dist, release=True):
         """edge scroll - performs task switching action.
 
         direction = 'LtoR' or 'RtoL' (finger movement direction)
@@ -154,7 +180,8 @@ class GaiaImageCompareTestCase(GaiaTestCase):
         limit = dist * frame.size['width']
         dist_unit = limit * time_increment
 
-        action = Actions(self.marionette)
+        assert isinstance(marionette, object)
+        action = Actions(marionette)
         action.press(frame, start_x, frame.size['height'] / 2)  # press either the left or right edge
 
         while abs(dist_travelled) < abs(limit):
@@ -164,16 +191,19 @@ class GaiaImageCompareTestCase(GaiaTestCase):
         if release:
             action.release()
         action.perform()
+        time.sleep(1)  # compensate for the time taken for edge scroll to bring another app to active
 
         return action
 
-    def pinch(self, locator, zoom, duration=200):
+    @staticmethod
+    def pinch(marionette, locator, zoom, duration=200):
         """pinch method - works for gallery. Bug 1025167 is raised for the Browser pinch method.
 
         zoom = 'in' or 'out'
         level = level of zoom, 'low' or 'high'"""
 
-        screen = self.marionette.find_element(*locator)
+        assert isinstance(marionette, object)
+        screen = marionette.find_element(*locator)
         mid_x = screen.size['width'] / 2
         mid_y = screen.size['height'] / 2
 
@@ -193,18 +223,25 @@ class GaiaImageCompareTestCase(GaiaTestCase):
             disp_x = - mid_x / 2
             disp_y = - mid_y / 2
 
-        pinch(self.marionette, screen, init_index_x, init_index_y, init_thumb_x, init_thumb_y,
+        pinch(marionette, screen, init_index_x, init_index_y, init_thumb_x, init_thumb_y,
               -disp_x, -disp_y, disp_x, disp_y, duration)
+        time.sleep(1)  # compensate for the time taken for pinch to complete
 
-    def scroll(self, locator, direction, distance, increments=None):
+    @staticmethod
+    def scroll( marionette, direction, distance,locator=None,screen=None, increments=None):
         """scroll - uses smooth_scroll method in gestures.py.
 
         direction = 'up' or 'down' (page location)
         distance = total distance to travel
         increments = rate of scroll
+        locator = locator of the screen that needs to be scrolled
+        screen = screen element that needs to be scrolled
+        locator is for backwards compatibility. screen should be used
         perform release afterwards """
 
-        screen = self.marionette.find_element(*locator)
+        if screen is None:
+            assert isinstance(marionette, object)
+            screen = marionette.find_element(*locator)
         vector = -1
         axis = 'x'
         if direction == 'up' or direction == 'down':
@@ -214,4 +251,5 @@ class GaiaImageCompareTestCase(GaiaTestCase):
         if direction == 'up' or direction == 'left':
             vector = 0
 
-        smooth_scroll(self.marionette, screen, axis, vector, distance, increments)
+        smooth_scroll(marionette, screen, axis, vector, distance, increments)
+        time.sleep(1)  # compensate for the time taken for dynamic scroll

--- a/tests/python/gaia-ui-tests/gaiatest/mixins/imagecompare.py
+++ b/tests/python/gaia-ui-tests/gaiatest/mixins/imagecompare.py
@@ -33,7 +33,12 @@ class GaiaImageCompareOptionsMixin(object):
 
         group.add_option('--screenshots-path',
                          default="screenshots",
-                         help="Path for screenshot images, relative to t he current location, "
+                         help="Path for screenshot images, relative to the current location, "
                               "Default folder is %default")
+
+        group.add_option('--locale',
+                         default = "undefined",
+                         help = "locale for the device, "
+                                "When not defined, will use the value from testvars.json file")
 
         self.verify_usage_handlers.append(self.check_fuzz_factor)

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/RTL/test_settings_RTL_POC.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/RTL/test_settings_RTL_POC.py
@@ -1,0 +1,177 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from gaiatest.gaia_graphics_test import GaiaImageCompareTestCase
+from gaiatest.apps.settings.app import Settings
+
+
+class TestSettingsRTL(GaiaImageCompareTestCase):
+
+    def test_settings_app(self):
+
+        settings = Settings(self.marionette)
+        settings.launch()
+
+        self.take_screenshot('main')
+        for i in range(0, 4):
+            GaiaImageCompareTestCase.scroll(self.marionette, 'down',
+                                            settings.screen_element.size['height'], screen=settings.screen_element)
+            self.take_screenshot('main')
+
+        #opening each subpage in Settings menu.  Privacy Control is not opened, because it is a separate app
+        #some subpages have their own subpages, and they need to be opened as well.
+        settings.open_wifi()
+        self.take_screenshot('wifi')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_sim_manager()
+        self.take_screenshot('sim_manager')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_call()
+        self.take_screenshot('call')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_message()
+        self.take_screenshot('message')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_cell_and_data()
+        self.take_screenshot('cell_and_data')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_bluetooth()
+        self.take_screenshot('bluetooth')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_internet_sharing()
+        self.take_screenshot('internet_sharing')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_sound()
+        self.take_screenshot('sound')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_display()
+        self.take_screenshot('display')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_homescreen()
+        self.take_screenshot('homescreen')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_search()
+        self.take_screenshot('search')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_navigation()
+        self.take_screenshot('navigation')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_notification()
+        self.take_screenshot('notification')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_date_and_time()
+        self.take_screenshot('date_and_time')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_language()
+        self.take_screenshot('language')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_keyboard()
+        self.take_screenshot('keyboard')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_themes()
+        self.take_screenshot('themes')
+        settings.return_to_prev_menu(settings.screen_element, gaia_header=False)
+
+        settings.open_addons()
+        self.take_screenshot('addons')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_achievements()
+        self.take_screenshot('achievements')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_firefox_accounts()
+        self.take_screenshot('firefox_accounts')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_findmydevice()
+        self.take_screenshot('findmydevice')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_screen_lock()
+        self.take_screenshot('screen_lock')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_app_permissions()
+        self.take_screenshot('app_permissions')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_do_not_track()
+        self.take_screenshot('do_not_track')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_browsing_privacy()
+        self.take_screenshot('browsing_privacy')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_media_storage()
+        self.take_screenshot('media_storage')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_application_storage()
+        self.take_screenshot('application_storage')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        ### Device Information and its sub pages
+        device_info_page = settings.open_device_info()
+        self.take_screenshot('dev_info')
+        GaiaImageCompareTestCase.scroll(self.marionette, 'down', device_info_page.screen_element.size['height'],
+                                        screen=device_info_page.screen_element)
+        self.take_screenshot('dev_info')
+
+        moreinfo_page = device_info_page.tap_more_info()
+        self.take_screenshot('dev_info-more_info')
+        GaiaImageCompareTestCase.scroll(self.marionette, 'down', device_info_page.screen_element.size['height'],
+                                        screen=moreinfo_page.screen)
+        self.take_screenshot('dev_info-more_info')
+        settings.return_to_prev_menu(device_info_page.screen_element)
+
+        device_info_page.tap_reset_phone()
+        self.take_screenshot('dev_info-reset')
+        device_info_page.confirm_reset(False)
+
+        device_info_page.tap_update_frequency()
+        self.take_screenshot('dev_info-update-freq')
+        device_info_page.exit_update_frequency()
+        settings.return_to_prev_menu(settings.screen_element)
+
+        ### Downloads page
+        settings.open_downloads()
+        self.take_screenshot('downloads')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_battery()
+        self.take_screenshot('battery')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_accessibility()
+        self.take_screenshot('accessibility')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_developer()
+        self.take_screenshot('developer')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_improve()
+        self.take_screenshot('improve')
+        settings.return_to_prev_menu(settings.screen_element)
+
+        settings.open_help()
+        self.take_screenshot('help')
+        settings.return_to_prev_menu(settings.screen_element)


### PR DESCRIPTION
following features are added to imagecompare:
- specify locale as gaiatest parameter
- put custom name per screenshot
- move failed diffs into mismatch folder

and a script is created to demo the RTL test automation in settings app
