### PR TITLE
Bug 1246092 - [TV] Circle animation during app transition dosen't close properly

### DIFF
--- a/tv_apps/smart-system/js/app_transition_controller.js
+++ b/tv_apps/smart-system/js/app_transition_controller.js
@@ -191,7 +191,7 @@
             // another overlay instead of reusing this overlay in the future
             homescreenWindowManager.getHomescreen().fadeOut();
             homescreenWindowManager.getHomescreen().showFadeOverlay(color);
-            this.app.element.classList.add('fast-fade-in');
+            this.app && this.app.element.classList.add('fast-fade-in');
           }.bind(this));
       } else {
         this.app.element.classList.add('transition-opening');


### PR DESCRIPTION
This patch:
If foreground app being closed during app transition is closed before app transition animation ends, it will causes null exception of foreground app and make app transition animation unable to close properly.
This patch add a check to the existence of foreground app being closed.
