### PR TITLE
Bug 1227705 - Use waitForCurtainUp before interacting in tests. r=mhenretty

### DIFF
--- a/apps/ftu/test/marionette/ftu_test.js
+++ b/apps/ftu/test/marionette/ftu_test.js
@@ -25,8 +25,7 @@ marionette('First Time Use >', function() {
 
   test('FTU user timing', function() {
     client.apps.switchToApp(Ftu.URL);
-    ftu.waitForLanguagesToLoad();
-    ftu.client.helper.waitForElement('#languages');
+    ftu.waitForFtuReady();
 
     var markersByName = client.executeScript(function() {
       var byName = {};

--- a/apps/ftu/test/marionette/language_pseudo_localization_test.js
+++ b/apps/ftu/test/marionette/language_pseudo_localization_test.js
@@ -14,6 +14,7 @@ marionette('First Time Use > Pseudo Localization', function() {
   test('FTU Languages without pseudo localization', function() {
     client.settings.set('devtools.pseudolocalization.enabled', false);
     client.apps.switchToApp(Ftu.URL);
+    ftu.waitForCurtainUp();
 
     var panel = ftu.getPanel('language');
     assert.ok(panel.displayed());
@@ -28,6 +29,7 @@ marionette('First Time Use > Pseudo Localization', function() {
   test('FTU Languages with pseudo localization', function() {
     client.settings.set('devtools.pseudolocalization.enabled', true);
     client.apps.switchToApp(Ftu.URL);
+    ftu.waitForCurtainUp();
 
     var panel = ftu.getPanel('language');
     assert.ok(panel.displayed());
@@ -40,7 +42,8 @@ marionette('First Time Use > Pseudo Localization', function() {
   test('Can select accented-english', function(done) {
     client.settings.set('devtools.pseudolocalization.enabled', true);
     client.apps.switchToApp(Ftu.URL);
-    client.helper.waitForElement('#languages');
+    ftu.waitForFtuReady();
+
     var header = client.helper.waitForElement(Ftu.Selectors.header);
     ftu.selectLanguage('fr-x-psaccent');
 

--- a/apps/ftu/test/marionette/lib/ftu.js
+++ b/apps/ftu/test/marionette/lib/ftu.js
@@ -28,6 +28,7 @@ Ftu.Selectors = {
   'header': '#activation-screen gaia-header h1',
   'languageItems': '#languages ul > li[data-value]',
   'finishScreen': '#finish-screen',
+  'splashScreen': '#splash-screen',
 
   // Tutorial Section
   'startTourButton': '#lets-go-button',
@@ -67,17 +68,27 @@ Ftu.prototype = {
   },
 
   clickThruToFinish: function() {
-    this.client.helper.waitForElement('#languages');
+    this.waitForFtuReady();
     var finishScreen = this.client.findElement(Ftu.Selectors.finishScreen);
     while (!finishScreen.displayed()) {
       this.goNext();
     }
   },
 
+  waitForCurtainUp: function() {
+    this.client.helper.waitForElementToDisappear(Ftu.Selectors.splashScreen);
+  },
+
   waitForLanguagesToLoad: function() {
+    this.client.helper.waitForElement('#languages');
     return this.client.waitFor(function() {
       return this.client.findElements(Ftu.Selectors.languageItems).length > 1;
     }.bind(this));
+  },
+
+  waitForFtuReady: function() {
+    this.waitForCurtainUp();
+    this.waitForLanguagesToLoad();
   },
 
   selectLanguage: function(language) {

--- a/apps/ftu/test/marionette/statusbar_test.js
+++ b/apps/ftu/test/marionette/statusbar_test.js
@@ -19,7 +19,7 @@ marionette('First Time Use >', function() {
       return system.statusbar.displayed();
     });
     client.apps.switchToApp(Ftu.URL);
-    client.helper.waitForElement('#languages');
+    ftu.waitForFtuReady();
     var finishScreen = client.findElement(Ftu.Selectors.finishScreen);
     while (!finishScreen.displayed()) {
       client.switchToFrame();
@@ -41,6 +41,10 @@ marionette('First Time Use >', function() {
   });
 
   test('statusbar icons should be dark', function() {
+    client.apps.switchToApp(Ftu.URL);
+    ftu.waitForCurtainUp();
+
+    client.switchToFrame();
     client.waitFor(function() {
       return system.statusbar.displayed();
     });

--- a/apps/ftu/test/marionette/wifi_hidden_network_test.js
+++ b/apps/ftu/test/marionette/wifi_hidden_network_test.js
@@ -17,6 +17,7 @@ marionette('First Time Use > Wifi Hidden Network Test', function() {
 
   test('Wi-Fi hidden network password 64 characters', function() {
     ftu.client.apps.switchToApp(Ftu.URL);
+    ftu.waitForFtuReady();
     ftu.clickThruPanel('#languages', '#forward');
     ftu.clickThruPanel('#wifi', '#join-hidden-button');
 
@@ -30,6 +31,7 @@ marionette('First Time Use > Wifi Hidden Network Test', function() {
 
   test('Wi-Fi hidden network show password', function() {
     ftu.client.apps.switchToApp(Ftu.URL);
+    ftu.waitForFtuReady();
     ftu.clickThruPanel('#languages', '#forward');
     ftu.clickThruPanel('#wifi', '#join-hidden-button');
 

--- a/apps/ftu/test/marionette/wifi_scanning_test.js
+++ b/apps/ftu/test/marionette/wifi_scanning_test.js
@@ -15,6 +15,7 @@ marionette('First Time Use > Wifi Scanning Test', function() {
 
   test('FTU Wifi Scanning Tests', function() {
     client.apps.switchToApp(Ftu.URL);
+    ftu.waitForFtuReady();
     ftu.clickThruPanel('#languages', '#forward');
     ftu.clickThruPanel('#wifi', '#forward');
     ftu.clickThruPanel('#date_and_time', '#back');


### PR DESCRIPTION
Could account for some of the flakiness in the FTU marionette tests - the splash screen needs to animate out before we can interact with anything else. In particular the FTU user timing test was failing every time for me
