### PR TITLE
Bug 1200401 - Handle the "onsuspend" event on the video like an error.

### DIFF
--- a/apps/video/js/metadata.js
+++ b/apps/video/js/metadata.js
@@ -186,7 +186,7 @@ function getMetadata(videofile, callback) {
   offscreenVideo.preload = 'metadata';
   offscreenVideo.src = url;
 
-  offscreenVideo.onerror = function(e) {
+  offscreenVideo.onerror = offscreenVideo.onsuspend = function(e) {
     // Something went wrong. Maybe the file was corrupt?
     console.error('Can\'t play video', videofile.name, e);
     metadata.isVideo = false;


### PR DESCRIPTION
But this causes the video app to _crash_ (Gecko)
