### PR TITLE
Bug 1188310: Use 'nodejs' tool for Node.js on Debian 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,9 @@ TEST_COMMON=dev_apps/test-agent/common
 ifeq ($(strip $(NODEJS)),)
   NODEJS := `which node`
 endif
+ifeq ($(strip $(NODEJS)),)
+  NODEJS := `which nodejs`
+endif
 
 ifeq ($(strip $(NPM)),)
   NPM := `which npm`


### PR DESCRIPTION
The tool 'node' seems to be called 'nodejs' on Debian 7. This patch
prepares the Makefile to handle this case.
