### PR TITLE
Bug 1210480 - Throw TryLaterError if Syncto server unreachable, r=ferjm

### DIFF
--- a/apps/sync/test/unit/sync-engine/kinto-mock.js
+++ b/apps/sync/test/unit/sync-engine/kinto-mock.js
@@ -140,7 +140,8 @@ var Kinto = (function() {
   var UnreachableKintoCollectionMock = function() {};
   UnreachableKintoCollectionMock.prototype = {
     sync() {
-      return Promise.reject(new Error());
+      return Promise.reject(new Error(`HTTP 0; TypeError: NetworkError when att\
+empting to fetch resource.`));
     },
     list() {},
     get() {},
@@ -155,7 +156,7 @@ var Kinto = (function() {
   HttpCodeKintoCollectionMock.prototype = {
     sync() {
       var err = new Error();
-      err.request = {
+      err.response = {
         status: this.status
       };
       return Promise.reject(err);

--- a/apps/sync/test/unit/sync-engine/syncengine_test.js
+++ b/apps/sync/test/unit/sync-engine/syncengine_test.js
@@ -276,6 +276,8 @@ ould be an object`).and.notify(done);
         se.syncNow({ history: {} }).catch(err => {
           if (field === 'assertion') {
             expect(err).to.be.instanceOf(SyncEngine.AuthError);
+          } else if (field === 'URL') {
+            expect(err).to.be.instanceOf(SyncEngine.TryLaterError);
           } else {
             expect(err).to.be.instanceOf(SyncEngine.UnrecoverableError);
           }


### PR DESCRIPTION
The errors we get from Kinto.js 1.0.0-rc4 are very raw, in this case I saw no other solution than checking the exact `Error#message` string.
