### PR TITLE
Bug 1220311 - Use webapps-manage so that IAC works correctly. r=kgrandon

### DIFF
--- a/apps/verticalhome/manifest.webapp
+++ b/apps/verticalhome/manifest.webapp
@@ -12,7 +12,7 @@
     "themeable":{},
     "mobileconnection":{},
     "open-remote-window":{},
-    "homescreen-webapps-manage": {},
+    "webapps-manage": {},
     "systemXHR": {},
     "settings":{ "access": "readwrite" },
     "moz-extremely-unstable-and-will-change-webcomponents":{}


### PR DESCRIPTION
When handling an IAC message, the home screen will be launched as a
regular app and not as a home screen. Because of this, the
homescreen-webapps-manage permission isn't granted and the app fails to
launch with an exception caused by this. Revert to using the old
webapps-manage permission for now.
