### PR TITLE
Bug 1214509 - Template interpolate method with default parameters

### DIFF
--- a/apps/sharedtest/test/unit/template_test.js
+++ b/apps/sharedtest/test/unit/template_test.js
@@ -61,8 +61,10 @@ suite('Template', function() {
 
   suite('interpolate', function() {
     var html = document.createElement('div');
+    var htmlNoIntrpltn = document.createElement('div');
     var css = document.createElement('div');
     html.appendChild(document.createComment('<span>${str}</span>'));
+    htmlNoIntrpltn.appendChild(document.createComment('<span>Nothing</span>'));
     css.appendChild(document.createComment('#foo { height: ${height}px; }'));
 
     test('interpolate(data) => html', function() {
@@ -81,6 +83,39 @@ suite('Template', function() {
       });
       assert.equal(typeof interpolated, 'string');
       assert.equal(interpolated, '#foo { height: 100px; }');
+    });
+
+    test('interpolate() => html', function() {
+      var tmpl = Template(htmlNoIntrpltn);
+      var interpolated = tmpl.interpolate();
+      assert.equal(typeof interpolated, 'string');
+      assert.equal(interpolated, '<span>Nothing</span>');
+    });
+
+    test('interpolate(data, options.safe[bad type]) => throws', function() {
+      var tmpl = Template(html);
+      var pseudoArray = { length: 1 };
+
+      assert.throw(() => tmpl.interpolate({}, { safe: pseudoArray }),
+        '"options.safe" must be an Array, not object');
+      assert.throw(() => tmpl.interpolate({}, { safe: 'badType' }),
+        '"options.safe" must be an Array, not string');
+    });
+
+    test('interpolate(data.undefined) => throws', function() {
+      var tmpl = Template(html);
+      assert.throw(tmpl.interpolate.bind(tmpl),
+        'No value provided for template identifier "str"');
+    });
+
+   test('interpolate(data.property[not a string]) => throws', function() {
+      var tmpl = Template(html);
+      assert.throw(() => tmpl.interpolate({ str: 666 }),
+        '"data.str" must be a String, not number');
+      assert.throw(() => tmpl.interpolate({ str: [] }),
+        '"data.str" must be a String, not object');
+      assert.throw(() => tmpl.interpolate({ str: {} }),
+        '"data.str" must be a String, not object');
     });
   });
 

--- a/apps/sms/views/conversation/js/conversation.js
+++ b/apps/sms/views/conversation/js/conversation.js
@@ -1748,7 +1748,7 @@ var ConversationView = {
 
     var lateArrivalInfos = this.computeLateArrivalInfos(message, messageStatus);
     if (lateArrivalInfos) {
-      var lateArrivalNoticeDOM = this.tmpl.lateArrivalNotice.prepare({})
+      var lateArrivalNoticeDOM = this.tmpl.lateArrivalNotice.prepare()
         .toDocumentFragment();
 
       document.l10n.setAttributes(

--- a/apps/sms/views/conversation/js/recipients.js
+++ b/apps/sms/views/conversation/js/recipients.js
@@ -20,7 +20,7 @@
     var number;
 
     opts = opts || {};
-    this.name = opts.name || opts.number || '';
+    this.name = String(opts.name || opts.number || '');
     this.number = (opts.number || '') + '';
     this.email = opts.email || '';
     this.editable = opts.editable || 'true';

--- a/apps/sms/views/conversation/test/unit/conversation_test.js
+++ b/apps/sms/views/conversation/test/unit/conversation_test.js
@@ -273,7 +273,11 @@ suite('conversation.js >', function() {
       for (var i = 0; i < 99; i++) {
         innerHTML += ConversationView.tmpl.message.interpolate({
           id: String(i),
-          bodyHTML: 'test #' + i
+          bodyHTML: 'test #' + i,
+          subject: '',
+          simInformationHTML: '',
+          timestamp: '',
+          messageStatusHTML: ''
         });
       }
       container.innerHTML = innerHTML;
@@ -4444,7 +4448,11 @@ suite('conversation.js >', function() {
         // fake content so that there is something to scroll
         container.innerHTML = ConversationView.tmpl.message.interpolate({
           id: '1',
-          bodyHTML: 'test #1'
+          bodyHTML: 'test #1',
+          subject: '',
+          simInformationHTML: '',
+          timestamp: '',
+          messageStatusHTML: ''
         });
 
         message = MockMessages.mms();

--- a/apps/sms/views/inbox/js/inbox.js
+++ b/apps/sms/views/inbox/js/inbox.js
@@ -786,7 +786,7 @@ var InboxView = {
     li.innerHTML = this.tmpl.thread.interpolate({
       hash: isDraft ? '#/composer' : '#/thread?id=' + id,
       mode: isDraft ? 'drafts' : 'threads',
-      id: isDraft ? draft.id : id,
+      id: String(isDraft ? draft.id : id),
       timestamp: String(timestamp)
     }, {
       safe: ['id']

--- a/apps/sms/views/shared/js/shared_components.js
+++ b/apps/sms/views/shared/js/shared_components.js
@@ -22,9 +22,9 @@
       }
 
       return getTemplate('phone-details-tmpl').prepare({
-        type: details.type,
-        number: details.number,
-        carrier: details.carrier,
+        type: details.type || '',
+        number: details.number || '',
+        carrier: details.carrier || '',
         hasTypeClass: !!details.type ? 'has-phone-type' : '',
         hasCarrierClass: !!details.carrier ? 'has-phone-carrier' : ''
       }, interpolationOptions);

--- a/apps/sms/views/shared/js/utils.js
+++ b/apps/sms/views/shared/js/utils.js
@@ -266,8 +266,8 @@
       }
 
       return {
-        type: (found.type && found.type[0]) || null,
-        carrier: hasUniqueCarriers || hasUniqueTypes ? found.carrier : null,
+        type: (found.type && found.type[0]) || '',
+        carrier: hasUniqueCarriers || hasUniqueTypes ? found.carrier : '',
         number: found.value
       };
     },

--- a/apps/sms/views/shared/test/unit/utils_test.js
+++ b/apps/sms/views/shared/test/unit/utils_test.js
@@ -478,14 +478,14 @@ suite('Utils', function() {
     test('Single no carrier', function() {
       // ie. contact.tel [ ... ]
       var tel = [
-        {value: '201', type: ['Mobile'], carrier: null}
+        {value: '201', type: ['Mobile'], carrier: ''}
       ];
 
       var a = Utils.getPhoneDetails('201', tel);
 
       assert.deepEqual(a, {
         type: tel[0].type[0],
-        carrier: null,
+        carrier: '',
         number: tel[0].value
       });
     });
@@ -493,14 +493,14 @@ suite('Utils', function() {
     test('No carrier, no type', function() {
       // ie. contact.tel [ ... ]
       var tel = [
-        {value: '201', type: [], carrier: null}
+        {value: '201', type: [], carrier: ''}
       ];
 
       var a = Utils.getPhoneDetails('201', tel);
 
       assert.deepEqual(a, {
-        type: null,
-        carrier: null,
+        type: '',
+        carrier: '',
         number: tel[0].value
       });
     });
@@ -571,12 +571,12 @@ suite('Utils', function() {
 
       assert.deepEqual(a, {
         type: tel[0].type[0],
-        carrier: null,
+        carrier: '',
         number: tel[0].value
       });
       assert.deepEqual(b, {
         type: tel[1].type[0],
-        carrier: null,
+        carrier: '',
         number: tel[1].value
       });
     });


### PR DESCRIPTION
- Set default values to Template.prototype.interpolate parameters
- Test for undefined data properties and throw errors
- Swap safe.indexOf with safe.includes and invert the logic of the ternary operator
