### PR TITLE
Bug 1217781 - [Shared] Fix layout of search form.

### DIFF
--- a/shared/pages/import/style/search.css
+++ b/shared/pages/import/style/search.css
@@ -32,6 +32,7 @@ form.search {
 
 form.search p {
   flex-basis: 100%;
+  flex-grow: 1;
 }
 
 #search-view.insearchmode form.search p {


### PR DESCRIPTION
The search input field wasn't growing enough. Therefore, there was some space after the "cancel" button. If the word cancel is to small (in certain locale as arabic), it can apppear shifted to the beginning. This patch makes the input field grow to avoid this.
