### PR TITLE
Bug 1198427 - A way to add extra apps to a target at build time R=ferjm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,6 +426,7 @@ GAIA_ALLAPPDIRS=$(shell find -L $(GAIA_DIR)$(SEP)apps $(GAIA_DIR)$(SEP)dev_apps 
 
 GAIA_APPDIRS?=$(shell $(call run-js-command,scan-appdir, \
 		GAIA_APP_CONFIG="$(GAIA_APP_CONFIG)" \
+		EXTRA_APPS="$(EXTRA_APPS)" \
 		GAIA_DIR="$(GAIA_DIR)" \
 		GAIA_DISTRIBUTION_DIR="$(GAIA_DISTRIBUTION_DIR)" \
 		GAIA_APP_SRCDIRS="$(GAIA_APP_SRCDIRS)"))

--- a/build/scan-appdir.js
+++ b/build/scan-appdir.js
@@ -71,7 +71,13 @@ ScanAppdir.prototype.pushPathSrc = function(srcFolder, path) {
 
 ScanAppdir.prototype.execute = function() {
   var baseSrc;
-  this.appList.split('\n').forEach(function(src) {
+  var distributionFolders = this.appList.split('\n');
+
+  if (utils.getEnv('EXTRA_APPS')) {
+    distributionFolders = distributionFolders.concat(utils.getEnv('EXTRA_APPS').split(' '));
+  }
+
+  distributionFolders.forEach(function(src) {
     src = src.trim();
     if (!src || src === '') {
       return;


### PR DESCRIPTION
A few open issue:
- Not sure how/where to add tests for this?
- Should update https://developer.mozilla.org/en-US/Firefox_OS/Developing_Gaia/Customizing_build-time_apps if/once this lands
- It's a bit ugly that you have to specify multiple apps with a '\ ', like:

```
EXTRA_APPS := "dev_apps/app1\ dev_apps/app2"
```

in local.mk now, to make sure bash handles that string correctly, any idea how to fix that?
