### PR TITLE
Bug 1186124 - Add "Power button locks immediately" option

### DIFF
--- a/apps/settings/elements/screen_lock.html
+++ b/apps/settings/elements/screen_lock.html
@@ -33,6 +33,19 @@
         <li class="passcode-enabled">
           <button class="passcode-edit" data-l10n-id="change-passcode"></button>
         </li>
+        <li class="passcode-enabled">
+          <p data-l10n-id="powerbutton-behavior">Power button behavior</p>
+          <span class="button icon icon-dialog">
+            <select name="lockscreen.passcode-lock.powerbutton-behavior">
+              <option value="screen-lock" data-l10n-id="powerbutton-screen-lock" selected>
+                Screen lock
+              </option>
+              <option value="passcode-lock" data-l10n-id="powerbutton-passcode-lock">
+                Immediate pass code lock
+              </option>
+            </select>
+          </span>
+        </li>
       </ul>
     </div>
 

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -909,6 +909,9 @@ after-thirty-minutes=After 30 minutes
 after-one-hour=After 1 hour
 require-passcode=Require passcode
 change-passcode=Change passcode
+powerbutton-behavior=Power button behavior
+powerbutton-screen-lock=Instant screen lock
+powerbutton-passcode-lock=Instant passcode lock
 
 # Security :: SIM PIN Lock
 noSimCard=No SIM card

--- a/apps/system/js/lock_screen_window_manager.js
+++ b/apps/system/js/lock_screen_window_manager.js
@@ -240,7 +240,15 @@
       // Should be replaced by a proper IAC API in bug 992277.
       var lockListener = (event) => {
         if (true === event.settingValue) {
-          this.openApp();
+          // Ignore when lockscreen is disabled.
+          // Prevents LSWM ending up in a broken, permanently-locked
+          // state when lock-immediately is sent to disabled lockscreen.
+          if (this.states.enabled) {
+            this.openApp();
+          } else {
+            console.warn('LockScreenWindowManager: Ignoring ' +
+              '\'lock-immediately\' on disabled lock screen.');
+          }
         }
       };
 

--- a/apps/system/lockscreen/js/lockscreen_bootstrap.js
+++ b/apps/system/lockscreen/js/lockscreen_bootstrap.js
@@ -25,6 +25,9 @@
     window.lockScreenStateManager = new window.LockScreenStateManager();
     window.lockScreenStateManager.start(window.lockScreen);
     window.lockScreenNotifications = new LockScreenNotifications();
+    window.lockScreenPowerbuttonManager =
+      new window.LockScreenPowerbuttonManager();
+    window.lockScreenPowerbuttonManager.start();
     // After Bug 1094759, screen locker initialises itself asynchronously,
     // so we need to make sure everthing is ready for the components depends
     // on it.

