### PR TITLE
Bug 1210252 - Migrate remaining mozL10n.DateTimeFormat use cases in System to mozIntl API

### DIFF
--- a/apps/download/pick.html
+++ b/apps/download/pick.html
@@ -12,6 +12,7 @@
     <link rel="localization" href="shared/locales/download/download.{locale}.properties">
     <link rel="localization" href="locales/download.{locale}.properties">
     <script type="text/javascript" src="shared/js/l10n.js"></script>
+    <script defer type="text/javascript" src="shared/js/moz_intl.js"></script>
 
     <!-- Web Components -->
     <script defer src="shared/elements/config.js"></script>
@@ -22,7 +23,6 @@
     <link rel="stylesheet" type="text/css" href="shared/style/lists.css">
     <link rel="stylesheet" href="style/pick.css">
 
-    <!-- <script type="text/javascript" src="shared/js/l10n_date.js"></script> -->
     <script type="text/javascript" defer src="shared/js/lazy_loader.js"></script>
     <script type="text/javascript" defer src="shared/js/download/download_store.js"></script>
     <!-- <script type="text/javascript" defer src="shared/js/mime_mapper.js"></script> -->

--- a/apps/download/test/unit/pick_test.js
+++ b/apps/download/test/unit/pick_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* global MockL10n, loadBodyHTML, DownloadStore, downloadPicker,
-          DownloadFormatter */
+          DownloadFormatter, MockMozIntl */
 /* global require, requireApp, suite, suiteTeardown, suiteSetup, test, assert,
           MocksHelper, sinon */
 
