### PR TITLE
Bug 1204002 - View source cannot find file in calendar app r=jrburke

### DIFF
--- a/apps/calendar/js/ext/page.js
+++ b/apps/calendar/js/ext/page.js
@@ -1,5 +1,24 @@
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.page=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+  /* globals require, module */
 
-;(function(){
+/**
+   * Module dependencies.
+   */
+
+  var pathtoRegexp = require('path-to-regexp');
+
+  /**
+   * Module exports.
+   */
+
+  module.exports = page;
+
+  /**
+   * To work properly with the URL
+   * history.location generated polyfill in https://github.com/devote/HTML5-History-API
+   */
+
+  var location = window.history.location || window.location;
 
   /**
    * Perform initial dispatch.
@@ -20,6 +39,12 @@
   var running;
 
   /**
+  * HashBang option
+  */
+
+  var hashbang = false;
+
+  /**
    * Register `path` with callback `fn()`,
    * or route `path`, or `page.start()`.
    *
@@ -37,19 +62,21 @@
 
   function page(path, fn) {
     // <callback>
-    if ('function' == typeof path) {
+    if ('function' === typeof path) {
       return page('*', path);
     }
 
     // route <path> to <callback ...>
-    if ('function' == typeof fn) {
+    if ('function' === typeof fn) {
       var route = new Route(path);
       for (var i = 1; i < arguments.length; ++i) {
         page.callbacks.push(route.middleware(arguments[i]));
       }
     // show <path> with [state]
     } else if ('string' == typeof path) {
-      page.show(path, fn);
+      'string' === typeof fn
+        ? page.redirect(path, fn)
+        : page.show(path, fn);
     // start [options]
     } else {
       page.start(path);
@@ -70,7 +97,7 @@
    */
 
   page.base = function(path){
-    if (0 == arguments.length) return base;
+    if (0 === arguments.length) return base;
     base = path;
   };
 
@@ -94,8 +121,12 @@
     if (false === options.dispatch) dispatch = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
     if (false !== options.click) window.addEventListener('click', onclick, false);
+    if (true === options.hashbang) hashbang = true;
     if (!dispatch) return;
-    page.replace(location.pathname + location.search, null, true, dispatch);
+    var url = (hashbang && ~location.hash.indexOf('#!'))
+      ? location.hash.substr(2) + location.search
+      : location.pathname + location.search + location.hash;
+    page.replace(url, null, true, dispatch);
   };
 
   /**
@@ -105,9 +136,10 @@
    */
 
   page.stop = function(){
+    if (!running) return;
     running = false;
-    removeEventListener('click', onclick, false);
-    removeEventListener('popstate', onpopstate, false);
+    window.removeEventListener('click', onclick, false);
+    window.removeEventListener('popstate', onpopstate, false);
   };
 
   /**
@@ -115,15 +147,31 @@
    *
    * @param {String} path
    * @param {Object} state
+   * @param {Boolean} dispatch
    * @return {Context}
    * @api public
    */
 
-  page.show = function(path, state){
+  page.show = function(path, state, dispatch){
     var ctx = new Context(path, state);
-    page.dispatch(ctx);
-    if (!ctx.unhandled) ctx.pushState();
+    if (false !== dispatch) page.dispatch(ctx);
+    if (false !== ctx.handled) ctx.pushState();
     return ctx;
+  };
+
+  /**
+   * Show `path` with optional `state` object.
+   *
+   * @param {String} from
+   * @param {String} to
+   * @api public
+   */
+  page.redirect = function(from, to) {
+    page(from, function (e) {
+      setTimeout(function() {
+        page.replace(to);
+      });
+    });
   };
 
   /**
@@ -138,9 +186,8 @@
   page.replace = function(path, state, init, dispatch){
     var ctx = new Context(path, state);
     ctx.init = init;
-    if (null == dispatch) dispatch = true;
-    if (dispatch) page.dispatch(ctx);
-    ctx.save();
+    ctx.save(); // save before dispatching, which may redirect
+    if (false !== dispatch) page.dispatch(ctx);
     return ctx;
   };
 
@@ -173,10 +220,19 @@
    */
 
   function unhandled(ctx) {
-    if (window.location.pathname + window.location.search == ctx.canonicalPath) return;
+    if (ctx.handled) return;
+    var current;
+
+    if (hashbang) {
+      current = base + location.hash.replace('#!','');
+    } else {
+      current = location.pathname + location.search;
+    }
+
+    if (current === ctx.canonicalPath) return;
     page.stop();
-    ctx.unhandled = true;
-    window.location = ctx.canonicalPath;
+    ctx.handled = false;
+    location.href = ctx.canonicalPath;
   }
 
   /**
@@ -189,16 +245,30 @@
    */
 
   function Context(path, state) {
-    if ('/' == path[0] && 0 != path.indexOf(base)) path = base + path;
+    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + path;
     var i = path.indexOf('?');
+
     this.canonicalPath = path;
     this.path = path.replace(base, '') || '/';
+
     this.title = document.title;
     this.state = state || {};
     this.state.path = path;
-    this.querystring = ~i ? path.slice(i + 1) : '';
-    this.pathname = ~i ? path.slice(0, i) : path;
+    this.querystring = ~i
+      ? path.slice(i + 1)
+      : '';
+    this.pathname = ~i
+      ? path.slice(0, i)
+      : path;
     this.params = [];
+
+    // fragment
+    this.hash = '';
+    if (!~this.path.indexOf('#')) return;
+    var parts = this.path.split('#');
+    this.path = parts[0];
+    this.hash = parts[1] || '';
+    this.querystring = this.querystring.split('#')[0];
   }
 
   /**
@@ -214,7 +284,11 @@
    */
 
   Context.prototype.pushState = function(){
-    history.pushState(this.state, this.title, this.canonicalPath);
+    history.pushState(this.state
+      , this.title
+      , hashbang && this.path !== '/'
+        ? '#!' + this.path
+        : this.canonicalPath);
   };
 
   /**
@@ -224,7 +298,11 @@
    */
 
   Context.prototype.save = function(){
-    history.replaceState(this.state, this.title, this.canonicalPath);
+    history.replaceState(this.state
+      , this.title
+      , hashbang && this.path !== '/'
+        ? '#!' + this.path
+        : this.canonicalPath);
   };
 
   /**
@@ -243,12 +321,12 @@
 
   function Route(path, options) {
     options = options || {};
-    this.path = path;
+    this.path = (path === '*') ? '(.*)' : path;
     this.method = 'GET';
-    this.regexp = pathtoRegexp(path
-      , this.keys = []
-      , options.sensitive
-      , options.strict);
+    this.regexp = pathtoRegexp(this.path,
+      this.keys = [],
+      options.sensitive,
+      options.strict);
   }
 
   /**
@@ -271,7 +349,7 @@
     return function(ctx, next){
       if (self.match(ctx.path, ctx.params)) return fn(ctx, next);
       next();
-    }
+    };
   };
 
   /**
@@ -285,17 +363,19 @@
    */
 
   Route.prototype.match = function(path, params){
-    var keys = this.keys
-      , qsIndex = path.indexOf('?')
-      , pathname = ~qsIndex ? path.slice(0, qsIndex) : path
-      , m = this.regexp.exec(pathname);
-  
+    var keys = this.keys,
+        qsIndex = path.indexOf('?'),
+        pathname = ~qsIndex
+          ? path.slice(0, qsIndex)
+          : path,
+        m = this.regexp.exec(decodeURIComponent(pathname));
+
     if (!m) return false;
 
     for (var i = 1, len = m.length; i < len; ++i) {
       var key = keys[i - 1];
 
-      var val = 'string' == typeof m[i]
+      var val = 'string' === typeof m[i]
         ? decodeURIComponent(m[i])
         : m[i];
 
@@ -309,46 +389,6 @@
     }
 
     return true;
-  };
-
-  /**
-   * Normalize the given path string,
-   * returning a regular expression.
-   *
-   * An empty array should be passed,
-   * which will contain the placeholder
-   * key names. For example "/user/:id" will
-   * then contain ["id"].
-   *
-   * @param  {String|RegExp|Array} path
-   * @param  {Array} keys
-   * @param  {Boolean} sensitive
-   * @param  {Boolean} strict
-   * @return {RegExp}
-   * @api private
-   */
-
-  function pathtoRegexp(path, keys, sensitive, strict) {
-    if (path instanceof RegExp) return path;
-    if (path instanceof Array) path = '(' + path.join('|') + ')';
-    path = path
-      .concat(strict ? '' : '/?')
-      .replace(/\/\(/g, '(?:/')
-      .replace(/\+/g, '__plus__')
-      .replace(/(\/)?(\.)?:(\w+)(?:(\(.*?\)))?(\?)?/g, function(_, slash, format, key, capture, optional){
-        keys.push({ name: key, optional: !! optional });
-        slash = slash || '';
-        return ''
-          + (optional ? '' : slash)
-          + '(?:'
-          + (optional ? slash : '')
-          + (format || '') + (capture || (format && '([^/.]+?)' || '([^/]+?)')) + ')'
-          + (optional || '');
-      })
-      .replace(/([\/.])/g, '\\$1')
-      .replace(/__plus__/g, '(.+)')
-      .replace(/\*/g, '(.*)');
-    return new RegExp('^' + path + '$', sensitive ? '' : 'i');
   };
 
   /**
@@ -368,17 +408,37 @@
 
   function onclick(e) {
     if (1 != which(e)) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey) return;
     if (e.defaultPrevented) return;
+
+    // ensure link
     var el = e.target;
     while (el && 'A' != el.nodeName) el = el.parentNode;
     if (!el || 'A' != el.nodeName) return;
-    var href = el.href;
-    var path = el.pathname + el.search;
-    if (el.hash || '#' == el.getAttribute('href')) return;
-    if (!sameOrigin(href)) return;
+
+    // ensure non-hash for the same path
+    var link = el.getAttribute('href');
+    if (el.pathname === location.pathname && (el.hash || '#' === link)) return;
+
+    // Check for mailto: in the href
+    if (link && link.indexOf("mailto:") > -1) return;
+
+    // check target
+    if (el.target) return;
+
+    // x-origin
+    if (!sameOrigin(el.href)) return;
+
+    // rebuild path
+    var path = el.pathname + el.search + (el.hash || '');
+
+    // same page
     var orig = path;
+
     path = path.replace(base, '');
-    if (base && orig == path) return;
+
+    if (base && orig === path) return;
+
     e.preventDefault();
     page.show(orig);
   }
@@ -389,7 +449,7 @@
 
   function which(e) {
     e = e || window.event;
-    return null == e.which
+    return null === e.which
       ? e.button
       : e.which;
   }
@@ -401,17 +461,179 @@
   function sameOrigin(href) {
     var origin = location.protocol + '//' + location.hostname;
     if (location.port) origin += ':' + location.port;
-    return 0 == href.indexOf(origin);
+    return (href && (0 === href.indexOf(origin)));
   }
 
-  /**
-   * Expose `page`.
-   */
+  page.sameOrigin = sameOrigin;
 
-  if ('undefined' == typeof module) {
-    window.page = page;
-  } else {
-    module.exports = page;
+},{"path-to-regexp":2}],2:[function(require,module,exports){
+/**
+ * Expose `pathtoRegexp`.
+ */
+module.exports = pathtoRegexp;
+
+/**
+ * The main path matching regexp utility.
+ *
+ * @type {RegExp}
+ */
+var PATH_REGEXP = new RegExp([
+  // Match already escaped characters that would otherwise incorrectly appear
+  // in future matches. This allows the user to escape special characters that
+  // shouldn't be transformed.
+  '(\\\\.)',
+  // Match Express-style parameters and un-named parameters with a prefix
+  // and optional suffixes. Matches appear as:
+  //
+  // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?"]
+  // "/route(\\d+)" => [undefined, undefined, undefined, "\d+", undefined]
+  '([\\/.])?(?:\\:(\\w+)(?:\\(((?:\\\\.|[^)])*)\\))?|\\(((?:\\\\.|[^)])*)\\))([+*?])?',
+  // Match regexp special characters that should always be escaped.
+  '([.+*?=^!:${}()[\\]|\\/])'
+].join('|'), 'g');
+
+/**
+ * Escape the capturing group by escaping special characters and meaning.
+ *
+ * @param  {String} group
+ * @return {String}
+ */
+function escapeGroup (group) {
+  return group.replace(/([=!:$\/()])/g, '\\$1');
+}
+
+/**
+ * Attach the keys as a property of the regexp.
+ *
+ * @param  {RegExp} re
+ * @param  {Array}  keys
+ * @return {RegExp}
+ */
+var attachKeys = function (re, keys) {
+  re.keys = keys;
+
+  return re;
+};
+
+/**
+ * Normalize the given path string, returning a regular expression.
+ *
+ * An empty array should be passed in, which will contain the placeholder key
+ * names. For example `/user/:id` will then contain `["id"]`.
+ *
+ * @param  {(String|RegExp|Array)} path
+ * @param  {Array}                 keys
+ * @param  {Object}                options
+ * @return {RegExp}
+ */
+function pathtoRegexp (path, keys, options) {
+  if (keys && !Array.isArray(keys)) {
+    options = keys;
+    keys = null;
   }
 
-})();
+  keys = keys || [];
+  options = options || {};
+
+  var strict = options.strict;
+  var end = options.end !== false;
+  var flags = options.sensitive ? '' : 'i';
+  var index = 0;
+
+  if (path instanceof RegExp) {
+    // Match all capturing groups of a regexp.
+    var groups = path.source.match(/\((?!\?)/g) || [];
+
+    // Map all the matches to their numeric keys and push into the keys.
+    keys.push.apply(keys, groups.map(function (match, index) {
+      return {
+        name:      index,
+        delimiter: null,
+        optional:  false,
+        repeat:    false
+      };
+    }));
+
+    // Return the source back to the user.
+    return attachKeys(path, keys);
+  }
+
+  if (Array.isArray(path)) {
+    // Map array parts into regexps and return their source. We also pass
+    // the same keys and options instance into every generation to get
+    // consistent matching groups before we join the sources together.
+    path = path.map(function (value) {
+      return pathtoRegexp(value, keys, options).source;
+    });
+
+    // Generate a new regexp instance by joining all the parts together.
+    return attachKeys(new RegExp('(?:' + path.join('|') + ')', flags), keys);
+  }
+
+  // Alter the path string into a usable regexp.
+  path = path.replace(PATH_REGEXP, function (match, escaped, prefix, key, capture, group, suffix, escape) {
+    // Avoiding re-escaping escaped characters.
+    if (escaped) {
+      return escaped;
+    }
+
+    // Escape regexp special characters.
+    if (escape) {
+      return '\\' + escape;
+    }
+
+    var repeat   = suffix === '+' || suffix === '*';
+    var optional = suffix === '?' || suffix === '*';
+
+    keys.push({
+      name:      key || index++,
+      delimiter: prefix || '/',
+      optional:  optional,
+      repeat:    repeat
+    });
+
+    // Escape the prefix character.
+    prefix = prefix ? '\\' + prefix : '';
+
+    // Match using the custom capturing group, or fallback to capturing
+    // everything up to the next slash (or next period if the param was
+    // prefixed with a period).
+    capture = escapeGroup(capture || group || '[^' + (prefix || '\\/') + ']+?');
+
+    // Allow parameters to be repeated more than once.
+    if (repeat) {
+      capture = capture + '(?:' + prefix + capture + ')*';
+    }
+
+    // Allow a parameter to be optional.
+    if (optional) {
+      return '(?:' + prefix + '(' + capture + '))?';
+    }
+
+    // Basic parameter support.
+    return prefix + '(' + capture + ')';
+  });
+
+  // Check whether the path ends in a slash as it alters some match behaviour.
+  var endsWithSlash = path[path.length - 1] === '/';
+
+  // In non-strict mode we allow an optional trailing slash in the match. If
+  // the path to match already ended with a slash, we need to remove it for
+  // consistency. The slash is only valid at the very end of a path match, not
+  // anywhere in the middle. This is important for non-ending mode, otherwise
+  // "/test/" will match "/test//route".
+  if (!strict) {
+    path = (endsWithSlash ? path.slice(0, -2) : path) + '(?:\\/(?=$))?';
+  }
+
+  // In non-ending mode, we need prompt the capturing groups to match as much
+  // as possible by using a positive lookahead for the end or next path segment.
+  if (!end) {
+    path += strict && endsWithSlash ? '' : '(?=\\/|$)';
+  }
+
+  return attachKeys(new RegExp('^' + path + (end ? '$' : ''), flags), keys);
+};
+
+},{}]},{},[1])(1)
+});

