### PR TITLE
Bug 1270625 - Add extend task graph scope to decision task r=auswerk

### DIFF
--- a/taskgraph.json
+++ b/taskgraph.json
@@ -19,7 +19,8 @@
         "scopes": [
           "docker-worker:cache:gaia-tc-vcs",
           "docker-worker:cache:gaia-linux-cache",
-          "docker-worker:cache:gaia-misc-caches"
+          "docker-worker:cache:gaia-misc-caches",
+          "scheduler:extend-task-graph:*"
         ],
         "payload": {
           "cache": {


### PR DESCRIPTION
This change should allow the decision task to work with new versions of our worker, which use a set of temporary credentials per task based on task.scopes.