--- a/apps/system/lockscreen/js/lockscreen_powerbutton_manager.js
+++ b/apps/system/lockscreen/js/lockscreen_powerbutton_manager.js
@@ -1,0 +1,116 @@
+/**
+ Copyright 2015, Mozilla Foundation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * LockScreen's handling of the power button is implemented here.
+ */
+(function(exports) {
+
+  var LockScreenPowerbuttonManager = function() {
+    /**
+     * Boolean value to track state of locksckscreen.enabled setting.
+     * We must default to false here to ensure that a potential race condition
+     * with the settings observer never results in a permanently locked device.
+     */
+    this.lockScreenEnabled = false;
+    /** String value defining power button behavior. Currently implemented:
+     * - 'screen-lock': default behavior of just locking the screen
+     * - 'passcode-lock': locks and immediately requires pass code on unlock
+     * Only settings listener should change this value to sync with data
+     * in Settings API.
+     */
+    this.buttonBehavior = 'screen-lock';
+  };
+
+  LockScreenPowerbuttonManager.prototype.start =
+    function lspm_start() {
+      window.SettingsListener.observe(
+        'lockscreen.passcode-lock.powerbutton-behavior',
+        'screen-lock', (function(value) {
+          this.setPowerbuttonLockBehavior(value);
+        }).bind(this));
+      window.SettingsListener.observe(
+        'lockscreen.enabled',
+        'screen-lock', (function(value) {
+          this.setLockScreenEnabled(value);
+        }).bind(this));
+      window.addEventListener('sleep', this);
+      return this;
+    };
+
+  /**
+   * The sleep handler hooks the 'sleep' event which is sent by the
+   * key manager when the power button is pressed, and it extends it
+   * by emitting a 'lockscreen.lock-immediately' pseudo event through
+   * settings when lockscreen is anabled and behavior is 'passcode-lock'.
+   */
+  LockScreenPowerbuttonManager.prototype.handleEvent =
+    function lspm_handleEvent(evt) {
+      switch (evt.type) {
+        case 'sleep':
+          var lockEnabled = this.lockScreenEnabled;
+          var powerPasscodeEnabled =
+            (this.buttonBehavior === 'passcode-lock');
+          if (lockEnabled && powerPasscodeEnabled) {
+            // FIXME(cr) this is currently used by Find My Device to force
+            // locking.
+            // Should be replaced by a proper IAC API in bug 992277.
+            return window.SettingsListener.getSettingsLock().set({
+              'lockscreen.lock-immediately': true
+            });
+          }
+      }
+    };
+
+  /**
+   * Value setter for the behavior settings observer. It interprets
+   * everything that is not 'passcode-lock' as the default behavior
+   * 'screen-lock'.
+   */
+  LockScreenPowerbuttonManager.prototype.setPowerbuttonLockBehavior =
+    function lspm_setPowerButtonLocksEnabled(value) {
+      switch (value) {
+        case 'passcode-lock':
+          this.buttonBehavior = 'passcode-lock';
+          break;
+        default:
+          this.buttonBehavior = 'screen-lock';
+      }
+    };
+
+  /**
+   * Value setter for the lockscreen.enabled settings observer. It
+   * interprets everything that is not true as its default false.
+   */
+  LockScreenPowerbuttonManager.prototype.setLockScreenEnabled =
+    function lspm_setLockScreenEnabled(value) {
+      if (typeof value === 'boolean') {
+        switch (value) {
+          case true:
+            this.lockScreenEnabled = true;
+            break;
+          default:
+            this.lockScreenEnabled = false;
+        }
+      } else {
+        this.lockScreenEnabled = false;
+      }
+    };
+
+  exports.LockScreenPowerbuttonManager = LockScreenPowerbuttonManager;
+})(window);

--- a/apps/system/lockscreen/lockscreen.html
+++ b/apps/system/lockscreen/lockscreen.html
@@ -42,6 +42,7 @@
   <script defer src="lockscreen/js/lockscreen_state_secure_app_launching.js"></script>
   <script defer src="lockscreen/js/lockscreen_state_logger.js"></script>
   <script defer src="lockscreen/js/lockscreen_state_manager.js"></script>
+  <script defer src="lockscreen/js/lockscreen_powerbutton_manager.js"></script>
   <script defer src="lockscreen/js/lockscreen_bootstrap.js"></script>
 
   <div id="lockscreen" class="uninit" data-panel="main" data-panel="main" data-z-index-level="lockscreen">

