### PR TITLE
Bug 1192489 - prevent Gecko's default window.open handler on mozbrowseropenwindow; r=timdream

### DIFF
--- a/apps/system/js/child_window_factory.js
+++ b/apps/system/js/child_window_factory.js
@@ -43,6 +43,10 @@
   ChildWindowFactory.prototype.handleEvent =
     function cwf_handleEvent(evt) {
       this.app.debug('[cwf] handling ' + evt.type);
+
+      // Prevent Gecko's default handler from opening the window.
+      evt.preventDefault();
+
       // Handle event from child window.
       if (evt.detail && evt.detail.instanceID &&
           evt.detail.instanceID !== this.app.instanceID) {

--- a/apps/system/js/wrapper_factory.js
+++ b/apps/system/js/wrapper_factory.js
@@ -30,6 +30,9 @@
     },
 
     handleEvent: function wf_handleEvent(evt) {
+      // Prevent Gecko's default handler from opening the window.
+      evt.preventDefault();
+
       if (evt.type === '_opened' || evt.type === '_terminated') {
         if (this._launchingApp === evt.detail) {
           this.forgetLastLaunchingWindow();

--- a/apps/system/test/unit/wrapper_factory_test.js
+++ b/apps/system/test/unit/wrapper_factory_test.js
@@ -79,6 +79,7 @@ suite('system/WrapperFactory', function() {
           type: 'mozbrowseropenwindow',
           target: { getAttribute: () => fakeManifestURL },
           stopImmediatePropagation: function () {},
+          preventDefault: function () {},
           detail: {
             url: 'fake',
             manifestURL: fakeManifestURL,

--- a/tv_apps/smart-system/js/child_window_factory.js
+++ b/tv_apps/smart-system/js/child_window_factory.js
@@ -40,6 +40,9 @@
 
   ChildWindowFactory.prototype.handleEvent =
     function cwf_handleEvent(evt) {
+      // Prevent Gecko's default handler from opening the window.
+      evt.preventDefault();
+
       // ChildWindowFactory handles window.open and activities. It listens the
       // closing event on the element of PopupWindow and ActivityWindow. Once
       // receiving _closing event, we can say this event is fired by one of

--- a/tv_apps/smart-system/js/wrapper_factory.js
+++ b/tv_apps/smart-system/js/wrapper_factory.js
@@ -13,6 +13,9 @@
     },
 
     handleEvent: function wf_handleEvent(evt) {
+      // Prevent Gecko's default handler from opening the window.
+      evt.preventDefault();
+
       var detail = evt.detail;
 
       // If it's a normal window.open request, ignore.


### PR DESCRIPTION
Over in [bug 1135261](https://bugzilla.mozilla.org/show_bug.cgi?id=1135261), I'm changing BrowserElementParent to respect the default status of mozbrowseropenwindow (and mozbrowserasyncscroll) events, so Gecko invokes its default handler for those events unless Event.preventDefault() has been called.  See [bug 1135261, comment 37](https://bugzilla.mozilla.org/show_bug.cgi?id=1135261#c37) for the details.

That change means that Gaia will need to start calling preventDefault() when handling mozbrowseropenwindow (and perhaps also mozbrowserasyncscroll).
