### PR TITLE
Bug 1234063 - Always specify sandbox for scripts to be executed; r=aus

### DIFF
--- a/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/client.js
@@ -1267,23 +1267,26 @@
      * @return {Object} self.
      */
     executeJsScript: function executeJsScript(script, args, timeout, callback) {
-      if (typeof(timeout) === 'function') {
+      if (typeof timeout === 'function') {
         callback = timeout;
         timeout = null;
       }
-      if (typeof(args) === 'function') {
+      if (typeof args === 'function') {
         callback = args;
         args = null;
       }
 
       timeout = (typeof(timeout) === 'boolean') ? timeout : true;
 
+      // the simpletest sandbox exposes
+      // necessary assertion functions in the global scope
       return this._executeScript({
         name: 'executeJSScript',
         parameters: {
           script: script,
           timeout: timeout,
-          args: args
+          args: args,
+          sandbox: 'simpletest',
         }
       }, callback || this.defaultCallback);
     },
@@ -1323,30 +1326,39 @@
      *
      * @method executeScript
      * @chainable
-     * @param {String} script to run.
-     * @param {Array} [args] optional args for script.
-     * @param {Function} callback will receive result of the return \
-     *                            call in the script if there is one.
-     * @param {String} optional sandbox is a tag referring to the sandbox you
-     *                 wish to use; if you specify a new tag, a new sandbox
-     *                 will be created. If you use the special tag 'system',
-     *                 the sandbox will be created using the system principal
-     *                 which has elevated privileges.
-     * @return {Object} self.
+
+     * @param {string} script
+     *     The script to evaluate.
+     * @param {Array.<?>} args
+     *     Optional args for script that will  be available as
+     *     {@code arguments} in the scope the script runs in.
+     * @param {function} callback
+     *     The callback will receive result of the return call in the
+     *     script if there is one.
+     * @param {string} sandbox
+     *     Name of the sandbox to evaluate the script in.  If undefined,
+     *     the default sandbox will be used.  If you specify "system",
+     *     the sandbox will have the system principal which gives
+     *     elevated privileges.
+     *
+     * @return {Marionette}
+     *     Reference to self.
      */
     executeScript: function executeScript(script, args, callback, sandbox) {
-      if (typeof(args) === 'function') {
+      if (typeof args === 'function') {
         callback = args;
         args = null;
       }
-      if (typeof(sandbox) === 'undefined')
+      if (typeof sandbox === 'undefined') {
         sandbox = 'default';
+      }
+
       return this._executeScript({
         name: 'executeScript',
         parameters: {
           script: script,
           args: args,
-          sandbox: sandbox
+          sandbox: sandbox,
         }
       }, callback || this.defaultCallback);
     },
@@ -1372,22 +1384,39 @@
      *
      * @method executeAsyncScript
      * @chainable
-     * @param {String} script script to run.
-     * @param {Array} [args] optional args for script.
-     * @param {Function} callback will receive result of the return \
-     *                            call in the script if there is one.
-     * @return {Object} self.
+     *
+     * @param {string} script
+     *     The script to evaluate.
+     * @param {Array.<?>} args
+     *     Optional args for script that will  be available as
+     *     {@code arguments} in the scope the script runs in.
+     * @param {function} callback
+     *     The callback will receive result of the return call in the
+     *     script if there is one.
+     * @param {string} sandbox
+     *     Name of the sandbox to evaluate the script in.  If undefined,
+     *     the default sandbox will be used.  If you specify "system",
+     *     the sandbox will have the system principal which gives
+     *     elevated privileges.
+     *
+     * @return {Marionette}
+     *     Reference to self.
      */
-    executeAsyncScript: function executeAsyncScript(script, args, callback) {
-      if (typeof(args) === 'function') {
+    executeAsyncScript: function(script, args, callback, sandbox) {
+      if (typeof args === 'function') {
         callback = args;
         args = null;
       }
+      if (typeof sandbox === 'undefined') {
+        sandbox = 'default';
+      }
+
       return this._executeScript({
         name: 'executeAsyncScript',
         parameters: {
           script: script,
-          args: args
+          args: args,
+          sandbox: sandbox,
         }
       }, callback || this.defaultCallback);
     },

--- a/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/client-test.js
@@ -1094,15 +1094,46 @@ suite('marionette/client', function() {
     });
 
     suite('.executeScript', function() {
-      setup(function() {
-        subject.executeScript(script, commandCallback);
-      });
-
       test('should call _executeScript', function() {
+        subject.executeScript(script, commandCallback);
         assert.deepEqual(calledWith, [
           {
             name: 'executeScript',
-            parameters: { script: script, args: null, sandbox: 'default' }
+            parameters: {
+              script: script,
+              args: null,
+              sandbox: 'default',
+            }
+          },
+          commandCallback
+        ]);
+      });
+
+      test('should call _executeScript with arguments', function() {
+        subject.executeScript(script, ['foo'], commandCallback);
+        assert.deepEqual(calledWith, [
+          {
+            name: 'executeScript',
+            parameters: {
+              script: script,
+              args: ['foo'],
+              sandbox: 'default',
+            }
+          },
+          commandCallback
+        ]);
+      });
+
+      test('should call _executeScript with custom sandbox', function() {
+        subject.executeScript(script, null, commandCallback, 'foo');
+        assert.deepEqual(calledWith, [
+          {
+            name: 'executeScript',
+            parameters: {
+              script: script,
+              args: null,
+              sandbox: 'foo',
+            }
           },
           commandCallback
         ]);
@@ -1117,21 +1148,57 @@ suite('marionette/client', function() {
       test('should call _executeScript', function() {
         assert.deepEqual(calledWith, [{
           name: 'executeJSScript',
-          parameters: {script: script, timeout: true, args: null}
+          parameters: {
+            script: script,
+            timeout: true,
+            args: null,
+            sandbox: 'simpletest',
+          }
         }, commandCallback]);
       });
     });
 
     suite('.executeAsyncScript', function() {
-      setup(function() {
-        subject.executeAsyncScript(script, commandCallback);
-      });
-
       test('should call _executeScript', function() {
+        subject.executeAsyncScript(script, commandCallback);
         assert.deepEqual(calledWith, [
           {
             name: 'executeAsyncScript',
-            parameters: {script: script, args: null}
+            parameters: {
+              script: script,
+              args: null,
+              sandbox: 'default',
+            }
+          },
+          commandCallback
+        ]);
+      });
+
+      test('should call _executeScript with arguments', function() {
+        subject.executeAsyncScript(script, ['foo'], commandCallback);
+        assert.deepEqual(calledWith, [
+          {
+            name: 'executeAsyncScript',
+            parameters: {
+              script: script,
+              args: ['foo'],
+              sandbox: 'default',
+            }
+          },
+          commandCallback
+        ]);
+      });
+
+      test('should call _executeScript with custom sandbox', function() {
+        subject.executeAsyncScript(script, null, commandCallback, 'foo');
+        assert.deepEqual(calledWith, [
+          {
+            name: 'executeAsyncScript',
+            parameters: {
+              script: script,
+              args: null,
+              sandbox: 'foo',
+            }
           },
           commandCallback
         ]);


### PR DESCRIPTION
All calls to the remote commands executeScript, executeAsyncScript,
and executeJSScript will send the `sandbox` parameter that implicitly
indicates to the Marionette server that the script must be evaluated
inside a sandbox where changes to the global environment _does not_
have any lasting side-effects.

This enables bug 1123506 to implement support for the WebDriver conformant
approach.
