### PR TITLE
Bug 1213894 - Progress bar doesn't appear for pinned chrome

### DIFF
--- a/apps/system/style/chrome/chrome.css
+++ b/apps/system/style/chrome/chrome.css
@@ -811,7 +811,8 @@ gaia-overflow-menu button#share {
 }
 
 /* Progress */
-.appWindow:not(.bar).collapsible > .chrome gaia-progress {
+.appWindow:not(.bar).collapsible > .chrome gaia-progress,
+.appWindow:not(.fullscreen-app) > .chrome gaia-progress {
   top: 7.3rem;
 }
 


### PR DESCRIPTION
A simple alternative to #32535
