### PR TITLE
[Do not merge] Bug 1225809 - Conflict-safe homescreen unpinning, r=Cwiiis

### DIFF
--- a/apps/homescreen/js/pages.js
+++ b/apps/homescreen/js/pages.js
@@ -219,9 +219,10 @@
       // Remove child immediately, datastore operations can be quite slow
       this.removeCard(this.selectedCard);
 
+      var revId = this.pagesStore.datastore.revisionId;
       this.pagesStore.get(id).then(entry => {
         entry.data.pinned = false;
-        this.pagesStore.datastore.put(entry.data, id).then(() => {},
+        this.pagesStore.datastore.put(entry.data, id, revId).then(() => {},
           e => {
             console.error('Error unpinning page:', e);
           });


### PR DESCRIPTION
With this change, unpinning a page will fail (instead of leading to data corruption) in the unlikely event that a change for that same URL is imported from Firefox Sync at the same time.
