### PR TITLE
Bug 1219153 - Remove whitespace in 'gaia-container' web component, to avoid flexbox sortedness assertion. r=Cwiiis

### DIFF
--- a/apps/homescreen/bower_components/gaia-container/script.js
+++ b/apps/homescreen/bower_components/gaia-container/script.js
@@ -735,8 +735,8 @@ window.GaiaContainer = (function(exports) {
   var template = document.createElement('template');
 
   template.innerHTML =
-    `<style>gaia-container { position: relative; display: block; }</style>
-     <content select='*'></content>`;
+    `<style>gaia-container { position: relative; display: block; }</style>` +
+    `<content select='*'></content>`;
 
   function GaiaContainerChild(element) {
     this._element = element;


### PR DESCRIPTION
…avoid flexbox sortedness assertion. r=Cwiiis

@CWiiis, this is effectively a whitespace-only change (removing whitespace from a string, and breaking that string across two lines so that it's not uber-long).

This prevents us from tripping over a bad interaction between flexbox & web-components & triggering a fatal assertion. See https://bugzilla.mozilla.org/show_bug.cgi?id=1219153#c24 for more. (This whitespace node is the thing that's a piece of the shadow DOM that's mentioned in that comment.)

Look OK?
