### PR TITLE
Bug 1218723 - settings: fix APN parenthesis display

### DIFF
--- a/apps/settings/style/apps.css
+++ b/apps/settings/style/apps.css
@@ -404,6 +404,10 @@ section ul.operate-certificate {
    padding-bottom: 1em;
  }
 
+ .apn-item .name {
+  unicode-bidi: -moz-plaintext;
+}
+
  /******************************************************************************
   * Internet sharing (Wi-Fi HotSpot)
   */


### PR DESCRIPTION
No ellipsis so we can use 'unicode-bidi:-moz-plaintext'

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla-b2g/gaia/32803)

<!-- Reviewable:end -->
