### PR TITLE
Bug 1224701 - Sending Email Notification bar is empty without text r=asuth

### DIFF
--- a/apps/email/js/sync.js
+++ b/apps/email/js/sync.js
@@ -498,7 +498,10 @@ define(function(require) {
       // If we are in the foreground, notify through the model, which
       // will display an in-app toast notification when appropriate.
       if (!document.hidden) {
-        model.notifyBackgroundSendStatus(data);
+        mozL10n.formatValue(descId).then(function(localizedDescription) {
+          data.localizedDescription = localizedDescription;
+          model.notifyBackgroundSendStatus(data);
+        });
       }
       // Otherwise, notify with a system notification in the case of
       // an error. By design, we don't use system-level notifications


### PR DESCRIPTION
Another thing I missed when reviewing [bug 1223275](https://bugzilla.mozilla.org/show_bug.cgi?id=1223275), the in-app toast expects the localized string to already be available. This uses the same async API in bug 1223275 to retrieve the text before sending it out in the data structure expected by message_list's onBackgroundSendStatus.
