### PR TITLE
Bug 123472 - Remove :-moz-full-screen-ancestor from gaia code R=fabrice

### DIFF
--- a/apps/system/js/core.js
+++ b/apps/system/js/core.js
@@ -20,6 +20,7 @@
     'WallpaperManager',
     'LayoutManager',
     'SoftwareButtonManager',
+    'FullscreenManager',
     'AppCore',
     'ScreenManager'
   ];

--- a/apps/system/js/fullscreen_manager.js
+++ b/apps/system/js/fullscreen_manager.js
@@ -1,0 +1,46 @@
+'use strict';
+
+(function(exports) {
+
+  /**
+   * FullscreenListener is a simple event listener that listens for
+   * fullscreenchange events and applies a class to its element
+   * when the element that is fullscreen is a descendent.  This is
+   * used in CSS to control what gets displayed in and out of
+   * fullscreen mode.
+   */
+  function FullscreenListener(element) {
+    if (!element) {
+      throw new Error('No element supplied');
+    }
+
+    this.element = element;
+    document.addEventListener('mozfullscreenchange', this);
+  }
+
+  FullscreenListener.prototype = {
+    handleEvent: function (event) {
+      let fullscreenElement = document.mozFullScreenElement;
+      let isFullscreenAncestor = fullscreenElement &&
+          this.element.contains(fullscreenElement);
+
+      this.element.classList.toggle('.fullscreen-ancestor',
+                                    isFullscreenAncestor);
+    },
+
+    stop: function () {
+      document.removeEventListener('mozfullscreenchange', this);
+    }
+  };
+
+  /**
+   * FullscreenManager is just a collection of listeners.
+   */
+  function FullscreenManager() {
+    this.listener = new FullscreenListener(document.getElementById('screen'));
+    console.log('FullscreenManager', 'fullscreen manager created');
+  }
+
+  exports.FullscreenManager = FullscreenManager;
+
+}(window));

--- a/apps/system/style/edges/edges.css
+++ b/apps/system/style/edges/edges.css
@@ -56,7 +56,7 @@
 }
 
 @media (orientation: landscape) {
-  #screen:not(:-moz-full-screen-ancestor).software-button-enabled #right-panel {
+  #screen:not(.fullscreen-ancestor).software-button-enabled #right-panel {
     width: 7rem;
     border-radius: 2rem 0 0 2rem;
   }

--- a/apps/system/style/permission_manager/permission_manager.css
+++ b/apps/system/style/permission_manager/permission_manager.css
@@ -20,7 +20,7 @@
   }
 }
 
-#screen:-moz-full-screen-ancestor > #permission-screen {
+#screen.fullscreen-ancestor > #permission-screen {
   top: 0;
   height: 100%;
 }

--- a/apps/system/style/software_button_manager/software_button_manager.css
+++ b/apps/system/style/software_button_manager/software_button_manager.css
@@ -30,8 +30,8 @@
   transition: none;
 }
 
-#screen:not(.locked):not(:-moz-full-screen-ancestor) #software-buttons.visible,
-#screen:not(.locked).permission-prompt:-moz-full-screen-ancestor #software-buttons.visible,
+#screen:not(.locked):not(.fullscreen-ancestor) #software-buttons.visible,
+#screen:not(.locked).permission-prompt.fullscreen-ancestor #software-buttons.visible,
 #screen.locked.attention #software-buttons.visible,
 #screen.locked.secure-app #software-buttons.visible {
   visibility: visible;
@@ -126,8 +126,8 @@
   visibility: hidden;
 }
 
-#screen.software-button-enabled:not(.fullscreen-layout-app):not(.locked):not(.permission-prompt):-moz-full-screen-ancestor #fullscreen-software-home-button,
-#screen.software-button-enabled.locked.secure-app:not(.fullscreen-layout-app):not(.permission-prompt):-moz-full-screen-ancestor #fullscreen-software-home-button {
+#screen.software-button-enabled:not(.fullscreen-layout-app):not(.locked):not(.permission-prompt).fullscreen-ancestor #fullscreen-software-home-button,
+#screen.software-button-enabled.locked.secure-app:not(.fullscreen-layout-app):not(.permission-prompt).fullscreen-ancestor #fullscreen-software-home-button {
   visibility: visible;
 }
 

--- a/apps/system/style/statusbar/statusbar.css
+++ b/apps/system/style/statusbar/statusbar.css
@@ -7,7 +7,7 @@
 /* In both fullscreen modes, accept pointer events to trigger the status bar
    unless the utility tray is showing. */
 #screen.fullscreen-app:not(.utility-tray) #top-panel,
