### PR TITLE
Bug 1201481 - Let AppTextSelectionDialogs from all opened apps share one single pref. observer in shared global states.

### DIFF
--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -10,7 +10,7 @@
   var AppTextSelectionDialogGlobalStates = function() {
     this._hasCutOrCopiedTimeoutId = null;
     this._isPrefOn = true;
-    this._appTSDs = new Set();
+    this.appTSDs = new Set();
     this.bindOnObservePrefChanged = this.onObservePrefChanged.bind(this);
     SettingsListener.observe('copypaste.enabled', true,
                              this.bindOnObservePrefChanged);
@@ -42,13 +42,13 @@
     function() {
       this._hasCutOrCopiedTimeoutId = null;
       this._isPrefOn = true;
-      this._appTSDs.clear();
+      this.appTSDs.clear();
     };
 
   AppTextSelectionDialogGlobalStates.prototype.onObservePrefChanged =
     function (value) {
       this._isPrefOn = value;
-      this._appTSDs.forEach(appTSD => {
+      this.appTSDs.forEach(appTSD => {
         this._isPrefOn ? appTSD.start() : appTSD.stop();
       });
     };
@@ -67,7 +67,7 @@
     this.textualmenuDetail = null;
     this.globalStates = _globalStates =
       _globalStates || new AppTextSelectionDialogGlobalStates();
-    this.globalStates._appTSDs.add(this);
+    this.globalStates.appTSDs.add(this);
   };
 
   AppTextSelectionDialog.prototype = Object.create(window.BaseUI.prototype);
@@ -100,7 +100,7 @@
   // from global states when destroying this app.
   AppTextSelectionDialog.prototype._unregisterEvents =
     function tsd__unregisterEvents() {
-      this.globalStates._appTSDs.delete(this);
+      this.globalStates.appTSDs.delete(this);
     };
 
   AppTextSelectionDialog.prototype.start = function tsd_start() {

--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -41,6 +41,8 @@
   AppTextSelectionDialogGlobalStates.prototype.resetAllStates =
     function() {
       this._hasCutOrCopiedTimeoutId = null;
+      this._isPrefOn = true;
+      this._appTSDs.clear();
     };
 
   AppTextSelectionDialogGlobalStates.prototype.onObservePrefChanged =

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -115,14 +115,31 @@ suite('system/AppTextSelectionDialog', function() {
     assert.isTrue(td.globalStates === td2.globalStates);
   });
 
+  test('test _appTSDs is correctly updated in global states', function() {
+    assert.isTrue(td.globalStates._appTSDs.size == 1);
+    assert.isTrue(td.globalStates._appTSDs.has(td));
+
+    var td2 = new AppTextSelectionDialog();
+    assert.isTrue(td.globalStates._appTSDs.size == 2);
+    assert.isTrue(td.globalStates._appTSDs.has(td2));
+  });
+
   test('switch settings value of copypaste.enabled', function() {
     var stubStart = this.sinon.stub(td, 'start');
     var stubStop = this.sinon.stub(td, 'stop');
+    var td2 = new AppTextSelectionDialog();
+    var stubStart2 = this.sinon.stub(td2, 'start');
+    var stubStop2 = this.sinon.stub(td2, 'stop');
+
     MockSettingsListener.mTriggerCallback('copypaste.enabled', false);
+    assert.isFalse(td.globalStates._isPrefOn);
     assert.isTrue(stubStop.calledOnce);
+    assert.isTrue(stubStop2.calledOnce);
 
     MockSettingsListener.mTriggerCallback('copypaste.enabled', true);
+    assert.isTrue(td.globalStates._isPrefOn);
     assert.isTrue(stubStart.calledOnce);
+    assert.isTrue(stubStart2.calledOnce);
   });
 
   test('_doCommand', function(done) {

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -115,13 +115,13 @@ suite('system/AppTextSelectionDialog', function() {
     assert.isTrue(td.globalStates === td2.globalStates);
   });
 
-  test('test _appTSDs is correctly updated in global states', function() {
-    assert.isTrue(td.globalStates._appTSDs.size == 1);
-    assert.isTrue(td.globalStates._appTSDs.has(td));
+  test('test appTSDs is correctly updated in global states', function() {
+    assert.isTrue(td.globalStates.appTSDs.size == 1);
+    assert.isTrue(td.globalStates.appTSDs.has(td));
 
     var td2 = new AppTextSelectionDialog();
-    assert.isTrue(td.globalStates._appTSDs.size == 2);
-    assert.isTrue(td.globalStates._appTSDs.has(td2));
+    assert.isTrue(td.globalStates.appTSDs.size == 2);
+    assert.isTrue(td.globalStates.appTSDs.has(td2));
   });
 
   test('switch settings value of copypaste.enabled', function() {


### PR DESCRIPTION
SettingsListener.observe is moved into shared global states. I use an AppTextSelectionDialog array in global states to keep all AppTextSelectionDialog instances from launched apps. The state of each AppTextSelectionDialog would be updated whenever copypaste.enable pref is changed.
