### PR TITLE
Bug 1218247 - disable adds-on support on TV 2.5. r=rexboy.

### DIFF
--- a/build/config/tv/custom-prefs.js
+++ b/build/config/tv/custom-prefs.js
@@ -11,3 +11,4 @@ user_pref('b2g.neterror.url',
 user_pref('dom.meta-viewport.enabled', false);
 user_pref('dom.presentation.enabled', true);
 user_pref('devtools.useragent.device_type', 'TV');
+user_pref('dom.apps.customization.enabled', false);


### PR DESCRIPTION
TV doesn't have corresponding UI/UX for adds-on. We need to disable it in TV 2.5 scope.
