### PR TITLE
Bug 1185688 - [Bluetooth] If user accepts pair request through notification, they receive a pop up saying the request is expired, r=tim

### DIFF
--- a/apps/bluetooth/message.html
+++ b/apps/bluetooth/message.html
@@ -23,11 +23,11 @@
   <body role="application">
     <form role="dialog" data-type="confirm" id="pairing-request-timeout" hidden>
       <section>
-        <h1 data-l10n-id="pairing-request-timeout-title">Bluetooth Pairing Request</h1>
-        <p data-l10n-id="pairing-request-timeout-description">Bluetooth pairing request expired. Try to pair again.</p>
+        <h1 data-l10n-id="pairing-request-timeout-title"></h1>
+        <p data-l10n-id="pairing-request-timeout-description"></p>
       </section>
       <menu>
-        <button data-l10n-id="ok" class="full recommend" id="incoming-pairing-timeout-confirm">OK</button>
+        <button data-l10n-id="ok" class="full recommend" id="incoming-pairing-timeout-confirm"></button>
       </menu>
     </form>
     <script data-main="js/startup_pair.js" src="js/vendor/alameda.js"></script>

--- a/apps/bluetooth/onpair.html
+++ b/apps/bluetooth/onpair.html
@@ -41,8 +41,8 @@
         </span>
       </section>
       <menu>
-        <button id="button-close" data-l10n-id="cancel">Cancel</button>
-        <button id="button-pair" class="recommend" data-l10n-id="pair">Pair</button>
+        <button id="button-close" data-l10n-id="cancel"></button>
+        <button id="button-pair" class="recommend" data-l10n-id="pair"></button>
       </menu>
     </form>
   </body>

--- a/apps/bluetooth/onpair_v1.html
+++ b/apps/bluetooth/onpair_v1.html
@@ -45,8 +45,8 @@
         </span>
       </section>
       <menu>
-        <button id="button-close" data-l10n-id="cancel">Cancel</button>
-        <button id="button-pair" class="recommend" data-l10n-id="pair">Pair</button>
+        <button id="button-close" data-l10n-id="cancel"></button>
+        <button id="button-pair" class="recommend" data-l10n-id="pair"></button>
       </menu>
     </form>
   </body>

--- a/apps/bluetooth/test/unit/modules/pair_manager_test.js
+++ b/apps/bluetooth/test/unit/modules/pair_manager_test.js
@@ -433,8 +433,17 @@ suite('Bluetooth app > PairManager ', function() {
         mockNotification = null;
       });
 
