### PR TITLE
Revert "Bug 1245443 - Using selector instead of findElement for waitForElement"

### DIFF
--- a/apps/music/test/marionette/lib/statusbar.js
+++ b/apps/music/test/marionette/lib/statusbar.js
@@ -21,11 +21,7 @@ Statusbar.prototype = {
 
   waitForPlayingIndicatorShown: function(shouldBeShown) {
     if (shouldBeShown) {
-      this.client.switchToFrame();
-      this.client.helper.waitFor(function() {
-        var el = this.client.findElement(Statusbar.Selector.playingIndicator);
-        return el;
-      }.bind(this));
+      this.client.helper.waitForElement(this.playingIndicator);
     } else {
       this.client.helper.waitForElementToDisappear(this.playingIndicator);
     }


### PR DESCRIPTION
This reverts commit 5bf3588afe0ef69a2d7e1a787efbd399ba71900d.
