### PR TITLE
Revert "Bug 1236248 - feed mozSetMessageHandler with the handler that is created in the main window. r=julien"

### DIFF
--- a/apps/sms/views/shared/js/shim_host_bootstrap.js
+++ b/apps/sms/views/shared/js/shim_host_bootstrap.js
@@ -10,7 +10,10 @@
 exports.bootstrap = function(appInstanceId) {
   // We can't handle system messages inside iframe right now, so we access
   // parent window here. This should be removed once bug 818000 is resolved.
-  ActivityShim.init(appInstanceId, parent.mozSetMessageHandler);
+  ActivityShim.init(
+    appInstanceId,
+    parent.navigator.mozSetMessageHandler.bind(parent.navigator)
+  );
   MozSettingsShim.init(navigator.mozSettings);
   MozMobileMessageShim.init(appInstanceId, navigator.mozMobileMessage);
   MozMobileConnectionsShim.init(appInstanceId, navigator.mozMobileConnections);

--- a/apps/sms/views/shared/js/utils.js
+++ b/apps/sms/views/shared/js/utils.js
@@ -940,16 +940,7 @@
         });
 
       return promise.then(
-        () => {
-          // Workaround for the Gecko XPCOM issue discussed in bug 1233552, in
-          // short if we pass handler function created inside nested iframe
-          // to the mozSetMessageHandler from the main window, then the handler
-          // could never be called in some cases (e.g. slow environment).
-          window.mozSetMessageHandler = function(type, handler) {
-            navigator.mozSetMessageHandler(type, (request) => handler(request));
-          };
-          shimHostIframe.contentWindow.bootstrap(appInstanceId);
-        }
+        () => shimHostIframe.contentWindow.bootstrap(appInstanceId)
       );
     },
 

--- a/shared/test/integration/tbpl-manifest.json
+++ b/shared/test/integration/tbpl-manifest.json
@@ -44,6 +44,8 @@
     "apps/settings/test/marionette/tests/app_permission_settings_test.js": "Bug 1004348 - Disable intermittent failing test, manipulate app permissions set geolocation of first app to Grant",
     "apps/settings/test/marionette/tests/hotspot_wifi_settings_test.js": "Bug 1006527 - Disable intermittent failing travis test, manipulate hotspot wifi settings resets settings for second load",
     "apps/settings/test/marionette/tests/message_settings_test.js": "",
+    "apps/sms/test/marionette/new_activity_test.js": "Bug 1235842 - Intermittent TEST-UNEXPECTED-FAIL | apps/sms/test/marionette/new_activity_test.js",
+    "apps/sms/test/marionette/share_activity_test.js": "Bug 1233552 - Intermittent TEST-UNEXPECTED-FAIL | apps/sms/test/marionette/share_activity_test.js | Messages as share target Share via Messages Activity close button Should close activity if in NewMessage view",
     "apps/system/fxa/test/marionette/fxa_screen_flow_test.js": "Bug 1064305 - [Marionette] FxA tests - intermittent timeout failures on system/fxa/test/marionette/fxa_screen_flow_test.js",
     "apps/system/test/marionette/audio_channel_competing_test.js": "Bug 1239338 - Intermittent apps/system/test/marionette/audio_channel_competing_test.js | Audio channel competing Public notification audio channel competes with audio channels Public notification channel competes with system channel",
     "apps/system/test/marionette/browser_chrome_new_window_test.js": "Bug 1180236 - Intermittent apps/system/test/marionette/browser_chrome_new_window_test.js | Browser Chrome - Open New Window open new window",


### PR DESCRIPTION
This reverts commit 84100fc54b611182c93700bd9cb06eafc8fd0808.
