### PR TITLE
Bug 1183829 - Add update script for locale repositories.

### DIFF
--- a/locales/.gitignore
+++ b/locales/.gitignore
@@ -1,3 +1,4 @@
 *
 !*.json
 !README.md
+!update.sh

--- a/locales/update.sh
+++ b/locales/update.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Fetch or update Gaia language repositories.
+# Invoke as ./update.sh or ./update.sh your_language_file.json
+
+# Base url for localization repositories.
+# This is the default for the master branch.
+# For other branches append a version, e.g.:
+# BASE_URL=https://hg.mozilla.org/releases/gaia-l10n/v2_1/
+BASE_URL=https://hg.mozilla.org/gaia-l10n/
+
+if test -f "$1"; then
+  BASE_LANGUAGES=$1
+else
+  BASE_LANGUAGES=$(dirname $0)/languages_all.json
+fi
+
+locales=$(cat ${BASE_LANGUAGES} | awk '/".*"/ {print $1}' | sed 's/"//g')
+for lc in ${locales}; do
+  if test -d ${lc}; then
+    echo "Updating ${lc}..."
+    pushd ${lc}
+    hg pull -u
+    popd
+  else
+    echo "Fetching ${lc}..."
+    hg clone ${BASE_URL}${lc}
+  fi
+done


### PR DESCRIPTION
MDN causually says 'download all the repositories' for the locales one wants to include in gaia. Here's a quick script to automate that for all the locales in the languages.json file.

https://developer.mozilla.org/en-US/Firefox_OS/Building#Building_multilocale

Takes a language.json file as an argument, or uses languages_dev.json
if no argument is given. Then for each locale in the json file it
either clones the corresponding hg repository, or if the directory
already exists tries to update it.
