### PR TITLE
Bug 1232936 - Properly hide checkbox in system app modals.

### DIFF
--- a/apps/system/js/app_modal_dialog.js
+++ b/apps/system/js/app_modal_dialog.js
@@ -306,7 +306,7 @@
           checkbox.querySelector('label').textContent =
             customPrompt.checkboxMessage;
         } else {
-          checkbox.parentNode.classList.add('hidden');
+          checkbox.style.display = 'none';
         }
 
         elements.customPrompt.focus();


### PR DESCRIPTION
The hidden attribute seemed to only work with building blocks.

https://bugzilla.mozilla.org/show_bug.cgi?id=1232936
