### PR TITLE
New version of moz-download checks for presence of b2g-desktop, mulet…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -837,8 +837,8 @@ mulet: node_modules
 	DEBUG=* ./node_modules/.bin/mozilla-download \
 	--product mulet \
 	--branch pine \
-	$(shell pwd)/firefox
-	touch -c firefox
+	$(shell pwd)
+	touch -c $@
 
 .PHONY: test-integration
 # $(PROFILE_FOLDER) should be `profile-test` when we do `make test-integration`.


### PR DESCRIPTION
… and firefox in a saner manner now. Revert back to previous syntax.
