### PR TITLE
Bug 1169154 - force update timezone string to prevent shows a blank area, r=yzen

### DIFF
--- a/apps/settings/js/panels/date_time/README.md
+++ b/apps/settings/js/panels/date_time/README.md
@@ -4,5 +4,5 @@
 
 We have different SIM card support by carrier
 
-* For SIM card from carriers supporting auto time zone update(ex: CHT), the timezone is grayed out when you turn on "set automatically".
-* For SIM card from carriers not supporting auto time zone update(ex: Taiwan mobile), the time zone should not be grayed out when you turn on "set automatically".
+* For SIM card from carriers(ex: CHT) supporting the auto time zone update protocol(NITZ), the timezone is grayed out when you turn on "set automatically".
+* For SIM card from carriers(ex: Taiwan mobile) not supporting auto time zone update, the time zone selection field should not be grayed out when you turn on "set automatically".

--- a/apps/settings/js/panels/date_time/panel.js
+++ b/apps/settings/js/panels/date_time/panel.js
@@ -8,6 +8,14 @@ define(function(require) {
   var DateTime = require('modules/date_time');
   var tzSelect = require('shared/tz_select');
 
+  var _debug = false;
+  var debug = function() {};
+  if (_debug) {
+    debug = function btam_debug(msg) {
+      console.log('--> [DateTime]: ' + msg);
+    };
+  }
+
   return function ctor_date_time_panel() {
     var HOUR_12 = 'ampm';
     var HOUR_24 = '24';
@@ -45,6 +53,7 @@ define(function(require) {
         this._boundSetTimezoneInfo = () => {
           // Only display the timezone info when auto time is enabled.
           var info = DateTime.clockAutoEnabled ? DateTime.timezone : '';
+          debug('Timezone: ' + info);
           this._elements.timezoneInfoText.textContent = info;
         };
 
@@ -208,6 +217,8 @@ define(function(require) {
           this._elements.timezonePickers.forEach((picker) => {
             picker.hidden = DateTime.timezoneAutoAvailable;
           });
+          debug('force update timezone string');
+          this._boundSetTimezoneInfo();
           this._elements.timezoneInfo.hidden = !DateTime.timezoneAutoAvailable;
         } else {
           this._elements.timeManual.classList.remove('disabled');


### PR DESCRIPTION
when the automatic timezone is the same as user specified timezone, the timezone change event is not being triggered, so we need force update it.
