### PR TITLE
Bug 1227577 - Develop a new marionette-client promises driver r=gaye,aus

### DIFF
--- a/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/index.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/index.js
@@ -9,6 +9,7 @@
   if (typeof(window) === 'undefined') {
     module.exports.Tcp = require('./tcp');
     module.exports.TcpSync = require('./tcp-sync');
+    module.exports.Promises = require('./promises');
   } else {
     if (typeof(window.TCPSocket) !== 'undefined') {
       module.exports.MozTcp = ns.require('drivers/moz-tcp');

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/promises.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/promises.js
@@ -1,0 +1,97 @@
+var Tcp = require('./tcp');
+var Response = require('../message').Response;
+var Command = require('../message').Command;
+
+Promises.Socket = Tcp.Socket;
+
+var DEFAULT_HOST = 'localhost';
+var DEFAULT_PORT = 2828;
+
+function Promises(options) {
+  if (!options) {
+    options = {};
+  }
+
+  this._lastId = 0;
+  this.host = options.host || DEFAULT_HOST;
+  this.port = options.port || DEFAULT_PORT;
+
+  this.connectionTimeout = options.connectionTimeout || 2000;
+  this.retryInterval = 300;
+  this.isSync = true;
+
+  this.tcp = new Tcp(options);
+  this.tcp._handshaking = false;
+  this.tcp._driver = this;
+
+  this.tcp.cbhandshake = function (data){
+    this._driver.marionetteProtocol = data.marionetteProtocol || 1;
+    this._driver.traits = data.traits;
+    this._driver.applicationType = data.applicationType;
+  }
+
+  // receiving command from the server
+  this.tcp._onClientCommand = function(data) {
+
+    if (this._handshaking){
+      this.cbhandshake(data);
+      this._handshaking = false;
+    }
+
+    var _response = new Response(0, data);
+    this._onDeviceResponse({
+      id: this.connectionId,
+      response: _response.toMsg()
+    });
+  };
+
+}
+
+Promises.prototype.connect = function(cb) {
+  var tcp = this.tcp;
+  this.tcp._handshaking = true;
+
+  return new Promise(function(resolve, reject) {
+    tcp.connect(function(err) {
+      if (err){
+        reject(err);
+      } else {
+        cb();
+        resolve();
+      }
+    });
+  });
+};
+
+Promises.prototype.send = function(obj, cb) {
+
+  var tcp = this.tcp;
+  var that = this;
+
+  return new Promise(function(resolve, reject) {
+    var out;
+
+    if (obj instanceof Command || obj instanceof Response) {
+      obj.id = ++that._lastId;
+      out = obj.toMsg();
+    } else {
+      out = obj;
+    }
+
+    tcp.send(out, function(res,err) {
+      if (!err) {
+        cb(res);
+        resolve(res);
+      } else {
+        reject(err);
+      }
+    });
+
+  });
+};
+
+Promises.prototype.close = function() {
+  this.tcp.close();
+};
+
+module.exports = Promises;

--- a/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/promises.js
+++ b/tests/jsmarionette/client/marionette-client/lib/marionette/drivers/promises.js
@@ -4,27 +4,18 @@ var Command = require('../message').Command;
 
 Promises.Socket = Tcp.Socket;
 
-var DEFAULT_HOST = 'localhost';
-var DEFAULT_PORT = 2828;
-
 function Promises(options) {
   if (!options) {
     options = {};
   }
-
-  this._lastId = 0;
-  this.host = options.host || DEFAULT_HOST;
-  this.port = options.port || DEFAULT_PORT;
-
-  this.connectionTimeout = options.connectionTimeout || 2000;
-  this.retryInterval = 300;
-  this.isSync = true;
 
   this.tcp = new Tcp(options);
   this.tcp._handshaking = false;
   this.tcp._driver = this;
 
   this.tcp.cbhandshake = function (data){
+    // if we don't set the marionetteProtocol on the driver,
+    // the session fail to open and the client stucks at [msg: 0]
     this._driver.marionetteProtocol = data.marionetteProtocol || 1;
     this._driver.traits = data.traits;
     this._driver.applicationType = data.applicationType;
@@ -44,47 +35,25 @@ function Promises(options) {
       response: _response.toMsg()
     });
   };
-
 }
 
-Promises.prototype.connect = function(cb) {
+Promises.prototype.connect = function() {
   var tcp = this.tcp;
   this.tcp._handshaking = true;
 
   return new Promise(function(resolve, reject) {
     tcp.connect(function(err) {
-      if (err){
-        reject(err);
-      } else {
-        cb();
-        resolve();
-      }
+      err ? reject(err) : resolve();
     });
   });
 };
 
-Promises.prototype.send = function(obj, cb) {
-
+Promises.prototype.send = function(obj) {
   var tcp = this.tcp;
-  var that = this;
 
   return new Promise(function(resolve, reject) {
-    var out;
-
-    if (obj instanceof Command || obj instanceof Response) {
-      obj.id = ++that._lastId;
-      out = obj.toMsg();
-    } else {
-      out = obj;
-    }
-
-    tcp.send(out, function(res,err) {
-      if (!err) {
-        cb(res);
-        resolve(res);
-      } else {
-        reject(err);
-      }
+    tcp.send(obj, function(res,err) {
+      err ? reject(err) : resolve(res);
     });
 
   });

--- a/tests/jsmarionette/client/marionette-client/package.json
+++ b/tests/jsmarionette/client/marionette-client/package.json
@@ -9,7 +9,8 @@
     "debug": "~0.6",
     "json-wire-protocol": "file:../json-wire-protocol",
     "socket-retry-connect": "file:../socket-retry-connect",
-    "sockit-to-me": "file:../sockit-to-me"
+    "sockit-to-me": "file:../sockit-to-me",
+    "promise": "7.0.4"
   },
 
   "devDependencies": {

--- a/tests/jsmarionette/client/marionette-client/test/marionette/drivers/promises-test.js
+++ b/tests/jsmarionette/client/marionette-client/test/marionette/drivers/promises-test.js
@@ -1,0 +1,97 @@
+/**
+ * Created by anatal on 12/10/15.
+ */
+/* global assert, helper */
+'use strict';
+suite('marionette/drivers/promises', function() {
+
+  if (typeof(window) !== 'undefined') {
+    return;
+  }
+
+  var Driver = require('../../../lib/marionette/drivers/promises');
+  var net = require('net');
+
+  function issueFirstResponse(subject) {
+    subject.tcp._onDeviceResponse({
+      id: subject.tcp.connectionId,
+      response: {}
+    });
+  }
+
+  setup(function() {
+  });
+
+  teardown(function() {
+  });
+
+  test('should return a fulfilled promise on connect', function(done) {
+    var port = 60769;
+    var subject = new Driver({ port: port });
+
+    var _promise = subject.connect(function(){
+    });
+
+    setTimeout(function() {
+      var server = net.createServer(function(socket) {
+        issueFirstResponse(subject);
+      }).listen(port);
+    }, 50);
+
+    _promise.then(
+      function onFulfill(){
+        done();
+      },
+      function onReject(aRejectReason) {
+      }
+    );
+
+  });
+
+  test('should send an object and receive a promise', function(done) {
+    var port = 60869;
+    var subject = new Driver({ port: port });
+    var sentobj = {type: 'foo'};
+
+    setTimeout(function() {
+
+      var _promiseconnection = subject.connect(function(){
+      });
+
+      setTimeout(function() {
+        var server = net.createServer(function(socket) {
+          issueFirstResponse(subject);
+          socket.on('data', function(data) {
+            socket.write(data);
+            server.close();
+          });
+
+        }).listen(port);
+      }, 50);
+
+      _promiseconnection.then(
+        function onFulfill(){
+
+            var _promisesend = subject.send(sentobj,
+            function (res){
+            });
+
+            // and wait..
+            _promisesend.then(
+              // fulfill of send promise
+              function onFulfill(res) {
+                if ( JSON.stringify(res[3]) === JSON.stringify(sentobj) ){
+                  done()
+                }
+              },
+              function onReject(aRejectReason) {
+              }
+            );
+        },
+        function onReject(aRejectReason) {
+        }
+      );
+    });
+   });
+  
+});

--- a/tests/jsmarionette/run_tests.js
+++ b/tests/jsmarionette/run_tests.js
@@ -14,6 +14,7 @@ var configs = Object.freeze({
       'test/node/connection-manager-test',
       'test/marionette/drivers/abstract-test',
       'test/marionette/drivers/tcp-test',
+      'test/marionette/drivers/promises-test',
       'test/marionette/drivers/tcp-sync-test',
       'test/marionette/actions-test',
       'test/marionette/client-test',


### PR DESCRIPTION
We have two existing marionette client "drivers" to handle tcp requests to the marionette server

```
asynchronously with node-style callbacks [1]
synchronously via sockit-to-me [2]
```

We'd now like to add an additional driver that handles request asynchronicity through promises.
