### PR TITLE
Bug 1193059 - Bring back unpair-msg and unpair-title strings to Settings

### DIFF
--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -505,7 +505,9 @@ error-pair-pincode    = Unable to pair with the device. Check that the PIN is co
 error-pair-toofast    = Unable to pair with the device. Too many requests.
 error-connect-title   = Unable to connect devices
 error-connect-msg     = Check that the device you’re trying to connect with is still in range and has Bluetooth turned on.
-unpair-confirm        = Unpair a connected device?\nYou are currently connected to this device. Unpairing will also disconnect from it.
+unpair-title          = Unpair a connected device?
+unpair-msg            = You are currently connected to this device. Unpairing will also disconnect from it.
+unpair-confirm        = {{unpair-title}}\n{{unpair-msg}}
 
 # Connectivity :: NFC
 nfc = NFC


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1193059
