### PR TITLE
Bug 1229011 - Make async TCP driver protocol 3 compatible; r=aus

### DIFF
--- a/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/tcp-sync.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/tcp-sync.js
@@ -179,7 +179,8 @@ TcpSync.prototype._readResponse = function() {
  *     An object that can be dumped into a JSON data structure,
  *     or a message that can be marshaled.
  * @param {Function} cb
- *     Callback to be called when a response for the request is received.
+ *     Callback to be invoked when a response for the request is
+ *     received.
  *
  * @return {?}
  *     The return value from the passed in callback.
@@ -198,7 +199,7 @@ TcpSync.prototype.send = function(obj, cb) {
  * @param {(Command|Response)} msg
  *     The message to send.
  * @param {Function} cb
- *     Callback to be called when a response for the command is received.
+ *     Callback to be invoked when a response for the request is received.
  *
  * @return {?}
  *     The return value from the passed in callback.
@@ -214,7 +215,7 @@ TcpSync.prototype.sendMessage = function(msg, cb) {
  * @param {Object} data
  *     An object that can be marshaled into a JSON data structure.
  * @param {Function} cb
- *     Callback to be called when a response for the request is received.
+ *     Callback to be invoked when a response for the request is received.
  *
  * @return {?}
  *     The return value from the passed in callback.


### PR DESCRIPTION
The asynchronous TCP driver in
tests/jsmarionette/client/marionette-client/lib/marionette/drivers/abstract.js
is not compatible with Marionette protocol level 3 that will get
introduced in bug 1211489.

This causes
tests/jsmarionette/runner/marionette-js-runner/test/integration/clientasync.js
to fail with bug 1211489 is applied to Gecko.

To fix this issue we apply the same logic from the synchronous TCP
driver to marshal and unmarshal messages when talking to a protocol
level 3 server.
