### PR TITLE
Bug 1210356 - Safer WebCryptoTransformer, r=ferjm

### DIFF
--- a/apps/sync/js/sync-engine/syncengine.js
+++ b/apps/sync/js/sync-engine/syncengine.js
@@ -104,8 +104,10 @@ var SyncEngine = (function() {
       encode: function(record) {
         return fswc.encrypt(record.payload, collectionName).then(
             payloadEnc => {
-          record.payload = JSON.stringify(payloadEnc);
-          return record;
+          return {
+            id: record.id,
+            payload: JSON.stringify(payloadEnc)
+          };
         });
       },
       decode: function(record) {
@@ -113,8 +115,10 @@ var SyncEngine = (function() {
         // syncResults:
         return fswc.decrypt(JSON.parse(record.payload), collectionName).
             then(payloadDec => {
-          record.payload = payloadDec;
-          return record;
+          return {
+            id: record.id,
+            payload: payloadDec
+          };
         });
       }
     };

--- a/apps/sync/test/unit/sync-engine/kinto-mock.js
+++ b/apps/sync/test/unit/sync-engine/kinto-mock.js
@@ -100,10 +100,7 @@ var Kinto = (function() {
       });
     },
 
-    create: function(payload, options = {}) {
-      var obj = {
-        payload: payload
-      };
+    create: function(obj, options = {}) {
       if (options.forceId) {
         if(!this._idSchemaUsed.validate(options.forceId)) {
           return Promise.reject(new Error('Invalid id: ' + options.forceId));


### PR DESCRIPTION
Instead of uploading the whole record, with its payload encrypted, upload only its id plus its encrypted payload. Will be safer against DataAdapters accidentally storing data outside the payload.
