### PR TITLE
Bug 1304038 - MakeFile  switch from pine to mozilla-central branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -836,7 +836,7 @@ endif
 mulet: node_modules
 	DEBUG=* ./node_modules/.bin/mozilla-download \
 	--product mulet \
-	--branch pine \
+	--branch mozilla-central \
 	$(shell pwd)
 	touch -c $@
 


### PR DESCRIPTION
The Gaia make file is still pointing to pine branch for the make mulet.