--- a/apps/calendar/js/router.js
+++ b/apps/calendar/js/router.js
@@ -12,6 +12,7 @@ function Router() {
   var len = COPY_METHODS.length;
 
   this.page = page;
+  this.page({ hashbang: true });
   this._activeObjects = [];
 
   for (; i < len; i++) {

--- a/apps/calendar/package.json
+++ b/apps/calendar/package.json
@@ -9,7 +9,7 @@
       "curl": "github:cujojs/curl/0.8.12#src/curl.js",
       "eventemitter2": "github:asyncly/EventEmitter2/0.4.14#lib/eventemitter2.js",
       "ical": "github:mozilla-comm/ical.js/v0.0.2#build/ical.js",
-      "page": "github:visionmedia/page.js/1.3.2#index.js",
+      "page": "github:visionmedia/page.js/1.4.1#page.js",
       "threads": "github:gaia-components/threads/master#threads.js",
       "uuid": "github:broofa/node-uuid/v1.4.1"
     }


### PR DESCRIPTION
So the issue was that calendar was using fake urls like `/month/` and `/event/add` in concert with this page.js library. With page.js, you create a bunch of "routes" that say stuff like when you notice that the url is `/month/`, call this function. Prior to page.js version 1.3, hashes (fragment ids) weren't supported. As of 1.4, there's this neat option called `hashbang` that you can set on page.js that makes it so that
1. All anchor elements with href='/xyz' go to `/#!/xyz` instead of `/xyz`.
2. Any time you tell the page.js router to navigate to `/xyz` it will navigate to `/#!/xyz` instead.

This seems to make all of the navigation happen correctly in the url fragment so that we're still always at `index.html` and view source can map back to an actual "server route".
