### PR TITLE
Bug 1223668 - Remote control client page preference

### DIFF
--- a/build/config/tv/custom-prefs.js
+++ b/build/config/tv/custom-prefs.js
@@ -12,3 +12,10 @@ user_pref('dom.meta-viewport.enabled', false);
 user_pref('dom.presentation.enabled', true);
 user_pref('devtools.useragent.device_type', 'TV');
 user_pref('dom.apps.customization.enabled', false);
+
+// Remote Control default setting, enable service and pairing
+user_pref("remotecontrol.service.enabled", true);
+user_pref("remotecontrol.service.pairing_required", true);
+// Remote control URL. Gecko loads its required static file in this app.
+user_pref("remotecontrol.client_page.prepath", "app://remote-control-client.gaiamobile.org");
+user_pref("remotecontrol.client_page.blacklist", "/client.html,/pairing.html");


### PR DESCRIPTION
Store remote control client page Gecko preference in Gaia
