### PR TITLE
Bug 1221943 - Include settings app for engineering build. r=rexboy.

### DIFF
--- a/build/config/tv/apps-engineering.list
+++ b/build/config/tv/apps-engineering.list
@@ -23,6 +23,7 @@ apps/gallery
 apps/keyboard
 apps/music
 apps/pdfjs
+apps/settings
 apps/video
 apps/wallpaper
 apps/marketplace.firefox.com


### PR DESCRIPTION
Testing presentation API and remote control on TV Gaia need WiFi connection. However there is no corresponding UI on TV Gaia now. I'll suggest we add apps/settings into build/config/tv/apps-engineering.list.
