### PR TITLE
Bug 1234732 - [email] HeaderCursor seems to be insantiated multiple times for message_list somehow r=asuth

### DIFF
--- a/apps/email/js/cards/message_list.js
+++ b/apps/email/js/cards/message_list.js
@@ -960,6 +960,10 @@ return [
 
       evt.removeListener('folderPickerClosing', this.onFolderPickerClosing);
 
+      if (this.headerCursor) {
+        this.headerCursor.die();
+      }
+
       var model = this.model;
       model.removeListener('folder', this._folderChanged);
       model.removeListener('newInboxMessages', this.onNewMail);

--- a/apps/email/js/header_cursor.js
+++ b/apps/email/js/header_cursor.js
@@ -26,6 +26,9 @@ define(function(require) {
 
     this.model = model;
 
+    // Local binding since it is passed as an evt listener.
+    this.onLatestFolder = this.onLatestFolder.bind(this);
+
     // Need to distinguish between search and nonsearch slices,
     // since there can be two cards that both are listening for
     // slice changes, but one is for search output, and one is
@@ -78,7 +81,6 @@ define(function(require) {
       }.bind(this));
 
       // Listen to model for folder changes.
-      this.onLatestFolder = this.onLatestFolder.bind(this);
       this.model.latest('folder', this.onLatestFolder);
     },
 
@@ -218,7 +220,7 @@ define(function(require) {
     },
 
     endSearch: function() {
-      this.die();
+      this.resetMessageSlice();
       this.searchMode = 'nonsearch';
       this.freshMessagesSlice();
     },
@@ -232,7 +234,7 @@ define(function(require) {
      * @param  {Slice} messagesSlice the new messagesSlice.
      */
     bindToSlice: function(messagesSlice) {
-      this.die();
+      this.resetMessageSlice();
 
       this.messagesSlice = messagesSlice;
       this.sliceEvents.forEach(function(type) {
@@ -283,14 +285,20 @@ define(function(require) {
       this.setCurrentMessage(message);
     },
 
-    die: function() {
+    resetMessageSlice: function() {
       if (this.messagesSlice) {
         this.messagesSlice.die();
         this.messagesSlice = null;
       }
 
       this.currentMessage = null;
+    },
+
+    die: function() {
+      this.model.removeListener('folder', this.onLatestFolder);
+      this.resetMessageSlice();
     }
+
   });
 
   /*


### PR DESCRIPTION
This issue was caused by two things:
- message_list was not calling .die() on the HeaderCursor it creates.
- header_cursor not properly removing the "folder" listener when it dies.

The end result: whenever a message_list is destroyed in an email app session, there would be a zombie HeaderCursor listening for folder change events and asking for new slices. Adding or removing an account is one of a small set of scenarios where this would occur.

The fix was to call headerCursor.die() in the message_list's die(), and then in header_cursor, remove the model 'folder' listener in its die() method. Previously header_cursor internally called die() to reset the local messagesSlice property. This was extracted as a separate `resetMessageSlice` method and that is called instead, with die() also calling resetMessageSlice().
