### PR TITLE
Bug 1212329 - system: rtl refactor lockscreen

### DIFF
--- a/apps/callscreen/index.html
+++ b/apps/callscreen/index.html
@@ -79,8 +79,10 @@
       <div id="lockscreen-header">
         <div id="lockscreen-conn-states">
         </div>
-        <div id="lockscreen-clock-time"></div>
-        <div id="lockscreen-date"></div>
+        <div id="lockscreen-clock-widget">
+          <div id="lockscreen-clock-time"></div>
+          <div id="lockscreen-date"></div>
+        </div>
       </div>
       <article id="calls" data-count="0">
         <section id="handled-call-template" role="dialog" hidden>
@@ -198,7 +200,7 @@
                 </span>
               </div>
             </section>
-            <footer id="callbar">
+            <footer id="callbar" dir="ltr">
               <button id="callbar-hang-up" data-l10n-id="hangup-a11y-button">
                 <div class="callbar-inner-button">
                 </div>

--- a/apps/callscreen/style/lockscreen.css
+++ b/apps/callscreen/style/lockscreen.css
@@ -9,8 +9,8 @@
   top: 0;
   left: 0;
   width: 100%;
-  -moz-box-sizing: border-box;
-  padding: 1.5rem 2.4rem 4.4rem;
+  box-sizing: border-box;
+  padding: 1.5rem 2.4rem 0;
   color: #fff;
   opacity: 1;
 }
@@ -21,7 +21,6 @@
   font-weight: 300;
   font-size: 1.4rem;
   padding-bottom: 1.4rem;
-
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -33,8 +32,7 @@
 
 #lockscreen-conn-states span:first-child {
   display: inline-block;
-  -moz-margin-end: 0.8rem;
-  overflow: visible;
+  margin-inline-end: 0.8rem;
 }
 
 #lockscreen-conn-states span:last-child {
@@ -49,7 +47,8 @@
 
 #lockscreen-clock-time {
   line-height: 0.9;
-  margin: -1.4rem 0 0 -0.4rem;
+  margin: -1.4rem 0 0;
+  margin-inline-start: -0.4rem;
   font-weight: 200;
   font-size: 8.5rem;
 }

--- a/apps/callscreen/style/oncall.css
+++ b/apps/callscreen/style/oncall.css
@@ -11,10 +11,6 @@
     -moz-user-select: none;
   }
 
-  html * {
-    overflow: hidden;
-  }
-
   .font-light {
     font-weight: 300;
   }
@@ -286,7 +282,7 @@
   .co-advanced-option.active-state:not([disabled]):active .icon.icon-on-hold {
     background-position: 0 -8rem;
   }
-  
+
   #callbar {
     display: flex;
     background: rgba(255, 255, 255, 0.85);
@@ -353,6 +349,7 @@
     width: 100%;
     height: 24rem;
     z-index: 500;
+    overflow: hidden;
   }
 
   #calls > section {
@@ -687,7 +684,7 @@
     background-image: url('images/handled_call/actionicon_callscreen_outgoingcall.png');
     background-size: 4rem;
   }
-  
+
   #calls.big-duration .handled-call.held .direction:before,
   #calls.big-duration #group-call.held .direction:before {
     background-image: url('images/handled_call/actionicon_callscreen_pausedcall.png');

--- a/apps/system/js/notification_screen.js
+++ b/apps/system/js/notification_screen.js
@@ -383,7 +383,7 @@ var NotificationScreen = {
     });
   },
 
