### PR TITLE
Bug 1204432 - LazyLoader for SyncEngine, r=ferjm

### DIFF
--- a/apps/sync/index.html
+++ b/apps/sync/index.html
@@ -14,4 +14,6 @@
        are still in development.
      </p>
   </body>
+  <script src="shared/js/lazy_loader.js"></script>
+  <script src="js/bootstrap.js"></script>
 </html>

--- a/apps/sync/test/unit/adapters/history_test.js
+++ b/apps/sync/test/unit/adapters/history_test.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/bootstrap_test.js
+++ b/apps/sync/test/unit/bootstrap_test.js
@@ -1,0 +1,203 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+
+'use strict';
+
+/* global
+  Bootstrap,
+  BootstrapFixture,
+  DataAdapters,
+  ERROR_SYNC_APP_SYNC_IN_PROGRESS,
+  ERROR_SYNC_INVALID_REQUEST_OPTIONS,
+  expect,
+  MockLazyLoader,
+  MockSyncEngine,
+  require,
+  requireApp,
+  setup,
+  suite,
+  test
+*/
+
+
+require('/shared/js/sync/errors.js');
+requireApp('sync/test/unit/fixtures/bootstrap.js');
+requireApp('sync/test/unit/improved_mock_lazy_loader.js');
+requireApp('sync/js/bootstrap.js');
+requireApp('sync/test/unit/sync-engine-mock.js');
+
+suite('Bootstrap', function() {
+  this.timeout(100);
+  suite('when script is loaded', () => {
+    test('DataAdapters global is exposed', function() {
+      expect(DataAdapters).to.be.an('object');
+    });
+  });
+
+  suite('Bootstrap.handleSyncRequest', function() {
+    setup(function() {
+      window.LazyLoader = MockLazyLoader;
+      window.SyncEngine = MockSyncEngine;
+    });
+
+    function run(shouldFail = false) {
+      MockSyncEngine.shouldFail = shouldFail;
+      return Bootstrap.handleSyncRequest({
+        assertion: 'test-assertion',
+        keys: { kA: 'test-kA', kB: 'test-kB' },
+        collections: {
+          'test-collection': {}
+        },
+        URL: 'test-URL'
+      });
+    }
+
+    function buildRequest() {
+      return {
+        URL: 'is a string',
+        assertion: 'is a string',
+        keys: {
+          kA: 'is a string',
+          kB: 'is a string'
+        },
+        collections: {
+          foo: {}
+        }
+      };
+    }
+
+    test('checks request is an object', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      expect(Bootstrap.handleSyncRequest()).to.be
+          .rejectedWith(ERROR_SYNC_INVALID_REQUEST_OPTIONS)
+          .and.notify(function(err) {
+            expect(spy.args[0][0]).to.equal('shared/js/sync/errors.js');
+            done(err);
+          });
+    });
+
+    test('checks request.URL is a string', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      var request = buildRequest();
+      delete request.URL;
+      expect(Bootstrap.handleSyncRequest()).to.be
+          .rejectedWith(ERROR_SYNC_INVALID_REQUEST_OPTIONS)
+          .and.notify(function(err) {
+            expect(spy.args[0][0]).to.equal('shared/js/sync/errors.js');
+            done(err);
+          });
+    });
+
+    test('checks request.assertion is a string', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      var request = buildRequest();
+      delete request.assertion;
+      expect(Bootstrap.handleSyncRequest()).to.be
+          .rejectedWith(ERROR_SYNC_INVALID_REQUEST_OPTIONS)
+          .and.notify(function(err) {
+            expect(spy.args[0][0]).to.equal('shared/js/sync/errors.js');
+            done(err);
+          });
+    });
+
+    test('checks request.keys.kB is a string', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      var request = buildRequest();
+      delete request.keys.kB;
+      expect(Bootstrap.handleSyncRequest()).to.be
+          .rejectedWith(ERROR_SYNC_INVALID_REQUEST_OPTIONS)
+          .and.notify(function(err) {
+            expect(spy.args[0][0]).to.equal('shared/js/sync/errors.js');
+            done(err);
+          });
+    });
+
+    test('checks request.collections is an object (not Array)', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      var request = buildRequest();
+      request.collections = [ 'foo' ];
+      expect(Bootstrap.handleSyncRequest()).to.be
+          .rejectedWith(ERROR_SYNC_INVALID_REQUEST_OPTIONS)
+          .and.notify(function(err) {
+            expect(spy.args[0][0]).to.equal('shared/js/sync/errors.js');
+            done(err);
+          });
+    });
+
+    test('loads main scripts', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      run().then(function() {
+        expect(spy.args[0][0]).to.deep.equal(BootstrapFixture.mainScripts);
+        done();
+      });
+    });
+
+    test('loads DataAdapter scripts', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      run().then(function() {
+        expect(spy.args[1][0]).to.deep.equal('js/adapters/test-collection.js');
+        done();
+      });
+    });
+
+    test('constructs SyncEngine', function(done) {
+      run().then(() => {
+        expect(MockSyncEngine.constructorOptions).to.deep.equal({
+          kB: 'test-kB',
+          URL: 'test-URL',
+          assertion: 'test-assertion',
+          adapters: DataAdapters
+        });
+        done();
+      });
+    });
+
+    test('calls SyncEngine#syncNow', function(done) {
+      run().then(() => {
+        expect(MockSyncEngine.syncOptions).to.deep.equal({
+          'test-collection': {}
+        });
+        done();
+      });
+    });
+
+    test('will report failures', function(done) {
+      expect(run(true)).to.be.rejectedWith('mock sync failure')
+          .and.notify(done);
+    });
+
+    test('will run only once at a time', function(done) {
+      var spy = this.sinon.spy(MockLazyLoader, 'load');
+      var firstSucceeded = false;
+      var secondFailed = false;
+      run().then(() => {
+        firstSucceeded = true;
+        if (secondFailed) {
+          done();
+        }
+      });
+      run().catch(err => {
+        expect(spy.withArgs('shared/js/sync/errors.js').called).to.equal(true);
+        expect(err.message).to.equal(ERROR_SYNC_APP_SYNC_IN_PROGRESS);
+        secondFailed = true;
+        if (firstSucceeded) {
+          done();
+        }
+      });
+    });
+
+    test('will run again after success', function(done) {
+      run().then(() => {
+        expect(run()).to.eventually.equal(undefined).and.notify(done);
+      });
+    });
+
+    test('will run again after failure', function(done) {
+      run(true).catch(err => {
+        expect(err.message).to.equal('mock sync failure');
+        return run();
+      }).then(done);
+    });
+  });
+});

