### PR TITLE
Bug 1151847 - [Network Alerts][Refactoring] Use notification "data"

### DIFF
--- a/apps/network-alerts/js/attention/attention.js
+++ b/apps/network-alerts/js/attention/attention.js
@@ -42,7 +42,8 @@ function sendNotification() {
         navigator.mozL10n.get(title), {
           body: body,
           tag: '' + Date.now(), // needs to be unique
-          icon: NotificationHelper.getIconURI(app) + '?titleID=' + title
+          icon: NotificationHelper.getIconURI(app),
+          data: { title }
         }
       );
 

--- a/apps/network-alerts/js/notification/notification.js
+++ b/apps/network-alerts/js/notification/notification.js
@@ -1,5 +1,3 @@
-/* global Utils */
-
 'use strict';
 
 (function(exports) {
@@ -18,7 +16,7 @@ function onNotification(message) {
     return;
   }
 
-  var title = Utils.parseParams(message.imageURL).titleID;
+  var title = message.data.title;
 
   var url = [
     'attention.html?title=',

--- a/apps/network-alerts/test/unit/attention/attention_test.js
+++ b/apps/network-alerts/test/unit/attention/attention_test.js
@@ -107,7 +107,7 @@ suite('Network Alerts - Attention Screen', function() {
 
       assert.equal(MockNotifications[0].title, localizedTitle);
       assert.equal(MockNotifications[0].body, body);
-      assert.ok(MockNotifications[0].icon.endsWith('titleID=' + title));
+      assert.equal(MockNotifications[0].data.title, title);
 
       sinon.assert.called(Notify.notify);
     });

--- a/apps/network-alerts/test/unit/notification/notification_test.js
+++ b/apps/network-alerts/test/unit/notification/notification_test.js
@@ -1,27 +1,16 @@
-/* global MocksHelper,
-  NotificationHandler,
-  Utils
+/* global NotificationHandler
  */
 'use strict';
 
-require('/test/unit/mock_utils.js');
 require('/js/notification/notification.js');
 
-var mocksForNotification = new MocksHelper([
-  'Utils'
-]);
-
 suite('Network Alerts - Notification handling', function() {
-  mocksForNotification.attachTestHelpers();
 
   setup(function() {
     this.sinon.stub(window, 'close');
     this.sinon.stub(window, 'open');
     // We only need titleID after parsing, so mock parseParams that simply
     // return fake titleID for testing.
-    this.sinon.stub(Utils, 'parseParams').returns({
-      titleID: 'titleID'
-    });
 
     if (!window.navigator.mozSetMessageHandler) {
       window.navigator.mozSetMessageHandler = function() {};
@@ -34,7 +23,8 @@ suite('Network Alerts - Notification handling', function() {
     var message = {
       title: 'Some title',
       body: 'Some body',
-      clicked: true
+      clicked: true,
+      data: { title: 'Some title' }
     };
 
     var handlerStub = window.navigator.mozSetMessageHandler;
@@ -42,7 +32,7 @@ suite('Network Alerts - Notification handling', function() {
 
     var expectedUrl = [
       'attention.html?',
-      'title=titleID&',
+      'title=Some%20title&',
       'body=Some%20body&',
       'notification=1'
     ].join('');


### PR DESCRIPTION
attribute instead of icon URL query string parameters
