### PR TITLE
Bug 1184869 - Support new MozMobileMessage.getSmscAddress impl.

### DIFF
--- a/shared/js/simslot.js
+++ b/shared/js/simslot.js
@@ -138,16 +138,27 @@
       console.error('can\'t access mozMobileMessage');
       cb(null);
     } else {
-      var req = mobileMessage.getSmscAddress(this.index);
-      req.onsuccess = function() {
-        var smsc = this.result.split(',')[0].replace(/"/g, '');
-        cb(smsc);
-      };
-
-      req.onerror = function() {
-        console.error(this.error);
-        cb(null);
-      };
+      // The return type of getSmscAddress can be either a DOMRequest which
+      // resolves to a string for legacy implementations, or
+      // a Promise which resolves to a SmscAddress object in Bug 1043250.
+      mobileMessage.getSmscAddress(this.index).then(
+        (result) => {
+          var smsc;
+          // Keep the legacy behavior for backward compatibility. The legacy
+          // interface resolves to a string, and is always assumed to be in text
+          // mode.
+          if (typeof result === 'string' || result instanceof String) {
+            smsc = result.split(',')[0].replace(/"/g, '');
+          } else {
+            smsc = result.address;
+          }
+          cb(smsc);
+        },
+        (error) => {
+          console.error(error);
+          cb(null);
+        }
+      );
     }
   };
 


### PR DESCRIPTION
Update SIMSlot.getSmsc() to support both legacy and new
MozMobileMessage.getSmscAddress() implementations.
