### PR TITLE
Bug 816783 - [email] Autocomplete known contacts when user manually types

### DIFF
--- a/apps/email/build/email.build.js
+++ b/apps/email/build/email.build.js
@@ -47,6 +47,10 @@
         'iframe_shims',
         'cards/editor_mixins',
 
+        // gesture_detector used by both compose and message_reader layer, so
+        // just include it in the base layer.
+        'shared/js/gesture_detector',
+
         // Bundle most likely card
         'cards/message_list'
       ]

--- a/apps/email/js/cards/cmp/autocomplete.js
+++ b/apps/email/js/cards/cmp/autocomplete.js
@@ -1,0 +1,548 @@
+'use strict';
+define(function(require) {
+
+var GestureDetector = require('shared/js/gesture_detector'),
+    itemTemplate = require('tmpl!./autocomplete_item.html'),
+    mozL10n = require('l10n!'),
+    regExpEscape = require('regExpEscape'),
+    transitionEnd = require('transition_end'),
+    validTypes = {
+      email: true,
+      text: true
+    };
+
+/**
+ * Converts a text string into a span and some text nodes that are placed
+ * as the children of node. The span contains the match for the queryRegExp.
+ * @param  {RegExp} queryRegExp The regexp whose match is highlighted via a
+ * span in the target text.
+ * @param  {String} text        The target text to find the match.
+ * @param  {Element} node       The element that will display the matched text.
+ */
+function formatMatchString(queryRegExp, text, node) {
+  // Just highlight the first match.
+  var match = queryRegExp.exec(text);
+
+  if (match) {
+    var index = match.index,
+        endIndex = index + queryRegExp.source.length;
+
+    var startString = text.substring(0, index);
+    if (startString) {
+      node.appendChild(document.createTextNode(startString));
+    }
+
+    var matchString = text.substring(index, endIndex);
+    if (matchString) {
+      var span = document.createElement('span');
+      span.classList.add('highlight');
+      span.textContent = matchString;
+      node.appendChild(span);
+    }
+
+    var endString = text.substring(endIndex);
+    if (endString) {
+      node.appendChild(document.createTextNode(endString));
+    }
+  } else {
+    node.textContent = text;
+  }
+}
+
+/**
+ * Given a node, if it or an ancestor has the CSS className, return the node
+ * with that className. Returns null if not a match.
+ * @param  {Node} node
+ * @return {Node}
+ */
+function findAncestorWithClass(node, className) {
+  for (; node; node = node.parentNode) {
+    if (node.classList && node.classList.contains(className)) {
+      return node;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Given a node, if it or an ancestor is an autocomplete item in the
+ * autocomplete list, return the autcomplete item node. Returns null if not a
+ * match.
+ * @param  {Node} node
+ * @return {Node}
+ */
+function getAutocompleteItem(node) {
+  return findAncestorWithClass(node, 'cmp-autocomplete-item');
+}
+
+/**
+ * Autocomplete custom element that contains a list of elements that show the
+ * autocomplete matches.
+ *
+ * This custom element relies on a CSS class-based API to bind to nodes outside
+ * of this autocomplete. The CSS/HTML structure expected by this autocomplete:
+ *
+ * - An element with the CSS class of "cmp-autocomplete-origin" that is the the
+ * master scroll area for the view. It should be an ancestor node to the
+ * autocomplete and also contain the 'cmp-autocomplete-input-list' element that
+ * has all the input elements. This element is used as the "origin" for the
+ * style.top placement of the autocomplete list.
+ *
+ * - An element that holds all the input fields, with the CSS class of
+ * "cmp-autocomplete-input-list". That inputArea will be translateY'd to make
+ * sure the current input focus is visible at the top of the view.
+ *
+ * - Individual rows that hold an autocomplete must specify a
+ * "cmp-autocomplete-input-label" CSS class, so that for a given input, that
+ * parent can be found to be marked as "active". This allows just that row to
+ * change its alignment so its label and + icon are aligned at the bottom with
+ * the text input.
+ *
+ * The autocomplete custom element also expects a "data-source" HTML attribute
+ * to be set on it, which indicates the module ID to use as the data source for
+ * the matches.
+ *
+ * The owner of this custom element instance (typically a view card), should
+ * override the getExistingEntries() method on the instance to return the
+ * current entries, to avoid dupes showing up in subsequent autocomplete
+ * matches.
+ */
+return [
+  require('../base')(),
+  {
+    createdCallback: function() {
+      //TODO: master hack only. In email-model-instance branch, this is not
+      //needed. In the branch, there is a separate 'base' that elements can
+      //mix in that is not assumed to be a card. For now, this is an equivalent
+      //result.
+      this.classList.remove('card');
+
+      this.lastTranslateY = 0;
+      this.inputAreaTranslated = Promise.resolve();
+
+      this.runQuery = this.runQuery.bind(this);
+      this.onFocus = this.onFocus.bind(this);
+      this.onDocumentEvent = this.onDocumentEvent.bind(this);
+      this.onInput = this.onInput.bind(this);
+
+      // Find (when cached HTML) or create list to hold the autocomplete matches
+      // Put the list inside the autocomplete element instead of off the
+      // document, as it should be within a given UI card, in case in-app
+      // overlay UIs like confirm dialogs need to be shown.
+      this.list = this.querySelector('.cmp-autocomplete-list');
+      if (!this.list) {
+        this.list = document.createElement('ul');
+        this.list.classList.add('cmp-autocomplete-list');
+        this.appendChild(this.list);
+      }
+      this.list.addEventListener('keydown', this.onMatchKeyDown.bind(this));
+      this.list.addEventListener('click', this.onMatchClick.bind(this));
+      this.list.innerHTML = '';
+      this.hideList();
+
+      // Find parent that is scrollable and is the origin for measurements.
+      var parentNode = this;
+      while((parentNode = parentNode.parentNode)) {
+        if (parentNode.classList.contains('cmp-autocomplete-origin')) {
+          this.originNode = parentNode;
+          break;
+        }
+      }
+
+      // Hold on to the element that holds all the input fields, to use it for
+      // sizing and setting scroll behavior amongst the inputs while the
+      // autocomplete is active.
+      this.inputArea = this.originNode
+                       .querySelector('.cmp-autocomplete-input-list');
+
+      // Listen for transitionend events on the inputArea, since translateY with
+      // a transition is used to move the input to the top of the view. Want to
+      // wait for the transition to end before showing autocomplete results.
+      // This allows the user to better track where the addresses have gone,
+      // and feels smoother.
+      transitionEnd(this.inputArea, this._translateYTransitionEnd.bind(this));
+
+      // Bind to events triggered by input field children. Need to mark the
+      // elements with an autocomplete class, and do not want to target just
+      // any input in the inputArea, so using explicit per-element bindings
+      // instead of event delegation.
+      var nodes = this.inputArea.querySelectorAll('input');
+      Array.from(nodes, function(inputNode) {
+        if (!validTypes.hasOwnProperty(inputNode.type)) {
+          return;
+        }
+
+        // Add a class to the input to mark it as participating in autocomplete.
+        // This is used to know if taps in them should be disregarded for
+        // onDocumentEvent purposes.
+        inputNode.classList.add('cmp-autocomplete-input');
+
+        inputNode.addEventListener('focus', this.onFocus);
+        inputNode.addEventListener('input', this.onInput);
+      }, this);
+
+      // Use a GestureDetector to know when user tries to scroll the inputArea
+      // element to see addresses that have been scrolled out of the way for
+      // autocomplete maximum real estate. No need to clean this up later, the
+      // destruction of the card using the autocomplete is enough: the watched
+      // element is destroyed along with the autocomplete.
+      this.detector = new GestureDetector(this.inputArea);
+      this.inputArea.addEventListener('pan', (event) => {
+        this.hide();
+      });
+      this.detector.startDetecting();
+
+      // Set up data source.
+      var dataSourceId = this.dataset.source;
+      if (dataSourceId) {
+        this.bindDataSource(dataSourceId);
+      }
+    },
+
+    /**
+     * Custom element callback when element is placed in the document.
+     */
+    attachedCallback: function() {
+      this.onResize = this.onResize.bind(this);
+      window.addEventListener('resize', this.onResize, false);
+
+      // Explicitly want to listen during the capture phase, since most code
+      // listens in bubble phase, and may stopPropagation. For autocomplete
+      // hiding though we always want it to disappear if event is outside of
+      // the interesting areas.
+      document.addEventListener('click', this.onDocumentEvent, true);
+      document.addEventListener('focus', this.onDocumentEvent, true);
+    },
+
+    /**
+     * Custom element callback when element is removed from the document.
+     */
+    detachedCallback: function() {
+      window.removeEventListener('resize', this.onResize, false);
+      document.removeEventListener('click', this.onDocumentClick, true);
+      document.addEventListener('focus', this.onDocumentEvent, true);
+    },
+
+    /**
+     * Triggered by input focus events.
+     */
+    onFocus: function(event) {
+      this.inputNode = event.target;
+
+      // If existing label node, be sure to remove the active class from it. In
+      // cases where the focus goes from one input to the other, hide() does not
+      // run to clear this state.
+      if (this.inputLabelNode) {
+        this.inputLabelNode.classList.remove('cmp-autocomplete-active');
+      }
+
+      this.inputLabelNode = findAncestorWithClass(this.inputNode,
+                                                'cmp-autocomplete-input-label');
+      this.inputLabelNode.classList.add('cmp-autocomplete-active');
+
+      this.query = this.inputNode.value.trim();
+      this.runThrottledQuery();
+    },
+
+    /**
+     * Triggered by any click or focus in the document. Used to determine if the
+     * autocomplete should be hidden.
+     */
+    onDocumentEvent: function(event) {
+      var target = event.target;
+
+      // If no classList, then it is not an element, and should be discarded.
+      if (!target.classList) {
+        this.hide();
+        return;
+      }
+
+      // If an autocomplete input, do not do anything, handled by other code in
+      // this module.
+      if (target.classList.contains('cmp-autocomplete-input')) {
+        return;
+      }
+
+      // Also ignore if it is part of an autocomplete-item.
+      if (getAutocompleteItem(target)) {
+        return;
+      }
+      this.hide();
+    },
+
+    /**
+     * Triggered by input element input events.
+     */
+    onInput: function(event) {
+      this.query = this.inputNode.value.trim();
+      this.runThrottledQuery();
+    },
+
+    /**
+     * Handles window resizes. Could be triggered by keyboard size changes.
+     */
+    onResize: function(event) {
+      if (this.inputNode && !this.isHidden) {
+        this.positionElements();
+      }
+    },
+
+    onMatchKeyDown: function(event) {
+      if (event.key === 'Enter' && !this.isHidden) {
+        this.onMatchClick(event);
+      }
+    },
+
+    /**
+     * Handles taps inside the autocomplete. The tap could occur outside a match
+     * element, in which case means the autocomplete should just close.
+     */
+    onMatchClick: function(event) {
+      var node = getAutocompleteItem(event.originalTarget);
+
+      if (node && node.match) {
+        event.preventDefault();
+        this.dispatchEvent(new CustomEvent('autocompleteSelected', {
+          detail: {
+            match: node.match,
+            inputNode: this.inputNode
+          }
+        }));
+      }
+    },
+
+    /**
+     * Loads the dataSource module.
+     * @param  {String} dataSourceId The module ID for the data source.
+     */
+    bindDataSource: function(dataSourceId) {
+      require([dataSourceId], (dataSource) => {
+        this.dataSource = dataSource;
+        if (this.query) {
+          this.runThrottledQuery();
+        }
+      });
+    },
+
+    /**
+     * Called to trigger finding matches from the dataSource. Set on a timeout
+     * to avoid multiple fast keystrokes from triggering too many rapid queries.
+     */
+    runThrottledQuery: function() {
+      if (!this.query || !this.dataSource) {
+        this.list.innerHTML = '';
+        this.positionAndHide();
+        return;
+      }
+
+      if (!this.timedQueryId) {
+        // The choice of delay tries to balance sending too many queries to the
+        // contacts API vs giving a feeling of responsiveness for the reaction
+        // of the autocomplete. This balance may be affected by the total number
+        // of contacts.
+        this.timedQueryId = setTimeout(this.runQuery, 350);
+      }
+    },
+
+    /**
+     * The owner of this autocomplete instance should set this value if they
+     * have extra spacing around the input that should be maintained for better
+     * visual display, and to avoid small scroll janks on initial positioning
+     * of the input element if it needs to be scrolled to the top of the view.
+     */
+    verticalSpace: 0,
+
+    /**
+     * This method can be overriden by the owner of the autocomplete to return
+     * existing entries already attached to the email. The result should be an
+     * array of objects that have "name" and "address" properties.
+     * @return {Array}   Array of existing entries.
+     */
+    getExistingEntries: function() {
+      return [];
+    },
+
+    /**
+     * Runs the query to find matches from the dataSource.
+     */
+    runQuery: function() {
+      this.timedQueryId = 0;
+
+      this.dataSource(this.query).then((result) => {
+        // Protect against old or out of date queries
+        if (result.query !== this.query) {
+          return;
+        }
+
+        var existingEntries = this.getExistingEntries();
+
+        var contacts = result.contacts;
+
+        this.list.innerHTML = '';
+
+        var queryRegExp = new RegExp(regExpEscape(this.query), 'i');
+
+        contacts.forEach((contact) => {
+          // Only care about contacts with an email address(es).
+          var emails = contact.email;
+          if (!emails || !emails.length) {
+            return;
+          }
+
+          // Contact name could be an array, just use the first one.
+          var name = contact.name;
+          if (Array.isArray(name)) {
+            name = name[0];
+          }
+
+          // Emails are an array, each one should get its own entry in the
+          // autocomplete.
+          emails.forEach((email) => {
+            var address = email.value;
+
+            // Do not add it if the email address is already an entry.
+            var hasExisting = existingEntries.some(function(entry) {
+              return entry.address === address;
+            });
+            if (hasExisting) {
+              return;
+            }
+
+            var node = itemTemplate.cloneNode(true),
+                detailsNode = node
+                               .querySelector('.cmp-autocomplete-item-details'),
+                nameNode = node.querySelector('.cmp-autocomplete-name'),
+                emailNode = node.querySelector('.cmp-autocomplete-email');
+
+            // Set the ariaLabel for the match, for screen reader use only.
+            mozL10n.setAttributes(detailsNode, 'compose-autocomplete-match',
+                                  { name: name, address: address });
+
+            formatMatchString(queryRegExp,
+                              name || address,
+                              nameNode);
+            formatMatchString(queryRegExp, address|| '', emailNode);
+
+            // Store the match data on the node for ease of access when items
+            // are tapped.
+            var match = {
+              name: name,
+              address: address
+            };
+            node.match = match;
+
+            this.list.appendChild(node);
+          });
+        });
+
+        // Always reshow on a query, since each keystroke has the possibility of
+        // breaking the input field to a new line.
+        if (this.list.children.length) {
+          this.show();
+        } else {
+          this.positionAndHide();
+        }
+      });
+    },
+
+    /**
+     * Positions the input area to the top of the view and sizes the list to
+     * take up as much view space as possible.
+     */
+    positionElements: function() {
+      // Always calculate the originTop since the whole card that contains the
+      // origin could be scrolled for some reason, even by an accident.
+      var originTop = this.originNode.getBoundingClientRect().top;
+
+      // Want to use the input element, and not a parent of it, for placement of
+      // the autocomplete, since the input element can move to different lines
+      // as typing occurs, where the parent's origin would not change, and would
+      // be a bad reference point to use.
+      var inputRect = this.inputNode.getBoundingClientRect();
+
+      // Scroll the area so that the input item is now at the top of the
+      // address area.
+      var translateY = inputRect.top - originTop +
+                      this.lastTranslateY -
+                      this.verticalSpace;
+
+      if (translateY !== this.lastTranslateY) {
+        this.lastTranslateY = translateY;
+
+        // Create a new promise to track the end of the inputArea translation.
+        this.inputAreaTranslated = new Promise((resolve) => {
+          // No need to track reject, only resolve/ok is followed in the
+          // transitionEnd machinery.
+          this._inputAreaResolve = resolve;
+        });
+
+        this.inputArea.style.transform = 'translateY(-' + translateY + 'px)';
+      }
+
+      return this.inputAreaTranslated.then(() => {
+        this.listTop = inputRect.height + (2 * this.verticalSpace);
+        this.list.style.top = this.listTop + 'px';
+        this.list.style.height = (window.innerHeight - this.listTop -
+                                  originTop) + 'px';
+
+        // Set the list scrollTop to the top because previous listing could have
+        // had it scrolled.
+        this.list.scrollTop = 0;
+      });
+    },
+
+    _translateYTransitionEnd: function(event) {
+      if (this._inputAreaResolve) {
+        this._inputAreaResolve();
+        this._inputAreaResolve = null;
+      }
+    },
+
+    show: function() {
+      // The originNode should be at the top of its scroll area, and set a
+      // CSS class on it that indicates the origin should not show scroll
+      // bars or allow scrolling, to avoid overlapping, confusing double
+      // scrollbars.
+      this.originNode.scrollTop = 0;
+      this.originNode.classList.add('cmp-autocomplete-noscroll');
+
+      this.positionElements().then(() => {
+        this.list.classList.remove('collapsed');
+      });
+    },
+
+    hide: function() {
+      this.hideList();
+
+      if (this.inputLabelNode) {
+        this.inputLabelNode.classList.remove('cmp-autocomplete-active');
+      }
+
+      this.inputArea.style.transform = 'translateY(0px)';
+      this.lastTranslateY = 0;
+
+      this.originNode.classList.remove('cmp-autocomplete-noscroll');
+    },
+
+    hideList: function() {
+      this.list.classList.add('collapsed');
+    },
+
+    /**
+     * Makes sure the input element is at the top of the view, but do not show
+     * the autocomplete list because there are no matches to show.
+     */
+    positionAndHide: function() {
+      this.positionElements().then(() => {
+        this.hideList();
+      });
+    },
+
+    get isHidden() {
+      return this.list.classList.contains('collapsed');
+    }
+  }
+];
+
+});

--- a/apps/email/js/cards/cmp/autocomplete_item.html
+++ b/apps/email/js/cards/cmp/autocomplete_item.html
@@ -1,0 +1,11 @@
+<li class="cmp-autocomplete-item">
+  <!-- Using an a tag so that screen reader properly activates a selection
+  when tapped. Using a div meant the ul element got the click. To get proper full bleed on the active/selected color, need to use another div inside
+  the a tag to get that while keeping the margins on text and border. -->
+  <a class="cmp-autocomplete-item-link" href="#">
+    <div class="cmp-autocomplete-item-details">
+      <span class="cmp-autocomplete-name" dir="auto" aria-hidden="true"></span>
+      <span class="cmp-autocomplete-email" dir="auto" aria-hidden="true"></span>
+    </div>
+  </a>
+</li>

--- a/apps/email/js/cards/cmp/autocomplete_source.js
+++ b/apps/email/js/cards/cmp/autocomplete_source.js
@@ -1,0 +1,53 @@
+'use strict';
+define(function(require) {
+
+var contacts = navigator.mozContacts;
+
+function makeResult(query, contacts) {
+  return {
+    query: query,
+    contacts: contacts
+  };
+}
+
+/**
+ * Finds matches for the given query in the name and email for known people.
+ * Returns a promise that resolves to an object that has the query and a
+ * "match" array of mozContact entries. The match array will be a zero length
+ * array for no matches. See this bug about expanding the data source beyond
+ * contacts matches:
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1188710
+ * @param  {String} query the name/email query to use.
+ * @return {Promise}
+ */
+return function match(query) {
+  return new Promise(function(resolve, reject) {
+    if (!contacts || !query) {
+      return resolve(makeResult(query, []));
+    }
+
+    var request = contacts.find({
+      filterBy: ['email', 'name', 'givenName', 'familyName'],
+      filterOp: 'startsWith',
+      // Do not overwhelm the user with choice, limit the results. It is likely
+      // easier for the user to keep typing to narrow the matches than scroll
+      // through a big list, and a small bound on the results will result in
+      // better performance, even when generating the UI for the matches.
+      filterLimit: 30,
+      filterValue: query
+    });
+
+    request.onsuccess = function () {
+      resolve(makeResult(query, this.result));
+    };
+
+    // It is OK to just eat errors, no need to show them in the UI, but let
+    // the log know for debugging purposes.
+    request.onerror = function (err) {
+      console.error('autocomplete_source contacts.find error: ' + err);
+      resolve(makeResult(query, []));
+    };
+  });
+};
+
+});

--- a/apps/email/js/cards/compose.html
+++ b/apps/email/js/cards/compose.html
@@ -18,65 +18,69 @@
       data-l10n-id="compose-header-short"></h1>
   </header>
 </section>
-<div data-prop="scrollContainer" class="scrollregion-below-header">
-  <div data-prop="addrBar" class="cmp-envelope-bar">
-    <div class="cmp-addr-bar">
-      <div data-event="click:onContainerClick"
-           class="cmp-envelope-line cmp-combo"
-           role="group" data-l10n-id="to-group">
-        <span class="cmp-to-label cmp-addr-label"
-              data-l10n-id="compose-to" aria-hidden="true"></span>
-        <div class="cmp-to-container cmp-addr-container">
-          <div class="cmp-bubble-container">
-              <input data-prop="toNode"
+<div data-prop="scrollContainer"
+     class="scrollregion-below-header cmp-autocomplete-origin">
+  <div data-prop="addrBar">
+    <div class="cmp-autocomplete-input-container">
+      <div class="cmp-autocomplete-input-list">
+        <div data-prop="firstEnvelopeLine"
+             data-event="click:onContainerClick"
+             class="cmp-envelope-line cmp-combo cmp-autocomplete-input-label"
+             role="group" data-l10n-id="to-group">
+          <span class="cmp-to-label cmp-addr-label"
+                data-l10n-id="compose-to" aria-hidden="true"></span>
+          <div class="cmp-to-container cmp-addr-container">
+            <div class="cmp-bubble-container">
+                <input data-prop="toNode"
+                      data-event="keydown:onAddressKeydown,input:onAddressInput"
+                      dir="auto"
+                      class="cmp-to-text cmp-addr-text" type="email" />
+            </div>
+          </div>
+          <div data-event="click:onContactAdd"
+               class="cmp-to-add cmp-contact-add"
+               role="button"
+               data-l10n-id="compose-contact-add"></div>
+        </div>
+        <!-- XXX: spec calls for showing cc/bcc merged until selected,
+             but there is also the case where replying itself might need
+             to expand, so we are deferring that feature -->
+        <div data-event="click:onContainerClick"
+             class="cmp-envelope-line cmp-combo cmp-autocomplete-input-label"
+             role="group" data-l10n-id="cc-group">
+          <span class="cmp-cc-label cmp-addr-label"
+                 data-l10n-id="compose-cc" aria-hidden="true"></span>
+          <div class="cmp-cc-container cmp-addr-container">
+            <div class="cmp-bubble-container">
+              <input data-prop="ccNode"
                      data-event="keydown:onAddressKeydown,input:onAddressInput"
                      dir="auto"
-                     class="cmp-to-text cmp-addr-text" type="email" />
+                     class="cmp-cc-text cmp-addr-text" type="email" />
+            </div>
           </div>
+          <div data-event="click:onContactAdd"
+               class="cmp-cc-add cmp-contact-add"
+               role="button"
+               data-l10n-id="compose-contact-add"></div>
         </div>
-        <div data-event="click:onContactAdd"
-             class="cmp-to-add cmp-contact-add"
-             role="button"
-             data-l10n-id="compose-contact-add"></div>
-      </div>
-      <!-- XXX: spec calls for showing cc/bcc merged until selected,
-           but there is also the case where replying itself might need
-           to expand, so we are deferring that feature -->
-      <div data-event="click:onContainerClick"
-           class="cmp-envelope-line cmp-combo"
-           role="group" data-l10n-id="cc-group">
-        <span class="cmp-cc-label cmp-addr-label"
-               data-l10n-id="compose-cc" aria-hidden="true"></span>
-        <div class="cmp-cc-container cmp-addr-container">
-          <div class="cmp-bubble-container">
-            <input data-prop="ccNode"
-                   data-event="keydown:onAddressKeydown,input:onAddressInput"
-                   dir="auto"
-                   class="cmp-cc-text cmp-addr-text" type="email" />
+        <div data-event="click:onContainerClick"
+             class="cmp-envelope-line cmp-combo cmp-autocomplete-input-label"
+             role="group" data-l10n-id="bcc-group">
+          <span class="cmp-bcc-label cmp-addr-label"
+                 data-l10n-id="compose-bcc" aria-hidden="true"></span>
+          <div class="cmp-bcc-container cmp-addr-container">
+            <div class="cmp-bubble-container">
+              <input data-prop="bccNode"
+                     data-event="keydown:onAddressKeydown,input:onAddressInput"
+                     dir="auto"
+                     class="cmp-bcc-text cmp-addr-text" type="email" />
+            </div>
           </div>
+          <div data-event="click:onContactAdd"
+               class="cmp-bcc-add cmp-contact-add"
+               role="button"
+               data-l10n-id="compose-contact-add"></div>
         </div>
-        <div data-event="click:onContactAdd"
-             class="cmp-cc-add cmp-contact-add"
-             role="button"
-             data-l10n-id="compose-contact-add"></div>
-      </div>
-      <div data-event="click:onContainerClick"
-           class="cmp-envelope-line cmp-combo"
-           role="group" data-l10n-id="bcc-group">
-        <span class="cmp-bcc-label cmp-addr-label"
-               data-l10n-id="compose-bcc" aria-hidden="true"></span>
-        <div class="cmp-bcc-container cmp-addr-container">
-          <div class="cmp-bubble-container">
-            <input data-prop="bccNode"
-                   data-event="keydown:onAddressKeydown,input:onAddressInput"
-                   dir="auto"
-                   class="cmp-bcc-text cmp-addr-text" type="email" />
-          </div>
-        </div>
-        <div data-event="click:onContactAdd"
-             class="cmp-bcc-add cmp-contact-add"
-             role="button"
-             data-l10n-id="compose-contact-add"></div>
       </div>
     </div>
     <div class="cmp-envelope-line cmp-subject">
@@ -106,4 +110,10 @@
        class="cmp-body-html"
        data-l10n-id="message-body-container">
   </div>
+  <!-- Autocomplete at the bottom since it should have the highest z order
+       placement, so that the autocomplete matches are visible. -->
+  <cmp-autocomplete data-prop="autocomplete"
+                    data-event="autocompleteSelected"
+                    data-source="cards/cmp/autocomplete_source">
+  </cmp-autocomplete>
 </div>

--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -26,6 +26,7 @@ var cmpAttachmentItemNode = require('tmpl!./cmp/attachment_item.html'),
     ConfirmDialog = require('confirm_dialog'),
     mimeToClass = require('mime_to_class'),
     fileDisplay = require('file_display'),
+    addrPropNames = ['to', 'cc', 'bcc'],
     dataIdCounter = 0;
 
 /**
@@ -123,12 +124,28 @@ return [
       var dataId = module.id + '-' + (dataIdCounter += 1);
       this._dataIdSaveDraft = dataId + '-saveDraft';
       this._dataIdSendEmail = dataId + '-sendEmail';
+
+      // Set up filter for the autocomplete results to avoid dupes in addresses.
+      this.autocomplete.getExistingEntries =
+                              this.getExistingEntriesForAutocomplete.bind(this);
     },
 
     onArgs: function(args) {
       this.composer = args.composer;
       this.composerData = args.composerData || {};
       this.activity = args.activity;
+    },
+
+    onCardVisible: function() {
+      // Once the card is visible, tell the autocomplete about some extra space
+      // to use when positioning the autocomplete so that there is nice space
+      // around the + button and there are not small scroll janks when
+      // positioning and scrolling the input to the top of the view.
+      var props = getComputedStyle(this.firstEnvelopeLine),
+          space = parseInt(props['padding-top'], 10) +
+                  parseInt(props['margin-top'], 10);
+
+      this.autocomplete.verticalSpace = space;
     },
 
     /**
@@ -451,6 +468,33 @@ return [
       return bubble;
     },
 
+    getExistingEntriesForAutocomplete: function() {
+      var addrs = this.extractAddresses(),
+          all = [];
+
+      addrPropNames.forEach(function(prop) {
+        var ary = addrs[prop];
+        if (ary.length) {
+          all = all.concat(ary);
+        }
+      });
+
+      return all;
+    },
+
+    autocompleteSelected: function(event) {
+      var match = event.detail.match,
+          inputNode = event.detail.inputNode;
+      this.addFromEntry(match, inputNode);
+    },
+
+    addFromEntry: function(match, inputNode) {
+      inputNode.style.width = '0.5rem';
+      this.insertBubble(inputNode, match.name, match.address);
+      inputNode.value = '';
+      inputNode.focus();
+    },
+
     /**
      * insertBubble: We can set the input text node, name and address to
      *               insert a bubble before text input.
@@ -518,6 +562,9 @@ return [
         //delete bubble
         var previousBubble = node.previousElementSibling;
         this.deleteBubble(previousBubble);
+        // Deleting a bubble changes the positions of the inputs, let the
+        // autocomplete know about it.
+        this.autocomplete.onInput();
       }
     },
 
@@ -527,6 +574,7 @@ return [
     onAddressInput: function(evt) {
       var node = evt.target;
 
+      var entryMatch;
       var makeBubble = false;
       // When do we want to tie off this e-mail address, put it into a bubble
       // and clear the input box so the user can type another address?
@@ -551,13 +599,12 @@ return [
           makeBubble = true;
           break;
       }
+
       if (makeBubble) {
-        // TODO: Need to match the email with contact name.
-        node.style.width = '0.5rem';
-        var mailbox = model.api.parseMailbox(node.value);
-        this.insertBubble(node, mailbox.name, mailbox.address);
-        node.value = '';
+        entryMatch = model.api.parseMailbox(node.value);
+        this.addFromEntry(entryMatch, node);
       }
+
       // XXX: Workaround to get the length of the string. Here we create a dummy
       //      div for computing actual string size for changing input
       //      size dynamically.

--- a/apps/email/js/config.js
+++ b/apps/email/js/config.js
@@ -36,12 +36,30 @@ if (typeof TestUrlResolver === 'undefined') {
 
       'shared/js/accessibility_helper': {
         exports: 'AccessibilityHelper'
+      },
+
+      'shared/js/gesture_detector': {
+        exports: 'GestureDetector'
       }
     },
     config: {
       template: {
         tagToId: function(tag) {
-           return tag.replace(/^cards-/, 'cards/').replace(/-/g, '_');
+           return tag.replace(/^cards-/, 'cards/')
+                  .replace(/^lst-/, 'cards/lst/')
+                  .replace(/^msg-/, 'cards/msg/')
+                  .replace(/^cmp-/, 'cards/cmp/')
+                  .replace(/-/g, '_');
+        }
+      },
+
+      element: {
+        idToTag: function(id) {
+          return id.toLowerCase()
+                 .replace(/^cards\/lst\//, 'lst-')
+                 .replace(/^cards\/msg\//, 'msg-')
+                 .replace(/^cards\/cmp\//, 'cmp-')
+                 .replace(/[^a-z]/g, '-');
         }
       }
     },

--- a/apps/email/js/element.js
+++ b/apps/email/js/element.js
@@ -1,17 +1,25 @@
 /**
- * element 0.0.0-native-register
- * Copyright (c) 2013-2014, The Dojo Foundation All Rights Reserved.
+ * element 0.0.1+
+ * Copyright (c) 2013-2015, The Dojo Foundation All Rights Reserved.
  * Available via the MIT or new BSD license.
  * see: http://github.com/jrburke/element for details
  */
 /*jshint browser: true */
 /*globals define */
-define(function() {
+define(function(require, exports, module) {
   'use strict';
   var slice = Array.prototype.slice,
       callbackSuffix = 'Callback',
       callbackSuffixLength = callbackSuffix.length,
-      charRegExp = /[^a-z]/g;
+      charRegExp = /[^a-z]/g,
+      idToTag = function(id) {
+        return id.toLowerCase().replace(charRegExp, '-');
+      },
+      moduleConfig = module.config();
+
+  if (moduleConfig.hasOwnProperty('idToTag')) {
+    idToTag = moduleConfig.idToTag;
+  }
 
   /**
    * Converts an attribute like a-long-attr to aLongAttr
@@ -174,9 +182,9 @@ define(function() {
 
         // Translate any characters that are unfit for custom element
         // names to dashes
-        id = id.toLowerCase().replace(charRegExp, '-');
+        var tagId = idToTag(id);
 
-        onload(document.registerElement(id, {
+        onload(document.registerElement(tagId, {
           prototype: proto
         }));
       });

--- a/apps/email/js/iframe_shims.js
+++ b/apps/email/js/iframe_shims.js
@@ -1,8 +1,6 @@
-define(['shared/js/gesture_detector'], function() {
+define(['shared/js/gesture_detector'], function(GestureDetector) {
 
 'use strict';
-
-var GestureDetector = window.GestureDetector;
 
 /**
  * Style tag to put in the header of the body.  We currently only support inline

--- a/apps/email/js/regExpEscape.js
+++ b/apps/email/js/regExpEscape.js
@@ -1,0 +1,13 @@
+'use strict';
+/**
+ * Taken from the ECMAScript proposal polyfill in the repo:
+ * https://github.com/benjamingr/RegExp.escape
+ * git commit: de7b32f9f72d15f9d580119963139d1027c46bbe
+ * Copyright CC0 1.0 Universal Benjamin Gruenbaum 2015
+ */
+
+define(function() {
+  return function regExpEscape(str) {
+    return str.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+  };
+});

--- a/apps/email/locales/email.en-US.properties
+++ b/apps/email/locales/email.en-US.properties
@@ -496,6 +496,12 @@ compose-to=To
 compose-cc=cc
 compose-bcc=bcc
 
+# LOCALIZATION NOTE(compose-autocomplete-match): For the compose card
+# autocomplete matches when entering an email, the ariaLabel to use for each
+# match. The following string is spoken by screen readers and not shown on the
+# screen.
+compose-autocomplete-match.ariaLabel={{name}} {{address}}
+
 # LOCALIZATION NOTE(compose-contact-add): For compose card, a label for an add
 # contact buttons rendered as a circled plus sign and used to add to, cc and bcc
 # recipients. The following string is spoken by screen readers and not shown on

--- a/apps/email/style/compose_cards.css
+++ b/apps/email/style/compose_cards.css
@@ -88,6 +88,88 @@ input.cmp-subject-text {
   text-overflow: ellipsis;
 }
 
+/* Allows the position absolute autocomplete list to be relative to this
+   element */
+.cmp-autocomplete-origin {
+  position: relative;
+}
+
+.cmp-autocomplete-input-container {
+  background-color: #f2f2f2;
+}
+
+.cmp-autocomplete-input-list {
+  transition: transform 200ms ease;
+}
+
+/* Prevents scrolling of areas under the autocomplete list to avoid confusing
+   dueling scrollbars */
+.cmp-autocomplete-noscroll {
+  overflow: hidden;
+}
+
+/* When the autocomplete is active, change the flex alignment so that the label
+and + buttons are visible when typing */
+.cmp-autocomplete-input-label.cmp-autocomplete-active {
+  align-items: flex-end;
+}
+
+.cmp-autocomplete-list {
+  box-sizing: border-box;
+  position: absolute;
+  left: 0;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  font-size: 1.4rem;
+  background-color: white;
+}
+
+.cmp-autocomplete-item {
+  overflow: hidden;
+  border-bottom: 0;
+}
+
+.cmp-autocomplete-item-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.cmp-autocomplete-item-link:focus,
+.cmp-autocomplete-item-link:active,
+.cmp-autocomplete-item-link:hover {
+  background-color: #b1f1ff;
+  outline: none;
+  color: inherit;
+}
+
+.cmp-autocomplete-item-details {
+  margin: 0 1.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 0.1rem solid #DBD9D9;
+  text-align: left;
+}
+
+html:-moz-dir(rtl) .cmp-autocomplete-item-details,
+html:-moz-dir(rtl) .cmp-autocomplete-item-details {
+  text-align: right;
+}
+
+.cmp-autocomplete-name,
+.cmp-autocomplete-email {
+  display: block;
+  line-height: 2.4rem;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.cmp-autocomplete-email {
+  color: #858585;
+}
+
 .cmp-contact-add {
   background: url("images/icons/actionicon_email_addrecipient.png") no-repeat center center / 3rem auto;
   width: 3rem;

--- a/apps/email/test/config.js
+++ b/apps/email/test/config.js
@@ -30,6 +30,31 @@
 
       'shared/js/accessibility_helper': {
         exports: 'AccessibilityHelper'
+      },
+
+      'shared/js/gesture_detector': {
+        exports: 'GestureDetector'
+      }
+    },
+    config: {
+      template: {
+        tagToId: function(tag) {
+           return tag.replace(/^cards-/, 'cards/')
+                  .replace(/^lst-/, 'cards/lst/')
+                  .replace(/^msg-/, 'cards/msg/')
+                  .replace(/^cmp-/, 'cards/cmp/')
+                  .replace(/-/g, '_');
+        }
+      },
+
+      element: {
+        idToTag: function(id) {
+          return id.toLowerCase()
+                 .replace(/^cards\/lst\//, 'lst-')
+                 .replace(/^cards\/msg\//, 'msg-')
+                 .replace(/^cards\/cmp\//, 'cmp-')
+                 .replace(/[^a-z]/g, '-');
+        }
       }
     },
     definePrim: 'prim'


### PR DESCRIPTION
This is an extraction of the autocomplete from the front end's conversation branch that works on current master.

It only uses the Contacts API for matches. Bug 1188710 tracks expanding that data source over time to include email addresses that the email app knows about.
- autocomplete.js is the main new file.
- compose.html did not change that much, using ?w=1 to view the diff on github would help show the difference: a new div was added to wrap all the envelope lines, the autocomplete tag was added as a sibling to that div, and a couple elements got some new CSS classes.
- element.js and config.js changed to allow custom elements to be loaded from different directories instead of as only direct children of the cards/ repo.

Did a quick test of RTL, using the mirrored locale with arabic keyboard and entry, and worked as expected, with content aligned right.

I will follow up on any screen reader changes in bug 1189092.
