### PR TITLE
Bug 1228448 - Remove unused switches.css file from the system index.html

### DIFF
--- a/apps/system/index.html
+++ b/apps/system/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="shared/elements/gaia-icons/gaia-icons.css">
     <link rel="stylesheet" type="text/css" href="style/system/initlogo.css">
 
     <!-- Shared code -->
@@ -29,7 +28,6 @@
     <link rel="stylesheet" type="text/css" href="style/ime_menu.css">
     <link rel="stylesheet" type="text/css" href="shared/style/confirm.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/input_areas.css">
-    <link rel="stylesheet" type="text/css" href="shared/style/switches.css"/>
     <link rel="stylesheet" type="text/css" href="shared/style/value_selector.css">
     <link rel="stylesheet" type="text/css" href="shared/style/date_selector.css">
     <link rel="stylesheet" type="text/css" href="shared/style/time_selector.css">


### PR DESCRIPTION
These switches have been ported to web components so we can stop including this shared CSS file now.

https://bugzilla.mozilla.org/show_bug.cgi?id=1228448
