### PR TITLE
Bug 1180168 - Fix x-axis scrolling while swiping up on card

### DIFF
--- a/apps/system/js/card.js
+++ b/apps/system/js/card.js
@@ -386,6 +386,7 @@
             if (verticalY > Math.abs(this.deltaX) &&
                 verticalY > this.SWIPE_WOBBLE_THRESHOLD) {
               this._dragPhase = 'cross-slide';
+              this.publish('crossslidestart');
               // dont try and transition while dragging
               this.element.style.transition = 'transform 0s linear';
               this.onCrossSlide(evt);
@@ -419,6 +420,10 @@
         } else {
           // return it to vertical center
           this._resetY();
+        }
+        if (this._dragPhase === 'cross-slide') {
+          this.publish('crossslideend');
+          this._dragPhase = '';
         }
         break;
     }

--- a/apps/system/js/task_manager.js
+++ b/apps/system/js/task_manager.js
@@ -306,7 +306,7 @@
     window.addEventListener('appterminated', this);
     window.addEventListener('wheel', this);
     window.addEventListener('resize', this);
-
+    window.addEventListener('card-crossslidestart', this);
     this.element.addEventListener('click', this);
   };
 
@@ -320,6 +320,7 @@
     window.removeEventListener('appterminated', this);
     window.removeEventListener('wheel', this);
     window.removeEventListener('resize', this);
+    window.removeEventListener('card-crossslidestart', this);
     this._showingEventsRegistered = false;
   };
 
@@ -745,7 +746,25 @@
           this.removeCard(card);
         }
         break;
+      case 'card-crossslidestart':
+        this.handleCardCrossSlide(evt);
+        break;
     }
+  };
+
+  TaskManager.prototype.handleCardCrossSlide = function(evt) {
+    if (this._handlingCrossSlide) {
+      return;
+    }
+    this._handlingCrossSlide = true;
+    var finish = (e) => {
+      if (this.element) {
+        this.element.style.overflowX = '';
+      }
+      this._handlingCrossSlide = false;
+    };
+    this.element.style.overflowX = 'hidden';
+    eventSafety(window, 'card-crossslideend', finish, 1000);
   };
 
   TaskManager.prototype.publish = function tm_publish(type, detail) {

--- a/apps/system/test/unit/task_manager_test.js
+++ b/apps/system/test/unit/task_manager_test.js
@@ -471,7 +471,7 @@ suite('system/TaskManager >', function() {
       }
     });
 
-    suite('display cardsview >', function() {
+    suite.only('display cardsview >', function() {
       setup(function() {
         this.sinon.stub(AppWindow.prototype, 'getSiteIconUrl')
             .returns(Promise.resolve('data:image/png;base64,abc+'));
@@ -582,6 +582,18 @@ suite('system/TaskManager >', function() {
           deltaX: 1
         });
         assert.ok(card.setVisibleForScreenReader.calledOnce);
+      });
+
+      test('cross-slide events', function() {
+        var startEvt = new CustomEvent('card-crossslidestart');
+        window.dispatchEvent(startEvt);
+        assert.equal(taskManager.element.style.overflowX, 'hidden');
+
+        this.sinon.clock.tick();
+
+        var endEvt = new CustomEvent('card-crossslideend');
+        window.dispatchEvent(endEvt);
+        assert.equal(taskManager.element.style.overflowX, '');
       });
     });
 


### PR DESCRIPTION
Dispatch an event when swiping up (cross-slide) so the task-manager can set overflow-x on the container. This seems to work pretty well but I've not been able to profile yet to see if it introduces new jank