-  updateToaster: function ns_updateToaster(detail, type, dir) {
+  updateToaster: function ns_updateToaster(detail, type) {
     if (detail.icon) {
       this.toasterIcon.src = detail.icon;
       this.toasterIcon.hidden = false;
@@ -394,8 +394,9 @@ var NotificationScreen = {
     this.toaster.dataset.notificationId = detail.id;
     this.toaster.dataset.type = type;
     this.toaster.lang = detail.lang;
-    this.toaster.dir = dir;
 
+    // No need to specify direction: we use dir auto in inner elements,
+    // and alignment is based on the UI direction
     this.toasterTitle.textContent = detail.title;
     this.toasterDetail.textContent = detail.text;
   },
@@ -413,17 +414,6 @@ var NotificationScreen = {
       (isPriorityNotification) ?
       this.container.querySelector('.priority-notifications') :
       this.container.querySelector('.other-notifications');
-
-    /* If dir "auto" was specified by the notification,
-     * use document direction instead because dir="auto"
-     * does not align the notification node according to
-     * the system language direction but instead it aligns
-     * every child element according to its own language
-     * which creates a UI mess we can't control by changing
-     * the system language.
-     */
-    var dir = (detail.dir === 'auto' || typeof detail.dir === 'undefined') ?
-      document.documentElement.dir : detail.dir;
 
     // We need to animate the ambient indicator when the toast
     // timesout, so we skip updating it here, by passing a skip bool
@@ -532,7 +522,7 @@ var NotificationScreen = {
 
     // Notification toaster
     if (notify) {
-      this.updateToaster(detail, type, dir);
+      this.updateToaster(detail, type);
       if (this.lockscreenPreview || !window.Service.query('locked')) {
         this.toaster.classList.add('displayed');
 

--- a/apps/system/lockscreen/style/lockscreen.css
+++ b/apps/system/lockscreen/style/lockscreen.css
@@ -3,6 +3,13 @@
  * callscreen/style/lockscreen.css
  **/
 
+/**
+ * BiDi note: because this stylesheet is 'scoped', instead of:
+ *     html[dir="rtl"] #volume { ... }
+ * we must use:
+ *     #volume:-moz-dir(rtl) { ... }
+ */
+
 #lockscreen {
   --panel-transition-secs: var(--transition-duration);
   position: absolute;
@@ -172,7 +179,7 @@
   top: 3rem;   /* 3rem = height of status bar */
   left: 0;
   width: 100%;
-  -moz-box-sizing: border-box;
+  box-sizing: border-box;
   padding: 1.5rem 2.4rem 0;
   color: #fff;
   transition: transform 0.2s ease, opacity 0.2s ease;
@@ -206,7 +213,7 @@
 
 #lockscreen-conn-states span:first-child {
   display: inline-block;
-  -moz-margin-end: 0.8rem;
+  margin-inline-end: 0.8rem;
 }
 
 #lockscreen-conn-states span:last-child {
@@ -221,10 +228,8 @@
 
 #lockscreen-clock-time {
   line-height: 0.9;
-  margin-top: -1.4rem;
-  margin-bottom: 0;
-  -moz-margin-start: -0.4rem;
-  -moz-margin-end: 0;
+  margin: -1.4rem 0 0;
+  margin-inline-start: -0.4rem;
   font-weight: 200;
   font-size: 8.5rem;
 }
@@ -293,7 +298,7 @@
   }
 
   #lockscreen-header {
-    -moz-padding-start: 6rem;
+    padding-inline-start: 6rem;
     font-weight: 300;
   }
 
@@ -342,8 +347,7 @@ button::-moz-focus-inner {
 #lockscreen-alt-camera.lockscreen-icon {
   border-radius: 2.5rem;
   background-color: rgba(255, 255, 255, 0.25);
-  -moz-box-sizing: border-box;
-  float: right;
+  box-sizing: border-box;
   pointer-events: auto;
   opacity: 0.1;
   transition: opacity var(--panel-transition-secs) ease;
@@ -351,6 +355,8 @@ button::-moz-focus-inner {
   height: 5rem;
   margin-top: 5rem;
 }
+#lockscreen-alt-camera.lockscreen-icon:-moz-dir(ltr) { float: right; }
+#lockscreen-alt-camera.lockscreen-icon:-moz-dir(rtl) { float: left; }
 
 #lockscreen-alt-camera-button {
   width: 100%;
@@ -428,7 +434,7 @@ button::-moz-focus-inner {
 #lockscreen-message {
   position: relative;
   top: 18rem;
-  left: 0;
+  offset-inline-start: 0;
   word-wrap: break-word;
   text-align: center;
   overflow-y: auto;
@@ -445,15 +451,4 @@ button::-moz-focus-inner {
   font-size: 1.4rem;
   font-weight: 700;
   color: black;
-}
-
-/* RTL View */
-
-#lockscreen-alt-camera.lockscreen-icon:-moz-dir(rtl) {
-  float: left;
-}
-
-#lockscreen-message:-moz-dir(rtl) {
-  left: unset;
-  right: 0;
 }

--- a/apps/system/lockscreen/style/lockscreen_fake_notification.css
+++ b/apps/system/lockscreen/style/lockscreen_fake_notification.css
@@ -1,3 +1,10 @@
+/**
+ * BiDi note: because this stylesheet is 'scoped', instead of:
+ *     html[dir="rtl"] #volume { ... }
+ * we must use:
+ *     #volume:-moz-dir(rtl) { ... }
+ */
+
 #lockscreen .fake-notification {
   height: 6rem;
   padding: 0 1.5rem;
@@ -9,11 +16,12 @@
 }
 
 #lockscreen .fake-notification [data-icon] {
-  float: left;
   width: 3rem;
   height: 3rem;
   margin: 1.5rem 0;
 }
+#lockscreen:-moz-dir(ltr) .fake-notification [data-icon] { float: left; }
+#lockscreen:-moz-dir(rtl) .fake-notification [data-icon] { float: right; }
 
 /* alert icon: white on red background */
 #lockscreen [data-icon].alert {

--- a/apps/system/lockscreen/style/lockscreen_inputpad.css
+++ b/apps/system/lockscreen/style/lockscreen_inputpad.css
@@ -1,3 +1,8 @@
+/**
+ * BiDi note: numeric passcodes are always displayed in LTR.
+ * This stylesheet must *NOT* be mirrored for RTL.
+ */
+
 #lockscreen-panel-passcode {
   /* > camera, unlock icons > canvas */
   z-index: 32;
@@ -11,13 +16,13 @@
   background-color: rgba(51, 51, 51, 0.3);
   margin: 0;
   padding: 0 1rem;
-  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 #lockscreen-passcode-code > span {
-  -moz-box-sizing: border-box;
+  box-sizing: border-box;
   display: block;
-  float: left;
+  float: left; /* BiDi-proof: passcodes are always LTR like all numbers */
   width: calc(25% - 1rem);
   margin: 1.5rem 0.5rem;
   height: calc(100% - 3rem);
@@ -45,12 +50,12 @@
   border-radius: 0.75rem;
   top: 50%;
   left: 50%;
-  -moz-margin-start: -0.75rem;
+  margin-left: -0.75rem;
   margin-top: -0.75rem;
 }
 
 #lockscreen-passcode-pad {
