### PR TITLE
Bug 1191863 - Fix fm radio transition.

### DIFF
--- a/apps/fm/index.html
+++ b/apps/fm/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="theme-color" content="#242d33">
     <title>FM Radio</title>
+    <link rel="stylesheet" href="app://theme.gaiamobile.org/shared/elements/gaia-theme/gaia-theme.css" type="text/css" />
     <link rel="stylesheet" href="style/fm.css" type="text/css" />
     <meta name="defaultLanguage" content="en-US">
     <meta name="availableLanguages" content="en-US">


### PR DESCRIPTION
FM radio never includes the gaia-theme stylesheet, so some default
variable were not set, especially --transition-duration.
