### PR TITLE
Bug 1225424 - Restore missing string, required for the pick activity when no videos are present

### DIFF
--- a/apps/video/locales/video.en-US.properties
+++ b/apps/video/locales/video.en-US.properties
@@ -51,6 +51,7 @@ error-unknown = An unknown video error occurred.
 video-hardware-in-use-title = Cannot play video
 video-hardware-in-use-text = Another app is currently using the video player.
 
+overlay-cancel-button = Cancel
 overlay-camera-button = Go to Camera
 
 name-label = Name


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1225424
