### PR TITLE
Bug 1178162 - Modify UtilityTray to use native scrolling for better performance.

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -202,6 +202,10 @@
 
   <body class="theme-settings" role="application">
     <div id="screen" aria-hidden="true">
+      <div id="windows" data-z-index-level="app">
+        <!-- application windows are added here -->
+      </div>
+
       <div id="os-logo" data-z-index-level="initlogo">
         <div id="carrier-logo"></div>
       </div>
@@ -233,12 +237,8 @@
       </div>
       <div id="rocketbar-results" class="hidden" data-z-index-level="rocketbar-results"></div>
 
-      <div id="windows" data-z-index-level="app">
-        <!-- application windows are added here -->
-      </div>
-
-      <div id="utility-tray" data-z-index-level="utility-tray">
-        <div id="notifications">
+      <div id="utility-tray-motion" data-z-index-level="utility-tray" class="tray utility-tray-loading">
+        <div class="tray-content" id="utility-tray">
           <!-- Notifications -->
           <div id="utility-tray-notifications" data-l10n-id="utilityTray" role="dialog" aria-label="Utility tray" data-z-index-level="utility-tray-notifications">
             <div id="statusbar-tray">
@@ -295,8 +295,10 @@
                 <div class="other-notifications"></div>
               </div>
             </div>
+          </div>
 
-            <div id="utility-tray-footer">
+          <div id="tray-footer-container" class="tray-footer">
+            <div id="utility-tray-footer" class="animate-out">
               <!-- Media playback notification -->
               <div id="media-playback-container" class="media-playback-container fake-notification" hidden>
                 <div class="media-playback-nowplaying">
@@ -311,7 +313,9 @@
               </div>
 
               <!-- Credit module -->
-              <div id="cost-control-widget"></div>
+              <div id="cost-control-widget">
+                <div id="cost-control-touch-overlay"></div>
+              </div>
 
               <!-- Quick settings -->
               <div id="quick-settings" role="toolbar">
@@ -324,14 +328,17 @@
                 </ul>
               </div>
             </div>
+            <div id="utility-tray-grippy"></div>
+            <div class="ambient-indicator" id="ambient-indicator" data-z-index-level="notification-toaster">
+              <div class="handle handle1"></div>
+              <div class="handle handle2"></div>
+            </div>
           </div>
-        </div>
 
-        <div id="utility-tray-grippy"></div>
-        <div class="ambient-indicator" id="ambient-indicator" data-z-index-level="notification-toaster">
-            <div class="handle handle1"></div>
-            <div class="handle handle2"></div>
         </div>
+        <div id="tray-invisible-gripper">
+        </div>
+        <div class="tray-dead-area"></div>
       </div>
 
       <!-- XXX: Before we can make LockScreen as a iframe or app, we need this to split LockScreen and System part in this way (Bug 1057198) -->

--- a/apps/system/js/app_chrome.js
+++ b/apps/system/js/app_chrome.js
@@ -150,6 +150,7 @@
                 <button type="button" class="forward-button"
                         data-l10n-id="forward-button" disabled></button>
                 <div class="urlbar js-chrome-ssl-information">
+                  <div class="urlbar-hit-area"></div>
                   <span class="pb-icon"></span>
                   <div class="site-icon"></div>
                   <div class="chrome-ssl-indicator chrome-title-container">
@@ -225,6 +226,7 @@
     this.menuButton = this.element.querySelector('.menu-button');
     this.windowsButton = this.element.querySelector('.windows-button');
     this.title = this.element.querySelector('.chrome-title-container > .title');
+    this.urlbar = this.element.querySelector('.urlbar');
     this.siteIcon = this.element.querySelector('.site-icon');
 
     if (this.useCombinedChrome()) {
@@ -320,7 +322,9 @@
   };
 
   AppChrome.prototype.handleClickEvent = function ac_handleClickEvent(evt) {
-    switch (evt.target) {
+    evt.stopPropagation(); // We'll handle all clicks here, thanks.
+
+    switch (evt.currentTarget) {
       case this.reloadButton:
         this.app.reload();
         break;
@@ -342,6 +346,7 @@
         this.onClickSiteIcon();
         break;
 
+      case this.urlbar:
       case this.title:
         this.titleClicked();
         break;
@@ -356,7 +361,8 @@
 
       case this.newWindowButton:
         evt.stopImmediatePropagation();
-        this.onNewWindow();
+        // XXX: this isn't a function!
+        // this.onNewWindow();
         break;
 
       case this.newPrivateWinButton:
@@ -605,6 +611,7 @@
       this.reloadButton.addEventListener('click', this);
       this.backButton.addEventListener('click', this);
       this.forwardButton.addEventListener('click', this);
+      this.urlbar.addEventListener('click', this);
       this.title.addEventListener('click', this);
       this.scrollable.addEventListener('scroll', this);
       this.menuButton.addEventListener('click', this);

--- a/apps/system/js/app_statusbar.js
+++ b/apps/system/js/app_statusbar.js
@@ -55,8 +55,8 @@
     if (this._dontStopEvent) {
       return;
     }
-    // If system is at fullscreen mode, let utility tray to handle the event.
-    if (!this.app || !this.app.isFullScreen()) {
+
+    if (!this.app || !(this.app.isFullScreen() || document.mozFullScreen)) {
       return;
     }
     this.app.debug('processing touch event...', evt.type);
@@ -77,6 +77,9 @@
         this.titleBar.style.transition = 'transform';
 
         this.chromeBar.classList.add('dragging');
+
+        // The status bar might show, so ensure it knows we're fullscreen.
+        this.publish('-fullscreen-statusbar-set-appearance');
         break;
 
       case 'touchmove':
@@ -128,16 +131,18 @@
           this._releaseBar();
         } else {
           this._dontStopEvent = true;
+          this.publish('-fullscreen-statusbar-show');
           this._touchForwarder.forward(evt);
           this._releaseAfterTimeout();
         }
         break;
       }
-  }; 
+  };
 
   AppStatusbar.prototype._releaseBar = function() {
     this.app.debug('releasing statusbar');
     this._dontStopEvent = false;
+    this.publish('-fullscreen-statusbar-hide');
     var titleBar = this.titleBar;
     var chromeBar = this.chromeBar;
 
@@ -172,20 +177,25 @@
     chromeBar.classList.add('dragged');
     chromeBar.classList.remove('dragging');
 
-    self._releaseTimeout = setTimeout(function() {
-      self._releaseBar();
+    function releaseFn() {
       window.removeEventListener('touchstart', closeOnTap);
-    }, this.RELEASE_TIMEOUT);
+      window.removeEventListener('utilitytraywillshow', releaseFn);
+      clearTimeout(self._releaseTimeout);
+      self._releaseBar();
+    }
+
+    window.addEventListener('touchstart', closeOnTap);
+    window.addEventListener('utilitytraywillshow', releaseFn);
+
+    self._releaseTimeout = setTimeout(releaseFn, this.RELEASE_TIMEOUT);
 
     function closeOnTap(evt) {
       if (evt.target != self._touchForwarder.destination) {
         return;
       }
-      window.removeEventListener('touchstart', closeOnTap);
       self.app.debug('user interaction, will release statusbar.');
-      self._releaseBar(titleBar);
+      releaseFn();
     }
-    window.addEventListener('touchstart', closeOnTap);
   };
   exports.AppStatusbar = AppStatusbar;
 }(window));

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -879,6 +879,9 @@
         return;
       }
 
+      this.screen.classList.toggle(
+        'fullscreen-app', this._activeApp.isFullScreen());
+
       var fullScreenLayout = this._activeApp.isFullScreenLayout();
       this.screen.classList.toggle('fullscreen-layout-app', fullScreenLayout);
 

--- a/apps/system/js/notification_screen.js
+++ b/apps/system/js/notification_screen.js
@@ -261,7 +261,10 @@ var NotificationScreen = {
       return;
     }
 
