### PR TITLE
Bug 1206113 - Imagecompare: Time Format cannot be selected unless Use Default is turned off 

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/date_and_time.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/date_and_time.py
@@ -7,12 +7,14 @@ from datetime import datetime
 from marionette_driver import expected, By, Wait
 
 from gaiatest.apps.base import Base
+from gaiatest.form_controls.binarycontrol import GaiaBinaryControl
 
 
 class DateAndTime(Base):
 
     _page_locator = (By.ID, 'dateTime')
-    _24h_selector_locator = (By.CSS_SELECTOR, 'select.time-format-time')
+    _use_default_switch_locator = (By.CSS_SELECTOR, '#dateTime .time-format-auto gaia-switch')
+    _24h_selector_locator = (By.CSS_SELECTOR, '.timeformat .button')
     _autotime_enabled_locator = (By.CSS_SELECTOR, '.time-auto')
     _autotime_enabled_switch_locator = (By.CSS_SELECTOR, '.time-auto label')
     _time_value = (By.CSS_SELECTOR, '.clock-time')
@@ -25,16 +27,27 @@ class DateAndTime(Base):
 
     def __init__(self, marionette):
         Base.__init__(self, marionette)
-
         Wait(self.marionette).until(expected.element_displayed(
             Wait(self.marionette).until(
                 expected.element_present(*self._24h_selector_locator))))
+
+    @property
+    def _default_format_switch(self):
+        return GaiaBinaryControl(self.marionette, self._use_default_switch_locator)
+
+    def enable_default_format(self):
+        self._default_format_switch.enable()
+
+    def disable_default_format(self):
+        self._default_format_switch.disable()
+        Wait(self.marionette).until(
+            expected.element_enabled(self.marionette.find_element(*self._24h_selector_locator)))
 
     def open_time_format(self):
         self.marionette.find_element(*self._24h_selector_locator).tap()
         self.marionette.switch_to_frame()
         Wait(self.marionette).until(
-            expected.element_present(*self._time_format_confirm_button_locator))
+            expected.element_enabled(self.marionette.find_element(*self._time_format_confirm_button_locator)))
 
     def close_time_format(self):
         self.marionette.find_element(*self._time_format_confirm_button_locator).tap()

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/RTL/test_settings_personalization_RTL.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/RTL/test_settings_personalization_RTL.py
@@ -100,6 +100,7 @@ class TestSettingsRTLPersonalization(GaiaImageCompareTestCase):
         GaiaImageCompareTestCase.scroll(self.marionette, 'down', date_time_page.screen_element.size['height'],
                                         screen=date_time_page.screen_element)
         self.take_screenshot('date_and_time')
+        date_time_page.disable_default_format()
         date_time_page.open_time_format()
         self.take_screenshot('date_and_time-time_format')
         date_time_page.close_time_format()


### PR DESCRIPTION
… Default is turned off
