### PR TITLE
Revert "Bug 1224544 - Ensure that the keypad background is always large enough to contain all the keys r=thills"

### DIFF
--- a/apps/callscreen/style/oncall.css
+++ b/apps/callscreen/style/oncall.css
@@ -116,7 +116,6 @@
     flex-direction: column;
     justify-content: flex-end;
     height: calc(100% - 16rem);
-    min-height: 35rem;
     background: rgba(255, 255, 255, 0.85);
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
This reverts commit 061207d0fc1c0c2fbe58a4fc536348466eda2d84, reversing changes made in d17640df68b3044d3f34ecbc3130533c89501def.
