### PR TITLE
Bug 1186100 - Making 'ls.lock-immediately' lock immediately

### DIFF
--- a/apps/system/js/lock_screen_window_manager.js
+++ b/apps/system/js/lock_screen_window_manager.js
@@ -241,6 +241,8 @@
       var lockListener = (event) => {
         if (true === event.settingValue) {
           this.openApp();
+          // Ensure passcode lock is enforced immediately
+          window.lockScreen.forcePassCodeUnlock();
         }
       };
 

--- a/apps/system/js/lock_screen_window_manager.js
+++ b/apps/system/js/lock_screen_window_manager.js
@@ -241,8 +241,6 @@
       var lockListener = (event) => {
         if (true === event.settingValue) {
           this.openApp();
-          // Ensure passcode lock is enforced immediately
-          window.lockScreen.forcePassCodeUnlock();
         }
       };
 

--- a/apps/system/lockscreen/js/lockscreen.js
+++ b/apps/system/lockscreen/js/lockscreen.js
@@ -354,11 +354,9 @@
       window.SettingsListener.observe('lockscreen.lock-immediately',
         false, (function ls_observeImmediately(value) {
         if (value === true) {
-          this.lock(true);
-          if (this.passCodeEnabled) {
-            // Enforce immediate pass code unlock
-            this.resetTimeoutForcibly();
-          }
+          // Enforce immediate pass code unlock
+          this.resetTimeoutForcibly();
+          window.dispatchEvent(new CustomEvent('lockscreen-request-lock'));
 		}
       }).bind(this));
 

--- a/apps/system/lockscreen/js/lockscreen.js
+++ b/apps/system/lockscreen/js/lockscreen.js
@@ -351,13 +351,15 @@
       // bug 992277. We don't need to use SettingsListener because
       // we're only interested in changes to the setting, and don't
       // keep track of its value.
-      navigator.mozSettings.addObserver('lockscreen.lock-immediately',
-        (function(event) {
-        if (event.settingValue === true) {
+      window.SettingsListener.observe('lockscreen.lock-immediately',
+        false, (function ls_observeImmediately(value) {
+        if (value === true) {
           this.lock(true);
-          // Enforce immediate pass code unlock
-          this.resetTimeoutForcibly();
-        }
+          if (this.passCodeEnabled) {
+            // Enforce immediate pass code unlock
+            this.resetTimeoutForcibly();
+          }
+		}
       }).bind(this));
 
       navigator.mozL10n.ready(this.l10nInit.bind(this));

--- a/apps/system/lockscreen/js/lockscreen.js
+++ b/apps/system/lockscreen/js/lockscreen.js
@@ -576,6 +576,12 @@
     }
   };
 
+  LockScreen.prototype.forcePassCodeUnlock =
+  function ls_forcePassCodeUnlock() {
+    this._lastLockedTimeStamp = 0;
+    this._lastUnlockedTimeStamp = 0;
+  };
+
   LockScreen.prototype.loadPanel =
   function ls_loadPanel(panel, callback) {
     this._loadingPanel = true;

--- a/apps/system/lockscreen/js/lockscreen.js
+++ b/apps/system/lockscreen/js/lockscreen.js
@@ -582,22 +582,6 @@
     }
   };
 
-  LockScreen.prototype.resetTimeoutForcibly =
-  function ls_resetTimeoutForcibly() {
-    // Pass code unlock requirement is checked against timeout of
-    // either timestamp. Resetting these to epoch 0 ensures that both
-    // will timeout even if one timestamp is set to Date.now()
-    // due to lockscreen activation or deactivation in a different
-    // code path, avoiding a potential race condition. The respective
-    // pre-calculated intervals are adjusted accordingly.
-    // Fixes bug 1186100
-    var now = Date.now();
-    this._lastLockedTimeStamp = 0;
-    this._lastLockedInterval = now;
-    this._lastUnlockedTimeStamp = 0;
-    this._lastUnlockedInterval = now;
-  };
-
   LockScreen.prototype.loadPanel =
   function ls_loadPanel(panel, callback) {
     this._loadingPanel = true;
@@ -924,6 +908,26 @@
       } else {
         return true;
       }
