### PR TITLE
Speculative fix for FxA device registration test failures

### DIFF
--- a/apps/system/fxa/test/marionette/fxa_screen_flow_test.js
+++ b/apps/system/fxa/test/marionette/fxa_screen_flow_test.js
@@ -17,7 +17,8 @@ marionette('Firefox Accounts Screen Flow Test (UITest app)', function() {
             'identity.fxaccounts.auth.uri': 'http://' +
               config.SERVER_HOST + ':' +
               config.SERVER_PORT + '/' +
-              config.SERVER_PATH
+              config.SERVER_PATH,
+            'identity.fxaccounts.skipDeviceRegistration': true
           }
         }
       });

--- a/tv_apps/smart-system/fxa/test/marionette/fxa_screen_flow_test.js
+++ b/tv_apps/smart-system/fxa/test/marionette/fxa_screen_flow_test.js
@@ -17,7 +17,8 @@ marionette('Firefox Accounts Screen Flow Test (UITest app)', function() {
             'identity.fxaccounts.auth.uri': 'http://' +
               config.SERVER_HOST + ':' +
               config.SERVER_PORT + '/' +
-              config.SERVER_PATH
+              config.SERVER_PATH,
+            'identity.fxaccounts.skipDeviceRegistration': true
           }
         }
       });


### PR DESCRIPTION
Over in [bug 1227527](https://bugzilla.mozilla.org/show_bug.cgi?id=1227527), we implemented device registration for Firefox Accounts. When that patch landed, it [broke some tests](https://treeherder.mozilla.org/logviewer.html#?job_id=6354136&repo=fx-team) from this repo. This PR is a tentative fix for those failures.

**Background:**

The browser patch does a couple of things that are problematic in test contexts.
1. Device registration makes an HTTP request to the FxA auth server.
2. Attempting to generate the default device name fails.

These caused a bunch of indirect breakages all over the place, which we mitigated by introducing a new boolean pref called `identity.fxaccounts.skipDeviceRegistration`. When that is `true`, device registration is a nop. The point of this PR is to re-use the same pref here so the patch can land.

**Questions:**

The biggest problem I have at the moment is that I haven't yet managed to run these tests locally to reproduce the issue. I followed the [instructions on MDN](https://developer.mozilla.org/en-US/Firefox_OS/Developing_Gaia/Testing_Gaia_code_changes) for building and testing Gaia and then ran `bin/gaia-test` using a local build of Nightly that has the device registration patch applied. That runs okay, but I don't see any mention of `fxa_screen_flow_test.js` listed. How should I be running these tests?

Another option I saw for maybe setting the pref was in `build/preferences.js`, but I figured the files changed here are better because they're FxA-specific and already appear to set FxA-specific preferences. Am I on the right track?