--- a/apps/sync/test/unit/crypto/fxsyncwebcrypto_test.js
+++ b/apps/sync/test/unit/crypto/fxsyncwebcrypto_test.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/crypto/keyderivation_test.js
+++ b/apps/sync/test/unit/crypto/keyderivation_test.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/crypto/stringconversion_test.js
+++ b/apps/sync/test/unit/crypto/stringconversion_test.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/fixtures/bootstrap.js
+++ b/apps/sync/test/unit/fixtures/bootstrap.js
@@ -1,0 +1,19 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+
+/* exported
+  BootstrapFixture
+*/
+
+var BootstrapFixture = {
+  mainScripts: [
+      'js/crypto/stringconversion.js',
+      'js/crypto/keyderivation.js',
+      'js/crypto/fxsyncwebcrypto.js',
+
+      'js/ext/kinto.dev.js',
+      'js/sync-engine/syncengine.js'
+  ]
+};

--- a/apps/sync/test/unit/fixtures/fxsyncwebcrypto.js
+++ b/apps/sync/test/unit/fixtures/fxsyncwebcrypto.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/fixtures/synctoserver.js
+++ b/apps/sync/test/unit/fixtures/synctoserver.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/improved_mock_lazy_loader.js
+++ b/apps/sync/test/unit/improved_mock_lazy_loader.js
@@ -1,0 +1,22 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+ 'use strict';
+/* exported MockLazyLoader */
+
+// We need this until https://bugzilla.mozilla.org/show_bug.cgi?id=1181687 is
+// fixed.
+
+var MockLazyLoader = {
+  load: function(fileArray, callback) {
+    if (callback) {
+      callback();
+    } else {
+      return Promise.resolve();
+    }
+  },
+
+  getJSON: function(file) {
+    return Promise.resolve({});
+  }
+};

--- a/apps/sync/test/unit/sync-engine-mock.js
+++ b/apps/sync/test/unit/sync-engine-mock.js
@@ -1,0 +1,26 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+
+/* exported
+  MockSyncEngine
+*/
+
+const MockSyncEngine = (() => {
+  var MockSyncEngine = function(options) {
+      MockSyncEngine.constructorOptions = options;
+  };
+  MockSyncEngine.prototype = {
+    syncNow: function(options) {
+      MockSyncEngine.syncOptions = options;
+      if (MockSyncEngine.shouldFail) {
+        return Promise.reject(new Error('mock sync failure'));
+      } else {
+        return Promise.resolve();
+      }
+    }
+  };
+  MockSyncEngine.shouldFail = false;
+  return MockSyncEngine;
+})();

--- a/apps/sync/test/unit/sync-engine/fxsyncwebcrypto-mock.js
+++ b/apps/sync/test/unit/sync-engine/fxsyncwebcrypto-mock.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/sync-engine/kinto-mock.js
+++ b/apps/sync/test/unit/sync-engine/kinto-mock.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/apps/sync/test/unit/sync-engine/syncengine_test.js
+++ b/apps/sync/test/unit/sync-engine/syncengine_test.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 'use strict';
 

--- a/shared/js/sync/errors.js
+++ b/shared/js/sync/errors.js
@@ -17,6 +17,8 @@
     ERROR_REQUEST_SYNC_REGISTRATION: 'sync-error-request-sync-registration',
     // Cannot get Firefox Accounts assertion.
     ERROR_GET_FXA_ASSERTION: 'sync-error-get-fxa-assertion',
+    // The request options passed to the Sync app failed basic DataType checks.
+    ERROR_SYNC_INVALID_REQUEST_OPTIONS: 'sync-error-invalid-request-options',
     // Cannot perform sync request.
     ERROR_SYNC_REQUEST: 'sync-error-request-failed'
   };
@@ -24,6 +26,8 @@
   var recoverableErrors = {
     // The app was killed while performing a sync operation.
     ERROR_SYNC_APP_KILLED: 'sync-error-app-killed',
+    // The app is already performing a sync request.
+    ERROR_SYNC_APP_SYNC_IN_PROGRESS: 'sync-error-app-sync-in-progress',
     // Error while trying to sync.
     ERROR_SYNC_APP_GENERIC: 'sync-error-app-generic',
     // The user is logged in with an unverified account.


### PR DESCRIPTION
I could do `SyncEngineMock.calledWith` and `SyncEngineMock.shouldFail` in a nice Sinon way, but as it's working this way and it's simple enough, I was hoping maybe we can make that a follow-up bug.

I added a comment (line 33 of apps/sync/js/launcher.js) to reference https://bugzilla.mozilla.org/show_bug.cgi?id=1206615 about adding Kinto.js, but wanted to land this first, since it's nicer to wait for Kinto.js 1.0 next week before we add that.
