### PR TITLE
  Bug 1182035 - Fixed app updates error in 2G

### DIFF
--- a/apps/system/js/update_manager.js
+++ b/apps/system/js/update_manager.js
@@ -189,6 +189,13 @@ var UpdateManager = {
 
   launchDownload: function um_launchDownload() {
     var self = this;
+
+    function systemUpdateAvailable() {
+      return self.updatesQueue.some(function(updatable) {
+        return (updatable instanceof SystemUpdatable);
+      });
+    }
+
     // If it's not connected to a wifi we need to verify what kind of
     // connection it has
     if (self._isNotWifiConnected()) {
@@ -198,9 +205,9 @@ var UpdateManager = {
         var update2G =
              reqUpdate.result && reqUpdate.result[self.UPDATE_2G_SETT] || false;
 
-        // If update 2G is available we don't need to know what kind
-        // of connection the phone has
-        if (update2G) {
+        // If update 2G is available or it isn't system update we don't need to
+        // know what kind of connection the phone has
+        if (update2G || !systemUpdateAvailable()) {
           self.showDownloadPrompt();
         } else {
           // We can download the update only if the current connection

--- a/apps/system/test/unit/update_manager_test.js
+++ b/apps/system/test/unit/update_manager_test.js
@@ -1444,7 +1444,6 @@ suite('system/UpdateManager', function() {
             connected: true
           }
         ],
-
         update2g: true,
         forbiddenDwnload: false
       },
@@ -1508,7 +1507,8 @@ suite('system/UpdateManager', function() {
         forbiddenDwnload: false
       },
       {
-        title: 'no WIFI, 2G, no Setting update2G -> download forbidden',
+        title: 'no WIFI, 2G, no Setting update2G, ' +
+               'System update available -> download forbidden',
         wifi: false,
         conns: [
           {
@@ -1519,10 +1519,28 @@ suite('system/UpdateManager', function() {
             connected: false
           }
         ],
+        systemUpdate: true,
         forbiddenDwnload: true
       },
       {
-        title: 'no WIFI, 2G, Setting update2G is true -> download available',
+        title: 'no WIFI, 2G, no Setting update2G, ' +
+               'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            type: 'gprs',
+            connected: true
+          },
+          {
+            connected: false
+          }
+        ],
+        systemUpdate: false,
+        forbiddenDwnload: false
+      },
+      {
+        title: 'no WIFI, 2G, Setting update2G is true, ' +
+               'System update available -> download available',
         wifi: false,
         conns: [
           {
@@ -1534,10 +1552,29 @@ suite('system/UpdateManager', function() {
           }
         ],
         update2g: true,
+        systemUpdate: true,
         forbiddenDwnload: false
       },
       {
-        title: 'no WIFI, 2G, Setting update2G is false -> download forbidden',
+        title: 'no WIFI, 2G, Setting update2G is true, ' +
+               'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            connected: false
+          },
+          {
+            type: 'gprs',
+            connected: true
+          }
+        ],
+        update2g: true,
+        systemUpdate: false,
+        forbiddenDwnload: false
+      },
+      {
+        title: 'no WIFI, 2G, Setting update2G is false, ' +
+               'System update available -> download forbidden',
         wifi: false,
         conns: [
           {
@@ -1549,12 +1586,32 @@ suite('system/UpdateManager', function() {
           }
         ],
         update2g: false,
+        systemUpdate: true,
         forbiddenDwnload: true
+      },
+      {
+        title: 'no WIFI, 2G, Setting update2G is false, ' +
+               'System update unavailable -> download available',
+        wifi: false,
+        conns: [
+          {
+            type: 'gprs',
+            connected: true
+          },
+          {
+            connected: false
+          }
+        ],
+        update2g: false,
+        systemUpdate: false,
+        forbiddenDwnload: false
       }
     ];
 
     testCases.forEach(function(testCase) {
       test(testCase.title, function() {
+        var systemUpdatable, appUpdatable;
+
         if (testCase.update2g === undefined) {
           delete MockNavigatorSettings.mSettings[UpdateManager.UPDATE_2G_SETT];
         } else {
@@ -1571,6 +1628,16 @@ suite('system/UpdateManager', function() {
             connected: testCase.conns[i].connected,
             type: testCase.conns[i].type
           };
+        }
+
+        appUpdatable = new MockAppUpdatable(new MockApp());
+        appUpdatable.name = 'Angry birds';
+        appUpdatable.size = '423459';
+        UpdateManager.addToUpdatableApps(appUpdatable);
+        UpdateManager.addToUpdatesQueue(appUpdatable);
+        if (testCase.systemUpdate) {
+          systemUpdatable = new MockSystemUpdatable();
+          UpdateManager.addToUpdatesQueue(systemUpdatable);
         }
 
         UpdateManager.launchDownload();


### PR DESCRIPTION
Fixed so when only there are app updates and update.2g enabled is false and device is in 2G, they are not blocked
