### PR TITLE
Bug 1261549 - Gaia does not build due to manifest error

### DIFF
--- a/build/config/phone/apps-engineering.list
+++ b/build/config/phone/apps-engineering.list
@@ -3,7 +3,6 @@ apps/keyboard
 apps/settings
 apps/system
 dev_apps/in_app_pay_test
-dev_apps/mochitest
 dev_apps/ds-test
 dev_apps/geoloc
 dev_apps/l20n-app


### PR DESCRIPTION
Removing mochitest resolves the issue.
