### PR TITLE
Bug 916097 - Don't share 'never' string between display and battery options. r=gasolin

### DIFF
--- a/apps/settings/elements/battery.html
+++ b/apps/settings/elements/battery.html
@@ -31,7 +31,7 @@
               <option value="0.05" data-l10n-id="powerSave-threshold" data-l10n-args='{"level":  "5"}'>5% battery left</option>
               <option value="0.15" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "15"}'>15% battery left</option>
               <option value="0.25" data-l10n-id="powerSave-threshold" data-l10n-args='{"level": "25"}'>25% battery left</option>
-              <option value="-1" data-l10n-id="never">Never</option>
+              <option value="-1" data-l10n-id="powerSave-never">Never</option>
             </select>
           </span>
         </li>

--- a/apps/settings/elements/display.html
+++ b/apps/settings/elements/display.html
@@ -38,7 +38,7 @@
               <option value="120" data-l10n-id="two-minutes"></option>
               <option value="300" data-l10n-id="five-minutes"></option>
               <option value="600" data-l10n-id="ten-minutes"></option>
-              <option value="0"   data-l10n-id="never"></option>
+              <option value="0"   data-l10n-id="screen-timeout-never"></option>
             </select>
           </span>
         </li>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -628,7 +628,7 @@ one-minute   =  1 minute
 two-minutes  =  2 minutes
 five-minutes =  5 minutes
 ten-minutes  = 10 minutes
-never=never
+screen-timeout-never=never
 lock-orientation=Lock Orientation
 
 # Personalization :: Navigation
@@ -1353,6 +1353,7 @@ batteryLevel-percent-charged   = {{level}}% (charged)
 powerSaveModeTitle=Power Save Mode
 powerSaveMode=Power Save Mode
 powerSave-threshold={{level}}% battery left
+powerSave-never=never
 turnOnAuto=Turn On Automatically
 
 # Device :: Accessibility


### PR DESCRIPTION
For better localizability, e.g. start with uppercase and lowercase depending on the context
