### PR TITLE
Bug 1210151 - [email] Prevent pasting of rich text in contenteditable fields

### DIFF
--- a/apps/email/js/cards/editor_mixins.js
+++ b/apps/email/js/cards/editor_mixins.js
@@ -6,7 +6,21 @@ define(function(require) {
 
     _bindEditor: function(textNode) {
       this._editorNode = textNode;
+
+      // Prevent pastes of rich HTML, since it has encoding, security and
+      // sanitation issues.
+      textNode.addEventListener('paste', function(event) {
+        event.preventDefault();
+        var text = event.clipboardData.getData('text/plain');
+
+        // Only insert if text. If no text, the execCommand fails with an
+        // error.
+        if (text) {
+          document.execCommand('insertText', false, text);
+        }
+      });
     },
+
     /**
      * Inserts an email into the contenteditable element
      */


### PR DESCRIPTION
editor_mixins is used both by compose and settings_signature, the two contenteditables in email, so this catches both cases: they both call _bindEditor to set up the editor functionality.

Tested with picture, rich text, and plain text and they work as expected.
