### PR TITLE
Bug 1229490 - Modify TV preferences to provide better web experience on large screen.

### DIFF
--- a/build/config/tv/custom-prefs.js
+++ b/build/config/tv/custom-prefs.js
@@ -8,7 +8,13 @@ user_pref('b2g.system_manifest_url',
           'app://smart-system.gaiamobile.org/manifest.webapp');
 user_pref('b2g.neterror.url',
           'app://smart-system.gaiamobile.org/net_error.html');
-user_pref('dom.meta-viewport.enabled', false);
+
+// Collaborate with meta-viewport to fulfill more complete web experience
+user_pref('apz.allow_zooming', true);
+// Larger value to provide better experience for apps/pages which targets on
+// TV but uses embed tag with hard-coded width/height
+user_pref('browser.viewport.desktopWidth', 1920);
+
 user_pref('dom.presentation.enabled', true);
 user_pref('devtools.useragent.device_type', 'TV');
 user_pref('dom.apps.customization.enabled', false);


### PR DESCRIPTION
Set apz.allow_zooming=true & browser.viewport.desktopWidth=1920 to provide better web experience on large screen. r=kats.
