### PR TITLE
Bug 1222016 - [TV Browser] There should be a pop-up window if user disconnect successfully

### DIFF
--- a/tv_apps/browser/js/sync/settings.js
+++ b/tv_apps/browser/js/sync/settings.js
@@ -163,6 +163,17 @@
       }
       switch (message.state) {
         case 'disabled':
+          // We want to show a dialog once Sync is disabled
+          // but we only want to do that if it's disabled via user action
+          // and the user has already logged in.
+          // (and not because it is already disabled from a previous run).
+          if (this.state === 'disabling' &&
+             (this.previousState === 'enabled' ||
+              this.previousState === 'syncing')) {
+            navigator.mozL10n.formatValue('fxsync-disabled').then(result => {
+              window.alert(result);
+            });
+          }
           this.showScreen(DISABLED);
           this.hideEnabling();
           break;
@@ -226,6 +237,7 @@
           });
           break;
       }
+      this.previousState = this.state;
       this.state = message.state;
     },
 

--- a/tv_apps/browser/test/unit/sync/settings_test.js
+++ b/tv_apps/browser/test/unit/sync/settings_test.js
@@ -172,6 +172,45 @@ suite('Sync settings >', function() {
     });
   });
 
+  suite('Disabled from disabling', function() {
+    var alertStub;
+    var formatValueStub;
+    suiteSetup(function() {
+      formatValueStub = sinon.stub(navigator.mozL10n, 'formatValue', key => {
+        return Promise.resolve(key);
+      });
+
+      alertStub = sinon.stub(window, 'alert');
+    });
+
+    suiteTeardown(function() {
+      showScreenSpy.reset();
+      formatValueStub.restore();
+      alertStub.restore();
+    });
+
+    teardown(function() {
+      alertStub.reset();
+    });
+
+    ['enabled', 'syncing'].forEach(previousState => {
+      test('should show disabled dialog',
+        function(done) {
+        subject.previousState = previousState;
+        subject.state = 'disabling';
+        onsyncchange({
+          state: 'disabled',
+          user: 'pepito'
+        });
+        setTimeout(function() {
+          expect(alertStub.calledOnce).to.equal(true);
+          expect(alertStub.args[0][0]).to.equal('fxsync-disabled');
+          done();
+        });
+      });
+    });
+  });
+
   suite('Enabled', function() {
     suiteSetup(function() {
       onsyncchange({


### PR DESCRIPTION
…sconnect successfully
- Only show the logged out dialog when a user has logged in before logging out.

Conflicts:
    tv_apps/browser/js/sync/settings.js
    tv_apps/browser/test/unit/sync/settings_test.js