+    // Otherwise, we're swiping on a notification, which should only be allowed
+    // when the utility tray is fully open.
     if (evt.touches.length !== 1 ||
+        !Service.query('UtilityTray.shown') ||
         (this._isTap && Math.abs(touchDiffY) >= this.SCROLL_THRESHOLD)) {
       this._touching = false;
       this.cancelSwipe();
@@ -275,6 +278,7 @@ var NotificationScreen = {
     }
     if (!this._isTap) {
       evt.preventDefault();
+      evt.stopPropagation(); // Prevent this event from bubbling up to the tray.
       this._notification.style.transform =
         'translateX(' + this._touchPosX + 'px)';
     }

--- a/apps/system/js/rocketbar.js
+++ b/apps/system/js/rocketbar.js
@@ -140,7 +140,7 @@
       // need to ensure that all events are properly fired so that the chrome
       // collapses. If for example we early exit, currently the chrome will
       // not collapse.
-      if (UtilityTray.active || UtilityTray.shown) {
+      if (UtilityTray.shown) {
         this._activateCall
           .then(this._closeSearch.bind(this));
       }
@@ -549,7 +549,7 @@
 
       this.rocketbar.classList.toggle('has-text', input.length);
 
-      if (UtilityTray.active || UtilityTray.shown) {
+      if (UtilityTray.shown) {
         this._closeSearch();
         return;
       }

--- a/apps/system/js/utility_tray_motion.js
+++ b/apps/system/js/utility_tray_motion.js
@@ -1,0 +1,475 @@
+'use strict';
+/* global Service */
+
+(function(exports) {
+
+/**
+ * UtilityTrayMotion manages the scrolling and snapping behavior of the
+ * UtilityTray.
+ *
+ * UtilityTrayMotion emits the following custom events from its root element:
+ *
+ * - "tray-motion-state", emitted when the element changes state.
+ * - "tray-motion-footer-position", emitted when the tray moves in such a way
+ *   that you might want to show or hide the fixed-position footer.
+ *
+ * The state of the utility tray motion (UtilityTrayMotion.state) will always
+ * be one of "opening", "closing", "open", or "closed".
+ *
+ * Rather than manually intercepting touch events to provide momentum, we use
+ * native scrolling to improve performance. A scrollable root div contains two
+ * sections, one with the utility tray contents, and one transparent unclickable
+ * area. When the tray is closed, only the invisible (dead area) fits on the
+ * screen; when the tray is open, only the visible area fits onscreen. Hence
+ * the screen is always overlaid with the utility tray, but the dead area
+ * has "pointer-events: none". See the following layout diagram:
+ *
+ *
+ *   +=====================================+
+ *   | .tray          #utility-tray-motion |
+ *   |   (scrollable)                      |
+ *   | +-------------------------------------+
+ *   | | .tray-content         #utility-tray |
+ *   | |   (opaque, grabbable)               |
+ *   | |                                     |
+ *   | |=====================================|    <-.
+ *   | | #tray-invisible-gripper             |      |
+ *   | |   (transparent, grabbable)          |      |
+ *   | |-------------------------------------|      | Visible Screen
+ *   | | .tray-dead-area                     |      |   (in this diagram, the
+ *   | |   (transparent, no touch events)    |      |    tray is fully closed.)
+ *   | |                                     |      |
+ *   | +-------------------------------------+    <-'
+ *   +=====================================+
+ *
+ *
+ * Note that we do _not_ use CSS scroll snapping here. As of July 2015, CSS
+ * scroll snapping's velocity calculations do not include the element's current
+ * scroll velocity when calculating fling velocity; this means that upon lifting
+ * your finger, you would be unable to scroll the utility tray quickly. Instead,
+ * we listen to scroll events, and based upon the current tray velocity and
+ * position, we decide when to fling the tray ourselves.
+ *
+ * With this implementation, if you fling the tray really fast, we recognize
+ * that the tray will make it to the final scroll position without assistance;
+ * this triggers the platform bounce effects. If you fling the tray too slowly,
+ * we'll recognize that the tray will get stuck in the middle of the screen,
+ * so we push it the rest of the way with `scrollTo()`.
+ *
+ *------------------------------------------------------------------------------
+ * TRACKING SCROLL POSITION
+ *
+ * Because we now support asynchronous scrolling (APZ), we can never predict
+ * the element's exact scroll position at any given time. We can monitor touch
+ * and scroll events, but `scrollTop` is always an out-of-date snapshot.
+ * We cannot cancel scroll events synchronously, nor can we rely on touch events
+ * to calculate the element's curent scroll offset, because the platform applies
+ * momentum itself.
+ *
+ * Fortunately, we can compensate for this lack of control by tracking the
+ * element's scrollTop whenever a touch or scroll event occurs. In this way,
+ * we can update the tray state ('open', 'closed', 'opening', 'closing') in
+ * response to changes in scroll position. When we need to move the tray
+ * manually, we use `scrollTo({ behavior: 'smooth'})`.
+ *
+ * @param {Element} el
+ */
+function UtilityTrayMotion(el) {
+  this.el = el;
+
+  ['touchstart', 'touchmove', 'touchend', 'touchcancel'].forEach((type) => {
+    this.el.addEventListener(type, this._ontouch.bind(this));
+  });
+  this.el.addEventListener('scroll', this._onscroll.bind(this));
+
+  // Since scroll events are unpredictable, we can't reliably calculate scroll
+  // velocity without averaging over a few samples. This value is primarily
+  // used to calculate whether or not the tray will close or open fully without
+  // further assistance; it is cleared when the tray changes direction to
+  // ensure quick velocity calculations in response to direction changes.
+  const VELOCITY_WINDOW_MS = 200;
+  this._velocityAverager = new TimeWindowedAverager(VELOCITY_WINDOW_MS);
+
+  // It can take a moment for scroll events to catch up with touch gestures.
+  // Don't force the tray to open or close until some time has passed.
+  this._lastTouchTime = 0;
+
+  this.isTouching = false;
+  this.currentTouch = null; // used by UtilityTray for event forwarding
+
+
+  // Begin closed. Note that scrollTop may be the inverse of what you'd expect;
+  // a scrollTop of zero indicates the tray is open; a scrollTop of scrollTopMax
+  // indicates the tray is closed.
+  this._setState('closing');
+  this.position = this.el.scrollTop = this.el.scrollTopMax;
+
+  // We may need to reposition ourselves when the visible buttons change.
+  // (CSS properly adjusts width and height, but the tray may be stuck in the
+  // middle of the screen.)
+  window.addEventListener('software-button-enabled',
+    this.requestFuturePosition.bind(this));
+  window.addEventListener('software-button-disabled',
+    this.requestFuturePosition.bind(this));
+
+
+  // When the window resizes (i.e. the device's orientation changes), we need
+  // to immediately update the dimensions of our element; otherwise the tray
+  // may appear stuck in the middle of the screen after the resize.
+  window.addEventListener('resize', () => {
+    this.markPosition('resize');
+  });
+
+  // Begin completely closed.
+  this.markPosition('resize');
+  this.close(true);
+}
+
+// We don't know that the element's scroll position has completely stopped until
+// we see the scroll position not moving after a bit of time. Whenever we think
+// the scroll position is changing, we set a timer to check the position again
+// in the near future. See <https://bugzil.la/1172171> for a scrollend event
+// proposal which could alleviate this issue.
+//
+// This value must be large enough that we expect to see a 'scroll' event
+// in response to a .scrollTo() call within this amount of time, otherwise
+// we will force the tray to close/open immediately.
+const FUTURE_POSITION_DELAY_MS = 300;
+
+UtilityTrayMotion.prototype = {
+  /**
+   * @member {string} state
+   *   "opening", "closing", "open", or "closed"
+   */
+  get state() {
+    return this._state;
+  },
+
+  /**
+   * Update the state, setting the state as a class on this.el, and dispatching
+   * the "tray-motion-state" event to notify observers.
+   */
+  _setState(newState) {
+    var oldState = this._state;
+    this._state = newState;
+    if (oldState !== newState) {
+      this.el.classList.remove(oldState);
+      this.el.classList.add(newState);
+      this.el.dispatchEvent(new CustomEvent('tray-motion-state', {
+        detail: { previousValue: oldState, value: newState }
+      }));
+    }
+  },
+
+  /**
+   * The velocity of the current scroll, in pixels per millisecond. Typical
+   * values are mostly between -2 and 2, with larger values for faster flings.
+   * Avoid relying on this number if possible. We take an average value here,
+   * because the instantaneous scroll velocity may be unreliable, due to the
+   * unpredictable timing of scroll events.
+   */
+  get velocity() {
+    return this._velocityAverager.currentAverage;
+  },
+
+  /**
+   * @member {number} percentVisible
+   *   A value between 0 (fully closed) and 1 (fully open), inclusive.
+   */
+  get percentVisible() {
+    return 1 - (this.position / this.maxPosition);
+  },
+
+  /**
+   * The desired scroll offset (i.e. between 0 and this.el.scrollTopMax),
+   * i.e. where the tray should rest if it is not currently being touched.
+   * Remember that when the position is zero, the tray is visible; when position
+   * is equal to scrollTopMax, the tray is hidden.
+   *
+   * If the velocity is zero, just continue to follow the orders of this.state.
+   */
+  get desiredPosition() {
+    var velocity = this.velocity;
+    if (velocity < 0) {
+      return 0;
+    } else if (velocity > 0) {
+      return this.maxPosition;
+    } else if (this.state === 'closing') {
+      return this.maxPosition;
+    } else if (this.state === 'opening') {
+      return 0;
+    } else {
+      return this.position;
+    }
+  },
+
+  /**
+   * Schedule a near-future position check, usually because we just saw a touch
+   * or scroll event, and need to revisit the scroll state momentarily to ensure
+   * we respond to the touch/scroll events appropriately.
+   */
+  requestFuturePosition() {
+    this.cancelRequestFuturePosition();
+    this._rfp = setTimeout(() => {
+      this._rfp = null;
+      this.markPosition('timeout');
+    }, FUTURE_POSITION_DELAY_MS);
+  },
+
+  cancelRequestFuturePosition() {
+    if (this._rfp) {
+      clearTimeout(this._rfp);
+      this._rfp = null;
+    }
+  },
+
+  isVelocityFastEnoughToFinishTheScrollWithoutHelp() {
+    // Calculate how far we think the tray will slide, given the current
+    // estimated velocity, accounting for some friction.
+
+    // The system friction is defined as a pref here:
+    // <http://mxr.mozilla.org/mozilla-central/source/gfx/thebes/gfxPrefs.h#159>
+    // If the system friction changes, we should ideally update this value, but
+    // we likely wouldn't see any ill effects. We're guessing at velocity
+    // already, which makes this only an estimate at best.
+    var friction = 0.002;
+    var pixelsLeftToTraverse = Math.abs(this.desiredPosition - this.position);
+
+    // This formula (the integral of the deceleration curve) provides the
+    // estimated sliding distance, as described in platform here:
+    // <http://mxr.mozilla.org/mozilla-central/source/gfx/layers/apz/src/AsyncPanZoomController.cpp#2164>
+    var slidingDistance =
+      Math.abs(-this.velocity / Math.log(1.0 - friction)) | 0;
+
+    return pixelsLeftToTraverse < slidingDistance;
+  },
+
+  /**
+   * Note the current scroll position, whether triggered by a touch, scroll,
+   * or timeout. Because we leave the core scroll behavior up to the platform,
+   * we can handle all of these events similarly: calculate our current
+   * position and velocity, update state, and decide if we need to `scrollTo()`
+   * to push the tray into its final position.
+   *
+   * @param {string} source
+   *   The reason we're marking this position change.
+   */
+  markPosition(source) {
+    this.requestFuturePosition();
+
+    var previousVelocity = this.velocity;
+    var previousPosition = this.position;
+    var previousMaxPosition = this.maxPosition;
+    this.position = this.el.scrollTop;
+    this.maxPosition = this.el.scrollTopMax;
+    this._velocityAverager.addPoint(Date.now(), this.position);
+
+    if ((previousVelocity > 0 && this.velocity < 0) ||
+        (previousVelocity < 0 && this.velocity > 0)) {
+      this._lastTouchTime = Date.now();
+    }
+
+    // Check for window resizes and layout changes:
+    if (previousMaxPosition !== this.maxPosition) {
+      if (this.state === 'closed' || this.state === 'closing') {
+        this.close(true);
+      } else {
+        this.open(true);
+      }
+    }
+
+    var notRecentlyTouched =
+      (this._lastTouchTime + FUTURE_POSITION_DELAY_MS < Date.now());
+
+    // Are we stuck or moving really slow?
+    if ((source === 'timeout' ||
+         (source === 'scroll' &&
+          !this.isVelocityFastEnoughToFinishTheScrollWithoutHelp())) &&
+        notRecentlyTouched &&
+        !this.isTouching) {
+      if (this.desiredPosition !== this.position) {
+        if (this.state === 'opening') {
+          this.open();
+        } else {
+          this.close();
+        }
+      }
+      else {
+        this._setState(this.state === 'opening' || this.state === 'open' ?
+          'open' : 'closed');
+        this.cancelRequestFuturePosition();
+      }
+    } else {
+      if (this.velocity < 0) {
+        this._setState('opening');
+      } else if (this.velocity > 0) {
+        this._setState('closing');
+      }
+    }
+
+    // For aesthetic reasons, if the tray is almost fully open (as position
+    // approaches zero), start dispatching motion events to allow UtilityTray
+    // to show or hide the fixed-position footer. Without this event,
+    // the footer must wait until this.state === 'open', which takes a while
+    // due to overscroll effects.
+    var CLOSE_TO_BOTTOM_PX = 50 * window.devicePixelRatio;
+    if (previousPosition < CLOSE_TO_BOTTOM_PX ||
+        this.position < CLOSE_TO_BOTTOM_PX) {
+      this.el.dispatchEvent(
+        new CustomEvent('tray-motion-footer-position'));
+    }
+  },
+
+  /**
+   * We don't know how long it will take for the system to respond to our
+   * scrollTo 'smooth' request. The FUTURE_POSITION_DELAY_MS timeout provides a
+   * good estimate, but in the case of a very unresponsive system, we don't want
+   * to fall into a loop of:
+   *
+   * 1. Requesting `scrollTo`
+   * 2. Timeout fires but element hasn't scrolled yet; call scrollTo again
+   *
+   * The right action, if we aren't seeing action from 'behavior: smooth',
+   * is to just fall back on an instant change, in which case we'll detect
+   * with certainty that the element has finished scrolling to the destination.
+   */
+  reliablyScrollTo(top, immediately) {
+    var prevOffset = this._previouslyRequestedOffset;
+    this._previouslyRequestedOffset = top;
+    if (prevOffset === top) {
+      immediately = true;
+    }
+
+    // XXX: Some sort of rounding error causes 1px of the tray to remain visible
+    // in certain configurations, but this fixes it:
+    if (top === this.maxPosition) {
+      top++;
+    }
+
+    this.el.scrollTo({
+      left: 0,
+      top: top,
+      behavior: immediately ? 'auto' : 'smooth'
+    });
+  },
+
+  /**
+   * Open the tray if not already opened.
+   *
+   * @param {boolean} immediately
+   */
+  open(immediately) {
+    this._setState('opening');
+    this._velocityAverager.reset();
+    this.markPosition('force');
+    this.reliablyScrollTo(0, immediately);
+  },
+
+  /**
+   * Close the tray if not already closed.
+   *
+   * @param {boolean} immediately
+   */
+  close(immediately) {
+    this._setState('closing');
+    this._velocityAverager.reset();
+    this.markPosition('force');
+    this.reliablyScrollTo(this.maxPosition, immediately);
+  },
+
+  _ontouch(evt) {
+    if (Service.query('locked') || Service.query('isFtuRunning')) {
+      evt.preventDefault();
+      return;
+    }
+
+    this.isTouching = (evt.touches.length > 0);
+    this.currentTouch = evt.touches && evt.touches[0];
+
+    if (evt.type === 'touchstart') {
+      this._velocityAverager.reset();
+    }
+
+    if (this.isTouching) {
+      this._lastTouchTime = Date.now();
+    }
+
+    requestAnimationFrame(this.markPosition.bind(this, evt.type));
+  },
+
+  _onscroll(evt) {
+    this._previouslyRequestedOffset = null;
+    // We only need to track scroll events if the user isn't touching; otherwise
+    // we would see a 'scroll' event corresponding with every 'touchmove' event.
+    if (!this.isTouching) {
+      requestAnimationFrame(this.markPosition.bind(this, 'scroll'));
+    }
+  }
+
+};
+
+
+/**
+ * Computes a windowed average, excluding points a certain amount of time in
+ * the past. Usage:
+ *
+ *   var averager = new TimeWindowedAverager(400);
+ *   averager.addPoint(Date.now() - 100, 0);
+ *   averager.addPoint(Date.now(), 50);
+ *   console.log(averager.currentAverage); // => 0.5
+ *
+ * @param {int} maxTimeDelta
+ *   The maximum number of milliseconds to include in the average. Values older
+ *   than (now - maxTimeDelta) are discarded.
+ */
+function TimeWindowedAverager(maxTimeDelta) {
+  /**
+   * The current average value of all points.
+   */
+  this.currentAverage = 0;
+
+  this._maxTimeDelta = maxTimeDelta;
+  this._points = [];
+}
+
+TimeWindowedAverager.prototype = {
+  /**
+   * Reset the current window (leading to an instantaneous average of zero).
+   */
+  reset() {
+    this._points.length = 0;
+  },
+
+  /**
+   * Add a point (e.g. a velocity) at the given time to the averaging
+   * calculation. (If the point is too old, it will be ignored). Old points
+   * will be removed.
+   */
+  addPoint(time, value) {
+    var now = Date.now();
+    this._points.push({ time, value });
+    // Discard points that are too old.
+    while (this._points[0].time < now - this._maxTimeDelta) {
+      this._points.shift();
+    }
+    // If we have enough points, compute a windowed average (distance / time).
+    if (this._points.length < 2) {
+      this.currentAverage = 0;
+    } else {
+      var totalDistance = 0;
+      var totalTime = 0;
+      for (var i = 1, len = this._points.length; i < len; i++) {
+        var a = this._points[i - 1], b = this._points[i];
+        totalDistance += b.value - a.value;
+        totalTime += b.time - a.time;
+      }
+      this.currentAverage = totalDistance / totalTime;
+    }
+  }
+};
+
+
+
+exports.UtilityTrayMotion = UtilityTrayMotion;
+
+})(window); // end function wrapper

--- a/apps/system/style/chrome/chrome.css
+++ b/apps/system/style/chrome/chrome.css
@@ -105,6 +105,14 @@
   width: calc(100% - 8rem);
 }
 
+/* Give the urlbar an extra hit target reaching toward the top of the screen. */
+.chrome:not(.maximized) .controls .urlbar-hit-area {
+  position: absolute;
+  width: 100%;
+  height: 3.2rem;
+  top: -0.8rem;
+}
+
 .search-app .chrome .controls .windows-button {
   display: inline;
 }

--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -125,7 +125,7 @@
 }
 
 #notification-bar [data-icon] {
-  margin: 0.5rem 0;
+  margin: 1.2rem 0;
 }
 
 #notification-bar .title-container {
