### PR TITLE
Bug 1185733 - change audio channel type to system

### DIFF
--- a/apps/callscreen/manifest.webapp
+++ b/apps/callscreen/manifest.webapp
@@ -20,6 +20,7 @@
     "settings":{ "access": "readwrite" },
     "time": {},
     "audio-channel-telephony":{},
+    "audio-channel-system":{},
     "idle":{},
     "device-storage:sdcard": { "access": "readonly" },
     "phonenumberservice": {}

--- a/apps/communications/dialer/test/unit/keypad_test.js
+++ b/apps/communications/dialer/test/unit/keypad_test.js
@@ -147,13 +147,13 @@ suite('dialer/keypad', function() {
   });
 
   suite('Keypad Manager', function() {
-    test('initializates the TonePlayer to use the notification audio channel',
+    test('initializates the TonePlayer to use the system audio channel',
     function() {
       this.sinon.spy(MockTonePlayer, 'init');
       KeypadManager.init(/* oncall */ false);
 
       sinon.assert.calledOnce(MockTonePlayer.init);
-      sinon.assert.calledWithExactly(MockTonePlayer.init, 'notification');
+      sinon.assert.calledWithExactly(MockTonePlayer.init, 'system');
     });
 
     test('sanitizePhoneNumber', function(done) {

--- a/apps/communications/manifest.webapp
+++ b/apps/communications/manifest.webapp
@@ -79,6 +79,7 @@
     "alarms": {},
     "systemXHR": {},
     "audio-channel-notification":{},
+    "audio-channel-system":{},
     "idle":{},
     "device-storage:sdcard": { "access": "readcreate" },
     "phonenumberservice": {},

--- a/apps/emergency-call/js/keypad.js
+++ b/apps/emergency-call/js/keypad.js
@@ -170,7 +170,7 @@ var KeypadManager = {
                                                 this.hangUpCallFromKeypad);
     }
 
-    TonePlayer.init('notification');
+    TonePlayer.init('system');
 
     this.render();
 

--- a/apps/emergency-call/manifest.webapp
+++ b/apps/emergency-call/manifest.webapp
@@ -12,6 +12,7 @@
   "fullscreen": true,
   "permissions": {
     "audio-channel-notification":{},
+    "audio-channel-system":{},
     "themeable":{},
     "telephony": {},
     "mobileconnection": {},

--- a/apps/emergency-call/test/unit/keypad_test.js
+++ b/apps/emergency-call/test/unit/keypad_test.js
@@ -76,12 +76,12 @@ suite('Keypad', function() {
   });
 
   suite('Keypad Manager', function() {
-    test('initializates the TonePlayer to use the "notification" channel',
+    test('initializates the TonePlayer to use the "system" channel',
     function() {
       this.sinon.spy(MockTonePlayer, 'init');
       KeypadManager.init(/* oncall */ false);
 
-      sinon.assert.calledWith(MockTonePlayer.init, 'notification');
+      sinon.assert.calledWith(MockTonePlayer.init, 'system');
     });
 
     test('sanitizePhoneNumber', function(done) {

--- a/shared/js/dialer/keypad.js
+++ b/shared/js/dialer/keypad.js
@@ -183,7 +183,9 @@ var KeypadManager = {
                                                 this.hangUpCallFromKeypad);
     }
 
-    TonePlayer.init(this._onCall ? 'telephony' : 'notification');
+    // According to the UX sound spec, we should use the "system" type for the
+    // dialer pad. See the attachment of the bug1068219.
+    TonePlayer.init('system');
 
     this.render();
     LazyLoader.load(['/shared/style/action_menu.css',


### PR DESCRIPTION
According to the UX sound spec, we should use the "system" type for the dialer pad.
