### PR TITLE
Bug 1182035 - Fixed app updates error in 2G

### DIFF
--- a/apps/system/js/update_manager.js
+++ b/apps/system/js/update_manager.js
@@ -258,7 +258,7 @@
         }
 
         //2G connection
-        if (self.connection2G) {
+        if (self.connection2G && self._systemUpdateDisplayed) {
           self.showForbiddenDownload();
           return;
         }

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -1610,7 +1610,7 @@ suite('system/UpdateManager', function() {
       },
       {
         title: 'Not WIFI, 2G, no Setting update2G, wifi prioritized' +
-          '-> download not available',
+          'System update available -> download not available',
         wifi: false,
         conns: [
           {
@@ -1623,11 +1623,30 @@ suite('system/UpdateManager', function() {
         ],
         update2g: false,
         wifiPrioritized: true,
+        systemUpdate: true,
         testResult: 'forbidden'
       },
       {
+        title: 'Not WIFI, 2G, no Setting update2G, wifi prioritized' +
+          'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            connected: false
+          },
+          {
+            type: 'gprs',
+            connected: true
+          }
+        ],
+        update2g: false,
+        wifiPrioritized: true,
+        systemUpdate: false,
+        testResult: 'wifiPrioritized'
+      },
+      {
         title: 'Not WIFI, 2G, no Setting update2G, wifi not prioritized' +
-          '-> download not available',
+          'System update available -> download not available',
         wifi: false,
         conns: [
           {
@@ -1640,7 +1659,26 @@ suite('system/UpdateManager', function() {
         ],
         update2g: false,
         wifiPrioritized: false,
+        systemUpdate: true,
         testResult: 'forbidden'
+      },
+      {
+        title: 'Not WIFI, 2G, no Setting update2G, wifi not prioritized' +
+          'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            connected: false
+          },
+          {
+            type: 'gprs',
+            connected: true
+          }
+        ],
+        update2g: false,
+        wifiPrioritized: false,
+        systemUpdate: false,
+        testResult: 'additionalCostIfNeeded'
       },
       {
         title: 'Not WIFI, No Data connection -> download not available',
@@ -1714,6 +1752,9 @@ suite('system/UpdateManager', function() {
             };
           }
         }
+
+        UpdateManager._systemUpdateDisplayed =
+           testCase.systemUpdate ? true : false;
 
         if (testCase.noConnection) {
           UpdateManager.downloadDialog.dataset.online = false;


### PR DESCRIPTION
Fixed so when only there are app updates and update.2g enabled is false and device is in 2G, they are not blocked
