### PR TITLE
Bug 1197060 - Fix dialog position when browserContainer is scrolled

### DIFF
--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -469,7 +469,8 @@
       var offset = 0;
       if (this.app && this.app.appChrome) {
         offset = this.app.appChrome.isMaximized() ?
-                 this.app.appChrome.height :
+                 this.app.appChrome.height -
+                   this.app.appChrome.scrollable.scrollTop :
                  Service.query('Statusbar.height');
       }
 

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -582,6 +582,9 @@ suite('system/AppTextSelectionDialog', function() {
             isMaximized: function() {
               return true;
             },
+            scrollable: {
+              scrollTop: 25
+            },
             height: 40
           }
         };
@@ -597,7 +600,8 @@ suite('system/AppTextSelectionDialog', function() {
           td.calculateDialogPostion(0, 0);
         assert.deepEqual(result, {
           top: positionDetail.rect.bottom * positionDetail.zoomFactor +
-            td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP + td.app.appChrome.height,
+            td.DISTANCE_FROM_SELECTEDAREA_TO_MENUTOP + td.app.appChrome.height -
+            td.app.appChrome.scrollable.scrollTop,
           left: ((positionDetail.rect.left + positionDetail.rect.right) *
             positionDetail.zoomFactor -
             td.numOfSelectOptions * td.TEXTDIALOG_WIDTH)/ 2


### PR DESCRIPTION
The scrollable (browserContainer) might be scrolled when AppChrome is
maximized. To make the position of the dialog correct, we need to
subtract the offset by scrollable.scrollTop.
