### PR TITLE
Bug 1219853 - [email] Go back to mozAlarms instead of request-sync

### DIFF
--- a/apps/email/docs/startup.md
+++ b/apps/email/docs/startup.md
@@ -28,7 +28,7 @@ The localStorage values are stamped with the signature of the app files, since c
 
 4) It continues to listen for mozSetMessageHandler entry point messages, and dispatches to handlers that have registered to `window.globalOnAppMessage`. `mail_app` calls `globalOnAppMessage`. The startupData is returned from calls to `globalOnAppMessage`, so this is how `mail_app` knows what startup entry point and view are suggested by `html_cache_restore`.
 
-`html_cache_restore` will **not** listen for mozSetMessageHandler messagesfor request-sync messages, because wake locks need to be acquired in that case, and given the complexity of that need, it relies on cronsync-main to do that work. `html_cache_restore` does detect if it was started from a request-sync message, but only uses that it setting up the startup state.
+`html_cache_restore` will **not** listen for mozSetMessageHandler messagesfor alarm messages, because wake locks need to be acquired in that case, and given the complexity of that need, it relies on cronsync-main to do that work. `html_cache_restore` does detect if it was started from a alarm message, but only uses that it setting up the startup state.
 
 ## config
 

--- a/apps/email/js/cards/settings_debug.html
+++ b/apps/email/js/cards/settings_debug.html
@@ -64,9 +64,6 @@
             href="#"
             class="tng-dbg-fastsync">Enable faster sync options</button>
 
-    <button data-event="click:showSyncs"
-            href="#">Show sync tasks in logcat</button>
-
     <button data-event="click:resetStartupCache"
             href="#">Reset startup cache</button>
   </section>

