### PR TITLE
Bug 1237067 - Reset Intl.DateTimeFormatter when language changes

### DIFF
--- a/apps/gallery/js/thumbnail_date_group.js
+++ b/apps/gallery/js/thumbnail_date_group.js
@@ -135,6 +135,13 @@ ThumbnailDateGroup.formatter = new Intl.DateTimeFormat(navigator.languages, {
   year: 'numeric',
 });
 
+ThumbnailDateGroup.resetFormatter = () => {
+  ThumbnailDateGroup.formatter = new Intl.DateTimeFormat(navigator.languages, {
+    month: 'long',
+    year: 'numeric',
+  });
+};
+
 ThumbnailDateGroup.prototype.localize = function() {
   var date = new Date(this.date);
 

--- a/apps/gallery/js/thumbnail_item.js
+++ b/apps/gallery/js/thumbnail_item.js
@@ -44,6 +44,16 @@ ThumbnailItem.formatter = new Intl.DateTimeFormat(navigator.languages, {
   year: 'numeric',
 });
 
+ThumbnailItem.resetFormatter = () => {
+  ThumbnailItem.formatter = new Intl.DateTimeFormat(navigator.languages, {
+    hour: 'numeric',
+    minute: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
 ThumbnailItem.prototype.localize = function() {
   var date = new Date(this.data.date);
 

--- a/apps/gallery/js/thumbnails.js
+++ b/apps/gallery/js/thumbnails.js
@@ -1,6 +1,6 @@
 /* exported Thumbnails */
 /* global ThumbnailList, ThumbnailDateGroup, MediaDB, LazyLoader */
-/* global photodb, files, picking, metadataParser */
+/* global ThumbnailItem, photodb, files, picking, metadataParser */
 (function(exports) {
   'use strict';
 
@@ -21,7 +21,11 @@
   // Bug 1135256: Having a listener in ThumbnailList prevents them from
   // being garbage collected since ready() holds a strong reference, so
   // we have a singleton listener here.
-  navigator.mozL10n.ready(thumbnails.list.localize.bind(thumbnails.list));
+  navigator.mozL10n.ready(() => {
+    ThumbnailDateGroup.resetFormatter();
+    ThumbnailItem.resetFormatter();
+    thumbnails.list.localize();
+  });
 
   // How many thumbnails are visible on a page.
   // Batch sizes are based on this.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1237067
