### PR TITLE
Bug 1196077 - [email] Refactor message_list into some smaller custom elements

### DIFF
--- a/apps/email/js/cards.js
+++ b/apps/email/js/cards.js
@@ -435,10 +435,10 @@ var cards = {
 
   // Filter is an optional paramater. It is a function that returns
   // true if the folder passed to it should be included in the selector
-  folderSelector: function(callback, filter) {
+  folderSelector: function(model, callback, filter) {
     var self = this;
 
-    require(['model', 'value_selector'], function(model, ValueSelector) {
+    require(['value_selector'], function(ValueSelector) {
       // XXX: Unified folders will require us to make sure we get the folder
       //      list for the account the message originates from.
       if (!self.folderPrompt) {

--- a/apps/email/js/cards/base_card.js
+++ b/apps/email/js/cards/base_card.js
@@ -1,0 +1,68 @@
+'use strict';
+define(function(require) {
+  var mozL10n = require('l10n!'),
+      base = require('./base');
+
+  // Set up the global time updates for all nodes.
+  (function() {
+    var formatter = new mozL10n.DateTimeFormat();
+    var updatePrettyDate = function updatePrettyDate() {
+      var labels = document.querySelectorAll('[data-time]');
+      var i = labels.length;
+      while (i--) {
+        labels[i].textContent = formatter.fromNow(
+          labels[i].dataset.time,
+          // the presence of the attribute is our indicator; not its value
+          'compactFormat' in labels[i].dataset);
+      }
+    };
+    var timer = setInterval(updatePrettyDate, 60 * 1000);
+
+    function updatePrettyDateOnEvent() {
+      clearInterval(timer);
+      updatePrettyDate();
+      timer = setInterval(updatePrettyDate, 60 * 1000);
+    }
+    // When user changes the language, update timestamps.
+    mozL10n.ready(updatePrettyDateOnEvent);
+
+    // On visibility change to not hidden, update timestamps
+    document.addEventListener('visibilitychange', function() {
+      if (document && !document.hidden) {
+        updatePrettyDateOnEvent();
+      } else {
+        // If not visible, clear the interval to be a battery good citizen.
+        clearInterval(timer);
+      }
+    });
+
+  })();
+
+  return function baseCard(templateMixins) {
+    // Set up the base mixin
+    return [
+      base(templateMixins),
+      {
+        createdCallback: function() {
+          // Set up extra classes and other node information that distinguishes
+          // as a card. Doing this here so that by the time the createdCallback
+          // provided by the card so that the DOM at that point can be used for
+          // HTML caching purposes.
+          if (this.extraClasses) {
+            this.classList.add.apply(this.classList,
+                                        this.extraClasses);
+          }
+
+          this.classList.add('card');
+        },
+
+        batchAddClass: function(searchClass, classToAdd) {
+          var nodes = this.getElementsByClassName(searchClass);
+          for (var i = 0; i < nodes.length; i++) {
+            nodes[i].classList.add(classToAdd);
+          }
+        }
+      }
+    ];
+  };
+});

--- a/apps/email/js/cards/cmp/autocomplete.js
+++ b/apps/email/js/cards/cmp/autocomplete.js
@@ -112,12 +112,6 @@ return [
   require('../base')(),
   {
     createdCallback: function() {
-      //TODO: master hack only. In email-model-instance branch, this is not
-      //needed. In the branch, there is a separate 'base' that elements can
-      //mix in that is not assumed to be a card. For now, this is an equivalent
-      //result.
-      this.classList.remove('card');
-
       this.lastTranslateY = 0;
       this.inputAreaTranslated = Promise.resolve();
 

--- a/apps/email/js/cards/compose.js
+++ b/apps/email/js/cards/compose.js
@@ -17,7 +17,6 @@ var cmpAttachmentItemNode = require('tmpl!./cmp/attachment_item.html'),
     evt = require('evt'),
     htmlCache = require('html_cache'),
     toaster = require('toaster'),
-    model = require('model'),
     iframeShims = require('iframe_shims'),
     Marquee = require('marquee'),
     mozL10n = require('l10n!'),
@@ -71,7 +70,7 @@ function focusInputAndPositionCursorFromContainerClick(event, input) {
 
 
 return [
-  require('./base')(require('template!./compose.html')),
+  require('./base_card')(require('template!./compose.html')),
   require('./editor_mixins'),
   {
     createdCallback: function() {
@@ -134,6 +133,7 @@ return [
       this.composer = args.composer;
       this.composerData = args.composerData || {};
       this.activity = args.activity;
+      this.model = args.model;
     },
 
     onCardVisible: function() {
@@ -211,7 +211,9 @@ return [
         if (this.composer) {
           this._loadStateFromComposer();
         } else {
-          var data = this.composerData;
+          var data = this.composerData,
+              model = this.model;
+
           model.latestOnce('folder', function(folder) {
             this.composer = model.api.beginMessageComposition(data.message,
                                                               folder,
@@ -336,7 +338,7 @@ return [
       // An address is valid if model.api.parseMailbox thinks it
       // contains a valid address. (It correctly classifies names that
       // are not valid addresses.)
-      var mailbox = model.api.parseMailbox(address);
+      var mailbox = this.model.api.parseMailbox(address);
       return mailbox && mailbox.address;
     },
 
@@ -358,7 +360,7 @@ return [
           addrList.push({ name: dataSet.name, address: dataSet.address });
         }
         if (node.value.trim().length !== 0) {
-          var mailbox = model.api.parseMailbox(node.value);
+          var mailbox = this.model.api.parseMailbox(node.value);
           addrList.push({ name: mailbox.name, address: mailbox.address });
         }
         addrList.forEach(function(addr) {
@@ -601,7 +603,7 @@ return [
       }
 
       if (makeBubble) {
-        entryMatch = model.api.parseMailbox(node.value);
+        entryMatch = this.model.api.parseMailbox(node.value);
         this.addFromEntry(entryMatch, node);
       }
 

--- a/apps/email/js/cards/confirm_dialog.js
+++ b/apps/email/js/cards/confirm_dialog.js
@@ -3,7 +3,7 @@ define(function(require) {
   var cards = require('cards');
 
   return [
-    require('./base')(require('template!./confirm_dialog.html')),
+    require('./base_card')(require('template!./confirm_dialog.html')),
     {
       onArgs: function(args) {
         var dialogBodyNode = args.dialogBodyNode,

--- a/apps/email/js/cards/lst/default_vscroll_data.js
+++ b/apps/email/js/cards/lst/default_vscroll_data.js
@@ -1,0 +1,33 @@
+// Default data used for the VScroll component, when data is not loaded yet for
+// display in the virtual scroll listing. The u2583 character is a solid bar
+// character, so a string of them gives a "redacted" look to a line. Just a
+// temporary placeholder until the real data comes in.
+define({
+  'isPlaceholderData': true,
+  'id': 'INVALID',
+  'author': {
+    'name': '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583',
+    'address': '',
+    'contactId': null
+  },
+  'to': [
+    {
+      'name': ' ',
+      'address': ' ',
+      'contactId': null
+    }
+  ],
+  'cc': null,
+  'bcc': null,
+  'date': '0',
+  'hasAttachments': false,
+  'snippet': '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583',
+  'isRead': true,
+  'isStarred': false,
+  'sendStatus': {},
+  'subject': '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583' +
+             '\u2583\u2583\u2583\u2583\u2583\u2583\u2583\u2583'
+});

--- a/apps/email/js/cards/lst/edit_controller.js
+++ b/apps/email/js/cards/lst/edit_controller.js
@@ -1,0 +1,190 @@
+'use strict';
+
+define(function(require, exports) {
+  var cards = require('cards'),
+      ConfirmDialog = require('confirm_dialog'),
+      deleteConfirmMsgNode = require('tmpl!../msg/delete_confirm.html'),
+      mozL10n = require('l10n!'),
+      toaster = require('toaster');
+
+  return {
+    createdCallback: function() {
+      this.editMode = false;
+      this.selectedMessages = null;
+      this.editModeEnabled = false;
+    },
+
+    setEditMode: function(editMode) {
+      // Do not bother if edit mode is not enabled yet.
+      if (!this.editModeEnabled) {
+        return;
+      }
+
+      this._setEditMode(editMode);
+    },
+
+    // This function is called from setEditMode() after ensuring that
+    // the backend is in a state where we can safely use edit mode.
+    _setEditMode: function(editMode) {
+      var i;
+
+      this.editMode = editMode;
+
+      if (editMode) {
+        this.classList.add('show-edit');
+
+        this.selectedMessages = [];
+        this.updateDomEditControls();
+      }
+      else {
+        this.classList.remove('show-edit');
+
+        this.selectedMessages = null;
+      }
+
+      // Reset checked mode for all message items.
+      var msgNodes = this.msgVScroll.querySelectorAll('.msg-header-item');
+      for (i = 0; i < msgNodes.length; i++) {
+        this.updateDomMessageChecked(msgNodes[i], false);
+      }
+
+      if (this.editModeChanged) {
+        this.editModeChanged(editMode);
+      }
+    },
+
+    // Event handler wired up in HTML template
+    setEditModeStart: function() {
+      this.setEditMode(true);
+    },
+
+    // Event handler wired up in HTML template
+    editHeaderClose: function() {
+      this.setEditMode(false);
+    },
+
+    /**
+     * Toggles the selection state of the node and therefore the stored
+     * `selectedMessages` state based on the previous state of the selection.
+     * The change in the total number of selections is then reflected in DOM
+     * updates.
+     * @param  {Element} msgNode
+     */
+    toggleSelection: function(msgNode) {
+      var header = msgNode.message;
+      var idx = this.selectedMessages.indexOf(header);
+      if (idx !== -1) {
+        this.selectedMessages.splice(idx, 1);
+      } else {
+        this.selectedMessages.push(header);
+      }
+      this.updateDomMessageChecked(msgNode, idx === -1);
+      this.updateDomEditControls();
+    },
+
+    /**
+     * Set or unset the select state on a node based on the edit mode.
+     */
+    updateDomSelectState: function(msgNode, message) {
+      if (this.editMode) {
+        this.updateDomMessageChecked(msgNode,
+          this.selectedMessages.indexOf(message) !== -1);
+      } else {
+        msgNode.removeAttribute('aria-selected');
+      }
+    },
+
+    /**
+     * Set the checked state for the message item in the list. It sets both
+     * checkbox checked and aria-selected states.
+     */
+    updateDomMessageChecked: function(msgNode, checked) {
+      var checkbox = msgNode.querySelector('input[type=checkbox]');
+      checkbox.checked = checked;
+      msgNode.setAttribute('aria-selected', checked);
+    },
+
+    /**
+     * Update the edit mode UI bits sensitive to a change in the set of selected
+     * messages.  This means the label that says how many messages are selected,
+     * whether the buttons are enabled, which of the toggle-pairs are visible.
+     */
+    updateDomEditControls: function() {
+      this.editHeader.updateDomHeaderCount(this.selectedMessages.length);
+      this.editToolbar.updateDomEditButtons(this.selectedMessages.length > 0);
+
+      // Enabling/disabling rules (not UX-signed-off):  Our bias is that people
+      // want to star messages and mark messages unread (since it they naturally
+      // end up unread), so unless messages are all in this state, we assume
+      // that is the desired action.
+      var numStarred = 0, numRead = 0;
+      for (var i = 0; i < this.selectedMessages.length; i++) {
+        var msg = this.selectedMessages[i];
+        if (msg.isStarred) {
+          numStarred++;
+        }
+        if (msg.isRead) {
+          numRead++;
+        }
+      }
+
+      // Unstar if everything is starred, otherwise star
+      this.setAsStarred = !(numStarred && numStarred ===
+                            this.selectedMessages.length);
+      this.editToolbar.updateDomStartButton(this.setAsStarred);
+
+      // Mark read if everything is unread, otherwise unread
+      this.setAsRead = (!!this.selectedMessages.length && numRead === 0);
+      this.editToolbar.updateDomReadButton(numRead > 0);
+    },
+
+    onDeleteMessages: function() {
+      if (this.selectedMessages.length === 0) {
+        return this.setEditMode(false);
+      }
+
+      var dialog = deleteConfirmMsgNode.cloneNode(true);
+      var content = dialog.getElementsByTagName('p')[0];
+      mozL10n.setAttributes(content, 'message-multiedit-delete-confirm',
+                            { n: this.selectedMessages.length });
+      ConfirmDialog.show(dialog,
+        { // Confirm
+          id: 'msg-delete-ok',
+          handler: function() {
+            var op = this.model.api.deleteMessages(this.selectedMessages);
+            toaster.toastOperation(op);
+            this.setEditMode(false);
+          }.bind(this)
+        },
+        { // Cancel
+          id: 'msg-delete-cancel',
+          handler: null
+        }
+      );
+    },
+
+    onStarMessages: function() {
+      var op = this.model.api.markMessagesStarred(this.selectedMessages,
+                                           this.setAsStarred);
+      this.setEditMode(false);
+      toaster.toastOperation(op);
+    },
+
+    onMarkMessagesRead: function() {
+      var op = this.model.api.markMessagesRead(this.selectedMessages,
+                                          this.setAsRead);
+      this.setEditMode(false);
+      toaster.toastOperation(op);
+    },
+
+    onMoveMessages: function() {
+      cards.folderSelector(this.model, function(folder) {
+        var op = this.model.api.moveMessages(this.selectedMessages, folder);
+        toaster.toastOperation(op);
+        this.setEditMode(false);
+      }.bind(this), function(folder) {
+        return folder.isValidMoveTarget;
+      });
+    }
+  };
+});

--- a/apps/email/js/cards/lst/edit_header.html
+++ b/apps/email/js/cards/lst/edit_header.html
@@ -1,0 +1,12 @@
+<section role="region">
+  <header>
+    <a href="#"
+       data-event="click:domEvt"
+       data-domevt-name="editHeaderClose"
+       role="button"
+       data-l10n-id="close-button">
+      <span class="icon icon-close"></span>
+    </a>
+    <h1 data-prop="headerNode"></h1>
+  </header>
+</section>

--- a/apps/email/js/cards/lst/edit_header.js
+++ b/apps/email/js/cards/lst/edit_header.js
@@ -1,0 +1,16 @@
+'use strict';
+
+define(function(require, exports) {
+  var mozL10n = require('l10n!');
+
+  return [
+    require('../base')(require('template!./edit_header.html')),
+    require('../mixins/dom_evt'),
+    {
+      updateDomHeaderCount: function(count) {
+        mozL10n.setAttributes(this.headerNode, 'message-multiedit-header',
+          { n: count });
+      }
+    }
+  ];
+});

--- a/apps/email/js/cards/lst/edit_toolbar.html
+++ b/apps/email/js/cards/lst/edit_toolbar.html
@@ -1,0 +1,31 @@
+<!-- Toolbar for multi-edit state -->
+<ul class="bb-tablist" role="toolbar">
+  <li role="presentation">
+    <button data-prop="deleteBtn"
+            data-event="click:domEvt"
+            data-domevt-name="onDeleteMessages"
+            class="icon msg-delete-btn"
+            data-l10n-id="message-delete-button"></button>
+  </li>
+  <li role="presentation">
+    <button data-prop="starBtn"
+            data-event="click:domEvt"
+            data-domevt-name="onStarMessages"
+            class="icon msg-star-btn"
+            data-l10n-id="message-star-button"></button>
+  </li>
+  <li role="presentation">
+    <button data-prop="readBtn"
+            data-event="click:domEvt"
+            data-domevt-name="onMarkMessagesRead"
+            class="icon msg-mark-read-btn"
+            data-l10n-id="message-mark-read-button"></button>
+  </li>
+  <li role="presentation">
+    <button data-prop="moveBtn"
+            data-event="click:domEvt"
+            data-domevt-name="onMoveMessages"
+            class="icon msg-move-btn"
+            data-l10n-id="message-move-button"></button>
+  </li>
+</ul>

--- a/apps/email/js/cards/lst/edit_toolbar.js
+++ b/apps/email/js/cards/lst/edit_toolbar.js
@@ -1,0 +1,47 @@
+'use strict';
+
+define(function(require, exports) {
+  var mozL10n = require('l10n!'),
+      toolbarEditButtonNames = ['starBtn', 'readBtn', 'deleteBtn', 'moveBtn'];
+
+  return [
+    require('../base')(require('template!./edit_toolbar.html')),
+    require('../mixins/dom_evt'),
+    {
+      updateDomFolderType: function(folderType) {
+        // You can't move messages in localdrafts or the outbox.
+        this.moveBtn.classList.toggle('collapsed',
+                                              folderType === 'localdrafts' ||
+                                              folderType === 'outbox');
+        // You can't flag or change the read status of messages in the outbox.
+        this.starBtn.classList.toggle('collapsed',
+                                              folderType === 'outbox');
+        this.readBtn.classList.toggle('collapsed',
+                                              folderType === 'outbox');
+      },
+
+      // If true, show the star button, otherwise show unstar button.
+      updateDomStartButton: function(isStarred) {
+        mozL10n.setAttributes(this.starBtn,
+                isStarred ? 'message-star-button' : 'message-unstar-button');
+      },
+
+      // If true, some messages read, so show readBtn as marking unread.
+      updateDomReadButton: function(hasUnread) {
+        // Update mark read/unread button to show what action will be taken.
+        this.readBtn.classList.toggle('unread', hasUnread);
+
+        mozL10n.setAttributes(this.readBtn, hasUnread ?
+          'message-mark-unread-button' : 'message-mark-read-button');
+      },
+
+      // Set how many messages to edit. If greater than zero, enable buttons.
+      updateDomEditButtons: function(hasMessages) {
+        // Update disabled state based on if there are selected messages
+        toolbarEditButtonNames.forEach(function(key) {
+          this[key].disabled = !hasMessages;
+        }.bind(this));
+      }
+    }
+  ];
+});

--- a/apps/email/js/cards/lst/msg_click.js
+++ b/apps/email/js/cards/lst/msg_click.js
@@ -1,0 +1,158 @@
+'use strict';
+
+define(function(require, exports) {
+
+var cards = require('cards'),
+    ConfirmDialog = require('confirm_dialog'),
+    largeMsgConfirmMsgNode = require('tmpl!../msg/large_message_confirm.html');
+
+/**
+ * Show a warning that the given message is large.
+ * Callback is called with cb(true|false) to continue.
+ */
+function showLargeMessageWarning(size, cb) {
+  var dialog = largeMsgConfirmMsgNode.cloneNode(true);
+  // TODO: If UX designers want the size included in the warning
+  // message, add it here.
+  ConfirmDialog.show(dialog,
+    { // Confirm
+      id: 'msg-large-message-ok',
+      handler: function() { cb(true); }
+    },
+    { // Cancel
+      id: 'msg-large-message-cancel',
+      handler: function() { cb(false); }
+    }
+  );
+}
+
+/**
+ * A mixin for lst cards that want tapping on a message to go to a message
+ * reader. Check all the `this` references below to see implicit dependencies
+ * on instance state.
+ * A longer range TODO is to remove or make explicit the dependencies.
+ */
+  return {
+    onClickMessage: function(event) {
+      var messageNode = event.detail;
+
+      // You cannot open a message if this is the outbox and it is syncing.
+      if (this.curFolder &&
+          this.curFolder.type === 'outbox' && this.outboxSyncInProgress) {
+        return;
+      }
+
+      var header = messageNode.message;
+
+      // Skip nodes that are default/placeholder ones.
+      if (header && header.isPlaceholderData) {
+        return;
+      }
+
+      // If in edit mode, the clicks on message nodes are about changing the
+      // selection for bulk edit actions.
+      if (this.editMode) {
+        this.toggleSelection(messageNode);
+        return;
+      }
+
+      if (this.curFolder && this.curFolder.type === 'localdrafts') {
+        var composer = header.editAsDraft(() => {
+          cards.pushCard('compose', 'animate', {
+            model: this.model,
+            composer
+          });
+        });
+        return;
+      }
+
+      // When tapping a message in the outbox, don't open the message;
+      // instead, move it to localdrafts and edit the message as a
+      // draft.
+      if (this.curFolder && this.curFolder.type === 'outbox') {
+        // If the message is currently being sent, abort.
+        if (header.sendStatus.state === 'sending') {
+          return;
+        }
+        var draftsFolder =
+              this.model.foldersSlice.getFirstFolderWithType('localdrafts');
+
+        console.log('outbox: Moving message to localdrafts.');
+        this.model.api.moveMessages([header], draftsFolder, function(moveMap) {
+          header.id = moveMap[header.id];
+          console.log('outbox: Editing message in localdrafts.');
+          var composer = header.editAsDraft(() => {
+            cards.pushCard('compose', 'animate', {
+              model: this.model,
+              composer
+            });
+          });
+        });
+
+        return;
+      }
+
+      var model = this.model,
+          headerCursor = this.headerCursor;
+
+      function pushMessageCard() {
+        cards.pushCard(
+          'message_reader', 'animate',
+          {
+            model,
+            headerCursor,
+
+            // The header here may be undefined here, since the click
+            // could be on a cached HTML node before the back end has
+            // started up. It is OK if header is not available as the
+            // message_reader knows how to wait for the back end to
+            // start up to get the header value later.
+            header,
+            // Use the property on the HTML, since the click could be
+            // from a cached HTML node and the real data object may not
+            // be available yet.
+            messageSuid: messageNode.dataset.id
+          });
+      }
+
+      if (header) {
+        this.headerCursor.setCurrentMessage(header);
+      } else if (messageNode.dataset.id) {
+        // a case where header was not set yet, like clicking on a
+        // html cached node, or virtual scroll item that is no
+        // longer backed by a header.
+        this.headerCursor.setCurrentMessageBySuid(messageNode.dataset.id);
+      } else {
+        // Not an interesting click, bail
+        return;
+      }
+
+      // If the message is really big, warn them before they open it.
+      // Ideally we'd only warn if you're on a cell connection
+      // (metered), but as of now `navigator.connection.metered` isn't
+      // implemented.
+
+      // This number is somewhat arbitrary, based on a guess that most
+      // plain-text/HTML messages will be smaller than this. If this
+      // value is too small, users get warned unnecessarily. Too large
+      // and they download a lot of data without knowing. Since we
+      // currently assume that all network connections are metered,
+      // they'll always see this if they get a large message...
+      var LARGE_MESSAGE_SIZE = 1 * 1024 * 1024;
+
+      // watch out, header might be undefined here (that's okay, see above)
+      if (header && header.bytesToDownloadForBodyDisplay > LARGE_MESSAGE_SIZE) {
+        showLargeMessageWarning(
+          header.bytesToDownloadForBodyDisplay, function(result) {
+          if (result) {
+            pushMessageCard();
+          } else {
+            // abort
+          }
+        });
+      } else {
+        pushMessageCard();
+      }
+    }
+  };
+});

--- a/apps/email/js/cards/lst/msg_vscroll.html
+++ b/apps/email/js/cards/lst/msg_vscroll.html
@@ -1,0 +1,22 @@
+<div data-prop="vScrollContainer" class="msg-vscroll-container"></div>
+<!-- maintain vertical space for the syncing/sync more div's
+     regardless of their displayed status so we don't scroll them
+     out of the way -->
+<div class="msg-messages-sync-container">
+  <p data-prop="syncingNode" class="msg-messages-syncing collapsed"
+     role="progressbar" data-l10n-id="messages-syncing-progressbar">
+    <span data-l10n-id="messages-syncing"></span>
+  </p>
+  <p data-prop="syncMoreNode"
+     data-event="click:onGetMoreMessages"
+     class="msg-messages-sync-more collapsed"
+     role="button">
+    <span data-l10n-id="messages-load-more"></span>
+  </p>
+</div>
+<div data-prop="messageEmptyContainer"
+     class="msg-list-empty-container collapsed">
+  <p data-prop="messageEmptyText"
+     class="msg-list-empty-message-text"
+     data-l10n-id="messages-folder-empty"></p>
+</div>

--- a/apps/email/js/cards/lst/msg_vscroll.js
+++ b/apps/email/js/cards/lst/msg_vscroll.js
@@ -1,0 +1,511 @@
+'use strict';
+
+define(function(require, exports) {
+
+var cards = require('cards'),
+    containerListen = require('container_listen'),
+    mozL10n = require('l10n!'),
+    msgHeaderItemNode = require('tmpl!../msg/header_item.html'),
+    toaster = require('toaster'),
+    VScroll = require('vscroll');
+
+var sliceEvents = ['splice', 'change', 'status', 'complete'];
+
+/**
+ * Minimum number of items there must be in the message slice
+ * for us to attempt to limit the selection of snippets to fetch.
+ */
+var MINIMUM_ITEMS_FOR_SCROLL_CALC = 10;
+
+/**
+ * Maximum amount of time between issuing snippet requests.
+ */
+var MAXIMUM_MS_BETWEEN_SNIPPET_REQUEST = 6000;
+
+/**
+ * Fetch up to 4kb while scrolling
+ */
+var MAXIMUM_BYTES_PER_MESSAGE_DURING_SCROLL = 4 * 1024;
+
+
+/**
+ * Component that shows a message-based vscroll. Assumes the following are set
+ * on the this component before vscroll is active:
+ * - headerCursor
+ */
+return [
+  require('../base')(require('template!./msg_vscroll.html')),
+  {
+    createdCallback: function() {
+      this.setAttribute('role', 'listbox');
+      this.setAttribute('aria-multiselectable', 'true');
+
+      mozL10n.setAttributes(this.messageEmptyText, this.dataset.emptyL10nId);
+
+      containerListen(this.vScrollContainer, 'click',
+                      this.onClickMessage.bind(this));
+    },
+
+    /**
+     * Call this from the createdCallback of the module that wants to display
+     * a message-based vscroll.
+     */
+    init: function(scrollContainer, bindData, defaultVScrollData) {
+      this.scrollContainer = scrollContainer;
+
+      // Set up the list data source for VScroll
+      var listFunc = (function(index) {
+         return this.headerCursor.messagesSlice.items[index];
+      }.bind(this));
+
+      listFunc.size = (function() {
+        // This method could get called during VScroll updates triggered
+        // by messages_splice. However at that point, the headerCount may
+        // not be correct, like when fetching more messages from the
+        // server. So approximate by using the size of slice.items.
+        var slice = this.headerCursor.messagesSlice;
+        // coerce headerCount to 0 if it was undefined to avoid a NaN
+        return Math.max(slice.headerCount || 0, slice.items.length);
+      }.bind(this));
+      this.listFunc = listFunc;
+
+      // We need to wait for the slice to complete before we can issue any
+      // sensible growth requests.
+      this.waitingOnChunk = true;
+      this.desiredHighAbsoluteIndex = 0;
+      this._needVScrollData = false;
+      this.vScroll = new VScroll(
+        this.vScrollContainer,
+        this.scrollContainer,
+        msgHeaderItemNode,
+        defaultVScrollData
+      );
+
+      // Called by VScroll wants to bind some data to a node it wants to
+      // display in the DOM.
+      this.vScroll.bindData = bindData;
+
+      // Called by VScroll when it detects it will need more data in the near
+      // future. VScroll does not know if it already asked for this
+      // information, so this function needs to be sure it actually needs to
+      // ask for more from the back end.
+      this.vScroll.prepareData = (function(highAbsoluteIndex) {
+        var items = this.headerCursor.messagesSlice &&
+                    this.headerCursor.messagesSlice.items,
+            headerCount = this.headerCursor.messagesSlice.headerCount;
+
+        if (!items || !headerCount) {
+          return;
+        }
+
+        // Make sure total amount stays within possible range.
+        if (highAbsoluteIndex > headerCount - 1) {
+          highAbsoluteIndex = headerCount - 1;
+        }
+
+        // We're already prepared if the slice is already that big.
+        if (highAbsoluteIndex < items.length) {
+          return;
+        }
+
+        this.loadNextChunk(highAbsoluteIndex);
+      }.bind(this));
+    },
+
+    setHeaderCursor: function(headerCursor) {
+      if (this.headerCursor) {
+        throw new Error('headerCursor already set');
+      }
+
+      this.headerCursor = headerCursor;
+
+      sliceEvents.forEach(function(type) {
+        var name = 'messages_' + type;
+        // Bind to local, but replace property name here so that removing the
+        // listeners are easier in die().
+        this[name] = this[name].bind(this);
+        headerCursor.on(name, this[name]);
+      }.bind(this));
+
+      this.onCurrentMessage = this.onCurrentMessage.bind(this);
+      headerCursor.on('currentMessage', this.onCurrentMessage);
+
+      // Find the containing element that is a card, for use when asking if that
+      // card is visible and extra work should be done.
+      var parent = this;
+      while((parent = parent.parentNode)) {
+        if (parent.classList.contains('card')) {
+          break;
+        }
+      }
+      this.cardParent = parent;
+
+      this._onVScrollStopped = this._onVScrollStopped.bind(this);
+      this.vScroll.on('scrollStopped', this._onVScrollStopped);
+    },
+
+    /**
+     * Used to remove the cached HTML from a cache restore of HTML. Do not use
+     * this for clearing the display of messages when the list of messages
+     * change, instead use methods on the vScroll object.
+     */
+    removeMessagesHtml: function() {
+      this.vScrollContainer.innerHTML = '';
+    },
+
+    onClickMessage: function(node, event) {
+      this.emitDomEvent('messageClick', node);
+    },
+
+    /**
+     * Waits for scrolling to stop before fetching snippets.
+     */
+    _onVScrollStopped: function() {
+      // Give any pending requests in the slice priority.
+      if (!this.headerCursor.messagesSlice ||
+          this.headerCursor.messagesSlice.pendingRequestCount) {
+        return;
+      }
+
+      // Do not bother fetching snippets if this card is not in view.
+      // The card could still have a scroll event triggered though
+      // by the next/previous work done in message_reader.
+      if (cards.isVisible(this.cardParent) && !this._hasSnippetRequest()) {
+        this._requestSnippets();
+      }
+    },
+
+    onGetMoreMessages: function() {
+      if (!this.headerCursor.messagesSlice) {
+        return;
+      }
+
+      // For accessibility purposes, focus on the first newly loaded item in the
+      // messages list. This will ensure that screen reader's cursor position
+      // will get updated to the right place.
+      this.vScroll.once('recalculated', function(calledFromTop, refIndex) {
+        // refIndex is the index of the first new message item.
+        this.vScrollContainer.querySelector(
+          '[data-index="' + refIndex + '"]').focus();
+      }.bind(this));
+
+      this.headerCursor.messagesSlice.requestGrowth(1, true);
+    },
+
+    isEmpty: function() {
+      return this.headerCursor.messagesSlice.items.length === 0;
+    },
+
+    /**
+     * Hide buttons that are not appropriate if we have no messages and display
+     * the appropriate l10n string in the message list proper.
+     */
+    showEmptyLayout: function() {
+      this.messageEmptyContainer.classList.remove('collapsed');
+      this.emit('emptyLayoutShown');
+    },
+    /**
+     * Show buttons we hid in `showEmptyLayout` and hide the "empty folder"
+     * message.
+     */
+    hideEmptyLayout: function() {
+      this.messageEmptyContainer.classList.add('collapsed');
+      this.emit('emptyLayoutHidden');
+    },
+
+    // The funny name because it is auto-bound as a listener for
+    // messagesSlice events in headerCursor using a naming convention.
+    messages_status: function(newStatus) {
+      var syncInProgress = true;
+      if (newStatus === 'synchronizing' ||
+         newStatus === 'syncblocked') {
+          this.syncingNode.classList.remove('collapsed');
+          this.syncMoreNode.classList.add('collapsed');
+          this.hideEmptyLayout();
+      } else if (newStatus === 'syncfailed' ||
+                 newStatus === 'synced') {
+        syncInProgress = false;
+        if (newStatus === 'syncfailed') {
+          // If there was a problem talking to the server, notify the user and
+          // provide a means to attempt to talk to the server again.  We have
+          // made onRefresh pretty clever, so it can do all the legwork on
+          // accomplishing this goal.
+          toaster.toast({
+            text: mozL10n.get('toaster-retryable-syncfailed')
+          });
+        }
+        this.syncingNode.classList.add('collapsed');
+      }
+      this.emit('syncInProgress', syncInProgress);
+    },
+
+    /**
+     * @param {number=} newEmailCount Optional number of new messages.
+     * The funny name because it is auto-bound as a listener for
+     * messagesSlice events in headerCursor using a naming convention.
+     */
+    messages_complete: function(newEmailCount) {
+      var headerCursor = this.headerCursor;
+
+      console.log('message_list complete:',
+                  headerCursor.messagesSlice.items.length, 'items of',
+                  headerCursor.messagesSlice.headerCount,
+                  'alleged known headers. canGrow:',
+                  headerCursor.messagesSlice.userCanGrowDownwards);
+
+    // Show "load more", but only if the slice can grow and if there is a
+    // non-zero headerCount. If zero headerCount, it likely means the folder
+    // has never been synchronized, and this display was an offline display,
+    // so it is hard to know if messages can be synchronized. In this case,
+    // canGrow is not enough of an indicator, because as far as the back end is
+    // concerned, it could grow, it just has no way to check for sure yet. So
+    // hide the "load more", the user can use the refresh icon once online to
+    // load messages.
+    if (headerCursor.messagesSlice.userCanGrowDownwards &&
+        headerCursor.messagesSlice.headerCount) {
+        this.syncMoreNode.classList.remove('collapsed');
+      } else {
+        this.syncMoreNode.classList.add('collapsed');
+      }
+
+      // Show empty layout, unless this is a slice with fake data that
+      // will get changed soon.
+      if (headerCursor.messagesSlice.items.length === 0) {
+        this.showEmptyLayout();
+      }
+
+      this.waitingOnChunk = false;
+      // Load next chunk if one is pending
+      if (this.desiredHighAbsoluteIndex) {
+        this.loadNextChunk(this.desiredHighAbsoluteIndex);
+        this.desiredHighAbsoluteIndex = 0;
+      }
+
+      // It's possible for a synchronization to result in a change to
+      // headerCount without resulting in a splice.  This is very likely
+      // to happen with a search filter when it was lying about another
+      // messages existing, but it's also possible to happen in
+      // synchronizations.
+      //
+      // XXX Our total correctness currently depends on headerCount only
+      // changing as a result of a synchronization triggered by this slice.
+      // This does not hold up when confronted with periodic background sync; we
+      // need to finish cleanup up the headerCount change notification stuff.
+      //
+      // (However, this is acceptable glitchage right now.  We just need to make
+      // sure it doesn't happen for searches since it's so blatant.)
+      //
+      // So, anyways, use updateDataBind() to cause VScroll to double-check that
+      // our list size didn't change from what it thought it was.  (It renders
+      // coordinate-space predictively based on our headerCount, but we
+      // currently only provide strong correctness guarantees for actually
+      // reported `items`, so we must do this.)  If our list size is the same,
+      // this call is effectively a no-op.
+      this.vScroll.updateDataBind(0, [], 0);
+
+      this.emit('messagesComplete', newEmailCount);
+    },
+
+    // The funny name because it is auto-bound as a listener for
+    // messagesSlice events in headerCursor using a naming convention.
+    messages_splice: function(index, howMany, addedItems,
+                              requested, moreExpected) {
+      var headerCursor = this.headerCursor;
+
+      // If no work to do, just skip it.
+      if (index === 0 && howMany === 0 && !addedItems.length) {
+        return;
+      }
+
+      this.emit('messagesSpliceStart', index, howMany, addedItems,
+                                       requested, moreExpected);
+
+      if (this._needVScrollData) {
+        this.vScroll.setData(this.listFunc);
+        this._needVScrollData = false;
+      }
+
+      this.vScroll.updateDataBind(index, addedItems, howMany);
+
+      // Remove the no message text while new messages added:
+      if (addedItems.length > 0) {
+        this.hideEmptyLayout();
+      }
+
+      // If the end result is no more messages, then show empty layout.
+      // This is needed mostly because local drafts do not trigger
+      // a messages_complete callback when removing the last draft
+      // from the compose triggered in that view. The scrollStopped
+      // is used to avoid a flash where the old message is briefly visible
+      // before cleared, and having the empty layout overlay it.
+      // Using the slice's headerCount because it is updated before splice
+      // listeners are notified, so should be accurate.
+      if (!headerCursor.messagesSlice.headerCount) {
+        this.vScroll.once('scrollStopped', function() {
+          // Confirm there are still no messages. Since this callback happens
+          // async, some items could have appeared since first issuing the
+          // request to show empty.
+          if (!headerCursor.messagesSlice.headerCount) {
+            this.showEmptyLayout();
+          }
+        }.bind(this));
+      }
+
+      this.emit('messagesSpliceEnd', index, howMany, addedItems,
+                                       requested, moreExpected);
+    },
+
+    // The funny name because it is auto-bound as a listener for
+    // messagesSlice events in headerCursor using a naming convention.
+    messages_change: function(message, index) {
+      this.emit('messagesChange', message, index);
+    },
+
+    /**
+     * Request data through desiredHighAbsoluteIndex if we don't have it
+     * already and we think it exists.  If we already have an outstanding
+     * request we will save off this most recent request to process once
+     * the current request completes.  Any previously queued request will
+     * be forgotten regardless of how it compares to the newly queued
+     * request.
+     *
+     * @param  {Number} desiredHighAbsoluteIndex
+     */
+    loadNextChunk: function(desiredHighAbsoluteIndex) {
+      // The recalculate logic will trigger a call to prepareData, so
+      // it's okay for us to bail.  It's advisable for us to bail
+      // because any calls to prepareData will be based on outdated
+      // index information.
+      if (this.vScroll.waitingForRecalculate) {
+        return;
+      }
+
+      if (this.waitingOnChunk) {
+        this.desiredHighAbsoluteIndex = desiredHighAbsoluteIndex;
+        return;
+      }
+
+      // Do not bother asking for more than exists
+      var headerCursor = this.headerCursor;
+      if (desiredHighAbsoluteIndex >= headerCursor.messagesSlice.headerCount) {
+        desiredHighAbsoluteIndex = headerCursor.messagesSlice.headerCount - 1;
+      }
+
+      // Do not bother asking for more than what is already
+      // fetched
+      var items = headerCursor.messagesSlice.items;
+      var curHighAbsoluteIndex = items.length - 1;
+      var amount = desiredHighAbsoluteIndex - curHighAbsoluteIndex;
+      if (amount > 0) {
+        // IMPORTANT NOTE!
+        // 1 is unfortunately a special value right now for historical reasons
+        // that the other side interprets as a request to grow downward with the
+        // default growth size.  XXX change backend and its tests...
+        console.log('message_list loadNextChunk growing', amount,
+                    (amount === 1 ? '(will get boosted to 15!) to' : 'to'),
+                    (desiredHighAbsoluteIndex + 1), 'items out of',
+                    headerCursor.messagesSlice.headerCount, 'alleged known');
+        headerCursor.messagesSlice.requestGrowth(
+          amount,
+          // the user is not requesting us to go synchronize new messages
+          false);
+        this.waitingOnChunk = true;
+      }
+    },
+
+    /**
+     * Scroll to make sure that the current message is in our visible window.
+     *
+     * @param {header_cursor.CurrentMessage} currentMessage representation of
+     *     the email we're currently reading.
+     * @param {Number} index the index of the message in the messagesSlice
+     */
+    onCurrentMessage: function(currentMessage, index) {
+      if (!currentMessage) {
+        return;
+      }
+
+      var visibleIndices = this.vScroll.getVisibleIndexRange();
+      if (visibleIndices &&
+          (index < visibleIndices[0] || index > visibleIndices[1])) {
+        this.vScroll.jumpToIndex(index);
+      }
+    },
+
+    _hasSnippetRequest: function() {
+      var max = MAXIMUM_MS_BETWEEN_SNIPPET_REQUEST;
+      var now = Date.now();
+
+      // if we before the maximum time to wait between requests...
+      var beforeTimeout =
+        (this._lastSnippetRequest + max) > now;
+
+      // there is an important case where the backend may be slow OR have some
+      // fatal error which would prevent us from ever requesting an new set of
+      // snippets because we wait until the last batch finishes. To prevent that
+      // from ever happening we maintain the request start time and if more then
+      // MAXIMUM_MS_BETWEEN_SNIPPET_REQUEST passes we issue a new request.
+      if (this._snippetRequestPending && beforeTimeout) {
+        return true;
+      }
+
+      return false;
+    },
+
+    _pendingSnippetRequest: function() {
+      this._snippetRequestPending = true;
+      this._lastSnippetRequest = Date.now();
+    },
+
+    _clearSnippetRequest: function() {
+      this._snippetRequestPending = false;
+    },
+
+    _requestSnippets: function() {
+      var headerCursor = this.headerCursor;
+      var items = headerCursor.messagesSlice.items;
+      var len = items.length;
+
+      if (!len) {
+        return;
+      }
+
+      var clearSnippets = this._clearSnippetRequest.bind(this);
+      var options = {
+        // this is per message
+        maximumBytesToFetch: MAXIMUM_BYTES_PER_MESSAGE_DURING_SCROLL
+      };
+
+      if (len < MINIMUM_ITEMS_FOR_SCROLL_CALC) {
+        this._pendingSnippetRequest();
+        headerCursor.messagesSlice.maybeRequestBodies(0,
+            MINIMUM_ITEMS_FOR_SCROLL_CALC - 1, options, clearSnippets);
+        return;
+      }
+
+      var visibleIndices = this.vScroll.getVisibleIndexRange();
+
+      if (visibleIndices) {
+        this._pendingSnippetRequest();
+        headerCursor.messagesSlice.maybeRequestBodies(
+          visibleIndices[0],
+          visibleIndices[1],
+          options,
+          clearSnippets
+        );
+      }
+    },
+
+    die: function() {
+      sliceEvents.forEach(function(type) {
+        var name = 'messages_' + type;
+        this.headerCursor.removeListener(name, this[name]);
+      }.bind(this));
+
+      this.headerCursor.removeListener('currentMessage', this.onCurrentMessage);
+      this.vScroll.destroy();
+    }
+  }
+];
+
+});

--- a/apps/email/js/cards/lst/peep_dom.js
+++ b/apps/email/js/cards/lst/peep_dom.js
@@ -1,0 +1,8 @@
+'use strict';
+define(function() {
+  return {
+    update: function(peep) {
+      peep.element.textContent = peep.name || peep.address;
+    }
+  };
+});

--- a/apps/email/js/cards/message_list.html
+++ b/apps/email/js/cards/message_list.html
@@ -26,67 +26,13 @@
             class="msg-list-header-folder-name"></span>
       <span data-prop="folderUnread"
             class="msg-list-header-folder-unread collapsed"></span>
-      </h1>
-  </header>
-</section>
-<!-- Multi-edit state header -->
-<section data-prop="editHeader"
-         class="msg-listedit-header collapsed" role="region">
-  <header>
-    <a href="#" data-event="click:setEditModeDone"
-       class="msg-listedit-cancel-btn" role="button"
-       data-l10n-id="close-button">
-      <span class="icon icon-close"></span>
-    </a>
-    <h1 data-prop="headerNode" class="msg-listedit-header-label">
     </h1>
   </header>
 </section>
-<!-- Search header -->
-<section role="region" data-prop="searchHeader"
-         class="msg-search-header msg-search-only">
-  <form role="search" data-event="submit:onSearchSubmit">
-    <button data-event="click:onCancelSearch"
-            class="msg-search-cancel" type="submit"
-            data-l10n-id="message-search-cancel"></button>
-    <p>
-      <input data-prop="searchInput" data-event="input:onSearchTextChange"
-             type="text" required="required" class="msg-search-text"
-             autocorrect="off"
-             inputmode="verbatim"
-             x-inputmode="verbatim"
-             dir="auto"
-             data-l10n-id="message-search-input" />
-      <button type="reset" data-l10n-id="form-clear-input" data-event="click:onClearSearch"></button>
-    </p>
-  </form>
-  <!-- Search filter switcher -->
-  <header class="msg-search-controls-bar">
-    <ul role="tablist" class="bb-tablist filter" data-type="filter">
-      <li role="presentation" class="msg-search-from msg-search-filter"
-          data-filter="author">
-        <a data-l10n-id="message-search-from" role="tab"
-          aria-selected="false"></a></li>
-      <li role="presentation" class="msg-search-to msg-search-filter"
-          data-filter="recipients">
-        <a data-l10n-id="message-search-to" role="tab"
-          aria-selected="false"></a></li>
-      <li role="presentation" class="msg-search-subject msg-search-filter"
-           data-filter="subject">
-        <a data-l10n-id="message-search-subject" role="tab"
-          aria-selected="false"></a>
-      </li>
-      <li role="presentation" class="msg-search-body msg-search-filter"
-           data-filter="body">
-        <a data-l10n-id="message-search-body" role="tab"
-          aria-selected="false"></a></li>
-      <li role="presentation" class="msg-search-body msg-search-filter"
-          data-filter="all">
-        <a data-l10n-id="message-search-all" role="tab"
-          aria-selected="true"></a></li>
-    </ul>
-  </header>
-</section>
+
+<!-- Multi-edit state header -->
+<lst-edit-header data-prop="editHeader"
+                       data-event="editHeaderClose"></lst-edit-header>
 <!-- Scroll region -->
 <div data-prop="scrollContainer" class="msg-list-scrollouter">
   <!-- exists so we can force a minimum height -->
@@ -104,31 +50,16 @@
                data-l10n-id="message-search-input" />
       </p>
     </form>
-    <div data-prop="messagesContainer" class="msg-messages-container"
-         role="listbox" aria-multiselectable="true">
-    </div>
-    <!-- maintain vertical space for the syncing/sync more div's
-         regardless of their displayed status so we don't scroll them
-         out of the way -->
-    <div class="msg-messages-sync-container">
-      <p data-prop="syncingNode" class="msg-messages-syncing collapsed"
-         role="progressbar" data-l10n-id="messages-syncing-progressbar">
-        <span data-l10n-id="messages-syncing"></span>
-      </p>
-      <p data-prop="syncMoreNode"
-         data-event="click:onGetMoreMessages"
-         class="msg-messages-sync-more collapsed"
-         role="button">
-        <span data-l10n-id="messages-load-more"></span>
-      </p>
-    </div>
+    <lst-msg-vscroll data-prop="msgVScroll"
+                     data-event="messageClick:onClickMessage"
+                     data-empty-l10n-id="messages-folder-empty">
+    </lst-msg-vscroll>
   </div>
 </div>
+
 <!-- New email notification bar -->
 <div class="message-list-topbar"></div>
-<!-- Conveys background send, plus undo-able recent actions -->
-<div class="msg-activity-infobar hidden">
-</div>
+
 <!-- Toolbar for non-multi-edit state -->
 <ul data-prop="normalToolbar" class="bb-tablist msg-list-action-toolbar"
     role="toolbar">
@@ -151,35 +82,8 @@
   </li>
 </ul>
 
-<!-- Toolbar for multi-edit state -->
-<ul data-prop="editToolbar"
-    class="bb-tablist msg-listedit-action-toolbar collapsed"
-    role="toolbar">
-  <li role="presentation">
-    <button data-prop="deleteBtn" data-event="click:onDeleteMessages"
-            class="icon msg-delete-btn"
-            data-l10n-id="message-delete-button"></button>
-  </li>
-  <li role="presentation">
-    <button data-prop="starBtn" data-event="click:onStarMessages"
-            class="icon msg-star-btn"
-            data-l10n-id="message-star-button"></button>
-  </li>
-  <li role="presentation">
-    <button data-prop="readBtn" data-event="click:onMarkMessagesRead"
-            class="icon msg-mark-read-btn"
-            data-l10n-id="message-mark-read-button"></button>
-  </li>
-  <li role="presentation">
-    <button data-prop="moveBtn" data-event="click:onMoveMessages"
-            class="icon msg-move-btn"
-            data-l10n-id="message-move-button"></button>
-  </li>
-</ul>
+<lst-edit-toolbar data-prop="editToolbar"
+                  data-event="onDeleteMessages,onStarMessages,
+                              onMarkMessagesRead,onMoveMessages">
+</lst-edit-toolbar>
 
-<div data-prop="messageEmptyContainer"
-     class="msg-list-empty-container collapsed">
-  <p data-prop="messageEmptyText"
-     class="msg-list-empty-message-text"
-     data-l10n-id="messages-folder-empty"></p>
-</div>

--- a/apps/email/js/cards/message_list_search.html
+++ b/apps/email/js/cards/message_list_search.html
@@ -1,0 +1,81 @@
+<!-- Search header -->
+<section data-prop="searchHeader"
+         class="msg-search-header"
+         role="region">
+  <form role="search" data-event="submit:onSearchSubmit">
+    <button data-event="click:onCancelSearch"
+            class="msg-search-cancel" type="submit"
+            data-l10n-id="message-search-cancel"></button>
+    <p>
+      <input data-prop="searchInput" data-event="input:onSearchTextChange"
+             type="text" required="required" class="msg-search-text"
+             autocorrect="off"
+             inputmode="verbatim"
+             x-inputmode="verbatim"
+             dir="auto"
+             data-l10n-id="message-search-input" />
+      <button type="reset"
+              data-l10n-id="form-clear-input"
+              data-event="click:onClearSearch"></button>
+    </p>
+  </form>
+  <!-- Search filter switcher -->
+  <header class="msg-search-controls-bar">
+    <ul role="tablist" class="bb-tablist filter" data-type="filter">
+      <li role="presentation" class="msg-search-from msg-search-filter"
+          data-filter="author">
+        <a data-l10n-id="message-search-from" role="tab"
+          aria-selected="false"></a></li>
+      <li role="presentation" class="msg-search-to msg-search-filter"
+          data-filter="recipients">
+        <a data-l10n-id="message-search-to" role="tab"
+          aria-selected="false"></a></li>
+      <li role="presentation" class="msg-search-subject msg-search-filter"
+           data-filter="subject">
+        <a data-l10n-id="message-search-subject" role="tab"
+          aria-selected="false"></a>
+      </li>
+      <li role="presentation" class="msg-search-body msg-search-filter"
+           data-filter="body">
+        <a data-l10n-id="message-search-body" role="tab"
+          aria-selected="false"></a></li>
+      <li role="presentation" class="msg-search-body msg-search-filter"
+          data-filter="all">
+        <a data-l10n-id="message-search-all" role="tab"
+          aria-selected="true"></a></li>
+    </ul>
+  </header>
+</section>
+
+<!-- Multi-edit state header -->
+<lst-edit-header data-prop="editHeader"
+                       data-event="editHeaderClose"></lst-edit-header>
+
+<!-- Scroll region -->
+<div data-prop="scrollContainer" class="msg-list-scrollouter">
+  <!-- exists so we can force a minimum height -->
+  <div class="msg-list-scrollinner">
+    <lst-msg-vscroll data-prop="msgVScroll"
+                     data-event="messageClick:onClickMessage"
+                     data-empty-l10n-id="messages-search-empty">
+    </lst-msg-vscroll>
+  </div>
+</div>
+
+<!-- New email notification bar -->
+<div class="message-list-topbar"></div>
+
+<!-- Toolbar for non-multi-edit state -->
+<ul data-prop="normalToolbar" class="bb-tablist msg-list-action-toolbar"
+    role="toolbar">
+  <li role="presentation">
+    <button data-prop="editBtn" data-event="click:setEditModeStart"
+            class="icon msg-edit-btn" data-l10n-id="edit-button"></button>
+  </li>
+</ul>
+
+<lst-edit-toolbar data-prop="editToolbar"
+                  data-event="onDeleteMessages,onStarMessages,
+                              onMarkMessagesRead,onMoveMessages">
+</lst-edit-toolbar>
+

--- a/apps/email/js/cards/message_list_search.js
+++ b/apps/email/js/cards/message_list_search.js
@@ -1,12 +1,324 @@
 'use strict';
 
 define(function(require, exports) {
-  return [
-    // Hack to get separate modules for search vs non-search, but eventually the
-    // search branches in message_list should be moved here.
-    require('./message_list'),
-    {
-      mode: 'search'
+
+var accessibilityHelper = require('shared/js/accessibility_helper'),
+    cards = require('cards'),
+    containerListen = require('container_listen'),
+    date = require('date'),
+    HeaderCursor = require('header_cursor'),
+    messageDisplay = require('message_display'),
+    MessageListTopBar = require('message_list_topbar'),
+    updatePeepDom = require('./lst/peep_dom').update;
+
+// We will display this loading data for any messages we are
+// pretending exist so that the UI has a reason to poke the search
+// slice to do more work.
+var defaultSearchVScrollData = {
+  header: require('./lst/default_vscroll_data'),
+  matches: []
+};
+
+var MATCHED_TEXT_CLASS = 'highlight';
+
+function appendMatchItemTo(matchItem, node) {
+  var text = matchItem.text;
+  var idx = 0;
+  for (var iRun = 0; iRun <= matchItem.matchRuns.length; iRun++) {
+    var run;
+    if (iRun === matchItem.matchRuns.length) {
+      run = { start: text.length, length: 0 };
+    } else {
+      run = matchItem.matchRuns[iRun];
     }
-  ];
+
+    // generate the un-highlighted span
+    if (run.start > idx) {
+      var tnode = document.createTextNode(text.substring(idx, run.start));
+      node.appendChild(tnode);
+    }
+
+    if (!run.length) {
+      continue;
+    }
+    var hspan = document.createElement('span');
+    hspan.classList.add(MATCHED_TEXT_CLASS);
+    hspan.textContent = text.substr(run.start, run.length);
+    node.appendChild(hspan);
+    idx = run.start + run.length;
+  }
+}
+
+
+return [
+  require('./base_card')(require('template!./message_list_search.html')),
+  require('./lst/edit_controller'),
+  require('./lst/msg_click'),
+
+  {
+
+    createdCallback: function() {
+      containerListen(this.querySelector('.filter'), 'click',
+                      this.onSearchFilterClick.bind(this));
+      this.searchFilterTabs = this.querySelectorAll('.filter [role="tab"]');
+
+      this.isFirstTimeVisible = true;
+
+      // Binding "this" to some functions as they are used for event listeners.
+      this._folderChanged = this._folderChanged.bind(this);
+
+      this.msgVScroll.on('emptyLayoutShown', function() {
+        this.editBtn.disabled = true;
+      }.bind(this));
+
+      this.msgVScroll.on('emptyLayoutHidden', function() {
+        this.editBtn.disabled = false;
+      }.bind(this));
+
+      this.msgVScroll.on('messagesChange', function(message, index) {
+        this.updateMatchedMessageDom(false, message);
+      }.bind(this));
+
+      this.msgVScroll.on('messagesComplete', function(newEmailCount) {
+        // Search does not trigger normal conditions for a folder changed,
+        // so if vScroll is missing its data, set it up now.
+        if (!this.msgVScroll.vScroll.list) {
+          this.msgVScroll.vScroll.setData(this.msgVScroll.listFunc);
+        }
+      }.bind(this));
+
+      var vScrollBindData = (function bindSearch(model, node) {
+        model.element = node;
+        node.message = model.header;
+        this.updateMatchedMessageDom(true, model);
+      }).bind(this);
+      this.msgVScroll.init(this.scrollContainer,
+                           vScrollBindData,
+                           defaultSearchVScrollData);
+
+      this._topBar = new MessageListTopBar(
+        this.querySelector('.message-list-topbar')
+      );
+      this._topBar.bindToElements(this.scrollContainer,
+                                  this.msgVScroll.vScroll);
+    },
+
+    onArgs: function(args) {
+      var model = this.model = args.model;
+      var headerCursor = this.headerCursor = args.headerCursor ||
+                                             new HeaderCursor(model);
+      this.msgVScroll.setHeaderCursor(headerCursor);
+
+      model.latest('folder', this._folderChanged);
+
+    },
+
+    onCardVisible: function() {
+      // First time this card is visible, want the search field focused if this
+      // is a search. Do not want to do it on every cardVisible, as the user
+      // could be scrolled/have their own place in the search results, and are
+      // likely going back and forth between this card and message_reader.
+      if (this.isFirstTimeVisible) {
+        this.searchInput.focus();
+      }
+
+      this.msgVScroll.vScroll.nowVisible();
+
+      this.isFirstTimeVisible = false;
+    },
+
+
+    showSearch: function(phrase, filter) {
+      console.log('sf: showSearch. phrase:', phrase, phrase.length);
+
+      this.curFolder = this.model.folder;
+      this.editModeEnabled = true;
+      this.msgVScroll.vScroll.clearDisplay();
+      this.curPhrase = phrase;
+      this.curFilter = filter;
+
+      // We are creating a new slice, so any pending snippet requests are moot.
+      this.msgVScroll._snippetRequestPending = false;
+      // Don't bother the new slice with requests until we hears it completion
+      // event.
+      this.msgVScroll.waitingOnChunk = true;
+      this.headerCursor.startSearch(phrase, {
+        author: filter === 'all' || filter === 'author',
+        recipients: filter === 'all' || filter === 'recipients',
+        subject: filter === 'all' || filter === 'subject',
+        body: filter === 'all' || filter === 'body'
+      });
+
+      return true;
+    },
+
+    onSearchFilterClick: function(filterNode, event) {
+      accessibilityHelper.setAriaSelected(filterNode.firstElementChild,
+        this.searchFilterTabs);
+      this.showSearch(this.searchInput.value, filterNode.dataset.filter);
+    },
+
+    onSearchTextChange: function(event) {
+      console.log('sf: typed, now:', this.searchInput.value);
+      this.showSearch(this.searchInput.value, this.curFilter);
+    },
+
+    onSearchSubmit: function(event) {
+      // Not a real form to submit, so stop actual submission.
+      event.preventDefault();
+
+      // Blur the focus away from the text input. This has the effect of hiding
+      // the keyboard. This is useful for the two cases where this function is
+      // currently triggered: Enter on the keyboard or Cancel on form submit.
+      // Note that the Cancel button has a type="submit", which is technically
+      // an incorrect use of that type. However the /shared styles depend on it
+      // being marked as such for style reasons.
+      this.searchInput.blur();
+    },
+
+    onCancelSearch: function(event) {
+      // Only care about real clicks on actual button, not fake ones triggered
+      // by a form submit from the Enter button on the keyboard.
+      // Note: the cancel button should not really be a type="submit", but it is
+      // that way because the /shared styles for this search form wants to see
+      // a submit. Longer term this should be changed in the /shared components.
+      // This event test is used because in form submit cases, the
+      // explicitOriginalTarget (the text input) is not the same as the target
+      // (the button).
+      if (event.explicitOriginalTarget !== event.target) {
+        return;
+      }
+
+      try {
+        this.headerCursor.endSearch();
+      }
+      catch (ex) {
+        console.error('problem killing slice:', ex, '\n', ex.stack);
+      }
+      cards.removeCardAndSuccessors(this, 'animate');
+    },
+
+    onClearSearch: function() {
+      this.showSearch('', this.curFilter);
+    },
+
+    /**
+     * Called from edit_controller mixin when the edit mode has changed. Used to
+     * allow classes mixing in edit_controller to update UI state based on edit
+     * state.
+     */
+    editModeChanged: function(enabled) {
+      if (enabled) {
+        // Set status color to match the edit header.
+        cards.setStatusColor(this.editHeader);
+      } else {
+        // Return the status color to match this card.
+        cards.setStatusColor(this);
+      }
+    },
+
+    updateMatchedMessageDom: function(firstTime, matchedHeader) {
+      var msgNode = matchedHeader.element,
+          matches = matchedHeader.matches,
+          message = matchedHeader.header;
+
+      if (!msgNode) {
+        return;
+      }
+
+      // If the placeholder data, indicate that in case VScroll
+      // wants to go back and fix later.
+      var classAction = message.isPlaceholderData ? 'add' : 'remove';
+      var defaultDataClass = this.msgVScroll.vScroll.itemDefaultDataClass;
+      msgNode.classList[classAction](defaultDataClass);
+
+      // Even though updateMatchedMessageDom is only used in searches,
+      // which likely will not be cached, the dataset.is is set to
+      // maintain parity withe updateMessageDom and so click handlers
+      // can always just use the dataset property.
+      msgNode.dataset.id = matchedHeader.id;
+
+      // some things only need to be done once
+      var dateNode = msgNode.querySelector('.msg-header-date');
+      var subjectNode = msgNode.querySelector('.msg-header-subject');
+      if (firstTime) {
+        // author
+        var authorNode = msgNode.querySelector('.msg-header-author');
+        if (matches.author) {
+          authorNode.textContent = '';
+          appendMatchItemTo(matches.author, authorNode);
+        }
+        else {
+          // we can only update the name if it wasn't matched on.
+          message.author.element = authorNode;
+          message.author.onchange = updatePeepDom;
+          message.author.onchange(message.author);
+        }
+
+        // date
+        dateNode.dataset.time = message.date.valueOf();
+        dateNode.textContent = date.prettyDate(message.date);
+
+        // subject
+        if (matches.subject) {
+          subjectNode.textContent = '';
+          appendMatchItemTo(matches.subject[0], subjectNode);
+        } else {
+          messageDisplay.subject(subjectNode, message);
+        }
+
+        // snippet
+        var snippetNode = msgNode.querySelector('.msg-header-snippet');
+        if (matches.body) {
+          snippetNode.textContent = '';
+          appendMatchItemTo(matches.body[0], snippetNode);
+        } else {
+          snippetNode.textContent = message.snippet;
+        }
+
+        // attachments (can't change within a message but can change between
+        // messages, and since we reuse DOM nodes...)
+        var attachmentsNode =
+          msgNode.querySelector('.msg-header-attachments');
+        attachmentsNode.classList.toggle('msg-header-attachments-yes',
+                                         message.hasAttachments);
+        // snippet needs to be shorter if icon is shown
+        snippetNode.classList.toggle('icon-short', message.hasAttachments);
+      }
+
+      // Set unread state.
+      msgNode.classList.toggle('unread', !message.isRead);
+
+      // star
+      var starNode = msgNode.querySelector('.msg-header-star');
+      starNode.classList.toggle('msg-header-star-starred', message.isStarred);
+      // subject needs to give space for star if it is visible
+      subjectNode.classList.toggle('icon-short', message.isStarred);
+
+      // edit mode select state, defined in lst/edit_controller
+      this.updateDomSelectState(msgNode, message);
+    },
+
+    _folderChanged: function(folder) {
+      // It is possible that the notification of latest folder is fired
+      // but in the meantime the foldersSlice could be cleared due to
+      // a change in the current account, before this listener is called.
+      // So skip this work if no foldersSlice, this method will be called
+      // again soon.
+      if (!this.model.foldersSlice) {
+        return;
+      }
+
+      this.curFolder = folder;
+
+      this.showSearch('', 'all');
+    },
+
+    die: function() {
+      this.msgVScroll.die();
+      this.model.removeListener('folder', this._folderChanged);
+    }
+  }
+];
+
 });

--- a/apps/email/js/cards/mixins/data-event.js
+++ b/apps/email/js/cards/mixins/data-event.js
@@ -6,6 +6,20 @@ define(function () {
     templateInsertedCallback: function () {
       slice.call(this.querySelectorAll('[data-event]'))
       .forEach(function (node) {
+        var parent = node;
+        // Make sure the node is not nested in another component.
+        while ((parent = parent.parentNode)) {
+          if (parent.nodeName.indexOf('-') !== -1) {
+            if (parent !== this) {
+              return;
+            }
+            break;
+          }
+        }
+        if (!parent) {
+          return;
+        }
+
         // Value is of type 'name:value,name:value',
         // with the :value part optional.
         node.dataset.event.split(',').forEach(function (pair) {
@@ -19,8 +33,8 @@ define(function () {
           method = parts[1].trim();
 
           if (typeof this[method] !== 'function') {
-            throw new Error('"' + method + '" is not a function, ' +
-                            'cannot bind with data-event');
+            throw new Error('"' + method +
+                            '" is not a function, cannot bind with data-event');
           }
 
           node.addEventListener(evtName, function(evt) {

--- a/apps/email/js/cards/mixins/data-prop.js
+++ b/apps/email/js/cards/mixins/data-prop.js
@@ -2,11 +2,26 @@
 define(function () {
   return {
     templateInsertedCallback: function () {
-      var nodes = this.querySelectorAll('[data-prop]'),
+      var node, parent,
+          nodes = this.querySelectorAll('[data-prop]'),
           length = nodes.length;
 
       for (var i = 0; i < length; i++) {
-        this[nodes[i].dataset.prop] = nodes[i];
+        // Make sure the node is not nested in another component.
+        node = nodes[i];
+        parent = node;
+        while ((parent = parent.parentNode)) {
+          if (parent.nodeName.indexOf('-') !== -1) {
+            if (parent !== this) {
+              node = null;
+            }
+            break;
+          }
+        }
+
+        if (node && parent) {
+          this[node.dataset.prop] = nodes[i];
+        }
       }
     }
   };

--- a/apps/email/js/cards/mixins/dom_evt.js
+++ b/apps/email/js/cards/mixins/dom_evt.js
@@ -1,0 +1,39 @@
+'use strict';
+define(function () {
+  /**
+   * domEvt can be used with data-event="" to translate internal template
+   * events into custom events emitted from the custom element that contains
+   * the template element that triggered the event. Use like so in the template:
+   *
+   * <a href="#" data-event="click:domEvt" data-domevt-name="headerClose">
+   *
+   * When that a tag receives a click event (from itself or its children) then
+   * domEvt will convert that to a custom event "headerClose", dispatched on the
+   * custom element.
+   *
+   * data-domevt-detail="something" allows passing a "detail" string in the
+   * custom event that will have the value of "something".
+   */
+  return {
+    domEvt: function (event) {
+      var target = event.currentTarget,
+          eventName = target.dataset.domevtName,
+          eventData = {},
+          eventDetail = target.dataset.domevtDetail;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!eventName) {
+        throw new Error('No data-domevt-name on element <' +
+                        target.nodeName + ' class="' + target.className + '">');
+      }
+
+      if (eventDetail) {
+        eventData.detail = eventDetail;
+      }
+
+      this.dispatchEvent(new CustomEvent(eventName, eventData));
+    }
+  };
+});

--- a/apps/email/js/cards/settings_account.js
+++ b/apps/email/js/cards/settings_account.js
@@ -11,7 +11,7 @@ var tngAccountSettingsServerNode =
     ConfirmDialog = require('confirm_dialog');
 
 return [
-  require('./base')(require('template!./settings_account.html')),
+  require('./base_card')(require('template!./settings_account.html')),
   require('./account_prefs_mixins'),
   {
     onArgs: function(args) {

--- a/apps/email/js/cards/settings_account_credentials.js
+++ b/apps/email/js/cards/settings_account_credentials.js
@@ -6,7 +6,8 @@ var mozL10n = require('l10n!'),
     oauthFetch = require('./oauth2/fetch');
 
 return [
-  require('./base')(require('template!./settings_account_credentials.html')),
+  require('./base_card')
+         (require('template!./settings_account_credentials.html')),
   {
     onArgs: function(args) {
       this.account = args.account;

--- a/apps/email/js/cards/settings_account_servers.js
+++ b/apps/email/js/cards/settings_account_servers.js
@@ -9,7 +9,8 @@ var mozL10n = require('l10n!'),
     cards = require('cards');
 
 return [
-  require('./base')(require('template!./settings_account_servers.html')),
+  require('./base_card')
+         (require('template!./settings_account_servers.html')),
   {
     onArgs: function(args) {
       this.account = args.account;

--- a/apps/email/js/cards/settings_debug.js
+++ b/apps/email/js/cards/settings_debug.js
@@ -17,7 +17,8 @@ if (!_secretDebug) {
 }
 
 return [
-  require('./base')(require('template!./settings_debug.html')),
+  require('./base_card')
+         (require('template!./settings_debug.html')),
   {
     createdCallback: function() {
       this.loggingSelect.value = MailAPI.config.debugLogging || '';

--- a/apps/email/js/cards/settings_main.js
+++ b/apps/email/js/cards/settings_main.js
@@ -7,7 +7,7 @@ var tngAccountItemNode = require('tmpl!./tng/account_item.html'),
     cards = require('cards');
 
 return [
-  require('./base')(require('template!./settings_main.html')),
+  require('./base_card')(require('template!./settings_main.html')),
   {
     createdCallback: function() {
       this.acctsSlice = MailAPI.viewAccounts(false);

--- a/apps/email/js/cards/settings_signature.js
+++ b/apps/email/js/cards/settings_signature.js
@@ -5,7 +5,7 @@ var backFormNode = require('tmpl!./sig/save_signature.html'),
     trailingRegExp = /\s+$/;
 
 return [
-  require('./base')(require('template!./settings_signature.html')),
+  require('./base_card')(require('template!./settings_signature.html')),
   require('./editor_mixins'),
 
   {

--- a/apps/email/js/cards/setup_account_info.js
+++ b/apps/email/js/cards/setup_account_info.js
@@ -12,7 +12,7 @@ var evt = require('evt'),
     FormNavigation = require('form_navigation');
 
 return [
-  require('./base')(require('template!./setup_account_info.html')),
+  require('./base_card')(require('template!./setup_account_info.html')),
   require('./setup_account_error_mixin'),
   {
     createdCallback: function() {

--- a/apps/email/js/cards/setup_account_password.js
+++ b/apps/email/js/cards/setup_account_password.js
@@ -14,7 +14,7 @@ function bindFormNavigation(instance) {
 }
 
 return [
-  require('./base')(require('template!./setup_account_password.html')),
+  require('./base_card')(require('template!./setup_account_password.html')),
   require('./setup_account_error_mixin'),
   {
     onArgs: function(args) {

--- a/apps/email/js/cards/setup_account_prefs.js
+++ b/apps/email/js/cards/setup_account_prefs.js
@@ -8,7 +8,7 @@ var cards = require('cards'),
     mozL10n = require('l10n!');
 
 return [
-  require('./base')(require('template!./setup_account_prefs.html')),
+  require('./base_card')(require('template!./setup_account_prefs.html')),
   require('./account_prefs_mixins'),
   {
     onArgs: function(args) {

--- a/apps/email/js/cards/setup_done.js
+++ b/apps/email/js/cards/setup_done.js
@@ -7,7 +7,7 @@ define(function(require) {
 var evt = require('evt');
 
 return [
-  require('./base')(require('template!./setup_done.html')),
+  require('./base_card')(require('template!./setup_done.html')),
   {
     onAddAnother: function() {
       evt.emit('addAccount');

--- a/apps/email/js/cards/setup_fix_gmail.js
+++ b/apps/email/js/cards/setup_fix_gmail.js
@@ -7,7 +7,7 @@ define(function(require) {
 var cards = require('cards');
 
 return [
-  require('./base')(require('template!./setup_fix_gmail.html')),
+  require('./base_card')(require('template!./setup_fix_gmail.html')),
   {
     extraClasses: ['anim-fade', 'anim-overlay'],
 

--- a/apps/email/js/cards/setup_fix_gmail_twofactor.js
+++ b/apps/email/js/cards/setup_fix_gmail_twofactor.js
@@ -1,7 +1,8 @@
 'use strict';
 define(function(require) {
   return [
-    require('./base')(require('template!./setup_fix_gmail_twofactor.html')),
+    require('./base_card')
+           (require('template!./setup_fix_gmail_twofactor.html')),
     require('./setup_fix_mixin')
   ];
 });

--- a/apps/email/js/cards/setup_fix_oauth2.js
+++ b/apps/email/js/cards/setup_fix_oauth2.js
@@ -5,7 +5,7 @@ var oauthFetch = require('./oauth2/fetch'),
     cards = require('cards');
 
 return [
-  require('./base')(require('template!./setup_fix_oauth2.html')),
+  require('./base_card')(require('template!./setup_fix_oauth2.html')),
   {
     extraClasses: ['anim-fade', 'anim-overlay'],
 

--- a/apps/email/js/cards/setup_fix_password.js
+++ b/apps/email/js/cards/setup_fix_password.js
@@ -4,7 +4,7 @@
 'use strict';
 define(function(require) {
   return [
-    require('./base')(require('template!./setup_fix_password.html')),
+    require('./base_card')(require('template!./setup_fix_password.html')),
     require('./setup_fix_mixin')
   ];
 });

--- a/apps/email/js/cards/setup_manual_config.js
+++ b/apps/email/js/cards/setup_manual_config.js
@@ -12,7 +12,7 @@ var cards = require('cards'),
     plainSocketWarningNode = require('tmpl!./tng/plain_socket_warning.html');
 
 return [
-  require('./base')(require('template!./setup_manual_config.html')),
+  require('./base_card')(require('template!./setup_manual_config.html')),
   require('./setup_account_error_mixin'),
   {
     onArgs: function(args) {

--- a/apps/email/js/cards/setup_oauth2.js
+++ b/apps/email/js/cards/setup_oauth2.js
@@ -5,7 +5,7 @@ var appSelf = require('app_self'),
     cards = require('cards');
 
 return [
-  require('./base')(require('template!./setup_oauth2.html')),
+  require('./base_card')(require('template!./setup_oauth2.html')),
   {
     onArgs: function(args) {
       this.onBrowserComplete = args.onBrowserComplete;

--- a/apps/email/js/cards/setup_progress.js
+++ b/apps/email/js/cards/setup_progress.js
@@ -23,7 +23,7 @@ var MailAPI = require('api'),
     oauthFetch = require('cards/oauth2/fetch');
 
 return [
-  require('./base')(require('template!./setup_progress.html')),
+  require('./base_card')(require('template!./setup_progress.html')),
   {
     onArgs: function(args) {
       this.args = args;

--- a/apps/email/js/cards_init.js
+++ b/apps/email/js/cards_init.js
@@ -4,11 +4,16 @@ define(function(require) {
     // Handle cases where a default card is needed for back navigation
     // after a non-default entry point (like an activity) is triggered.
     cards.pushDefaultCard = function(onPushed) {
-      cards.pushCard('message_list', 'none', {
-        onPushed: onPushed
-      },
-      // Default to "before" placement.
-      'left');
+      // Dynamically require model_create, so that cards init does not depend
+      // explicitly on the model, just use it if a default card is needed.
+      require(['model_create'], function(modelCreate) {
+        cards.pushCard('message_list', 'none', {
+          model: modelCreate.defaultModel,
+          onPushed: onPushed
+        },
+        // Default to "before" placement.
+        'left');
+      });
     };
   };
 });

--- a/apps/email/js/config.js
+++ b/apps/email/js/config.js
@@ -77,7 +77,8 @@ if (navigator.mozAudioChannelManager) {
 // case, html_cache_restore needs to know the model state, if there is an
 // account, before proceeding with the startup view to select.
 if (window.startupOnModelLoaded) {
-  requirejs(['console_hook', 'model'], function(hook, model) {
+  requirejs(['console_hook', 'model_create'], function(hook, modelCreate) {
+    var model = modelCreate.defaultModel;
     model.init();
     window.startupOnModelLoaded(model, function() {
       require(['mail_app']);

--- a/apps/email/js/container_listen.js
+++ b/apps/email/js/container_listen.js
@@ -1,0 +1,23 @@
+'use strict';
+define(function() {
+  /**
+   * Add an event listener on a container that, when an event is encounted
+   * on a descendant, walks up the tree to find the immediate child of the
+   * container and tells us what the click was on.
+   */
+  return function containerListen(containerNode, eventName, func) {
+    containerNode.addEventListener(eventName, function(event) {
+      var node = event.target;
+      // bail if they clicked on the container and not a child...
+      if (node === containerNode) {
+        return;
+      }
+      while (node && node.parentNode !== containerNode) {
+        node = node.parentNode;
+      }
+      if (node) {
+        func(node, event);
+      }
+    }, false);
+  };
+});

--- a/apps/email/js/html_cache.js
+++ b/apps/email/js/html_cache.js
@@ -121,6 +121,19 @@ exports.saveFromNode = function saveFromNode(moduleId, node) {
   cl.remove('after');
   cl.add('center');
 
+  // Also make sure all custom element have their "data-cached" attribute set
+  // on them. Depend on the custom element base.js in email to set this class
+  // name. This performs better than a querySelectorAll('*') approach.
+  var nodes = node.querySelectorAll('.email-ce');
+  for (var i = 0; i < nodes.length; i++) {
+    nodes[i].dataset.cached = 'cached';
+  }
+
+  // If the passed-in node should be cached, be sure to mark it as cached.
+  if (node.classList.contains('email-ce')) {
+    node.dataset.cached = 'cached';
+  }
+
   var html = node.outerHTML;
   exports.save(moduleId, html);
 };

--- a/apps/email/js/template.js
+++ b/apps/email/js/template.js
@@ -1,13 +1,13 @@
 /**
- * template 0.0.0-native-register
- * Copyright (c) 2013-2014, The Dojo Foundation All Rights Reserved.
+ * template 0.0.1
+ * Copyright (c) 2013-2015, The Dojo Foundation All Rights Reserved.
  * Available via the MIT or new BSD license.
  * see: http://github.com/jrburke/element for details
  */
 /*jshint browser: true, strict: false */
 /*globals define, requirejs */
 define(function(require, exports, module) {
-  var template, fetchText, templateDiv,
+  var template, fetchText,
       isReady = false,
       readyQueue = [],
       tagRegExp = /<(\w+-[\w-]+)(\s|>)/g,
@@ -30,10 +30,6 @@ define(function(require, exports, module) {
   }
   if (moduleConfig.hasOwnProperty('tagToId')) {
     tagToId = moduleConfig.tagToId;
-  }
-
-  if (typeof document !== 'undefined') {
-    templateDiv = document.createElement('div');
   }
 
   /**
@@ -165,7 +161,10 @@ define(function(require, exports, module) {
     makeTemplateFn: function(text) {
       return function() {
         var e,
-            frag = document.createDocumentFragment();
+            frag = document.createDocumentFragment(),
+            // Use a fresh div for each creation, otherwise run into failures
+            // with templates that have nested custom elements.
+            templateDiv = document.createElement('div');
 
         // For the security conscious: the contents of `text` comes from the
         // require('template!...') calls that exercises this module's

--- a/apps/email/style/message_cards.css
+++ b/apps/email/style/message_cards.css
@@ -5,6 +5,39 @@
   will-change: scroll-position;
 }
 
+/**
+ * message list cards: toggle card UI state based on show-edit class
+ */
+cards-message-list lst-edit-header,
+cards-message-list lst-edit-toolbar,
+cards-message-list-search lst-edit-header,
+cards-message-list-search lst-edit-toolbar {
+  display: none;
+}
+cards-message-list.show-edit lst-edit-header,
+cards-message-list.show-edit lst-edit-toolbar,
+cards-message-list-search.show-edit lst-edit-header,
+cards-message-list-search.show-edit lst-edit-toolbar {
+  display: block;
+}
+cards-message-list.show-edit .msg-list-header,
+cards-message-list.show-edit .msg-list-action-toolbar,
+cards-message-list-search.show-edit .msg-search-header,
+cards-message-list-search.show-edit .msg-list-action-toolbar {
+  display: none;
+}
+
+cards-message-list-search .msg-list-scrollouter {
+  height: calc(100% - 12rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+  will-change: scroll-position;
+}
+
+cards-message-list-search.show-edit .msg-list-scrollouter {
+  height: calc(100% - 9.5rem);
+}
+
 .msg-list-scrollinner {
   /* Give it a z-index of 0 so that all its contents are forced into a single stacking
      context. This simplifies display list construction because our many positioned
@@ -58,10 +91,6 @@ section[role="region"] > header:first-child h1.msg-list-header-folder-label {
 cards-message-list-search .msg-search-header form,
 cards-message-list-search .msg-search-header .bb-tablist {
   z-index: 10;
-}
-
-cards-message-list-search .msg-search-tease-bar {
-  display: none;
 }
 
 /* For search filters, make sure the contents do not line break and overflow
@@ -730,8 +759,10 @@ html:-moz-dir(rtl) .msg-attachment-filesize {
 /* Scrollable Area has to have a solid
   * opaque background to optimize Gecko.
   * See Bug 962699. */
-.msg-messages-container {
+lst-msg-vscroll,
+.msg-vscroll-container {
   position: relative;
+  display: block;
   background-color: #fff;
   overflow: hidden;
 }
@@ -753,34 +784,34 @@ html:-moz-dir(rtl) .msg-attachment-filesize {
 }
 
 /* Message list edit mode layout control */
-.msg-messages-container label.negative {
+.msg-vscroll-container label.negative {
   height: 8rem;
   width: 4rem;
   display: none;
   pointer-events: none;
 }
-.msg-messages-container.show-edit label.negative {
+.show-edit .msg-vscroll-container label.negative {
   display: inline-block;
 }
 
-.msg-messages-container.show-edit .msg-header-unread-section {
+.show-edit .msg-vscroll-container .msg-header-unread-section {
   left: 3.9rem;
 }
-html:-moz-dir(rtl) .msg-messages-container.show-edit .msg-header-unread-section {
+html:-moz-dir(rtl) .show-edit .msg-vscroll-container .msg-header-unread-section {
   right: 3.9rem;
   left: auto;
 }
 
-.msg-messages-container.show-edit .msg-header-syncing-section {
+.show-edit .msg-vscroll-container .msg-header-syncing-section {
   left: 3.5rem;
 }
 
-html:-moz-dir(rtl) .msg-messages-container.show-edit .msg-header-syncing-section {
+html:-moz-dir(rtl) .show-edit .msg-vscroll-container .msg-header-syncing-section {
   right: 3.5rem;
   left: auto;
 }
 
-.msg-messages-container.show-edit .msg-header-details-section {
+.show-edit .msg-vscroll-container .msg-header-details-section {
   -moz-padding-start: 4.5rem;
 }
 
@@ -788,12 +819,9 @@ html:-moz-dir(rtl) .msg-messages-container.show-edit .msg-header-syncing-section
   Empty message-list container
 */
 .msg-list-empty-container {
-  position: absolute;
-  top: 9rem;
-  left: 1.5rem;
-  right: 1.5rem;
   width: calc(100% - 3rem);
   height: 20rem;
+  margin: 0 auto;
 }
 
 .msg-list-empty-message-text {
@@ -808,7 +836,6 @@ html:-moz-dir(rtl) .msg-messages-container.show-edit .msg-header-syncing-section
 }
 
 cards-message-list-search .msg-list-empty-message-text {
-  top: 0;
   border-top: 0;
 }
 

--- a/apps/email/test/marionette/lib/email.js
+++ b/apps/email/test/marionette/lib/email.js
@@ -51,7 +51,7 @@ var Selector = {
   composeErrorMessage: 'cards-compose .cmp-error-message',
   refreshButton: '.card.center .msg-refresh-btn',
   messageHeaderItem:
-  '.msg-messages-container .msg-header-item',
+  '.msg-vscroll-container .msg-header-item',
   cardMessageReader: 'cards-message-reader',
   currentCardInputs: '.card.center input[type="text"]',
   replyMenuButton: '.msg-reply-btn',

--- a/apps/email/test/marionette/lib/email_data.js
+++ b/apps/email/test/marionette/lib/email_data.js
@@ -20,7 +20,7 @@ EmailData.prototype = {
   getCurrentAccount: function() {
     var client = this.client;
     return client.executeAsyncScript(function() {
-      var model = window.wrappedJSObject.require('model');
+      var model = window.wrappedJSObject.require('model_create').defaultModel;
       model.latest('account', function(account) {
         marionetteScriptFinished(account._wireRep);
       });
@@ -38,7 +38,7 @@ EmailData.prototype = {
     return client.executeAsyncScript(function(key, value) {
 
       var account,
-          model = window.wrappedJSObject.require('model'),
+          model = window.wrappedJSObject.require('model_create').defaultModel,
           acctsSlice = model.api.viewAccounts(false);
 
       function checkDone() {

--- a/apps/email/test/unit/header_cursor_test.js
+++ b/apps/email/test/unit/header_cursor_test.js
@@ -18,10 +18,11 @@ suite('HeaderCursor', function() {
   suiteSetup(function(done) {
     testConfig({ done: done }, [
       'evt',
-      'header_cursor'
-    ], function(_evt, HeaderCursor) {
+      'header_cursor',
+      'model_create',
+    ], function(_evt, HeaderCursor, mc) {
       evt = _evt;
-      headerCursor = HeaderCursor.cursor;
+      headerCursor = new HeaderCursor(mc.defaultModel);
       CurrentMessage = HeaderCursor.CurrentMessage;
     });
   });

--- a/apps/email/test/unit/model_acctsslice_startup_test.js
+++ b/apps/email/test/unit/model_acctsslice_startup_test.js
@@ -15,10 +15,10 @@ suite('model acctsSlice, startup', function() {
         suiteTeardown: suiteTeardown,
         done: done
       },
-      ['api', 'model'],
-      function(a, m) {
+      ['api', 'model_create'],
+      function(a, mc) {
         api = a;
-        model = m;
+        model = mc.defaultModel;
       }
     );
   });

--- a/apps/email/test/unit/model_create_test.js
+++ b/apps/email/test/unit/model_create_test.js
@@ -6,7 +6,7 @@
 requireApp('email/js/alameda.js');
 requireApp('email/test/config.js');
 
-suite('model', function() {
+suite('model_create', function() {
   var model;
 
   suiteSetup(function(done) {
@@ -15,9 +15,9 @@ suite('model', function() {
         suiteTeardown: suiteTeardown,
         done: done
       },
-      ['model'],
-      function(m) {
-        model = m;
+      ['model_create'],
+      function(mc) {
+        model = mc.defaultModel;
       }
     );
   });


### PR DESCRIPTION
There are three parts to this refactor. The unifying theme is instance based, smaller pieces. These parts were part of the general convoy effort, but landing them now will help reduce the overall convoy review hit and allows for some other front end refactors that do not depend on convoy to occur in the meantime.

Keeping the separate commits to help review the three pieces separately. The last commit is some fixes for the "model now instance-based" first commit. These fixes were found in testing after the message_list refactoring to smaller pieces. Since some of the changes are in these refactored pieces, it was easier to add them to the end of the commit list instead of reordering them to fit with the original commit. The main theme of the fix commit: make sure to pass the model instance when pushing a compose card.

Notes on the commits:
## model now instance-based with a defaultModel instance

The goal of this change is to change cards to receive their data/model as an instance via onArgs. model.js is now model_create, and it allows creating instances. There is a model_create defaultModel that is used as a bootstrap model, one that can be used for any entry point into the app, and for use when cards.pushStartCard() is needed from an activity entry point to go back to the message_list.

It is not very interesting on its own, just sets the stage for individual cards to receive their data via instance creation (onArgs in the cards case) instead of holding on to a global.
## HeaderCursor to instance

Builds on the conceptual change with passing model around to allow creating instances of HeaderCursor in each card. Now message_list and message_list_search will get their own HeaderCursor instances, with allow them separate messages slices, and avoids the weirdness where "searchMode" needed to be checked.

HeaderCursor still tracks "searchMode" for now, but it is just informational now, not used for checks (now that the _Break message_list into smaller pieces_ commit is part of this pull request).

With the convoy changes, HeaderCursor will be replaced with ListCursor instances, and with that, tracking searchMode at all goes completely away. I expect ListCursor to be something that could be considered for the (B) concept talked about in [bug 937959 comment 6](https://bugzilla.mozilla.org/show_bug.cgi?id=937959#c6).

There is a small change in mail_app.js onVisibilityChange function: it was getting called on a notification entry point, where the visibility change call happened before the notification startup completed. onVisibilityChange is there specifically for the sync case, so the check in that function was scoped to just that startup case.

I will be testing v2.2 to be sure that is not an issue there, but I suspect the visibilitychange issue is only an issue for master. It is not horrible if it happens, we just push a message_list card then immediately push a message_reader card, but felt it was best to avoid work if we can.
## Break message_list into smaller pieces

This is the most interesting change. There are a lot of files touched, but they are mostly moving the cards to mix in base_card instead of base. base is now used as the basic custom element baseline for all the email custom elements, and now there are some email custom elements that are base-derived custom elements, where only full fledged card modules mix in base_card.

**message_list** has been refactored to use some email custom elements, with the related HTML and JS for those elements moved out of message_list. Looking at the .html files for these modules gives the best overview of what moved where:
- **lst/edit_header**
- **lst/msg_vscroll**: Handles the VScroll instance and the specific message list logic around the basic VScroll.
- **lst/edit_toolbar**

The move of the HTML and logic were mostly mechanical copy/paste operations.

**message_list_search** is now its own fully realized card, and not a mixin hack of message_list. With that change the search specific HTML/logic has been moved out of message_list. message_list_search uses some of the new smaller email custom elements also used in message_list.

The **mixins/data-event.js** and **mixins/data-prop.js** mixins have fixes to only apply themselves if the element using those attributes is not inside another custom element. This was needed because the custom element approach used in email. Their interior DOM structure is visible for caching purposes and there is no hard concept of a private DOM. Using shadowRoot would give that privacy, but that would not work with the HTML cache that email uses, where the HTML should be complete on its own without needing any backing JS to be loaded for the first render.

One of the reasons to land this pull request is to then look at changing the approach to the HTML cache to allow shadowRoot-based elements. But the changes in data-event/data-prop allow the HTML cache to continue to work with email custom elements made up of other email custom elements.

There is a new mixin, **mixins/dom_evt.js**, and it just allows converting a DOM event inside the custom element to a custom event name that is emitted out of the custom element, and doing so declaratively in the HTML template.

**container_listen.js** was extracted from the old cards base.js bindContainerHandler, as it was a specialized function only needed in some scenarios, not all base_card derivatives.

**html_cache.js** was modified to make sure all email custom elements (which have a .email-ce CSS class on them courtesy of base.js) get data-cached set on them, so that when they are hydrated from the HTML cache, the hydrated HTML is used for the internals instead of creating a new internal DOM structure from the template (template.js does the data-cached checking).

This refactoring to smaller pieces is carried forward in the convoy branch further, where conv_list is introduced.
## model now instance-based - fixes

Just fixes for the first commit where I forgot to pass model in some cases, and there were changes on master that happened after the initial commit was done. Also removes the autocomplete.js hack that was on master that is no longer needed now that base.js does not assume a full card base.

---

Tested activity and notification entry points, and manually testing of features. The cards that are not message_list/message_list_search/message_reader/compose are mostly unaffected by the changes, except for the base->base_card mixin change.

Commits will be squashed to one commit if review is passed.