-  -moz-box-sizing: border-box;
+  box-sizing: border-box;
   position: absolute;
   bottom: 0;
   height: 20.4rem;
@@ -59,9 +64,9 @@
 }
 
 #lockscreen-passcode-pad > a {
-  -moz-box-sizing: border-box;
+  box-sizing: border-box;
   display: block;
-  float: left;
+  float: left; /* BiDi-proof: passcodes are always LTR like all numbers */
   width: 33.333%;
   height: 5.1rem;
   outline: none;

--- a/apps/system/lockscreen/style/lockscreen_media_playback.css
+++ b/apps/system/lockscreen/style/lockscreen_media_playback.css
@@ -1,3 +1,8 @@
+/**
+ * BiDi note: media controls are always displayed in LTR (hardware legacy).
+ * This stylesheet must *NOT* be mirrored for RTL.
+ */
+
 #lockscreen .media-playback-container {
   height: auto;
   padding: 0 1.8rem;

--- a/apps/system/lockscreen/style/notifications.css
+++ b/apps/system/lockscreen/style/notifications.css
@@ -1,4 +1,11 @@
-/* Individual style; to avoid utility tray patches breark lockscreen notitifications. */
+/**
+ * BiDi note: because this stylesheet is 'scoped', instead of:
+ *     html[dir="rtl"] #volume { ... }
+ * we must use:
+ *     #volume:-moz-dir(rtl) { ... }
+ */
+
+ /* Individual style; to avoid utility tray patches to break lockscreen notitifications. */
 #notifications-lockscreen-container .notification {
   position: relative;
   height: 6rem;
@@ -17,6 +24,12 @@
 #notifications-lockscreen-container .notification div {
   pointer-events: none;
 }
+:-moz-dir(ltr) #notifications-lockscreen-container .notification div {
+  text-align: left;
+}
+:-moz-dir(rtl) #notifications-lockscreen-container .notification div {
+  text-align: right;
+}
 
 #notifications-lockscreen-container .notification > div.title-container {
   margin-top: 1rem;
@@ -28,7 +41,7 @@
 
 #notifications-lockscreen-container .notification > div {
   width: calc(100% - 6.5rem);
-  -moz-margin-start: 5rem;
+  margin-inline-start: 5rem;
   color: #bfbfbf;
   font-size: 1.4rem;
   line-height: 1.9rem;
@@ -39,20 +52,21 @@
 }
 
 #notifications-lockscreen-container .notification > img {
-  float: left;
   display: block;
   width: 3rem;
   height: 3rem;
   margin: 1.5rem 1rem;
   pointer-events: none;
 }
+:-moz-dir(ltr) #notifications-lockscreen-container .notification > img { float: left; }
+:-moz-dir(rtl) #notifications-lockscreen-container .notification > img { float: right; }
 
 #notifications-lockscreen-container .notification > div.title-container .title {
   flex: 1;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  -moz-margin-end: .5rem;
+  margin-inline-end: .5rem;
 }
 
 #notifications-lockscreen-container .notification.actionable {
