### PR TITLE
Bug 1223677 - Early return in handlePresentation if protocol is not app

### DIFF
--- a/tv_apps/smart-system/js/app_window_factory.js
+++ b/tv_apps/smart-system/js/app_window_factory.js
@@ -106,18 +106,20 @@
       var parseUrl = detail.url.split('/');
       var protocol = parseUrl[0].toUpperCase();
       var self = this;
-      var manifestURL;
+      var manifestURL = null;
       var requestId = detail.id;
+
+      // Check the protocol type
+      if (protocol !== 'APP:') {
+        return;
+      }
 
       // We assume the URL is in the following format:
       // app://<domain name>/<path>
       // And we limit length to 3 to get rid of the <path> part.
       parseUrl.length = 3;
-      if (protocol === 'APP:') {
-        manifestURL = parseUrl.join('/') + '/manifest.webapp';
-      } else {
-        manifestURL = null;
-      }
+      manifestURL = parseUrl.join('/') + '/manifest.webapp';
+
       var config = new BrowserConfigHelper({
         url: detail.url,
         manifestURL: manifestURL


### PR DESCRIPTION
If presentation-api is allowed by those apps with presentation permission, I think it's better to ignore non-app protocol in handlePresentation
