### PR TITLE
Bug 1213057 - [System] [RTL] extended menus

### DIFF
--- a/apps/system/style/action_menu/action_menu_extended.css
+++ b/apps/system/style/action_menu/action_menu_extended.css
@@ -43,23 +43,17 @@
 form[role="dialog"][data-type="action"] > menu > button.icon,
 form[role="dialog"][data-type="object"] > menu > button.icon {
   background-repeat: no-repeat;
-  padding-inline-start: 4rem;
-  background-size: 3rem;
-  background-position: 0.5rem center;
-}
-
-form[role="dialog"][data-type="action"] > menu > button.tail-icon,
-form[role="dialog"][data-type="object"] > menu > button.tail-icon {
-  background-repeat: no-repeat;
   background-size: 3rem;
 }
-html[dir="ltr"] form[role="dialog"][data-type="action"] > menu > button.tail-icon,
-html[dir="ltr"] form[role="dialog"][data-type="object"] > menu > button.tail-icon {
-  background-position: right 0.5rem top 0.5rem;
-}
-html[dir="rtl"] form[role="dialog"][data-type="action"] > menu > button.tail-icon,
-html[dir="rtl"] form[role="dialog"][data-type="object"] > menu > button.tail-icon {
+html[dir="ltr"] form[role="dialog"][data-type="action"] > menu > button.icon,
+html[dir="ltr"] form[role="dialog"][data-type="object"] > menu > button.icon {
   background-position: left 0.5rem top 0.5rem;
+  padding-left: 4rem;
+}
+html[dir="rtl"] form[role="dialog"][data-type="action"] > menu > button.icon,
+html[dir="rtl"] form[role="dialog"][data-type="object"] > menu > button.icon {
+  background-position: right 0.5rem top 0.5rem;
+  padding-right: 4rem;
 }
 
 form[role="dialog"][data-type="action"],
@@ -122,6 +116,7 @@ form[role="dialog"][data-type="action"] > menu > gaia-checkbox {
   form[role="dialog"][data-type="action"] > menu,
   form[role="dialog"][data-type="object"] > menu {
     top: calc(50% - 24rem + 7rem);
+    offset-inline-start: calc(50% - 34rem);
     width: 56rem; /* 68 - 12 */
     height: 31rem; /* 38 - 7 */
     padding: 0 6rem;
@@ -129,7 +124,6 @@ form[role="dialog"][data-type="action"] > menu > gaia-checkbox {
     background-color: #4d4d4d;
     border: none;
     z-index:1;
-    offset-inline-start: calc(50% - 34rem);
   }
 
   form[role="dialog"][data-type="action"] > menu > button,
@@ -150,12 +144,12 @@ form[role="dialog"][data-type="action"] > menu > gaia-checkbox {
   form[role="dialog"][data-type="object"] > menu > button:last-child {
     position: absolute;
     margin-top: 1.5rem;
+    margin-inline-start: calc(50% - 9rem);
     font-size: 2.3rem;
     line-height: 2.3rem;
     font-weight: 400;
     width: 18rem;
     height: 4rem;
-    margin-inline-start: calc(50% - 9rem);
   }
 
   form[role="dialog"][data-type="action"] > menu > button:last-child:before,

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -69,7 +69,7 @@ apps/sms/views/inbox/style/inbox.css 0 2
 apps/sms/views/shared/style/common.css 0 1
 apps/sms/views/shared/style/sms.css 0 2
 apps/system/mobile_id/style/mobile_id.css 0 16
-apps/system/style/action_menu/action_menu_extended.css 3 0
+apps/system/style/action_menu/action_menu_extended.css 2 0
 apps/system/style/app_install_manager/app_install_manager.css 2 0
 apps/system/style/bluetooth_transfer/bluetooth_transfer.css 1 0
 apps/system/style/cards_view/cards_view.css 5 0


### PR DESCRIPTION
Proper BiDi mirroring of the extended menus + removal of the unused `.tail-icon` class selector.

https://bugzilla.mozilla.org/show_bug.cgi?id=1213057
