### PR TITLE
Bug 1258193 - Check undefined variables to workaround disappearing calendar events

### DIFF
--- a/apps/calendar/js/day_observer.js
+++ b/apps/calendar/js/day_observer.js
@@ -138,7 +138,7 @@ exports.removeAllListeners = function() {
 // cache data and show the event details faster on the most common cases
 exports.findAssociated = function(busytimeId) {
   return queryBusytime(busytimeId).then(busytime => {
-    return queryEvent(busytime.eventId).then(event => {
+    if (busytime) return queryEvent(busytime.eventId).then(event => {
       return {
         busytime: busytime,
         event: event
@@ -172,7 +172,7 @@ function cacheBusytime(busy) {
   }
 
   busytimes.set(_id, busy);
-  eventsToBusytimes.get(eventId).push(_id);
+  if (eventsToBusytimes.get(eventId)) eventsToBusytimes.get(eventId).push(_id);
   registerBusytimeChange(_id);
 }
 
@@ -262,7 +262,7 @@ function sortedInsert(group, busy) {
   });
   var event = events.get(busy.eventId);
   var calendarStore = core.storeFactory.get('Calendar');
-  group.splice(index, 0, {
+  if (event) group.splice(index, 0, {
     event: event,
     busytime: busy,
     color: calendarStore.getColorByCalendarId(event.calendarId)

--- a/apps/calendar/js/day_observer.js
+++ b/apps/calendar/js/day_observer.js
@@ -138,7 +138,7 @@ exports.removeAllListeners = function() {
 // cache data and show the event details faster on the most common cases
 exports.findAssociated = function(busytimeId) {
   return queryBusytime(busytimeId).then(busytime => {
-    if (busytime) return queryEvent(busytime.eventId).then(event => {
+    if (typeof busytime !== 'undefined') return queryEvent(busytime.eventId).then(event => {
       return {
         busytime: busytime,
         event: event
@@ -172,7 +172,7 @@ function cacheBusytime(busy) {
   }
 
   busytimes.set(_id, busy);
-  if (eventsToBusytimes.get(eventId)) eventsToBusytimes.get(eventId).push(_id);
+  if (typeof eventsToBusytimes.get(eventId) !== 'undefined') eventsToBusytimes.get(eventId).push(_id);
   registerBusytimeChange(_id);
 }
 
@@ -262,7 +262,7 @@ function sortedInsert(group, busy) {
   });
   var event = events.get(busy.eventId);
   var calendarStore = core.storeFactory.get('Calendar');
-  if (event) group.splice(index, 0, {
+  if (typeof event !== 'undefined') group.splice(index, 0, {
     event: event,
     busytime: busy,
     color: calendarStore.getColorByCalendarId(event.calendarId)


### PR DESCRIPTION
I had errors in the console because of these variables being undefined.
Adding these checks solved the issue of events disappearing after a restart.
I did not investigate more on the reasons behind that.
