### PR TITLE
Bug 1184820 - update imagecompare tests to accomodate changes in Bug 1180819

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/gaia_graphics_test.py
+++ b/tests/python/gaia-ui-tests/gaiatest/gaia_graphics_test.py
@@ -58,12 +58,13 @@ class GaiaImageCompareTestCase(GaiaTestCase):
             settings['language.current'] = self.locale
         return settings
 
-    def take_screenshot(self,page_name = None):
+    def take_screenshot(self,page_name=None, prewait=0):
         """
         invokes screen capture event, crops the status bar, and saves to the file
         page_name: a (optional) name that is given to the screenshot image file
         """
-
+        if prewait > 0:
+            time.sleep(prewait)
         # if the status bar is visible, crop it off
         current_frame = self.marionette.get_active_frame()
         self.marionette.switch_to_frame()

--- a/tests/python/gaia-ui-tests/gaiatest/mixins/imagecompare.py
+++ b/tests/python/gaia-ui-tests/gaiatest/mixins/imagecompare.py
@@ -21,7 +21,7 @@ class GaiaImageCompareOptionsMixin(object):
 
         group.add_option('--fuzz-factor',
                          type='int',
-                         default=10,
+                         default=15,
                          metavar='int',
                          help='fuzz value supplied to ImageMagick call, in percentage. '
                               'Default value is %default percent.')

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/orientation_zoom_base.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/orientation_zoom_base.py
@@ -8,7 +8,6 @@ from marionette_driver import By
 
 from gaiatest.gaia_graphics_test import GaiaImageCompareTestCase
 from gaiatest.apps.gallery.app import Gallery
-from gaiatest.apps.search.app import Search
 
 
 class OrientationZoomBase(GaiaImageCompareTestCase):
@@ -42,10 +41,13 @@ class OrientationZoomBase(GaiaImageCompareTestCase):
         # scroll back and forth in different display mode
         self.change_orientation('landscape-primary')
         self.take_screenshot()
-        self.scroll(image._current_image_locator, 'right', 400)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'right',
+                                        400, locator=image._current_image_locator)
+
         self.change_orientation('portrait-primary')
         self.take_screenshot()
-        self.scroll(image._current_image_locator, 'left', 400)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'left',
+                                        400, locator=image._current_image_locator)
 
         # flip A LOT
         for x in range(0, 4):
@@ -53,47 +55,29 @@ class OrientationZoomBase(GaiaImageCompareTestCase):
             self.change_orientation('portrait-primary')
         self.take_screenshot()
 
-        # do pinch zoom while filpping the phone
-        self.pinch(image._current_frame_locator, 'in', 20)
+        # do pinch zoom while flipping the phone
+        GaiaImageCompareTestCase.pinch(self.marionette, image._current_frame_locator, 'in', 20)
+
         self.take_screenshot()
-        self.scroll(image._current_frame_locator, 'right', 300)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'right',
+                                        300, locator=image._current_image_locator)
         self.take_screenshot()
         self.change_orientation('landscape-primary')
-        self.pinch(image._current_frame_locator, 'out', 50)
+        GaiaImageCompareTestCase.pinch(self.marionette, image._current_frame_locator, 'out', 50)
         self.take_screenshot()
         self.change_orientation('portrait-primary')
 
         image.double_tap_image()
-        self.take_screenshot()
+        self.take_screenshot(prewait=3) #takes time for zoom-in action to complete
 
         # go back and forth with flicking then exit gallery app
-        self.scroll(image._current_frame_locator, 'right', 150)
-        self.take_screenshot()
-        self.scroll(image._current_frame_locator, 'left', 150)
-        self.take_screenshot()
-        self.apps.kill(gallery.app)
-        time.sleep(2)
-        self.take_screenshot()
+        GaiaImageCompareTestCase.scroll(self.marionette, 'right',
+                                        150, locator=image._current_frame_locator)
 
