### PR TITLE
Bug 1220282 - do not force notification's inner direction.

### DIFF
--- a/shared/js/notification_helper.js
+++ b/shared/js/notification_helper.js
@@ -35,7 +35,6 @@
             options.body = body;
           }
           options.lang = document.documentElement.getAttribute('lang');
-          options.dir = document.documentElement.getAttribute('dir');
 
           var notification = new window.Notification(title, options);
 


### PR DESCRIPTION
Direction is now applied to content of notification, instead of being
applied to deal with alignment. Alignment is instead dealt properly in
CSS (see bug 1219618 for this work).

So there's no more reason to create a notification with the current
UI direction. We should either:
- let the application force the direction of the content if it wants to
  (in accordance with W3C specs)
- Let the default behavior (dir="auto") apply and localize properly in edge cases (for example the SIM1 position when dual-sim).
