### PR TITLE
Bug 1199838 - [Downloads] Add additional padding to download checkboxes to match the rest of the settings app

### DIFF
--- a/apps/settings/style/downloads.css
+++ b/apps/settings/style/downloads.css
@@ -76,6 +76,7 @@
 
 #downloads.edit #downloadList li {
   pointer-events: all;
+  margin: 0 1.5rem;
 }
 
 /* End of the styles while editing*/


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1199838
