### PR TITLE
Bug 1194063 - Remove unused shortcut timer.

### DIFF
--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -14,7 +14,6 @@
     this.instanceID = _id++;
     this.event = null;
     this._enabled = false;
-    this._shortcutTimeout = null;
     this._injected = false;
     this._hasCutOrCopied = false;
     this._isCommandSendable = false;
@@ -30,11 +29,6 @@
   AppTextSelectionDialog.prototype.TEXTDIALOG_HEIGHT = 52;
 
   AppTextSelectionDialog.prototype.TEXTDIALOG_WIDTH = 54;
-
-  // Based on UX spec, there would be a temporary shortcut and only appears
-  // after the action 'copy/cut'. In this use case, the utility bubble will be
-  // time-out after 3 secs if no action is taken.
-  AppTextSelectionDialog.prototype.SHORTCUT_TIMEOUT = 3000;
 
   // If text is not pasted immediately after copy/cut, the text will be viewed
   // as pasted after 15 seconds (count starting from the moment when there's no
@@ -178,7 +172,6 @@
       detail.commands.canCut = false;
       detail.commands.canCopy = false;
       detail.commands.canSelectAll = false;
-      this._triggerShortcutTimeout();
       this.show(detail);
     };
 
@@ -187,22 +180,7 @@
       // make sure cut command option is only shown on editable element
       detail.commands.canCut = detail.commands.canCut && 
                                  detail.selectionEditable;
-      this._resetShortcutTimeout();
       this.show(detail);
-    };
-
-  AppTextSelectionDialog.prototype._resetShortcutTimeout =
-    function tsd__resetShortcutTimeout() {
-      window.clearTimeout(this._shortcutTimeout);
-      this._shortcutTimeout = null;
-    };
-
-  AppTextSelectionDialog.prototype._triggerShortcutTimeout =
-    function tsd__triggerShortcutTimeout() {
-      this._resetShortcutTimeout();
-      this._shortcutTimeout = window.setTimeout(function() {
-        this.close();
-      }.bind(this), this.SHORTCUT_TIMEOUT);
     };
 
   AppTextSelectionDialog.prototype._fetchElements =
@@ -365,7 +343,6 @@
 
 
   AppTextSelectionDialog.prototype.show = function tsd_show(detail) {
-    this._resetShortcutTimeout();
     var numOfSelectOptions = 0;
     var options = [ 'Paste', 'Copy', 'Cut', 'SelectAll' ];
 
@@ -485,7 +462,6 @@
     this.hide();
     this.element.blur();
     this.textualmenuDetail = null;
-    this._resetShortcutTimeout();
   };
 
   exports.AppTextSelectionDialog = AppTextSelectionDialog;

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -215,10 +215,8 @@ suite('system/AppTextSelectionDialog', function() {
     td.render();
     var stubHide = this.sinon.stub(td, 'hide');
     this.sinon.stub(td.element, 'blur');
-    this.sinon.stub(td, '_resetShortcutTimeout');
     td.close();
     assert.isTrue(stubHide.calledOnce);
-    assert.isTrue(td._resetShortcutTimeout.called);
     assert.isTrue(td.element.blur.called);
   });
 
@@ -242,25 +240,6 @@ suite('system/AppTextSelectionDialog', function() {
 
     clock.tick(td.RESET_CUT_OR_PASTE_TIMEOUT);
     assert.isFalse(td._hasCutOrCopied);
-  });
-
-  test('_resetShortcutTimeout', function() {
-    td._shortcutTimeout = 'timeout';
-    this.sinon.stub(window, 'clearTimeout');
-    td._resetShortcutTimeout();
-    assert.isTrue(window.clearTimeout.calledWith('timeout'));
-    assert.isTrue(td._shortcutTimeout === null);
-  });
-
-  test('_triggerShortcutTimeout', function() {
-    this.sinon.stub(td, '_resetShortcutTimeout');
-    this.sinon.stub(td, 'close');
-    var clock = this.sinon.useFakeTimers();
-
-    td._triggerShortcutTimeout();
-    clock.tick(td.SHORTCUT_TIMEOUT);
-    assert.isTrue(td.close.called);
-    assert.isTrue(td._resetShortcutTimeout.called);
   });
 
   suite('handleEvent caretstatechanged event', function() {
@@ -317,11 +296,9 @@ suite('system/AppTextSelectionDialog', function() {
         testDetail.collapsed = true;
         testDetail.reason = 'taponcaret';
         td._hasCutOrCopied = true;
-        this.sinon.stub(td, '_triggerShortcutTimeout');
         td.handleEvent(fakeTextSelectInAppEvent);
         assert.isTrue(stubShow.calledWith(testDetail));
         assert.isFalse(testDetail.commands.canSelectAll);
-        assert.isTrue(td._triggerShortcutTimeout.calledOnce);
       });
 
     test('should not render when bubble has showed before', function() {
@@ -363,18 +340,6 @@ suite('system/AppTextSelectionDialog', function() {
         td.handleEvent(fakeTextSelectInAppEvent);
         assert.isTrue(stubHide.calledOnce);
       });
-
-    test('should close paste bubble in 3 seconds if user tap on context and' +
-         ' has cut/copied before', function() {
-
-      var fakeTimer = this.sinon.useFakeTimers();
-      testDetail.reason = 'longpressonemptycontent';
-      td._hasCutOrCopied = true;
-      testDetail.collapsed = true;
-      td.handleEvent(fakeTextSelectInAppEvent);
-      fakeTimer.tick(td.SHORTCUT_TIMEOUT);
-      assert.isTrue(stubClose.calledOnce);
-    });
   });
 
   suite('_elementEventHandler', function() {


### PR DESCRIPTION
After applying Gecko patches in bug 1194063, Gaia will always receive
caret state changed event after 3 seconds timeout whether the content is
empty or not. No need to use the shortcut timer to close text selection
dialog.
