### PR TITLE
Bug 1210234 - Move IntlHelper to be available synchronously for onring.js in Clock

### DIFF
--- a/apps/clock/onring.html
+++ b/apps/clock/onring.html
@@ -18,7 +18,8 @@
     <script defer src="/shared/js/l10n.js"></script>
     <script defer src="/shared/js/date_time_helper.js"></script>
     <script defer src="/shared/js/moz_intl.js"></script>
-    <script defer src="/shared/js/intl_helper.js"></script>
+    <!-- We need IntlHelper synchronously for onring.js -->
+    <script src="/shared/js/intl_helper.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1210234
