### PR TITLE
Bug 1218928 - Remove unnecessary scope

### DIFF
--- a/tests/taskcluster/tasks/eslint.yml
+++ b/tests/taskcluster/tasks/eslint.yml
@@ -9,7 +9,6 @@ task:
     # Source caches contains various sources (including a tarball of gaia source
     # tree)
     - docker-worker:cache:gaia-misc-caches
-    - docker-worker:image:quay.io/mozilla/gaia-taskenv:*
 
   payload:
     env:


### PR DESCRIPTION
This was missed in 03a953f68931048bf19f9ce7da651a38d11ff5db because this task is unfortunate enough to list the scope explicitly, rather than having it added dynamically by the autolander.
