### PR TITLE
Bug 1187979 - Improve Inputpad's touch and visual feeback

### DIFF
--- a/apps/system/lockscreen/js/lockscreen_inputpad.js
+++ b/apps/system/lockscreen/js/lockscreen_inputpad.js
@@ -117,6 +117,7 @@
         this.updatePassCodeUI();
         break;
       case 'touchstart':
+        // TODO: ignore while on error timeout
         touch = evt.changedTouches[0];
         target = document.elementFromPoint(touch.clientX, touch.clientY);
         key = this._keyForTarget(target);
@@ -133,6 +134,7 @@
         }
         break;
       case 'touchmove':
+        // TODO: ignore while on error timeout
         touch = evt.changedTouches[0];
         target = document.elementFromPoint(touch.clientX, touch.clientY);
         key = this._keyForTarget(target);
@@ -150,6 +152,7 @@
         break;
       case 'touchend':
       case 'click':
+        // TODO: ignore while on error timeout
         if (evt.type == 'touchend') {
           evt.preventDefault();  // prevent the 'click'
           touch = evt.changedTouches[0];
@@ -170,49 +173,51 @@
     }
   };
 
+  LockScreenInputpad.prototype._anchorForTarget = function(target) {
+    // Find ancestorial anchor that has info on the key
+    // Current structure: a > div > span
+    try {
+      if (target.tagName !== 'A') {
+        target = target.parentNode;
+      }
+      if (target.tagName !== 'A') {
+        target = target.parentNode;
+      }
+      if (target.tagName == 'A') {
+        return target;
+      }
+      return null;
+    }
+    catch (e) {
+      return null;
+    }
+  };
+
   LockScreenInputpad.prototype._keyForTarget = function(target) {
-    // find ancestorial a
-    // current structure: a > div > span
-    if (target.tagName !== 'A') {
-      target = target.parentNode;
+    var anchor = this._anchorForTarget(target);
+    if (anchor) {
+      return anchor.dataset.key;
+    } else {
+      return null;
     }
-    if (target.tagName !== 'A') {
-      target = target.parentNode;
-    }
-    if (target.tagName !== 'A') {
-      return undefined;
-    }
-    return target.dataset.key;
   };
 
   LockScreenInputpad.prototype._makeKeyActive = function(target) {
-    // find ancestorial a
-    // current structure: a > div > span
-    if (target.tagName !== 'A') {
-      target = target.parentNode;
+    var anchor = this._anchorForTarget(target);
+    if (anchor) {
+      anchor.classList.add('active-key');
+    } else {
+      throw Error('lsip_makeKeyActive called with non-key node');
     }
-    if (target.tagName !== 'A') {
-      target = target.parentNode;
-    }
-    if (target.tagName !== 'A') {
-      return;
-    }
-    target.classList.add('active-key');
   };
 
   LockScreenInputpad.prototype._makeKeyInactive = function(target) {
-    // find ancestorial a
-    // current structure: a > div > span
-    if (target.tagName !== 'A') {
-      target = target.parentNode;
+    var anchor = this._anchorForTarget(target);
+    if (anchor) {
+      anchor.classList.remove('active-key');
+    } else {
+      throw Error('lsip_makeKeyInactive called with non-key node');
     }
-    if (target.tagName !== 'A') {
-      target = target.parentNode;
-    }
-    if (target.tagName !== 'A') {
-      return;
-    }
-    target.classList.remove('active-key');
   };
 
   LockScreenInputpad.prototype.dispatchEvent = function(evt) {

--- a/apps/system/lockscreen/js/lockscreen_inputpad.js
+++ b/apps/system/lockscreen/js/lockscreen_inputpad.js
@@ -129,7 +129,8 @@
         }
         this._makeKeyActive(target);
         this.lastTouched = target;
-        if (this.states.padVibrationEnabled) {
+        if (this.states.padVibrationEnabled &&
+          !this.states.passCodeErrorTimeoutPending) {
           navigator.vibrate(this.configs.padVibrationDuration);
         }
         break;

--- a/apps/system/lockscreen/js/lockscreen_inputpad.js
+++ b/apps/system/lockscreen/js/lockscreen_inputpad.js
@@ -147,8 +147,8 @@
     var key = this._keyForTarget(target);
     if (key) {
       this._visualizeKeypress(target);
-      if (this.states.padVibrationEnabled
-        && !this.states.passCodeErrorTimeoutPending) {
+      if (this.states.padVibrationEnabled &&
+          !this.states.passCodeErrorTimeoutPending) {
         navigator.vibrate(this.configs.padVibrationDuration);
       }
     }
@@ -197,8 +197,8 @@
     // null, requesting internal reset.
     // Comparing DOM elements is tricky. .isEqualNode() and friends
     // do not always work as expected. Comparing textContent instead.
-    if (!target || !this.lastTouchedKey
-      || target.textContent !== this.lastTouchedKey.textContent) {
+    if (!target || !this.lastTouchedKey ||
+        target.textContent !== this.lastTouchedKey.textContent) {
       // Make old key inactive if there was one
       if (this.lastTouchedKey) {
         this._makeKeyInactive(this.lastTouchedKey);

--- a/apps/system/lockscreen/js/lockscreen_inputpad.js
+++ b/apps/system/lockscreen/js/lockscreen_inputpad.js
@@ -136,7 +136,7 @@
         touch = evt.changedTouches[0];
         target = document.elementFromPoint(touch.clientX, touch.clientY);
         key = this._keyForTarget(target);
-        if (target !== this.lastTouched) {
+        if (target.textContent !== this.lastTouched.textContent) {
           if (this.lastTouched) {
             this._makeKeyInactive(this.lastTouched);
           }

--- a/apps/system/lockscreen/style/lockscreen_inputpad.css
+++ b/apps/system/lockscreen/style/lockscreen_inputpad.css
@@ -129,13 +129,13 @@
 }
 
 /* if not fufilled, show it is pressed */
-#lockscreen-passcode-pad:not(.passcode-fulfilled) > a:active {
+#lockscreen-passcode-pad:not(.passcode-fulfilled) > a.active-key {
   background-color: #4a5255;
   color: #00caf2;
   text-shadow: none;
 }
 
-#lockscreen-passcode-pad:not(.passcode-fulfilled) > a.lockscreen-passcode-pad-func:active > div > span{
+#lockscreen-passcode-pad:not(.passcode-fulfilled) > a.lockscreen-passcode-pad-func.active-key > div > span{
   color: #00caf2;
 }
 
@@ -188,7 +188,7 @@
   margin-top: -2.6rem;
 }
 
-#lockscreen-passcode-pad:not(.passcode-fulfilled)  > a:active > div > span {
+#lockscreen-passcode-pad:not(.passcode-fulfilled) > a.active-key > div > span {
   color: transparent;
   text-shadow: none;
 }

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -66,8 +66,9 @@ suite('LockScreenInputpad', function() {
     setup(function () {
       MockHtml = document.createElement('html');
       MockHtml.appendChild(document.createElement('div'));
-      MockHtml.firstChild.innerHTML = `<a role="key" href="#" data-key="2" ` +
-        `class="row0"><div>2<span>ABC</span></div></a>`;
+      // Don't use +, or eslint will jump at you for unsafe innerHTML
+      MockHtml.firstChild.innerHTML = `<a role="key" href="#" data-key="2"
+        class="row0"><div>2<span>ABC</span></div></a>`;
     });
 
     test('find the correct anchor element for click targets', function () {

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -66,7 +66,6 @@ suite('LockScreenInputpad', function() {
     setup(function () {
       MockHtml = document.createElement('html');
       MockHtml.appendChild(document.createElement('div'));
-      var html =
       MockHtml.firstChild.innerHTML = `<a role="key" href="#" data-key="2" ` +
         `class="row0"><div>2<span>ABC</span></div></a>`;
     });

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -59,6 +59,49 @@ suite('LockScreenInputpad', function() {
       .classList.contains('disabled'));
   });
 
+  suite('InputPad key helper functions >', function() {
+
+    var MockHtml;
+
+    setup(function () {
+      MockHtml = document.createElement('html');
+      MockHtml.appendChild(document.createElement('div'));
+      var html =
+      MockHtml.firstChild.innerHTML = `<a role="key" href="#" data-key="2" ` +
+        `class="row0"><div>2<span>ABC</span></div></a>`;
+    });
+
+    test('find the correct anchor element for click targets', function () {
+      var method = subject._anchorForTarget;
+      var a = MockHtml.firstChild.firstChild;  // the anchor to find
+      assert.isTrue(a === method(a),
+        'anchor detection fails for a level 0 click target');
+      assert.isTrue(a === method(a.firstElementChild),
+        'anchor detection fails for a level 1 click target');
+      assert.isTrue(a === method(a.firstElementChild.firstElementChild),
+        'anchor detection fails for a level 2 click target');
+      // The tested method currently only supports up to 2nd-level
+      // children and we don't really care if it supports more.
+      assert.isNull(method(MockHtml),
+        'anchor detection fails unexpectedly for top element');
+      assert.isNull(method(MockHtml.firstElementChild),
+        'anchor detection fails unexpectedly for non-keypad element');
+    });
+
+    test('decorate active keys with CSS classes', function() {
+      var a = MockHtml.firstChild.firstChild;  // the anchor to find
+      var activeClass = 'active-key';
+      a.classList.remove(activeClass);
+      subject._makeKeyActive(a);
+      assert.isTrue(a.classList.contains(activeClass),
+        'do not mark key anchor active with CSS class');
+      subject._makeKeyInactive(a);
+      assert.isFalse(a.classList.contains(activeClass),
+        'do not mark key anchor inactive by removing CSS class');
+    });
+
+  });
+
   suite('updatePassCodeUI >', function() {
     test('it would add passcode-entered class while passcode entered',
     function() {
@@ -244,7 +287,7 @@ suite('LockScreenInputpad', function() {
       });
     });
 
-    suite('click', function() {
+    suite('typing', function() {
       var evt;
       setup(function() {
         evt = {
@@ -268,28 +311,6 @@ suite('LockScreenInputpad', function() {
           'handlePassCodeInput');
         subject.handleEvent(evt);
         assert.isTrue(stubHandlePassCodeInput.calledWith('f'));
-      });
-      test('it would vibrate', function() {
-        var method = subject.handle;
-        var mockThis = {
-          passcodePad: document.createElement('div'),
-          lockScreen: {
-            overlay: document.createElement('div'),
-            checkPassCode: () => {}
-          },
-          states: {
-            passCodeEntered: '123',
-            padVibrationEnabled: true
-          },
-          configs: {
-            padVibrationDuration: 100
-          },
-          updatePassCodeUI: () => {},
-          padVibrationEnabled: true
-        };
-        var stubVibrate = this.sinon.stub(navigator, 'vibrate');
-        method.call(mockThis, '4');
-        assert.isTrue(stubVibrate.called);
       });
       test('it would clear notification opening ID', function() {
         var method = subject.handlePassCodeInput;

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -252,12 +252,12 @@ suite('LockScreenInputpad', function() {
           preventDefault: function() {}
         };
         evt.target = {
-          tagName: 'div',
+          tagName: 'DIV',
           parentNode: {
             dataset: {
               key: 'f'
             },
-            tagName: 'a'
+            tagName: 'A'
           },
           dataset: {}
         };
@@ -270,7 +270,7 @@ suite('LockScreenInputpad', function() {
         assert.isTrue(stubHandlePassCodeInput.calledWith('f'));
       });
       test('it would vibrate', function() {
-        var method = subject.handlePassCodeInput;
+        var method = subject.handle;
         var mockThis = {
           passcodePad: document.createElement('div'),
           lockScreen: {

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -3,7 +3,6 @@
 
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
 requireApp('system/lockscreen/js/lockscreen_inputpad.js');
-var fs = require('fs');
 
 var mocks = new window.MocksHelper([
   'SettingsListener'
@@ -151,7 +150,8 @@ suite('LockScreenInputpad', function() {
       };
       var result = subject._touchTarget(event);
       assert.isTrue(stubFromPoint.calledWith(23,42),
-        'touchTarget does not call .elementFromPoint() with expected arguments');
+        'touchTarget does not call .elementFromPoint() ' +
+        'with expected arguments');
       assert.isTrue(result === 'CORRECT_ELEMENT',
         'touchTarget does not find the expected element');
       stubFromPoint.restore();
@@ -182,14 +182,14 @@ suite('LockScreenInputpad', function() {
 
       oldTarget.classList.remove(activeClass);
       subject._visualizeKeypress(oldTarget);
-      assert.isFalse(oldTarget.classList.contains(activeClass)
-        && !newTarget.classList.contains(activeClass),
+      assert.isFalse(oldTarget.classList.contains(activeClass) &&
+        !newTarget.classList.contains(activeClass),
         'vizualizeKeypress changes inactive state without key change');
 
       oldTarget.classList.add(activeClass);
       subject._visualizeKeypress(oldTarget);
-      assert.isTrue(oldTarget.classList.contains(activeClass)
-        && !newTarget.classList.contains(activeClass),
+      assert.isTrue(oldTarget.classList.contains(activeClass) &&
+        !newTarget.classList.contains(activeClass),
         'vizualizeKeypress changes active state without key change');
 
       subject._visualizeKeypress(newTarget);
@@ -531,10 +531,10 @@ suite('LockScreenInputpad', function() {
 
       test('it correctly handles key input', function() {
         subject.handlePassCodeInput(twoKey);
-        assert.isTrue(subject.states.passCodeEntered === "2",
+        assert.isTrue(subject.states.passCodeEntered === '2',
           'it does not correctly handle the first key');
         subject.handlePassCodeInput(threeKey);
-        assert.isTrue(subject.states.passCodeEntered === "23",
+        assert.isTrue(subject.states.passCodeEntered === '23',
           'it does not correctly handle the second key');
       });
 
@@ -542,7 +542,7 @@ suite('LockScreenInputpad', function() {
         subject.handlePassCodeInput(twoKey);
         subject.handlePassCodeInput(threeKey);
         subject.handlePassCodeInput(backKey);
-        assert.isTrue(subject.states.passCodeEntered === "2",
+        assert.isTrue(subject.states.passCodeEntered === '2',
           'it does not correctly handle the back key');
       });
 
@@ -551,7 +551,7 @@ suite('LockScreenInputpad', function() {
         subject.handlePassCodeInput(threeKey);
         subject.handlePassCodeInput(twoKey);
         subject.handlePassCodeInput(threeKey);
-        assert.isTrue(stubCheckPassCode.calledWith("2323"),
+        assert.isTrue(stubCheckPassCode.calledWith('2323'),
           'it does not properly check the pass code');
       });
 

--- a/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
+++ b/apps/system/test/unit/lockscreen/lockscreen_inputpad_test.js
@@ -3,6 +3,7 @@
 
 requireApp('system/shared/test/unit/mocks/mock_settings_listener.js');
 requireApp('system/lockscreen/js/lockscreen_inputpad.js');
+var fs = require('fs');
 
 var mocks = new window.MocksHelper([
   'SettingsListener'
@@ -12,17 +13,58 @@ suite('LockScreenInputpad', function() {
   var subject;
   var mockLockScreenFacade;
   var mockGetElementById;
+  var mockHtmlKeypad;
+  var oneKey;
+  var twoKey;
+  var threeKey;
+  var emergencyKey;
+  var cancelKey;
+  var backKey;
   mocks.attachTestHelpers();
+
   setup(function() {
     mockGetElementById = sinon.stub(window.document, 'getElementById',
-    function() {
-      var elem = document.createElement('div');
-      elem.querySelector = function() {
-        return document.createElement('div');
-      };
-      return elem;
-    });
+      function() {
+        var elem = document.createElement('div');
+        elem.querySelector = function() {
+          return document.createElement('div');
+        };
+        return elem;
+      });
     mockLockScreenFacade = {};
+
+    // Build a mock keypad that helper functions can work on.
+    // Uses verbatim HTML from keypad from lockscreen_inputpad_frame.html
+    mockHtmlKeypad = document.createElement('html');
+    mockHtmlKeypad.appendChild(document.createElement('div'));
+    // Don't use + to concatenate strings, or eslint will jump
+    // at you for use of unsafe innerHTML.
+    mockHtmlKeypad.firstChild.innerHTML = `
+        <a role="key" href="#" data-key="1"
+          class="row0"><div>1<span></span></div></a>
+        <a role="key" href="#" data-key="2"
+          class="row0"><div>2<span>ABC</span></div></a>
+        <a role="key" href="#" data-key="3"
+          class="row0"><div>3<span>DEF</span></div></a>
+        <a role="button" href="#" data-key="e"
+          class="lockscreen-passcode-pad-func last-row row3"><div>
+          <span data-l10n-id="emergency-call-button">Emergency Call</span>
+          </div></a>
+        <a role="key" href="#" data-key="0" class="last-row row3">
+          <div>0</div></a>
+        <a role="button" href="#" data-key="c"
+          class="lockscreen-passcode-pad-func last-row row3"><div>
+          <span data-l10n-id="cancel">Cancel</span></div></a>
+        <a role="button" href="#" data-key="b" class="last-row row3">
+          <div data-l10n-id="undo">⌫</div></a>
+      `;
+    oneKey = mockHtmlKeypad.firstChild.children[0];
+    twoKey = mockHtmlKeypad.firstChild.children[1];
+    threeKey = mockHtmlKeypad.firstChild.children[2];
+    emergencyKey = mockHtmlKeypad.firstChild.children[3];
+    cancelKey = mockHtmlKeypad.firstChild.children[5];
+    backKey = mockHtmlKeypad.firstChild.children[6];
+
     subject = new LockScreenInputpad(mockLockScreenFacade);
     var stub = sinon.stub(subject, 'toggleEmergencyButton');
     subject.start();
@@ -51,7 +93,7 @@ suite('LockScreenInputpad', function() {
       }
     };
     subject.passcodePad = document.createElement('div');
-    subject.passcodePad.innerHTML = `<a data-key="e">`;
+    subject.passcodePad.appendChild(emergencyKey);
     subject.emergencyCallBtn =
       subject.passcodePad.querySelector('a[data-key=e]');
     subject.toggleEmergencyButton();
@@ -59,45 +101,106 @@ suite('LockScreenInputpad', function() {
       .classList.contains('disabled'));
   });
 
-  suite('InputPad key helper functions >', function() {
+  suite('Inputpad key helper functions >', function() {
 
-    var MockHtml;
-
-    setup(function () {
-      MockHtml = document.createElement('html');
-      MockHtml.appendChild(document.createElement('div'));
-      // Don't use +, or eslint will jump at you for unsafe innerHTML
-      MockHtml.firstChild.innerHTML = `<a role="key" href="#" data-key="2"
-        class="row0"><div>2<span>ABC</span></div></a>`;
-    });
-
-    test('find the correct anchor element for click targets', function () {
+    test('find the correct anchor element for touch targets', function () {
       var method = subject._anchorForTarget;
-      var a = MockHtml.firstChild.firstChild;  // the anchor to find
+      var a = twoKey;  // key to work with is "2"
       assert.isTrue(a === method(a),
-        'anchor detection fails for a level 0 click target');
+        'anchor detection fails for a level 0 target');
       assert.isTrue(a === method(a.firstElementChild),
-        'anchor detection fails for a level 1 click target');
+        'anchor detection fails for a level 1 target');
       assert.isTrue(a === method(a.firstElementChild.firstElementChild),
-        'anchor detection fails for a level 2 click target');
+        'anchor detection fails for a level 2 target');
       // The tested method currently only supports up to 2nd-level
       // children and we don't really care if it supports more.
-      assert.isNull(method(MockHtml),
-        'anchor detection fails unexpectedly for top element');
-      assert.isNull(method(MockHtml.firstElementChild),
-        'anchor detection fails unexpectedly for non-keypad element');
+      assert.isNull(method(mockHtmlKeypad),
+        'anchorForTarget fails unexpectedly for top element');
+      assert.isNull(method(mockHtmlKeypad.firstElementChild),
+        'anchorForTarget fails unexpectedly for non-keypad element');
+      assert.isNull(method(null),
+        'anchorForTarget improperly handles null targets');
     });
 
-    test('decorate active keys with CSS classes', function() {
-      var a = MockHtml.firstChild.firstChild;  // the anchor to find
+    test('extract the correct key from touch targets', function () {
+      // Get a pointer to a sub-element of mock key "2"
+      var target = twoKey.firstElementChild;
+      assert.isTrue('2' === subject._keyForTarget(target),
+        'keyForTarget does not extract the expected key value');
+      assert.isNull(subject._keyForTarget(null),
+        'keyForTarget does not properly handle null targets');
+    });
+
+    test('find the correct element for touch events', function () {
+      // This is not a good test, but since at this point our
+      // unit testing can't fully simulate a rendered web page such
+      // that document.elementFromPoint() is fully functional, all we
+      // can do is check whether it is called with the expected
+      // arguments.
+      var stubFromPoint = sinon.stub(document, 'elementFromPoint',
+        function() {
+          return 'CORRECT_ELEMENT';
+        });
+      var event = {
+        changedTouches: [
+          {
+            clientX: 23,
+            clientY: 42
+          }
+        ]
+      };
+      var result = subject._touchTarget(event);
+      assert.isTrue(stubFromPoint.calledWith(23,42),
+        'touchTarget does not call .elementFromPoint() with expected arguments');
+      assert.isTrue(result === 'CORRECT_ELEMENT',
+        'touchTarget does not find the expected element');
+      stubFromPoint.restore();
+    });
+
+    test('decorates active key with CSS classes', function() {
+      var a = twoKey;  // anchor of key "2"
       var activeClass = 'active-key';
       a.classList.remove(activeClass);
       subject._makeKeyActive(a);
       assert.isTrue(a.classList.contains(activeClass),
-        'do not mark key anchor active with CSS class');
+        'makeActive does not add set active-key CSS class');
       subject._makeKeyInactive(a);
       assert.isFalse(a.classList.contains(activeClass),
-        'do not mark key anchor inactive by removing CSS class');
+        'makeInactive does not remove active-key CSS class');
+    });
+
+    test('correctly visualizes touchmove key transitions', function() {
+      var oldTarget = twoKey;  // anchor of key "2"
+      var newTarget = threeKey;  // anchor of key "3"
+      var activeClass = 'active-key';
+      oldTarget.classList.remove(activeClass);
+      newTarget.classList.remove(activeClass);
+
+      subject._visualizeKeypress(oldTarget);
+      assert.isTrue(oldTarget.classList.contains(activeClass),
+        'vizualizeKeypress does not make initial keys active');
+
+      oldTarget.classList.remove(activeClass);
+      subject._visualizeKeypress(oldTarget);
+      assert.isFalse(oldTarget.classList.contains(activeClass)
+        && !newTarget.classList.contains(activeClass),
+        'vizualizeKeypress changes inactive state without key change');
+
+      oldTarget.classList.add(activeClass);
+      subject._visualizeKeypress(oldTarget);
+      assert.isTrue(oldTarget.classList.contains(activeClass)
+        && !newTarget.classList.contains(activeClass),
+        'vizualizeKeypress changes active state without key change');
+
+      subject._visualizeKeypress(newTarget);
+      assert.isFalse(oldTarget.classList.contains(activeClass),
+        'vizualizeKeypress does not make old keys inactive');
+      assert.isTrue(newTarget.classList.contains(activeClass),
+        'makeInactive does not make new keys active');
+
+      subject._visualizeKeypress(null);
+      assert.isFalse(newTarget.classList.contains(activeClass),
+        'vizualizeKeypress does not reset active keys on null');
     });
 
   });
@@ -155,7 +258,6 @@ suite('LockScreenInputpad', function() {
 
     test('it would clear error class when not in error timeout state',
       function() {
-        var method = subject.updatePassCodeUI;
         var mockSubject = {
           states: {
             passCodeEntered: '',
@@ -165,7 +267,7 @@ suite('LockScreenInputpad', function() {
           passcodeCode: document.createElement('div')
         };
         mockSubject.passcodeCode.classList.add('error');
-        method.apply(mockSubject);
+        subject.updatePassCodeUI.apply(mockSubject);
         assert.isFalse(mockSubject.passcodeCode
           .classList.contains('error'),
           'error class was not cleared outside error timeout');
@@ -287,49 +389,187 @@ suite('LockScreenInputpad', function() {
       });
     });
 
-    suite('typing', function() {
+    suite('keypad input events >', function() {
+      var target;
       var evt;
+      var stubPreventDefault;
+      var stubFromPoint;
+      var spyVisualize;
+      var stubVibrate;
+      var stubHandleInput;
+
       setup(function() {
+        target = mockHtmlKeypad.firstChild.children[1]; // key "2"
         evt = {
-          type: 'click',
+          type: 'foofoo',
+          target: target,
+          changedTouches: [
+            {
+              clientX: 23,
+              clientY: 42
+            }
+          ],
           preventDefault: function() {}
         };
-        evt.target = {
-          tagName: 'DIV',
-          parentNode: {
-            dataset: {
-              key: 'f'
-            },
-            tagName: 'A'
-          },
-          dataset: {}
-        };
+        stubPreventDefault = sinon.stub(evt, 'preventDefault');
+        stubFromPoint = sinon.stub(document, 'elementFromPoint',
+          function() {
+            return evt.target;
+          });
+        // Using a spy when internal state must be updated
+        // _visualizeKeypress keeps track of lastTouchedKey state
+        spyVisualize = sinon.spy(subject, '_visualizeKeypress');
+        stubVibrate = sinon.stub(navigator, 'vibrate');
+        stubHandleInput = sinon.stub(subject, 'handlePassCodeInput');
+      });
 
+      teardown(function() {
+        stubPreventDefault.restore();
+        stubFromPoint.restore();
+        spyVisualize.restore();
+        stubVibrate.restore();
+        stubHandleInput.restore();
       });
-      test('it would get the key', function() {
-        var stubHandlePassCodeInput = sinon.stub(subject,
-          'handlePassCodeInput');
-        subject.handleEvent(evt);
-        assert.isTrue(stubHandlePassCodeInput.calledWith('f'));
+
+      suite('touchstart >', function() {
+        setup(function() {
+          evt.type = 'touchstart';
+        });
+        test('updates keypad', function() {
+          subject.handleEvent(evt);
+          assert.isTrue(spyVisualize.calledWith(evt.target),
+            'does not update keypad');
+        });
+        test('vibrates', function() {
+          subject.states.padVibrationEnabled = true;
+          subject.handleEvent(evt);
+          assert.isTrue(stubVibrate.called,
+            'onTouchStart does not vibrate');
+          stubVibrate.restore();
+        });
       });
-      test('it would clear notification opening ID', function() {
-        var method = subject.handlePassCodeInput;
-        var mockThis = {
-          lockScreen: {
-            invokeSecureApp: function() {},
-            _unlockingMessage: {
-              notificationId: 'fakeid'
-            }
-          },
-          dispatchEvent: function() {}
+
+      suite('touchmove >', function() {
+        setup(function() {
+          evt.type = 'touchmove';
+        });
+        test('updates keypad', function() {
+          // Call with key "2"
+          subject.handleEvent(evt);
+          assert.isTrue(spyVisualize.calledWith(evt.target),
+            'does not update keypad');
+        });
+      });
+
+      suite('touchend >', function() {
+        setup(function() {
+          evt.type = 'touchend';
+        });
+        test('prevents default click event', function() {
+          subject.handleEvent(evt);
+          assert.isTrue(stubPreventDefault.called,
+            'does not prevent default click event');
+        });
+        test('updates keypad', function() {
+          subject.handleEvent(evt);
+          assert.isTrue(spyVisualize.calledWith(null),
+            'does not update keypad');
+        });
+        test('handles the right key', function() {
+          subject.handleEvent(evt);
+          assert.isTrue(stubHandleInput.calledWith(target),
+            'does not handle the expected key');
+        });
+      });
+
+      suite('click >', function() {
+        setup(function() {
+          evt.type = 'click';
+        });
+        test('calls click handler', function() {
+          var stubOnClick = sinon.stub(subject, 'onClick');
+          evt.type = 'click';
+          subject.handleEvent(evt);
+          assert.isTrue(stubOnClick.calledWith(evt),
+            'onClick handler is not called as expected');
+          stubOnClick.restore();
+        });
+      });
+    });
+
+    suite('pass code input >', function() {
+      var stubUpdatePassCodeUI;
+      var stubInvokeSecureApp;
+      var stubDispatchEvent;
+      var stubCheckPassCode;
+
+      setup(function() {
+
+        // Build a mock lockscreen
+        subject.lockScreen = {
+          invokeSecureApp: function() {},
+          checkPassCode: function() {},
+          _unlockingMessage: {
+            notificationId: 'fakeid'
+          }
         };
-        method.call(mockThis, 'e');
+        subject.passcodePad = { classList: new Set() };
+        stubUpdatePassCodeUI = sinon.stub(subject, 'updatePassCodeUI');
+        stubInvokeSecureApp =
+          sinon.stub(subject.lockScreen, 'invokeSecureApp');
+        stubDispatchEvent = sinon.stub(subject, 'dispatchEvent');
+        stubCheckPassCode =
+          sinon.stub(subject.lockScreen, 'checkPassCode');
+      });
+
+      teardown(function() {
+        stubUpdatePassCodeUI.restore();
+        stubInvokeSecureApp.restore();
+        stubDispatchEvent.restore();
+        stubCheckPassCode.restore();
+      });
+
+      test('it correctly handles key input', function() {
+        subject.handlePassCodeInput(twoKey);
+        assert.isTrue(subject.states.passCodeEntered === "2",
+          'it does not correctly handle the first key');
+        subject.handlePassCodeInput(threeKey);
+        assert.isTrue(subject.states.passCodeEntered === "23",
+          'it does not correctly handle the second key');
+      });
+
+      test('back key works as expected', function() {
+        subject.handlePassCodeInput(twoKey);
+        subject.handlePassCodeInput(threeKey);
+        subject.handlePassCodeInput(backKey);
+        assert.isTrue(subject.states.passCodeEntered === "2",
+          'it does not correctly handle the back key');
+      });
+
+      test('it checks the pass code when it should', function() {
+        subject.handlePassCodeInput(twoKey);
+        subject.handlePassCodeInput(threeKey);
+        subject.handlePassCodeInput(twoKey);
+        subject.handlePassCodeInput(threeKey);
+        assert.isTrue(stubCheckPassCode.calledWith("2323"),
+          'it does not properly check the pass code');
+      });
+
+      test('it opens the emergency dialer', function() {
+        subject.handlePassCodeInput(emergencyKey);
+        assert.isTrue(stubInvokeSecureApp.calledWith('emergency-call'),
+          'it fails to open the emergency dialer when requested');
+      });
+
+      test('it would clear notification opening ID', function() {
+        subject.dispatchEvent = function() {};
+        subject.handlePassCodeInput(emergencyKey);
         assert.isUndefined(
-          mockThis.lockScreen._unlockingMessage.notificationId);
-        mockThis.lockScreen._unlockingMessage.notificationId = 'fakeid';
-        method.call(mockThis, 'c');
+          subject.lockScreen._unlockingMessage.notificationId);
+        subject.lockScreen._unlockingMessage.notificationId = 'fakeid';
+        subject.handlePassCodeInput(cancelKey);
         assert.isUndefined(
-          mockThis.lockScreen._unlockingMessage.notificationId);
+          subject.lockScreen._unlockingMessage.notificationId);
       });
     });
   });


### PR DESCRIPTION
Inputpad looks and feels wonky compared to the slick look and feel of
the keyboard panel used while setting the pass code in Settings. Much of
the reason comes from that it only vibrates on key release, the other
that it does not behave well when the user is sliding a finger over the
keys. There is also a considerable delay between touching a key and a
visual reaction to the extent that it's skipped when typing mildly fast.

This prototype patch addresses all of the above:
- make InputPad vibrate instantly on touch
- make InputPad respect user's touchmove
- visualize key presses instantly
