### PR TITLE
Bug 1178197 - Avoid browserbox's naive folder name inference logic. r=jrburke

### DIFF
--- a/apps/email/js/ext/ext/browserbox.js
+++ b/apps/email/js/ext/ext/browserbox.js
@@ -2086,8 +2086,8 @@
         for (i = 0; i < SPECIAL_USE_BOX_FLAGS.length; i++) {
             type = SPECIAL_USE_BOX_FLAGS[i];
             if (SPECIAL_USE_BOXES[type].indexOf(name) >= 0) {
-                mailbox.flags = [].concat(mailbox.flags || []).concat(type);
                 mailbox.specialUse = type;
+                mailbox.specialUseFlag = type;
                 return type;
             }
         }


### PR DESCRIPTION
propagate https://github.com/mozilla-b2g/gaia-email-libs-and-more/pull/398
