### PR TITLE
Bug 1182330 - [Clock] expose set alarm functionality through IAC for the Vaani app r=mcav

### DIFF
--- a/apps/clock/js/app.js
+++ b/apps/clock/js/app.js
@@ -3,6 +3,7 @@ define(function(require) {
 
 var Tabs = require('tabs');
 var View = require('view');
+var connectionHandler = require('connection/handler');
 var rAF = mozRequestAnimationFrame || requestAnimationFrame;
 
 /**
@@ -13,6 +14,7 @@ var App = {
    * Load the Tabs and Panels, attach events and navigate to the default view.
    */
   init: function() {
+    connectionHandler.init();
     this.tabs = new Tabs(document.getElementById('clock-tabs'));
 
     window.addEventListener('hashchange', this);

--- a/apps/clock/js/connection/create_alarm.js
+++ b/apps/clock/js/connection/create_alarm.js
@@ -1,0 +1,42 @@
+define(function(require, exports, module) {
+'use strict';
+
+var Alarm = require('alarm');
+var parseTime = require('ext/parse_loose_time');
+
+module.exports = function(event, port) {
+  var time = event.data.time;
+  var timeObject = typeof time === 'object' ? time : parseTime(time);
+
+  if (!isValidTime(timeObject)) {
+    port.postMessage({
+      error: `Invalid alarm time "${time}"`
+    });
+    return;
+  }
+
+  var alarm = new Alarm(timeObject);
+  alarm.schedule('normal').then(() => {
+    window.dispatchEvent(new CustomEvent('alarm-changed', {
+      detail: { alarm: alarm, showBanner: false }
+    }));
+    port.postMessage({
+      hour: timeObject.hour,
+      minute: timeObject.minute,
+      time: alarm.getNextAlarmFireTime().getTime()
+    });
+  }).catch(err => {
+    port.postMessage({
+      error: `${err.message} ${err.stack}`
+    });
+  });
+};
+
+function isValidTime(time) {
+  // time can be "null" and "typeof null === 'object'"
+  return time && typeof time === 'object' && 'hour' in time &&
+    time.hour >= 0 && time.hour <= 24 && 'minute' in time &&
+    time.minute >= 0 && time.minute <= 59;
+}
+
+});

--- a/apps/clock/js/connection/handler.js
+++ b/apps/clock/js/connection/handler.js
@@ -1,0 +1,22 @@
+define(function(require, exports) {
+'use strict';
+
+var handlers = {
+  'create_alarm': require('./create_alarm')
+};
+
+exports.init = function() {
+  navigator.mozSetMessageHandler('connection', req => {
+    var port = req.port;
+    var handler = handlers[req.keyword];
+
+    if (!handler) {
+      console.error(`can't find handler for connection "${req.keyword}"`);
+      return;
+    }
+
+    port.onmessage = event => handler(event, port);
+  });
+};
+
+});

--- a/apps/clock/js/ext/parse_loose_time.js
+++ b/apps/clock/js/ext/parse_loose_time.js
@@ -1,0 +1,138 @@
+/**
+ * parse-loose-time v1.0.0
+ * https://github.com/millermedeiros/parse-loose-time/
+ * released under the MIT License
+ */
+define(function(require, exports, module) {
+'use strict';
+
+// Release the ZALGO!
+var numeric = /\d{1,2}[^\d]*(\d{2})?/i;
+var oclock = /\d+.*o.*clock/i;
+var british = /(half|quarter|\d+).*(to|past)[^\d]*\d{1,2}/i;
+var knownWords = [
+  'noon',
+  'noontime',
+  'midday',
+  'half-day',
+  'midnight'
+];
+// match "p" after digit for "pm"
+var rPm = /\d\s*(o.*clock\s*)?p/i;
+
+var checkKnowWords = {
+  test: function(str) {
+    return knownWords.indexOf(str) !== -1;
+  }
+};
+
+var map = [
+  [checkKnowWords, parseWords],
+  [british, parseBritish],
+  [oclock, parseOClock],
+  [numeric, parseNumeric]
+];
+
+module.exports = parseTime;
+function parseTime(time) {
+  time = time.trim().toLowerCase();
+  // node 0.12 don't support Array#find :/
+  var fn;
+  map.some(function(a) {
+    if (a[0].test(time)) {
+      fn = a[1];
+      return true;
+    }
+  });
+  return fn ? fn(time) : null;
+}
+
+function parseNumeric(str) {
+  var hour;
+  var minute;
+  var num = extractNumbers(str);
+
+  switch (num.length) {
+    case 4:
+      hour = num.slice(0, 2);
+      minute = num.slice(2, 4);
+      break;
+    case 3:
+      hour = num.slice(0, 1);
+      minute = num.slice(1, 3);
+      break;
+    case 2:
+    case 1:
+      hour = num.slice(0, 2);
+      minute = 0;
+      break;
+    default:
+      return '';
+  }
+
+  hour = Number(hour);
+  minute = Number(minute);
+
+  if (num.length === 2 && hour > 24) {
+    return null;
+  }
+
+  if (hour < 12 && str.match(rPm)) {
+    hour += 12;
+  }
+
+  return {
+    hour: Math.min(hour, 24),
+    minute: Math.min(minute, 59)
+  };
+}
+
+function extractNumbers(str) {
+  return str.replace(/[^0-9]/g, '');
+}
+
+function parseOClock(str) {
+  // yes, we will consider "1:23 o'clock" the same as "1 o'clock"
+  var time = parseNumeric(str);
+  if (!time) {
+    return null;
+  }
+  time.minute = 0;
+  return time;
+}
+
+function parseBritish(str) {
+  // need to handle case where it is a custom numeric value
+  var parts = str.match(/(.+)(to|past)(.+)/i);
+  var time = parseNumeric(parts[3]);
+  if (!time) {
+    return null;
+  }
+
+  var diff;
+  if (str.indexOf('quarter') !== -1) {
+    diff = 15;
+  } else if (str.indexOf('half') !== -1) {
+    diff = 30;
+  } else {
+    diff = Number(extractNumbers(parts[1]));
+  }
+
+  var isTo = str.indexOf('to') !== -1;
+  if (isTo) {
+    time.hour -= 1;
+    time.minute = 60 - diff;
+  } else {
+    time.minute = diff;
+  }
+
+  return time;
+}
+
+function parseWords(str) {
+  if (str === 'midnight') {
+    return { hour: 0, minute: 0 };
+  }
+  return { hour: 12, minute: 0 };
+}
+});

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -41,6 +41,15 @@
     "284": "/style/icons/clock_284.png"
   },
   "orientation": "default",
+  "connections": {
+    "create_alarm": {
+      "handler_path": "/index.html",
+      "description": "Create alarm",
+      "rules": {
+        "manifestURLs": ["app://vaani.gaiamobile.org/manifest.webapp"]
+      }
+    }
+  },
   "messages": [
      { "alarm": "/index.html" }
   ]


### PR DESCRIPTION
usage is basically:

``` js
navigator.mozApps.getSelf().onsuccess = function() {
  this.result.connect('create_alarm').then(createAlarm);
};

function createAlarm(ports) {
  var port = ports[0];

  port.onmessage = function(event) {
    var data = event.data;
    if (data.error) {
      alert('Error setting alarm: ' + data.error);
      return;
    }
    alert('Alarm set to: ' + (new Date(data.time)));
  };

  port.postMessage({ time: '9 30 am' });
}
```

uses an external library for the time parsing: https://github.com/millermedeiros/parse-loose-time/
