### PR TITLE
Revert "Bug 1186587 - Don't ensure() the homescreen for every Service.query('getHomescreen') r=kgrandon"

### DIFF
--- a/apps/system/js/homescreen_window_manager.js
+++ b/apps/system/js/homescreen_window_manager.js
@@ -46,17 +46,17 @@
     },
 
     /**
-     * getHomescreen returns the homescreen app window based and optionally
-     * makes sure it's loaded (ensure).
+     * getHomescreen returns the homescreen app window based on if it is
+     * triggered by home event.
      *
      * @memberOf HomescreenWindowManager.prototype
      */
-    getHomescreen: function getHomescreen(ensure) {
+    getHomescreen: function getHomescreen(isHomeEvent) {
       if (!this.homescreenLauncher) {
         return null;
       }
-      var home  = this.homescreenLauncher.getHomescreen();
-      if (ensure) {
+      var home  = this.homescreenLauncher.getHomescreen(true);
+      if (isHomeEvent) {
         home.ensure(true);
       }
       return home;

--- a/apps/system/test/unit/homescreen_window_manager_test.js
+++ b/apps/system/test/unit/homescreen_window_manager_test.js
@@ -20,7 +20,6 @@ suite('system/HomescreenWindowManager', function() {
 
   suite('getHomescreen', function() {
     var homescreenWinMgr;
-    var spyGetHome;
     var stubEnsureHome;
     setup(function() {
       homescreenWinMgr = BaseModule.instantiate('HomescreenWindowManager');
@@ -35,7 +34,6 @@ suite('system/HomescreenWindowManager', function() {
         ready: true
       });
       homescreenWinMgr.homescreenLauncher.start();
-      spyGetHome = this.sinon.spy(fakeLauncher, 'getHomescreen');
       stubEnsureHome = this.sinon.stub(fakeHome, 'ensure');
     });
 
@@ -46,16 +44,14 @@ suite('system/HomescreenWindowManager', function() {
       homescreenWinMgr.homescreenLauncher.mTeardown();
     });
 
-    test('with ensure = false', function() {
+    test('with isHomeEvent = false', function() {
       assert.deepEqual(homescreenWinMgr.getHomescreen(), fakeHome);
-      assert.isTrue(spyGetHome.calledWith(undefined));
       assert.isFalse(stubEnsureHome.called,
         'we donot ensure home while not called with home event');
     });
 
-    test('with ensure = true', function() {
+    test('with isHomeEvent = true', function() {
       assert.deepEqual(homescreenWinMgr.getHomescreen(true), fakeHome);
-      assert.isTrue(spyGetHome.calledWith(undefined));
       assert.isTrue(stubEnsureHome.called,
         'we should ensure home with home event');
       assert.isTrue(stubEnsureHome.calledWith(true),


### PR DESCRIPTION
This reverts commit 62d9420fc0915ab11ad5d23e105c929d4b5afae6.

Testing another backout

https://bugzilla.mozilla.org/show_bug.cgi?id=1188459
