### PR TITLE
Bug 1164790 - [Settings] Set correct direction authorized number

### DIFF
--- a/apps/settings/js/panels/call_fdn_list/panel.js
+++ b/apps/settings/js/panels/call_fdn_list/panel.js
@@ -130,7 +130,9 @@ define(function(require) {
         var nameContainer = document.createElement('span');
         var numberContainer = document.createElement('small');
 
+        nameContainer.dir = 'auto';
         nameContainer.textContent = contact.name;
+        numberContainer.dir = 'auto';
         numberContainer.textContent = contact.number;
         li.appendChild(numberContainer);
         li.appendChild(nameContainer);


### PR DESCRIPTION
An international number should have a dir="auto".
Likewise, the name is an input from the user. It needs a dir="auto"
