### PR TITLE
Bug 1222364 - [Stingray][fling-player][TV][2.5] UI polish, behaviour updates and skip error message

### DIFF
--- a/tv_apps/fling-player/index.html
+++ b/tv_apps/fling-player/index.html
@@ -67,7 +67,7 @@
       <section role="region" id="loading-section">
         <gaia-loading></gaia-loading>
       </section>
-      <section id="initial-message-section" class="fade-out" data-l10n-id="playing-video-from-device"></section>
+      <section id="initial-message-section" class="fade-out" data-l10n-id="playing-video-sent-from-device"></section>
     </article>
   </body>
 

--- a/tv_apps/fling-player/js/video_player.js
+++ b/tv_apps/fling-player/js/video_player.js
@@ -44,10 +44,6 @@
     return isNaN(s) ? 0 : s;
   };
 
-  proto.addEventListener = function (type, handle) {
-    return this._video.addEventListener(type, handle);
-  };
-
   proto.show = function () {
     this._video.hidden = false;
   };

--- a/tv_apps/fling-player/locales/fling-player.en-US.properties
+++ b/tv_apps/fling-player/locales/fling-player.en-US.properties
@@ -1,1 +1,1 @@
-playing-video-from-device=Playing video casted from device
+playing-video-sent-from-device=Playing video sent from {{ device }}

--- a/tv_apps/fling-player/style/fling_player.css
+++ b/tv_apps/fling-player/style/fling_player.css
@@ -28,7 +28,7 @@ a:hover, a:active, a:focus {
 }
 
 article, section, video {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -60,6 +60,7 @@ article, section, video {
   top: auto;
   bottom: 30rem;
   left: 50%;
+  margin-right: -50%;
   transform: translate(-50%, 0);
   color: #fff;
   font-size: 5rem;

--- a/tv_apps/fling-player/test/unit/video_player_test.js
+++ b/tv_apps/fling-player/test/unit/video_player_test.js
@@ -122,17 +122,6 @@ suite('fling-player/VideoPlayer', function() {
     assert.equal(video.currentTime, origin);
   });
 
-  test('should add event listener', function () {
-
-    var type = 'playing';
-    var handle = function () {};
-    var exp = sinon.mock(video);
-
-    exp.expects('addEventListener').once().withExactArgs(type, handle);
-    player.addEventListener(type, handle);
-    exp.verify();
-  });
-
   suite('Event handling', function () {
 
     var exp;


### PR DESCRIPTION
Update the implemented:
- Show the controlling device's display name on the initial loading
- Keep the control panel showing when paused
- Move focus back to the play button after the control panel is hidden for 60 secs
- Go back to the very 1st video frame when video is ended

Other:
- Handle to ignore invalid or unknown message exception so the player still can work for valid message casted
- Polish UI to fix UI slightly out of position
