### PR TITLE
Bug 1202450 - FxA IAC method getAccounts -> getAccount, r=ferjm

### DIFF
--- a/apps/ftu/js/ui.js
+++ b/apps/ftu/js/ui.js
@@ -463,7 +463,7 @@ var UIManager = {
     // bug 1113551. In any case, the user should be able to manage her account
     // from the Settings app afterwards.
     this.skipFxA = true;
-    FxAccountsIACHelper.getAccounts((account) => {
+    FxAccountsIACHelper.getAccount((account) => {
       this.skipFxA = false;
       this.onFxALogin(account);
     }, () => {
@@ -479,7 +479,7 @@ var UIManager = {
   },
 
   onFxAFlowDone: function ui_onFxAFlowDone() {
-    FxAccountsIACHelper.getAccounts((account) => {
+    FxAccountsIACHelper.getAccount((account) => {
       if (!account) {
         return;
       }

--- a/apps/ftu/test/unit/mock_fx_accounts_iac_helper.js
+++ b/apps/ftu/test/unit/mock_fx_accounts_iac_helper.js
@@ -3,15 +3,15 @@
 'use strict';
 
 var MockFxAccountsIACHelper = {
-  getAccountsNoCallback: false,
+  getAccountNoCallback: false,
   logoutNoCallback: false,
-  getAccountsError: null,
+  getAccountError: null,
   account: null,
 
   reset: function() {
     this.account = null;
-    this.getAccountsError = null;
-    this.getAccountsNoCallback = null;
+    this.getAccountError = null;
+    this.getAccountNoCallback = null;
     this.logoutNoCallback = null;
   },
 
@@ -19,13 +19,13 @@ var MockFxAccountsIACHelper = {
 
   openFlow: function() {},
 
-  getAccounts: function(successCb, errorCb) {
-    if (this.getAccountsNoCallback) {
+  getAccount: function(successCb, errorCb) {
+    if (this.getAccountNoCallback) {
       return;
     }
 
-    if (this.getAccountsError) {
-      errorCb(this.getAccountsError);
+    if (this.getAccountError) {
+      errorCb(this.getAccountError);
       return;
     }
 

--- a/apps/ftu/test/unit/ui_manager_test.js
+++ b/apps/ftu/test/unit/ui_manager_test.js
@@ -281,7 +281,7 @@ suite('UI Manager > ', function() {
       });
     });
 
-    suite('Account login - getAccounts no account', function() {
+    suite('Account login - getAccount no account', function() {
       setup(function() {
         createAccountButton.disabled = false;
         nextButton.setAttribute('data-l10n-id', 'skip');
@@ -302,9 +302,9 @@ suite('UI Manager > ', function() {
       });
     });
 
-    suite('Account login - getAccounts error', function() {
+    suite('Account login - getAccount error', function() {
       setup(function() {
-        MockFxAccountsIACHelper.getAccountsError = 'WHATEVER';
+        MockFxAccountsIACHelper.getAccountError = 'WHATEVER';
         createAccountButton.disabled = false;
         nextButton.setAttribute('data-l10n-id', 'skip');
         UIManager.onFxAFlowDone();
@@ -343,10 +343,10 @@ suite('UI Manager > ', function() {
       });
     });
 
-    suite('FTU initiates with a existing FxA login - getAccounts does not ' +
+    suite('FTU initiates with a existing FxA login - getAccount does not ' +
           'give any results (or maybe it does but not in time)', function() {
       setup(function() {
-        MockFxAccountsIACHelper.getAccountsNoCallback = true;
+        MockFxAccountsIACHelper.getAccountNoCallback = true;
         UIManager.skipFxA = false;
         UIManager.checkInitialFxAStatus();
       });
@@ -360,12 +360,12 @@ suite('UI Manager > ', function() {
       });
     });
 
-    suite('FTU initiates with a existing FxA login - getAccounts error - ' +
+    suite('FTU initiates with a existing FxA login - getAccount error - ' +
           'logout ok', function() {
       var logoutSpy;
 
       setup(function() {
-        MockFxAccountsIACHelper.getAccountsError = 'WHATEVER';
+        MockFxAccountsIACHelper.getAccountError = 'WHATEVER';
         UIManager.skipFxA = false;
         logoutSpy = this.sinon.spy(MockFxAccountsIACHelper, 'logout');
         UIManager.checkInitialFxAStatus();
@@ -384,12 +384,12 @@ suite('UI Manager > ', function() {
       });
     });
 
-    suite('FTU initiates with a existing FxA login - getAccounts error - ' +
+    suite('FTU initiates with a existing FxA login - getAccount error - ' +
           'logout no result or error', function() {
       var logoutSpy;
 
       setup(function() {
-        MockFxAccountsIACHelper.getAccountsError = 'WHATEVER';
+        MockFxAccountsIACHelper.getAccountError = 'WHATEVER';
         MockFxAccountsIACHelper.logoutNoCallback = true;
         UIManager.skipFxA = false;
         logoutSpy = this.sinon.spy(MockFxAccountsIACHelper, 'logout');

--- a/apps/settings/js/firefox_accounts/menu.js
+++ b/apps/settings/js/firefox_accounts/menu.js
@@ -20,7 +20,7 @@ var FxaMenu = (function fxa_menu() {
   }
 
   function refreshStatus() {
-    fxaHelper.getAccounts(onStatusChange, onStatusError);
+    fxaHelper.getAccount(onStatusChange, onStatusError);
   }
 
   // if e == null, user is logged out.

--- a/apps/settings/js/firefox_accounts/panel.js
+++ b/apps/settings/js/firefox_accounts/panel.js
@@ -52,7 +52,7 @@ var FxaPanel = (function fxa_panel() {
   }
 
   function refreshStatus() {
-    fxaHelper.getAccounts(onFxAccountStateChange, onFxAccountError);
+    fxaHelper.getAccount(onFxAccountStateChange, onFxAccountError);
   }
 
   // if e == null, user is logged out.
@@ -137,7 +137,7 @@ var FxaPanel = (function fxa_panel() {
     if (e.target.classList.contains('disabled')) {
       return;
     }
-    fxaHelper.getAccounts(function onGetAccounts(accts) {
+    fxaHelper.getAccount(function onGetAccounts(accts) {
       var email = accts && accts.email;
       if (!email) {
         return onFxAccountStateChange(accts);

--- a/apps/settings/test/unit/firefox_accounts_panel_test.js
+++ b/apps/settings/test/unit/firefox_accounts_panel_test.js
@@ -136,20 +136,20 @@ suite('firefox accounts panel > ', function() {
   });
 
   suite('resendVerificationEmail tests > ', function() {
-    var getAccountsSpy;
+    var getAccountSpy;
 
     suiteSetup(function() {
-      getAccountsSpy = sinon.stub(MockFxAccountsIACHelper, 'getAccounts');
+      getAccountSpy = sinon.stub(MockFxAccountsIACHelper, 'getAccount');
       FxaPanel.init(MockFxAccountsIACHelper);
     });
 
     suiteTeardown(function() {
-      MockFxAccountsIACHelper.getAccounts.restore();
-      getAccountsSpy = null;
+      MockFxAccountsIACHelper.getAccount.restore();
+      getAccountSpy = null;
     });
 
     setup(function() {
-      getAccountsSpy.reset();
+      getAccountSpy.reset();
     });
 
     test('on resend click, if link is enabled, get accounts', function() {
@@ -167,7 +167,7 @@ suite('firefox accounts panel > ', function() {
         }
       };
       FxaPanel._onResendClick.call(null, fakeEvt);
-      assert.isTrue(getAccountsSpy.called);
+      assert.isTrue(getAccountSpy.called);
     });
 
     test('on resend click, if link is disabled, do nothing', function() {
@@ -185,7 +185,7 @@ suite('firefox accounts panel > ', function() {
         }
       };
       FxaPanel._onResendClick.call(null, fakeEvt);
-      assert.isFalse(getAccountsSpy.called);
+      assert.isFalse(getAccountSpy.called);
     });
 
     test('_onResend should alert resend message', function(done) {

--- a/apps/settings/test/unit/mock_fx_accounts_iac_helper.js
+++ b/apps/settings/test/unit/mock_fx_accounts_iac_helper.js
@@ -11,7 +11,7 @@ var MockFxAccountsIACHelper = (function() {
 
   var currentState = null;
 
-  function getAccounts(cb) {
+  function getAccount(cb) {
     cb(currentState);
   }
 
@@ -62,7 +62,7 @@ var MockFxAccountsIACHelper = (function() {
   }
 
   return {
-    getAccounts: getAccounts,
+    getAccount: getAccount,
     resendVerificationEmail: resendVerificationEmail,
     setCurrentState: setCurrentState,
     getCurrentState: getCurrentState,

--- a/apps/system/fxa/test/marionette/test-fxa-client/index.html
+++ b/apps/system/fxa/test/marionette/test-fxa-client/index.html
@@ -11,7 +11,7 @@
   <body>
     <section role="dialog">
       <menu>
-        <button id="getAccounts">Get Fx Accounts</button>
+        <button id="getAccount">Get Fx Account</button>
         <button id="openFlow">Launch FxAccounts flow</button>
         <button id="logout">Logout</button>
         <div class="refresh-auth">

--- a/apps/system/fxa/test/marionette/test-fxa-client/js/app.js
+++ b/apps/system/fxa/test/marionette/test-fxa-client/js/app.js
@@ -30,7 +30,7 @@ var TestFxAClient = function TestFxAClient() {
   var init = function init() {
     resultEl = document.getElementById('result');
     resultTextEl = document.getElementById('result-text');
-    getFxAccountsButton = document.getElementById('getAccounts');
+    getFxAccountsButton = document.getElementById('getAccount');
     launchFxAFlowButton = document.getElementById('openFlow');
     logoutButton = document.getElementById('logout');
     refreshAuthButton = document.getElementById('refreshAuthentication');
@@ -101,7 +101,7 @@ var TestFxAClient = function TestFxAClient() {
       case 'openFlow':
         FxAccountsIACHelper[method](showResponse, showError);
         break;
-      case 'getAccounts':
+      case 'getAccount':
       case 'logout':
         Overlay.show();
         FxAccountsIACHelper[method](showResponse, showError);

--- a/apps/system/js/fx_accounts_client.js
+++ b/apps/system/js/fx_accounts_client.js
@@ -70,9 +70,9 @@ var FxAccountsClient = function FxAccountsClient() {
 
   // === API ===
 
-  var getAccounts = function getAccounts(successCb, errorCb) {
+  var getAccount = function getAccount(successCb, errorCb) {
     sendMessage({
-      method: 'getAccounts'
+      method: 'getAccount'
     }, successCb, errorCb);
   };
 
@@ -136,7 +136,7 @@ var FxAccountsClient = function FxAccountsClient() {
   };
 
   return {
-    'getAccounts': getAccounts,
+    'getAccount': getAccount,
     'getAssertion': getAssertion,
     'getKeys': getKeys,
     'logout': logout,

--- a/apps/system/js/fx_accounts_manager.js
+++ b/apps/system/js/fx_accounts_manager.js
@@ -77,7 +77,7 @@ var FxAccountsManager = {
     var methodName = event.detail.name;
 
     switch (methodName) {
-      case 'getAccounts':
+      case 'getAccount':
       case 'logout':
         (function(methodName) {
           LazyLoader.load('js/fx_accounts_client.js', function() {

--- a/apps/system/test/unit/fx_accounts_client_test.js
+++ b/apps/system/test/unit/fx_accounts_client_test.js
@@ -71,9 +71,9 @@ suite('system/FxAccountsClient >', function() {
 
   // API calls
 
-  suite('getAccounts', function() {
+  suite('getAccount', function() {
     setup(function() {
-      FxAccountsClient.getAccounts(successCb, errorCb);
+      FxAccountsClient.getAccount(successCb, errorCb);
     });
 
     test('Event dispatched to chrome side', function() {
@@ -82,12 +82,12 @@ suite('system/FxAccountsClient >', function() {
       assert.ok(MockDispatchedEvents[0].detail.id);
       assert.ok(MockDispatchedEvents[0].detail.data);
       assert.deepEqual(MockDispatchedEvents[0].detail.data, {
-        method: 'getAccounts'
+        method: 'getAccount'
       });
     });
   });
 
-  suite('getAccounts reply success', function() {
+  suite('getAccount reply success', function() {
     setup(function() {
       MockEventListener.mozFxAccountsChromeEvent({
         detail: {
@@ -112,9 +112,9 @@ suite('system/FxAccountsClient >', function() {
     });
   });
 
-  suite('getAccounts', function() {
+  suite('getAccount', function() {
     setup(function() {
-      FxAccountsClient.getAccounts(successCb, errorCb);
+      FxAccountsClient.getAccount(successCb, errorCb);
     });
 
     test('Event dispatched to chrome side', function() {
@@ -123,12 +123,12 @@ suite('system/FxAccountsClient >', function() {
       assert.ok(MockDispatchedEvents[0].detail.id);
       assert.ok(MockDispatchedEvents[0].detail.data);
       assert.deepEqual(MockDispatchedEvents[0].detail.data, {
-        method: 'getAccounts'
+        method: 'getAccount'
       });
     });
   });
 
-  suite('getAccounts reply error', function() {
+  suite('getAccount reply error', function() {
     setup(function() {
       MockEventListener.mozFxAccountsChromeEvent({
         detail: {

--- a/apps/system/test/unit/fx_accounts_manager_test.js
+++ b/apps/system/test/unit/fx_accounts_manager_test.js
@@ -51,12 +51,12 @@ suite('system/FxAccountManager >', function() {
     });
   });
 
-  suite('On getAccounts port message, successCb', function() {
+  suite('On getAccount port message, successCb', function() {
     setup(function() {
       FxAccountsClient._successMsg = 'success';
       FxAccountsManager.onPortMessage({
         'detail': {
-          'name': 'getAccounts'
+          'name': 'getAccount'
         }
       });
     });
@@ -65,8 +65,8 @@ suite('system/FxAccountManager >', function() {
       FxAccountsClient._reset();
     });
 
-    test('FxAccountsClient.getAccounts called', function() {
-      assert.equal(FxAccountsClient._call, 'getAccounts');
+    test('FxAccountsClient.getAccount called', function() {
+      assert.equal(FxAccountsClient._call, 'getAccount');
     });
 
     test('Got fxa-mgmt port', function() {
@@ -77,18 +77,18 @@ suite('system/FxAccountManager >', function() {
       assert.equal(MockIACPort._messages.length, 1);
       assert.ok(MockIACPort._messages[0] instanceof Object);
       assert.deepEqual(MockIACPort._messages[0], {
-        'methodName': 'getAccounts',
+        'methodName': 'getAccount',
         'data': 'success'
       });
     });
   });
 
-  suite('On getAccounts port message, errorCb', function() {
+  suite('On getAccount port message, errorCb', function() {
     setup(function() {
       FxAccountsClient._errorMsg = 'error';
       FxAccountsManager.onPortMessage({
         'detail': {
-          'name': 'getAccounts'
+          'name': 'getAccount'
         }
       });
     });
@@ -97,8 +97,8 @@ suite('system/FxAccountManager >', function() {
       FxAccountsClient._reset();
     });
 
-    test('FxAccountsClient.getAccounts called', function() {
-      assert.equal(FxAccountsClient._call, 'getAccounts');
+    test('FxAccountsClient.getAccount called', function() {
+      assert.equal(FxAccountsClient._call, 'getAccount');
     });
 
     test('Got fxa-mgmt port', function() {
@@ -109,7 +109,7 @@ suite('system/FxAccountManager >', function() {
       assert.equal(MockIACPort._messages.length, 1);
       assert.ok(MockIACPort._messages[0] instanceof Object);
       assert.deepEqual(MockIACPort._messages[0], {
-        'methodName': 'getAccounts',
+        'methodName': 'getAccount',
         'error': 'error'
       });
     });

--- a/apps/system/test/unit/fxa_iac_client_test.js
+++ b/apps/system/test/unit/fxa_iac_client_test.js
@@ -69,7 +69,7 @@ suite('FirefoxOS Accounts IAC Client Suite', function() {
     assert.equal(Object.keys(FxAccountsIACHelper).length, 9);
   });
 
-  ['getAccounts', 'openFlow', 'logout'].forEach(function(method) {
+  ['getAccount', 'openFlow', 'logout'].forEach(function(method) {
     suite(method + ' suite', function() {
       setup(function() {
         postMessageSpy = sinon.spy(port, 'postMessage');
@@ -306,7 +306,7 @@ suite('FirefoxOS Accounts IAC Client Suite', function() {
       // two requests -- one to be sent as soon as the connection's ready,
       // the other after that.
       FxAccountsIACHelper.logout(otherListener);
-      FxAccountsIACHelper.getAccounts(listener);
+      FxAccountsIACHelper.getAccount(listener);
       this.clock.tick(1000);
       assert.isTrue(callbackCalled);
       assert.isTrue(otherCallbackCalled);
@@ -316,8 +316,8 @@ suite('FirefoxOS Accounts IAC Client Suite', function() {
       callbackCalled = false;
       otherCallbackCalled = false;
       FxAccountsIACHelper.reset();
-      FxAccountsIACHelper.getAccounts(listener);
-      FxAccountsIACHelper.getAccounts(otherListener);
+      FxAccountsIACHelper.getAccount(listener);
+      FxAccountsIACHelper.getAccount(otherListener);
       this.clock.tick(1000);
       assert.isTrue(callbackCalled);
       assert.isTrue(otherCallbackCalled);

--- a/apps/system/test/unit/iac_handler_test.js
+++ b/apps/system/test/unit/iac_handler_test.js
@@ -105,7 +105,7 @@ suite('IACHandler > ', function() {
 
     test('IACHandler can send to fxa-mgmt successfully', function() {
       var message = {
-        method: 'getAccounts'
+        method: 'getAccount'
       };
 
       fakePort.postMessage({

--- a/apps/system/test/unit/mock_fxa_client.js
+++ b/apps/system/test/unit/mock_fxa_client.js
@@ -22,8 +22,8 @@ var MockFxAccountsClient = {
     successCb(this._successMsg);
   },
 
-  getAccounts: function(successCb, errorCb) {
-    this._call = 'getAccounts';
+  getAccount: function(successCb, errorCb) {
+    this._call = 'getAccount';
     this._triggerCallback(successCb, errorCb);
   },
 

--- a/shared/js/fxa_iac_client.js
+++ b/shared/js/fxa_iac_client.js
@@ -14,7 +14,7 @@ var FxAccountsIACHelper = function FxAccountsIACHelper() {
   var port;
 
   // callbacks is a set of arrays containing {successCb, errorCb} pairs,
-  // keyed on the method name, for example, callbacks.getAccounts.
+  // keyed on the method name, for example, callbacks.getAccount.
   var callbacks = {};
   var eventListeners = {};
 
@@ -186,9 +186,9 @@ var FxAccountsIACHelper = function FxAccountsIACHelper() {
     port.postMessage(message);
   };
 
-  var getAccounts = function getAccounts(successCb, errorCb) {
+  var getAccount = function getAccount(successCb, errorCb) {
     sendMessage({
-      'name': 'getAccounts'
+      'name': 'getAccount'
     }, successCb, errorCb);
   };
 
@@ -228,7 +228,7 @@ var FxAccountsIACHelper = function FxAccountsIACHelper() {
 
   return {
     'addEventListener': addEventListener,
-    'getAccounts': getAccounts,
+    'getAccount': getAccount,
     'init': init,
     'logout': logout,
     'openFlow': openFlow,


### PR DESCRIPTION
Gaia is wrongly sending the `getAccounts` method name, where it should be sending `getAccount`. In current Gecko this is worked around with [a dirty hack](https://mxr.mozilla.org/mozilla-central/source/b2g/components/FxAccountsMgmtService.jsm#96), which we will be able to remove once this patch has been in Gaia master long enough.
