### PR TITLE
Bug 1235470 - Move fullscreen z-index rule from ua.css to zindex.css

### DIFF
--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -338,6 +338,13 @@
   z-index: 0;
 }
 
+/* This rule is moved from ua.css as a temporary workaround to keep the current
+ * behavior in gaia. This, as well as the overlay promoting code below, should
+ * be removed in the future. See bug 1235470, bug 1235471, and bug 1235472. */
+*|*:-moz-full-screen:not(:root) {
+  z-index: 2147483647 !important;
+}
+
 /* We promote the following overlays on top of the fullscreen web content. */
 #screen:-moz-full-screen-ancestor > [data-z-index-level="sleep-menu"],
 #screen:-moz-full-screen-ancestor > [data-z-index-level="action-menu"],

--- a/build/csslint/xfail.list
+++ b/build/csslint/xfail.list
@@ -125,7 +125,7 @@ apps/system/style/update_manager/update_manager.css 4 0
 apps/system/style/utility_tray/utility_tray.css 4 0
 apps/system/style/window.css 0 3
 apps/system/style/wrapper/wrapper.css 0 1
-apps/system/style/zindex.css 0 4
+apps/system/style/zindex.css 0 5
 apps/video/style/info.css 0 2
 apps/video/style/video.css 0 9
 apps/video/style/video_tablet.css 0 11


### PR DESCRIPTION
This is the gaia side change for [bug 1235470](https://bugzilla.mozilla.org/show_bug.cgi?id=1235470). The gecko side change has been r+ed in [bug 1215365](https://bugzilla.mozilla.org/show_bug.cgi?id=1215365) so I can land that any time as soon as the gaia code get updated.
