### PR TITLE
Bug 1188934 - Harden LockScreen against Settings race conditions

### DIFF
--- a/apps/system/lockscreen/js/lockscreen.js
+++ b/apps/system/lockscreen/js/lockscreen.js
@@ -62,14 +62,7 @@
     * in Settings API.
     * Will be ignored if 'enabled' is set to false.
     */
-    passCodeEnabled: false,
-
-    /*
-    * Flag to signal that initializing observer callback has fired and
-    * that the state of passCodeEnabled now reflects the Settings value.
-    * Helps detecting unlock race conditions.
-    */
-    _passCodeEnabledSynced: false,
+    passCodeEnabled: true,
 
     /*
     * Boolean returns whether the screen is enabled, as mutated by screenchange
@@ -414,7 +407,6 @@
 
       window.SettingsListener.observe(
           'lockscreen.passcode-lock.enabled', false, (function(value) {
-        this._passCodeEnabledSynced = true;
         this.setPassCodeEnabled(value);
       }).bind(this));
 
@@ -695,18 +687,6 @@
 
   LockScreen.prototype.unlock =
   function ls_unlock(instant, detail) {
-    // Do not unlock before Settings values have been synced
-    // via observer callbacks. Avoids race condition.
-    if (!this._passCodeEnabledSynced) {
-      console.error('Ignoring unlock attempt during settings race condition');
-      return;
-    }
-    return this.forceUnlock(instant, detail);
-  };
-
-  LockScreen.prototype.forceUnlock =
-  function ls_forceUnlock(instant, detail) {
-
     var wasAlreadyUnlocked = !this.locked;
     this.locked = false;
 


### PR DESCRIPTION
This adds an internal check to LockScreen.unlock() that detects whether
or not the settings observer callback has written the user-configured
settings value for passCodeEnabled. If it hasn't, unlock() gracefully
refuses to unlock, and logs an error message to the console.

It also introduces LockScreen.forceUnlock() that does not check for
the race condition (identical to the old .unlock() behavior). Please
use this if you really mean to unconditionally unlock and circumvent
the pass code check.
