### PR TITLE
Bug 1212588 - [Accessibility] Keyboard delete should have a role key instead of button.

### DIFF
--- a/apps/callscreen/index.html
+++ b/apps/callscreen/index.html
@@ -248,7 +248,7 @@
               <input id="phone-number-view" type="text" class="phone-number-font font-light" readonly="readonly" data-l10n-id="phoneNumberInput">
             </div>
           </div>
-          <div id="keypad-delete" role="button" data-l10n-id="keypadDelete">
+          <div id="keypad-delete" role="key" data-l10n-id="keypadDelete">
             <div></div>
           </div>
         </div>

--- a/apps/communications/dialer/index.html
+++ b/apps/communications/dialer/index.html
@@ -160,7 +160,7 @@
             <div class="phone-number-view-wrapper-input">
               <input id="phone-number-view" type="text" class="phone-number-font font-light textfield" readonly="readonly" data-l10n-id="phoneNumberInput">
             </div>
-            <button id="keypad-delete" class="reset-button" data-value="delete" data-l10n-id="keypadDelete">
+            <button role="key" id="keypad-delete" class="reset-button" data-value="delete" data-l10n-id="keypadDelete">
             </button>
           </div>
           <section id="suggestion-bar" class="suggestion-bar hide">

--- a/apps/communications/dialer/test/unit/mock_dialer_index.html
+++ b/apps/communications/dialer/test/unit/mock_dialer_index.html
@@ -6,7 +6,7 @@
               <input id="phone-number-view" type="text" class="phone-number-font font-light" readonly="readonly" data-l10n-id="phoneNumberInput">
               <div id="fake-phone-number-view"></div>
             </div>
-            <button id="keypad-delete" data-value="delete" data-l10n-id="keypadDelete">
+            <button role="key" id="keypad-delete" data-value="delete" data-l10n-id="keypadDelete">
             </button>
             </div>
           </div>

--- a/apps/emergency-call/index.html
+++ b/apps/emergency-call/index.html
@@ -68,7 +68,7 @@
             <input id="phone-number-view" type="text" class="phone-number-font font-light textfield" readonly="readonly" data-l10n-id="phoneNumberInput">
             <div id="fake-phone-number-view"></div>
           </div>
-          <button id="keypad-delete" class="reset-button" data-value="delete" data-l10n-id="keypadDelete">
+          <button role="key" id="keypad-delete" class="reset-button" data-value="delete" data-l10n-id="keypadDelete">
           </button>
         </div>
         <section id="ice-contacts-bar" class="ice-contacts-bar" hidden data-l10n-id="ice-contacts-bar-text">ICE Contacts - In Case of Emergency

--- a/apps/keyboard/js/keyboard/layout_normalizer.js
+++ b/apps/keyboard/js/keyboard/layout_normalizer.js
@@ -34,6 +34,14 @@ LayoutKeyNormalizer.prototype._isSpecialKey = function(key) {
   return hasSpecialCode || key.keyCode <= 0;
 };
 