+      test('notification should be close, confirm dialog should not be ' +
+        'called if pair request not expired yet', function() {
+        PairManager._isExpired = false;
+        assert.isTrue(mockNotification.close.called);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        assert.isFalse(PairExpiredDialog.showConfirm.called);
+      });
+
       test('notification should be close, confirm dialog should be called ' +
         'if it is not visible', function() {
+        PairManager._isExpired = true;
         assert.isTrue(mockNotification.close.called);
         MockNavigatormozApps.mTriggerLastRequestSuccess();
         assert.isTrue(PairExpiredDialog.showConfirm.called);

--- a/apps/bluetooth/test/unit/modules/pair_manager_v1_test.js
+++ b/apps/bluetooth/test/unit/modules/pair_manager_v1_test.js
@@ -320,8 +320,17 @@ suite('Bluetooth app > PairManager ', function() {
         mockNotification = null;
       });
 
+      test('notification should be close, confirm dialog should not be ' +
+        'called if pair request not expired yet', function() {
+        PairManager._isExpired = false;
+        assert.isTrue(mockNotification.close.called);
+        MockNavigatormozApps.mTriggerLastRequestSuccess();
+        assert.isFalse(PairExpiredDialog.showConfirm.called);
+      });
+
       test('notification should be close, confirm dialog should be called ' +
         'if it is not visible', function() {
+        PairManager._isExpired = true;
         assert.isTrue(mockNotification.close.called);
         MockNavigatormozApps.mTriggerLastRequestSuccess();
         assert.isTrue(PairExpiredDialog.showConfirm.called);

--- a/apps/bluetooth/transfer.html
+++ b/apps/bluetooth/transfer.html
@@ -33,29 +33,27 @@
     <!-- Enable Bluetooth View -->
     <form role="dialog" data-type="confirm" id="enable-bluetooth-view" hidden>
       <section>
-        <h1 data-l10n-id="confirmation">Confirmation</h1>
+        <h1 data-l10n-id="confirmation"></h1>
         <p>
           <img id="icon" src="style/images/settings_bluetooth.png" alt="Bluetooth Icon"/>
-          <strong data-l10n-id="bluetooth">Bluetooth</strong>
-          <small data-l10n-id="bluetooth-status-description">Bluetooth is disabled</small>
+          <strong data-l10n-id="bluetooth"></strong>
+          <small data-l10n-id="bluetooth-status-description"></small>
         </p>
-        <p data-l10n-id="turn-bluetooth-on">Do you want to turn Bluetooth on?</p>
+        <p data-l10n-id="turn-bluetooth-on"></p>
       </section>
       <menu>
         <button type="reset" id="enable-bluetooth-button-cancel" data-l10n-id="cancel">Cancel</button>
-        <button type="submit" class="recommend" id="enable-bluetooth-button-turn-on" data-l10n-id="turn-on">Turn On</button>
+        <button type="submit" class="recommend" id="enable-bluetooth-button-turn-on" data-l10n-id="turn-on"></button>
       </menu>
     </form>
     <!-- Bluetooth File Transfer Failed View -->
     <form role="dialog" data-type="confirm" id="alert-view" hidden>
       <section>
-        <h1 data-l10n-id="error-transfer-title">Bluetooth file transfer failed</h1>
-        <p data-l10n-id="error-transfer-settings">
-          Bluetooth file transfer failed. Check that the Bluetooth settings are correct.
-        </p>
+        <h1 data-l10n-id="error-transfer-title"></h1>
+        <p data-l10n-id="error-transfer-settings"></p>
       </section>
       <menu>
-        <button class="full danger" id="alert-button-ok" data-l10n-id="ok">OK</button>
+        <button class="full danger" id="alert-button-ok" data-l10n-id="ok"></button>
       </menu>
     </form>
     <!-- Devices List View -->
@@ -66,23 +64,21 @@
       <div>
         <!-- Devices List View :: Paired Devices List -->
         <gaia-subheader id="bluetooth-paired-title" class="bluetooth-paired-title" skin="organic">
-          <span data-l10n-id="bluetooth-paired-devices">Paired Devices</span>
+          <span data-l10n-id="bluetooth-paired-devices"></span>
         </gaia-subheader>
         <ul id="bluetooth-paired-devices" class="bluetooth-paired-devices devices">
         </ul>
         <!-- Devices List View :: Found Devices List -->
         <gaia-subheader id="bluetooth-found-title" class="bluetooth-found-title" skin="organic">
-          <span data-l10n-id="bluetooth-devices-in-area">Devices found</span>
+          <span data-l10n-id="bluetooth-devices-in-area"></span>
         </gaia-subheader>
         <ul id="bluetooth-devices" class="bluetooth-devices devices">
         </ul>
         <!-- Devices List View :: Search Button -->
-        <div id="bluetooth-searching" data-l10n-id="search-for-device" class="bluetooth-searching explanation">
-          Searching for devices…
-        </div>
+        <div id="bluetooth-searching" data-l10n-id="search-for-device" class="bluetooth-searching explanation"></div>
         <ul id="bluetooth-search" class="bluetooth-search">
           <li>
-            <button id="search-device" class="search-device" data-l10n-id="search-device" disabled>Search for Devices</button>
+            <button id="search-device" class="search-device" data-l10n-id="search-device" disabled></button>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
- fix issue
- use arrow syntax
- remove strings in html tags
## The basic flow explanation to help the review process:

when screen locked, `fireNotification` is called to show the notification
https://github.com/mozilla-b2g/gaia/blob/master/apps/bluetooth/js/modules/pair_manager.js#L257

At this time, `this.pendingPairing` object is stored https://github.com/mozilla-b2g/gaia/blob/master/apps/bluetooth/js/modules/pair_manager.js#L282

And the click handler is hooked to show the expired dialog `pairingRequestExpiredNotificationHandler` is registered
https://github.com/mozilla-b2g/gaia/blob/master/apps/bluetooth/js/modules/pair_manager.js#L298

The patch interpret if `this.pendingPairing` object is exist in `showPendingPairing` after user unlock the screen,
https://github.com/mozilla-b2g/gaia/blob/master/apps/bluetooth/js/modules/pair_manager.js#L337

And control if we need to show the expired dialog 
https://github.com/mozilla-b2g/gaia/blob/master/apps/bluetooth/js/modules/pair_manager.js#L323