@@ -82,7 +96,7 @@
   position: absolute;
   width: 100%;
   top: -1.1rem;
-  left: 0;
+  offset-inline-start: 0;
   height: 6rem;
   background-color: rgba(51, 51, 51, 0.3);
   z-index: -1;  /* make this as 'background' */
@@ -101,12 +115,12 @@
   position: absolute;
   width: calc(100% - 4.8rem);
   top: -1.1rem;
-  left: 0;
+  offset-inline-start: 0;
   height: 6rem;
   z-index: -1;  /* make this as 'background' */
   border-top: none;
   border-bottom: 0.1rem solid rgba(255, 255, 255, 0.3);
-  -moz-margin-start: 2.4rem;
+  margin-inline-start: 2.4rem;
 }
 
 #notifications-lockscreen-container > div:last-child::after {
@@ -120,7 +134,7 @@
 }
 
 #notifications-lockscreen-container .button-actionable {
-  border-left: 0.1rem rgba(255, 255, 255, 0.15) solid;
+  border-inline-start: 0.1rem rgba(255, 255, 255, 0.15) solid;
   color: rgba(0, 202, 242, 1);
   display: inline-block;
 
@@ -132,7 +146,7 @@
   position: absolute;
 
   /* from the border line to the text */
-  -moz-padding-start: var(--padleft-button);
+  padding-inline-start: var(--padleft-button);
 
   /* 0.3rem is the magic number to make it (with the border) vertical-align: middle*/
   top: 0.3rem;
@@ -140,7 +154,7 @@
   /* 100% - the actionable area + the margin of the actionable area */
   /* The 0.8rem is for alignment of the position of previous timestamp */
   /* The 0.3rem is for centering the vertical bar of the button */
-  left: calc(100% - var(--width-actionable-button) + 1.4rem);
+  offset-inline-start: calc(100% - var(--width-actionable-button) + 1.4rem);
   height: 3.5rem;
   line-height: 3.3rem;  /* to make the lable vertical-align: middle */
   transition-property: color, text;
@@ -245,9 +259,9 @@
   /* delegate border to :after element while keeping layout correct */
   border-bottom: 0.1rem solid rgba(0, 0, 0, 0);
   height: 4.8rem;
-  margin: 0 0 0 0;
-  -moz-padding-start: 2.4rem;
-  -moz-padding-end: 2.4rem;
+  margin: 0;
+  padding-inline-start: 2.4rem;
+  padding-inline-end: 2.4rem;
   width: calc(100% - 4.8rem);
 }
 
@@ -266,7 +280,7 @@
 
 #notifications-lockscreen-container .notification > div {
   width: calc(100% - 3.6rem);
-  -moz-margin-start: 3.6rem;
+  margin-inline-start: 3.6rem;
   color: #ffffff;
 }
 
@@ -291,7 +305,7 @@
 
   flex: initial;
   top: -.2rem;
-  right: 1.5rem;
+  offset-inline-end: 1.5rem;
   padding: 0;
   max-width: 6.5rem;
   font-size: 1.2rem;
@@ -303,10 +317,9 @@
   white-space: nowrap;
 }
 
-
 #notifications-lockscreen-container .notification > img {
   margin-top: 0.8rem;
-  -moz-margin-start: 0;
+  margin-inline-start: 0;
   width: 2.4rem;
   height: 2.4rem;
 }
@@ -321,7 +334,6 @@
   border-top: 0.1rem solid rgba(255, 255, 255, 0.0);
 
   position: absolute;
-  left: 0;
   z-index: 1;
   background-size: 1.6rem 1.6rem;
   margin: 0 2.4rem;
@@ -329,6 +341,8 @@
   opacity: 0;
   transition: opacity var(--transition-duration) ease;
 }
+:-moz-dir(ltr) #lockscreen-notification-arrow { left: 0; }
+:-moz-dir(rtl) #lockscreen-notification-arrow { right: 0; }
 
 #lockscreen-notification-arrow.visible {
   opacity: 1;
@@ -358,52 +372,4 @@
        container should not be scrollable with collapsed */
     display: none;
   }
