### PR TITLE
Bug 1197787 - Don't use `arguments` in arrow function in calendar_service.js

### DIFF
--- a/apps/calendar/js/backend/calendar_service.js
+++ b/apps/calendar/js/backend/calendar_service.js
@@ -24,8 +24,7 @@ function start() {
 }
 
 function method(endpoint, handler) {
-  service.method(endpoint, () => {
-    var args = Array.slice(arguments);
+  service.method(endpoint, (...args) => {
     return co(function *() {
       yield start();
       return handler.apply(null, args);


### PR DESCRIPTION
We're changing the semantics in bug 889158 to match the spec, so we need to fix this one.
