### PR TITLE
Bug 1191705 - Format the VERBOSE log r=gaye

### DIFF
--- a/tests/jsmarionette/runner/marionette-js-runner/lib/runtime/hostmanager.js
+++ b/tests/jsmarionette/runner/marionette-js-runner/lib/runtime/hostmanager.js
@@ -3,6 +3,7 @@ var Logger = require('marionette-js-logger');
 var Marionette = require('marionette-client');
 var Promise = require('promise');
 var debug = require('debug')('marionette-js-runner:hostmanager');
+var prettyjson = require('prettyjson');
 
 /**
  * @constructor
@@ -125,7 +126,7 @@ HostManager.prototype = {
           if (verbose) {
             client.logger.pollMessages();
             client.logger.on('message', function(msg) {
-              console.log(JSON.stringify(msg));
+              console.log(prettyjson.render(msg) + '\n');
             });
           }
 

--- a/tests/jsmarionette/runner/marionette-js-runner/package.json
+++ b/tests/jsmarionette/runner/marionette-js-runner/package.json
@@ -28,6 +28,7 @@
     "mocha-json-proxy": "file:../../mocha/mocha-json-proxy",
     "mozilla-runner": "file:../mozilla-runner",
     "object-assign": "^1.0.0",
+    "prettyjson": "1.1.2",
     "promise": "^6.0.1",
     "uuid": "^2.0.1"
   },


### PR DESCRIPTION
The VERBOSE log will look like

```
window:       app://calendar.gaiamobile.org/index.html
level:        log
message:      app [calendar]  "Will initialize calendar app"
filename:     app://calendar.gaiamobile.org/js/bundle.js
lineNumber:   3305
functionName: module.exports/<
timeStamp:    1438849701253

window:       app://calendar.gaiamobile.org/index.html
level:        log
message:      db [calendar]  "Will load b2g-calendar db."
filename:     app://calendar.gaiamobile.org/js/bundle.js
lineNumber:   3305
functionName: module.exports/<
timeStamp:    1438849701254

...
```
