### PR TITLE
Bug 819304 - "Clear all" button should have a hit state

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -122,6 +122,7 @@
 
 #notification-bar {
   height: 4.5rem;
+  padding: 0 0 0 1.5rem;
 }
 
 #notification-bar [data-icon] {
@@ -148,13 +149,18 @@
   flex: initial;
   width: auto;
   height: 4.5rem;
-  padding: 0;
+  padding: 0 1.5rem;
   border: 0;
-  background: none;
+  border-radius: 0;
   color: #008eab;
+  background: none;
   font: italic normal 1.3rem/1.3rem auto;
 }
 
+#notification-bar button:active {
+  background-color: #00caf2;
+  color: #000000;
+}
 #notification-bar button[disabled] {
   color: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
The Clear all button on the notification tray now has a hit state. If the action is carried out then the color of background changes from #00caf2 to transparent.
