### PR TITLE
Bug 1218063 - Imagecompare: go_back_and_exit() method in header.py does not work in RTL

### DIFF
--- a/tests/python/gaia-ui-tests/gaiatest/apps/gallery/regions/view_image.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/gallery/regions/view_image.py
@@ -37,9 +37,7 @@ class ViewImage(Base):
         return element.text
 
     def tap_back_button(self):
-        GaiaHeader(self.marionette, self._header_locator).go_back_and_exit(
-            app=self, add_statusbar_height=False)
-        self.apps.switch_to_displayed_app()
+        GaiaHeader(self.marionette, self._header_locator).go_back(exit_app=True, app=self)
 
     def tap_save_image(self):
         self.marionette.find_element(*self._save_image_button_locator).tap()

--- a/tests/python/gaia-ui-tests/gaiatest/apps/ring_tone/app.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/ring_tone/app.py
@@ -38,7 +38,7 @@ class RingTone(Base):
         save_button.tap()
 
     def tap_exit(self):
-        GaiaHeader(self.marionette, self._header_locator).go_back_and_exit(app=self)
+        GaiaHeader(self.marionette, self._header_locator).go_back(app=self,exit_app=True)
 
     def cancel_share(self):
         self.marionette.find_element(*self._actions_cancel_locator).tap()

--- a/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/keyboard.py
+++ b/tests/python/gaia-ui-tests/gaiatest/apps/settings/regions/keyboard.py
@@ -99,4 +99,4 @@ class BuiltInKeyBoard(Base):
         GaiaHeader(self.marionette, self._user_dict_header_locator).go_back()
 
     def tap_exit(self):
-        GaiaHeader(self.marionette, self._header_locator).go_back_and_exit(app=self)
+        GaiaHeader(self.marionette, self._header_locator).go_back(app=self, exit_app=True, statusbar=True)

--- a/tests/python/gaia-ui-tests/gaiatest/form_controls/header.py
+++ b/tests/python/gaia-ui-tests/gaiatest/form_controls/header.py
@@ -11,22 +11,24 @@ class GaiaHeader(Widget):
     _back_button_locator = (By.CSS_SELECTOR, 'button.action-button')
     _close_button_locator = (By.CSS_SELECTOR, 'button[type="reset"]')
 
-    def go_back(self):
+    def go_back(self,app=None, exit_app=False, statusbar=False):
         Wait(self.marionette).until(expected.element_enabled(self.root_element) and
                                     expected.element_displayed(self.root_element))
         self.marionette.switch_to_shadow_root(self.root_element)
         element = self.marionette.find_element(*self._back_button_locator)
-        if element.is_displayed():
-            element.tap()
-            self.marionette.switch_to_shadow_root()
-        else: # This header has a close button instead of a back button
-            self.marionette.switch_to_shadow_root()
-            self.root_element.find_element(*self._close_button_locator).tap()
-        Wait(self.marionette).until(expected.element_not_displayed(self.root_element))
+        _back_button_present = True
 
-    def go_back_and_exit(self, app=None, add_statusbar_height=True):
-        Wait(self.marionette).until(expected.element_enabled(self.root_element) and
-                                    expected.element_displayed(self.root_element))
-        self.tap_element_from_system_app(self.root_element, add_statusbar_height=add_statusbar_height, x=20)
-        app.wait_to_not_be_displayed()
-        self.apps.switch_to_displayed_app()
+        if not element.is_displayed(): # This header has a close button instead of a back button
+            self.marionette.switch_to_shadow_root()
+            element = self.root_element.find_element(*self._close_button_locator)
+            _back_button_present = False
+
+        if exit_app:
+            self.tap_element_from_system_app(element, statusbar)
+            app.wait_to_not_be_displayed()
+            self.apps.switch_to_displayed_app()
+        else:
+            element.tap()
+            if _back_button_present:
+                self.marionette.switch_to_shadow_root()
+            Wait(self.marionette).until(expected.element_not_displayed(self.root_element))

--- a/tests/python/gaia-ui-tests/gaiatest/tests/graphics/RTL/test_settings_personalization_RTL.py
+++ b/tests/python/gaia-ui-tests/gaiatest/tests/graphics/RTL/test_settings_personalization_RTL.py
@@ -27,7 +27,6 @@ class TestSettingsRTLPersonalization(GaiaImageCompareTestCase):
             self.take_screenshot('sound-ringtones')
 
         ringtone_page.tap_exit()
-        settings.switch_to_settings_app()
         Wait(self.marionette).until(lambda m: sound_page.ring_tone_selector_visible)
 
         alerts_page = sound_page.tap_alerts_selector()
@@ -37,7 +36,6 @@ class TestSettingsRTLPersonalization(GaiaImageCompareTestCase):
                                             screen=alerts_page.screen_element)
             self.take_screenshot('sound-alerts')
         alerts_page.tap_exit()
-        settings.switch_to_settings_app()
         Wait(self.marionette).until(lambda m: sound_page.ring_tone_selector_visible)
 
         manage_page = sound_page.tap_manage_tones_selector()
@@ -51,7 +49,6 @@ class TestSettingsRTLPersonalization(GaiaImageCompareTestCase):
         self.take_screenshot('sound-manage_tones-share')
         manage_page.cancel_share()
         manage_page.tap_exit()
-        settings.switch_to_settings_app()
         Wait(self.marionette).until(lambda m: sound_page.ring_tone_selector_visible)
         settings.return_to_prev_menu(settings.screen_element, sound_page.screen_element)
 


### PR DESCRIPTION
…es not work in RTL
