### PR TITLE
Bug 1188648 - Always use --host-log to save gecko output to gecko-out…

### DIFF
--- a/tests/taskcluster/tasks/marionette_js_tests.yml
+++ b/tests/taskcluster/tasks/marionette_js_tests.yml
@@ -25,6 +25,7 @@ task:
       REPORTER: 'mocha-tbpl-reporter'
       TEST_MANIFEST: '{{gaia}}/shared/test/integration/tbpl-manifest.json'
       NODE_MODULES_SRC: npm-cache
+      HOST_LOG: artifacts/gecko_output.log
 
     command:
       - entrypoint


### PR DESCRIPTION
…put.log. r=gaye
