### PR TITLE
Bug 1229656 - fix labels alignment on rtl style, r=Arash-M

### DIFF
--- a/shared/style/confirm.css
+++ b/shared/style/confirm.css
@@ -208,7 +208,7 @@ form[role="dialog"][data-type="confirm"] dl > dt {
   text-align: left;
 }
 html[dir="ltr"] form[role="dialog"][data-type="confirm"] dl > dt { float: left; }
-html[dir="rtl"] form[role="dialog"][data-type="confirm"] dl > dt { float: right; }
+html[dir="rtl"] form[role="dialog"][data-type="confirm"] dl > dt { float: right; text-align: right; }
 
 form[role="dialog"][data-type="confirm"] dl > dd {
   padding-inline-end: 1.5rem;


### PR DESCRIPTION
This is happening because on "shared/confirm.css" the role for "dl > dt" is defining "text-align: left". The obvious fix to me would be to overwrite it on RTL to "text-align: right". I submitted a PR on Github for this. After this fix the labels looks like the following screenshot.

![fixed](https://cloud.githubusercontent.com/assets/849640/11615317/80291866-9c72-11e5-90c3-11e92f431f6e.png)
