### PR TITLE
Bug 889158 - Remove 'arguments' occurences from arrow functions. r=

### DIFF
--- a/dev_apps/music-nga/elements/music-search.js
+++ b/dev_apps/music-nga/elements/music-search.js
@@ -204,8 +204,7 @@ proto.setResults = function(results) {
 
 function debounce(fn, ms) {
   var timeout;
-  return () => {
-    var args = arguments;
+  return (...args) => {
     clearTimeout(timeout);
     timeout = setTimeout(() => fn.apply(this, args), ms);
   };

--- a/dev_apps/music-nga/elements/music-seek-bar.js
+++ b/dev_apps/music-nga/elements/music-seek-bar.js
@@ -234,8 +234,7 @@ Object.defineProperty(proto, 'remainingTime', {
 function throttle(fn, ms) {
   var last = Date.now();
   var timeout;
-  return () => {
-    var args = arguments;
+  return (...args) => {
     var now = Date.now();
     if (now < last + ms) {
       clearTimeout(timeout);

--- a/dev_apps/music-nga/js/db.js
+++ b/dev_apps/music-nga/js/db.js
@@ -13,8 +13,7 @@ App.refreshViews = debounce(() => { // XXX
 
 function debounce(fn, ms) { // XXX
   var timeout;
-  return () => {
-    var args = arguments;
+  return (...args) => {
     clearTimeout(timeout);
     timeout = setTimeout(() => fn.apply(this, args), ms);
   };


### PR DESCRIPTION
r? @justindarc 
