### PR TITLE
Bug 1210341 - Remove additional subtraction in keyboard overlapping examination. r=timdream

### DIFF
--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -73,22 +73,23 @@
 
   AppTextSelectionDialog.prototype = Object.create(window.BaseUI.prototype);
 
-  AppTextSelectionDialog.prototype.TEXTDIALOG_HEIGHT = 52;
+  AppTextSelectionDialog.prototype.TEXTDIALOG_HEIGHT = 46;
 
-  AppTextSelectionDialog.prototype.TEXTDIALOG_WIDTH = 54;
+  AppTextSelectionDialog.prototype.TEXTDIALOG_WIDTH = 48;
 
   // Distance between selected area and the bottom of menu when menu show on
   // the top of selected area.
-  // By UI spec, 12px from the top of dialog to utility menu.
+  // By UI spec, 12px from the top of selected area to utility menu.
   AppTextSelectionDialog.prototype.DISTANCE_FROM_MENUBOTTOM_TO_SELECTEDAREA =
     12;
 
   // Distance between selected area and the top of menu when menu show on
   // the bottom of selected area.
-  // caret tile height is controlled by gecko, we estimate the height as
-  // 22px. So 22px plus 12px which defined in UI spec, we get 34px from
-  // the bottom of selected area to utility menu.
-  AppTextSelectionDialog.prototype.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 43;
+  // Caret height is 36px which is controlled by gecko (libpref/init/all.js).
+  // Note that 36px includes 28px for caret and 8px for space underneath caret.
+  // So 28px plus 12px which defined in UI spec, we get 40px from the bottom
+  // of selected area to utility menu.
+  AppTextSelectionDialog.prototype.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 40;
 
   // Minimum distance between bubble and boundary.
   AppTextSelectionDialog.prototype.DISTANCE_FROM_BOUNDARY = 5;

--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -450,6 +450,15 @@
         posTop = selectDialogBottom + distanceFromBottom;
       }
 
+      var offset = 0;
+      if (this.app && this.app.appChrome) {
+        offset = this.app.appChrome.isMaximized() ?
+                 this.app.appChrome.height -
+                   this.app.appChrome.scrollable.scrollTop :
+                 Service.query('Statusbar.height');
+      }
+      posTop += offset;
+
       // Put dialog in the center of selected area if it overlap keyboard.
       if (posTop >= (frameHeight - distanceFromBottom - selectOptionHeight)) {
         posTop = (((selectDialogTop >= 0) ? selectDialogTop : 0) +
@@ -467,16 +476,8 @@
           this.DISTANCE_FROM_BOUNDARY;
       }
 
-      var offset = 0;
-      if (this.app && this.app.appChrome) {
-        offset = this.app.appChrome.isMaximized() ?
-                 this.app.appChrome.height -
-                   this.app.appChrome.scrollable.scrollTop :
-                 Service.query('Statusbar.height');
-      }
-
       return {
-        top: posTop + offset,
+        top: posTop,
         left: posLeft
       };
     };

--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -460,7 +460,7 @@
       posTop += offset;
 
       // Put dialog in the center of selected area if it overlap keyboard.
