### PR TITLE
Bug 1192400 - fixing an issue with waiting for keyboard when in a different app frame.

### DIFF
--- a/apps/system/test/marionette/lib/system.js
+++ b/apps/system/test/marionette/lib/system.js
@@ -10,6 +10,8 @@ module.exports = System;
 
 System.URL = 'app://system.gaiamobile.org/manifest.webapp';
 
+System.origin = 'app://system.gaiamobile.org';
+
 System.Selector = Object.freeze({
   screen: '#screen',
   activeHomescreenFrame: '#homescreen.appWindow.active',
@@ -81,6 +83,8 @@ System.prototype = {
   client: null,
 
   URL: System.URL,
+
+  origin: System.origin,
 
   Selector: System.Selector,
 
@@ -407,13 +411,27 @@ System.prototype = {
   },
 
   waitForKeyboard: function() {
+    var origin = this.client.apps.getSelf().origin;
+    if (origin !== this.origin) {
+      this.client.switchToFrame();
+    }
     this.client.helper.waitForElement(System.Selector.activeKeyboard);
+    if (origin !== this.origin) {
+      this.client.apps.switchToApp(origin);
+    }
   },
 
   waitForKeyboardToDisappear: function() {
+    var origin = this.client.apps.getSelf().origin;
+    if (origin !== this.origin) {
+      this.client.switchToFrame();
+    }
     this.client.helper.waitForElementToDisappear(
       System.Selector.activeKeyboard
     );
+    if (origin !== this.origin) {
+      this.client.apps.switchToApp(origin);
+    }
   },
 
   goHome: function() {

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -35,7 +35,6 @@
     "apps/settings/test/marionette/tests/hotspot_wifi_settings_test.js": "Bug 1006527 - Disable intermittent failing travis test, manipulate hotspot wifi settings resets settings for second load",
     "apps/settings/test/marionette/tests/message_settings_test.js": "",
     "apps/system/fxa/test/marionette/fxa_screen_flow_test.js": "Bug 1064305 - [Marionette] FxA tests - intermittent timeout failures on system/fxa/test/marionette/fxa_screen_flow_test.js",
-    "apps/system/test/marionette/activity_action_menu_test.js": "Bug 1168363 - Intermittent activity_action_menu_test.js | activity action menu test works after opening an app",
     "apps/system/test/marionette/app_usage_metrics_test.js": "Bug 1049137 - Intermittent failing test, TEST-UNEXPECTED-FAIL | App Usage Metrics > Uninstalled apps are counted",
     "apps/system/test/marionette/global_overlay_window_test.js": "Bug 1117125 - Update b2g desktop in tbpl after bug 1101029 lands",
     "apps/system/test/marionette/keyboard_edge_resize_test.js": "Bug 1147618",


### PR DESCRIPTION
This PR depends on #31290 and only second commit is relevant.
