### PR TITLE
Bug 1205609 - [v2.5][Gaia::UI Tests]test_settings_passcode.py:"AttributeError: 

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/screen_lock.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/screen_lock.py
@@ -57,4 +57,4 @@ class ScreenLock(PageRegion):
             *self._screen_lock_passcode_section_locator))
         self.marionette.find_element(*self._passcode_create_locator).tap()
         Wait(self.marionette).until(expected.element_displayed(
-            *self._screen_lock_section_locator))
+            *self._root_locator))


### PR DESCRIPTION
…uteError: 'ScreenLock' object has no attribute '_screen_lock_section_locator'
