### PR TITLE
Bug 1268827 - [TV][Home] Focus remains in homescreen when first time entering rename dialog

### DIFF
--- a/tv_apps/smart-system/js/value_selector/value_selector.js
+++ b/tv_apps/smart-system/js/value_selector/value_selector.js
@@ -1,5 +1,5 @@
 /* global BaseUI, LazyLoader, InputParser, ValueSelector, SpinDatePicker,
-          ValuePicker, Template */
+          ValuePicker, Template, focusManager */
 
 'use strict';
 
@@ -229,9 +229,7 @@
     }
     this.element.blur();
     this.element.hidden = true;
-    if (this.app) {
-      this.app.focus();
-    }
+    focusManager.focus();
     this.publish('hidden');
   };
 


### PR DESCRIPTION
When pressing down to hide keyboard under the prompt for the 1st time, it would trigger the injection of the value selector element. The value selector element is rendered without the hidden set initially.

In the end of the injection operation, the operation would hide the value selector and call focus on the background app since it is not hidden. As a result, the foreground prompt loses the focus.

From the 2nd time on, because the value selector has already been hidden. the foreground prompt would not loses the focus.

We should call focus on the focusManager not on the background app directly so as to let the focusManager control which element is the right one to gain focus.
