### PR TITLE
Bug 1227991 - client.js sends wrong variable to Marionette server; r=aus

### DIFF
--- a/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
@@ -489,7 +489,7 @@
 
       var driverSent;
       try {
-        driverSent = this.driver.send(body, cb);
+        driverSent = this.driver.send(data, cb);
       } catch (e) {
         // !!! HACK HACK HACK !!!
         // single retry when not connected. this should never happen, but
@@ -497,7 +497,7 @@
         if (e && e.message && e.message.indexOf('not connected') !== -1) {
           console.info('Will attempt re-connect and re-send *ONCE*');
           this.driver.connect(function() {
-            this.driver.send(body, cb);
+            this.driver.send(data, cb);
           }.bind(this));
         } else {
           // Unhandled.


### PR DESCRIPTION
This patch rectifies an obvious mistake in an earlier rebase where the
Marionette client is passing on the unserialised body to the Marionette
server instead of the serialised version stored in the data variable.

This only happens to work right now because the server is not using
protocol level 3 yet.