-        # Launch browser.  Go to Mozilla FirefoxOS site
-        # Scroll up/down, change orientation, scroll up/down
-        # commented out due to bug 1127324
-
-        # search = Search(self.marionette)
-        # search.launch()
-        # browser = search.go_to_url('http://mozilla.org/firefoxos')
-        # browser.wait_for_page_to_load()
-        # browser.switch_to_content()
-        #
-        # self.take_screenshot()
-        # self.marionette.switch_to_frame()
-        # self.scroll(browser._browser_frame_locator, 'up', 400)
-        # self.take_screenshot()
-        # self.change_orientation('landscape-primary')
-        # self.scroll(browser._browser_frame_locator, 'down', 300)
-        # self.take_screenshot()
-        # self.scroll(browser._browser_frame_locator, 'down', 300)
-        # self.take_screenshot()
+        self.take_screenshot()
+        GaiaImageCompareTestCase.scroll(self.marionette, 'left',
+                                        150, locator=image._current_frame_locator)
+        self.take_screenshot()
 
     # take screenshot and pause, otherwise there will be a collision
     def change_orientation(self, orientation, wait=2):

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_browser_navigation.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_browser_navigation.py
@@ -37,5 +37,7 @@ class TestBrowserNavigation(GaiaImageCompareTestCase):
         self.take_screenshot()
 
         self.marionette.switch_to_frame()
-        self.scroll(browser._browser_frame_locator, 'down', 400)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'down',
+                                        400, locator=browser._browser_frame_locator)
+
         self.take_screenshot()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_calendar_flick.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_calendar_flick.py
@@ -38,23 +38,32 @@ class TestCalendar(GaiaImageCompareTestCase):
 
         calendar.tap_week_display_button()
         self.take_screenshot()
-        self.scroll(calendar._week_view_locator, 'down', 300)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'down',
+                                        300, locator=calendar._week_view_locator)
         self.take_screenshot()
-        self.scroll(calendar._week_view_locator, 'up', 300)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'up',
+                                        300, locator=calendar._week_view_locator)
         self.take_screenshot()
-        self.scroll(calendar._week_view_locator, 'right', 100)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'right',
+                                        100, locator=calendar._week_view_locator)
         self.take_screenshot()
-        self.scroll(calendar._week_view_locator, 'left', 100)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'left',
+                                        100, locator=calendar._week_view_locator)
         self.take_screenshot()
 
         calendar.tap_day_display_button()
         self.take_screenshot()
-        self.scroll(calendar._day_view_locator, 'down', 300)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'down',
+                                        300, locator=calendar._day_view_locator)
         self.take_screenshot()
-        self.scroll(calendar._day_view_locator, 'up', 300)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'up',
+                                        300, locator=calendar._day_view_locator)
         self.take_screenshot()
-        self.scroll(calendar._day_view_locator, 'right', 100)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'right',
+                                        100, locator=calendar._day_view_locator)
         self.take_screenshot()
-        self.scroll(calendar._day_view_locator, 'left', 100)
-        self.scroll(calendar._day_view_locator, 'left', 100)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'left',
+                                        100, locator=calendar._day_view_locator)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'left',
+                                        100, locator=calendar._day_view_locator)
         self.take_screenshot()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_drag_drop.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_drag_drop.py
@@ -19,7 +19,6 @@ class testDragDrop(GaiaImageCompareTestCase):
 
     def test_drag_drop(self):
 
-        self.take_screenshot()
         self.homescreen.wait_for_number_of_apps(1)
 
         # Assert that we are not in edit mode.

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_homescreen_change_wallpaper.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_homescreen_change_wallpaper.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import time
+
 from gaiatest.gaia_graphics_test import GaiaImageCompareTestCase
 from gaiatest.apps.homescreen.app import Homescreen
 
@@ -18,7 +20,8 @@ class TestHomescreenChangeWallpaper(GaiaImageCompareTestCase):
         https://moztrap.mozilla.org/manage/case/1902/
         reusing /functional/homescreen/test_homescreen_change_wallpaper.py script
         """
-
+        # wait until the homescreen is fully drawn
+        time.sleep(3)
         self.take_screenshot()
         homescreen = Homescreen(self.marionette)
         self.apps.switch_to_displayed_app()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_marketplace_download_execute_map_app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/test_marketplace_download_execute_map_app.py
@@ -71,10 +71,14 @@ class TestSearchMarketplaceAndInstallApp(GaiaImageCompareTestCase):
         self.take_screenshot()
 
         # move around
-        self.scroll(self._map_locator, 'right', 100)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'right',
+                                        100, locator=self._map_locator)
+
         time.sleep(self.draw_wait_time)
         self.take_screenshot()
-        self.scroll(self._map_locator, 'down', 100)
+        GaiaImageCompareTestCase.scroll(self.marionette, 'down',
+                                        100, locator=self._map_locator)
+
         time.sleep(self.draw_wait_time)
         self.take_screenshot()
 


### PR DESCRIPTION
Existing imagecompare tests need to use new scroll/pinch method, as well as deal with the reduced time.sleep() duration before taking screenshot.
