### PR TITLE
Bug 1182035 - Fixed app updates error in 2G

### DIFF
--- a/apps/system/js/update_manager.js
+++ b/apps/system/js/update_manager.js
@@ -246,7 +246,7 @@ var UpdateManager = {
       }
 
       //2G connection
-      if (self.connection2G) {
+      if (self.connection2G && self._systemUpdateDisplayed) {
         self.showForbiddenDownload();
         return;
       }

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -1603,8 +1603,8 @@ suite('system/UpdateManager', function() {
         roaming: true
       },
       {
-        title: 'Not WIFI, 2G, no Setting update2G, wifi prioritized' +
-          '-> download not available',
+        title: 'Not WIFI, 2G, no Setting update2G, wifi prioritized, ' +
+          'System update available -> download not available',
         wifi: false,
         conns: [
           {
@@ -1617,11 +1617,30 @@ suite('system/UpdateManager', function() {
         ],
         update2g: false,
         wifiPrioritized: true,
+        systemUpdate: true,
         testResult: 'forbidden'
       },
       {
-        title: 'Not WIFI, 2G, no Setting update2G, wifi not prioritized' +
-          '-> download not available',
+        title: 'Not WIFI, 2G, no Setting update2G, wifi prioritized, ' +
+          'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            connected: false
+          },
+          {
+            type: 'gprs',
+            connected: true
+          }
+        ],
+        update2g: false,
+        wifiPrioritized: true,
+        systemUpdate: false,
+        testResult: 'wifiPrioritized'
+      },
+      {
+        title: 'Not WIFI, 2G, no Setting update2G, wifi not prioritized, ' +
+          'System update available -> download not available',
         wifi: false,
         conns: [
           {
@@ -1634,7 +1653,26 @@ suite('system/UpdateManager', function() {
         ],
         update2g: false,
         wifiPrioritized: false,
+        systemUpdate: true,
         testResult: 'forbidden'
+      },
+      {
+        title: 'Not WIFI, 2G, no Setting update2G, wifi not prioritized, ' +
+          'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            connected: false
+          },
+          {
+            type: 'gprs',
+            connected: true
+          }
+        ],
+        update2g: false,
+        wifiPrioritized: false,
+        systemUpdate: false,
+        testResult: 'additionalCostIfNeeded'
       },
       {
         title: 'Not WIFI, No Data connection -> download not available',
@@ -1708,6 +1746,9 @@ suite('system/UpdateManager', function() {
             };
           }
         }
+
+        UpdateManager._systemUpdateDisplayed =
+           testCase.systemUpdate ? true : false;
 
         if (testCase.noConnection) {
           UpdateManager.downloadDialog.dataset.online = false;


### PR DESCRIPTION
Fixed so when only there are app updates and update.2g enabled is false and device is in 2G, they are not blocked
