### PR TITLE
Bug 1206473 - Adapt to new version of kinto.min.js, r=ferjm

### DIFF
--- a/apps/sync/js/bootstrap.js
+++ b/apps/sync/js/bootstrap.js
@@ -29,8 +29,7 @@ const Bootstrap = (() => {
       'js/crypto/keyderivation.js',
       'js/crypto/fxsyncwebcrypto.js',
 
-      // to be added in https://bugzilla.mozilla.org/show_bug.cgi?id=1206615:
-      'js/ext/kinto.dev.js',
+      'js/ext/kinto.min.js',
       'js/sync-engine/syncengine.js'
     ]);
   };

--- a/apps/sync/test/unit/fixtures/bootstrap.js
+++ b/apps/sync/test/unit/fixtures/bootstrap.js
@@ -13,7 +13,7 @@ var BootstrapFixture = {
       'js/crypto/keyderivation.js',
       'js/crypto/fxsyncwebcrypto.js',
 
-      'js/ext/kinto.dev.js',
+      'js/ext/kinto.min.js',
       'js/sync-engine/syncengine.js'
   ]
 };


### PR DESCRIPTION
Quite a few things changed in https://github.com/Kinto/kinto.js/releases/tag/v1.0.0-rc.4 - mainly, the `Collection#use`, `Collection#createIdSchema` and `Collection#createRemoteTransformer` were removed.

With this patch, https://github.com/michielbdejong/gaia/commits/1200539-sync-app-integration-tests works again, testing the integration of bootstrap.js, SyncEngine, FxSyncWebCrypto, Kinto.js, and the history DataAdapter.
