### PR TITLE
Bug 1240905 - close not kill http.Server instances

### DIFF
--- a/shared/test/integration/server_child.js
+++ b/shared/test/integration/server_child.js
@@ -35,7 +35,7 @@ Server.prototype = {
 
   stop: function() {
     if (this.http) {
-      this.http.kill();
+      this.http.close();
     }
   },
 

--- a/tests/jsmarionette/plugins/marionette-js-logger/test/server_helper/server_child.js
+++ b/tests/jsmarionette/plugins/marionette-js-logger/test/server_helper/server_child.js
@@ -11,7 +11,7 @@ var Server = {
 
   stop: function() {
     if (this.http) {
-      this.http.kill();
+      this.http.close();
     }
   },
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1240905

I don't see that http.Server ever had a kill() method, but we do use this name elsewhere so perhaps this was wrapped wrapped originally. 
