### PR TITLE
Bug 1188026 - dont reset when mozlocationchange isnt a change

### DIFF
--- a/apps/system/js/app_window.js
+++ b/apps/system/js/app_window.js
@@ -1121,23 +1121,24 @@
 
   AppWindow.prototype._handle_mozbrowserlocationchange =
     function aw__handle_mozbrowserlocationchange(evt) {
-      this.favicons = {};
-      this.webManifestURL = null;
-      this.webManifest = null;
-      this.config.url = evt.detail;
-      this.title = evt.detail;
       if (!this.manifest) {
         this.name = new URL(evt.detail).hostname;
       }
       // Integration test needs to locate the frame by this attribute.
       this.browser.element.dataset.url = evt.detail;
+      if (this.config.url !== evt.detail) {
+        this.title = evt.detail;
+        this.favicons = {};
+        this.webManifestURL = null;
+        this.webManifest = null;
+        this.config.url = evt.detail;
+      }
       this.publish('locationchange');
     };
 
 
   AppWindow.prototype._handle_mozbrowsericonchange =
     function aw__handle_mozbrowsericonchange(evt) {
-
       var href = evt.detail.href;
       var sizes = evt.detail.sizes;
 

--- a/apps/system/test/unit/app_window_test.js
+++ b/apps/system/test/unit/app_window_test.js
@@ -2125,6 +2125,37 @@ suite('system/AppWindow', function() {
       app1.config.url = url;
     });
 
+    test('Locationchange event to same URL', function() {
+      var app1 = new AppWindow(fakeAppConfig1);
+      var url = app1.config.url;
+
+      app1.handleEvent({
+        type: 'mozbrowserlocationchange',
+        detail: 'http://fakeURL.changed'
+      });
+
+      app1.handleEvent({
+        type: 'mozbrowsericonchange',
+        detail: {
+          href: 'http://fakeURL.favicon',
+          sizes: 60
+        }
+      });
+      var favicons = app1.favicons;
+      assert.equal(Object.keys(favicons).length, 1);
+
+      this.sinon.stub(app1, 'publish');
+      app1.handleEvent({
+        type: 'mozbrowserlocationchange',
+        detail: 'http://fakeURL.changed'
+      });
+      assert.deepEqual(app1.favicons, favicons);
+      // we *do* expect publish to be called,
+      // not doing so seems to break marionette tests
+      assert.isTrue(app1.publish.calledOnce);
+      app1.config.url = url;
+    });
+
     test('Locationchange event resets name and title', function() {
       var app1 = new AppWindow(fakeWrapperConfig);
 


### PR DESCRIPTION
Maybe could go further still and not re-publish as a locationchange if the new event doesnt actually change the config.url? 
