### PR TITLE
Bug 1235472 - Fix typo in class used by FullscreenManager r=fabrice

### DIFF
--- a/apps/system/js/fullscreen_manager.js
+++ b/apps/system/js/fullscreen_manager.js
@@ -24,7 +24,7 @@
       let isFullscreenAncestor = fullscreenElement &&
           this.element.contains(fullscreenElement);
 
-      this.element.classList.toggle('.fullscreen-ancestor',
+      this.element.classList.toggle('fullscreen-ancestor',
                                     isFullscreenAncestor);
     },
 


### PR DESCRIPTION
Sorry, I put a dot in a classname by mistake!
