### PR TITLE
Revert "[email] Bump compose attachment size limit on trunk to 22MiB.…

### DIFF
--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -29,15 +29,9 @@ var cmpAttachmentItemNode = require('tmpl!./cmp/attachment_item.html'),
     dataIdCounter = 0;
 
 /**
- * Previously we limited to 5MiB because of device limitations primarily
- * related to downloading attachments larger than 5MiB on Tarako devices.
- * On more capable devices this is less of a concern and the dominating
- * factor becomes the limits of the mail providers themselves.  The value
- * converged upon by most providers is 25MiB.  Because of encoding overhead
- * and message body concerns, for now we're sticking to 22MiB, but we should
- * bump this as appropriate.
+ * Max composer attachment size is defined as 5120000 bytes.
  */
-var MAX_ATTACHMENT_SIZE = 22 * 1024 * 1024;
+var MAX_ATTACHMENT_SIZE = 5120000;
 
 /**
  * To make it easier to focus input boxes, we have clicks on their owning

--- a/apps/email/js/cards/message_reader.js
+++ b/apps/email/js/cards/message_reader.js
@@ -1081,10 +1081,7 @@ return [
             var attachment = body.attachments[iAttach], state;
             var extension = attachment.filename.split('.').pop();
 
-            // Keeping in-sync with the compose.js value of 22 now, plus some
-            // slop to deal with encoding and just be fine with the general
-            // provider upper bound of 25.
-            var MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024;
+            var MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024;
             var attachmentDownloadable = true;
             var mimeClass = mimeToClass(attachment.mimetype ||
                             MimeMapper.guessTypeFromExtension(extension));


### PR DESCRIPTION
Reverts mozilla-b2g/gaia#30962

Bug number didn't make it into the commit message.