+LayoutKeyNormalizer.prototype._isButton = function(key) {
+  var SPECIAL_BUTTONS = [
+      KeyEvent.DOM_VK_RETURN
+  ];
+
+  return this._isSpecialKey(key) && SPECIAL_BUTTONS.indexOf(key.keyCode) !== -1;
+};
+
 LayoutKeyNormalizer.prototype._getUpperCaseValue = function(key) {
   if (KeyEvent.DOM_VK_SPACE === key.keyCode ||
       this._isSpecialKey(key) ||
@@ -61,6 +69,8 @@ function(key, showAlternatesIndicator) {
   key.uppercaseValue = upperCaseKeyChar;
 
   key.isSpecialKey = this._isSpecialKey(key);
+
+  key.isButton = this._isButton(key);
 
   if (showAlternatesIndicator) {
     key.className = 'alternate-indicator';

--- a/apps/keyboard/js/views/key_view.js
+++ b/apps/keyboard/js/views/key_view.js
@@ -10,18 +10,21 @@ function KeyView(target, options, viewManager) {
   this.attributeList = options.attributeList || [];
   this.classNames = ['keyboard-key'];
 
-  if (target.isSpecialKey) {
-    this.classNames.push('special-key');
-  } else {
-    // The 'key' role tells an assistive technology that these buttons
-    // are used for composing text or numbers, and should be easier to
-    // activate than usual buttons. We keep special keys, like backspace,
-    // as buttons so that their activation is not performed by mistake.
+  // The 'key' role tells an assistive technology that these buttons
+  // are used for composing text or numbers, and should be easier to
+  // activate than usual buttons. We keep some keys as buttons so that
+  // their activation is not performed by mistake.
+  if (!target.isButton) {
     this.attributeList.push({
       key: 'role',
       value: 'key'
     });
+  }
 
+  if (target.isSpecialKey) {
+    this.classNames.push('special-key');
+
+  } else {
     if (options.classNames) {
       this.classNames = this.classNames.concat(options.classNames);
     }

--- a/apps/keyboard/test/unit/keyboard/layout_normalizer_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_normalizer_test.js
@@ -76,6 +76,56 @@ suite('LayoutKeyNormalizer', function() {
     });
   });
 
+  suite('isButton', function() {
+    // As per bug#1212588, some special keys are to be regarded as
+    // buttons (as per accesibility programs), but not all of
+    // them. This unit test makes sure the functionality exists in the
+    // layout normalizer. In case different keys are later decided to
+    // swap roles, please change this test so that it stays
+    // meaningful.
+
+    var key = {
+      keyCode: KeyEvent.DOM_VK_ALT,
+      value: 'alt'
+    };
+
+    var button = {
+      keyCode: KeyEvent.DOM_VK_RETURN,
+      value: 'enter'
+    };
+
+    test('Alt is a key', function(){
+      var normalizer = new LayoutKeyNormalizer();
+
+      assert.isFalse(normalizer._isButton(key),
+                     'alt should be regarded as a role=key, not a button.');
+    });
+
+    test('Return is a button', function(){
+      var normalizer = new LayoutKeyNormalizer();
+
+      assert.isTrue(normalizer._isButton(button),
+                    'return should be regarded as a role=button, not a key.');
+    });
+
+    test('isButton present on normalized key', function(){
+      var normalizer = new LayoutNormalizer({
+        keys: [
+          [{value: 'a'}]
+        ],
+        upperCase: {'a': 'C'}
+      });
+
+      normalizer.normalize();
+
+      assert.isTrue(
+        normalizer._layout.pages[0].keys[0][0].hasOwnProperty('isButton'),
+        'a synthetic key made from a simple keyboard layout ' +
+          'should have property isButton');
+    });
+  });
+
+
   suite('getUpperCaseValue', function() {
     // For space key, special key, and composite key tests,
     // we're deliberately not passing layout,
@@ -623,7 +673,8 @@ suite('Layout normalization: Cross-module integrated tests', function() {
           keyCodeUpper: 67,
           lowercaseValue: 'a',
           uppercaseValue: 'C',
-          isSpecialKey: false
+          isSpecialKey: false,
+          isButton: false
         }]
       ], 'upperCase of "a" should be "C" in this crafted test');
   });

--- a/apps/system/lockscreen/lockscreen_inputpad_frame.html
+++ b/apps/system/lockscreen/lockscreen_inputpad_frame.html
@@ -22,7 +22,7 @@
       <a role="button" href="#" data-key="e" class="lockscreen-passcode-pad-func last-row row3"><div><span data-l10n-id="emergency-call-button">Emergency Call</span></div></a>
       <a role="key" href="#" data-key="0" class="last-row row3"><div>0</div></a>
       <a role="button" href="#" data-key="c" class="lockscreen-passcode-pad-func last-row row3"><div><span data-l10n-id="cancel">Cancel</span></div></a>
-      <a role="button" href="#" data-key="b" class="last-row row3"><div data-l10n-id="undo">⌫</div></a>
+      <a role="key" href="#" data-key="b" class="last-row row3"><div data-l10n-id="undo">⌫</div></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This fixes callscreen, communications dialer, emergency call and system
keyboard for them to have the delete key in the keyboard rendered as
role=key for screen readers.
