### PR TITLE
Bug 1217761 - update gaia-icons for edit icon.

### DIFF
--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -36,6 +36,7 @@
 
     <link rel="stylesheet" type="text/css" href="app://theme.gaiamobile.org/shared/elements/gaia-theme/gaia-theme.css">
     <link rel="stylesheet" type="text/css" href="/shared/elements/gaia-icons/gaia-icons.css">
+    <link rel="stylesheet" type="text/css" href="/shared/elements/gaia-icons/bidi-helper.css">
 
     <link rel="stylesheet" type="text/css" href="/shared/style/option_menu.css">
 

--- a/apps/settings/index.html
+++ b/apps/settings/index.html
@@ -28,6 +28,7 @@
     <link rel="stylesheet" type="text/css" href="style/dialog.css">
     <link rel="stylesheet" type="text/css" href="style/icc.css">
     <!-- Panel Stylesheets
+    <link rel="stylesheet" type="text/css" href="shared/elements/gaia-icons/bidi-helper.css">
     <link rel="stylesheet" type="text/css" href="shared/style/confirm.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/progress_activity.css"/>
     <link rel="stylesheet" type="text/css" href="style/homescreens.css"/>

--- a/apps/settings/js/modules/panel_cache.js
+++ b/apps/settings/js/modules/panel_cache.js
@@ -23,6 +23,7 @@ define(function(require) {
       LazyLoader.load(['shared/style/action_menu.css',
                        'shared/style/confirm.css',
                        'shared/style/progress_activity.css',
+                       'shared/elements/gaia-icons/bidi-helper.css',
                        'shared/elements/gaia_buttons/script.js',
                        'shared/elements/gaia_confirm/script.js',
                        'style/homescreens.css',

--- a/shared/bower.json
+++ b/shared/bower.json
@@ -10,7 +10,7 @@
     "gaia-component": "gaia-components/gaia-component",
     "gaia-header": "gaia-components/gaia-header#~0.9.5",
     "gaia-theme": "gaia-components/gaia-theme#~0.4.6",
-    "gaia-icons": "gaia-components/gaia-icons#~0.10.5",
+    "gaia-icons": "gaia-components/gaia-icons#~1.0.2",
     "gaia-toast": "gaia-components/gaia-toast",
     "gaia-site-icon": "gaia-components/gaia-site-icon",
     "gaia-dialog": "gaia-components/gaia-dialog",

--- a/shared/elements/gaia-icons/.bower.json
+++ b/shared/elements/gaia-icons/.bower.json
@@ -37,6 +37,6 @@
     "commit": "42dfa3ed9a9ffa09733dc8db08a06d3dd9d0a081"
   },
   "_source": "git://github.com/gaia-components/gaia-icons.git",
-  "_target": "^1.0.0",
+  "_target": "~1.0.2",
   "_originalSource": "gaia-components/gaia-icons"
 }


### PR DESCRIPTION
Edit icon must be mirrored in downloads and call log view.
