### PR TITLE
Bug 1205159 - Remove toolbars.css in html_transformer app and instead use icons.css

### DIFF
--- a/tools/html_transformer/test/fixtures/basic.html
+++ b/tools/html_transformer/test/fixtures/basic.html
@@ -5,7 +5,7 @@
 <body>
   <!-- hello -->
   <p>A really great thing to say</p>
-  <link rel="stylesheet" type="text/css" href="/shared/style/toolbars.css">
+  <link rel="stylesheet" type="text/css" href="/shared/style/icons.css">
   <link rel="stylesheet" type="text/css" href="app://theme.gaiamobile.org/shared/elements/gaia-theme/style.css">
   <script defer src="shared/js/component_utils.js"></script>
   <script defer src="shared/elements/gaia_subheader/script.js"></script>

--- a/tools/html_transformer/test/html_transformer_test.js
+++ b/tools/html_transformer/test/html_transformer_test.js
@@ -26,7 +26,7 @@ suite('htmlTransformer', function() {
       .to
       .deep
       .equal([
-        'shared/style/toolbars.css',
+        'shared/style/icons.css',
         'shared/elements/gaia-theme/style.css',
         'shared/js/component_utils.js',
         'shared/elements/gaia_subheader/script.js',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1205159