@@ -166,9 +166,6 @@
 
 #notifications-container {
   width: 100%;
-
-  /* minus cost control, quick settings, bar and grippy */
-  height: calc(100% - 6rem - 6.8rem - 4.5rem - 1.2rem);
   flex: 1;
   overflow-y: scroll;
   overflow-x: hidden;

--- a/apps/system/style/quick_settings/quick_settings.css
+++ b/apps/system/style/quick_settings/quick_settings.css
@@ -11,8 +11,8 @@
 
 #quick-settings > ul {
   display: flex;
-  padding: 0 1.5rem;
   margin: 0;
+  padding: 0;
 }
 
 #quick-settings li {
@@ -20,6 +20,7 @@
   padding: 0;
   margin: 0;
   list-style: none;
+  text-align: center;
 }
 
 #quick-settings.non-mobile li {

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -4,7 +4,17 @@
   left: 0;
   width: 100%;
   height: 2rem;
+  /* #top-panel will only receive pointer events when in a fullscreen app. */
+  pointer-events: none;
 }
+
+/* In both fullscreen modes, accept pointer events to trigger the status bar
+   unless the utility tray is showing. */
+#screen.fullscreen-app:not(.utility-tray) #top-panel,
+#screen:not(.utility-tray):-moz-full-screen-ancestor > #top-panel {
+  pointer-events: all;
+}
+
 
 #screen.rocketbar-focused #left-panel,
 #screen.rocketbar-focused #right-panel {
@@ -94,6 +104,13 @@ to be available for moz-elements */
 
 #screen.attention #statusbar {
   top: 0;
+  background-color: black;
+}
+
+/* AppChrome would normally provide the theme color for the statusbar.
+   However, when in native full-screen mode, AppChrome isn't visible; just
+   use black for now, as we do with #screen.attention. */
+#screen:-moz-full-screen-ancestor #statusbar {
   background-color: black;
 }
 

--- a/apps/system/style/update_manager/update_manager.css
+++ b/apps/system/style/update_manager/update_manager.css
@@ -200,6 +200,8 @@
 #system-update-splash
 {
   position: fixed;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   background-color: #2d2d2d;

--- a/apps/system/style/utility_tray/utility_tray.css
+++ b/apps/system/style/utility_tray/utility_tray.css
@@ -1,23 +1,74 @@
-#screen.lockscreen-camera > #utility-tray {
-  display: none;
-}
-
-#utility-tray {
-  position: absolute;
-  top: calc(-100% + .2rem);
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: hsla(0, 0%, 20%, .95);
-  margin: 0;
-
-  transform: translateY(0);
+/* Since the UtilityTray overlays the entire screen, we must ensure that it
+   doesn't get displayed until after it has loaded. This class is removed in
+   utility_tray.js. */
+.utility-tray-loading {
   visibility: hidden;
 }
 
-#utility-tray.visible {
-  visibility: visible;
+.tray {
+  --tray-invisible-gripper-height: 2rem;
+  --scrollbar-width: 15px;
+  --software-buttons-width-adjustment: 0px;
+  --software-buttons-height-adjustment: 0px;
+
+  position: relative;
+  width: calc(100% + var(--scrollbar-width));
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: scroll;
+
+  pointer-events: none;
+  will-change: scroll-position;
 }
+
+/* NOTE: csslint treats variable-only rules as "empty" errors, per
+   <https://github.com/CSSLint/csslint/issues/538>. */
+@media (orientation: portrait) {
+  #screen.software-button-enabled .tray {
+    --software-buttons-height-adjustment: var(--software-home-button-height);
+  }
+}
+
+@media (orientation: landscape) {
+  #screen.software-button-enabled .tray {
+    --software-buttons-width-adjustment: var(--software-home-button-height);
+  }
+}
+
+.tray-dead-area {
+  height: calc(100% - var(--tray-invisible-gripper-height));
+}
+
+.tray-content {
+  height: calc(100% - var(--software-buttons-height-adjustment));
+  width: calc(100% - var(--scrollbar-width) - var(--software-buttons-width-adjustment));
+  pointer-events: all;
+  background-color: hsla(0, 0%, 20%, .95);
+  position: relative;
+}
+
+.tray-footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+}
+
+#tray-invisible-gripper {
+  height: var(--tray-invisible-gripper-height);
+  pointer-events: all;
+}
+
+.tray.open #tray-invisible-gripper {
+  pointer-events: none;
+}
+
+/* Special visibility overrides */
+
+#screen.lockscreen-camera > #utility-tray {
+  visibility: hidden;
+}
+
+/* Statusbar */
 
 #statusbar-tray {
   background-image: none;
@@ -27,7 +78,8 @@
   filter: none;
 }
 
-#screen.utility-tray-in-transition #utility-tray #statusbar-tray {
+#screen.utility-tray-in-transition #statusbar-tray,
+#screen:-moz-full-screen-ancestor #statusbar-tray {
   background-image: -moz-element(#statusbar-maximized);
 }
 
@@ -35,12 +87,14 @@
   position: absolute;
   left: 0;
   line-height: var(--statusbar-height);
-  visibility: hidden;
 }
 
-#utility-tray.visible #statusbar-tray > .sb-start-upper {
-  visibility: visible;
+html[dir="rtl"] #statusbar-tray > .sb-start-upper {
+  left: unset;
+  right: 0;
 }
+
+/* Notifications indicator */
 
 #ambient-indicator {
   height: .2rem;
@@ -50,13 +104,9 @@
   background-color: #00D3FF;
   transition: opacity .5s ease .5s;
   position: absolute;
-  bottom: 0;
   pointer-events: none;
 }
 
-#utility-tray.on-edge-gesture {
-  top: -100%;
-}
 
 #screen:not(.locked) #ambient-indicator.unread {
   opacity: 1;
@@ -87,93 +137,81 @@
   margin: -0.4rem auto;
 }
 
-.utility-tray #utility-tray {
-  visibility: visible;
-}
-
 @keyframes handle {
   0%   { transform: scaleX(1.0); opacity: 1;}
   100% { transform: scaleX(4.0); opacity: 0;}
 }
 
-
-@media (orientation: portrait) {
-  #screen.software-button-enabled #utility-tray {
-    top: calc(-100% + .2rem + var(--software-home-button-height));
-    height: calc(100% - var(--software-home-button-height));
-  }
-}
-
-@media (orientation: landscape) {
-  #screen.software-button-enabled #utility-tray {
-    width: calc(100% - var(--software-home-button-height));
-  }
-}
-
-#notifications {
-  height: calc(100% - 2rem);
-  overflow: hidden;
-}
-
 #utility-tray-notifications {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  position: sticky;
+  top: 0;
+  margin-bottom: 2rem;
 }
+
+/* Utility Tray Footer (the buttons at the bottom of the tray) */
 
 #utility-tray-footer {
   background: hsla(0, 0%, 100%, .05);
 }
 
