### PR TITLE
Bug 1209041 - <gaia-header> update 

### DIFF
--- a/apps/bluetooth/test/unit/_transfer.html
+++ b/apps/bluetooth/test/unit/_transfer.html
@@ -31,7 +31,7 @@
     </form>
     <!-- Devices List View -->
     <section role="region" id="devices-list-view" class="devices-list-view current" data-rendered="true" hidden>
-      <gaia-header id="devices-list-header" class="devices-list-header" action="close">
+      <gaia-header ignore-dir id="devices-list-header" class="devices-list-header" action="close">
         <h1 data-l10n-id="bluetooth"></h1>
       </gaia-header>
       <div>

--- a/apps/bluetooth/transfer.html
+++ b/apps/bluetooth/transfer.html
@@ -58,7 +58,7 @@
     </form>
     <!-- Devices List View -->
     <section role="region" id="devices-list-view" class="devices-list-view current" data-rendered="true" hidden>
-      <gaia-header id="devices-list-header" class="devices-list-header" action="close">
+      <gaia-header ignore-dir id="devices-list-header" class="devices-list-header" action="close">
         <h1 data-l10n-id="bluetooth"></h1>
       </gaia-header>
       <div>

--- a/apps/calendar/elements/advanced_settings.html
+++ b/apps/calendar/elements/advanced_settings.html
@@ -1,6 +1,6 @@
 <element name="advanced-settings" extends="section">
   <template>
-    <gaia-header id="advanced-settings-header">
+    <gaia-header ignore-dir id="advanced-settings-header">
       <h1 data-l10n-id="advanced-settings-header"></h1>
       <a href="/settings/" data-l10n-id="done"></a>
     </gaia-header>

--- a/apps/calendar/elements/create_account.html
+++ b/apps/calendar/elements/create_account.html
@@ -1,6 +1,6 @@
 <element name="create-account" extends="section">
   <template>
-    <gaia-header id="create-account-header" action="back">
+    <gaia-header ignore-dir id="create-account-header" action="back">
       <h1 data-l10n-id="add-account"></h1>
     </gaia-header>
 

--- a/apps/calendar/elements/modify_account.html
+++ b/apps/calendar/elements/modify_account.html
@@ -1,6 +1,6 @@
 <element name="modify-account" extends="section">
   <template>
-    <gaia-header id="modify-account-header" action="back">
+    <gaia-header ignore-dir id="modify-account-header" action="back">
       <h1 data-l10n-id="account-header"></h1>
       <button class="save" data-l10n-id="save">Save</button>
     </gaia-header>

--- a/apps/calendar/elements/modify_event.html
+++ b/apps/calendar/elements/modify_event.html
@@ -1,6 +1,6 @@
 <element name="modify-event" extends="section">
   <template>
-    <gaia-header id="modify-event-header" action="close">
+    <gaia-header ignore-dir id="modify-event-header" action="close">
       <h1 data-l10n-id="new-event-header" class="save-text"></h1>
       <h1 data-l10n-id="edit-event-header" class="done-text"></h1>
       <button class="save">

--- a/apps/calendar/elements/oauth.html
+++ b/apps/calendar/elements/oauth.html
@@ -1,6 +1,6 @@
 <element name="oauth" extends="section">
   <template>
-    <gaia-header id="oauth-header" action="back">
+    <gaia-header ignore-dir id="oauth-header" action="back">
       <h1 class="oauth-browser-title">
         &nbsp;
       </h1>

--- a/apps/calendar/elements/settings.html
+++ b/apps/calendar/elements/settings.html
@@ -1,6 +1,6 @@
 <element name="settings" extends="section">
   <template>
-    <gaia-header id="settings-header" action="menu">
+    <gaia-header ignore-dir id="settings-header" action="menu">
       <h1></h1>
     </gaia-header>
 

--- a/apps/calendar/elements/show_event.html
+++ b/apps/calendar/elements/show_event.html
@@ -1,6 +1,6 @@
 <element name="show-event" extends="section">
   <template>
-    <gaia-header id="show-event-header" action="back">
+    <gaia-header ignore-dir id="show-event-header" action="back">
       <h1 id="view-event-header" data-l10n-id="view-event-header"></h1>
       <button class="edit">
         <span data-l10n-id="edit">Edit</span>

--- a/apps/calendar/index.html
+++ b/apps/calendar/index.html
@@ -71,7 +71,7 @@
 <section is="settings" id="settings" role="region"></section>
 
 <section id="time-views" role="region">
-  <gaia-header id="time-header" action="menu">
+  <gaia-header ignore-dir id="time-header" action="menu">
     <h1 id="current-month-year" aria-labelledby="current-time-indicator"></h1>
     <a href="/event/add/" data-icon="add" data-l10n-id="new-event-link"></a>
   </gaia-header>

