### PR TITLE
Bug 1179703 - Handle overlapping wifi statuschange events

### DIFF
--- a/apps/ftu/test/unit/wifi_test.js
+++ b/apps/ftu/test/unit/wifi_test.js
@@ -625,6 +625,9 @@ suite('wifi > ', function() {
 
         WifiManager.api.onstatuschange({status: 'disconnected',
           network: previousNetwork});
+        // bug 1179703
+        WifiManager.api.onstatuschange({status: 'connecting',
+          network: previousNetwork});
         WifiManager.api.onstatuschange({status: 'connected',
           network: currentNetwork});
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1179703

Harden the UI side of the status updates, handle the case where the outgoing/disconnected network raises a bogus connecting event on its way out. 
