### PR TITLE
Bug 1182332 - [Clock] expose timer functionality through IAC for the Vaani app r=mcav

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -21,6 +21,7 @@ apps/calendar/js/common/presets.js
 apps/email/js/alameda.js
 apps/email/js/tmpl_builder.js
 apps/clock/js/alameda.js
+apps/clock/js/ext/**
 apps/clock/js/text_builder.js
 shared/js/uuid.js
 shared/js/l20n.js

--- a/apps/clock/js/connection/alarm.js
+++ b/apps/clock/js/connection/alarm.js
@@ -1,10 +1,17 @@
-define(function(require, exports, module) {
+define(function(require, exports) {
 'use strict';
 
 var Alarm = require('alarm');
 var parseTime = require('ext/parse_loose_time');
 
-module.exports = function(event, port) {
+exports.onmessage = function(event, port) {
+  if (event.type !== 'create') {
+    port.postMessage({
+      error: `Error: Invalid gaia_alarm message type "${event.type}"`
+    });
+    return;
+  }
+
   var time = event.data.time;
   var timeObject = typeof time === 'object' ? time : parseTime(time);
 

--- a/apps/clock/js/connection/handler.js
+++ b/apps/clock/js/connection/handler.js
@@ -2,7 +2,8 @@ define(function(require, exports) {
 'use strict';
 
 var handlers = {
-  'create_alarm': require('./create_alarm')
+  'gaia_alarm': require('./alarm'),
+  'gaia_timer': require('./timer')
 };
 
 exports.init = function() {
@@ -15,7 +16,21 @@ exports.init = function() {
       return;
     }
 
-    port.onmessage = event => handler(event, port);
+    // IACMessagePort don't support onstart & onclose events as of 2015-07-21
+    // but for timer we do need to emulate this behavior
+    if (handler.onstart) {
+      handler.onstart(req);
+    }
+
+    if (handler.onmessage || handler.onclose) {
+      port.onmessage = event => {
+        if (event.data.type === 'close' && handler.onclose) {
+          handler.onclose(req);
+          return;
+        }
+        handler.onmessage && handler.onmessage(event, port);
+      };
+    }
   });
 };
 

--- a/apps/clock/js/connection/timer.js
+++ b/apps/clock/js/connection/timer.js
@@ -1,0 +1,78 @@
+define(function(require, exports) {
+'use strict';
+
+var Timer = require('timer');
+var parseDuration = require('ext/parse_duration');
+var port;
+var timer;
+
+exports.onstart = function(request) {
+  port = request.port;
+
+  window.addEventListener('timer-start', onTimerEvent);
+  window.addEventListener('timer-pause', onTimerEvent);
+  window.addEventListener('timer-end', onTimerEvent);
+  window.addEventListener('timer-tick', onTimerEvent);
+};
+
+exports.onclose = function() {
+  port = null;
+  timer = null;
+
+  window.removeEventListener('timer-start', onTimerEvent);
+  window.removeEventListener('timer-pause', onTimerEvent);
+  window.removeEventListener('timer-end', onTimerEvent);
+  window.removeEventListener('timer-tick', onTimerEvent);
+};
+
+function onTimerEvent(evt) {
+  if (!port) {
+    return;
+  }
+
+  port.postMessage({
+    type: evt.type,
+    remaining: evt.detail.remaining
+  });
+}
+
+exports.onmessage = function(event) {
+  if (timer) {
+    exec(event);
+  } else {
+    Timer.singleton((err, t) => {
+      timer = t;
+      exec(event);
+    });
+  }
+};
+
+function exec(event) {
+  var { type, duration } = event.data;
+  if (type === 'create') {
+    create(duration);
+    return;
+  }
+  // type: [start, pause, cancel]
+  timer[type]();
+  timer.commit();
+}
+
+function create(inputDuration) {
+  var duration = parseDuration(String(inputDuration));
+
+  if (!duration) {
+    port.postMessage({
+      error: `Invalid timer duration "${inputDuration}"`
+    });
+    return;
+  }
+
+  // we don't check the timer state since we assume the user wants to override
+  // any running timer and start it immediately
+  timer.duration = duration;
+  timer.start();
+  timer.commit();
+}
+
+});

--- a/apps/clock/js/ext/parse_duration.js
+++ b/apps/clock/js/ext/parse_duration.js
@@ -1,0 +1,70 @@
+/**
+ * parse-duration v0.1.1
+ * Released under the MIT License
+ * https://github.com/jkroso/parse-duration
+ */
+define(function(require, exports, module) {
+
+var duration = /(-?\d*\.?\d+(?:e[-+]?\d+)?)\s*([a-zμ]*)/ig
+
+module.exports = parse
+
+/**
+ * conversion ratios
+ */
+
+parse.nanosecond =
+parse.ns = 1 / 1e6
+
+parse.μs =
+parse.microsecond = 1 / 1e3
+
+parse.millisecond =
+parse.ms = 1
+
+parse.second =
+parse.sec =
+parse.s = parse.ms * 1000
+
+parse.minute =
+parse.min =
+parse.m = parse.s * 60
+
+parse.hour =
+parse.hr =
+parse.h = parse.m * 60
+
+parse.day =
+parse.d = parse.h * 24
+
+parse.week =
+parse.wk =
+parse.w = parse.d * 7
+
+parse.month = parse.d * (365.25 / 12)
+
+parse.year =
+parse.yr =
+parse.y = parse.d * 365.25
+
+/**
+ * convert `str` to ms
+ *
+ * @param {String} str
+ * @return {Number}
+ */
+
+function parse(str){
+  var result = 0
+  // ignore commas
+  str = str.replace(/(\d),(\d)/g, '$1$2')
+  str.replace(duration, function(_, n, units){
+    units = parse[units]
+      || parse[units.toLowerCase().replace(/s$/, '')]
+      || 1
+    result += parseFloat(n, 10) * units
+  })
+  return result
+}
+
+});

--- a/apps/clock/manifest.webapp
+++ b/apps/clock/manifest.webapp
@@ -42,9 +42,16 @@
   },
   "orientation": "default",
   "connections": {
-    "create_alarm": {
+    "gaia_alarm": {
       "handler_path": "/index.html",
       "description": "Create alarm",
+      "rules": {
+        "manifestURLs": ["app://vaani.gaiamobile.org/manifest.webapp"]
+      }
+    },
+    "gaia_timer": {
+      "handler_path": "/index.html",
+      "description": "Create, pause, start and cancel Timer",
       "rules": {
         "manifestURLs": ["app://vaani.gaiamobile.org/manifest.webapp"]
       }


### PR DESCRIPTION
ended up reverting a few changes and only updated the logic related to the buttons state (always base the display on the `timer.state` and `timer.remaining`) and also used the `timer` events dispatched by the `Timer`... kinda ugly to dispatch events on the `window` object itself but since app currently doesn't have any `EventEmitter` implementation and was using this type of communication in other parts I thought it was _good enough_...

you can test it through my [test Vaani app](https://dl.dropboxusercontent.com/u/16658475/fxos/fake_vaani.zip).. easiest way is to extract the zip inside your local gaia repo (`apps/vaani` folder) and run `make reset-gaia` (need to run `reset-gaia` to update all the list of available connections, otherwise IAC won't work)... - after the clock manifest is updated you can just override both apps as needed, no need to `reset-gaia`

I also updated the `alarm` feature to keep it consistent.
