### PR TITLE
Bug 1218928 - Remove invalid scopes from taskgraph.json

### DIFF
--- a/taskgraph.json
+++ b/taskgraph.json
@@ -18,9 +18,7 @@
           "docker-worker:cache:gaia-tc-vcs",
           "docker-worker:cache:gaia-linux-cache",
           "docker-worker:cache:gaia-misc-caches",
-          "docker-worker:image:quay.io/mozilla/raptor-tester:latest",
-          "queue:define-task:aws-provisioner/gaia",
-          "queue:create-task:aws-provisioner/gaia"
+          "docker-worker:image:quay.io/mozilla/raptor-tester:latest"
         ],
         "payload": {
           "cache": {


### PR DESCRIPTION
These two scopes don't correspond to anything anymore -- wrong provisionerId, wrong workerType.  Keeping them in task.scopes means that they need to be in the role for this repository, even though they are not actually used.