--- a/apps/email/js/cards/settings_debug.js
+++ b/apps/email/js/cards/settings_debug.js
@@ -43,32 +43,7 @@ return [
     },
 
     fastSync: function() {
-      _secretDebug.fastSync = [100000, 200000];
-    },
-
-    showSyncs: function() {
-      var navSync = navigator.sync;
-      if (!navSync) {
-        console.error('navigator.sync not available');
-        return;
-      }
-
-      navSync.registrations().then(function(regs) {
-        console.log('navigator.sync registrations count: ', regs.length);
-        regs.forEach(function(reg) {
-          console.log('Registered task: ' + reg.task);
-          Object.keys(reg).forEach(function(key) {
-            if (key === 'data') {
-              console.log(key + ': ' + JSON.stringify(reg[key]));
-            } else {
-              console.log(key + ': ' + reg[key]);
-            }
-          });
-          console.log('-----------');
-        });
-      }, function(err) {
-        console.error('navigator.sync.registrations failed: ', err);
-      });
+      _secretDebug.fastSync = [20000, 60000];
     },
 
     resetStartupCache: function() {

--- a/apps/email/js/ext/main-frame-setup.js
+++ b/apps/email/js/ext/main-frame-setup.js
@@ -5,7 +5,7 @@
  * Main: Spawns worker
  * Worker: Loads core JS
  * Worker: 'hello' => main
- * Main: 'hello' => worker with online status and navigator.sync status
+ * Main: 'hello' => worker with online status and mozAlarms status
  * Worker: Creates MailUniverse
  * Worker 'mailbridge'.'hello' => main
  * Main: Creates MailAPI, sends event to UI

--- a/apps/email/js/ext/worker-support/cronsync-main.js
+++ b/apps/email/js/ext/worker-support/cronsync-main.js
@@ -9,6 +9,15 @@ define(function(require) {
     console.log('cronsync-main: ' + str);
   }
 
+  function makeData(accountIds, interval, date) {
+    return {
+      type: 'sync',
+      accountIds: accountIds,
+      interval: interval,
+      timestamp: date.getTime()
+    };
+  }
+
   // Creates a string key from an array of string IDs. Uses a space
   // separator since that cannot show up in an ID.
   function makeAccountKey(accountIds) {
@@ -62,163 +71,175 @@ define(function(require) {
     },
 
     /**
-     * Clears all sync-based tasks. Normally not called, except perhaps for
+     * Clears all sync-based alarms. Normally not called, except perhaps for
      * tests or debugging.
      */
     clearAll: function() {
-      var navSync = navigator.sync;
-      if (!navSync) {
+      var mozAlarms = navigator.mozAlarms;
+      if (!mozAlarms) {
         return;
       }
 
-      navSync.registrations().then(function(registrations) {
-        if (!registrations.length) {
+      var r = mozAlarms.getAll();
+
+      r.onsuccess = function(event) {
+        var alarms = event.target.result;
+        if (!alarms) {
           return;
         }
 
-        registrations.forEach(function(registeredTask) {
-          navSync.unregister(registeredTask.task);
+        alarms.forEach(function(alarm) {
+          if (alarm.data && alarm.data.type === 'sync') {
+            mozAlarms.remove(alarm.id);
+          }
         });
-      }.bind(this),
-      function(err) {
-        console.error('cronsync-main clearAll navigator.sync.registrations ' +
-                      'error: ' + err);
-      }.bind(this));
+      }.bind(this);
+      r.onerror = function(err) {
+        console.error('cronsync-main clearAll mozAlarms.getAll: error: ' +
+                      err);
+      }.bind(this);
     },
 
     /**
-     * Makes sure there is an sync task set for every account in
-     * the list.
-     * @param  {Object} syncData. An object with keys that are
-     * 'interval' + intervalInMilliseconds, and values are arrays
-     * of account IDs that should be synced at that interval.
+     * Makes sure there is an alarm set for every account in the list.
+     * @param  {Object} syncData. An object with keys that are 'interval' +
+     * intervalInMilliseconds, and values are arrays of account IDs that should
+     * be synced at that interval.
      */
     ensureSync: function (syncData) {
-      var navSync = navigator.sync;
-      if (!navSync) {
-        console.warn('no navigator.sync support!');
-        // Let backend know work has finished, even though it was a no-op.
-        this._sendMessage('syncEnsured');
+
+      var mozAlarms = navigator.mozAlarms;
+      if (!mozAlarms) {
+        console.warn('no mozAlarms support!');
         return;
       }
 
       debug('ensureSync called');
 
-      navSync.registrations().then(function(registrations) {
+      var request = mozAlarms.getAll();
+
+      request.onsuccess = function(event) {
         debug('success!');
 
-        // Find all IDs being tracked by sync tasks
-        var expiredTasks = [],
-            okTaskIntervals = {},
-            uniqueTasks = {};
+        var alarms = event.target.result;
+        // If there are no alarms a falsey value may be returned.  We want
+        // to not die and also make sure to signal we completed, so just make
+        // an empty list.
+        if (!alarms) {
+          alarms = [];
+        }
 
-        registrations.forEach(function(task) {
-          // minInterval in seconds, but use milliseconds for sync values
-          // internally.
-          var intervalKey = 'interval' + (task.minInterval * 1000),
+        // Find all IDs being tracked by alarms
+        var expiredAlarmIds = [],
+            okAlarmIntervals = {},
+            uniqueAlarms = {};
+
+        alarms.forEach(function(alarm) {
+          // Only care about sync alarms.
+          if (!alarm.data || !alarm.data.type || alarm.data.type !== 'sync') {
+            return;
+          }
+
+          var intervalKey = 'interval' + alarm.data.interval,
               wantedAccountIds = syncData[intervalKey];
 
           if (!wantedAccountIds || !hasSameValues(wantedAccountIds,
-                                                  task.data.accountIds)) {
-            debug('account array mismatch, canceling existing sync task');
-            expiredTasks.push(task);
+                                                  alarm.data.accountIds)) {
+            debug('account array mismatch, canceling existing alarm');
+            expiredAlarmIds.push(alarm.id);
           } else {
-            // Confirm the existing sync task is still good.
+            // Confirm the existing alarm is still good.
             var interval = toInterval(intervalKey),
+                now = Date.now(),
+                alarmTime = alarm.data.timestamp,
                 accountKey = makeAccountKey(wantedAccountIds);
 
-            // If the interval is nonzero, and there is no other task found
+            // If the interval is nonzero, and there is no other alarm found
             // for that account combo, and if it is not in the past and if it
             // is not too far in the future, it is OK to keep.
-            if (interval && !uniqueTasks.hasOwnProperty(accountKey)) {
-              debug('existing sync task is OK: ' + interval);
-              uniqueTasks[accountKey] = true;
-              okTaskIntervals[intervalKey] = true;
+            if (interval && !uniqueAlarms.hasOwnProperty(accountKey) &&
+                alarmTime > now && alarmTime < now + interval) {
+              debug('existing alarm is OK: ' + accountKey);
+              uniqueAlarms[accountKey] = true;
+              okAlarmIntervals[intervalKey] = true;
             } else {
-              debug('existing sync task is out of interval range, canceling');
-              expiredTasks.push(task);
+              debug('existing alarm is out of interval range, canceling');
+              expiredAlarmIds.push(alarm.id);
             }
           }
         });
 
-        expiredTasks.forEach(function(expiredTask) {
-          navSync.unregister(expiredTask.task);
+        expiredAlarmIds.forEach(function(alarmId) {
+          mozAlarms.remove(alarmId);
         });
 
-        var taskMax = 0,
-            taskCount = 0,
+        var alarmMax = 0,
+            alarmCount = 0,
             self = this;
 
-        // Called when sync tasks are confirmed to be set.
+        // Called when alarms are confirmed to be set.
         function done() {
-          taskCount += 1;
-          if (taskCount < taskMax) {
+          alarmCount += 1;
+          if (alarmCount < alarmMax) {
             return;
           }
 
           debug('ensureSync completed');
           // Indicate ensureSync has completed because the
-          // back end is waiting to hear sync task was set
-          // before triggering sync complete.
+          // back end is waiting to hear alarm was set before
+          // triggering sync complete.
           self._sendMessage('syncEnsured');
         }
 
         Object.keys(syncData).forEach(function(intervalKey) {
-          // Skip if the existing sync task is already good.
-          if (okTaskIntervals.hasOwnProperty(intervalKey)) {
+          // Skip if the existing alarm is already good.
+          if (okAlarmIntervals.hasOwnProperty(intervalKey)) {
             return;
           }
 
           var interval = toInterval(intervalKey),
-              accountIds = syncData[intervalKey];
+              accountIds = syncData[intervalKey],
+              date = new Date(Date.now() + interval);
 
           // Do not set an timer for a 0 interval, bad things happen.
           if (!interval) {
             return;
           }
 
-          taskMax += 1;
+          alarmMax += 1;
 
-          navSync.register('interval' + interval, {
-            // minInterval is in seconds.
-            minInterval: interval / 1000,
-            oneShot: false,
-            data: {
-              accountIds: accountIds,
-              interval: interval
-            },
-            wifiOnly: false,
-            // TODO: allow this to be more generic, getting this passed in
-            // from the page using this module. This assumes the current page
-            // without query strings or fragment IDs is the desired entry point.
-            wakeUpPage: location.href.split('?')[0].split('#')[0] })
-          .then(function() {
-            debug('success: navigator.sync.register for ' + 'IDs: ' +
-                  accountIds +
+          var alarmRequest = mozAlarms.add(date, 'ignoreTimezone',
+                                       makeData(accountIds, interval, date));
+
+          alarmRequest.onsuccess = function() {
+            debug('success: mozAlarms.add for ' + 'IDs: ' + accountIds +
                   ' at ' + interval + 'ms');
             done();
-          }, function(err) {
-            console.error('cronsync-main navigator.sync.register for IDs: ' +
+          };
+
+          alarmRequest.onerror = function(err) {
+            console.error('cronsync-main mozAlarms.add for IDs: ' +
                           accountIds +
                           ' failed: ' + err);
-          });
+          };
         });
 
-        // If no sync tasks were added, indicate ensureSync is done.
-        if (!taskMax) {
+        // If no alarms were added, indicate ensureSync is done.
+        if (!alarmMax) {
           done();
         }
-      }.bind(this),
-      function(err) {
-        console.error('cronsync-main ensureSync navigator.sync.register: ' +
-                      'error: ' + err);
-      });
+      }.bind(this);
+
+      request.onerror = function(err) {
+        console.error('cronsync-main ensureSync mozAlarms.getAll: error: ' +
+                      err);
+      };
     }
   };
 
   if (navigator.mozSetMessageHandler) {
-    navigator.mozSetMessageHandler('request-sync', function onRequestSync(e) {
-      console.log('mozSetMessageHandler: received a request-sync');
+    navigator.mozSetMessageHandler('alarm', function onAlarm(alarm) {
+      console.log('mozSetMessageHandler: received an alarm');
 
       // Important for gaia email app to know when a mozSetMessageHandler has
       // been dispatched. Could be removed if notification close events did not
@@ -229,7 +250,11 @@ define(function(require) {
         window.appDispatchedMessage = true;
       }
 
-      var data = e.data;
+      // Do not bother with alarms that are not sync alarms.
+      var data = alarm.data;
+      if (!data || data.type !== 'sync') {
+        return;
+      }
 
       // Need to acquire the wake locks during this notification
       // turn of the event loop -- later turns are not guaranteed to
@@ -253,9 +278,9 @@ define(function(require) {
                              makeAccountKey(data.accountIds), locks);
       }
 
-      debug('request-sync started at ' + (new Date()));
+      debug('alarm dispatch started at ' + (new Date()));
 
-      dispatcher._sendMessage('requestSync',
+      dispatcher._sendMessage('alarm',
                               [data.accountIds, data.interval]);
     });
   }

--- a/apps/email/js/mail_app.js
+++ b/apps/email/js/mail_app.js
@@ -56,10 +56,10 @@ function pushStartCard(id, addedArgs) {
 }
 
 // Handles visibility changes: if the app becomes visible after starting up
-// hidden because of a request-sync, start showing some UI.
+// hidden because of an alarm, start showing some UI.
 document.addEventListener('visibilitychange', function onVisibilityChange() {
   if (!document.hidden && !started &&
-      startupData && startupData.entry === 'request-sync') {
+      startupData && startupData.entry === 'alarm') {
     pushStartCard('message_list');
   }
 }, false);
@@ -287,10 +287,10 @@ var startupData = globalOnAppMessage({
 console.log('startupData: ' + JSON.stringify(startupData, null, '  '));
 
 // If not a mozSetMessageHandler entry point, start up the UI now. Or, if
-// a request-sync started the app, but the app became visible during the
+// an alarm started the app, but the app became visible during the
 // startup. In that case, make sure we show something to the user.
 if (startupData.entry === 'default' ||
-   (startupData.entry === 'request-sync' && !document.hidden)) {
+   (startupData.entry === 'alarm' && !document.hidden)) {
   pushStartCard(startupData.view);
 }
 

--- a/apps/email/manifest.webapp
+++ b/apps/email/manifest.webapp
@@ -8,10 +8,12 @@
     "url": "https://github.com/mozilla-b2g/gaia"
   },
   "messages": [
+    { "alarm": "/index.html" },
     { "notification": "/index.html" },
     { "request-sync": "/index.html" }
   ],
   "permissions": {
+    "alarms":{},
     "themeable":{},
     "browser": {},
     "audio-channel-notification":{},

--- a/apps/email/test/marionette/lib/email_sync.js
+++ b/apps/email/test/marionette/lib/email_sync.js
@@ -16,6 +16,9 @@ EmailSync.prototype = {
     this.client.contentScript.inject(
       SHARED_PATH + '/mock_navigator_moz_set_message_handler.js'
     );
+    this.client.contentScript.inject(
+      SHARED_PATH + '/mock_navigator_mozalarms.js'
+    );
   },
 
   /**
@@ -26,13 +29,16 @@ EmailSync.prototype = {
     // trigger sync in Email App
     this.client.executeScript(function() {
       var interval = 1000;
-      var task = {
+      var date = new Date(Date.now() + interval).getTime();
+      var alarm = {
         data: {
+          type: 'sync',
           accountIds: ['0', '1'],
-          interval: interval
+          interval: interval,
+          timestamp: date
         }
       };
-      return window.wrappedJSObject.fireMessageHandler(task, 'request-sync');
+      return window.wrappedJSObject.fireMessageHandler(alarm, 'alarm');
     });
   }
 };

--- a/apps/email/test/marionette/notification_set_interval_test.js
+++ b/apps/email/test/marionette/notification_set_interval_test.js
@@ -7,6 +7,8 @@ var EmailData = require('./lib/email_data');
 var assert = require('assert');
 var serverHelper = require('./lib/server_helper');
 
+var SHARED_PATH = __dirname + '/../../../../shared/test/integration';
+
 marionette('email notifications, set interval', function() {
   var app,
       client = marionette.client(),
@@ -17,8 +19,24 @@ marionette('email notifications, set interval', function() {
                   }
                 }, this);
 
+
+  function getAlarms(client) {
+    var alarms;
+    client.waitFor(function() {
+      alarms = client.executeScript(function() {
+        var alarms = window.wrappedJSObject.navigator.__mozFakeAlarms;
+        if (alarms && alarms.length) {
+            return alarms;
+        }
+       });
+      return alarms;
+    });
+    return alarms;
+  }
+
   setup(function() {
     app = new Email(client);
+    client.contentScript.inject(SHARED_PATH + '/mock_navigator_mozalarms.js');
     app.launch();
   });
 
@@ -36,6 +54,12 @@ marionette('email notifications, set interval', function() {
     // change.
     var emailData = new EmailData(client);
     emailData.waitForCurrentAccountUpdate('syncInterval', 3600000);
+
+    // Make sure an alarm was set.
+    var alarms = getAlarms(client);
+    assert(alarms.length === 1, 'have one alarm');
+    var alarm = alarms[0];
+    assert(alarm.interval === 3600000, 'has correct interval value');
 
     // Close the app, relaunch and make sure syncInterval was
     // persisted correctly


### PR DESCRIPTION
This is like a reversion of [bug 1098289](https://bugzilla.mozilla.org/show_bug.cgi?id=1098289), but some things have moved around a bit.

The other major difference: email still listens for request-sync entry points, to catch an email client that was using them then upgrades to this one. In that case, the request-sync registrations are removed and the app just starts up in the background going to the message list. During our normal startup process, that triggers the ensureSync alarm checking and we set the alarms correctly for the next sync.

End result: we miss one sync in the upgrade case, but be set with alarms for the next sync.

An alternative might be to just drop the webapp manifest stuff around request-sync and hope that does not cause a lingering issue with request-sync registrations. Or trace the code to try it, but I do not trust just code reading for this, I would want to test it. It is difficult to test since I am not sure of a good way of updating the webapp manifest permissions stuff on a push, just know how to do a gaia reset to get it the new info updated with b2g.

Plus, by actually waking up with the request-sync message, we get a chance to seamlessly upgrade to the alarms without the user needing to manually open the app first. Not sure if that is worth the cost of keeping request-sync in the manifest though. So that part might need more discussion.
