### PR TITLE
Bug 1235881 - Fixed wrong activation of video controls

### DIFF
--- a/apps/system/test/marionette/lib/video_player.js
+++ b/apps/system/test/marionette/lib/video_player.js
@@ -58,15 +58,13 @@ VideoPlayer.prototype = {
   },
 
   invokeControls: function() {
-    this.client.waitFor(function() {
-      return !this.visibleControls();
-    }.bind(this));
+    if (!this.visibleControls()) {
+      this.rootElement.tap();
 
-    this.rootElement.tap();
-
-    this.client.waitFor(function() {
-      return this.visibleControls();
-    }.bind(this));
+      this.client.waitFor(function() {
+        return this.visibleControls();
+      }.bind(this));
+    }
   },
 
   _tapVideoControl: function(name) {

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -65,7 +65,6 @@
     "apps/system/test/marionette/browser_chrome_new_window_test.js": "Bug 1180236 - Intermittent apps/system/test/marionette/browser_chrome_new_window_test.js | Browser Chrome - Open New Window open new window",
     "apps/system/test/marionette/browser_clear_browsing_history_test.js": "Bug 1236038 - TEST-UNEXPECTED-FAIL | apps/system/test/marionette/browser_clear_browsing_history_test.js | Browser test Clear browsing history",
     "apps/system/test/marionette/browser_launch_window_open_test.js": "Bug 1180238 - Intermittent TEST-UNEXPECTED-FAIL | apps/system/test/marionette/browser_launch_window_open_test.js | Browser - Launch the same origin after navigating away checks for web compat issues",
-    "apps/system/test/marionette/browser_video_test.js": "Bug 1235881 - Intermittent TEST-UNEXPECTED-FAIL | apps/system/test/marionette/browser_video_test.js | Video Confirm video playback",
     "apps/system/test/marionette/browser_site_loading_background_test.js": "Bug 1233864 - Intermittent browser_site_loading_background_test.js | Browser - Site loading background validate loading background color",
     "apps/system/test/marionette/cell_broadcast_system_test.js": "Bug 1230362 - Intermittent cell_broadcast_system_test.js | mozApps - lockscreen enabled CellBroadcastSystem is shown when a message arrives, and clear notification",
     "apps/system/test/marionette/context_menu_test.js": "Bug 1233567 - Intermittent TEST-UNEXPECTED-FAIL | apps/system/test/marionette/context_menu_test.js",


### PR DESCRIPTION
To activate the player's video controls, the test-bed first waited for them to (automatically) disappear after user inactivity. This led to certain different outcomes due to a competition between the test video play time and ui/system/decoding performance. 
Now, if the controls are already visible, the video control activation routine does not do anything. However: This introduces some low probability race condition, as the controls - if not retriggered - will disappear at some point in time. This point in time could lie between the last positive check for visibility and the following action.
