### PR TITLE
Bug 1194547 - Clean up app screenshoting a bit. r=albertopq

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -1398,6 +1398,12 @@
       // will be null if there is no blob
       var screenshotURL = this.requestScreenshotURL();
 
+      if (!screenshotURL) {
+        this.element.classList.add('no-screenshot');
+        this.screenshotOverlay.style.backgroundImage = 'none';
+        return Promise.resolve();
+      }
+
       //  return promise to make sure the image is ready
       var promise = new Promise((resolve) => {
          var image = document.createElement('img');
@@ -1406,9 +1412,9 @@
           }.bind(this);
           image.src = screenshotURL;
       });
-      this.screenshotOverlay.style.backgroundImage = screenshotURL ?
-          'url(' + screenshotURL + ')' : 'none';
-      this.element.classList.toggle('no-screenshot', !screenshotURL);
+      this.screenshotOverlay.style.backgroundImage =
+        'url(' + screenshotURL + ')';
+      this.element.classList.remove('no-screenshot');
       return promise;
     };
 
@@ -1689,7 +1695,7 @@
     this.debug('request RESIZE...active? ', this.isActive());
     var bottom = this.getBottomMostWindow();
     if (!bottom.shouldResize() || this.isTransitioning()) {
-      return;
+      return Promise.resolve();
     }
     if (this.frontWindow) {
       return Promise.all(
@@ -1984,9 +1990,6 @@
   AppWindow.prototype.ready = function aw_ready(callback) {
     if (!this.element) {
       return;
-    }
-    if (this._screenshotBlob) {
-      this._showScreenshotOverlay();
     }
 
     this.debug('requesting to open');

--- a/apps/system/js/app_window_manager.js
+++ b/apps/system/js/app_window_manager.js
@@ -319,14 +319,12 @@
       var switching = appCurrent && !appCurrent.isHomescreen &&
                       !appNext.isHomescreen;
 
-      this._updateActiveApp(appNext.instanceID);
-
       var that = this;
       if (appCurrent && this.service.query('keyboardEnabled')) {
         this.stopRecording();
 
         // Ask keyboard to hide before we switch the app.
-      window.addEventListener('keyboardhidden', function onhiddenkeyboard() {
+        window.addEventListener('keyboardhidden', function onhiddenkeyboard() {
           window.removeEventListener('keyboardhidden', onhiddenkeyboard);
           that.switchApp(appCurrent, appNext, switching);
         });
@@ -363,7 +361,10 @@
      */
     switchApp: function awm_switchApp(appCurrent, appNext, switching,
                                       openAnimation, closeAnimation) {
+
       this.debug('before ready check' + appCurrent + appNext);
+      this._updateActiveApp(appNext.instanceID);
+
       appNext.ready(function() {
         if (appNext.isDead()) {
           if (!appNext.isHomescreen) {

--- a/apps/system/js/attention_window.js
+++ b/apps/system/js/attention_window.js
@@ -93,7 +93,6 @@
     this.debug('intance id: ' + this.instanceID);
     return `<div class="${this.CLASS_LIST}" id="${this.instanceID}">
             <div class="browser-container"></div>
-            <div class="screenshot-overlay"></div>
             </div>`;
   };
 
@@ -122,7 +121,6 @@
     this.browserContainer.insertBefore(this.browser.element, null);
     this.frame = this.element;
     this.iframe = this.browser.element;
-    this.screenshotOverlay = this.element.querySelector('.screenshot-overlay');
 
     this._registerEvents();
     this.installSubComponents();

--- a/apps/system/js/callscreen_window.js
+++ b/apps/system/js/callscreen_window.js
@@ -104,7 +104,6 @@
     this.browserContainer.insertBefore(this.browser.element, null);
     this.frame = this.element;
     this.iframe = this.browser.element;
-    this.screenshotOverlay = this.element.querySelector('.screenshot-overlay');
 
     this._registerEvents();
     this.installSubComponents();

--- a/apps/system/test/unit/app_window_manager_test.js
+++ b/apps/system/test/unit/app_window_manager_test.js
@@ -789,8 +789,6 @@ suite('system/AppWindowManager', function() {
     });
 
     test('app to app', function() {
-      var stub_updateActiveApp = this.sinon.stub(subject,
-        '_updateActiveApp');
       injectRunningApps(app1, app2);
       subject._activeApp = app1;
       var stubSwitchApp = this.sinon.stub(subject, 'switchApp');
@@ -802,7 +800,6 @@ suite('system/AppWindowManager', function() {
       assert.isTrue(stubSwitchApp.called);
       assert.deepEqual(stubSwitchApp.getCall(0).args[0], app1);
       assert.deepEqual(stubSwitchApp.getCall(0).args[1], app2);
-      assert.isTrue(stub_updateActiveApp.called);
     });
 
     test('Continunous app open requests', function() {
@@ -927,12 +924,15 @@ suite('system/AppWindowManager', function() {
       var stubReady = this.sinon.stub(app2, 'ready');
       var stubAppNextOpen = this.sinon.stub(app2, 'open');
       var stubAppCurrentClose = this.sinon.stub(app1, 'close');
+      var stub_updateActiveApp = this.sinon.stub(subject,
+        '_updateActiveApp');
       subject.switchApp(app1, app2, true);
       stubReady.yield();
       assert.isTrue(stubAppNextOpen.called);
       assert.isTrue(stubAppCurrentClose.called);
       assert.isTrue(stubAppNextOpen.calledWith('invoked'));
       assert.isTrue(stubAppCurrentClose.calledWith('invoking'));
+      assert.isTrue(stub_updateActiveApp.called);
     });
 
     test('close app to cardsview', function() {

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -1135,18 +1135,6 @@ suite('system/AppWindow', function() {
       this.sinon.clock.tick(0);
       assert.isTrue(callback.calledOnce);
     });
-
-    test('Call _showScreenshotOverlay', function() {
-      app1._screenshotBlob = 'fakeBlob';
-      app1.ready();
-      assert.isTrue(showScreenshotOverlay.calledOnce);
-    });
-
-    test('Do not call _showScreenshotOverlay', function() {
-      app1._screenshotBlob = null;
-      app1.ready();
-      assert.isFalse(showScreenshotOverlay.called);
-    });
   });
 
   suite('Browser Mixin', function() {


### PR DESCRIPTION
- don't show the screenshot overlay when |ready| is called
- make sure methods than return promises _always_ return promises
- make sure we screenshot correctly when exiting an app displaying the keyboard
- don't do useless screenshot work for AttentionWindows
