### PR TITLE
Bug 1223683 - [Email]While canceling the change of the signature, the Cancel button formatting r=asuth

### DIFF
--- a/apps/email/js/cards/sig/save_signature.html
+++ b/apps/email/js/cards/sig/save_signature.html
@@ -2,6 +2,8 @@
   <menu>
     <button id="sig-save" data-l10n-id="signature-save"></button>
     <button id="sig-discard" class="danger" data-l10n-id="signature-discard-confirm"></button>
-    <button id="sig-cancel" data-l10n-id="message-multiedit-cancel"></button>
+    <span class="last-button-container">
+      <button id="sig-cancel" data-l10n-id="message-multiedit-cancel"></button>
+    </span>
   </menu>
 </form>


### PR DESCRIPTION
Shared styles changed, the span wrapping matches what was done for other dialogs like this, fixes the issue.