-#screen:not(.utility-tray):-moz-full-screen-ancestor > #top-panel {
+#screen:not(.utility-tray).fullscreen-ancestor > #top-panel {
   pointer-events: all;
 }
 
@@ -92,7 +92,7 @@ to be available for moz-elements */
 /* AppChrome would normally provide the theme color for the statusbar.
    However, when in native full-screen mode, AppChrome isn't visible; just
    use black for now, as we do with #screen.attention. */
-#screen:-moz-full-screen-ancestor #statusbar {
+#screen.fullscreen-ancestor #statusbar {
   background-color: black;
 }
 

--- a/apps/system/style/system/system.css
+++ b/apps/system/style/system/system.css
@@ -273,7 +273,7 @@ textarea,
   pointer-events: none;
 }
 
-#screen:-moz-full-screen-ancestor #dialog-overlay,
+#screen.fullscreen-ancestor #dialog-overlay,
 #dialog-overlay.fullscreen {
   top: 0;
   bottom: 0;

--- a/apps/system/style/utility_tray/utility_tray.css
+++ b/apps/system/style/utility_tray/utility_tray.css
@@ -89,7 +89,7 @@ html[dir="ltr"] #statusbar-tray { background-position: right; }
 html[dir="rtl"] #statusbar-tray { background-position: left; }
 
 #screen.utility-tray-in-transition #statusbar-tray,
-#screen:-moz-full-screen-ancestor #statusbar-tray,
+#screen.fullscreen-ancestor #statusbar-tray,
 #screen.utility-tray-in-transition #utility-tray #statusbar-tray {
   background-image: -moz-element(#statusbar-icons);
 }

--- a/apps/system/style/window.css
+++ b/apps/system/style/window.css
@@ -354,11 +354,6 @@ html[dir="rtl"] .appWindow.invoked {
   visibility: visible;
 }
 
-/* Bug 1071235: Workaround for bug 1076783 */
-.browser-container:-moz-full-screen-ancestor > .screenshot-overlay {
-  visibility: hidden;
-}
-
 .appWindow.collapsible .screenshot-overlay {
   margin-top: var(--rocketbar-urlbar-height);
 }
@@ -595,7 +590,7 @@ html[dir="rtl"] .appWindow.invoked {
   the transform for this case.
   See: https://bugzilla.mozilla.org/show_bug.cgi?id=1212960
 */
-#screen:-moz-full-screen-ancestor > #windows > .appWindow:not(.homescreen):not(.lockScreenWindow):not(.attentionWindow):not(.lockScreenInputWindow).active {
+#screen.fullscreen-ancestor > #windows > .appWindow:not(.homescreen):not(.lockScreenWindow):not(.attentionWindow):not(.lockScreenInputWindow).active {
   transform: unset;
 }
 

--- a/apps/system/style/window_layout.css
+++ b/apps/system/style/window_layout.css
@@ -150,13 +150,13 @@
 
 /* Fullscreen windows */
 
-#screen:-moz-full-screen-ancestor .appWindow > div,
+#screen.fullscreen-ancestor .appWindow > div,
 .appWindow.fullscreen-app > div:not(.titlebar):not(.maximized) {
   top: 0;
   height: 100%;
 }
 
-#screen:-moz-full-screen-ancestor .appWindow > .titlebar,
+#screen.fullscreen-ancestor .appWindow > .titlebar,
 .appWindow.fullscreen-app > .titlebar {
   transform: translateY(calc(var(--statusbar-height) * -1));
   /* Same z-index as: https://github.com/mozilla-b2g/gaia/pull/22174/files#diff-889fcaf0800608d5aaa275a452c7492fR23 */
@@ -167,7 +167,7 @@
   transform: translateY(0);
 }
 
-#screen:-moz-full-screen-ancestor .appWindow > .titlebar.dragged,
+#screen.fullscreen-ancestor .appWindow > .titlebar.dragged,
 .appWindow.fullscreen-app > .titlebar.dragged {
   transform: translateY(0);
 }

--- a/apps/system/style/zindex.css
+++ b/apps/system/style/zindex.css
@@ -129,7 +129,7 @@
    triggered by #top-panel, therefore we must ensure it has an appropriate
    z-index in fullscreen modes.
    (The z-indexes differ depending on whether this is a .fullscreen-app or a
-   -moz-full-screen-ancestor; when -moz-full-screen, the z-index is assigned to
+   .fullscreen-ancestor; when -moz-full-screen, the z-index is assigned to
    MAX_INT here in zindex.css) */
 #screen.fullscreen-app:not(.utility-tray) #top-panel {
   z-index: 16386;
@@ -346,32 +346,32 @@
 }
 
 /* We promote the following overlays on top of the fullscreen web content. */