-      if (posTop >= (frameHeight - distanceFromBottom - selectOptionHeight)) {
+      if (posTop >= (frameHeight - selectOptionHeight)) {
         posTop = (((selectDialogTop >= 0) ? selectDialogTop : 0) +
           ((selectDialogBottom >= frameHeight) ? frameHeight :
             selectDialogBottom) - selectOptionHeight) / 2;

--- a/apps/system/style/textselection_dialog/textselection_dialog.css
+++ b/apps/system/style/textselection_dialog/textselection_dialog.css
@@ -1,7 +1,7 @@
 #text-selection-dialog-root > .textselection-dialog,
 .appWindow > .textselection-dialog {
   display: none;
-  height: 5.2rem;
+  height: 4.6rem;
   width: auto;
   position: absolute;
   background-color: #606b6e;
@@ -41,8 +41,8 @@ html[dir="rtl"] .appWindow > .textselection-dialog {
   background-repeat: no-repeat;
   background-position: center;
   background-size: 3rem;
-  height: 5.2rem;
-  width: 5.2rem;
+  height: 4.6rem;
+  width: 4.6rem;
   display: inline-block;
 }
 
@@ -62,7 +62,7 @@ html[dir="rtl"] .appWindow > .textselection-dialog {
   content: '';
   background-color: #525b5e;
   width: 0.1rem;
-  height: 4.4rem;
+  height: 3.9rem;
   margin-top: 0.4rem;
   display: none;
 }

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -526,14 +526,14 @@ suite('system/AppTextSelectionDialog', function() {
     setup(function() {
       windowHeight = MockService.mockQueryWith('LayoutManager.height');
       windowWidth = MockService.mockQueryWith('LayoutManager.width');
-      td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 12;
-      td.DISTANCE_FROM_MENUBOTTOM_TO_SELECTEDAREA = 43;
+      td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP = 40;
+      td.DISTANCE_FROM_MENUBOTTOM_TO_SELECTEDAREA = 12;
       td.DISTANCE_FROM_BOUNDARY = 5;
-      td.TEXTDIALOG_WIDTH = 52;
-      td.TEXTDIALOG_HEIGHT = 48;
+      td.TEXTDIALOG_WIDTH = 48;
+      td.TEXTDIALOG_HEIGHT = 46;
     });
 
-    test('if space is enough', function() {
+    test('if space above is enough', function() {
       var positionDetail = {
         rect: {}
       };
@@ -552,6 +552,51 @@ suite('system/AppTextSelectionDialog', function() {
         left: ((positionDetail.rect.left + positionDetail.rect.right) *
           positionDetail.zoomFactor - td.numOfSelectOptions *
           td.TEXTDIALOG_WIDTH)/ 2
+      });
+    });
+
+    test('if no space above', function() {
+      var positionDetail = {
+        rect: {}
+      };
+      positionDetail.rect.top = 10;
+      positionDetail.rect.bottom = windowHeight - 100;
+      positionDetail.rect.left = windowWidth - 300;
+      positionDetail.rect.right = windowWidth - 100;
+      positionDetail.zoomFactor = 1;
+      td.textualmenuDetail = positionDetail;
+      td.numOfSelectOptions = 3;
+      var result =
+        td.calculateDialogPostion(0, 0);
+      assert.deepEqual(result, {
+        top: positionDetail.rect.bottom * positionDetail.zoomFactor +
+          td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP,
+        left: ((positionDetail.rect.left + positionDetail.rect.right) *
+          positionDetail.zoomFactor -
+          td.numOfSelectOptions * td.TEXTDIALOG_WIDTH)/ 2
+      });
+    });
+
+    test('if no space above and underneath', function() {
+      var positionDetail = {
+        rect: {}
+      };
+      positionDetail.rect.top = 10;
+      positionDetail.rect.bottom = windowHeight - 10;
+      positionDetail.rect.left = windowWidth - 10;
+      positionDetail.rect.right = windowWidth;
+      positionDetail.zoomFactor = 1;
+      td.textualmenuDetail = positionDetail;
+      td.numOfSelectOptions = 3;
+      var result =
+        td.calculateDialogPostion(0, 0);
+      assert.deepEqual(result, {
+        top: (positionDetail.rect.top * positionDetail.zoomFactor +
+          positionDetail.rect.bottom * positionDetail.zoomFactor -
+          td.TEXTDIALOG_HEIGHT) / 2,
+        left: windowWidth -
+          td.numOfSelectOptions * td.TEXTDIALOG_WIDTH -
+          td.DISTANCE_FROM_BOUNDARY
       });
     });
 
@@ -595,7 +640,7 @@ suite('system/AppTextSelectionDialog', function() {
           }
         };
         positionDetail.rect.top = 10;
-        positionDetail.rect.bottom = windowHeight - 100;
+        positionDetail.rect.bottom = windowHeight - 150;
         positionDetail.rect.left = windowWidth - 300;
         positionDetail.rect.right = windowWidth - 100;
         positionDetail.zoomFactor = 1;
@@ -628,7 +673,7 @@ suite('system/AppTextSelectionDialog', function() {
           }
         };
         positionDetail.rect.top = 10;
-        positionDetail.rect.bottom = windowHeight - 100;
+        positionDetail.rect.bottom = windowHeight - 150;
         positionDetail.rect.left = windowWidth - 300;
         positionDetail.rect.right = windowWidth - 100;
         positionDetail.zoomFactor = 1;


### PR DESCRIPTION
In the original code, we calculate posTop with (selectDialogBottom + distanceFromBottom), then examine whether the dialog is overlapped by keyboard with (frameHeight - distanceFromBottom - selectOptionHeight). Since we already add distanceFromBottom in the first place, there's no need to subtract distanceFromBottom in the examination.

Two things are also fixed:
1. Update distance parameter in AppTextSelectionDialog since selection caret has been enlarged for a while.
2. Examine whether selection dialog is overlapped by keyboard in the very end. The original logic adds offset to posTop "after" overlapping examination. This may cause a potential bug if adding offset to posTop leads dialog to be overlapped by keyboard.
