### PR TITLE
Bug 1200517 - Let text-selection-dialog show on top of ActivityWindow.

### DIFF
--- a/apps/system/style/textselection_dialog/textselection_dialog.css
+++ b/apps/system/style/textselection_dialog/textselection_dialog.css
@@ -11,7 +11,7 @@
   transition: opacity var(--transition-duration) ease;
 }
 .appWindow > .textselection-dialog {
-  z-index: 2;
+  z-index: 65537;
 }
 
 #text-selection-dialog-root > .textselection-dialog {


### PR DESCRIPTION
When adding page to home screen in bookmark app, there's an appWindow with class name 'ActivityWindow' is created. Since ActivityWindow is under bookmark app
w/ z-index = 65536, the app-based text-selection-dialog under bookmark app w/ z-index = 2 is covered, which looks like a no show.

In this patch, the z-index change only applies to the text-selection-dialog under each appWindow, so this won't affect the z-index relationships between appWindows and other divs (ex. notifications).