-#screen:-moz-full-screen-ancestor > [data-z-index-level="sleep-menu"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="action-menu"],
-#screen.locked:-moz-full-screen-ancestor > [data-z-index-level="statusbar"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="lockscreen-camera"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="system-dialog"],
+#screen.fullscreen-ancestor > [data-z-index-level="sleep-menu"],
+#screen.fullscreen-ancestor > [data-z-index-level="action-menu"],
+#screen.locked.fullscreen-ancestor > [data-z-index-level="statusbar"],
+#screen.fullscreen-ancestor > [data-z-index-level="lockscreen-camera"],
+#screen.fullscreen-ancestor > [data-z-index-level="system-dialog"],
 
-#screen:-moz-full-screen-ancestor > [data-z-index-level="app"] > .appWindow.active > [data-z-index-level="value-selector"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="system-overlay"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="dialog-overlay"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="app"] > .appWindow.attentionWindow,
-#screen:-moz-full-screen-ancestor > [data-z-index-level="app"] > .appWindow.active > .modal-dialog,
-#screen:-moz-full-screen-ancestor > [data-z-index-level="keyboards"],
+#screen.fullscreen-ancestor > [data-z-index-level="app"] > .appWindow.active > [data-z-index-level="value-selector"],
+#screen.fullscreen-ancestor > [data-z-index-level="system-overlay"],
+#screen.fullscreen-ancestor > [data-z-index-level="dialog-overlay"],
+#screen.fullscreen-ancestor > [data-z-index-level="app"] > .appWindow.attentionWindow,
+#screen.fullscreen-ancestor > [data-z-index-level="app"] > .appWindow.active > .modal-dialog,
+#screen.fullscreen-ancestor > [data-z-index-level="keyboards"],
 
-#screen:-moz-full-screen-ancestor > [data-z-index-level="notification-toaster"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="cards-view"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="permission-screen"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="app-install-dialog"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="app-uninstall-dialog"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="ime-layout-dialog"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="fullscreen-software-home-button"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="software-buttons"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="gesture-panel"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="attention-indicator"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="utility-tray"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="statusbar"],
-#screen:-moz-full-screen-ancestor > [data-z-index-level="global-overlays"] {
+#screen.fullscreen-ancestor > [data-z-index-level="notification-toaster"],
+#screen.fullscreen-ancestor > [data-z-index-level="cards-view"],
+#screen.fullscreen-ancestor > [data-z-index-level="permission-screen"],
+#screen.fullscreen-ancestor > [data-z-index-level="app-install-dialog"],
+#screen.fullscreen-ancestor > [data-z-index-level="app-uninstall-dialog"],
+#screen.fullscreen-ancestor > [data-z-index-level="ime-layout-dialog"],
+#screen.fullscreen-ancestor > [data-z-index-level="fullscreen-software-home-button"],
+#screen.fullscreen-ancestor > [data-z-index-level="software-buttons"],
+#screen.fullscreen-ancestor > [data-z-index-level="gesture-panel"],
+#screen.fullscreen-ancestor > [data-z-index-level="attention-indicator"],
+#screen.fullscreen-ancestor > [data-z-index-level="utility-tray"],
+#screen.fullscreen-ancestor > [data-z-index-level="statusbar"],
+#screen.fullscreen-ancestor > [data-z-index-level="global-overlays"] {
   z-index: 2147483647;
 }
 
@@ -382,7 +382,7 @@
   z-index: 2147483647;
 }
 
-#screen:-moz-full-screen-ancestor > #statusbar:not(.fullscreen) {
+#screen.fullscreen-ancestor > #statusbar:not(.fullscreen) {
   display: none;
 }
 

--- a/disabled_apps/clock/style/picker/value_selector.css
+++ b/disabled_apps/clock/style/picker/value_selector.css
@@ -17,7 +17,7 @@
   top: 4rem;
 }
 
-#screen:-moz-full-screen-ancestor #value-seletcor,
+#screen.fullscreen-ancestor #value-seletcor,
 #screen.fullscreen-app #value-selector {
   height: 100%;
   top: 0;

--- a/shared/style/smart-screen/animations.css
+++ b/shared/style/smart-screen/animations.css
@@ -1,5 +1,5 @@
 .animation-circle,
-#screen:-moz-full-screen-ancestor .appWindow > div.animation-circle,
+#screen.fullscreen-ancestor .appWindow > div.animation-circle,
 .appWindow.fullscreen-app > div:not(.titlebar):not(.maximized).animation-circle {
   position: fixed;
   z-index: 9999;


### PR DESCRIPTION
Added a FullscreenManager to system core that is responsible for
adding/removing a class from #screen when there is a fullscreen
descendent.

This patch reinstates the soft home button.
