### PR TITLE
Bug 1209275 - Wrong date & time displayed when user adds new event r=…

### DIFF
--- a/apps/calendar/js/views/modify_event.js
+++ b/apps/calendar/js/views/modify_event.js
@@ -441,7 +441,11 @@ ModifyEvent.prototype = {
    * @private
    */
   _overrideEvent: function(search) {
-    search = search || window.location.search;
+    if (!search) {
+      var hash = window.location.hash;
+      search = hash.split('?')[1];
+    }
+
     if (!search || search.length === 0) {
       return;
     }


### PR DESCRIPTION
…jrburke

This fixes a regression introduced in f13c650f765d0df385f9a7cb0b4bf2eb8b666fe4. In that patch, we changed calendar's url scheme to use url fragments so that we could prevent our client-side routing from breaking view source (which expects each url to correspond to an HTML file). However, event creation was using urls (particularly `location.search` ie `?startDate=...&endDate=...&startTime=...&endDate=...&title=...`). The pref we flipped on page.js (`hashbang = true`) to enable the fragment usage made it so that our urls for event creation now look like `http://calendar.gaiamobile.org/index.html/#!/event/add/?startDate=09-29-15`. We were using `location.search` previously to access the urlparams which only looks for urlparams which come before the `#` (which indicates the start of the fragment id `location.hash`). With our new url scheme, these parameters weren't being picked up, so calendar ignored the url and assumed that all events should be created starting at the top of the next hour. The change here modifies the way that we pull the querystring so that we don't ignore those event parameters.