-#utility-tray > #utility-tray-grippy {
+@keyframes tray-footer-in {
+  0% { transform: scaleY(0.9); opacity: 0; }
+  15% { transform: scaleY(1.08); opacity: 1; }
+  30% { transform: scaleY(0.94); }
+  65% { transform: scaleY(1.03); }
+  100% { transform: scaleY(1); }
+}
+
+/* NOTE: We cannot modify transform() on the way out, because the user may be
+   dragging from on top of the footer; changing the transform mid-scroll
+   interrupts the scroll gesture. Fortunately, opacity is fine. */
+@keyframes tray-footer-out {
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+#utility-tray-footer {
+  transform-origin: bottom left;
+  opacity: 0;
+  transform: scaleY(0);
+}
+
+#utility-tray-footer.animate-in {
+  animation: tray-footer-in 200ms;
+  animation-timing-function: ease-in-out;
+  transform: scaleY(1);
+  opacity: 1;
+}
+
+#utility-tray-footer.animate-out {
+  animation: tray-footer-out 50ms;
+  animation-timing-function: ease-out;
+  opacity: 0;
+  transform: scaleY(1);
+}
+
+/* The _visible_ grippy at the bottom of the utility tray. */
+
+#utility-tray-grippy {
   width: 100%;
   height: 2rem;
   margin: 0;
+  position: relative; /* float above */
   background: hsla(0, 0%, 20%, 1) url(images/grippy.png) no-repeat center / 7.2rem;
 }
 
-/* In order to make the utility tray easier to drag when the SHB is enabled */
-/* we  use a pseudoelement that increases the dragging area */
-@media (orientation: portrait) {
-  #screen.software-button-enabled #utility-tray > #utility-tray-grippy:after {
-    height: var(--software-home-button-height);
-    content: "";
-    display: block;
-    position: relative;
-    bottom: -2rem;
-    background-color: transparent;
-    pointer-events: none;
-  }
-}
+/* Icons */
 
-#screen.utility-tray.software-button-enabled #utility-tray > #utility-tray-grippy:after {
-  pointer-events: all;
-}
-
-[data-icon] {
-  float: left;
+#utility-tray .utility-tray-notifications [data-icon] {
+  display: inline-block;
   width: 3rem;
   height: 3rem;
-  margin: 1.5rem 0;
+  margin: 1.5rem auto;
 }
 
-[data-icon]:before {
+#utility-tray .utility-tray-notifications [data-icon]:before {
   /* The icons should appear 24 x 24px but each glyph only takes 80% of the space
    So we compensate by adding 20%, that is 30px. */
   font-size: 3rem;
   line-height: 3rem;
-}
-
-@media (orientation: landscape) {
-  #screen.software-button-enabled #utility-tray-notifications {
-    width: calc(100%);
-  }
-}
-
-/* RTL View */
-
-html[dir="rtl"] #statusbar-tray > .sb-start-upper {
-  left: unset;
-  right: 0
 }

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -120,6 +120,17 @@
   z-index: 16386;
 }
 
+/* When an app is fullscreen and the utility tray is closed,
+   a swipe-from-the-top must reveal the statusbar first. This is
+   triggered by #top-panel, therefore we must ensure it has an appropriate
+   z-index in fullscreen modes.
+   (The z-indexes differ depending on whether this is a .fullscreen-app or a
+   -moz-full-screen-ancestor; when -moz-full-screen, the z-index is assigned to
+   MAX_INT here in zindex.css) */
+#screen.fullscreen-app:not(.utility-tray) #top-panel {
+  z-index: 16386;
+}
+
 /* The View Source window has to go just below the utility tray. */
 #screen > [data-z-index-level="view-source"] {
   z-index: 16384;
@@ -346,6 +357,7 @@
 #screen:-moz-full-screen-ancestor > [data-z-index-level="gesture-panel"],
 #screen:-moz-full-screen-ancestor > [data-z-index-level="attention-indicator"],
 #screen:-moz-full-screen-ancestor > [data-z-index-level="utility-tray"],
+#screen:-moz-full-screen-ancestor > [data-z-index-level="statusbar"],
 #screen:-moz-full-screen-ancestor > [data-z-index-level="global-overlays"] {
   z-index: 2147483647;
 }
@@ -355,6 +367,10 @@
 #screen.fullscreen-layout-app > [data-z-index-level="gesture-panel"],
 #screen.fullscreen-layout-app > [data-z-index-level="fullscreen-layout-software-home-button"] {
   z-index: 2147483647;
+}
+
+#screen:-moz-full-screen-ancestor > #statusbar:not(.fullscreen) {
+  display: none;
 }
 
 /**

--- a/apps/system/test/marionette/attention_window_interactions_test.js
+++ b/apps/system/test/marionette/attention_window_interactions_test.js
@@ -39,7 +39,7 @@ marionette('AttentionWindow interactions', function() {
   });
 
   test('the utility tray should be actionable', function() {
-    utilityTray.swipeDown(system.topPanel);
+    utilityTray.swipeDown();
     utilityTray.waitForOpened();
   });
 

--- a/apps/system/test/marionette/browser_fullscreen_utility_tray_test.js
+++ b/apps/system/test/marionette/browser_fullscreen_utility_tray_test.js
@@ -52,10 +52,9 @@ marionette('Browser - fullscreen utility tray access', function() {
   });
 
   test('test fullscreen webpage utility tray access', function() {
-    utilityTray.swipeDown(system.topPanel);
-    utilityTray.waitForOpened();
+    utilityTray.open();
 
-    var sameIndex = system.utilityTray.scriptWith(function(element) {
+    var sameIndex = system.utilityTrayMotion.scriptWith(function(element) {
       var fsElem = document.mozFullScreenElement;
       var fsIndex = getComputedStyle(fsElem).getPropertyValue('z-index');
       var utIndex = getComputedStyle(element).getPropertyValue('z-index');
@@ -63,7 +62,7 @@ marionette('Browser - fullscreen utility tray access', function() {
     });
     assert.ok(sameIndex, 'UtilityTray has the same (maximum) zIndex value');
 
-    var after = system.utilityTray.scriptWith(function(element) {
+    var after = system.utilityTrayMotion.scriptWith(function(element) {
       var fsElem = document.mozFullScreenElement;
       var expected = Node.DOCUMENT_POSITION_FOLLOWING;
       return fsElem.compareDocumentPosition(element) === expected;

--- a/apps/system/test/marionette/fullscreen_statusbar_test.js
+++ b/apps/system/test/marionette/fullscreen_statusbar_test.js
@@ -5,6 +5,7 @@ marionette('Fullscreen status bar >', function() {
 
   var VIDEO_APP = 'app://video.gaiamobile.org';
 
+  var assert = require('assert');
   var client = marionette.client({
     desiredCapabilities: { raisesAccessibilityExceptions: true }
   });
@@ -28,9 +29,16 @@ marionette('Fullscreen status bar >', function() {
   test('Swiping from the top should open the statusbar', function() {
     var top = sys.topPanel;
 
-    actions.flick(top, 100, 0, 100, 250).perform();
+    // When in fullscreen, #top-panel should handle the first swipe.
+    assert.equal(top.cssProperty('pointer-events'), 'all');
+
+    actions.flick(top, 100, 0, 100, 250, 250).perform();
     client.waitFor(function() {
       return (titlebar.location().y === 0);
     });
+
+    // After the statusbar is shown, #top-panel should ignore future touches
+    // so that a second swipe from the top will open the utility tray.
+    assert.equal(top.cssProperty('pointer-events'), 'none');
   });
 });

--- a/apps/system/test/marionette/lib/input_management.js
+++ b/apps/system/test/marionette/lib/input_management.js
@@ -99,19 +99,8 @@ InputManagement.prototype = {
   dragDownUtilityTray: function dragDownUtilityTray() {
     this.client.switchToFrame();
 
-    var topPanel = this.client.findElement('#top-panel');
-    var chain = this.actions.press(topPanel, 100, 0).moveByOffset(100, 300);
-    chain.release().perform();
-
-    var utilityTray = this.client.findElement('#utility-tray');
-    var ambientIndicator = this.client.findElement('#ambient-indicator');
-    var trayHeight = utilityTray.size().height - ambientIndicator.size().height;
-
-    // wait for utility tray to show completely
-    this.client.waitFor(function() {
-      var currentTransform = utilityTray.cssProperty('transform');
-      var expectedTransform = 'matrix(1, 0, 0, 1, 0, ' + trayHeight + ')';
-      return (currentTransform === expectedTransform);
+    this.client.executeScript(function() {
+      window.wrappedJSObject.UtilityTray.show(/* immediately: */ true);
     });
   },
 

--- a/apps/system/test/marionette/lib/lockscreen_notification_selector.js
+++ b/apps/system/test/marionette/lib/lockscreen_notification_selector.js
@@ -16,7 +16,10 @@
 
   LockScreenNotificationSelector.prototype.start =
   function (client) {
-    this.client = client;
+    // XXX: Remove the low searchTimeout when https://bugzil.la/1141519 lands.
+    //      Currently, Marionette can hang during findElements() due to
+    //      uncaught exceptions in other contexts; this works around that.
+    this.client = client.scope({ searchTimeout: 2000 });
     return this;
   };
 

--- a/apps/system/test/marionette/lib/rocketbar.js
+++ b/apps/system/test/marionette/lib/rocketbar.js
@@ -90,6 +90,10 @@ Rocketbar.prototype = {
     title.click();
   },
 
+  waitForInputToBecomeVisible: function() {
+    this.client.helper.waitForElement(this.selectors.input);
+  },
+
   /**
    * Send keys to the Rocketbar (needs to be focused first).
    */

--- a/apps/system/test/marionette/lib/system.js
+++ b/apps/system/test/marionette/lib/system.js
@@ -73,6 +73,7 @@ System.Selector = Object.freeze({
   rightPanel: '#right-panel',
   siteIcon: '.appWindow.active .chrome .site-icon',
   utilityTray: '#utility-tray',
+  utilityTrayMotion: '#utility-tray-motion',
   visibleForm: '#action-menu > form.visible',
   cancelActivity: '#action-menu form.visible button[data-action="cancel"]',
   nfcIcon: '.statusbar-nfc',
@@ -300,6 +301,10 @@ System.prototype = {
 
   get utilityTray() {
     return this.client.findElement(System.Selector.utilityTray);
+  },
+
+  get utilityTrayMotion() {
+    return this.client.findElement(System.Selector.utilityTrayMotion);
   },
 
   get topPanel() {

--- a/apps/system/test/marionette/lib/utility_tray.js
+++ b/apps/system/test/marionette/lib/utility_tray.js
@@ -13,6 +13,8 @@
       return window.innerHeight;
     });
     this.halfHeight = height / 2;
+
+    this.waitForLoaded();
   };
 
   UtilityTray.prototype = {
@@ -22,11 +24,38 @@
       notifContainer: '#desktop-notifications-container',
       notification: '#desktop-notifications-container .notification',
       grippy: '#utility-tray-grippy',
-      quickSettings: '#quick-settings-full-app'
+      invisibleGrippy: '#tray-invisible-gripper',
+      quickSettings: '#quick-settings-full-app',
+    },
+
+    waitForLoaded: function() {
+      return this.client.waitFor(function() {
+        return this.client.executeScript(function() {
+          var win = window.wrappedJSObject;
+          return !!(win.UtilityTray &&
+                    win.UtilityTray.motion.el.scrollTopMax > 0);
+        });
+      }.bind(this));
     },
 
     get visible() {
+      return !!this.screenElement;
+    },
+
+    get screenElement() {
       return this.client.findElement(this.Selectors.screen);
+    },
+
+    get _motionState() {
+      return this.client.executeScript(function() {
+        return window.wrappedJSObject.UtilityTray.motion.state;
+      });
+    },
+
+    get shown() {
+      return this.client.executeScript(function() {
+        return window.wrappedJSObject.UtilityTray.shown;
+      });
     },
 
     get quickSettings() {
@@ -44,7 +73,7 @@
           return el.getBoundingClientRect();
         });
         var expectedTop = 0;
