### PR TITLE
Bug 1215216 - Listen for iac-ftucomms event to now when FTU starts. r=kgrandon

### DIFF
--- a/apps/ftu/test/unit/app_test.js
+++ b/apps/ftu/test/unit/app_test.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+require('/shared/js/event_safety.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_apps.js');
 require('/shared/test/unit/mocks/mock_navigator_moz_mobile_connections.js');
 require('/shared/test/unit/mocks/mock_l10n.js');

--- a/apps/system/js/ftu_launcher.js
+++ b/apps/system/js/ftu_launcher.js
@@ -209,9 +209,6 @@
     '_handle_iac-ftucomms': function(evt) {
       var message = evt.detail;
       switch (message) {
-        case 'started':
-          this.publish('started');
-          break;
         case 'done':
           this.setBypassHome(true);
           break;

--- a/apps/system/test/unit/ftu_launcher_test.js
+++ b/apps/system/test/unit/ftu_launcher_test.js
@@ -85,9 +85,9 @@ suite('launch ftu >', function() {
       publishStub = this.sinon.stub(subject, 'publish');
     });
 
-    test('handle started event', function() {
+    test('dont publish ftustarted on ftucomms started event', function() {
       subject['_handle_iac-ftucomms'](mockIACFTUCommsStartedEvent);
-      assert.isTrue(publishStub.calledWith('started'));
+      assert.isFalse(publishStub.calledWith('started'));
     });
 
     test('handle step event', function() {


### PR DESCRIPTION
This was a event name collision, uncovered by making FtuLauncher start (and the publishing of ftustarted via BaseModule) async. Rather than rename everything I just decided not to re-publish this event from FtuLauncher, and have Accessibility listen for the iac-ftucomms event directly. 
