### PR TITLE
Bug 1227527 - Disable FxA device registration

### DIFF
--- a/build/config/phone/custom-prefs.js
+++ b/build/config/phone/custom-prefs.js
@@ -2,3 +2,6 @@
 user_pref('devtools.responsiveUI.customWidth', 320);
 user_pref('devtools.responsiveUI.customHeight', 480);
 user_pref('devtools.responsiveUI.currentPreset', 'custom');
+
+// Disable Firefox Accounts device registration because it depends on Sync.
+user_pref('identity.fxaccounts.skipDeviceRegistration', true);

--- a/build/config/tablet/custom-prefs.js
+++ b/build/config/tablet/custom-prefs.js
@@ -3,3 +3,6 @@ user_pref('devtools.responsiveUI.customWidth', 1280);
 user_pref('devtools.responsiveUI.customHeight', 800);
 user_pref('devtools.responsiveUI.currentPreset', 'custom');
 user_pref('devtools.useragent.device_type', 'Tablet');
+
+// Disable Firefox Accounts device registration because it depends on Sync.
+user_pref('identity.fxaccounts.skipDeviceRegistration', true);

--- a/build/config/tv/custom-prefs.js
+++ b/build/config/tv/custom-prefs.js
@@ -26,3 +26,6 @@ user_pref('remotecontrol.service.pairing_required', true);
 user_pref('remotecontrol.client_page.prepath',
           'app://remote-control-client.gaiamobile.org');
 user_pref('remotecontrol.client_page.blacklist', '/client.html,/pairing.html');
+
+// Disable Firefox Accounts device registration because it depends on Sync.
+user_pref('identity.fxaccounts.skipDeviceRegistration', true);


### PR DESCRIPTION
@ferjm, it turns out that refactoring the device name stuff out of Sync in the desktop patch [is more complicated than I realised](https://bugzilla.mozilla.org/show_bug.cgi?id=1227527#c62). So it's easiest if we get that one landed by disabling device registration here and then make it FxOS-friendly in a separate effort.

Can you review this PR for me? Or do you know who I should be asking if not?
