### PR TITLE
Bug 1185121 - fix punctuation for contacts error messages

### DIFF
--- a/apps/communications/contacts/locales/contacts.en-US.properties
+++ b/apps/communications/contacts/locales/contacts.en-US.properties
@@ -18,9 +18,9 @@ deleteConfirmMsg   = Delete contact?
 remove             = Remove
 delete             = Delete
 comments           = Comments
-no_contact_phones  = This contact does not have a phone number
-no_contact_email   = This contact does not have an email address
-no_contact_data    = This contact does not have a phone number and email address
+no_contact_phones  = This contact does not have a phone number.
+no_contact_email   = This contact does not have an email address.
+no_contact_data    = This contact does not have a phone number and email address.
 removePhotoConfirm = Remove contact picture?
 loadingContacts    = Loading contacts…
 # LOCALIZATION NOTE(noContactsActivity2): Shown when trying to pick a contact
@@ -113,7 +113,7 @@ exportContactsAction    = Export
 simExport-title        = Export to SIM
 memoryCardExport-title = Export to memory card
 btExport-title         = Export to Bluetooth
-memoryCardUMSEnabled   = Cannot use memory card because USB storage is enabled
+memoryCardUMSEnabled   = Cannot use memory card because USB storage is enabled.
 exportErrorTitle       = Export error
 
 contactsExported2        = {[ plural(exported) ]}
@@ -124,14 +124,14 @@ contactsExported2[few]   = {{exported}}/{{total}} contacts exported
 contactsExported2[many]  = {{exported}}/{{total}} contacts exported
 contactsExported2[other] = {{exported}}/{{total}} contacts exported
 
-exportError-general         = Some error happened while exporting
-exportError-SD-shared       = Can’t access memory card because it’s shared
-exportError-SD-unavailable  = Memory card is not available
-exportError-SD-noSpace      = There’s not enough space on the memory card to export the contacts
-exportError-SIM-unavailable = SIM card is not available
-exportError-BT-shared       = Can’t access memory card because it’s shared
-exportError-BT-unavailable  = Memory card is not available
-exportError-BT-noSpace      = There’s not enough space on the memory card to export the contacts
+exportError-general         = Some error happened while exporting.
+exportError-SD-shared       = Can’t access memory card because it’s shared.
+exportError-SD-unavailable  = Memory card is not available.
+exportError-SD-noSpace      = There’s not enough space on the memory card to export the contacts.
+exportError-SIM-unavailable = SIM card is not available.
+exportError-BT-shared       = Can’t access memory card because it’s shared.
+exportError-BT-unavailable  = Memory card is not available.
+exportError-BT-noSpace      = There’s not enough space on the memory card to export the contacts.
 
 
 # Social networks
@@ -169,7 +169,7 @@ loggingOutFb      	= Logging out from Facebook
 cleanFbConfirmMsg 	= Remove all Facebook data?
 renewPwdMsg       	= Your password in Facebook has changed. Please, update it.
 notEnabledYet     	= Not enabled yet
-genericNoConnection = To import contacts connect to Wi-Fi or data network
+genericNoConnection = To import contacts connect to Wi-Fi or data network.
 # Used for export, just in case the strings will diverge on time
 simCard             = SIM card
 memoryCard          = Memory card
@@ -185,12 +185,12 @@ ICEDescription                = Add two contacts for making “In Case of Emerge
 ICEContact1                   = ICE Contact 1
 ICESelectContact              = Select a contact
 ICEContact2                   = ICE Contact 2
-ICERepeatedContact            = This contact is already an existing ICE contact
-ICEUnknownError               = There was an error setting the contact as ICE
-ICEContactNoNumber            = This contact doesn't have a phone number
-ICEFacebookContactNotAllowed  = Facebook contacts cannot be set as ICE contacts
+ICERepeatedContact            = This contact is already an existing ICE contact.
+ICEUnknownError               = There was an error setting the contact as ICE.
+ICEContactNoNumber            = This contact doesn't have a phone number.
+ICEFacebookContactNotAllowed  = Facebook contacts cannot be set as ICE contacts.
 
-ICEContactDelTel    = Deleted phone numbers are removed from ICE Contact
+ICEContactDelTel    = Deleted phone numbers are removed from ICE Contact.
 ICEContactDelTelAll = All the numbers are deleted. This contact is removed from the ICE Contacts.
 
 # No contacts


### PR DESCRIPTION
Added a few needed "." (periods) that were missing from several properties in Contacts app.
