### PR TITLE
Bug 1203473 - [Settings] Define AppStorage using new syntax provided by Observable, r=yzen

### DIFF
--- a/apps/settings/js/panels/app_storage/panel.js
+++ b/apps/settings/js/panels/app_storage/panel.js
@@ -15,7 +15,7 @@ define(function(require) {
     var _freeSpaceText = null;
 
     var _updateUsePercentage = function() {
-      _spaceBarElement.value = AppStorage.storage.usedPercentage;
+      _spaceBarElement.value = AppStorage.usedPercentage;
     };
 
     var _refreshText = function(element, size) {
@@ -23,13 +23,13 @@ define(function(require) {
         'storageSize', size);
     };
     var _updateTotalSize = function() {
-      _refreshText(_totalSpaceText, AppStorage.storage.totalSize);
+      _refreshText(_totalSpaceText, AppStorage.totalSize);
     };
     var _updateUsedSize = function() {
-      _refreshText(_usedSpaceText, AppStorage.storage.usedSize);
+      _refreshText(_usedSpaceText, AppStorage.usedSize);
     };
     var _updateFreeSize = function() {
-      _refreshText(_freeSpaceText, AppStorage.storage.freeSize);
+      _refreshText(_freeSpaceText, AppStorage.freeSize);
     };
 
     var _updateElements = function() {
@@ -48,20 +48,20 @@ define(function(require) {
       },
 
       onBeforeShow: function() {
-        AppStorage.storage.observe('usedPercentage', _updateUsePercentage);
-        AppStorage.storage.observe('totalSize', _updateTotalSize);
-        AppStorage.storage.observe('usedSize', _updateUsedSize);
-        AppStorage.storage.observe('freeSize', _updateFreeSize);
+        AppStorage.observe('usedPercentage', _updateUsePercentage);
+        AppStorage.observe('totalSize', _updateTotalSize);
+        AppStorage.observe('usedSize', _updateUsedSize);
+        AppStorage.observe('freeSize', _updateFreeSize);
 
         _updateElements();
         AppStorage.updateInfo();
       },
 
       onHide: function() {
-        AppStorage.storage.unobserve('usedPercentage', _updateUsePercentage);
-        AppStorage.storage.unobserve('totalSize', _updateTotalSize);
-        AppStorage.storage.unobserve('usedSize', _updateUsedSize);
-        AppStorage.storage.unobserve('freeSize', _updateFreeSize);
+        AppStorage.unobserve('usedPercentage', _updateUsePercentage);
+        AppStorage.unobserve('totalSize', _updateTotalSize);
+        AppStorage.unobserve('usedSize', _updateUsedSize);
+        AppStorage.unobserve('freeSize', _updateFreeSize);
       }
     });
   };

--- a/apps/settings/js/panels/root/storage_app_item.js
+++ b/apps/settings/js/panels/root/storage_app_item.js
@@ -41,11 +41,11 @@ define(function(require) {
         this._enabled = value;
       }
       if (value) { //observe
-        AppStorage.storage.observe('freeSize', this._boundUpdateAppFreeSpace);
+        AppStorage.observe('freeSize', this._boundUpdateAppFreeSpace);
         this._updateAppFreeSpace();
         window.addEventListener('localized', this);
       } else { //unobserve
-        AppStorage.storage.unobserve('freeSize', this._boundUpdateAppFreeSpace);
+        AppStorage.unobserve('freeSize', this._boundUpdateAppFreeSpace);
         window.removeEventListener('localized', this);
       }
     },
@@ -53,7 +53,7 @@ define(function(require) {
     // Application Storage
     _updateAppFreeSpace: function storage_updateAppFreeSpace() {
       DeviceStorageHelper.showFormatedSize(this._element,
-        'availableSize', AppStorage.storage.freeSize);
+        'availableSize', AppStorage.freeSize);
     },
 
     handleEvent: function storage_handleEvent(evt) {

--- a/apps/settings/test/unit/modules/app_storage_test.js
+++ b/apps/settings/test/unit/modules/app_storage_test.js
@@ -24,13 +24,6 @@ suite('AppStorage > ', function() {
     realDeviceStorage = null;
   });
 
-  suite('initiation', function() {
-    test('AppStorage is enabled while get the instance',
-      function() {
-        assert.ok(AppStorage.enabled);
-    });
-  });
-
   suite('_getSpaceInfo', function() {
     setup(function() {
       this.sinon.spy(AppStorage._appStorage, 'freeSpace');
@@ -44,14 +37,14 @@ suite('AppStorage > ', function() {
 
         var req = AppStorage._appStorage.freeSpace.getCall(0).returnValue;
         req.fireSuccess(100);
-        assert.equal(100, AppStorage.storage.freeSize);
+        assert.equal(100, AppStorage.freeSize);
 
         assert.ok(AppStorage._appStorage.usedSpace.called);
         var req2 = AppStorage._appStorage.usedSpace.getCall(0).returnValue;
         req2.fireSuccess(300);
-        assert.equal(300, AppStorage.storage.usedSize);
-        assert.equal(400, AppStorage.storage.totalSize);
-        assert.equal(75, AppStorage.storage.usedPercentage);
+        assert.equal(300, AppStorage.usedSize);
+        assert.equal(400, AppStorage.totalSize);
+        assert.equal(75, AppStorage.usedPercentage);
     });
   });
 });

--- a/apps/settings/test/unit/panels/app_storage/panel_test.js
+++ b/apps/settings/test/unit/panels/app_storage/panel_test.js
@@ -26,17 +26,13 @@ suite('AppStoragePanel', function() {
 
     // Define MockAppStorage
     this.MockAppStorage = {
-      isMock: true,
-      enabled: true,
       updateInfo: function () {},
-      storage: {
-        usedPercentage: 1,
-        totalSize: 1,
-        usedSize: 1,
-        freeSize: 1,
-        observe: function() {},
-        unobserve: function() {}
-      }
+      usedPercentage: 1,
+      totalSize: 1,
+      usedSize: 1,
+      freeSize: 1,
+      observe: function() {},
+      unobserve: function() {}
     };
     define('MockAppStorage', function() {
       return that.MockAppStorage;
@@ -62,28 +58,28 @@ suite('AppStoragePanel', function() {
   });
 
   test('observe appStorage when onBeforeShow', function() {
-    this.sinon.stub(this.MockAppStorage.storage, 'observe');
+    this.sinon.stub(this.MockAppStorage, 'observe');
     this.panel.beforeShow();
-    assert.ok(this.MockAppStorage.storage.observe.calledWith(
+    assert.ok(this.MockAppStorage.observe.calledWith(
       sinon.match('usedPercentage')));
-    assert.ok(this.MockAppStorage.storage.observe.calledWith(
+    assert.ok(this.MockAppStorage.observe.calledWith(
       sinon.match('totalSize')));
-    assert.ok(this.MockAppStorage.storage.observe.calledWith(
+    assert.ok(this.MockAppStorage.observe.calledWith(
       sinon.match('usedSize')));
-    assert.ok(this.MockAppStorage.storage.observe.calledWith(
+    assert.ok(this.MockAppStorage.observe.calledWith(
       sinon.match('freeSize')));
   });
 
   test('unobserve appStorage when onHide', function() {
-    this.sinon.stub(this.MockAppStorage.storage, 'unobserve');
+    this.sinon.stub(this.MockAppStorage, 'unobserve');
     this.panel.hide();
-    assert.ok(this.MockAppStorage.storage.unobserve.calledWith(
+    assert.ok(this.MockAppStorage.unobserve.calledWith(
       sinon.match('usedPercentage')));
-    assert.ok(this.MockAppStorage.storage.unobserve.calledWith(
+    assert.ok(this.MockAppStorage.unobserve.calledWith(
       sinon.match('totalSize')));
-    assert.ok(this.MockAppStorage.storage.unobserve.calledWith(
+    assert.ok(this.MockAppStorage.unobserve.calledWith(
       sinon.match('usedSize')));
-    assert.ok(this.MockAppStorage.storage.unobserve.calledWith(
+    assert.ok(this.MockAppStorage.unobserve.calledWith(
       sinon.match('freeSize')));
   });
 });

--- a/apps/settings/test/unit/panels/root/storage_app_item_test.js
+++ b/apps/settings/test/unit/panels/root/storage_app_item_test.js
@@ -13,15 +13,12 @@ suite('AppStorageItem', function() {
     // Define MockAppStorage
     this.MockAppStorage = {
       isMock: true,
-      enabled: true,
-      storage: {
-        usedPercentage: 1,
-        totalSize: 1,
-        usedSize: 1,
-        freeSize: 1,
-        observe: function() {},
-        unobserve: function() {}
-      }
+      usedPercentage: 1,
+      totalSize: 1,
+      usedSize: 1,
+      freeSize: 1,
+      observe: function() {},
+      unobserve: function() {}
     };
 
     var requireCtx = testRequire([], map, function() {});
@@ -40,27 +37,39 @@ suite('AppStorageItem', function() {
   });
 
   test('when enabled = true', function() {
-    this.sinon.stub(this.MockAppStorage.storage, 'observe');
+    this.sinon.stub(this.MockAppStorage, 'observe');
     this.sinon.stub(this.subject, '_updateAppFreeSpace');
     this.sinon.stub(this.subject, '_boundUpdateAppFreeSpace');
     this.subject.enabled = true;
 
     sinon.assert.called(this.subject._updateAppFreeSpace);
-    sinon.assert.calledOnce(this.MockAppStorage.storage.observe);
-    assert.isTrue(this.MockAppStorage.storage.observe.calledWith('freeSize',
+    sinon.assert.calledOnce(this.MockAppStorage.observe);
+    assert.isTrue(this.MockAppStorage.observe.calledWith('freeSize',
       this.subject._boundUpdateAppFreeSpace));
   });
 
   test('when enabled = false', function() {
-    // The default enabled value is false. Set to true first.
-    this.subject._enabled = true;
-    this.sinon.stub(this.MockAppStorage.storage, 'unobserve');
+    this.sinon.stub(this.MockAppStorage, 'unobserve');
     this.sinon.stub(this.subject, '_updateAppFreeSpace');
     this.sinon.stub(this.subject, '_boundUpdateAppFreeSpace');
+    // The default enabled value is false. Set to true first.
+    this.subject._enabled = true;
     this.subject.enabled = false;
 
-    sinon.assert.calledOnce(this.MockAppStorage.storage.unobserve);
-    assert.isTrue(this.MockAppStorage.storage.unobserve.calledWith('freeSize',
+    sinon.assert.calledOnce(this.MockAppStorage.unobserve);
+    assert.isTrue(this.MockAppStorage.unobserve.calledWith('freeSize',
       this.subject._boundUpdateAppFreeSpace));
+  });
+
+  test('when current = false and enabled = false', function() {
+    this.sinon.stub(this.MockAppStorage, 'unobserve');
+    this.sinon.stub(this.subject, '_updateAppFreeSpace');
+    this.sinon.stub(this.subject, '_boundUpdateAppFreeSpace');
+    // set enabled value to false to let the further false set not action.
+    this.subject._enabled = false;
+    this.subject.enabled = false;
+
+    assert.isFalse(this.MockAppStorage.unobserve.called);
+    assert.isFalse(this.MockAppStorage.unobserve.called);
   });
 });


### PR DESCRIPTION
refer https://github.com/mozilla-b2g/gaia/pull/30741 for turning current implementation to read only observable.

The patch turn `this.storage.[observables]` to `this.[observables]` because current observable module does not support define as sub objects. Now we set properties via private like property `this._xxx` and get observable via `this.[observables]`.