-        return (rect.top === expectedTop);
+        return (rect.top === expectedTop) && this._motionState === 'open';
       }.bind(this));
     },
 
@@ -54,8 +83,8 @@
         var rect = element.scriptWith(function(el) {
           return el.getBoundingClientRect();
         });
-        var expectedTop = -(rect.height - 2);
-        return (rect.top === expectedTop);
+        var expectedTop = -rect.height;
+        return (rect.top === expectedTop) && this._motionState === 'closed';
       }.bind(this));
     },
 
@@ -81,26 +110,23 @@
       });
     },
 
-    swipeDown: function swipeDown(element) {
+    swipeDown: function swipeDown() {
+      var element = this.client.findElement(this.Selectors.invisibleGrippy);
       this.client.waitFor(function() {
         return element.displayed;
       });
-
-      // Works better than actions.flick().
       this.actions
-        .press(element)
-        .moveByOffset(0, this.halfHeight)
-        .release()
+        .flick(element, 10, 10, 10, 400, 500)
         .perform();
     },
 
-    swipeUp: function swipeUp(element) {
-      var halfWidth = this.halfWidth;
+    swipeUp: function swipeUp() {
+      var element = this.client.findElement(this.Selectors.grippy);
       this.client.waitFor(function() {
         return element.displayed;
       });
       this.actions
-        .flick(element, halfWidth, 10, halfWidth, -this.halfHeight, 100)
+        .flick(element, 10, 10, 10, -400, 500)
         .perform();
     }
 

--- a/apps/system/test/marionette/update_dialog_confirm_test.js
+++ b/apps/system/test/marionette/update_dialog_confirm_test.js
@@ -76,10 +76,19 @@ marionette('Software Home Button - Update Dialog Confirm', function() {
     var input = client.findElement('#statusbar');
     client.waitFor(input.displayed.bind(input));
     triggerUpdateDownload();
-    client.helper.waitForElement('#dialog-screen');
+
+    client.helper.waitForElement('#dialog-screen').scriptWith(function(el) {
+      el.addEventListener('touchend', function() {
+        el.classList.add('was-tapped');
+      });
+    });
+
+    // Tap on the screen coordinate where the rocketbar lives.
     input.tap(25, 25);
-    // Waiting for the element to disappear is how we assert the element won't
-    // show up since internally marionette will poll for it's appearance.
-    client.helper.waitForElementToDisappear(system.Selector.activeKeyboard);
+
+    // The tap should have been intercepted by the dialog screen, proving that
+    // the dialog was on top of the rocketbar.
+    client.helper.waitForElement('#dialog-screen.was-tapped');
   });
+
 });

--- a/apps/system/test/marionette/utility_tray_shb_test.js
+++ b/apps/system/test/marionette/utility_tray_shb_test.js
@@ -24,12 +24,7 @@ marionette('Utility Tray with SHB', function() {
   test('Swiping up', function() {
     utilityTray.open();
     utilityTray.waitForOpened();
-    var element = utilityTray.visible;
-    var screenHeight = element.size().height;
-
-    actions.flick(element, 50, screenHeight, 50, -(screenHeight / 2), 100)
-      .perform();
-
+    utilityTray.swipeUp();
     utilityTray.waitForClosed();
   });
 });

--- a/apps/system/test/unit/app_statusbar_test.js
+++ b/apps/system/test/unit/app_statusbar_test.js
@@ -218,6 +218,11 @@ suite('system/AppStatusbar', function() {
             assertStatusBarReleased();
           });
 