--- a/apps/system/test/unit/lockscreen/lockscreen_powerbutton_manager_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_powerbutton_manager_test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+requireApp('system/lockscreen/js/lockscreen_powerbutton_manager.js');
+
+/* global MocksHelper */
+
+require('/shared/test/unit/mocks/mock_custom_event.js');
+require('/shared/test/unit/mocks/mock_settings_listener.js');
+
+var mocks = new MocksHelper([
+  'CustomEvent', 'SettingsListener'
+]).init();
+
+suite('LockScreenPowerbuttonManager >', function() {
+  var subject;
+
+  // .attackTestHelpers() registers its own suite setup and teardown
+  // functions.
+  mocks.attachTestHelpers();
+
+  suiteSetup(function() {
+    subject = new window.LockScreenPowerbuttonManager();
+  });
+
+  suite('startup behavior >', function() {
+    var stubObserver;
+    var stubListener;
+    setup(function() {
+      stubObserver = sinon.stub(window.SettingsListener, 'observe');
+      stubListener = sinon.stub(window, 'addEventListener');
+    });
+    teardown(function() {
+      stubObserver.restore();
+      stubListener.restore();
+    });
+    test('registers settings observers and event listener',
+      function () {
+        subject.start();
+        assert.isTrue(stubObserver.calledWith(
+          'lockscreen.passcode-lock.powerbutton-behavior'),
+          'does not register behavior settings observer');
+        assert.isTrue(stubObserver.calledWith(
+            'lockscreen.enabled'),
+          'does not register LS enabled settings observer');
+        assert.isTrue(stubListener.calledWith('sleep'),
+          'does not register event listener');
+      });
+  });
+
+  suite('settings observers >', function() {
+    test('behavior value setter works as expected', function() {
+      subject.buttonBehavior = 'DUMMY_FOR_OVERWRITE_TEST';
+      subject.setPowerbuttonLockBehavior('screen-lock');
+      assert.isTrue(subject.buttonBehavior === 'screen-lock',
+        'does not correctly handle \'screen-lock\' value');
+      subject.setPowerbuttonLockBehavior('passcode-lock');
+      assert.isTrue(subject.buttonBehavior === 'passcode-lock',
+        'does not correctly handle \'passcode-lock\' value');
+      subject.setPowerbuttonLockBehavior(0);
+      assert.isTrue(subject.buttonBehavior === 'screen-lock',
+        'does not correctly handle invalid value');
+    });
+    test('LS enabled value setter works as expected', function() {
+      subject.lockScreenEnabled = 'DUMMY_FOR_OVERWRITE_TEST';
+      subject.setLockScreenEnabled(false);
+      assert.isTrue(subject.lockScreenEnabled === false,
+        'does not correctly handle false value');
+      subject.setLockScreenEnabled(true);
+      assert.isTrue(subject.lockScreenEnabled === true,
+        'does not correctly handle true value');
+      subject.setLockScreenEnabled(0);
+      assert.isTrue(subject.lockScreenEnabled === false,
+        'does not correctly handle invalid value');
+    });
+  });
+
+  suite('handles \'sleep\' event >', function() {
+    var spySettingsSet;
+    suiteSetup(function() {
+      spySettingsSet = sinon.spy(window.MockLock, 'set');
+    });
+    suiteTeardown(function() {
+      spySettingsSet.restore();
+    });
+    setup(function() {
+      spySettingsSet.reset();
+    });
+
+    test('sets \'lock-immediately\' when it should',
+      function() {
+        subject.buttonBehavior = 'passcode-lock';
+        subject.lockScreenEnabled = true;
+        subject.handleEvent(new CustomEvent('sleep'));
+        assert.isTrue(spySettingsSet.calledWith({
+            'lockscreen.lock-immediately': true
+          }),
+          'fails to set \'lock-immediately\' setting');
+      });
+
+    test('no \'lock-immediately\' when lockscreen disabled',
+      function() {
+        subject.lockScreenEnabled = false;
+        subject.buttonBehavior = 'passcode-lock';
+        subject.handleEvent(new CustomEvent('sleep'));
+        assert.isFalse(spySettingsSet.called,
+          'sends \'lock-immediately\' to disabled lockscreen');
+      });
+
+    test('no \'lock-immediately\' in screen-lock mode',
+      function() {
+        subject.lockScreenEnabled = true;
+        subject.buttonBehavior = 'screen-lock';
+        subject.handleEvent(new CustomEvent('sleep'));
+        assert.isFalse(spySettingsSet.called,
+          'sends \'lock-immediately\' in screen-lock mode');
+      });
+  });
+
+});

--- a/apps/system/test/unit/lockscreen/lockscreen_window_manager_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_window_manager_test.js
@@ -376,10 +376,27 @@ suite('system/LockScreenWindowManager', function() {
     test('Open the app when asked via lock-immediately setting', function() {
       subject.registerApp(appFake);
       var stubOpen = this.sinon.stub(appFake, 'open');
+      subject.states.enabled = true;
       window.MockNavigatorSettings.mTriggerObservers(
         'lockscreen.lock-immediately', {settingValue: true});
       assert.isTrue(stubOpen.called,
         'the manager didn\'t open the app when requested');
+      subject.unregisterApp(appFake);
+    });
+
+    test('Ignores lock-immediately when lockscreen disabled', function() {
+      subject.registerApp(appFake);
+      var stubOpen = this.sinon.stub(appFake, 'open');
+      var stubWarn = this.sinon.stub(console, 'warn');
+      subject.states.enabled = false;
+      window.MockNavigatorSettings.mTriggerObservers(
+        'lockscreen.lock-immediately', {settingValue: true});
+      assert.isFalse(stubOpen.called,
+        'the manager opened while lockscreen disabled');
+      assert.isTrue(stubWarn.called,
+        'the manager did not warn about it');
+      stubOpen.restore();
+      stubWarn.restore();
       subject.unregisterApp(appFake);
     });
 


### PR DESCRIPTION
As outlined in [bug 1186124](http://bugzil.la/1186124), this adds a prototype of an
option that immediately requires a pass code after pushing the power button regardless
of the pass code timeout setting.

This is a prototype meant for starting the discussion. No tests, no review, lack of
translations, and perhaps not even the best way to go about this.