--- a/apps/calendar/test/unit/oauth_window_test.js
+++ b/apps/calendar/test/unit/oauth_window_test.js
@@ -26,7 +26,7 @@ suite('OAuthWindow', function() {
     element = document.createElement('section');
     element.innerHTML = [
       '<section role="region">',
-        '<gaia-header id="oauth-header" action="cancel">',
+        '<gaia-header ignore-dir id="oauth-header" action="cancel">',
           '<h1 class="oauth-browser-title"></h1>',
         '</gaia-header>',
         '<div class="browser-container"></div>',

--- a/apps/calendar/test/unit/views/create_account_test.js
+++ b/apps/calendar/test/unit/views/create_account_test.js
@@ -21,7 +21,7 @@ suite('Views.CreateAccount', function() {
     div.id = 'test';
     div.innerHTML = [
       '<div id="create-account-view">',
-        '<gaia-header id="create-account-header" action="back">',
+        '<gaia-header ignore-dir id="create-account-header" action="back">',
           '<h1>Add an account</h1>',
         '</gaia-header>',
         '<ul id="create-account-presets"></ul>',

--- a/apps/calendar/test/unit/views/event_base_test.js
+++ b/apps/calendar/test/unit/views/event_base_test.js
@@ -34,7 +34,7 @@ suite('Views.EventBase', function() {
     div.id = 'test';
     div.innerHTML = [
       '<div id="event-test">',
-        '<gaia-header id="event-test-header" action="cancel">',
+        '<gaia-header ignore-dir id="event-test-header" action="cancel">',
           '<button class="primary">primary</button>',
         '</gaia-header>',
       '</div>'

--- a/apps/calendar/test/unit/views/modify_account_test.js
+++ b/apps/calendar/test/unit/views/modify_account_test.js
@@ -94,7 +94,7 @@ suite('Views.ModifyAccount', function() {
     div.id = 'test';
     div.innerHTML = [
       '<div id="modify-account-view">',
-        '<gaia-header id="modify-account-header" action="back">',
+        '<gaia-header ignore-dir id="modify-account-header" action="back">',
           '<h1>Account</h1>',
           '<button class="save">Save</button>',
         '</gaia-header>',

--- a/apps/calendar/test/unit/views/time_header_test.js
+++ b/apps/calendar/test/unit/views/time_header_test.js
@@ -29,7 +29,7 @@ suite('Views.TimeHeader', function() {
     div.id = 'test';
     div.innerHTML = [
       '<div id="wrapper"></div>',
-      '<gaia-header id="time-header" action="menu">',
+      '<gaia-header ignore-dir id="time-header" action="menu">',
         '<h1></h1>',
       '</gaia-header>'
     ].join('');

--- a/apps/clock/js/panels/alarm_edit/panel.html
+++ b/apps/clock/js/panels/alarm_edit/panel.html
@@ -1,4 +1,4 @@
-<gaia-header id="alarm-header" action="close">
+<gaia-header ignore-dir id="alarm-header" action="close">
   <h1 class="new-alarm-title" data-l10n-id="newAlarm"></h1>
   <h1 class="edit-alarm-title" data-l10n-id="editAlarm"></h1>
   <button id="alarm-done" data-l10n-id="done"></button>

--- a/apps/collection/update.html
+++ b/apps/collection/update.html
@@ -33,7 +33,7 @@
   </head>
   <body class="theme-media">
     <section role="region">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 data-l10n-id="edit-collection-header"></h1>
         <button id="done-button" disabled type="button" data-l10n-id="done"></button>
       </gaia-header>

--- a/apps/collection/view.html
+++ b/apps/collection/view.html
@@ -72,12 +72,12 @@
   </head>
   <body class="theme-media">
     <section role="region">
-        <gaia-header id="header" action="close">
-            <h1 id="name"></h1>
+        <gaia-header ignore-dir id="header" action="close">
+          <h1 id="name"></h1>
         </gaia-header>
 
         <section id="edit-header" class="skin-dark" role="region">
-          <gaia-header>
+          <gaia-header ignore-dir>
             <h1 data-l10n-id="edit-mode"></h1>
             <a href="#" data-l10n-id="edit-done" id="exit-edit-mode"></a>
           </gaia-header>

--- a/apps/communications/contacts/elements/details.html
+++ b/apps/communications/contacts/elements/details.html
@@ -1,6 +1,6 @@
 <element name="view-contact-details" extends="section">
   <template>
-    <gaia-header id='details-view-header' action="back">
+    <gaia-header ignore-dir id='details-view-header' action="back">
       <h1 id='contact-name-title'><bdi class="ellipsis-dir-fix"></bdi></h1>
       <div class='favorite-indicator'></div>
       <button id="edit-contact-button" data-icon="edit-contact" data-l10n-id="editButton"></button>

--- a/apps/communications/contacts/elements/form.html
+++ b/apps/communications/contacts/elements/form.html
@@ -1,6 +1,6 @@
 <element name="view-contact-form" extends="section">
   <template>
-    <gaia-header id="contact-form-header" action="close">
+    <gaia-header ignore-dir id="contact-form-header" action="close">
       <h1 id='contact-form-title' data-l10n-id="addContact"></h1>
       <button id="save-button" data-l10n-id="done">Done</button>
     </gaia-header>

--- a/apps/communications/contacts/elements/ice.html
+++ b/apps/communications/contacts/elements/ice.html
@@ -1,6 +1,6 @@
 <element name="ice-view" extends="section">
   <template>
-    <gaia-header id="ice-header" action="back">
+    <gaia-header ignore-dir id="ice-header" action="back">
       <h1 data-l10n-id="ice_contacts"></h1>
     </gaia-header>
     <arcticle class="view-body">

--- a/apps/communications/contacts/elements/multiple_select.html
+++ b/apps/communications/contacts/elements/multiple_select.html
@@ -9,7 +9,7 @@
         <p>Org</p>
       </li>
     </template>
-    <gaia-header id="multiple-select-view-header" action="close">
+    <gaia-header ignore-dir id="multiple-select-view-header" action="close">
       <h1 id="multiple-select-view-title">Filename</h1>
       <button id="save-button" data-l10n-id="importAll">Import all</button>
     </gaia-header>

--- a/apps/communications/contacts/elements/settings.html
+++ b/apps/communications/contacts/elements/settings.html
@@ -1,7 +1,7 @@
 <element name="settings" extends="article">
   <template>
     <section data-theme="organic" id="view-settings" role="region" class="skin-organic view view-bottom theme-settings">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="settings"></h1>
         <button id="settings-close" data-l10n-id="done">Done</button>
       </gaia-header>
@@ -49,7 +49,7 @@
       </article>
     </section>
     <section data-theme="organic" id="import-settings" role="region" class="skin-organic view view-right theme-settings">
-      <gaia-header id="import-settings-header" action="back">
+      <gaia-header ignore-dir id="import-settings-header" action="back">
         <h1 id='import-settings-title'></h1>
       </gaia-header>
       <article class="view-body">
@@ -93,7 +93,7 @@
       </article>
     </section>
     <section data-theme="organic" id="ice-settings" role="region" class="skin-organic view view-right theme-settings">
-      <gaia-header id="ice-settings-header" action="back">
+      <gaia-header ignore-dir id="ice-settings-header" action="back">
         <h1 id='ice-settings-title' data-l10n-id="ICESettingTitle"></h1>
       </gaia-header>
       <article class="view-body">

--- a/apps/communications/contacts/elements/tag.html
+++ b/apps/communications/contacts/elements/tag.html
@@ -1,6 +1,6 @@
 <element name="view-select-tag" extends="section">
   <template>
-    <gaia-header id="settings-header" action="back">
+    <gaia-header ignore-dir id="settings-header" action="back">
       <h1 data-l10n-id="label"></h1>
       <button id="settings-done" data-l10n-id="done">Done</button>
     </gaia-header>

--- a/apps/communications/contacts/fb_link.html
+++ b/apps/communications/contacts/fb_link.html
@@ -69,7 +69,7 @@
   <body role="application" class="theme-communications skin-comms">
     <section role="region" id="content" class="link">
 
-      <gaia-header id="link-header" action="close">
+      <gaia-header ignore-dir id="link-header" action="close">
         <h1 data-l10n-id="fbFriends"></h1>
       </gaia-header>
 

--- a/apps/communications/contacts/index.html
+++ b/apps/communications/contacts/index.html
@@ -153,7 +153,7 @@
 
       <!-- Contacts List Section -->
       <section id='view-contacts-list' role="region" data-state="active" class="view view-noscroll view-contacts-list">
-        <gaia-header id="contacts-list-header">
+        <gaia-header ignore-dir id="contacts-list-header">
           <h1 id="app-title" data-l10n-id="contacts"></h1>
           <button id="add-contact-button" data-icon="add" data-l10n-id="addButton"></button>
           <button id="settings-button" data-icon="settings" data-l10n-id="settingsButton"></button>
@@ -228,7 +228,7 @@
       </section>
     <form id="selectable-form" role="dialog" data-type="edit" class="hide">
       <section role="region" class="theme-settings">
-        <gaia-header id="selectable-form-header" action="close">
+        <gaia-header ignore-dir id="selectable-form-header" action="close">
           <h1 id="edit-title" data-l10n-id="contacts"></h1>
           <button type="button" id="select-action"></button>
         </gaia-header>

--- a/apps/communications/contacts/test/unit/import/mock_import.html
+++ b/apps/communications/contacts/test/unit/import/mock_import.html
@@ -1,5 +1,5 @@
 <section role="region" id="content" class="import">
-  <gaia-header id="link-header" action="close">
+  <gaia-header ignore-dir id="link-header" action="close">
     <h1 data-l10n-id="fbFriends">Facebook Friends</h1>
     <button  id="import-action" data-l10n-id="import" disabled>
       Import

--- a/apps/communications/contacts/test/unit/mock_contact_list_dom.js.html
+++ b/apps/communications/contacts/test/unit/mock_contact_list_dom.js.html
@@ -1,7 +1,7 @@
 var ContactListDom =
 '      <!-- Contacts List Section -->' +
 '      <section id="view-contacts-list" role="region" data-state="active" class="view view-noscroll view-contacts-list">' +
-'        <gaia-header id="activity-header" action="close">' +
+'        <gaia-header ignore-dir id="activity-header" action="close">' +
 '          <h1 id="app-title" data-l10n-id="contacts">Contacts</h1>' +
 '          <button id="add-contact-button" data-icon="add" data-l10n-id="addButton"></button>' +
 '          <button id="settings-button" data-icon="settings" data-l10n-id="settingsButton"></button>' +

--- a/apps/communications/contacts/test/unit/mock_contacts_index.html
+++ b/apps/communications/contacts/test/unit/mock_contacts_index.html
@@ -6,7 +6,7 @@
       <link rel="localization" href="/shared/locales/import_contacts/import_contacts.{locale}.properties">
         <!-- Contacts List Section -->
       <section id='view-contacts-list' role="region" data-state="active" class="view view-noscroll view-contacts-list">
-        <gaia-header id="activity-header" action="close">
+        <gaia-header ignore-dir id="activity-header" action="close">
           <h1 id="app-title" data-l10n-id="contacts">Contacts</h1>
           <button id="add-contact-button" data-icon="add" data-l10n-id="addButton"></button>
           <button id="settings-button" data-icon="settings" data-l10n-id="settingsButton"></button>
@@ -81,7 +81,7 @@
       </section>    <!-- Search view -->
 
       <section id='view-screenshot' role="region" class="view hide">
-        <gaia-header id="activity-header" action="close">
+        <gaia-header ignore-dir id="activity-header" action="close">
           <h1 id="app-title" data-l10n-id="contacts">Contacts</h1>
           <button id="add-contact-button" data-icon="add" data-l10n-id="addButton"></button>
           <button id="settings-button" data-icon="settings" data-l10n-id="settingsButton"></button>
@@ -92,7 +92,7 @@
 
       <!-- Contact Details Section -->
       <section id='view-contact-details' role="region" class="view view-right view-contact-profile">
-        <gaia-header id='details-view-header' action="back">
+        <gaia-header ignore-dir id='details-view-header' action="back">
           <h1 id='contact-name-title'><bdi></bdi></h1>
           <button id="edit-contact-button" data-icon="edit-contact" data-l10n-id="editButton"></button>
         </gaia-header>
@@ -196,7 +196,7 @@
 
       <!-- Edit Section -->
       <section id='view-contact-form' role="region" class="view view-bottom view-edit-contact">
-        <gaia-header id="contact-form-header" action="close">
+        <gaia-header ignore-dir id="contact-form-header" action="close">
           <h1 id='contact-form-title' data-l10n-id="addContact">Add contact</h1>
           <button id="save-button" data-l10n-id="done">Done</button>
         </gaia-header>
@@ -367,7 +367,7 @@
 
       <!-- Tag selection -->
       <section id="view-select-tag" role="region" class="view view-right view-select-tag">
-        <gaia-header id="settings-header" action="back">
+        <gaia-header ignore-dir id="settings-header" action="back">
           <h1 data-l10n-id="label">Label</h1>
           <button id="settings-done" data-l10n-id="done">Done</button>
         </gaia-header>
@@ -385,7 +385,7 @@
       </section>
 
      <section data-theme="organic" id="view-settings" role="region" class="skin-organic view view-bottom theme-settings">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="settings">Settings</h1>
         <button id="settings-close" data-l10n-id="done">Done</button>
       </gaia-header>
@@ -433,7 +433,7 @@
       </article>
     </section>
     <section data-theme="organic" id="import-settings" role="region" class="skin-organic view view-right theme-settings">
-      <gaia-header id="import-settings-header" action="back">
+      <gaia-header ignore-dir id="import-settings-header" action="back">
         <h1 id='import-settings-title'></h1>
       </gaia-header>
       <article class="view-body">
@@ -490,7 +490,7 @@
       </article>
     </section>
     <section data-theme="organic" id="ice-settings" role="region" class="skin-organic view view-right theme-settings">
-      <gaia-header id="ice-settings-header" action="back">
+      <gaia-header ignore-dir id="ice-settings-header" action="back">
         <h1 id='ice-settings-title' data-l10n-id="ICESettingTitle">ICE Contacts</h1>
       </gaia-header>
       <article class="view-body">

--- a/apps/communications/contacts/test/unit/mock_details_dom.js.html
+++ b/apps/communications/contacts/test/unit/mock_details_dom.js.html
@@ -1,7 +1,7 @@
 'use strict';
 
 var MockDetailsDom = '<section id="view-contact-details" role="region" class="view view-right view-contact-profile">' +
-        '<gaia-header id="details-view-header" action="back">' +
+        '<gaia-header ignore-dir id="details-view-header" action="back">' +
           '<h1 id="contact-name-title"><bdi></bdi></h1>' +
           '<button id="edit-contact-button" data-icon="edit-contact" data-l10n-id="editButton"></button>' +
         '</gaia-header>' +

--- a/apps/communications/contacts/test/unit/mock_form_dom.js.html
+++ b/apps/communications/contacts/test/unit/mock_form_dom.js.html
@@ -1,5 +1,5 @@
 var MockFormDom = '<section id="view-contact-form" role="region" data-mirror="mirror-contact-form" class="view view-edit-contact">';
-    MockFormDom += '  <gaia-header id="contact-form-header" action="edit">';
+    MockFormDom += '  <gaia-header ignore-dir id="contact-form-header" action="edit">';
     MockFormDom += '    <h1 id="contact-form-title" data-l10n-id="addContact">Add contact</h1>';
     MockFormDom += '    <button id="save-button" data-l10n-id="done">Done</button>';
     MockFormDom += '  </gaia-header>';

--- a/apps/communications/contacts/test/unit/mock_link.html
+++ b/apps/communications/contacts/test/unit/mock_link.html
@@ -1,7 +1,7 @@
 
     <section role="region" id="content" class="link">
 
-      <gaia-header id="link-header" action="close">
+      <gaia-header ignore-dir id="link-header" action="close">
         <h1 data-l10n-id="fbFriends">Facebook Friends</h1>
       </gaia-header>
 

--- a/apps/communications/contacts/test/unit/mock_matching_contacts.html
+++ b/apps/communications/contacts/test/unit/mock_matching_contacts.html
@@ -1,5 +1,5 @@
 <section role="region">
-      <gaia-header id="merge-header" action="close">
+      <gaia-header ignore-dir id="merge-header" action="close">
         <h1 id="title" data-l10n-id="mergeDuplicateTitle">Merge duplicates</h1>
       </gaia-header>
 

--- a/apps/communications/contacts/test/unit/mock_selection_dom.js.html
+++ b/apps/communications/contacts/test/unit/mock_selection_dom.js.html
@@ -1,7 +1,7 @@
 var MockSelectionDom =
 '      <!-- Tag selection -->' +
 '      <section id="view-select-tag" role="region" class="view view-right view-select-tag">' +
-'        <gaia-header id="settings-header" action="back">' +
+'        <gaia-header ignore-dir id="settings-header" action="back">' +
 '          <h1 data-l10n-id="label">Label</h1>' +
 '          <button id="settings-done" data-l10n-id="done">Done</button>' +
 '        </gaia-header>' +

--- a/apps/communications/contacts/test/unit/views/list_test.js
+++ b/apps/communications/contacts/test/unit/views/list_test.js
@@ -267,7 +267,7 @@ suite('Render contacts list', function() {
     selectSection = document.createElement('form');
     selectSection.id = 'selectable-form';
     selectSection.innerHTML = '<section role="region">' +
-    '<gaia-header id="selectable-form-header" action="close">' +
+    '<gaia-header ignore-dir id="selectable-form-header" action="close">' +
       '<h1 id="edit-title" data-l10n-id="contacts"></h1>' +
       '<button type="button" id="select-action"></button>' +
     '</gaia-header>' +

--- a/apps/communications/dialer/elements/call-info-view.html
+++ b/apps/communications/dialer/elements/call-info-view.html
@@ -1,7 +1,7 @@
 <element name="call-info-view" extends="form">
   <template>
 
-  <gaia-header id="call-info-gaia-header" action="back">
+  <gaia-header ignore-dir id="call-info-gaia-header" action="back">
     <h1 id="call-info-title"></h1>
   </gaia-header>
 

--- a/apps/communications/dialer/elements/edit-mode.html
+++ b/apps/communications/dialer/elements/edit-mode.html
@@ -2,7 +2,7 @@
   <template>
 
      <section role="region" class="theme-settings">
-       <gaia-header id="edit-mode-header" action="close">
+       <gaia-header ignore-dir id="edit-mode-header" action="close">
          <h1 id="header-edit-mode-text" data-l10n-id="edit"></h1>
          <button id="delete-button" data-l10n-id="delete" disabled>Delete</button>
        </gaia-header>

--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -124,7 +124,7 @@
         <a id="option-recents" role="tab" aria-controls="recents-panel" class="icon icon-recents" data-l10n-id="recents" aria-selected="false" data-destination="recents"></a>
         <div id="recents-panel" role="tabpanel" class="bb-tabpanel" aria-labelledby="option-recents">
           <section role="region">
-            <gaia-header>
+            <gaia-header ignore-dir>
               <h1 data-l10n-id="callLog"></h1>
               <button id="call-log-icon-edit" data-icon="edit" disabled data-l10n-id="callLogEditButton"></button>
             </gaia-header>
@@ -256,7 +256,7 @@
 
     <article id="mmi-screen" role="region" hidden>
       <section role="region">
-        <gaia-header id="mmi-header" action="close">
+        <gaia-header ignore-dir id="mmi-header" action="close">
           <h1 id="header-title">USSD</h1>
           <button id="send" data-l10n-id="send" disabled> Send </button>
         </gaia-header>

--- a/apps/costcontrol/elements/appdetail-view.html
+++ b/apps/costcontrol/elements/appdetail-view.html
@@ -1,6 +1,6 @@
 <element name="appdetail-view" extends="section">
   <template>
-    <gaia-header action="back">
+    <gaia-header ignore-dir action="back">
       <h1>{{localized-app-name}}</h1>
     </gaia-header>
 

--- a/apps/costcontrol/elements/topup-dialog.html
+++ b/apps/costcontrol/elements/topup-dialog.html
@@ -1,7 +1,7 @@
 <element name="topup-dialog" extends="section">
   <template>
 
-    <gaia-header id="topup-header" action="close">
+    <gaia-header ignore-dir id="topup-header" action="close">
       <h1 data-l10n-id="top-up"></h1>
       <button id="topup-send-button" data-l10n-id="send">Send</button>
     </gaia-header>

--- a/apps/costcontrol/fte.html
+++ b/apps/costcontrol/fte.html
@@ -63,7 +63,7 @@
 
    <!-- Global Step 1 -->
     <section role="region" class="view step" data-viewport="" id="step-1">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-welcome-title"></h1>
       </gaia-header>
       <section class="content vbox">
@@ -85,7 +85,7 @@
 
     <!-- Step 2 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="step-2">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-plantype-title"></h1>
       </gaia-header>
       <ul class="content choices">
@@ -113,7 +113,7 @@
 
     <!-- Prepaid step 2 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="prepaid-step-2">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-prepaid2-title"></h1>
       </gaia-header>
       <section class="content">
@@ -145,7 +145,7 @@
 
     <!-- Prepaid step 3 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="prepaid-step-3">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-prepaid3-title"></h1>
       </gaia-header>
       <section class="content">
@@ -238,7 +238,7 @@
 
     <!-- Postpaid step 2 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="postpaid-step-2">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-postpaid2-title"></h1>
       </gaia-header>
        <ul class="content settings">
@@ -318,7 +318,7 @@
 
     <!-- Postpaid step 3 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="postpaid-step-3">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-postpaid3-title"></h1>
       </gaia-header>
       <section class="content">
@@ -349,7 +349,7 @@
 
     <!-- Non VIVO step 2 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="non-vivo-step-1">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-onlydata2-title"></h1>
       </gaia-header>
       <ul class="content settings">
@@ -429,7 +429,7 @@
 
     <!-- Non VIVO step 3 -->
     <section role="region" class="view step gaia-list" data-viewport="right" id="non-vivo-step-2">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="fte-onlydata3-title"></h1>
       </gaia-header>
       <ul class="content settings">
@@ -459,7 +459,7 @@
 
   <!-- Data usage limits -->
   <section aria-labelledby="limit-dialog-heading" id="data-limit-dialog" role="dialog" class="view" data-viewport="bottom">
-    <gaia-header id="limit-dialog-header" action="close">
+    <gaia-header ignore-dir id="limit-dialog-header" action="close">
       <h1 id="limit-dialog-heading" data-l10n-id="data-limit-header"></h1>
       <button id="data-usage-done-button" data-l10n-id="done" class="recommend">Done</button>
     </gaia-header>

--- a/apps/costcontrol/index.html
+++ b/apps/costcontrol/index.html
@@ -91,7 +91,7 @@
       <div id="tabpanel">
         <!-- XXX: The order of sections is important (tabs should be place above
              the overlays) and we should distinguish between TABS and OVERLAY VIEWS -->
-        <gaia-header>
+        <gaia-header ignore-dir>
           <h1 data-l10n-id="usage"></h1>
           <button class="settings-button" data-icon="settings" data-l10n-id="settings-button"></button>
         </gaia-header>

--- a/apps/costcontrol/settings.html
+++ b/apps/costcontrol/settings.html
@@ -54,7 +54,7 @@
     <section role="region" class="window skin-organic">
       <!-- Settings view -->
       <section role="region" id="settings-view" class="view">
-        <gaia-header>
+        <gaia-header ignore-dir>
           <h1 data-l10n-id="settings"></h1>
           <button id="close-settings" data-l10n-id="done">done</button>
         </gaia-header>
@@ -210,7 +210,7 @@
 
       <!-- Data usage limits -->
       <section aria-labelledby="limit-dialog-heading" role="dialog" id="data-limit-dialog" class="view" data-viewport="bottom">
-        <gaia-header id="limit-dialog-header" action="close">
+        <gaia-header ignore-dir id="limit-dialog-header" action="close">
           <h1 id="limit-dialog-heading" data-l10n-id="data-limit-header"></h1>
           <button id="data-usage-done-button" data-l10n-id="done" class="recommend">Done</button>
         </gaia-header>

--- a/apps/download/pick.html
+++ b/apps/download/pick.html
@@ -40,7 +40,7 @@
 
   <body class="theme-media">
     <section role="region" class="skin-dark">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 data-l10n-id="select-download"></h1>
       </gaia-header>
 

--- a/apps/fl/pick.html
+++ b/apps/fl/pick.html
@@ -30,7 +30,7 @@
   </head>
   <body class="theme-media">
     <section role="region">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 id="title"></h1>
         <button id="done" data-l10n-id="done" hidden>Done</button>
       </gaia-header>

--- a/apps/ftu/index.html
+++ b/apps/ftu/index.html
@@ -129,7 +129,7 @@
   </section>
 
   <section id="unlock-sim-screen" role="region" class="skin-organic">
-    <gaia-header id="unlock-sim-action" action="back">
+    <gaia-header ignore-dir id="unlock-sim-action" action="back">
       <h1 id="unlock-sim-header"></h1>
     </gaia-header>
     <article role="main">
@@ -195,7 +195,7 @@
   </section>
 
   <section id="sim-info-screen" role="region" class="skin-organic">
-    <gaia-header>
+    <gaia-header ignore-dir>
       <h1 id="sim-info-header" data-l10n-id="simManager"></h1>
     </gaia-header>
     <article role="main">
@@ -239,7 +239,7 @@
   </section>
 
   <section id="activation-screen" role="region" class="skin-organic no-options">
-    <gaia-header>
+    <gaia-header ignore-dir>
       <h1 id="main-title"></h1>
       <button id="wifi-refresh-button" data-l10n-id="refresh">Refresh</button>
     </gaia-header>

--- a/apps/ftu/test/unit/mock_navigation_index.html
+++ b/apps/ftu/test/unit/mock_navigation_index.html
@@ -1,4 +1,4 @@
-<gaia-header>
+<gaia-header ignore-dir>
     <h1 id="main-title"></h1>
     <button id="wifi-refresh-button" data-l10n-id="refresh">Refresh</button>
 </gaia-header>

--- a/apps/gallery/index.html
+++ b/apps/gallery/index.html
@@ -74,13 +74,13 @@
     <!-- for all views that display the thumbnails -->
     <section role="region" id="thumbnail-views" class="skin-dark">
       <!-- This header only shown on tablet view  -->
-      <gaia-header id="thumbnails-list-top" class="thumbnails-list" title-start="0" title-end="0" no-font-fit>
+      <gaia-header ignore-dir id="thumbnails-list-top" class="thumbnails-list" title-start="0" title-end="0" no-font-fit>
         <h1 id="thumbnail-list-title" data-l10n-id="gallery"></h1>
       </gaia-header>
-      <gaia-header id="selected-header" class="thumbnails-select" action="close" title-start="50" title-end="0" no-font-fit>
+      <gaia-header ignore-dir id="selected-header" class="thumbnails-select" action="close" title-start="50" title-end="0" no-font-fit>
         <h1 id="thumbnails-number-selected"></h1>
       </gaia-header>
-      <gaia-header id="pick-header" class="thumbnails-pick" action="close" title-start="50" title-end="0" no-font-fit>
+      <gaia-header ignore-dir id="pick-header" class="thumbnails-pick" action="close" title-start="50" title-end="0" no-font-fit>
         <h1 id="pick-header-title" data-l10n-id="pickoneimage2"></h1>
       </gaia-header>
 
@@ -103,7 +103,7 @@
     </section>
 
     <section role="region" id="fullscreen-view" class="skin-dark">
-      <gaia-header id="fullscreen-toolbar-header" action="back" class="large-only" title-start="50" no-font-fit>
+      <gaia-header ignore-dir id="fullscreen-toolbar-header" action="back" class="large-only" title-start="50" no-font-fit>
         <h1 data-l10n-id="gallery" id="fullscreen-title"></h1>
         <a id="fullscreen-camera-button-large">
           <span data-icon="camera"></span>
@@ -161,7 +161,7 @@
     </form>
 
     <section role="region" id="crop-view" class="skin-dark">
-      <gaia-header id="crop-top" action="back" title-start="50" no-font-fit>
+      <gaia-header ignore-dir id="crop-top" action="back" title-start="50" no-font-fit>
         <h1 id="crop-header" data-l10n-id="cropimage"></h1>
         <button id="crop-done-button" data-l10n-id="done">done</button>
       </gaia-header>
@@ -171,7 +171,7 @@
     </section>
 
     <section role="region" id="edit-view" class="skin-dark">
-      <gaia-header id="edit-header" action="close" title-start="50" no-font-fit>
+      <gaia-header ignore-dir id="edit-header" action="close" title-start="50" no-font-fit>
         <h1 id="edit-title" data-l10n-id="edit"></h1>
         <button id="edit-save-button" data-l10n-id="save">Save</button>
         <button id="edit-tool-apply-button" data-l10n-id="apply" hidden>Apply</button>

--- a/apps/gallery/open.html
+++ b/apps/gallery/open.html
@@ -40,7 +40,7 @@
 
   <body role="application" class="theme-media">
     <section id="open" role="region" class="skin-dark">
-      <gaia-header id="header" action="back">
+      <gaia-header ignore-dir id="header" action="back">
         <h1 id="filename"></h1>
         <button id="save" data-l10n-id="save" class="hidden"></button>
       </gaia-header>

--- a/apps/keyboard/settings.html
+++ b/apps/keyboard/settings.html
@@ -56,7 +56,7 @@
 </head>
 <body class="skin-organic theme-settings">
   <section role="region" id="general" class="current">
-    <gaia-header id="general-header" action="back">
+    <gaia-header ignore-dir id="general-header" action="back">
       <h1 data-l10n-id="settingsPageTitle"></h1>
     </gaia-header>
     <!-- Don't change the div.id attribute below, if you want to modify it,
@@ -152,7 +152,7 @@
     </div>
   </section>
   <section role="region" id="panel-ud-wordlist">
-    <gaia-header id="ud-wordlist-header" action="back">
+    <gaia-header ignore-dir id="ud-wordlist-header" action="back">
       <h1 data-l10n-id="userDictionaryPanelHeader"></h1>
       <button id="ud-addword-btn" data-icon="add" data-href="#ud-editword" data-l10n-id="userDictionaryAddButton"></button>
     </gaia-header>
@@ -167,7 +167,7 @@
     </div>
   </section>
   <section role="dialog" id="panel-ud-editword">
-    <gaia-header id="ud-editword-header" action="close">
+    <gaia-header ignore-dir id="ud-editword-header" action="close">
       <h1 data-l10n-id="userDictionaryAdd" id="ud-editword-add-header"></h1>
       <h1 data-l10n-id="userDictionaryEdit" id="ud-editword-edit-header"></h1>
       <button id="ud-saveword-btn" data-l10n-id="userDictionarySaveButton"></button>

--- a/apps/pdfjs/content/web/viewer.html
+++ b/apps/pdfjs/content/web/viewer.html
@@ -39,7 +39,7 @@ limitations under the License.
 
   <body>
     <section role="region" id="activityHeader" class="skin-organic theme-settings">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 id="activityTitle"></h1>
       </gaia-header>
 

--- a/apps/privacy-panel/js/rp/passcode.js
+++ b/apps/privacy-panel/js/rp/passcode.js
@@ -1,6 +1,6 @@
 /**
  * PassCode panel.
- * 
+ *
  * @module PassCodePanel
  * @return {Object}
  */

--- a/apps/privacy-panel/templates/about/main.html
+++ b/apps/privacy-panel/templates/about/main.html
@@ -1,6 +1,6 @@
 <element name="about" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#root">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/ala/custom.html
+++ b/apps/privacy-panel/templates/ala/custom.html
@@ -1,6 +1,6 @@
 <element name="ala-custom" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="back" href="#">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/ala/exception.html
+++ b/apps/privacy-panel/templates/ala/exception.html
@@ -1,6 +1,6 @@
 <element name="ala-exception" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#ala-exceptions">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/ala/exceptions.html
+++ b/apps/privacy-panel/templates/ala/exceptions.html
@@ -1,6 +1,6 @@
 <element name="ala-exceptions" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#ala-main">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/ala/main.html
+++ b/apps/privacy-panel/templates/ala/main.html
@@ -1,6 +1,6 @@
 <element name="ala-main" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#root">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/rp/change_pass.html
+++ b/apps/privacy-panel/templates/rp/change_pass.html
@@ -1,6 +1,6 @@
 <element name="rp-change-pass" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#rp-main">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/rp/features.html
+++ b/apps/privacy-panel/templates/rp/features.html
@@ -1,6 +1,6 @@
 <element name="rp-features" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#root">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/rp/main.html
+++ b/apps/privacy-panel/templates/rp/main.html
@@ -1,6 +1,6 @@
 <element name="rp-main" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#root">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/rp/passcode.html
+++ b/apps/privacy-panel/templates/rp/passcode.html
@@ -1,6 +1,6 @@
 <element name="rp-passcode" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#rp-screenlock">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/rp/screenlock.html
+++ b/apps/privacy-panel/templates/rp/screenlock.html
@@ -1,6 +1,6 @@
 <element name="rp-screenlock" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#rp-features">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/privacy-panel/templates/tc/perm_details.html
+++ b/apps/privacy-panel/templates/tc/perm_details.html
@@ -1,6 +1,6 @@
 <element name="tc-permDetails" extends="section">
   <template>
-    <gaia-header>
+    <gaia-header ignore-dir>
       <a class="pp-link back" href="#tc-permissions">
         <span class="icon gaia-icon-back"></span>
       </a>

--- a/apps/ringtones/manage.html
+++ b/apps/ringtones/manage.html
@@ -50,7 +50,7 @@
 
   <body class="theme-settings">
     <section role="region" class="skin-organic">
-      <gaia-header id="header" action="back">
+      <gaia-header ignore-dir id="header" action="back">
         <h1 data-l10n-id="manage-title-2"></h1>
         <button id="add" data-icon="add" data-l10n-id="addButton"></button>
       </gaia-header>

--- a/apps/ringtones/pick.html
+++ b/apps/ringtones/pick.html
@@ -43,7 +43,7 @@
 
   <body class="theme-settings">
     <section role="region">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 id="title" data-l10n-id="pick-title"></h1>
         <button id="set" data-l10n-id="pick-set" disabled>set</button>
       </gaia-header>

--- a/apps/ringtones/share.html
+++ b/apps/ringtones/share.html
@@ -30,7 +30,7 @@
 
   <body class="theme-media">
     <section role="region" class="skin-dark">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 id="title" data-l10n-id="create-title"></h1>
         <button id="save" data-l10n-id="create-save" disabled>save</button>
       </gaia-header>

--- a/apps/settings/elements/about.html
+++ b/apps/settings/elements/about.html
@@ -1,7 +1,7 @@
 <element name="about" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="deviceInfo-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/about_legal.html
+++ b/apps/settings/elements/about_legal.html
@@ -1,7 +1,7 @@
 <element name="about-legal" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#about">
+    <gaia-header ignore-dir action="back" data-href="#about">
       <h1 data-l10n-id="about-legal-info-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/about_licensing.html
+++ b/apps/settings/elements/about_licensing.html
@@ -1,7 +1,7 @@
 <element name="about-licensing" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#about-legal">
+    <gaia-header ignore-dir action="back" data-href="#about-legal">
       <h1 data-l10n-id="open-source-notices-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/about_more_info.html
+++ b/apps/settings/elements/about_more_info.html
@@ -1,7 +1,7 @@
 <element name="about-moreInfo" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#about">
+    <gaia-header ignore-dir action="back" data-href="#about">
       <h1 data-l10n-id="more-info-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/about_source_code.html
+++ b/apps/settings/elements/about_source_code.html
@@ -1,7 +1,7 @@
 <element name="about-source-code" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#about-legal">
+    <gaia-header ignore-dir action="back" data-href="#about-legal">
       <h1 data-l10n-id="obtaining-source-code-header"></h1>
     </gaia-header>
     <iframe src="resources/obtaining_source_code.html" id="obtain-sc"></iframe>

--- a/apps/settings/elements/about_your_privacy.html
+++ b/apps/settings/elements/about_your_privacy.html
@@ -1,7 +1,7 @@
 <element name="about-yourPrivacy" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#about">
+    <gaia-header ignore-dir action="back" data-href="#about">
       <h1 data-l10n-id="your-privacy-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/about_your_rights.html
+++ b/apps/settings/elements/about_your_rights.html
@@ -1,7 +1,7 @@
 <element name="about-yourRights" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#about">
+    <gaia-header ignore-dir action="back" data-href="#about">
       <h1 data-l10n-id="your-rights-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/accessibility.html
+++ b/apps/settings/elements/accessibility.html
@@ -1,7 +1,7 @@
 <element name="accessibility" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="accessibility-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/accessibility_audio.html
+++ b/apps/settings/elements/accessibility_audio.html
@@ -1,7 +1,7 @@
 <element name="accessibility-audio" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#accessibility">
+    <gaia-header ignore-dir action="back" data-href="#accessibility">
       <h1 data-l10n-id="accessibility-audio"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/accessibility_colors.html
+++ b/apps/settings/elements/accessibility_colors.html
@@ -1,7 +1,7 @@
 <element name="accessibility-colors" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#accessibility">
+    <gaia-header ignore-dir action="back" data-href="#accessibility">
       <h1 data-l10n-id="colorFilter-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/accessibility_screenreader.html
+++ b/apps/settings/elements/accessibility_screenreader.html
@@ -1,7 +1,7 @@
 <element name="accessibility-screenreader" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#accessibility">
+    <gaia-header ignore-dir action="back" data-href="#accessibility">
       <h1 data-l10n-id="screenReader-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/achievements.html
+++ b/apps/settings/elements/achievements.html
@@ -1,7 +1,7 @@
 <element name="achievements" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="achievements"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/addon_details.html
+++ b/apps/settings/elements/addon_details.html
@@ -1,7 +1,7 @@
 <element name="addon-details" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#addons" hidden>
+    <gaia-header ignore-dir action="back" data-href="#addons" hidden>
       <h1 class="addon-details-header" data-l10n-id="addon-details-header1"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/addons.html
+++ b/apps/settings/elements/addons.html
@@ -1,7 +1,7 @@
 <element name="addons" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="addons-header"></h1>
       <button class="addons-add" data-icon="add" data-l10n-id="addButton"></button>
     </gaia-header>

--- a/apps/settings/elements/apn_editor.html
+++ b/apps/settings/elements/apn_editor.html
@@ -1,7 +1,7 @@
 <element name="apn-editor" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#apn-list">
+    <gaia-header ignore-dir action="back" data-href="#apn-list">
       <h1 data-l10n-id="apn-editor-header"></h1>
       <button class="ok"><span data-l10n-id="ok"></span></button>
     </gaia-header>

--- a/apps/settings/elements/apn_list.html
+++ b/apps/settings/elements/apn_list.html
@@ -1,7 +1,7 @@
 <element name="apn-list" extends="section">
   <template>
 
-    <gaia-header action="back">
+    <gaia-header ignore-dir action="back">
       <h1></h1>
     </gaia-header>
 

--- a/apps/settings/elements/apn_settings.html
+++ b/apps/settings/elements/apn_settings.html
@@ -1,7 +1,7 @@
 <element name="apn-settings" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#carrier">
+    <gaia-header ignore-dir action="back" data-href="#carrier">
       <h1 data-l10n-id="apnSettings-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/app_permissions.html
+++ b/apps/settings/elements/app_permissions.html
@@ -1,7 +1,7 @@
 <element name="appPermissions" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="root">
+    <gaia-header ignore-dir action="back" data-href="root">
       <h1 data-l10n-id="appPermissions-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/app_permissions_details.html
+++ b/apps/settings/elements/app_permissions_details.html
@@ -1,7 +1,7 @@
 <element name="appPermissions-details" extends="section">
   <template>
 
-    <gaia-header action="back">
+    <gaia-header ignore-dir action="back">
       <h1 class="detail-title"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/application_storage.html
+++ b/apps/settings/elements/application_storage.html
@@ -1,7 +1,7 @@
 <element name="applicationStorage" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="appStorage-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/battery.html
+++ b/apps/settings/elements/battery.html
@@ -1,7 +1,7 @@
 <element name="battery" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="battery-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/bluetooth.html
+++ b/apps/settings/elements/bluetooth.html
@@ -1,7 +1,7 @@
 <element name="bluetooth" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="bluetooth-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/bluetooth_v2.html
+++ b/apps/settings/elements/bluetooth_v2.html
@@ -1,7 +1,7 @@
 <element name="bluetooth_v2" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="bluetooth-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/browsing_privacy.html
+++ b/apps/settings/elements/browsing_privacy.html
@@ -1,7 +1,7 @@
 <element name="browsingPrivacy" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="browsingPrivacy-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/call.html
+++ b/apps/settings/elements/call.html
@@ -1,7 +1,7 @@
 <element name="call" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="callSettings-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/call_barring_passcode_change.html
+++ b/apps/settings/elements/call_barring_passcode_change.html
@@ -1,7 +1,7 @@
 <element name="call-barring-passcode-change" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#call-cbSettings">
+    <gaia-header ignore-dir action="back" data-href="#call-cbSettings">
       <h1 data-l10n-id="callBarring-current-passcode" data-mode="edit"></h1>
       <h1 data-l10n-id="callBarring-new-passcode" data-mode="new"></h1>
       <button id="passcode-confirm" class="passcode-change" data-mode="new" data-l10n-id="change">Change</button>

--- a/apps/settings/elements/call_cf_mobile_busy_settings.html
+++ b/apps/settings/elements/call_cf_mobile_busy_settings.html
@@ -1,7 +1,7 @@
 <element name="call-cf-mobile-busy-settings" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="callForwarding-header"></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/call_cf_no_reply_settings.html
+++ b/apps/settings/elements/call_cf_no_reply_settings.html
@@ -1,7 +1,7 @@
 <element name="call-cf-no-reply-settings" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="callForwarding-header"></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/call_cf_not_reachable_settings.html
+++ b/apps/settings/elements/call_cf_not_reachable_settings.html
@@ -1,7 +1,7 @@
 <element name="call-cf-not-reachable-settings" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="callForwarding-header"></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/call_cf_unconditional_settings.html
+++ b/apps/settings/elements/call_cf_unconditional_settings.html
@@ -1,7 +1,7 @@
 <element name="call-cf-unconditional-settings" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="callForwarding-header"></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/call_fdn_list.html
+++ b/apps/settings/elements/call_fdn_list.html
@@ -1,7 +1,7 @@
 <element name="call-fdnList" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#call-fdnSettings">
+    <gaia-header ignore-dir action="back" data-href="#call-fdnSettings">
       <h1 data-l10n-id="fdn-authorizedNumbers-header"></h1>
       <button class="fdnContact"><span data-l10n-id="add" class="icon icon-add"></span></button>
     </gaia-header>

--- a/apps/settings/elements/call_fdn_list_add.html
+++ b/apps/settings/elements/call_fdn_list_add.html
@@ -1,7 +1,7 @@
 <element name="call-fdnList-add" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 class="fdnContact-title"></h1>
       <button type="submit" class="fdnContact-submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/call_fdn_settings.html
+++ b/apps/settings/elements/call_fdn_settings.html
@@ -1,7 +1,7 @@
 <element name="call-fdnSettings" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#call">
+    <gaia-header ignore-dir action="back" data-href="#call">
       <h1 data-l10n-id="fdnSettings-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/call_forwarding.html
+++ b/apps/settings/elements/call_forwarding.html
@@ -1,7 +1,7 @@
 <element name="call-forwarding" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#call">
+    <gaia-header ignore-dir action="back" data-href="#call">
       <h1 data-l10n-id="callForwarding-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/call_iccs.html
+++ b/apps/settings/elements/call_iccs.html
@@ -1,7 +1,7 @@
 <element name="call-iccs" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="selectASIMCard"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/call_voice_mail_settings.html
+++ b/apps/settings/elements/call_voice_mail_settings.html
@@ -1,7 +1,7 @@
 <element name="call-voiceMailSettings" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="voiceMail-header"></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/carrier.html
+++ b/apps/settings/elements/carrier.html
@@ -1,7 +1,7 @@
 <element name="carrier" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="cellularAndData-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/carrier_detail.html
+++ b/apps/settings/elements/carrier_detail.html
@@ -1,7 +1,7 @@
 <element name="carrier-detail" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#carrier">
+    <gaia-header ignore-dir action="back" data-href="#carrier">
       <h1 data-l10n-id="netOperator-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/crash_reports.html
+++ b/apps/settings/elements/crash_reports.html
@@ -1,7 +1,7 @@
 <element name="crashReports" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#improveBrowserOS">
+    <gaia-header ignore-dir action="back" data-href="#improveBrowserOS">
       <h1 data-l10n-id="crashReports-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/date_time.html
+++ b/apps/settings/elements/date_time.html
@@ -1,7 +1,7 @@
 <element name="dateTime" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="dateAndTime-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/developer.html
+++ b/apps/settings/elements/developer.html
@@ -5,7 +5,7 @@
 <element name="developer" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="developer-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/developer_hud.html
+++ b/apps/settings/elements/developer_hud.html
@@ -1,7 +1,7 @@
 <element name="developer-hud" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#developer">
+    <gaia-header ignore-dir action="back" data-href="#developer">
       <h1 data-l10n-id="hud-settings-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/developer_service_workers.html
+++ b/apps/settings/elements/developer_service_workers.html
@@ -5,7 +5,7 @@
 <element name="developer-service-workers" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#developer">
+    <gaia-header ignore-dir action="back" data-href="#developer">
       <h1 data-l10n-id="service-worker"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/display.html
+++ b/apps/settings/elements/display.html
@@ -1,7 +1,7 @@
 <element name="display" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="display-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/do_not_track.html
+++ b/apps/settings/elements/do_not_track.html
@@ -1,7 +1,7 @@
 <element name="doNotTrack" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="doNotTrack-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/downloads.html
+++ b/apps/settings/elements/downloads.html
@@ -1,11 +1,11 @@
 <element name="downloads" extends="section">
   <template>
-    <gaia-header id="downloads-header" action="back" data-href="#root">
+
+    <gaia-header ignore-dir id="downloads-header" action="back" data-href="#root">
       <h1 data-l10n-id="downloads"></h1>
       <button id="downloads-edit-button" data-icon="edit" data-l10n-id="editButton"></button>
     </gaia-header>
-
-    <gaia-header id="downloads-edit-header" action="close" hidden="hidden">
+    <gaia-header ignore-dir id="downloads-edit-header" action="close" hidden="hidden">
       <h1 id="downloads-title-edit" data-l10n-id="downloads-edit"></h1>
       <button disabled id="downloads-delete-button" data-l10n-id="downloads-delete"></button>
     </gaia-header>

--- a/apps/settings/elements/findmydevice.html
+++ b/apps/settings/elements/findmydevice.html
@@ -1,7 +1,7 @@
 <element name="findmydevice" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="findmydevice"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/firefox_accounts.html
+++ b/apps/settings/elements/firefox_accounts.html
@@ -1,7 +1,7 @@
 <element name="fxa" extends="section" id="fxa-container">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="fxa-accounts-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/firefox_sync.html
+++ b/apps/settings/elements/firefox_sync.html
@@ -1,7 +1,7 @@
 <element name="fxsync" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="fxsync"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/help.html
+++ b/apps/settings/elements/help.html
@@ -1,7 +1,7 @@
 <element name="help" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="help"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/homescreen_details.html
+++ b/apps/settings/elements/homescreen_details.html
@@ -1,7 +1,7 @@
 <element name="homescreen-details" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#homescreens-list">
+    <gaia-header ignore-dir action="back" data-href="#homescreens-list">
       <h1 class="detail-title"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/homescreens.html
+++ b/apps/settings/elements/homescreens.html
@@ -1,7 +1,7 @@
 <element name="homescreens" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="home-screens"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/homescreens_list.html
+++ b/apps/settings/elements/homescreens_list.html
@@ -1,7 +1,7 @@
 <element name="homescreens-list" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#homescreens">
+    <gaia-header ignore-dir action="back" data-href="#homescreens">
       <h1 data-l10n-id="change-home-screen"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/hotspot.html
+++ b/apps/settings/elements/hotspot.html
@@ -1,7 +1,7 @@
 <element name="hotspot" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="internetSharing-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/hotspot_wifi_settings.html
+++ b/apps/settings/elements/hotspot_wifi_settings.html
@@ -1,7 +1,7 @@
 <element name="hotspot-wifiSettings" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="hotspotSettings-header"></h1>
       <button class="save-hotspotSettings" type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/icc.html
+++ b/apps/settings/elements/icc.html
@@ -1,7 +1,7 @@
 <element name="icc" extends="section">
   <template>
 
-    <gaia-header id="icc-stk-main-header" action="back">
+    <gaia-header ignore-dir id="icc-stk-main-header" action="back">
       <h1 id="icc-stk-header" data-l10n-id="simToolkit-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/improve_browser_os.html
+++ b/apps/settings/elements/improve_browser_os.html
@@ -1,7 +1,7 @@
 <element name="improveBrowserOS" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="improveBrowserOSTitle"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/improve_browser_os_choose_feedback.html
+++ b/apps/settings/elements/improve_browser_os_choose_feedback.html
@@ -1,7 +1,7 @@
 <element name="improveBrowserOS-chooseFeedback" extends="section">
   <template>
 
-  	<gaia-header action="back" data-href="#improveBrowserOS">
+  	<gaia-header ignore-dir action="back" data-href="#improveBrowserOS">
       <h1 data-l10n-id="sendFeedbackTitle"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/improve_browser_os_send_feedback.html
+++ b/apps/settings/elements/improve_browser_os_send_feedback.html
@@ -1,7 +1,7 @@
 <element name="improveBrowserOS-sendFeedback" extends="section">
   <template>
 
-  	<gaia-header action="back" id="feedback-header">
+  	<gaia-header ignore-dir action="back" id="feedback-header">
       <h1 id="feedback-title"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/keyboard.html
+++ b/apps/settings/elements/keyboard.html
@@ -1,7 +1,7 @@
 <element name="keyboard" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="keyboards-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/keyboard_selection_add_more.html
+++ b/apps/settings/elements/keyboard_selection_add_more.html
@@ -1,7 +1,7 @@
 <element name="keyboard-selection-addMore" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#keyboard">
+    <gaia-header ignore-dir action="back" data-href="#keyboard">
       <h1 data-l10n-id="selectKeyboards-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/languages.html
+++ b/apps/settings/elements/languages.html
@@ -1,7 +1,7 @@
 <element name="languages" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="language-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/media_storage.html
+++ b/apps/settings/elements/media_storage.html
@@ -1,7 +1,7 @@
 <element name="mediaStorage" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="mediaStorage-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/messaging.html
+++ b/apps/settings/elements/messaging.html
@@ -1,7 +1,7 @@
 <element name="messaging" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="messagingSettings-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/messaging_details.html
+++ b/apps/settings/elements/messaging_details.html
@@ -1,7 +1,7 @@
 <element name="messaging-details" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#messaging">
+    <gaia-header ignore-dir action="back" data-href="#messaging">
       <h1 data-l10n-id="messaging-sim-settings"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/navigation.html
+++ b/apps/settings/elements/navigation.html
@@ -1,7 +1,7 @@
 <element name="navigation" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="navigation-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/notifications.html
+++ b/apps/settings/elements/notifications.html
@@ -1,7 +1,7 @@
 <element name="notifications" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="notifications-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/operator_settings.html
+++ b/apps/settings/elements/operator_settings.html
@@ -1,7 +1,7 @@
 <element name="operator-settings" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#carrier">
+    <gaia-header ignore-dir action="back" data-href="#carrier">
       <h1 data-l10n-id="netOperator-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/root.html
+++ b/apps/settings/elements/root.html
@@ -1,7 +1,7 @@
 <element name="root" extends="section">
   <template>
 
-    <gaia-header id="main-header">
+    <gaia-header ignore-dir id="main-header">
       <h1 id="main-list-title" data-l10n-id="settings"></h1>
       <a id="activityDoneButton" role="menuitem" data-l10n-id="done"></a>
     </gaia-header>

--- a/apps/settings/elements/screen_lock.html
+++ b/apps/settings/elements/screen_lock.html
@@ -1,7 +1,7 @@
 <element name="screenLock" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="screenLock-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/screen_lock_passcode.html
+++ b/apps/settings/elements/screen_lock_passcode.html
@@ -1,7 +1,7 @@
 <element name="screenLock-passcode" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/search.html
+++ b/apps/settings/elements/search.html
@@ -1,7 +1,7 @@
 <element name="search" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="search-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/simcard_manager.html
+++ b/apps/settings/elements/simcard_manager.html
@@ -1,7 +1,7 @@
 <element name="sim-manager" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="simManager-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/simpin.html
+++ b/apps/settings/elements/simpin.html
@@ -1,7 +1,7 @@
 <element name="simpin" extends="section">
   <template>
 
-    <gaia-header class="simpin-header" action="back" data-href="#root">
+    <gaia-header ignore-dir class="simpin-header" action="back" data-href="#root">
       <h1 data-l10n-id="simSecurity-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/simpin_dialog.html
+++ b/apps/settings/elements/simpin_dialog.html
@@ -1,7 +1,7 @@
 <element name="simpin-dialog" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1></h1>
       <button data-l10n-id="done" type="submit"></button>

--- a/apps/settings/elements/sound.html
+++ b/apps/settings/elements/sound.html
@@ -1,7 +1,7 @@
 <element name="sound" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="sound-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/usb_storage.html
+++ b/apps/settings/elements/usb_storage.html
@@ -1,7 +1,7 @@
 <element name="usbStorage" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="enableUSBStorage1"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/wifi.html
+++ b/apps/settings/elements/wifi.html
@@ -1,7 +1,7 @@
 <element name="wifi" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#root">
+    <gaia-header ignore-dir action="back" data-href="#root">
       <h1 data-l10n-id="wifi-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/wifi_auth.html
+++ b/apps/settings/elements/wifi_auth.html
@@ -1,7 +1,7 @@
 <element name="wifi-auth" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-ssid> Network Authentication </h1>
       <button type="submit"><span data-l10n-id="ok">OK</span></button>

--- a/apps/settings/elements/wifi_enter_certificate_nickname.html
+++ b/apps/settings/elements/wifi_enter_certificate_nickname.html
@@ -1,7 +1,7 @@
 <element name="wifi-enterCertificateNickname" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="enterCertificateNickname"></h1>
       <button type="submit"><span data-l10n-id="done"></span></button>

--- a/apps/settings/elements/wifi_join_hidden.html
+++ b/apps/settings/elements/wifi_join_hidden.html
@@ -1,7 +1,7 @@
 <element name="wifi-joinHidden" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="authentication-header"></h1>
       <button type="submit"><span data-l10n-id="ok"></span></button>

--- a/apps/settings/elements/wifi_manage_certificates.html
+++ b/apps/settings/elements/wifi_manage_certificates.html
@@ -1,7 +1,7 @@
 <element name="wifi-manageCertificates" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#wifi">
+    <gaia-header ignore-dir action="back" data-href="#wifi">
       <h1 data-l10n-id="manageCertificates-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/wifi_manage_networks.html
+++ b/apps/settings/elements/wifi_manage_networks.html
@@ -1,7 +1,7 @@
 <element name="wifi-manageNetworks" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#wifi">
+    <gaia-header ignore-dir action="back" data-href="#wifi">
       <h1 data-l10n-id="manageNetworks-header"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/wifi_select_certificate_file.html
+++ b/apps/settings/elements/wifi_select_certificate_file.html
@@ -1,7 +1,7 @@
 <element name="wifi-selectCertificateFile" extends="section">
   <template>
 
-    <gaia-header action="back" data-href="#wifi-manageCertificates">
+    <gaia-header ignore-dir action="back" data-href="#wifi-manageCertificates">
       <h1 data-l10n-id="selectCertificateFile"></h1>
     </gaia-header>
 

--- a/apps/settings/elements/wifi_status.html
+++ b/apps/settings/elements/wifi_status.html
@@ -1,7 +1,7 @@
 <element name="wifi-status" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-ssid> Network Status </h1>
       <button type="submit"><span data-l10n-id="forget"></span></button>

--- a/apps/settings/elements/wifi_wps.html
+++ b/apps/settings/elements/wifi_wps.html
@@ -1,7 +1,7 @@
 <element name="wifi-wps" extends="section">
   <template>
 
-    <gaia-header>
+    <gaia-header ignore-dir>
       <button type="reset"><span data-icon="close" data-l10n-id="closeButton"></span></button>
       <h1 data-l10n-id="wpsMessage-header"></h1>
       <button type="submit"><span data-l10n-id="ok">OK</span></button>

--- a/apps/settings/test/unit/_achievements.html
+++ b/apps/settings/test/unit/_achievements.html
@@ -1,4 +1,4 @@
-<gaia-header action="back" data-href="#root">
+<gaia-header ignore-dir action="back" data-href="#root">
   <h1 data-l10n-id="achievements"></h1>
 </gaia-header>
 

--- a/apps/settings/test/unit/_addons.html
+++ b/apps/settings/test/unit/_addons.html
@@ -1,4 +1,4 @@
-<gaia-header action="back" data-href="#root">
+<gaia-header ignore-dir action="back" data-href="#root">
   <h1 data-l10n-id="addons-header"></h1>
   <button class="addons-add" data-icon="add" data-l10n-id="addButton"></button>
 </gaia-header>

--- a/apps/settings/test/unit/_firefox_sync.html
+++ b/apps/settings/test/unit/_firefox_sync.html
@@ -1,4 +1,4 @@
-<gaia-header action="back" data-href="#root">
+<gaia-header ignore-dir action="back" data-href="#root">
   <h1 data-l10n-id="fxsync"></h1>
 </gaia-header>
 

--- a/apps/settings/test/unit/_send_feedback.html
+++ b/apps/settings/test/unit/_send_feedback.html
@@ -1,4 +1,4 @@
-<gaia-header action="back" id="feedback-header">
+<gaia-header ignore-dir action="back" id="feedback-header">
   <h1 id="feedback-title"></h1>
 </gaia-header>
 <div>

--- a/apps/sms/index.html
+++ b/apps/sms/index.html
@@ -137,7 +137,7 @@
           at the start and end of the line -->
         <!-- see https://github.com/gaia-components/gaia-header/ for more information -->
         <!-- WARNING: the actual value depends on the actual CSS being used in gaia-header -->
-        <gaia-header class="view-header regular-header" title-start="0" title-end="100">
+        <gaia-header ignore-dir class="view-header regular-header" title-start="0" title-end="100">
           <h1 data-l10n-id="messages"></h1>
           <a href="#/composer" id="threads-composer-link" data-icon="compose" data-l10n-id="composeLink"></a>
           <a id="threads-options-button" data-icon="more" data-l10n-id="actionsButton"></a>
@@ -155,7 +155,7 @@
 
         <form id="threads-edit-form" role="dialog" data-type="edit">
           <section role="region" class="theme-settings">
-            <gaia-header id="threads-edit-header" action="close" no-font-fit>
+            <gaia-header ignore-dir id="threads-edit-header" action="close" no-font-fit>
               <h1 id="threads-edit-mode" data-l10n-id="selectThreads-title"></h1>
               <button id="threads-check-uncheck-all-button" class="edit-button" data-l10n-id="select-all"></button>
             </gaia-header>
@@ -180,7 +180,7 @@
       </section>
 
       <section class="panel panel-ConversationView editable-select-mode" role="region" aria-hidden="true">
-        <gaia-header id="messages-header" class="view-header regular-header" action="back" no-font-fit>
+        <gaia-header ignore-dir id="messages-header" class="view-header regular-header" action="back" no-font-fit>
           <h1 id="messages-header-text" aria-hidden="true"></h1>
           <button id="messages-call-number-button" data-icon="call" class="hide" data-l10n-id="callButton"></button>
           <button id="messages-options-button" data-icon="more" data-l10n-id="actionsButton"></button>
@@ -290,7 +290,7 @@
         </article>
         <form role="dialog" id="messages-edit-form" data-type="edit" >
           <section role="region" class="theme-settings">
-            <gaia-header id="messages-edit-header" action="close" no-font-fit>
+            <gaia-header ignore-dir id="messages-edit-header" action="close" no-font-fit>
               <h1 id="messages-edit-mode" data-l10n-id="deleteMessages-title"></h1>
               <button id="messages-check-uncheck-all-button" class="edit-button" data-l10n-id="select-all"></button>
             </gaia-header>
@@ -309,7 +309,7 @@
       </section>
 
       <section class="panel panel-GroupView" role="region" aria-hidden="true">
-        <gaia-header id="information-group-header" class="header" action="back" no-font-fit>
+        <gaia-header ignore-dir id="information-group-header" class="header" action="back" no-font-fit>
           <h1 data-l10n-id="participant" class="header-text"></h1>
         </gaia-header>
         <article class="view-body article-list" data-type="list">
@@ -318,7 +318,7 @@
       </section>
 
       <section class="panel panel-ReportView" role="region" aria-hidden="true">
-        <gaia-header id="information-report-header" class="header" action="close" no-font-fit>
+        <gaia-header ignore-dir id="information-report-header" class="header" action="close" no-font-fit>
           <h1 data-l10n-id="message-report"></h1>
         </gaia-header>
         <article class="view-body article-list report-view container" data-type="list">

--- a/apps/sms/views/conversation/index.html
+++ b/apps/sms/views/conversation/index.html
@@ -124,7 +124,7 @@
   <iframe src="/views/shared/shim_host.html" class="shim-host" hidden></iframe>
   <article id="main-wrapper" class="wrapper conversation-view">
     <section class="panel panel-ConversationView editable-select-mode" role="region" aria-hidden="true">
-      <gaia-header id="messages-header" class="view-header regular-header" action="back" no-font-fit>
+      <gaia-header ignore-dir id="messages-header" class="view-header regular-header" action="back" no-font-fit>
         <h1 id="messages-header-text" aria-hidden="true"></h1>
         <button id="messages-call-number-button" data-icon="call" class="hide" data-l10n-id="callButton"></button>
         <button id="messages-options-button" data-icon="more" data-l10n-id="actionsButton"></button>
@@ -234,7 +234,7 @@
       </article>
       <form role="dialog" id="messages-edit-form" data-type="edit" >
         <section role="region" class="theme-settings">
-          <gaia-header id="messages-edit-header" action="close" no-font-fit>
+          <gaia-header ignore-dir id="messages-edit-header" action="close" no-font-fit>
             <h1 id="messages-edit-mode" data-l10n-id="deleteMessages-title"></h1>
             <button id="messages-check-uncheck-all-button" class="edit-button" data-l10n-id="select-all"></button>
           </gaia-header>
@@ -253,7 +253,7 @@
     </section>
 
     <section class="panel panel-GroupView" role="region" aria-hidden="true">
-      <gaia-header id="information-group-header" class="header" action="back" no-font-fit>
+      <gaia-header ignore-dir id="information-group-header" class="header" action="back" no-font-fit>
         <h1 data-l10n-id="participant" class="header-text"></h1>
       </gaia-header>
       <article class="view-body article-list" data-type="list">
@@ -262,7 +262,7 @@
     </section>
 
     <section class="panel panel-ReportView" role="region" aria-hidden="true">
-      <gaia-header id="information-report-header" class="header" action="close" no-font-fit>
+      <gaia-header ignore-dir id="information-report-header" class="header" action="close" no-font-fit>
         <h1 data-l10n-id="message-report"></h1>
       </gaia-header>
       <article class="view-body article-list report-view container" data-type="list">

--- a/apps/sms/views/inbox/index.html
+++ b/apps/sms/views/inbox/index.html
@@ -97,7 +97,7 @@
           at the start and end of the line -->
         <!-- see https://github.com/gaia-components/gaia-header/ for more information -->
         <!-- WARNING: the actual value depends on the actual CSS being used in gaia-header -->
-        <gaia-header class="view-header regular-header" title-start="0" title-end="100">
+        <gaia-header ignore-dir class="view-header regular-header" title-start="0" title-end="100">
           <h1 data-l10n-id="messages"></h1>
           <a href="#/composer" id="threads-composer-link" data-icon="compose" data-l10n-id="composeLink"></a>
           <a id="threads-options-button" data-icon="more" data-l10n-id="actionsButton"></a>
@@ -115,7 +115,7 @@
 
         <form id="threads-edit-form" role="dialog" data-type="edit">
           <section role="region" class="theme-settings">
-            <gaia-header id="threads-edit-header" action="close" no-font-fit>
+            <gaia-header ignore-dir id="threads-edit-header" action="close" no-font-fit>
               <h1 id="threads-edit-mode" data-l10n-id="selectThreads-title"></h1>
               <button id="threads-check-uncheck-all-button" class="edit-button" data-l10n-id="select-all"></button>
             </gaia-header>

--- a/apps/verticalhome/index.html
+++ b/apps/verticalhome/index.html
@@ -79,7 +79,7 @@
     <div id="curtain"></div>
 
     <section id="edit-header" role="region">
-      <gaia-header>
+      <gaia-header ignore-dir>
         <h1 data-l10n-id="edit-mode"></h1>
         <a href="#" data-l10n-id="edit-done" id="exit-edit-mode"></a>
       </gaia-header>
@@ -102,7 +102,7 @@
     </gaia-menu>
 
     <section id="edit-group" role="region" hidden>
-      <gaia-header id="edit-group-header" action="close">
+      <gaia-header ignore-dir id="edit-group-header" action="close">
         <h1 data-l10n-id="edit-group-header"></h1>
         <button id="edit-group-save" disabled type="button" data-l10n-id="edit-done"></button>
       </gaia-header>

--- a/apps/video/index.html
+++ b/apps/video/index.html
@@ -51,11 +51,11 @@
     <div id="app-container">
       <div id="two-column-spearator"></div>
       <section role="region" id="thumbnail-views">
-        <gaia-header id="picker-header" action="back" class="thumbnails-list">
+        <gaia-header ignore-dir id="picker-header" action="back" class="thumbnails-list">
           <h1 id="picker-title" data-l10n-id="pick-title"></h1>
           <h1 id="thumbnail-list-title">Video</h1>
         </gaia-header>
-        <gaia-header id="thumbnails-select-top" action="close"
+        <gaia-header ignore-dir id="thumbnails-select-top" action="close"
                      class="thumbnails-select">
           <h1 id="thumbnails-number-selected"></h1>
         </gaia-header>
@@ -87,7 +87,7 @@
         <div id="spinner-overlay" class="hidden" role="progress"
              data-l10n-id="spinner-overlay"><div id="spinner"></div></div>
         <!-- video controls header -->
-        <gaia-header id="player-header" action="back" class="video-controls">
+        <gaia-header ignore-dir id="player-header" action="back" class="video-controls">
           <h1 id="video-title"></h1>
           <button id="options" data-icon="more"
                   data-l10n-id="options-more"></button>

--- a/apps/video/view.html
+++ b/apps/video/view.html
@@ -19,7 +19,7 @@
              data-l10n-id="spinner-overlay"><div id="spinner"></div></div>
     <section role="region" id="player-view" class="video-controls-hidden">
       <!-- video controls header -->
-      <gaia-header id="player-header" action="back" class="video-controls">
+      <gaia-header ignore-dir id="player-header" action="back" class="video-controls">
         <h1 id="video-title"></h1>
         <button id="save" data-l10n-id="save" hidden></button>
       </gaia-header>

--- a/apps/wallpaper/pick.html
+++ b/apps/wallpaper/pick.html
@@ -24,7 +24,7 @@
 
   <body class="theme-media">
     <section role="region" class="skin-dark">
-      <gaia-header id="header" action="close">
+      <gaia-header ignore-dir id="header" action="close">
         <h1 data-l10n-id="select-wallpaper"></h1>
       </gaia-header>
     </section>

--- a/apps/wappush/index.html
+++ b/apps/wappush/index.html
@@ -53,7 +53,7 @@
   <body role="application" class="theme-productivity">
     <!-- SI SL message screen -->
     <article id="si-sl-screen" role="main" hidden>
-      <gaia-header id="header-si-sl" action="close">
+      <gaia-header ignore-dir id="header-si-sl" action="close">
         <h1 id="title-si-sl"></h1>
       </gaia-header>
 
@@ -69,7 +69,7 @@
 
       <!-- Client provisioning APNs screen -->
       <article id="cp-apn-screen" role="main" class="view">
-        <gaia-header id="header-apn-list" action="close">
+        <gaia-header ignore-dir id="header-apn-list" action="close">
           <h1 id="title-apn"></h1>
           <button id="apn-accept" data-l10n-id="next" class="full recommend"></button>
         </gaia-header>
@@ -82,7 +82,7 @@
 
       <!-- Client provisioning details screen -->
       <article id="cp-details-screen" role="main" class="view right">
-        <gaia-header id="header-details" action="close">
+        <gaia-header ignore-dir id="header-details" action="close">
           <h1 id="title-details"></h1>
           <button id="details-accept" data-l10n-id="next" class="full recommend"></button>
         </gaia-header>
@@ -95,7 +95,7 @@
 
       <!-- Client provisioning message screen -->
       <article id="cp-pin-screen" role="main" class="view right">
-        <gaia-header id="header-pin" action="back">
+        <gaia-header ignore-dir id="header-pin" action="back">
           <h1 id="title-pin"></h1>
           <button id="pin-accept" data-l10n-id="done" class="full recommend"></button>
         </gaia-header>

--- a/shared/bower.json
+++ b/shared/bower.json
@@ -7,10 +7,13 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gaia-header": "gaia-components/gaia-header#~0.8.0",
+    "gaia-header": "gaia-components/gaia-header#~0.9.0",
     "gaia-theme": "gaia-components/gaia-theme#~0.4.6",
     "gaia-icons": "gaia-components/gaia-icons#~0.9.0",
     "gaia-toast": "gaia-components/gaia-toast",
     "gaia-site-icon": "gaia-components/gaia-site-icon"
+  },
+  "resolutions": {
+    "gaia-component": "~0.4.0"
   }
 }

--- a/shared/elements/gaia-component/.bower.json
+++ b/shared/elements/gaia-component/.bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-component",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
@@ -8,19 +8,21 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
+    "README.md",
+    "package.json",
     "node_modules",
     "bower_components",
     "test",
     "tests"
   ],
   "homepage": "https://github.com/gaia-components/gaia-component",
-  "_release": "0.3.5",
+  "_release": "0.4.0",
   "_resolution": {
     "type": "version",
-    "tag": "v0.3.5",
-    "commit": "e29dfbd8e07a96cbe521df8067120b78c306b584"
+    "tag": "v0.4.0",
+    "commit": "8667e09f44553c32f1a97860cc2a18a0d9d313ef"
   },
   "_source": "git://github.com/gaia-components/gaia-component.git",
-  "_target": "~0.3.0",
+  "_target": "~0.4.0",
   "_originalSource": "gaia-components/gaia-component"
 }

--- a/shared/elements/gaia-component/bower.json
+++ b/shared/elements/gaia-component/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-component",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
@@ -8,6 +8,8 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
+    "README.md",
+    "package.json",
     "node_modules",
     "bower_components",
     "test",

--- a/shared/elements/gaia-header/.bower.json
+++ b/shared/elements/gaia-header/.bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-header",
-  "version": "0.8.0",
+  "version": "0.9.4",
   "homepage": "https://github.com/gaia-components/gaia-header",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
@@ -18,8 +18,8 @@
     "README.md"
   ],
   "dependencies": {
-    "gaia-icons": "gaia-components/gaia-icons#~0.7.0",
-    "gaia-component": "gaia-components/gaia-component#~0.3.0",
+    "gaia-icons": "gaia-components/gaia-icons#~0.10.0",
+    "gaia-component": "gaia-components/gaia-component#~0.4.0",
     "font-fit": "gaia-components/font-fit#~0.3.0"
   },
   "devDependencies": {
@@ -27,13 +27,13 @@
     "gaia-fonts": "gaia-components/gaia-fonts",
     "base": "gaia-components/base"
   },
-  "_release": "0.8.0",
+  "_release": "0.9.4",
   "_resolution": {
     "type": "version",
-    "tag": "v0.8.0",
-    "commit": "87fd477efac136dc7c87127e4a411f717940bb98"
+    "tag": "v0.9.4",
+    "commit": "d08d8cb70d51f27996859e57df7af82afad5ddd9"
   },
   "_source": "git://github.com/gaia-components/gaia-header.git",
-  "_target": "~0.8.0",
+  "_target": "~0.9.0",
   "_originalSource": "gaia-components/gaia-header"
 }

--- a/shared/elements/gaia-header/.jshintrc
+++ b/shared/elements/gaia-header/.jshintrc
@@ -1,6 +1,33 @@
 {
-  "laxbreak": true,
+  "camelcase": false,
+  "curly": true,
+  "forin": false,
+  "latedef": "nofunc",
+  "newcap": false,
+  "noarg": true,
+  "node": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": "vars",
+  "strict": true,
+  "trailing": true,
+  "maxlen": 80,
+
+  "eqnull": true,
   "esnext": true,
-  "boss": true,
-  "node": true
+  "expr": true,
+  "globalstrict": true,
+
+  "maxerr": 1000,
+  "regexdash": true,
+  "laxcomma": true,
+  "proto": true,
+
+  "browser": true,
+  "devel": true,
+  "nonstandard": true,
+  "worker": true,
+
+  "-W078": true
 }

--- a/shared/elements/gaia-header/bower.json
+++ b/shared/elements/gaia-header/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-header",
-  "version": "0.8.0",
+  "version": "0.9.4",
   "homepage": "https://github.com/gaia-components/gaia-header",
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
@@ -18,8 +18,8 @@
     "README.md"
   ],
   "dependencies": {
-    "gaia-icons": "gaia-components/gaia-icons#~0.7.0",
-    "gaia-component": "gaia-components/gaia-component#~0.3.0",
+    "gaia-icons": "gaia-components/gaia-icons#~0.10.0",
+    "gaia-component": "gaia-components/gaia-component#~0.4.0",
     "font-fit": "gaia-components/font-fit#~0.3.0"
   },
   "devDependencies": {

--- a/shared/elements/gaia-header/dist/gaia-header.js
+++ b/shared/elements/gaia-header/dist/gaia-header.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.GaiaHeader=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.GaiaHeader = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 ;(function(define){define(function(require,exports,module){
 'use strict';
 
@@ -133,14 +133,13 @@ c(require,exports,module);}:function(c){var m={exports:{}};c(function(n){
 return w[n];},m.exports,m);w[n]=m.exports;};})('font-fit',this));
 
 },{}],2:[function(require,module,exports){
-;(function(define){define(function(require,exports,module){
-'use strict';
-
+/* globals define */
+;(function(define){'use strict';define(function(require,exports,module){
 /**
  * Locals
  */
-
-var textContent = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
+var textContent = Object.getOwnPropertyDescriptor(Node.prototype,
+    'textContent');
 var innerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML');
 var removeAttribute = Element.prototype.removeAttribute;
 var setAttribute = Element.prototype.setAttribute;
@@ -156,13 +155,26 @@ var noop  = function() {};
  */
 exports.register = function(name, props) {
   var baseProto = getBaseProto(props.extends);
+  var template = props.template || baseProto.templateString;
+
+  // Components are extensible by default but can be declared
+  // as non extensible as an optimization to avoid
+  // storing the template strings
+  var extensible = props.extensible = props.hasOwnProperty('extensible')?
+    props.extensible : true;
 
   // Clean up
   delete props.extends;
 
   // Pull out CSS that needs to be in the light-dom
-  if (props.template) {
-    var output = processCss(props.template, name);
+  if (template) {
+    // Stores the string to be reprocessed when
+    // a new component extends this one
+    if (extensible && props.template) {
+      props.templateString = props.template;
+    }
+
+    var output = processCss(template, name);
 
     props.template = document.createElement('template');
     props.template.innerHTML = output.template;
@@ -179,7 +191,7 @@ exports.register = function(name, props) {
 
   // Merge base getter/setter attributes with the user's,
   // then define the property descriptors on the prototype.
-  var descriptors = Object.assign(props.attrs || {}, base.descriptors);
+  var descriptors = mixin(props.attrs || {}, base.descriptors);
 
   // Store the orginal descriptors somewhere
   // a little more private and delete the original
@@ -210,7 +222,7 @@ var base = {
     created: noop,
 
     createdCallback: function() {
-      if (this.rtl) { addDirObserver(); }
+      if (this.dirObserver) { addDirObserver(); }
       injectLightCss(this);
       this.created();
     },
@@ -240,8 +252,20 @@ var base = {
       this.attributeChanged(name, from, to);
     },
 
-    attachedCallback: function() { this.attached(); },
-    detachedCallback: function() { this.detached(); },
+    attachedCallback: function() {
+      if (this.dirObserver) {
+        this.setInnerDirAttributes = setInnerDirAttributes.bind(null, this);
+        document.addEventListener('dirchanged', this.setInnerDirAttributes);
+      }
+      this.attached();
+    },
+
+    detachedCallback: function() {
+      if (this.dirObserver) {
+        document.removeEventListener('dirchanged', this.setInnerDirAttributes);
+      }
+      this.detached();
+    },
 
     /**
      * A convenient method for setting up
@@ -253,6 +277,7 @@ var base = {
       if (!this.template) { return; }
       var node = document.importNode(this.template.content, true);
       this.createShadowRoot().appendChild(node);
+      if (this.dirObserver) { setInnerDirAttributes(this); }
       return this.shadowRoot;
     },
 
@@ -294,7 +319,9 @@ var base = {
         if (this.lightStyle) { this.appendChild(this.lightStyle); }
       },
 
-      get: textContent.get
+      get: function() {
+        return textContent.get();
+      }
     },
 
     innerHTML: {
@@ -320,34 +347,35 @@ var defaultPrototype = createProto(HTMLElement.prototype, base.properties);
  * Returns a suitable prototype based
  * on the object passed.
  *
+ * @private
  * @param  {HTMLElementPrototype|undefined} proto
  * @return {HTMLElementPrototype}
- * @private
  */
 function getBaseProto(proto) {
   if (!proto) { return defaultPrototype; }
   proto = proto.prototype || proto;
-  return !proto.GaiaComponent
-    ? createProto(proto, base.properties)
-    : proto;
+  return !proto.GaiaComponent ?
+    createProto(proto, base.properties) : proto;
 }
 
 /**
  * Extends the given proto and mixes
  * in the given properties.
  *
+ * @private
  * @param  {Object} proto
  * @param  {Object} props
  * @return {Object}
  */
 function createProto(proto, props) {
-  return Object.assign(Object.create(proto), props);
+  return mixin(Object.create(proto), props);
 }
 
 /**
  * Detects presence of shadow-dom
  * CSS selectors.
  *
+ * @private
  * @return {Boolean}
  */
 var hasShadowCSS = (function() {
@@ -375,6 +403,7 @@ var regex = {
  * them to work from the <style scoped>
  * injected at the root of the component.
  *
+ * @private
  * @return {String}
  */
 function processCss(template, name) {
@@ -416,14 +445,15 @@ function processCss(template, name) {
  * <style> in the head of the
  * document.
  *
+ * @private
  * @param  {String} css
  */
 function injectGlobalCss(css) {
-  if (!css) return;
+  if (!css) {return;}
   var style = document.createElement('style');
   style.innerHTML = css.trim();
-  headReady().then(() => {
-    document.head.appendChild(style)
+  headReady().then(function() {
+    document.head.appendChild(style);
   });
 }
 
@@ -434,7 +464,7 @@ function injectGlobalCss(css) {
  * @private
  */
 function headReady() {
-  return new Promise(resolve => {
+  return new Promise(function(resolve) {
     if (document.head) { return resolve(); }
     window.addEventListener('load', function fn() {
       window.removeEventListener('load', fn);
@@ -460,10 +490,16 @@ function headReady() {
  */
 function injectLightCss(el) {
   if (hasShadowCSS) { return; }
-  el.lightStyle = document.createElement('style');
-  el.lightStyle.setAttribute('scoped', '');
-  el.lightStyle.innerHTML = el.lightCss;
-  el.appendChild(el.lightStyle);
+  var stylesheet = el.querySelector('style');
+
+  if (!stylesheet) {
+    stylesheet = document.createElement('style');
+    stylesheet.setAttribute('scoped', '');
+    stylesheet.appendChild(document.createTextNode(el.lightCss));
+    el.appendChild(stylesheet);
+  }
+
+  el.lightStyle = stylesheet;
 }
 
 /**
@@ -474,7 +510,8 @@ function injectLightCss(el) {
  *
  *   toCamelCase('foo-bar'); //=> 'fooBar'
  *
- * @param  {Sring} string
+ * @private
+ * @param  {String} string
  * @return {String}
  */
 function toCamelCase(string) {
@@ -491,12 +528,33 @@ function toCamelCase(string) {
 var dirObserver;
 
 /**
- * Observes the document `dir` (direction)
- * attribute and dispatches a global event
- * when it changes.
+ * Workaround for bug 1100912: applies a `dir` attribute to all shadowRoot
+ * children so that :-moz-dir() selectors work on shadow DOM elements.
  *
- * Components can listen to this event and
- * make internal changes if need be.
+ * In order to keep decent performances, the `dir` is the component dir if
+ * defined, or the document dir otherwise. This won't work if the component's
+ * direction is defined by CSS or inherited from a parent container.
+ *
+ * This method should be removed when bug 1100912 is fixed.
+ *
+ * @private
+ * @param  {WebComponent}
+ */
+function setInnerDirAttributes(component) {
+  var dir = component.dir || document.dir;
+  Array.from(component.shadowRoot.children).forEach(element => {
+    if (element.nodeName !== 'STYLE') {
+      element.dir = dir;
+    }
+  });
+}
+
+/**
+ * Observes the document `dir` (direction) attribute and when it changes:
+ *  - dispatches a global `dirchanged` event;
+ *  - forces the `dir` attribute of all shadowRoot children.
+ *
+ * Components can listen to this event and make internal changes if needed.
  *
  * @private
  */
@@ -514,31 +572,53 @@ function addDirObserver() {
   }
 }
 
+/**
+ * Copy the values of all properties from
+ * source object `target` to a target object `source`.
+ * It will return the target object.
+ *
+ * @private
+ * @param   {Object} target
+ * @param   {Object} source
+ * @returns {Object}
+ */
+function mixin(target, source) {
+  for (var key in source) {
+    target[key] = source[key];
+  }
+  return target;
+}
+
 });})(typeof define=='function'&&define.amd?define
 :(function(n,w){'use strict';return typeof module=='object'?function(c){
 c(require,exports,module);}:function(c){var m={exports:{}};c(function(n){
 return w[n];},m.exports,m);w[n]=m.exports;};})('gaia-component',this));
 
 },{}],3:[function(require,module,exports){
-(function(define){define(function(require,exports,module){
-/*jshint laxbreak:true*/
+/* global define */
+(function(define){'use strict';define(function(require,exports,module){
 
 /**
  * Exports
  */
 
-var base = window.GAIA_ICONS_BASE_URL
-  || window.COMPONENTS_BASE_URL
-  || 'bower_components/';
+var base = window.GAIA_ICONS_BASE_URL ||
+           window.COMPONENTS_BASE_URL ||
+           'bower_components/';
 
-// Load it if it's not already loaded
-if (!isLoaded()) { load(base + 'gaia-icons/gaia-icons.css'); }
+if (!document.documentElement) {
+  window.addEventListener('load', load);
+} else {
+  load();
+}
 
-function load(href) {
+function load() {
+  if (isLoaded()) { return; }
+
   var link = document.createElement('link');
   link.rel = 'stylesheet';
   link.type = 'text/css';
-  link.href = href;
+  link.href = base + 'gaia-icons/gaia-icons.css';
   document.head.appendChild(link);
   exports.loaded = true;
 }
@@ -550,17 +630,17 @@ function isLoaded() {
 }
 
 });})(typeof define=='function'&&define.amd?define
-:(function(n,w){return typeof module=='object'?function(c){
+:(function(n,w){'use strict';return typeof module=='object'?function(c){
 c(require,exports,module);}:function(c){var m={exports:{}};c(function(n){
 return w[n];},m.exports,m);w[n]=m.exports;};})('gaia-icons',this));
 
 },{}],4:[function(require,module,exports){
+/* globals define */
 ;(function(define){'use strict';define(function(require,exports,module){
 
 /**
  * Dependencies
  */
-
 var component = require('gaia-component');
 var fontFit = require('font-fit');
 
@@ -613,11 +693,11 @@ const MINIMUM_FONT_SIZE_CENTERED = 20;
  * This is the minimum font size that we can take
  * when the header title is not centered in the window.
  */
-const MINIMUM_FONT_SIZE_UNCENTERED = 18;
+const MINIMUM_FONT_SIZE_UNCENTERED = 16;
 
 /**
- * This is the maximum font size that we can use for
- * the heade title.
+ * This is the maximum font-size
+ * for the header title.
  */
 const MAXIMUM_FONT_SIZE = 23;
 
@@ -627,6 +707,8 @@ const MAXIMUM_FONT_SIZE = 23;
  * @return {Element} constructor
  */
 module.exports = component.register('gaia-header', {
+  extensible: false, // discards some strings
+  dirObserver: true, // triggers a workaround for bug 1100912 in gaia-component
 
   /**
    * Called when the element is first created.
@@ -643,15 +725,16 @@ module.exports = component.register('gaia-header', {
     // Elements
     this.els = {
       actionButton: this.shadowRoot.querySelector('.action-button'),
-      buttons: this.querySelectorAll('button, a'),
-      titles: this.querySelectorAll('h1')
+      titles: this.getElementsByTagName('h1')
     };
 
     // Events
-    this.els.actionButton.addEventListener('click', e => this.onActionButtonClick(e));
+    this.els.actionButton.addEventListener('click',
+      e => this.onActionButtonClick(e));
     this.observer = new MutationObserver(this.onMutation.bind(this));
 
     // Properties
+    this.ignoreDir = this.hasAttribute('ignore-dir');
     this.titleEnd = this.getAttribute('title-end');
     this.titleStart = this.getAttribute('title-start');
     this.noFontFit = this.getAttribute('no-font-fit');
@@ -766,7 +849,7 @@ module.exports = component.register('gaia-header', {
    *
    * @param  {HTMLH1Element} el
    * @param  {Number} space
-   * @return {Object} {fontSize, marginStart, overflowing, id}
+   * @return {Object} {id, fontSize, marginStart, overflowing, padding}
    * @private
    */
   getTitleStyle: function(el, space) {
@@ -813,7 +896,7 @@ module.exports = component.register('gaia-header', {
   },
 
   /**
-   * Set's styles on the title elements.
+   * Sets styles on the title elements.
    *
    * If there is already an unresolved Promise
    * we return it instead of scheduling another.
@@ -833,7 +916,8 @@ module.exports = component.register('gaia-header', {
 
     // Return existing unresolved
     // promise, or make a new one
-    return this.unresolved[key] = this.unresolved[key] || new Promise((resolve) => {
+    if (this.unresolved[key]) { return this.unresolved[key]; }
+    this.unresolved[key] = new Promise((resolve) => {
       this.pending[key] = this.nextTick(() => {
         var styles = this._titleStyles;
         var els = this.els.titles;
@@ -854,25 +938,24 @@ module.exports = component.register('gaia-header', {
   },
 
   /**
-   * Fit text and center a title between
-   * the buttons before and after.
+   * Fit text and center a title between the buttons before and after.
    *
-   * Right now, because gaia-header is not
-   * fully rtl-compatible (due to Gaia),
-   * we're using `marginLeft` etc. These
-   * will be changed to `marginStart` etc
-   * when we become fully RTL.
-   *
-   * @param  {HTMLH1Element} title
-   * @param  {Number} space
+   * @param  {HTMLH1Element} el
+   * @param  {Object} style
    * @private
    */
   setTitleStyle: function(el, style) {
     debug('set title style', style);
     this.observerStop();
-    el.style.marginLeft = style.marginStart + 'px';
-    el.style.paddingLeft = style.padding.start + 'px';
-    el.style.paddingRight = style.padding.end + 'px';
+    if (this.ignoreDir) {
+      el.style.marginLeft = style.marginStart + 'px';
+      el.style.paddingLeft = style.padding.start + 'px';
+      el.style.paddingRight = style.padding.end + 'px';
+    } else {
+      el.style.marginInlineStart = style.marginStart + 'px';
+      el.style.paddingInlineStart = style.padding.start + 'px';
+      el.style.paddingInlineEnd = style.padding.end + 'px';
+    }
     el.style.fontSize = style.fontSize + 'px';
     setStyleId(el, style.id);
     this.observerStart();
@@ -881,7 +964,7 @@ module.exports = component.register('gaia-header', {
   /**
    * Run font-fit on a title with
    * the given amount of content space.
-
+   *
    * @param {String} text
    * @param {Number} space
    * @param {Object} optional {[min]}
@@ -1010,9 +1093,8 @@ module.exports = component.register('gaia-header', {
    * @private
    */
   getWidth: function() {
-    var value = this.notFlush
-      ? this.clientWidth
-      : window.innerWidth;
+    var value = this.notFlush ?
+      this.clientWidth : window.innerWidth;
 
     debug('get width', value);
     return value;
@@ -1153,7 +1235,7 @@ module.exports = component.register('gaia-header', {
         if (action === this._action) { return; }
         this.setAttr('action', action);
         this._action = action;
-      },
+      }
     },
 
     titleStart: {
@@ -1205,12 +1287,29 @@ module.exports = component.register('gaia-header', {
         if (value) { this.setAttr('no-font-fit', ''); }
         else { this.removeAttr('no-font-fit'); }
       }
+    },
+
+    // The [ignore-dir] attribute can be used to force the older behavior of
+    // gaia-header, where the whole header is always displayed in LTR mode.
+    ignoreDir: {
+      get: function() { return this._ignoreDir || false; },
+      set: function(value) {
+        debug('set ignore-dir', value);
+        value = !!(value || value === '');
+
+        if (value === this.ignoreDir) { return; }
+        this._ignoreDir = value;
+        this.dirObserver = !value;
+
+        if (value) { this.setAttr('ignore-dir', ''); }
+        else { this.removeAttr('ignore-dir'); }
+      }
     }
   },
 
   template: `<div class="inner">
     <button class="action-button">
-      <content select=".l10n-action"></content>
+      <content select="[l10n-action]"></content>
     </button>
     <content></content>
   </div>
@@ -1247,7 +1346,6 @@ module.exports = component.register('gaia-header', {
   .inner {
     display: flex;
     min-height: 50px;
-    direction: ltr;
     -moz-user-select: none;
 
     background:
@@ -1318,8 +1416,10 @@ module.exports = component.register('gaia-header', {
   }
 
   [action=close] .action-button:before { content: 'close' }
-  [action=back] .action-button:before { content: 'back' }
   [action=menu] .action-button:before { content: 'menu' }
+
+  [action=back]:-moz-dir(ltr) .action-button:before { content: 'back' }
+  [action=back]:-moz-dir(rtl) .action-button:before { content: 'forward' }
 
   /** Action Button Icon
    ---------------------------------------------------------*/
@@ -1345,12 +1445,12 @@ module.exports = component.register('gaia-header', {
    * Example:
    *
    *   <gaia-header action="back">
-   *     <span class="l10n-action" aria-label="Back">Localized text</span>
+   *     <span l10n-action aria-label="Back">Localized text</span>
    *     <h1>title</h1>
    *   </gaia-header>
    */
 
-  ::content .l10n-action {
+  ::content [l10n-action] {
     position: absolute;
     left: 0;
     top: 0;
@@ -1391,18 +1491,23 @@ module.exports = component.register('gaia-header', {
   }
 
   /**
-   * [dir=rtl]
+   * [ignore-dir]
    *
-   * When the document is in RTL mode we still
-   * want the <h1> text to be reversed to that
-   * strings like '1 selected' become 'selected 1'.
+   * When the <gaia-header> component has an [ignore-dir] attribute, header
+   * direction is forced to LTR but we still want the <h1> text to be reversed
+   * so that strings like '1 selected' become 'selected 1'.
    *
-   * When we're happy for gaia-header to be fully
-   * RTL responsive we won't need this rule anymore,
-   * but this depends on all Gaia apps being ready.
+   * When we're happy for <gaia-header> to be fully RTL responsive we won't need
+   * these rules anymore, but this depends on all Gaia apps being ready.
+   *
+   * This should be safe to remove when bug 1179459 lands.
    */
 
-  :host-context([dir=rtl]) ::content h1 {
+  :host[ignore-dir] {
+    direction: ltr;
+  }
+
+  :host[ignore-dir]:-moz-dir(rtl) h1 {
     direction: rtl;
   }
 
@@ -1524,10 +1629,16 @@ module.exports = component.register('gaia-header', {
  * Determines whether passed element
  * contributes to the layout in gaia-header.
  *
+ * Children with `[l10n-action]` get distributed
+ * inside the action-button so don't occupy
+ * space before the `<h1>`.
+ *
  * @param  {Element}  el
  * @return {Boolean}
  */
-function contributesToLayout(el) { return el.tagName !== 'STYLE'; }
+function contributesToLayout(el) {
+  return el.localName !== 'style' && !el.hasAttribute('l10n-action');
+}
 
 /**
  * Set a 'style id' property that

--- a/shared/elements/gaia-header/gaia-header.js
+++ b/shared/elements/gaia-header/gaia-header.js
@@ -1,9 +1,9 @@
+/* globals define */
 ;(function(define){'use strict';define(function(require,exports,module){
 
 /**
  * Dependencies
  */
-
 var component = require('gaia-component');
 var fontFit = require('font-fit');
 
@@ -56,11 +56,11 @@ const MINIMUM_FONT_SIZE_CENTERED = 20;
  * This is the minimum font size that we can take
  * when the header title is not centered in the window.
  */
-const MINIMUM_FONT_SIZE_UNCENTERED = 18;
+const MINIMUM_FONT_SIZE_UNCENTERED = 16;
 
 /**
- * This is the maximum font size that we can use for
- * the heade title.
+ * This is the maximum font-size
+ * for the header title.
  */
 const MAXIMUM_FONT_SIZE = 23;
 
@@ -70,6 +70,8 @@ const MAXIMUM_FONT_SIZE = 23;
  * @return {Element} constructor
  */
 module.exports = component.register('gaia-header', {
+  extensible: false, // discards some strings
+  dirObserver: true, // triggers a workaround for bug 1100912 in gaia-component
 
   /**
    * Called when the element is first created.
@@ -86,15 +88,16 @@ module.exports = component.register('gaia-header', {
     // Elements
     this.els = {
       actionButton: this.shadowRoot.querySelector('.action-button'),
-      buttons: this.querySelectorAll('button, a'),
-      titles: this.querySelectorAll('h1')
+      titles: this.getElementsByTagName('h1')
     };
 
     // Events
-    this.els.actionButton.addEventListener('click', e => this.onActionButtonClick(e));
+    this.els.actionButton.addEventListener('click',
+      e => this.onActionButtonClick(e));
     this.observer = new MutationObserver(this.onMutation.bind(this));
 
     // Properties
+    this.ignoreDir = this.hasAttribute('ignore-dir');
     this.titleEnd = this.getAttribute('title-end');
     this.titleStart = this.getAttribute('title-start');
     this.noFontFit = this.getAttribute('no-font-fit');
@@ -209,7 +212,7 @@ module.exports = component.register('gaia-header', {
    *
    * @param  {HTMLH1Element} el
    * @param  {Number} space
-   * @return {Object} {fontSize, marginStart, overflowing, id}
+   * @return {Object} {id, fontSize, marginStart, overflowing, padding}
    * @private
    */
   getTitleStyle: function(el, space) {
@@ -256,7 +259,7 @@ module.exports = component.register('gaia-header', {
   },
 
   /**
-   * Set's styles on the title elements.
+   * Sets styles on the title elements.
    *
    * If there is already an unresolved Promise
    * we return it instead of scheduling another.
@@ -276,7 +279,8 @@ module.exports = component.register('gaia-header', {
 
     // Return existing unresolved
     // promise, or make a new one
-    return this.unresolved[key] = this.unresolved[key] || new Promise((resolve) => {
+    if (this.unresolved[key]) { return this.unresolved[key]; }
+    this.unresolved[key] = new Promise((resolve) => {
       this.pending[key] = this.nextTick(() => {
         var styles = this._titleStyles;
         var els = this.els.titles;
@@ -297,25 +301,24 @@ module.exports = component.register('gaia-header', {
   },
 
   /**
-   * Fit text and center a title between
-   * the buttons before and after.
+   * Fit text and center a title between the buttons before and after.
    *
-   * Right now, because gaia-header is not
-   * fully rtl-compatible (due to Gaia),
-   * we're using `marginLeft` etc. These
-   * will be changed to `marginStart` etc
-   * when we become fully RTL.
-   *
-   * @param  {HTMLH1Element} title
-   * @param  {Number} space
+   * @param  {HTMLH1Element} el
+   * @param  {Object} style
    * @private
    */
   setTitleStyle: function(el, style) {
     debug('set title style', style);
     this.observerStop();
-    el.style.marginLeft = style.marginStart + 'px';
-    el.style.paddingLeft = style.padding.start + 'px';
-    el.style.paddingRight = style.padding.end + 'px';
+    if (this.ignoreDir) {
+      el.style.marginLeft = style.marginStart + 'px';
+      el.style.paddingLeft = style.padding.start + 'px';
+      el.style.paddingRight = style.padding.end + 'px';
+    } else {
+      el.style.marginInlineStart = style.marginStart + 'px';
+      el.style.paddingInlineStart = style.padding.start + 'px';
+      el.style.paddingInlineEnd = style.padding.end + 'px';
+    }
     el.style.fontSize = style.fontSize + 'px';
     setStyleId(el, style.id);
     this.observerStart();
@@ -324,7 +327,7 @@ module.exports = component.register('gaia-header', {
   /**
    * Run font-fit on a title with
    * the given amount of content space.
-
+   *
    * @param {String} text
    * @param {Number} space
    * @param {Object} optional {[min]}
@@ -453,9 +456,8 @@ module.exports = component.register('gaia-header', {
    * @private
    */
   getWidth: function() {
-    var value = this.notFlush
-      ? this.clientWidth
-      : window.innerWidth;
+    var value = this.notFlush ?
+      this.clientWidth : window.innerWidth;
 
     debug('get width', value);
     return value;
@@ -596,7 +598,7 @@ module.exports = component.register('gaia-header', {
         if (action === this._action) { return; }
         this.setAttr('action', action);
         this._action = action;
-      },
+      }
     },
 
     titleStart: {
@@ -648,12 +650,29 @@ module.exports = component.register('gaia-header', {
         if (value) { this.setAttr('no-font-fit', ''); }
         else { this.removeAttr('no-font-fit'); }
       }
+    },
+
+    // The [ignore-dir] attribute can be used to force the older behavior of
+    // gaia-header, where the whole header is always displayed in LTR mode.
+    ignoreDir: {
+      get: function() { return this._ignoreDir || false; },
+      set: function(value) {
+        debug('set ignore-dir', value);
+        value = !!(value || value === '');
+
+        if (value === this.ignoreDir) { return; }
+        this._ignoreDir = value;
+        this.dirObserver = !value;
+
+        if (value) { this.setAttr('ignore-dir', ''); }
+        else { this.removeAttr('ignore-dir'); }
+      }
     }
   },
 
   template: `<div class="inner">
     <button class="action-button">
-      <content select=".l10n-action"></content>
+      <content select="[l10n-action]"></content>
     </button>
     <content></content>
   </div>
@@ -690,7 +709,6 @@ module.exports = component.register('gaia-header', {
   .inner {
     display: flex;
     min-height: 50px;
-    direction: ltr;
     -moz-user-select: none;
 
     background:
@@ -761,8 +779,10 @@ module.exports = component.register('gaia-header', {
   }
 
   [action=close] .action-button:before { content: 'close' }
-  [action=back] .action-button:before { content: 'back' }
   [action=menu] .action-button:before { content: 'menu' }
+
+  [action=back]:-moz-dir(ltr) .action-button:before { content: 'back' }
+  [action=back]:-moz-dir(rtl) .action-button:before { content: 'forward' }
 
   /** Action Button Icon
    ---------------------------------------------------------*/
@@ -788,12 +808,12 @@ module.exports = component.register('gaia-header', {
    * Example:
    *
    *   <gaia-header action="back">
-   *     <span class="l10n-action" aria-label="Back">Localized text</span>
+   *     <span l10n-action aria-label="Back">Localized text</span>
    *     <h1>title</h1>
    *   </gaia-header>
    */
 
-  ::content .l10n-action {
+  ::content [l10n-action] {
     position: absolute;
     left: 0;
     top: 0;
@@ -834,18 +854,23 @@ module.exports = component.register('gaia-header', {
   }
 
   /**
-   * [dir=rtl]
+   * [ignore-dir]
    *
-   * When the document is in RTL mode we still
-   * want the <h1> text to be reversed to that
-   * strings like '1 selected' become 'selected 1'.
+   * When the <gaia-header> component has an [ignore-dir] attribute, header
+   * direction is forced to LTR but we still want the <h1> text to be reversed
+   * so that strings like '1 selected' become 'selected 1'.
    *
-   * When we're happy for gaia-header to be fully
-   * RTL responsive we won't need this rule anymore,
-   * but this depends on all Gaia apps being ready.
+   * When we're happy for <gaia-header> to be fully RTL responsive we won't need
+   * these rules anymore, but this depends on all Gaia apps being ready.
+   *
+   * This should be safe to remove when bug 1179459 lands.
    */
 
-  :host-context([dir=rtl]) ::content h1 {
+  :host[ignore-dir] {
+    direction: ltr;
+  }
+
+  :host[ignore-dir]:-moz-dir(rtl) h1 {
     direction: rtl;
   }
 
@@ -967,10 +992,16 @@ module.exports = component.register('gaia-header', {
  * Determines whether passed element
  * contributes to the layout in gaia-header.
  *
+ * Children with `[l10n-action]` get distributed
+ * inside the action-button so don't occupy
+ * space before the `<h1>`.
+ *
  * @param  {Element}  el
  * @return {Boolean}
  */
-function contributesToLayout(el) { return el.tagName !== 'STYLE'; }
+function contributesToLayout(el) {
+  return el.localName !== 'style' && !el.hasAttribute('l10n-action');
+}
 
 /**
  * Set a 'style id' property that

--- a/tv_apps/smart-system/fxa/fxa_module.html
+++ b/tv_apps/smart-system/fxa/fxa_module.html
@@ -51,7 +51,7 @@
   </head>
   <body class="theme-settings">
     <section role="region">
-      <gaia-header id="fxa-module-header" action="close">
+      <gaia-header ignore-dir id="fxa-module-header" action="close">
         <h1 data-l10n-id="firefox-accounts-title"></h1>
       </gaia-header>
       <div class="bb-steps">

--- a/tv_apps/smart-system/index.html
+++ b/tv_apps/smart-system/index.html
@@ -385,7 +385,7 @@
 
           <!-- "Crash Reports" information page -->
           <section role="region">
-            <gaia-header id="crash-reports-header" action="close">
+            <gaia-header ignore-dir id="crash-reports-header" action="close">
               <h1 data-l10n-id="crashReports"></h1>
             </gaia-header>
             <div>
@@ -404,7 +404,7 @@
         <div id="trustedui-container" class="up theme-settings">
           <div id="trustedui-inner">
             <section role="region" class="title-container skin-organic">
-              <gaia-header id="trustedui-header" action="close">
+              <gaia-header ignore-dir id="trustedui-header" action="close">
                 <h1 id="trustedui-title"></h1>
               </gaia-header>
               <div id="trustedui-throbber"></div>

--- a/tv_apps/smart-system/js/app_authentication_dialog.js
+++ b/tv_apps/smart-system/js/app_authentication_dialog.js
@@ -87,7 +87,7 @@
     return '<section class="authentication-dialog skin-organic" ' +
             'id="' + this.CLASS_NAME + this.instanceID + '"' +
             'role="region">' +
-            '<gaia-header action="close" ' +
+            '<gaia-header ignore-dir action="close" ' +
               'class="authentication-dialog-http-authentication-header">' +
               '<button class="'+
               'authentication-dialog-http-authentication-cancel">' +

--- a/tv_apps/smart-system/js/app_chrome.js
+++ b/tv_apps/smart-system/js/app_chrome.js
@@ -115,7 +115,7 @@
     return `<div class="chrome" id="${className}">
             <gaia-progress></gaia-progress>
             <section role="region" class="bar">
-              <gaia-header action="close">
+              <gaia-header ignore-dir action="close">
                 <h1 class="title"></h1>
               </gaia-header>
             </section>

--- a/tv_apps/smart-system/js/entry_sheet.js
+++ b/tv_apps/smart-system/js/entry_sheet.js
@@ -45,7 +45,7 @@ window.EntrySheet = (function invocation() {
   function view() {
     return '<div class="' + EntrySheet.className + '">' +
       '<section role="region" class="skin-organic header">' +
-        '<gaia-header action="close">' +
+        '<gaia-header ignore-dir action="close">' +
           '<h1 class="title">' + '</h1>' +
         '</gaia-header>' +
         '<div class="throbber"></div>' +


### PR DESCRIPTION
Deploy `<gaia-header>` version 0.9.1 in shared/elements and add a `dir="ltr"` attribute to all existing `<gaia-header>` occurrences in Gaia, except:
- apps/camera, because it uses its own (older) version of gaia-header
- apps/music, because it uses its own (older) version of gaia-header
- apps/system, because it has already been refactored and supports RTL navigation

https://bugzilla.mozilla.org/show_bug.cgi?id=1209041