+    };
+
+  /**
+   * Reset lock/unlock time stamps such that checkPassCodeTimeout
+   * will return that pass code must be checked.
+   */
+  LockScreen.prototype.resetTimeoutForcibly =
+    function ls_resetTimeoutForcibly() {
+      // Pass code unlock requirement is checked against timeout of
+      // either timestamp. Resetting these to epoch 0 ensures that both
+      // will timeout even if one timestamp is set to Date.now()
+      // due to lockscreen activation or deactivation in a different
+      // code path, avoiding a potential race condition. The respective
+      // pre-calculated intervals are adjusted accordingly.
+      // Fixes bug 1186100
+      var now = Date.now();
+      this._lastLockedTimeStamp = 0;
+      this._lastLockedInterval = now;
+      this._lastUnlockedTimeStamp = 0;
+      this._lastUnlockedInterval = now;
     };
 
   /**

--- a/apps/system/test/unit/lockscreen/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_test.js
@@ -600,10 +600,10 @@ suite('system/LockScreen >', function() {
     subject.passCodeRequestTimeout = 60 * 1000;  // 60 seconds
     subject.unlock();  // or .lock() won't update timestamps
     subject.lock();
-    assert.isFalse(subject.checkPassCodeTimeout(),
+    assert.isFalse(subject.checkPassCodeTimeout(subject.passCodeRequestTimeout),
       'pass code timeout check triggers right after lock');
     subject.resetTimeoutForcibly();
-    assert.isTrue(subject.checkPassCodeTimeout(),
+    assert.isTrue(subject.checkPassCodeTimeout(subject.passCodeRequestTimeout),
       'resetTimeoutForcibly does not trigger pass code after lock');
   });
 

--- a/apps/system/test/unit/lockscreen/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_test.js
@@ -575,12 +575,17 @@ suite('system/LockScreen >', function() {
     });
 
     test('Locks when lock-immediately setting is set to true', function () {
+      var stubDispatch = this.sinon.stub(window, 'dispatchEvent');
       subject.enabled = true;
       subject.unlock();  // or lock screen is already enabled
       window.MockSettingsListener.mTriggerCallback(
         'lockscreen.lock-immediately', true);
-      assert.isTrue(subject.locked,
-        'does not lock after lock-immediately setting is changed');
+      assert.isTrue(stubDispatch.calledWithMatch(sinon.match(
+          function(e) {
+            return e.type === 'lockscreen-request-lock';
+          })),
+        'does not request lock after lock-immediately setting is changed');
+      stubDispatch.restore();
     });
 
     test('resets lock/unlock timestamps', function () {

--- a/apps/system/test/unit/lockscreen/lockscreen_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_test.js
@@ -568,11 +568,43 @@ suite('system/LockScreen >', function() {
     assert.equal(subject.message.hidden, true);
   });
 
-  test('Lock when asked via lock-immediately setting', function() {
-    window.MockNavigatorSettings.mTriggerObservers(
-      'lockscreen.lock-immediately', {settingValue: true});
-    assert.isTrue(subject.locked,
-      'it didn\'t lock after the lock-immediately setting got changed');
+  suite('lockscreen.lock-immediately settings observer >', function() {
+
+    setup(function() {
+      subject.init();  // to register observers
+    });
+
+    test('Locks when lock-immediately setting is set to true', function () {
+      subject.enabled = true;
+      subject.unlock();  // or lock screen is already enabled
+      window.MockSettingsListener.mTriggerCallback(
+        'lockscreen.lock-immediately', true);
+      assert.isTrue(subject.locked,
+        'does not lock after lock-immediately setting is changed');
+    });
+
+    test('resets lock/unlock timestamps', function () {
+      subject.enabled = true;
+      subject.passCodeEnabled = true;
+      var spy = this.sinon.spy(subject, 'resetTimeoutForcibly');
+      window.MockSettingsListener.mTriggerCallback(
+        'lockscreen.lock-immediately', true);
+      assert.isTrue(spy.called,
+        'lock-immediately does not reset timestamps');
+    });
+  });
+
+  test('resetTimeoutForcibly triggers password check after lock', function () {
+    subject.enabled = true;
+    subject.passCodeEnabled = true;
+    subject.passCodeRequestTimeout = 60 * 1000;  // 60 seconds
+    subject.unlock();  // or .lock() won't update timestamps
+    subject.lock();
+    assert.isFalse(subject.checkPassCodeTimeout(),
+      'pass code timeout check triggers right after lock');
+    subject.resetTimeoutForcibly();
+    assert.isTrue(subject.checkPassCodeTimeout(),
+      'resetTimeoutForcibly does not trigger pass code after lock');
   });
 
   test('Locks the screen: the overlay would be set as locked', function() {


### PR DESCRIPTION
This is a proposed fix for [bug 1186100](http://bugzil.la/1186100) where 'lockscreen.lock-immediately'
as sent by _FindMyDevice_ doesn't lock the device immediately with a pass code
when a pass code timeout has been set.

On unlock, `LockScreen.checkPassCodeTimeout()` only asks for the pass code
when either `.fetchLockedInterval()` or `.fetchUnlockedInterval()` exceed
the pass code timeout.

Setting both `_lastLockedTimeStamp` and `_lastUnlockedTimeStamp` to
something deep in the past will enforce pass code entry on unlock and
avoid a potential race condition.
