### PR TITLE
Bug 1202967 - Screen will be freezed if you launch camera by pressing HW camera key in Recent View

### DIFF
--- a/apps/system/js/hierarchy_manager.js
+++ b/apps/system/js/hierarchy_manager.js
@@ -19,7 +19,8 @@
     'launchactivity',
     'mozChromeEvent',
     'windowopened',
-    'windowclosed'
+    'windowclosed',
+    'cardviewclosed'
   ];
   BaseModule.create(HierarchyManager, {
     name: 'HierarchyManager',
@@ -158,6 +159,7 @@
       switch (evt.type) {
         case 'windowopened':
         case 'windowclosed':
+        case 'cardviewclosed':
           this.updateTopMostWindow();
           break;
         case 'mozChromeEvent':

--- a/apps/system/test/unit/hierarchy_manager_test.js
+++ b/apps/system/test/unit/hierarchy_manager_test.js
@@ -88,15 +88,24 @@ suite('system/HierarchyManager', function() {
   });
 
   suite('Update top most window', function() {
-    test('should update top most window when window is opened', function() {
+    setup(function() {
       this.sinon.stub(subject, 'publish');
       this.sinon.stub(subject, 'getTopMostWindow').returns(new MockAppWindow());
+    });
+
+    test('should update top most window when window is opened', function() {
       window.dispatchEvent(new CustomEvent('windowopened'));
       assert.isTrue(subject.publish.calledWith('topmostwindowchanged'));
-      var oldTop = subject.getTopMostWindow();
-      subject.getTopMostWindow.returns(oldTop);
-      window.dispatchEvent(new CustomEvent('windowopened'));
-      assert.isTrue(subject.publish.calledOnce);
+    });
+
+    test('should update top most window when window is closed', function() {
+      window.dispatchEvent(new CustomEvent('windowclosed'));
+      assert.isTrue(subject.publish.calledWith('topmostwindowchanged'));
+    });
+
+    test('should update top most window when card view is closed', function() {
+      window.dispatchEvent(new CustomEvent('cardviewclosed'));
+      assert.isTrue(subject.publish.calledWith('topmostwindowchanged'));
     });
   });
 


### PR DESCRIPTION
- fixed by forcing HierarchyManager to update top most window after TaskManager is closed
