### PR TITLE
Bug 1205895 - Stop event propagation after handling commands

### DIFF
--- a/apps/system/js/app_text_selection_dialog.js
+++ b/apps/system/js/app_text_selection_dialog.js
@@ -334,6 +334,7 @@
         this.close();
       }
       evt.preventDefault();
+      evt.stopPropagation();
     };
 
   AppTextSelectionDialog.prototype.copyHandler =

--- a/apps/system/test/unit/app_text_selection_dialog_test.js
+++ b/apps/system/test/unit/app_text_selection_dialog_test.js
@@ -160,6 +160,10 @@ suite('system/AppTextSelectionDialog', function() {
   });
 
   test('_doCommand in app', function() {
+    var stubPreventDefault = this.sinon.stub(fakeTextSelectInAppEvent,
+                                             'preventDefault');
+    var stubStopPropagation = this.sinon.stub(fakeTextSelectInAppEvent,
+                                              'stopPropagation');
     this.sinon.stub(td, 'close');
     td.app = {
       element: true
@@ -173,6 +177,8 @@ suite('system/AppTextSelectionDialog', function() {
       .calledWith('testCommand'));
     assert.isTrue(td.close.calledOnce,
       'should call close when trigger _doCommand');
+    assert.isTrue(stubPreventDefault.calledOnce);
+    assert.isTrue(stubStopPropagation.calledOnce);
   });
 
   test('_doCommand, when _isCommandSendable is false', function() {


### PR DESCRIPTION
We should stop 'click' event propagation after handling the
commands (cut, copy, etc.) in app text selection dialog.
