### PR TITLE
Bug 1193172 - Fix transitions with --transition-duration.

### DIFF
--- a/apps/callscreen/index.html
+++ b/apps/callscreen/index.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <meta charset="utf-8">
     <title>Dialer</title>
+    <link rel="stylesheet" type="text/css" href="app://theme.gaiamobile.org/shared/elements/gaia-theme/gaia-theme.css" />
     <link rel="stylesheet" type="text/css" href="/style/oncall.css">
     <link rel="stylesheet" type="text/css" href="/style/conference_group_ui.css">
     <link rel="stylesheet" type="text/css" href="/style/oncall_status_bar.css">


### PR DESCRIPTION
The files `style/oncall.css` and `style/lockscreen.css` uses the variable `--transition-duration`, but didn't include the stylesheet that defines it. This PR adds it to index.html.
