### PR TITLE
Bug 1213946 - Use |now.toString()| instead of |new Date(now)| in mont…

### DIFF
--- a/apps/calendar/test/unit/views/month_day_agenda_test.js
+++ b/apps/calendar/test/unit/views/month_day_agenda_test.js
@@ -54,7 +54,7 @@ suite('Views.MonthDayAgenda', function() {
         navigator.mozL10n.get(format)
       ), 'should set the currentDate textContent');
 
-      assert.deepEqual(new Date(currentDate.dataset.date), new Date(now));
+      assert.equal(currentDate.dataset.date, now.toString());
       assert.deepEqual(currentDate.dataset.l10nDateFormat, format);
 
       assert.ok(


### PR DESCRIPTION
…h_day_agenda_test.js. r=julienw

In bug 1187233 we're changing |new Date(now)| to create a copy (which will preserve milliseconds).
