### PR TITLE
Bug 1226573 - manually handle focus movement between promotion list and app list, r=rex

### DIFF
--- a/tv_apps/app-deck/js/app_deck.js
+++ b/tv_apps/app-deck/js/app_deck.js
@@ -43,6 +43,8 @@
 
     _cardManager: undefined,
 
+    _outOfControlArea: true,
+
     /**
      * Initialize AppDeck. This is the main entry of the whole app.
      *
@@ -86,7 +88,6 @@
           SharedUtils.nodeListToArray(
             document.querySelectorAll('.navigable:not(.app-banner)'))
             .concat(appGridElements);
-        that._navigableElements.unshift(that._appDeckListScrollable);
         that._spatialNavigator = new SpatialNavigator(that._navigableElements);
 
         that._keyNavigationAdapter.on('move', that.onMove.bind(that));
@@ -97,7 +98,8 @@
         that._spatialNavigator.on('unfocus', that.onUnfocus.bind(that));
         that._appDeckListScrollable.on('focus',
           that.onFocusOnAppDeckListScrollable.bind(that));
-        that._spatialNavigator.focus();
+        // start focusing on promotion list
+        that._appDeckListScrollable.focus();
         that._contextMenu = new ContextMenu();
         that._contextMenu.init(that);
         Applications.on('install', that.onAppInstalled.bind(that));
@@ -271,20 +273,31 @@
 
     onEnter: function ad_onEnter() {
       var focused = this._spatialNavigator.getFocusedElement();
-      if (focused.dataset && focused.dataset.manifestURL) {
+      if (focused && focused.dataset && focused.dataset.manifestURL) {
         Applications.launch(
           focused.dataset.manifestURL, focused.dataset.entryPoint);
       }
     },
 
     onMove: function ad_onMove(key) {
-      var focused = this._spatialNavigator.getFocusedElement();
-      if (focused instanceof XScrollable) {
-        if (focused.spatialNavigator.move(key)) {
-          return;
+      // When we are not in the SpatialNavigator's control area,
+      // use XScrollable object's spatial navigator to move.
+      // If it fails to move, and it's a 'down' operation, then we
+      // move into the last focused element within SpatialNavigator's
+      // control area.
+      if (this._outOfControlArea) {
+        if (!this._appDeckListScrollable.spatialNavigator.move(key) &&
+            key == 'down') {
+          this._spatialNavigator.focus(this._lastFocusedSmartButton);
+          this._outOfControlArea = false;
+        }
+      } else {
+        // Vice versa.
+        if (!this._spatialNavigator.move(key) && key == 'up') {
+          this._appDeckListScrollable.focus();
+          this._outOfControlArea = true;
         }
       }
-      this._spatialNavigator.move(key);
     },
 
     onAppInstalled: function ad_onAppInstalled(apps) {


### PR DESCRIPTION
…nd app list.
1. remove promotion list from app's spatialNavigator control.
2. set a flag to indicate focusing area when focus moves between promotion list and app list.
3. in each area, call its spatial navigator to move focus.