+          test('or if the utility tray hides', function() {
+            window.dispatchEvent(new CustomEvent('utilitytraywillshow'));
+            assertStatusBarReleased();
+          });
+
           test('or if the user interacts with the app', function() {
             // We're faking a touchstart event on the app iframe
             var iframe = app.browser.element;

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -40,7 +40,7 @@ var mocksForAppWindowManager = new MocksHelper([
 
 suite('system/AppWindowManager', function() {
   mocksForAppWindowManager.attachTestHelpers();
-  var app1, app2, app3, app4, app5, app6, app7, browser1, home;
+  var app1, app2, app3, app4, app5, app6, app7, appFullScreen, browser1, home;
   var subject;
   var settingsCore, realMozSettings;
 
@@ -78,6 +78,7 @@ suite('system/AppWindowManager', function() {
     app5 = new AppWindow(fakeAppConfig5Background);
     app6 = new AppWindow(fakeAppConfig6Browser);
     app7 = new AppWindow(fakeAppConfig7Activity);
+    appFullScreen = new AppWindow(fakeAppConfig8FullScreen);
     browser1 = new AppWindow(fakeBrowserConfig);
 
     settingsCore = BaseModule.instantiate('SettingsCore');
@@ -156,6 +157,14 @@ suite('system/AppWindowManager', function() {
     origin: 'app://www.fake7',
     isActivity: true,
     parentApp: ''
+  };
+
+  var fakeAppConfig8FullScreen = {
+    url: 'app://www.fake8/index.html',
+    manifest: {},
+    manifestURL: 'app://wwww.fake8/ManifestURL',
+    origin: 'app://www.fake8',
+    fullscreen: true
   };
 
   var fakeActivityConfigInline = {
@@ -755,6 +764,13 @@ suite('system/AppWindowManager', function() {
       assert.equal(spyPublish.firstCall.args[0], 'activeappchanged');
       assert.deepEqual(subject._activeApp, app1);
       assert.isFalse(stubStart.calledOnce);
+    });
+
+    test('sets .fullscreen-app when app.isFullScreen()', function() {
+      injectRunningApps(appFullScreen);
+      subject._activeApp = app2;
+      subject._updateActiveApp(app1.instanceID);
+      assert.isTrue(subject.screen.classList.contains('fullscreen-app'));
     });
 
     test('should not publish activeappchanged if activeApp is the same',

--- a/apps/system/test/unit/notification_screen_test.js
+++ b/apps/system/test/unit/notification_screen_test.js
@@ -74,6 +74,7 @@ suite('system/NotificationScreen >', function() {
     return {
       timeStamp: Date.now(),
       preventDefault: function() {},
+      stopPropagation: function() {},
       touches: [{
         target: target,
         pageX: x,
@@ -705,6 +706,7 @@ suite('system/NotificationScreen >', function() {
     });
 
     test('should disable scrolling during a swipe', function() {
+      MockService.mockQueryWith('UtilityTray.shown', true);
       var overflow = NotificationScreen.notificationsContainer.style.overflow;
       assert.equal(overflow, '');
 
@@ -719,6 +721,8 @@ suite('system/NotificationScreen >', function() {
     });
 
     test('should account for speed when dismissing', function() {
+      MockService.mockQueryWith('UtilityTray.shown', true);
+
       // Short but fast swipe
       var close = this.sinon.stub(NotificationScreen, 'swipeCloseNotification');
       NotificationScreen.touchstart(fakeEvt(notificationNode, 1, 1));
@@ -761,7 +765,17 @@ suite('system/NotificationScreen >', function() {
         'mozContentNotificationEvent', contentNotificationEventStub);
     });
 
+    test('tapping on notification disabled when tray not shown', function() {
+      MockService.mockQueryWith('UtilityTray.shown', false);
+      NotificationScreen.touchstart(fakeEvt(notificationNode, 10, 10));
+      NotificationScreen.touchmove(fakeEvt(notificationNode, 10, 10));
+      NotificationScreen.touchend(fakeEvt(notificationNode, 10, 10));
+
+      sinon.assert.notCalled(notifClickedStub);
+    });
+
     test('tapping on the notification', function() {
+      MockService.mockQueryWith('UtilityTray.shown', true);
       NotificationScreen.touchstart(fakeEvt(notificationNode, 10, 10));
       NotificationScreen.touchmove(fakeEvt(notificationNode, 10, 10));
       NotificationScreen.touchend(fakeEvt(notificationNode, 10, 10));

--- a/apps/system/test/unit/rocketbar_test.js
+++ b/apps/system/test/unit/rocketbar_test.js
@@ -752,13 +752,13 @@ suite('system/Rocketbar', function() {
       assert.isFalse(closeSearchStub.calledOnce);
     });
 
-    test('With utility tray active', function() {
-      MockUtilityTray.active = true;
+    test('With utility tray shown', function() {
+      MockUtilityTray.shown = true;
       subject.input.value = 'abc';
       subject.results.classList.remove('hidden');
       subject.handleInput();
       assert.ok(closeSearchStub.calledOnce);
-      MockUtilityTray.active = false;
+      MockUtilityTray.shown = false;
     });
 
   });
@@ -989,12 +989,12 @@ suite('system/Rocketbar', function() {
 
   test('calls _closeSearch if the utility tray is active', function(done) {
     subject.active = true;
-    MockUtilityTray.active = true;
+    MockUtilityTray.shown = true;
 
     var stub = this.sinon.stub(subject, '_closeSearch');
     subject.activate().then(() => {
       assert.ok(stub.calledOnce);
-      MockUtilityTray.active = false;
+      MockUtilityTray.shown = false;
       done();
     });
   });
@@ -1069,4 +1069,3 @@ suite('system/Rocketbar', function() {
     });
   });
 });
-

--- a/apps/system/test/unit/statusbar_test.js
+++ b/apps/system/test/unit/statusbar_test.js
@@ -358,12 +358,12 @@ suite('system/Statusbar', function() {
       });
 
       test('it should not forward events when the tray is opened', function() {
-        UtilityTray.active = true;
+        UtilityTray.shown = true;
         fakeDispatch('touchstart', 100, 0);
         fakeDispatch('touchmove', 100, 100);
 
         assert.isFalse(app.handleStatusbarTouch.called);
-        UtilityTray.active = false;
+        UtilityTray.shown = false;
       });
     });
   });

--- a/apps/system/test/unit/utility_tray_test.js
+++ b/apps/system/test/unit/utility_tray_test.js
@@ -1,964 +1,141 @@
-/* global MocksHelper, UtilityTray, MockService */
-
 'use strict';
 
-requireApp('system/shared/test/unit/mocks/mock_lazy_loader.js');
-requireApp('system/test/unit/mock_app_window.js');
-requireApp('system/test/unit/mock_software_button_manager.js');
-require('/shared/test/unit/mocks/mock_service.js');
+requireApp('system/js/utility_tray_motion.js');
+requireApp('system/js/utility_tray.js');
 
-var mocksHelperForUtilityTray = new MocksHelper([
-  'LazyLoader',
-  'Service',
-  'SoftwareButtonManager'
-]);
-mocksHelperForUtilityTray.init();
+/**
+ * This unit test suite only sanity-checks the basic mechanics of the tray.
+ * Integration tests check tray motion and state more thoroughly, as well as
+ * proper event handling and dispatching.
+ */
+suite('UtilityTrayMotion', function() {
+  var SCROLL_TOP_MAX = 100;
 
-suite('system/UtilityTray', function() {
-  var stubById;
-  var fakeEvt;
-  var originalSoftwareButtonManager;
-  mocksHelperForUtilityTray.attachTestHelpers();
-
-  function createEvent(type, bubbles, cancelable, detail) {
-    var evt = new CustomEvent(type, {
-      bubbles: bubbles || false,
-      cancelable: cancelable || false,
-      detail: detail
-    });
-
-    return evt;
-  }
-
-  function fakeTouches(yPoints, target) {
-    target = target || UtilityTray.topPanel;
-
-
-    var start = yPoints[0];
-    var moves = yPoints.slice(1);
-    var end = yPoints.slice(-1);
-    var lastY = start;
-
-    fakeTouchStart(start, target);
-
-    moves.forEach(y => {
-      fakeTouchMove(lastY, y, target);
-      lastY = y;
-    });
-
-    fakeTouchEnd(end, target);
-  }
-
-  function fakeTouchStart(y, target) {
-    UtilityTray.screenHeight = 480;
-    UtilityTray.onTouchStart({
-      target: target,
-      touches: [{ target: target, pageX: 42, pageY: y }],
-      timeStamp: Date.now(),
-      preventDefault: () => {}
-    });
-  }
-
-  function fakeTouchMove(start, end, target) {
-    var y = start;
-    while (y != end) {
-      UtilityTray.onTouchMove({
-        target: target,
-        timeStamp: Date.now(),
-        touches: [{ target: target, pageX: 42, pageY: y }],
-        preventDefault: () => {}
-      });
-
-      if (y < end) {
-        y++;
-      } else {
-        y--;
-      }
+  var motion, el;
+  window.Service = {
+    locked: false,
+    isFtuRunning: false,
+    getTopMostWindow: null,
+    query(value) {
+      return this[value];
     }
-  }
+  };
 
-  function fakeTouchEnd(y, target) {
-    UtilityTray.onTouchEnd({
-      target: target,
-      timeStamp: Date.now(),
-      changedTouches: [{ target: target, pageX: 42, pageY: y }],
-      preventDefault: () => {},
-      stopImmediatePropagation: () => {}
-    });
-  }
+  setup(() => {
+    el = document.createElement('div');
+    var child = document.createElement('div');
+    child.style.cssText = `height: ${SCROLL_TOP_MAX * 2}px;`;
+    el.appendChild(child);
+    el.style.cssText = `height: ${SCROLL_TOP_MAX}px; overflow-y: scroll`;
+    document.body.appendChild(el);
+    motion = new window.UtilityTrayMotion(el);
+  });
 
-  function fakeTransitionEnd() {
-    UtilityTray.overlay.dispatchEvent(createEvent('transitionend'));
-  }
-
-  setup(function(done) {
-    originalSoftwareButtonManager = window.softwareButtonManager;
-    window.softwareButtonManager = window.MocksoftwareButtonManager;
-
-    MockService.mockQueryWith('getTopMostWindow', {
-      isTransitioning: function() {},
-      getTopMostWindow: function() { return this; },
-      appChrome: {
-        titleClicked: function() {},
-        useCombinedChrome: function() {},
-        isMaximized: function() {}
+  function openTray(done) {
+    motion.open();
+    var listener = () => {
+      assert.notEqual(motion.state, 'closing');
+      assert.notEqual(motion.state, 'closed');
+      if (motion.state === 'open') {
+        el.removeEventListener('tray-motion-state', listener);
+        assert.equal(el.scrollTop, 0);
+        done();
       }
+    };
+    el.addEventListener('tray-motion-state', listener);
+  }
+
+  test('open', function(done) {
+    assert.equal(el.scrollTop, SCROLL_TOP_MAX);
+    openTray(done);
+  });
+
+  test('open and close: check state and motion events', function(done) {
+    openTray(() => {
+      assert.equal(el.scrollTop, 0);
+      motion.close();
+      var fn = () => {
+        assert.notEqual(motion.state, 'opening');
+        assert.notEqual(motion.state, 'open');
+        if (motion.state === 'closed') {
+          assert.equal(el.scrollTop, SCROLL_TOP_MAX);
+          el.removeEventListener('tray-motion-state', fn);
+          done();
+        }
+      };
+      el.addEventListener('tray-motion-state', fn);
     });
+  });
 
-    var statusbar = document.createElement('div');
-    statusbar.style.cssText = 'height: 100px; display: block;';
-
-    var statusbarIcons = document.createElement('div');
-    statusbarIcons.style.cssText = 'height: 100px; display: block;';
-
-    var grippy = document.createElement('div');
-    grippy.style.cssText = 'height: 100px; display: block;';
-
-    var overlay = document.createElement('div');
-    overlay.style.cssText = 'height: 100px; display: block;';
-
-    var screen = document.createElement('div');
-    screen.style.cssText = 'height: 100px; display: block;';
-
-    var placeholder = document.createElement('div');
-    placeholder.style.cssText = 'height: 100px; display: block;';
-
-    var notifications = document.createElement('div');
-    notifications.style.cssText = 'height: 100px; display: block;';
-
-    var notification = document.createElement('div');
-    notification.className = 'notification';
-    notifications.style.cssText = 'height: 100px; display: block;';
-
-    var stickyNotification = document.createElement('div');
-    stickyNotification.className = 'fake-notification';
-    stickyNotification.style.cssText = 'height: 100px; display: block;';
-
-    var someButton = document.createElement('button');
-    var someListItem = document.createElement('li');
-
-    var topPanel = document.createElement('div');
-    topPanel.style.cssText = 'height: 20px; display: block;';
-
-    var ambientIndicator = document.createElement('div');
-    ambientIndicator.style.cssText = 'height: 2px; display: block;';
-
-    var softwareButtons = document.createElement('div');
-    softwareButtons.style.cssText = 'height: 20px; display: block;';
-
-    /**
-     * Assemble
-     */
-
-    statusbar.appendChild(statusbarIcons);
-    topPanel.appendChild(statusbar);
-    notifications.appendChild(notification);
-    overlay.appendChild(stickyNotification);
-    overlay.appendChild(someButton);
-    overlay.appendChild(someListItem);
-    overlay.appendChild(notifications);
-    overlay.appendChild(grippy);
-
-    stubById = this.sinon.stub(document, 'getElementById', function(id) {
-      switch (id) {
-        case 'statusbar':
-          return statusbar;
-        case 'statusbar-icons':
-          return statusbarIcons;
-        case 'utility-tray-grippy':
-          return grippy;
-        case 'utility-tray':
-          return overlay;
-        case 'screen':
-          return screen;
-        case 'notifications-placeholder':
-          return placeholder;
-        case 'utility-tray-notifications':
-          return notifications;
-        case 'top-panel':
-          return topPanel;
-        case 'ambient-indicator':
-          return ambientIndicator;
-        case 'software-buttons':
-          return softwareButtons;
-        default:
-          return null;
-      }
-    });
-    requireApp('system/js/utility_tray.js', function() {
-      UtilityTray.init();
+  test('handling timeout event received while open', function(done) {
+    // If the tray is already open, another 'timeout' event should leave
+    // the tray open as-is, not attempt to close it.
+    openTray(() => {
+      assert.equal(el.scrollTop, 0);
+      motion.markPosition('timeout');
+      assert.equal(motion.state, 'open');
       done();
     });
   });
 
-  teardown(function() {
-    stubById.restore();
-    MockService.mockQueryWith('locked', false);
-    MockService.mockQueryWith('getTopMostWindow', null);
-
-    window.softwareButtonManager = originalSoftwareButtonManager;
+  test('Closes in response to window resize when closed', function() {
+    var stub = sinon.stub(motion, 'markPosition');
+    window.dispatchEvent(new CustomEvent('resize'));
+    assert.isTrue(stub.called);
+    assert.equal(stub.firstCall.args[0], 'resize');
   });
 
-  suite('show', function() {
-    setup(function() {
-      UtilityTray.show(true);
-    });
-
-    test('shown should be true', function() {
-      assert.equal(UtilityTray.shown, true);
-    });
-
-    test('Test screen element\'s class list', function() {
-      assert.equal(UtilityTray.screen.classList.contains('utility-tray'), true);
+  test('Opens in response to window resize when open', function(done) {
+    openTray(() => {
+      var stub = sinon.stub(motion, 'markPosition');
+      window.dispatchEvent(new CustomEvent('resize'));
+      assert.isTrue(stub.called);
+      assert.equal(stub.firstCall.args[0], 'resize');
+      done();
     });
   });
 
-  suite('hide', function() {
-    setup(function() {
-      UtilityTray.hide(true);
-    });
+  test('reliablyScrollTo', function() {
+    var stub = sinon.stub(motion.el, 'scrollTo');
 
-    test('should do nothing if is already hidden', function() {
-      assert.equal(UtilityTray.shown, false);
-      this.sinon.stub(UtilityTray, 'validateCachedSizes');
-      UtilityTray.hide(true);
-      assert.isFalse(UtilityTray.validateCachedSizes.called);
-    });
+    motion.reliablyScrollTo(0);
+    motion.reliablyScrollTo(10);
+    motion.reliablyScrollTo(10);
 
-    test('shown should be false', function() {
-      assert.equal(UtilityTray.shown, false);
-    });
-
-    test('lastY and startY should be undefined', function() {
-      assert.equal(UtilityTray.lastY, undefined);
-      assert.equal(UtilityTray.startY, undefined);
-    });
-
-    test('Test screen element\'s class list', function() {
-      assert.equal(UtilityTray.screen.
-        classList.contains('utility-tray'), false);
-    });
+    assert.isTrue(stub.calledThrice);
+    assert.deepEqual(stub.firstCall.args[0].top, 0);
+    assert.deepEqual(stub.secondCall.args[0].top, 10);
+    assert.deepEqual(stub.thirdCall.args[0].top, 10);
+    assert.deepEqual(stub.firstCall.args[0].behavior, 'smooth');
+    assert.deepEqual(stub.secondCall.args[0].behavior, 'smooth');
+    assert.deepEqual(stub.thirdCall.args[0].behavior, 'auto');
   });
 
-  suite('onTouch', function() {
-    suite('tapping the left corner', function() {
-      var appChrome, titleStub, app;
+});
 
-      setup(function() {
-        app = MockService.mockQueryWith('getTopMostWindow');
-        appChrome = app.appChrome;
-        titleStub = this.sinon.stub(appChrome, 'titleClicked');
-      });
+suite('UtilityTray', function() {
 
-      teardown(function() {
-        fakeTransitionEnd();
-      });
+  test('Hides when responding to certain events', function() {
 
-      test('should call to titleClicked', function() {
-        this.sinon.stub(appChrome, 'useCombinedChrome').returns(true);
-        this.sinon.stub(appChrome, 'isMaximized').returns(false);
-        this.sinon.stub(app, 'isTransitioning').returns(false);
-        fakeTouches([0, 2]);
-        assert.isTrue(titleStub.called);
-      });
-
-      test('should not call to titleClicked if isTransitioning', function() {
-        this.sinon.stub(appChrome, 'useCombinedChrome').returns(true);
-        this.sinon.stub(appChrome, 'isMaximized').returns(false);
-        this.sinon.stub(app, 'isTransitioning').returns(true);
-        fakeTouches([0, 2]);
-        assert.isFalse(titleStub.called);
-      });
-
-      test('should not call to titleClicked if !combinedView', function() {
-        this.sinon.stub(appChrome, 'useCombinedChrome').returns(false);
-        this.sinon.stub(appChrome, 'isMaximized').returns(false);
-        this.sinon.stub(app, 'isTransitioning').returns(false);
-        fakeTouches([0, 2]);
-        assert.isFalse(titleStub.called);
-      });
-
-      test('should not call to titleClicked if is maximized', function() {
-        this.sinon.stub(appChrome, 'useCombinedChrome').returns(true);
-        this.sinon.stub(appChrome, 'isMaximized').returns(true);
-        this.sinon.stub(app, 'isTransitioning').returns(false);
-        fakeTouches([0, 2]);
-        assert.isFalse(titleStub.called);
-      });
-
-      test('should hide the Utility tray', function() {
-        UtilityTray.show(true);
-        fakeTouches([0, 2]);
-        assert.equal(UtilityTray.showing, false);
-      });
-
-      test('the tray can be opened after', function() {
-        fakeTouches([0, 2]);
-        assert.isFalse(UtilityTray.shown);
-        fakeTouches([0, 400]);
-        fakeTransitionEnd();
-        assert.isTrue(UtilityTray.shown);
-      });
+    [
+      'emergencyalert',
+      'displayapp',
+      'keyboardchanged',
+      'keyboardchangecanceled',
+      'simlockshow',
+      'appopening',
+      'activityopening',
+      'sheets-gesture-begin',
+      'attentionopened',
+      'attentionwill-become-active',
+      'imemenushow'
+    ].forEach(function(eventType) {
+      var hideFn = sinon.stub(window.UtilityTray, 'hide');
+      window.UtilityTray.handleEvent(new CustomEvent(eventType));
+      assert.isTrue(hideFn.calledOnce, eventType + ' causes hide');
+      hideFn.restore();
     });
 
-    suite('showing', function() {
-      var publishStub;
-
-      setup(function() {
-        UtilityTray.isTap = true;
-        UtilityTray.hide(true);
-        publishStub = this.sinon.stub(UtilityTray, 'publish');
-      });
-
-      teardown(function() {
-        fakeTransitionEnd();
-      });
-
-      test('should not be shown by a tap', function() {
-        fakeTouches([0, 5]);
-        assert.equal(UtilityTray.showing, false);
-      });
-
-      test('should not trigger overlayopening event by a tap', function() {
-        fakeTouches([0, 5]);
-        assert.isFalse(publishStub.calledWith('-overlayopening'));
-      });
-
-      test('should be shown by a drag from the top', function() {
-        fakeTouches([0, 100]);
-        assert.isTrue(UtilityTray.showing, true);
-      });
-
-      test('should trigger overlayopening event', function() {
-        fakeTouches([0, 100]);
-        assert.isTrue(publishStub.calledWith('-overlayopening'));
-      });
-
-      test('Should be hidden when dragged down then up', function() {
-        UtilityTray.hide(true);
-        var target = UtilityTray.topPanel;
-        fakeTouchStart(100, target); // touch
-        fakeTouchMove(100, 400, target); // drag down
-        fakeTouchMove(400, 100, target); // drag up
-        fakeTouchEnd(100, target); // release
-        assert.isFalse(UtilityTray.showing);
-      });
-
-      test('should add utility-tray-in-transition class with drag from top',
-        function() {
-          fakeTouches([0, 100]);
-          assert.isTrue(UtilityTray.screen.classList.contains(
-            'utility-tray-in-transition'));
-        }
-      );
-
-      test('should send a touchcancel to the oop active app' +
-           'since the subsequent events will be swallowed', function() {
-        UtilityTray.screen.classList.remove('utility-tray');
-
-        var app = {
-          iframe: {
-            sendTouchEvent: function() {}
-          },
-          config: {
-            oop: true
-          }
-        };
-        MockService.mockQueryWith('getTopMostWindow', app);
-        this.sinon.spy(app.iframe, 'sendTouchEvent');
-
-        fakeTouches([0, 100]);
-
-        sinon.assert.calledWith(app.iframe.sendTouchEvent, 'touchcancel');
-      });
-
-      test('should not send a touchcancel to the in-process active app' +
-           'since the subsequent events will be swallowed', function() {
-        UtilityTray.screen.classList.remove('utility-tray');
-
-        var app = {
-          iframe: {
-            sendTouchEvent: function() {}
-          },
-          config: {
-            oop: false
-          }
-        };
-        MockService.mockQueryWith('getTopMostWindow', app);
-        this.sinon.spy(app.iframe, 'sendTouchEvent');
-
-        fakeTouches([0, 100]);
-
-        sinon.assert.notCalled(app.iframe.sendTouchEvent);
-      });
-    });
-
-    suite('hiding', function() {
-      setup(function() {
-        UtilityTray.show(true);
-      });
-
-      teardown(function() {
-        fakeTransitionEnd();
-      });
-
-      test('should not be hidden by a tap', function() {
-        fakeTouches([480, 475], UtilityTray.grippy);
-        assert.equal(UtilityTray.showing, true);
-      });
-
-      test('should be hidden by a drag from the bottom', function() {
-        fakeTouches([480, 380], UtilityTray.grippy);
-        assert.equal(UtilityTray.showing, false);
-      });
-
-      test('should be hidden by a drag from the softwareButtons', function() {
-        fakeTouches([480, 380], UtilityTray.softwareButtons);
-        assert.equal(UtilityTray.showing, false);
-      });
-
-      test('should add utility-tray-in-transition class on drag from bottom',
-        function() {
-          fakeTouches([480, 380], UtilityTray.grippy);
-          assert.isTrue(UtilityTray.screen.classList.contains(
-            'utility-tray-in-transition'));
-        }
-      );
-    });
   });
 
-  test('setFocus', function() {
-    assert.isFalse(UtilityTray.setFocus());
-  });
-
-  // handleEvent
-  suite('handleEvent: attentionopened', function() {
-    setup(function() {
-      fakeEvt = createEvent('attentionopened');
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-    });
-
-    test('should be hidden', function() {
-      assert.equal(UtilityTray.showing, false);
-    });
-  });
-
-  // handleEvent
-  suite('handleEvent: sheets-gesture-begin', function() {
-    setup(function() {
-      fakeEvt = createEvent('sheets-gesture-begin');
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-    });
-
-    test('should hide the ambientIndicator', function() {
-      assert.isTrue(UtilityTray.overlay.classList.contains('on-edge-gesture'));
-    });
-  });
-
-  // handleEvent
-  suite('handleEvent: sheets-gesture-end', function() {
-    setup(function() {
-      fakeEvt = createEvent('sheets-gesture-end');
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-      fakeTransitionEnd();
-    });
-
-    test('should unhide the ambientIndicator', function() {
-      assert.isFalse(UtilityTray.overlay.classList.contains('on-edge-gesture'));
-    });
-  });
-
-  suite('handleEvent: cardviewbeforeshow', function() {
-    setup(function() {
-      fakeEvt = createEvent('cardviewbeforeshow');
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-    });
-
-    test('should be hidden', function() {
-      assert.equal(UtilityTray.shown, false);
-    });
-  });
-
-  suite('handleEvent: home', function() {
-    setup(function() {
-      fakeEvt = createEvent('home', true);
-
-      UtilityTray.show();
-      UtilityTray.respondToHierarchyEvent(fakeEvt);
-    });
-
-    test('should be hidden', function() {
-      assert.equal(UtilityTray.shown, false);
-    });
-  });
-
-  suite('handleEvent: screenchange', function() {
-    teardown(function() {
-      UtilityTray.active = false;
-    });
-
-    function triggerEvent(active) {
-      fakeEvt = createEvent('screenchange', false, false,
-                            { screenEnabled: false });
-      UtilityTray.active = active;
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-      fakeTransitionEnd();
-    }
-
-    test('should be hidden when inactive', function() {
-      triggerEvent(false);
-      assert.equal(UtilityTray.shown, false);
-    });
-
-    test('should still be visible when active', function() {
-      triggerEvent(true);
-      assert.equal(UtilityTray.shown, true);
-    });
-  });
-
-  suite('handleEvent: emergencyalert', function() {
-    setup(function() {
-      fakeEvt = createEvent('emergencyalert');
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-    });
-
-    test('should be hidden', function() {
-      assert.equal(UtilityTray.showing, false);
-    });
-  });
-
-  suite('handleEvent: accessibility-control', function() {
-    var swipeDown = new CustomEvent('mozChromeEvent', {
-      detail: {
-        type: 'accessibility-control',
-        details: JSON.stringify({ eventType: 'edge-swipe-down' })
-      }
-    });
-
-    function assertIsShowing(isShowing) {
-      assert.equal(UtilityTray.overlay.classList.contains('visible'),
-                   isShowing);
-      assert.equal(UtilityTray.showing, isShowing);
-    }
-
-    setup(function() {
-      UtilityTray.hide();
-      UtilityTray.overlay.classList.remove('visible');
-    });
-
-    teardown(function() {
-      fakeTransitionEnd();
-    });
-
-    test('first swipe should show', function() {
-      UtilityTray.handleEvent(swipeDown);
-      assertIsShowing(true);
-    });
-
-    test('first swipe should not show when locked', function() {
-      MockService.mockQueryWith('locked', true);
-      UtilityTray.handleEvent(swipeDown);
-      assertIsShowing(false);
-    });
-
-    test('first swipe should not show when running FTU', function() {
-      MockService.mockQueryWith('isFtuRunning', true);
-      UtilityTray.handleEvent(swipeDown);
-      assertIsShowing(false);
-    });
-
-    test('second swipe should hide', function() {
-      UtilityTray.show();
-      var evt = new CustomEvent('mozChromeEvent', {
-        detail: {
-          type: 'accessibility-control',
-          details: JSON.stringify({ eventType: 'edge-swipe-down' })
-        }
-      });
-      UtilityTray.handleEvent(evt);
-      assertIsShowing(false);
-    });
-  });
-
-  suite('handleEvent: imemenushow', function() {
-    setup(function() {
-      UtilityTray.show();
-    });
-
-    test('should be hidden', function() {
-      fakeEvt = createEvent('imemenushow', false, true, {});
-      UtilityTray.handleEvent(fakeEvt);
-      assert.equal(UtilityTray.shown, false);
-    });
-  });
-
-  suite('handleEvent: launchapp', function() {
-    setup(function() {
-      UtilityTray.show();
-    });
-
-    test('should be hidden', function() {
-      fakeEvt = createEvent('launchapp', false, true, {
-        origin: 'app://otherApp'
-      });
-      UtilityTray.handleEvent(fakeEvt);
-      assert.equal(UtilityTray.showing, false);
-    });
-
-    test('should not be hidden if the event is sent from background app',
-      function() {
-        var findMyDeviceOrigin =
-          window.location.origin.replace('system', 'findmydevice');
-        fakeEvt = createEvent('launchapp', false, true, {
-          origin: findMyDeviceOrigin
-        });
-        UtilityTray.handleEvent(fakeEvt);
-        assert.equal(UtilityTray.showing, true);
-    });
-
-    test('should not be hidden when event marked stayBackground', function() {
-      fakeEvt = createEvent('launchapp', false, true, {
-        origin: 'app://otherApp',
-        stayBackground: true
-      });
-      UtilityTray.handleEvent(fakeEvt);
-      assert.equal(UtilityTray.showing, true);
-    });
-  });
-
-  suite('handleEvent: touchstart', function() {
-    mocksHelperForUtilityTray.attachTestHelpers();
-
-    setup(function() {
-      UtilityTray.hide();
-      UtilityTray.transitioning = false;
-      fakeEvt = createEvent('touchstart', true, true);
-      fakeEvt.touches = [0];
-    });
-
-    teardown(function() {
-      UtilityTray.active = false;
-    });
-
-    test('onTouchStart is not called if LockScreen is locked', function() {
-      MockService.mockQueryWith('locked', true);
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      UtilityTray.statusbarIcons.dispatchEvent(fakeEvt);
-      assert.ok(stub.notCalled);
-    });
-
-    test('onTouchStart is called if LockScreen is not locked', function() {
-      MockService.mockQueryWith('locked', false);
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      UtilityTray.grippy.dispatchEvent(fakeEvt);
-      assert.ok(stub.calledOnce);
-    });
-
-    test('events on the topPanel are handled', function() {
-      MockService.mockQueryWith('locked', false);
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      UtilityTray.topPanel.dispatchEvent(fakeEvt);
-      assert.ok(stub.calledOnce);
-    });
-
-    test('onTouchStart is called when ftu is running', function() {
-      MockService.mockQueryWith('isFtuRunning', true);
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      UtilityTray.topPanel.dispatchEvent(fakeEvt);
-      assert.ok(stub.notCalled);
-    });
-
-    test('preventDefault if the target is the statusbar', function() {
-      assert.isFalse(UtilityTray.statusbarIcons.dispatchEvent(fakeEvt));
-    });
-
-    test('preventDefault if the target is the grippy', function() {
-      assert.isFalse(UtilityTray.grippy.dispatchEvent(fakeEvt));
-    });
-
-    test('Test UtilityTray.active, should be true', function() {
-      /* XXX: This is to test UtilityTray.active,
-              it works in local test but breaks in travis. */
-      // assert.equal(UtilityTray.active, true);
-    });
-
-    test('onTouchStart is not called if already opened', function() {
-      UtilityTray.show();
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      UtilityTray.topPanel.dispatchEvent(fakeEvt);
-      assert.ok(stub.notCalled);
-    });
-
-    test('not called if non-draggable target', function() {
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      var overlay = UtilityTray.overlay;
-      var notification = overlay.querySelector('.notification');
-      var stickyNotification = overlay.querySelector('.fake-notification');
-      var button = overlay.querySelector('button');
-      var li = overlay.querySelector('li');
-
-      [
-        stickyNotification,
-        notification,
-        button,
-        li
-      ].forEach(el => {
-        var fakeEvt = createEvent('touchstart', true, true);
-        fakeEvt.touches = [0];
-        el.dispatchEvent(fakeEvt);
-        assert.ok(stub.notCalled);
-      });
-    });
-
-    test('not called if button is target', function() {
-      var stub = this.sinon.stub(UtilityTray, 'startMove');
-      var notification = UtilityTray.notifications
-        .querySelector('.notification');
-      notification.dispatchEvent(fakeEvt);
-      sinon.assert.notCalled(stub);
-    });
-
-    suite('Custom events', function() {
-      setup(function() {
-        UtilityTray.active = false;
-        UtilityTray.shown = false;
-      });
-
-      test('should fire a utilitytraywillhide event', function(done) {
-        window.addEventListener('utilitytraywillhide', function gotIt() {
-          window.removeEventListener('utilitytraywillhide', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-        UtilityTray.shown = true;
-        UtilityTray.grippy.dispatchEvent(fakeEvt);
-      });
-
-      test('should fire a utilitytraywillshow event', function(done) {
-        window.addEventListener('utilitytraywillshow', function gotIt() {
-          window.removeEventListener('utilitytraywillshow', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-        UtilityTray.overlay.dispatchEvent(fakeEvt);
-      });
-    });
-  });
-
-  suite('handleEvent: touchend', function() {
-    setup(function() {
-      fakeEvt = createEvent('touchend', true, true);
-      fakeEvt.changedTouches = [0];
-
-      UtilityTray.active = true;
-    });
-
-    test('Test UtilityTray.active, should be false', function() {
-      UtilityTray.statusbarIcons.dispatchEvent(fakeEvt);
-      assert.equal(UtilityTray.active, false);
-    });
-  });
-
-  suite('handleEvent: transitionend', function() {
-    setup(function() {
-      UtilityTray.hide();
-      UtilityTray.screen.classList.add('utility-tray-in-transition');
-      fakeTransitionEnd();
-    });
-
-    test('Test utilitytrayhide is correcly dispatched', function() {
-      assert.equal(UtilityTray.screen.
-        classList.contains('utility-tray'), false);
-    });
-
-    test('Ensure utility-tray-in-transition class is removed', function() {
-      assert.isFalse(UtilityTray.screen.classList.contains(
-        'utility-tray-in-transition'));
-    });
-  });
-
-  suite('handleEvent: activityopening', function() {
-    setup(function() {
-      fakeEvt = createEvent('activityopening');
-      UtilityTray.show();
-      UtilityTray.handleEvent(fakeEvt);
-    });
-
-    test('should be hidden', function() {
-      assert.equal(UtilityTray.shown, false);
-    });
-  });
-
-  suite('hide() events', function() {
-    function doAction(shown) {
-      UtilityTray.showing = true;
-      UtilityTray.shown = shown;
-      UtilityTray.hide();
-      fakeTransitionEnd();
-    }
-
-    test('utilitytraywillhide is dispatched when inactive', function(done) {
-      window.addEventListener('utilitytraywillhide',
-        function gotIt() {
-          window.removeEventListener('utilitytraywillhide', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      UtilityTray.active = false;
-      doAction(true);
-    });
-
-    test('utility-tray-overlayclosed is correctly dispatched', function(done) {
-      window.addEventListener('utility-tray-overlayclosed',
-        function gotIt() {
-          window.removeEventListener('utility-tray-overlayclosed', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(true);
-    });
-
-    test('utilitytrayhide is correctly dispatched', function(done) {
-      window.addEventListener('utilitytrayhide',
-        function gotIt() {
-          window.removeEventListener('utilitytrayhide', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(true);
-    });
-
-    test('utilitytray-deactivated is correctly dispatched', function(done) {
-      window.addEventListener('utilitytray-deactivated',
-        function gotIt() {
-          window.removeEventListener('utilitytray-deactivated', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(true);
-    });
-
-    test('utility-tray-abortopen is called when the tray ' +
-      'is closed before it is fully opened', function(done) {
-      window.addEventListener('utility-tray-abortopen',
-        function gotIt() {
-          window.removeEventListener('utility-tray-abortopen', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-
-      UtilityTray.hide(true);
-
-      var target = UtilityTray.topPanel;
-
-      fakeTouches([2, 200, 2], target);
-    });
-
-    test('The tray does not move when tapped', function() {
-      UtilityTray.show(true);
-
-      var target = UtilityTray.overlay;
-      var startY = target.style.transform;
-
-      fakeTouchStart(200, target);
-      fakeTouchMove(200, 196, target);
-      assert.equal(startY, target.style.transform);
-      fakeTouchEnd(200, target);
-
-      fakeTouchStart(200, target);
-      fakeTouchMove(200, 190, target);
-      assert.notEqual(startY, target.style.transform);
-      fakeTouchEnd(190, target);
-    });
-  });
-
-  suite('show() events', function() {
-    function doAction(shown) {
-      UtilityTray.shown = shown;
-      UtilityTray.show();
-      fakeTransitionEnd();
-    }
-
-    test('utilitytraywillshow is dispatched when inactive', function(done) {
-      window.addEventListener('utilitytraywillshow', function gotIt() {
-          window.removeEventListener('utilitytraywillshow', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      UtilityTray.active = false;
-      doAction(false);
-    });
-
-    test('utility-tray-overlayopened is correctly dispatched', function(done) {
-      window.addEventListener('utility-tray-overlayopened',
-        function gotIt() {
-          window.removeEventListener('utility-tray-overlayopened', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(false);
-    });
-
-    test('utilitytrayshow is correctly dispatched', function(done) {
-      window.addEventListener('utilitytrayshow',
-        function gotIt() {
-          window.removeEventListener('utilitytrayshow', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(false);
-    });
-
-    test('utilitytray-activated is correctly dispatched', function(done) {
-      window.addEventListener('utilitytray-activated',
-        function gotIt() {
-          window.removeEventListener('utilitytray-activated', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(false);
-    });
-
-    test('utility-tray-abortclose is correctly dispatched', function(done) {
-      window.addEventListener('utility-tray-abortclose',
-        function gotIt() {
-          window.removeEventListener('utility-tray-abortclose', gotIt);
-          assert.isTrue(true, 'got the event');
-          done();
-        });
-      doAction(true);
-    });
-  });
-
-  suite('handle software button bar', function() {
-    test('enabling/disabling soft home updates the cached height', function() {
-      var adjustedHeight = UtilityTray.screenHeight - 50;
-      var stub = sinon.stub(
-          UtilityTray.overlay,
-          'getBoundingClientRect',
-          function() {
-            return {width: 100, height: adjustedHeight};
-          }
-      );
-
-      var sbEnabledEvt = createEvent('software-button-enabled');
-      UtilityTray.handleEvent(sbEnabledEvt);
-
-      assert.equal(UtilityTray.screenHeight, adjustedHeight);
-
-      adjustedHeight += 50;
-      var sbDisabledEvt = createEvent('software-button-disabled');
-      UtilityTray.handleEvent(sbDisabledEvt);
-
-      assert.equal(UtilityTray.screenHeight, adjustedHeight);
-
-      stub.restore();
-    });
-  });
 });

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -73,7 +73,7 @@ apps/system/style/net_error.css 1 0
 apps/system/style/sound_manager/sound_manager.css 1 3
 apps/system/style/system/system.css 0 2
 apps/system/style/themes/default/core.css 0 5
-apps/system/style/utility_tray/utility_tray.css 1 0
+apps/system/style/utility_tray/utility_tray.css 3 0
 apps/system/style/window.css 0 3
 apps/system/style/wrapper/wrapper.css 0 1
 apps/system/style/zindex.css 0 4


### PR DESCRIPTION
This patch updates the utility tray to make use of native scrolling, leading to better performance.

Flagging for `feedback?` rather than review, because I haven't yet updated the tests. I'm working on the tests now, and will ask for a full review pass when I've been able to incorporate your feedback and update the tests.

For best understanding, I'd recommend visiting js/utility_tray_motion.js first, which contains detailed comments on the implementation of the tray's scroll and motion behavior, followed by js/utility_tray.js.

Since native scrolling limits us in ways touches do not, the behavior of the tray has changed slightly, as follows:
- In order to maintain the "peek at notifications" behavior, the transition is slightly different. Previously, the tray appeared stationary as you swiped down, i.e. just being unclipped as the tray expanded. This cannot be done currently with scrolling alone. Instead, we hide the footer when the tray is in transition. Along with careful use of "position: sticky", we retain the ability to peek at notifications in this patch.
- You can now drag from most any area of the tray, rather than only the bottom grippy.

I've been careful to ensure this behaves correctly when faced with screen rotation, software-home-button settings changes, rocketbar clicks, and dragging from the bottom and top of the screen. There are a lot of edge cases to consider, though, so do let me know if I missed something.

Also, as this is my first contribution to System, feel free to note if I've missed style or conventions as well.
