### PR TITLE
Bug 1216102 - provide correct configuration for TV as a presentation receiver. r=rexboy.

### DIFF
--- a/build/config/tv/custom-prefs.js
+++ b/build/config/tv/custom-prefs.js
@@ -9,7 +9,5 @@ user_pref('b2g.system_manifest_url',
 user_pref('b2g.neterror.url',
           'app://smart-system.gaiamobile.org/net_error.html');
 user_pref('dom.meta-viewport.enabled', false);
-user_pref('dom.presentation.discoverable', true);
-user_pref('dom.presentation.discovery.enabled', true);
 user_pref('dom.presentation.enabled', true);
 user_pref('devtools.useragent.device_type', 'TV');

--- a/build/config/tv/settings.json
+++ b/build/config/tv/settings.json
@@ -1,4 +1,5 @@
 {
+ "dom.presentation.discoverable": true,
  "homescreen.appName": "smart-home",
   "sync.collections.bookmarks.enabled": true
 }


### PR DESCRIPTION
TV only needs to be discovered by controlling device, but doesn't need to discovery remote devices proactively.
