### PR TITLE
Bug 1186313 - Fix intializing errors of text selection dialog

### DIFF
--- a/apps/system/js/text_selection_dialog.js
+++ b/apps/system/js/text_selection_dialog.js
@@ -223,11 +223,6 @@
         return;
       }
 
-      if (!this._injected) {
-        this.render();
-        this._injected = true;
-      }
-
       if (states.indexOf('selectall') !== -1 ||
           states.indexOf('mouseup') !== -1 ||
           (states.indexOf('updateposition') !== -1 &&
@@ -405,6 +400,11 @@
     var numOfSelectOptions = 0;
     var options = [ 'Paste', 'Copy', 'Cut', 'SelectAll' ];
 
+    // Check this._injected here to make sure this.elements is initialzed.
+    if (!this._injected) {
+      this.render();
+      this._injected = true;
+    }
     // Based on UI spec, we should have dividers ONLY between each select option
     // So, we use css to put divider in pseudo element and set the last visible
     // option without it.

--- a/apps/system/test/unit/text_selection_dialog_test.js
+++ b/apps/system/test/unit/text_selection_dialog_test.js
@@ -372,14 +372,6 @@ suite('system/TextSelectionDialog', function() {
       assert.isFalse(stubRender.calledOnce);
     });
 
-    test('should render when first show', function() {
-      testDetail.visible = true;
-      testDetail.isCollapsed = false;
-      td.handleEvent(fakeTextSelectInAppEvent);
-      assert.isTrue(stubRender.calledOnce);
-      assert.isTrue(td._injected);
-    });
-
     test('should not render when bubble has showed before', function() {
       td._injected = true;
       td.handleEvent(fakeTextSelectInAppEvent);


### PR DESCRIPTION
Check this._injected in TextSelectionDialog when calling TextSelectionDialog.show() to make sure we already call _fetchElements(), which initializes TextSelectionDialog.elements.
