### PR TITLE
Bug 1234163 - [TV][Stingray]Pin webpage bookmark from appdeck to home

### DIFF
--- a/shared/js/smart-screen/bookmark_manager.js
+++ b/shared/js/smart-screen/bookmark_manager.js
@@ -65,12 +65,7 @@
         xhr.send();
 
         xhr.onload = function() {
-          var reader = new FileReader();
-          reader.readAsDataURL(xhr.response);
-
-          reader.onloadend = function() {
-            resolve(reader.result);
-          };
+          resolve(xhr.response);
         };
 
         xhr.onerror = function() {

--- a/shared/js/smart-screen/card_manager.js
+++ b/shared/js/smart-screen/card_manager.js
@@ -1,5 +1,5 @@
 /* global evt, SharedUtils, Promise, PipedPromise, Application, CardStore,
-        Deck, Folder, AsyncSemaphore */
+          Deck, Folder, AsyncSemaphore, AppBookmark */
 
 (function(exports) {
   'use strict';
@@ -49,12 +49,14 @@
     _deserializeCardEntry: function cm_deserializeCardEntry(cardEntry) {
       var cardInstance;
       switch (cardEntry.type) {
-        case 'AppBookmark':
         case 'Application':
           cardInstance = Application.deserialize(cardEntry, this.installedApps);
           break;
         case 'Deck':
           cardInstance = Deck.deserialize(cardEntry, this.installedApps);
+          break;
+        case 'AppBookmark':
+          cardInstance = AppBookmark.deserialize(cardEntry);
           break;
         case 'Folder':
           cardInstance = Folder.deserialize(cardEntry);
@@ -701,10 +703,13 @@
     },
 
     // TODO: need to be protected by semaphore
+    // TODO: some comparison are based on card type. We may move these part to
+    //       card class themselves.
     // There are three types of query:
     // 1. query by cardId
     // 2. query by manifestURL and optionally launchURL
-    // 3. query by cardEntry (i.e. serialized card)
+    // 3. query by bookmark url
+    // 4. query by cardEntry (i.e. serialized card)
     findCardFromCardList: function cm_findCardFromCardList(query) {
       var found;
       this._cardList.some(function(card) {
@@ -732,6 +737,11 @@
               return true;
             }
           } else {
+            found = card;
+            return true;
+          }
+        } else if (query.url) {
+          if (query.url === card.url) {
             found = card;
             return true;
           }

--- a/shared/js/smart-screen/cards/app_bookmark.js
+++ b/shared/js/smart-screen/cards/app_bookmark.js
@@ -1,0 +1,46 @@
+/* global Card */
+
+(function(exports) {
+  'use strict';
+
+  function AppBookmark(options) {
+    this.url = options.url;
+    this.name = options.name;
+    this.group = options.group;
+    this.thumbnail = options.thumbnail;
+    Card.prototype.constructor.call(this);
+  }
+
+  AppBookmark.deserialize = function ab_deserialize(cardEntry) {
+    var cardInstance;
+    if (cardEntry && cardEntry.type === 'AppBookmark') {
+      cardInstance = new AppBookmark({
+        name: cardEntry.name,
+        url: cardEntry.url,
+        group: cardEntry.group,
+        thumbnail: cardEntry.thumbnail
+      });
+    }
+    return cardInstance;
+  };
+
+  AppBookmark.prototype = Object.create(Card.prototype);
+
+  AppBookmark.prototype.constructor = AppBookmark;
+
+  AppBookmark.prototype.launch = function ab_launch(args) {
+    window.open(this.url, '_blank', 'remote=true,applike=true');
+  };
+
+  AppBookmark.prototype.serialize = function ab_serialize() {
+    return {
+      type: 'AppBookmark',
+      name: this.name,
+      url: this.url,
+      group: this.group,
+      thumbnail: this.thumbnail
+    };
+  };
+
+  exports.AppBookmark = AppBookmark;
+}(window));

--- a/shared/js/smart-screen/cards/folder.js
+++ b/shared/js/smart-screen/cards/folder.js
@@ -116,7 +116,8 @@
   // There are three types of query:
   // 1. query by cardId
   // 2. query by manifestURL and optionally launchURL
-  // 3. query by cardEntry (i.e. serialized card)
+  // 3. query by bookmark url
+  // 4. query by cardEntry (i.e. serialized card)
   Folder.prototype.findCard = function folder_findCard(query) {
     var found;
     this._cardsInFolder.some(function(card, index) {
@@ -136,6 +137,11 @@
           found = card;
           return true;
         }
+      } else if (query.url) {
+        if (query.url === card.url) {
+          found = card;
+        }
+        return true;
       } else if (query.cardEntry) {
         // XXX: this could be bad at performance because we serialize card
         // in every loop. We might need improvement on this query.

--- a/tv_apps/app-deck/index.html
+++ b/tv_apps/app-deck/index.html
@@ -36,6 +36,7 @@
     <script defer src="shared/js/smart-screen/cards/application.js"></script>
     <script defer src="shared/js/smart-screen/cards/deck.js"></script>
     <script defer src="shared/js/smart-screen/cards/folder.js"></script>
+    <script defer src="shared/js/smart-screen/cards/app_bookmark.js"></script>
     <script defer src="shared/js/smart-screen/card_manager.js"></script>
     <script defer src="shared/js/smart-screen/bookmark_manager.js"></script>
 
@@ -81,6 +82,7 @@
       </section>
       <menu type="context" id="context-menu">
         <menuitem icon="style/icons/ic_pin.png" data-l10n-id="pin-to-home" id="pin-to-home"></menuitem>
+        <menuitem icon="style/icons/ic_pin.png" data-l10n-id="unpin-from-home" id="unpin-from-home"></menuitem>
         <menuitem icon="style/icons/ic_delete.png" data-l10n-id="remove-card" id="remove-card"></menuitem>
       </menu>
     </article>

--- a/tv_apps/app-deck/js/app_deck.js
+++ b/tv_apps/app-deck/js/app_deck.js
@@ -21,8 +21,7 @@
    * @requires CardManager
    * @requires {@link PromotionList}
    *
-   * @fires AppDeck#focus-on-pinable
-   * @fires AppDeck#focus-on-nonpinable
+   * @fires AppDeck#focus
    */
   var AppDeck = function() {
   };
@@ -43,6 +42,8 @@
     _appDeckListScrollable: undefined,
 
     _cardManager: undefined,
+
+    _bookmarkManager: undefined,
 
     _outOfControlArea: true,
 
@@ -190,8 +191,12 @@
       bookmarkButton.classList.add('app-button');
       bookmarkButton.classList.add('navigable');
       bookmarkButton.setAttribute('label', bookmark.name);
-      bookmark.icon &&
-        (bookmarkButton.style.backgroundImage = 'url("' + bookmark.icon + '")');
+
+      if(bookmark.icon) {
+        var iconURL = URL.createObjectURL(bookmark.icon);
+        bookmarkButton.dataset.revokableURL = iconURL;
+        bookmarkButton.style.backgroundImage = 'url("' + iconURL + '")';
+      }
       return bookmarkButton;
     },
 
@@ -222,53 +227,51 @@
 
           this._appDeckGridViewElem.removeChild(targetElem);
           this._spatialNavigator.remove(targetElem);
+          URL.revokeObjectURL(targetElem.dataset.revokableURL);
           break;
       }
     },
 
     /**
-     * Notify other module that currently focused element is pinable (could be
-     * pinned on Home) or nonpinable (could not be pinned on Home)
+     * Notify other modules about details of currently focused element.
      *
      * @public
      * @method  AppDeck#fireFocusEvent
      * @param  {HTMLElement} elem - currently focused element
      */
+    /**
+     * This event is fired whenever the focus in AppDeck moves to a pinnable
+     * element (For now it's an app or a bookmark).
+     * @event AppDeck#focus
+     * @type {Object}
+     * @property {HTMLElement} elem - currently focused element
+     * @property {Boolean} pinned - Has it been pinned to Home
+     */
     fireFocusEvent: function ad_fireFocusEvent(elem) {
       var that = this;
-      if (elem && elem.dataset && elem.dataset.manifestURL) {
-        this._cardManager.isPinned({
+      var type = elem && elem.getAttribute('app-type');
+
+      var query;
+      if (type === 'app') {
+        query = {
           manifestURL: elem.dataset.manifestURL,
           entryPoint: elem.dataset.entryPoint
-        }).then(function(pinned) {
-          /**
-           * This event fires whenever focus in AppDeck move to a pinable
-           * element (representing na app).
-           * @event AppDeck#focus-on-pinable
-           * @type {Object}
-           * @property {Boolean} pinned - Is current focused pinable element
-           *                            pinned or not
-           * @property {String} manifestURL - manifestURL of current focused
-           *                                element
-           * @property {String} name - name of current focused pinable element
-           * @property {Boolean} removable - Is current focused pinable element
-           *                               removable or not
-           */
-          that.fire('focus-on-pinable', {
-            pinned: pinned,
-            manifestURL: elem.dataset.manifestURL,
-            // entryPoint is deprecated
-            entryPoint: elem.dataset.entryPoint,
-            name: elem.dataset.name,
-            removable: elem.dataset.removable === 'true'
-          });
-        });
+        };
+      } else if (type === 'bookmark') {
+        query = {
+          url: elem.dataset.url
+        };
       } else {
-        /**
-         * @event AppDeck#focus-on-nonpinable
-         */
-        this.fire('focus-on-nonpinable');
+        // We have no other types for now.
+        return;
       }
+
+      this._cardManager.isPinned(query).then(pinned => {
+        that.fire('focus', {
+          elem: elem,
+          pinned: pinned
+        });
+      });
     },
 
     onFocus: function ad_onFocus(elem) {

--- a/tv_apps/app-deck/js/context_menu.js
+++ b/tv_apps/app-deck/js/context_menu.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global MozActivity, Applications, SharedUtils */
+/* global MozActivity, Applications, BookmarkManager */
 /* jshint nonew: false */
 
 (function(exports) {
@@ -18,12 +18,14 @@
 
   ContextMenu.prototype = {
     pinToHomeElem: document.getElementById('pin-to-home'),
+    unpinFromHomeElem: document.getElementById('unpin-from-home'),
     mainSection: document.getElementById('main-section'),
     removeElem: document.getElementById('remove-card'),
     contextMenuElem: document.getElementById('context-menu'),
 
     _appDeck: undefined,
-    _app: undefined,
+    _target: {},
+
 
     /**
      * Initialize ContextMenu
@@ -33,16 +35,16 @@
      * @param  {AppDeck} appDeck - instance of {@link AppDeck}
      */
     init: function cm_init(appDeck) {
-      this.mainSection.addEventListener('contextmenu',
-        this.onContextMenu.bind(this));
-
       this._appDeck = appDeck;
-      this._appDeck.on('focus-on-pinable', this.onFocusOnPinable.bind(this));
-      this._appDeck.on('focus-on-nonpinable',
-        this.onFocusOnNonpinable.bind(this));
+      this._appDeck.on('focus', this.onFocus.bind(this));
+
+      this._bookmarkManager = BookmarkManager;
 
       this.pinToHomeElem.addEventListener('click', this.pinOrUnpin.bind(this));
-      this.removeElem.addEventListener('click', this.uninstall.bind(this));
+      this.unpinFromHomeElem.addEventListener(
+                                          'click', this.pinOrUnpin.bind(this));
+
+      this.removeElem.addEventListener('click', this.onRemove.bind(this));
     },
 
     _selfApp: undefined,
@@ -91,35 +93,28 @@
     },
 
     /**
-     * Shorthand function to derive launchURL from [app](http://mzl.la/1DJP6oZ)
-     * instance
-     *
-     * @private
-     * @method ContextMenu#_composeLaunchURL
-     * @param  {DOMApplication} app - see [here](http://mzl.la/1DJP6oZ)
-     * @return {String}  launchURL
-     */
-    _composeLaunchURL: function cm_composeLaunchURL(app) {
-      return app.manifestURL.replace('manifest.webapp', '') + app.entryPoint;
-    },
-
-    /**
      * To tell smart-home what app we would like to unpin
      *
      * @private
      * @method  ContextMetnu#_sendUnpinMessage
-     * @param  {DOMApplication} app - the [app](http://mzl.la/1DJP6oZ) we'd like
-     *                              to unpin from Home
+     * @param  {HTMLElement} cardElem - the card we'd like to unpin from Home
      */
-    _sendUnpinMessage: function cm_sendUnpinMessage(app) {
-      // Notice that here we didn't specify launchURL because we assume all
-      // 'Application' in app-deck are launched by calling app.launch().
-      // However, in the case of other deck-like app, if we are going to pin
-      // application which is launched by different launchURL, we must specify
-      // 'launchURL' here.
-      this.sendMessage('unpin', {
-        manifestURL: app.manifestURL
-      });
+    _sendUnpinMessage: function cm_sendUnpinMessage(cardElem) {
+      var type = cardElem.getAttribute('app-type');
+      if (type === 'app') {
+        // Notice that here we didn't specify launchURL because we assume all
+        // 'Application' in app-deck are launched by calling app.launch().
+        // However, in the case of other deck-like app, if we are going to pin
+        // application which is launched by different launchURL, we must specify
+        // 'launchURL' here.
+        this.sendMessage('unpin', {
+          manifestURL: cardElem.dataset.manifestURL
+        });
+      } else if (type === 'bookmark') {
+        this.sendMessage('unpin', {
+          url: cardElem.dataset.url
+        });
+      }
     },
 
     /**
@@ -133,81 +128,93 @@
      * @method  ContextMenu#pinOrUnpin
      */
     pinOrUnpin: function cm_pinOrUnpin() {
-      if (this._app) {
-        var app = this._app;
-        if (app.pinned) {
-          this._sendUnpinMessage(app);
-        } else {
-          // XXX: preferredSize should be determined by
-          // real offsetWidth of cardThumbnailElem in smart-home instead of
-          // hard-coded value
-          Applications.getIconBlob(app.manifestURL, app.entryPoint, 354,
-            function(blob) {
-              // Notice that here we didn't specify launchURL because we assume
-              // all 'Application' in app-deck are launched by calling
-              // app.launch().
-              // However, in the case of other deck-like app, if we are going to
-              // pin application which is launched by different launchURL, we
-              // must specify 'launchURL' here.
-              new MozActivity({
-                name: 'pin',
-                data: {
-                  type: 'Application',
-                  group: 'application',
-                  manifestURL: app.manifestURL,
-                  // We use app's original icon instead of screenshot here
-                  // because we are in app deck. For the case of getting
-                  // screenshot, please refer to bug 1100238.
-                  thumbnail: blob
-                }
-              });
+      var cardElem = this._target.elem;
+      var type = this._getTargetType();
+      var dataset = cardElem.dataset;
 
-            });
-        }
+      if (this._target.pinned) {
+        this._sendUnpinMessage(this._target.elem);
+      } else if (type === 'app') {
+        // XXX: preferredSize should be determined by
+        // real offsetWidth of cardThumbnailElem in smart-home instead of
+        // hard-coded value
+        Applications.getIconBlob(
+                        dataset.manifestURL, dataset.entryPoint, 354, blob => {
+          // Notice that here we didn't specify launchURL because we assume
+          // all 'Application' in app-deck are launched by calling
+          // app.launch().
+          // However, in the case of other deck-like app, if we are going to
+          // pin application which is launched by different launchURL, we
+          // must specify 'launchURL' here.
+          new MozActivity({
+            name: 'pin',
+            data: {
+              type: 'Application',
+              group: 'application',
+              manifestURL: dataset.manifestURL,
+              // We use app's original icon instead of screenshot here
+              // because we are in app deck. For the case of getting
+              // screenshot, please refer to bug 1100238.
+              thumbnail: blob
+            }
+          });
+        });
+      } else if (type === 'bookmark') {
+        this._bookmarkManager.get(dataset.url).then(card => {
+          new MozActivity({
+            name: 'pin',
+            data: {
+              name: {raw: card.name},
+              type: 'AppBookmark',
+              group: 'application',
+              url: card.url,
+              thumbnail: card.icon
+            }
+          });
+        });
       }
+    },
+
+    onRemove: function cm_onRemove() {
+      var type = this._getTargetType();
+      if (this._target.pinned) {
+        this._sendUnpinMessage(this._target.elem);
+      }
+      if (type === 'app') {
+        this.uninstall(this._target.elem);
+      } else if (type === 'bookmark') {
+        this._bookmarkManager.remove(this._target.elem.dataset.url);
+      }
+    },
+
+    _getTargetType: function cm_getType() {
+      return this._target.elem && this._target.elem.getAttribute('app-type');
     },
 
     /**
      * Uninstall app represented by current focused SmartButton
      * @public
      * @method  ContextMenu#uninstall
+     * @param  {HTMLElement} cardElem - the card we'd like to unpin from Home
      */
-    uninstall: function cm_uninstall() {
-      if (this._app && this._app.removable) {
-        var app = this._app;
-        // unpin app before uninstall it
-        if (app.pinned) {
-          this._sendUnpinMessage(app);
-        }
-        var appInstance = Applications.installedApps[app.manifestURL];
-        if (appInstance) {
-          navigator.mozApps.mgmt.uninstall(appInstance);
-        }
+    uninstall: function cm_uninstall(cardElem) {
+      var appInstance =
+                      Applications.installedApps[cardElem.dataset.manifestURL];
+      if (appInstance) {
+        navigator.mozApps.mgmt.uninstall(appInstance);
       }
     },
 
-    onFocusOnPinable: function cm_onFocusOnPinable(detail) {
-      this._app = detail;
-      var l10nPayload =
-        (detail && detail.pinned) ? 'unpin-from-home' : 'pin-to-home';
-      SharedUtils.localizeElement(this.pinToHomeElem, l10nPayload);
-      if (detail.removable === false) {
-        this.contextMenuElem.removeChild(this.removeElem);
+    onFocus: function cm_onFocus(target) {
+      this._target = target;
+
+      this.contextMenuElem.innerHTML = '';
+      if (target.pinned) {
+        this.contextMenuElem.appendChild(this.unpinFromHomeElem);
       } else {
-        this.contextMenuElem.insertBefore(this.removeElem,
-          this.pinToHomeElem.nextElementSibling);
+        this.contextMenuElem.appendChild(this.pinToHomeElem);
       }
-    },
-
-    onFocusOnNonpinable: function cm_onFocusOnNonpinable() {
-      this._app = undefined;
-    },
-
-    onContextMenu: function cm_onContextMenu(evt) {
-      // stop showing context menu if we are not focus on pinable element
-      if (!this._app) {
-        evt.preventDefault();
-      }
+      this.contextMenuElem.appendChild(this.removeElem);
     }
   };
 

--- a/tv_apps/smart-home/index.html
+++ b/tv_apps/smart-home/index.html
@@ -46,6 +46,7 @@
     <script defer src="shared/js/smart-screen/cards/application.js"></script>
     <script defer src="shared/js/smart-screen/cards/deck.js"></script>
     <script defer src="shared/js/smart-screen/cards/folder.js"></script>
+    <script defer src="shared/js/smart-screen/cards/app_bookmark.js"></script>
     <script defer src="shared/js/smart-screen/card_manager.js"></script>
     <script defer src="shared/js/smart-screen/animations.js"></script>
     <script defer src="shared/js/smart-screen/simple_key_navigation.js"></script>

--- a/tv_apps/smart-home/js/home.js
+++ b/tv_apps/smart-home/js/home.js
@@ -2,7 +2,7 @@
 /* global Application, FilterManager, CardManager, Clock, Deck, Edit, Folder,
           KeyNavigationAdapter, MessageHandler, MozActivity, SearchBar,
           SharedUtils, SpatialNavigator, URL, XScrollable, Animations,
-          Utils, FTEWizard */
+          Utils, FTEWizard, AppBookmark */
 /* jshint nonew: false */
 
 (function(exports) {
@@ -480,6 +480,9 @@
         } else {
           this._createWave(cardButton, card);
         }
+      } else if (card instanceof AppBookmark) {
+        cardButton.setAttribute('app-type', 'appbookmark');
+        this._fillCardIcon(cardButton, card);
       } else if (card instanceof Folder) {
         cardButton.setAttribute('app-type', 'folder');
         cardButton.dataset.icon = 'folder';

--- a/tv_apps/smart-home/js/message_handler.js
+++ b/tv_apps/smart-home/js/message_handler.js
@@ -44,12 +44,14 @@
      * @method  MessageHandler#pin
      * @param {Object} cardEntry - cardEntry representing the card
      * @param {String} cardEntry.type - valid values are 'Application', 'Deck',
-     *                                and 'Folder'
+     *                                'AppBookmark', and 'Folder'
      * @param {String} cardEntry.group - valud values are 'tv', 'application',
      *                                 'device', and 'dashboard'
      * @param {String} cardEntry.manifestURL - manifestURL, if the card
-     *                                       represent an app or a deck
+     *                                       represents an app or a deck
      * @param {String} cardEntry.launchURL - optional
+     * @param {String} cardEntry.url - URL, if the card represents a bookmark
+     * @param {String} cardEntry.name.raw - optional display name
      * @param {Blob} cardEntry.thumnail - see [blob](http://mzl.la/1BRI7IV)
      */
     pin: function mh_pin(cardEntry) {
@@ -63,8 +65,10 @@
      * @public
      * @method  MessageHandler#unpin
      * @param  {Object} data
-     * @param  {String} data.manifestURL - manifestURL of the unpinned app
-     * @param  {String} data.launchURL - optional
+     * @param  {String} data.manifestURL - manifestURL if unpinning an app
+     * @param  {String} data.launchURL - optional launchURL if unpinning an
+     *                                   app
+     * @param  {String} data.url - link URL when unpinning an bookmark
      */
     unpin: function mh_unpin(data) {
       var home = this._home;

--- a/tv_apps/smart-home/manifest.webapp
+++ b/tv_apps/smart-home/manifest.webapp
@@ -17,16 +17,17 @@
   "activities": {
     "pin": {
       "filters": {
-        "manifestURL": {
+        "type": {
           "required": true
-        }
+        },
+        "manifestURL": { "pattern": "(https?|app):.{1,16384}" },
+        "url": { "pattern": "https?:.{1,16384}" }
       }
     },
     "unpin": {
       "filters": {
-        "manifestURL": {
-          "required": true
-        }
+        "manifestURL": { "pattern": "(https?|app):.{1,16384}" },
+        "url": { "pattern":"https?:.{1,16384}" }
       }
     }
   },

--- a/tv_apps/smart-home/style/home.css
+++ b/tv_apps/smart-home/style/home.css
@@ -303,7 +303,8 @@ smart-button[type="app-button"][app-type="tv"] > span.name {
   background-color: #d90c83;
 }
 
-smart-button[type="app-button"][app-type="app"] > span.name {
+smart-button[type="app-button"][app-type="app"] > span.name,
+smart-button[type="app-button"][app-type="appbookmark"] > span.name {
   background-color: rgba(0, 0, 0, 0.4);
 }
 

--- a/tv_apps/smart-home/test/unit/home_test.js
+++ b/tv_apps/smart-home/test/unit/home_test.js
@@ -10,6 +10,7 @@ require('/shared/js/smart-screen/cards/card.js');
 require('/shared/js/smart-screen/cards/application.js');
 require('/shared/js/smart-screen/cards/deck.js');
 require('/shared/js/smart-screen/cards/folder.js');
+require('/shared/js/smart-screen/cards/app_bookmark.js');
 require('/shared/js/smart-screen/clock.js');
 require('/shared/test/unit/mocks/mock_event_target.js');
 require('mock_card_manager.js');


### PR DESCRIPTION
Significant changes include:
- Add a card type named `AppBookmark` for saving bookmarks in Home app. (But `AppBookmark` is not used for bookmarks in App-deck. App-deck has its own data structure for them.
- Let `CardManager.FindCardInCardlist` and `Folder.FindCard` support searching `appBookmark` instances by its URL.
- For saving icons, use blob rather than base64 since Home uses blob and thus we can prevent unnecessary conversion.
- pin/unpin activity in Home should support bookmark.
- `AppDeck.contextMenu` now passes button elements rather then `app` as parameter in most of its functions, since bookmarks are not apps.
- Enable right-click of bookmark icons in app deck.
  ... and more. Please just feel free to ask me if you feel confused.
