### PR TITLE
Bug 1264167 - [TV][Home] Renaming card under folder does not take effect immediately after inputing new name.

### DIFF
--- a/shared/js/smart-screen/card_manager.js
+++ b/shared/js/smart-screen/card_manager.js
@@ -492,6 +492,17 @@
           this.writeCardlistInCardStore().then(function() {
             that.fire('card-updated', that._cardList[index], index);
           });
+        } else {
+          var folder = this.findContainingFolder({ cardId: item.cardId });
+          if (folder) { // The card is under a folder not in _cardList
+            var list = folder.getCardList();
+            var idx = list.findIndex(function(elem) {
+              return elem.cardId === item.cardId;
+            });
+            if (idx >= 0) {
+              folder.updateCard(list[idx], idx);
+            }
+          }
         }
       }, this);
     },

--- a/tv_apps/smart-home/js/home.js
+++ b/tv_apps/smart-home/js/home.js
@@ -109,7 +109,8 @@
                           that.onCardInserted.bind(that, that.cardScrollable));
         that.cardManager.on('card-removed',
                           that.onCardRemoved.bind(that, that.cardScrollable));
-        that.cardManager.on('card-updated', that.onCardUpdated.bind(that));
+        that.cardManager.on('card-updated',
+                          that.onCardUpdated.bind(that, that.cardScrollable));
         that.cardManager.on('folder-changed', that.onFolderChanged.bind(that));
 
         that.spatialNavigator.on('focus', that.handleFocus.bind(that));
@@ -168,6 +169,8 @@
                         that.onCardInserted.bind(that, that.folderScrollable));
             card.on('card-removed',
                         that.onCardRemoved.bind(that, that.folderScrollable));
+            card.on('card-updated',
+                        that.onCardUpdated.bind(that, that.folderScrollable));
           }
         });
         that._fteWizard = new FTEWizard('homeFTE');
@@ -269,6 +272,8 @@
                 this.onCardInserted.bind(this, this.folderScrollable));
         card.on('card-removed',
                 this.onCardRemoved.bind(this, this.folderScrollable));
+        card.on('card-updated',
+                this.onCardUpdated.bind(this, this.folderScrollable));
       }
 
       var newCardElem = this.createCardNode(card);
@@ -302,9 +307,8 @@
       }
     },
 
-    onCardUpdated: function(card, idx) {
-      var cardButton = this.cardScrollable.getItemFromNode(
-                                              this.cardScrollable.getNode(idx));
+    onCardUpdated: function(scrollable, card, idx) {
+      var cardButton = scrollable.getItemFromNode(scrollable.getNode(idx));
       CardUtil.updateCardName(cardButton, card);
     },
 


### PR DESCRIPTION
When renaming card, cardManager and home do not handle the case of renaming card under folder.
As a result, renaming card under folder does not take effect immediately after inputing new name.
This patch check if card under folder is being renamed and do corresponding handling to fix the issue.
