### PR TITLE
Bug 1235762 - noop to force TreeHerder run, DO NOT MERGE, r=weilonge

### DIFF
--- a/apps/sync/doc/build-instructions.md
+++ b/apps/sync/doc/build-instructions.md
@@ -1,5 +1,6 @@
 # Trying out the Sync app
 
+
 ## From master
 
 You can use the latest B2G Desktop build from [here](https://www.dropbox.com/sh/wlw1kcbida471qw/AADqlITy328M8QMPxKokVflha?dl=0).


### PR DESCRIPTION
DO NOT MERGE

This is just to trigger a TreeHerder run as per https://bugzilla.mozilla.org/show_bug.cgi?id=1235762#c6
