### PR TITLE
Bug 1220563 - [System] correct alignment for toaster notifications.

### DIFF
--- a/apps/system/style/notifications/notifications.css
+++ b/apps/system/style/notifications/notifications.css
@@ -67,9 +67,11 @@
 }
 html[dir="ltr"] #notification-container > div {
   left: 5.6rem;
+  text-align: left;
 }
 html[dir="rtl"] #notification-container > div {
   right: 5.6rem;
+  text-align: right;
 }
 
 .toaster-title {


### PR DESCRIPTION
We don't want the alignment to depend on the dir parameter of the
notification, but rather on the system UI direction.
