### PR TITLE
Bug 1186347 - Delay calling render() until calling show(). r=timdream

### DIFF
--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -123,10 +123,6 @@
       }
       this.debug('on receive caret state change event');
       this.debug(JSON.stringify(detail));
-      if (!this._injected) {
-        this.render();
-        this._injected = true;
-      }
       if (detail.reason === 'visibilitychange' && !detail.caretVisible) {
          this.hide();
          return;
@@ -354,6 +350,12 @@
     this._resetShortcutTimeout();
     var numOfSelectOptions = 0;
     var options = [ 'Paste', 'Copy', 'Cut', 'SelectAll' ];
+
+    // Check this._injected here to make sure this.elements is initialized.
+    if (!this._injected) {
+      this.render();
+      this._injected = true;
+    }
 
     // Based on UI spec, we should have dividers ONLY between each select option
     // So, we use css to put divider in pseudo element and set the last visible

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -323,13 +323,6 @@ suite('system/AppTextSelectionDialog', function() {
         assert.isTrue(td._triggerShortcutTimeout.calledOnce);
       });
 
-    test('should render when first show', function() {
-      td._injected = false;
-      td.handleEvent(fakeTextSelectInAppEvent);
-      assert.isTrue(stubRender.calledOnce);
-      assert.isTrue(td._injected);
-    });
-
     test('should not render when bubble has showed before', function() {
       td._injected = true;
       td.handleEvent(fakeTextSelectInAppEvent);

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -262,7 +262,7 @@ suite('system/AppTextSelectionDialog', function() {
     assert.isTrue(td._resetShortcutTimeout.called);
   });
 
-  suite('handleEven selectionstatechanged event', function() {
+  suite('handleEvent caretstatechanged event', function() {
     var stubClose, stubHide, stubShow, stubRender, stubEvent;
     var testDetail;
     setup(function() {
@@ -576,7 +576,7 @@ suite('system/AppTextSelectionDialog', function() {
       });
     });
 
-    test('if the utility bubble is triggerer in app and appChrome is maxmized',
+    test('if the utility bubble is triggered in app and appChrome is maxmized',
       function() {
         var positionDetail = {
           rect: {}
@@ -608,8 +608,8 @@ suite('system/AppTextSelectionDialog', function() {
         });
       });
 
-    test('if the utility bubble is triggerer in app and appChrome is ' +
-         'not maxmized',
+    test('if the utility bubble is triggered in app and appChrome is ' +
+         'not maximized',
       function() {
         var positionDetail = {
           rect: {}


### PR DESCRIPTION
The old text selection dialog did the same in bug 1186313. I migrate the
patch to new selection dialog.
