### PR TITLE
Bug 1199592 - customize device type on simulator. r=evelyn,fabrice

### DIFF
--- a/build/config/tablet/custom-prefs.js
+++ b/build/config/tablet/custom-prefs.js
@@ -2,3 +2,4 @@
 user_pref('devtools.responsiveUI.customWidth', 1280);
 user_pref('devtools.responsiveUI.customHeight', 800);
 user_pref('devtools.responsiveUI.currentPreset', 'custom');
+user_pref('devtools.useragent.device_type', 'Tablet');

--- a/build/config/tv/custom-prefs.js
+++ b/build/config/tv/custom-prefs.js
@@ -12,3 +12,4 @@ user_pref('dom.meta-viewport.enabled', false);
 user_pref('dom.presentation.discoverable', true);
 user_pref('dom.presentation.discovery.enabled', true);
 user_pref('dom.presentation.enabled', true);
+user_pref('devtools.useragent.device_type', 'TV');


### PR DESCRIPTION
The behavior of TV browser app should be similar to desktop browser, thus we don't need to override UA string like mobile devices.
