### PR TITLE
Bug 1181201 - Use autoplay attribute on tutorial video

### DIFF
--- a/apps/ftu/index.html
+++ b/apps/ftu/index.html
@@ -644,7 +644,7 @@
       </section>
       <section id="tutorial-step-media">
         <img id="tutorial-step-image" class="step-img-base" role="presentation">
-        <video id="tutorial-step-video" class="step-video-base" role="presentation" preload="auto" hidden loop></video>
+        <video id="tutorial-step-video" class="step-video-base" role="presentation" autoplay hidden loop></video>
       </section>
     </article>
     <gaia-buttons id="tutorial-nav-bar" class="nav" skin="dark">

--- a/tests/python/gaia-unit-tests/gaia_unit_test/disabled.json
+++ b/tests/python/gaia-unit-tests/gaia_unit_test/disabled.json
@@ -1,5 +1,4 @@
 [
   "communications/facebook/test/unit/facebook_connector_test.js",
-  "ftu/test/unit/tutorial_test.js",
   "keyboard/test/unit/imes/jspinyin/jspinyin_test.js"
 ]


### PR DESCRIPTION
Swap the preload="auto" with autoplay attribute - which is functionally equivalent in this context, 
