### PR TITLE
Bug 1183175 - use gmail entry for mozillafoundation.org

### DIFF
--- a/apps/email/autoconfig/mozillafoundation.org
+++ b/apps/email/autoconfig/mozillafoundation.org
@@ -1,0 +1,30 @@
+<clientConfig version="1.1">
+  <emailProvider id="googlemail.com">
+    <domain>gmail.com</domain>
+    <domain>googlemail.com</domain>
+    <!-- MX, for Google Apps -->
+    <domain>google.com</domain>
+    <displayName>Google Mail</displayName>
+    <displayShortName>GMail</displayShortName>
+    <incomingServer type="imap">
+      <hostname>imap.gmail.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>xoauth2</authentication>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.gmail.com</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>xoauth2</authentication>
+    </outgoingServer>
+    <oauth2Settings>
+      <secretGroup>google</secretGroup>
+      <authEndpoint>https://accounts.google.com/o/oauth2/auth</authEndpoint>
+      <tokenEndpoint>https://accounts.google.com/o/oauth2/token</tokenEndpoint>
+      <scope>https://mail.google.com/</scope>
+    </oauth2Settings>
+  </emailProvider>
+</clientConfig>


### PR DESCRIPTION
Because of ISPDB bug 1177436 we need to copy the gmail.com entry to
mozillafoundation.org like we did for mozilla.com for slightly different
reasons.  (The transition from Zimbra to GMail necessitated it while we
were waiting for DNS changes that would make MX resolution work.)