@@ -10,6 +10,7 @@ require('/shared/js/download/download_store.js');
 require('/shared/js/download/download_formatter.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_set_message_handler.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
+require('/shared/test/unit/mocks/mock_moz_intl.js');
 require('/shared/test/unit/mocks/mock_lazy_loader.js');
 
 var mocksHelperForDownloadPicker = new MocksHelper([
@@ -20,6 +21,7 @@ suite('pick.js >', function() {
 
   var realSetMessageHandler = null;
   var realL10n = null;
+  var realMozIntl = null;
   var downloads = [];
 
   function createSource(name, type) {
@@ -40,6 +42,8 @@ suite('pick.js >', function() {
   suiteSetup(function(done) {
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
+    realMozIntl = window.mozIntl;
+    window.mozIntl = MockMozIntl;
     realSetMessageHandler = navigator.mozSetMessageHandler;
     navigator.mozSetMessageHandler = window.MockNavigatormozSetMessageHandler;
     navigator.mozSetMessageHandler.mSetup();
@@ -66,6 +70,7 @@ suite('pick.js >', function() {
     navigator.mozL10n = realL10n;
     navigator.mozSetMessageHandler.mTeardown();
     navigator.mozSetMessageHandler = realSetMessageHandler;
+    window.mozIntl = realMozIntl;
     DownloadStore.getAll.restore();
   });
 

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -80,7 +80,7 @@
     <link rel="localization" href="locales/device_type/settings.device.{locale}.properties">
 
     <script src="shared/js/l10n.js"></script>
-    <script src="shared/js/l10n_date.js"></script>
+    <script src="shared/js/moz_intl.js"></script>
     <script defer src="shared/js/date_time_helper.js"></script>
 
     <!-- Lazy loader -->

--- a/apps/settings/test/unit/download_formatter_test.js
+++ b/apps/settings/test/unit/download_formatter_test.js
@@ -1,22 +1,27 @@
-/* global MockL10n, DownloadFormatter, MockDownload */
+/* global MockL10n, DownloadFormatter, MockDownload, MockMozIntl */
 'use strict';
 
 require('/shared/test/unit/mocks/mock_download.js');
 require('/shared/js/download/download_formatter.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
+require('/shared/test/unit/mocks/mock_moz_intl.js');
 
 
 suite('DownloadFormatter', function() {
-  var realL10n;
+  var realL10n, realMozIntl;
 
   suiteSetup(function() {
+    realMozIntl = window.mozIntl;
+    window.mozIntl = MockMozIntl;
     realL10n = navigator.mozL10n;
     navigator.mozL10n = MockL10n;
   });
 
   suiteTeardown(function() {
     navigator.mozL10n = realL10n;
+    window.mozIntl = realMozIntl;
     realL10n = null;
+    realMozIntl = null;
   });
 
   test(' getFormattedSize KB', function(done) {
@@ -212,30 +217,13 @@ suite('DownloadFormatter', function() {
 
   test(' getDate', function(done) {
     var now = new Date();
-    var expectedPrettyDate = 'pretty' + now.toString();
-
-    // We can't use MockLazyLoader here because it cannot chain Promises
-    window.LazyLoader = {
-      load: function(imports) {
-        return Promise.resolve();
-      }
-    };
-
-    sinon.stub(navigator.mozL10n, 'DateTimeFormat', function(date) {
-      return {
-        relativeDate: function(date, useCompactFormat) {
-          return Promise.resolve(expectedPrettyDate);
-        }
-      };
-    });
 
     var mockDownload = new MockDownload({
       startTime: now
     });
 
     DownloadFormatter.getDate(mockDownload).then(function(date) {
-      assert.equal(date, expectedPrettyDate);
-      done();
-    });
+      assert.equal(date, 'pretty date');
+    }).then(done, done);
   });
 });

--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -8,7 +8,6 @@
 
     <!-- Shared code -->
     <script src="shared/js/l10n.js"></script>
-    <script src="shared/js/l10n_date.js"></script>
     <script src="shared/js/moz_intl.js"></script>
     <script src="shared/js/dump.js"></script>
 

--- a/apps/system/js/notification_screen.js
+++ b/apps/system/js/notification_screen.js
@@ -1,5 +1,5 @@
 /* global LazyLoader, MediaPlaybackWidget, Service,
-          SettingsListener, SettingsURL, toneUpgrader */
+          SettingsListener, SettingsURL, toneUpgrader, mozIntl */
 
 'use strict';
 
@@ -373,10 +373,12 @@ var NotificationScreen = {
 
   updateTimestamps: function ns_updateTimestamps() {
     var timestamps = [...document.querySelectorAll('.timestamp')];
-    var formatter = navigator.mozL10n.DateTimeFormat();
+    var formatter = mozIntl._gaia.RelativeDate(navigator.languages, {
+      style: 'short'
+    });
 
     timestamps.forEach(timestamp => {
-      formatter.relativeDate(new Date(timestamp.dataset.timestamp)).then(
+      formatter.format(new Date(timestamp.dataset.timestamp)).then(
         str => { timestamp.textContent = str; }
       );
     });
@@ -468,7 +470,10 @@ var NotificationScreen = {
     var timestamp = detail.timestamp ? new Date(detail.timestamp) : new Date();
     time.classList.add('timestamp');
     time.dataset.timestamp = timestamp;
-    navigator.mozL10n.DateTimeFormat().relativeDate(timestamp, true).then(
+    var formatter = mozIntl._gaia.RelativeDate(navigator.languages, {
+      style: 'short'
+    });
+    formatter.format(timestamp).then(
       str => {
         time.textContent = str;
       }

--- a/apps/system/lockscreen/js/lockscreen_notifications.js
+++ b/apps/system/lockscreen/js/lockscreen_notifications.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global LockScreenNotificationBuilder, LazyLoader */
+/* global LockScreenNotificationBuilder, LazyLoader, mozIntl */
 
 (function(exports) {
   /**
@@ -578,11 +578,13 @@
   LockScreenNotifications.prototype.updateTimestamps =
   function lsn_updateTimestamps() {
     var timestamps = [...document.querySelectorAll('.notification .timestamp')];
-    var formatter = navigator.mozL10n.DateTimeFormat();
+    var formatter = mozIntl._gaia.RelativeDate(navigator.languages, {
+      style: 'short'
+    });
 
     timestamps.forEach((element) => {
       var date = new Date(element.dataset.timestamp);
-      formatter.relativeDate(date, true).then(str => {
+      formatter.format(date).then(str => {
         element.textContent = str;
       });
     });

--- a/apps/system/test/unit/notification_screen_test.js
+++ b/apps/system/test/unit/notification_screen_test.js
@@ -6,6 +6,7 @@
   NotificationScreen,
   MockNavigatorMozTelephony,
   MockCall,
+  MockMozIntl,
   MockService
  */
 
@@ -23,6 +24,7 @@ require('/shared/test/unit/mocks/mock_settings_url.js');
 require('/shared/test/unit/mocks/mock_settings_listener.js');
 require('/shared/test/unit/mocks/mock_service.js');
 require('/shared/test/unit/mocks/mock_audio.js');
+require('/shared/test/unit/mocks/mock_moz_intl.js');
 
 var mocksForNotificationScreen = new MocksHelper([
   'Audio',
@@ -31,7 +33,7 @@ var mocksForNotificationScreen = new MocksHelper([
   'SettingsListener',
   'SettingsURL',
   'Service',
-  'LazyLoader'
+  'LazyLoader',
 ]).init();
 
 suite('system/NotificationScreen >', function() {
@@ -40,7 +42,7 @@ suite('system/NotificationScreen >', function() {
     fakeToasterDetail, fakeSomeNotifications, fakeAmbientIndicator,
     fakeNotifContainer;
   var fakePriorityNotifContainer, fakeOtherNotifContainer;
-  var realMozL10n;
+  var realMozL10n, realMozIntl;
   var isDocumentHidden;
 
   function sendChromeNotificationEvent(detail) {
@@ -131,21 +133,9 @@ suite('system/NotificationScreen >', function() {
     document.body.appendChild(fakeToasterDetail);
 
     realMozL10n = navigator.mozL10n;
-    MockL10n.DateTimeFormat = function() {
-      return {
-        relativeDate: function(time, compact) {
-          var retval;
-          var delta = new Date().getTime() - time.getTime();
-          if (delta >= 0 && delta < 60 * 1000) {
-            retval = 'now';
-          } else if (delta >= 60 * 1000) {
-            retval = '1m ago';
-          }
-          return Promise.resolve(retval);
-        }
-      };
-    };
+    realMozIntl = window.mozIntl;
     navigator.mozL10n = MockL10n;
+    window.mozIntl = MockMozIntl;
 
     isDocumentHidden = false;
     Object.defineProperty(document, 'hidden', {
@@ -171,6 +161,7 @@ suite('system/NotificationScreen >', function() {
     fakeButton.parentNode.removeChild(fakeButton);
 
     navigator.mozL10n = realMozL10n;
+    window.mozIntl = realMozIntl;
   });
 
   suite('chrome events >', function() {
@@ -336,9 +327,9 @@ suite('system/NotificationScreen >', function() {
     test('should update timestamps properly', function() {
       var callCount = 0;
 
-      sinon.stub(navigator.mozL10n, 'DateTimeFormat', function() {
+      sinon.stub(window.mozIntl._gaia, 'RelativeDate', function() {
         return {
-          relativeDate: function() {
+          format: function() {
             callCount++;
             return Promise.resolve();
           }

--- a/shared/js/download/download_formatter.js
+++ b/shared/js/download/download_formatter.js
@@ -1,4 +1,4 @@
-/* global LazyLoader */
+/* global mozIntl */
 
 /**
  * This lib relies on `l10n.js' to implement localizable date/time strings.
@@ -71,9 +71,8 @@
         console.error(ex);
       }
 
-      return LazyLoader.load(['shared/js/l10n_date.js']).then(() => {
-        return navigator.mozL10n.DateTimeFormat().relativeDate(date);
-      });
+      var formatter = mozIntl._gaia.RelativeDate(navigator.languages);
+      return formatter.format(date);
     },
     getUUID: function(download) {
       return download.id || this.getFileName(download);

--- a/shared/test/unit/mocks/mock_moz_intl.js
+++ b/shared/test/unit/mocks/mock_moz_intl.js
@@ -40,7 +40,7 @@ global.MockMozIntl = {
     RelativeDate: function(locales, options) {
       return {
         format: function(value) {
-          return Promise.resolve();
+          return Promise.resolve('pretty date');
         }
       };
     },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1210252
