### PR TITLE
Bug 1227856 - Remove unused action menu building block usage from cost control

### DIFF
--- a/apps/costcontrol/settings.html
+++ b/apps/costcontrol/settings.html
@@ -9,7 +9,6 @@
     <!-- Building blocks -->
     <link rel="stylesheet" type="text/css" href="shared/style/buttons.css">
     <link rel="stylesheet" type="text/css" href="shared/style/input_areas.css">
-    <link rel="stylesheet" type="text/css" href="shared/style/action_menu.css">
     <link rel="stylesheet" type="text/css" href="shared/style/confirm.css">
     <link rel="stylesheet" type="text/css" href="shared/style/layout.css">
 
@@ -240,7 +239,7 @@
       </section>
 
       <!-- Reset confirmation -->
-      <gaia-menu class="view" data-type="action" data-viewport="ethereal" id="reset-data-dialog">
+      <gaia-menu class="view" data-viewport="ethereal" id="reset-data-dialog">
         <header data-l10n-id="reset-data-usage">Reset Data usage</header>
       </gaia-menu>
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1227856
