### PR TITLE
Bug 1270393 - [TV][Home] Always prompt confirmation dialog if press back key on card selection page of creating folder

### DIFF
--- a/tv_apps/smart-home/js/card_picker.js
+++ b/tv_apps/smart-home/js/card_picker.js
@@ -136,12 +136,17 @@
     onKeyUp: function(evt) {
       if (SharedUtils.isBackKey(evt) && this.mode == 'add' &&
           this.isShown && !this.isKeyboardOpened) {
-        document.l10n.formatValue('cancel-add-folder').then(message => {
-          if (confirm(message)) {
-            this.mode = null;
-            this.hide();
-          }
-        });
+        if (this.selected.length > 0) {
+          document.l10n.formatValue('cancel-add-folder').then(message => {
+            if (confirm(message)) {
+              this.mode = null;
+              this.hide();
+            }
+          });
+        } else {
+          this.mode = null;
+          this.hide();
+        }
       }
     },
 


### PR DESCRIPTION
This patch implements the specs. When adding folder, but pressing Back key without no card selected, we should just go back to home screen directly and no confirming prompt is needed. 
