### PR TITLE
Bug 1171848 - put scrollbar at the right position for textarea

### DIFF
--- a/apps/communications/contacts/elements/form.html
+++ b/apps/communications/contacts/elements/form.html
@@ -99,8 +99,9 @@
           <p class="setbox-item">
             <textarea placeholder="Comment" data-field="note"
               data-l10n-id="comment" name="comment[#i#]" class="textfield"
-              type="text" x-inputmode="latin-prose" id="note_#i#"
-              dir="auto">#note#</textarea>
+              type="text" x-inputmode="latin-prose" id="note_#i#">
+                #note#
+            </textarea>
            <button type="reset">Clear</button>
           </p>
         </dd>


### PR DESCRIPTION
If you put a dir="auto" on an element, its direction is viewed as LTR
when it is empty, and the scrollbar is on the left. This is bug 1103011.
But here, we already have a unicode-bidi: -moz-plaintext on the element.
So we don't need any dir="auto" anyway.