-}
-
-/* Right-To-Left layout */
-:-moz-dir(rtl) #notifications-lockscreen-container .notification > img {
-  float: right;
-}
-
-:-moz-dir(rtl) #notifications-lockscreen-container .notification::before {
-  left: unset;
-  right: 0;
-}
-
-:-moz-dir(rtl) #notifications-lockscreen-container .notification::after {
-  left: unset;
-  right: 0;
-}
-
-:-moz-dir(rtl) #notifications-lockscreen-container .button-actionable {
-  border-left: unset;
-  border-right: 0.1rem rgba(255, 255, 255, 0.15) solid;
-  left: unset;
-  right: calc(100% - var(--width-actionable-button) + 1.4rem);
-}
-
-:-moz-dir(rtl) #notifications-lockscreen-container .notification > .title-container .timestamp {
-  left: 1.5rem;
-  right: unset;
-}
-
-:-moz-dir(rtl) #lockscreen-notification-arrow {
-  left: unset;
-  right: 0;
-}
-
-/*
- * For the notification title, we need to use dir="auto" to display
- * parenthesis and periods in their proper place. However, we still
- * want the text to align right when in an RTL language, so we use
- * the following override. See bug 1134453 and bug 1142925.
- */
-:-moz-dir(rtl) #notifications-lockscreen-container .notification:not([data-predefined-dir="ltr"]) .title-container .title:-moz-dir(ltr) {
-  text-align: right;
-  -moz-margin-end: unset;
-  margin-left: 0.5rem;
-}
-
-:-moz-dir(rtl) #notifications-lockscreen-container .notification:not([data-predefined-dir="ltr"]) .detail-content:-moz-dir(ltr) {
-  text-align: right;
 }

--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -245,9 +245,11 @@ html[dir="rtl"] #notifications-container .notification > div { margin-right: 3.7
   text-overflow: ellipsis;
 }
 html[dir="ltr"] #notifications-container .notification > div.title-container .title {
+  text-align: left;
   margin-right: .5rem;
 }
 html[dir="rtl"] #notifications-container .notification > div.title-container .title {
+  text-align: right;
   margin-left: .5rem;
 }
 
@@ -307,30 +309,4 @@ html[dir="rtl"] #notifications-container .notification > div.title-container .ti
   to {
     transform: rotate(360deg);
   }
-}
-
-
-#notifications-container .notification[data-predefined-dir="rtl"] > div.detail {
-  direction: rtl;
-}
-
-#notifications-container .notification[data-predefined-dir="ltr"] > div.detail {
-  direction: ltr;
-}
-
-
-/*
- * For the notification title, we need to use dir="auto" to display
- * parenthesis and periods in their proper place. However, we still
- * want the text to align right when in an RTL language, so we use
- * the following override. See bug 1134453 and bug 1142925.
- */
-html[dir="rtl"] #notifications-container .notification:not([data-predefined-dir="ltr"]) .title-container .title:-moz-dir(ltr) {
-  text-align: right;
-  margin-right: unset;
-  margin-left: 0.5rem;
-}
-
-html[dir="rtl"] #notifications-container .notification:not([data-predefined-dir="ltr"]) .detail-content:-moz-dir(ltr) {
-  text-align: right;
 }

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -8,6 +8,7 @@ apps/calendar/style/modify_event_view.css 0 4
 apps/calendar/style/month.css 0 2
 apps/calendar/style/settings.css 0 1
 apps/calendar/style/ui.css 0 2
+apps/callscreen/style/lockscreen.css 2 0
 apps/callscreen/style/oncall.css 0 1
 apps/camera/bower_components/gaia-theme/gaia-theme.css 5 0
 apps/camera/style/notification.css 1 0
@@ -80,10 +81,8 @@ apps/sms/views/inbox/style/edit-mode.css 1 0
 apps/sms/views/inbox/style/inbox.css 1 2
 apps/sms/views/new_message/style/recipients.css 4 0
 apps/sms/views/shared/style/common.css 0 1
-apps/sms/views/shared/style/composer.css 5 0
-apps/sms/views/shared/style/edit-mode.css 1 0
-apps/sms/views/shared/style/sms.css 1 2
-apps/system/fxa/style/fxa.css 1 0
+apps/system/lockscreen/style/lockscreen.css 3 0
+apps/system/lockscreen/style/notifications.css 9 0
 apps/system/mobile_id/style/mobile_id.css 0 16
 apps/system/style/action_menu/action_menu_extended.css 2 0
 apps/system/style/app_install_manager/app_install_manager.css 2 0


### PR DESCRIPTION
Followup of commit 688b18f
Changes included:
- Notifications: data-predefined-dir isn't used anymore.
  The position/alignment are now (ltr/rtl): timestamp left (resp right),
  icon right (resp left), title and details left (resp. right).
  Ellipsis position depends on the content direction (dir=auto).
- Lockscreen: both lockcsreens (normal and callscreen) layout are back to
  being identical
- Decline call button is always on the left (in ltr and rtl)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla-b2g/gaia/32395)

<!-- Reviewable:end -->
