### PR TITLE
 Bug 1166202 - Fixed web title in transform view

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -601,7 +601,7 @@
               <div class="identification-overlay">
                 <div>
                   <div class="icon"></div>
-                  <span class="title"></span>
+                  <span class="title" dir="auto"></span>
                 </div>
               </div>
               <div class="fade-overlay"></div>


### PR DESCRIPTION
[1166202](https://bugzilla.mozilla.org/show_bug.cgi?id=1166202)
The web title in transform view truncates at **right** side of **LTR** text earlier was truncating to **left** side of **LTR** text for **RTL** Languages (such as Arabic, Urdu).
