### PR TITLE
Bug 1183058 - [Contacts]Enable "Order by last name", and then kill th…

### DIFF
--- a/apps/communications/contacts/js/views/settings.js
+++ b/apps/communications/contacts/js/views/settings.js
@@ -449,9 +449,7 @@ contacts.Settings = (function() {
   // Listens for any change in the ordering preferences
   var onOrderingChange = function onOrderingChange(evt) {
     newOrderByLastName = orderCheckBox.checked;
-    utils.cookie.update({order: newOrderByLastName});
     updateOrderingUI();
-    Cache.evict();
   };
 
   // Import contacts from SIM card and updates ui
@@ -690,6 +688,8 @@ contacts.Settings = (function() {
     if (newOrderByLastName != null &&
         newOrderByLastName != orderByLastName && contacts.List) {
       contacts.List.setOrderByLastName(newOrderByLastName);
+      utils.cookie.update({order: newOrderByLastName});
+      Cache.evict();
       // Force the reset of the dom, we know that we changed the order
       contacts.List.load(null, true);
       orderByLastName = newOrderByLastName;


### PR DESCRIPTION
…e contact app or reboot device without tapping "Done", and "Order by last name" will not work when it is enable unless you kill contact and relaunch again. r=borjasalguero
