### PR TITLE
Bug 1213083 - Switch Notification timestamps to use mozIntl._gaia.RelativeDate().formatElement

### DIFF
--- a/apps/system/js/notification_screen.js
+++ b/apps/system/js/notification_screen.js
@@ -378,9 +378,8 @@ var NotificationScreen = {
     });
 
     timestamps.forEach(timestamp => {
-      formatter.format(new Date(timestamp.dataset.timestamp)).then(
-        str => { timestamp.textContent = str; }
-      );
+      formatter.formatElement(
+        timestamp, new Date(timestamp.dataset.timestamp));
     });
   },
 
@@ -473,11 +472,7 @@ var NotificationScreen = {
     var formatter = mozIntl._gaia.RelativeDate(navigator.languages, {
       style: 'short'
     });
-    formatter.format(timestamp).then(
-      str => {
-        time.textContent = str;
-      }
-    );
+    formatter.formatElement(time, timestamp);
     titleContainer.appendChild(time);
 
     notificationNode.appendChild(titleContainer);

--- a/apps/system/lockscreen/js/lockscreen_notifications.js
+++ b/apps/system/lockscreen/js/lockscreen_notifications.js
@@ -584,9 +584,7 @@
 
     timestamps.forEach((element) => {
       var date = new Date(element.dataset.timestamp);
-      formatter.format(date).then(str => {
-        element.textContent = str;
-      });
+      formatter.formatElement(element, date);
     });
   };
 

--- a/apps/system/test/unit/notification_screen_test.js
+++ b/apps/system/test/unit/notification_screen_test.js
@@ -329,9 +329,8 @@ suite('system/NotificationScreen >', function() {
 
       sinon.stub(window.mozIntl._gaia, 'RelativeDate', function() {
         return {
-          format: function() {
+          formatElement: function() {
             callCount++;
-            return Promise.resolve();
           }
         };
       });

--- a/shared/test/unit/mocks/mock_moz_intl.js
+++ b/shared/test/unit/mocks/mock_moz_intl.js
@@ -42,7 +42,7 @@ global.MockMozIntl = {
         format: function(value) {
           return Promise.resolve('pretty date');
         },
-      formatElement: function(element, time, maxDiff) {}
+        formatElement: function(element, time, maxDiff) {}
       };
     },
   }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1213083
