### PR TITLE
Bug 1197570 - don't load manifest when no basedir r=asppsa

### DIFF
--- a/build/multilocale.js
+++ b/build/multilocale.js
@@ -460,6 +460,10 @@ function L10nManager(gaiaDir,
    * @returns {Object} res    - Manifest l10n resource
    */
   function getManifestProperties(webapp, locale) {
+    if (self.localeBasedir === null) {
+      return null;
+    }
+
     var parent = utils.getFile(webapp.sourceDirectoryFilePath, '..');
     var propFile = utils.getFile(self.localeBasedir, locale, parent.leafName,
       webapp.sourceDirectoryName, 'manifest.properties');


### PR DESCRIPTION
If there is no locale basedir, getManifestProperties tries to open an
invalid path, triggering an error.  This patch makes
getManifestProperties return null instead.
